### PR TITLE
Codex/fix cli input 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "python-telegram-bot[socks]>=21.0",
     "lark-oapi>=1.0.0",
     "socksio>=1.0.0",
+    "prompt-toolkit>=3.0.47",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cli_input_minimal.py
+++ b/tests/test_cli_input_minimal.py
@@ -4,25 +4,45 @@ import nanobot.cli.commands as commands
 
 
 def test_read_interactive_input_uses_plain_input(monkeypatch) -> None:
-    captured: dict[str, object] = {}
-
-    def fake_print(*args, **kwargs):
-        captured["printed"] = args
-        captured["print_kwargs"] = kwargs
-
+    captured: dict[str, str] = {}
     def fake_input(prompt: str = "") -> str:
         captured["prompt"] = prompt
         return "hello"
 
-    monkeypatch.setattr(commands.console, "print", fake_print)
     monkeypatch.setattr(builtins, "input", fake_input)
+    monkeypatch.setattr(commands, "_PROMPT_SESSION", None)
+    monkeypatch.setattr(commands, "_READLINE", None)
 
     value = commands._read_interactive_input()
 
     assert value == "hello"
-    assert captured["prompt"] == ""
-    assert captured["print_kwargs"] == {"end": ""}
-    assert captured["printed"] == ("[bold blue]You:[/bold blue] ",)
+    assert captured["prompt"] == "You: "
+
+
+def test_read_interactive_input_prefers_prompt_session(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakePromptSession:
+        async def prompt_async(self, label: object) -> str:
+            captured["label"] = label
+            return "hello"
+
+    monkeypatch.setattr(commands, "_PROMPT_SESSION", FakePromptSession())
+    monkeypatch.setattr(commands, "_PROMPT_SESSION_LABEL", "LBL")
+
+    value = __import__("asyncio").run(commands._read_interactive_input_async())
+
+    assert value == "hello"
+    assert captured["label"] == "LBL"
+
+
+def test_prompt_text_for_readline_modes(monkeypatch) -> None:
+    monkeypatch.setattr(commands, "_READLINE", object())
+    monkeypatch.setattr(commands, "_USING_LIBEDIT", True)
+    assert commands._prompt_text() == "\033[1;34mYou:\033[0m "
+
+    monkeypatch.setattr(commands, "_USING_LIBEDIT", False)
+    assert "\001" in commands._prompt_text()
 
 
 def test_flush_pending_tty_input_skips_non_tty(monkeypatch) -> None:
@@ -34,4 +54,3 @@ def test_flush_pending_tty_input_skips_non_tty(monkeypatch) -> None:
     monkeypatch.setattr(commands.os, "isatty", lambda _fd: False)
 
     commands._flush_pending_tty_input()
-


### PR DESCRIPTION
## Summary

This PR fixes interactive CLI input behavior in `nanobot agent`, especially for wrapped long CJK text on macOS terminals.

## What It Fixes

- Arrow keys no longer leak escape sequences like `^[[A` / `^[[B` into input.
- Up/Down now prefer visual line movement inside wrapped input, then fall back to history at boundaries.
- `You:` prompt rendering remains stable while navigating/editing.
- Prevents event-loop issues in interactive mode by using async-safe prompt handling.

## Implementation

- Updated interactive input handling in `nanobot/cli/commands.py`.
- Uses `prompt_toolkit` path first for robust wrapped-input behavior.
- Keeps readline/libedit fallback for compatibility.
- Added/updated focused tests in `tests/test_cli_input_minimal.py`.

## Validation

- Manual test on macOS terminal with long wrapped Chinese input.
- `pytest` passes locally.

<img width="1092" height="404" alt="03543036-000a-44a7-9e03-35b9d078bc88" src="https://github.com/user-attachments/assets/df8aadd9-8121-4c9d-b643-7040727889b4" />
