### PR TITLE
Fixes Access Denied because only the LID was used.

### DIFF
--- a/bridge/src/whatsapp.ts
+++ b/bridge/src/whatsapp.ts
@@ -20,6 +20,7 @@ const VERSION = '0.1.0';
 export interface InboundMessage {
   id: string;
   sender: string;
+  pn: string;
   content: string;
   timestamp: number;
   isGroup: boolean;
@@ -123,6 +124,7 @@ export class WhatsAppClient {
         this.options.onMessage({
           id: msg.key.id || '',
           sender: msg.key.remoteJid || '',
+          pn: msg.key.remoteJidAlt || '',
           content,
           timestamp: msg.messageTimestamp as number,
           isGroup,

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -100,12 +100,16 @@ class WhatsAppChannel(BaseChannel):
         
         if msg_type == "message":
             # Incoming message from WhatsApp
+            # Deprecated by whatsapp: old phone number style typically: <phone>@s.whatspp.net
+            pn = data.get("pn", "")
+            # New LID sytle typically: 
             sender = data.get("sender", "")
             content = data.get("content", "")
             
-            # sender is typically: <phone>@s.whatsapp.net
-            # Extract just the phone number as chat_id
-            chat_id = sender.split("@")[0] if "@" in sender else sender
+            # Extract just the phone number or lid as chat_id
+            user_id = pn if pn else sender
+            sender_id = user_id.split("@")[0] if "@" in sender else sender
+            logger.info(f"Sender {sender}")
             
             # Handle voice transcription if it's a voice message
             if content == "[Voice Message]":
@@ -113,8 +117,8 @@ class WhatsAppChannel(BaseChannel):
                 content = "[Voice Message: Transcription not available for WhatsApp yet]"
             
             await self._handle_message(
-                sender_id=chat_id,
-                chat_id=sender,  # Use full JID for replies
+                sender_id=sender_id,
+                chat_id=sender,  # Use full LID for replies
                 content=content,
                 metadata={
                     "message_id": data.get("id"),


### PR DESCRIPTION
Resolves the Access Denied issue because the original phone number is not used.

Tries to get the phone number if possible; otherwise, the new unique ID is used. 

Fixes: #224 