### PR TITLE
feat: Multi-Node Management with Reverse WebSocket Connection

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -53,6 +53,7 @@ class AgentLoop:
         restrict_to_workspace: bool = False,
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
+        node_server: Any = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         from nanobot.cron.service import CronService
@@ -68,6 +69,7 @@ class AgentLoop:
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
+        self.node_server = node_server
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
@@ -83,7 +85,7 @@ class AgentLoop:
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
         )
-        
+
         self._running = False
         self._mcp_servers = mcp_servers or {}
         self._mcp_stack: AsyncExitStack | None = None
@@ -98,29 +100,35 @@ class AgentLoop:
         self.tools.register(WriteFileTool(allowed_dir=allowed_dir))
         self.tools.register(EditFileTool(allowed_dir=allowed_dir))
         self.tools.register(ListDirTool(allowed_dir=allowed_dir))
-        
+
         # Shell tool
         self.tools.register(ExecTool(
             working_dir=str(self.workspace),
             timeout=self.exec_config.timeout,
             restrict_to_workspace=self.restrict_to_workspace,
         ))
-        
+
         # Web tools
         self.tools.register(WebSearchTool(api_key=self.brave_api_key))
         self.tools.register(WebFetchTool())
-        
+
         # Message tool
         message_tool = MessageTool(send_callback=self.bus.publish_outbound)
         self.tools.register(message_tool)
-        
+
         # Spawn tool (for subagents)
         spawn_tool = SpawnTool(manager=self.subagents)
         self.tools.register(spawn_tool)
-        
+
         # Cron tool (for scheduling)
         if self.cron_service:
             self.tools.register(CronTool(self.cron_service))
+
+        # Nodes tool (for multi-node management)
+        if self.node_server:
+            from nanobot.agent.tools.nodes import NodesTool
+            nodes_tool = NodesTool(node_server=self.node_server)
+            self.tools.register(nodes_tool)
     
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""

--- a/nanobot/agent/tools/nodes.py
+++ b/nanobot/agent/tools/nodes.py
@@ -1,0 +1,122 @@
+"""Nodes tool for managing remote nodes."""
+
+from typing import Any
+
+from loguru import logger
+
+from nanobot.agent.tools.base import Tool
+
+
+class NodesTool(Tool):
+    """Tool for managing and interacting with remote nodes."""
+
+    def __init__(self, node_server: Any = None):
+        """
+        Initialize the nodes tool.
+
+        Args:
+            node_server: NodeServer instance (optional, if None, tool will be read-only)
+        """
+        self._node_server = node_server
+
+    def set_node_server(self, node_server: Any) -> None:
+        """Set the node server instance."""
+        self._node_server = node_server
+
+    @property
+    def name(self) -> str:
+        return "nodes"
+
+    @property
+    def description(self) -> str:
+        return "Manage and interact with remote nanobot nodes (list, run commands, check status)."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "run", "status"],
+                    "description": "Action to perform: list (connected nodes), run (execute command), status (check node status)"
+                },
+                "node": {
+                    "type": "string",
+                    "description": "Node name (required for 'run' and 'status' actions)"
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Command to execute (required for 'run' action)"
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Timeout in seconds for command execution (default: 60)",
+                    "default": 60
+                }
+            },
+            "required": ["action"]
+        }
+
+    async def execute(
+        self,
+        action: str,
+        node: str | None = None,
+        command: str | None = None,
+        timeout: int = 60,
+        **kwargs: Any
+    ) -> str:
+        """Execute the nodes tool action."""
+
+        if action == "list":
+            return await self._list_nodes()
+        elif action == "run":
+            return await self._run_command(node, command, timeout)
+        elif action == "status":
+            return await self._check_status(node)
+        else:
+            return f"Error: Unknown action '{action}'. Use 'list', 'run', or 'status'."
+
+    async def _list_nodes(self) -> str:
+        """List all connected nodes."""
+        if not self._node_server:
+            return "Node server is not available. This tool can only be used on the main nanobot instance."
+
+        nodes = self._node_server.connected_nodes
+
+        if not nodes:
+            return "No nodes currently connected."
+
+        return f"Connected nodes ({len(nodes)}):\n" + "\n".join(f"  - {n}" for n in nodes)
+
+    async def _run_command(self, node: str | None, command: str | None, timeout: int) -> str:
+        """Run a command on a remote node."""
+        if not self._node_server:
+            return "Node server is not available. This tool can only be used on the main nanobot instance."
+
+        if not node:
+            return "Error: 'node' parameter is required for 'run' action."
+
+        if not command:
+            return "Error: 'command' parameter is required for 'run' action."
+
+        logger.info(f"Running command on node '{node}': {command}")
+
+        result = await self._node_server.exec(node, command, timeout)
+
+        return f"Node: {node}\nCommand: {command}\nOutput:\n{result}"
+
+    async def _check_status(self, node: str | None) -> str:
+        """Check the status of a node."""
+        if not self._node_server:
+            return "Node server is not available. This tool can only be used on the main nanobot instance."
+
+        if not node:
+            return "Error: 'node' parameter is required for 'status' action."
+
+        nodes = self._node_server.connected_nodes
+
+        if node in nodes:
+            return f"Node '{node}' is connected and active."
+        else:
+            return f"Node '{node}' is not connected.\n\nConnected nodes:\n" + "\n".join(f"  - {n}" for n in nodes)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -327,23 +327,29 @@ def gateway(
     from nanobot.cron.service import CronService
     from nanobot.cron.types import CronJob
     from nanobot.heartbeat.service import HeartbeatService
-    
+    from nanobot.nodes.service import NodeServer
+
     if verbose:
         import logging
         logging.basicConfig(level=logging.DEBUG)
-    
+
     console.print(f"{__logo__} Starting nanobot gateway on port {port}...")
-    
+
     config = load_config()
     bus = MessageBus()
     provider = _make_provider(config)
     session_manager = SessionManager(config.workspace_path)
-    
+
+    # Create node server if enabled
+    node_server = None
+    if config.nodes.server.enabled:
+        node_server = NodeServer(config.nodes.server)
+
     # Create cron service first (callback set after agent creation)
     cron_store_path = get_data_dir() / "cron" / "jobs.json"
     cron = CronService(cron_store_path)
-    
-    # Create agent with cron service
+
+    # Create agent with cron service and node server
     agent = AgentLoop(
         bus=bus,
         provider=provider,
@@ -359,6 +365,7 @@ def gateway(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
+        node_server=node_server,
     )
     
     # Set cron callback (needs agent)
@@ -405,11 +412,18 @@ def gateway(
         console.print(f"[green]✓[/green] Cron: {cron_status['jobs']} scheduled jobs")
     
     console.print(f"[green]✓[/green] Heartbeat: every 30m")
-    
+
+    if node_server:
+        console.print(f"[green]✓[/green] Node server: enabled on port {config.nodes.server.port}")
+    else:
+        console.print("[dim]Node server: disabled[/dim]")
+
     async def run():
         try:
             await cron.start()
             await heartbeat.start()
+            if node_server:
+                await node_server.start()
             await asyncio.gather(
                 agent.run(),
                 channels.start_all(),
@@ -422,6 +436,8 @@ def gateway(
             cron.stop()
             agent.stop()
             await channels.stop_all()
+            if node_server:
+                await node_server.stop()
     
     asyncio.run(run())
 
@@ -701,6 +717,70 @@ def channels_login():
 
 cron_app = typer.Typer(help="Manage scheduled tasks")
 app.add_typer(cron_app, name="cron")
+
+
+# ============================================================================
+# Node Commands
+# ============================================================================
+
+node_app = typer.Typer(help="Manage remote nodes")
+app.add_typer(node_app, name="node")
+
+
+@node_app.command("run")
+def node_run(
+    name: str = typer.Option(..., "--name", "-n", help="Node name"),
+    server: str = typer.Option(..., "--server", "-s", help="Server WebSocket URL (e.g., ws://host:18792)"),
+    token: str = typer.Option(..., "--token", "-t", help="Authentication token"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
+):
+    """Run as a node client and connect to the main server."""
+    if verbose:
+        import logging
+        logging.basicConfig(level=logging.DEBUG)
+
+    from nanobot.nodes.service import NodeClient
+    from nanobot.nodes.types import NodeClientConfig
+
+    config = NodeClientConfig(
+        enabled=True,
+        name=name,
+        server_url=server,
+        token=token
+    )
+
+    client = NodeClient(config)
+    client._running = True
+
+    console.print(f"{__logo__} Connecting to server as node '{name}'...")
+
+    try:
+        asyncio.run(client.run())
+    except KeyboardInterrupt:
+        console.print("\nShutting down...")
+    finally:
+        asyncio.run(client.stop())
+
+
+@node_app.command("list")
+def node_list():
+    """List connected nodes (requires node server to be running)."""
+    from nanobot.config.loader import load_config
+    from nanobot.nodes.service import NodeServer
+
+    config = load_config()
+
+    if not config.nodes.server.enabled:
+        console.print("[yellow]Node server is not enabled in config[/yellow]")
+        console.print("Enable it by setting nodes.server.enabled = true in config.json")
+        return
+
+    # Note: This is a simple status check. For real-time status, the node server must be running.
+    console.print(f"{__logo__} Node Server Status\n")
+    console.print(f"Node server: {'[green]enabled[/green]' if config.nodes.server.enabled else '[dim]disabled[/dim]'}")
+    console.print(f"Port: {config.nodes.server.port}")
+    console.print("\n[dim]To see connected nodes, the node server must be running via 'nanobot gateway'[/dim]")
+    console.print("[dim]Use the 'nodes' tool in the agent to list connected nodes[/dim]")
 
 
 @cron_app.command("list")

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel, Field, ConfigDict
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
 
+from nanobot.nodes.types import NodeServerConfig, NodeClientConfig
+
 
 class Base(BaseModel):
     """Base model that accepts both camelCase and snake_case keys."""
@@ -265,6 +267,13 @@ class ToolsConfig(Base):
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
 
+class NodesConfig(Base):
+    """Multi-node management configuration."""
+
+    server: NodeServerConfig = Field(default_factory=NodeServerConfig)
+    client: NodeClientConfig = Field(default_factory=NodeClientConfig)
+
+
 class Config(BaseSettings):
     """Root configuration for nanobot."""
 
@@ -273,6 +282,7 @@ class Config(BaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    nodes: NodesConfig = Field(default_factory=NodesConfig)
 
     @property
     def workspace_path(self) -> Path:

--- a/nanobot/nodes/__init__.py
+++ b/nanobot/nodes/__init__.py
@@ -1,0 +1,6 @@
+"""Multi-node management for nanobot."""
+
+from nanobot.nodes.types import NodeServerConfig, NodeClientConfig, NodesConfig
+from nanobot.nodes.service import NodeServer, NodeClient
+
+__all__ = ["NodeServerConfig", "NodeClientConfig", "NodesConfig", "NodeServer", "NodeClient"]

--- a/nanobot/nodes/service.py
+++ b/nanobot/nodes/service.py
@@ -1,0 +1,273 @@
+"""Node service for managing remote connections."""
+
+import asyncio
+import json
+from typing import Any, Callable
+import websockets
+from websockets.server import WebSocketServerProtocol
+from websockets.exceptions import ConnectionClosed
+
+from loguru import logger
+
+from nanobot.nodes.types import NodeServerConfig, NodeClientConfig
+
+
+class NodeServer:
+    """
+    WebSocket server that accepts connections from remote nodes.
+
+    Runs on the main nanobot instance.
+    """
+
+    def __init__(self, config: NodeServerConfig):
+        self.config = config
+        self._clients: dict[str, WebSocketServerProtocol] = {}  # node_name -> websocket
+        self._server: Any = None
+        self._running = False
+
+    @property
+    def connected_nodes(self) -> list[str]:
+        """Get list of connected node names."""
+        return list(self._clients.keys())
+
+    async def start(self) -> None:
+        """Start the WebSocket server."""
+        if not self.config.enabled:
+            logger.info("Node server is disabled")
+            return
+
+        host = "0.0.0.0"
+        port = self.config.port
+
+        logger.info(f"Starting node server on {host}:{port}")
+
+        async def handle_connection(websocket: WebSocketServerProtocol) -> None:
+            """Handle a new node connection."""
+            try:
+                # Authentication
+                auth_msg = await websocket.recv()
+                auth_data = json.loads(auth_msg)
+
+                if auth_data.get("type") != "auth":
+                    logger.warning(f"Invalid auth message from {websocket.remote_address}")
+                    await websocket.send(json.dumps({"type": "error", "message": "Auth required"}))
+                    return
+
+                token = auth_data.get("token")
+                node_name = auth_data.get("node_name")
+
+                if token != self.config.token:
+                    logger.warning(f"Invalid token from {websocket.remote_address}")
+                    await websocket.send(json.dumps({"type": "error", "message": "Invalid token"}))
+                    return
+
+                if not node_name:
+                    logger.warning(f"No node_name from {websocket.remote_address}")
+                    await websocket.send(json.dumps({"type": "error", "message": "node_name required"}))
+                    return
+
+                logger.info(f"Node '{node_name}' connected from {websocket.remote_address}")
+
+                # Send success response
+                await websocket.send(json.dumps({"type": "auth_success"}))
+
+                # Store client
+                self._clients[node_name] = websocket
+
+                # Keep connection alive and handle commands
+                async for message in websocket:
+                    try:
+                        data = json.loads(message)
+                        if data.get("type") == "heartbeat":
+                            await websocket.send(json.dumps({"type": "heartbeat_ack"}))
+                    except json.JSONDecodeError:
+                        logger.warning(f"Invalid JSON from {node_name}")
+
+            except ConnectionClosed:
+                logger.info(f"Node '{node_name}' disconnected")
+            except Exception as e:
+                logger.error(f"Error handling node connection: {e}")
+            finally:
+                # Remove client
+                if node_name in self._clients:
+                    del self._clients[node_name]
+
+        self._server = await websockets.serve(handle_connection, host, port)
+        self._running = True
+        logger.info(f"Node server started on {host}:{port}")
+
+    async def stop(self) -> None:
+        """Stop the WebSocket server."""
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._running = False
+            logger.info("Node server stopped")
+
+    async def exec(self, node: str, command: str, timeout: int = 60) -> str:
+        """
+        Execute a command on a remote node.
+
+        Args:
+            node: Node name
+            command: Command to execute
+            timeout: Timeout in seconds
+
+        Returns:
+            Command output
+        """
+        if node not in self._clients:
+            return f"Error: Node '{node}' not connected"
+
+        websocket = self._clients[node]
+
+        try:
+            # Send command
+            await websocket.send(json.dumps({
+                "type": "exec",
+                "command": command,
+                "timeout": timeout
+            }))
+
+            # Wait for response with timeout
+            response = await asyncio.wait_for(websocket.recv(), timeout=timeout + 10)
+            data = json.loads(response)
+
+            if data.get("type") == "exec_result":
+                return data.get("output", "")
+            elif data.get("type") == "error":
+                return f"Error: {data.get('message', 'Unknown error')}"
+            else:
+                return f"Error: Unexpected response type: {data.get('type')}"
+
+        except asyncio.TimeoutError:
+            return f"Error: Command timeout after {timeout}s"
+        except ConnectionClosed:
+            # Remove disconnected node
+            if node in self._clients:
+                del self._clients[node]
+            return f"Error: Node '{node}' disconnected"
+        except Exception as e:
+            logger.error(f"Error executing command on {node}: {e}")
+            return f"Error: {str(e)}"
+
+
+class NodeClient:
+    """
+    WebSocket client that connects to the main nanobot instance.
+
+    Runs on remote nodes.
+    """
+
+    def __init__(self, config: NodeClientConfig):
+        self.config = config
+        self._websocket: Any = None
+        self._running = False
+
+    async def run(self) -> None:
+        """Connect to the server and handle commands."""
+        if not self.config.enabled:
+            logger.info("Node client is disabled")
+            return
+
+        logger.info(f"Connecting to {self.config.server_url} as '{self.config.name}'")
+
+        while self._running:
+            try:
+                async with websockets.connect(self.config.server_url) as websocket:
+                    self._websocket = websocket
+
+                    # Send authentication
+                    await websocket.send(json.dumps({
+                        "type": "auth",
+                        "token": self.config.token,
+                        "node_name": self.config.name
+                    }))
+
+                    # Wait for auth response
+                    auth_response = await websocket.recv()
+                    auth_data = json.loads(auth_response)
+
+                    if auth_data.get("type") != "auth_success":
+                        logger.error(f"Auth failed: {auth_data.get('message', 'Unknown error')}")
+                        await asyncio.sleep(10)
+                        continue
+
+                    logger.info(f"Connected to server as '{self.config.name}'")
+
+                    # Main loop: handle commands
+                    async for message in websocket:
+                        try:
+                            data = json.loads(message)
+
+                            if data.get("type") == "exec":
+                                await self._handle_exec(websocket, data)
+                            elif data.get("type") == "heartbeat":
+                                await websocket.send(json.dumps({"type": "heartbeat_ack"}))
+
+                        except json.JSONDecodeError:
+                            logger.warning(f"Invalid JSON from server")
+                        except Exception as e:
+                            logger.error(f"Error handling message: {e}")
+
+            except ConnectionClosed:
+                logger.warning("Connection to server closed, reconnecting...")
+            except Exception as e:
+                logger.error(f"Connection error: {e}")
+
+            if self._running:
+                await asyncio.sleep(5)
+
+    async def _handle_exec(self, websocket: Any, data: dict) -> None:
+        """Handle an exec command from the server."""
+        command = data.get("command", "")
+        timeout = data.get("timeout", 60)
+
+        logger.info(f"Executing: {command}")
+
+        try:
+            # Execute command
+            process = await asyncio.create_subprocess_shell(
+                command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=timeout
+                )
+                output = stdout.decode("utf-8", errors="replace")
+                error = stderr.decode("utf-8", errors="replace")
+
+                if error:
+                    output += f"\n[stderr]\n{error}"
+
+                await websocket.send(json.dumps({
+                    "type": "exec_result",
+                    "output": output,
+                    "exit_code": process.returncode
+                }))
+
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                await websocket.send(json.dumps({
+                    "type": "error",
+                    "message": f"Command timeout after {timeout}s"
+                }))
+
+        except Exception as e:
+            logger.error(f"Error executing command: {e}")
+            await websocket.send(json.dumps({
+                "type": "error",
+                "message": str(e)
+            }))
+
+    async def stop(self) -> None:
+        """Stop the client."""
+        self._running = False
+        if self._websocket:
+            await self._websocket.close()
+        logger.info("Node client stopped")

--- a/nanobot/nodes/types.py
+++ b/nanobot/nodes/types.py
@@ -1,0 +1,27 @@
+"""Node types and configuration."""
+
+from pydantic import BaseModel, Field
+
+
+class NodeServerConfig(BaseModel):
+    """Server configuration (runs on main instance)."""
+
+    enabled: bool = False
+    port: int = 18792
+    token: str = ""
+
+
+class NodeClientConfig(BaseModel):
+    """Client configuration (runs on remote node)."""
+
+    enabled: bool = False
+    name: str = ""
+    server_url: str = ""
+    token: str = ""
+
+
+class NodesConfig(BaseModel):
+    """Nodes configuration."""
+
+    server: NodeServerConfig = Field(default_factory=NodeServerConfig)
+    client: NodeClientConfig = Field(default_factory=NodeClientConfig)


### PR DESCRIPTION
Implements Multi-Node/Remote Host Management for nanobot via reverse WebSocket connections. Closes #775

**Features:**
- Reverse WebSocket connection (solves NAT)
- Token-based authentication
- Remote command execution
- Auto-reconnect

**Usage:**
Main: \
anobot gateway\ with nodes.server.enabled=true
Remote: \
anobot node run --name vps1 --server ws://host:18792 --token xxx\

**Agent tool:** nodes(action=list/run/status)