### PR TITLE
Add max iterations info to fallback message

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -243,7 +243,10 @@ class AgentLoop:
                 break
         
         if final_content is None:
-            final_content = "I've completed processing but have no response to give."
+            if iteration >= self.max_iterations:
+                final_content = f"Reached {self.max_iterations} iterations without completion."
+            else:
+                final_content = "I've completed processing but have no response to give."
         
         # Log response preview
         preview = final_content[:120] + "..." if len(final_content) > 120 else final_content


### PR DESCRIPTION
When LLM reaches max iterations without completion, show a clearer message indicating the iteration limit was reached.