### PR TITLE
feat: add OpenRouter prompt caching via cache_control

### DIFF
--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -100,6 +100,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://openrouter.ai/api/v1",
         strip_model_prefix=False,
         model_overrides=(),
+        supports_prompt_caching=True,
     ),
 
     # AiHubMix: global gateway, OpenAI-compatible interface.


### PR DESCRIPTION
https://openrouter.ai/docs/guides/best-practices/prompt-caching

Related: https://github.com/HKUDS/nanobot/pull/854