### PR TITLE
Fix: handle empty LLM responses in agent loop and Telegram channel

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -209,7 +209,7 @@ class AgentLoop:
                 final_content = response.content
                 break
         
-        if final_content is None:
+        if not final_content or not final_content.strip():
             final_content = "I've completed processing but have no response to give."
         
         # Save to session
@@ -301,7 +301,7 @@ class AgentLoop:
                 final_content = response.content
                 break
         
-        if final_content is None:
+        if not final_content or not final_content.strip():
             final_content = "Background task completed."
         
         # Save to session (mark as system message in history)

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -157,6 +157,10 @@ class TelegramChannel(BaseChannel):
             logger.warning("Telegram bot not running")
             return
         
+        if not msg.content or not msg.content.strip():
+            logger.warning("Skipping empty Telegram message")
+            return
+            
         try:
             # chat_id should be the Telegram chat ID (integer)
             chat_id = int(msg.chat_id)

--- a/tests/test_empty_response_fix.py
+++ b/tests/test_empty_response_fix.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMProvider, LLMResponse
+from pathlib import Path
+
+@pytest.mark.asyncio
+async def test_agent_loop_handles_empty_response():
+    # Mock dependencies
+    bus = MagicMock(spec=MessageBus)
+    provider = MagicMock(spec=LLMProvider)
+    workspace = Path("/tmp/nanobot_test")
+    workspace.mkdir(parents=True, exist_ok=True)
+    
+    # Mock LLM response with empty content
+    mock_response = LLMResponse(content="", tool_calls=[])
+    provider.chat = AsyncMock(return_value=mock_response)
+    provider.get_default_model.return_value = "test-model"
+    
+    loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+    
+    # Inbound message
+    msg = InboundMessage(
+        channel="test",
+        sender_id="user",
+        chat_id="123",
+        content="hello"
+    )
+    
+    # Process message
+    response = await loop._process_message(msg)
+    
+    # Verify response content is the default message, not empty string
+    assert response.content == "I've completed processing but have no response to give."
+
+@pytest.mark.asyncio
+async def test_telegram_channel_skips_empty_message():
+    from nanobot.channels.telegram import TelegramChannel
+    from nanobot.config.schema import TelegramConfig
+    
+    bus = MagicMock(spec=MessageBus)
+    config = TelegramConfig(token="fake-token")
+    channel = TelegramChannel(config=config, bus=bus)
+    
+    # Mock the telegram application and bot
+    channel._app = MagicMock()
+    channel._app.bot.send_message = AsyncMock()
+    
+    # Outbound message with empty content
+    msg = OutboundMessage(
+        channel="telegram",
+        chat_id="123",
+        content=""
+    )
+    
+    # Send message
+    await channel.send(msg)
+    
+    # Verify send_message was NOT called
+    channel._app.bot.send_message.assert_not_called()
+
+    # Outbound message with whitespace content
+    msg_ws = OutboundMessage(
+        channel="telegram",
+        chat_id="123",
+        content="   "
+    )
+    
+    # Send message
+    await channel.send(msg_ws)
+    
+    # Verify send_message was NOT called
+    channel._app.bot.send_message.assert_not_called()


### PR DESCRIPTION
This PR fixes issue #100 where empty LLM responses (often from providers like Groq) caused crashes in the Telegram channel.

Changes:
1. Modified  to provide a default message when  is empty or whitespace-only.
2. Added a guard clause in  to skip sending empty messages, preventing Telegram API 'Message text is empty' errors.
3. Added a unit test  to verify the fix.