### PR TITLE
fix(channels): clean up old media files to prevent unbounded disk growth

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -1,12 +1,31 @@
 """Base channel interface for chat platforms."""
 
+import time
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
+
+# Media directory shared across channels
+MEDIA_DIR = Path.home() / ".nanobot" / "media"
+MEDIA_MAX_AGE_SECS = 3600  # Clean up files older than 1 hour
+
+
+def cleanup_old_media() -> None:
+    """Delete media files older than MEDIA_MAX_AGE_SECS."""
+    if not MEDIA_DIR.exists():
+        return
+    cutoff = time.time() - MEDIA_MAX_AGE_SECS
+    for f in MEDIA_DIR.iterdir():
+        try:
+            if f.is_file() and f.stat().st_mtime < cutoff:
+                f.unlink()
+        except Exception:
+            pass
 
 
 class BaseChannel(ABC):

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
-from nanobot.channels.base import BaseChannel
+from nanobot.channels.base import BaseChannel, cleanup_old_media
 from nanobot.config.schema import DiscordConfig
 
 
@@ -258,6 +258,10 @@ class DiscordChannel(BaseChannel):
             except Exception as e:
                 logger.warning("Failed to download Discord attachment: {}", e)
                 content_parts.append(f"[attachment: {filename} - download failed]")
+
+        # Clean up old media files to prevent unbounded disk growth
+        if media_paths:
+            cleanup_old_media()
 
         reply_to = (payload.get("referenced_message") or {}).get("id")
 

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -11,7 +11,7 @@ from telegram.request import HTTPXRequest
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
-from nanobot.channels.base import BaseChannel
+from nanobot.channels.base import BaseChannel, cleanup_old_media
 from nanobot.config.schema import TelegramConfig
 
 
@@ -393,7 +393,11 @@ class TelegramChannel(BaseChannel):
                 content_parts.append(f"[{media_type}: download failed]")
         
         content = "\n".join(content_parts) if content_parts else "[empty message]"
-        
+
+        # Clean up old media files to prevent unbounded disk growth
+        if media_paths:
+            cleanup_old_media()
+
         logger.debug("Telegram message from {}: {}...", sender_id, content[:50])
         
         str_chat_id = str(chat_id)


### PR DESCRIPTION
## Summary

- Add `cleanup_old_media()` utility to `BaseChannel` — deletes media files older than 1 hour
- Call it from Telegram and Discord channels whenever new media is downloaded
- Prevents `~/.nanobot/media/` from growing indefinitely

## Changes
- `nanobot/channels/base.py` — add `cleanup_old_media()` function
- `nanobot/channels/telegram.py` — call cleanup after media download
- `nanobot/channels/discord.py` — call cleanup after media download

Fixes #896