### PR TITLE
chore: deduplicate *.pyc entry in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .assets
 .env
-*.pyc
 dist/
 build/
 docs/


### PR DESCRIPTION
## Summary
This PR removes a duplicate `*.pyc` entry from `.gitignore`.

## Motivation
Nanobot’s philosophy emphasizes *minimal, clean code/config*. Keeping `.gitignore` free of redundant patterns improves readability and avoids small sources of maintenance noise as the project evolves.

## Changes
- Deduplicated the `*.pyc` ignore rule in `.gitignore` (no behavior change).

## Impact
- No functional impact; purely a housekeeping cleanup.