### PR TITLE
feat: add extra_body provider config for data privacy controls

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -313,6 +313,7 @@ def _make_provider(config: Config):
         api_base=config.get_api_base(model),
         default_model=model,
         extra_headers=p.extra_headers if p else None,
+        extra_body=p.extra_body if p else None,
         provider_name=provider_name,
     )
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -1,6 +1,7 @@
 """Configuration schema using Pydantic."""
 
 from pathlib import Path
+from typing import Any
 from pydantic import BaseModel, Field, ConfigDict
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
@@ -201,6 +202,7 @@ class ProviderConfig(Base):
     api_key: str = ""
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
+    extra_body: dict[str, Any] | None = None  # Extra request body params (e.g. OpenRouter provider routing)
 
 
 class ProvidersConfig(Base):

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -22,16 +22,18 @@ class LiteLLMProvider(LLMProvider):
     """
     
     def __init__(
-        self, 
-        api_key: str | None = None, 
+        self,
+        api_key: str | None = None,
         api_base: str | None = None,
         default_model: str = "anthropic/claude-opus-4-5",
         extra_headers: dict[str, str] | None = None,
+        extra_body: dict[str, Any] | None = None,
         provider_name: str | None = None,
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
+        self.extra_body = extra_body or {}
         
         # Detect gateway / local deployment.
         # provider_name (from config key) is the primary signal;
@@ -151,6 +153,10 @@ class LiteLLMProvider(LLMProvider):
         # Pass extra headers (e.g. APP-Code for AiHubMix)
         if self.extra_headers:
             kwargs["extra_headers"] = self.extra_headers
+
+        # Pass extra body params (e.g. OpenRouter provider routing: {"provider": {"only": [...]}})
+        if self.extra_body:
+            kwargs["extra_body"] = self.extra_body
         
         if tools:
             kwargs["tools"] = tools


### PR DESCRIPTION
## Summary

Adds an `extra_body` field to `ProviderConfig`, enabling users to pass arbitrary request body parameters through to LiteLLM. This is useful for providers like OpenRouter that support routing preferences and data privacy controls via request body params.

- Adds `extra_body: dict[str, Any] | None` to `ProviderConfig` (mirrors existing `extra_headers` pattern)
- Passes `extra_body` through `LiteLLMProvider` to LiteLLM's `acompletion()`
- Wires it up in `_make_provider()`

## Example

```jsonc
{
  "providers": {
    "openrouter": {
      "apiKey": "sk-or-...",
      "extraBody": {
        "provider": {
          // restrict to specific providers (e.g. for data residency)
          "only": ["fireworks", "together"],
          // opt out of data collection/training
          "data_collection": "deny",
          // zero data retention mode
          "zdr": true
        }
      }
    }
  }
}
```

See [OpenRouter provider routing docs](https://openrouter.ai/docs/features/provider-routing) for all available options.

## Test plan

- [x] Tested locally with OpenRouter provider routing
- [x] Full test suite passes (57/57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)