### PR TITLE
fix: use is_relative_to for path restriction to prevent sibling dir bypass

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -12,7 +12,7 @@ def _resolve_path(path: str, workspace: Path | None = None, allowed_dir: Path | 
     if not p.is_absolute() and workspace:
         p = workspace / p
     resolved = p.resolve()
-    if allowed_dir and not str(resolved).startswith(str(allowed_dir.resolve())):
+    if allowed_dir and not resolved.is_relative_to(allowed_dir.resolve()):
         raise PermissionError(f"Path {path} is outside allowed directory {allowed_dir}")
     return resolved
 


### PR DESCRIPTION
## Summary

- Replace string `startswith` check with `Path.is_relative_to()` in `_resolve_path()`
- Prevents path restriction bypass via sibling directories with matching name prefixes

## Problem

When `tools.restrictToWorkspace=true` is enabled, the path restriction check in `filesystem.py` uses string comparison:

```python
if not str(resolved).startswith(str(allowed_dir.resolve())):
    raise PermissionError(...)
```

This allows paths in sibling directories to pass the check:

```python
allowed_dir = "/home/user/workspace"
# This PASSES the check — the string prefix matches!
"/home/user/workspace_evil/secret".startswith("/home/user/workspace")  # True
```

## Fix

One-line change to use `Path.is_relative_to()` (Python 3.9+):

```python
if allowed_dir and not resolved.is_relative_to(allowed_dir.resolve()):
    raise PermissionError(...)
```

`is_relative_to()` correctly checks path containment using path components, not string prefixes.

## Test plan

- [ ] `read_file("../outside.txt")` with `restrictToWorkspace=true` → blocked
- [ ] Paths within workspace → allowed
- [ ] Path like `/workspace_evil/file` when workspace is `/workspace` → blocked (was allowed before)
- [ ] Relative paths resolved against workspace → work correctly

Closes #888