### PR TITLE
fix vllm provider

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -114,7 +114,7 @@ class LiteLLMProvider(LLMProvider):
         # For vLLM, use hosted_vllm/ prefix per LiteLLM docs
         # Convert openai/ prefix to hosted_vllm/ if user specified it
         if self.is_vllm:
-            model = f"hosted_vllm/{model}"
+            model = f"hosted_/{model}"
         
         # kimi-k2.5 only supports temperature=1.0
         if "kimi-k2.5" in model.lower():


### PR DESCRIPTION
Fix for Error calling LLM: litellm.BadRequestError: LLM Provider NOT provided on self host model (vllm provider)
[(https://github.com/HKUDS/nanobot/issues/250)]

acording to new scheme, to get api base, model should use "vllm/{modelname}" to get apiBase :

```
def get_api_base(self, model: str | None = None) -> str | None:
        """Get API base URL based on model name."""
        model = (model or self.agents.defaults.model).lower()
        if "openrouter" in model:
            return self.providers.openrouter.api_base or "https://openrouter.ai/api/v1"
        if any(k in model for k in ("zhipu", "glm", "zai")):
            return self.providers.zhipu.api_base
        if "vllm" in model:
            return self.providers.vllm.api_base
        return None
```

work with this config.
```
"agents": {
"defaults": {
"workspace": "/workspaces/nanobot/.nanobot/workspace",
"model": "vllm/qwen3-1.7b-32k",
"maxTokens": 8192,
"temperature": 0.7,
"maxToolIterations": 20
}
"providers": {
"vllm": {
"apiKey": "dummy",
"apiBase": "http://localhost:11434/v1"
}
```