### PR TITLE
add zhipu ai support to litellm provider

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -207,6 +207,7 @@ def gateway(
         model=config.agents.defaults.model,
         max_iterations=config.agents.defaults.max_tool_iterations,
         brave_api_key=config.tools.web.search.api_key or None,
+        zhipu_api_key=config.providers.zhipu.api_key or None,
         exec_config=config.tools.exec,
         cron_service=cron,
     )
@@ -315,6 +316,7 @@ def agent(
         provider=provider,
         workspace=config.workspace_path,
         brave_api_key=config.tools.web.search.api_key or None,
+        zhipu_api_key=config.providers.zhipu.api_key or None,
         exec_config=config.tools.exec,
     )
     

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -12,34 +12,45 @@ from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 class LiteLLMProvider(LLMProvider):
     """
     LLM provider using LiteLLM for multi-provider support.
-    
+
     Supports OpenRouter, Anthropic, OpenAI, Gemini, and many other providers through
     a unified interface.
     """
-    
+
     def __init__(
-        self, 
-        api_key: str | None = None, 
+        self,
+        api_key: str | None = None,
         api_base: str | None = None,
         default_model: str = "anthropic/claude-opus-4-5"
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
-        
+
         # Detect OpenRouter by api_key prefix or explicit api_base
         self.is_openrouter = (
             (api_key and api_key.startswith("sk-or-")) or
             (api_base and "openrouter" in api_base)
         )
-        
+
+        # Detect Zhipu by api_base or model name
+        self.is_zhipu = (
+            (api_base and "bigmodel" in api_base) or
+            ("zhipu" in default_model) or
+            ("glm" in default_model)
+        )
+
         # Track if using custom endpoint (vLLM, etc.)
-        self.is_vllm = bool(api_base) and not self.is_openrouter
-        
+        # Exclude Zhipu from vLLM detection
+        self.is_vllm = bool(api_base) and not self.is_openrouter and not self.is_zhipu
+
         # Configure LiteLLM based on provider
         if api_key:
             if self.is_openrouter:
                 # OpenRouter mode - set key
                 os.environ["OPENROUTER_API_KEY"] = api_key
+            elif self.is_zhipu:
+                # Zhipu/ZhipuAI mode - use OpenAI-compatible API
+                os.environ["OPENAI_API_KEY"] = api_key
             elif self.is_vllm:
                 # vLLM/custom endpoint - uses OpenAI-compatible API
                 os.environ["OPENAI_API_KEY"] = api_key
@@ -51,17 +62,15 @@ class LiteLLMProvider(LLMProvider):
                 os.environ.setdefault("OPENAI_API_KEY", api_key)
             elif "gemini" in default_model.lower():
                 os.environ.setdefault("GEMINI_API_KEY", api_key)
-            elif "zhipu" in default_model or "glm" in default_model or "zai" in default_model:
-                os.environ.setdefault("ZHIPUAI_API_KEY", api_key)
             elif "groq" in default_model:
                 os.environ.setdefault("GROQ_API_KEY", api_key)
-        
-        if api_base:
+
+        if api_base and not self.is_zhipu:
             litellm.api_base = api_base
-        
+
         # Disable LiteLLM logging noise
         litellm.suppress_debug_info = True
-    
+
     async def chat(
         self,
         messages: list[dict[str, Any]],
@@ -72,56 +81,50 @@ class LiteLLMProvider(LLMProvider):
     ) -> LLMResponse:
         """
         Send a chat completion request via LiteLLM.
-        
+
         Args:
             messages: List of message dicts with 'role' and 'content'.
             tools: Optional list of tool definitions in OpenAI format.
             model: Model identifier (e.g., 'anthropic/claude-sonnet-4-5').
             max_tokens: Maximum tokens in response.
             temperature: Sampling temperature.
-        
+
         Returns:
             LLMResponse with content and/or tool calls.
         """
         model = model or self.default_model
-        
+
         # For OpenRouter, prefix model name if not already prefixed
         if self.is_openrouter and not model.startswith("openrouter/"):
             model = f"openrouter/{model}"
-        
-        # For Zhipu/Z.ai, ensure prefix is present
-        # Handle cases like "glm-4.7-flash" -> "zai/glm-4.7-flash"
-        if ("glm" in model.lower() or "zhipu" in model.lower()) and not (
-            model.startswith("zhipu/") or 
-            model.startswith("zai/") or 
-            model.startswith("openrouter/")
-        ):
-            model = f"zai/{model}"
-        
+
+        # For Zhipu/Z.ai, don't add prefix since we use OpenAI-compatible API
+        # The model name should already be in the correct format (e.g., "openai/glm-4")
+
         # For vLLM, use hosted_vllm/ prefix per LiteLLM docs
         # Convert openai/ prefix to hosted_vllm/ if user specified it
         if self.is_vllm:
             model = f"hosted_vllm/{model}"
-        
+
         # For Gemini, ensure gemini/ prefix if not already present
         if "gemini" in model.lower() and not model.startswith("gemini/"):
             model = f"gemini/{model}"
-        
+
         kwargs: dict[str, Any] = {
             "model": model,
             "messages": messages,
             "max_tokens": max_tokens,
             "temperature": temperature,
         }
-        
+
         # Pass api_base directly for custom endpoints (vLLM, etc.)
         if self.api_base:
             kwargs["api_base"] = self.api_base
-        
+
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
-        
+
         try:
             response = await acompletion(**kwargs)
             return self._parse_response(response)
@@ -131,12 +134,12 @@ class LiteLLMProvider(LLMProvider):
                 content=f"Error calling LLM: {str(e)}",
                 finish_reason="error",
             )
-    
+
     def _parse_response(self, response: Any) -> LLMResponse:
         """Parse LiteLLM response into our standard format."""
         choice = response.choices[0]
         message = choice.message
-        
+
         tool_calls = []
         if hasattr(message, "tool_calls") and message.tool_calls:
             for tc in message.tool_calls:
@@ -148,13 +151,13 @@ class LiteLLMProvider(LLMProvider):
                         args = json.loads(args)
                     except json.JSONDecodeError:
                         args = {"raw": args}
-                
+
                 tool_calls.append(ToolCallRequest(
                     id=tc.id,
                     name=tc.function.name,
                     arguments=args,
                 ))
-        
+
         usage = {}
         if hasattr(response, "usage") and response.usage:
             usage = {
@@ -162,14 +165,14 @@ class LiteLLMProvider(LLMProvider):
                 "completion_tokens": response.usage.completion_tokens,
                 "total_tokens": response.usage.total_tokens,
             }
-        
+
         return LLMResponse(
             content=message.content,
             tool_calls=tool_calls,
             finish_reason=choice.finish_reason or "stop",
             usage=usage,
         )
-    
+
     def get_default_model(self) -> str:
         """Get the default model."""
         return self.default_model


### PR DESCRIPTION
```markdown
## 功能：添加智谱 AI Coding Plan 支持

### 主要修改
- 新增 Zhipu AI 检测逻辑
- 使用 OpenAI 兼容 API 配置智谱
- 支持 zai/glm-4.7 模型
- 配置 apiBase: https://open.bigmodel.cn/api/coding/paas/v4
- 加入智谱coding plan mcp支持（可选）

### 修改文件
- `nanobot/agent/loop.py`（可选）
- `nanobot/cli/commands.py`（可选）
- `nanobot/providers/litellm_provider.py`

### config.json参考
- `~/.nanobot/config.json`

{
  "providers": {
    "zhipu": {
      "apiKey": "zhipu coding plan key here",
      "apiBase": "https://open.bigmodel.cn/api/coding/paas/v4"
    }
  },
  "agents": {
    "defaults": {
      "provider": "zhipu",
      "model": "zai/glm-4.7",
      "workspace": "~/.nanobot/workspace",
      "max_tokens": 32768,
      "temperature": 0.3,
      "max_tool_iterations": 20
    }
  }

### 智谱 AI Coding Plan官方文档参考
- `https://docs.bigmodel.cn/cn/coding-plan/overview`
- `https://docs.bigmodel.cn/cn/coding-plan/tool/others`
- `https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server`
- `https://docs.bigmodel.cn/cn/coding-plan/mcp/reader-mcp-server`
- `https://docs.bigmodel.cn/cn/coding-plan/mcp/zread-mcp-server`
```