### PR TITLE
fix: correct session key restoration in list_sessions

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -191,7 +191,7 @@ class SessionManager:
                         data = json.loads(first_line)
                         if data.get("_type") == "metadata":
                             sessions.append({
-                                "key": path.stem.replace("_", ":"),
+                                "key": path.stem.replace("_", ":", 1),
                                 "created_at": data.get("created_at"),
                                 "updated_at": data.get("updated_at"),
                                 "path": str(path)


### PR DESCRIPTION
## Summary

Fixed a bug where underscores in `chat_id` were incorrectly converted to colons when listing sessions.

## Problem

When storing sessions, colons in keys (format: `channel:chat_id`) are replaced with underscores for safe filenames. Previously, `list_sessions()` replaced ALL underscores back to colons, breaking keys where `chat_id` originally contained underscores.

## Example

| State | Value |
|-------|-------|
| Original key | `telegram:user_123` |
| Stored as | `telegram_user_123.jsonl` |
| Before fix | `telegram:user:123` (incorrect) |
| After fix | `telegram:user_123` (correct) |

## Solution

Only replace the first underscore with a colon using `replace("_", ":", 1)`, since session keys have exactly one colon separator between channel and chat_id.

## Changes

- `nanobot/session/manager.py`: Change `replace("_", ":")` to `replace("_", ":", 1)`