### PR TITLE
feat: make heartbeat interval configurable

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -234,8 +234,8 @@ def gateway(
     heartbeat = HeartbeatService(
         workspace=config.workspace_path,
         on_heartbeat=on_heartbeat,
-        interval_s=30 * 60,  # 30 minutes
-        enabled=True
+        interval_s=config.heartbeat.interval_s,
+        enabled=True,
     )
     
     # Create channel manager
@@ -249,9 +249,9 @@ def gateway(
     cron_status = cron.status()
     if cron_status["jobs"] > 0:
         console.print(f"[green]✓[/green] Cron: {cron_status['jobs']} scheduled jobs")
-    
-    console.print(f"[green]✓[/green] Heartbeat: every 30m")
-    
+
+    console.print(f"[green]✓[/green] Heartbeat: every {config.heartbeat.interval_s // 60}m")
+
     async def run():
         try:
             await cron.start()

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -62,6 +62,12 @@ class GatewayConfig(BaseModel):
     port: int = 18790
 
 
+class HeartbeatConfig(BaseModel):
+    """Heartbeat service configuration."""
+
+    interval_s: int = 30 * 60  # 30 minutes by default
+
+
 class WebSearchConfig(BaseModel):
     """Web search tool configuration."""
     api_key: str = ""  # Brave Search API key
@@ -91,6 +97,7 @@ class Config(BaseSettings):
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
+    heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
     
     @property

--- a/workspace/HEARTBEAT.md
+++ b/workspace/HEARTBEAT.md
@@ -1,6 +1,6 @@
 # Heartbeat Tasks
 
-This file is checked every 30 minutes by your nanobot agent.
+This file is checked periodically by your nanobot agent.
 Add tasks below that you want the agent to work on periodically.
 
 If this file has no tasks (only headers and comments), the agent will skip the heartbeat.


### PR DESCRIPTION
Previously, the heartbeat interval was hardcoded to 30 minutes. This change moves the configuration to the `.nanobot/config.json`, keeping the 30-minute interval as the default.

**Changes:**
1.  Added a new `HeartbeatConfig` model with an `interval_s` field, defaulting to 30 minutes.
2.  Modified the gateway command to read the interval from `config.heartbeat.interval_s` instead of the hardcoded value.
3.  Updated the startup console message to dynamically display the configured interval in minutes.