### PR TITLE
feat: add sender_id and metadata support to context building

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -126,6 +126,8 @@ When remembering something, write to {workspace_path}/memory/MEMORY.md"""
         media: list[str] | None = None,
         channel: str | None = None,
         chat_id: str | None = None,
+        sender_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """
         Build the complete message list for an LLM call.
@@ -137,6 +139,8 @@ When remembering something, write to {workspace_path}/memory/MEMORY.md"""
             media: Optional list of local file paths for images/media.
             channel: Current channel (telegram, feishu, etc.).
             chat_id: Current chat/user ID.
+            sender_id: ID of the message sender.
+            metadata: Additional metadata associated with the message.
 
         Returns:
             List of messages including system prompt.
@@ -147,6 +151,12 @@ When remembering something, write to {workspace_path}/memory/MEMORY.md"""
         system_prompt = self.build_system_prompt(skill_names)
         if channel and chat_id:
             system_prompt += f"\n\n## Current Session\nChannel: {channel}\nChat ID: {chat_id}"
+        if sender_id:
+            system_prompt += f"\nSender ID: {sender_id}"
+        if metadata:
+            # Format metadata in a readable way
+            metadata_str = "\n".join([f"{k}: {v}" for k, v in metadata.items()])
+            system_prompt += f"\n## Metadata\n{metadata_str}"
         messages.append({"role": "system", "content": system_prompt})
 
         # History

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -182,6 +182,8 @@ class AgentLoop:
             media=msg.media if msg.media else None,
             channel=msg.channel,
             chat_id=msg.chat_id,
+            sender_id=msg.sender_id,
+            metadata=msg.metadata,
         )
         
         # Agent loop
@@ -291,6 +293,8 @@ class AgentLoop:
             current_message=msg.content,
             channel=origin_channel,
             chat_id=origin_chat_id,
+            sender_id=msg.sender_id,
+            metadata=msg.metadata,
         )
         
         # Agent loop (limited for announce handling)


### PR DESCRIPTION
- Add sender_id and metadata parameters to build_messages method in context.py
- Pass sender_id and metadata from agent loop to context builder
- Display sender_id and metadata in system prompt for better context awareness