### PR TITLE
Fix: Telegram proxy issue

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -116,10 +116,9 @@ class TelegramChannel(BaseChannel):
         self._running = True
         
         # Build the application with larger connection pool to avoid pool-timeout on long runs
-        req = HTTPXRequest(connection_pool_size=16, pool_timeout=5.0, connect_timeout=30.0, read_timeout=30.0)
+        proxy_url = self.config.proxy or None
+        req = HTTPXRequest(connection_pool_size=16, pool_timeout=5.0, connect_timeout=30.0, read_timeout=30.0, proxy=proxy_url)
         builder = Application.builder().token(self.config.token).request(req).get_updates_request(req)
-        if self.config.proxy:
-            builder = builder.proxy(self.config.proxy).get_updates_proxy(self.config.proxy)
         self._app = builder.build()
         self._app.add_error_handler(self._on_error)
         


### PR DESCRIPTION
Fix Telegram start error: "The parameter `proxy` may only be set, if no request instance was set"