### PR TITLE
feat: add custom provider and non-destructive onboard

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -155,21 +155,21 @@ def main(
 @app.command()
 def onboard():
     """Initialize nanobot configuration and workspace."""
-    from nanobot.config.loader import get_config_path, save_config
+    from nanobot.config.loader import get_config_path, load_config, save_config
     from nanobot.config.schema import Config
     from nanobot.utils.helpers import get_workspace_path
     
     config_path = get_config_path()
     
     if config_path.exists():
-        console.print(f"[yellow]Config already exists at {config_path}[/yellow]")
-        if not typer.confirm("Overwrite?"):
-            raise typer.Exit()
-    
-    # Create default config
-    config = Config()
-    save_config(config)
-    console.print(f"[green]✓[/green] Created config at {config_path}")
+        # Load existing config — Pydantic fills in defaults for any new fields
+        config = load_config()
+        save_config(config)
+        console.print(f"[green]✓[/green] Config refreshed at {config_path} (existing values preserved)")
+    else:
+        config = Config()
+        save_config(config)
+        console.print(f"[green]✓[/green] Created config at {config_path}")
     
     # Create workspace
     workspace = get_workspace_path()

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -179,6 +179,7 @@ class ProviderConfig(BaseModel):
 
 class ProvidersConfig(BaseModel):
     """Configuration for LLM providers."""
+    custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -62,6 +62,20 @@ class ProviderSpec:
 
 PROVIDERS: tuple[ProviderSpec, ...] = (
 
+    # === Custom (user-provided OpenAI-compatible endpoint) =================
+    # No auto-detection — only activates when user explicitly configures "custom".
+
+    ProviderSpec(
+        name="custom",
+        keywords=(),
+        env_key="OPENAI_API_KEY",
+        display_name="Custom",
+        litellm_prefix="openai",
+        skip_prefixes=("openai/",),
+        is_gateway=True,
+        strip_model_prefix=True,
+    ),
+
     # === Gateways (detected by api_key / api_base, not model name) =========
     # Gateways can route any model, so they win in fallback.
 


### PR DESCRIPTION
## Summary
- Add a `custom` provider entry (gateway mode, OpenAI-compatible) so users can connect to any endpoint (e.g. MiniMax, local LLMs) without waiting for native support.
- Refactor `nanobot onboard` to load-merge-save instead of overwrite, so existing config values (API keys, tokens) are preserved while new schema fields are auto-populated.

## Changes
### Custom Provider (`schema.py` + `registry.py`)
- New `custom` field in `ProvidersConfig` for any OpenAI-compatible endpoint
- New `ProviderSpec` with `is_gateway=True`, `litellm_prefix="openai"`, `strip_model_prefix=True`
- `keywords=()` ensures it only activates when explicitly configured, never by model-name matching

### Non-destructive Onboard (`commands.py`)
- Previously: `nanobot onboard` on existing config prompted "Overwrite?" and replaced everything with empty defaults
- Now: loads existing config via Pydantic (which auto-fills new fields with defaults), then saves back — existing values preserved, new fields added