### PR TITLE
fix: avoid sending empty content entries in assistant messages

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -225,14 +225,20 @@ To recall past events, grep {workspace_path}/memory/HISTORY.md"""
         Returns:
             Updated message list.
         """
-        msg: dict[str, Any] = {"role": "assistant", "content": content or ""}
-        
+        msg: dict[str, Any] = {"role": "assistant"}
+
+        # Only include the content key when there is non-empty text.
+        # Some LLM backends reject empty text blocks, so omit the key
+        # to avoid sending empty content entries.
+        if content is not None and content != "":
+            msg["content"] = content
+
         if tool_calls:
             msg["tool_calls"] = tool_calls
-        
-        # Thinking models reject history without this
+
+        # Include reasoning content when provided (required by some thinking models)
         if reasoning_content:
             msg["reasoning_content"] = reasoning_content
-        
+
         messages.append(msg)
         return messages


### PR DESCRIPTION
Without this fix, it will cause error for some LLM providers:
```
[~/nanobot Tue Feb 17 03:08:23] nanobot agent -m "Show me the content of /etc/timezone"

🐈 nanobot
Error calling LLM: litellm.BadRequestError: OpenrouterException -                                           
{"code":400,"message":"{"type":"error","error":{"type":"invalid_request_error","message":"messages: text    
content blocks must be non-empty"},"request_id":"req_011CYCuUYYjZ8X9x56Ycuf1o"}（traceid:                   
87627a13e7e99418a2f94e2ebf3bdedd） (request id: 202602171108521298760415fJ6TBhA) (request id:               
20260217110851966988570oG8gBirn) (request id: 20260217030851806253415UWlPaA1l) (request id:                 
20260217110851727718369HSviflhm)","requestId":"46460681-108f-432e-aa99-4ef90736e214"}    
```