### PR TITLE
fix: consume message bus in CLI mode for subagent result delivery

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -519,6 +519,28 @@ def agent(
         signal.signal(signal.SIGINT, _exit_on_sigint)
         
         async def run_interactive():
+            # Start bus consumer in background so subagent results are
+            # picked up and processed (they publish to bus.inbound).
+            bus_consumer_task = asyncio.create_task(agent_loop.run())
+
+            # Consume outbound messages produced by the bus consumer
+            # (e.g. subagent result summaries) and print them to the CLI.
+            async def _print_bus_outbound():
+                while True:
+                    try:
+                        msg = await asyncio.wait_for(
+                            bus.consume_outbound(), timeout=1.0
+                        )
+                        if msg.content:
+                            console.print()
+                            _print_agent_response(msg.content, render_markdown=markdown)
+                    except asyncio.TimeoutError:
+                        continue
+                    except asyncio.CancelledError:
+                        break
+
+            outbound_printer_task = asyncio.create_task(_print_bus_outbound())
+
             try:
                 while True:
                     try:
@@ -532,7 +554,7 @@ def agent(
                             _restore_terminal()
                             console.print("\nGoodbye!")
                             break
-                        
+
                         with _thinking_ctx():
                             response = await agent_loop.process_direct(user_input, session_id, on_progress=_cli_progress)
                         _print_agent_response(response, render_markdown=markdown)
@@ -545,6 +567,12 @@ def agent(
                         console.print("\nGoodbye!")
                         break
             finally:
+                agent_loop.stop()
+                outbound_printer_task.cancel()
+                await asyncio.gather(
+                    bus_consumer_task, outbound_printer_task,
+                    return_exceptions=True,
+                )
                 await agent_loop.close_mcp()
         
         asyncio.run(run_interactive())


### PR DESCRIPTION
## Summary

- Start `agent_loop.run()` as a background task in CLI interactive mode so subagent results published to the message bus are consumed and processed
- Add an outbound queue consumer that prints subagent responses to the terminal
- Proper cleanup via `agent_loop.stop()` and `asyncio.gather()` on exit

## Problem

When using `nanobot agent` (CLI interactive mode), the `spawn` tool creates subagents that publish their results to `bus.inbound` via `SubagentManager._announce_result()`. However, nothing consumes from the bus in CLI mode — `process_direct()` bypasses the bus entirely, and `agent_loop.run()` (the bus consumer) is never started.

This causes all subagent results to pile up in the queue and never get delivered to the user.

## Root Cause

In `commands.py`, the interactive loop uses `process_direct()` which calls `_process_message()` directly without the bus:

```python
async def run_interactive():
    while True:
        response = await agent_loop.process_direct(user_input, session_id)
        # process_direct() never starts the bus consumer
```

Compare with gateway mode which starts `agent_loop.run()` (the bus consumer) alongside channels:

```python
await asyncio.gather(
    agent.run(),        # ← Consumes bus.inbound
    channels.start_all(),
)
```

## Fix

Start the bus consumer and an outbound printer as background tasks in the interactive loop:

```python
async def run_interactive():
    # Consume bus.inbound (subagent results arrive here)
    bus_consumer_task = asyncio.create_task(agent_loop.run())

    # Print outbound messages (subagent summaries) to terminal
    async def _print_bus_outbound():
        while True:
            msg = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
            if msg.content:
                _print_agent_response(msg.content, render_markdown=markdown)

    outbound_printer_task = asyncio.create_task(_print_bus_outbound())

    try:
        # ... existing input loop using process_direct() ...
    finally:
        agent_loop.stop()
        outbound_printer_task.cancel()
        await asyncio.gather(bus_consumer_task, outbound_printer_task, return_exceptions=True)
        await agent_loop.close_mcp()
```

**How it works:**
1. User messages → `process_direct()` → direct processing (unchanged)
2. Subagent results → `bus.publish_inbound()` → `agent_loop.run()` picks them up → processes system message → `bus.publish_outbound()` → `_print_bus_outbound()` prints to terminal

## Test plan

- [ ] `nanobot agent` interactive mode starts normally
- [ ] Regular messages work as before (via `process_direct`)
- [ ] Spawning a subagent → result is printed to terminal when complete
- [ ] Exit commands (`exit`, `quit`, Ctrl+C) cleanly shut down background tasks
- [ ] No hanging on exit (background tasks are properly cancelled)

Closes #779