### PR TITLE
Add core runtime safety primitives (policy + gate + emptiness + audit) — no behavior change

### DIFF
--- a/FITSEC.md
+++ b/FITSEC.md
@@ -1,0 +1,180 @@
+# FIT-Sec Integration for nanoBot
+
+This fork integrates the **FIT Framework** security layer into nanoBot, providing policy-controlled tool execution with the Omega taxonomy.
+
+## Overview
+
+FIT-Sec adds three core safety primitives to nanoBot:
+
+1. **Omega Taxonomy** - Classifies tools by blast radius (O0/O1/O2)
+2. **Monitorability Gate** - Ensures estimator quality before high-risk actions
+3. **Emptiness Window** - Safety mode that preserves cognition but removes commit power
+
+## Quick Start
+
+### Using SecureAgentLoop (Recommended)
+
+Replace `AgentLoop` with `SecureAgentLoop` to enable FIT-Sec:
+
+```python
+from nanobot.agent.secure_loop import SecureAgentLoop
+
+# Create secure agent loop
+agent = SecureAgentLoop(
+    bus=message_bus,
+    provider=llm_provider,
+    workspace=Path("./workspace"),
+    strict_mode=True,  # Deny unknown tools
+)
+
+# Grant temporary approval for shell commands (O2)
+agent.grant_tool_approval("exec", duration_seconds=300)
+
+# Process messages with security checks
+response = await agent.process_direct("List files in current directory")
+```
+
+### Using SecureToolRegistry Directly
+
+```python
+from nanobot.agent.tools.secure_registry import SecureToolRegistry
+from nanobot.fitsec import OmegaLevel
+
+registry = SecureToolRegistry(
+    workspace=Path("./workspace"),
+    strict_mode=True,
+)
+
+# Register custom tool with explicit Omega level
+registry.register(my_tool, omega_level=OmegaLevel.OMEGA_1)
+
+# Execute with policy checks
+try:
+    result = await registry.execute("my_tool", {"arg": "value"})
+except PolicyDeniedError:
+    print("Action blocked by policy")
+```
+
+## Omega Classifications
+
+| Level | Risk | Default Policy | Example Tools |
+|-------|------|----------------|---------------|
+| **O0** | Safe | ALLOW | read_file, list_dir, web_search, message |
+| **O1** | Medium | ALLOW (audited) | write_file, edit_file |
+| **O2** | High | DENY | exec, spawn, cron |
+
+### Customizing Omega Mappings
+
+```python
+from nanobot.fitsec import OmegaLevel
+
+custom_mappings = {
+    "my_safe_tool": OmegaLevel.OMEGA_0,
+    "my_risky_tool": OmegaLevel.OMEGA_2,
+}
+
+registry = SecureToolRegistry(omega_mappings=custom_mappings)
+```
+
+## Safety Controls
+
+### Granting O2 Approval
+
+O2 tools require explicit, time-bounded approval:
+
+```python
+# Grant 5-minute approval
+agent.grant_tool_approval("exec", duration_seconds=300)
+
+# Revoke approval
+agent.revoke_tool_approval("exec")
+```
+
+### Emptiness Window (Safety Mode)
+
+Enter safety mode when uncertain or debugging:
+
+```python
+# Enter Emptiness - blocks O1/O2 tools
+agent.enter_safety_mode("Investigating anomaly")
+
+# O0 tools still work
+result = await registry.execute("read_file", {"path": "log.txt"})
+
+# O1/O2 tools are blocked
+# raises EmptinessActiveError
+
+# Exit safety mode
+agent.exit_safety_mode()
+```
+
+### Emergency Stop
+
+Immediately block all non-O0 operations:
+
+```python
+agent.emergency_stop("Critical error detected")
+```
+
+## Audit Trail
+
+All tool executions are logged:
+
+```python
+# Get audit summary
+summary = agent.get_audit_summary()
+print(f"Total: {summary['total']}")
+print(f"Allowed: {summary['allowed']}")
+print(f"Denied: {summary['denied']}")
+print(f"By Omega: {summary['by_omega_level']}")
+```
+
+Audit logs are written to `{workspace}/.nanobot/audit.jsonl` in append-only JSONL format.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    SecureAgentLoop                       │
+├─────────────────────────────────────────────────────────┤
+│  ┌─────────────────────────────────────────────────┐    │
+│  │              SecureToolRegistry                  │    │
+│  │  ┌─────────────┐    ┌─────────────────────────┐ │    │
+│  │  │ ToolRegistry│ -> │    FitSecRuntime        │ │    │
+│  │  │  (nanoBot)  │    │  ┌─────────────────┐    │ │    │
+│  │  └─────────────┘    │  │ PolicyEngine    │    │ │    │
+│  │                     │  │ MonitorGate     │    │ │    │
+│  │                     │  │ EmptinessWindow │    │ │    │
+│  │                     │  │ AuditLogger     │    │ │    │
+│  │                     │  └─────────────────┘    │ │    │
+│  │                     └─────────────────────────┘ │    │
+│  └─────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Running Tests
+
+```bash
+python test_fitsec_integration.py
+```
+
+Expected output:
+```
+[OK] O0 (read_file) ALLOWED
+[OK] O1 (write_file) ALLOWED
+[OK] O2 (exec) DENIED by default
+[OK] O2 (exec) ALLOWED with approval
+[OK] Emptiness blocks O1+ tools
+[OK] O0 allowed during Emptiness
+```
+
+## FIT Framework Reference
+
+For more details on the FIT Framework theory:
+- Omega Taxonomy: Blast radius classification for safe defaults
+- Monitorability Gate: FPR controllability before high-stakes actions
+- Emptiness Window: Remove commit power while preserving cognition
+
+## License
+
+MIT License (same as nanoBot)

--- a/nanobot/fitsec/__init__.py
+++ b/nanobot/fitsec/__init__.py
@@ -1,0 +1,96 @@
+"""
+FIT-Sec Runtime for Local Agents
+================================
+
+A security layer for AI agent runtimes implementing FIT safety principles.
+
+Core primitives:
+1. Ω taxonomy - classify tools by blast radius (Ω0/Ω1/Ω2)
+2. Monitorability Gate - block execution when safety mechanisms aren't operational
+3. Emptiness Window - remove commit power while preserving cognition
+
+Usage:
+    from fitsec import FitSecRuntime, ToolManifest, OmegaLevel, ToolCall
+
+    # Create runtime
+    runtime = FitSecRuntime()
+
+    # Register a safe tool (Ω0)
+    runtime.register_tool(
+        ToolManifest(
+            tool_id="file_read",
+            omega_level=OmegaLevel.OMEGA_0,
+            description="Read file contents",
+        ),
+        executor=my_file_reader,
+    )
+
+    # Execute through security layer
+    result = runtime.execute(ToolCall(
+        tool_id="file_read",
+        action="read",
+        args={"path": "/workspace/readme.md"},
+    ))
+
+    # Enter Emptiness mode (blocks Ω1/Ω2)
+    runtime.enter_emptiness("Suspicious activity detected")
+
+    # Check status
+    print(runtime.get_status())
+"""
+
+__version__ = "0.3.0"
+
+from .types import (
+    OmegaLevel,
+    Decision,
+    GateStatus,
+    EmptinessState,
+    ToolManifest,
+    ToolCall,
+    GateMetrics,
+    PolicyDecision,
+    AuditEntry,
+    FitSecError,
+    ToolNotRegisteredError,
+    PolicyDeniedError,
+    GateFailedError,
+    EmptinessActiveError,
+)
+
+from .runtime import FitSecRuntime, ToolRegistry
+from .policy import PolicyEngine
+from .gate import MonitorabilityGate, EmergencyGate
+from .audit import AuditLogger
+from .emptiness import EmptinessWindow, ReviewPacket
+
+__all__ = [
+    # Version
+    "__version__",
+    # Core types
+    "OmegaLevel",
+    "Decision",
+    "GateStatus",
+    "EmptinessState",
+    "ToolManifest",
+    "ToolCall",
+    "GateMetrics",
+    "PolicyDecision",
+    "AuditEntry",
+    "ReviewPacket",
+    # Exceptions
+    "FitSecError",
+    "ToolNotRegisteredError",
+    "PolicyDeniedError",
+    "GateFailedError",
+    "EmptinessActiveError",
+    # Runtime
+    "FitSecRuntime",
+    "ToolRegistry",
+    # Components
+    "PolicyEngine",
+    "MonitorabilityGate",
+    "EmergencyGate",
+    "AuditLogger",
+    "EmptinessWindow",
+]

--- a/nanobot/fitsec/audit.py
+++ b/nanobot/fitsec/audit.py
@@ -1,0 +1,163 @@
+"""
+FIT-Sec Audit Logger
+====================
+Append-only event stream for tool call decisions and executions.
+"""
+from __future__ import annotations
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .types import (
+    AuditEntry,
+    PolicyDecision,
+    ToolCall,
+    ToolManifest,
+)
+
+
+class AuditLogger:
+    """
+    Append-only audit log for all tool call decisions.
+
+    Every decision is logged with:
+    - Requested action
+    - Ω-level
+    - Policy decision + rationale
+    - Gate metrics snapshot
+    - Execution result or error
+    """
+
+    def __init__(
+        self,
+        log_path: Optional[Path] = None,
+        in_memory: bool = False,
+    ):
+        self._log_path = log_path
+        self._in_memory = in_memory
+        self._entries: List[AuditEntry] = []
+
+        # Ensure log directory exists
+        if log_path and not in_memory:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def log(
+        self,
+        tool_call: ToolCall,
+        manifest: Optional[ToolManifest],
+        policy_decision: PolicyDecision,
+        executed: bool,
+        result: Optional[Any] = None,
+        error: Optional[str] = None,
+    ) -> AuditEntry:
+        """Log a tool call decision and outcome."""
+        entry = AuditEntry(
+            entry_id=str(uuid.uuid4()),
+            tool_call=tool_call,
+            manifest=manifest,
+            policy_decision=policy_decision,
+            executed=executed,
+            result=result,
+            error=error,
+            timestamp=time.time(),
+        )
+
+        self._entries.append(entry)
+
+        if self._log_path and not self._in_memory:
+            self._append_to_file(entry)
+
+        return entry
+
+    def _append_to_file(self, entry: AuditEntry) -> None:
+        """Append entry to JSONL file."""
+        record = self._entry_to_dict(entry)
+        with open(self._log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    def _entry_to_dict(self, entry: AuditEntry) -> Dict[str, Any]:
+        """Convert entry to serializable dict."""
+        return {
+            "entry_id": entry.entry_id,
+            "timestamp": entry.timestamp,
+            "timestamp_iso": time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime(entry.timestamp)
+            ),
+            "tool_call": {
+                "tool_id": entry.tool_call.tool_id,
+                "action": entry.tool_call.action,
+                "args": entry.tool_call.args,
+            },
+            "manifest": entry.manifest.to_dict() if entry.manifest else None,
+            "decision": entry.policy_decision.to_dict(),
+            "executed": entry.executed,
+            "result_type": type(entry.result).__name__ if entry.result else None,
+            "error": entry.error,
+        }
+
+    def get_entries(
+        self,
+        limit: Optional[int] = None,
+        tool_id: Optional[str] = None,
+        decision_filter: Optional[str] = None,
+    ) -> List[AuditEntry]:
+        """Query audit entries."""
+        entries = self._entries
+
+        if tool_id:
+            entries = [e for e in entries if e.tool_call.tool_id == tool_id]
+
+        if decision_filter:
+            entries = [
+                e for e in entries
+                if e.policy_decision.decision.name == decision_filter
+            ]
+
+        if limit:
+            entries = entries[-limit:]
+
+        return entries
+
+    def get_summary(self) -> Dict[str, Any]:
+        """Get summary statistics."""
+        total = len(self._entries)
+        if total == 0:
+            return {"total": 0}
+
+        allowed = sum(
+            1 for e in self._entries
+            if e.policy_decision.decision.name == "ALLOW"
+        )
+        denied = sum(
+            1 for e in self._entries
+            if e.policy_decision.decision.name == "DENY"
+        )
+        executed = sum(1 for e in self._entries if e.executed)
+        errors = sum(1 for e in self._entries if e.error)
+
+        by_omega = {}
+        for e in self._entries:
+            omega = e.policy_decision.omega_level.name
+            by_omega[omega] = by_omega.get(omega, 0) + 1
+
+        return {
+            "total": total,
+            "allowed": allowed,
+            "denied": denied,
+            "executed": executed,
+            "errors": errors,
+            "by_omega_level": by_omega,
+        }
+
+    def export_jsonl(self, path: Path) -> None:
+        """Export all entries to JSONL file."""
+        with open(path, "w", encoding="utf-8") as f:
+            for entry in self._entries:
+                record = self._entry_to_dict(entry)
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    def clear(self) -> None:
+        """Clear in-memory entries (does not affect file log)."""
+        self._entries = []

--- a/nanobot/fitsec/emptiness.py
+++ b/nanobot/fitsec/emptiness.py
@@ -1,0 +1,166 @@
+"""
+FIT-Sec Emptiness Window
+========================
+Operational safety mode that removes commit power while preserving cognition.
+
+This implements the "Controlled Nirvana" concept from FIT Phase II:
+- Pause irreversible actions
+- Keep reasoning, planning, summarization alive
+- Generate review packets for human oversight
+"""
+from __future__ import annotations
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .types import EmptinessState, OmegaLevel, ToolCall
+
+
+@dataclass
+class ReviewPacket:
+    """Human review artifact generated during Emptiness mode."""
+    packet_id: str
+    timestamp: float
+    blocked_calls: List[ToolCall]
+    proposed_plan: Optional[str] = None
+    dry_run_diffs: List[Dict[str, Any]] = field(default_factory=list)
+    context_summary: Optional[str] = None
+    recommendation: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "packet_id": self.packet_id,
+            "timestamp": self.timestamp,
+            "blocked_calls": [
+                {"tool_id": c.tool_id, "action": c.action, "args": c.args}
+                for c in self.blocked_calls
+            ],
+            "proposed_plan": self.proposed_plan,
+            "dry_run_diffs": self.dry_run_diffs,
+            "context_summary": self.context_summary,
+            "recommendation": self.recommendation,
+        }
+
+
+class EmptinessWindow:
+    """
+    Emptiness Window controller.
+
+    When active:
+    - Ω1/Ω2 actions are blocked
+    - Only safe reads (Ω0) are allowed
+    - Blocked calls are collected into review packets
+    - The window is "sticky" - stays active until explicitly cleared
+    """
+
+    def __init__(self):
+        self._state = EmptinessState.NORMAL
+        self._activated_at: Optional[float] = None
+        self._activation_reason: str = ""
+        self._blocked_calls: List[ToolCall] = []
+        self._review_packets: List[ReviewPacket] = []
+
+    @property
+    def state(self) -> EmptinessState:
+        """Current emptiness state."""
+        return self._state
+
+    @property
+    def is_active(self) -> bool:
+        """Check if Emptiness Window is active."""
+        return self._state == EmptinessState.EMPTINESS
+
+    def activate(self, reason: str = "Manual activation") -> None:
+        """
+        Activate Emptiness Window.
+
+        This removes all commit power (Ω1/Ω2) while keeping
+        cognition and audit alive.
+        """
+        if self._state == EmptinessState.NORMAL:
+            self._state = EmptinessState.EMPTINESS
+            self._activated_at = time.time()
+            self._activation_reason = reason
+            self._blocked_calls = []
+
+    def deactivate(self, require_review: bool = True) -> Optional[ReviewPacket]:
+        """
+        Deactivate Emptiness Window and return to normal operation.
+
+        If require_review=True and there are blocked calls,
+        generates a review packet.
+        """
+        packet = None
+        if self._state == EmptinessState.EMPTINESS:
+            if require_review and self._blocked_calls:
+                packet = self._generate_review_packet()
+
+            self._state = EmptinessState.NORMAL
+            self._activated_at = None
+            self._activation_reason = ""
+            self._blocked_calls = []
+
+        return packet
+
+    def check_allowed(self, omega_level: OmegaLevel) -> bool:
+        """
+        Check if an action at given Ω level is allowed.
+
+        During Emptiness:
+        - Ω0 (safe reads): allowed
+        - Ω1/Ω2: blocked
+        """
+        if self._state == EmptinessState.NORMAL:
+            return True
+
+        # In Emptiness mode, only Ω0 is allowed
+        return omega_level == OmegaLevel.OMEGA_0
+
+    def record_blocked_call(self, tool_call: ToolCall) -> None:
+        """Record a blocked tool call for later review."""
+        if self._state == EmptinessState.EMPTINESS:
+            self._blocked_calls.append(tool_call)
+
+    def _generate_review_packet(self) -> ReviewPacket:
+        """Generate a review packet from blocked calls."""
+        import uuid
+        packet = ReviewPacket(
+            packet_id=str(uuid.uuid4()),
+            timestamp=time.time(),
+            blocked_calls=self._blocked_calls.copy(),
+            recommendation=f"{len(self._blocked_calls)} action(s) blocked during Emptiness Window",
+        )
+        self._review_packets.append(packet)
+        return packet
+
+    def get_status(self) -> Dict[str, Any]:
+        """Get current Emptiness Window status."""
+        return {
+            "state": self._state.name,
+            "is_active": self.is_active,
+            "activated_at": self._activated_at,
+            "activation_reason": self._activation_reason,
+            "blocked_calls_count": len(self._blocked_calls),
+            "duration_seconds": (
+                time.time() - self._activated_at
+                if self._activated_at else None
+            ),
+        }
+
+    def get_blocked_calls(self) -> List[ToolCall]:
+        """Get list of blocked calls during current Emptiness window."""
+        return self._blocked_calls.copy()
+
+    def get_review_packets(self) -> List[ReviewPacket]:
+        """Get all generated review packets."""
+        return self._review_packets.copy()
+
+    def add_dry_run_diff(self, diff: Dict[str, Any]) -> None:
+        """Add a dry-run diff to current session (for review packet)."""
+        # This would be populated during "what-if" planning
+        pass
+
+    def set_proposed_plan(self, plan: str) -> None:
+        """Set the proposed plan text (for review packet)."""
+        # This captures what the agent would do if allowed
+        pass

--- a/nanobot/fitsec/gate.py
+++ b/nanobot/fitsec/gate.py
@@ -1,0 +1,143 @@
+"""
+FIT-Sec Monitorability Gate
+===========================
+Dynamic gate based on operational usability metrics.
+
+Key principle: execution is blocked when the detector/policy
+is not *operationally usable* (not just "accurate").
+"""
+from __future__ import annotations
+from typing import Optional
+
+from .types import GateMetrics, GateStatus
+
+
+class MonitorabilityGate:
+    """
+    Evaluates operational usability of safety mechanisms.
+
+    The gate checks:
+    1. FPR controllability - false positives are bounded
+    2. Coverage @ target FPR - sufficient detection without FPR overflow
+    3. Calibration sanity - probability outputs are reliable
+    4. Lead time stability - alerts come early enough consistently
+    """
+
+    def __init__(
+        self,
+        fpr_target: float = 0.05,
+        coverage_target: float = 0.80,
+        calibration_threshold: float = 0.70,
+        lead_time_cv_max: float = 0.50,
+    ):
+        self.fpr_target = fpr_target
+        self.coverage_target = coverage_target
+        self.calibration_threshold = calibration_threshold
+        self.lead_time_cv_max = lead_time_cv_max
+
+        # Current metrics (can be updated by external metric providers)
+        self._metrics: Optional[GateMetrics] = None
+
+    def update_metrics(self, metrics: GateMetrics) -> None:
+        """Update gate metrics from external provider."""
+        self._metrics = metrics
+
+    def check(self, metrics: Optional[GateMetrics] = None) -> GateStatus:
+        """
+        Evaluate the monitorability gate.
+
+        Returns GateStatus indicating pass/fail and reason.
+        """
+        m = metrics or self._metrics
+
+        if m is None:
+            # No metrics = unknown state
+            # Conservative: we could return UNKNOWN or FAIL
+            # For safety, we allow with UNKNOWN (policy layer handles)
+            return GateStatus.UNKNOWN
+
+        # Check FPR controllability
+        if m.fpr is not None and m.fpr > m.fpr_target:
+            return GateStatus.FAIL_FPR
+
+        # Check coverage at target FPR
+        if m.coverage_at_fpr is not None and m.coverage_at_fpr < m.coverage_target:
+            return GateStatus.FAIL_COVERAGE
+
+        # Check calibration sanity
+        if m.calibration_score is not None and m.calibration_score < m.calibration_threshold:
+            return GateStatus.FAIL_CALIBRATION
+
+        # Check lead time stability (if applicable)
+        if m.lead_time_mean is not None and m.lead_time_std is not None:
+            if m.lead_time_mean > 0:
+                cv = m.lead_time_std / m.lead_time_mean
+                if cv > m.lead_time_cv_max:
+                    return GateStatus.FAIL_LEAD_TIME
+
+        return GateStatus.PASS
+
+    def get_metrics(self) -> Optional[GateMetrics]:
+        """Get current metrics snapshot."""
+        return self._metrics
+
+    def is_operational(self, metrics: Optional[GateMetrics] = None) -> bool:
+        """Simple boolean check for operational usability."""
+        status = self.check(metrics)
+        return status in (GateStatus.PASS, GateStatus.UNKNOWN)
+
+    def get_failure_reason(self, metrics: Optional[GateMetrics] = None) -> Optional[str]:
+        """Get human-readable failure reason if gate fails."""
+        status = self.check(metrics)
+
+        if status == GateStatus.PASS:
+            return None
+        if status == GateStatus.UNKNOWN:
+            return None
+
+        m = self._metrics
+        if m is None:
+            return f"Gate failed: {status.name} (no metrics)"
+
+        fpr_str = f"{m.fpr:.3f}" if m.fpr is not None else "N/A"
+        cov_str = f"{m.coverage_at_fpr:.3f}" if m.coverage_at_fpr is not None else "N/A"
+        cal_str = f"{m.calibration_score:.3f}" if m.calibration_score is not None else "N/A"
+
+        reasons = {
+            GateStatus.FAIL_FPR: f"FPR ({fpr_str}) exceeds target ({self.fpr_target})",
+            GateStatus.FAIL_COVERAGE: f"Coverage ({cov_str}) below target ({self.coverage_target})",
+            GateStatus.FAIL_CALIBRATION: f"Calibration ({cal_str}) below threshold ({self.calibration_threshold})",
+            GateStatus.FAIL_LEAD_TIME: "Lead time coefficient of variation too high",
+        }
+        return reasons.get(status, f"Gate failed: {status.name}")
+
+
+class EmergencyGate:
+    """
+    Emergency gate that triggers Emptiness Window.
+
+    When activated, this gate returns FAIL for all checks,
+    forcing the runtime into Emptiness mode.
+    """
+
+    def __init__(self):
+        self._emergency_active = False
+        self._reason: str = ""
+
+    def activate(self, reason: str = "Manual emergency activation") -> None:
+        """Activate emergency mode."""
+        self._emergency_active = True
+        self._reason = reason
+
+    def deactivate(self) -> None:
+        """Deactivate emergency mode."""
+        self._emergency_active = False
+        self._reason = ""
+
+    def is_active(self) -> bool:
+        """Check if emergency mode is active."""
+        return self._emergency_active
+
+    def get_reason(self) -> str:
+        """Get activation reason."""
+        return self._reason

--- a/nanobot/fitsec/policy.py
+++ b/nanobot/fitsec/policy.py
@@ -1,0 +1,209 @@
+"""
+FIT-Sec Policy Engine
+=====================
+Static policy rules for tool execution authorization.
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from .types import (
+    Decision,
+    OmegaLevel,
+    PolicyDecision,
+    GateStatus,
+    ToolCall,
+    ToolManifest,
+)
+
+
+class PolicyEngine:
+    """
+    Evaluates tool calls against security policy.
+
+    Default policy:
+    - O0: ALLOW
+    - O1: ALLOW if audit enabled
+    - O2: DENY unless explicitly granted in approval window
+    """
+
+    def __init__(
+        self,
+        policy_path: Optional[Path] = None,
+        default_omega2_deny: bool = True,
+    ):
+        self.default_omega2_deny = default_omega2_deny
+        self._grants: Dict[str, Set[str]] = {}  # tool_id -> allowed actions
+        self._omega2_approvals: Dict[str, float] = {}  # tool_id -> expiry timestamp
+        self._blocked_tools: Set[str] = set()
+        self._allowed_network_domains: Set[str] = set()
+
+        if policy_path and policy_path.exists():
+            self._load_policy(policy_path)
+
+    def _load_policy(self, path: Path) -> None:
+        """Load policy from JSON file."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        # Load grants
+        for tool_id, actions in data.get("grants", {}).items():
+            self._grants[tool_id] = set(actions)
+
+        # Load blocked tools
+        self._blocked_tools = set(data.get("blocked_tools", []))
+
+        # Load network allowlist
+        self._allowed_network_domains = set(data.get("allowed_network_domains", []))
+
+    def evaluate(
+        self,
+        tool_call: ToolCall,
+        manifest: Optional[ToolManifest],
+        gate_status: GateStatus = GateStatus.UNKNOWN,
+    ) -> PolicyDecision:
+        """
+        Evaluate a tool call against policy.
+
+        Returns PolicyDecision with ALLOW/DENY/REVIEW.
+        """
+        import time
+
+        # No manifest = unknown tool = deny
+        if manifest is None:
+            return PolicyDecision(
+                decision=Decision.DENY,
+                omega_level=OmegaLevel.UNKNOWN,
+                gate_status=gate_status,
+                rationale="Tool not registered (no manifest)",
+            )
+
+        omega = manifest.omega_level
+
+        # Blocked tool check
+        if tool_call.tool_id in self._blocked_tools:
+            return PolicyDecision(
+                decision=Decision.DENY,
+                omega_level=omega,
+                gate_status=gate_status,
+                rationale=f"Tool '{tool_call.tool_id}' is blocked by policy",
+            )
+
+        # O0: safe, always allow
+        if omega == OmegaLevel.OMEGA_0:
+            return PolicyDecision(
+                decision=Decision.ALLOW,
+                omega_level=omega,
+                gate_status=gate_status,
+                rationale="O0 (safe) - allowed by default",
+            )
+
+        # O1: allow if gate passes
+        if omega == OmegaLevel.OMEGA_1:
+            if gate_status in (GateStatus.PASS, GateStatus.UNKNOWN):
+                return PolicyDecision(
+                    decision=Decision.ALLOW,
+                    omega_level=omega,
+                    gate_status=gate_status,
+                    rationale="O1 (medium risk) - allowed with audit",
+                )
+            else:
+                return PolicyDecision(
+                    decision=Decision.DENY,
+                    omega_level=omega,
+                    gate_status=gate_status,
+                    rationale=f"O1 blocked: gate failed ({gate_status.name})",
+                )
+
+        # O2: deny by default, require explicit approval
+        if omega == OmegaLevel.OMEGA_2:
+            # Check for time-bounded approval
+            if tool_call.tool_id in self._omega2_approvals:
+                expiry = self._omega2_approvals[tool_call.tool_id]
+                if time.time() < expiry:
+                    return PolicyDecision(
+                        decision=Decision.ALLOW,
+                        omega_level=omega,
+                        gate_status=gate_status,
+                        rationale="O2 - explicitly approved (time-bounded)",
+                    )
+                else:
+                    del self._omega2_approvals[tool_call.tool_id]
+
+            # Check grant list
+            if tool_call.tool_id in self._grants:
+                allowed_actions = self._grants[tool_call.tool_id]
+                if "*" in allowed_actions or tool_call.action in allowed_actions:
+                    return PolicyDecision(
+                        decision=Decision.ALLOW,
+                        omega_level=omega,
+                        gate_status=gate_status,
+                        rationale="O2 - granted by policy",
+                    )
+
+            # Default deny
+            if self.default_omega2_deny:
+                return PolicyDecision(
+                    decision=Decision.DENY,
+                    omega_level=omega,
+                    gate_status=gate_status,
+                    rationale="O2 (high risk) - denied by default, requires approval",
+                )
+            else:
+                return PolicyDecision(
+                    decision=Decision.REVIEW,
+                    omega_level=omega,
+                    gate_status=gate_status,
+                    rationale="O2 (high risk) - requires human review",
+                )
+
+        # Unknown omega level = treat as O2
+        return PolicyDecision(
+            decision=Decision.DENY,
+            omega_level=omega,
+            gate_status=gate_status,
+            rationale="Unknown O level - denied for safety",
+        )
+
+    def grant_omega2_approval(
+        self,
+        tool_id: str,
+        duration_seconds: float = 300.0,  # 5 minute default
+    ) -> None:
+        """Grant time-bounded approval for an O2 tool."""
+        import time
+        self._omega2_approvals[tool_id] = time.time() + duration_seconds
+
+    def revoke_omega2_approval(self, tool_id: str) -> None:
+        """Revoke O2 approval for a tool."""
+        self._omega2_approvals.pop(tool_id, None)
+
+    def block_tool(self, tool_id: str) -> None:
+        """Add tool to blocklist."""
+        self._blocked_tools.add(tool_id)
+
+    def unblock_tool(self, tool_id: str) -> None:
+        """Remove tool from blocklist."""
+        self._blocked_tools.discard(tool_id)
+
+    def add_network_domain(self, domain: str) -> None:
+        """Add domain to network egress allowlist."""
+        self._allowed_network_domains.add(domain)
+
+    def check_network_domain(self, domain: str) -> bool:
+        """Check if domain is in network allowlist."""
+        if not self._allowed_network_domains:
+            return True  # No restrictions if empty
+        return domain in self._allowed_network_domains
+
+    def export_policy(self) -> Dict[str, Any]:
+        """Export current policy state."""
+        return {
+            "grants": {k: list(v) for k, v in self._grants.items()},
+            "blocked_tools": list(self._blocked_tools),
+            "allowed_network_domains": list(self._allowed_network_domains),
+            "omega2_approvals": {
+                k: v for k, v in self._omega2_approvals.items()
+            },
+        }

--- a/nanobot/fitsec/runtime.py
+++ b/nanobot/fitsec/runtime.py
@@ -1,0 +1,310 @@
+"""
+FIT-Sec Runtime
+===============
+Main orchestrator for the FIT security layer.
+
+Data flow:
+1. Tool call proposed
+2. Classify O level from manifest
+3. Check Emptiness Window
+4. Check Monitorability Gate
+5. Evaluate Policy
+6. Execute in sandbox OR block
+7. Log to audit
+
+Design constraints:
+- Deterministic policy decisions
+- No hidden tool execution
+- Default deny for O2
+- Safe failure: if uncertain → block and generate review packet
+"""
+from __future__ import annotations
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from .types import (
+    Decision,
+    EmptinessActiveError,
+    FitSecError,
+    GateFailedError,
+    GateMetrics,
+    GateStatus,
+    OmegaLevel,
+    PolicyDecision,
+    PolicyDeniedError,
+    ToolCall,
+    ToolManifest,
+    ToolNotRegisteredError,
+)
+from .policy import PolicyEngine
+from .gate import MonitorabilityGate, EmergencyGate
+from .audit import AuditLogger
+from .emptiness import EmptinessWindow
+
+
+class ToolRegistry:
+    """Registry of declared tools with their manifests."""
+
+    def __init__(self):
+        self._tools: Dict[str, ToolManifest] = {}
+        self._executors: Dict[str, Callable] = {}
+
+    def register(
+        self,
+        manifest: ToolManifest,
+        executor: Optional[Callable] = None,
+    ) -> None:
+        """Register a tool with its manifest and optional executor."""
+        self._tools[manifest.tool_id] = manifest
+        if executor:
+            self._executors[manifest.tool_id] = executor
+
+    def get_manifest(self, tool_id: str) -> Optional[ToolManifest]:
+        """Get manifest for a tool."""
+        return self._tools.get(tool_id)
+
+    def get_executor(self, tool_id: str) -> Optional[Callable]:
+        """Get executor function for a tool."""
+        return self._executors.get(tool_id)
+
+    def list_tools(self) -> Dict[str, ToolManifest]:
+        """List all registered tools."""
+        return self._tools.copy()
+
+
+class FitSecRuntime:
+    """
+    Main FIT-Sec runtime orchestrator.
+
+    Provides:
+    - Tool registration with O classification
+    - Policy-based execution control
+    - Monitorability gate enforcement
+    - Emptiness Window support
+    - Complete audit logging
+    """
+
+    def __init__(
+        self,
+        policy_path: Optional[Path] = None,
+        audit_path: Optional[Path] = None,
+        strict_mode: bool = True,
+    ):
+        self.strict_mode = strict_mode
+
+        # Components
+        self.registry = ToolRegistry()
+        self.policy = PolicyEngine(policy_path=policy_path)
+        self.gate = MonitorabilityGate()
+        self.emergency_gate = EmergencyGate()
+        self.emptiness = EmptinessWindow()
+        self.audit = AuditLogger(
+            log_path=audit_path,
+            in_memory=(audit_path is None),
+        )
+
+    def register_tool(
+        self,
+        manifest: ToolManifest,
+        executor: Optional[Callable] = None,
+    ) -> None:
+        """Register a tool with manifest and optional executor."""
+        self.registry.register(manifest, executor)
+
+    def execute(
+        self,
+        tool_call: ToolCall,
+        dry_run: bool = False,
+    ) -> Any:
+        """
+        Execute a tool call through the security layer.
+
+        Args:
+            tool_call: The proposed tool invocation
+            dry_run: If True, evaluate but don't execute
+
+        Returns:
+            Tool execution result
+
+        Raises:
+            ToolNotRegisteredError: Tool not in registry
+            PolicyDeniedError: Policy denied the action
+            GateFailedError: Monitorability gate failed
+            EmptinessActiveError: Blocked by Emptiness Window
+        """
+        manifest = self.registry.get_manifest(tool_call.tool_id)
+
+        # Step 1: Check manifest exists
+        if manifest is None:
+            decision = PolicyDecision(
+                decision=Decision.DENY,
+                omega_level=OmegaLevel.UNKNOWN,
+                gate_status=GateStatus.UNKNOWN,
+                rationale="Tool not registered",
+            )
+            self.audit.log(
+                tool_call=tool_call,
+                manifest=None,
+                policy_decision=decision,
+                executed=False,
+                error="ToolNotRegisteredError",
+            )
+            raise ToolNotRegisteredError(f"Tool '{tool_call.tool_id}' not registered")
+
+        omega = manifest.omega_level
+
+        # Step 2: Check Emptiness Window
+        if not self.emptiness.check_allowed(omega):
+            self.emptiness.record_blocked_call(tool_call)
+            decision = PolicyDecision(
+                decision=Decision.DENY,
+                omega_level=omega,
+                gate_status=GateStatus.UNKNOWN,
+                rationale="Blocked by Emptiness Window",
+            )
+            self.audit.log(
+                tool_call=tool_call,
+                manifest=manifest,
+                policy_decision=decision,
+                executed=False,
+                error="EmptinessActiveError",
+            )
+            raise EmptinessActiveError(
+                f"Action blocked: Emptiness Window active (O{omega.value})"
+            )
+
+        # Step 3: Check Emergency Gate
+        if self.emergency_gate.is_active() and omega != OmegaLevel.OMEGA_0:
+            decision = PolicyDecision(
+                decision=Decision.DENY,
+                omega_level=omega,
+                gate_status=GateStatus.UNKNOWN,
+                rationale=f"Emergency gate active: {self.emergency_gate.get_reason()}",
+            )
+            self.audit.log(
+                tool_call=tool_call,
+                manifest=manifest,
+                policy_decision=decision,
+                executed=False,
+                error="EmergencyGateActive",
+            )
+            raise GateFailedError("Emergency gate is active")
+
+        # Step 4: Check Monitorability Gate (for O1/O2)
+        gate_status = GateStatus.PASS
+        if omega in (OmegaLevel.OMEGA_1, OmegaLevel.OMEGA_2):
+            gate_status = self.gate.check()
+            if gate_status not in (GateStatus.PASS, GateStatus.UNKNOWN):
+                if self.strict_mode:
+                    decision = PolicyDecision(
+                        decision=Decision.DENY,
+                        omega_level=omega,
+                        gate_status=gate_status,
+                        rationale=f"Monitorability gate failed: {gate_status.name}",
+                        metrics_snapshot=self.gate.get_metrics(),
+                    )
+                    self.audit.log(
+                        tool_call=tool_call,
+                        manifest=manifest,
+                        policy_decision=decision,
+                        executed=False,
+                        error="GateFailedError",
+                    )
+                    raise GateFailedError(
+                        self.gate.get_failure_reason() or gate_status.name
+                    )
+
+        # Step 5: Evaluate Policy
+        decision = self.policy.evaluate(tool_call, manifest, gate_status)
+
+        # Step 6: Handle decision
+        if decision.decision == Decision.DENY:
+            self.audit.log(
+                tool_call=tool_call,
+                manifest=manifest,
+                policy_decision=decision,
+                executed=False,
+                error="PolicyDeniedError",
+            )
+            raise PolicyDeniedError(decision.rationale)
+
+        if decision.decision == Decision.REVIEW:
+            # Generate review packet
+            self.emptiness.record_blocked_call(tool_call)
+            self.audit.log(
+                tool_call=tool_call,
+                manifest=manifest,
+                policy_decision=decision,
+                executed=False,
+                error="RequiresReview",
+            )
+            raise PolicyDeniedError(f"Requires human review: {decision.rationale}")
+
+        # Step 7: Execute (if not dry run)
+        if dry_run:
+            self.audit.log(
+                tool_call=tool_call,
+                manifest=manifest,
+                policy_decision=decision,
+                executed=False,
+                result="[DRY RUN]",
+            )
+            return {"dry_run": True, "would_execute": True}
+
+        executor = self.registry.get_executor(tool_call.tool_id)
+        if executor is None:
+            self.audit.log(
+                tool_call=tool_call,
+                manifest=manifest,
+                policy_decision=decision,
+                executed=False,
+                error="NoExecutor",
+            )
+            raise FitSecError(f"No executor registered for '{tool_call.tool_id}'")
+
+        # Execute and log
+        try:
+            result = executor(tool_call.action, tool_call.args)
+            self.audit.log(
+                tool_call=tool_call,
+                manifest=manifest,
+                policy_decision=decision,
+                executed=True,
+                result=result,
+            )
+            return result
+        except Exception as e:
+            self.audit.log(
+                tool_call=tool_call,
+                manifest=manifest,
+                policy_decision=decision,
+                executed=True,
+                error=str(e),
+            )
+            raise
+
+    def enter_emptiness(self, reason: str = "Manual") -> None:
+        """Enter Emptiness Window mode."""
+        self.emptiness.activate(reason)
+
+    def exit_emptiness(self) -> None:
+        """Exit Emptiness Window mode."""
+        self.emptiness.deactivate()
+
+    def emergency_stop(self, reason: str = "Emergency stop") -> None:
+        """Activate emergency gate (blocks all O1/O2)."""
+        self.emergency_gate.activate(reason)
+
+    def emergency_clear(self) -> None:
+        """Clear emergency gate."""
+        self.emergency_gate.deactivate()
+
+    def get_status(self) -> Dict[str, Any]:
+        """Get runtime status."""
+        return {
+            "emptiness": self.emptiness.get_status(),
+            "emergency_active": self.emergency_gate.is_active(),
+            "emergency_reason": self.emergency_gate.get_reason(),
+            "registered_tools": len(self.registry.list_tools()),
+            "audit_summary": self.audit.get_summary(),
+        }

--- a/nanobot/fitsec/types.py
+++ b/nanobot/fitsec/types.py
@@ -1,0 +1,153 @@
+"""
+FIT-Sec Runtime Type Definitions
+================================
+Core types for the FIT security layer.
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any, Dict, List, Optional
+import time
+
+
+class OmegaLevel(Enum):
+    """Blast radius classification for tool actions.
+
+    Ω0: Safe/reversible - pure read, local compute, no network writes
+    Ω1: Medium risk - network requests, workspace writes, send messages
+    Ω2: High risk/irreversible - shell exec, credentials, deploy, privilege changes
+    """
+    OMEGA_0 = 0  # Safe
+    OMEGA_1 = 1  # Medium
+    OMEGA_2 = 2  # High/Irreversible
+    UNKNOWN = 99  # Unclassified (treated as Ω2)
+
+
+class Decision(Enum):
+    """Policy decision outcomes."""
+    ALLOW = auto()
+    DENY = auto()
+    REVIEW = auto()  # Requires human review
+
+
+class GateStatus(Enum):
+    """Monitorability gate status."""
+    PASS = auto()
+    FAIL_FPR = auto()         # FPR not controllable
+    FAIL_COVERAGE = auto()    # Coverage too low at target FPR
+    FAIL_CALIBRATION = auto() # Probability outputs degenerate
+    FAIL_LEAD_TIME = auto()   # Alert timing unstable
+    UNKNOWN = auto()          # No metrics available
+
+
+class EmptinessState(Enum):
+    """Emptiness Window state."""
+    NORMAL = auto()      # Full execution power
+    EMPTINESS = auto()   # Cognition only, no commit power
+
+
+@dataclass
+class ToolManifest:
+    """Declared capabilities and constraints for a tool."""
+    tool_id: str
+    omega_level: OmegaLevel
+    description: str
+    capabilities: List[str] = field(default_factory=list)
+    network_domains: List[str] = field(default_factory=list)  # Allowed egress
+    fs_paths: List[str] = field(default_factory=list)  # Allowed FS access
+    requires_approval: bool = False
+    hash_sha256: Optional[str] = None  # For supply chain verification
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tool_id": self.tool_id,
+            "omega_level": self.omega_level.name,
+            "description": self.description,
+            "capabilities": self.capabilities,
+            "network_domains": self.network_domains,
+            "fs_paths": self.fs_paths,
+            "requires_approval": self.requires_approval,
+            "hash_sha256": self.hash_sha256,
+        }
+
+
+@dataclass
+class ToolCall:
+    """A proposed tool invocation."""
+    tool_id: str
+    action: str
+    args: Dict[str, Any] = field(default_factory=dict)
+    context: Dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass
+class GateMetrics:
+    """Operational usability metrics for the monitorability gate."""
+    fpr: Optional[float] = None           # False positive rate
+    fpr_target: float = 0.05              # Target FPR ceiling
+    coverage_at_fpr: Optional[float] = None
+    coverage_target: float = 0.80         # Minimum coverage at target FPR
+    calibration_score: Optional[float] = None
+    calibration_threshold: float = 0.7    # Minimum calibration quality
+    lead_time_mean: Optional[float] = None
+    lead_time_std: Optional[float] = None
+    lead_time_cv_max: float = 0.5         # Max coefficient of variation
+
+
+@dataclass
+class PolicyDecision:
+    """Result of a policy evaluation."""
+    decision: Decision
+    omega_level: OmegaLevel
+    gate_status: GateStatus
+    rationale: str
+    metrics_snapshot: Optional[GateMetrics] = None
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "decision": self.decision.name,
+            "omega_level": self.omega_level.name,
+            "gate_status": self.gate_status.name,
+            "rationale": self.rationale,
+            "timestamp": self.timestamp,
+        }
+
+
+@dataclass
+class AuditEntry:
+    """Audit log entry for a tool call decision."""
+    entry_id: str
+    tool_call: ToolCall
+    manifest: Optional[ToolManifest]
+    policy_decision: PolicyDecision
+    executed: bool
+    result: Optional[Any] = None
+    error: Optional[str] = None
+    timestamp: float = field(default_factory=time.time)
+
+
+class FitSecError(Exception):
+    """Base exception for FIT-Sec runtime errors."""
+    pass
+
+
+class ToolNotRegisteredError(FitSecError):
+    """Tool not found in registry."""
+    pass
+
+
+class PolicyDeniedError(FitSecError):
+    """Action denied by policy."""
+    pass
+
+
+class GateFailedError(FitSecError):
+    """Monitorability gate check failed."""
+    pass
+
+
+class EmptinessActiveError(FitSecError):
+    """Action blocked due to Emptiness Window."""
+    pass

--- a/tests/test_fitsec_core_runtime.py
+++ b/tests/test_fitsec_core_runtime.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from nanobot.fitsec.runtime import FitSecRuntime
+from nanobot.fitsec.types import (
+    OmegaLevel,
+    ToolCall,
+    ToolManifest,
+    ToolNotRegisteredError,
+    PolicyDeniedError,
+)
+
+
+def test_unregistered_tool_denied_and_audited() -> None:
+    rt = FitSecRuntime(audit_path=None, strict_mode=True)
+
+    call = ToolCall(tool_id="nope", action="execute", args={"x": 1})
+    with pytest.raises(ToolNotRegisteredError):
+        rt.execute(call)
+
+    entries = rt.audit.get_entries(limit=1)
+    assert len(entries) == 1
+    assert entries[0].error == "ToolNotRegisteredError"
+
+
+def test_o2_denied_by_default_and_audited() -> None:
+    rt = FitSecRuntime(audit_path=None, strict_mode=True)
+
+    rt.register_tool(
+        ToolManifest(
+            tool_id="exec",
+            omega_level=OmegaLevel.OMEGA_2,
+            description="dangerous",
+            requires_approval=True,
+        ),
+        executor=lambda action, args: "OK",
+    )
+
+    call = ToolCall(tool_id="exec", action="execute", args={"cmd": "echo hi"})
+    with pytest.raises(PolicyDeniedError):
+        rt.execute(call)
+
+    entries = rt.audit.get_entries(tool_id="exec")
+    assert len(entries) == 1
+    assert entries[0].executed is False
+    assert entries[0].error == "PolicyDeniedError"
+
+
+def test_o2_approval_allows_execution_and_audits() -> None:
+    rt = FitSecRuntime(audit_path=None, strict_mode=True)
+
+    rt.register_tool(
+        ToolManifest(
+            tool_id="exec",
+            omega_level=OmegaLevel.OMEGA_2,
+            description="dangerous",
+            requires_approval=True,
+        ),
+        executor=lambda action, args: f"OK:{args.get('cmd')}",
+    )
+
+    rt.policy.grant_omega2_approval("exec", duration_seconds=10.0)
+
+    call = ToolCall(tool_id="exec", action="execute", args={"cmd": "echo hi"})
+    out = rt.execute(call)
+    assert out == "OK:echo hi"
+
+    entries = rt.audit.get_entries(tool_id="exec")
+    assert len(entries) == 1
+    assert entries[0].executed is True
+    assert entries[0].error is None
+
+
+def test_omega2_approval_expires() -> None:
+    rt = FitSecRuntime(audit_path=None, strict_mode=True)
+    rt.register_tool(
+        ToolManifest(
+            tool_id="exec",
+            omega_level=OmegaLevel.OMEGA_2,
+            description="dangerous",
+            requires_approval=True,
+        ),
+        executor=lambda action, args: "OK",
+    )
+
+    rt.policy.grant_omega2_approval("exec", duration_seconds=0.01)
+    time.sleep(0.02)
+
+    call = ToolCall(tool_id="exec", action="execute", args={})
+    with pytest.raises(PolicyDeniedError):
+        rt.execute(call)
+


### PR DESCRIPTION
- What: Add nanobot/fitsec core runtime (policy/gate/emptiness/audit/types) + FITSEC.md + core unit tests.
- Behavior change: None (not wired into agent/tools/CLI).
- Tests: test_fitsec_core_runtime.py.