### PR TITLE
feat: add tool allowlist via tools.enabled config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,16 @@ For OpenRouter - recommended for global users:
     "defaults": {
       "model": "anthropic/claude-opus-4-5"
     }
+  },
+  "tools": {
+    "enabled": []
   }
 }
 ```
+
+> `tools.enabled` is optional. Leave it empty (default) to enable all built-in tools.
+> Set a non-empty list to allow only selected tools.
+> Example allowlist: `"tools": { "enabled": ["read_file", "write_file", "message"] }`
 
 **3. Chat**
 
@@ -580,6 +587,7 @@ That's it! Environment variables, model prefixing, config matching, and `nanobot
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `tools.enabled` | `[]` (enable all) | Tool allowlist. Empty list keeps all built-in tools enabled. Non-empty list registers only named tools. Available names: `read_file`, `write_file`, `edit_file`, `list_dir`, `exec`, `web_search`, `web_fetch`, `message`, `spawn`, `cron` (only when cron service is active). |
 | `tools.restrictToWorkspace` | `false` | When `true`, restricts **all** agent tools (shell, file read/write/edit, list) to the workspace directory. Prevents path traversal and out-of-scope access. |
 | `channels.*.allowFrom` | `[]` (allow all) | Whitelist of user IDs. Empty = allow everyone; non-empty = only listed users can interact. |
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -359,6 +359,7 @@ def gateway(
         exec_config=config.tools.exec,
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
+        enabled_tools=config.tools.enabled,
         session_manager=session_manager,
     )
     
@@ -462,6 +463,7 @@ def agent(
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
+        enabled_tools=config.tools.enabled,
     )
     
     # Show spinner when logs are off (no output to miss); skip when logs are on

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -177,6 +177,7 @@ class ExecToolConfig(BaseModel):
 
 class ToolsConfig(BaseModel):
     """Tools configuration."""
+    enabled: list[str] = Field(default_factory=list)  # Empty = all tools enabled
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory


### PR DESCRIPTION
## 🎯 功能概述

新增工具白名单功能，允许用户通过 `config.json` 中的 `tools.enabled` 字段控制哪些工具被注册。

## 💡 动机

此前用户如果想限制 agent 可用的工具（例如禁用 shell 执行或文件写入），只能深入源码手动修改工具注册逻辑，门槛高且不易维护。该功能将工具权限控制提升到配置层面，用户只需编辑 `config.json` 即可完成。

## ✨ 主要特性

- ✅ **工具白名单** - `tools.enabled` 为空列表（默认）时启用全部工具；设置非空列表时仅注册指定工具
- ✅ **未知工具警告** - 配置中引用不存在的工具名时在启动时输出警告日志
- ✅ **子代理同步** - SubagentManager 同样遵守白名单配置，行为一致

## 📝 变更说明

### 修改文件
- `nanobot/config/schema.py` - `ToolsConfig` 新增 `enabled: list[str]` 字段
- `nanobot/agent/loop.py` - AgentLoop 按白名单注册工具，新增辅助方法
- `nanobot/agent/subagent.py` - SubagentManager 支持白名单
- `nanobot/cli/commands.py` - `gateway` 和 `agent` 命令传递 `enabled_tools` 参数
- `README.md` - 新增配置项文档说明和使用示例

## 使用示例

```json
{
  "tools": {
    "enabled": ["read_file", "write_file", "message"]
  }
}
```

空列表或省略该字段则启用全部工具。