### PR TITLE
feat: add Azure OpenAI provider support

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -279,6 +279,7 @@ def _make_provider(config):
         default_model=model,
         extra_headers=p.extra_headers if p else None,
         provider_name=config.get_provider_name(),
+        api_version=p.api_version if p else None,
     )
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -172,6 +172,7 @@ class ProviderConfig(BaseModel):
     """LLM provider configuration."""
     api_key: str = ""
     api_base: str | None = None
+    api_version: str | None = None  # API version (required for Azure OpenAI)
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
 
 
@@ -188,6 +189,7 @@ class ProvidersConfig(BaseModel):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
+    azure: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
 
 

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -21,8 +21,9 @@ class ProviderSpec:
     """One LLM provider's metadata. See PROVIDERS below for real examples.
 
     Placeholders in env_extras values:
-      {api_key}  — the user's API key
-      {api_base} — api_base from config, or this spec's default_api_base
+      {api_key}      — the user's API key
+      {api_base}     — api_base from config, or this spec's default_api_base
+      {api_version}  — api_version from config (used by Azure OpenAI)
     """
 
     # identity
@@ -137,6 +138,28 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_key_prefix="",
         detect_by_base_keyword="",
         default_api_base="",
+        strip_model_prefix=False,
+        model_overrides=(),
+    ),
+
+    # Azure OpenAI: uses "azure/" prefix for LiteLLM routing.
+    # Requires api_base (resource endpoint) and api_version.
+    ProviderSpec(
+        name="azure",
+        keywords=("azure",),
+        env_key="AZURE_API_KEY",
+        display_name="Azure OpenAI",
+        litellm_prefix="azure",             # gpt-4o → azure/gpt-4o
+        skip_prefixes=("azure/",),          # avoid double-prefix
+        env_extras=(
+            ("AZURE_API_BASE", "{api_base}"),
+            ("AZURE_API_VERSION", "{api_version}"),
+        ),
+        is_gateway=False,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="",
+        default_api_base="",                # user must provide in config
         strip_model_prefix=False,
         model_overrides=(),
     ),


### PR DESCRIPTION
## Summary

- Add Azure OpenAI as a first-class provider, enabling users to connect nanobot to Azure-hosted OpenAI deployments
- Add `api_version` field to `ProviderConfig` to support Azure's required API versioning
- Wire `api_version` through the full call chain: config → CLI → LiteLLMProvider → litellm.acompletion()

## Changes

| File | Change |
|------|--------|
| `nanobot/providers/registry.py` | Add Azure `ProviderSpec` with `azure/` prefix, `AZURE_API_KEY`/`AZURE_API_BASE`/`AZURE_API_VERSION` env mapping |
| `nanobot/config/schema.py` | Add `api_version` to `ProviderConfig`; add `azure` to `ProvidersConfig` |
| `nanobot/providers/litellm_provider.py` | Accept `api_version` param; resolve `{api_version}` placeholder in env_extras; pass `api_version` to `acompletion()` for `azure/` models |
| `nanobot/cli/commands.py` | Pass `p.api_version` through `_make_provider()` |

## Usage

```json
{
  "providers": {
    "azure": {
      "apiKey": "your-azure-key",
      "apiBase": "https://your-resource.openai.azure.com",
      "apiVersion": "2025-01-01-preview"
    }
  },
  "agents": {
    "defaults": {
      "model": "azure/your-deployment-name"
    }
  }
}
```

## Test plan

- [x] Verify `nanobot status` shows Azure OpenAI in provider list
- [x] Verify `nanobot agent -m "Hello"` works with Azure config
- [x] Verify existing providers (OpenAI, Anthropic, etc.) are unaffected
