### PR TITLE
fix: store session key in metadata to avoid lossy filename reconstruction

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -154,6 +154,7 @@ class SessionManager:
         with open(path, "w", encoding="utf-8") as f:
             metadata_line = {
                 "_type": "metadata",
+                "key": session.key,
                 "created_at": session.created_at.isoformat(),
                 "updated_at": session.updated_at.isoformat(),
                 "metadata": session.metadata,
@@ -186,8 +187,11 @@ class SessionManager:
                     if first_line:
                         data = json.loads(first_line)
                         if data.get("_type") == "metadata":
+                            # Prefer the key stored in metadata; fall back to
+                            # filename-based heuristic for legacy files.
+                            key = data.get("key") or path.stem.replace("_", ":", 1)
                             sessions.append({
-                                "key": path.stem.replace("_", ":"),
+                                "key": key,
                                 "created_at": data.get("created_at"),
                                 "updated_at": data.get("updated_at"),
                                 "path": str(path)


### PR DESCRIPTION
## Summary

- Persists the original session key in the JSONL metadata line during `save()`
- Reads it back in `list_sessions()` instead of reverse-engineering from filename
- Falls back to `replace("_", ":", 1)` for legacy files that lack the key field

## Problem

`list_sessions()` reconstructed keys with `path.stem.replace("_", ":")`, turning ALL underscores into colons. A session key like `cli:user_name` → filename `cli_user_name.jsonl` → reconstructed as `cli:user:name` (wrong).

## Test plan

- [ ] Verify `nanobot sessions list` shows correct keys after saving new sessions
- [ ] Verify legacy session files (without `key` in metadata) still display with reasonable keys

Closes #899