### PR TITLE
feat: add discord.py-based Discord channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Talk to your nanobot through Telegram, Discord, WhatsApp, or Feishu — anytime,
 | Channel | Setup |
 |---------|-------|
 | **Telegram** | Easy (just a token) |
-| **Discord** | Easy (bot token + intents) |
+| **Discord** | Easy (bot token) |
 | **WhatsApp** | Medium (scan QR) |
 | **Feishu** | Medium (app credentials) |
 
@@ -208,6 +208,8 @@ nanobot gateway
 <details>
 <summary><b>Discord</b></summary>
 
+Uses the [discord.py](https://discordpy.readthedocs.io/) library. The bot responds to **DMs** automatically and to **guild messages** when mentioned (`@botname`).
+
 **1. Create a bot**
 - Go to https://discord.com/developers/applications
 - Create an application → Bot → Add Bot
@@ -215,13 +217,18 @@ nanobot gateway
 
 **2. Enable intents**
 - In the Bot settings, enable **MESSAGE CONTENT INTENT**
-- (Optional) Enable **SERVER MEMBERS INTENT** if you plan to use allow lists based on member data
 
-**3. Get your User ID**
+**3. Invite the bot**
+- OAuth2 → URL Generator
+- Scopes: `bot`
+- Bot Permissions: `Send Messages`, `Read Message History`, `Attach Files`
+- Open the generated invite URL and add the bot to your server
+
+**4. Get your User ID**
 - Discord Settings → Advanced → enable **Developer Mode**
 - Right-click your avatar → **Copy User ID**
 
-**4. Configure**
+**5. Configure**
 
 ```json
 {
@@ -235,17 +242,19 @@ nanobot gateway
 }
 ```
 
-**5. Invite the bot**
-- OAuth2 → URL Generator
-- Scopes: `bot`
-- Bot Permissions: `Send Messages`, `Read Message History`
-- Open the generated invite URL and add the bot to your server
-
 **6. Run**
 
 ```bash
 nanobot gateway
 ```
+
+**Features:**
+- Threaded replies to the original message
+- Typing indicator while the agent is thinking
+- Automatic message splitting (2000-char Discord limit)
+- File attachment support (images, documents)
+- Bot mention stripping for cleaner input
+- Safe mentions (prevents accidental @everyone/@here pings)
 
 </details>
 
@@ -452,7 +461,7 @@ PRs welcome! The codebase is intentionally small and readable. 🤗
 - [ ] **Multi-modal** — See and hear (images, voice, video)
 - [ ] **Long-term memory** — Never forget important context
 - [ ] **Better reasoning** — Multi-step planning and reflection
-- [ ] **More integrations** — Discord, Slack, email, calendar
+- [ ] **More integrations** — Slack, email, calendar
 - [ ] **Self-improvement** — Learn from feedback and mistakes
 
 ### Contributors

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -77,6 +77,17 @@ class ChannelManager:
                 logger.info("Feishu channel enabled")
             except ImportError as e:
                 logger.warning(f"Feishu channel not available: {e}")
+
+        # Discord channel
+        if self.config.channels.discord.enabled:
+            try:
+                from nanobot.channels.discord import DiscordChannel
+                self.channels["discord"] = DiscordChannel(
+                    self.config.channels.discord, self.bus
+                )
+                logger.info("Discord channel enabled")
+            except ImportError as e:
+                logger.warning(f"Discord channel not available: {e}")
     
     async def start_all(self) -> None:
         """Start WhatsApp channel and the outbound dispatcher."""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -392,6 +392,15 @@ def channels_status():
         tg_config
     )
 
+    # Discord
+    dc = config.channels.discord
+    dc_config = f"token: {dc.token[:10]}..." if dc.token else "[dim]not configured[/dim]"
+    table.add_row(
+        "Discord",
+        "✓" if dc.enabled else "✗",
+        dc_config
+    )
+
     console.print(table)
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -34,9 +34,7 @@ class DiscordConfig(BaseModel):
     """Discord channel configuration."""
     enabled: bool = False
     token: str = ""  # Bot token from Discord Developer Portal
-    allow_from: list[str] = Field(default_factory=list)  # Allowed user IDs
-    gateway_url: str = "wss://gateway.discord.gg/?v=10&encoding=json"
-    intents: int = 37377  # GUILDS + GUILD_MESSAGES + DIRECT_MESSAGES + MESSAGE_CONTENT
+    allow_from: list[str] = Field(default_factory=list)  # Allowed user IDs or usernames
 
 
 class ChannelsConfig(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "croniter>=2.0.0",
     "python-telegram-bot>=21.0",
     "lark-oapi>=1.0.0",
+    "discord.py>=2.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Add Discord as a chat channel using discord.py. The bot responds to DMs automatically and to @mentions in guild channels. Includes attachment handling, threaded messages, message splitting for Discord's 2000-char limit, and allowlist support.

I like using the discord.py library as it makes for a cleaner implementation IMHO. Not assuming or expecting this will be merged, but wanted to present the alternative.