### PR TITLE
fix(agent): filter out tool call hints from progress streaming to chat channels

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -348,6 +348,10 @@ class AgentLoop:
         async def _bus_progress(content: str) -> None:
             meta = dict(msg.metadata or {})
             meta["_progress"] = True
+            # Skip internal tool call hints for chat channels (e.g. 'web_search("...")')
+            # These are useful in CLI but leak implementation details in user chat
+            if "(" in content and content.endswith(")") and not content.startswith("["):
+                return
             await self.bus.publish_outbound(OutboundMessage(
                 channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
             ))


### PR DESCRIPTION
## Summary

- Filter tool-hint-shaped messages (e.g. `web_search("query")`) from `_bus_progress`
- These internal tool call hints are useful in CLI mode but leak implementation details when sent to Telegram/Discord/etc.
- CLI mode is unaffected — it uses its own `_cli_progress` callback
- LLM thinking text (actual progress) is still forwarded to chat channels

Fixes #954