### PR TITLE
fix: use loguru native formatting to prevent KeyError on curly braces

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -219,7 +219,7 @@ class AgentLoop:
                 for tool_call in response.tool_calls:
                     tools_used.append(tool_call.name)
                     args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
-                    logger.info(f"Tool call: {tool_call.name}({args_str[:200]})")
+                    logger.info("Tool call: {}({})", tool_call.name, args_str[:200])
                     result = await self.tools.execute(tool_call.name, tool_call.arguments)
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
@@ -247,7 +247,7 @@ class AgentLoop:
                     if response:
                         await self.bus.publish_outbound(response)
                 except Exception as e:
-                    logger.error(f"Error processing message: {e}")
+                    logger.error("Error processing message: {}", e)
                     await self.bus.publish_outbound(OutboundMessage(
                         channel=msg.channel,
                         chat_id=msg.chat_id,
@@ -292,7 +292,7 @@ class AgentLoop:
             return await self._process_system_message(msg)
         
         preview = msg.content[:80] + "..." if len(msg.content) > 80 else msg.content
-        logger.info(f"Processing message from {msg.channel}:{msg.sender_id}: {preview}")
+        logger.info("Processing message from {}:{}: {}", msg.channel, msg.sender_id, preview)
         
         key = session_key or msg.session_key
         session = self.sessions.get_or_create(key)
@@ -344,7 +344,7 @@ class AgentLoop:
             final_content = "I've completed processing but have no response to give."
         
         preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
-        logger.info(f"Response to {msg.channel}:{msg.sender_id}: {preview}")
+        logger.info("Response to {}:{}: {}", msg.channel, msg.sender_id, preview)
         
         session.add_message("user", msg.content)
         session.add_message("assistant", final_content,
@@ -469,7 +469,7 @@ Respond with ONLY valid JSON, no markdown fences."""
                 text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
             result = json_repair.loads(text)
             if not isinstance(result, dict):
-                logger.warning(f"Memory consolidation: unexpected response type, skipping. Response: {text[:200]}")
+                logger.warning("Memory consolidation: unexpected response type, skipping. Response: {}", text[:200])
                 return
 
             if entry := result.get("history_entry"):
@@ -484,7 +484,7 @@ Respond with ONLY valid JSON, no markdown fences."""
                 session.last_consolidated = len(session.messages) - keep_count
             logger.info(f"Memory consolidation done: {len(session.messages)} messages, last_consolidated={session.last_consolidated}")
         except Exception as e:
-            logger.error(f"Memory consolidation failed: {e}")
+            logger.error("Memory consolidation failed: {}", e)
 
     async def process_direct(
         self,

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -160,7 +160,7 @@ class SubagentManager:
                     # Execute tools
                     for tool_call in response.tool_calls:
                         args_str = json.dumps(tool_call.arguments)
-                        logger.debug(f"Subagent [{task_id}] executing: {tool_call.name} with arguments: {args_str}")
+                        logger.debug("Subagent [{}] executing: {} with arguments: {}", task_id, tool_call.name, args_str)
                         result = await tools.execute(tool_call.name, tool_call.arguments)
                         messages.append({
                             "role": "tool",
@@ -180,7 +180,7 @@ class SubagentManager:
             
         except Exception as e:
             error_msg = f"Error: {str(e)}"
-            logger.error(f"Subagent [{task_id}] failed: {e}")
+            logger.error("Subagent [{}] failed: {}", task_id, e)
             await self._announce_result(task_id, label, task, error_msg, origin, "error")
     
     async def _announce_result(

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -77,4 +77,4 @@ async def connect_mcp_servers(
 
             logger.info(f"MCP server '{name}': connected, {len(tools.tools)} tools registered")
         except Exception as e:
-            logger.error(f"MCP server '{name}': failed to connect: {e}")
+            logger.error("MCP server '{}': failed to connect: {}", name, e)

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -62,7 +62,7 @@ class MessageBus:
                     try:
                         await callback(msg)
                     except Exception as e:
-                        logger.error(f"Error dispatching to {msg.channel}: {e}")
+                        logger.error("Error dispatching to {}: {}", msg.channel, e)
             except asyncio.TimeoutError:
                 continue
     

--- a/nanobot/channels/dingtalk.py
+++ b/nanobot/channels/dingtalk.py
@@ -65,7 +65,7 @@ class NanobotDingTalkHandler(CallbackHandler):
             sender_id = chatbot_msg.sender_staff_id or chatbot_msg.sender_id
             sender_name = chatbot_msg.sender_nick or "Unknown"
 
-            logger.info(f"Received DingTalk message from {sender_name} ({sender_id}): {content}")
+            logger.info("Received DingTalk message from {} ({}): {}", sender_name, sender_id, content)
 
             # Forward to Nanobot via _on_message (non-blocking).
             # Store reference to prevent GC before task completes.
@@ -78,7 +78,7 @@ class NanobotDingTalkHandler(CallbackHandler):
             return AckMessage.STATUS_OK, "OK"
 
         except Exception as e:
-            logger.error(f"Error processing DingTalk message: {e}")
+            logger.error("Error processing DingTalk message: {}", e)
             # Return OK to avoid retry loop from DingTalk server
             return AckMessage.STATUS_OK, "Error"
 
@@ -142,13 +142,13 @@ class DingTalkChannel(BaseChannel):
                 try:
                     await self._client.start()
                 except Exception as e:
-                    logger.warning(f"DingTalk stream error: {e}")
+                    logger.warning("DingTalk stream error: {}", e)
                 if self._running:
                     logger.info("Reconnecting DingTalk stream in 5 seconds...")
                     await asyncio.sleep(5)
 
         except Exception as e:
-            logger.exception(f"Failed to start DingTalk channel: {e}")
+            logger.exception("Failed to start DingTalk channel: {}", e)
 
     async def stop(self) -> None:
         """Stop the DingTalk bot."""
@@ -186,7 +186,7 @@ class DingTalkChannel(BaseChannel):
             self._token_expiry = time.time() + int(res_data.get("expireIn", 7200)) - 60
             return self._access_token
         except Exception as e:
-            logger.error(f"Failed to get DingTalk access token: {e}")
+            logger.error("Failed to get DingTalk access token: {}", e)
             return None
 
     async def send(self, msg: OutboundMessage) -> None:
@@ -218,11 +218,11 @@ class DingTalkChannel(BaseChannel):
         try:
             resp = await self._http.post(url, json=data, headers=headers)
             if resp.status_code != 200:
-                logger.error(f"DingTalk send failed: {resp.text}")
+                logger.error("DingTalk send failed: {}", resp.text)
             else:
                 logger.debug(f"DingTalk message sent to {msg.chat_id}")
         except Exception as e:
-            logger.error(f"Error sending DingTalk message: {e}")
+            logger.error("Error sending DingTalk message: {}", e)
 
     async def _on_message(self, content: str, sender_id: str, sender_name: str) -> None:
         """Handle incoming message (called by NanobotDingTalkHandler).
@@ -231,7 +231,7 @@ class DingTalkChannel(BaseChannel):
         permission checks before publishing to the bus.
         """
         try:
-            logger.info(f"DingTalk inbound: {content} from {sender_name}")
+            logger.info("DingTalk inbound: {} from {}", content, sender_name)
             await self._handle_message(
                 sender_id=sender_id,
                 chat_id=sender_id,  # For private chat, chat_id == sender_id
@@ -242,4 +242,4 @@ class DingTalkChannel(BaseChannel):
                 },
             )
         except Exception as e:
-            logger.error(f"Error publishing DingTalk message: {e}")
+            logger.error("Error publishing DingTalk message: {}", e)

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -51,7 +51,7 @@ class DiscordChannel(BaseChannel):
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.warning(f"Discord gateway error: {e}")
+                logger.warning("Discord gateway error: {}", e)
                 if self._running:
                     logger.info("Reconnecting to Discord gateway in 5 seconds...")
                     await asyncio.sleep(5)
@@ -101,7 +101,7 @@ class DiscordChannel(BaseChannel):
                     return
                 except Exception as e:
                     if attempt == 2:
-                        logger.error(f"Error sending Discord message: {e}")
+                        logger.error("Error sending Discord message: {}", e)
                     else:
                         await asyncio.sleep(1)
         finally:
@@ -116,7 +116,7 @@ class DiscordChannel(BaseChannel):
             try:
                 data = json.loads(raw)
             except json.JSONDecodeError:
-                logger.warning(f"Invalid JSON from Discord gateway: {raw[:100]}")
+                logger.warning("Invalid JSON from Discord gateway: {}", raw[:100])
                 continue
 
             op = data.get("op")
@@ -175,7 +175,7 @@ class DiscordChannel(BaseChannel):
                 try:
                     await self._ws.send(json.dumps(payload))
                 except Exception as e:
-                    logger.warning(f"Discord heartbeat failed: {e}")
+                    logger.warning("Discord heartbeat failed: {}", e)
                     break
                 await asyncio.sleep(interval_s)
 
@@ -219,7 +219,7 @@ class DiscordChannel(BaseChannel):
                 media_paths.append(str(file_path))
                 content_parts.append(f"[attachment: {file_path}]")
             except Exception as e:
-                logger.warning(f"Failed to download Discord attachment: {e}")
+                logger.warning("Failed to download Discord attachment: {}", e)
                 content_parts.append(f"[attachment: {filename} - download failed]")
 
         reply_to = (payload.get("referenced_message") or {}).get("id")

--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -94,7 +94,7 @@ class EmailChannel(BaseChannel):
                         metadata=item.get("metadata", {}),
                     )
             except Exception as e:
-                logger.error(f"Email polling error: {e}")
+                logger.error("Email polling error: {}", e)
 
             await asyncio.sleep(poll_seconds)
 
@@ -143,7 +143,7 @@ class EmailChannel(BaseChannel):
         try:
             await asyncio.to_thread(self._smtp_send, email_msg)
         except Exception as e:
-            logger.error(f"Error sending email to {to_addr}: {e}")
+            logger.error("Error sending email to {}: {}", to_addr, e)
             raise
 
     def _validate_config(self) -> bool:

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -156,7 +156,7 @@ class FeishuChannel(BaseChannel):
                 try:
                     self._ws_client.start()
                 except Exception as e:
-                    logger.warning(f"Feishu WebSocket error: {e}")
+                    logger.warning("Feishu WebSocket error: {}", e)
                 if self._running:
                     import time; time.sleep(5)
         
@@ -177,7 +177,7 @@ class FeishuChannel(BaseChannel):
             try:
                 self._ws_client.stop()
             except Exception as e:
-                logger.warning(f"Error stopping WebSocket client: {e}")
+                logger.warning("Error stopping WebSocket client: {}", e)
         logger.info("Feishu bot stopped")
     
     def _add_reaction_sync(self, message_id: str, emoji_type: str) -> None:
@@ -194,11 +194,11 @@ class FeishuChannel(BaseChannel):
             response = self._client.im.v1.message_reaction.create(request)
             
             if not response.success():
-                logger.warning(f"Failed to add reaction: code={response.code}, msg={response.msg}")
+                logger.warning("Failed to add reaction: code={}, msg={}", response.code, response.msg)
             else:
                 logger.debug(f"Added {emoji_type} reaction to message {message_id}")
         except Exception as e:
-            logger.warning(f"Error adding reaction: {e}")
+            logger.warning("Error adding reaction: {}", e)
 
     async def _add_reaction(self, message_id: str, emoji_type: str = "THUMBSUP") -> None:
         """
@@ -312,10 +312,10 @@ class FeishuChannel(BaseChannel):
                     logger.debug(f"Uploaded image {os.path.basename(file_path)}: {image_key}")
                     return image_key
                 else:
-                    logger.error(f"Failed to upload image: code={response.code}, msg={response.msg}")
+                    logger.error("Failed to upload image: code={}, msg={}", response.code, response.msg)
                     return None
         except Exception as e:
-            logger.error(f"Error uploading image {file_path}: {e}")
+            logger.error("Error uploading image {}: {}", file_path, e)
             return None
 
     def _upload_file_sync(self, file_path: str) -> str | None:
@@ -339,10 +339,10 @@ class FeishuChannel(BaseChannel):
                     logger.debug(f"Uploaded file {file_name}: {file_key}")
                     return file_key
                 else:
-                    logger.error(f"Failed to upload file: code={response.code}, msg={response.msg}")
+                    logger.error("Failed to upload file: code={}, msg={}", response.code, response.msg)
                     return None
         except Exception as e:
-            logger.error(f"Error uploading file {file_path}: {e}")
+            logger.error("Error uploading file {}: {}", file_path, e)
             return None
 
     def _send_message_sync(self, receive_id_type: str, receive_id: str, msg_type: str, content: str) -> bool:
@@ -360,14 +360,14 @@ class FeishuChannel(BaseChannel):
             response = self._client.im.v1.message.create(request)
             if not response.success():
                 logger.error(
-                    f"Failed to send Feishu {msg_type} message: code={response.code}, "
-                    f"msg={response.msg}, log_id={response.get_log_id()}"
+                    "Failed to send Feishu {} message: code={}, msg={}, log_id={}",
+                    msg_type, response.code, response.msg, response.get_log_id()
                 )
                 return False
             logger.debug(f"Feishu {msg_type} message sent to {receive_id}")
             return True
         except Exception as e:
-            logger.error(f"Error sending Feishu {msg_type} message: {e}")
+            logger.error("Error sending Feishu {} message: {}", msg_type, e)
             return False
 
     async def send(self, msg: OutboundMessage) -> None:
@@ -409,7 +409,7 @@ class FeishuChannel(BaseChannel):
                 )
 
         except Exception as e:
-            logger.error(f"Error sending Feishu message: {e}")
+            logger.error("Error sending Feishu message: {}", e)
     
     def _on_message_sync(self, data: "P2ImMessageReceiveV1") -> None:
         """
@@ -481,4 +481,4 @@ class FeishuChannel(BaseChannel):
             )
             
         except Exception as e:
-            logger.error(f"Error processing Feishu message: {e}")
+            logger.error("Error processing Feishu message: {}", e)

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -142,7 +142,7 @@ class ChannelManager:
         try:
             await channel.start()
         except Exception as e:
-            logger.error(f"Failed to start channel {name}: {e}")
+            logger.error("Failed to start channel {}: {}", name, e)
 
     async def start_all(self) -> None:
         """Start all channels and the outbound dispatcher."""
@@ -180,7 +180,7 @@ class ChannelManager:
                 await channel.stop()
                 logger.info(f"Stopped {name} channel")
             except Exception as e:
-                logger.error(f"Error stopping {name}: {e}")
+                logger.error("Error stopping {}: {}", name, e)
     
     async def _dispatch_outbound(self) -> None:
         """Dispatch outbound messages to the appropriate channel."""
@@ -198,7 +198,7 @@ class ChannelManager:
                     try:
                         await channel.send(msg)
                     except Exception as e:
-                        logger.error(f"Error sending to {msg.channel}: {e}")
+                        logger.error("Error sending to {}: {}", msg.channel, e)
                 else:
                     logger.warning(f"Unknown channel: {msg.channel}")
                     

--- a/nanobot/channels/mochat.py
+++ b/nanobot/channels/mochat.py
@@ -322,7 +322,7 @@ class MochatChannel(BaseChannel):
                 await self._api_send("/api/claw/sessions/send", "sessionId", target.id,
                                      content, msg.reply_to)
         except Exception as e:
-            logger.error(f"Failed to send Mochat message: {e}")
+            logger.error("Failed to send Mochat message: {}", e)
 
     # ---- config / init helpers ---------------------------------------------
 
@@ -380,7 +380,7 @@ class MochatChannel(BaseChannel):
 
         @client.event
         async def connect_error(data: Any) -> None:
-            logger.error(f"Mochat websocket connect error: {data}")
+            logger.error("Mochat websocket connect error: {}", data)
 
         @client.on("claw.session.events")
         async def on_session_events(payload: dict[str, Any]) -> None:
@@ -407,7 +407,7 @@ class MochatChannel(BaseChannel):
             )
             return True
         except Exception as e:
-            logger.error(f"Failed to connect Mochat websocket: {e}")
+            logger.error("Failed to connect Mochat websocket: {}", e)
             try:
                 await client.disconnect()
             except Exception:
@@ -444,7 +444,7 @@ class MochatChannel(BaseChannel):
             "limit": self.config.watch_limit,
         })
         if not ack.get("result"):
-            logger.error(f"Mochat subscribeSessions failed: {ack.get('message', 'unknown error')}")
+            logger.error("Mochat subscribeSessions failed: {}", ack.get('message', 'unknown error'))
             return False
 
         data = ack.get("data")
@@ -466,7 +466,7 @@ class MochatChannel(BaseChannel):
             return True
         ack = await self._socket_call("com.claw.im.subscribePanels", {"panelIds": panel_ids})
         if not ack.get("result"):
-            logger.error(f"Mochat subscribePanels failed: {ack.get('message', 'unknown error')}")
+            logger.error("Mochat subscribePanels failed: {}", ack.get('message', 'unknown error'))
             return False
         return True
 
@@ -488,7 +488,7 @@ class MochatChannel(BaseChannel):
             try:
                 await self._refresh_targets(subscribe_new=self._ws_ready)
             except Exception as e:
-                logger.warning(f"Mochat refresh failed: {e}")
+                logger.warning("Mochat refresh failed: {}", e)
             if self._fallback_mode:
                 await self._ensure_fallback_workers()
 
@@ -502,7 +502,7 @@ class MochatChannel(BaseChannel):
         try:
             response = await self._post_json("/api/claw/sessions/list", {})
         except Exception as e:
-            logger.warning(f"Mochat listSessions failed: {e}")
+            logger.warning("Mochat listSessions failed: {}", e)
             return
 
         sessions = response.get("sessions")
@@ -536,7 +536,7 @@ class MochatChannel(BaseChannel):
         try:
             response = await self._post_json("/api/claw/groups/get", {})
         except Exception as e:
-            logger.warning(f"Mochat getWorkspaceGroup failed: {e}")
+            logger.warning("Mochat getWorkspaceGroup failed: {}", e)
             return
 
         raw_panels = response.get("panels")
@@ -598,7 +598,7 @@ class MochatChannel(BaseChannel):
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.warning(f"Mochat watch fallback error ({session_id}): {e}")
+                logger.warning("Mochat watch fallback error ({}): {}", session_id, e)
                 await asyncio.sleep(max(0.1, self.config.retry_delay_ms / 1000.0))
 
     async def _panel_poll_worker(self, panel_id: str) -> None:
@@ -625,7 +625,7 @@ class MochatChannel(BaseChannel):
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.warning(f"Mochat panel polling error ({panel_id}): {e}")
+                logger.warning("Mochat panel polling error ({}): {}", panel_id, e)
             await asyncio.sleep(sleep_s)
 
     # ---- inbound event processing ------------------------------------------
@@ -836,7 +836,7 @@ class MochatChannel(BaseChannel):
         try:
             data = json.loads(self._cursor_path.read_text("utf-8"))
         except Exception as e:
-            logger.warning(f"Failed to read Mochat cursor file: {e}")
+            logger.warning("Failed to read Mochat cursor file: {}", e)
             return
         cursors = data.get("cursors") if isinstance(data, dict) else None
         if isinstance(cursors, dict):
@@ -852,7 +852,7 @@ class MochatChannel(BaseChannel):
                 "cursors": self._session_cursor,
             }, ensure_ascii=False, indent=2) + "\n", "utf-8")
         except Exception as e:
-            logger.warning(f"Failed to save Mochat cursor file: {e}")
+            logger.warning("Failed to save Mochat cursor file: {}", e)
 
     # ---- HTTP helpers ------------------------------------------------------
 

--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -80,7 +80,7 @@ class QQChannel(BaseChannel):
             try:
                 await self._client.start(appid=self.config.app_id, secret=self.config.secret)
             except Exception as e:
-                logger.warning(f"QQ bot error: {e}")
+                logger.warning("QQ bot error: {}", e)
             if self._running:
                 logger.info("Reconnecting QQ bot in 5 seconds...")
                 await asyncio.sleep(5)
@@ -108,7 +108,7 @@ class QQChannel(BaseChannel):
                 content=msg.content,
             )
         except Exception as e:
-            logger.error(f"Error sending QQ message: {e}")
+            logger.error("Error sending QQ message: {}", e)
 
     async def _on_message(self, data: "C2CMessage") -> None:
         """Handle incoming message from QQ."""
@@ -131,4 +131,4 @@ class QQChannel(BaseChannel):
                 metadata={"message_id": data.id},
             )
         except Exception as e:
-            logger.error(f"Error handling QQ message: {e}")
+            logger.error("Error handling QQ message: {}", e)

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -55,7 +55,7 @@ class SlackChannel(BaseChannel):
             self._bot_user_id = auth.get("user_id")
             logger.info(f"Slack bot connected as {self._bot_user_id}")
         except Exception as e:
-            logger.warning(f"Slack auth_test failed: {e}")
+            logger.warning("Slack auth_test failed: {}", e)
 
         logger.info("Starting Slack Socket Mode client...")
         await self._socket_client.connect()
@@ -70,7 +70,7 @@ class SlackChannel(BaseChannel):
             try:
                 await self._socket_client.close()
             except Exception as e:
-                logger.warning(f"Slack socket close failed: {e}")
+                logger.warning("Slack socket close failed: {}", e)
             self._socket_client = None
 
     async def send(self, msg: OutboundMessage) -> None:
@@ -90,7 +90,7 @@ class SlackChannel(BaseChannel):
                 thread_ts=thread_ts if use_thread else None,
             )
         except Exception as e:
-            logger.error(f"Error sending Slack message: {e}")
+            logger.error("Error sending Slack message: {}", e)
 
     async def _on_socket_request(
         self,
@@ -164,7 +164,7 @@ class SlackChannel(BaseChannel):
                     timestamp=event.get("ts"),
                 )
         except Exception as e:
-            logger.debug(f"Slack reactions_add failed: {e}")
+            logger.debug("Slack reactions_add failed: {}", e)
 
         await self._handle_message(
             sender_id=sender_id,

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -171,7 +171,7 @@ class TelegramChannel(BaseChannel):
             await self._app.bot.set_my_commands(self.BOT_COMMANDS)
             logger.debug("Telegram bot commands registered")
         except Exception as e:
-            logger.warning(f"Failed to register bot commands: {e}")
+            logger.warning("Failed to register bot commands: {}", e)
         
         # Start polling (this runs until stopped)
         await self._app.updater.start_polling(
@@ -238,7 +238,7 @@ class TelegramChannel(BaseChannel):
                     await sender(chat_id=chat_id, **{param: f})
             except Exception as e:
                 filename = media_path.rsplit("/", 1)[-1]
-                logger.error(f"Failed to send media {media_path}: {e}")
+                logger.error("Failed to send media {}: {}", media_path, e)
                 await self._app.bot.send_message(chat_id=chat_id, text=f"[Failed to send: {filename}]")
 
         # Send text content
@@ -248,11 +248,11 @@ class TelegramChannel(BaseChannel):
                     html = _markdown_to_telegram_html(chunk)
                     await self._app.bot.send_message(chat_id=chat_id, text=html, parse_mode="HTML")
                 except Exception as e:
-                    logger.warning(f"HTML parse failed, falling back to plain text: {e}")
+                    logger.warning("HTML parse failed, falling back to plain text: {}", e)
                     try:
                         await self._app.bot.send_message(chat_id=chat_id, text=chunk)
                     except Exception as e2:
-                        logger.error(f"Error sending Telegram message: {e2}")
+                        logger.error("Error sending Telegram message: {}", e2)
     
     async def _on_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /start command."""
@@ -353,12 +353,12 @@ class TelegramChannel(BaseChannel):
                     
                 logger.debug(f"Downloaded {media_type} to {file_path}")
             except Exception as e:
-                logger.error(f"Failed to download media: {e}")
+                logger.error("Failed to download media: {}", e)
                 content_parts.append(f"[{media_type}: download failed]")
         
         content = "\n".join(content_parts) if content_parts else "[empty message]"
         
-        logger.debug(f"Telegram message from {sender_id}: {content[:50]}...")
+        logger.debug("Telegram message from {}: {}...", sender_id, content[:50])
         
         str_chat_id = str(chat_id)
         
@@ -401,11 +401,11 @@ class TelegramChannel(BaseChannel):
         except asyncio.CancelledError:
             pass
         except Exception as e:
-            logger.debug(f"Typing indicator stopped for {chat_id}: {e}")
+            logger.debug("Typing indicator stopped for {}: {}", chat_id, e)
     
     async def _on_error(self, update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Log polling / handler errors instead of silently swallowing them."""
-        logger.error(f"Telegram error: {context.error}")
+        logger.error("Telegram error: {}", context.error)
 
     def _get_extension(self, media_type: str, mime_type: str | None) -> str:
         """Get file extension based on media type."""

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -53,14 +53,14 @@ class WhatsAppChannel(BaseChannel):
                         try:
                             await self._handle_bridge_message(message)
                         except Exception as e:
-                            logger.error(f"Error handling bridge message: {e}")
+                            logger.error("Error handling bridge message: {}", e)
                     
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 self._connected = False
                 self._ws = None
-                logger.warning(f"WhatsApp bridge connection error: {e}")
+                logger.warning("WhatsApp bridge connection error: {}", e)
                 
                 if self._running:
                     logger.info("Reconnecting in 5 seconds...")
@@ -89,14 +89,14 @@ class WhatsAppChannel(BaseChannel):
             }
             await self._ws.send(json.dumps(payload))
         except Exception as e:
-            logger.error(f"Error sending WhatsApp message: {e}")
+            logger.error("Error sending WhatsApp message: {}", e)
     
     async def _handle_bridge_message(self, raw: str) -> None:
         """Handle a message from the bridge."""
         try:
             data = json.loads(raw)
         except json.JSONDecodeError:
-            logger.warning(f"Invalid JSON from bridge: {raw[:100]}")
+            logger.warning("Invalid JSON from bridge: {}", raw[:100])
             return
         
         msg_type = data.get("type")
@@ -145,4 +145,4 @@ class WhatsAppChannel(BaseChannel):
             logger.info("Scan QR code in the bridge terminal to connect WhatsApp")
         
         elif msg_type == "error":
-            logger.error(f"WhatsApp bridge error: {data.get('error')}")
+            logger.error("WhatsApp bridge error: {}", data.get('error'))

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -99,7 +99,7 @@ class CronService:
                     ))
                 self._store = CronStore(jobs=jobs)
             except Exception as e:
-                logger.warning(f"Failed to load cron store: {e}")
+                logger.warning("Failed to load cron store: {}", e)
                 self._store = CronStore()
         else:
             self._store = CronStore()
@@ -236,7 +236,7 @@ class CronService:
         except Exception as e:
             job.state.last_status = "error"
             job.state.last_error = str(e)
-            logger.error(f"Cron: job '{job.name}' failed: {e}")
+            logger.error("Cron: job '{}' failed: {}", job.name, e)
         
         job.state.last_run_at_ms = start_ms
         job.updated_at_ms = _now_ms()

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -97,7 +97,7 @@ class HeartbeatService:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error(f"Heartbeat error: {e}")
+                logger.error("Heartbeat error: {}", e)
     
     async def _tick(self) -> None:
         """Execute a single heartbeat tick."""
@@ -121,7 +121,7 @@ class HeartbeatService:
                     logger.info(f"Heartbeat: completed task")
                     
             except Exception as e:
-                logger.error(f"Heartbeat execution failed: {e}")
+                logger.error("Heartbeat execution failed: {}", e)
     
     async def trigger_now(self) -> str | None:
         """Manually trigger a heartbeat."""

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -61,5 +61,5 @@ class GroqTranscriptionProvider:
                     return data.get("text", "")
                     
         except Exception as e:
-            logger.error(f"Groq transcription error: {e}")
+            logger.error("Groq transcription error: {}", e)
             return ""

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -144,7 +144,7 @@ class SessionManager:
                 last_consolidated=last_consolidated
             )
         except Exception as e:
-            logger.warning(f"Failed to load session {key}: {e}")
+            logger.warning("Failed to load session {}: {}", key, e)
             return None
     
     def save(self, session: Session) -> None:


### PR DESCRIPTION
## Summary
- Replace f-string interpolation in loguru logger calls with loguru's native `{}` placeholder formatting across 18 files
- Prevents `KeyError` crashes when logged values (error messages, user content, JSON data) contain curly braces `{}`
- Conservative approach: only changes logger calls where the interpolated variable could realistically contain braces

## Problem
When an exception message or user-provided content contains curly braces (e.g. JSON snippets like `{"key": "value"}`), loguru interprets the `{}` inside f-strings as format placeholders. This causes a `KeyError` crash in the logging call itself, masking the original error and crashing the agent loop.

For example, an API returning `{"error": "invalid input"}` in its exception would cause:
```python
logger.error(f"Error processing message: {e}")
# If str(e) = 'API returned {"error": "invalid input"}'
# loguru sees: "Error processing message: API returned {"error": "invalid input"}"
# loguru tries to format {error} as a placeholder -> KeyError: 'error'
```

## Root Cause
Loguru uses `str.format()`-style formatting internally. When an f-string is passed as the message, the string is already interpolated by Python before loguru sees it. If the interpolated value contains `{...}`, loguru interprets those as additional format placeholders and raises a `KeyError`.

## Fix
Replace dangerous f-string patterns with loguru's native positional formatting:

```python
# Before (dangerous - curly braces in str(e) cause KeyError)
logger.error(f"Error processing message: {e}")

# After (safe - loguru handles the formatting)
logger.error("Error processing message: {}", e)
```

This approach is safe because loguru only replaces explicitly provided `{}` placeholders with the corresponding positional arguments. Any curly braces inside the argument values are treated as literal text.

Changes applied across 18 files:
- `nanobot/agent/loop.py` - error handlers, message previews, tool call args, LLM response text
- `nanobot/agent/subagent.py` - tool execution args, error handlers
- `nanobot/agent/tools/mcp.py` - MCP connection errors
- `nanobot/bus/queue.py` - dispatch errors
- `nanobot/channels/` - all channel error handlers (Slack, Telegram, WhatsApp, Discord, Feishu, DingTalk, QQ, Mochat, Email)
- `nanobot/channels/manager.py` - channel start/stop errors
- `nanobot/cron/service.py` - job execution errors
- `nanobot/heartbeat/service.py` - heartbeat errors
- `nanobot/providers/transcription.py` - transcription errors
- `nanobot/session/manager.py` - session load errors

Logger calls with safe interpolations (integers from `len()`, internal identifiers, config values) were intentionally left unchanged.

## Test plan
- [ ] Verify agent starts and processes messages normally with all channels
- [ ] Trigger an error with a message containing JSON/curly braces (e.g. send `{"test": true}` as a message that causes a processing error) and confirm no `KeyError` in logs
- [ ] Confirm log output format is unchanged (loguru's `{}` formatting produces identical output to f-string interpolation)
- [ ] Run existing test suite to verify no regressions

Closes #857