### PR TITLE
fix: add python-socks dependency for SOCKS proxy support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "croniter>=2.0.0",
     "python-telegram-bot>=21.0",
     "lark-oapi>=1.0.0",
+    "python-socks>=2.8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem
When running behind a SOCKS proxy, the Feishu channel fails to connect with the following error:
```
connecting through a SOCKS proxy requires python-socks
```

## Solution
Added `python-socks>=2.8.0` to the dependencies in `pyproject.toml`. This package is required by `lark-oapi` when establishing WebSocket connections through SOCKS proxies.

## Testing
- Tested with SOCKS proxy enabled
- Verified dependency auto-installs correctly with `pip install -e .`
- Feishu channel connects successfully after fix

## Changes
- Added `python-socks>=2.8.0` to `dependencies` in `pyproject.toml`