### PR TITLE
fix: use json_repair for robust LLM response parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ⚡️ Delivers core agent functionality in just **~4,000** lines of code — **99% smaller** than Clawdbot's 430k+ lines.
 
-📏 Real-time line count: **3,656 lines** (run `bash core_agent_lines.sh` to verify anytime)
+📏 Real-time line count: **3,663 lines** (run `bash core_agent_lines.sh` to verify anytime)
 
 ## 📢 News
 

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -1,6 +1,7 @@
 """LiteLLM provider implementation for multi-provider support."""
 
 import json
+import json_repair
 import os
 from typing import Any
 
@@ -173,10 +174,7 @@ class LiteLLMProvider(LLMProvider):
                 # Parse arguments from JSON string if needed
                 args = tc.function.arguments
                 if isinstance(args, str):
-                    try:
-                        args = json.loads(args)
-                    except json.JSONDecodeError:
-                        args = {"raw": args}
+                    args = json_repair.loads(args)
                 
                 tool_calls.append(ToolCallRequest(
                     id=tc.id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "python-socks[asyncio]>=2.4.0",
     "prompt-toolkit>=3.0.0",
     "mcp>=1.0.0",
+    "json-repair>=0.30.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Replace `json.loads` with `json_repair.loads` for all LLM output parsing (memory consolidation + tool call arguments)
- Fixes `JSONDecodeError` when LLM returns malformed/empty JSON during memory consolidation
- Add `json-repair` dependency

## Changed files
- `nanobot/agent/loop.py` — consolidation response parsing
- `nanobot/providers/litellm_provider.py` — tool call argument parsing
- `pyproject.toml` — add `json-repair>=0.30.0`