### PR TITLE
fix: fixed not logging tool uses if a think fragment had them attached.

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -198,7 +198,9 @@ class AgentLoop:
             if response.has_tool_calls:
                 if on_progress:
                     clean = self._strip_think(response.content)
-                    await on_progress(clean or self._tool_hint(response.tool_calls))
+                    if clean: 
+                        await on_progress(clean)
+                    await on_progress(self._tool_hint(response.tool_calls))
 
                 tool_call_dicts = [
                     {


### PR DESCRIPTION
if a think fragment had a tool attached, the tool use would not log. now it does