### PR TITLE
Add feature session reset synchronization and add Telegram command menu

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -40,7 +40,8 @@ class AgentLoop:
         workspace: Path,
         model: str | None = None,
         max_iterations: int = 20,
-        brave_api_key: str | None = None
+        brave_api_key: str | None = None,
+        sessions: SessionManager | None = None
     ):
         self.bus = bus
         self.provider = provider
@@ -48,9 +49,9 @@ class AgentLoop:
         self.model = model or provider.get_default_model()
         self.max_iterations = max_iterations
         self.brave_api_key = brave_api_key
-        
+
         self.context = ContextBuilder(workspace)
-        self.sessions = SessionManager(workspace)
+        self.sessions = sessions or SessionManager(workspace)
         self.tools = ToolRegistry()
         self.subagents = SubagentManager(
             provider=provider,

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -1,32 +1,37 @@
 """Base channel interface for chat platforms."""
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
+
+if TYPE_CHECKING:
+    from nanobot.session import SessionManager
 
 
 class BaseChannel(ABC):
     """
     Abstract base class for chat channel implementations.
-    
+
     Each channel (Telegram, Discord, etc.) should implement this interface
     to integrate with the nanobot message bus.
     """
-    
+
     name: str = "base"
-    
-    def __init__(self, config: Any, bus: MessageBus):
+
+    def __init__(self, config: Any, bus: MessageBus, sessions: "SessionManager | None" = None):
         """
         Initialize the channel.
-        
+
         Args:
             config: Channel-specific configuration.
             bus: The message bus for communication.
+            sessions: Optional session manager for conversation history.
         """
         self.config = config
         self.bus = bus
+        self.sessions = sessions
         self._running = False
     
     @abstractmethod

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -166,6 +166,7 @@ def gateway(
     from nanobot.cron.service import CronService
     from nanobot.cron.types import CronJob
     from nanobot.heartbeat.service import HeartbeatService
+    from nanobot.session import SessionManager
     
     if verbose:
         import logging
@@ -194,7 +195,10 @@ def gateway(
         api_base=api_base,
         default_model=config.agents.defaults.model
     )
-    
+
+    # Create shared session manager
+    sessions = SessionManager(config.workspace_path)
+
     # Create agent
     agent = AgentLoop(
         bus=bus,
@@ -202,7 +206,8 @@ def gateway(
         workspace=config.workspace_path,
         model=config.agents.defaults.model,
         max_iterations=config.agents.defaults.max_tool_iterations,
-        brave_api_key=config.tools.web.search.api_key or None
+        brave_api_key=config.tools.web.search.api_key or None,
+        sessions=sessions
     )
     
     # Create cron service
@@ -238,7 +243,7 @@ def gateway(
     )
     
     # Create channel manager
-    channels = ChannelManager(config, bus)
+    channels = ChannelManager(config, bus, sessions=sessions)
     
     if channels.enabled_channels:
         console.print(f"[green]✓[/green] Channels enabled: {', '.join(channels.enabled_channels)}")

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -156,22 +156,45 @@ class SessionManager:
     def delete(self, key: str) -> bool:
         """
         Delete a session.
-        
+
         Args:
             key: Session key.
-        
+
         Returns:
             True if deleted, False if not found.
         """
         # Remove from cache
         self._cache.pop(key, None)
-        
+
         # Remove file
         path = self._get_session_path(key)
         if path.exists():
             path.unlink()
             return True
         return False
+
+    def archive(self, key: str) -> Path | None:
+        """
+        Archive a session by renaming with timestamp.
+
+        Example: telegram_123456.jsonl → telegram_123456_20260203_143022.jsonl
+
+        Returns:
+            Path to archived file, or None if session not found.
+        """
+        path = self._get_session_path(key)
+        if not path.exists():
+            return None
+
+        # Remove from cache
+        self._cache.pop(key, None)
+
+        # Rename with timestamp
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        archive_path = path.with_name(f"{path.stem}_{timestamp}.jsonl")
+        path.rename(archive_path)
+
+        return archive_path
     
     def list_sessions(self) -> list[dict[str, Any]]:
         """


### PR DESCRIPTION
## Summary

- Add automatic Telegram bot commands menu via `set_my_commands`
- Fix `/reset` command not clearing session properly

## Changes

**`nanobot/channels/telegram.py`**

Added `set_my_commands` call in the `start()` method to register bot commands:
- `/start` - Start the bot
- `/reset` - Reset the session

**`nanobot/cli/commands.py`**

- Create a shared `SessionManager` instance
- Pass it to both `AgentLoop` and `ChannelManager`

**`nanobot/agent/loop.py`**

- Add optional `sessions` parameter to constructor

**`nanobot/channels/manager.py`**

- Add optional `sessions` parameter to constructor

## Bug fix

Previously, `AgentLoop` and `ChannelManager` each created their own `SessionManager` instance. When `/reset` was called, it only cleared the session from the channel's SessionManager, but the AgentLoop still had the old session cached. Now both share the same instance.

## Test plan

- [ ] Restart the gateway: `nanobot gateway`
- [ ] Open Telegram chat with the bot
- [ ] Type `/` and verify the commands menu appears
- [ ] Send a message, get a response
- [ ] Type `/reset`
- [ ] Send another message and verify the bot doesn't remember the previous conversation

# Screenshots : 

<img width="1760" height="878" alt="image" src="https://github.com/user-attachments/assets/75f2fec9-f3ba-4804-9956-657400084486" />

<img width="148" height="320" alt="IMG_6115" src="https://github.com/user-attachments/assets/1e0338c7-be37-4c1c-a180-0a4f7c3599eb" />

<img width="148" height="320" alt="IMG_6116" src="https://github.com/user-attachments/assets/afed7a4f-4cad-4c88-8ff7-f03897492a01" />
