### PR TITLE
feat(cron): timezone support, store polling, edit command

### DIFF
--- a/PR_CRON.md
+++ b/PR_CRON.md
@@ -1,0 +1,37 @@
+# Cron improvements: timezone support, store polling, edit command
+
+## Summary
+
+This PR improves the cron/scheduler service and CLI so that:
+
+1. **New jobs are picked up without restart** — when the job list is empty or all jobs are disabled, the service still wakes periodically and reloads the store from disk, so jobs added via `nanobot cron add` (e.g. from the agent’s `exec` tool) are picked up without restarting the gateway.
+2. **Cron expressions support timezones** — `nanobot cron add --cron "0 9 * * *" --tz Europe/Moscow` runs at 09:00 Moscow time; the server’s local time is no longer required.
+3. **One-shot jobs default to delete-after-run** — `add_job(delete_after_run=...)` defaults to `True` when `schedule.kind == "at"`, so one-shot jobs don’t clutter the list.
+4. **Jobs can be edited** — new `nanobot cron edit` command and `CronService.update_job()` to update name, message, schedule, deliver/to/channel.
+
+## Changes
+
+### `nanobot/cron/service.py`
+
+- **POLL_WHEN_EMPTY_SEC (30)** — when there are no due jobs, the timer still fires at most every 30s; `_on_timer()` calls `_load_store(force_reload=True)` so the in-memory store is synced with the JSON file and new jobs (e.g. from CLI/exec) are picked up.
+- **`_load_store(force_reload=False)`** — optional re-read from disk for the above.
+- **`_compute_next_run()` for cron** — when `schedule.tz` is set, use `zoneinfo.ZoneInfo` and interpret the cron expression in that timezone; otherwise keep using server local time.
+- **`_arm_timer()`** — always arms a timer (cap delay at POLL_WHEN_EMPTY_SEC) so the service keeps waking and reloading when the list is empty.
+- **`add_job(..., delete_after_run=None)`** — when `None`, set to `True` for `kind=="at"`, else `False`.
+- **`update_job(job_id, name=..., message=..., schedule=..., deliver=..., channel=..., to=...)`** — update existing job fields and recompute next run when schedule changes.
+
+### `nanobot/cli/commands.py`
+
+- **`cron add`** — add `--tz` option; pass `tz` into `CronSchedule` when using `--cron`.
+- **`cron edit`** — new command: edit job by ID with `--name`, `--message`, `--every` / `--cron` / `--at`, `--tz`, `--deliver` / `--no-deliver`, `--to`, `--channel`. If only `--tz` is given for a cron job, keeps current expression and updates timezone.
+
+## Heartbeat
+
+Heartbeat logic is unchanged; no code changes in this PR. The same behavior as upstream is kept.
+
+## Testing
+
+- With no jobs (or all disabled), gateway stays running and `nanobot cron add ...` from another process is picked up within ~30s without restart.
+- `nanobot cron add --cron "0 9 * * *" --tz Europe/Moscow` schedules next run at 09:00 Moscow time.
+- `nanobot cron edit <id> --message "New task"` and `nanobot cron edit <id> --tz Asia/Yekaterinburg` update the job and next run.
+- One-shot `--at` jobs are removed after run (or disabled if not delete_after_run).

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -532,6 +532,7 @@ def cron_add(
     message: str = typer.Option(..., "--message", "-m", help="Message for agent"),
     every: int = typer.Option(None, "--every", "-e", help="Run every N seconds"),
     cron_expr: str = typer.Option(None, "--cron", "-c", help="Cron expression (e.g. '0 9 * * *')"),
+    tz: str = typer.Option(None, "--tz", help="IANA timezone for cron (e.g. Asia/Yekaterinburg, Europe/Moscow)"),
     at: str = typer.Option(None, "--at", help="Run once at time (ISO format)"),
     deliver: bool = typer.Option(False, "--deliver", "-d", help="Deliver response to channel"),
     to: str = typer.Option(None, "--to", help="Recipient for delivery"),
@@ -541,12 +542,12 @@ def cron_add(
     from nanobot.config.loader import get_data_dir
     from nanobot.cron.service import CronService
     from nanobot.cron.types import CronSchedule
-    
+
     # Determine schedule type
     if every:
         schedule = CronSchedule(kind="every", every_ms=every * 1000)
     elif cron_expr:
-        schedule = CronSchedule(kind="cron", expr=cron_expr)
+        schedule = CronSchedule(kind="cron", expr=cron_expr, tz=tz or None)
     elif at:
         import datetime
         dt = datetime.datetime.fromisoformat(at)
@@ -605,6 +606,66 @@ def cron_enable(
         console.print(f"[green]✓[/green] Job '{job.name}' {status}")
     else:
         console.print(f"[red]Job {job_id} not found[/red]")
+
+
+@cron_app.command("edit")
+def cron_edit(
+    job_id: str = typer.Argument(..., help="Job ID to edit"),
+    name: str = typer.Option(None, "--name", "-n", help="Update job name"),
+    message: str = typer.Option(None, "--message", "-m", help="Update message for agent"),
+    every: int = typer.Option(None, "--every", "-e", help="Update to run every N seconds"),
+    cron_expr: str = typer.Option(None, "--cron", "-c", help="Update cron expression"),
+    tz: str = typer.Option(None, "--tz", help="Update IANA timezone for cron"),
+    at: str = typer.Option(None, "--at", help="Update to run once at time (ISO format)"),
+    deliver: bool = typer.Option(None, "--deliver", "-d", help="Enable delivery"),
+    no_deliver: bool = typer.Option(False, "--no-deliver", help="Disable delivery"),
+    to: str = typer.Option(None, "--to", help="Update recipient for delivery"),
+    channel: str = typer.Option(None, "--channel", help="Update channel for delivery"),
+):
+    """Edit an existing scheduled job."""
+    from nanobot.config.loader import get_data_dir
+    from nanobot.cron.service import CronService
+    from nanobot.cron.types import CronSchedule
+
+    store_path = get_data_dir() / "cron" / "jobs.json"
+    service = CronService(store_path)
+
+    schedule = None
+    if every:
+        schedule = CronSchedule(kind="every", every_ms=every * 1000)
+    elif cron_expr:
+        schedule = CronSchedule(kind="cron", expr=cron_expr, tz=tz or None)
+    elif at:
+        import datetime
+        dt = datetime.datetime.fromisoformat(at)
+        schedule = CronSchedule(kind="at", at_ms=int(dt.timestamp() * 1000))
+    elif tz:
+        jobs = service.list_jobs(include_disabled=True)
+        current_job = next((j for j in jobs if j.id == job_id), None)
+        if current_job and current_job.schedule.kind == "cron":
+            schedule = CronSchedule(kind="cron", expr=current_job.schedule.expr, tz=tz)
+
+    deliver_flag = None
+    if no_deliver:
+        deliver_flag = False
+    elif deliver:
+        deliver_flag = True
+
+    job = service.update_job(
+        job_id=job_id,
+        name=name,
+        message=message,
+        schedule=schedule,
+        deliver=deliver_flag,
+        channel=channel,
+        to=to,
+    )
+
+    if job:
+        console.print(f"[green]✓[/green] Updated job '{job.name}' ({job.id})")
+    else:
+        console.print(f"[red]Job {job_id} not found[/red]")
+        raise typer.Exit(1)
 
 
 @cron_app.command("run")


### PR DESCRIPTION
- POLL_WHEN_EMPTY_SEC + force_reload: pick up jobs added via CLI/exec without restart
- _compute_next_run: support schedule.tz (IANA) for cron expressions
- add_job: delete_after_run defaults to True for one-shot (at) jobs
- update_job(): update name, message, schedule, deliver, channel, to
- CLI: cron add --tz; cron edit with --name, --message, --cron, --tz, etc.