### PR TITLE
fix: status command now respects workspace from config

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -609,17 +609,23 @@ def status():
     """Show nanobot status."""
     from nanobot.config.loader import load_config, get_config_path
     from nanobot.utils.helpers import get_workspace_path
-    
+
     config_path = get_config_path()
-    workspace = get_workspace_path()
-    
-    console.print(f"{__logo__} nanobot Status\n")
-    
-    console.print(f"Config: {config_path} {'[green]✓[/green]' if config_path.exists() else '[red]✗[/red]'}")
-    console.print(f"Workspace: {workspace} {'[green]✓[/green]' if workspace.exists() else '[red]✗[/red]'}")
-    
+
+    # Load config first to get the correct workspace path
     if config_path.exists():
         config = load_config()
+        workspace = config.workspace_path
+    else:
+        config = None
+        workspace = get_workspace_path()
+
+    console.print(f"{__logo__} nanobot Status\n")
+
+    console.print(f"Config: {config_path} {'[green]✓[/green]' if config_path.exists() else '[red]✗[/red]'}")
+    console.print(f"Workspace: {workspace} {'[green]✓[/green]' if workspace.exists() else '[red]✗[/red]'}")
+
+    if config is not None:
         console.print(f"Model: {config.agents.defaults.model}")
         
         # Check API keys


### PR DESCRIPTION
## Summary

Fixes a bug where the `status` command ignores the `workspace` setting from the configuration file and always displays the default path (`~/.nanobot/workspace`).

**Problem:**
- The `status` command was calling `get_workspace_path()` without any parameters
- This caused it to always return the default workspace path, regardless of what was configured
- Other commands (like those at lines 200, 232, 307) correctly use `config.workspace_path`

**Solution:**
- Load the config first and use `config.workspace_path` when config exists
- Fall back to default path only when no config file exists
- Avoid loading config twice by restructuring the logic

**Changes:**
- Modified `nanobot/cli/commands.py` in the `status()` function
- Now consistent with how other commands handle workspace paths