### PR TITLE
fix(session): handle errors in legacy session migration

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -108,9 +108,12 @@ class SessionManager:
         if not path.exists():
             legacy_path = self._get_legacy_session_path(key)
             if legacy_path.exists():
-                import shutil
-                shutil.move(str(legacy_path), str(path))
-                logger.info("Migrated session {} from legacy path", key)
+                try:
+                    import shutil
+                    shutil.move(str(legacy_path), str(path))
+                    logger.info("Migrated session {} from legacy path", key)
+                except Exception as e:
+                    logger.warning("Failed to migrate session {}: {}", key, e)
 
         if not path.exists():
             return None


### PR DESCRIPTION
## Summary

- Wrap `shutil.move()` in `_load()` with try/except for legacy session migration
- Without this, migration failures (permissions, disk full, concurrent access) crash session loading entirely
- Now logs a warning and falls back gracefully — session loads from legacy path on next attempt

Fixes #863