### PR TITLE
feat(feishu): make reaction emoji configurable

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -276,7 +276,8 @@ class FeishuChannel(BaseChannel):
             msg_type = message.message_type
             
             # Add reaction to indicate "seen"
-            await self._add_reaction(message_id, "THUMBSUP")
+            if self.config.reaction_emoji:
+                await self._add_reaction(message_id, self.config.reaction_emoji)
             
             # Parse message content
             if msg_type == "text":

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -28,6 +28,7 @@ class FeishuConfig(BaseModel):
     encrypt_key: str = ""  # Encrypt Key for event subscription (optional)
     verification_token: str = ""  # Verification Token for event subscription (optional)
     allow_from: list[str] = Field(default_factory=list)  # Allowed user open_ids
+    reaction_emoji: str = "THUMBSUP"  # Emoji reaction on received messages (e.g. THUMBSUP, OK, DONE, OnIt, HEART; empty to disable). Full list: https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce
 
 
 class DingTalkConfig(BaseModel):


### PR DESCRIPTION
## Summary
- Add `reactionEmoji` config option to Feishu channel configuration
- Defaults to `THUMBSUP` for backward compatibility
- Set to empty string to disable reactions entirely
- Added link to Feishu emoji reference documentation

## Config Example
```json
{
  "channels": {
    "feishu": {
      "reactionEmoji": "OK"
    }
  }
}
```

Supported values: `THUMBSUP`, `OK`, `DONE`, `OnIt`, `HEART`, `EYES`, `LGTM`, `CheckMark`, etc.

Full list: https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-reaction/emojis-introduce