### PR TITLE
feat: add DeepSeek provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ docs/
 *.pyz
 *.pywz
 *.pyzz
+.venv/
+__pycache__/

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -50,6 +50,7 @@ class ProvidersConfig(BaseModel):
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
+    deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -91,9 +92,10 @@ class Config(BaseSettings):
         return Path(self.agents.defaults.workspace).expanduser()
     
     def get_api_key(self) -> str | None:
-        """Get API key in priority order: OpenRouter > Anthropic > OpenAI > Gemini > Zhipu > vLLM."""
+        """Get API key in priority order: OpenRouter > DeepSeek > Anthropic > OpenAI > Gemini > Zhipu > vLLM."""
         return (
             self.providers.openrouter.api_key or
+            self.providers.deepseek.api_key or
             self.providers.anthropic.api_key or
             self.providers.openai.api_key or
             self.providers.gemini.api_key or

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -43,6 +43,8 @@ class LiteLLMProvider(LLMProvider):
             elif self.is_vllm:
                 # vLLM/custom endpoint - uses OpenAI-compatible API
                 os.environ["OPENAI_API_KEY"] = api_key
+            elif "deepseek" in default_model:
+                os.environ.setdefault("DEEPSEEK_API_KEY", api_key)
             elif "anthropic" in default_model:
                 os.environ.setdefault("ANTHROPIC_API_KEY", api_key)
             elif "openai" in default_model or "gpt" in default_model:
@@ -102,6 +104,10 @@ class LiteLLMProvider(LLMProvider):
         # For Gemini, ensure gemini/ prefix if not already present
         if "gemini" in model.lower() and not model.startswith("gemini/"):
             model = f"gemini/{model}"
+        
+        # Force set env vars for the provider based on model
+        if "deepseek" in model:
+            os.environ["DEEPSEEK_API_KEY"] = self.api_key
         
         kwargs: dict[str, Any] = {
             "model": model,


### PR DESCRIPTION
## Summary
Add native DeepSeek API support as a first-class provider, alongside existing OpenRouter/Anthropic/OpenAI/Gemini/Zhipu providers.

## Changes
- **`nanobot/config/schema.py`**: Add `deepseek` field to `ProvidersConfig`, include in `get_api_key()` priority chain
- **`nanobot/providers/litellm_provider.py`**: Set `DEEPSEEK_API_KEY` env var during init and before each LLM call

## Config Example
```json
{
  "providers": {
    "deepseek": {
      "api_key": "sk-xxx"
    }
  },
  "agents": {
    "defaults": {
      "model": "deepseek/deepseek-chat"
    }
  }
}
```

## Why
- DeepSeek is one of the most popular LLM providers, especially in China
- litellm already supports `deepseek/` model prefix natively, but nanobot's config layer didn't recognize it
- Related: #25

## Notes
- Config uses `api_key` (snake_case) matching Pydantic field names
- No `api_base` override needed — litellm resolves DeepSeek's endpoint automatically
- The env var is force-set before each call to ensure reliability in async contexts