### PR TITLE
fix(web-tools): improve error message display

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -87,7 +87,7 @@ class WebSearchTool(Tool):
                     lines.append(f"   {desc}")
             return "\n".join(lines)
         except Exception as e:
-            return f"Error: {e}"
+            return f"Error: {type(e).__name__}: {e}" if str(e) else f"Error: {type(e).__name__}"
 
 
 class WebFetchTool(Tool):
@@ -148,7 +148,8 @@ class WebFetchTool(Tool):
             return json.dumps({"url": url, "finalUrl": str(r.url), "status": r.status_code,
                               "extractor": extractor, "truncated": truncated, "length": len(text), "text": text})
         except Exception as e:
-            return json.dumps({"error": str(e), "url": url})
+            error_msg = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
+            return json.dumps({"error": error_msg, "url": url})
     
     def _to_markdown(self, html: str) -> str:
         """Convert HTML to markdown."""


### PR DESCRIPTION
## 修改总结

### 修改内容

修改了 [web.py](file:///home/ahwei/nanobot/nanobot/agent/tools/web.py) 中两个工具类的异常处理：

**WebSearchTool (第91行)：**
```python
# 修改前
return f"Error: {e}"

# 修改后
return f"Error: {type(e).__name__}: {e}" if str(e) else f"Error: {type(e).__name__}"
```

**WebFetchTool (第152-153行)：**
```python
# 修改前
return json.dumps({"error": str(e), "url": url})

# 修改后
error_msg = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
return json.dumps({"error": error_msg, "url": url})
```

---

### 问题原因

httpx/httpcore 库的异常类设计存在缺陷：

1. `ConnectTimeout`、`ReadTimeout` 等异常类定义为**空类**，没有自定义 `__init__` 或 `__str__` 方法
2. 当底层 `socket.timeout` 异常发生时，被转换为 `ConnectTimeout(socket_timeout_exception)`
3. 由于没有自定义 `__str__`，Python 默认的异常字符串转换无法正确处理传入的异常对象
4. 结果：`str(e)` 返回空字符串 `""`

---

### 效果对比

| 场景 | 修改前 | 修改后 |
|------|--------|--------|
| 连接超时 | `Error: ` | `Error: ConnectTimeout` |
| 读取超时 | `Error: ` | `Error: ReadTimeout` |
| 普通错误 | `Error: some message` | `Error: SomeError: some message` |

现在即使异常消息为空，用户也能看到具体的异常类型，便于快速诊断网络问题。