### PR TITLE
fix exec: allow URL query 'format' (e.g. wttr.in?format=3), only block Windows …

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -26,7 +26,8 @@ class ExecTool(Tool):
             r"\brm\s+-[rf]{1,2}\b",          # rm -r, rm -rf, rm -fr
             r"\bdel\s+/[fq]\b",              # del /f, del /q
             r"\brmdir\s+/s\b",               # rmdir /s
-            r"\b(format|mkfs|diskpart)\b",   # disk operations
+            r"\b(mkfs|diskpart)\b",          # disk operations
+            r"(^|\s)format\s+[a-z]\s*[:/]",  # Windows format C: or format / (not URL ?format=)
             r"\bdd\s+if=",                   # dd
             r">\s*/dev/sd",                  # write to disk
             r"\b(shutdown|reboot|poweroff)\b",  # system power


### PR DESCRIPTION
## Summary

Relax the exec tool’s safety guard so that commands containing a URL query parameter named `format` (e.g. `curl -s "wttr.in/Beijing?format=3"`) are no longer blocked, while still blocking dangerous disk-format commands.

## Problem

The weather skill uses `exec` to run `curl wttr.in/...?format=3` for weather. The guard used the pattern `\b(format|mkfs|diskpart)\b`, which also matched the word `format` inside URLs. As a result, legitimate curl calls were rejected with:

`Error: Command blocked by safety guard (dangerous pattern detected)`

## Solution

- Narrow the rule so only real disk-format usage is blocked:
  - Keep blocking `mkfs` and `diskpart` as whole words.
  - Replace the generic `format` match with a more specific pattern: `(^|\s)format\s+[a-z]\s*[:/]`, which matches Windows-style `format C:` or `format /` but not `?format=3` in URLs.
- Weather-related curl commands (e.g. `wttr.in/...?format=3`) now run successfully.