### PR TITLE
feat: OpenRouter app attribution headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ For OpenRouter - recommended for global users:
 }
 ```
 
+`nanobot onboard` seeds OpenRouter attribution headers by default; set `providers.openrouter.extraHeaders` to `{}` to opt out.
+
 **3. Chat**
 
 ```bash

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -25,6 +25,10 @@ app = typer.Typer(
 
 console = Console()
 EXIT_COMMANDS = {"exit", "quit", "/exit", "/quit", ":q"}
+OPENROUTER_DEFAULT_EXTRA_HEADERS = {
+    "HTTP-Referer": "https://github.com/HKUDS/nanobot",
+    "X-Title": "nanobot",
+}
 
 # ---------------------------------------------------------------------------
 # Lightweight CLI input: readline for arrow keys / history, termios for flush
@@ -158,6 +162,19 @@ def _is_exit_command(command: str) -> bool:
     return command.lower() in EXIT_COMMANDS
 
 
+def _seed_openrouter_attribution_headers(config) -> None:
+    """Seed OpenRouter attribution headers when unset during onboarding."""
+    if config.providers.openrouter.extra_headers is None:
+        config.providers.openrouter.extra_headers = dict(OPENROUTER_DEFAULT_EXTRA_HEADERS)
+
+
+def _resolve_runtime_extra_headers(provider_name: str | None, extra_headers: dict[str, str] | None) -> dict[str, str] | None:
+    """Apply runtime OpenRouter attribution fallback when headers are unset."""
+    if provider_name == "openrouter" and extra_headers is None:
+        return dict(OPENROUTER_DEFAULT_EXTRA_HEADERS)
+    return extra_headers
+
+
 async def _read_interactive_input_async() -> str:
     """Read user input with arrow keys and history (runs input() in a thread)."""
     try:
@@ -203,6 +220,7 @@ def onboard():
     
     # Create default config
     config = Config()
+    _seed_openrouter_attribution_headers(config)
     save_config(config)
     console.print(f"[green]✓[/green] Created config at {config_path}")
     
@@ -303,6 +321,7 @@ def _make_provider(config):
     """Create LiteLLMProvider from config. Exits if no API key found."""
     from nanobot.providers.litellm_provider import LiteLLMProvider
     p = config.get_provider()
+    provider_name = config.get_provider_name()
     model = config.agents.defaults.model
     if not (p and p.api_key) and not model.startswith("bedrock/"):
         console.print("[red]Error: No API key configured.[/red]")
@@ -312,8 +331,8 @@ def _make_provider(config):
         api_key=p.api_key if p else None,
         api_base=config.get_api_base(),
         default_model=model,
-        extra_headers=p.extra_headers if p else None,
-        provider_name=config.get_provider_name(),
+        extra_headers=_resolve_runtime_extra_headers(provider_name, p.extra_headers if p else None),
+        provider_name=provider_name,
     )
 
 

--- a/tests/test_onboard_openrouter_defaults.py
+++ b/tests/test_onboard_openrouter_defaults.py
@@ -1,0 +1,54 @@
+from nanobot.cli.commands import (
+    OPENROUTER_DEFAULT_EXTRA_HEADERS,
+    _make_provider,
+    _resolve_runtime_extra_headers,
+    _seed_openrouter_attribution_headers,
+)
+from nanobot.config.schema import Config
+import pytest
+
+
+def test_do_not_override_intentionally_empty_openrouter_headers() -> None:
+    config = Config()
+    config.providers.openrouter.extra_headers = {}
+
+    _seed_openrouter_attribution_headers(config)
+
+    assert config.providers.openrouter.extra_headers == {}
+
+
+@pytest.mark.parametrize(
+    ("extra_headers", "expected"),
+    [
+        (None, OPENROUTER_DEFAULT_EXTRA_HEADERS),
+        ({}, {}),
+    ],
+)
+def test_runtime_fallback_handles_unset_and_explicit_empty(
+    extra_headers: dict[str, str] | None, expected: dict[str, str]
+) -> None:
+    resolved = _resolve_runtime_extra_headers("openrouter", extra_headers)
+
+    assert resolved == expected
+
+
+def test_make_provider_applies_openrouter_runtime_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class DummyProvider:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("nanobot.providers.litellm_provider.LiteLLMProvider", DummyProvider)
+
+    config = Config()
+    config.providers.openrouter.api_key = "sk-test"
+    config.providers.openrouter.extra_headers = None
+    config.agents.defaults.model = "openrouter/anthropic/claude-opus-4-5"
+
+    _make_provider(config)
+
+    assert captured["provider_name"] == "openrouter"
+    assert captured["extra_headers"] == OPENROUTER_DEFAULT_EXTRA_HEADERS


### PR DESCRIPTION
### What This Does
- During `nanobot onboard`, seed OpenRouter attribution headers in generated config **only when `providers.openrouter.extraHeaders` is unset (`None`)**:
  - `HTTP-Referer: https://github.com/HKUDS/nanobot`
  - `X-Title: nanobot`
- Add a runtime fallback in provider setup so existing users also get attribution headers when OpenRouter is selected and `extraHeaders` is unset.
- Keep user intent intact:
  - If a user already set custom headers, they are preserved.
  - If a user intentionally sets `{}` (empty headers), onboarding and runtime both respect that opt-out.

### Why
- OpenRouter supports app attribution via `HTTP-Referer` and `X-Title`.
- Defaulting these values improves nanobot visibility in OpenRouter app analytics/rankings.
- Runtime fallback means users do not need to re-run onboarding to benefit.

### What This Does NOT Change
- No provider routing/model-selection behavior.
- No forced attribution for users who explicitly opt out with `{}`.
- No changes to non-OpenRouter providers.

### Scope
- `nanobot/cli/commands.py`
  - onboarding seed helper
  - runtime header resolver used in `_make_provider`
  - shared default attribution constants
- `tests/test_onboard_openrouter_defaults.py`
  - regression coverage for preserving explicit empty headers
  - runtime fallback coverage for unset vs explicit empty headers

### Verification
- `uv run pytest tests/test_onboard_openrouter_defaults.py` (pass)

References:
- OpenRouter App Attribution docs: https://openrouter.ai/docs/app-attribution
- OpenRouter Rankings: https://openrouter.ai/rankings

_Attribution: Prepared with OpenCode (gpt-5.3-codex)_