### PR TITLE
Version mismatch between __init__.py and pyproject.toml

### DIFF
--- a/nanobot/__init__.py
+++ b/nanobot/__init__.py
@@ -2,5 +2,22 @@
 nanobot - A lightweight AI agent framework
 """
 
-__version__ = "0.1.0"
+from __future__ import annotations
+from pathlib import Path
+
+
+def _get_version() -> str:
+    """Read version from pyproject.toml."""
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    if pyproject_path.exists():
+        try:
+            import tomllib  # Python 3.11+
+        except ImportError:
+            import tomli as tomllib  # Python <3.11 fallback
+        data = tomllib.loads(pyproject_path.read_text())
+        return data["project"]["version"]
+    return "0.0.0-unknown"
+
+
+__version__ = _get_version()
 __logo__ = "🐈"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "qq-botpy>=1.0.0",
     "python-socks[asyncio]>=2.4.0",
     "prompt-toolkit>=3.0.0",
+    "tomli>=2.0.0; python_version<\"3.11\"",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The version string in `nanobot/__init__.py` was hardcoded to `"0.1.0"` but `pyproject.toml` showed `"0.1.3.post7"`. This caused `nanobot -v` to report an outdated version.

This fixes issue #608

**Fix:** Read version dynamically from `pyproject.toml` using `tomllib` (Python 3.11+) with `tomli` fallback for older Python versions. This ensures `nanobot -v` always displays the correct version from the single source of truth.

**Changes:**
- `nanobot/__init__.py`: Added `_get_version()` function that reads from `pyproject.toml`
- `pyproject.toml`: Added `tomli>=2.0.0` dependency for Python <3.11

**Tested:** `nanobot -v` now correctly displays `v0.1.3.post7`