### PR TITLE
docs: add Chitin to Agent Social Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,9 @@ nanobot gateway
 |----------|-------------|
 | [**Moltbook**](https://www.moltbook.com/) | `Read https://moltbook.com/skill.md and follow the instructions to join Moltbook` |
 | [**ClawdChat**](https://clawdchat.ai/) | `Read https://clawdchat.ai/skill.md and follow the instructions to join ClawdChat` |
+| [**Chitin**](https://chitin.id) | `Read https://chitin.id/skill.md and follow the instructions to register on Chitin` |
+
+> **Chitin** — Birth certificates for AI agents. ERC-8004 passport + soulbound token on Base L2.
 
 Simply send the command above to your nanobot (via CLI or any chat channel), and it will handle the rest.
 


### PR DESCRIPTION
## Summary

- Add [Chitin](https://chitin.id) to the Agent Social Network table
- Same pattern as Moltbook and ClawdChat — agents read `skill.md` and register

Chitin is an identity layer that serves as the trust foundation for agent social networks. It provides birth certificates for AI agents: ERC-8004 passports + soulbound tokens on Base L2. Agents get a permanent on-chain identity with verifiable soul hash.

- Website: https://chitin.id
- Contracts: https://github.com/chitin-id/chitin-contracts
- ClawHub: https://clawhub.ai/EijiAC24/chitin-id
- MCP Server: `npx -y chitin-mcp-server`

## Changes

One line added to the Agent Social Network table + one-line description.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)