### PR TITLE
test(provider): add registry matching and litellm response coverage

### DIFF
--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,102 @@
+"""Tests for LiteLLMProvider request/response behavior."""
+
+import os
+import types
+
+import pytest
+
+from nanobot.providers.litellm_provider import LiteLLMProvider
+
+
+async def test_chat_clamps_max_tokens_to_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """chat should clamp max_tokens values below one before calling LiteLLM."""
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content="ok", tool_calls=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=None,
+        )
+
+    monkeypatch.setattr("nanobot.providers.litellm_provider.acompletion", fake_acompletion)
+
+    provider = LiteLLMProvider(api_key="test-key", default_model="gpt-4o-mini")
+    response = await provider.chat(messages=[{"role": "user", "content": "hi"}], max_tokens=0)
+
+    assert captured["max_tokens"] == 1
+    assert response.content == "ok"
+
+
+async def test_chat_returns_error_response_on_completion_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """chat should convert LiteLLM exceptions into an error-shaped LLMResponse."""
+
+    async def fake_acompletion(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("nanobot.providers.litellm_provider.acompletion", fake_acompletion)
+
+    provider = LiteLLMProvider(api_key="test-key", default_model="gpt-4o-mini")
+    response = await provider.chat(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.finish_reason == "error"
+    assert response.content == "Error calling LLM: boom"
+
+
+def test_parse_response_reads_tool_calls_and_usage() -> None:
+    """_parse_response should parse tool calls JSON and usage fields from LiteLLM responses."""
+    provider = LiteLLMProvider(default_model="gpt-4o-mini")
+
+    response = types.SimpleNamespace(
+        choices=[
+            types.SimpleNamespace(
+                message=types.SimpleNamespace(
+                    content="tool response",
+                    tool_calls=[
+                        types.SimpleNamespace(
+                            id="tool_1",
+                            function=types.SimpleNamespace(
+                                name="search",
+                                arguments='{"query":"nanobot"}',
+                            ),
+                        )
+                    ],
+                    reasoning_content="reasoning",
+                ),
+                finish_reason="tool_calls",
+            )
+        ],
+        usage=types.SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+    )
+
+    parsed = provider._parse_response(response)
+
+    assert parsed.content == "tool response"
+    assert parsed.finish_reason == "tool_calls"
+    assert parsed.reasoning_content == "reasoning"
+    assert parsed.usage == {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
+    assert len(parsed.tool_calls) == 1
+    assert parsed.tool_calls[0].id == "tool_1"
+    assert parsed.tool_calls[0].name == "search"
+    assert parsed.tool_calls[0].arguments == {"query": "nanobot"}
+
+
+def test_provider_sets_env_and_resolves_model_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """provider should map model to prefixed route and export provider API key env."""
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+
+    provider = LiteLLMProvider(api_key="dash-key", default_model="qwen-max")
+
+    assert provider._resolve_model("qwen-max") == "dashscope/qwen-max"
+    assert provider.get_default_model() == "qwen-max"
+    assert provider._gateway is None
+    assert provider.api_key == "dash-key"
+    assert provider.api_base is None
+    assert os.environ["DASHSCOPE_API_KEY"] == "dash-key"

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,0 +1,45 @@
+"""Tests for provider registry matching and gateway detection."""
+
+from nanobot.providers.registry import find_by_model, find_gateway
+
+
+def test_find_by_model_matches_keyword_case_insensitive() -> None:
+    """find_by_model should match provider keywords regardless of case."""
+    spec = find_by_model("QWEN-MAX")
+
+    assert spec is not None
+    assert spec.name == "dashscope"
+
+
+def test_find_by_model_skips_gateway_provider_keywords() -> None:
+    """find_by_model should not return gateway specs matched only by gateway keywords."""
+    spec = find_by_model("openrouter-only-model")
+
+    assert spec is None
+
+
+def test_find_gateway_detects_by_provider_name() -> None:
+    """find_gateway should return gateway/local spec when provider_name is explicit."""
+    gateway = find_gateway(provider_name="openrouter")
+    local = find_gateway(provider_name="vllm")
+
+    assert gateway is not None
+    assert gateway.name == "openrouter"
+    assert local is not None
+    assert local.name == "vllm"
+
+
+def test_find_gateway_detects_by_api_key_prefix() -> None:
+    """find_gateway should detect OpenRouter from the sk-or- api key prefix."""
+    spec = find_gateway(api_key="sk-or-example")
+
+    assert spec is not None
+    assert spec.name == "openrouter"
+
+
+def test_find_gateway_detects_by_api_base_keyword() -> None:
+    """find_gateway should detect AiHubMix from api_base keyword matching."""
+    spec = find_gateway(api_base="https://api.aihubmix.com/v1")
+
+    assert spec is not None
+    assert spec.name == "aihubmix"


### PR DESCRIPTION
### Summary
- Adds provider-registry matching tests for model keyword and gateway detection rules.
- Adds LiteLLM provider tests for token clamping, error handling, and response parsing.
- Adds environment/model-resolution coverage to prevent provider routing regressions.

### How it works
Mocks `acompletion` and uses isolated env monkeypatching; no external API calls.

### New files
| File | Purpose |
|------|---------|
| `tests/test_provider_registry.py` | Provider match and gateway-detection coverage |
| `tests/test_litellm_provider.py` | LiteLLMProvider request/response branch coverage |

### Test plan
- `pytest tests/test_provider_registry.py tests/test_litellm_provider.py -v`
- `ruff check tests/test_provider_registry.py tests/test_litellm_provider.py`
