### PR TITLE
feat: add tool call transparency feature

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -211,6 +211,8 @@ def gateway(
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         session_manager=session_manager,
+        tool_call_transparency=config.agents.defaults.tool_call_transparency,
+        tool_call_max_length=config.agents.defaults.tool_call_max_length,
     )
     
     # Set cron callback (needs agent)
@@ -305,6 +307,8 @@ def agent(
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
+        tool_call_transparency=config.agents.defaults.tool_call_transparency,
+        tool_call_max_length=config.agents.defaults.tool_call_max_length,
     )
     
     if message:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -54,6 +54,8 @@ class AgentDefaults(BaseModel):
     max_tokens: int = 8192
     temperature: float = 0.7
     max_tool_iterations: int = 20
+    tool_call_transparency: bool = False  # Enable to show tool calls to users
+    tool_call_max_length: int = 500  # Max length of tool call display (0 = no limit)
 
 
 class AgentsConfig(BaseModel):


### PR DESCRIPTION
Add new configuration options to enable showing tool calls to users:

- tool_call_transparency: bool (default: false) When enabled, notifies users about tool calls with name and parameters

- tool_call_max_length: int (default: 500) Controls max length of displayed parameters (0 = no limit)

Changes:
- Add configuration options to AgentDefaults in schema.py
- Modify AgentLoop to support tool call transparency
- Add _format_tool_call_notice method for user-friendly formatting
- Update commands.py to pass new config to AgentLoop instances

This feature helps users understand what tools the agent is using and with what parameters, improving transparency and debuggability.