### PR TITLE
feat: optional Hindsight integration for semantic agent memory

### DIFF
--- a/PR_HINDSIGHT.md
+++ b/PR_HINDSIGHT.md
@@ -1,0 +1,38 @@
+# Optional Hindsight integration for semantic agent memory
+
+## Summary
+
+This PR adds **optional** integration with [Hindsight](https://github.com/vectorize-io/hindsight) — a semantic memory service for AI agents. When enabled, nanobot uses Hindsight for **recall** (retrieve relevant memories by query), optional **reflect** (summaries from memory), and **retain** (store conversation turns). This complements the existing file-based memory (MEMORY.md, daily notes) without changing behavior when Hindsight is disabled.
+
+## Changes
+
+- **`nanobot/agent/hindsight_client.py`** (new): Thin async wrapper around the `hindsight-client` library. Exposes `recall()`, `reflect()`, and `retain()` with timeouts and graceful handling of missing dependency or server errors. All Hindsight calls are best-effort (errors are logged, not raised).
+- **`nanobot/agent/context.py`**:
+  - `ContextBuilder` accepts optional `hindsight_config`. `build_system_prompt()` accepts optional `hindsight_context` and appends a "Hindsight (learned memory)" section when non-empty.
+  - `build_messages()` is now **async**. When Hindsight is enabled, it calls `recall()` (and optionally `reflect()`) for the current user message, then injects the result into the system prompt. Adds `session_key` for per-session memory banks and `_hindsight_bank_id()` helper.
+- **`nanobot/agent/loop.py`**:
+  - New `_retain_fire_and_forget()` helper; after saving the session, when Hindsight is enabled, schedules a non-blocking `retain()` with the user/assistant exchange.
+  - `AgentLoop` accepts optional `hindsight_config` and passes it to `ContextBuilder`. All `build_messages()` call sites now `await` it.
+- **`nanobot/config/schema.py`**:
+  - New `HindsightConfig` with `enabled`, `base_url`, `bank_id`, `use_reflect`, `bank_id_per_session`.
+  - `Config` gains `hindsight: HindsightConfig` (default: disabled).
+- **`nanobot/cli/commands.py`**: Both `gateway` and `agent` commands pass `hindsight_config=config.hindsight` into `AgentLoop`.
+- **`pyproject.toml`**: New optional dependency group `hindsight` with `hindsight-client>=0.4.0`. Install with `pip install nanobot-ai[hindsight]`.
+- **`docs/hindsight-integration.md`** (new): English documentation for configuration, parameters, and running Hindsight with Docker/OpenRouter.
+
+## Design notes
+
+- **Optional dependency**: `hindsight-client` is only required when `hindsight.enabled` is true. If enabled but the package is missing, a warning is logged and recall/reflect/retain are no-ops.
+- **No blocking on Hindsight**: Recall/reflect run before the LLM call (with timeouts). Retain runs in a fire-and-forget task so response latency is not affected.
+- **Backward compatible**: Default config keeps Hindsight disabled; existing deployments are unchanged.
+- **Session-scoped banks**: Optional `bank_id_per_session` uses `nanobot:{session_key}` as the Hindsight bank ID for per-conversation memory.
+
+## Testing
+
+- Config load: `hindsight` section is optional and defaults to disabled.
+- With `enabled: false` (default), no HTTP calls to Hindsight and no "Hindsight (learned memory)" block in the prompt.
+- With `enabled: true` and a running Hindsight server (and `pip install nanobot-ai[hindsight]`), the agent receives recall (and optionally reflect) in the system prompt and each turn is retained after the reply.
+
+## Documentation
+
+See `docs/hindsight-integration.md` for setup, config reference, and an example of running Hindsight in Docker with OpenRouter.

--- a/docs/hindsight-integration.md
+++ b/docs/hindsight-integration.md
@@ -1,0 +1,85 @@
+# Hindsight Integration
+
+## Overview
+
+**Hindsight** is an external semantic memory system for AI agents ([vectorize-io/hindsight](https://github.com/vectorize-io/hindsight)). It supports storing facts and experience (**retain**), semantic search (**recall**), and generating summaries from memory (**reflect**).
+
+In nanobot, Hindsight integration is **optional** and complements the built-in file-based memory (diaries, MEMORY.md):
+
+- Before building the agent context, nanobot calls Hindsight **recall** (and optionally **reflect**) for the current message and injects the result into the system prompt as a "Hindsight (learned memory)" section.
+- After the agent responds, the conversation is sent asynchronously to Hindsight via **retain**, so memory is updated over time.
+
+Hindsight runs as a separate service: nanobot only talks to it over HTTP (recall/reflect/retain). Which LLM Hindsight uses (OpenAI, OpenRouter, etc.) is configured on the **Hindsight server**, not in nanobot's config.
+
+## Configuration
+
+Config file: `~/.nanobot/config.json`. Section: `hindsight`.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable Hindsight (recall/reflect/retain). |
+| `base_url` | string | `http://localhost:8888` | Hindsight API base URL. |
+| `bank_id` | string | `"default"` | Memory bank ID in Hindsight. |
+| `use_reflect` | bool | `false` | When true, also call reflect() and add result to agent context. |
+| `bank_id_per_session` | bool | `false` | When true, use per-session bank: `nanobot:{session_key}`. |
+
+### Example
+
+```json
+{
+  "hindsight": {
+    "enabled": true,
+    "base_url": "http://localhost:8888",
+    "bank_id": "default",
+    "use_reflect": false,
+    "bank_id_per_session": true
+  }
+}
+```
+
+Install the optional dependency and run a Hindsight server:
+
+```bash
+pip install nanobot-ai[hindsight]
+# or
+pip install hindsight-client
+```
+
+## Running Hindsight with Docker (OpenRouter)
+
+Hindsight supports any **OpenAI-compatible** API. OpenRouter provides such an API, so you can point Hindsight at OpenRouter by setting provider to `openai` and base URL to OpenRouter.
+
+### Environment variables for Hindsight
+
+- `HINDSIGHT_API_LLM_PROVIDER=openai` — use OpenAI-compatible protocol.
+- `HINDSIGHT_API_LLM_BASE_URL=https://openrouter.ai/api/v1` — OpenRouter endpoint.
+- `HINDSIGHT_API_LLM_API_KEY=sk-or-v1-...` — API key from [openrouter.ai](https://openrouter.ai).
+- `HINDSIGHT_API_LLM_MODEL` — model ID (e.g. `anthropic/claude-3.5-sonnet` or `openai/gpt-4o`).
+
+### Run the container
+
+```bash
+docker run --rm -it -p 8888:8888 -p 9999:9999 \
+  -e HINDSIGHT_API_LLM_PROVIDER=openai \
+  -e HINDSIGHT_API_LLM_BASE_URL=https://openrouter.ai/api/v1 \
+  -e HINDSIGHT_API_LLM_API_KEY=sk-or-v1-YOUR_OPENROUTER_KEY \
+  -e HINDSIGHT_API_LLM_MODEL=anthropic/claude-3.5-sonnet \
+  -v "$HOME/.hindsight-docker:/home/hindsight/.pg0" \
+  ghcr.io/vectorize-io/hindsight:latest
+```
+
+- **8888** — API (use this as `hindsight.base_url` in nanobot config, e.g. `http://localhost:8888`).
+- **9999** — Hindsight web UI (optional).
+
+Set nanobot config to something like:
+
+```json
+"hindsight": {
+  "enabled": true,
+  "base_url": "http://localhost:8888"
+}
+```
+
+Then run the gateway or agent; with Hindsight enabled, nanobot will call recall/reflect at `base_url` and send each dialogue to retain after the response. The LLM used by Hindsight itself is determined by the container's environment variables (e.g. OpenRouter).

--- a/nanobot/agent/hindsight_client.py
+++ b/nanobot/agent/hindsight_client.py
@@ -1,0 +1,163 @@
+"""Optional Hindsight client wrapper for semantic agent memory. Requires hindsight-client."""
+
+import asyncio
+from typing import Any
+
+from loguru import logger
+
+_HINDSIGHT_CLIENT = None
+
+
+def _get_client(base_url: str):  # noqa: ANN201
+    """Lazy import of Hindsight; returns None if package not installed or import fails."""
+    global _HINDSIGHT_CLIENT
+    if _HINDSIGHT_CLIENT is not None:
+        return _HINDSIGHT_CLIENT
+    try:
+        from hindsight_client import Hindsight
+        _HINDSIGHT_CLIENT = Hindsight
+        return Hindsight
+    except ImportError:
+        logger.warning(
+            "Hindsight is enabled but hindsight-client is not installed. "
+            "Install with: pip install nanobot-ai[hindsight] or pip install hindsight-client"
+        )
+        return None
+
+
+async def recall(base_url: str, bank_id: str, query: str, timeout: float = 10.0) -> str:
+    """Retrieve relevant memories from Hindsight. Returns empty string on error or if disabled."""
+    Klass = _get_client(base_url)
+    if not Klass or not query.strip():
+        return ""
+
+    client = None
+    try:
+        client = Klass(base_url=base_url)
+
+        def _sync_recall() -> str:
+            results = client.recall(bank_id=bank_id, query=query)
+            if isinstance(results, str):
+                return results
+            if not results:
+                return ""
+            # Extract text from RecallResult objects and join
+            texts = []
+            for item in results:
+                if hasattr(item, "text") and item.text:
+                    texts.append(item.text)
+            return "\n\n".join(texts) if texts else ""
+
+        result = await asyncio.wait_for(
+            asyncio.to_thread(_sync_recall),
+            timeout=timeout,
+        )
+        if result:
+            logger.debug(f"Hindsight recall (bank={bank_id}): {result[:100]}...")
+        return result
+    except asyncio.TimeoutError:
+        logger.warning("Hindsight recall timed out")
+        return ""
+    except Exception as e:
+        logger.warning(f"Hindsight recall failed: {e}")
+        return ""
+    finally:
+        if client:
+            try:
+                # Shield cleanup from cancellation to ensure connection closes
+                await asyncio.wait_for(asyncio.shield(client.aclose()), timeout=2.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                # If cleanup times out or fails, try to close synchronously as fallback
+                try:
+                    if hasattr(client, 'close'):
+                        client.close()
+                except Exception:
+                    pass
+
+
+async def reflect(base_url: str, bank_id: str, query: str, timeout: float = 15.0) -> str:
+    """Reflect on memories; returns disposition-aware summary. Empty string on error."""
+    Klass = _get_client(base_url)
+    if not Klass or not query.strip():
+        return ""
+
+    client = None
+    try:
+        client = Klass(base_url=base_url)
+
+        def _sync_reflect() -> str:
+            result = client.reflect(bank_id=bank_id, query=query)
+            if isinstance(result, str):
+                return result
+            return str(result) if result is not None else ""
+
+        result = await asyncio.wait_for(
+            asyncio.to_thread(_sync_reflect),
+            timeout=timeout,
+        )
+        if result:
+            logger.debug(f"Hindsight reflect (bank={bank_id}): {result[:100]}...")
+        return result
+    except asyncio.TimeoutError:
+        logger.warning("Hindsight reflect timed out")
+        return ""
+    except Exception as e:
+        logger.warning(f"Hindsight reflect failed: {e}")
+        return ""
+    finally:
+        if client:
+            try:
+                # Shield cleanup from cancellation to ensure connection closes
+                await asyncio.wait_for(asyncio.shield(client.aclose()), timeout=2.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                # If cleanup times out or fails, try to close synchronously as fallback
+                try:
+                    if hasattr(client, 'close'):
+                        client.close()
+                except Exception:
+                    pass
+
+
+async def retain(
+    base_url: str,
+    bank_id: str,
+    content: str,
+    context: str | None = None,
+    timeout: float = 15.0,
+) -> None:
+    """Store content in Hindsight (fire-and-forget). Logs and swallows errors."""
+    Klass = _get_client(base_url)
+    if not Klass or not content.strip():
+        return
+
+    client = None
+    try:
+        client = Klass(base_url=base_url)
+
+        def _sync_retain() -> None:
+            client.retain(bank_id=bank_id, content=content, context=context or "")
+
+        await asyncio.wait_for(
+            asyncio.to_thread(_sync_retain),
+            timeout=timeout,
+        )
+        logger.info(f"Hindsight retain (bank={bank_id}): stored {len(content)} chars")
+    except asyncio.TimeoutError:
+        logger.warning("Hindsight retain timed out")
+    except Exception as e:
+        logger.warning(f"Hindsight retain failed: {e}")
+    finally:
+        if client:
+            try:
+                # Use shield to protect cleanup from cancellation, with longer timeout
+                await asyncio.wait_for(asyncio.shield(client.aclose()), timeout=3.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError, Exception) as e:
+                # If cleanup times out or fails, try to close synchronously as fallback
+                # This is best-effort cleanup; pending tasks will be cleaned up on process exit
+                try:
+                    if hasattr(client, 'close'):
+                        client.close()
+                except Exception:
+                    pass
+                # Suppress the warning about pending tasks - they'll be cleaned up eventually
+                logger.debug(f"Hindsight retain cleanup completed with pending tasks (non-critical): {type(e).__name__}")

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -207,6 +207,7 @@ def gateway(
         model=config.agents.defaults.model,
         max_iterations=config.agents.defaults.max_tool_iterations,
         brave_api_key=config.tools.web.search.api_key or None,
+        hindsight_config=config.hindsight,
         exec_config=config.tools.exec,
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
@@ -316,6 +317,7 @@ def agent(
         provider=provider,
         workspace=config.workspace_path,
         brave_api_key=config.tools.web.search.api_key or None,
+        hindsight_config=config.hindsight,
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
     )

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -109,6 +109,15 @@ class ToolsConfig(BaseModel):
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
 
 
+class HindsightConfig(BaseModel):
+    """Hindsight agent memory (optional). Semantic retain/recall/reflect alongside file memory."""
+    enabled: bool = False
+    base_url: str = "http://localhost:8888"
+    bank_id: str = "default"
+    use_reflect: bool = False  # When True, also call reflect() and add to context
+    bank_id_per_session: bool = False  # When True, bank_id is nanobot:{session_key}
+
+
 class Config(BaseSettings):
     """Root configuration for nanobot."""
     agents: AgentsConfig = Field(default_factory=AgentsConfig)
@@ -116,7 +125,8 @@ class Config(BaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
-    
+    hindsight: HindsightConfig = Field(default_factory=HindsightConfig)
+
     @property
     def workspace_path(self) -> Path:
         """Get expanded workspace path."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "ruff>=0.1.0",
 ]
+hindsight = [
+    "hindsight-client>=0.4.0",
+]
 
 [project.scripts]
 nanobot = "nanobot.cli.commands:app"


### PR DESCRIPTION
- Add hindsight_client.py with recall/reflect/retain (async, optional dependency)
- ContextBuilder: hindsight_config, async build_messages with recall/reflect injection
- AgentLoop: fire-and-forget retain after response, pass hindsight_config
- Config: HindsightConfig and hindsight section
- CLI: pass config.hindsight to AgentLoop in gateway and agent
- Optional dependency: pip install nanobot-ai[hindsight]
- Docs: docs/hindsight-integration.md (English)