### PR TITLE
feat: include timezone in system prompt current time

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -73,7 +73,7 @@ Skills with available="false" need dependencies installed first - you can try in
     def _get_identity(self) -> str:
         """Get the core identity section."""
         from datetime import datetime
-        now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
+        now = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M (%A), %Z (UTC%z)")
         workspace_path = str(self.workspace.expanduser().resolve())
         system = platform.system()
         runtime = f"{'macOS' if system == 'Darwin' else system} {platform.machine()}, Python {platform.python_version()}"


### PR DESCRIPTION
The agent now sees the timezone (e.g. CET, UTC+0100) alongside the current time, so it can give timezone-aware answers and schedule tasks correctly for the user's locale.
This compensates for situations where the agent is led to believe they are in a different timezone.