### PR TITLE
fix(subagent): add edit_file tool and time context to sub agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ⚡️ Delivers core agent functionality in just **~4,000** lines of code — **99% smaller** than Clawdbot's 430k+ lines.
 
-📏 Real-time line count: **3,510 lines** (run `bash core_agent_lines.sh` to verify anytime)
+📏 Real-time line count: **3,578 lines** (run `bash core_agent_lines.sh` to verify anytime)
 
 ## 📢 News
 

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -12,7 +12,7 @@ from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMProvider
 from nanobot.agent.tools.registry import ToolRegistry
-from nanobot.agent.tools.filesystem import ReadFileTool, WriteFileTool, ListDirTool
+from nanobot.agent.tools.filesystem import ReadFileTool, WriteFileTool, EditFileTool, ListDirTool
 from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.web import WebSearchTool, WebFetchTool
 
@@ -101,6 +101,7 @@ class SubagentManager:
             allowed_dir = self.workspace if self.restrict_to_workspace else None
             tools.register(ReadFileTool(allowed_dir=allowed_dir))
             tools.register(WriteFileTool(allowed_dir=allowed_dir))
+            tools.register(EditFileTool(allowed_dir=allowed_dir))
             tools.register(ListDirTool(allowed_dir=allowed_dir))
             tools.register(ExecTool(
                 working_dir=str(self.workspace),
@@ -210,12 +211,17 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
     
     def _build_subagent_prompt(self, task: str) -> str:
         """Build a focused system prompt for the subagent."""
+        from datetime import datetime
+        import time as _time
+        now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
+        tz = _time.strftime("%Z") or "UTC"
+
         return f"""# Subagent
 
-You are a subagent spawned by the main agent to complete a specific task.
+## Current Time
+{now} ({tz})
 
-## Your Task
-{task}
+You are a subagent spawned by the main agent to complete a specific task.
 
 ## Rules
 1. Stay focused - complete only the assigned task, nothing else
@@ -236,6 +242,7 @@ You are a subagent spawned by the main agent to complete a specific task.
 
 ## Workspace
 Your workspace is at: {self.workspace}
+Skills are available at: {self.workspace}/skills/ (read SKILL.md files as needed)
 
 When you have completed the task, provide a clear summary of your findings or actions."""
     


### PR DESCRIPTION
## Summary

Enhance subagent with missing capabilities that the main agent already has:

- **Add `edit_file` tool** — main agent has it, subagent was missing it. Without it, subagent has to read entire files and rewrite them just to change a few lines.
- **Add current time & timezone** — subagent had no time awareness, causing issues with any time-sensitive task.
- **Add skills path hint** — one line telling subagent where to find skills, so it can `read_file` them on demand.
- **Remove duplicate task** — task was in both system prompt and user message; keep only user message.

## Changes

Single file: `nanobot/agent/subagent.py`

| Change | Lines |
|--------|-------|
| Add `EditFileTool` import + register | +2 |
| Add time/timezone to prompt | +4 |
| Add skills path to prompt | +1 |
| Remove duplicate task from prompt | -3 |
| **Net** | **+4** |

## Why

Subagent is meant to be a lightweight worker, but missing `edit_file` was a functional gap — not a design choice. Time and skills awareness cost almost nothing in tokens but meaningfully improve task quality.