### PR TITLE
Strip thinking blocks

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -68,6 +68,7 @@ class AgentLoop:
         restrict_to_workspace: bool = False,
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
+        strip_thinking_blocks: bool = False,
     ):
         from nanobot.config.schema import ExecToolConfig
         from nanobot.cron.service import CronService
@@ -83,6 +84,7 @@ class AgentLoop:
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
+        self.strip_thinking_blocks = strip_thinking_blocks
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
@@ -357,10 +359,8 @@ class AgentLoop:
         if final_content is None:
             final_content = "I've completed processing but have no response to give."
         
-        # Strip thinking blocks from the response before sending to the user.
-        # Handles <think>...</think> (e.g. DeepSeek-R1) and bare </think>
-        # prefixes (e.g. GLM models that omit the opening tag).
-        final_content = _strip_thinking_blocks(final_content)
+        if self.strip_thinking_blocks:
+            final_content = _strip_thinking_blocks(final_content)
         
         preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
         logger.info(f"Response to {msg.channel}:{msg.sender_id}: {preview}")

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -368,6 +368,7 @@ def gateway(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
+        strip_thinking_blocks=config.agents.defaults.strip_thinking_blocks,
     )
     
     # Set cron callback (needs agent)
@@ -484,6 +485,7 @@ def agent(
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
+        strip_thinking_blocks=config.agents.defaults.strip_thinking_blocks,
     )
     
     # Show spinner when logs are off (no output to miss); skip when logs are on

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -187,6 +187,7 @@ class AgentDefaults(Base):
     temperature: float = 0.7
     max_tool_iterations: int = 20
     memory_window: int = 50
+    strip_thinking_blocks: bool = False  # Strip <think>...</think> blocks from responses
 
 
 class AgentsConfig(Base):


### PR DESCRIPTION
# What it does
This PR provides a new configuration option to strip thinking blocks from models that output them. Specifically GLM models. The common patterns are:

1. \<think\>...\</think\> Response...
2. ...\</think\> Response...

This change uses a regex to find thinking blocks and strip them out before the response is sent back to the user.

## Before
```bash
$ nanobot agent -m "Hello"

🐈 nanobot
Okay, the user keeps saying "hello" repeatedly. They might be testing if I'm responsive or maybe just being playful. Let me
check the conversation history.

Looking back, they asked about my name multiple times and now are sending "hello" again. My previous responses were friendly
but short. The last time they said "Hello", I got an error from the LLM system. Maybe the model had some issues processing it,
but now it's working again.

I need to respond in a way that's consistent with my persona, helpful, and not too robotic. Since they keep
greeting me, maybe they want a bit more engagement or are waiting for something specific. I should acknowledge their hello
warmly and prompt them to ask what they need help with. Maybe add an emoji to keep it casual.


Also, in the rules, it says to reply directly without using the message tool unless necessary. So just a normal text response
here. Let me make sure my answer is inviting but concise. "Hi there! How can I assist you today?" sounds good. It's friendly
and opens the door for them to state their request clearly.

Hi there! 🌟 How can I assist you today?
```


## After
```bash
$ nanobot agent -m "Hello"

🐈 nanobot
Hey! 😊 What’s on your mind? Let’s get started!
```

# Config changes
```bash
# ~/.nanobot/config.json
{
    "agents": {
        "defaults": {
            "stripThinkingBlocks": true # Defaults to false
        }
    }
}
```