### PR TITLE
fix: add Telegram channel to `channels status` command

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -348,21 +348,31 @@ app.add_typer(channels_app, name="channels")
 def channels_status():
     """Show channel status."""
     from nanobot.config.loader import load_config
-    
+
     config = load_config()
-    
+
     table = Table(title="Channel Status")
     table.add_column("Channel", style="cyan")
     table.add_column("Enabled", style="green")
-    table.add_column("Bridge URL", style="yellow")
-    
+    table.add_column("Configuration", style="yellow")
+
+    # WhatsApp
     wa = config.channels.whatsapp
     table.add_row(
         "WhatsApp",
         "✓" if wa.enabled else "✗",
         wa.bridge_url
     )
-    
+
+    # Telegram
+    tg = config.channels.telegram
+    tg_config = f"token: {tg.token[:10]}..." if tg.token else "[dim]not configured[/dim]"
+    table.add_row(
+        "Telegram",
+        "✓" if tg.enabled else "✗",
+        tg_config
+    )
+
     console.print(table)
 
 


### PR DESCRIPTION
## Summary
Fixes the bug where `nanobot channels status` only displays WhatsApp channel status, completely omitting Telegram despite it being fully implemented in the codebase.

## Problem
The `channels status` command (commands.py:347-366) only showed WhatsApp channel information:
- Users couldn't see Telegram channel status via CLI
- This created confusion about whether Telegram was supported
- The feature was working correctly, just missing from the status display

## Solution
- Added Telegram channel status display to the table
- Renamed "Bridge URL" column to "Configuration" for better generality
- Shows Telegram token (first 10 chars) or "not configured" message
- Added code comments to distinguish WhatsApp and Telegram sections

## Changes
- Modified `nanobot/cli/commands.py` (15 insertions, 5 deletions)
- Both WhatsApp and Telegram channels now display in status output

## Testing
You can verify the fix by running:
```bash
nanobot channels status
```

Both WhatsApp and Telegram channels should now appear in the output table.

## Related
This addresses the missing Telegram display issue in the CLI status command.