### PR TITLE
fix: incorrect tz in cron

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -50,6 +50,10 @@ class CronTool(Tool):
                     "type": "string",
                     "description": "Cron expression like '0 9 * * *' (for scheduled tasks)"
                 },
+                "timezone": {
+                    "type": "string",
+                    "description": "Timezone for cron expression (e.g. 'Asia/Bangkok', 'America/New_York'). Defaults to local timezone if not specified."
+                },
                 "job_id": {
                     "type": "string",
                     "description": "Job ID (for remove)"
@@ -64,18 +68,19 @@ class CronTool(Tool):
         message: str = "",
         every_seconds: int | None = None,
         cron_expr: str | None = None,
+        timezone: str | None = None,
         job_id: str | None = None,
         **kwargs: Any
     ) -> str:
         if action == "add":
-            return self._add_job(message, every_seconds, cron_expr)
+            return self._add_job(message, every_seconds, cron_expr, timezone)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
             return self._remove_job(job_id)
         return f"Unknown action: {action}"
-    
-    def _add_job(self, message: str, every_seconds: int | None, cron_expr: str | None) -> str:
+
+    def _add_job(self, message: str, every_seconds: int | None, cron_expr: str | None, timezone: str | None) -> str:
         if not message:
             return "Error: message is required for add"
         if not self._channel or not self._chat_id:
@@ -85,7 +90,7 @@ class CronTool(Tool):
         if every_seconds:
             schedule = CronSchedule(kind="every", every_ms=every_seconds * 1000)
         elif cron_expr:
-            schedule = CronSchedule(kind="cron", expr=cron_expr)
+            schedule = CronSchedule(kind="cron", expr=cron_expr, tz=timezone)
         else:
             return "Error: either every_seconds or cron_expr is required"
         

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -721,6 +721,7 @@ def cron_add(
     every: int = typer.Option(None, "--every", "-e", help="Run every N seconds"),
     cron_expr: str = typer.Option(None, "--cron", "-c", help="Cron expression (e.g. '0 9 * * *')"),
     at: str = typer.Option(None, "--at", help="Run once at time (ISO format)"),
+    timezone: str = typer.Option(None, "--timezone", "--tz", help="Timezone (e.g. 'Asia/Ho_Chi_Minh', 'America/New_York'). Defaults to local timezone."),
     deliver: bool = typer.Option(False, "--deliver", "-d", help="Deliver response to channel"),
     to: str = typer.Option(None, "--to", help="Recipient for delivery"),
     channel: str = typer.Option(None, "--channel", help="Channel for delivery (e.g. 'telegram', 'whatsapp')"),
@@ -729,12 +730,12 @@ def cron_add(
     from nanobot.config.loader import get_data_dir
     from nanobot.cron.service import CronService
     from nanobot.cron.types import CronSchedule
-    
+
     # Determine schedule type
     if every:
         schedule = CronSchedule(kind="every", every_ms=every * 1000)
     elif cron_expr:
-        schedule = CronSchedule(kind="cron", expr=cron_expr)
+        schedule = CronSchedule(kind="cron", expr=cron_expr, tz=timezone)
     elif at:
         import datetime
         dt = datetime.datetime.fromisoformat(at)

--- a/nanobot/skills/cron/SKILL.md
+++ b/nanobot/skills/cron/SKILL.md
@@ -24,6 +24,11 @@ Dynamic task (agent executes each time):
 cron(action="add", message="Check HKUDS/nanobot GitHub stars and report", every_seconds=600)
 ```
 
+With timezone (for cron expressions):
+```
+cron(action="add", message="Good morning!", cron_expr="0 7 * * *", timezone="Asia/Ho_Chi_Minh")
+```
+
 List/remove:
 ```
 cron(action="list")
@@ -38,3 +43,11 @@ cron(action="remove", job_id="abc123")
 | every hour | every_seconds: 3600 |
 | every day at 8am | cron_expr: "0 8 * * *" |
 | weekdays at 5pm | cron_expr: "0 17 * * 1-5" |
+
+## Timezone Support
+
+When using `cron_expr`, you can specify a timezone using the `timezone` parameter:
+- If specified: Uses the given timezone (e.g., "Asia/Ho_Chi_Minh", "America/New_York")
+- If not specified: Uses the system's local timezone
+
+**Note:** The `every_seconds` mode doesn't need timezone as it's interval-based.


### PR DESCRIPTION
msg: `Create a reminder at 8:00 with the content “Test”.`

```
> nanobot cron list
                        Scheduled Jobs
┏━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃ ID       ┃ Name ┃ Schedule    ┃ Status  ┃ Next Run         ┃
┡━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
│ 936059ca │ Test │ 26 19 * * * │ enabled │ 2026-02-10 20:00 │
└──────────┴──────┴─────────────┴─────────┴──────────────────┘
> timedatectl
               Local time: Mon 2026-02-09 19:53:14 +07
           Universal time: Mon 2026-02-09 12:53:14 UTC
                 RTC time: n/a
                Time zone: Asia/Ho_Chi_Minh (+07, +0700)
System clock synchronized: yes
              NTP service: active
          RTC in local TZ: no
```