### PR TITLE
Fix provider selection and avoid vLLM mis-detection for custom OpenAI endpointsFix provider selection and vLLM detection

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -182,6 +182,7 @@ def gateway(
     api_key = config.get_api_key()
     api_base = config.get_api_base()
     model = config.agents.defaults.model
+    provider_name = config.get_provider()
     is_bedrock = model.startswith("bedrock/")
 
     if not api_key and not is_bedrock:
@@ -192,7 +193,8 @@ def gateway(
     provider = LiteLLMProvider(
         api_key=api_key,
         api_base=api_base,
-        default_model=config.agents.defaults.model
+        default_model=config.agents.defaults.model,
+        use_vllm=provider_name == "vllm",
     )
     
     # Create agent
@@ -293,6 +295,7 @@ def agent(
     api_key = config.get_api_key()
     api_base = config.get_api_base()
     model = config.agents.defaults.model
+    provider_name = config.get_provider()
     is_bedrock = model.startswith("bedrock/")
 
     if not api_key and not is_bedrock:
@@ -303,7 +306,8 @@ def agent(
     provider = LiteLLMProvider(
         api_key=api_key,
         api_base=api_base,
-        default_model=config.agents.defaults.model
+        default_model=config.agents.defaults.model,
+        use_vllm=provider_name == "vllm",
     )
     
     agent_loop = AgentLoop(

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -112,25 +112,52 @@ class Config(BaseSettings):
     
     def get_api_key(self) -> str | None:
         """Get API key in priority order: OpenRouter > Anthropic > OpenAI > Gemini > Zhipu > Groq > vLLM."""
-        return (
-            self.providers.openrouter.api_key or
-            self.providers.anthropic.api_key or
-            self.providers.openai.api_key or
-            self.providers.gemini.api_key or
-            self.providers.zhipu.api_key or
-            self.providers.groq.api_key or
-            self.providers.vllm.api_key or
-            None
-        )
+        provider = self.get_provider()
+        if provider == "openrouter":
+            return self.providers.openrouter.api_key
+        if provider == "anthropic":
+            return self.providers.anthropic.api_key
+        if provider == "openai":
+            return self.providers.openai.api_key
+        if provider == "gemini":
+            return self.providers.gemini.api_key
+        if provider == "zhipu":
+            return self.providers.zhipu.api_key
+        if provider == "groq":
+            return self.providers.groq.api_key
+        if provider == "vllm":
+            return self.providers.vllm.api_key or None
+        return None
     
     def get_api_base(self) -> str | None:
-        """Get API base URL if using OpenRouter, Zhipu or vLLM."""
-        if self.providers.openrouter.api_key:
+        """Get API base URL in priority order (OpenRouter > OpenAI > Zhipu > vLLM)."""
+        provider = self.get_provider()
+        if provider == "openrouter":
             return self.providers.openrouter.api_base or "https://openrouter.ai/api/v1"
-        if self.providers.zhipu.api_key:
+        if provider == "openai":
+            return self.providers.openai.api_base
+        if provider == "zhipu":
             return self.providers.zhipu.api_base
-        if self.providers.vllm.api_base:
+        if provider == "vllm":
             return self.providers.vllm.api_base
+        return None
+    
+    def get_provider(self) -> str | None:
+        """Get active provider based on configured credentials (same priority as get_api_key)."""
+        if self.providers.openrouter.api_key:
+            return "openrouter"
+        if self.providers.anthropic.api_key:
+            return "anthropic"
+        if self.providers.openai.api_key:
+            return "openai"
+        if self.providers.gemini.api_key:
+            return "gemini"
+        if self.providers.zhipu.api_key:
+            return "zhipu"
+        if self.providers.groq.api_key:
+            return "groq"
+        if self.providers.vllm.api_base:
+            return "vllm"
         return None
     
     class Config:


### PR DESCRIPTION
## Summary
- Add explicit provider selection and route api_key/api_base through the active provider only
- Pass vLLM intent into LiteLLMProvider instead of inferring from any api_base
- Avoid adding hosted_vllm/ prefix unless vLLM is explicitly selected

## Testing
- Run and pass
