### PR TITLE
feat: Add support for NVIDIA NIM (Inference Microservices) provider d…

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -78,6 +78,7 @@ class ProvidersConfig(BaseModel):
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
+    nvidia_nim: ProviderConfig = Field(default_factory=ProviderConfig)
 
 
 class GatewayConfig(BaseModel):
@@ -141,6 +142,8 @@ class Config(BaseSettings):
             "moonshot": self.providers.moonshot,
             "kimi": self.providers.moonshot,
             "vllm": self.providers.vllm,
+            "nvidia": self.providers.nvidia_nim,
+            "nim": self.providers.nvidia_nim,
         }
         for keyword, provider in providers.items():
             if keyword in model and provider.api_key:
@@ -159,7 +162,7 @@ class Config(BaseSettings):
             self.providers.anthropic, self.providers.openai,
             self.providers.gemini, self.providers.zhipu,
             self.providers.moonshot, self.providers.vllm,
-            self.providers.groq,
+            self.providers.groq, self.providers.nvidia_nim,
         ]:
             if provider.api_key:
                 return provider.api_key
@@ -172,6 +175,8 @@ class Config(BaseSettings):
             return self.providers.openrouter.api_base or "https://openrouter.ai/api/v1"
         if any(k in model for k in ("zhipu", "glm", "zai")):
             return self.providers.zhipu.api_base
+        if "nvidia" in model or "nim" in model:
+            return self.providers.nvidia_nim.api_base or "https://integrate.api.nvidia.com/v1"
         if "vllm" in model:
             return self.providers.vllm.api_base
         return None


### PR DESCRIPTION
…etection, configuration, and model prefixing.

## Summary

Adds support for [NVIDIA NIM](https://build.nvidia.com/) as an LLM provider, enabling nanobot to use models hosted on NVIDIA's inference platform, including Z-AI's GLM-4.7.

## Changes

### `nanobot/providers/litellm_provider.py`
- Added NVIDIA NIM detection via `nvapi-` API key prefix or `nvidia` in api_base URL
- Set `NVIDIA_NIM_API_KEY` and `NVIDIA_NIM_API_BASE` environment variables for LiteLLM
- Auto-prefix models with `nvidia_nim/` for proper LiteLLM routing
- Updated Zhipu/GLM detection to exclude `nvidia_nim/` prefixed models (avoids conflict with `z-ai/glm4.7` on NIM)

### `nanobot/config/schema.py`
- Added `nvidia_nim` to `ProvidersConfig`
- Updated `get_api_key()` priority chain to include NVIDIA NIM
- Updated `get_api_base()` to return NVIDIA NIM default base URL (`https://integrate.api.nvidia.com/v1`)

## Usage

```json
{
  "providers": {
    "nvidiaNim": {
      "apiKey": "nvapi-xxx"
    }
  },
  "agents": {
    "defaults": {
      "model": "z-ai/glm4.7"
    }
  }
}
```

```bash
nanobot agent -m "Hello from NVIDIA NIM!"
```

## Related Links
- [NVIDIA NIM API Catalog](https://build.nvidia.com/)
- [LiteLLM NVIDIA NIM Docs](https://docs.litellm.ai/docs/providers/nvidia_nim)
- [GLM-4.7 on NIM](https://build.nvidia.com/z-ai/glm4_7)