### PR TITLE
test(tool): add schema validator and registry lifecycle coverage

### DIFF
--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,87 @@
+from typing import Any
+
+from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.registry import ToolRegistry
+
+
+class EchoTool(Tool):
+    @property
+    def name(self) -> str:
+        return "echo"
+
+    @property
+    def description(self) -> str:
+        return "echoes message"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        return kwargs["message"]
+
+
+class BrokenTool(Tool):
+    @property
+    def name(self) -> str:
+        return "broken"
+
+    @property
+    def description(self) -> str:
+        return "always fails"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs: Any) -> str:
+        raise RuntimeError("boom")
+
+
+def test_register_get_unregister_lifecycle() -> None:
+    """Registers, fetches, and unregisters tools by name."""
+    registry = ToolRegistry()
+    tool = EchoTool()
+    registry.register(tool)
+    assert registry.get("echo") is tool
+    assert "echo" in registry
+    registry.unregister("echo")
+    assert registry.get("echo") is None
+    assert "echo" not in registry
+
+
+def test_get_definitions_and_tool_names() -> None:
+    """Returns OpenAI schemas and current tool names."""
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    definitions = registry.get_definitions()
+    assert len(definitions) == 1
+    assert definitions[0]["function"]["name"] == "echo"
+    assert registry.tool_names == ["echo"]
+
+
+async def test_execute_success() -> None:
+    """Executes registered tool and returns success output."""
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    result = await registry.execute("echo", {"message": "hello"})
+    assert result == "hello"
+
+
+async def test_execute_not_found() -> None:
+    """Returns not-found error when tool name is unknown."""
+    registry = ToolRegistry()
+    result = await registry.execute("missing", {})
+    assert result == "Error: Tool 'missing' not found"
+
+
+async def test_execute_exception() -> None:
+    """Returns execution error when tool raises an exception."""
+    registry = ToolRegistry()
+    registry.register(BrokenTool())
+    result = await registry.execute("broken", {})
+    assert result == "Error executing broken: boom"

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import pytest
+
 from nanobot.agent.tools.base import Tool
 from nanobot.agent.tools.registry import ToolRegistry
 
@@ -82,7 +84,69 @@ def test_validate_params_ignores_unknown_fields() -> None:
 
 
 async def test_registry_returns_validation_error() -> None:
+    """Returns a validation error string when required params are missing."""
     reg = ToolRegistry()
     reg.register(SampleTool())
     result = await reg.execute("sample", {"query": "hi"})
     assert "Invalid parameters" in result
+
+
+def test_validate_params_max_length() -> None:
+    """Rejects strings that exceed maxLength in schema."""
+
+    class MaxLenTool(Tool):
+        @property
+        def name(self) -> str:
+            return "max_len"
+
+        @property
+        def description(self) -> str:
+            return "max length validator"
+
+        @property
+        def parameters(self) -> dict[str, Any]:
+            return {
+                "type": "object",
+                "properties": {"title": {"type": "string", "maxLength": 3}},
+            }
+
+        async def execute(self, **kwargs: Any) -> str:
+            return "ok"
+
+    tool = MaxLenTool()
+    errors = tool.validate_params({"title": "long"})
+    assert any("title must be at most 3 chars" in e for e in errors)
+
+
+def test_validate_params_rejects_non_object_schema() -> None:
+    """Raises ValueError when the root schema type is not object."""
+
+    class InvalidSchemaTool(Tool):
+        @property
+        def name(self) -> str:
+            return "invalid_schema"
+
+        @property
+        def description(self) -> str:
+            return "invalid schema"
+
+        @property
+        def parameters(self) -> dict[str, Any]:
+            return {"type": "array", "items": {"type": "string"}}
+
+        async def execute(self, **kwargs: Any) -> str:
+            return "ok"
+
+    tool = InvalidSchemaTool()
+    with pytest.raises(ValueError, match="Schema must be object type"):
+        tool.validate_params({})
+
+
+def test_to_schema_shape() -> None:
+    """Builds OpenAI function schema with required top-level keys."""
+    tool = SampleTool()
+    schema = tool.to_schema()
+    assert schema["type"] == "function"
+    assert schema["function"]["name"] == tool.name
+    assert schema["function"]["description"] == tool.description
+    assert schema["function"]["parameters"] == tool.parameters


### PR DESCRIPTION
### Summary
- Adds schema-validation branch coverage for tool parameter checking.
- Adds registry lifecycle and execution-path tests for tool registration and dispatch.
- Covers not-found and exception paths to prevent silent runtime failures.

### How it works
Pure unit tests with in-test tool doubles; no network/API keys.

### New files
| File | Purpose |
|------|---------|
| `tests/test_tool_validation.py` | Additional validator branch coverage |
| `tests/test_tool_registry.py` | Registry lifecycle and execute-path coverage |

### Test plan
- `pytest tests/test_tool_validation.py tests/test_tool_registry.py -v`
- `ruff check tests/test_tool_validation.py tests/test_tool_registry.py`
