### PR TITLE
fix: preserve reasoning_content and tool_calls in conversation history

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -239,7 +239,10 @@ class AgentLoop:
         
         # Save to session
         session.add_message("user", msg.content)
-        session.add_message("assistant", final_content)
+        # Preserve reasoning_content for reasoning models (Kimi K2.5, DeepSeek-R1, etc.)
+        # These models require reasoning_content in assistant messages when thinking is enabled
+        reasoning_content = getattr(response, 'reasoning_content', None)
+        session.add_message("assistant", final_content, reasoning_content=reasoning_content)
         self.sessions.save(session)
         
         return OutboundMessage(
@@ -339,7 +342,9 @@ class AgentLoop:
         
         # Save to session (mark as system message in history)
         session.add_message("user", f"[System: {msg.sender_id}] {msg.content}")
-        session.add_message("assistant", final_content)
+        # Preserve reasoning_content for reasoning models
+        reasoning_content = getattr(response, 'reasoning_content', None)
+        session.add_message("assistant", final_content, reasoning_content=reasoning_content)
         self.sessions.save(session)
         
         return OutboundMessage(


### PR DESCRIPTION
## Fix: Preserve reasoning_content and tool_calls in conversation history

### Problem
Multi-turn conversations with reasoning models (Kimi K2.5, DeepSeek-R1, etc.) fail with:

Error calling LLM: litellm.BadRequestError: Hosted_vllmException - {"error":{"message":"thinking is enabled but reasoning_content is missing in assistant tool call message at index 52","type":"invalid_request_error"}}

### Solution
- Preserve `tool_calls`, `reasoning_content`, and tool message fields in session history
- Save `reasoning_content` alongside assistant message content in both `_process_message()` and `_process_system_message()`

### Changed Files
- `nanobot/session/manager.py` - `Session.get_history()` 
- `nanobot/agent/loop.py` - Assistant message persistence (2 locations)
