### PR TITLE
feat(slack): add media file upload support

### DIFF
--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -84,11 +84,26 @@ class SlackChannel(BaseChannel):
             channel_type = slack_meta.get("channel_type")
             # Only reply in thread for channel/group messages; DMs don't use threads
             use_thread = thread_ts and channel_type != "im"
-            await self._web_client.chat_postMessage(
-                channel=msg.chat_id,
-                text=self._to_mrkdwn(msg.content),
-                thread_ts=thread_ts if use_thread else None,
-            )
+            thread_ts_param = thread_ts if use_thread else None
+
+            # Send text message if content is present
+            if msg.content:
+                await self._web_client.chat_postMessage(
+                    channel=msg.chat_id,
+                    text=self._to_mrkdwn(msg.content),
+                    thread_ts=thread_ts_param,
+                )
+
+            # Upload media files if present
+            for media_path in msg.media or []:
+                try:
+                    await self._web_client.files_upload_v2(
+                        channel=msg.chat_id,
+                        file=media_path,
+                        thread_ts=thread_ts_param,
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to upload file {media_path}: {e}")
         except Exception as e:
             logger.error(f"Error sending Slack message: {e}")
 


### PR DESCRIPTION
Use files_upload_v2 API to upload media attachments in Slack messages. This enables the message tool's media parameter to work correctly when sending images or other files through the Slack channel.

Requires files:write OAuth scope.