### PR TITLE
Fix: LiteLLM hosted_vllm/ routing breaks vLLM API key auth and model routing

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -326,11 +326,17 @@ class AgentLoop:
         Returns:
             The agent's response.
         """
+        # Respect caller-provided session key (format: channel:chat_id).
+        if ":" in session_key:
+            channel, chat_id = session_key.split(":", 1)
+        else:
+            channel, chat_id = "cli", session_key
+
         msg = InboundMessage(
-            channel="cli",
+            channel=channel,
             sender_id="user",
-            chat_id="direct",
-            content=content
+            chat_id=chat_id,
+            content=content,
         )
         
         response = await self._process_message(msg)


### PR DESCRIPTION
## Fixes
- **Direct OpenAI-compatible call**  
  When `providers.vllm.apiBase` is set, bypass LiteLLM’s special prefix logic and call  
  `POST {apiBase}/chat/completions`, then parse the OpenAI-style response.
- **Tools/function call compatibility**  
  Send `tools`/`tool_choice` and parse both `tool_calls` and legacy `function_call`.
- **CLI session isolation**  
  `nanobot agent -s xxx` now truly uses `cli:xxx` instead of always writing to `cli:direct`.

## Files changed
- `nanobot/providers/litellm_provider.py`  
  Add OpenAI-compatible direct call + response parsing.
- `nanobot/agent/loop.py`  
  Fix ignored CLI `session_key`.
