### PR TITLE
feat(heartbeat): add run_on_start for immediate first tick

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -365,7 +365,8 @@ def gateway(
         workspace=config.workspace_path,
         on_heartbeat=on_heartbeat,
         interval_s=30 * 60,  # 30 minutes
-        enabled=True
+        enabled=True,
+        run_on_start=True,
     )
     
     # Create channel manager

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -49,11 +49,13 @@ class HeartbeatService:
         on_heartbeat: Callable[[str], Coroutine[Any, Any, str]] | None = None,
         interval_s: int = DEFAULT_HEARTBEAT_INTERVAL_S,
         enabled: bool = True,
+        run_on_start: bool = False,
     ):
         self.workspace = workspace
         self.on_heartbeat = on_heartbeat
         self.interval_s = interval_s
         self.enabled = enabled
+        self.run_on_start = run_on_start
         self._running = False
         self._task: asyncio.Task | None = None
     
@@ -89,6 +91,12 @@ class HeartbeatService:
     
     async def _run_loop(self) -> None:
         """Main heartbeat loop."""
+        if self.run_on_start:
+            try:
+                logger.info("Heartbeat: running startup tick")
+                await self._tick()
+            except Exception as e:
+                logger.error(f"Heartbeat startup tick error: {e}")
         while self._running:
             try:
                 await asyncio.sleep(self.interval_s)


### PR DESCRIPTION
## Summary

- Adds a `run_on_start` parameter to `HeartbeatService` (default `False`) that fires the heartbeat immediately on startup before entering the regular interval loop
- The gateway command now passes `run_on_start=True` so the agent checks HEARTBEAT.md tasks immediately when the gateway starts
- Without this, the first heartbeat only fires after 30 minutes, meaning any pending tasks in HEARTBEAT.md are ignored for the first half hour after startup

## Changes

- `nanobot/heartbeat/service.py` — new `run_on_start` parameter in `__init__`, startup tick in `_run_loop()` before the sleep loop
- `nanobot/cli/commands.py` — passes `run_on_start=True` to the gateway's HeartbeatService

## Test plan

- [ ] Verify gateway starts and heartbeat fires immediately (check logs for "Heartbeat: running startup tick")
- [ ] Verify regular 30-minute interval still works after the initial tick
- [ ] Verify `run_on_start=False` (default) preserves old behavior — no immediate tick
- [ ] Verify startup tick handles errors gracefully without crashing the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)