### PR TITLE
Persist tool calls in session history

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -195,6 +195,7 @@ class AgentLoop:
                 messages = self.context.add_assistant_message(
                     messages, response.content, tool_call_dicts
                 )
+                session.add_message("assistant", response.content or "", tool_calls=tool_call_dicts)
                 
                 # Execute tools
                 for tool_call in response.tool_calls:
@@ -203,6 +204,12 @@ class AgentLoop:
                     result = await self.tools.execute(tool_call.name, tool_call.arguments)
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
+                    )
+                    session.add_message(
+                        "tool",
+                        result,
+                        tool_call_id=tool_call.id,
+                        name=tool_call.name,
                     )
             else:
                 # No tool calls, we're done
@@ -289,6 +296,7 @@ class AgentLoop:
                 messages = self.context.add_assistant_message(
                     messages, response.content, tool_call_dicts
                 )
+                session.add_message("assistant", response.content or "", tool_calls=tool_call_dicts)
                 
                 for tool_call in response.tool_calls:
                     args_str = json.dumps(tool_call.arguments)
@@ -296,6 +304,12 @@ class AgentLoop:
                     result = await self.tools.execute(tool_call.name, tool_call.arguments)
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
+                    )
+                    session.add_message(
+                        "tool",
+                        result,
+                        tool_call_id=tool_call.id,
+                        name=tool_call.name,
                     )
             else:
                 final_content = response.content


### PR DESCRIPTION
## Summary
- store assistant tool calls in session history
- store tool results with tool name and call id
- applies to both normal and system (subagent) flows

## Why
Tool interactions were not persisted, making debugging and replay difficult. This preserves the full tool trail alongside user and assistant messages.

## Testing
- python -m pytest