### PR TITLE
fix(telegram): preserve file extension for generic documents

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -309,7 +309,11 @@ class TelegramChannel(BaseChannel):
         if media_file and self._app:
             try:
                 file = await self._app.bot.get_file(media_file.file_id)
-                ext = self._get_extension(media_type, getattr(media_file, 'mime_type', None))
+                ext = self._get_extension(
+                    media_type, 
+                    getattr(media_file, 'mime_type', None),
+                    getattr(media_file, 'file_name', None)
+                )
                 
                 # Save to workspace/media/
                 from pathlib import Path
@@ -386,8 +390,12 @@ class TelegramChannel(BaseChannel):
         except Exception as e:
             logger.debug(f"Typing indicator stopped for {chat_id}: {e}")
     
-    def _get_extension(self, media_type: str, mime_type: str | None) -> str:
-        """Get file extension based on media type."""
+    def _get_extension(self, media_type: str, mime_type: str | None, filename: str | None = None) -> str:
+        """
+        Get file extension based on media type.
+        If mime_type is unknown, try to get extension from filename.
+        """
+        # 1. Try known mime types
         if mime_type:
             ext_map = {
                 "image/jpeg": ".jpg", "image/png": ".png", "image/gif": ".gif",
@@ -396,5 +404,14 @@ class TelegramChannel(BaseChannel):
             if mime_type in ext_map:
                 return ext_map[mime_type]
         
-        type_map = {"image": ".jpg", "voice": ".ogg", "audio": ".mp3", "file": ""}
-        return type_map.get(media_type, "")
+        # 2. Try simple type mapping
+        type_map = {"image": ".jpg", "voice": ".ogg", "audio": ".mp3"}
+        if media_type in type_map:
+            return type_map[media_type]
+            
+        # 3. Fallback: try to get extension from filename
+        if filename:
+            from pathlib import Path
+            return Path(filename).suffix
+            
+        return ""


### PR DESCRIPTION
# Description

This PR fixes an issue where generic files (e.g., PDFs, JSON, text files) sent to the Telegram bot would lose their file extensions when saved.

## Changes

- Modified [_get_extension](cci:1://file:///Users/ericzhang/projects/nanobot/nanobot/nanobot/channels/telegram.py:392:4-416:17) in [nanobot/channels/telegram.py](cci:7://file:///Users/ericzhang/projects/nanobot/nanobot/nanobot/channels/telegram.py:0:0-0:0) to accept an optional `filename`.
- Added fallback logic: if the MIME type is unknown (or returns an empty extension), the extension is extracted from the original filename.
- Updated [_on_message](cci:1://file:///Users/ericzhang/projects/nanobot/nanobot/nanobot/channels/telegram.py:263:4-367:9) to pass the filename from the Telegram file object.

## Verification

Verified using a reproduction script with mock objects. Confirmed that extensions are correctly preserved for:
- PDF files (`application/pdf`) -> `.pdf`
- JSON files (`application/json`) -> `.json`
- Text files (`text/plain`) -> `.txt`
- Archives (`unknown/type`) -> `.gz` (last suffix)

Existing image/audio logic remains unchanged.