### PR TITLE
fix: use bounded eviction for email dedup instead of clearing entire set

### DIFF
--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -6,6 +6,7 @@ import imaplib
 import re
 import smtplib
 import ssl
+from collections import OrderedDict
 from datetime import date
 from email import policy
 from email.header import decode_header, make_header
@@ -55,7 +56,7 @@ class EmailChannel(BaseChannel):
         self.config: EmailConfig = config
         self._last_subject_by_chat: dict[str, str] = {}
         self._last_message_id_by_chat: dict[str, str] = {}
-        self._processed_uids: set[str] = set()  # Capped to prevent unbounded growth
+        self._processed_uids: OrderedDict[str, None] = OrderedDict()  # Bounded dedup cache
         self._MAX_PROCESSED_UIDS = 100000
 
     async def start(self) -> None:
@@ -301,10 +302,12 @@ class EmailChannel(BaseChannel):
                 )
 
                 if dedupe and uid:
-                    self._processed_uids.add(uid)
-                    # mark_seen is the primary dedup; this set is a safety net
+                    self._processed_uids[uid] = None
                     if len(self._processed_uids) > self._MAX_PROCESSED_UIDS:
-                        self._processed_uids.clear()
+                        # Evict oldest 20% instead of clearing everything
+                        evict_count = self._MAX_PROCESSED_UIDS // 5
+                        for _ in range(evict_count):
+                            self._processed_uids.popitem(last=False)
 
                 if mark_seen:
                     client.store(imap_id, "+FLAGS", "\\Seen")


### PR DESCRIPTION
## Summary
- Replace the email channel's dedup `set` with an `OrderedDict`-based bounded cache that evicts the oldest 20% of entries when the cap is exceeded, instead of clearing the entire structure.

## Problem
When `_processed_uids` exceeds the 100K cap, the entire set is cleared with `.clear()`. This causes all previously seen UIDs to be forgotten at once, allowing mass re-processing of old emails that were already handled. In high-volume mailboxes this leads to duplicate processing storms every time the cap is hit.

## Fix
```python
# Before (email.py __init__):
self._processed_uids: set[str] = set()

# After:
self._processed_uids: OrderedDict[str, None] = OrderedDict()
```

```python
# Before (dedup logic):
if dedupe and uid:
    self._processed_uids.add(uid)
    if len(self._processed_uids) > self._MAX_PROCESSED_UIDS:
        self._processed_uids.clear()

# After:
if dedupe and uid:
    self._processed_uids[uid] = None
    if len(self._processed_uids) > self._MAX_PROCESSED_UIDS:
        evict_count = self._MAX_PROCESSED_UIDS // 5
        for _ in range(evict_count):
            self._processed_uids.popitem(last=False)
```

`OrderedDict` tracks insertion order, so `popitem(last=False)` removes the oldest entries first. The `in` operator works identically for membership checks, so the dedup guard at line 262 (`uid in self._processed_uids`) requires no changes.

## Test plan
- [ ] Unit test: insert 100,001 UIDs, verify the structure retains the most recent 80,000 (oldest 20K evicted)
- [ ] Unit test: confirm `uid in self._processed_uids` returns `True` for recent UIDs and `False` for evicted UIDs
- [ ] Integration test: simulate a polling loop that exceeds the cap and verify no previously-seen UID is re-processed unless it was in the evicted oldest 20%
- [ ] Verify no regression in normal dedup behavior below the cap

Closes #890