### PR TITLE
 Drop unsupported parameters for providers.

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -64,6 +64,8 @@ class LiteLLMProvider(LLMProvider):
         
         # Disable LiteLLM logging noise
         litellm.suppress_debug_info = True
+        # Drop unsupported parameters for providers (e.g., gpt-5 rejects some params)
+        litellm.drop_params = True
     
     async def chat(
         self,


### PR DESCRIPTION
The error message from GPT model  is really confusing because of wrong temperature setting. It also makes the agent not working. 