### PR TITLE
feat: add configurable subagent_max_iterations setting

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -59,6 +59,7 @@ class AgentLoop:
         restrict_to_workspace: bool = False,
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
+        subagent_max_iterations: int = 50,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -87,6 +88,7 @@ class AgentLoop:
             brave_api_key=brave_api_key,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            max_iterations=subagent_max_iterations,
         )
 
         self._running = False

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -37,6 +37,7 @@ class SubagentManager:
         brave_api_key: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
+        max_iterations: int = 50,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.provider = provider
@@ -48,6 +49,7 @@ class SubagentManager:
         self.brave_api_key = brave_api_key
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
+        self.max_iterations = max_iterations
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
     
     async def spawn(
@@ -123,7 +125,7 @@ class SubagentManager:
             ]
             
             # Run agent loop (limited iterations)
-            max_iterations = 15
+            max_iterations = self.max_iterations
             iteration = 0
             final_result: str | None = None
             

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -368,6 +368,7 @@ def gateway(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
+        subagent_max_iterations=config.agents.defaults.subagent_max_iterations,
     )
     
     # Set cron callback (needs agent)
@@ -484,6 +485,7 @@ def agent(
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
+        subagent_max_iterations=config.agents.defaults.subagent_max_iterations,
     )
     
     # Show spinner when logs are off (no output to miss); skip when logs are on
@@ -934,6 +936,7 @@ def cron_run(
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
+        subagent_max_iterations=config.agents.defaults.subagent_max_iterations,
     )
 
     store_path = get_data_dir() / "cron" / "jobs.json"

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -187,6 +187,7 @@ class AgentDefaults(Base):
     max_tokens: int = 8192
     temperature: float = 0.7
     max_tool_iterations: int = 20
+    subagent_max_iterations: int = 50
     memory_window: int = 50
 
 


### PR DESCRIPTION
## Summary
- Add `subagent_max_iterations` config field to `AgentDefaults` (default: 50)
- Thread the value through `AgentLoop` → `SubagentManager`, replacing the hardcoded `max_iterations = 15`
- All 3 `AgentLoop` call sites in `cli/commands.py` now pass the config value

## Motivation
The subagent loop had a hardcoded `max_iterations = 15`. Long-running subagent tasks (e.g. polling for torrent completion) exhaust these iterations and silently give up. The main agent's `max_tool_iterations` is already configurable but was not passed to subagents.

Fixes #970

## Test plan
- [x] All 63 existing tests pass
- [x] Verified default value (50) via Pydantic model instantiation
- [x] Verified config override works (`AgentDefaults(subagent_max_iterations=100)`)
- Can be overridden in config.json: `"subagentMaxIterations": 100` in agent defaults