### PR TITLE
fix(slack): add exception handling to socket listener

### DIFF
--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -179,18 +179,21 @@ class SlackChannel(BaseChannel):
         except Exception as e:
             logger.debug("Slack reactions_add failed: {}", e)
 
-        await self._handle_message(
-            sender_id=sender_id,
-            chat_id=chat_id,
-            content=text,
-            metadata={
-                "slack": {
-                    "event": event,
-                    "thread_ts": thread_ts,
-                    "channel_type": channel_type,
-                }
-            },
-        )
+        try:
+            await self._handle_message(
+                sender_id=sender_id,
+                chat_id=chat_id,
+                content=text,
+                metadata={
+                    "slack": {
+                        "event": event,
+                        "thread_ts": thread_ts,
+                        "channel_type": channel_type,
+                    }
+                },
+            )
+        except Exception as e:
+            logger.error("Error handling Slack message from {}: {}", sender_id, e)
 
     def _is_allowed(self, sender_id: str, chat_id: str, channel_type: str) -> bool:
         if channel_type == "im":


### PR DESCRIPTION
## Summary

- Wrap `_handle_message()` call in `_on_socket_request()` with try/except
- Without this, any exception (bus full, permission error, etc.) crashes the Socket Mode event loop
- Other channels (Telegram, Discord) already have explicit error handlers

## Test Plan
- [ ] Normal messages still processed correctly
- [ ] Errors in message handling are logged instead of crashing the listener

Fixes #895