### PR TITLE
feat: add Venice.ai provider support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -187,6 +187,7 @@ class ProvidersConfig(BaseModel):
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
+    venice: ProviderConfig = Field(default_factory=ProviderConfig)  # Venice.ai (privacy-focused)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
 
 

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -241,6 +241,27 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         ),
     ),
 
+    # Venice.ai: Privacy-focused, uncensored models. OpenAI-compatible.
+    # Uses "openai/" prefix with custom api_base to route via LiteLLM.
+    ProviderSpec(
+        name="venice",
+        keywords=("venice",),
+        env_key="VENICE_API_KEY",
+        display_name="Venice.ai",
+        litellm_prefix="openai",            # Venice models → openai/{model}
+        skip_prefixes=(),
+        env_extras=(
+            ("OPENAI_API_BASE", "{api_base}"),
+        ),
+        is_gateway=False,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="venice",
+        default_api_base="https://api.venice.ai/api/v1",
+        strip_model_prefix=False,
+        model_overrides=(),
+    ),
+
     # === Local deployment (matched by config key, NOT by api_base) =========
 
     # vLLM / any OpenAI-compatible local server.


### PR DESCRIPTION
## Summary
Add Venice.ai as a new LLM provider for privacy-focused, uncensored inference.

## Changes
- Add Venice provider spec to `nanobot/providers/registry.py` (21 lines)
- Add `venice` field to `ProvidersConfig` in `nanobot/config/schema.py` (1 line)

## About Venice.ai
- OpenAI-compatible API at `https://api.venice.ai/api/v1`
- Privacy-focused inference (no data retention)
- Uncensored model lineup
- Standard Bearer auth

## Usage
json
{
"providers": {
    "venice": {
      "apiKey": "your-venice-api-key"
    }
  }
}
## Testing
- [ ] Verify Venice API key works
- [ ] Confirm models load correctly

---
**Note:** This is my first open-source contribution! 🎉
