### PR TITLE
feat: add Kimi Code support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -54,6 +54,7 @@ class ProvidersConfig(BaseModel):
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
+    kimi: ProviderConfig = Field(default_factory=ProviderConfig)
 
 
 class GatewayConfig(BaseModel):
@@ -99,7 +100,7 @@ class Config(BaseSettings):
         return Path(self.agents.defaults.workspace).expanduser()
     
     def get_api_key(self) -> str | None:
-        """Get API key in priority order: OpenRouter > Anthropic > OpenAI > Gemini > Zhipu > Groq > vLLM."""
+        """Get API key in priority order: OpenRouter > Anthropic > OpenAI > Gemini > Zhipu > Groq > vLLM > Kimi."""
         return (
             self.providers.openrouter.api_key or
             self.providers.anthropic.api_key or
@@ -108,17 +109,20 @@ class Config(BaseSettings):
             self.providers.zhipu.api_key or
             self.providers.groq.api_key or
             self.providers.vllm.api_key or
+            self.providers.kimi.api_key or
             None
         )
     
     def get_api_base(self) -> str | None:
-        """Get API base URL if using OpenRouter, Zhipu or vLLM."""
+        """Get API base URL if using OpenRouter, Zhipu or vLLM, or Kimi."""
         if self.providers.openrouter.api_key:
             return self.providers.openrouter.api_base or "https://openrouter.ai/api/v1"
         if self.providers.zhipu.api_key:
             return self.providers.zhipu.api_base
         if self.providers.vllm.api_base:
             return self.providers.vllm.api_base
+        if self.providers.kimi.api_key:
+            return self.providers.kimi.api_base or "https://api.kimi.com/coding/"
         return None
     
     class Config:


### PR DESCRIPTION
This PR adds support for Kimi Code API (https://www.kimi.com/code).

## Changes

### Configuration (`nanobot/config/schema.py`)
- Added `kimi` provider to `ProvidersConfig`
- Updated `get_api_key()` to include Kimi in priority order
- Updated `get_api_base()` to return Kimi API base (https://api.kimi.com/coding/)

### Provider (`nanobot/providers/litellm_provider.py`)
- Added Kimi detection by API key prefix (`sk-kimi-`) or API base URL
- Set `KIMI_API_KEY` environment variable when Kimi is detected
- Configure default API base to https://api.kimi.com/coding/
- Fixed vLLM detection to exclude Kimi endpoints (prevents conflicts)
- Changed vLLM model prefix from `hosted_vllm/` to `openai/` for better compatibility

## Usage

Add to your `~/.nanobot/config.json`:

```json
{
  "providers": {
    "kimi": {
      "apiKey": "sk-kimi-...",
      "apiBase": null
    }
  },
  "agents": {
    "defaults": {
      "model": "kimi-k2.5"
    }
  }
}
```

Or via environment variable:
```bash
export NANOBOT__PROVIDERS__KIMI__API_KEY="sk-kimi-..."
```

## Testing
- Tested with Kimi k2.5 model
- Verified API authentication works correctly
- Confirmed no conflicts with existing providers (vLLM, OpenRouter, etc.)