### PR TITLE
fix: /help command bypasses ACL on Telegram

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -146,7 +146,7 @@ class TelegramChannel(BaseChannel):
         # Add command handlers
         self._app.add_handler(CommandHandler("start", self._on_start))
         self._app.add_handler(CommandHandler("new", self._forward_command))
-        self._app.add_handler(CommandHandler("help", self._forward_command))
+        self._app.add_handler(CommandHandler("help", self._on_help))
         
         # Add message handler for text, photos, voice, documents
         self._app.add_handler(
@@ -258,14 +258,28 @@ class TelegramChannel(BaseChannel):
         """Handle /start command."""
         if not update.message or not update.effective_user:
             return
-        
+
         user = update.effective_user
         await update.message.reply_text(
             f"👋 Hi {user.first_name}! I'm nanobot.\n\n"
             "Send me a message and I'll respond!\n"
             "Type /help to see available commands."
         )
-    
+
+    async def _on_help(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /help command directly, bypassing access control.
+
+        /help is informational and should be accessible to all users,
+        even those not in the allowFrom list.
+        """
+        if not update.message:
+            return
+        await update.message.reply_text(
+            "🐈 nanobot commands:\n"
+            "/new — Start a new conversation\n"
+            "/help — Show available commands"
+        )
+
     @staticmethod
     def _sender_id(user) -> str:
         """Build sender_id with username for allowlist matching."""


### PR DESCRIPTION
## Summary

- Add dedicated `_on_help` handler for the `/help` command in Telegram channel
- `/help` now responds directly without routing through the message bus ACL check
- Consistent with how `/start` already works (has its own handler)

## Problem

The `/help` slash command always failed on Telegram with:

```
Access denied for sender xxxxxxxx on channel telegram. Add them to allowFrom list in config to grant access.
```

This happened because `/help` was routed through `_forward_command` → `_handle_message` → `is_allowed()`, which rejects users not in the `allowFrom` list.

## Root Cause

In `telegram.py`, both `/new` and `/help` used `_forward_command`, which calls `BaseChannel._handle_message()`. That method checks `is_allowed()` before forwarding to the bus. Since `/help` is purely informational, it should not require authorization.

Meanwhile, `/start` already had its own handler (`_on_start`) that replied directly, bypassing the ACL — so `/start` always worked while `/help` did not.

## Fix

Added a `_on_help` handler that replies directly to the user (like `/start`), bypassing the message bus and ACL check entirely.

## Test plan

- [ ] Send `/help` on Telegram as an unauthorized user → should receive help text
- [ ] Send `/help` on Telegram as an authorized user → should receive help text
- [ ] Send `/new` on Telegram as an authorized user → should still work via bus
- [ ] Send `/start` → should still work as before

Closes #687


