### PR TITLE
feat(a2a): Add A2A Protocol support for agent-to-agent communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Connect nanobot to your favorite chat platform.
 | **Slack** | Bot token + App-Level token |
 | **Email** | IMAP/SMTP credentials |
 | **QQ** | App ID + App Secret |
+| **A2A** | Just enable — Agent-to-Agent protocol for multi-agent systems |
 
 <details>
 <summary><b>Telegram</b> (Recommended)</summary>
@@ -633,6 +634,49 @@ Give nanobot its own email account. It polls **IMAP** for incoming mail and repl
 ```bash
 nanobot gateway
 ```
+
+</details>
+
+<details>
+<summary><b>A2A Protocol</b> (Agent-to-Agent)</summary>
+
+Expose your nanobot as an A2A-compatible agent that other agents can discover and call.
+
+```bash
+pip install "nanobot-ai[a2a]"
+```
+
+**Configure**
+
+```json
+{
+  "channels": {
+    "a2a": {
+      "enabled": true,
+      "port": 8080,
+      "publicHost": "https://my-agent.example.com"
+    }
+  }
+}
+```
+
+**Run**
+
+```bash
+nanobot gateway
+```
+
+Your agent will be discoverable at:
+- Agent Card: `http://localhost:8080/.well-known/agent.json`
+- A2A Endpoint: `http://localhost:8080/`
+
+nanobot can also **call other A2A agents** using the built-in `call_a2a_agent` tool:
+
+```
+User: Ask the travel agent at https://travel.example.com to book a flight to Paris
+```
+
+See [A2A Protocol](https://a2a-protocol.org) for more info.
 
 </details>
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -25,6 +25,7 @@ from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMProvider
+from nanobot.agent.tools import A2A_TOOL_AVAILABLE
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
@@ -129,6 +130,11 @@ class AgentLoop:
         self.tools.register(SpawnTool(manager=self.subagents))
         if self.cron_service:
             self.tools.register(CronTool(self.cron_service))
+
+        # A2A client tool (for calling other A2A agents)
+        if A2A_TOOL_AVAILABLE:
+            from nanobot.agent.tools.a2a_client import A2AClientTool
+            self.tools.register(A2AClientTool())
 
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""

--- a/nanobot/agent/tools/__init__.py
+++ b/nanobot/agent/tools/__init__.py
@@ -3,4 +3,12 @@
 from nanobot.agent.tools.base import Tool
 from nanobot.agent.tools.registry import ToolRegistry
 
-__all__ = ["Tool", "ToolRegistry"]
+# Optional A2A client tool (requires a2a-sdk)
+try:
+    from nanobot.agent.tools.a2a_client import A2AClientTool
+    A2A_TOOL_AVAILABLE = True
+except ImportError:
+    A2AClientTool = None  # type: ignore
+    A2A_TOOL_AVAILABLE = False
+
+__all__ = ["Tool", "ToolRegistry", "A2AClientTool", "A2A_TOOL_AVAILABLE"]

--- a/nanobot/agent/tools/a2a_client.py
+++ b/nanobot/agent/tools/a2a_client.py
@@ -1,0 +1,263 @@
+"""A2A client tool for calling external A2A agents.
+
+This tool allows nanobot to communicate with other A2A-compatible agents,
+enabling multi-agent workflows and delegation.
+
+See: https://a2a-protocol.org
+"""
+
+import json
+from typing import Any
+from uuid import uuid4
+
+from loguru import logger
+
+from nanobot.agent.tools.base import Tool
+
+try:
+    import httpx
+    from a2a.client import A2ACardResolver, A2AClient
+    from a2a.types import (
+        MessageSendParams,
+        SendMessageRequest,
+    )
+    A2A_CLIENT_AVAILABLE = True
+except ImportError:
+    A2A_CLIENT_AVAILABLE = False
+
+
+class A2AClientTool(Tool):
+    """
+    Call an external A2A agent to perform a task.
+    
+    Use this tool when you need capabilities from another specialized agent,
+    such as:
+    - A travel booking agent
+    - A data analysis agent
+    - A code review agent
+    - Any other A2A-compatible service
+    
+    The tool will:
+    1. Discover the agent's capabilities via its Agent Card
+    2. Send your message to the agent
+    3. Return the agent's response
+    """
+    
+    def __init__(self, timeout: int = 120):
+        """
+        Initialize the A2A client tool.
+        
+        Args:
+            timeout: Request timeout in seconds.
+        """
+        self._timeout = timeout
+    
+    @property
+    def name(self) -> str:
+        return "call_a2a_agent"
+    
+    @property
+    def description(self) -> str:
+        return """Call an external A2A agent to perform a task.
+
+Use this when you need specialized capabilities from another agent.
+First, you can optionally discover what the agent can do, then send your request.
+
+Args:
+    agent_url: The base URL of the A2A agent (e.g., "https://travel-agent.example.com")
+    message: The message/task to send to the agent
+    discover_only: If true, only return the agent's capabilities without sending a message
+
+Returns:
+    If discover_only: The agent's capabilities and skills
+    Otherwise: The agent's response to your message
+
+Examples:
+    - call_a2a_agent("https://travel.example.com", "Book a flight to Paris for next Monday")
+    - call_a2a_agent("https://code-review.example.com", "Review this Python function: ...")
+    - call_a2a_agent("https://unknown-agent.example.com", "", discover_only=True)
+"""
+    
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "agent_url": {
+                    "type": "string",
+                    "description": "Base URL of the A2A agent (e.g., https://agent.example.com)",
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Message or task to send to the agent",
+                },
+                "discover_only": {
+                    "type": "boolean",
+                    "description": "If true, only discover the agent's capabilities without sending a message",
+                },
+            },
+            "required": ["agent_url"],
+        }
+    
+    async def execute(
+        self,
+        agent_url: str,
+        message: str = "",
+        discover_only: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        """
+        Execute an A2A call to an external agent.
+        
+        Args:
+            agent_url: Base URL of the target A2A agent.
+            message: Message to send (required if not discover_only).
+            discover_only: If true, only fetch and return the agent card.
+        
+        Returns:
+            Agent's response or capabilities description.
+        """
+        if not A2A_CLIENT_AVAILABLE:
+            return "Error: A2A client not available. Install with: pip install 'a2a-sdk[http-server]'"
+        
+        if not discover_only and not message:
+            return "Error: message is required when discover_only is False"
+        
+        # Normalize URL
+        agent_url = agent_url.rstrip("/")
+        
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as httpx_client:
+                # Resolve the agent card
+                resolver = A2ACardResolver(
+                    httpx_client=httpx_client,
+                    base_url=agent_url,
+                )
+                
+                try:
+                    agent_card = await resolver.get_agent_card()
+                except Exception as e:
+                    return f"Error: Could not discover agent at {agent_url}. Is it running? ({e})"
+                
+                logger.info(f"Discovered A2A agent: {agent_card.name}")
+                
+                # If discover_only, return the agent's capabilities
+                if discover_only:
+                    return self._format_agent_card(agent_card)
+                
+                # Create the A2A client
+                client = A2AClient(
+                    httpx_client=httpx_client,
+                    agent_card=agent_card,
+                )
+                
+                # Build the message request
+                message_id = uuid4().hex
+                send_payload = {
+                    "message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": message}],
+                        "messageId": message_id,
+                    }
+                }
+                
+                request = SendMessageRequest(
+                    id=str(uuid4()),
+                    params=MessageSendParams(**send_payload),
+                )
+                
+                logger.info(f"Sending message to {agent_card.name}: {message[:100]}...")
+                
+                # Send the message
+                response = await client.send_message(request)
+                
+                # Extract the response text
+                return self._extract_response(response, agent_card.name)
+                
+        except Exception as e:
+            if "timeout" in str(e).lower():
+                return f"Error: Request to {agent_url} timed out after {self._timeout}s"
+            logger.error(f"A2A client error: {e}")
+            return f"Error calling A2A agent: {e}"
+    
+    def _format_agent_card(self, card: Any) -> str:
+        """Format an agent card as a readable string."""
+        lines = [
+            f"# Agent: {card.name}",
+            f"**Description:** {card.description}",
+            f"**URL:** {card.url}",
+            f"**Version:** {card.version}",
+            "",
+            "## Capabilities",
+            f"- Streaming: {card.capabilities.streaming if card.capabilities else 'unknown'}",
+            "",
+            "## Skills",
+        ]
+        
+        if card.skills:
+            for skill in card.skills:
+                lines.append(f"\n### {skill.name}")
+                lines.append(f"*{skill.description}*")
+                if skill.examples:
+                    lines.append("\nExamples:")
+                    for example in skill.examples[:3]:  # Limit examples
+                        lines.append(f"  - {example}")
+        else:
+            lines.append("No specific skills advertised.")
+        
+        return "\n".join(lines)
+    
+    def _extract_response(self, response: Any, agent_name: str) -> str:
+        """Extract text content from an A2A response."""
+        try:
+            # The response structure varies, try common patterns
+            result = response.result
+            
+            # Check for artifacts
+            if hasattr(result, 'artifacts') and result.artifacts:
+                texts = []
+                for artifact in result.artifacts:
+                    if hasattr(artifact, 'parts'):
+                        for part in artifact.parts:
+                            if hasattr(part, 'root') and hasattr(part.root, 'text'):
+                                texts.append(part.root.text)
+                            elif hasattr(part, 'text'):
+                                texts.append(part.text)
+                if texts:
+                    return "\n".join(texts)
+            
+            # Check for history (conversation-style response)
+            if hasattr(result, 'history') and result.history:
+                for msg in reversed(result.history):
+                    if hasattr(msg, 'role') and msg.role == 'agent':
+                        if hasattr(msg, 'parts'):
+                            for part in msg.parts:
+                                if hasattr(part, 'root') and hasattr(part.root, 'text'):
+                                    return part.root.text
+                                elif hasattr(part, 'text'):
+                                    return part.text
+            
+            # Check for status
+            if hasattr(result, 'status'):
+                status = result.status
+                if hasattr(status, 'message') and status.message:
+                    if hasattr(status.message, 'parts'):
+                        for part in status.message.parts:
+                            if hasattr(part, 'root') and hasattr(part.root, 'text'):
+                                return part.root.text
+                            elif hasattr(part, 'text'):
+                                return part.text
+            
+            # Fallback: serialize the result
+            if hasattr(result, 'model_dump'):
+                return f"Response from {agent_name}:\n```json\n{json.dumps(result.model_dump(exclude_none=True), indent=2)}\n```"
+            
+            return f"Agent {agent_name} completed the task but returned no extractable text."
+            
+        except Exception as e:
+            logger.warning(f"Error extracting A2A response: {e}")
+            return f"Agent {agent_name} responded but the response format was unexpected: {e}"
+
+
+# Alias for backwards compatibility
+A2AAgentTool = A2AClientTool

--- a/nanobot/channels/__init__.py
+++ b/nanobot/channels/__init__.py
@@ -3,4 +3,12 @@
 from nanobot.channels.base import BaseChannel
 from nanobot.channels.manager import ChannelManager
 
-__all__ = ["BaseChannel", "ChannelManager"]
+# Optional A2A channel (requires a2a-sdk)
+try:
+    from nanobot.channels.a2a import A2AChannel
+    A2A_CHANNEL_AVAILABLE = True
+except ImportError:
+    A2AChannel = None  # type: ignore
+    A2A_CHANNEL_AVAILABLE = False
+
+__all__ = ["BaseChannel", "ChannelManager", "A2AChannel", "A2A_CHANNEL_AVAILABLE"]

--- a/nanobot/channels/a2a.py
+++ b/nanobot/channels/a2a.py
@@ -1,0 +1,343 @@
+"""A2A Protocol channel implementation.
+
+This channel allows nanobot to receive requests from other A2A-compatible agents,
+turning nanobot into a discoverable AI service.
+
+See: https://a2a-protocol.org
+"""
+
+import asyncio
+from typing import Any, AsyncIterator
+from uuid import uuid4
+
+from loguru import logger
+
+try:
+    from a2a.server.apps import A2AStarletteApplication
+    from a2a.server.agent_execution import AgentExecutor, RequestContext
+    from a2a.server.events import EventQueue
+    from a2a.server.request_handlers import DefaultRequestHandler
+    from a2a.server.tasks import InMemoryTaskStore
+    from a2a.types import (
+        AgentCapabilities,
+        AgentCard,
+        AgentSkill,
+        Part,
+        TextPart,
+    )
+    from a2a.utils import new_agent_text_message, completed_task, new_artifact
+
+    A2A_AVAILABLE = True
+except ImportError:
+    A2A_AVAILABLE = False
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import A2AConfig
+
+
+class NanobotAgentExecutor(AgentExecutor):
+    """
+    A2A AgentExecutor that routes requests through nanobot's message bus.
+    
+    This bridges the A2A protocol to nanobot's internal message handling,
+    allowing the agent loop to process A2A requests like any other channel.
+    """
+    
+    def __init__(self, bus: MessageBus, config: A2AConfig):
+        self.bus = bus
+        self.config = config
+        self._pending_responses: dict[str, asyncio.Future[str]] = {}
+    
+    async def execute(
+        self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> None:
+        """
+        Execute an A2A request by routing through nanobot's agent loop.
+        
+        Args:
+            context: The A2A request context containing the message.
+            event_queue: Queue for sending events back to the A2A client.
+        """
+        # Extract user input from the A2A message
+        user_input = context.get_user_input()
+        if not user_input:
+            await event_queue.enqueue_event(
+                new_agent_text_message("I didn't receive any message content.")
+            )
+            return
+        
+        task_id = context.task_id or uuid4().hex
+        context_id = context.context_id or uuid4().hex
+        
+        logger.info(f"A2A request received: task={task_id}, input={user_input[:100]}...")
+        
+        # Create a future to wait for the response
+        response_future: asyncio.Future[str] = asyncio.Future()
+        response_key = f"a2a:{task_id}"
+        self._pending_responses[response_key] = response_future
+        
+        try:
+            # Create an inbound message and publish to the bus
+            msg = InboundMessage(
+                channel="a2a",
+                sender_id=f"a2a:{context_id}",
+                chat_id=task_id,
+                content=user_input,
+                metadata={
+                    "task_id": task_id,
+                    "context_id": context_id,
+                    "a2a_request": True,
+                }
+            )
+            
+            await self.bus.publish_inbound(msg)
+            
+            # Wait for response with timeout
+            timeout = self.config.request_timeout
+            try:
+                response = await asyncio.wait_for(response_future, timeout=timeout)
+            except asyncio.TimeoutError:
+                response = f"Request timed out after {timeout} seconds."
+                logger.warning(f"A2A request {task_id} timed out")
+            
+            # Send the response back through A2A
+            await event_queue.enqueue_event(new_agent_text_message(response))
+            
+        finally:
+            # Clean up
+            self._pending_responses.pop(response_key, None)
+    
+    async def cancel(
+        self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> None:
+        """Cancel a running task."""
+        task_id = context.task_id
+        response_key = f"a2a:{task_id}"
+        
+        if response_key in self._pending_responses:
+            future = self._pending_responses.pop(response_key)
+            if not future.done():
+                future.set_result("Task was cancelled.")
+        
+        logger.info(f"A2A task {task_id} cancelled")
+    
+    def complete_request(self, task_id: str, response: str) -> bool:
+        """
+        Complete a pending A2A request with a response.
+        
+        Called by the A2A channel when an outbound message is received.
+        
+        Args:
+            task_id: The task ID to complete.
+            response: The response content.
+            
+        Returns:
+            True if a pending request was found and completed.
+        """
+        response_key = f"a2a:{task_id}"
+        future = self._pending_responses.get(response_key)
+        
+        if future and not future.done():
+            future.set_result(response)
+            return True
+        
+        return False
+
+
+def build_agent_card(config: A2AConfig, name: str, description: str) -> AgentCard:
+    """
+    Build an A2A Agent Card from nanobot configuration.
+    
+    The Agent Card is the discovery document that tells other agents
+    what this agent can do.
+    
+    Args:
+        config: A2A channel configuration.
+        name: Agent name.
+        description: Agent description.
+    
+    Returns:
+        An AgentCard describing this nanobot instance.
+    """
+    # Define the default skill (general assistant)
+    skills = [
+        AgentSkill(
+            id="assistant",
+            name="General Assistant",
+            description="Full-stack AI assistant with tools for code, search, memory, and more.",
+            tags=["assistant", "coding", "search", "memory"],
+            examples=[
+                "Search the web for recent AI news",
+                "Write a Python function to sort a list",
+                "Help me debug this code",
+            ],
+        )
+    ]
+    
+    # Add custom skills from config
+    for skill_cfg in config.skills:
+        skills.append(AgentSkill(
+            id=skill_cfg.get("id", "custom"),
+            name=skill_cfg.get("name", "Custom Skill"),
+            description=skill_cfg.get("description", ""),
+            tags=skill_cfg.get("tags", []),
+            examples=skill_cfg.get("examples", []),
+        ))
+    
+    # Build the URL
+    host = config.public_host or f"http://localhost:{config.port}"
+    url = f"{host.rstrip('/')}"
+    
+    return AgentCard(
+        name=name,
+        description=description,
+        url=url,
+        version="0.1.3",
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+        capabilities=AgentCapabilities(
+            streaming=config.streaming,
+            push_notifications=False,
+        ),
+        skills=skills,
+    )
+
+
+class A2AChannel(BaseChannel):
+    """
+    A2A Protocol channel for nanobot.
+    
+    Exposes nanobot as an A2A-compatible agent that other agents can discover
+    and communicate with using the Agent-to-Agent protocol.
+    
+    Features:
+    - Agent Card at /.well-known/agent.json
+    - JSON-RPC endpoint for message/send and message/stream
+    - Integration with nanobot's agent loop via the message bus
+    """
+    
+    name = "a2a"
+    
+    def __init__(
+        self,
+        config: A2AConfig,
+        bus: MessageBus,
+        agent_name: str = "nanobot",
+        agent_description: str = "Ultra-lightweight AI assistant",
+    ):
+        if not A2A_AVAILABLE:
+            raise ImportError(
+                "A2A SDK not installed. Install with: pip install 'a2a-sdk[http-server]'"
+            )
+        
+        super().__init__(config, bus)
+        self.config: A2AConfig = config
+        self.agent_name = agent_name
+        self.agent_description = agent_description
+        
+        # Create the executor that bridges A2A to nanobot
+        self.executor = NanobotAgentExecutor(bus, config)
+        
+        # Build the A2A application
+        self.agent_card = build_agent_card(
+            config, agent_name, agent_description
+        )
+        
+        self.request_handler = DefaultRequestHandler(
+            agent_executor=self.executor,
+            task_store=InMemoryTaskStore(),
+        )
+        
+        self.a2a_app = A2AStarletteApplication(
+            agent_card=self.agent_card,
+            http_handler=self.request_handler,
+        )
+        
+        self._server: Any = None
+        self._serve_task: asyncio.Task | None = None
+    
+    async def start(self) -> None:
+        """Start the A2A server."""
+        import uvicorn
+        
+        self._running = True
+        
+        logger.info(f"Starting A2A server on {self.config.host}:{self.config.port}")
+        logger.info(f"Agent Card: http://{self.config.host}:{self.config.port}/.well-known/agent.json")
+        
+        # Build the Starlette app
+        app = self.a2a_app.build()
+        
+        # Configure uvicorn
+        uvi_config = uvicorn.Config(
+            app,
+            host=self.config.host,
+            port=self.config.port,
+            log_level="warning",  # Reduce noise
+        )
+        
+        self._server = uvicorn.Server(uvi_config)
+        
+        # Run the server
+        await self._server.serve()
+    
+    async def stop(self) -> None:
+        """Stop the A2A server."""
+        self._running = False
+        
+        if self._server:
+            logger.info("Stopping A2A server...")
+            self._server.should_exit = True
+            self._server = None
+    
+    async def send(self, msg: OutboundMessage) -> None:
+        """
+        Handle an outbound message for the A2A channel.
+        
+        This completes pending A2A requests with the response from the agent loop.
+        
+        Args:
+            msg: The outbound message containing the response.
+        """
+        task_id = msg.chat_id
+        
+        # Complete the pending A2A request
+        if self.executor.complete_request(task_id, msg.content):
+            logger.debug(f"A2A response sent for task {task_id}")
+        else:
+            logger.warning(f"No pending A2A request for task {task_id}")
+
+
+async def start_a2a_channel(
+    config: A2AConfig,
+    bus: MessageBus,
+    agent_name: str = "nanobot",
+    agent_description: str = "Ultra-lightweight AI assistant",
+) -> A2AChannel:
+    """
+    Create and start an A2A channel.
+    
+    Args:
+        config: A2A configuration.
+        bus: The message bus.
+        agent_name: Name for the agent card.
+        agent_description: Description for the agent card.
+    
+    Returns:
+        The started A2A channel.
+    """
+    channel = A2AChannel(
+        config=config,
+        bus=bus,
+        agent_name=agent_name,
+        agent_description=agent_description,
+    )
+    
+    await channel.start()
+    return channel

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -149,6 +149,20 @@ class ChannelManager:
             except ImportError as e:
                 logger.warning("Matrix channel not available: {}", e)
 
+        # A2A Protocol channel
+        if self.config.channels.a2a.enabled:
+            try:
+                from nanobot.channels.a2a import A2AChannel
+                self.channels["a2a"] = A2AChannel(
+                    self.config.channels.a2a,
+                    self.bus,
+                    agent_name=self.config.agents.defaults.model.split("/")[-1] if "/" in self.config.agents.defaults.model else "nanobot",
+                    agent_description="Ultra-lightweight AI assistant powered by nanobot",
+                )
+                logger.info("A2A channel enabled on port {}", self.config.channels.a2a.port)
+            except ImportError as e:
+                logger.warning("A2A channel not available: {}. Install with: pip install 'a2a-sdk[http-server]'", e)
+
         self._validate_allow_from()
 
     def _validate_allow_from(self) -> None:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -200,6 +200,23 @@ class MatrixConfig(Base):
     group_allow_from: list[str] = Field(default_factory=list)
     allow_room_mentions: bool = False
 
+class A2AConfig(Base):
+    """A2A Protocol channel configuration.
+
+    Exposes nanobot as an A2A-compatible agent that other agents can discover
+    and communicate with. See: https://a2a-protocol.org
+    """
+    enabled: bool = False
+    host: str = "0.0.0.0"
+    port: int = 8080
+    public_host: str | None = None  # Public URL for agent card (e.g., https://myagent.example.com)
+    streaming: bool = True  # Enable streaming responses
+    request_timeout: int = 300  # Timeout for processing requests (seconds)
+    skills: list[dict] = Field(default_factory=list)  # Additional skills to advertise
+    # Authentication (optional)
+    auth_token: str | None = None  # Bearer token for authenticated requests
+
+
 class ChannelsConfig(Base):
     """Configuration for chat channels."""
 
@@ -215,6 +232,7 @@ class ChannelsConfig(Base):
     slack: SlackConfig = Field(default_factory=SlackConfig)
     qq: QQConfig = Field(default_factory=QQConfig)
     matrix: MatrixConfig = Field(default_factory=MatrixConfig)
+    a2a: A2AConfig = Field(default_factory=A2AConfig)
 
 
 class AgentDefaults(Base):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ dev = [
     "pytest-asyncio>=1.3.0,<2.0.0",
     "ruff>=0.1.0",
 ]
+a2a = [
+    "a2a-sdk[http-server]>=0.2.0",
+]
+all = [
+    "a2a-sdk[http-server]>=0.2.0",
+]
 
 [project.scripts]
 nanobot = "nanobot.cli.commands:app"


### PR DESCRIPTION
## Summary

This PR adds full [A2A Protocol](https://a2a-protocol.org) support to nanobot, enabling agent-to-agent communication.

## Features

### 1. A2A Server (`channels/a2a.py`)
- Exposes nanobot as an A2A-compatible agent
- Agent Card served at `/.well-known/agent.json`
- JSON-RPC endpoint for `message/send` and `message/stream`
- Integrates with nanobot's message bus and agent loop

### 2. A2A Client Tool (`agent/tools/a2a_client.py`)
- `call_a2a_agent` tool for calling external A2A agents
- Agent discovery and capability inspection
- Message sending with response extraction

### 3. Configuration (`config/schema.py`)
- `A2AConfig` with host, port, streaming, skills
- Optional `public_host` for Agent Card URL
- Request timeout configuration

## Installation

```bash
pip install "nanobot-ai[a2a]"
```

## Configuration

```json
{
  "channels": {
    "a2a": {
      "enabled": true,
      "port": 8080,
      "publicHost": "https://my-agent.example.com"
    }
  }
}
```

## Usage

### As an A2A Server
```bash
nanobot gateway
# Agent Card: http://localhost:8080/.well-known/agent.json
```

### Calling Other A2A Agents
The agent can use the `call_a2a_agent` tool to communicate with other A2A-compatible agents:

```
User: Ask the travel agent at https://travel.example.com to book a flight to Paris
```

## Architecture

```
┌──────────────────────────────────────────────┐
│                   nanobot                     │
│                                               │
│  channels/                                    │
│    telegram.py  discord.py  a2a.py  ← NEW    │
│              │                                │
│              ↓                                │
│  bus/ → agent/loop.py → tools/               │
│                           a2a_client.py ← NEW │
└──────────────────────────────────────────────┘

External A2A Agent ←→ a2a.py (server)
nanobot ←→ a2a_client.py (tool) ←→ External A2A Agent
```

## Testing

```bash
# Start nanobot with A2A
nanobot gateway

# Verify Agent Card
curl http://localhost:8080/.well-known/agent.json

# Test with A2A Inspector
git clone https://github.com/a2aproject/a2a-inspector.git
cd a2a-inspector
uv run . --agent-url http://localhost:8080
```

## References

- [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
- [A2A Python SDK](https://github.com/a2aproject/a2a-python)
- [A2A Samples](https://github.com/a2aproject/a2a-samples)