### PR TITLE
feat: add ClawHub skill

### DIFF
--- a/nanobot/skills/README.md
+++ b/nanobot/skills/README.md
@@ -21,4 +21,5 @@ The skill format and metadata structure follow OpenClaw's conventions to maintai
 | `weather` | Get weather info using wttr.in and Open-Meteo |
 | `summarize` | Summarize URLs, files, and YouTube videos |
 | `tmux` | Remote-control tmux sessions |
+| `clawhub` | Search and install skills from ClawHub registry |
 | `skill-creator` | Create new skills |

--- a/nanobot/skills/clawhub/SKILL.md
+++ b/nanobot/skills/clawhub/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: clawhub
+description: Search and install agent skills from ClawHub, the public skill registry.
+homepage: https://clawhub.ai
+metadata: {"nanobot":{"emoji":"🦞"}}
+---
+
+# ClawHub
+
+Public skill registry for AI agents. Search by natural language (vector search).
+
+## When to use
+
+Use this skill when the user asks any of:
+- "find a skill for …"
+- "search for skills"
+- "install a skill"
+- "what skills are available?"
+- "update my skills"
+
+## Search
+
+```bash
+npx --yes clawhub@latest search "web scraping" --limit 5
+```
+
+## Install
+
+```bash
+npx --yes clawhub@latest install <slug> --workdir ~/.nanobot/workspace
+```
+
+Replace `<slug>` with the skill name from search results. This places the skill into `~/.nanobot/workspace/skills/`, where nanobot loads workspace skills from. Always include `--workdir`.
+
+## Update
+
+```bash
+npx --yes clawhub@latest update --all --workdir ~/.nanobot/workspace
+```
+
+## List installed
+
+```bash
+npx --yes clawhub@latest list --workdir ~/.nanobot/workspace
+```
+
+## Notes
+
+- Requires Node.js (`npx` comes with it).
+- No API key needed for search and install.
+- Login (`npx --yes clawhub@latest login`) is only required for publishing.
+- `--workdir ~/.nanobot/workspace` is critical — without it, skills install to the current directory instead of the nanobot workspace.
+- After install, remind the user to start a new session to load the skill.


### PR DESCRIPTION
## Summary

- Add built-in `clawhub` skill that enables nanobot to search, install, update, and list agent skills from [ClawHub](https://clawhub.ai), the public skill registry
- Uses `npx --yes clawhub@latest` for zero-install execution (requires Node.js 20+)
- All install/update/list commands include `--workdir ~/.nanobot/workspace` to ensure skills land in the correct directory for nanobot to load
- Update skills README table with new entry

## Test plan

- [x] Verified `npx --yes clawhub@latest search "web scraping" --limit 5` returns results
- [x] Verified `npx --yes clawhub@latest install <slug> --workdir ~/.nanobot/workspace` installs to correct path
- [x] Verified nanobot agent can trigger the skill via natural language ("help me to search skill about ...")
- [x] Verified `SkillsLoader` correctly parses the SKILL.md frontmatter and metadata