### PR TITLE
feat(qq): add group chat support alongside existing C2C messages

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -13,16 +13,17 @@ from nanobot.config.schema import QQConfig
 
 try:
     import botpy
-    from botpy.message import C2CMessage
+    from botpy.message import C2CMessage, GroupMessage
 
     QQ_AVAILABLE = True
 except ImportError:
     QQ_AVAILABLE = False
     botpy = None
     C2CMessage = None
+    GroupMessage = None
 
 if TYPE_CHECKING:
-    from botpy.message import C2CMessage
+    from botpy.message import C2CMessage, GroupMessage
 
 
 def _make_bot_class(channel: "QQChannel") -> "type[botpy.Client]":
@@ -38,6 +39,9 @@ def _make_bot_class(channel: "QQChannel") -> "type[botpy.Client]":
 
         async def on_c2c_message_create(self, message: "C2CMessage"):
             await channel._on_message(message)
+
+        async def on_group_at_message_create(self, message: "GroupMessage"):
+            await channel._on_group_message(message)
 
         async def on_direct_message_create(self, message):
             await channel._on_message(message)
@@ -72,7 +76,7 @@ class QQChannel(BaseChannel):
         self._client = BotClass()
 
         self._bot_task = asyncio.create_task(self._run_bot())
-        logger.info("QQ bot started (C2C private message)")
+        logger.info("QQ bot started (C2C + group chat)")
 
     async def _run_bot(self) -> None:
         """Run the bot connection with auto-reconnect."""
@@ -102,16 +106,25 @@ class QQChannel(BaseChannel):
             logger.warning("QQ client not initialized")
             return
         try:
-            await self._client.api.post_c2c_message(
-                openid=msg.chat_id,
-                msg_type=0,
-                content=msg.content,
-            )
+            metadata = msg.metadata or {}
+            if metadata.get("msg_type") == "group":
+                await self._client.api.post_group_message(
+                    group_openid=metadata["group_openid"],
+                    msg_type=0,
+                    content=msg.content,
+                    msg_id=metadata.get("message_id"),
+                )
+            else:
+                await self._client.api.post_c2c_message(
+                    openid=msg.chat_id,
+                    msg_type=0,
+                    content=msg.content,
+                )
         except Exception as e:
             logger.error(f"Error sending QQ message: {e}")
 
     async def _on_message(self, data: "C2CMessage") -> None:
-        """Handle incoming message from QQ."""
+        """Handle incoming C2C/direct message from QQ."""
         try:
             # Dedup by message ID
             if data.id in self._processed_ids:
@@ -132,3 +145,39 @@ class QQChannel(BaseChannel):
             )
         except Exception as e:
             logger.error(f"Error handling QQ message: {e}")
+
+    async def _on_group_message(self, data: "GroupMessage") -> None:
+        """Handle incoming group @bot message from QQ."""
+        try:
+            # Dedup by message ID
+            if data.id in self._processed_ids:
+                return
+            self._processed_ids.append(data.id)
+
+            group_openid = data.group_openid
+            member_openid = data.author.member_openid
+
+            # Strip the leading @bot mention that botpy delivers as-is
+            content = (data.content or "").strip()
+            # The @mention typically appears as a leading slash or whitespace-prefixed segment
+            # botpy delivers it with a leading space after the mention; strip it
+            if content.startswith("/"):
+                content = content[1:].strip()
+            content = content.strip()
+            if not content:
+                return
+
+            logger.debug(f"QQ group message from {member_openid} in group {group_openid}")
+
+            await self._handle_message(
+                sender_id=member_openid,
+                chat_id=group_openid,
+                content=content,
+                metadata={
+                    "msg_type": "group",
+                    "group_openid": group_openid,
+                    "message_id": data.id,
+                },
+            )
+        except Exception as e:
+            logger.error(f"Error handling QQ group message: {e}")


### PR DESCRIPTION
Previously the QQ channel only handled private (C2C) messages, silently dropping group @bot mentions. This adds on_group_at_message_create handler, routes send() between post_c2c_message and post_group_message based on metadata, and uses group_openid as chat_id for per-group sessions.