### PR TITLE
fix(security): prevent path traversal bypass via startswith check

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -13,8 +13,11 @@ def _resolve_path(path: str, workspace: Path | None = None, allowed_dir: Path | 
     if not p.is_absolute() and workspace:
         p = workspace / p
     resolved = p.resolve()
-    if allowed_dir and not str(resolved).startswith(str(allowed_dir.resolve())):
-        raise PermissionError(f"Path {path} is outside allowed directory {allowed_dir}")
+    if allowed_dir:
+        try:
+            resolved.relative_to(allowed_dir.resolve())
+        except ValueError:
+            raise PermissionError(f"Path {path} is outside allowed directory {allowed_dir}")
     return resolved
 
 


### PR DESCRIPTION
## Summary

- Replace unsafe `str(resolved).startswith(str(allowed_dir))` with `Path.relative_to()` for directory restriction validation
- `startswith` allows bypass: `/home/user/workspace_evil` passes check against `/home/user/workspace`
- `relative_to()` correctly validates the path is actually *inside* the allowed directory tree

## Before (vulnerable)
```python
if allowed_dir and not str(resolved).startswith(str(allowed_dir.resolve())):
    raise PermissionError(...)
```

## After (safe)
```python
if allowed_dir:
    try:
        resolved.relative_to(allowed_dir.resolve())
    except ValueError:
        raise PermissionError(...)
```

## Test Plan
- [ ] Path inside workspace → allowed
- [ ] Path outside workspace → blocked
- [ ] Path with similar prefix (e.g. `workspace_evil`) → blocked (was bypassing before)
- [ ] Symlink traversal → blocked

Fixes #888