### PR TITLE
feat(perf): async memory consolidation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-12 - [Async Memory Consolidation]
+**Learning:** Moving heavy LLM operations (like memory consolidation) to background tasks requires careful handling of shared mutable state (sessions). Using an offset-based approach for trimming (`messages[n_removed:]`) is safer than negative slicing (`messages[-keep:]`) when the list can grow concurrently. Also, always track background tasks in a set to prevent garbage collection.
+**Action:** When optimizing long-running operations in async loops, always ensure state consistency and task lifecycle management.


### PR DESCRIPTION
Moved memory consolidation to a background task to prevent blocking the main agent loop during message processing. This significantly reduces per-message latency when the session history exceeds the memory window.

- `AgentLoop.process_message` now spawns `_consolidate_memory` as a background task using `asyncio.create_task`.
- Added `_active_consolidations` set to prevent concurrent consolidations for the same session.
- Added `_background_tasks` set to hold references to running tasks.
- Updated `_consolidate_memory` to safely trim session messages by removing only the processed prefix (`messages[n_removed:]`), ensuring new messages added during the async operation are preserved.
- Wrapped consolidation logic in `try...finally` to ensure cleanup of `_active_consolidations`.