### PR TITLE
Adds a standard GitHub Actions workflow to automate Docker image builds and pushes to DockerHub.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/nanobot
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+
+      - name: Build Summary
+        run: |
+          echo "✅ Docker image pushed: ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What This Does
- Builds multi-platform Docker images (`linux/amd64`, `linux/arm64`)
- Pushes built images to a container registry
- Tags images with branch name, commit SHA, and latest marker
- Uses GitHub Actions cache for faster build times
- Supports manual workflow dispatch
- Prevents concurrent builds with concurrency control

## Configuration
Users need to set these secrets in their repository:
- `DOCKER_USERNAME`: Container registry username
- `DOCKER_PASSWORD`: Container registry access token

## Triggers
- On push to `main` branch
- Manual dispatch via GitHub UI

## Benefits
- Automated container builds on every commit
- Multi-platform support (AMD64/ARM64)
- Optimized build caching
- Standard workflow pattern for open source projects