### PR TITLE
feat(agent): support custom identity via IDENTITY.md

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -80,9 +80,18 @@ Skills with available="false" need dependencies installed first - you can try in
         system = platform.system()
         runtime = f"{'macOS' if system == 'Darwin' else system} {platform.machine()}, Python {platform.python_version()}"
         
-        return f"""# nanobot 🐈
+        # Use custom identity from IDENTITY.md if present, otherwise default
+        identity_file = self.workspace / "IDENTITY.md"
+        if identity_file.exists():
+            header = "# Agent"
+            intro = "You are an AI agent. Your identity is defined in IDENTITY.md below. You have access to tools that allow you to:"
+        else:
+            header = "# nanobot 🐈"
+            intro = "You are nanobot, a helpful AI assistant. You have access to tools that allow you to:"
 
-You are nanobot, a helpful AI assistant. You have access to tools that allow you to:
+        return f"""{header}
+
+{intro}
 - Read, write, and edit files
 - Execute shell commands
 - Search the web and fetch web pages


### PR DESCRIPTION
## Summary

- When `IDENTITY.md` exists in the workspace, the hardcoded "You are nanobot, a helpful AI assistant" intro is replaced with a neutral line that defers to the IDENTITY.md content (which is already loaded as a bootstrap file)
- When `IDENTITY.md` is absent, the original default is preserved — full backward compatibility
- Enables users to fully customize their agent's identity through workspace files without code changes

## Changes

`nanobot/agent/context.py` — `_get_identity()` now checks for `IDENTITY.md` in the workspace. If present, uses a generic header (`# Agent`) and intro. If absent, keeps the original `# nanobot` header and intro.

## Test plan

- [ ] Verify default behavior unchanged: remove IDENTITY.md from workspace, confirm system prompt still says "You are nanobot"
- [ ] Verify custom identity: add IDENTITY.md to workspace, confirm system prompt says "You are an AI agent. Your identity is defined in IDENTITY.md below."
- [ ] Verify IDENTITY.md content is still loaded as a bootstrap file (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)