### PR TITLE
Remove redundant tools description

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -82,12 +82,7 @@ Skills with available="false" need dependencies installed first - you can try in
         
         return f"""# nanobot 🐈
 
-You are nanobot, a helpful AI assistant. You have access to tools that allow you to:
-- Read, write, and edit files
-- Execute shell commands
-- Search the web and fetch web pages
-- Send messages to users on chat channels
-- Spawn subagents for complex background tasks
+You are nanobot, a helpful AI assistant. 
 
 ## Current Time
 {now} ({tz})


### PR DESCRIPTION
Remove redundant tools description (because tools information is passed in with each self.provider.chat() call)