### PR TITLE
feat: add interleaved chain-of-thought to agent loop

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -103,7 +103,7 @@ IMPORTANT: When responding to direct questions or conversations, reply directly 
 Only use the 'message' tool when you need to send a message to a specific chat channel (like WhatsApp).
 For normal conversation, just respond with text - do not call the message tool.
 
-Always be helpful, accurate, and concise. When using tools, explain what you're doing.
+Always be helpful, accurate, and concise. When using tools, think step by step: what you know, what you need, and why you chose this tool.
 When remembering something, write to {workspace_path}/memory/MEMORY.md"""
     
     def _load_bootstrap_files(self) -> str:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -225,6 +225,8 @@ class AgentLoop:
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
+                # Interleaved CoT: reflect before next action
+                messages.append({"role": "user", "content": "Reflect on the results and decide next steps."})
             else:
                 # No tool calls, we're done
                 final_content = response.content
@@ -330,6 +332,8 @@ class AgentLoop:
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
+                # Interleaved CoT: reflect before next action
+                messages.append({"role": "user", "content": "Reflect on the results and decide next steps."})
             else:
                 final_content = response.content
                 break


### PR DESCRIPTION
## Summary

Add interleaved chain-of-thought (ICoT) to the agent loop in just **+5 lines of code**, staying true to nanobot's ultra-lightweight philosophy.

Instead of building a heavy reasoning framework with separate think/act/observe phases and multiple LLM calls per iteration, we achieve ICoT with two surgical changes:

1. **System prompt**: One sentence that nudges the model to reason before acting — "think step by step: what you know, what you need, and why you chose this tool"
2. **Reflection injection**: One line after tool execution that appends a reflection prompt to the context, guiding the model to analyze results before its next move

This naturally forms a **Think → Act → Observe → Reflect** loop without any architectural overhead — no extra LLM calls, no new abstractions, no additional dependencies. The cost is ~20 tokens per tool-use round.

### Why this approach?

nanobot delivers core agent functionality in ~4,000 lines of code. A full ICoT framework (explicit reasoning phases, separate planning calls, observation summarizers) would add complexity that contradicts this principle. Our approach lets the existing `while` loop do all the work — we just give the model better context to reason with. Simple prompt engineering, maximum leverage.

## Changes

| File | Change |
|------|--------|
| `nanobot/agent/context.py` | Updated system prompt to encourage step-by-step reasoning before tool calls |
| `nanobot/agent/loop.py` | Added one-line reflection prompt after tool execution in both `_process_message` and `_process_system_message` |

## Cost

- Zero extra LLM calls — reflection prompt is appended to context before the next (already scheduled) iteration
- ~20 tokens per tool-use round
- No new dependencies, fully backward compatible with all providers