### PR TITLE
feat: session management with multi-session support

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -268,7 +268,7 @@ class AgentLoop:
         if msg.content.strip().startswith("/"):
             cmd_response = await self.command_handler.process(
                 msg, 
-                session,
+                key,
                 provider=self.provider,
                 model=self.model,
                 memory_window=self.memory_window

--- a/nanobot/io/commands.py
+++ b/nanobot/io/commands.py
@@ -28,9 +28,11 @@ class CommandArgumentParser(argparse.ArgumentParser):
 
 class CommandHandler:
     """
-    Handles meta commands: /new, /reset, /help.
+    Handles meta commands like /model, /session, /help, /status.
     
     Uses argparse for robust command parsing with subcommands support.
+    CommandHandler does NOT directly operate on sessions.
+    Instead, it interacts with SessionManager and ChannelManager.
     """
     
     def __init__(self, sessions: "SessionManager"):
@@ -51,6 +53,19 @@ class CommandHandler:
             description='nanobot commands'
         )
         subparsers = self.parser.add_subparsers(dest='command', help='Available commands')
+
+        # /session command
+        session_parser = subparsers.add_parser(
+            'session', 
+            help='💬 Session Management',
+            description='Manage conversation sessions'
+        )
+        session_parser.add_argument(
+            'action', 
+            nargs='?', 
+            default='info', 
+            help='info | list | consolidate | <session_id>'
+        )
         
         # /reset command
         subparsers.add_parser(
@@ -73,13 +88,13 @@ class CommandHandler:
             description='Show available commands and usage'
         )
     
-    async def process(self, msg, session, provider, model: str, memory_window: int = 50) -> str:
+    async def process(self, msg, user_key, provider, model: str, memory_window: int = 50) -> str:
         """
         Process a command and return response.
         
         Args:
             msg: The inbound message
-            session: The current session
+            user_key: The current user
             provider: LLM provider for memory consolidation
             model: Model name for consolidation
             memory_window: Memory window size for consolidation
@@ -91,8 +106,10 @@ class CommandHandler:
         cmd_content = msg.content.strip()[1:]  # Remove leading '/'
         cmd_parts = cmd_content.split(maxsplit=1)
         command = cmd_parts[0]
-        cmd_line = f"{command}".strip()
+        args = cmd_parts[1] if len(cmd_parts) > 1 else ""
+        cmd_line = f"{command} {args}".strip()
         logger.info(f"Processing command: /{cmd_line}")
+        session = self.sessions.get_or_create(user_key)
         try:
             # Parse command
             parsed_args = self.parser.parse_args(cmd_line.split())
@@ -100,8 +117,10 @@ class CommandHandler:
             # Dispatch to handler
             if parsed_args.command == 'reset':
                 return await self.handle_reset(session)
+            elif parsed_args.command == 'session':
+                return await self.handle_session(parsed_args, user_key,provider, model, memory_window)
             elif parsed_args.command == 'new':
-                return await self.handle_new(session, provider, model, memory_window)
+                return await self.handle_new(user_key)
             elif parsed_args.command == 'help':
                 return self.handle_help()
             else:
@@ -116,7 +135,7 @@ class CommandHandler:
             logger.error(f"Command processing error: {e}")
             return f"❌ Error processing command: {str(e)}\n\nType /help for usage"
     
-    async def handle_new(self, session, provider, model: str, memory_window: int = 50) -> str:
+    async def handle_new(self,user_key) -> str:
         """
         Handle /new command - create a new session.
         
@@ -129,15 +148,9 @@ class CommandHandler:
         Returns:
             Response message
         """
-        await self.sessions.create_new_session(
-            session=session,
-            provider=provider,
-            model=model,
-            memory_window=memory_window
-        )
+        session = self.sessions.create_new_session(user_key)
         return (
             f"🆕 **New Session Created**\n\n"
-            f"🐈 Memory from previous session has been consolidated.\n"
             f"Session key: `{session.key}`"
         )
     
@@ -156,6 +169,100 @@ class CommandHandler:
         self.sessions.save(session)
         
         return "✅ Session reset! All messages cleared. Configuration preserved."
+       
+    async def handle_session(self, args: argparse.Namespace, user_key: str,provider, model, memory_window) -> str:
+        """Handle session commands: info, list, consolidate, or switch to <id>."""
+        action = args.action
+        
+        if action == 'list':
+            return self._handle_session_list(user_key)
+        elif action == 'info' or action is None:
+            return self._handle_session_info(user_key)
+        elif action == 'consolidate':
+            return await self._handle_session_consolidate(user_key,provider, model, memory_window)
+        else:
+            # Treat as session ID to switch to
+            return self._handle_session_switch(user_key,action)
+    
+    def _handle_session_list(self,user_key) -> str:
+        """List all sessions in markdown format."""
+        sessions = self.sessions.list_sessions()
+        
+        if not sessions:
+            return "📋 No sessions found"
+        
+        # Build markdown list
+        lines = ["📋 **Available Sessions:**", ""]
+        
+        for i, session in enumerate(sessions[:20], 1):  # Show top 20
+            logger.debug(session)
+            key = session.get('key', 'unknown')
+            updated = session.get('updated_at', 'unknown')
+            msg_count = session.get("message_count", 0)
+            
+            # Mark current session
+            current_session_id = self.sessions.session_table.get(user_key)
+            is_current = "⭐ " if key == current_session_id else ""
+            
+            lines.append(f"{i}. {is_current}`{key}` - {msg_count} messages (updated: {updated})")
+        
+        # Add summary if there are more sessions
+        if len(sessions) > 20:
+            lines.append("")
+            lines.append(f"... and {len(sessions) - 20} more sessions")
+        
+        lines.append("")
+        lines.append("💡 Use `/session <session_id>` to switch to a specific session")
+        
+        return "\n".join(lines)
+    
+    def _handle_session_info(self, user_key: str) -> str:
+        """Show current session info."""
+        info = self.sessions.get_session_info(user_key)
+        
+        
+        lines = [
+            f"💬 **Session Info**",
+            f"\nSession id: `{info['session_id']}`",
+            f"\nKey: `{info['user_key']}`",
+            f"\nMessages: {info['message_count']}",
+            f"\nCreated: {info['created_at']}",
+            f"\nUpdated: {info['updated_at']}",
+        ]
+        return "\n".join(lines)
+    
+    def _handle_session_switch(self, user_key: str, session_id: str) -> str:
+        """Switch to another session."""
+        # Note: In current architecture, session switching is handled by channel/client
+        # This is more of an informational command
+        results = self.sessions.switch_session(user_key, session_id)
+        if results is True:
+            return (
+                f"✅ **Session Switched**\n\n"
+                f"Now using session: `{session_id}`"
+            )
+        else:
+            return f"❌ Session `{session_id}` not found. Use `/session list` to see available sessions."
+    
+    async def _handle_session_consolidate(self, user_key: str,provider, model, memory_window) -> str:
+        """Consolidate current session's memory."""
+        session = self.sessions.get_or_create(user_key)
+        
+        if not session.messages:
+            return "ℹ️ No messages to consolidate in current session."
+        
+        message_count = len(session.messages)
+        
+        try:
+            consolidate,response = await self.sessions.consolidate_memory(session,provider, model, archive_all=False,memory_window=memory_window)
+            if consolidate:
+                self.sessions.save(session)
+            return f"{response}"
+        except Exception as e:
+            logger.error(f"Consolidation failed: {e}")
+            return f"❌ Failed to consolidate memory: {str(e)}"
+    
+   
     
     def handle_help(self) -> str:
         """
@@ -164,18 +271,86 @@ class CommandHandler:
         Returns:
             Help text with all available commands
         """
-        lines = [
-            "🤖 **Available Commands**",
-            "",
-            "**New Session**",
-            "• `/new` - Create a new conversation session",
-            "",
-            "**Reset Session**",
-            "• `/reset` - Clear all messages in current session",
-            "",
-            "**Help**",
-            "• `/help` - Show this help message",
+        lines = ["# 🤖 nanobot Commands", ""]
+        # Custom examples for specific commands (no verbose descriptions)
+        custom_examples = {
+            'session': [
+                "/session                  # show current session info",
+                "/session list             # list all sessions",
+                "/session consolidate      # compress memory",
+                "/session <session_id>     # switch to session",
+            ],
+            'reset': [
+                "/reset                    # clear all messages",
+            ],
+            'new': [
+                "/new                      # create new session",
+            ],
+            'help': [
+                "/help                     # show this help",
+            ],
+        }
+        
+        # Get all subparsers
+        subparsers_actions = [
+            action for action in self.parser._actions 
+            if isinstance(action, argparse._SubParsersAction)
         ]
+        
+        if subparsers_actions:
+            for subparsers_action in subparsers_actions:
+                for choice, subparser in subparsers_action.choices.items():
+                    # Get help text from the subparsers_action, not from subparser
+                    help_text = subparsers_action.choices[choice].description or choice
+                    
+                    # Format command with description
+                    lines.append(f"### `/{choice}`")
+                    lines.append(f"> {help_text}")
+                    lines.append("")
+                    
+                    # Use custom examples if available
+                    if choice in custom_examples:
+                        lines.append("```")
+                        for example in custom_examples[choice]:
+                            lines.append(example)
+                        lines.append("```")
+                        lines.append("")
+                    else:
+                        # Add argument details for other commands
+                        args_help = []
+                        for action in subparser._actions:
+                            if action.dest not in ['help', 'command']:
+                                if action.dest == 'action' and action.help:
+                                    args_help.append(action.help)
+                                elif action.option_strings:
+                                    opt_str = '/'.join(action.option_strings)
+                                    args_help.append(f"`{opt_str}` - {action.help}")
+                                elif action.help:
+                                    dest_display = f"<{action.dest}>"
+                                    if action.nargs in ['+', '*']:
+                                        dest_display = f"<{action.dest}...>"
+                                    args_help.append(f"`{dest_display}` - {action.help}")
+                        
+                        if args_help:
+                            for help_item in args_help:
+                                lines.append(help_item)
+                            lines.append("")
+                        
+                        # Add example if available
+                        if hasattr(subparser, 'epilog') and subparser.epilog:
+                            lines.append(f"**{subparser.epilog}**")
+                            lines.append("")
+        
+        # Add tips
+        lines.extend([
+            "---",
+            "",
+            "## 💡 Tips",
+            "",
+            "- All commands must start with `/`",
+            "- Model changes only affect the current session",
+            "- Each session can use a different model independently",
+        ])
         
         return "\n".join(lines)
     


### PR DESCRIPTION
⚠️ Note: This PR depends on #677 . Please review/merge that one first."

This PR is the second step towards the session management discussed in PR https://github.com/HKUDS/nanobot/pull/607.
It introduces a dedicated Session Management system, allowing users to create, switch, and manage multiple contexts without losing historical data.

**Key Changes:**

**Session Mapping Table**: Added a session table within the SessionManager to map users to multiple unique Session IDs. This decouples the User ID from the Session ID.

**Non-Destructive Logic**: 
- Previously, creating a new session required consolidating and clearing the old one because the user key was tied directly to the session.

- With this update, creating a new session simply initializes a new ID. The old session remains intact and untouched.

- Memory Integrity: Memory consolidation (session_consolidate) is no longer automatic. It only occurs when explicitly invoked by the user, preventing accidental loss of conversation history.

**CLI Command Support: Added handling for interaction commands:**
```
Session	
/session	Show info about the current session
/session list	List all existing sessions
/session <id>	Switch to a different session
/session consolidate	Manually trigger memory compression
Management	
/new	Start a completely new conversation session
/reset	Clear all messages in the current session
Help	
/help	Show the help menu with all available command
```

Next Steps / Roadmap:

[x] Decoupled command handler (Completed)

[x] Session Management (This PR)

[ ] Permission Management: Implementing "Human-in-the-loop" approvals for sensitive tool calls based on session metadata.