### PR TITLE
feat: Support custom LLM provider which  use openai compatible API

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -179,9 +179,10 @@ def gateway(
     bus = MessageBus()
     
     # Create provider (supports OpenRouter, Anthropic, OpenAI, Bedrock)
-    api_key = config.get_api_key()
-    api_base = config.get_api_base()
-    model = config.agents.defaults.model
+    llm_cfg = config.get_llm_config()
+    model = llm_cfg["model"]
+    api_key = llm_cfg["api_key"]
+    api_base = llm_cfg["api_base"]
     is_bedrock = model.startswith("bedrock/")
 
     if not api_key and not is_bedrock:
@@ -192,7 +193,8 @@ def gateway(
     provider = LiteLLMProvider(
         api_key=api_key,
         api_base=api_base,
-        default_model=config.agents.defaults.model
+        default_model=model,
+        pass_through=llm_cfg.get("pass_through", False)
     )
     
     # Create cron service first (callback set after agent creation)
@@ -204,7 +206,7 @@ def gateway(
         bus=bus,
         provider=provider,
         workspace=config.workspace_path,
-        model=config.agents.defaults.model,
+        model=model,
         max_iterations=config.agents.defaults.max_tool_iterations,
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
@@ -295,9 +297,10 @@ def agent(
     
     config = load_config()
     
-    api_key = config.get_api_key()
-    api_base = config.get_api_base()
-    model = config.agents.defaults.model
+    llm_cfg = config.get_llm_config()
+    model = llm_cfg["model"]
+    api_key = llm_cfg["api_key"]
+    api_base = llm_cfg["api_base"]
     is_bedrock = model.startswith("bedrock/")
 
     if not api_key and not is_bedrock:
@@ -308,7 +311,8 @@ def agent(
     provider = LiteLLMProvider(
         api_key=api_key,
         api_base=api_base,
-        default_model=config.agents.defaults.model
+        default_model=model,
+        pass_through=llm_cfg.get("pass_through", False)
     )
     
     agent_loop = AgentLoop(


### PR DESCRIPTION
This PR introduces support for Custom Providers, allowing users to define arbitrary LLM provider names in 
config.json
 and map them directly to OpenAI-compatible endpoints. It implements a "pass-through" mode that bypasses the complex internal model prefixing logic in 
LiteLLMProvider
, ensuring seamless integration with third-party services such as NVIDIA, NanoGPT, and Z.ai coding plain.

1. Add the Provider Definition
In the providers section of your config.json, you can now add a new block with any name you like (e.g., "my_favorite_api").

```json
"providers": {
  "my_favorite_api": {
    "apiKey": "your-secret-key",
    "apiBase": "https://api.example.com/v1"
  }
}
```
Key (e.g., my_favorite_api): This is your custom Provider ID. You will use this as a prefix for your model name.
apiKey: Your API credential.
apiBase: The base URL of the service. 

2. Configure the Agent Model
To tell the agent to use your custom provider, set the 
model
 field using the format: {Provider ID}/{Model Name}.

```json
"agents": {
  "defaults": {
    "model": "my_favorite_api/gpt-4-turbo"
  }
}
```

Example:
1. NanoGPT
```json
"providers": {
  "nanogpt": {
    "apiKey": "sk-xxx",
    "apiBase": "https://nano-gpt.com/api/v1"
  }
},
"agents": {
  "defaults": { "model": "nanogpt/openai/gpt-4o" }
}
```
2. NVIDIA
```json
"providers": {
  "nvidia": {
    "apiKey": "nvapi-xxx",
    "apiBase": "https://integrate.api.nvidia.com/v1"
  }
},
"agents": {
  "defaults": { "model": "nvidia/z-ai/glm4.7" }
}
```
3. Z.ai (coding plan API)
```json
"providers": {
  "zai-coding-plan": {
    "apiKey": "xxx",
    "apiBase": "https://api.z.ai/api/coding/paas/v4"
  }
},
"agents": {
  "defaults": { "model": "zai-coding-plan/glm-4.7" }
}
```