### PR TITLE
feat: add config-driven reasoning_effort parameter for thinking models

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -50,6 +50,7 @@ class AgentLoop:
         cron_service: "CronService | None" = None,
         restrict_to_workspace: bool = False,
         session_manager: SessionManager | None = None,
+        reasoning_effort: str | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         from nanobot.cron.service import CronService
@@ -65,6 +66,7 @@ class AgentLoop:
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
+        self.reasoning_effort = reasoning_effort
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
@@ -79,6 +81,7 @@ class AgentLoop:
             brave_api_key=brave_api_key,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            reasoning_effort=self.reasoning_effort,
         )
         
         self._running = False
@@ -154,6 +157,7 @@ class AgentLoop:
                 model=self.model,
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
+                reasoning_effort=self.reasoning_effort,
             )
 
             if response.has_tool_calls:
@@ -393,6 +397,7 @@ Respond with ONLY valid JSON, no markdown fences."""
                     {"role": "user", "content": prompt},
                 ],
                 model=self.model,
+                reasoning_effort=self.reasoning_effort,
             )
             text = (response.content or "").strip()
             if text.startswith("```"):

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -37,6 +37,7 @@ class SubagentManager:
         brave_api_key: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
+        reasoning_effort: str | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.provider = provider
@@ -48,6 +49,7 @@ class SubagentManager:
         self.brave_api_key = brave_api_key
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
+        self.reasoning_effort = reasoning_effort
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
     
     async def spawn(
@@ -136,6 +138,7 @@ class SubagentManager:
                     model=self.model,
                     temperature=self.temperature,
                     max_tokens=self.max_tokens,
+                    reasoning_effort=self.reasoning_effort,
                 )
                 
                 if response.has_tool_calls:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -346,6 +346,7 @@ def gateway(
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         session_manager=session_manager,
+        reasoning_effort=config.agents.defaults.reasoning_effort,
     )
     
     # Set cron callback (needs agent)
@@ -453,6 +454,7 @@ def agent(
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
+        reasoning_effort=config.agents.defaults.reasoning_effort,
     )
     
     # Show spinner when logs are off (no output to miss); skip when logs are on

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -163,6 +163,7 @@ class AgentDefaults(BaseModel):
     temperature: float = 0.7
     max_tool_iterations: int = 20
     memory_window: int = 50
+    reasoning_effort: str | None = None  # "low", "medium", "high" for thinking models
 
 
 class AgentsConfig(BaseModel):

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -48,6 +48,7 @@ class LLMProvider(ABC):
         model: str | None = None,
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        reasoning_effort: str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request.
@@ -58,6 +59,7 @@ class LLMProvider(ABC):
             model: Model identifier (provider-specific).
             max_tokens: Maximum tokens in response.
             temperature: Sampling temperature.
+            reasoning_effort: Thinking depth for reasoning models ("low", "medium", "high").
         
         Returns:
             LLMResponse with content and/or tool calls.

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -106,6 +106,7 @@ class LiteLLMProvider(LLMProvider):
         model: str | None = None,
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        reasoning_effort: str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request via LiteLLM.
@@ -116,6 +117,7 @@ class LiteLLMProvider(LLMProvider):
             model: Model identifier (e.g., 'anthropic/claude-sonnet-4-5').
             max_tokens: Maximum tokens in response.
             temperature: Sampling temperature.
+            reasoning_effort: Thinking depth for reasoning models ("low", "medium", "high").
         
         Returns:
             LLMResponse with content and/or tool calls.
@@ -135,6 +137,10 @@ class LiteLLMProvider(LLMProvider):
         
         # Apply model-specific overrides (e.g. kimi-k2.5 temperature)
         self._apply_model_overrides(model, kwargs)
+        
+        # Pass reasoning_effort for thinking models (e.g. gpt-5-mini, o1, o3)
+        if reasoning_effort:
+            kwargs["reasoning_effort"] = reasoning_effort
         
         # Pass api_key directly — more reliable than env vars alone
         if self.api_key:


### PR DESCRIPTION
## Summary

- Adds a new `reasoningEffort` config option to agent defaults (`"low"`, `"medium"`, `"high"`) that gets threaded through `AgentLoop` -> `LLMProvider.chat()` -> LiteLLM `acompletion()`, enabling configurable thinking depth for OpenAI reasoning models (gpt-5-mini, o1, o3, etc.).
- Propagates the setting to subagents via `SubagentManager` so spawned background tasks also use the configured reasoning effort.
- When the parameter is `null`/unset it is omitted entirely from the API call; when set on a model that doesn't support it, LiteLLM's existing `drop_params = True` silently discards it.

## Changed files

| File | Change |
|------|--------|
| `config/schema.py` | Add optional `reasoning_effort` field to `AgentDefaults` |
| `providers/base.py` | Add param to abstract `chat()` signature |
| `providers/litellm_provider.py` | Accept & forward to `acompletion()` kwargs |
| `agent/loop.py` | Store & pass to both `chat()` call sites + `SubagentManager` |
| `agent/subagent.py` | Accept & pass to subagent `chat()` call |
| `cli/commands.py` | Wire config value into both `AgentLoop` constructions |

## Config example

```json
{
  "agents": {
    "defaults": {
      "model": "openai/gpt-5-mini",
      "reasoningEffort": "high"
    }
  }
}
```

## Test plan

- [x] Verified clean diff against upstream/main (6 files, +19 lines, no unrelated changes)
- [x] Start nanobot gateway with `reasoningEffort: "high"` and verify reasoning model produces thinking tokens
- [x] Set `reasoningEffort` to `null` and verify no `reasoning_effort` key in the LiteLLM request
- [x] Switch to a non-reasoning model (e.g. claude) and confirm param is silently dropped

Made with [Cursor](https://cursor.com)