### PR TITLE
fix(feishu): Prevent error logs from unhandled reaction and read events

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -23,6 +23,8 @@ try:
         CreateMessageReactionRequestBody,
         Emoji,
         P2ImMessageReceiveV1,
+        P2ImMessageMessageReadV1,
+        P2ImMessageReactionCreatedV1,
     )
     FEISHU_AVAILABLE = True
 except ImportError:
@@ -82,12 +84,18 @@ class FeishuChannel(BaseChannel):
             .log_level(lark.LogLevel.INFO) \
             .build()
         
-        # Create event handler (only register message receive, ignore other events)
+        # Create event handler (register message receive and other common events)
         event_handler = lark.EventDispatcherHandler.builder(
             self.config.encrypt_key or "",
             self.config.verification_token or "",
         ).register_p2_im_message_receive_v1(
             self._on_message_sync
+        ).register_p2_im_message_reaction_created_v1(
+            self._on_reaction_created
+        ).register_p2_im_message_message_read_v1(
+            self._on_message_read
+        ).register_p2_im_chat_access_event_bot_p2p_chat_entered_v1(
+            self._on_bot_p2p_chat_entered
         ).build()
         
         # Create WebSocket client for long connection
@@ -305,3 +313,26 @@ class FeishuChannel(BaseChannel):
             
         except Exception as e:
             logger.error(f"Error processing Feishu message: {e}")
+
+    def _on_reaction_created(self, data: "P2ImMessageReactionCreatedV1") -> None:
+        """
+        Handler for message reaction events.
+        We don't need to process these, but registering prevents error logs.
+        """
+        pass
+    
+    def _on_message_read(self, data: "P2ImMessageMessageReadV1") -> None:
+        """
+        Handler for message read events.
+        We don't need to process these, but registering prevents error logs.
+        """
+        pass
+    
+    def _on_bot_p2p_chat_entered(self, data: Any) -> None:
+        """
+        Handler for bot entering p2p chat events.
+        This is triggered when a user opens a chat with the bot.
+        We don't need to process these, but registering prevents error logs.
+        """
+        logger.debug("Bot entered p2p chat (user opened chat window)")
+        pass


### PR DESCRIPTION
## Summary
This PR adds event handlers for common Feishu/Lark events that were previously unhandled, preventing error logs from cluttering the application output.

## Changes
- ✅ Register handler for message reaction created events (`P2ImMessageReactionCreatedV1`)
- ✅ Register handler for message read events (`P2ImMessageMessageReadV1`)
- ✅ Register handler for bot entering p2p chat events (`P2ImChatAccessEventBotP2pChatEnteredV1`)
- ✅ Import required event types from `lark_oapi.api.im.v1`

## Motivation
When users interact with the Feishu bot (e.g., reacting to messages, reading messages, or opening chat windows), these events trigger callbacks but were not registered, causing error logs. While these events don't require processing for the bot's core functionality, registering empty handlers prevents unnecessary error messages and improves log cleanliness.

## Technical Details
- Added three new event handler methods with pass-through implementations
- No changes to existing message processing logic
- Maintains backward compatibility
- Follows the existing event handler pattern in the codebase

## Testing
- [x] Tested with Feishu bot in production environment
- [x] Verified that error logs no longer appear for these events
- [x] Confirmed that message processing continues to work as expected

## Related Issues
Fixes issues with error logs appearing when users:
- React to bot messages with emojis
- Mark bot messages as read
- Open a new chat window with the bot
