### PR TITLE
Add lightweight memory retrieval using BM25 (#80)

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -24,12 +24,13 @@ class ContextBuilder:
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
     
-    def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
+    def build_system_prompt(self, skill_names: list[str] | None = None, query: str | None = None) -> str:
         """
         Build the system prompt from bootstrap files, memory, and skills.
         
         Args:
             skill_names: Optional list of skills to include.
+            query: Optional query for memory retrieval.
         
         Returns:
             Complete system prompt.
@@ -45,7 +46,7 @@ class ContextBuilder:
             parts.append(bootstrap)
         
         # Memory context
-        memory = self.memory.get_memory_context()
+        memory = self.memory.get_memory_context(query=query)
         if memory:
             parts.append(f"# Memory\n\n{memory}")
         
@@ -134,7 +135,7 @@ When remembering something, write to {workspace_path}/memory/MEMORY.md"""
         messages = []
 
         # System prompt
-        system_prompt = self.build_system_prompt(skill_names)
+        system_prompt = self.build_system_prompt(skill_names, query=current_message)
         messages.append({"role": "system", "content": system_prompt})
 
         # History

--- a/nanobot/agent/retrieval.py
+++ b/nanobot/agent/retrieval.py
@@ -1,0 +1,81 @@
+"""Lightweight memory retrieval using BM25."""
+
+import re
+from typing import List, Tuple
+from rank_bm25 import BM25Okapi
+
+def tokenize(text: str) -> List[str]:
+    """
+    Simple tokenizer for BM25.
+    Lowercases and extracts alphanumeric words.
+    """
+    return re.findall(r'\w+', text.lower())
+
+class MemoryRetriever:
+    """
+    Handles retrieval of relevant memory chunks using BM25.
+    """
+    
+    def __init__(self, chunks: List[str]):
+        self.chunks = chunks
+        self.tokenized_corpus = [tokenize(chunk) for chunk in chunks]
+        self.bm25 = BM25Okapi(self.tokenized_corpus)
+
+    def retrieve(self, query: str, top_k: int = 5) -> List[Tuple[str, float]]:
+        """
+        Retrieve top-k relevant chunks for a given query.
+        """
+        if not self.chunks:
+            return []
+            
+        tokenized_query = tokenize(query)
+        scores = self.bm25.get_scores(tokenized_query)
+        
+        # Combine chunks with their scores
+        chunk_scores = list(zip(self.chunks, scores))
+        
+        # Sort by score descending and take top_k
+        sorted_results = sorted(chunk_scores, key=lambda x: x[1], reverse=True)
+        
+        # Filter out zero scores to ensure relevance
+        relevant_results = [res for res in sorted_results[:top_k] if res[1] > 0]
+        
+        return relevant_results
+
+def split_markdown_into_chunks(content: str, max_chunk_size: int = 1000) -> List[str]:
+    """
+    Split markdown content into semantic chunks.
+    Prioritizes splitting by headers, then by double newlines.
+    """
+    if not content:
+        return []
+
+    # Split by headers (h1, h2, h3) but keep the headers with the content
+    # This regex looks for a newline followed by a header
+    raw_chunks = re.split(r'\n(?=#+ )', content)
+    
+    final_chunks = []
+    for chunk in raw_chunks:
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+            
+        # If a chunk is still too large, split it by double newlines
+        if len(chunk) > max_chunk_size:
+            sub_chunks = chunk.split('\n\n')
+            current_sub_chunk = ""
+            
+            for sub in sub_chunks:
+                if len(current_sub_chunk) + len(sub) < max_chunk_size:
+                    current_sub_chunk += ("\n\n" if current_sub_chunk else "") + sub
+                else:
+                    if current_sub_chunk:
+                        final_chunks.append(current_sub_chunk.strip())
+                    current_sub_chunk = sub
+            
+            if current_sub_chunk:
+                final_chunks.append(current_sub_chunk.strip())
+        else:
+            final_chunks.append(chunk)
+            
+    return final_chunks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "rich>=13.0.0",
     "croniter>=2.0.0",
     "python-telegram-bot>=21.0",
+    "rank-bm25>=0.2.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR implements lightweight memory retrieval using BM25 as requested in issue #80.

### Changes:
- Added `nanobot/agent/retrieval.py` for BM25-based retrieval and semantic markdown chunking.
- Updated `nanobot/agent/memory.py` to support query-based retrieval from long-term and recent memories.
- Integrated retrieval into `nanobot/agent/context.py` to inject only top-k relevant memory chunks based on the current user message.
- Added `rank-bm25` to `pyproject.toml` dependencies.

This improvement reduces token usage and improves relevance as the agent memory grows.