### PR TITLE
docs: add uv installation instructions (fixes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@
 
 ## 📦 Install
 
+**Install with [uv](https://github.com/astral-sh/uv)** (recommended for speed)
+
+```bash
+uv tool install nanobot-ai
+```
+
 **Install from PyPi**
 
 ```bash


### PR DESCRIPTION
This PR adds instructions for installing nanobot using `uv`, as requested in issue #5.