### PR TITLE
fix: Resolve "Unrecognized chat message" error for StepFun and strict providers

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -227,9 +227,9 @@ To recall past events, grep {workspace_path}/memory/HISTORY.md"""
         """
         msg: dict[str, Any] = {"role": "assistant"}
 
-        # Omit empty content — some backends reject empty text blocks
-        if content:
-            msg["content"] = content
+        # Always include content — some providers (e.g. StepFun) reject
+        # assistant messages that omit the key entirely.
+        msg["content"] = content
 
         if tool_calls:
             msg["tool_calls"] = tool_calls


### PR DESCRIPTION
## Problem
Intermittent `litellm.BadRequestError` with `"Unrecognized chat message"` when using **Step 3.5 Flash** via OpenRouter. The StepFun API is stricter than others and rejects messages with unknown fields (like `reasoning_content`) or missing [content](cci:1://file:///d:/Projects/nanobot-fork/nanobot/agent/context.py:163:4-179:56) keys in assistant responses.

## Root Cause
1. **Field Leaking:** Non-standard fields like `reasoning_content` (from Kimi/DeepSeek) were passed to providers that don't support them.
2. **Missing Content:** When an assistant message only contained tool calls, the [content](cci:1://file:///d:/Projects/nanobot-fork/nanobot/agent/context.py:163:4-179:56) key was omitted, which StepFun treats as an invalid message structure.

## Changes
- **LiteLLMProvider:** Added a sanitization layer [_sanitize_messages](cci:1://file:///d:/Projects/nanobot-fork/nanobot/providers/litellm_provider.py:111:4-127:24) that filters messages against a white-list of OpenAI-compatible keys.
- **ContextBuilder:** Modified [add_assistant_message](cci:1://file:///d:/Projects/nanobot-fork/nanobot/agent/context.py:208:4-241:23) to always include the [content](cci:1://file:///d:/Projects/nanobot-fork/nanobot/agent/context.py:163:4-179:56) key (even if it's `None`), ensuring compatibility with strict API schemas.

## Manual Verification
- Confirmed that the "Unrecognized chat message" error no longer appears during multi-turn conversations with StepFun models.
- Verified that assistant messages containing tool calls now include a `content: null` field as required by the provider.

> [!IMPORTANT]
> Fix is made by Opus 4.6 and applied by Gemini 3 Pro High in Google Antigravity