### PR TITLE
  feat: add OpenAI-compatible API channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Connect nanobot to your favorite chat platform.
 | **Slack** | Bot token + App-Level token |
 | **Email** | IMAP/SMTP credentials |
 | **QQ** | App ID + App Secret |
+| **OpenAI-compatible frontends** (Open WebUI, ChatBox, ...) | Host + Port + Optional API key |
 
 <details>
 <summary><b>Telegram</b> (Recommended)</summary>
@@ -557,6 +558,57 @@ Give nanobot its own email account. It polls **IMAP** for incoming mail and repl
 
 ```bash
 nanobot gateway
+```
+
+</details>
+
+<details>
+<summary><b>OpenAI-compatible frontends (Open WebUI, ChatBox, ...)</b></summary>
+
+Exposes an OpenAI-compatible `/v1/chat/completions` endpoint, allowing you to connect nanobot to any OpenAI-compatible frontend (Open WebUI, ChatBox, etc.).
+
+Can be used to add nanobot as a conversation agent in Home Assistant using the [Extended OpenAI Conversation](https://www.home-assistant.io/integrations/openai_conversation/) integration.
+
+**1. Configure**
+
+```json
+{
+  "channels": {
+    "openai": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 18791,
+      "apiKey": "your-secret-key"
+    }
+  }
+}
+```
+
+> - `host`: Server bind address (default: `127.0.0.1`)
+> - `port`: Server port (default: `18791`)
+> - `apiKey`: Optional Bearer token for authentication. Leave empty (`""`) to disable auth.
+
+**2. Run**
+
+```bash
+nanobot gateway
+```
+
+**3. Connect from any OpenAI-compatible client**
+
+- **Base URL**: `http://127.0.0.1:18791/v1`
+- **API Key**: Your configured `apiKey` (or anything if auth is disabled)
+- **Model**: `nanobot`
+
+Example with curl:
+```bash
+curl http://127.0.0.1:18791/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-key" \
+  -d '{
+    "model": "nanobot",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
 ```
 
 </details>

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -21,7 +21,7 @@ from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
-from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.events import InboundMessage, MessageType, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMProvider
 from nanobot.session.manager import Session, SessionManager
@@ -349,7 +349,7 @@ class AgentLoop:
             meta = dict(msg.metadata or {})
             meta["_progress"] = True
             await self.bus.publish_outbound(OutboundMessage(
-                channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
+                channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta, type=MessageType.PROGRESS
             ))
 
         final_content, tools_used = await self._run_agent_loop(

--- a/nanobot/bus/events.py
+++ b/nanobot/bus/events.py
@@ -2,7 +2,14 @@
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
 from typing import Any
+
+
+class MessageType(Enum):
+    """Type of outbound message."""
+    RESPONSE = "response"
+    PROGRESS = "progress"
 
 
 @dataclass
@@ -33,5 +40,4 @@ class OutboundMessage:
     reply_to: str | None = None
     media: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
-
-
+    type: MessageType = MessageType.RESPONSE

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -137,6 +137,17 @@ class ChannelManager:
             except ImportError as e:
                 logger.warning("QQ channel not available: {}", e)
     
+        # OpenAI-compatible API channel
+        if self.config.channels.openai.enabled:
+            try:
+                from nanobot.channels.openai import OpenAIChannel
+                self.channels["openai"] = OpenAIChannel(
+                    self.config.channels.openai, self.bus
+                )
+                logger.info("OpenAI-compatible API channel enabled")
+            except ImportError as e:
+                logger.warning(f"OpenAI API channel not available: {e}")
+
     async def _start_channel(self, name: str, channel: BaseChannel) -> None:
         """Start a channel and log any exceptions."""
         try:

--- a/nanobot/channels/openai.py
+++ b/nanobot/channels/openai.py
@@ -1,0 +1,214 @@
+"""OpenAI-compatible HTTP API channel using FastAPI."""
+
+import asyncio
+import json
+import time
+import uuid
+from typing import Any
+
+import uvicorn
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from nanobot.bus.events import MessageType, OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import OpenAIConfig
+
+SENDER_ID = "default"
+CHAT_ID = "1"
+
+
+class ChatMessage(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    messages: list[ChatMessage] = Field(..., min_length=1)
+    stream: bool = False
+
+
+def _error_body(
+    message: str,
+    error_type: str,
+    param: str | None = None,
+    code: str | None = None,
+) -> dict:
+    """Build an OpenAI-style error response body."""
+    return {"error": {"message": message, "type": error_type, "param": param, "code": code}}
+
+
+class OpenAIAPIError(HTTPException):
+    """HTTPException subclass that renders OpenAI-style error bodies."""
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        error_type: str,
+        param: str | None = None,
+        code: str | None = None,
+    ):
+        super().__init__(status_code=status_code)
+        self.message = message
+        self.error_type = error_type
+        self.param = param
+        self.code = code
+
+
+_bearer = HTTPBearer(auto_error=False)
+
+
+async def _verify_api_key(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
+) -> None:
+    """Validate Bearer token against the configured API key."""
+    api_key = getattr(app.state, "api_key", "")
+    if not api_key:
+        return
+    if credentials is None or credentials.credentials != api_key:
+        raise OpenAIAPIError(
+            401,
+            "Incorrect API key provided",
+            "authentication_error",
+            code="invalid_api_key",
+        )
+
+
+app = FastAPI(title="Nanobot OpenAI-compatible API", dependencies=[Depends(_verify_api_key)])
+
+
+@app.exception_handler(RequestValidationError)
+async def _validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    first = exc.errors()[0]
+    param = ".".join(
+        str(loc) for loc in first.get("loc", []) if isinstance(loc, str) and loc != "body"
+    )
+    return JSONResponse(
+        status_code=400,
+        content=_error_body(
+            message=first.get("msg", "Validation error"),
+            error_type="invalid_request_error",
+            param=param or None,
+            code=None,
+        ),
+    )
+
+
+@app.exception_handler(OpenAIAPIError)
+async def _openai_error_handler(request: Request, exc: OpenAIAPIError) -> JSONResponse:
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=_error_body(exc.message, exc.error_type, exc.param, exc.code),
+    )
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(body: ChatCompletionRequest):
+    try:
+        response_text = await app.state.handle_message(body.messages[-1].content)
+    except asyncio.TimeoutError:
+        raise OpenAIAPIError(504, "Request timed out", "server_error")
+
+    # Build chunk response
+    response: dict[str, Any] = {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": "nanobot",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": response_text},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+    if body.stream:
+
+        async def generate():
+            yield f"data: {json.dumps(response)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(generate(), media_type="text/event-stream")
+
+    # Transform to non-streaming response
+    response["object"] = "chat.completion"
+    response["choices"][0]["message"] = response["choices"][0].pop("delta")
+
+    return JSONResponse(content=response)
+
+
+@app.get("/v1/models")
+async def list_models() -> JSONResponse:
+    return JSONResponse(
+        content={
+            "object": "list",
+            "data": [{"id": "nanobot", "object": "model", "created": 0, "owned_by": "nanobot"}],
+        }
+    )
+
+
+class OpenAIChannel(BaseChannel):
+    """
+    Channel that exposes an OpenAI-compatible /v1/chat/completions endpoint.
+
+    This allows nanobot to be used with any OpenAI-compatible frontend
+    (Open WebUI, ChatBox, etc.).
+    """
+
+    name = "openai"
+
+    def __init__(self, config: OpenAIConfig, bus: MessageBus):
+        super().__init__(config=config, bus=bus)
+        self._queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1)
+        self._server: uvicorn.Server | None = None
+        app.state.api_key = config.api_key
+        app.state.handle_message = self._dispatch
+
+    async def start(self) -> None:
+        """Start the uvicorn ASGI server."""
+        self._running = True
+        uv_config = uvicorn.Config(
+            app,
+            host=self.config.host,
+            port=self.config.port,
+            log_level="warning",
+        )
+        self._server = uvicorn.Server(uv_config)
+        logger.info(f"OpenAI-compatible API listening on {self.config.host}:{self.config.port}")
+        await self._server.serve()
+
+    async def stop(self) -> None:
+        """Shut down the ASGI server."""
+        self._running = False
+        if self._server:
+            self._server.should_exit = True
+            self._server = None
+        logger.info("OpenAI-compatible API stopped")
+
+    async def _dispatch(self, content: str) -> str:
+        """Drain stale responses, publish to bus, and wait for the reply."""
+        try:
+            self._queue.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+        await self._handle_message(sender_id=SENDER_ID, chat_id=CHAT_ID, content=content)
+        return await asyncio.wait_for(self._queue.get(), timeout=20)
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Deliver a response to the waiting HTTP request."""
+        if msg.type == MessageType.PROGRESS:
+            return
+        try:
+            self._queue.put_nowait(msg.content)
+        except asyncio.QueueFull:
+            logger.warning("OpenAI channel: no HTTP request waiting, discarding response")

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -165,6 +165,15 @@ class QQConfig(Base):
     allow_from: list[str] = Field(default_factory=list)  # Allowed user openids (empty = public access)
 
 
+class OpenAIConfig(Base):
+    """OpenAI-compatible API channel configuration."""
+
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = 18791
+    api_key: str = ""
+
+
 class ChannelsConfig(Base):
     """Configuration for chat channels."""
 
@@ -177,6 +186,7 @@ class ChannelsConfig(Base):
     email: EmailConfig = Field(default_factory=EmailConfig)
     slack: SlackConfig = Field(default_factory=SlackConfig)
     qq: QQConfig = Field(default_factory=QQConfig)
+    openai: OpenAIConfig = Field(default_factory=OpenAIConfig)
 
 
 class AgentDefaults(Base):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "prompt-toolkit>=3.0.50,<4.0.0",
     "mcp>=1.26.0,<2.0.0",
     "json-repair>=0.57.0,<1.0.0",
+    "fastapi>=0.129.2,<1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Hello!

Okay maybe a little controversial, but I propose we add a channel that exposes and OpenAI chat completion endpoint.

**Why?**

1. To easily test nanobot in any frontend available that support OpenAI with a custom base URL: WebUI, ChatBox, etc...
2. To integrate nanobot in HomeAssistant of course using the Extended [OpenAI Conversation integration](https://github.com/jekalmin/extended_openai_conversation) for instance.

**Example with a home assistant instance / nanobot / and the [music assisant mcp](https://github.com/davidpadbury/music-assistant-mcp/tree/main/src/music_assistant_mcp)**

<img width="220" height="300" alt="Screenshot From 2026-02-19 18-51-25" src="https://github.com/user-attachments/assets/9d62cfe6-1654-4dd8-a12c-474dab1b92de" />

Current limitation: only one **chat_id**, all conversations end up using the same session, not really a problem if you don't leave with 20 people.