### PR TITLE
fix: Codex provider routing for GitHub Copilot models

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -287,11 +287,34 @@ class Config(BaseSettings):
         from nanobot.providers.registry import PROVIDERS
 
         model_lower = (model or self.agents.defaults.model).lower()
+        model_normalized = model_lower.replace("-", "_")
+        model_prefix = model_lower.split("/", 1)[0] if "/" in model_lower else ""
+        normalized_prefix = model_prefix.replace("-", "_")
+
+        def _matches_model_prefix(spec_name: str) -> bool:
+            if not model_prefix:
+                return False
+            return normalized_prefix == spec_name
+
+        def _keyword_matches(keyword: str) -> bool:
+            keyword_lower = keyword.lower()
+            return (
+                keyword_lower in model_lower
+                or keyword_lower.replace("-", "_") in model_normalized
+            )
+
+        # Explicit provider prefix in model name wins over generic keyword matches.
+        # This prevents `github-copilot/...codex` from being treated as OpenAI Codex.
+        for spec in PROVIDERS:
+            p = getattr(self.providers, spec.name, None)
+            if p and _matches_model_prefix(spec.name):
+                if spec.is_oauth or p.api_key:
+                    return p, spec.name
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
             p = getattr(self.providers, spec.name, None)
-            if p and any(kw in model_lower for kw in spec.keywords):
+            if p and any(_keyword_matches(kw) for kw in spec.keywords):
                 if spec.is_oauth or p.api_key:
                     return p, spec.name
 

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -80,7 +80,7 @@ class OpenAICodexProvider(LLMProvider):
 
 
 def _strip_model_prefix(model: str) -> str:
-    if model.startswith("openai-codex/"):
+    if model.startswith("openai-codex/") or model.startswith("openai_codex/"):
         return model.split("/", 1)[1]
     return model
 

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -384,10 +384,24 @@ def find_by_model(model: str) -> ProviderSpec | None:
     """Match a standard provider by model-name keyword (case-insensitive).
     Skips gateways/local — those are matched by api_key/api_base instead."""
     model_lower = model.lower()
+    model_normalized = model_lower.replace("-", "_")
+    model_prefix = model_lower.split("/", 1)[0] if "/" in model_lower else ""
+    normalized_prefix = model_prefix.replace("-", "_")
+
+    # Prefer explicit provider prefix in model name.
     for spec in PROVIDERS:
         if spec.is_gateway or spec.is_local:
             continue
-        if any(kw in model_lower for kw in spec.keywords):
+        if model_prefix and normalized_prefix == spec.name:
+            return spec
+
+    for spec in PROVIDERS:
+        if spec.is_gateway or spec.is_local:
+            continue
+        if any(
+            kw in model_lower or kw.replace("-", "_") in model_normalized
+            for kw in spec.keywords
+        ):
             return spec
     return None
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,6 +6,10 @@ import pytest
 from typer.testing import CliRunner
 
 from nanobot.cli.commands import app
+from nanobot.config.schema import Config
+from nanobot.providers.litellm_provider import LiteLLMProvider
+from nanobot.providers.openai_codex_provider import _strip_model_prefix
+from nanobot.providers.registry import find_by_model
 
 runner = CliRunner()
 
@@ -90,3 +94,37 @@ def test_onboard_existing_workspace_safe_create(mock_paths):
     assert "Created workspace" not in result.stdout
     assert "Created AGENTS.md" in result.stdout
     assert (workspace_dir / "AGENTS.md").exists()
+
+
+def test_config_matches_github_copilot_codex_with_hyphen_prefix():
+    config = Config()
+    config.agents.defaults.model = "github-copilot/gpt-5.3-codex"
+
+    assert config.get_provider_name() == "github_copilot"
+
+
+def test_config_matches_openai_codex_with_hyphen_prefix():
+    config = Config()
+    config.agents.defaults.model = "openai-codex/gpt-5.1-codex"
+
+    assert config.get_provider_name() == "openai_codex"
+
+
+def test_find_by_model_prefers_explicit_prefix_over_generic_codex_keyword():
+    spec = find_by_model("github-copilot/gpt-5.3-codex")
+
+    assert spec is not None
+    assert spec.name == "github_copilot"
+
+
+def test_litellm_provider_canonicalizes_github_copilot_hyphen_prefix():
+    provider = LiteLLMProvider(default_model="github-copilot/gpt-5.3-codex")
+
+    resolved = provider._resolve_model("github-copilot/gpt-5.3-codex")
+
+    assert resolved == "github_copilot/gpt-5.3-codex"
+
+
+def test_openai_codex_strip_prefix_supports_hyphen_and_underscore():
+    assert _strip_model_prefix("openai-codex/gpt-5.1-codex") == "gpt-5.1-codex"
+    assert _strip_model_prefix("openai_codex/gpt-5.1-codex") == "gpt-5.1-codex"


### PR DESCRIPTION
Issue fix: https://github.com/HKUDS/nanobot/issues/834

When setting the model to `github_copilot/gpt-5.3-codex`, the provider will route to `openai_codex` by mistake.

## Summary
- prioritize explicit model prefixes over generic keyword matches during provider selection
- normalize hyphen/underscore provider identifiers for matching (e.g. `github-copilot` vs `github_copilot`)
- canonicalize explicit provider prefixes before LiteLLM prefixing to avoid malformed model IDs
- support both `openai-codex/` and `openai_codex/` in OpenAI Codex model prefix stripping
- add regression tests for GitHub Copilot Codex and OpenAI Codex matching behavior

## Root Cause
`github-copilot/gpt-5.3-codex` was incorrectly matched as `openai_codex` because matching relied on keyword scans in registry order, and `openai_codex` had a broad `codex` keyword that matched first.

## Verification
- with virtualenv activated, `python3.12 ./nanobot/__main__.py agent -m "hello"` now works with `github-copilot/gpt-5.3-codex`
- targeted provider-matching assertions pass locally


Result:
<img width="628" height="468" alt="image" src="https://github.com/user-attachments/assets/0f826b6d-afa5-4d29-8d0d-96eaffa32fb5" />


