### PR TITLE
[Fix-204]: use correct ZAI_API_KEY for Zhipu/GLM models #204

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -52,7 +52,7 @@ class LiteLLMProvider(LLMProvider):
             elif "gemini" in default_model.lower():
                 os.environ.setdefault("GEMINI_API_KEY", api_key)
             elif "zhipu" in default_model or "glm" in default_model or "zai" in default_model:
-                os.environ.setdefault("ZHIPUAI_API_KEY", api_key)
+                os.environ.setdefault("ZAI_API_KEY", api_key)
             elif "groq" in default_model:
                 os.environ.setdefault("GROQ_API_KEY", api_key)
         


### PR DESCRIPTION
fix #204 

LiteLLM's zai provider reads ZAI_API_KEY, not ZHIPUAI_API_KEY. This fixes authentication errors when using Zhipu/GLM models.