### PR TITLE
feat: Add media sending support to message tool and Telegram channel

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -52,6 +52,10 @@ class MessageTool(Tool):
                 "chat_id": {
                     "type": "string",
                     "description": "Optional: target chat/user ID"
+                },
+                "media": {
+                    "type": "string",
+                    "description": "Optional: path to media file (image, video, etc.) to send"
                 }
             },
             "required": ["content"]
@@ -62,6 +66,7 @@ class MessageTool(Tool):
         content: str, 
         channel: str | None = None, 
         chat_id: str | None = None,
+        media: str | None = None,
         **kwargs: Any
     ) -> str:
         channel = channel or self._default_channel
@@ -76,11 +81,13 @@ class MessageTool(Tool):
         msg = OutboundMessage(
             channel=channel,
             chat_id=chat_id,
-            content=content
+            content=content,
+            media=[media] if media else []
         )
         
         try:
             await self._send_callback(msg)
-            return f"Message sent to {channel}:{chat_id}"
+            media_info = f" with media {media}" if media else ""
+            return f"Message sent to {channel}:{chat_id}{media_info}"
         except Exception as e:
             return f"Error sending message: {str(e)}"


### PR DESCRIPTION
- Add 'media' parameter to MessageTool for sending images/videos/audio
- Update TelegramChannel.send() to handle OutboundMessage.media field
- Add _send_media() helper to send photos, videos, audio, and documents
- Supports: jpg, png, gif, webp, mp4, mov, avi, webm, mp3, ogg, m4a, wav
- Unknown file types are sent as documents
- Caption (message content) is attached to the first media item

This enables the agent to send screenshots, images, and other media files back to users through Telegram.

Was done by nanobot, tested by binding over installed files:

podman run -it   -v ~/.nanobot:/root/.nanobot   -v ~/.nanobot/workspace/projects/nanobot/nanobot/agent/tools/message.py:/usr/local/lib/python3.12/site-packages/nanobot/agent/tools/message.py:ro   -v ~/.nanobot/workspace/projects/nanobot/nanobot/channels/telegram.py:/usr/local/lib/python3.12/site-packages/nanobot/channels/telegram.py:ro   gateway

and all 4 types worked -- nice