### PR TITLE
Fix: add slash commands to system prompt

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -107,7 +107,13 @@ For normal conversation, just respond with text - do not call the message tool.
 
 Always be helpful, accurate, and concise. When using tools, think step by step: what you know, what you need, and why you chose this tool.
 When remembering something important, write to {workspace_path}/memory/MEMORY.md
-To recall past events, grep {workspace_path}/memory/HISTORY.md"""
+To recall past events, grep {workspace_path}/memory/HISTORY.md
+
+## User Commands
+Users can send these slash commands (handled before reaching you):
+- /new — Clear conversation history and start a fresh session
+- /help — Show available commands
+If a user asks how to start a new session or reset the conversation, tell them to send /new."""
     
     def _load_bootstrap_files(self) -> str:
         """Load all bootstrap files from workspace."""


### PR DESCRIPTION
## Summary
- The LLM has no knowledge of `/new` and `/help` slash commands because they are intercepted in `agent/loop.py` before reaching the model
- When users ask how to start a new session, the bot incorrectly suggests restarting the service
- Added a "User Commands" section to the system prompt in `agent/context.py` so the LLM can properly guide users

## Test plan
- [ ] Send a message asking "how do I start a new session?" and verify the bot mentions `/new`
- [ ] Verify `/new` and `/help` still work as before (no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)