### PR TITLE
feat: add vision support for image recognition in Telegram

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -152,7 +152,8 @@ class AgentLoop:
         # Build initial messages (use get_history for LLM-formatted messages)
         messages = self.context.build_messages(
             history=session.get_history(),
-            current_message=msg.content
+            current_message=msg.content,
+            media=msg.media if msg.media else None,
         )
         
         # Agent loop


### PR DESCRIPTION
## Summary
- Images sent via Telegram are now base64-encoded and passed to the LLM using the multimodal content format, enabling the agent to see and understand images.
- Only two files changed with minimal modifications: `context.py` adds image encoding logic, `loop.py` passes media paths through.
- Text-only messages are unaffected; the new path only activates when `msg.media` is non-empty.

## Changes
- **`nanobot/agent/context.py`**: `build_messages()` accepts an optional `media` parameter; new `_build_user_content()` and `_encode_image()` methods handle base64 encoding.
- **`nanobot/agent/loop.py`**: Pass `msg.media` to `context.build_messages()` in `_process_message()`.

## Test
- [x] Send an image with text via Telegram → agent correctly describes the image
- [x] Send text-only message → behavior unchanged

## Future Work
- Add image support for WhatsApp (requires bridge-side media download)
- Support more modalities (audio transcription, video frame extraction)