### PR TITLE
feat: add Telnyx as LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Config file: `~/.nanobot/config.json`
 | `dashscope` | LLM (Qwen) | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
 | `moonshot` | LLM (Moonshot/Kimi) | [platform.moonshot.cn](https://platform.moonshot.cn) |
 | `zhipu` | LLM (Zhipu GLM) | [open.bigmodel.cn](https://open.bigmodel.cn) |
+| `telnyx` | LLM + **Voice AI** (TTS, SIP, call control) | [portal.telnyx.com](https://portal.telnyx.com) |
 | `vllm` | LLM (local, any OpenAI-compatible server) | — |
 
 <details>

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -90,6 +90,7 @@ class ProvidersConfig(BaseModel):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
+    telnyx: ProviderConfig = Field(default_factory=ProviderConfig)  # Telnyx LLM inference
 
 
 class GatewayConfig(BaseModel):

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -262,6 +262,25 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         model_overrides=(),
     ),
 
+    # Telnyx: OpenAI-compatible LLM inference API with voice AI capabilities.
+    # Uses "openai/" prefix for LiteLLM routing to custom api_base.
+    ProviderSpec(
+        name="telnyx",
+        keywords=("telnyx",),
+        env_key="OPENAI_API_KEY",           # OpenAI-compatible
+        display_name="Telnyx",
+        litellm_prefix="openai",            # → openai/{model}
+        skip_prefixes=("openai/",),         # avoid double-prefix
+        env_extras=(),
+        is_gateway=True,
+        is_local=False,
+        detect_by_key_prefix="KEY",         # Telnyx API keys start with KEY
+        detect_by_base_keyword="telnyx",
+        default_api_base="https://api.telnyx.com/v2/ai",
+        strip_model_prefix=True,            # anthropic/claude-3 → claude-3 → openai/claude-3
+        model_overrides=(),
+    ),
+
     # === Auxiliary (not a primary LLM provider) ============================
 
     # Groq: mainly used for Whisper voice transcription, also usable for LLM.


### PR DESCRIPTION
## What

Adds [Telnyx](https://telnyx.com) as an LLM provider. Telnyx offers OpenAI-compatible LLM inference at `api.telnyx.com/v2/ai` with access to models from Anthropic, Meta, Mistral, and others.

Also supports Voice AI capabilities (TTS, SIP trunking, real-time call control) for building voice-enabled AI assistants.

## Changes

- Add Telnyx `ProviderSpec` to `providers/registry.py` (gateway type, OpenAI-compatible)
- Add `telnyx` field to `ProvidersConfig` in `config/schema.py`
- Add Telnyx to providers table in `README.md`

## Config Example

```json
{
  "providers": {
    "telnyx": { "apiKey": "KEYxxxxxxxx" }
  },
  "agents": {
    "defaults": { "model": "meta-llama/Meta-Llama-3.1-70B-Instruct" }
  }
}
```

## Why Telnyx?

- **LLM inference**: OpenAI-compatible API, supports major model families
- **Voice AI**: Native TTS, SIP trunking, and programmable call control — build voice agents that talk on the phone
- **Telecom-native**: Numbers, SMS, and voice in one platform — no need to stitch together multiple services

Follows the 2-step provider pattern documented in the README. No changes to core logic needed.