### PR TITLE
Show raw url to link whatsapp device in case qr is not readable

### DIFF
--- a/bridge/src/whatsapp.ts
+++ b/bridge/src/whatsapp.ts
@@ -77,6 +77,7 @@ export class WhatsAppClient {
       if (qr) {
         // Display QR code in terminal
         console.log('\n📱 Scan this QR code with WhatsApp (Linked Devices):\n');
+        console.log(`\n or just navigate to: ${qr}`);
         qrcode.generate(qr, { small: true });
         this.options.onQR(qr);
       }


### PR DESCRIPTION
qr code is unreadable in logs, let's see if url is usable