### PR TITLE
fix(providers): normalize empty reasoning_content to None at provider level

### DIFF
--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -40,7 +40,7 @@ class CustomProvider(LLMProvider):
         return LLMResponse(
             content=msg.content, tool_calls=tool_calls, finish_reason=choice.finish_reason or "stop",
             usage={"prompt_tokens": u.prompt_tokens, "completion_tokens": u.completion_tokens, "total_tokens": u.total_tokens} if u else {},
-            reasoning_content=getattr(msg, "reasoning_content", None),
+            reasoning_content=getattr(msg, "reasoning_content", None) or None,
         )
 
     def get_default_model(self) -> str:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -257,7 +257,7 @@ class LiteLLMProvider(LLMProvider):
                 "total_tokens": response.usage.total_tokens,
             }
         
-        reasoning_content = getattr(message, "reasoning_content", None)
+        reasoning_content = getattr(message, "reasoning_content", None) or None
         
         return LLMResponse(
             content=message.content,


### PR DESCRIPTION
## Summary

- Normalize empty `reasoning_content` (`""`) to `None` at the provider level in both `LiteLLMProvider` and `CustomProvider`
- `getattr(message, "reasoning_content", None)` can return `""` (empty string) from LLM responses, which is truthy and gets passed downstream
- This complements PR #947 which fixed the consumer side (`context.py`) but didn't address the root cause at the source

## Root Cause

```python
# Before: getattr returns "" (empty string), not None
reasoning_content = getattr(message, "reasoning_content", None)  # → ""

# After: "" or None evaluates to None
reasoning_content = getattr(message, "reasoning_content", None) or None  # → None
```

## Files Changed

- `nanobot/providers/litellm_provider.py` — main provider (OpenRouter, DeepSeek, etc.)
- `nanobot/providers/custom_provider.py` — custom OpenAI-compatible endpoints

## Test Plan

- [ ] Test with DeepSeek provider in thinking mode — verify no `reasoning_content` error
- [ ] Test with non-thinking models — verify normal responses unaffected

Fixes #946