### PR TITLE
feat: add Google Vertex AI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ uv tool install nanobot-ai
 pip install nanobot-ai
 ```
 
+**Vertex AI support** (optional, adds google-cloud-aiplatform)
+
+```bash
+# PyPI
+pip install "nanobot-ai[vertex]"
+
+# From source
+pip install -e .[vertex]
+
+# Or with uv
+uv tool install "nanobot-ai[vertex]"
+```
+
 ## 🚀 Quick Start
 
 > [!TIP]
@@ -258,6 +271,7 @@ Config file: `~/.nanobot/config.json`
 | `openai` | LLM (GPT direct) | [platform.openai.com](https://platform.openai.com) |
 | `groq` | LLM + **Voice transcription** (Whisper) | [console.groq.com](https://console.groq.com) |
 | `gemini` | LLM (Gemini direct) | [aistudio.google.com](https://aistudio.google.com) |
+| `vertex_ai` | LLM (Vertex AI) | [cloud.google.com/vertex-ai](https://cloud.google.com/vertex-ai) |
 
 
 <details>
@@ -276,6 +290,10 @@ Config file: `~/.nanobot/config.json`
     },
     "groq": {
       "apiKey": "gsk_xxx"
+    },
+    "vertex_ai": {
+      "vertex_project": "id",
+      "vertex_location": "global"
     }
   },
   "channels": {

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -182,9 +182,8 @@ def gateway(
     api_key = config.get_api_key()
     api_base = config.get_api_base()
     model = config.agents.defaults.model
-    is_bedrock = model.startswith("bedrock/")
 
-    if not api_key and not is_bedrock:
+    if not api_key and not model.startswith(("bedrock/", "vertex_ai/")):
         console.print("[red]Error: No API key configured.[/red]")
         console.print("Set one in ~/.nanobot/config.json under providers.openrouter.apiKey")
         raise typer.Exit(1)
@@ -192,7 +191,8 @@ def gateway(
     provider = LiteLLMProvider(
         api_key=api_key,
         api_base=api_base,
-        default_model=config.agents.defaults.model
+        default_model=config.agents.defaults.model,
+        **config.get_provider_kwargs(),
     )
     
     # Create agent
@@ -293,9 +293,8 @@ def agent(
     api_key = config.get_api_key()
     api_base = config.get_api_base()
     model = config.agents.defaults.model
-    is_bedrock = model.startswith("bedrock/")
 
-    if not api_key and not is_bedrock:
+    if not api_key and not model.startswith(("bedrock/", "vertex_ai/")):
         console.print("[red]Error: No API key configured.[/red]")
         raise typer.Exit(1)
 
@@ -303,7 +302,8 @@ def agent(
     provider = LiteLLMProvider(
         api_key=api_key,
         api_base=api_base,
-        default_model=config.agents.defaults.model
+        default_model=config.agents.defaults.model,
+        **config.get_provider_kwargs()
     )
     
     agent_loop = AgentLoop(

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -45,6 +45,12 @@ class ProviderConfig(BaseModel):
     api_base: str | None = None
 
 
+class VertexAIConfig(BaseModel):
+    """Vertex AI provider configuration."""
+    vertex_project: str = ""
+    vertex_location: str = "global"
+
+
 class ProvidersConfig(BaseModel):
     """Configuration for LLM providers."""
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -54,6 +60,7 @@ class ProvidersConfig(BaseModel):
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
+    vertex_ai: VertexAIConfig = Field(default_factory=VertexAIConfig)
 
 
 class GatewayConfig(BaseModel):
@@ -120,6 +127,16 @@ class Config(BaseSettings):
         if self.providers.vllm.api_base:
             return self.providers.vllm.api_base
         return None
+    
+    def get_provider_kwargs(self) -> dict[str, str]:
+        """Get provider-specific configuration parameters."""
+        kwargs = {}
+        # Only pass Vertex params when project is explicitly set
+        if self.providers.vertex_ai.vertex_project:
+            kwargs["vertex_project"] = self.providers.vertex_ai.vertex_project
+            if self.providers.vertex_ai.vertex_location:
+                kwargs["vertex_location"] = self.providers.vertex_ai.vertex_location
+        return kwargs
     
     class Config:
         env_prefix = "NANOBOT_"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "ruff>=0.1.0",
 ]
+vertex = [
+    "google-cloud-aiplatform>=1.135.0",
+]
 
 [project.scripts]
 nanobot = "nanobot.cli.commands:app"


### PR DESCRIPTION
## Add Vertex AI Provider Support

### Summary

This PR adds support for Google Cloud Vertex AI as an LLM provider, allowing users to use Vertex AI models (e.g., `vertex_ai/gemini-3-pro-preview`) with nanobot.

### Changes

- **pyproject.toml**: Added `vertex` optional dependency (`google-cloud-aiplatform>=1.135.0`)
- **schema.py**: Added `VertexAIConfig` class and `get_provider_kwargs()` method for Vertex AI configuration
- **litellm_provider.py**: 
  - Support Vertex AI environment variables (`VERTEXAI_PROJECT`, `VERTEXAI_LOCATION`)
  - Fixed Gemini model prefix logic to exclude `vertex_ai/` prefixed models
- **commands.py**: Added `vertex_ai/` to providers that don't require an API key
- **README.md**: Added Vertex AI documentation and configuration examples

### Installation

```bash
# Install with Vertex AI support
pip install "nanobot-ai[vertex]"

# Or from source
pip install -e .[vertex]
```

### Configuration

```json
{
  "providers": {
    "vertex_ai": {
      "vertex_project": "your-gcp-project-id",
      "vertex_location": "global"
    }
  },
  "agents": {
    "defaults": {
      "model": "vertex_ai/gemini-3-pro-preview"
    }
  }
}
```

### Prerequisites

Users need to authenticate with Google Cloud before using Vertex AI:

```bash
gcloud auth application-default login
```
