### PR TITLE
feat(channels): add Slack and Mattermost channel support

### DIFF
--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -53,7 +53,29 @@ class ChannelManager:
                 logger.info("WhatsApp channel enabled")
             except ImportError as e:
                 logger.warning(f"WhatsApp channel not available: {e}")
-    
+
+        # Slack channel
+        if self.config.channels.slack.enabled:
+            try:
+                from nanobot.channels.slack import SlackChannel
+                self.channels["slack"] = SlackChannel(
+                    self.config.channels.slack, self.bus
+                )
+                logger.info("Slack channel enabled")
+            except ImportError as e:
+                logger.warning(f"Slack channel not available: {e}")
+
+        # Mattermost channel
+        if self.config.channels.mattermost.enabled:
+            try:
+                from nanobot.channels.mattermost import MattermostChannel
+                self.channels["mattermost"] = MattermostChannel(
+                    self.config.channels.mattermost, self.bus
+                )
+                logger.info("Mattermost channel enabled")
+            except ImportError as e:
+                logger.warning(f"Mattermost channel not available: {e}")
+
     async def start_all(self) -> None:
         """Start WhatsApp channel and the outbound dispatcher."""
         if not self.channels:

--- a/nanobot/channels/mattermost.py
+++ b/nanobot/channels/mattermost.py
@@ -1,0 +1,160 @@
+"""Mattermost channel implementation using mattermostdriver."""
+
+import asyncio
+import json
+from urllib.parse import urlparse
+
+from loguru import logger
+from mattermostdriver import Driver
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import MattermostConfig
+
+
+class MattermostChannel(BaseChannel):
+    """
+    Mattermost channel using WebSocket connection.
+
+    Connects to Mattermost via mattermostdriver and listens for messages.
+    """
+
+    name = "mattermost"
+
+    def __init__(self, config: MattermostConfig, bus: MessageBus):
+        super().__init__(config, bus)
+        self.config: MattermostConfig = config
+        self._driver: Driver | None = None
+        self._bot_user_id: str | None = None
+
+    async def start(self) -> None:
+        """Start the Mattermost client with WebSocket connection."""
+        if not self.config.url or not self.config.token:
+            logger.error("Mattermost URL and token must be configured")
+            return
+
+        # Parse the URL to extract scheme, host, and port
+        parsed = urlparse(self.config.url)
+
+        # Extract scheme (default to https)
+        scheme = parsed.scheme or "https"
+
+        # Extract host (without scheme)
+        host = parsed.netloc or parsed.path
+
+        # Extract port from netloc if present
+        port = None
+        if ':' in host:
+            host, port_str = host.rsplit(':', 1)
+            try:
+                port = int(port_str)
+            except ValueError:
+                port = None
+
+        # Default port based on scheme if not specified
+        if port is None:
+            port = 443 if scheme == "https" else 80
+
+        # Create driver with parsed options
+        self._driver = Driver({
+            'url': host,
+            'token': self.config.token,
+            'scheme': scheme,
+            'port': port
+        })
+
+        try:
+            # Login to Mattermost
+            self._driver.login()
+
+            # Get bot user info
+            user_info = self._driver.users.get_user('me')
+            self._bot_user_id = user_info['id']
+
+            logger.info(f"Mattermost bot @{user_info.get('username', 'unknown')} connected")
+
+            # Initialize WebSocket with event handler
+            self._driver.init_websocket(self._event_handler)
+
+            self._running = True
+
+            # Keep running until stopped
+            while self._running:
+                await asyncio.sleep(1)
+
+        except Exception as e:
+            logger.error(f"Failed to start Mattermost client: {e}")
+            self._running = False
+
+    def _event_handler(self, event: str) -> None:
+        """
+        Handle WebSocket events from Mattermost.
+
+        This is called by mattermostdriver's WebSocket in a sync context.
+        We need to schedule the async handler.
+        """
+        try:
+            # Parse the event JSON
+            data = json.loads(event)
+
+            # Check if this is a posted message event
+            if data.get('event') != 'posted':
+                return
+
+            # Extract post data
+            post_data = data.get('data', {}).get('post', '{}')
+            post = json.loads(post_data)
+
+            # Extract message details
+            user_id = post.get('user_id')
+            channel_id = post.get('channel_id')
+            message = post.get('message', '')
+
+            # Ignore messages from the bot itself
+            if user_id == self._bot_user_id:
+                return
+
+            # Check if sender is allowed
+            if not self.is_allowed(user_id):
+                logger.debug(f"Ignoring message from unauthorized user: {user_id}")
+                return
+
+            # Schedule async message handling
+            asyncio.create_task(
+                self._handle_message(
+                    sender_id=user_id,
+                    chat_id=channel_id,
+                    content=message
+                )
+            )
+
+        except Exception as e:
+            logger.error(f"Error handling Mattermost event: {e}")
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Send a message through Mattermost."""
+        if not self._driver:
+            logger.warning("Mattermost driver not running")
+            return
+
+        try:
+            # Mattermost supports standard markdown, no conversion needed
+            self._driver.posts.create_post({
+                "channel_id": msg.chat_id,
+                "message": msg.content
+            })
+        except Exception as e:
+            logger.error(f"Error sending Mattermost message: {e}")
+
+    async def stop(self) -> None:
+        """Stop the Mattermost client."""
+        self._running = False
+
+        if self._driver:
+            logger.info("Stopping Mattermost client...")
+            try:
+                self._driver.disconnect()
+            except Exception as e:
+                logger.error(f"Error disconnecting Mattermost: {e}")
+            self._driver = None

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -1,0 +1,166 @@
+"""Slack channel implementation using slack-bolt with Socket Mode."""
+
+import asyncio
+import re
+
+from loguru import logger
+from slack_bolt.async_app import AsyncApp
+from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import SlackConfig
+
+
+def _markdown_to_slack_mrkdwn(text: str) -> str:
+    """
+    Convert markdown to Slack mrkdwn format.
+    """
+    if not text:
+        return ""
+
+    # 1. Extract and protect code blocks
+    code_blocks: list[str] = []
+    def save_code_block(m: re.Match) -> str:
+        code_blocks.append(m.group(1))
+        return f"\x00CB{len(code_blocks) - 1}\x00"
+
+    text = re.sub(r'```[\w]*\n?([\s\S]*?)```', save_code_block, text)
+
+    # 2. Extract and protect inline code
+    inline_codes: list[str] = []
+    def save_inline_code(m: re.Match) -> str:
+        inline_codes.append(m.group(1))
+        return f"\x00IC{len(inline_codes) - 1}\x00"
+
+    text = re.sub(r'`([^`]+)`', save_inline_code, text)
+
+    # 3. Convert bold **text** to *text*
+    text = re.sub(r'\*\*(.+?)\*\*', r'*\1*', text)
+
+    # 4. Convert links [text](url) to <url|text>
+    text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<\2|\1>', text)
+
+    # 5. Restore inline code with backticks
+    for i, code in enumerate(inline_codes):
+        text = text.replace(f"\x00IC{i}\x00", f"`{code}`")
+
+    # 6. Restore code blocks with triple backticks
+    for i, code in enumerate(code_blocks):
+        text = text.replace(f"\x00CB{i}\x00", f"```{code}```")
+
+    return text
+
+
+class SlackChannel(BaseChannel):
+    """
+    Slack channel using Socket Mode (WebSocket).
+
+    No public server needed - uses WebSocket connection.
+    """
+
+    name = "slack"
+
+    def __init__(self, config: SlackConfig, bus: MessageBus):
+        super().__init__(config, bus)
+        self.config: SlackConfig = config
+        self._app: AsyncApp | None = None
+        self._handler: AsyncSocketModeHandler | None = None
+        self._bot_user_id: str | None = None
+
+    async def start(self) -> None:
+        """Start the Slack bot with Socket Mode."""
+        if not self.config.bot_token or not self.config.app_token:
+            logger.error("Slack bot_token and app_token must be configured")
+            return
+
+        self._running = True
+
+        # Create Slack app
+        self._app = AsyncApp(token=self.config.bot_token)
+
+        # Register message event handler
+        @self._app.event("message")
+        async def handle_message(event, say):
+            await self._on_message(event, say)
+
+        # Get bot user ID
+        try:
+            auth_response = await self._app.client.auth_test()
+            self._bot_user_id = auth_response["user_id"]
+            logger.info(f"Slack bot user ID: {self._bot_user_id}")
+        except Exception as e:
+            logger.error(f"Failed to get bot user ID: {e}")
+            return
+
+        # Create Socket Mode handler
+        self._handler = AsyncSocketModeHandler(self._app, self.config.app_token)
+
+        logger.info("Starting Slack bot (Socket Mode)...")
+
+        # Start the handler (non-blocking)
+        await self._handler.start_async()
+
+        logger.info("Slack bot connected via Socket Mode")
+
+        # Keep running until stopped
+        while self._running:
+            await asyncio.sleep(1)
+
+    async def stop(self) -> None:
+        """Stop the Slack bot."""
+        self._running = False
+
+        if self._handler:
+            logger.info("Stopping Slack bot...")
+            await self._handler.close_async()
+            self._handler = None
+
+        self._app = None
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Send a message through Slack."""
+        if not self._app:
+            logger.warning("Slack bot not running")
+            return
+
+        try:
+            # Convert markdown to Slack mrkdwn
+            mrkdwn_content = _markdown_to_slack_mrkdwn(msg.content)
+
+            await self._app.client.chat_postMessage(
+                channel=msg.chat_id,
+                text=mrkdwn_content
+            )
+        except Exception as e:
+            logger.error(f"Error sending Slack message: {e}")
+
+    async def _on_message(self, event, say) -> None:
+        """Handle incoming messages from Slack."""
+        # Extract event fields
+        user = event.get("user")
+        channel = event.get("channel")
+        text = event.get("text", "")
+        subtype = event.get("subtype")
+
+        # Ignore bot's own messages
+        if user == self._bot_user_id:
+            return
+
+        # Ignore messages with subtypes (edits, joins, etc.)
+        if subtype:
+            return
+
+        # Check if user is allowed
+        if not user or not self.is_allowed(user):
+            return
+
+        logger.debug(f"Slack message from {user}: {text[:50]}...")
+
+        # Forward to the message bus
+        await self._handle_message(
+            sender_id=user,
+            chat_id=channel,
+            content=text
+        )

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -19,10 +19,28 @@ class TelegramConfig(BaseModel):
     allow_from: list[str] = Field(default_factory=list)  # Allowed user IDs or usernames
 
 
+class SlackConfig(BaseModel):
+    """Slack channel configuration."""
+    enabled: bool = False
+    bot_token: str = ""  # xoxb-... Bot User OAuth Token
+    app_token: str = ""  # xapp-... App-Level Token (Socket Mode)
+    allow_from: list[str] = Field(default_factory=list)  # Allowed user IDs
+
+
+class MattermostConfig(BaseModel):
+    """Mattermost channel configuration."""
+    enabled: bool = False
+    url: str = ""  # https://mattermost.example.com
+    token: str = ""  # Personal Access Token
+    allow_from: list[str] = Field(default_factory=list)  # Allowed user IDs
+
+
 class ChannelsConfig(BaseModel):
     """Configuration for chat channels."""
     whatsapp: WhatsAppConfig = Field(default_factory=WhatsAppConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
+    slack: SlackConfig = Field(default_factory=SlackConfig)
+    mattermost: MattermostConfig = Field(default_factory=MattermostConfig)
 
 
 class AgentDefaults(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,16 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "ruff>=0.1.0",
 ]
+slack = [
+    "slack-bolt>=1.18.0",
+]
+mattermost = [
+    "mattermostdriver>=7.3.0",
+]
+all = [
+    "slack-bolt>=1.18.0",
+    "mattermostdriver>=7.3.0",
+]
 
 [project.scripts]
 nanobot = "nanobot.cli.commands:app"


### PR DESCRIPTION
## Summary
- Add Slack channel support via Socket Mode (WebSocket) - no public server needed
- Add Mattermost channel support via mattermostdriver WebSocket
- Both channels follow existing Telegram/WhatsApp patterns

## Changes
- `nanobot/config/schema.py`: Add SlackConfig, MattermostConfig
- `nanobot/channels/slack.py`: Slack channel implementation (slack-bolt Socket Mode)
- `nanobot/channels/mattermost.py`: Mattermost channel implementation (mattermostdriver)
- `nanobot/channels/manager.py`: Register channels
- `pyproject.toml`: Add optional dependencies

## Installation
```bash
pip install nanobot-ai[slack]       # Slack only
pip install nanobot-ai[mattermost]  # Mattermost only
pip install nanobot-ai[all]         # All channels
```

## Configuration
```json
{
  "channels": {
    "slack": {
      "enabled": true,
      "bot_token": "xoxb-...",
      "app_token": "xapp-...",
      "allow_from": ["U12345678"]
    },
    "mattermost": {
      "enabled": true,
      "url": "https://mattermost.example.com",
      "token": "your-personal-access-token",
      "allow_from": ["user-id-1"]
    }
  }
}
```

## Test plan
- [x] Test Slack channel connection (Socket Mode)
- [x] Test Mattermost channel connection (WebSocket)
- [x] Verify message send/receive
- [x] Verify allow_from permission check