### PR TITLE
feat: Add Nvidia Nim API Support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -189,7 +189,7 @@ class ProvidersConfig(BaseModel):
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
-
+    nvidia: ProviderConfig = Field(default_factory=ProviderConfig) # NVIDIA NIM API
 
 class GatewayConfig(BaseModel):
     """Gateway/server configuration."""

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -65,6 +65,24 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
     # === Gateways (detected by api_key / api_base, not model name) =========
     # Gateways can route any model, so they win in fallback.
 
+    # NVIDIA NIM API
+    ProviderSpec(
+        name="nvidia",
+        keywords=("nvidia", "nvidia_nim"),
+        env_key="NVIDIA_API_KEY",
+        display_name="NVIDIA NIM",
+        litellm_prefix="",
+        skip_prefixes=(),
+        env_extras=(),
+        is_gateway=True,
+        is_local=False,
+        detect_by_key_prefix="nvapi-",
+        detect_by_base_keyword="nvidia",
+        default_api_base="https://integrate.api.nvidia.com/v1",
+        strip_model_prefix=False,
+        model_overrides=(),
+    ),
+
     # OpenRouter: global gateway, keys start with "sk-or-"
     ProviderSpec(
         name="openrouter",


### PR DESCRIPTION
### Description
Added support for NVIDIA NIM API.
from https://github.com/HKUDS/nanobot#providers

### Usage
1. Visit https://build.nvidia.com/
2. Select the model you wish to use.
3. Click **View Code** in the top right corner to get the exact model identifier.
   - Example for Kimi k2.5: `"model": "moonshotai/kimi-k2.5"`>>"nvidia_nim/moonshotai/kimi-k2.5"
4. Configure your `config.json` as shown in the example below.

### Configuration Example

```json
{
...
  "agents": {
    "defaults": {
      "model": "nvidia_nim/moonshotai/kimi-k2.5",
      "provider": "nvidia",
      "temperature": 1.0,
      "maxTokens": 16384,
      "maxToolIterations": 20,
      "systemPrompt": "..."
    }
  },
...
  "providers": {
    "nvidia": {
      "apiKey": "nvapi-YOUR_KEY",
      "apiBase": "https://integrate.api.nvidia.com/v1"
    }
  },
...
}
```

### Code Changes Reference

#### 1. nanobot/config/schema.py
```python
...
class ProvidersConfig(BaseModel):
    """Configuration for LLM providers."""
    anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
    ...
    aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
    nvidia: ProviderConfig = Field(default_factory=ProviderConfig) # NVIDIA NIM API

class GatewayConfig(BaseModel):
...
```

#### 2. nanobot/providers/registry.py
```python
...
PROVIDERS: tuple[ProviderSpec, ...] = (
    # === Gateways (detected by api_key / api_base, not model name) =========
    # Gateways can route any model, so they win in fallback.

    # NVIDIA NIM API
    ProviderSpec(
        name="nvidia",
        keywords=("nvidia", "nvidia_nim"),
        env_key="NVIDIA_API_KEY",
        display_name="NVIDIA NIM",
        litellm_prefix="",
        skip_prefixes=(),
        env_extras=(),
        is_gateway=True,
        is_local=False,
        detect_by_key_prefix="nvapi-",
        detect_by_base_keyword="nvidia",
        default_api_base="https://integrate.api.nvidia.com/v1",
        strip_model_prefix=False,
        model_overrides=(),
    ),

    # OpenRouter: global gateway, keys start with "sk-or-"
    ProviderSpec(
        name="openrouter",
...
```