### PR TITLE
fix: convert remaining f-string logger calls to loguru native format

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -105,8 +105,9 @@ class BaseChannel(ABC):
         """
         if not self.is_allowed(sender_id):
             logger.warning(
-                f"Access denied for sender {sender_id} on channel {self.name}. "
-                f"Add them to allowFrom list in config to grant access."
+                "Access denied for sender {} on channel {}. "
+                "Add them to allowFrom list in config to grant access.",
+                sender_id, self.name,
             )
             return
         

--- a/nanobot/channels/dingtalk.py
+++ b/nanobot/channels/dingtalk.py
@@ -58,7 +58,8 @@ class NanobotDingTalkHandler(CallbackHandler):
 
             if not content:
                 logger.warning(
-                    f"Received empty or unsupported message type: {chatbot_msg.message_type}"
+                    "Received empty or unsupported message type: {}",
+                    chatbot_msg.message_type,
                 )
                 return AckMessage.STATUS_OK, "OK"
 
@@ -126,7 +127,8 @@ class DingTalkChannel(BaseChannel):
             self._http = httpx.AsyncClient()
 
             logger.info(
-                f"Initializing DingTalk Stream Client with Client ID: {self.config.client_id}..."
+                "Initializing DingTalk Stream Client with Client ID: {}...",
+                self.config.client_id,
             )
             credential = Credential(self.config.client_id, self.config.client_secret)
             self._client = DingTalkStreamClient(credential)


### PR DESCRIPTION
## Summary

Follow-up to #864. Converts 3 remaining f-string logger calls to loguru's native `{}` format:

- `channels/base.py:107` — `logger.warning(f"Access denied for sender {sender_id}...")`
- `channels/dingtalk.py:60` — `logger.warning(f"Received empty or unsupported message type: {chatbot_msg.message_type}")`
- `channels/dingtalk.py:128` — `logger.info(f"Initializing DingTalk Stream Client...")`

## Problem

Same as #857 — if interpolated values contain curly braces (e.g., a sender ID like `{test}`), loguru interprets them as format placeholders and raises `KeyError`.

## Test plan

- [ ] Verify base channel access-denied message logs correctly
- [ ] Verify DingTalk channel startup and empty-message warning logs correctly