### PR TITLE
feat(provider): add Volcengine (Doubao) support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -189,6 +189,7 @@ class ProvidersConfig(BaseModel):
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
+    doubao: ProviderConfig = Field(default_factory=ProviderConfig)  # Volcengine Doubao
 
 
 class GatewayConfig(BaseModel):

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -1,5 +1,7 @@
 """Base LLM provider interface."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -83,9 +83,17 @@ class LiteLLMProvider(LLMProvider):
         
         # Standard mode: auto-prefix for known providers
         spec = find_by_model(model)
-        if spec and spec.litellm_prefix:
-            if not any(model.startswith(s) for s in spec.skip_prefixes):
-                model = f"{spec.litellm_prefix}/{model}"
+        if spec:
+            # Support stripping prefix for standard providers (e.g. doubao/ep-xxx -> ep-xxx)
+            if spec.strip_model_prefix and "/" in model:
+                # Only strip if the prefix matches one of the provider's keywords or name
+                prefix, rest = model.split("/", 1)
+                if prefix.lower() == spec.name or prefix.lower() in spec.keywords:
+                    model = rest
+
+            if spec.litellm_prefix:
+                if not any(model.startswith(s) for s in spec.skip_prefixes):
+                    model = f"{spec.litellm_prefix}/{model}"
         
         return model
     

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -260,6 +260,25 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         model_overrides=(),
     ),
 
+    # Volcengine (Doubao): needs "volcengine/" prefix for LiteLLM routing.
+    # Compatible with OpenAI SDK.
+    ProviderSpec(
+        name="doubao",
+        keywords=("doubao", "volcengine"),
+        env_key="VOLCENGINE_API_KEY",
+        display_name="Doubao",
+        litellm_prefix="volcengine",        # doubao-pro-32k → volcengine/doubao-pro-32k
+        skip_prefixes=("volcengine/",),     # avoid double-prefix
+        env_extras=(),
+        is_gateway=False,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="",
+        default_api_base="https://ark.cn-beijing.volces.com/api/v3",
+        strip_model_prefix=True,            # doubao/ep-xxx -> ep-xxx -> volcengine/ep-xxx
+        model_overrides=(),
+    ),
+
     # === Local deployment (matched by config key, NOT by api_base) =========
 
     # vLLM / any OpenAI-compatible local server.


### PR DESCRIPTION
- Add Doubao provider definition in registry with prefix stripping
- Update configuration schema to include 'doubao' field
- Enhance LiteLLM provider to support stripping prefixes for standard providers
- Fix type hint compatibility in base.py for Python 3.9+