### PR TITLE
test(email): add polling, validation, and smtp edge-path coverage

### DIFF
--- a/tests/test_email_channel.py
+++ b/tests/test_email_channel.py
@@ -1,5 +1,5 @@
-from email.message import EmailMessage
 from datetime import date
+from email.message import EmailMessage
 
 import pytest
 
@@ -309,3 +309,191 @@ def test_fetch_messages_between_dates_uses_imap_since_before_without_mark_seen(m
     assert fake.search_args is not None
     assert fake.search_args[1:] == ("SINCE", "06-Feb-2026", "BEFORE", "07-Feb-2026")
     assert fake.store_calls == []
+
+
+@pytest.mark.asyncio
+async def test_start_polls_once_then_stops_on_next_sleep(monkeypatch) -> None:
+    """Start runs polling loop and exits after stop condition is toggled."""
+    channel = EmailChannel(_make_config(), MessageBus())
+    calls = {"fetch": 0, "handle": 0}
+
+    def _fake_fetch():
+        calls["fetch"] += 1
+        return [
+            {
+                "sender": "alice@example.com",
+                "subject": "Loop subject",
+                "message_id": "<loop@example.com>",
+                "content": "loop body",
+                "metadata": {},
+            }
+        ]
+
+    async def _fake_handle(**_kwargs):
+        calls["handle"] += 1
+
+    async def _fake_sleep(_seconds: int):
+        channel._running = False
+
+    monkeypatch.setattr(channel, "_fetch_new_messages", _fake_fetch)
+    monkeypatch.setattr(channel, "_handle_message", _fake_handle)
+    monkeypatch.setattr("nanobot.channels.email.asyncio.sleep", _fake_sleep)
+    await channel.start()
+
+    assert calls["fetch"] == 1
+    assert calls["handle"] == 1
+    assert channel.is_running is False
+    assert channel._last_subject_by_chat["alice@example.com"] == "Loop subject"
+    assert channel._last_message_id_by_chat["alice@example.com"] == "<loop@example.com>"
+
+
+@pytest.mark.asyncio
+async def test_stop_sets_running_false() -> None:
+    """Stop flips running state off."""
+    channel = EmailChannel(_make_config(), MessageBus())
+    channel._running = True
+    await channel.stop()
+    assert channel.is_running is False
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("imap_host", ""),
+        ("imap_username", ""),
+        ("imap_password", ""),
+        ("smtp_host", ""),
+        ("smtp_username", ""),
+        ("smtp_password", ""),
+    ],
+)
+def test_validate_config_fails_when_required_field_missing(field: str, value: str) -> None:
+    """Validation fails when a required config field is missing."""
+    cfg = _make_config()
+    setattr(cfg, field, value)
+    channel = EmailChannel(cfg, MessageBus())
+    assert channel._validate_config() is False
+
+
+def test_reply_subject_handles_existing_reply_and_custom_prefix() -> None:
+    """Reply subject keeps existing Re prefix and applies custom prefix otherwise."""
+    cfg = _make_config()
+    cfg.subject_prefix = "Antwort: "
+    channel = EmailChannel(cfg, MessageBus())
+    assert channel._reply_subject("Re: Existing") == "Re: Existing"
+    assert channel._reply_subject("Topic") == "Antwort: Topic"
+
+
+def test_reply_subject_falls_back_for_empty_subject() -> None:
+    """Reply subject falls back when base subject is empty."""
+    channel = EmailChannel(_make_config(), MessageBus())
+    assert channel._reply_subject("   ") == "Re: nanobot reply"
+
+
+def test_extract_uid_returns_empty_without_uid_header() -> None:
+    """UID extraction returns empty string when no UID exists."""
+    fetched = [(b"1 (BODY[] {12})", b"hello"), b")"]
+    assert EmailChannel._extract_uid(fetched) == ""
+
+
+def test_extract_uid_handles_bytearray_header() -> None:
+    """UID extraction supports bytearray header values."""
+    fetched = [(bytearray(b"5 (UID 777 BODY[] {12})"), b"hello"), b")"]
+    assert EmailChannel._extract_uid(fetched) == "777"
+
+
+def test_decode_header_value_falls_back_on_exception(monkeypatch) -> None:
+    """Header decoding returns raw value if decoding fails."""
+    monkeypatch.setattr("nanobot.channels.email.make_header", lambda _parts: (_ for _ in ()).throw(ValueError("bad")))
+    assert EmailChannel._decode_header_value("raw-subject") == "raw-subject"
+
+
+def test_smtp_send_uses_ssl_client_when_enabled(monkeypatch) -> None:
+    """SMTP send uses SSL transport when configured."""
+    msg = EmailMessage()
+    msg["From"] = "bot@example.com"
+    msg["To"] = "alice@example.com"
+    msg["Subject"] = "s"
+    msg.set_content("body")
+
+    class FakeSMTPSSL:
+        def __init__(self, _host: str, _port: int, timeout: int = 30) -> None:
+            self.logged_in = False
+            self.sent = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def login(self, _user: str, _pw: str):
+            self.logged_in = True
+
+        def send_message(self, _msg: EmailMessage):
+            self.sent = True
+
+    instances: list[FakeSMTPSSL] = []
+
+    def _factory(host: str, port: int, timeout: int = 30):
+        instance = FakeSMTPSSL(host, port, timeout=timeout)
+        instances.append(instance)
+        return instance
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP_SSL", _factory)
+    cfg = _make_config()
+    cfg.smtp_use_ssl = True
+    channel = EmailChannel(cfg, MessageBus())
+    channel._smtp_send(msg)
+
+    assert len(instances) == 1
+    assert instances[0].logged_in is True
+    assert instances[0].sent is True
+
+
+def test_smtp_send_skips_starttls_when_disabled(monkeypatch) -> None:
+    """SMTP send skips STARTTLS when smtp_use_tls is false."""
+    msg = EmailMessage()
+    msg["From"] = "bot@example.com"
+    msg["To"] = "alice@example.com"
+    msg["Subject"] = "s"
+    msg.set_content("body")
+
+    class FakeSMTP:
+        def __init__(self, _host: str, _port: int, timeout: int = 30) -> None:
+            self.started_tls = False
+            self.logged_in = False
+            self.sent = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def starttls(self, context=None):
+            self.started_tls = True
+
+        def login(self, _user: str, _pw: str):
+            self.logged_in = True
+
+        def send_message(self, _msg: EmailMessage):
+            self.sent = True
+
+    instances: list[FakeSMTP] = []
+
+    def _factory(host: str, port: int, timeout: int = 30):
+        instance = FakeSMTP(host, port, timeout=timeout)
+        instances.append(instance)
+        return instance
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP", _factory)
+    cfg = _make_config()
+    cfg.smtp_use_tls = False
+    channel = EmailChannel(cfg, MessageBus())
+    channel._smtp_send(msg)
+
+    assert len(instances) == 1
+    assert instances[0].started_tls is False
+    assert instances[0].logged_in is True
+    assert instances[0].sent is True


### PR DESCRIPTION
### Summary
- Adds EmailChannel edge-path tests for polling lifecycle and stop semantics.
- Adds config validation tests for missing required IMAP/SMTP fields.
- Adds helper-branch coverage for subject handling, UID parsing, and header decode fallback.
- Adds SMTP transport branch tests for SSL and non-TLS behavior.

### How it works
Unit tests monkeypatch IMAP/SMTP clients and async loop behavior, then assert on side effects and returned values. No network, no API keys.

### New files
| File | Purpose |
|------|---------|
|  | Extended edge/error-path coverage for EmailChannel |

### Test plan
- ============================= test session starts ==============================
platform darwin -- Python 3.11.12, pytest-9.0.2, pluggy-1.6.0 -- /opt/homebrew/opt/python@3.11/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/e/dev/experiments/nanobot-test-unsafe/nanobot-pr3
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 22 items

tests/test_email_channel.py::test_fetch_new_messages_parses_unseen_and_marks_seen PASSED [  4%]
tests/test_email_channel.py::test_extract_text_body_falls_back_to_html PASSED [  9%]
tests/test_email_channel.py::test_start_returns_immediately_without_consent PASSED [ 13%]
tests/test_email_channel.py::test_send_uses_smtp_and_reply_subject PASSED [ 18%]
tests/test_email_channel.py::test_send_skips_when_auto_reply_disabled PASSED [ 22%]
tests/test_email_channel.py::test_send_skips_when_consent_not_granted PASSED [ 27%]
tests/test_email_channel.py::test_fetch_messages_between_dates_uses_imap_since_before_without_mark_seen PASSED [ 31%]
tests/test_email_channel.py::test_start_polls_once_then_stops_on_next_sleep PASSED [ 36%]
tests/test_email_channel.py::test_stop_sets_running_false PASSED         [ 40%]
tests/test_email_channel.py::test_validate_config_fails_when_required_field_missing[imap_host-] PASSED [ 45%]
tests/test_email_channel.py::test_validate_config_fails_when_required_field_missing[imap_username-] PASSED [ 50%]
tests/test_email_channel.py::test_validate_config_fails_when_required_field_missing[imap_password-] PASSED [ 54%]
tests/test_email_channel.py::test_validate_config_fails_when_required_field_missing[smtp_host-] PASSED [ 59%]
tests/test_email_channel.py::test_validate_config_fails_when_required_field_missing[smtp_username-] PASSED [ 63%]
tests/test_email_channel.py::test_validate_config_fails_when_required_field_missing[smtp_password-] PASSED [ 68%]
tests/test_email_channel.py::test_reply_subject_handles_existing_reply_and_custom_prefix PASSED [ 72%]
tests/test_email_channel.py::test_reply_subject_falls_back_for_empty_subject PASSED [ 77%]
tests/test_email_channel.py::test_extract_uid_returns_empty_without_uid_header PASSED [ 81%]
tests/test_email_channel.py::test_extract_uid_handles_bytearray_header PASSED [ 86%]
tests/test_email_channel.py::test_decode_header_value_falls_back_on_exception PASSED [ 90%]
tests/test_email_channel.py::test_smtp_send_uses_ssl_client_when_enabled PASSED [ 95%]
tests/test_email_channel.py::test_smtp_send_skips_starttls_when_disabled PASSED [100%]

============================== 22 passed in 0.16s ==============================
- All checks passed!