### PR TITLE
增加支持飞书富文本内容接收。Add support for receiving Feishu rich text content.

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -40,15 +40,19 @@ MSG_TYPE_MAP = {
 
 
 def _extract_post_text(content_json: dict) -> str:
-    """Extract plain text from Feishu post (rich text) message content."""
-    for lang_key in ("zh_cn", "en_us", "ja_jp"):
-        lang_content = content_json.get(lang_key)
+    """Extract plain text from Feishu post (rich text) message content.
+    
+    Supports two formats:
+    1. Direct format: {"title": "...", "content": [...]}
+    2. Localized format: {"zh_cn": {"title": "...", "content": [...]}}
+    """
+    def extract_from_lang(lang_content: dict) -> str | None:
         if not isinstance(lang_content, dict):
-            continue
+            return None
         title = lang_content.get("title", "")
         content_blocks = lang_content.get("content", [])
         if not isinstance(content_blocks, list):
-            continue
+            return None
         text_parts = []
         if title:
             text_parts.append(title)
@@ -64,7 +68,21 @@ def _extract_post_text(content_json: dict) -> str:
                         text_parts.append(element.get("text", ""))
                     elif tag == "at":
                         text_parts.append(f"@{element.get('user_name', 'user')}")
-        return " ".join(text_parts).strip()
+        return " ".join(text_parts).strip() if text_parts else None
+    
+    # Try direct format first
+    if "content" in content_json:
+        result = extract_from_lang(content_json)
+        if result:
+            return result
+    
+    # Try localized format
+    for lang_key in ("zh_cn", "en_us", "ja_jp"):
+        lang_content = content_json.get(lang_key)
+        result = extract_from_lang(lang_content)
+        if result:
+            return result
+    
     return ""
 
 


### PR DESCRIPTION
## 飞书富文本消息解析功能 - 综合总结

### 功能概述

这两次提交为飞书频道新增了**富文本消息内容提取功能**，使系统能够从飞书的帖子类型消息中提取纯文本内容，便于后续处理和显示。

---

### 技术实现

**新增函数**: `_extract_post_text(content_json: dict) -> str`

**支持的解析元素**:
| 元素类型 | 标签 | 提取内容 |
|---------|------|---------|
| 标题 | `title` | 帖子标题 |
| 文本 | `text` | 纯文本内容 |
| 链接 | `a` | 链接显示文本 |
| 提及 | `at` | `@用户名` 格式 |

**支持的消息格式**:
1. **直接格式**: `{"title": "...", "content": [...]}`
2. **本地化格式**: `{"zh_cn": {"title": "...", "content": [...]}}`

---

### 代码变更

| 提交 | 类型 | 变更 |
|-----|------|------|
| 第一次 | feat | 新增 `_extract_post_text` 函数，在消息处理中增加 `post` 类型支持 |
| 第二次 | refactor | 重构函数，抽取内部函数 `extract_from_lang`，支持双格式解析 |

---

### 影响范围

修改文件: [nanobot/channels/feishu.py](file:///home/ahwei/nanobot/nanobot/channels/feishu.py)

总计变更: **+59 行, -6 行**

该功能增强了飞书频道的消息处理能力，使用户发送的富文本帖子消息能够被正确解析为纯文本内容。