### PR TITLE
feat: add setting to toggle tool hint visibility in responses

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -60,6 +60,7 @@ class AgentLoop:
         restrict_to_workspace: bool = False,
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
+        include_tool_hints_in_responses: bool = True,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -74,6 +75,7 @@ class AgentLoop:
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
+        self.include_tool_hints_in_responses = include_tool_hints_in_responses
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
@@ -220,7 +222,9 @@ class AgentLoop:
                     clean = self._strip_think(response.content)
                     if clean:
                         await on_progress(clean)
-                    await on_progress(self._tool_hint(response.tool_calls))
+
+                    if self.include_tool_hints_in_responses:
+                        await on_progress(self._tool_hint(response.tool_calls))
 
                 tool_call_dicts = [
                     {

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -366,6 +366,7 @@ def gateway(
         exec_config=config.tools.exec,
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
+        include_tool_hints_in_responses=config.tools.include_tool_hints_in_responses,
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
     )
@@ -483,9 +484,10 @@ def agent(
         exec_config=config.tools.exec,
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
+        include_tool_hints_in_responses=config.tools.include_tool_hints_in_responses,
         mcp_servers=config.tools.mcp_servers,
     )
-    
+
     # Show spinner when logs are off (no output to miss); skip when logs are on
     def _thinking_ctx():
         if logs:
@@ -932,6 +934,7 @@ def cron_run(
         memory_window=config.agents.defaults.memory_window,
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
+        include_tool_hints_in_responses=config.tools.include_tool_hints_in_responses,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
     )

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -268,6 +268,7 @@ class ToolsConfig(Base):
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
+    include_tool_hints_in_responses: bool = True # If true, the assistant will add tool hints to their responses when they call tools
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
 


### PR DESCRIPTION
This adds an optional setting to `config.json`, `includeToolHintsInResponses`, to allow users to toggle the visibility of assistant tool call hints in chat. This is useful for a few reasons:

* Security: I've seen my own agents print out sensitive data in-chat (e.g. environment variables with API key) as they invoked tools. This will hide them.
* Usability: showing the tool hints is useful for debugging purposes or when people want to have immediate traceability, but for many people, myself included, I'd rather just have a clean message history with the bot, with no tool call noise. 

The setting will be enabled by default, so tool call hints will behave as they currently do, while allowing users to opt out of getting them.