### PR TITLE
feat: implement configurable llm_timeout (default 5m)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -46,6 +46,7 @@ class AgentLoop:
         cron_service: "CronService | None" = None,
         restrict_to_workspace: bool = False,
         session_manager: SessionManager | None = None,
+        llm_timeout: int = 900,
     ):
         from nanobot.config.schema import ExecToolConfig
         from nanobot.cron.service import CronService
@@ -58,6 +59,7 @@ class AgentLoop:
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
+        self.llm_timeout = llm_timeout
         
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
@@ -195,7 +197,8 @@ class AgentLoop:
             response = await self.provider.chat(
                 messages=messages,
                 tools=self.tools.get_definitions(),
-                model=self.model
+                model=self.model,
+                timeout=self.llm_timeout
             )
             
             # Handle tool calls
@@ -301,7 +304,8 @@ class AgentLoop:
             response = await self.provider.chat(
                 messages=messages,
                 tools=self.tools.get_definitions(),
-                model=self.model
+                model=self.model,
+                timeout=self.llm_timeout
             )
             
             if response.has_tool_calls:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -211,6 +211,7 @@ def gateway(
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         session_manager=session_manager,
+        llm_timeout=config.agents.defaults.llm_timeout,
     )
     
     # Set cron callback (needs agent)
@@ -305,6 +306,7 @@ def agent(
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
+        llm_timeout=config.agents.defaults.llm_timeout,
     )
     
     if message:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -54,6 +54,7 @@ class AgentDefaults(BaseModel):
     max_tokens: int = 8192
     temperature: float = 0.7
     max_tool_iterations: int = 20
+    llm_timeout: int = 300  # Default 5 minutes
 
 
 class AgentsConfig(BaseModel):

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -47,6 +47,7 @@ class LLMProvider(ABC):
         model: str | None = None,
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        timeout: int | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request.

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -105,6 +105,7 @@ class LiteLLMProvider(LLMProvider):
         model: str | None = None,
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        timeout: int | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request via LiteLLM.
@@ -115,9 +116,7 @@ class LiteLLMProvider(LLMProvider):
             model: Model identifier (e.g., 'anthropic/claude-sonnet-4-5').
             max_tokens: Maximum tokens in response.
             temperature: Sampling temperature.
-        
-        Returns:
-            LLMResponse with content and/or tool calls.
+            timeout: Request timeout in seconds.
         """
         model = self._resolve_model(model or self.default_model)
         
@@ -127,6 +126,9 @@ class LiteLLMProvider(LLMProvider):
             "max_tokens": max_tokens,
             "temperature": temperature,
         }
+        
+        if timeout:
+            kwargs["timeout"] = timeout
         
         # Apply model-specific overrides (e.g. kimi-k2.5 temperature)
         self._apply_model_overrides(model, kwargs)


### PR DESCRIPTION
Adds llm_timeout to config, defaulting to 300s (5m). Updates AgentLoop and providers to respect this timeout.