### PR TITLE
Change default gateway port to 18790

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -154,7 +154,7 @@ This file stores important information that should persist across sessions.
 
 @app.command()
 def gateway(
-    port: int = typer.Option(18789, "--port", "-p", help="Gateway port"),
+    port: int = typer.Option(18790, "--port", "-p", help="Gateway port"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
 ):
     """Start the nanobot gateway."""

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -55,7 +55,7 @@ class ProvidersConfig(BaseModel):
 class GatewayConfig(BaseModel):
     """Gateway/server configuration."""
     host: str = "0.0.0.0"
-    port: int = 18789
+    port: int = 18790
 
 
 class WebSearchConfig(BaseModel):


### PR DESCRIPTION
Hi! I noticed that the default port 18789 conflicts with OpenClaw's browser relay. Changing the default to 18790 might be better for users running both platforms simultaneously. What do you think?