### PR TITLE
fix: use Pydantic alias_generator to prevent mangling of env var keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ __pycache__/
 poetry.lock
 .pytest_cache/
 botpy.log
-tests/

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -2,7 +2,6 @@
 
 import json
 from pathlib import Path
-from typing import Any
 
 from nanobot.config.schema import Config
 
@@ -21,45 +20,41 @@ def get_data_dir() -> Path:
 def load_config(config_path: Path | None = None) -> Config:
     """
     Load configuration from file or create default.
-    
+
     Args:
         config_path: Optional path to config file. Uses default if not provided.
-    
+
     Returns:
         Loaded configuration object.
     """
     path = config_path or get_config_path()
-    
+
     if path.exists():
         try:
             with open(path) as f:
                 data = json.load(f)
             data = _migrate_config(data)
-            return Config.model_validate(convert_keys(data))
+            return Config.model_validate(data)
         except (json.JSONDecodeError, ValueError) as e:
             print(f"Warning: Failed to load config from {path}: {e}")
             print("Using default configuration.")
-    
+
     return Config()
 
 
 def save_config(config: Config, config_path: Path | None = None) -> None:
     """
     Save configuration to file.
-    
+
     Args:
         config: Configuration to save.
         config_path: Optional path to save to. Uses default if not provided.
     """
     path = config_path or get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    
-    # Convert to camelCase format
-    data = config.model_dump()
-    data = convert_to_camel(data)
-    
+
     with open(path, "w") as f:
-        json.dump(data, f, indent=2)
+        json.dump(config.model_dump(by_alias=True), f, indent=2)
 
 
 def _migrate_config(data: dict) -> dict:
@@ -70,37 +65,3 @@ def _migrate_config(data: dict) -> dict:
     if "restrictToWorkspace" in exec_cfg and "restrictToWorkspace" not in tools:
         tools["restrictToWorkspace"] = exec_cfg.pop("restrictToWorkspace")
     return data
-
-
-def convert_keys(data: Any) -> Any:
-    """Convert camelCase keys to snake_case for Pydantic."""
-    if isinstance(data, dict):
-        return {camel_to_snake(k): convert_keys(v) for k, v in data.items()}
-    if isinstance(data, list):
-        return [convert_keys(item) for item in data]
-    return data
-
-
-def convert_to_camel(data: Any) -> Any:
-    """Convert snake_case keys to camelCase."""
-    if isinstance(data, dict):
-        return {snake_to_camel(k): convert_to_camel(v) for k, v in data.items()}
-    if isinstance(data, list):
-        return [convert_to_camel(item) for item in data]
-    return data
-
-
-def camel_to_snake(name: str) -> str:
-    """Convert camelCase to snake_case."""
-    result = []
-    for i, char in enumerate(name):
-        if char.isupper() and i > 0:
-            result.append("_")
-        result.append(char.lower())
-    return "".join(result)
-
-
-def snake_to_camel(name: str) -> str:
-    """Convert snake_case to camelCase."""
-    components = name.split("_")
-    return components[0] + "".join(x.title() for x in components[1:])

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -1,11 +1,30 @@
 """Configuration schema using Pydantic."""
 
 from pathlib import Path
-from pydantic import BaseModel, Field, ConfigDict
+
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic_settings import BaseSettings
 
 
-class WhatsAppConfig(BaseModel):
+def _snake_to_camel(name: str) -> str:
+    """Convert snake_case to camelCase for JSON serialization."""
+    components = name.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
+class _Base(BaseModel):
+    """Base model with camelCase alias generation.
+
+    Pydantic's alias_generator only converts model field names,
+    never arbitrary dict keys (env vars, headers, server names, etc.).
+    """
+    model_config = ConfigDict(
+        alias_generator=_snake_to_camel,
+        populate_by_name=True,
+    )
+
+
+class WhatsAppConfig(_Base):
     """WhatsApp channel configuration."""
     enabled: bool = False
     bridge_url: str = "ws://localhost:3001"
@@ -13,7 +32,7 @@ class WhatsAppConfig(BaseModel):
     allow_from: list[str] = Field(default_factory=list)  # Allowed phone numbers
 
 
-class TelegramConfig(BaseModel):
+class TelegramConfig(_Base):
     """Telegram channel configuration."""
     enabled: bool = False
     token: str = ""  # Bot token from @BotFather
@@ -21,7 +40,7 @@ class TelegramConfig(BaseModel):
     proxy: str | None = None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
 
 
-class FeishuConfig(BaseModel):
+class FeishuConfig(_Base):
     """Feishu/Lark channel configuration using WebSocket long connection."""
     enabled: bool = False
     app_id: str = ""  # App ID from Feishu Open Platform
@@ -31,7 +50,7 @@ class FeishuConfig(BaseModel):
     allow_from: list[str] = Field(default_factory=list)  # Allowed user open_ids
 
 
-class DingTalkConfig(BaseModel):
+class DingTalkConfig(_Base):
     """DingTalk channel configuration using Stream mode."""
     enabled: bool = False
     client_id: str = ""  # AppKey
@@ -39,7 +58,7 @@ class DingTalkConfig(BaseModel):
     allow_from: list[str] = Field(default_factory=list)  # Allowed staff_ids
 
 
-class DiscordConfig(BaseModel):
+class DiscordConfig(_Base):
     """Discord channel configuration."""
     enabled: bool = False
     token: str = ""  # Bot token from Discord Developer Portal
@@ -47,7 +66,8 @@ class DiscordConfig(BaseModel):
     gateway_url: str = "wss://gateway.discord.gg/?v=10&encoding=json"
     intents: int = 37377  # GUILDS + GUILD_MESSAGES + DIRECT_MESSAGES + MESSAGE_CONTENT
 
-class EmailConfig(BaseModel):
+
+class EmailConfig(_Base):
     """Email channel configuration (IMAP inbound + SMTP outbound)."""
     enabled: bool = False
     consent_granted: bool = False  # Explicit owner permission to access mailbox data
@@ -78,17 +98,17 @@ class EmailConfig(BaseModel):
     allow_from: list[str] = Field(default_factory=list)  # Allowed sender email addresses
 
 
-class MochatMentionConfig(BaseModel):
+class MochatMentionConfig(_Base):
     """Mochat mention behavior configuration."""
     require_in_groups: bool = False
 
 
-class MochatGroupRule(BaseModel):
+class MochatGroupRule(_Base):
     """Mochat per-group mention requirement."""
     require_mention: bool = False
 
 
-class MochatConfig(BaseModel):
+class MochatConfig(_Base):
     """Mochat channel configuration."""
     enabled: bool = False
     base_url: str = "https://mochat.io"
@@ -114,14 +134,14 @@ class MochatConfig(BaseModel):
     reply_delay_ms: int = 120000
 
 
-class SlackDMConfig(BaseModel):
+class SlackDMConfig(_Base):
     """Slack DM policy configuration."""
     enabled: bool = True
     policy: str = "open"  # "open" or "allowlist"
     allow_from: list[str] = Field(default_factory=list)  # Allowed Slack user IDs
 
 
-class SlackConfig(BaseModel):
+class SlackConfig(_Base):
     """Slack channel configuration."""
     enabled: bool = False
     mode: str = "socket"  # "socket" supported
@@ -134,7 +154,7 @@ class SlackConfig(BaseModel):
     dm: SlackDMConfig = Field(default_factory=SlackDMConfig)
 
 
-class QQConfig(BaseModel):
+class QQConfig(_Base):
     """QQ channel configuration using botpy SDK."""
     enabled: bool = False
     app_id: str = ""  # 机器人 ID (AppID) from q.qq.com
@@ -142,7 +162,7 @@ class QQConfig(BaseModel):
     allow_from: list[str] = Field(default_factory=list)  # Allowed user openids (empty = public access)
 
 
-class ChannelsConfig(BaseModel):
+class ChannelsConfig(_Base):
     """Configuration for chat channels."""
     whatsapp: WhatsAppConfig = Field(default_factory=WhatsAppConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
@@ -155,7 +175,7 @@ class ChannelsConfig(BaseModel):
     qq: QQConfig = Field(default_factory=QQConfig)
 
 
-class AgentDefaults(BaseModel):
+class AgentDefaults(_Base):
     """Default agent configuration."""
     workspace: str = "~/.nanobot/workspace"
     model: str = "anthropic/claude-opus-4-5"
@@ -165,19 +185,19 @@ class AgentDefaults(BaseModel):
     memory_window: int = 50
 
 
-class AgentsConfig(BaseModel):
+class AgentsConfig(_Base):
     """Agent configuration."""
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
 
 
-class ProviderConfig(BaseModel):
+class ProviderConfig(_Base):
     """LLM provider configuration."""
     api_key: str = ""
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
 
 
-class ProvidersConfig(BaseModel):
+class ProvidersConfig(_Base):
     """Configuration for LLM providers."""
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -195,29 +215,29 @@ class ProvidersConfig(BaseModel):
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenAI Codex (OAuth)
 
 
-class GatewayConfig(BaseModel):
+class GatewayConfig(_Base):
     """Gateway/server configuration."""
     host: str = "0.0.0.0"
     port: int = 18790
 
 
-class WebSearchConfig(BaseModel):
+class WebSearchConfig(_Base):
     """Web search tool configuration."""
     api_key: str = ""  # Brave Search API key
     max_results: int = 5
 
 
-class WebToolsConfig(BaseModel):
+class WebToolsConfig(_Base):
     """Web tools configuration."""
     search: WebSearchConfig = Field(default_factory=WebSearchConfig)
 
 
-class ExecToolConfig(BaseModel):
+class ExecToolConfig(_Base):
     """Shell exec tool configuration."""
     timeout: int = 60
 
 
-class MCPServerConfig(BaseModel):
+class MCPServerConfig(_Base):
     """MCP server connection configuration (stdio or HTTP)."""
     command: str = ""  # Stdio: command to run (e.g. "npx")
     args: list[str] = Field(default_factory=list)  # Stdio: command arguments
@@ -225,7 +245,7 @@ class MCPServerConfig(BaseModel):
     url: str = ""  # HTTP: streamable HTTP endpoint URL
 
 
-class ToolsConfig(BaseModel):
+class ToolsConfig(_Base):
     """Tools configuration."""
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
@@ -240,12 +260,12 @@ class Config(BaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
-    
+
     @property
     def workspace_path(self) -> Path:
         """Get expanded workspace path."""
         return Path(self.agents.defaults.workspace).expanduser()
-    
+
     def _match_provider(self, model: str | None = None) -> tuple["ProviderConfig | None", str | None]:
         """Match provider config and its registry name. Returns (config, spec_name)."""
         from nanobot.providers.registry import PROVIDERS
@@ -282,7 +302,7 @@ class Config(BaseSettings):
         """Get API key for the given model. Falls back to first available key."""
         p = self.get_provider(model)
         return p.api_key if p else None
-    
+
     def get_api_base(self, model: str | None = None) -> str | None:
         """Get API base URL for the given model. Applies default URLs for known gateways."""
         from nanobot.providers.registry import find_by_name
@@ -297,8 +317,10 @@ class Config(BaseSettings):
             if spec and spec.is_gateway and spec.default_api_base:
                 return spec.default_api_base
         return None
-    
+
     model_config = ConfigDict(
+        alias_generator=_snake_to_camel,
+        populate_by_name=True,
         env_prefix="NANOBOT_",
-        env_nested_delimiter="__"
+        env_nested_delimiter="__",
     )

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,469 @@
+"""Tests for config schema-driven loading (alias_generator approach)."""
+
+import json
+
+from nanobot.config.loader import _migrate_config, load_config, save_config
+from nanobot.config.schema import (
+    Config,
+    MCPServerConfig,
+    ProviderConfig,
+    ToolsConfig,
+    _snake_to_camel,
+)
+
+# ---------------------------------------------------------------------------
+# _snake_to_camel helper
+# ---------------------------------------------------------------------------
+
+class TestSnakeToCamel:
+    """Tests for the alias_generator helper."""
+
+    def test_simple(self):
+        assert _snake_to_camel("snake_case") == "snakeCase"
+
+    def test_multiple_words(self):
+        assert _snake_to_camel("this_is_a_test") == "thisIsATest"
+
+    def test_single_word(self):
+        assert _snake_to_camel("word") == "word"
+
+    def test_already_no_underscores(self):
+        assert _snake_to_camel("alreadycamel") == "alreadycamel"
+
+    def test_empty_string(self):
+        assert _snake_to_camel("") == ""
+
+    def test_field_names_from_schema(self):
+        """Verify the helper produces correct aliases for real schema fields."""
+        assert _snake_to_camel("mcp_servers") == "mcpServers"
+        assert _snake_to_camel("extra_headers") == "extraHeaders"
+        assert _snake_to_camel("restrict_to_workspace") == "restrictToWorkspace"
+        assert _snake_to_camel("bridge_url") == "bridgeUrl"
+        assert _snake_to_camel("api_key") == "apiKey"
+        assert _snake_to_camel("max_tool_iterations") == "maxToolIterations"
+
+
+# ---------------------------------------------------------------------------
+# Model validation: loading camelCase JSON
+# ---------------------------------------------------------------------------
+
+class TestModelValidateFromCamelCase:
+    """Config.model_validate should accept camelCase keys from JSON."""
+
+    def test_loads_top_level_fields(self):
+        data = {
+            "agents": {"defaults": {"model": "gpt-4", "maxTokens": 4096}},
+        }
+        cfg = Config.model_validate(data)
+        assert cfg.agents.defaults.model == "gpt-4"
+        assert cfg.agents.defaults.max_tokens == 4096
+
+    def test_loads_mcp_server(self):
+        data = {
+            "tools": {
+                "mcpServers": {
+                    "tavily": {
+                        "command": "npx",
+                        "args": ["-y", "@mcptools/mcp-tavily"],
+                        "env": {"TAVILY_API_KEY": "tvly-secret"},
+                    }
+                }
+            }
+        }
+        cfg = Config.model_validate(data)
+        srv = cfg.tools.mcp_servers["tavily"]
+        assert srv.command == "npx"
+        assert srv.args == ["-y", "@mcptools/mcp-tavily"]
+        assert srv.env == {"TAVILY_API_KEY": "tvly-secret"}
+
+    def test_loads_provider_with_extra_headers(self):
+        data = {
+            "providers": {
+                "openai": {
+                    "apiKey": "sk-xxx",
+                    "extraHeaders": {
+                        "X-Custom-Header": "value",
+                        "Authorization": "Bearer xyz",
+                    },
+                }
+            }
+        }
+        cfg = Config.model_validate(data)
+        assert cfg.providers.openai.api_key == "sk-xxx"
+        assert cfg.providers.openai.extra_headers == {
+            "X-Custom-Header": "value",
+            "Authorization": "Bearer xyz",
+        }
+
+    def test_loads_snake_case_fields_too(self):
+        """populate_by_name=True means snake_case field names also work."""
+        data = {
+            "tools": {
+                "restrict_to_workspace": True,
+                "mcp_servers": {
+                    "test": {"command": "echo"},
+                },
+            }
+        }
+        cfg = Config.model_validate(data)
+        assert cfg.tools.restrict_to_workspace is True
+        assert "test" in cfg.tools.mcp_servers
+
+    def test_defaults_when_empty(self):
+        cfg = Config.model_validate({})
+        assert cfg.agents.defaults.model == "anthropic/claude-opus-4-5"
+        assert cfg.tools.mcp_servers == {}
+        assert cfg.providers.openai.api_key == ""
+
+
+# ---------------------------------------------------------------------------
+# Env var / arbitrary dict key preservation
+# ---------------------------------------------------------------------------
+
+class TestEnvKeyPreservation:
+    """Env var keys must never be mangled by alias_generator."""
+
+    def test_uppercase_env_keys_preserved(self):
+        srv = MCPServerConfig.model_validate({
+            "command": "npx",
+            "env": {"TAVILY_API_KEY": "secret", "NODE_ENV": "production"},
+        })
+        assert srv.env == {"TAVILY_API_KEY": "secret", "NODE_ENV": "production"}
+
+    def test_mixed_case_env_keys_preserved(self):
+        srv = MCPServerConfig.model_validate({
+            "command": "cmd",
+            "env": {"myKey": "val", "UPPER": "1", "lower": "2"},
+        })
+        assert srv.env == {"myKey": "val", "UPPER": "1", "lower": "2"}
+
+    def test_env_keys_with_special_chars(self):
+        srv = MCPServerConfig.model_validate({
+            "command": "cmd",
+            "env": {"MY_VAR_123": "x", "PATH": "/usr/bin"},
+        })
+        assert srv.env["MY_VAR_123"] == "x"
+        assert srv.env["PATH"] == "/usr/bin"
+
+    def test_empty_env_dict(self):
+        srv = MCPServerConfig.model_validate({"command": "cmd", "env": {}})
+        assert srv.env == {}
+
+    def test_extra_headers_preserved(self):
+        prov = ProviderConfig.model_validate({
+            "apiKey": "sk-xxx",
+            "extraHeaders": {"X-Request-ID": "abc", "APP-Code": "hub123"},
+        })
+        assert prov.extra_headers == {"X-Request-ID": "abc", "APP-Code": "hub123"}
+
+    def test_mcp_server_names_preserved(self):
+        """MCP server names are dict keys and must not be converted."""
+        data = {
+            "mcpServers": {
+                "my-custom-server": {"command": "cmd1"},
+                "another_server": {"command": "cmd2"},
+                "CamelServer": {"command": "cmd3"},
+            }
+        }
+        cfg = ToolsConfig.model_validate(data)
+        assert "my-custom-server" in cfg.mcp_servers
+        assert "another_server" in cfg.mcp_servers
+        assert "CamelServer" in cfg.mcp_servers
+
+
+# ---------------------------------------------------------------------------
+# model_dump(by_alias=True): saving to camelCase
+# ---------------------------------------------------------------------------
+
+class TestModelDumpByAlias:
+    """model_dump(by_alias=True) should produce camelCase field names."""
+
+    def test_simple_field_aliases(self):
+        srv = MCPServerConfig(command="npx", args=["-y", "pkg"])
+        d = srv.model_dump(by_alias=True)
+        assert d["command"] == "npx"
+        assert d["args"] == ["-y", "pkg"]
+
+    def test_nested_config_aliases(self):
+        cfg = Config()
+        d = cfg.model_dump(by_alias=True)
+        assert "agents" in d
+        assert "tools" in d
+        assert "providers" in d
+        assert "maxTokens" in d["agents"]["defaults"]
+        assert "mcpServers" in d["tools"]
+        assert "restrictToWorkspace" in d["tools"]
+        assert "extraHeaders" in d["providers"]["openai"]
+
+    def test_env_keys_preserved_on_dump(self):
+        srv = MCPServerConfig(
+            command="npx",
+            env={"TAVILY_API_KEY": "tvly-secret", "NODE_ENV": "production"},
+        )
+        d = srv.model_dump(by_alias=True)
+        assert d["env"] == {"TAVILY_API_KEY": "tvly-secret", "NODE_ENV": "production"}
+
+    def test_extra_headers_preserved_on_dump(self):
+        prov = ProviderConfig(
+            api_key="sk-xxx",
+            extra_headers={"X-Custom": "val", "APP-Code": "abc"},
+        )
+        d = prov.model_dump(by_alias=True)
+        assert d["extraHeaders"] == {"X-Custom": "val", "APP-Code": "abc"}
+        assert d["apiKey"] == "sk-xxx"
+
+    def test_mcp_server_names_preserved_on_dump(self):
+        cfg = ToolsConfig(mcp_servers={
+            "my-server": MCPServerConfig(command="cmd"),
+            "UPPER_SERVER": MCPServerConfig(command="cmd2"),
+        })
+        d = cfg.model_dump(by_alias=True)
+        assert "my-server" in d["mcpServers"]
+        assert "UPPER_SERVER" in d["mcpServers"]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: load camelCase JSON → model_validate → model_dump → same JSON
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    """Config should round-trip through model_validate + model_dump(by_alias=True)."""
+
+    def test_mcp_config_round_trip(self):
+        original = {
+            "tools": {
+                "mcpServers": {
+                    "tavily": {
+                        "command": "npx",
+                        "args": ["-y", "@mcptools/mcp-tavily"],
+                        "env": {"TAVILY_API_KEY": "tvly-secret-key"},
+                    }
+                }
+            }
+        }
+        cfg = Config.model_validate(original)
+        dumped = cfg.model_dump(by_alias=True)
+
+        tavily = dumped["tools"]["mcpServers"]["tavily"]
+        assert tavily["command"] == "npx"
+        assert tavily["args"] == ["-y", "@mcptools/mcp-tavily"]
+        assert tavily["env"]["TAVILY_API_KEY"] == "tvly-secret-key"
+
+    def test_full_config_round_trip(self):
+        original = {
+            "tools": {
+                "mcpServers": {
+                    "server1": {
+                        "command": "cmd",
+                        "env": {"API_KEY": "key1", "DEBUG_MODE": "true"},
+                    }
+                },
+                "restrictToWorkspace": True,
+            },
+            "providers": {
+                "openai": {
+                    "apiKey": "sk-xxx",
+                    "extraHeaders": {"X-Request-ID": "123"},
+                }
+            },
+            "agents": {
+                "defaults": {
+                    "model": "gpt-4",
+                    "maxTokens": 4096,
+                    "maxToolIterations": 30,
+                }
+            },
+        }
+        cfg = Config.model_validate(original)
+        dumped = cfg.model_dump(by_alias=True)
+
+        # Env keys preserved
+        assert dumped["tools"]["mcpServers"]["server1"]["env"]["API_KEY"] == "key1"
+        assert dumped["tools"]["mcpServers"]["server1"]["env"]["DEBUG_MODE"] == "true"
+        # Header keys preserved
+        assert dumped["providers"]["openai"]["extraHeaders"]["X-Request-ID"] == "123"
+        # camelCase field names used
+        assert dumped["providers"]["openai"]["apiKey"] == "sk-xxx"
+        assert dumped["tools"]["restrictToWorkspace"] is True
+        assert dumped["agents"]["defaults"]["maxTokens"] == 4096
+        assert dumped["agents"]["defaults"]["maxToolIterations"] == 30
+
+    def test_multiple_mcp_servers_round_trip(self):
+        original = {
+            "tools": {
+                "mcpServers": {
+                    "tavily": {
+                        "command": "npx",
+                        "env": {"TAVILY_API_KEY": "key1"},
+                    },
+                    "github": {
+                        "command": "gh-mcp",
+                        "env": {"GITHUB_TOKEN": "ghp_xxx"},
+                    },
+                }
+            }
+        }
+        cfg = Config.model_validate(original)
+        dumped = cfg.model_dump(by_alias=True)
+        servers = dumped["tools"]["mcpServers"]
+        assert servers["tavily"]["env"]["TAVILY_API_KEY"] == "key1"
+        assert servers["github"]["env"]["GITHUB_TOKEN"] == "ghp_xxx"
+
+
+# ---------------------------------------------------------------------------
+# load_config / save_config integration
+# ---------------------------------------------------------------------------
+
+class TestLoadSaveConfig:
+    """Integration tests using actual file I/O."""
+
+    def test_load_config_from_file(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "tools": {
+                "mcpServers": {
+                    "tavily": {
+                        "command": "npx",
+                        "args": ["-y", "@mcptools/mcp-tavily"],
+                        "env": {"TAVILY_API_KEY": "tvly-secret"},
+                    }
+                }
+            },
+            "agents": {"defaults": {"maxTokens": 2048}},
+        }))
+        cfg = load_config(config_file)
+        assert cfg.tools.mcp_servers["tavily"].env["TAVILY_API_KEY"] == "tvly-secret"
+        assert cfg.agents.defaults.max_tokens == 2048
+
+    def test_load_config_missing_file_returns_default(self, tmp_path):
+        cfg = load_config(tmp_path / "nonexistent.json")
+        assert cfg.agents.defaults.model == "anthropic/claude-opus-4-5"
+        assert cfg.tools.mcp_servers == {}
+
+    def test_load_config_invalid_json_returns_default(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text("not valid json{{{")
+        cfg = load_config(config_file)
+        assert cfg.agents.defaults.model == "anthropic/claude-opus-4-5"
+
+    def test_save_config_creates_file(self, tmp_path):
+        cfg = Config()
+        config_file = tmp_path / "subdir" / "config.json"
+        save_config(cfg, config_file)
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert "agents" in data
+        assert "mcpServers" in data["tools"]
+
+    def test_save_and_reload_preserves_env_keys(self, tmp_path):
+        """The critical test: save → reload must preserve env var keys."""
+        config_file = tmp_path / "config.json"
+
+        cfg = Config.model_validate({
+            "tools": {
+                "mcpServers": {
+                    "tavily": {
+                        "command": "npx",
+                        "env": {"TAVILY_API_KEY": "tvly-roundtrip"},
+                    }
+                }
+            }
+        })
+        save_config(cfg, config_file)
+
+        # Reload from file
+        reloaded = load_config(config_file)
+        assert reloaded.tools.mcp_servers["tavily"].env["TAVILY_API_KEY"] == "tvly-roundtrip"
+
+    def test_save_and_reload_preserves_extra_headers(self, tmp_path):
+        config_file = tmp_path / "config.json"
+
+        cfg = Config.model_validate({
+            "providers": {
+                "aihubmix": {
+                    "apiKey": "sk-hub",
+                    "extraHeaders": {"APP-Code": "my-code"},
+                }
+            }
+        })
+        save_config(cfg, config_file)
+
+        reloaded = load_config(config_file)
+        assert reloaded.providers.aihubmix.extra_headers["APP-Code"] == "my-code"
+
+    def test_saved_json_uses_camel_case(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        cfg = Config.model_validate({
+            "tools": {"restrictToWorkspace": True},
+            "agents": {"defaults": {"maxTokens": 1024}},
+        })
+        save_config(cfg, config_file)
+        raw = json.loads(config_file.read_text())
+        assert "restrictToWorkspace" in raw["tools"]
+        assert "maxTokens" in raw["agents"]["defaults"]
+        # snake_case keys should NOT appear in saved JSON
+        assert "restrict_to_workspace" not in raw["tools"]
+        assert "max_tokens" not in raw["agents"]["defaults"]
+
+
+# ---------------------------------------------------------------------------
+# _migrate_config
+# ---------------------------------------------------------------------------
+
+class TestMigrateConfig:
+    """Tests for the config migration function."""
+
+    def test_migrates_restrict_to_workspace(self):
+        data = {
+            "tools": {
+                "exec": {"restrictToWorkspace": True, "timeout": 60},
+            }
+        }
+        result = _migrate_config(data)
+        assert result["tools"]["restrictToWorkspace"] is True
+        assert "restrictToWorkspace" not in result["tools"]["exec"]
+
+    def test_no_migration_needed(self):
+        data = {"tools": {"restrictToWorkspace": False}}
+        result = _migrate_config(data)
+        assert result["tools"]["restrictToWorkspace"] is False
+
+    def test_does_not_overwrite_existing(self):
+        data = {
+            "tools": {
+                "restrictToWorkspace": False,
+                "exec": {"restrictToWorkspace": True},
+            }
+        }
+        result = _migrate_config(data)
+        # Existing top-level value should not be overwritten
+        assert result["tools"]["restrictToWorkspace"] is False
+
+    def test_empty_config(self):
+        assert _migrate_config({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# _Base model behavior
+# ---------------------------------------------------------------------------
+
+class TestBaseModel:
+    """Tests for the _Base model's alias_generator behavior."""
+
+    def test_alias_generator_only_affects_field_names(self):
+        """alias_generator should not touch dict values or dict keys inside fields."""
+        srv = MCPServerConfig.model_validate({
+            "command": "test_command",
+            "env": {"SOME_KEY": "some_value"},
+        })
+        assert srv.command == "test_command"
+        assert "SOME_KEY" in srv.env
+
+    def test_inherits_config_from_base(self):
+        """All schema models should inherit alias_generator from _Base."""
+        d = MCPServerConfig(command="test").model_dump(by_alias=True)
+        assert "command" in d
+
+        d = ProviderConfig(api_key="k").model_dump(by_alias=True)
+        assert "apiKey" in d
+        assert "extraHeaders" in d


### PR DESCRIPTION
## Summary

- **Fix**: Config loading mangled arbitrary dict keys (e.g. `TAVILY_API_KEY` became `t_a_v_i_l_y__a_p_i__k_e_y`) because `convert_keys()` recursively converted ALL dict keys using `camel_to_snake()`. This broke MCP server env vars and provider extra headers.
- **Solution**: Replace manual key conversion with Pydantic `alias_generator`. Add a `_Base(BaseModel)` with `alias_generator=_snake_to_camel` and `populate_by_name=True`. All 21 schema models now inherit from `_Base`. The alias generator only converts model field names, never arbitrary dict keys.
- **Cleanup**: Remove `convert_keys`, `convert_to_camel`, `camel_to_snake`, `snake_to_camel` from loader.py. Remove unused `from typing import Any`. Loader now just calls `Config.model_validate(data)` and `config.model_dump(by_alias=True)`.
- **Tests**: Add 38 tests covering alias helper, model validation, env/header key preservation, round-trip, and file I/O integration. Remove `tests/` from `.gitignore`.

## Test plan

- [x] All 93 tests pass (`pytest tests/ -v`)
- [x] Ruff linter passes with zero errors
- [x] Verified real config with `TAVILY_API_KEY` loads correctly
- [x] Verified save-and-reload round-trip preserves env var keys
- [ ] Manually test MCP server spawning with env vars (e.g. Tavily)

.... Generated with [Cortex Code](https://docs.snowflake.com/user-guide/snowflake-cortex/cortex-agents)