### PR TITLE
fix(cron): preserve timezone for cron schedules

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -50,6 +50,10 @@ class CronTool(Tool):
                     "type": "string",
                     "description": "Cron expression like '0 9 * * *' (for scheduled tasks)"
                 },
+                "tz": {
+                    "type": "string",
+                    "description": "IANA timezone for cron expressions (e.g. 'America/Vancouver')"
+                },
                 "at": {
                     "type": "string",
                     "description": "ISO datetime for one-time execution (e.g. '2026-02-12T10:30:00')"
@@ -68,30 +72,40 @@ class CronTool(Tool):
         message: str = "",
         every_seconds: int | None = None,
         cron_expr: str | None = None,
+        tz: str | None = None,
         at: str | None = None,
         job_id: str | None = None,
         **kwargs: Any
     ) -> str:
         if action == "add":
-            return self._add_job(message, every_seconds, cron_expr, at)
+            return self._add_job(message, every_seconds, cron_expr, tz, at)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
             return self._remove_job(job_id)
         return f"Unknown action: {action}"
     
-    def _add_job(self, message: str, every_seconds: int | None, cron_expr: str | None, at: str | None) -> str:
+    def _add_job(
+        self,
+        message: str,
+        every_seconds: int | None,
+        cron_expr: str | None,
+        tz: str | None,
+        at: str | None,
+    ) -> str:
         if not message:
             return "Error: message is required for add"
         if not self._channel or not self._chat_id:
             return "Error: no session context (channel/chat_id)"
+        if tz and not cron_expr:
+            return "Error: tz can only be used with cron_expr"
         
         # Build schedule
         delete_after = False
         if every_seconds:
             schedule = CronSchedule(kind="every", every_ms=every_seconds * 1000)
         elif cron_expr:
-            schedule = CronSchedule(kind="cron", expr=cron_expr)
+            schedule = CronSchedule(kind="cron", expr=cron_expr, tz=tz)
         elif at:
             from datetime import datetime
             dt = datetime.fromisoformat(at)

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -32,7 +32,8 @@ def _compute_next_run(schedule: CronSchedule, now_ms: int) -> int | None:
         try:
             from croniter import croniter
             from zoneinfo import ZoneInfo
-            base_time = time.time()
+            # Use the caller-provided reference time for deterministic scheduling.
+            base_time = now_ms / 1000
             tz = ZoneInfo(schedule.tz) if schedule.tz else datetime.now().astimezone().tzinfo
             base_dt = datetime.fromtimestamp(base_time, tz=tz)
             cron = croniter(schedule.expr, base_dt)


### PR DESCRIPTION
## Summary
This PR addresses the cron timezone portion of #685.

## What changed
- Use the provided `now_ms` reference when computing cron next-run times (deterministic scheduling basis).
- Keep timezone metadata (`tz`) when creating cron jobs from:
  - CLI (`nanobot cron add --cron '...' --tz '...'`)
  - agent cron tool (`cron` action with `tz`)
- Improve `nanobot cron list` display to show cron timezone and render next-run in that timezone when available.

## Why
Issue #685 reported jobs configured for `America/Vancouver` running at the wrong local time.
This patch keeps timezone context across scheduling entry points and avoids accidental loss of timezone metadata.

## Scope
- Fixes timezone scheduling behavior only.
- Does not implement the separate email-integration/tooling part of #685.

Fixes #685
