### PR TITLE
feat: add NanoGPT provider support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -79,6 +79,7 @@ class ProvidersConfig(BaseModel):
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
+    nanogpt: ProviderConfig = Field(default_factory=ProviderConfig)
 
 
 class GatewayConfig(BaseModel):
@@ -144,6 +145,7 @@ class Config(BaseSettings):
             "moonshot": self.providers.moonshot,
             "kimi": self.providers.moonshot,
             "vllm": self.providers.vllm,
+            "nanogpt": self.providers.nanogpt,
         }
         for keyword, provider in providers.items():
             if keyword in model and provider.api_key:
@@ -173,6 +175,8 @@ class Config(BaseSettings):
         model = (model or self.agents.defaults.model).lower()
         if "openrouter" in model:
             return self.providers.openrouter.api_base or "https://openrouter.ai/api/v1"
+        if "nanogpt" in model:
+            return self.providers.nanogpt.api_base or "https://nano-gpt.com/api/v1"
         if any(k in model for k in ("zhipu", "glm", "zai")):
             return self.providers.zhipu.api_base
         if "vllm" in model:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -43,6 +43,8 @@ class LiteLLMProvider(LLMProvider):
             elif self.is_vllm:
                 # vLLM/custom endpoint - uses OpenAI-compatible API
                 os.environ["HOSTED_VLLM_API_KEY"] = api_key
+            elif "nanogpt" in default_model:
+                os.environ.setdefault("NANOGPT_API_KEY", api_key)
             elif "deepseek" in default_model:
                 os.environ.setdefault("DEEPSEEK_API_KEY", api_key)
             elif "anthropic" in default_model:
@@ -94,30 +96,37 @@ class LiteLLMProvider(LLMProvider):
         if self.is_openrouter and not model.startswith("openrouter/"):
             model = f"openrouter/{model}"
         
+
+        # For Nanogpt, ensure nanogpt/ prefix
+        if "nanogpt" in model.lower() and not model.startswith("nanogpt/"):
+            model = f"nanogpt/{model}"
+
         # For Zhipu/Z.ai, ensure prefix is present
         # Handle cases like "glm-4.7-flash" -> "zai/glm-4.7-flash"
         if ("glm" in model.lower() or "zhipu" in model.lower()) and not (
             model.startswith("zhipu/") or 
             model.startswith("zai/") or 
-            model.startswith("openrouter/")
+            model.startswith("openrouter/") or
+            model.startswith("nanogpt/")
         ):
             model = f"zai/{model}"
 
         # For DashScope/Qwen, ensure dashscope/ prefix
         if ("qwen" in model.lower() or "dashscope" in model.lower()) and not (
             model.startswith("dashscope/") or
-            model.startswith("openrouter/")
+            model.startswith("openrouter/") or
+            model.startswith("nanogpt/")
         ):
             model = f"dashscope/{model}"
 
         # For Moonshot/Kimi, ensure moonshot/ prefix (before vLLM check)
         if ("moonshot" in model.lower() or "kimi" in model.lower()) and not (
-            model.startswith("moonshot/") or model.startswith("openrouter/")
+            model.startswith("moonshot/") or model.startswith("openrouter/") or model.startswith("nanogpt/")
         ):
             model = f"moonshot/{model}"
 
         # For Gemini, ensure gemini/ prefix if not already present
-        if "gemini" in model.lower() and not model.startswith("gemini/"):
+        if "gemini" in model.lower() and not (model.startswith("gemini/") or model.startswith("nanogpt/")):
             model = f"gemini/{model}"
 
 


### PR DESCRIPTION
Add support for [NanoGPT](https://nano-gpt.com/) as a new LLM provider. This includes:
- Added nanogpt provider configuration to schema
- Set up API base URL (defaults to https://nano-gpt.com/api/v1)
- Added NANOGPT_API_KEY environment variable handling
- Implemented model prefix handling for nanogpt models
- Updated model prefix logic to avoid conflicts with other providers

Configuration Example:

```json
{
  "agents": {
    "defaults": {
      "workspace": "~/.nanobot/workspace",
      "model": "nanogpt/deepseek/deepseek-v3.2",
      "maxToolIterations": 20
    }
  },
  "providers": {
    "nanogpt": {
      "apiKey": "<api_key>",
      "apiBase": "https://nano-gpt.com/api/v1"
    }
  },
}
```