### PR TITLE
fix: pydantic deprecation configdict

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -1,7 +1,7 @@
 """Configuration schema using Pydantic."""
 
 from pathlib import Path
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from pydantic_settings import BaseSettings
 
 
@@ -281,6 +281,7 @@ class Config(BaseSettings):
                 return spec.default_api_base
         return None
     
-    class Config:
-        env_prefix = "NANOBOT_"
-        env_nested_delimiter = "__"
+    model_config = ConfigDict(
+        env_prefix="NANOBOT_",
+        env_nested_delimiter="__"
+    )


### PR DESCRIPTION
## Summary
Resolves the `PydanticDeprecatedSince20` warning by replacing the legacy inner `class Config` with the modern `model_config = ConfigDict(...)` pattern in [nanobot/config/schema.py](cci:7://file:///home/sergio/repos/nanobot/nanobot/config/schema.py:0:0-0:0).

## Changes
- Updated [nanobot/config/schema.py](cci:7://file:///home/sergio/repos/nanobot/nanobot/config/schema.py:0:0-0:0) to import `ConfigDict`.
- Replaced `class Config` with `model_config` in the root [Config](cci:2://file:///home/sergio/repos/nanobot/nanobot/config/schema.py:222:0-286:5) class.

## Testing
- Verified with `uv run pytest` (All 16 tests pass with 0 warnings).
- Verified `nanobot status` still correctly loads and displays configuration.