### PR TITLE
feat: add MCP client support via FastMCP library

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -331,6 +331,11 @@ def gateway(
     cron_store_path = get_data_dir() / "cron" / "jobs.json"
     cron = CronService(cron_store_path)
     
+    # MCP servers status
+    mcp_servers = [n for n, s in config.mcp.servers.items() if s.enabled]
+    if mcp_servers:
+        console.print(f"[green]✓[/green] MCP servers: {', '.join(mcp_servers)}")
+
     # Create agent with cron service
     agent = AgentLoop(
         bus=bus,
@@ -346,6 +351,7 @@ def gateway(
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         session_manager=session_manager,
+        mcp_config=config.mcp,
     )
     
     # Set cron callback (needs agent)
@@ -405,7 +411,7 @@ def gateway(
             console.print("\nShutting down...")
             heartbeat.stop()
             cron.stop()
-            agent.stop()
+            await agent.stop_async()
             await channels.stop_all()
     
     asyncio.run(run())
@@ -453,6 +459,7 @@ def agent(
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
+        mcp_config=config.mcp,
     )
     
     # Show spinner when logs are off (no output to miss); skip when logs are on

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -223,6 +223,24 @@ class ToolsConfig(BaseModel):
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
 
 
+class McpServerConfig(BaseModel):
+    """Single MCP server configuration."""
+    enabled: bool = True
+    type: str = "http"  # "http" or "stdio"
+    # HTTP transport
+    url: str = ""
+    headers: dict[str, str] = Field(default_factory=dict)
+    # Stdio transport
+    command: str = ""
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+
+
+class McpConfig(BaseModel):
+    """MCP client configuration."""
+    servers: dict[str, McpServerConfig] = Field(default_factory=dict)
+
+
 class Config(BaseSettings):
     """Root configuration for nanobot."""
     agents: AgentsConfig = Field(default_factory=AgentsConfig)
@@ -230,6 +248,7 @@ class Config(BaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    mcp: McpConfig = Field(default_factory=McpConfig)
     
     @property
     def workspace_path(self) -> Path:

--- a/nanobot/mcp/__init__.py
+++ b/nanobot/mcp/__init__.py
@@ -1,0 +1,6 @@
+"""MCP (Model Context Protocol) client integration."""
+
+from nanobot.mcp.client import McpClientManager
+from nanobot.mcp.tools import McpToolAdapter
+
+__all__ = ["McpClientManager", "McpToolAdapter"]

--- a/nanobot/mcp/client.py
+++ b/nanobot/mcp/client.py
@@ -1,0 +1,123 @@
+"""MCP client manager: connects to MCP servers and discovers tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport, StdioTransport
+from loguru import logger
+
+from nanobot.config.schema import McpConfig, McpServerConfig
+from nanobot.mcp.tools import McpToolAdapter
+
+
+class McpClientManager:
+    """
+    Manages connections to one or more MCP servers.
+
+    Call :meth:`start` to connect to every *enabled* server listed in the
+    config, discover their tools, and create :class:`McpToolAdapter` wrappers.
+    Call :meth:`stop` to tear down all connections.
+    """
+
+    def __init__(self, config: McpConfig) -> None:
+        self._config = config
+        self._clients: dict[str, Any] = {}        # server_name -> FastMCP Client
+        self._contexts: dict[str, Any] = {}        # server_name -> async-context manager state
+        self._tools: list[McpToolAdapter] = []
+        self._started = False
+
+    # -- public API -----------------------------------------------------------
+
+    async def start(self) -> list[McpToolAdapter]:
+        """Connect to all enabled MCP servers and return discovered tools."""
+        if self._started:
+            return self._tools
+
+        self._tools = []
+
+        for name, server_cfg in self._config.servers.items():
+            if not server_cfg.enabled:
+                logger.info(f"MCP server '{name}' is disabled, skipping")
+                continue
+
+            try:
+                transport = self._build_transport(name, server_cfg)
+                client = Client(transport)
+
+                # Enter the async-with context so the connection stays open
+                ctx = client.__aenter__()
+                await ctx
+                self._clients[name] = client
+                self._contexts[name] = client
+
+                # Discover tools
+                remote_tools = await client.list_tools()
+                logger.info(
+                    f"MCP server '{name}': connected, {len(remote_tools)} tool(s) found"
+                )
+
+                for tool in remote_tools:
+                    adapter = McpToolAdapter(
+                        server_name=name,
+                        tool_name=tool.name,
+                        tool_description=tool.description or "",
+                        input_schema=tool.inputSchema if hasattr(tool, "inputSchema") else {},
+                        client=client,
+                    )
+                    self._tools.append(adapter)
+
+            except Exception as e:
+                logger.warning(f"MCP server '{name}' failed to connect: {e}")
+
+        self._started = True
+        return self._tools
+
+    async def stop(self) -> None:
+        """Disconnect all MCP clients."""
+        for name, client in list(self._contexts.items()):
+            try:
+                await client.__aexit__(None, None, None)
+            except Exception as e:
+                logger.debug(f"Error closing MCP client '{name}': {e}")
+        self._clients.clear()
+        self._contexts.clear()
+        self._tools.clear()
+        self._started = False
+
+    def get_tools(self) -> list[McpToolAdapter]:
+        """Return the list of discovered MCP tool adapters (after start)."""
+        return list(self._tools)
+
+    @property
+    def is_started(self) -> bool:
+        return self._started
+
+    # -- internals ------------------------------------------------------------
+
+    @staticmethod
+    def _build_transport(
+        name: str, cfg: McpServerConfig
+    ) -> Any:
+        """Create the appropriate FastMCP transport from config."""
+        if cfg.type == "http":
+            if not cfg.url:
+                raise ValueError(f"MCP server '{name}': HTTP transport requires a 'url'")
+            return StreamableHttpTransport(
+                url=cfg.url,
+                headers=cfg.headers or {},
+            )
+        elif cfg.type == "stdio":
+            if not cfg.command:
+                raise ValueError(f"MCP server '{name}': stdio transport requires a 'command'")
+            return StdioTransport(
+                command=cfg.command,
+                args=cfg.args or [],
+                env=cfg.env or {},
+            )
+        else:
+            raise ValueError(
+                f"MCP server '{name}': unsupported transport type '{cfg.type}' "
+                f"(expected 'http' or 'stdio')"
+            )

--- a/nanobot/mcp/tools.py
+++ b/nanobot/mcp/tools.py
@@ -1,0 +1,72 @@
+"""MCP tool adapter: wraps an MCP server tool as a nanobot Tool."""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from loguru import logger
+
+from nanobot.agent.tools.base import Tool
+
+if TYPE_CHECKING:
+    from fastmcp import Client as McpClient
+
+
+class McpToolAdapter(Tool):
+    """
+    Adapts a single MCP tool into nanobot's Tool interface.
+
+    The tool name is namespaced as ``mcp__{server}__{original_name}`` so it
+    cannot collide with built-in tools or tools from other MCP servers.
+    """
+
+    def __init__(
+        self,
+        server_name: str,
+        tool_name: str,
+        tool_description: str,
+        input_schema: dict[str, Any],
+        client: McpClient,
+    ) -> None:
+        self._server_name = server_name
+        self._tool_name = tool_name
+        self._description = tool_description or f"MCP tool {tool_name} from {server_name}"
+        self._input_schema = input_schema or {
+            "type": "object",
+            "properties": {},
+        }
+        self._client = client
+
+    # -- Tool interface -------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return f"mcp__{self._server_name}__{self._tool_name}"
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return self._input_schema
+
+    async def execute(self, **kwargs: Any) -> str:
+        """Forward the call to the MCP server via the FastMCP client."""
+        try:
+            result = await self._client.call_tool(self._tool_name, kwargs)
+
+            # Extract text from the result content blocks
+            parts: list[str] = []
+            for block in result.content:
+                if hasattr(block, "text"):
+                    parts.append(block.text)
+                else:
+                    parts.append(str(block))
+
+            return "\n".join(parts) if parts else "(empty result)"
+        except Exception as e:
+            logger.warning(
+                f"MCP tool {self.name} execution failed: {e}"
+            )
+            return f"Error calling MCP tool '{self._tool_name}' on server '{self._server_name}': {e}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "qq-botpy>=1.0.0",
     "python-socks[asyncio]>=2.4.0",
     "prompt-toolkit>=3.0.0",
+    "fastmcp>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,405 @@
+"""Tests for MCP client integration (config, adapter, manager, registry)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.config.schema import McpConfig, McpServerConfig
+from nanobot.mcp.tools import McpToolAdapter
+from nanobot.mcp.client import McpClientManager
+
+
+# ============================================================================
+# Config parsing
+# ============================================================================
+
+
+def test_mcp_server_config_http_defaults() -> None:
+    cfg = McpServerConfig()
+    assert cfg.enabled is True
+    assert cfg.type == "http"
+    assert cfg.url == ""
+    assert cfg.headers == {}
+    assert cfg.command == ""
+    assert cfg.args == []
+    assert cfg.env == {}
+
+
+def test_mcp_server_config_from_dict_http() -> None:
+    data = {
+        "type": "http",
+        "url": "http://localhost:8000/mcp",
+        "headers": {"Authorization": "Bearer tok"},
+    }
+    cfg = McpServerConfig.model_validate(data)
+    assert cfg.type == "http"
+    assert cfg.url == "http://localhost:8000/mcp"
+    assert cfg.headers == {"Authorization": "Bearer tok"}
+
+
+def test_mcp_server_config_from_dict_stdio() -> None:
+    data = {
+        "type": "stdio",
+        "command": "python",
+        "args": ["server.py", "--verbose"],
+        "env": {"API_KEY": "secret"},
+    }
+    cfg = McpServerConfig.model_validate(data)
+    assert cfg.type == "stdio"
+    assert cfg.command == "python"
+    assert cfg.args == ["server.py", "--verbose"]
+    assert cfg.env == {"API_KEY": "secret"}
+
+
+def test_mcp_server_config_disabled() -> None:
+    cfg = McpServerConfig.model_validate({"enabled": False, "url": "http://x"})
+    assert cfg.enabled is False
+
+
+def test_mcp_config_empty() -> None:
+    cfg = McpConfig()
+    assert cfg.servers == {}
+
+
+def test_mcp_config_multiple_servers() -> None:
+    data = {
+        "servers": {
+            "srv1": {"type": "http", "url": "http://a/mcp"},
+            "srv2": {"type": "stdio", "command": "node", "args": ["s.js"]},
+        }
+    }
+    cfg = McpConfig.model_validate(data)
+    assert len(cfg.servers) == 2
+    assert cfg.servers["srv1"].url == "http://a/mcp"
+    assert cfg.servers["srv2"].command == "node"
+
+
+# ============================================================================
+# McpToolAdapter
+# ============================================================================
+
+
+def _make_adapter(
+    server: str = "test_srv",
+    tool: str = "greet",
+    desc: str = "Say hello",
+    schema: dict | None = None,
+    client: Any = None,
+) -> McpToolAdapter:
+    return McpToolAdapter(
+        server_name=server,
+        tool_name=tool,
+        tool_description=desc,
+        input_schema=schema or {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        },
+        client=client or MagicMock(),
+    )
+
+
+def test_adapter_name_format() -> None:
+    adapter = _make_adapter(server="google_workspace", tool="list_emails")
+    assert adapter.name == "mcp__google_workspace__list_emails"
+
+
+def test_adapter_description() -> None:
+    adapter = _make_adapter(desc="Fetch calendar events")
+    assert adapter.description == "Fetch calendar events"
+
+
+def test_adapter_default_description() -> None:
+    adapter = McpToolAdapter(
+        server_name="s",
+        tool_name="t",
+        tool_description="",
+        input_schema={},
+        client=MagicMock(),
+    )
+    assert "MCP tool t from s" in adapter.description
+
+
+def test_adapter_parameters() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"q": {"type": "string"}},
+        "required": ["q"],
+    }
+    adapter = _make_adapter(schema=schema)
+    assert adapter.parameters == schema
+
+
+def test_adapter_to_schema() -> None:
+    adapter = _make_adapter()
+    schema = adapter.to_schema()
+    assert schema["type"] == "function"
+    assert schema["function"]["name"] == "mcp__test_srv__greet"
+    assert schema["function"]["description"] == "Say hello"
+    assert "properties" in schema["function"]["parameters"]
+
+
+def test_adapter_is_tool_subclass() -> None:
+    adapter = _make_adapter()
+    assert isinstance(adapter, Tool)
+
+
+async def test_adapter_execute_success() -> None:
+    """Mock client.call_tool and verify adapter forwards args and returns text."""
+    mock_client = AsyncMock()
+    text_block = MagicMock()
+    text_block.text = "Hello, Alice!"
+    mock_client.call_tool.return_value = MagicMock(content=[text_block])
+
+    adapter = _make_adapter(client=mock_client)
+    result = await adapter.execute(name="Alice")
+
+    mock_client.call_tool.assert_awaited_once_with("greet", {"name": "Alice"})
+    assert result == "Hello, Alice!"
+
+
+async def test_adapter_execute_multiple_blocks() -> None:
+    """Multiple content blocks are joined with newlines."""
+    mock_client = AsyncMock()
+    b1 = MagicMock()
+    b1.text = "Line 1"
+    b2 = MagicMock()
+    b2.text = "Line 2"
+    mock_client.call_tool.return_value = MagicMock(content=[b1, b2])
+
+    adapter = _make_adapter(client=mock_client)
+    result = await adapter.execute(name="Bob")
+    assert result == "Line 1\nLine 2"
+
+
+async def test_adapter_execute_empty_result() -> None:
+    mock_client = AsyncMock()
+    mock_client.call_tool.return_value = MagicMock(content=[])
+
+    adapter = _make_adapter(client=mock_client)
+    result = await adapter.execute(name="X")
+    assert result == "(empty result)"
+
+
+async def test_adapter_execute_error_handling() -> None:
+    """On exception, adapter returns a descriptive error string (no crash)."""
+    mock_client = AsyncMock()
+    mock_client.call_tool.side_effect = ConnectionError("server down")
+
+    adapter = _make_adapter(server="srv", tool="t", client=mock_client)
+    result = await adapter.execute(name="X")
+    assert "Error calling MCP tool" in result
+    assert "server down" in result
+
+
+# ============================================================================
+# McpClientManager
+# ============================================================================
+
+
+def test_manager_not_started_initially() -> None:
+    cfg = McpConfig(servers={"s": McpServerConfig(url="http://x/mcp")})
+    mgr = McpClientManager(cfg)
+    assert mgr.is_started is False
+    assert mgr.get_tools() == []
+
+
+async def test_manager_start_discovers_tools() -> None:
+    """Mock FastMCP Client to simulate tool discovery."""
+    fake_tool = MagicMock()
+    fake_tool.name = "do_thing"
+    fake_tool.description = "Does the thing"
+    fake_tool.inputSchema = {
+        "type": "object",
+        "properties": {"x": {"type": "integer"}},
+    }
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.list_tools.return_value = [fake_tool]
+    mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+    cfg = McpConfig(servers={
+        "my_srv": McpServerConfig(type="http", url="http://localhost:9999/mcp"),
+    })
+    mgr = McpClientManager(cfg)
+
+    with patch("nanobot.mcp.client.Client", return_value=mock_client_instance):
+        tools = await mgr.start()
+
+    assert mgr.is_started is True
+    assert len(tools) == 1
+    assert tools[0].name == "mcp__my_srv__do_thing"
+    assert tools[0].description == "Does the thing"
+
+
+async def test_manager_start_skips_disabled_server() -> None:
+    cfg = McpConfig(servers={
+        "off": McpServerConfig(enabled=False, url="http://localhost/mcp"),
+    })
+    mgr = McpClientManager(cfg)
+
+    # Should not even attempt to import/create a Client
+    tools = await mgr.start()
+    assert tools == []
+    assert mgr.is_started is True
+
+
+async def test_manager_start_unreachable_server() -> None:
+    """Unreachable server logs warning but doesn't crash; returns no tools."""
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__ = AsyncMock(side_effect=ConnectionError("refused"))
+
+    cfg = McpConfig(servers={
+        "bad": McpServerConfig(type="http", url="http://localhost:1/mcp"),
+    })
+    mgr = McpClientManager(cfg)
+
+    with patch("nanobot.mcp.client.Client", return_value=mock_client_instance):
+        tools = await mgr.start()
+
+    assert tools == []
+    assert mgr.is_started is True
+
+
+async def test_manager_start_idempotent() -> None:
+    """Calling start() twice returns same tools without reconnecting."""
+    fake_tool = MagicMock()
+    fake_tool.name = "t"
+    fake_tool.description = "d"
+    fake_tool.inputSchema = {}
+
+    mock_client = AsyncMock()
+    mock_client.list_tools.return_value = [fake_tool]
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    cfg = McpConfig(servers={
+        "s": McpServerConfig(type="http", url="http://x/mcp"),
+    })
+    mgr = McpClientManager(cfg)
+
+    with patch("nanobot.mcp.client.Client", return_value=mock_client):
+        tools1 = await mgr.start()
+        tools2 = await mgr.start()
+
+    assert tools1 == tools2
+    # Client constructor should have been called only once
+    assert mock_client.__aenter__.await_count == 1
+
+
+async def test_manager_stop_cleans_up() -> None:
+    mock_client = AsyncMock()
+    mock_client.list_tools.return_value = []
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    cfg = McpConfig(servers={
+        "s": McpServerConfig(type="http", url="http://x/mcp"),
+    })
+    mgr = McpClientManager(cfg)
+
+    with patch("nanobot.mcp.client.Client", return_value=mock_client):
+        await mgr.start()
+
+    assert mgr.is_started is True
+
+    await mgr.stop()
+    assert mgr.is_started is False
+    assert mgr.get_tools() == []
+    mock_client.__aexit__.assert_awaited()
+
+
+# ============================================================================
+# McpClientManager._build_transport
+# ============================================================================
+
+
+def test_build_transport_http() -> None:
+    cfg = McpServerConfig(type="http", url="http://localhost:8000/mcp")
+    with patch("nanobot.mcp.client.StreamableHttpTransport") as mock_cls:
+        McpClientManager._build_transport("test", cfg)
+        mock_cls.assert_called_once_with(url="http://localhost:8000/mcp", headers={})
+
+
+def test_build_transport_http_with_headers() -> None:
+    cfg = McpServerConfig(
+        type="http", url="http://x/mcp", headers={"X-Key": "val"}
+    )
+    with patch("nanobot.mcp.client.StreamableHttpTransport") as mock_cls:
+        McpClientManager._build_transport("test", cfg)
+        mock_cls.assert_called_once_with(
+            url="http://x/mcp", headers={"X-Key": "val"}
+        )
+
+
+def test_build_transport_stdio() -> None:
+    cfg = McpServerConfig(
+        type="stdio", command="python", args=["s.py"], env={"K": "V"}
+    )
+    with patch("nanobot.mcp.client.StdioTransport") as mock_cls:
+        McpClientManager._build_transport("test", cfg)
+        mock_cls.assert_called_once_with(
+            command="python", args=["s.py"], env={"K": "V"}
+        )
+
+
+def test_build_transport_http_missing_url() -> None:
+    cfg = McpServerConfig(type="http", url="")
+    try:
+        McpClientManager._build_transport("test", cfg)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "url" in str(e).lower()
+
+
+def test_build_transport_stdio_missing_command() -> None:
+    cfg = McpServerConfig(type="stdio", command="")
+    try:
+        McpClientManager._build_transport("test", cfg)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "command" in str(e).lower()
+
+
+def test_build_transport_unknown_type() -> None:
+    cfg = McpServerConfig(type="websocket")
+    try:
+        McpClientManager._build_transport("test", cfg)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "unsupported" in str(e).lower()
+
+
+# ============================================================================
+# ToolRegistry integration
+# ============================================================================
+
+
+def test_registry_includes_mcp_tool() -> None:
+    adapter = _make_adapter()
+    reg = ToolRegistry()
+    reg.register(adapter)
+
+    assert reg.has("mcp__test_srv__greet")
+    defs = reg.get_definitions()
+    names = [d["function"]["name"] for d in defs]
+    assert "mcp__test_srv__greet" in names
+
+
+async def test_registry_execute_delegates_to_mcp_tool() -> None:
+    mock_client = AsyncMock()
+    text_block = MagicMock()
+    text_block.text = "result"
+    mock_client.call_tool.return_value = MagicMock(content=[text_block])
+
+    adapter = _make_adapter(client=mock_client)
+    reg = ToolRegistry()
+    reg.register(adapter)
+
+    result = await reg.execute("mcp__test_srv__greet", {"name": "World"})
+    assert result == "result"
+    mock_client.call_tool.assert_awaited_once_with("greet", {"name": "World"})


### PR DESCRIPTION
## Summary

- Adds MCP (Model Context Protocol) client integration to nanobot using the [FastMCP](https://gofastmcp.com/) library
- The agent can now connect to external MCP servers and use their tools transparently alongside built-in tools (read_file, exec, web_search, etc.)
- Supports both **HTTP** (streamable-http) and **stdio** transports, configurable from `config.json` or environment variables

## Changes

- **`pyproject.toml`**: Added `fastmcp>=2.0.0` dependency
- **`nanobot/mcp/`** (new package):
  - `tools.py`: `McpToolAdapter` — wraps MCP tools as nanobot `Tool` instances with `mcp__{server}__{tool}` namespacing
  - `client.py`: `McpClientManager` — manages FastMCP client connections, discovers tools, handles lifecycle
- **`nanobot/config/schema.py`**: Added `McpServerConfig`, `McpConfig` models and `mcp` field on root `Config`
- **`nanobot/agent/loop.py`**: `AgentLoop` accepts `mcp_config`, lazy-starts MCP clients on first use, async cleanup on stop
- **`nanobot/cli/commands.py`**: Both `gateway` and `agent` commands pass MCP config; gateway logs MCP status
- **`tests/test_mcp.py`**: 30 unit tests covering config parsing, adapter behavior, manager lifecycle, transport building, and registry integration

## Configuration example

```json
{
  "mcp": {
    "servers": {
      "google-workspace": {
        "type": "http",
        "url": "http://0.0.0.0:8000/mcp"
      },
      "local-server": {
        "type": "stdio",
        "command": "python",
        "args": ["server.py"]
      }
    }
  }
}
```

## Test plan

- [x] All 30 new MCP tests pass
- [x] All 55 existing tests pass (no regressions)
- [ ] Manual test: configure an HTTP MCP server in config.json and verify tools are discovered
- [ ] Manual test: verify agent can call MCP tools during conversation

Made with [Cursor](https://cursor.com)