### PR TITLE
fix: wait for killed process after shell timeout to prevent fd leaks

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -81,6 +81,12 @@ class ExecTool(Tool):
                 )
             except asyncio.TimeoutError:
                 process.kill()
+                # Wait for the process to fully terminate so pipes are
+                # drained and file descriptors are released.
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    pass
                 return f"Error: Command timed out after {self.timeout} seconds"
             
             output_parts = []


### PR DESCRIPTION
## Summary

- After `process.kill()` on timeout, await `process.wait()` with a 5s bound to let the process fully terminate

## Problem

When a shell command times out in `ExecTool.execute()`, `process.kill()` is sent but `process.wait()` is never called. The subprocess pipes remain undrained and file descriptors stay open. If many commands time out over the lifetime of a nanobot gateway, file descriptor leaks accumulate and can eventually cause `OSError: [Errno 24] Too many open files`.

## Fix

```python
except asyncio.TimeoutError:
    process.kill()
    try:
        await asyncio.wait_for(process.wait(), timeout=5.0)
    except asyncio.TimeoutError:
        pass  # Process did not exit in time, nothing more we can do
    return f"Error: Command timed out after {self.timeout} seconds"
```

## Test plan

- [ ] Run a command that hangs (e.g. `sleep 999`) with a short timeout
- [ ] Verify the process is fully terminated after timeout (no zombie)
- [ ] Verify no file descriptor leak after repeated timeouts