### PR TITLE
chore(compose): update docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+services:
+  nanobot-gateway:
+    build: .
+    image: nanobot:latest
+    container_name: nanobot-gateway
+    env_file:
+      - .env
+    environment:
+      NANOBOT_CONFIG: /root/.nanobot/config.json
+    volumes:
+      - ~/.nanobot:/root/.nanobot
+    ports:
+      - "18790:18790"
+    command: ["gateway"]
+    restart: unless-stopped
+
+  nanobot-onboard:
+    image: nanobot:latest
+    container_name: nanobot-onboard
+    env_file:
+      - .env
+    environment:
+      NANOBOT_CONFIG: /root/.nanobot/config.json
+    volumes:
+      - ~/.nanobot:/root/.nanobot
+    command: ["onboard"]
+    restart: "no"
+
+  nanobot-whatsapp-login:
+    image: nanobot:latest
+    container_name: nanobot-whatsapp-login
+    env_file:
+      - .env
+    environment:
+      NANOBOT_CONFIG: /root/.nanobot/config.json
+    volumes:
+      - ~/.nanobot:/root/.nanobot
+    command: ["channels", "login"]
+    restart: "no"
+
+  nanobot-agent:
+    image: nanobot:latest
+    container_name: nanobot-agent
+    env_file:
+      - .env
+    environment:
+      NANOBOT_CONFIG: /root/.nanobot/config.json
+    volumes:
+      - ~/.nanobot:/root/.nanobot
+    command: ["agent"]
+    stdin_open: true
+    tty: true
+    restart: "no"
+
+  nanobot-status:
+    image: nanobot:latest
+    container_name: nanobot-status
+    env_file:
+      - .env
+    environment:
+      NANOBOT_CONFIG: /root/.nanobot/config.json
+    volumes:
+      - ~/.nanobot:/root/.nanobot
+    command: ["status"]
+    restart: "no"


### PR DESCRIPTION
**Title**
Add docker-compose services and env template for nanobot

**Summary**
- expand `docker-compose.yml` with gateway, onboard, WhatsApp login, agent, and status services
- add shared env config (`.env` support) and mount `~/.nanobot` for persistence
- include `.env.example` to document optional environment variables

**Testing**
- `docker compose config` (note: expects a `.env` file if referenced)

```
# env.example
# Optional runtime configuration for nanobot container(s)
# Copy to .env and adjust as needed.

# Path to the config file inside the container (default shown below)
NANOBOT_CONFIG=/root/.nanobot/config.json

# Example: override Python runtime behavior if needed
# PYTHONUNBUFFERED=1
```
