### PR TITLE
feat: Add a direct HTTP request method for LLM endpoints

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -75,6 +75,30 @@ def onboard():
 
 
 
+def get_provider(config):
+    """Get the appropriate provider based on configuration."""
+    api_key = config.get_api_key()
+    api_base = config.get_api_base()
+    model = config.agents.defaults.model
+
+    # Use HTTP provider if explicitly configured
+    if config.providers.http.api_base or config.providers.http.api_key:
+        from nanobot.providers import OpenAIHTTPProvider
+        return OpenAIHTTPProvider(
+            api_key=config.providers.http.api_key or api_key,
+            api_base=config.providers.http.api_base or api_base,
+            default_model=model
+        )
+
+    # Otherwise use LiteLLM
+    from nanobot.providers import LiteLLMProvider
+    return LiteLLMProvider(
+        api_key=api_key,
+        api_base=api_base,
+        default_model=model
+    )
+
+
 def _create_workspace_templates(workspace: Path):
     """Create default workspace template files."""
     templates = {
@@ -160,7 +184,6 @@ def gateway(
     """Start the nanobot gateway."""
     from nanobot.config.loader import load_config, get_data_dir
     from nanobot.bus.queue import MessageBus
-    from nanobot.providers.litellm_provider import LiteLLMProvider
     from nanobot.agent.loop import AgentLoop
     from nanobot.channels.manager import ChannelManager
     from nanobot.cron.service import CronService
@@ -178,22 +201,16 @@ def gateway(
     # Create components
     bus = MessageBus()
     
-    # Create provider (supports OpenRouter, Anthropic, OpenAI, Bedrock)
-    api_key = config.get_api_key()
-    api_base = config.get_api_base()
+    # Create provider (auto-detects HTTP or LiteLLM based on config)
     model = config.agents.defaults.model
     is_bedrock = model.startswith("bedrock/")
 
-    if not api_key and not is_bedrock:
+    if not config.get_api_key() and not is_bedrock:
         console.print("[red]Error: No API key configured.[/red]")
-        console.print("Set one in ~/.nanobot/config.json under providers.openrouter.apiKey")
+        console.print("Set one in ~/.nanobot/config.json under providers")
         raise typer.Exit(1)
-    
-    provider = LiteLLMProvider(
-        api_key=api_key,
-        api_base=api_base,
-        default_model=config.agents.defaults.model
-    )
+
+    provider = get_provider(config)
     
     # Create agent
     agent = AgentLoop(
@@ -284,26 +301,19 @@ def agent(
     """Interact with the agent directly."""
     from nanobot.config.loader import load_config
     from nanobot.bus.queue import MessageBus
-    from nanobot.providers.litellm_provider import LiteLLMProvider
     from nanobot.agent.loop import AgentLoop
-    
+
     config = load_config()
-    
-    api_key = config.get_api_key()
-    api_base = config.get_api_base()
+
     model = config.agents.defaults.model
     is_bedrock = model.startswith("bedrock/")
 
-    if not api_key and not is_bedrock:
+    if not config.get_api_key() and not is_bedrock:
         console.print("[red]Error: No API key configured.[/red]")
         raise typer.Exit(1)
 
     bus = MessageBus()
-    provider = LiteLLMProvider(
-        api_key=api_key,
-        api_base=api_base,
-        default_model=config.agents.defaults.model
-    )
+    provider = get_provider(config)
     
     agent_loop = AgentLoop(
         bus=bus,
@@ -641,12 +651,15 @@ def status():
         has_anthropic = bool(config.providers.anthropic.api_key)
         has_openai = bool(config.providers.openai.api_key)
         has_gemini = bool(config.providers.gemini.api_key)
+        has_http = bool(config.providers.http.api_base or config.providers.http.api_key)
         has_vllm = bool(config.providers.vllm.api_base)
-        
+
         console.print(f"OpenRouter API: {'[green]✓[/green]' if has_openrouter else '[dim]not set[/dim]'}")
         console.print(f"Anthropic API: {'[green]✓[/green]' if has_anthropic else '[dim]not set[/dim]'}")
         console.print(f"OpenAI API: {'[green]✓[/green]' if has_openai else '[dim]not set[/dim]'}")
         console.print(f"Gemini API: {'[green]✓[/green]' if has_gemini else '[dim]not set[/dim]'}")
+        http_status = f"[green]✓ {config.providers.http.api_base}[/green]" if has_http else "[dim]not set[/dim]"
+        console.print(f"HTTP Provider: {http_status}")
         vllm_status = f"[green]✓ {config.providers.vllm.api_base}[/green]" if has_vllm else "[dim]not set[/dim]"
         console.print(f"vLLM/Local: {vllm_status}")
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -54,6 +54,7 @@ class ProvidersConfig(BaseModel):
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
+    http: ProviderConfig = Field(default_factory=ProviderConfig)
 
 
 class GatewayConfig(BaseModel):
@@ -92,7 +93,7 @@ class Config(BaseSettings):
         return Path(self.agents.defaults.workspace).expanduser()
     
     def get_api_key(self) -> str | None:
-        """Get API key in priority order: OpenRouter > Anthropic > OpenAI > Gemini > Zhipu > Groq > vLLM."""
+        """Get API key in priority order: OpenRouter > Anthropic > OpenAI > Gemini > Zhipu > Groq > HTTP > vLLM."""
         return (
             self.providers.openrouter.api_key or
             self.providers.anthropic.api_key or
@@ -100,16 +101,19 @@ class Config(BaseSettings):
             self.providers.gemini.api_key or
             self.providers.zhipu.api_key or
             self.providers.groq.api_key or
+            self.providers.http.api_key or
             self.providers.vllm.api_key or
             None
         )
     
     def get_api_base(self) -> str | None:
-        """Get API base URL if using OpenRouter, Zhipu or vLLM."""
+        """Get API base URL if using OpenRouter, Zhipu, HTTP or vLLM."""
         if self.providers.openrouter.api_key:
             return self.providers.openrouter.api_base or "https://openrouter.ai/api/v1"
         if self.providers.zhipu.api_key:
             return self.providers.zhipu.api_base
+        if self.providers.http.api_base:
+            return self.providers.http.api_base
         if self.providers.vllm.api_base:
             return self.providers.vllm.api_base
         return None

--- a/nanobot/providers/__init__.py
+++ b/nanobot/providers/__init__.py
@@ -2,5 +2,6 @@
 
 from nanobot.providers.base import LLMProvider, LLMResponse
 from nanobot.providers.litellm_provider import LiteLLMProvider
+from nanobot.providers.openai_http_provider import OpenAIHTTPProvider
 
-__all__ = ["LLMProvider", "LLMResponse", "LiteLLMProvider"]
+__all__ = ["LLMProvider", "LLMResponse", "LiteLLMProvider", "OpenAIHTTPProvider"]

--- a/nanobot/providers/openai_http_provider.py
+++ b/nanobot/providers/openai_http_provider.py
@@ -1,0 +1,166 @@
+"""OpenAI-compatible HTTP provider using direct async requests."""
+
+import json
+from typing import Any
+
+import aiohttp
+
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+
+
+class OpenAIHTTPProvider(LLMProvider):
+    """
+    LLM provider using direct async HTTP requests to OpenAI-compatible APIs.
+
+    This provider sends requests directly to any OpenAI-compatible API endpoint
+    without using LiteLLM. Useful for custom deployments or when you want
+    more control over the HTTP requests.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        default_model: str = "gpt-4-turbo-preview",
+        timeout: int = 300
+    ):
+        """
+        Initialize the HTTP provider.
+
+        Args:
+            api_key: API key for authentication
+            api_base: Base URL for the API (e.g., "https://api.openai.com/v1")
+            default_model: Default model to use
+            timeout: Request timeout in seconds
+        """
+        super().__init__(api_key, api_base)
+        self.default_model = default_model
+        self.timeout = timeout
+
+        # Set default API base if not provided
+        if not self.api_base:
+            self.api_base = "https://api.openai.com/v1"
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+    ) -> LLMResponse:
+        """
+        Send a chat completion request via direct HTTP.
+
+        Args:
+            messages: List of message dicts with 'role' and 'content'.
+            tools: Optional list of tool definitions in OpenAI format.
+            model: Model identifier (e.g., 'gpt-4-turbo-preview').
+            max_tokens: Maximum tokens in response.
+            temperature: Sampling temperature.
+
+        Returns:
+            LLMResponse with content and/or tool calls.
+        """
+        model = model or self.default_model
+
+        # Construct the API endpoint
+        endpoint = f"{self.api_base.rstrip('/')}/chat/completions"
+
+        # Build request payload
+        payload = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+
+        if tools:
+            payload["tools"] = tools
+            payload["tool_choice"] = "auto"
+
+        # Set up headers
+        headers = {
+            "Content-Type": "application/json",
+        }
+
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        try:
+            # Make async HTTP request
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    endpoint,
+                    json=payload,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=self.timeout)
+                ) as response:
+                    response.raise_for_status()
+                    data = await response.json()
+                    return self._parse_response(data)
+
+        except aiohttp.ClientError as e:
+            return LLMResponse(
+                content=f"HTTP request error: {str(e)}",
+                finish_reason="error",
+            )
+        except json.JSONDecodeError as e:
+            return LLMResponse(
+                content=f"Failed to parse response JSON: {str(e)}",
+                finish_reason="error",
+            )
+        except Exception as e:
+            return LLMResponse(
+                content=f"Error calling LLM: {str(e)}",
+                finish_reason="error",
+            )
+
+    def _parse_response(self, data: dict[str, Any]) -> LLMResponse:
+        """Parse OpenAI API response into our standard format."""
+        try:
+            choice = data["choices"][0]
+            message = choice["message"]
+
+            # Parse tool calls if present
+            tool_calls = []
+            if "tool_calls" in message and message["tool_calls"]:
+                for tc in message["tool_calls"]:
+                    # Parse arguments from JSON string
+                    args = tc["function"]["arguments"]
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except json.JSONDecodeError:
+                            args = {"raw": args}
+
+                    tool_calls.append(ToolCallRequest(
+                        id=tc["id"],
+                        name=tc["function"]["name"],
+                        arguments=args,
+                    ))
+
+            # Parse usage information if present
+            usage = {}
+            if "usage" in data:
+                usage = {
+                    "prompt_tokens": data["usage"].get("prompt_tokens", 0),
+                    "completion_tokens": data["usage"].get("completion_tokens", 0),
+                    "total_tokens": data["usage"].get("total_tokens", 0),
+                }
+
+            return LLMResponse(
+                content=message.get("content"),
+                tool_calls=tool_calls,
+                finish_reason=choice.get("finish_reason", "stop"),
+                usage=usage,
+            )
+        except (KeyError, IndexError) as e:
+            return LLMResponse(
+                content=f"Failed to parse response structure: {str(e)}",
+                finish_reason="error",
+            )
+
+    def get_default_model(self) -> str:
+        """Get the default model."""
+        return self.default_model


### PR DESCRIPTION
Some LLM endpoints have special format of model name and can NOT pass litellm's completing requset
This new http method can be used directly with such endpoints