### PR TITLE
feat: add Amazon Bedrock support

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -178,11 +178,13 @@ def gateway(
     # Create components
     bus = MessageBus()
     
-    # Create provider (supports OpenRouter, Anthropic, OpenAI)
+    # Create provider (supports OpenRouter, Anthropic, OpenAI, Bedrock)
     api_key = config.get_api_key()
     api_base = config.get_api_base()
-    
-    if not api_key:
+    model = config.agents.defaults.model
+    is_bedrock = model.startswith("bedrock/")
+
+    if not api_key and not is_bedrock:
         console.print("[red]Error: No API key configured.[/red]")
         console.print("Set one in ~/.nanobot/config.json under providers.openrouter.apiKey")
         raise typer.Exit(1)
@@ -289,11 +291,13 @@ def agent(
     
     api_key = config.get_api_key()
     api_base = config.get_api_base()
-    
-    if not api_key:
+    model = config.agents.defaults.model
+    is_bedrock = model.startswith("bedrock/")
+
+    if not api_key and not is_bedrock:
         console.print("[red]Error: No API key configured.[/red]")
         raise typer.Exit(1)
-    
+
     bus = MessageBus()
     provider = LiteLLMProvider(
         api_key=api_key,


### PR DESCRIPTION
## Summary

Enable Amazon Bedrock models in nanobot by skipping API key validation for `bedrock/` model prefix.

Fixes #20

## Problem

nanobot currently requires an API key for all LLM providers:

```python
if not api_key:
    console.print("[red]Error: No API key configured.[/red]")
    raise typer.Exit(1)
```

However, **AWS Bedrock doesn't use API keys**. It uses IAM credentials via:
- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
- AWS credentials file (`~/.aws/credentials`)
- IAM roles (when running on AWS)

## Solution

Skip API key validation when the configured model starts with `bedrock/`:

```python
model = config.agents.defaults.model
is_bedrock = model.startswith("bedrock/")

if not api_key and not is_bedrock:
    # Show error only for non-Bedrock providers
```

This is the minimal change needed because:
1. **LiteLLM already handles Bedrock** - no new provider code needed
2. **AWS credentials work automatically** - boto3 handles auth
3. **Model prefix is sufficient** - `bedrock/` clearly indicates the provider

## Usage

**1. Set AWS credentials:**
```bash
export AWS_ACCESS_KEY_ID="your-access-key"
export AWS_SECRET_ACCESS_KEY="your-secret-key"
export AWS_REGION_NAME="us-east-1"
```

**2. Configure nanobot** (`~/.nanobot/config.json`):
```json
{
  "agents": {
    "defaults": {
      "model": "bedrock/anthropic.claude-3-sonnet-20240229-v1:0"
    }
  }
}
```

**3. Run:**
```bash
nanobot agent -m "Hello from Bedrock!"
```

## Changes

- `nanobot/cli/commands.py`: Add Bedrock exception to API key validation (+4 lines of logic)