### PR TITLE
fix: correct API key environment variable for vLLM mode

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -42,7 +42,7 @@ class LiteLLMProvider(LLMProvider):
                 os.environ["OPENROUTER_API_KEY"] = api_key
             elif self.is_vllm:
                 # vLLM/custom endpoint - uses OpenAI-compatible API
-                os.environ["OPENAI_API_KEY"] = api_key
+                os.environ["HOSTED_VLLM_API_KEY"] = api_key
             elif "anthropic" in default_model:
                 os.environ.setdefault("ANTHROPIC_API_KEY", api_key)
             elif "openai" in default_model or "gpt" in default_model:


### PR DESCRIPTION
# Problem
According to [LiteLLM's vLLM documentation](https://docs.litellm.ai/docs/providers/vllm), when using the `hosted_vllm/` prefix, LiteLLM expects the `HOSTED_VLLM_API_KEY` environment variable. 

Without the correct environment variable set, LiteLLM defaults to using `Authorization: Bearer fake-api-key`, which causes authentication failures with actual vLLM endpoints.

# Solution
Updated the environment variable assignment in the vLLM detection branch to use `HOSTED_VLLM_API_KEY` instead of `OPENAI_API_KEY`, ensuring proper authentication with vLLM endpoints.
