### PR TITLE
fix: replace canned dead-end messages with LLM-generated summaries

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -224,7 +224,21 @@ class AgentLoop:
                 break
         
         if final_content is None:
-            final_content = "I've completed processing but have no response to give."
+            # LLM ended on tool calls with no text — ask it to summarize
+            # The messages list already contains full tool call/result context
+            messages.append({
+                "role": "user",
+                "content": "[System] Summarize what you just did in 1-2 sentences. Be concise and natural."
+            })
+            try:
+                summary_response = await self.provider.chat(
+                    messages=messages,
+                    tools=None,
+                    model=self.model
+                )
+                final_content = summary_response.content or "I've completed processing but have no response to give."
+            except Exception:
+                final_content = "I've completed processing but have no response to give."
         
         # Save to session
         session.add_message("user", msg.content)
@@ -243,6 +257,9 @@ class AgentLoop:
         
         The chat_id field contains "original_channel:original_chat_id" to route
         the response back to the correct destination.
+        
+        System messages are summarized directly — no tool loop. The subagent
+        already did the work; we just need the LLM to present the result naturally.
         """
         logger.info(f"Processing system message from {msg.sender_id}")
         
@@ -260,68 +277,23 @@ class AgentLoop:
         session_key = f"{origin_channel}:{origin_chat_id}"
         session = self.sessions.get_or_create(session_key)
         
-        # Update tool contexts
-        message_tool = self.tools.get("message")
-        if isinstance(message_tool, MessageTool):
-            message_tool.set_context(origin_channel, origin_chat_id)
-        
-        spawn_tool = self.tools.get("spawn")
-        if isinstance(spawn_tool, SpawnTool):
-            spawn_tool.set_context(origin_channel, origin_chat_id)
-        
-        cron_tool = self.tools.get("cron")
-        if isinstance(cron_tool, CronTool):
-            cron_tool.set_context(origin_channel, origin_chat_id)
-        
-        # Build messages with the announce content
+        # Build messages with the announce content — but ask for a summary, not action
         messages = self.context.build_messages(
             history=session.get_history(),
-            current_message=msg.content,
+            current_message=msg.content + "\n\nSummarize this naturally for the user. Keep it brief (1-2 sentences). Do not mention technical details like \"subagent\" or task IDs.",
             channel=origin_channel,
             chat_id=origin_chat_id,
         )
         
-        # Agent loop (limited for announce handling)
-        iteration = 0
-        final_content = None
-        
-        while iteration < self.max_iterations:
-            iteration += 1
-            
+        # Single LLM call with no tools — just summarize, don't act
+        try:
             response = await self.provider.chat(
                 messages=messages,
-                tools=self.tools.get_definitions(),
+                tools=None,
                 model=self.model
             )
-            
-            if response.has_tool_calls:
-                tool_call_dicts = [
-                    {
-                        "id": tc.id,
-                        "type": "function",
-                        "function": {
-                            "name": tc.name,
-                            "arguments": json.dumps(tc.arguments)
-                        }
-                    }
-                    for tc in response.tool_calls
-                ]
-                messages = self.context.add_assistant_message(
-                    messages, response.content, tool_call_dicts
-                )
-                
-                for tool_call in response.tool_calls:
-                    args_str = json.dumps(tool_call.arguments)
-                    logger.debug(f"Executing tool: {tool_call.name} with arguments: {args_str}")
-                    result = await self.tools.execute(tool_call.name, tool_call.arguments)
-                    messages = self.context.add_tool_result(
-                        messages, tool_call.id, tool_call.name, result
-                    )
-            else:
-                final_content = response.content
-                break
-        
-        if final_content is None:
+            final_content = response.content or "Background task completed."
+        except Exception:
             final_content = "Background task completed."
         
         # Save to session (mark as system message in history)

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -190,9 +190,7 @@ class SubagentManager:
 Task: {task}
 
 Result:
-{result}
-
-Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not mention technical details like "subagent" or task IDs."""
+{result}"""
         
         # Inject as system message to trigger main agent
         msg = InboundMessage(


### PR DESCRIPTION
## Problem

When the LLM's final response consists entirely of tool calls with no accompanying text, the agent falls back to canned strings like *"I've completed processing but have no response to give."* or *"Background task completed."* — robotic and context-free.

## Solution

Use one additional LLM call with `tools=None` (forcing a text-only response) to summarize what just happened. The LLM already has the full conversation context, so it produces a natural, informative summary. Falls back to the original canned messages only if the summary call fails.

For system messages (subagent announces), the handler is simplified: instead of running a full tool loop (which could re-execute work the subagent already did), it makes a single `tools=None` call to summarize the result. The summarization instruction is moved from the subagent announce payload into the system message handler where it belongs.

## Changes

- **`nanobot/agent/loop.py`** — `_process_message`: when the loop ends with no text, append a summary prompt and make one more LLM call with `tools=None`
- **`nanobot/agent/loop.py`** — `_process_system_message`: replace the full agent loop with a single summary-only LLM call (no tools, no tool context setup)
- **`nanobot/agent/subagent.py`** — `_announce_result`: remove the inline summarization instruction from announce content (now handled by the system message handler)

## Testing

Tested locally — subagent completions and multi-tool-call responses now produce natural summaries instead of dead-end messages.