### PR TITLE
fix: improve Zhipu AI support and fix provider detection priority

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -48,9 +48,6 @@ class LiteLLMProvider(LLMProvider):
             elif self.is_aihubmix:
                 # AiHubMix gateway - OpenAI-compatible
                 os.environ["OPENAI_API_KEY"] = api_key
-            elif self.is_vllm:
-                # vLLM/custom endpoint - uses OpenAI-compatible API
-                os.environ["HOSTED_VLLM_API_KEY"] = api_key
             elif "deepseek" in default_model:
                 os.environ.setdefault("DEEPSEEK_API_KEY", api_key)
             elif "anthropic" in default_model:
@@ -60,8 +57,11 @@ class LiteLLMProvider(LLMProvider):
             elif "gemini" in default_model.lower():
                 os.environ.setdefault("GEMINI_API_KEY", api_key)
             elif "zhipu" in default_model or "glm" in default_model or "zai" in default_model:
-                os.environ.setdefault("ZAI_API_KEY", api_key)
-                os.environ.setdefault("ZHIPUAI_API_KEY", api_key)
+                os.environ["ZAI_API_KEY"] = api_key
+                os.environ["ZHIPUAI_API_KEY"] = api_key
+                if api_base:
+                    os.environ["ZAI_API_BASE"] = api_base
+                    os.environ["ZHIPUAI_API_BASE"] = api_base
             elif "dashscope" in default_model or "qwen" in default_model.lower():
                 os.environ.setdefault("DASHSCOPE_API_KEY", api_key)
             elif "groq" in default_model:
@@ -69,9 +69,9 @@ class LiteLLMProvider(LLMProvider):
             elif "moonshot" in default_model or "kimi" in default_model:
                 os.environ.setdefault("MOONSHOT_API_KEY", api_key)
                 os.environ.setdefault("MOONSHOT_API_BASE", api_base or "https://api.moonshot.cn/v1")
-        
-        if api_base:
-            litellm.api_base = api_base
+            elif self.is_vllm:
+                # vLLM/custom endpoint - uses OpenAI-compatible API
+                os.environ["HOSTED_VLLM_API_KEY"] = api_key
         
         # Disable LiteLLM logging noise
         litellm.suppress_debug_info = True

--- a/tests/test_zhipu_provider.py
+++ b/tests/test_zhipu_provider.py
@@ -1,0 +1,75 @@
+import os
+import pytest
+from nanobot.providers.litellm_provider import LiteLLMProvider
+
+def test_zhipu_provider_env_vars():
+    # Clear existing env vars
+    for key in ["ZAI_API_KEY", "ZHIPUAI_API_KEY", "ZAI_API_BASE", "ZHIPUAI_API_BASE"]:
+        if key in os.environ:
+            del os.environ[key]
+            
+    api_key = "test-key"
+    api_base = "https://test.api.z.ai/v4"
+    
+    # Test with zai prefix
+    provider = LiteLLMProvider(
+        api_key=api_key,
+        api_base=api_base,
+        default_model="zai/glm-4"
+    )
+    
+    assert os.environ.get("ZAI_API_KEY") == api_key
+    assert os.environ.get("ZHIPUAI_API_KEY") == api_key
+    assert os.environ.get("ZAI_API_BASE") == api_base
+    assert os.environ.get("ZHIPUAI_API_BASE") == api_base
+
+def test_zhipu_provider_model_prefixing():
+    provider = LiteLLMProvider(
+        api_key="test-key",
+        default_model="glm-4"
+    )
+    
+    # We need to mock acompletion to test the model prefixing in chat
+    # But we can also test the logic by calling a private method if it existed, 
+    # or just trust the logic if we can't easily mock.
+    # Let's try to mock litellm.acompletion
+    
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+    
+    with patch("nanobot.providers.litellm_provider.acompletion", new_callable=AsyncMock) as mock_acompletion:
+        mock_acompletion.return_value.choices = [AsyncMock()]
+        mock_acompletion.return_value.choices[0].message.content = "test"
+        mock_acompletion.return_value.choices[0].finish_reason = "stop"
+        mock_acompletion.return_value.usage.prompt_tokens = 1
+        mock_acompletion.return_value.usage.completion_tokens = 1
+        mock_acompletion.return_value.usage.total_tokens = 2
+        
+        asyncio.run(provider.chat(messages=[{"role": "user", "content": "hi"}]))
+        
+        # Check if model was prefixed with zai/
+        args, kwargs = mock_acompletion.call_args
+        assert kwargs["model"] == "zai/glm-4"
+
+def test_zhipu_provider_no_double_prefixing():
+    provider = LiteLLMProvider(
+        api_key="test-key",
+        default_model="zai/glm-4"
+    )
+    
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+    
+    with patch("nanobot.providers.litellm_provider.acompletion", new_callable=AsyncMock) as mock_acompletion:
+        mock_acompletion.return_value.choices = [AsyncMock()]
+        mock_acompletion.return_value.choices[0].message.content = "test"
+        mock_acompletion.return_value.choices[0].finish_reason = "stop"
+        mock_acompletion.return_value.usage.prompt_tokens = 1
+        mock_acompletion.return_value.usage.completion_tokens = 1
+        mock_acompletion.return_value.usage.total_tokens = 2
+        
+        asyncio.run(provider.chat(messages=[{"role": "user", "content": "hi"}]))
+        
+        # Check if model was NOT double prefixed
+        args, kwargs = mock_acompletion.call_args
+        assert kwargs["model"] == "zai/glm-4"


### PR DESCRIPTION
This PR improves Zhipu AI support by:
1. Correctly setting ZAI_API_KEY and ZHIPUAI_API_KEY.
2. Setting ZAI_API_BASE and ZHIPUAI_API_BASE if api_base is provided.
3. Fixing the provider detection priority in LiteLLMProvider so that Zhipu AI (and other specific providers) are detected correctly even when an api_base is provided (which previously caused them to be treated as generic vLLM endpoints).
4. Adding a new test file `tests/test_zhipu_provider.py` to verify these changes.

Fixes #2