### PR TITLE
fix: preserve interim content as fallback when retry produces empty response

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -245,7 +245,8 @@ class AgentLoop:
                     final_content = None
                     continue
                 # Fall back to interim content if retry produced nothing
-                if not final_content and interim_content:
+                # and no tools were used (if tools ran, interim was truly interim)
+                if not final_content and interim_content and not tools_used:
                     final_content = interim_content
                 break
 


### PR DESCRIPTION
## Summary

- Save the first text-only response as `interim_content` before retrying
- If the retry produces an empty or `None` response, fall back to the saved content
- Fixes regression introduced in #825 that broke models responding with direct text

## Problem

After #825 was merged, models that respond with direct text (no tools) had their answer discarded. For example, with gpt-oss via Ollama:

```
$ nanobot agent -m "2+2"
🐈 nanobot
I've completed processing but have no response to give.
```

The model's actual answer ("2 + 2 = 4") was thrown away by the retry mechanism.

## Root Cause

The retry logic in `_run_agent_loop()` (from #825) always discards the first text-only response (`final_content = None`) and retries. If the model has already given its final answer and the retry produces an empty/minimal response, the original answer is lost:

```python
# Before: always discards first response
if not tools_used and not text_only_retried and final_content:
    text_only_retried = True
    final_content = None  # ← Original answer lost forever
    continue
```

## Fix

Save the first response as fallback before clearing it:

```python
if not tools_used and not text_only_retried and final_content:
    text_only_retried = True
    interim_content = final_content  # ← Save as fallback
    final_content = None
    continue
# Fall back to interim content if retry produced nothing
if not final_content and interim_content:
    final_content = interim_content
break
```

**Behavior matrix:**

| Scenario | Before (broken) | After (fixed) |
|----------|----------------|---------------|
| Model sends text then tools | ✅ Tools execute | ✅ Tools execute |
| Model sends direct answer (no tools) | ❌ Answer lost | ✅ Falls back to first response |
| Model sends two text responses | ✅ Uses second | ✅ Uses second |
| Model sends text then empty retry | ❌ Returns None | ✅ Falls back to first response |

## Test plan

- [ ] `nanobot agent -m "2+2"` with text-only model (e.g. Ollama) → returns correct answer
- [ ] Model that sends interim text then uses tools → tools execute normally
- [ ] Model that sends two meaningful text responses → second one is used
- [ ] Max iterations respected

Closes #878