### PR TITLE
refactor(loop): remove interim text retry, use system prompt constraint instead

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -106,6 +106,7 @@ Only use the 'message' tool when you need to send a message to a specific chat c
 For normal conversation, just respond with text - do not call the message tool.
 
 Always be helpful, accurate, and concise. Before calling tools, briefly tell the user what you're about to do (one short sentence in the user's language).
+If you need to use tools, call them directly — never send a preliminary message like "Let me check" without actually calling a tool.
 When remembering something important, write to {workspace_path}/memory/MEMORY.md
 To recall past events, grep {workspace_path}/memory/HISTORY.md"""
     

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -202,8 +202,6 @@ class AgentLoop:
         iteration = 0
         final_content = None
         tools_used: list[str] = []
-        text_only_retried = False
-        interim_content: str | None = None  # Fallback if retry produces nothing
 
         while iteration < self.max_iterations:
             iteration += 1
@@ -249,19 +247,6 @@ class AgentLoop:
                     )
             else:
                 final_content = self._strip_think(response.content)
-                # Some models send an interim text response before tool calls.
-                # Give them one retry; save the content as fallback in case
-                # the retry produces nothing useful (e.g. model already answered).
-                if not tools_used and not text_only_retried and final_content:
-                    text_only_retried = True
-                    interim_content = final_content
-                    logger.debug("Interim text response (no tools used yet), retrying: {}", final_content[:80])
-                    final_content = None
-                    continue
-                # Fall back to interim content if retry produced nothing
-                # and no tools were used (if tools ran, interim was truly interim)
-                if not final_content and interim_content and not tools_used:
-                    final_content = interim_content
                 break
 
         return final_content, tools_used


### PR DESCRIPTION
## Summary

Remove the interim text retry mechanism (introduced in #825, patched in #887) and replace it with a system prompt constraint.

## Problem

PR #825 added a retry mechanism: if the model returns text without tool calls on the first response, the framework retries once, hoping the model will call tools on the second attempt.

This approach had several issues:

1. **Wasted tokens on every pure-text conversation** — saying "hi" triggers two LLM calls instead of one, because the framework always retries before accepting a text-only response
2. **Identical input on retry** — the retry sends the exact same message list, so the model is likely to produce the same result, making the retry ineffective for the target scenario (weak models like MiniMax m2.5 sending "Let me investigate" before tool calls)
3. **Introduced a regression** — retrying and discarding the first response could lose valid answers, requiring PR #887 to add fallback logic (`interim_content`)
4. **Increased complexity** — two extra state variables (`text_only_retried`, `interim_content`), conditional branching, and a `continue` in the agent loop, all for a marginal edge case

## Solution

From first principles: **the framework should not guess whether the model intended to call tools**. If the model returns text, that's its answer.

For models that tend to send preliminary messages ("Let me check") without calling tools, the correct fix is at the prompt level, not the framework level:

> If you need to use tools, call them directly — never send a preliminary message like "Let me check" without actually calling a tool.

This single sentence in the system prompt addresses the root cause without any runtime cost.

## Changes

- **`loop.py`**: Removed `text_only_retried`, `interim_content`, retry `continue`, and fallback logic. The else branch is now just: get content → break. (-15 lines)
- **`context.py`**: Added one-line tool-calling constraint to system prompt. (+1 line)

## Net effect

- **-15 lines, +1 line** — simpler agent loop
- **Zero wasted LLM calls** on pure-text conversations
- **No regression risk** — no state to track, no fallback to lose
- Supersedes #825 and #887