### PR TITLE
fix: use openai/ prefix for OpenAI-compatible endpoints

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -98,10 +98,11 @@ class LiteLLMProvider(LLMProvider):
         ):
             model = f"zai/{model}"
         
-        # For vLLM, use hosted_vllm/ prefix per LiteLLM docs
-        # Convert openai/ prefix to hosted_vllm/ if user specified it
+        # For custom OpenAI-compatible endpoints (vLLM, Doubao, Moonshot, etc.)
+        # Use openai/ prefix which works with most OpenAI-compatible APIs
         if self.is_vllm:
-            model = f"hosted_vllm/{model}"
+            if not model.startswith("openai/"):
+                model = f"openai/{model}"
         
         # For Gemini, ensure gemini/ prefix if not already present
         if "gemini" in model.lower() and not model.startswith("gemini/"):


### PR DESCRIPTION
The hosted_vllm/ prefix doesn't work well with some OpenAI-compatible APIs like Doubao (ByteDance) and Moonshot. Using openai/ prefix provides better compatibility across different providers.