### PR TITLE
fix: memory consolidation not awaited for single chat

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -85,6 +85,7 @@ class AgentLoop:
         )
         
         self._running = False
+        self._pending_consolidations: list[asyncio.Task] = []
         self._mcp_servers = mcp_servers or {}
         self._mcp_stack: AsyncExitStack | None = None
         self._mcp_connected = False
@@ -279,7 +280,8 @@ class AgentLoop:
                 temp_session.messages = messages_to_archive
                 await self._consolidate_memory(temp_session, archive_all=True)
 
-            asyncio.create_task(_consolidate_and_cleanup())
+            task = asyncio.create_task(_consolidate_and_cleanup())
+            self._pending_consolidations.append(task)
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
                                   content="New session started. Memory consolidation in progress.")
         if cmd == "/help":
@@ -287,7 +289,8 @@ class AgentLoop:
                                   content="🐈 nanobot commands:\n/new — Start a new conversation\n/help — Show available commands")
         
         if len(session.messages) > self.memory_window:
-            asyncio.create_task(self._consolidate_memory(session))
+            task = asyncio.create_task(self._consolidate_memory(session))
+            self._pending_consolidations.append(task)
 
         self._set_tool_context(msg.channel, msg.chat_id)
         initial_messages = self.context.build_messages(
@@ -473,4 +476,13 @@ Respond with ONLY valid JSON, no markdown fences."""
         )
         
         response = await self._process_message(msg, session_key=session_key)
+
+        # Await any pending consolidation tasks so they complete before the
+        # process exits (critical for single-message mode).
+        # It adds a few seconds delay for interactive mode while the user is
+        # reading the response.
+        if self._pending_consolidations:
+            await asyncio.gather(*self._pending_consolidations, return_exceptions=True)
+            self._pending_consolidations.clear()
+
         return response.content if response else ""


### PR DESCRIPTION
## Summary

This PR fixes memory was not consolidated when using the agent in single message mode

### 1. Feature/Fix Name (Critical)

* Add pending consolidation tasks to `_pending_consolidations`  and await any pending tasks `process_direct` function

---

## Testing
```
 $ nanobot agent -m "I m happy since today is Chinese new year"
 ......
 $ nanobot agent -m "/new"
 $ nanobot agent -m "do you remmeber why am I happy?"

🐈 nanobot
Yes, I do remember now! 🎉                                                                                                                                                                                             

You're happy because it's Chinese New Year — the Year of the Snake! 🐍                                                                                                                                                 

You mentioned this earlier today. Happy Chinese New Year! 新年快乐！                                                                                                                                                   

Are you doing anything special to celebrate?                                                                
```