### PR TITLE
This PR fixes the model double-prefix issue for using GLM model through OpenRouter.

### DIFF
--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -186,7 +186,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="ZAI_API_KEY",
         display_name="Zhipu AI",
         litellm_prefix="zai",              # glm-4 → zai/glm-4
-        skip_prefixes=("zhipu/", "zai/", "openrouter/", "hosted_vllm/"),
+        skip_prefixes=("zhipu/", "zai/", "z-ai/", "openrouter/", "hosted_vllm/"),
         env_extras=(
             ("ZHIPUAI_API_KEY", "{api_key}"),
         ),


### PR DESCRIPTION
Fixes #404

This PR fixes Zhipu model routing when the model already starts with z-ai/.

Change:
Add z-ai/ to Zhipu skip_prefixes in registry.py
Add a regression test in test_tool_validation.py to ensure z-ai/glm-4.5 is not rewritten to zai/z-ai/glm-4.5.
