### PR TITLE
fix(cli): use resolved npm path on Windows for bridge setup and start

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -617,8 +617,9 @@ def _get_bridge_dir() -> Path:
     if (user_bridge / "dist" / "index.js").exists():
         return user_bridge
     
-    # Check for npm
-    if not shutil.which("npm"):
+    # Check for npm (use resolved path so Windows finds npm.cmd)
+    npm_cmd = shutil.which("npm")
+    if not npm_cmd:
         console.print("[red]npm not found. Please install Node.js >= 18.[/red]")
         raise typer.Exit(1)
     
@@ -648,10 +649,10 @@ def _get_bridge_dir() -> Path:
     # Install and build
     try:
         console.print("  Installing dependencies...")
-        subprocess.run(["npm", "install"], cwd=user_bridge, check=True, capture_output=True)
+        subprocess.run([npm_cmd, "install"], cwd=user_bridge, check=True, capture_output=True)
         
         console.print("  Building...")
-        subprocess.run(["npm", "run", "build"], cwd=user_bridge, check=True, capture_output=True)
+        subprocess.run([npm_cmd, "run", "build"], cwd=user_bridge, check=True, capture_output=True)
         
         console.print("[green]✓[/green] Bridge ready\n")
     except subprocess.CalledProcessError as e:
@@ -666,11 +667,17 @@ def _get_bridge_dir() -> Path:
 @channels_app.command("login")
 def channels_login():
     """Link device via QR code."""
+    import shutil
     import subprocess
     from nanobot.config.loader import load_config
     
     config = load_config()
     bridge_dir = _get_bridge_dir()
+    
+    npm_cmd = shutil.which("npm")
+    if not npm_cmd:
+        console.print("[red]npm not found. Please install Node.js.[/red]")
+        raise typer.Exit(1)
     
     console.print(f"{__logo__} Starting bridge...")
     console.print("Scan the QR code to connect.\n")
@@ -680,7 +687,7 @@ def channels_login():
         env["BRIDGE_TOKEN"] = config.channels.whatsapp.bridge_token
     
     try:
-        subprocess.run(["npm", "start"], cwd=bridge_dir, check=True, env=env)
+        subprocess.run([npm_cmd, "start"], cwd=bridge_dir, check=True, env=env)
     except subprocess.CalledProcessError as e:
         console.print(f"[red]Bridge failed: {e}[/red]")
     except FileNotFoundError:


### PR DESCRIPTION
On Windows, subprocess.run(["npm", ...]) fails with FileNotFoundError because CreateProcess does not resolve "npm" to npm.cmd. Use the path returned by shutil.which("npm") for all npm subprocess calls in _get_bridge_dir() (install, build) and channels_login() (start), so the correct executable (e.g. npm.cmd) is used.