### PR TITLE
Fix cron tool to support one-time jobs and reload store

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -249,7 +249,8 @@ class CronService:
     # ========== Public API ==========
     
     def list_jobs(self, include_disabled: bool = False) -> list[CronJob]:
-        """List all jobs."""
+        """List all jobs (reloads from disk to catch external changes)."""
+        self._store = None
         store = self._load_store()
         jobs = store.jobs if include_disabled else [j for j in store.jobs if j.enabled]
         return sorted(jobs, key=lambda j: j.state.next_run_at_ms or float('inf'))

--- a/nanobot/skills/cron/SKILL.md
+++ b/nanobot/skills/cron/SKILL.md
@@ -14,7 +14,12 @@ Use the `cron` tool to schedule reminders or recurring tasks.
 
 ## Examples
 
-Fixed reminder:
+One-time reminder:
+```
+cron(action="add", message="Call the doctor", run_at="2024-12-25T09:00:00")
+```
+
+Recurring reminder:
 ```
 cron(action="add", message="Time to take a break!", every_seconds=1200)
 ```
@@ -34,6 +39,8 @@ cron(action="remove", job_id="abc123")
 
 | User says | Parameters |
 |-----------|------------|
+| in 2 hours | run_at: (calculate ISO datetime) |
+| tomorrow at 9am | run_at: "2024-01-15T09:00:00" |
 | every 20 minutes | every_seconds: 1200 |
 | every hour | every_seconds: 3600 |
 | every day at 8am | cron_expr: "0 8 * * *" |


### PR DESCRIPTION
- Add run_at parameter for scheduling one-time jobs (ISO datetime)
- Reload jobs from disk in list_jobs() to see CLI-added jobs
- Update skill docs with one-time job examples

Reference to https://github.com/HKUDS/nanobot/issues/432