### PR TITLE
test(bus): add outbound dispatch and channel routing coverage

### DIFF
--- a/tests/test_bus_queue.py
+++ b/tests/test_bus_queue.py
@@ -1,0 +1,75 @@
+"""Tests for the async message bus queue behavior."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
+
+
+@pytest.mark.asyncio
+async def test_publish_and_consume_inbound_and_outbound_messages() -> None:
+    """Publishes and consumes inbound and outbound messages through the queue."""
+    bus = MessageBus()
+    inbound = InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="ping")
+    outbound = OutboundMessage(channel="telegram", chat_id="c1", content="pong")
+
+    await bus.publish_inbound(inbound)
+    await bus.publish_outbound(outbound)
+
+    got_inbound = await bus.consume_inbound()
+    got_outbound = await bus.consume_outbound()
+
+    assert got_inbound == inbound
+    assert got_outbound == outbound
+
+
+@pytest.mark.asyncio
+async def test_dispatch_outbound_sends_messages_to_channel_subscribers() -> None:
+    """Dispatches outbound messages to subscribers registered for that channel."""
+    bus = MessageBus()
+    received: list[OutboundMessage] = []
+
+    async def _subscriber(msg: OutboundMessage) -> None:
+        received.append(msg)
+
+    bus.subscribe_outbound("telegram", _subscriber)
+    task = asyncio.create_task(bus.dispatch_outbound())
+
+    msg = OutboundMessage(channel="telegram", chat_id="c1", content="hello")
+    await bus.publish_outbound(msg)
+    await asyncio.sleep(0.05)
+
+    bus.stop()
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert received == [msg]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_outbound_continues_when_a_subscriber_raises() -> None:
+    """Continues dispatching to remaining subscribers when one callback fails."""
+    bus = MessageBus()
+    received: list[OutboundMessage] = []
+
+    async def _broken_subscriber(_msg: OutboundMessage) -> None:
+        raise RuntimeError("boom")
+
+    async def _healthy_subscriber(msg: OutboundMessage) -> None:
+        received.append(msg)
+
+    bus.subscribe_outbound("telegram", _broken_subscriber)
+    bus.subscribe_outbound("telegram", _healthy_subscriber)
+    task = asyncio.create_task(bus.dispatch_outbound())
+
+    msg = OutboundMessage(channel="telegram", chat_id="c1", content="resilient")
+    await bus.publish_outbound(msg)
+    await asyncio.sleep(0.05)
+
+    bus.stop()
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert received == [msg]

--- a/tests/test_channel_manager.py
+++ b/tests/test_channel_manager.py
@@ -1,0 +1,132 @@
+"""Tests for channel manager dispatch and lifecycle behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.manager import ChannelManager
+
+
+def _disabled_channels() -> SimpleNamespace:
+    return SimpleNamespace(
+        telegram=SimpleNamespace(enabled=False),
+        whatsapp=SimpleNamespace(enabled=False),
+        discord=SimpleNamespace(enabled=False),
+        feishu=SimpleNamespace(enabled=False),
+        mochat=SimpleNamespace(enabled=False),
+        dingtalk=SimpleNamespace(enabled=False),
+        email=SimpleNamespace(enabled=False),
+        slack=SimpleNamespace(enabled=False),
+        qq=SimpleNamespace(enabled=False),
+    )
+
+
+def _minimal_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        channels=_disabled_channels(),
+        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+    )
+
+
+class FakeChannel:
+    """Minimal async fake channel for manager tests."""
+
+    def __init__(self, fail_send: bool = False) -> None:
+        self.fail_send = fail_send
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.send_calls = 0
+        self.sent: list[OutboundMessage] = []
+        self.is_running = False
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        self.is_running = True
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        self.is_running = False
+
+    async def send(self, msg: OutboundMessage) -> None:
+        self.send_calls += 1
+        if self.fail_send:
+            raise RuntimeError("send failed")
+        self.sent.append(msg)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_outbound_routes_messages_and_survives_send_errors(monkeypatch) -> None:
+    """Routes outbound messages to channels and continues after send failures."""
+    monkeypatch.setattr(ChannelManager, "_init_channels", lambda self: None)
+    bus = MessageBus()
+    manager = ChannelManager(_minimal_config(), bus)
+    ok_channel = FakeChannel()
+    failing_channel = FakeChannel(fail_send=True)
+    manager.channels = {"ok": ok_channel, "bad": failing_channel}
+
+    task = asyncio.create_task(manager._dispatch_outbound())
+    await bus.publish_outbound(OutboundMessage(channel="ok", chat_id="c1", content="a"))
+    await bus.publish_outbound(OutboundMessage(channel="bad", chat_id="c1", content="b"))
+    await bus.publish_outbound(OutboundMessage(channel="unknown", chat_id="c1", content="c"))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert len(ok_channel.sent) == 1
+    assert ok_channel.sent[0].content == "a"
+    assert failing_channel.send_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_start_all_and_stop_all_manage_dispatcher_and_channels(monkeypatch) -> None:
+    """Starts channels with dispatcher task and stops all cleanly."""
+    monkeypatch.setattr(ChannelManager, "_init_channels", lambda self: None)
+    started = asyncio.Event()
+
+    async def _fake_dispatch_outbound(self: ChannelManager) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(ChannelManager, "_dispatch_outbound", _fake_dispatch_outbound)
+    bus = MessageBus()
+    manager = ChannelManager(_minimal_config(), bus)
+    first = FakeChannel()
+    second = FakeChannel()
+    manager.channels = {"one": first, "two": second}
+
+    await manager.start_all()
+    assert started.is_set()
+    assert manager._dispatch_task is not None
+    assert first.start_calls == 1
+    assert second.start_calls == 1
+
+    await manager.stop_all()
+    assert first.stop_calls == 1
+    assert second.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_init_channels_uses_monkeypatched_module_imports(monkeypatch) -> None:
+    """Builds enabled channel from monkeypatched module without external imports."""
+    bus = MessageBus()
+    config = _minimal_config()
+    config.channels.telegram.enabled = True
+
+    class _TelegramFake(FakeChannel):
+        def __init__(self, _cfg: SimpleNamespace, _bus: MessageBus, groq_api_key: str) -> None:
+            super().__init__()
+            self.groq_api_key = groq_api_key
+
+    fake_module = SimpleNamespace(TelegramChannel=_TelegramFake)
+    monkeypatch.setitem(sys.modules, "nanobot.channels.telegram", fake_module)
+
+    manager = ChannelManager(config, bus)
+
+    assert "telegram" in manager.channels
+    assert isinstance(manager.channels["telegram"], _TelegramFake)


### PR DESCRIPTION
### Summary
- Adds async message bus tests for publish/consume and subscriber dispatch.
- Adds resilience coverage when one outbound subscriber fails.
- Adds channel manager routing/lifecycle tests with fake channels only.

### How it works
Uses fake channels and monkeypatched channel initialization to avoid external integrations.

### New files
| File | Purpose |
|------|---------|
| `tests/test_bus_queue.py` | MessageBus queue and dispatch behavior coverage |
| `tests/test_channel_manager.py` | ChannelManager routing and lifecycle coverage |

### Test plan
- `pytest tests/test_bus_queue.py tests/test_channel_manager.py -v`
- `ruff check tests/test_bus_queue.py tests/test_channel_manager.py`
