### PR TITLE
fix(gitignore): remove broad tests/ ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@ docs/
 __pycache__/
 poetry.lock
 .pytest_cache/
-tests/
 botpy.log


### PR DESCRIPTION
### Summary
- Remove `tests/` from `.gitignore`.
- Restore normal behavior so new test files under `tests/` appear in `git status` without force-add.

### Context
- The `tests/` ignore rule was introduced in `34dc933`.
- Existing tracked tests continue to work, but new tests are silently ignored.

### Scope
- `.gitignore` only.
- No runtime behavior changes.

### Verification
- `touch tests/test_tmp_ignore_check.py`
- `git check-ignore -v tests/test_tmp_ignore_check.py` (no match after this change)
- `git status` shows the file as untracked
- remove temp file afterward

Closes #395