### PR TITLE
fixed dingtalk exception.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "socksio>=1.0.0",
     "slack-sdk>=3.26.0",
     "qq-botpy>=1.0.0",
+    "python-socks[asyncio]>=2.4.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
fixed dingtalk connect exception.

> Message: 'unknown exception'
Arguments: (ImportError('connecting through a SOCKS proxy requires python-socks'),)
2026-02-10 10:20:31,957 dingtalk_stream.client INFO     open connection, url=https://api.dingtalk.com/v1.0/gateway/connections/open [stream.py:149]
^C2026-02-10 10:20:33,619 dingtalk_stream.client INFO     endpoint is {'endpoint': 'wss://wss-open-connection-union.dingtalk.com:443/connect', 'ticket': '1411e74a-0627-11f1-80c0-7e88154b8801'} [stream.py:71]