### PR TITLE
fix: avoid "Unknown channel: CLI" error on heartbeats

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -516,7 +516,6 @@ Respond with ONLY valid JSON, no markdown fences."""
             sender_id="user",
             chat_id=chat_id,
             content=content,
-            # metadata={"fromHeartbeat": session_key == "heartbeat"}
         )
         
         response = await self._process_message(msg, session_key=session_key, on_progress=on_progress)


### PR DESCRIPTION
When reading the HEARTBEAT.md file with the read_file tool, nanobot wants to notify usage on the origin channel (cli:direct), when it does not exist when nanobot is in gateway mode.