### PR TITLE
Fix bug: cron service ignored timezone in schedule calculation

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -29,10 +29,14 @@ def _compute_next_run(schedule: CronSchedule, now_ms: int) -> int | None:
     
     if schedule.kind == "cron" and schedule.expr:
         try:
+            from datetime import datetime
+            from zoneinfo import ZoneInfo
             from croniter import croniter
-            cron = croniter(schedule.expr, time.time())
-            next_time = cron.get_next()
-            return int(next_time * 1000)
+            tz = ZoneInfo(schedule.tz) if schedule.tz else ZoneInfo("UTC")
+            base = datetime.now(tz)
+            cron = croniter(schedule.expr, base)
+            next_time = cron.get_next(datetime)
+            return int(next_time.timestamp() * 1000)
         except Exception:
             return None
     
@@ -142,7 +146,7 @@ class CronService:
             ]
         }
         
-        self.store_path.write_text(json.dumps(data, indent=2))
+        self.store_path.write_text(json.dumps(data, indent=2,ensure_ascii=False))
     
     async def start(self) -> None:
         """Start the cron service."""


### PR DESCRIPTION
This PR fixes a bug where cron schedules ignored the configured timezone. The cron service now computes next run times using the schedule’s tz, ensuring correct execution time across DST changes.