### PR TITLE
fix: add asyncio.Lock to CronService to prevent concurrent store corruption

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -78,14 +78,14 @@ class CronTool(Tool):
         **kwargs: Any
     ) -> str:
         if action == "add":
-            return self._add_job(message, every_seconds, cron_expr, tz, at)
+            return await self._add_job(message, every_seconds, cron_expr, tz, at)
         elif action == "list":
-            return self._list_jobs()
+            return await self._list_jobs()
         elif action == "remove":
-            return self._remove_job(job_id)
+            return await self._remove_job(job_id)
         return f"Unknown action: {action}"
     
-    def _add_job(
+    async def _add_job(
         self,
         message: str,
         every_seconds: int | None,
@@ -105,7 +105,7 @@ class CronTool(Tool):
                 ZoneInfo(tz)
             except (KeyError, Exception):
                 return f"Error: unknown timezone '{tz}'"
-        
+
         # Build schedule
         delete_after = False
         if every_seconds:
@@ -120,8 +120,8 @@ class CronTool(Tool):
             delete_after = True
         else:
             return "Error: either every_seconds, cron_expr, or at is required"
-        
-        job = self._cron.add_job(
+
+        job = await self._cron.add_job(
             name=message[:30],
             schedule=schedule,
             message=message,
@@ -132,16 +132,16 @@ class CronTool(Tool):
         )
         return f"Created job '{job.name}' (id: {job.id})"
     
-    def _list_jobs(self) -> str:
-        jobs = self._cron.list_jobs()
+    async def _list_jobs(self) -> str:
+        jobs = await self._cron.list_jobs()
         if not jobs:
             return "No scheduled jobs."
         lines = [f"- {j.name} (id: {j.id}, {j.schedule.kind})" for j in jobs]
         return "Scheduled jobs:\n" + "\n".join(lines)
     
-    def _remove_job(self, job_id: str | None) -> str:
+    async def _remove_job(self, job_id: str | None) -> str:
         if not job_id:
             return "Error: job_id is required for remove"
-        if self._cron.remove_job(job_id):
+        if await self._cron.remove_job(job_id):
             return f"Removed job {job_id}"
         return f"Job {job_id} not found"

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -409,14 +409,14 @@ def gateway(
     else:
         console.print("[yellow]Warning: No channels enabled[/yellow]")
     
-    cron_status = cron.status()
-    if cron_status["jobs"] > 0:
-        console.print(f"[green]✓[/green] Cron: {cron_status['jobs']} scheduled jobs")
-    
     console.print(f"[green]✓[/green] Heartbeat: every 30m")
-    
+
     async def run():
         try:
+            cron_status = await cron.status()
+            if cron_status["jobs"] > 0:
+                console.print(f"[green]✓[/green] Cron: {cron_status['jobs']} scheduled jobs")
+
             await cron.start()
             await heartbeat.start()
             await asyncio.gather(
@@ -726,7 +726,7 @@ def cron_list(
     store_path = get_data_dir() / "cron" / "jobs.json"
     service = CronService(store_path)
     
-    jobs = service.list_jobs(include_disabled=all)
+    jobs = asyncio.run(service.list_jobs(include_disabled=all))
     
     if not jobs:
         console.print("No scheduled jobs.")
@@ -806,14 +806,14 @@ def cron_add(
     service = CronService(store_path)
     
     try:
-        job = service.add_job(
+        job = asyncio.run(service.add_job(
             name=name,
             schedule=schedule,
             message=message,
             deliver=deliver,
             to=to,
             channel=channel,
-        )
+        ))
     except ValueError as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1) from e
@@ -832,7 +832,7 @@ def cron_remove(
     store_path = get_data_dir() / "cron" / "jobs.json"
     service = CronService(store_path)
     
-    if service.remove_job(job_id):
+    if asyncio.run(service.remove_job(job_id)):
         console.print(f"[green]✓[/green] Removed job {job_id}")
     else:
         console.print(f"[red]Job {job_id} not found[/red]")
@@ -850,7 +850,7 @@ def cron_enable(
     store_path = get_data_dir() / "cron" / "jobs.json"
     service = CronService(store_path)
     
-    job = service.enable_job(job_id, enabled=not disable)
+    job = asyncio.run(service.enable_job(job_id, enabled=not disable))
     if job:
         status = "disabled" if disable else "enabled"
         console.print(f"[green]✓[/green] Job '{job.name}' {status}")

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -219,6 +219,9 @@ class CronService:
     
     async def _on_timer(self) -> None:
         """Handle timer tick - run due jobs."""
+        # Snapshot due jobs under lock, then release before executing.
+        # _execute_job awaits the on_job callback which may re-enter
+        # CronService (e.g. via CronTool), so the lock must not be held.
         async with self._lock:
             if not self._store:
                 return
@@ -229,9 +232,10 @@ class CronService:
                 if j.enabled and j.state.next_run_at_ms and now >= j.state.next_run_at_ms
             ]
 
-            for job in due_jobs:
-                await self._execute_job(job)
+        for job in due_jobs:
+            await self._execute_job(job)
 
+        async with self._lock:
             self._save_store()
             self._arm_timer()
     
@@ -352,17 +356,26 @@ class CronService:
     
     async def run_job(self, job_id: str, force: bool = False) -> bool:
         """Manually run a job."""
+        # Locate job under lock, then release before executing to avoid
+        # deadlock when the on_job callback re-enters CronService.
+        job = None
         async with self._lock:
             store = self._load_store()
-            for job in store.jobs:
-                if job.id == job_id:
-                    if not force and not job.enabled:
+            for j in store.jobs:
+                if j.id == job_id:
+                    if not force and not j.enabled:
                         return False
-                    await self._execute_job(job)
-                    self._save_store()
-                    self._arm_timer()
-                    return True
-            return False
+                    job = j
+                    break
+            if job is None:
+                return False
+
+        await self._execute_job(job)
+
+        async with self._lock:
+            self._save_store()
+            self._arm_timer()
+        return True
     
     async def status(self) -> dict:
         """Get service status."""

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -72,6 +72,7 @@ class CronService:
         self._store: CronStore | None = None
         self._timer_task: asyncio.Task | None = None
         self._running = False
+        self._lock = asyncio.Lock()
     
     def _load_store(self) -> CronStore:
         """Load jobs from disk."""
@@ -218,20 +219,21 @@ class CronService:
     
     async def _on_timer(self) -> None:
         """Handle timer tick - run due jobs."""
-        if not self._store:
-            return
-        
-        now = _now_ms()
-        due_jobs = [
-            j for j in self._store.jobs
-            if j.enabled and j.state.next_run_at_ms and now >= j.state.next_run_at_ms
-        ]
-        
-        for job in due_jobs:
-            await self._execute_job(job)
-        
-        self._save_store()
-        self._arm_timer()
+        async with self._lock:
+            if not self._store:
+                return
+
+            now = _now_ms()
+            due_jobs = [
+                j for j in self._store.jobs
+                if j.enabled and j.state.next_run_at_ms and now >= j.state.next_run_at_ms
+            ]
+
+            for job in due_jobs:
+                await self._execute_job(job)
+
+            self._save_store()
+            self._arm_timer()
     
     async def _execute_job(self, job: CronJob) -> None:
         """Execute a single job."""
@@ -268,13 +270,14 @@ class CronService:
     
     # ========== Public API ==========
     
-    def list_jobs(self, include_disabled: bool = False) -> list[CronJob]:
+    async def list_jobs(self, include_disabled: bool = False) -> list[CronJob]:
         """List all jobs."""
-        store = self._load_store()
-        jobs = store.jobs if include_disabled else [j for j in store.jobs if j.enabled]
-        return sorted(jobs, key=lambda j: j.state.next_run_at_ms or float('inf'))
+        async with self._lock:
+            store = self._load_store()
+            jobs = store.jobs if include_disabled else [j for j in store.jobs if j.enabled]
+            return sorted(jobs, key=lambda j: j.state.next_run_at_ms or float('inf'))
     
-    def add_job(
+    async def add_job(
         self,
         name: str,
         schedule: CronSchedule,
@@ -285,83 +288,88 @@ class CronService:
         delete_after_run: bool = False,
     ) -> CronJob:
         """Add a new job."""
-        store = self._load_store()
-        _validate_schedule_for_add(schedule)
-        now = _now_ms()
-        
-        job = CronJob(
-            id=str(uuid.uuid4())[:8],
-            name=name,
-            enabled=True,
-            schedule=schedule,
-            payload=CronPayload(
-                kind="agent_turn",
-                message=message,
-                deliver=deliver,
-                channel=channel,
-                to=to,
-            ),
-            state=CronJobState(next_run_at_ms=_compute_next_run(schedule, now)),
-            created_at_ms=now,
-            updated_at_ms=now,
-            delete_after_run=delete_after_run,
-        )
-        
-        store.jobs.append(job)
-        self._save_store()
-        self._arm_timer()
-        
-        logger.info("Cron: added job '{}' ({})", name, job.id)
-        return job
-    
-    def remove_job(self, job_id: str) -> bool:
-        """Remove a job by ID."""
-        store = self._load_store()
-        before = len(store.jobs)
-        store.jobs = [j for j in store.jobs if j.id != job_id]
-        removed = len(store.jobs) < before
-        
-        if removed:
+        async with self._lock:
+            store = self._load_store()
+            _validate_schedule_for_add(schedule)
+            now = _now_ms()
+
+            job = CronJob(
+                id=str(uuid.uuid4())[:8],
+                name=name,
+                enabled=True,
+                schedule=schedule,
+                payload=CronPayload(
+                    kind="agent_turn",
+                    message=message,
+                    deliver=deliver,
+                    channel=channel,
+                    to=to,
+                ),
+                state=CronJobState(next_run_at_ms=_compute_next_run(schedule, now)),
+                created_at_ms=now,
+                updated_at_ms=now,
+                delete_after_run=delete_after_run,
+            )
+
+            store.jobs.append(job)
             self._save_store()
             self._arm_timer()
-            logger.info("Cron: removed job {}", job_id)
-        
-        return removed
+
+            logger.info("Cron: added job '{}' ({})", name, job.id)
+            return job
     
-    def enable_job(self, job_id: str, enabled: bool = True) -> CronJob | None:
-        """Enable or disable a job."""
-        store = self._load_store()
-        for job in store.jobs:
-            if job.id == job_id:
-                job.enabled = enabled
-                job.updated_at_ms = _now_ms()
-                if enabled:
-                    job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
-                else:
-                    job.state.next_run_at_ms = None
+    async def remove_job(self, job_id: str) -> bool:
+        """Remove a job by ID."""
+        async with self._lock:
+            store = self._load_store()
+            before = len(store.jobs)
+            store.jobs = [j for j in store.jobs if j.id != job_id]
+            removed = len(store.jobs) < before
+
+            if removed:
                 self._save_store()
                 self._arm_timer()
-                return job
-        return None
+                logger.info("Cron: removed job {}", job_id)
+
+            return removed
+    
+    async def enable_job(self, job_id: str, enabled: bool = True) -> CronJob | None:
+        """Enable or disable a job."""
+        async with self._lock:
+            store = self._load_store()
+            for job in store.jobs:
+                if job.id == job_id:
+                    job.enabled = enabled
+                    job.updated_at_ms = _now_ms()
+                    if enabled:
+                        job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
+                    else:
+                        job.state.next_run_at_ms = None
+                    self._save_store()
+                    self._arm_timer()
+                    return job
+            return None
     
     async def run_job(self, job_id: str, force: bool = False) -> bool:
         """Manually run a job."""
-        store = self._load_store()
-        for job in store.jobs:
-            if job.id == job_id:
-                if not force and not job.enabled:
-                    return False
-                await self._execute_job(job)
-                self._save_store()
-                self._arm_timer()
-                return True
-        return False
+        async with self._lock:
+            store = self._load_store()
+            for job in store.jobs:
+                if job.id == job_id:
+                    if not force and not job.enabled:
+                        return False
+                    await self._execute_job(job)
+                    self._save_store()
+                    self._arm_timer()
+                    return True
+            return False
     
-    def status(self) -> dict:
+    async def status(self) -> dict:
         """Get service status."""
-        store = self._load_store()
-        return {
-            "enabled": self._running,
-            "jobs": len(store.jobs),
-            "next_wake_at_ms": self._get_next_wake_ms(),
-        }
+        async with self._lock:
+            store = self._load_store()
+            return {
+                "enabled": self._running,
+                "jobs": len(store.jobs),
+                "next_wake_at_ms": self._get_next_wake_ms(),
+            }

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -73,6 +73,7 @@ class CronService:
         self._timer_task: asyncio.Task | None = None
         self._running = False
         self._lock = asyncio.Lock()
+        self._running_jobs: set[str] = set()
     
     def _load_store(self) -> CronStore:
         """Load jobs from disk."""
@@ -240,37 +241,48 @@ class CronService:
             self._arm_timer()
     
     async def _execute_job(self, job: CronJob) -> None:
-        """Execute a single job."""
-        start_ms = _now_ms()
-        logger.info("Cron: executing job '{}' ({})", job.name, job.id)
-        
+        """Execute a single job.
+
+        Uses _running_jobs as a per-job guard to prevent duplicate execution
+        when _on_timer and run_job overlap on the same job.
+        """
+        if job.id in self._running_jobs:
+            logger.debug("Cron: job '{}' ({}) already running, skipping", job.name, job.id)
+            return
+        self._running_jobs.add(job.id)
         try:
-            response = None
-            if self.on_job:
-                response = await self.on_job(job)
-            
-            job.state.last_status = "ok"
-            job.state.last_error = None
-            logger.info("Cron: job '{}' completed", job.name)
-            
-        except Exception as e:
-            job.state.last_status = "error"
-            job.state.last_error = str(e)
-            logger.error("Cron: job '{}' failed: {}", job.name, e)
-        
-        job.state.last_run_at_ms = start_ms
-        job.updated_at_ms = _now_ms()
-        
-        # Handle one-shot jobs
-        if job.schedule.kind == "at":
-            if job.delete_after_run:
-                self._store.jobs = [j for j in self._store.jobs if j.id != job.id]
+            start_ms = _now_ms()
+            logger.info("Cron: executing job '{}' ({})", job.name, job.id)
+
+            try:
+                response = None
+                if self.on_job:
+                    response = await self.on_job(job)
+
+                job.state.last_status = "ok"
+                job.state.last_error = None
+                logger.info("Cron: job '{}' completed", job.name)
+
+            except Exception as e:
+                job.state.last_status = "error"
+                job.state.last_error = str(e)
+                logger.error("Cron: job '{}' failed: {}", job.name, e)
+
+            job.state.last_run_at_ms = start_ms
+            job.updated_at_ms = _now_ms()
+
+            # Handle one-shot jobs
+            if job.schedule.kind == "at":
+                if job.delete_after_run:
+                    self._store.jobs = [j for j in self._store.jobs if j.id != job.id]
+                else:
+                    job.enabled = False
+                    job.state.next_run_at_ms = None
             else:
-                job.enabled = False
-                job.state.next_run_at_ms = None
-        else:
-            # Compute next run
-            job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
+                # Compute next run
+                job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
+        finally:
+            self._running_jobs.discard(job.id)
     
     # ========== Public API ==========
     

--- a/tests/test_cron_service.py
+++ b/tests/test_cron_service.py
@@ -4,23 +4,25 @@ from nanobot.cron.service import CronService
 from nanobot.cron.types import CronSchedule
 
 
-def test_add_job_rejects_unknown_timezone(tmp_path) -> None:
+@pytest.mark.asyncio
+async def test_add_job_rejects_unknown_timezone(tmp_path) -> None:
     service = CronService(tmp_path / "cron" / "jobs.json")
 
     with pytest.raises(ValueError, match="unknown timezone 'America/Vancovuer'"):
-        service.add_job(
+        await service.add_job(
             name="tz typo",
             schedule=CronSchedule(kind="cron", expr="0 9 * * *", tz="America/Vancovuer"),
             message="hello",
         )
 
-    assert service.list_jobs(include_disabled=True) == []
+    assert await service.list_jobs(include_disabled=True) == []
 
 
-def test_add_job_accepts_valid_timezone(tmp_path) -> None:
+@pytest.mark.asyncio
+async def test_add_job_accepts_valid_timezone(tmp_path) -> None:
     service = CronService(tmp_path / "cron" / "jobs.json")
 
-    job = service.add_job(
+    job = await service.add_job(
         name="tz ok",
         schedule=CronSchedule(kind="cron", expr="0 9 * * *", tz="America/Vancouver"),
         message="hello",


### PR DESCRIPTION
## Summary

- Adds `asyncio.Lock` to `CronService` to serialize access to the in-memory job store
- Wraps `_on_timer()`, `list_jobs()`, `add_job()`, `remove_job()`, `enable_job()`, `run_job()`, and `status()` with the lock to prevent race conditions between timer-driven execution and agent/CLI-initiated mutations
- Converts the sync public methods (`list_jobs`, `add_job`, `remove_job`, `enable_job`, `status`) to `async def` and updates all callers in `CronTool` and CLI commands

## Problem

When a cron job fires (`_on_timer`) while the agent simultaneously calls `add_job()` or `remove_job()` via the `CronTool`, both paths perform unsynchronized load → modify → save on the shared `_store`, causing lost writes or inconsistent state.

## Test plan

- [ ] Verify `nanobot cron list`, `nanobot cron add`, `nanobot cron remove`, `nanobot cron enable` commands work correctly
- [ ] Verify cron jobs fire normally via `nanobot gateway`
- [ ] Verify agent `cron` tool add/list/remove actions work during active cron timer

Closes #862