### PR TITLE
feat: Add per-user memory with collections (brand_guides, briefs, projects)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -20,6 +20,7 @@ from nanobot.agent.tools.web import WebSearchTool, WebFetchTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.cron import CronTool
+from nanobot.agent.tools.memory import MemoryTool
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.subagent import SubagentManager
 from nanobot.session.manager import Session, SessionManager
@@ -56,6 +57,7 @@ class AgentLoop:
     ):
         from nanobot.config.schema import ExecToolConfig
         from nanobot.cron.service import CronService
+
         self.bus = bus
         self.provider = provider
         self.workspace = workspace
@@ -83,13 +85,13 @@ class AgentLoop:
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
         )
-        
+
         self._running = False
         self._mcp_servers = mcp_servers or {}
         self._mcp_stack: AsyncExitStack | None = None
         self._mcp_connected = False
         self._register_default_tools()
-    
+
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
         # File tools (restrict to workspace if configured)
@@ -98,36 +100,42 @@ class AgentLoop:
         self.tools.register(WriteFileTool(allowed_dir=allowed_dir))
         self.tools.register(EditFileTool(allowed_dir=allowed_dir))
         self.tools.register(ListDirTool(allowed_dir=allowed_dir))
-        
+
         # Shell tool
-        self.tools.register(ExecTool(
-            working_dir=str(self.workspace),
-            timeout=self.exec_config.timeout,
-            restrict_to_workspace=self.restrict_to_workspace,
-        ))
-        
+        self.tools.register(
+            ExecTool(
+                working_dir=str(self.workspace),
+                timeout=self.exec_config.timeout,
+                restrict_to_workspace=self.restrict_to_workspace,
+            )
+        )
+
         # Web tools
         self.tools.register(WebSearchTool(api_key=self.brave_api_key))
         self.tools.register(WebFetchTool())
-        
+
         # Message tool
         message_tool = MessageTool(send_callback=self.bus.publish_outbound)
         self.tools.register(message_tool)
-        
+
         # Spawn tool (for subagents)
         spawn_tool = SpawnTool(manager=self.subagents)
         self.tools.register(spawn_tool)
-        
+
         # Cron tool (for scheduling)
         if self.cron_service:
             self.tools.register(CronTool(self.cron_service))
-    
+
+        # Memory tool (for managing memory collections)
+        self.tools.register(MemoryTool(self.context.memory))
+
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""
         if self._mcp_connected or not self._mcp_servers:
             return
         self._mcp_connected = True
         from nanobot.agent.tools.mcp import connect_mcp_servers
+
         self._mcp_stack = AsyncExitStack()
         await self._mcp_stack.__aenter__()
         await connect_mcp_servers(self._mcp_servers, self.tools, self._mcp_stack)
@@ -145,6 +153,10 @@ class AgentLoop:
         if cron_tool := self.tools.get("cron"):
             if isinstance(cron_tool, CronTool):
                 cron_tool.set_context(channel, chat_id)
+
+        if memory_tool := self.tools.get("memory"):
+            if isinstance(memory_tool, MemoryTool):
+                memory_tool.set_user(chat_id)
 
     async def _run_agent_loop(self, initial_messages: list[dict]) -> tuple[str | None, list[str]]:
         """
@@ -177,15 +189,14 @@ class AgentLoop:
                     {
                         "id": tc.id,
                         "type": "function",
-                        "function": {
-                            "name": tc.name,
-                            "arguments": json.dumps(tc.arguments)
-                        }
+                        "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
                     }
                     for tc in response.tool_calls
                 ]
                 messages = self.context.add_assistant_message(
-                    messages, response.content, tool_call_dicts,
+                    messages,
+                    response.content,
+                    tool_call_dicts,
                     reasoning_content=response.reasoning_content,
                 )
 
@@ -197,7 +208,9 @@ class AgentLoop:
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
-                messages.append({"role": "user", "content": "Reflect on the results and decide next steps."})
+                messages.append(
+                    {"role": "user", "content": "Reflect on the results and decide next steps."}
+                )
             else:
                 final_content = response.content
                 break
@@ -212,24 +225,23 @@ class AgentLoop:
 
         while self._running:
             try:
-                msg = await asyncio.wait_for(
-                    self.bus.consume_inbound(),
-                    timeout=1.0
-                )
+                msg = await asyncio.wait_for(self.bus.consume_inbound(), timeout=1.0)
                 try:
                     response = await self._process_message(msg)
                     if response:
                         await self.bus.publish_outbound(response)
                 except Exception as e:
                     logger.error(f"Error processing message: {e}")
-                    await self.bus.publish_outbound(OutboundMessage(
-                        channel=msg.channel,
-                        chat_id=msg.chat_id,
-                        content=f"Sorry, I encountered an error: {str(e)}"
-                    ))
+                    await self.bus.publish_outbound(
+                        OutboundMessage(
+                            channel=msg.channel,
+                            chat_id=msg.chat_id,
+                            content=f"Sorry, I encountered an error: {str(e)}",
+                        )
+                    )
             except asyncio.TimeoutError:
                 continue
-    
+
     async def close_mcp(self) -> None:
         """Close MCP connections."""
         if self._mcp_stack:
@@ -243,28 +255,30 @@ class AgentLoop:
         """Stop the agent loop."""
         self._running = False
         logger.info("Agent loop stopping")
-    
-    async def _process_message(self, msg: InboundMessage, session_key: str | None = None) -> OutboundMessage | None:
+
+    async def _process_message(
+        self, msg: InboundMessage, session_key: str | None = None
+    ) -> OutboundMessage | None:
         """
         Process a single inbound message.
-        
+
         Args:
             msg: The inbound message to process.
             session_key: Override session key (used by process_direct).
-        
+
         Returns:
             The response message, or None if no response needed.
         """
         # System messages route back via chat_id ("channel:chat_id")
         if msg.channel == "system":
             return await self._process_system_message(msg)
-        
+
         preview = msg.content[:80] + "..." if len(msg.content) > 80 else msg.content
         logger.info(f"Processing message from {msg.channel}:{msg.sender_id}: {preview}")
-        
+
         key = session_key or msg.session_key
         session = self.sessions.get_or_create(key)
-        
+
         # Handle slash commands
         cmd = msg.content.strip().lower()
         if cmd == "/new":
@@ -280,12 +294,18 @@ class AgentLoop:
                 await self._consolidate_memory(temp_session, archive_all=True)
 
             asyncio.create_task(_consolidate_and_cleanup())
-            return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
-                                  content="New session started. Memory consolidation in progress.")
+            return OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content="New session started. Memory consolidation in progress.",
+            )
         if cmd == "/help":
-            return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
-                                  content="🐈 nanobot commands:\n/new — Start a new conversation\n/help — Show available commands")
-        
+            return OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content="🐈 nanobot commands:\n/new — Start a new conversation\n/help — Show available commands",
+            )
+
         if len(session.messages) > self.memory_window:
             asyncio.create_task(self._consolidate_memory(session))
 
@@ -296,36 +316,39 @@ class AgentLoop:
             media=msg.media if msg.media else None,
             channel=msg.channel,
             chat_id=msg.chat_id,
+            user_id=msg.chat_id,
         )
         final_content, tools_used = await self._run_agent_loop(initial_messages)
 
         if final_content is None:
             final_content = "I've completed processing but have no response to give."
-        
+
         preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
         logger.info(f"Response to {msg.channel}:{msg.sender_id}: {preview}")
-        
+
         session.add_message("user", msg.content)
-        session.add_message("assistant", final_content,
-                            tools_used=tools_used if tools_used else None)
+        session.add_message(
+            "assistant", final_content, tools_used=tools_used if tools_used else None
+        )
         self.sessions.save(session)
-        
+
         return OutboundMessage(
             channel=msg.channel,
             chat_id=msg.chat_id,
             content=final_content,
-            metadata=msg.metadata or {},  # Pass through for channel-specific needs (e.g. Slack thread_ts)
+            metadata=msg.metadata
+            or {},  # Pass through for channel-specific needs (e.g. Slack thread_ts)
         )
-    
+
     async def _process_system_message(self, msg: InboundMessage) -> OutboundMessage | None:
         """
         Process a system message (e.g., subagent announce).
-        
+
         The chat_id field contains "original_channel:original_chat_id" to route
         the response back to the correct destination.
         """
         logger.info(f"Processing system message from {msg.sender_id}")
-        
+
         # Parse origin from chat_id (format: "channel:chat_id")
         if ":" in msg.chat_id:
             parts = msg.chat_id.split(":", 1)
@@ -335,7 +358,7 @@ class AgentLoop:
             # Fallback
             origin_channel = "cli"
             origin_chat_id = msg.chat_id
-        
+
         session_key = f"{origin_channel}:{origin_chat_id}"
         session = self.sessions.get_or_create(session_key)
         self._set_tool_context(origin_channel, origin_chat_id)
@@ -344,22 +367,21 @@ class AgentLoop:
             current_message=msg.content,
             channel=origin_channel,
             chat_id=origin_chat_id,
+            user_id=origin_chat_id,
         )
         final_content, _ = await self._run_agent_loop(initial_messages)
 
         if final_content is None:
             final_content = "Background task completed."
-        
+
         session.add_message("user", f"[System: {msg.sender_id}] {msg.content}")
         session.add_message("assistant", final_content)
         self.sessions.save(session)
-        
+
         return OutboundMessage(
-            channel=origin_channel,
-            chat_id=origin_chat_id,
-            content=final_content
+            channel=origin_channel, chat_id=origin_chat_id, content=final_content
         )
-    
+
     async def _consolidate_memory(self, session, archive_all: bool = False) -> None:
         """Consolidate old messages into MEMORY.md + HISTORY.md.
 
@@ -372,29 +394,39 @@ class AgentLoop:
         if archive_all:
             old_messages = session.messages
             keep_count = 0
-            logger.info(f"Memory consolidation (archive_all): {len(session.messages)} total messages archived")
+            logger.info(
+                f"Memory consolidation (archive_all): {len(session.messages)} total messages archived"
+            )
         else:
             keep_count = self.memory_window // 2
             if len(session.messages) <= keep_count:
-                logger.debug(f"Session {session.key}: No consolidation needed (messages={len(session.messages)}, keep={keep_count})")
+                logger.debug(
+                    f"Session {session.key}: No consolidation needed (messages={len(session.messages)}, keep={keep_count})"
+                )
                 return
 
             messages_to_process = len(session.messages) - session.last_consolidated
             if messages_to_process <= 0:
-                logger.debug(f"Session {session.key}: No new messages to consolidate (last_consolidated={session.last_consolidated}, total={len(session.messages)})")
+                logger.debug(
+                    f"Session {session.key}: No new messages to consolidate (last_consolidated={session.last_consolidated}, total={len(session.messages)})"
+                )
                 return
 
-            old_messages = session.messages[session.last_consolidated:-keep_count]
+            old_messages = session.messages[session.last_consolidated : -keep_count]
             if not old_messages:
                 return
-            logger.info(f"Memory consolidation started: {len(session.messages)} total, {len(old_messages)} new to consolidate, {keep_count} keep")
+            logger.info(
+                f"Memory consolidation started: {len(session.messages)} total, {len(old_messages)} new to consolidate, {keep_count} keep"
+            )
 
         lines = []
         for m in old_messages:
             if not m.get("content"):
                 continue
             tools = f" [tools: {', '.join(m['tools_used'])}]" if m.get("tools_used") else ""
-            lines.append(f"[{m.get('timestamp', '?')[:16]}] {m['role'].upper()}{tools}: {m['content']}")
+            lines.append(
+                f"[{m.get('timestamp', '?')[:16]}] {m['role'].upper()}{tools}: {m['content']}"
+            )
         conversation = "\n".join(lines)
         current_memory = memory.read_long_term()
 
@@ -415,7 +447,10 @@ Respond with ONLY valid JSON, no markdown fences."""
         try:
             response = await self.provider.chat(
                 messages=[
-                    {"role": "system", "content": "You are a memory consolidation agent. Respond only with valid JSON."},
+                    {
+                        "role": "system",
+                        "content": "You are a memory consolidation agent. Respond only with valid JSON.",
+                    },
                     {"role": "user", "content": prompt},
                 ],
                 model=self.model,
@@ -428,7 +463,9 @@ Respond with ONLY valid JSON, no markdown fences."""
                 text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
             result = json_repair.loads(text)
             if not isinstance(result, dict):
-                logger.warning(f"Memory consolidation: unexpected response type, skipping. Response: {text[:200]}")
+                logger.warning(
+                    f"Memory consolidation: unexpected response type, skipping. Response: {text[:200]}"
+                )
                 return
 
             if entry := result.get("history_entry"):
@@ -441,7 +478,9 @@ Respond with ONLY valid JSON, no markdown fences."""
                 session.last_consolidated = 0
             else:
                 session.last_consolidated = len(session.messages) - keep_count
-            logger.info(f"Memory consolidation done: {len(session.messages)} messages, last_consolidated={session.last_consolidated}")
+            logger.info(
+                f"Memory consolidation done: {len(session.messages)} messages, last_consolidated={session.last_consolidated}"
+            )
         except Exception as e:
             logger.error(f"Memory consolidation failed: {e}")
 
@@ -454,23 +493,18 @@ Respond with ONLY valid JSON, no markdown fences."""
     ) -> str:
         """
         Process a message directly (for CLI or cron usage).
-        
+
         Args:
             content: The message content.
             session_key: Session identifier (overrides channel:chat_id for session lookup).
             channel: Source channel (for tool context routing).
             chat_id: Source chat ID (for tool context routing).
-        
+
         Returns:
             The agent's response.
         """
         await self._connect_mcp()
-        msg = InboundMessage(
-            channel=channel,
-            sender_id="user",
-            chat_id=chat_id,
-            content=content
-        )
-        
+        msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
+
         response = await self._process_message(msg, session_key=session_key)
         return response.content if response else ""

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -1,30 +1,223 @@
-"""Memory system for persistent agent memory."""
+"""Memory system for persistent agent memory with user isolation and collections."""
 
 from pathlib import Path
+from datetime import datetime
+from typing import Any
 
-from nanobot.utils.helpers import ensure_dir
+from nanobot.utils.helpers import ensure_dir, safe_filename
 
 
 class MemoryStore:
-    """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
+    """
+    Multi-layer memory system:
+
+    1. Global collections: brand_guides, briefs, projects (shared across users)
+    2. User memory: per-user preferences and history
+    3. Legacy: MEMORY.md/HISTORY.md for backward compatibility
+
+    Structure:
+        memory/
+        ├── global/
+        │   ├── brand_guides/
+        │   ├── briefs/
+        │   └── projects/
+        ├── users/
+        │   └── {user_id}/
+        │       ├── preferences.md
+        │       └── history.md
+        ├── MEMORY.md (legacy)
+        └── HISTORY.md (legacy)
+    """
+
+    COLLECTIONS = ["brand_guides", "briefs", "projects"]
 
     def __init__(self, workspace: Path):
+        self.workspace = workspace
         self.memory_dir = ensure_dir(workspace / "memory")
+
+        self.global_dir = ensure_dir(self.memory_dir / "global")
+        self.users_dir = ensure_dir(self.memory_dir / "users")
+
+        for coll in self.COLLECTIONS:
+            ensure_dir(self.global_dir / coll)
+
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.history_file = self.memory_dir / "HISTORY.md"
 
+    def _get_user_dir(self, user_id: str) -> Path:
+        """Get or create user-specific directory."""
+        safe_id = safe_filename(user_id)
+        return ensure_dir(self.users_dir / safe_id)
+
+    def _get_collection_dir(self, collection: str, global_only: bool = False) -> Path:
+        """Get collection directory."""
+        if global_only:
+            return ensure_dir(self.global_dir / collection)
+        return ensure_dir(self.global_dir / collection)
+
+    def _get_user_history_file(self, user_id: str) -> Path:
+        """Get user-specific history file."""
+        return self._get_user_dir(user_id) / "history.md"
+
+    def _get_user_preferences_file(self, user_id: str) -> Path:
+        """Get user-specific preferences file."""
+        return self._get_user_dir(user_id) / "preferences.md"
+
+    def list_collections(self, collection: str | None = None) -> list[str]:
+        """List available memory collections or items in a collection."""
+        if collection:
+            coll_dir = self._get_collection_dir(collection, global_only=True)
+            if coll_dir.exists():
+                return [f.stem for f in coll_dir.glob("*.md")]
+            return []
+        return list(self.COLLECTIONS)
+
+    def list_items(self, collection: str, user_id: str | None = None) -> list[dict[str, Any]]:
+        """List items in a collection. If user_id provided, include user's memory."""
+        items = []
+        coll_dir = self._get_collection_dir(collection, global_only=True)
+
+        if coll_dir.exists():
+            for f in coll_dir.glob("*.md"):
+                items.append(
+                    {
+                        "name": f.stem,
+                        "path": str(f.relative_to(self.memory_dir)),
+                        "type": "global",
+                        "modified": datetime.fromtimestamp(f.stat().st_mtime).isoformat(),
+                    }
+                )
+
+        if user_id:
+            user_hist = self._get_user_history_file(user_id)
+            if user_hist.exists():
+                items.append(
+                    {
+                        "name": "history",
+                        "path": str(user_hist.relative_to(self.memory_dir)),
+                        "type": "user",
+                        "modified": datetime.fromtimestamp(user_hist.stat().st_mtime).isoformat(),
+                    }
+                )
+
+            user_pref = self._get_user_preferences_file(user_id)
+            if user_pref.exists():
+                items.append(
+                    {
+                        "name": "preferences",
+                        "path": str(user_pref.relative_to(self.memory_dir)),
+                        "type": "user",
+                        "modified": datetime.fromtimestamp(user_pref.stat().st_mtime).isoformat(),
+                    }
+                )
+
+        return items
+
+    def read(self, collection: str, name: str, user_id: str | None = None) -> str:
+        """Read content from a memory collection or user memory."""
+        if user_id and collection == "users":
+            if name == "history":
+                path = self._get_user_history_file(user_id)
+            elif name == "preferences":
+                path = self._get_user_preferences_file(user_id)
+            else:
+                path = self._get_user_dir(user_id) / f"{name}.md"
+        else:
+            path = self._get_collection_dir(collection, global_only=True) / f"{name}.md"
+
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+        return ""
+
+    def write(self, collection: str, name: str, content: str, user_id: str | None = None) -> str:
+        """Write content to a memory collection or user memory."""
+        if user_id and collection == "users":
+            if name == "history":
+                path = self._get_user_history_file(user_id)
+            elif name == "preferences":
+                path = self._get_user_preferences_file(user_id)
+            else:
+                path = self._get_user_dir(user_id) / f"{name}.md"
+        else:
+            path = self._get_collection_dir(collection, global_only=True) / f"{name}.md"
+
+        path.write_text(content, encoding="utf-8")
+        return f"Written to {path.relative_to(self.memory_dir)}"
+
+    def delete(self, collection: str, name: str, user_id: str | None = None) -> bool:
+        """Delete content from a memory collection or user memory."""
+        if user_id and collection == "users":
+            if name == "history":
+                path = self._get_user_history_file(user_id)
+            elif name == "preferences":
+                path = self._get_user_preferences_file(user_id)
+            else:
+                path = self._get_user_dir(user_id) / f"{name}.md"
+        else:
+            path = self._get_collection_dir(collection, global_only=True) / f"{name}.md"
+
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+    def append_history(self, entry: str, user_id: str | None = None) -> None:
+        """Append to global history or user-specific history."""
+        if user_id:
+            history_file = self._get_user_history_file(user_id)
+        else:
+            history_file = self.history_file
+
+        with open(history_file, "a", encoding="utf-8") as f:
+            f.write(entry.rstrip() + "\n\n")
+
+    def get_user_context(self, user_id: str) -> str:
+        """Get user-specific memory context for agent prompts."""
+        parts = []
+
+        user_pref = self._get_user_preferences_file(user_id)
+        if user_pref.exists():
+            content = user_pref.read_text(encoding="utf-8")
+            if content:
+                parts.append(f"## User Preferences\n{content}")
+
+        parts.append(
+            f"## User Memory Location\nUser ID: {user_id}\n- Preferences: {self._get_user_preferences_file(user_id)}\n- History: {self._get_user_history_file(user_id)}"
+        )
+
+        return "\n\n".join(parts)
+
+    def get_global_context(self, collections: list[str] | None = None) -> str:
+        """Get global memory context from specified collections."""
+        if collections is None:
+            collections = self.COLLECTIONS
+
+        parts = []
+        for coll in collections:
+            coll_dir = self._get_collection_dir(coll, global_only=True)
+            if coll_dir.exists():
+                items = list(coll_dir.glob("*.md"))
+                if items:
+                    part = f"## {coll.replace('_', ' ').title()}\n"
+                    for f in items:
+                        content = f.read_text(encoding="utf-8")
+                        if content:
+                            part += f"\n### {f.stem}\n{content}\n"
+                    parts.append(part)
+
+        return "\n\n".join(parts) if parts else ""
+
     def read_long_term(self) -> str:
+        """Legacy: Read from MEMORY.md."""
         if self.memory_file.exists():
             return self.memory_file.read_text(encoding="utf-8")
         return ""
 
     def write_long_term(self, content: str) -> None:
+        """Legacy: Write to MEMORY.md."""
         self.memory_file.write_text(content, encoding="utf-8")
 
-    def append_history(self, entry: str) -> None:
-        with open(self.history_file, "a", encoding="utf-8") as f:
-            f.write(entry.rstrip() + "\n\n")
-
     def get_memory_context(self) -> str:
+        """Legacy: Get memory context for backward compatibility."""
         long_term = self.read_long_term()
         return f"## Long-term Memory\n{long_term}" if long_term else ""

--- a/nanobot/agent/tools/memory.py
+++ b/nanobot/agent/tools/memory.py
@@ -1,0 +1,152 @@
+"""Memory tool for CRUD operations on memory collections."""
+
+from typing import Any
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.agent.tools.base import Tool
+
+
+class MemoryTool(Tool):
+    """Tool for managing memory collections (brand guides, briefs, projects, user memory)."""
+
+    def __init__(self, memory_store: MemoryStore):
+        self._memory = memory_store
+        self._user_id = ""
+
+    def set_user(self, user_id: str) -> None:
+        """Set the current user ID for user-scoped operations."""
+        self._user_id = user_id
+
+    @property
+    def name(self) -> str:
+        return "memory"
+
+    @property
+    def description(self) -> str:
+        return """Manage memory collections. Collections: brand_guides, briefs, projects (global/shared), users (per-user).
+Actions: read, write, list, delete, search."""
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["read", "write", "list", "delete", "search", "list_collections"],
+                    "description": "Action to perform",
+                },
+                "collection": {
+                    "type": "string",
+                    "enum": ["brand_guides", "briefs", "projects", "users"],
+                    "description": "Memory collection (brand_guides, briefs, projects, users)",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the memory item (without .md extension)",
+                },
+                "content": {"type": "string", "description": "Content to write (for write action)"},
+                "query": {"type": "string", "description": "Search query (for search action)"},
+            },
+            "required": ["action"],
+        }
+
+    async def execute(
+        self,
+        action: str,
+        collection: str | None = None,
+        name: str | None = None,
+        content: str | None = None,
+        query: str | None = None,
+        **kwargs: Any,
+    ) -> str:
+        if action == "list_collections":
+            return self._list_collections()
+        elif action == "list":
+            return self._list(collection)
+        elif action == "read":
+            return self._read(collection, name)
+        elif action == "write":
+            return self._write(collection, name, content)
+        elif action == "delete":
+            return self._delete(collection, name)
+        elif action == "search":
+            return self._search(query, collection)
+        return f"Unknown action: {action}"
+
+    def _list_collections(self) -> str:
+        """List available collections."""
+        collections = self._memory.list_collections()
+        return "Available collections:\n- " + "\n- ".join(collections)
+
+    def _list(self, collection: str | None) -> str:
+        """List items in a collection."""
+        if not collection:
+            return "Error: collection is required for list action"
+
+        items = self._memory.list_items(collection, self._user_id or None)
+        if not items:
+            return f"No items in collection '{collection}'"
+
+        lines = [f"Items in {collection}:"]
+        for item in items:
+            lines.append(f"- {item['name']} ({item['type']}, modified: {item['modified']})")
+
+        return "\n".join(lines)
+
+    def _read(self, collection: str | None, name: str | None) -> str:
+        """Read from a memory collection."""
+        if not collection or not name:
+            return "Error: collection and name are required for read action"
+
+        content = self._memory.read(collection, name, self._user_id or None)
+        if not content:
+            return f"No content found for '{name}' in collection '{collection}'"
+
+        return content
+
+    def _write(self, collection: str | None, name: str | None, content: str | None) -> str:
+        """Write to a memory collection."""
+        if not collection or not name:
+            return "Error: collection, name, and content are required for write action"
+
+        if content is None:
+            return "Error: content is required for write action"
+
+        user_id = self._user_id if collection == "users" else None
+        result = self._memory.write(collection, name, content, user_id)
+        return result
+
+    def _delete(self, collection: str | None, name: str | None) -> str:
+        """Delete from a memory collection."""
+        if not collection or not name:
+            return "Error: collection and name are required for delete action"
+
+        user_id = self._user_id if collection == "users" else None
+        if self._memory.delete(collection, name, user_id):
+            return f"Deleted '{name}' from collection '{collection}'"
+        return f"Item '{name}' not found in collection '{collection}'"
+
+    def _search(self, query: str | None, collection: str | None) -> str:
+        """Search across memory collections."""
+        if not query:
+            return "Error: query is required for search action"
+
+        results = []
+
+        if collection:
+            collections = [collection]
+        else:
+            collections = self._memory.COLLECTIONS + (["users"] if self._user_id else [])
+
+        for coll in collections:
+            items = self._memory.list_items(coll, self._user_id or None)
+            for item in items:
+                content = self._memory.read(coll, item["name"], self._user_id or None)
+                if query.lower() in content.lower():
+                    results.append(f"## {coll}/{item['name']}\n{content[:500]}...")
+
+        if not results:
+            return f"No results found for '{query}'"
+
+        return "\n\n---\n\n".join(results[:5])


### PR DESCRIPTION
## Summary

- Add multi-layer memory system with per-user isolation
- New global collections: `brand_guides`, `briefs`, `projects` (shared across users)
- New user memory: per-user `preferences.md` and `history.md`
- New `memory` tool with CRUD operations: `list_collections`, `list`, `read`, `write`, `delete`, `search`
- Backward compatibility with legacy `MEMORY.md`/`HISTORY.md`

## Changes

1. **nanobot/agent/memory.py**: Rewritten `MemoryStore` class with new structure
2. **nanobot/agent/tools/memory.py**: New tool for managing memory collections
3. **nanobot/agent/context.py**: Updated to include user and global memory in prompts
4. **nanobot/agent/loop.py**: Register `MemoryTool` and pass user_id

## Memory Structure

```
~/.nanobot/workspace/memory/
├── global/
│   ├── brand_guides/
│   ├── briefs/
│   └── projects/
├── users/
│   └── {user_id}/
│       ├── preferences.md
│       └── history.md
├── MEMORY.md (legacy)
└── HISTORY.md (legacy)
```

## Usage

```python
# List collections
memory(action="list_collections")

# Write to global collection
memory(action="write", collection="brand_guides", name="company", content="...")

# Write user preferences
memory(action="write", collection="users", name="preferences", content="...")

# Search
memory(action="search", query="keyword")
```