### PR TITLE
fix(telegram): Slash commands failing access check due to missing username in sender_id

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -226,8 +226,14 @@ class TelegramChannel(BaseChannel):
         """Forward slash commands to the bus for unified handling in AgentLoop."""
         if not update.message or not update.effective_user:
             return
+        
+        user = update.effective_user
+        sender_id = str(user.id)
+        if user.username:
+            sender_id = f"{sender_id}|{user.username}"
+        
         await self._handle_message(
-            sender_id=str(update.effective_user.id),
+            sender_id=sender_id,
             chat_id=str(update.message.chat_id),
             content=update.message.text,
         )


### PR DESCRIPTION
Slash commands (/new, /help, etc.) were being rejected by the access check because `_forward_command` only passed the bare user ID (e.g., `11111111`), while `allowFrom` in the config uses the `id|username` format (e.g., `11111111|my_username`).

The fix makes `_forward_command` build the `sender_id` the same way `_on_message` does (which means including the username when available).

Before:
```python
sender_id = str(user.id)
```

After:
```python
sender_id = str(user.id)
if user.username:
    sender_id = f"{sender_id}|{user.username}"
```