### PR TITLE
Update Slack message text fallback response

### DIFF
--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -84,7 +84,7 @@ class SlackChannel(BaseChannel):
             use_thread = thread_ts and channel_type != "im"
             await self._web_client.chat_postMessage(
                 channel=msg.chat_id,
-                text=msg.content or "",
+                text=msg.content or "<empty_response_from_the_bot>",
                 thread_ts=thread_ts if use_thread else None,
             )
         except Exception as e:


### PR DESCRIPTION
Slack doesn't accept an empty string in the `text` parameter. However, Nanobot sometimes sends an empty response. This may need a change in the bot's logic as well; still, it should also be gracefully handled by the channel. I suggest changing the default message to '<empty_response_from_the_bot>' when the content is empty, so the user will know that the bot was trying to respond with an empty message.

Fix for #674 