### PR TITLE
feat: add voice transcription support with groq (fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ nanobot/
 
 ## 🗺️ Roadmap
 
+- [x] **Voice Transcription** — Support for Groq Whisper (Issue #13)
 - [ ] **Multi-modal** — See and hear (images, voice, video)
 - [ ] **Long-term memory** — Never forget important context
 - [ ] **Better reasoning** — Multi-step planning and reflection

--- a/bridge/src/whatsapp.ts
+++ b/bridge/src/whatsapp.ts
@@ -160,6 +160,11 @@ export class WhatsAppClient {
       return `[Document] ${message.documentMessage.caption}`;
     }
 
+    // Voice/Audio message
+    if (message.audioMessage) {
+      return `[Voice Message]`;
+    }
+
     return null;
   }
 

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -36,6 +36,8 @@ class ChannelManager:
         if self.config.channels.telegram.enabled:
             try:
                 from nanobot.channels.telegram import TelegramChannel
+                # Inject parent config for access to providers
+                self.config.channels.telegram.parent = self.config
                 self.channels["telegram"] = TelegramChannel(
                     self.config.channels.telegram, self.bus
                 )
@@ -47,6 +49,8 @@ class ChannelManager:
         if self.config.channels.whatsapp.enabled:
             try:
                 from nanobot.channels.whatsapp import WhatsAppChannel
+                # Inject parent config for access to providers
+                self.config.channels.whatsapp.parent = self.config
                 self.channels["whatsapp"] = WhatsAppChannel(
                     self.config.channels.whatsapp, self.bus
                 )

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -107,6 +107,11 @@ class WhatsAppChannel(BaseChannel):
             # Extract just the phone number as chat_id
             chat_id = sender.split("@")[0] if "@" in sender else sender
             
+            # Handle voice transcription if it's a voice message
+            if content == "[Voice Message]":
+                logger.info(f"Voice message received from {chat_id}, but direct download from bridge is not yet supported.")
+                content = "[Voice Message: Transcription not available for WhatsApp yet]"
+            
             await self._handle_message(
                 sender_id=chat_id,
                 chat_id=sender,  # Use full JID for replies

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -50,6 +50,7 @@ class ProvidersConfig(BaseModel):
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
+    groq: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
 
 
@@ -89,11 +90,12 @@ class Config(BaseSettings):
         return Path(self.agents.defaults.workspace).expanduser()
     
     def get_api_key(self) -> str | None:
-        """Get API key in priority order: OpenRouter > Anthropic > OpenAI > vLLM."""
+        """Get API key in priority order: OpenRouter > Anthropic > OpenAI > Groq > vLLM."""
         return (
             self.providers.openrouter.api_key or
             self.providers.anthropic.api_key or
             self.providers.openai.api_key or
+            self.providers.groq.api_key or
             self.providers.vllm.api_key or
             None
         )

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -47,6 +47,8 @@ class LiteLLMProvider(LLMProvider):
                 os.environ.setdefault("ANTHROPIC_API_KEY", api_key)
             elif "openai" in default_model or "gpt" in default_model:
                 os.environ.setdefault("OPENAI_API_KEY", api_key)
+            elif "groq" in default_model:
+                os.environ.setdefault("GROQ_API_KEY", api_key)
         
         if api_base:
             litellm.api_base = api_base

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -1,0 +1,65 @@
+"""Voice transcription provider using Groq."""
+
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+from loguru import logger
+
+
+class GroqTranscriptionProvider:
+    """
+    Voice transcription provider using Groq's Whisper API.
+    
+    Groq offers extremely fast transcription with a generous free tier.
+    """
+    
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or os.environ.get("GROQ_API_KEY")
+        self.api_url = "https://api.groq.com/openai/v1/audio/transcriptions"
+    
+    async def transcribe(self, file_path: str | Path) -> str:
+        """
+        Transcribe an audio file using Groq.
+        
+        Args:
+            file_path: Path to the audio file.
+            
+        Returns:
+            Transcribed text.
+        """
+        if not self.api_key:
+            logger.warning("Groq API key not configured for transcription")
+            return ""
+        
+        path = Path(file_path)
+        if not path.exists():
+            logger.error(f"Audio file not found: {file_path}")
+            return ""
+        
+        try:
+            async with httpx.AsyncClient() as client:
+                with open(path, "rb") as f:
+                    files = {
+                        "file": (path.name, f),
+                        "model": (None, "whisper-large-v3"),
+                    }
+                    headers = {
+                        "Authorization": f"Bearer {self.api_key}",
+                    }
+                    
+                    response = await client.post(
+                        self.api_url,
+                        headers=headers,
+                        files=files,
+                        timeout=60.0
+                    )
+                    
+                    response.raise_for_status()
+                    data = response.json()
+                    return data.get("text", "")
+                    
+        except Exception as e:
+            logger.error(f"Groq transcription error: {e}")
+            return ""


### PR DESCRIPTION
This PR adds support for voice transcription using Groq Whisper API.

Key changes:
- Added `GroqTranscriptionProvider` in `nanobot/providers/transcription.py`.
- Updated `TelegramChannel` to automatically transcribe voice and audio messages if a Groq API key is provided.
- Added `groq` to `ProvidersConfig` in `schema.py`.
- Updated `ChannelManager` to pass the root config to channels for provider access.
- Updated `README.md` roadmap.