### PR TITLE
fix: allow rm -f in exec tool safety guard

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -23,7 +23,7 @@ class ExecTool(Tool):
         self.timeout = timeout
         self.working_dir = working_dir
         self.deny_patterns = deny_patterns or [
-            r"\brm\s+-[rf]{1,2}\b",          # rm -r, rm -rf, rm -fr
+            r"\brm\s+-\w*r\w*\b",              # rm -r, rm -rf, rm -fr (recursive)
             r"\bdel\s+/[fq]\b",              # del /f, del /q
             r"\brmdir\s+/s\b",               # rmdir /s
             r"\b(format|mkfs|diskpart)\b",   # disk operations


### PR DESCRIPTION
## Summary

- The deny pattern `\brm\s+-[rf]{1,2}\b` incorrectly blocked `rm -f` (single file force delete) along with `rm -rf` (recursive delete). Narrowed the regex to `\brm\s+-\w*r\w*\b` so it only blocks commands containing the `-r` flag.

## Test plan

- [x] Run `rm -f somefile` via exec tool, verify it is allowed
- [x] Run `rm -rf somedir` via exec tool, verify it is still blocked
- [x] Run `rm -r somedir` via exec tool, verify it is still blocked
