### PR TITLE
feat: stream intermediate progress to user during tool execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ⚡️ Delivers core agent functionality in just **~4,000** lines of code — **99% smaller** than Clawdbot's 430k+ lines.
 
-📏 Real-time line count: **3,696 lines** (run `bash core_agent_lines.sh` to verify anytime)
+📏 Real-time line count: **3,761 lines** (run `bash core_agent_lines.sh` to verify anytime)
 
 ## 📢 News
 

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -105,7 +105,7 @@ IMPORTANT: When responding to direct questions or conversations, reply directly 
 Only use the 'message' tool when you need to send a message to a specific chat channel (like WhatsApp).
 For normal conversation, just respond with text - do not call the message tool.
 
-Always be helpful, accurate, and concise. When using tools, think step by step: what you know, what you need, and why you chose this tool.
+Always be helpful, accurate, and concise. Before calling tools, briefly tell the user what you're about to do (one short sentence in the user's language).
 When remembering something important, write to {workspace_path}/memory/MEMORY.md
 To recall past events, grep {workspace_path}/memory/HISTORY.md"""
     

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -494,11 +494,14 @@ def agent(
         # Animated spinner is safe to use with prompt_toolkit input handling
         return console.status("[dim]nanobot is thinking...[/dim]", spinner="dots")
 
+    async def _cli_progress(content: str) -> None:
+        console.print(f"  [dim]↳ {content}[/dim]")
+
     if message:
         # Single message mode
         async def run_once():
             with _thinking_ctx():
-                response = await agent_loop.process_direct(message, session_id)
+                response = await agent_loop.process_direct(message, session_id, on_progress=_cli_progress)
             _print_agent_response(response, render_markdown=markdown)
             await agent_loop.close_mcp()
         
@@ -531,7 +534,7 @@ def agent(
                             break
                         
                         with _thinking_ctx():
-                            response = await agent_loop.process_direct(user_input, session_id)
+                            response = await agent_loop.process_direct(user_input, session_id, on_progress=_cli_progress)
                         _print_agent_response(response, render_markdown=markdown)
                     except KeyboardInterrupt:
                         _restore_terminal()


### PR DESCRIPTION
## Summary

Stream intermediate progress to users during multi-step tool execution, so they see what the agent is doing instead of staring at a blank screen.

**Before:** User sends a message → silence until final answer.
**After:** User sees `↳ Let check the GitHub star count` or `↳ web_search("HKUDS repos")` in real time.

## Changes

- **`loop.py`** — Add `on_progress` callback to `_run_agent_loop` / `_process_message` / `process_direct`. Strip `<think>` tags from model output. Fall back to tool hints with arguments when content is empty. Remove ICoT injection that caused mixed-language output.
- **`context.py`** — Prompt model to briefly explain actions before calling tools (one sentence, user's language).
- **`commands.py`** — CLI renders progress as dim `↳` lines; gateway falls back to bus publish.
- **`tests/test_on_progress.py`** — 26 tests covering `_strip_think`, `_tool_hint`, callback pipeline, and bus fallback.

## Design

Three-layer progress guarantee:

| Layer | Source | Example |
|-------|--------|---------|
| Model explains | Prompt guides model to say what it's doing | `↳ Let me search HKUDS's repository.` |
| Tool hint | Fallback when content is None / think-only | `↳ web_search("HKUDS repos")` |
| Strip think | Clean `<think>` tags before display | No internal reasoning leaks |

Progress is fire-and-forget — not saved to session history.