### PR TITLE
fix: clarify message tool parameter descriptions

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -47,11 +47,11 @@ class MessageTool(Tool):
                 },
                 "channel": {
                     "type": "string",
-                    "description": "Optional: target channel (telegram, discord, etc.)"
+                    "description": "Optional: target platform (telegram, discord, etc.)"
                 },
                 "chat_id": {
                     "type": "string",
-                    "description": "Optional: target chat/user ID"
+                    "description": "Optional: target chat/channel/user ID"
                 }
             },
             "required": ["content"]


### PR DESCRIPTION
## Summary

When asked to send a message to a different chat (e.g. a group channel instead of the current DM), the LLM puts the platform-specific channel ID into the `channel` parameter instead of `chat_id`, causing the outbound dispatcher to fail with `Unknown channel`.

This happens because the `channel` parameter description says "target channel" which the LLM interprets as the target chat channel, not the platform type.

Fix: change `channel` description from "target channel" to "target platform", and add "channel" to the `chat_id` description so the LLM knows where to put platform-specific channel IDs.

## Test plan

- In a DM conversation, ask nanobot to send a message to a specific group channel
- Verify the LLM correctly sets `channel` to the platform name and `chat_id` to the group channel ID
- Verify the message is delivered to the target channel