### PR TITLE
fix(agent): keep empty fallback sentinel CLI-only

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -273,9 +273,15 @@ class AgentLoop:
                 )
                 try:
                     response = await self._process_message(msg)
-                    await self.bus.publish_outbound(response or OutboundMessage(
-                        channel=msg.channel, chat_id=msg.chat_id, content="",
-                    ))
+                    if response is not None:
+                        await self.bus.publish_outbound(response)
+                    elif msg.channel == "cli":
+                        await self.bus.publish_outbound(OutboundMessage(
+                            channel=msg.channel,
+                            chat_id=msg.chat_id,
+                            content="",
+                            metadata=msg.metadata or {},
+                        ))
                 except Exception as e:
                     logger.error("Error processing message: {}", e)
                     await self.bus.publish_outbound(OutboundMessage(


### PR DESCRIPTION
## Summary
- Fix `AgentLoop.run` so the empty fallback outbound is emitted only for `cli` when `_process_message(...)` returns `None`.
- Keep normal publish behavior unchanged when a real response exists.
- Prevent non-CLI channels from receiving a CLI-specific empty sentinel event.

## Architectural rationale (layering)
- The empty fallback is a **CLI protocol concern**: interactive CLI needs a turn-completion signal even when a tool already replied.
- Therefore, `cli` is the **exception path**, not the default model for all channels.
- Applying channel-level fixes (dropping empty messages in each channel) inverts that model and spreads policy to the wrong layer.

## Why fix in loop is better than fix in channels
- **Single source of truth:** fallback policy is defined where fallback is created (`AgentLoop.run`).
- **No policy duplication:** avoids implementing/maintaining "drop empty" logic across every channel.
- **Consistent behavior:** current channels differ in empty-content handling; loop-level fix removes that variance for this case.
- **Future-proofing:** new channels inherit correct behavior automatically, without remembering extra guards.
- **Root-cause fix:** stops emitting non-applicable fallback events instead of relying on downstream filtering.

## Verification
- `ruff check nanobot/agent/loop.py`
- Runtime check with mocked `_process_message -> None` for non-CLI inbound confirms no outbound fallback is published.

Fixes #925