### PR TITLE
feat: add Moonshot provider support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -77,6 +77,7 @@ class ProvidersConfig(BaseModel):
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
+    moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
 
 
 class GatewayConfig(BaseModel):
@@ -122,7 +123,7 @@ class Config(BaseSettings):
         return Path(self.agents.defaults.workspace).expanduser()
     
     def get_api_key(self) -> str | None:
-        """Get API key in priority order: OpenRouter > DeepSeek > Anthropic > OpenAI > Gemini > Zhipu > Groq > vLLM."""
+        """Get API key in priority order: OpenRouter > DeepSeek > Anthropic > OpenAI > Gemini > Zhipu > Groq > Moonshot > vLLM."""
         return (
             self.providers.openrouter.api_key or
             self.providers.deepseek.api_key or
@@ -131,16 +132,19 @@ class Config(BaseSettings):
             self.providers.gemini.api_key or
             self.providers.zhipu.api_key or
             self.providers.groq.api_key or
+            self.providers.moonshot.api_key or
             self.providers.vllm.api_key or
             None
         )
     
     def get_api_base(self) -> str | None:
-        """Get API base URL if using OpenRouter, Zhipu or vLLM."""
+        """Get API base URL if using OpenRouter, Zhipu, Moonshot or vLLM."""
         if self.providers.openrouter.api_key:
             return self.providers.openrouter.api_base or "https://openrouter.ai/api/v1"
         if self.providers.zhipu.api_key:
             return self.providers.zhipu.api_base
+        if self.providers.moonshot.api_key:
+            return self.providers.moonshot.api_base
         if self.providers.vllm.api_base:
             return self.providers.vllm.api_base
         return None


### PR DESCRIPTION
**Changes:**
- Add moonshot to ProvidersConfig schema
- Add MOONSHOT_API_BASE environment variable for custom endpoint
- Handle kimi-k2.5 model temperature restriction (must be 1.0)
- Fix is_vllm detection to exclude moonshot provider

**Background:**

Moonshot AI's kimi-k2.5 model has a unique restriction - it only accepts `temperature: 1.0` and will reject any other value with an error:

```json
{"error":{"message":"invalid temperature: only 1 is allowed for this model","type":"invalid_request_error"}}