### PR TITLE
fix(context): Fix 'Missing `reasoning_content` field' error for deepseek provider.

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -235,7 +235,7 @@ To recall past events, grep {workspace_path}/memory/HISTORY.md"""
             msg["tool_calls"] = tool_calls
 
         # Include reasoning content when provided (required by some thinking models)
-        if reasoning_content:
+        if reasoning_content is not None:
             msg["reasoning_content"] = reasoning_content
 
         messages.append(msg)


### PR DESCRIPTION
Fix issue [#946](https://github.com/HKUDS/nanobot/issues/946)