### PR TITLE
feat: add Telegram PlanBridge command/callback loop

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+import urllib.error
+import urllib.request
 
 from loguru import logger
-from telegram import BotCommand, Update
-from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
+from telegram import BotCommand, InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -96,6 +107,10 @@ class TelegramChannel(BaseChannel):
         BotCommand("start", "Start the bot"),
         BotCommand("reset", "Reset conversation history"),
         BotCommand("help", "Show available commands"),
+        BotCommand("plan_reply", "Reply to plan questions"),
+        BotCommand("plan_run", "Run a ready plan"),
+        BotCommand("plan_cancel", "Cancel plan execution"),
+        BotCommand("task_status", "Query Codex task status"),
     ]
     
     def __init__(
@@ -112,6 +127,8 @@ class TelegramChannel(BaseChannel):
         self._app: Application | None = None
         self._chat_ids: dict[str, int] = {}  # Map sender_id to chat_id for replies
         self._typing_tasks: dict[str, asyncio.Task] = {}  # chat_id -> typing loop task
+        self._pending_exec_confirms: set[tuple[str, str]] = set()  # (chat_id, task_id)
+        self._workspace_path = str(Path.home() / ".nanobot" / "workspace")
     
     async def start(self) -> None:
         """Start the Telegram bot with long polling."""
@@ -131,12 +148,16 @@ class TelegramChannel(BaseChannel):
         self._app.add_handler(CommandHandler("start", self._on_start))
         self._app.add_handler(CommandHandler("reset", self._on_reset))
         self._app.add_handler(CommandHandler("help", self._on_help))
-        
+        self._app.add_handler(CommandHandler("plan_reply", self._on_plan_reply))
+        self._app.add_handler(CommandHandler("plan_run", self._on_plan_run))
+        self._app.add_handler(CommandHandler("plan_cancel", self._on_plan_cancel))
+        self._app.add_handler(CommandHandler("task_status", self._on_task_status))
+        self._app.add_handler(CallbackQueryHandler(self._on_callback_query))
+
         # Add message handler for text, photos, voice, documents
         self._app.add_handler(
             MessageHandler(
-                (filters.TEXT | filters.PHOTO | filters.VOICE | filters.AUDIO | filters.Document.ALL) 
-                & ~filters.COMMAND, 
+                (filters.TEXT | filters.PHOTO | filters.VOICE | filters.AUDIO | filters.Document.ALL),
                 self._on_message
             )
         )
@@ -159,8 +180,8 @@ class TelegramChannel(BaseChannel):
         
         # Start polling (this runs until stopped)
         await self._app.updater.start_polling(
-            allowed_updates=["message"],
-            drop_pending_updates=True  # Ignore old messages on startup
+            allowed_updates=["message", "callback_query"],
+            drop_pending_updates=self.config.drop_pending_updates
         )
         
         # Keep running until stopped
@@ -190,12 +211,15 @@ class TelegramChannel(BaseChannel):
         
         # Stop typing indicator for this chat
         self._stop_typing(msg.chat_id)
+        text_content = (msg.content or "").strip()
+        if not text_content:
+            text_content = "抱歉，这次回复为空。请再发一次，我马上重试。"
         
         try:
             # chat_id should be the Telegram chat ID (integer)
             chat_id = int(msg.chat_id)
             # Convert markdown to Telegram HTML
-            html_content = _markdown_to_telegram_html(msg.content)
+            html_content = _markdown_to_telegram_html(text_content)
             await self._app.bot.send_message(
                 chat_id=chat_id,
                 text=html_content,
@@ -209,7 +233,7 @@ class TelegramChannel(BaseChannel):
             try:
                 await self._app.bot.send_message(
                     chat_id=int(msg.chat_id),
-                    text=msg.content
+                    text=text_content
                 )
             except Exception as e2:
                 logger.error(f"Error sending Telegram message: {e2}")
@@ -256,11 +280,15 @@ class TelegramChannel(BaseChannel):
             "🐈 <b>nanobot commands</b>\n\n"
             "/start — Start the bot\n"
             "/reset — Reset conversation history\n"
-            "/help — Show this help message\n\n"
+            "/help — Show this help message\n"
+            "/plan_reply & /plan-reply — Reply to PlanBridge questions\n"
+            "/plan_run & /plan-run — Execute a ready plan\n"
+            "/plan_cancel & /plan-cancel — Cancel a pending plan run\n"
+            "/task_status & /task-status — Query task status\n\n"
             "Just send me a text message to chat!"
         )
         await update.message.reply_text(help_text, parse_mode="HTML")
-    
+
     async def _on_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming messages (text, photos, voice, documents)."""
         if not update.message or not update.effective_user:
@@ -277,7 +305,29 @@ class TelegramChannel(BaseChannel):
         
         # Store chat_id for replies
         self._chat_ids[sender_id] = chat_id
-        
+
+        # Handle hyphen-style plan commands that may not be parsed by Telegram command menu.
+        if message.text:
+            if await self._maybe_handle_plan_text_command(
+                update=update,
+                sender_id=sender_id,
+                text=message.text,
+            ):
+                return
+
+            # Optional auto-bind for plain text replies when exactly one needs_input task is open.
+            if (
+                self.config.plan_bridge_auto_bind_natural_language
+                and not message.text.strip().startswith("/")
+                and not (message.photo or message.voice or message.audio or message.document)
+            ):
+                if await self._maybe_auto_bind_plan_reply(
+                    update=update,
+                    sender_id=sender_id,
+                    text=message.text.strip(),
+                ):
+                    return
+
         # Build content from text and/or media
         content_parts = []
         media_paths = []
@@ -312,7 +362,6 @@ class TelegramChannel(BaseChannel):
                 ext = self._get_extension(media_type, getattr(media_file, 'mime_type', None))
                 
                 # Save to workspace/media/
-                from pathlib import Path
                 media_dir = Path.home() / ".nanobot" / "media"
                 media_dir.mkdir(parents=True, exist_ok=True)
                 
@@ -361,6 +410,429 @@ class TelegramChannel(BaseChannel):
                 "first_name": user.first_name,
                 "is_group": message.chat.type != "private"
             }
+        )
+
+    async def _on_plan_reply(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /plan_reply command."""
+        if not update.message or not update.effective_user:
+            return
+        sender_id = self._sender_id(update.effective_user.id, update.effective_user.username)
+        if not self.is_allowed(sender_id):
+            await update.message.reply_text("未授权用户，无法执行该操作。")
+            return
+        if len(context.args) < 2:
+            await update.message.reply_text("用法：/plan-reply <task_id> <你的回答>")
+            return
+        task_id = context.args[0].strip()
+        answer = " ".join(context.args[1:]).strip()
+        await self._submit_plan_reply(update.message.chat_id, task_id, answer)
+
+    async def _on_plan_run(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /plan_run command."""
+        if not update.message or not update.effective_user:
+            return
+        sender_id = self._sender_id(update.effective_user.id, update.effective_user.username)
+        if not self.is_allowed(sender_id):
+            await update.message.reply_text("未授权用户，无法执行该操作。")
+            return
+        if len(context.args) < 1:
+            await update.message.reply_text("用法：/plan-run <task_id>")
+            return
+        await self._submit_plan_run(update.message.chat_id, context.args[0].strip())
+
+    async def _on_plan_cancel(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /plan_cancel command."""
+        if not update.message or not update.effective_user:
+            return
+        sender_id = self._sender_id(update.effective_user.id, update.effective_user.username)
+        if not self.is_allowed(sender_id):
+            await update.message.reply_text("未授权用户，无法执行该操作。")
+            return
+        if len(context.args) < 1:
+            await update.message.reply_text("用法：/plan-cancel <task_id>")
+            return
+        await self._cancel_task(update.message.chat_id, context.args[0].strip())
+
+    async def _on_task_status(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /task_status command."""
+        if not update.message or not update.effective_user:
+            return
+        sender_id = self._sender_id(update.effective_user.id, update.effective_user.username)
+        if not self.is_allowed(sender_id):
+            await update.message.reply_text("未授权用户，无法执行该操作。")
+            return
+        if len(context.args) < 1:
+            await update.message.reply_text("用法：/task-status <task_id>")
+            return
+        task_id = context.args[0].strip()
+        try:
+            task = await self._listener_get_json(f"/tasks/{task_id}")
+        except RuntimeError as e:
+            await update.message.reply_text(f"查询失败：{e}")
+            return
+        await update.message.reply_text(self._format_task_status(task))
+
+    async def _on_callback_query(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle PlanBridge action buttons from codex-listener messages."""
+        if not update.callback_query or not update.effective_user:
+            return
+        if not self.config.plan_bridge_buttons_enabled:
+            return
+
+        query = update.callback_query
+        data = query.data or ""
+        sender_id = self._sender_id(update.effective_user.id, update.effective_user.username)
+        if not self.is_allowed(sender_id):
+            await query.answer("未授权", show_alert=True)
+            return
+
+        if not data.startswith("pb1|"):
+            await query.answer()
+            return
+
+        parts = data.split("|", 2)
+        if len(parts) != 3:
+            await query.answer("无效按钮")
+            return
+        _, action, task_id = parts
+        chat_id = str(query.message.chat_id) if query.message else ""
+
+        await query.answer()
+
+        if action == "exec":
+            if self.config.plan_bridge_require_execute_confirm:
+                self._pending_exec_confirms.add((chat_id, task_id))
+                keyboard = InlineKeyboardMarkup(
+                    [
+                        [
+                            InlineKeyboardButton("✅ 确认执行", callback_data=f"pb1|exec_confirm|{task_id}"),
+                            InlineKeyboardButton("❎ 取消", callback_data=f"pb1|exec_abort|{task_id}"),
+                        ]
+                    ]
+                )
+                if query.message:
+                    await query.message.reply_text(
+                        f"请二次确认是否执行计划（task_id={task_id}）。",
+                        reply_markup=keyboard,
+                    )
+                return
+            await self._submit_plan_run(chat_id, task_id)
+            return
+
+        if action == "exec_confirm":
+            if self.config.plan_bridge_require_execute_confirm and (chat_id, task_id) not in self._pending_exec_confirms:
+                if query.message:
+                    await query.message.reply_text("确认态已失效，请重新点击“执行计划”。")
+                return
+            self._pending_exec_confirms.discard((chat_id, task_id))
+            await self._submit_plan_run(chat_id, task_id)
+            return
+
+        if action == "exec_abort":
+            self._pending_exec_confirms.discard((chat_id, task_id))
+            if query.message:
+                await query.message.reply_text(f"已取消执行（task_id={task_id}）。")
+            return
+
+        if action == "cancel":
+            self._pending_exec_confirms.discard((chat_id, task_id))
+            if query.message:
+                await query.message.reply_text(f"已记录取消，不会执行该计划（task_id={task_id}）。")
+            return
+
+    async def _maybe_handle_plan_text_command(
+        self,
+        update: Update,
+        sender_id: str,
+        text: str,
+    ) -> bool:
+        """Handle hyphen-style plan commands in plain text."""
+        if not update.message:
+            return False
+
+        raw = text.strip()
+        if not raw.startswith("/"):
+            return False
+
+        m = re.match(
+            r"^/(plan-reply|plan_run|plan-run|plan_cancel|plan-cancel|task-status|task_status|plan_reply)\b(?:@\w+)?\s*(.*)$",
+            raw,
+            flags=re.IGNORECASE,
+        )
+        if not m:
+            return False
+
+        if not self.is_allowed(sender_id):
+            await update.message.reply_text("未授权用户，无法执行该操作。")
+            return True
+
+        cmd = m.group(1).lower().replace("_", "-")
+        rest = (m.group(2) or "").strip()
+
+        if cmd == "plan-reply":
+            parts = rest.split(maxsplit=1)
+            if len(parts) < 2:
+                await update.message.reply_text("用法：/plan-reply <task_id> <你的回答>")
+                return True
+            await self._submit_plan_reply(update.message.chat_id, parts[0].strip(), parts[1].strip())
+            return True
+
+        if cmd == "plan-run":
+            if not rest:
+                await update.message.reply_text("用法：/plan-run <task_id>")
+                return True
+            await self._submit_plan_run(update.message.chat_id, rest.split(maxsplit=1)[0].strip())
+            return True
+
+        if cmd == "plan-cancel":
+            if not rest:
+                await update.message.reply_text("用法：/plan-cancel <task_id>")
+                return True
+            await self._cancel_task(update.message.chat_id, rest.split(maxsplit=1)[0].strip())
+            return True
+
+        if cmd == "task-status":
+            if not rest:
+                await update.message.reply_text("用法：/task-status <task_id>")
+                return True
+            task_id = rest.split(maxsplit=1)[0].strip()
+            try:
+                task = await self._listener_get_json(f"/tasks/{task_id}")
+            except RuntimeError as e:
+                await update.message.reply_text(f"查询失败：{e}")
+                return True
+            await update.message.reply_text(self._format_task_status(task))
+            return True
+
+        return False
+
+    async def _maybe_auto_bind_plan_reply(
+        self,
+        update: Update,
+        sender_id: str,
+        text: str,
+    ) -> bool:
+        """Auto-bind plain text reply to exactly one open needs_input task."""
+        if not update.message or not text:
+            return False
+        if not self.is_allowed(sender_id):
+            return False
+
+        try:
+            open_tasks = await self._list_open_needs_input_tasks()
+        except RuntimeError as e:
+            logger.warning(f"Auto-bind skipped: {e}")
+            return False
+
+        if len(open_tasks) == 0:
+            return False
+        if len(open_tasks) > 1:
+            ids = ", ".join(t["task_id"] for t in open_tasks[:5] if t.get("task_id"))
+            await update.message.reply_text(
+                "检测到多个待回答 Plan 任务，请使用：/plan-reply <task_id> <你的回答>\n"
+                f"候选 task_id: {ids}"
+            )
+            return True
+
+        task = open_tasks[0]
+        task_id = str(task.get("task_id", "")).strip()
+        if not task_id:
+            return False
+        await self._submit_plan_reply(update.message.chat_id, task_id, text)
+        return True
+
+    async def _submit_plan_reply(self, chat_id: int | str, task_id: str, answer: str) -> None:
+        """Create a plan_bridge child task by replying to needs_input."""
+        try:
+            parent = await self._listener_get_json(f"/tasks/{task_id}")
+        except RuntimeError as e:
+            await self._reply_text(chat_id, f"读取任务失败：{e}")
+            return
+
+        if parent.get("bridge_stage") != "needs_input":
+            await self._reply_text(chat_id, f"任务 {task_id} 当前不是 needs_input 阶段。")
+            return
+        session_id = str(parent.get("session_id") or "").strip()
+        if not session_id:
+            await self._reply_text(chat_id, f"任务 {task_id} 缺少 session_id，无法 resume。")
+            return
+
+        prompt = (
+            "用户已回答上一轮澄清问题。请继续 PlanBridge。\n"
+            "要求：如果还需要信息，输出 planmode.v1 needs_input JSON；"
+            "如果信息充分，输出 planmode.v1 plan_ready JSON。\n"
+            "禁止执行实现。\n\n"
+            f"用户回答：{answer}"
+        )
+        payload = {
+            "prompt": prompt,
+            "cwd": self._workspace_path,
+            "workflow_mode": "plan_bridge",
+            "resume_session_id": session_id,
+            "parent_task_id": task_id,
+        }
+        try:
+            created = await self._listener_post_json("/tasks", payload)
+        except RuntimeError as e:
+            await self._reply_text(chat_id, f"提交失败：{e}")
+            return
+        new_id = created.get("task_id")
+        await self._reply_text(chat_id, f"已提交续跑任务：{new_id}")
+
+    async def _submit_plan_run(self, chat_id: int | str, task_id: str) -> None:
+        """Create a normal execution task from a plan_ready task."""
+        try:
+            parent = await self._listener_get_json(f"/tasks/{task_id}")
+        except RuntimeError as e:
+            await self._reply_text(chat_id, f"读取任务失败：{e}")
+            return
+
+        if parent.get("bridge_stage") != "plan_ready":
+            await self._reply_text(chat_id, f"任务 {task_id} 当前不是 plan_ready 阶段。")
+            return
+        plan_md = str(parent.get("bridge_plan") or "").strip()
+        if not plan_md:
+            await self._reply_text(chat_id, f"任务 {task_id} 没有可执行计划内容。")
+            return
+
+        prompt = (
+            "执行以下已确认计划。\n"
+            "要求：按计划执行；涉及删除/覆盖前先二次确认；"
+            "最终输出关键验收结果。\n\n"
+            f"{plan_md}"
+        )
+        payload = {
+            "prompt": prompt,
+            "cwd": self._workspace_path,
+            "workflow_mode": "normal",
+            "parent_task_id": task_id,
+        }
+        try:
+            created = await self._listener_post_json("/tasks", payload)
+        except RuntimeError as e:
+            await self._reply_text(chat_id, f"提交执行任务失败：{e}")
+            return
+        new_id = created.get("task_id")
+        await self._reply_text(chat_id, f"已提交执行任务：{new_id}")
+
+    async def _cancel_task(self, chat_id: int | str, task_id: str) -> None:
+        """Cancel a running/pending listener task."""
+        try:
+            task = await self._listener_delete_json(f"/tasks/{task_id}")
+        except RuntimeError as e:
+            await self._reply_text(chat_id, f"取消失败：{e}")
+            return
+        status = task.get("status")
+        await self._reply_text(chat_id, f"已处理取消请求：task_id={task_id}, status={status}")
+
+    async def _list_open_needs_input_tasks(self) -> list[dict[str, Any]]:
+        """Return unresolved plan_bridge needs_input tasks."""
+        tasks = await self._listener_get_json("/tasks")
+        if not isinstance(tasks, list):
+            return []
+        referenced: set[str] = set()
+        for t in tasks:
+            if isinstance(t, dict):
+                parent = t.get("parent_task_id")
+                if isinstance(parent, str) and parent.strip():
+                    referenced.add(parent.strip())
+        result: list[dict[str, Any]] = []
+        for t in tasks:
+            if not isinstance(t, dict):
+                continue
+            task_id = str(t.get("task_id") or "").strip()
+            if not task_id:
+                continue
+            if t.get("bridge_stage") != "needs_input":
+                continue
+            if task_id in referenced:
+                continue
+            if str(t.get("workflow_mode") or "") != "plan_bridge":
+                continue
+            if not str(t.get("session_id") or "").strip():
+                continue
+            result.append(t)
+        return result
+
+    def _sender_id(self, user_id: int, username: str | None) -> str:
+        """Build sender id with username compatibility."""
+        if username:
+            return f"{user_id}|{username}"
+        return str(user_id)
+
+    async def _reply_text(self, chat_id: int | str, text: str) -> None:
+        """Reply to chat with a plain text message."""
+        if not self._app:
+            return
+        try:
+            await self._app.bot.send_message(chat_id=int(chat_id), text=text)
+        except Exception as e:
+            logger.warning(f"Reply failed: {e}")
+
+    def _listener_url(self, path: str) -> str:
+        """Build listener API URL."""
+        base = self.config.codex_listener_base_url.rstrip("/")
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"{base}{path}"
+
+    async def _listener_get_json(self, path: str) -> Any:
+        return await self._listener_request_json("GET", path, None)
+
+    async def _listener_post_json(self, path: str, payload: dict[str, Any]) -> Any:
+        return await self._listener_request_json("POST", path, payload)
+
+    async def _listener_delete_json(self, path: str) -> Any:
+        return await self._listener_request_json("DELETE", path, None)
+
+    async def _listener_request_json(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None,
+    ) -> Any:
+        """HTTP JSON request to codex-listener."""
+        url = self._listener_url(path)
+
+        def _request() -> Any:
+            data = None
+            headers: dict[str, str] = {}
+            if payload is not None:
+                data = json.dumps(payload).encode("utf-8")
+                headers["Content-Type"] = "application/json"
+            req = urllib.request.Request(url, data=data, headers=headers, method=method)
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+                if not raw:
+                    return {}
+                return json.loads(raw)
+
+        try:
+            return await asyncio.to_thread(_request)
+        except urllib.error.HTTPError as e:
+            detail = e.reason
+            try:
+                body = e.read().decode("utf-8", errors="replace")
+                parsed = json.loads(body)
+                if isinstance(parsed, dict) and parsed.get("detail"):
+                    detail = parsed.get("detail")
+            except Exception:
+                pass
+            raise RuntimeError(f"HTTP {e.code}: {detail}") from e
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+            raise RuntimeError(str(e)) from e
+
+    def _format_task_status(self, task: dict[str, Any]) -> str:
+        """Build a compact task status summary."""
+        task_id = task.get("task_id")
+        status = task.get("status")
+        bridge = task.get("bridge_stage")
+        session_id = task.get("session_id")
+        return (
+            f"task_id={task_id}\n"
+            f"status={status}\n"
+            f"bridge_stage={bridge}\n"
+            f"session_id={session_id}"
         )
     
     def _start_typing(self, chat_id: str) -> None:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -18,6 +18,13 @@ class TelegramConfig(BaseModel):
     token: str = ""  # Bot token from @BotFather
     allow_from: list[str] = Field(default_factory=list)  # Allowed user IDs or usernames
     proxy: str | None = None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
+    drop_pending_updates: bool = True  # Drop queued updates on startup
+    startup_retry_attempts: int = 3  # Startup retries when Telegram polling fails
+    startup_retry_delay_seconds: int = 5  # Delay between startup retries
+    codex_listener_base_url: str = "http://127.0.0.1:19823"  # Codex-Listener API base URL
+    plan_bridge_buttons_enabled: bool = True  # Show PlanBridge inline buttons from listener
+    plan_bridge_auto_bind_natural_language: bool = True  # Auto-bind plain text replies to single open needs_input task
+    plan_bridge_require_execute_confirm: bool = True  # Require second tap before creating execution task
 
 
 class FeishuConfig(BaseModel):


### PR DESCRIPTION
## 概要
- 在 nanobot 频道中添加 Telegram PlanBridge 控制
- 支持 Telegram 回调查询和内联按钮操作
- 添加 PlanBridge 命令：
  - `/plan_reply` (别名 `/plan-reply` 文本)
  - `/plan_run` (别名 `/plan-run` 文本)
  - `/plan_cancel` (别名 `/plan-cancel` 文本)
  - `/task_status` (别名 `/task-status` 文本)
- 为单个打开的 `needs_input` 任务添加自然语言自动绑定
- 为 `plan_ready` 运行操作添加执行二次确认保护
- 在 Telegram 配置中添加可配置的监听器 URL 和 PlanBridge 开关

## 范围说明 
- 此 PR 在 `nanobot/agent/loop.py` 中包含一个额外的非按钮核心改进：
  - 当达到工具迭代限制或最终内容为空时，提供更好的回退响应
  - 用可操作的摘要文本替换通用的空响应

## 文件
- `nanobot/channels/telegram.py`
- `nanobot/config/schema.py`
- `nanobot/channels/manager.py`
- `nanobot/agent/loop.py`

## 验证
- `python3 -m py_compile` 通过了修改的文件
- 从频道辅助方法测试了监听器 `/tasks` 集成
- 通过 `/tasks` API 验证了 PlanBridge 子任务提交
- 服务健康已验证：`codex-listener` 和 `nanobot-gateway` 处于活动状态

相关https://github.com/TalexCK/Codex-Listener/pull/7