### PR TITLE
fix: Support for Gemini models via Openrouter (prevent double prefix)

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -105,7 +105,7 @@ class LiteLLMProvider(LLMProvider):
             (("glm", "zhipu"), "zai", ("zhipu/", "zai/", "openrouter/", "hosted_vllm/")),
             (("qwen", "dashscope"), "dashscope", ("dashscope/", "openrouter/")),
             (("moonshot", "kimi"), "moonshot", ("moonshot/", "openrouter/")),
-            (("gemini",), "gemini", ("gemini/",)),
+            (("gemini",), "gemini", ("gemini/", "openrouter/")),
         ]
         model_lower = model.lower()
         for keywords, prefix, skip in _prefix_rules:


### PR DESCRIPTION
### Problem
When using Gemini models via OpenRouter (e.g., `openrouter/google/gemini-3-pro-preview`), the `litellm_provider` logic automatically prepends `gemini/`, resulting in an invalid model ID: `gemini/openrouter/google/gemini-3-pro-preview`. This causes a `400 Bad Request` from the provider.

### Solution
Updated the prefix rules in `nanobot/providers/litellm_provider.py` to skip adding the `gemini/` prefix if the model ID starts with `openrouter/`.

### Testing
Verified that setting `model: "openrouter/google/gemini-3-pro-preview"` in `config.json` now correctly routes requests to OpenRouter without the redundant prefix.