### PR TITLE
fix(qq): make start() long-running per base channel contract

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -71,8 +71,8 @@ class QQChannel(BaseChannel):
         BotClass = _make_bot_class(self)
         self._client = BotClass()
 
-        self._bot_task = asyncio.create_task(self._run_bot())
         logger.info("QQ bot started (C2C private message)")
+        await self._run_bot()
 
     async def _run_bot(self) -> None:
         """Run the bot connection with auto-reconnect."""


### PR DESCRIPTION
## Summary

- QQ channel `start()` created a background task and returned immediately
- This violates the base `Channel` contract: _"This should be a long-running async task"_
- Gateway exits prematurely when QQ is the only enabled channel
- Now directly awaits `_run_bot()` to stay alive, matching other channels (Telegram, Discord, etc.)

Fixes #894