### PR TITLE
feat(discord): A2UI — Agent-to-UI structured reply rendering

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -18,7 +18,7 @@ class ContextBuilder:
     into a coherent prompt for the LLM.
     """
     
-    BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md", "IDENTITY.md"]
+    BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md", "IDENTITY.md", "A2UI.md"]
     
     def __init__(self, workspace: Path):
         self.workspace = workspace

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -1,4 +1,11 @@
-"""Discord channel implementation using Discord Gateway websocket."""
+"""Discord channel implementation using Discord Gateway websocket.
+
+Supports:
+- Standard text message send/receive via REST API
+- A2UI (Agent-to-UI) structured replies → Discord Components V2
+- Interactive callbacks (buttons, selects) via Gateway interactions
+- Surface state management (create/update/delete stateful UI messages)
+"""
 
 import asyncio
 import json
@@ -9,9 +16,20 @@ import httpx
 import websockets
 from loguru import logger
 
-from nanobot.bus.events import OutboundMessage
+from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
+from nanobot.channels.discord_a2ui import (
+    SurfaceState,
+    StructuredReply,
+    clear_session_surfaces,
+    get_session_id,
+    structured_reply_from_text,
+)
+from nanobot.channels.discord_renderer import (
+    build_message_payload,
+    _decode_custom_id,
+)
 from nanobot.config.schema import DiscordConfig
 
 
@@ -43,7 +61,7 @@ def _split_message(content: str, max_len: int = MAX_MESSAGE_LEN) -> list[str]:
 
 
 class DiscordChannel(BaseChannel):
-    """Discord channel using Gateway websocket."""
+    """Discord channel using Gateway websocket with A2UI support."""
 
     name = "discord"
 
@@ -55,6 +73,15 @@ class DiscordChannel(BaseChannel):
         self._heartbeat_task: asyncio.Task | None = None
         self._typing_tasks: dict[str, asyncio.Task] = {}
         self._http: httpx.AsyncClient | None = None
+
+        # A2UI state
+        self._surface_states: dict[tuple[str, str], SurfaceState] = {}
+        # Maps (session_id, surface_id) → Discord message ID
+        self._surface_messages: dict[tuple[str, str], str] = {}
+        # Maps Discord message ID → owner user ID (for interaction auth)
+        self._interaction_owners: dict[str, str] = {}
+        # Stores the last user message per session for "rerun" action
+        self._last_user_messages: dict[str, str] = {}
 
     async def start(self) -> None:
         """Start the Discord gateway connection."""
@@ -95,32 +122,201 @@ class DiscordChannel(BaseChannel):
             await self._http.aclose()
             self._http = None
 
+    # ------------------------------------------------------------------
+    # Outbound: send messages
+    # ------------------------------------------------------------------
+
     async def send(self, msg: OutboundMessage) -> None:
-        """Send a message through Discord REST API."""
+        """Send a message through Discord REST API with A2UI support."""
+
         if not self._http:
             logger.warning("Discord HTTP client not initialized")
             return
 
-        url = f"{DISCORD_API_BASE}/channels/{msg.chat_id}/messages"
-        headers = {"Authorization": f"Bot {self.config.token}"}
-
         try:
-            chunks = _split_message(msg.content or "")
-            if not chunks:
+            is_progress = msg.metadata.get("_progress", False)
+            logger.debug("A2UI send: progress={}, content_len={}",
+                         is_progress, len(msg.content or ""))
+
+            if is_progress:
+                # Progress messages are always plain text
+                await self._send_plain_text(msg.chat_id, msg.content, msg.reply_to)
                 return
 
-            for i, chunk in enumerate(chunks):
-                payload: dict[str, Any] = {"content": chunk}
+            # Parse content through A2UI pipeline
+            session_id = self._session_id_from_metadata(msg.metadata)
+            owner_id = msg.metadata.get("owner_id", "")
 
-                # Only set reply reference on the first chunk
-                if i == 0 and msg.reply_to:
-                    payload["message_reference"] = {"message_id": msg.reply_to}
-                    payload["allowed_mentions"] = {"replied_user": False}
+            structured = structured_reply_from_text(
+                msg.content or "", session_id, self._surface_states
+            )
 
-                if not await self._send_payload(url, headers, payload):
-                    break  # Abort remaining chunks on failure
+            logger.debug(
+                "A2UI parsed: a2ui_comps={}, directives={}, ui_intent={}, md_len={}",
+                len(structured.a2ui_components),
+                len(structured.surface_directives),
+                structured.ui_intent is not None,
+                len(structured.markdown),
+            )
+
+            # Handle surface directives
+            if structured.surface_directives:
+                logger.info("A2UI: handling {} surface directives", len(structured.surface_directives))
+                await self._handle_surface_directives(
+                    msg.chat_id, session_id, owner_id, structured
+                )
+                return
+
+            # Build and send rich message
+            if structured.a2ui_components or (structured.ui_intent and structured.ui_intent.buttons):
+                logger.info("A2UI: sending rich Components V2 message")
+                await self._send_rich_message(
+                    msg.chat_id, structured, owner_id, msg.reply_to
+                )
+            else:
+                # Plain text with optional image embeds
+                await self._send_text_with_embeds(
+                    msg.chat_id, structured, msg.reply_to
+                )
+        except Exception as e:
+            logger.error("Discord send() error: {}", e, exc_info=True)
+            # Last-resort fallback: send the PARSED markdown, not the raw JSON
+            try:
+                fallback_text = structured.markdown if 'structured' in locals() else (msg.content or "")
+                await self._send_plain_text(msg.chat_id, fallback_text, msg.reply_to)
+            except Exception:
+                logger.error("Discord fallback send also failed")
         finally:
             await self._stop_typing(msg.chat_id)
+
+    async def _send_plain_text(
+        self, channel_id: str, content: str | None, reply_to: str | None = None
+    ) -> None:
+        """Send plain text message(s), splitting if necessary."""
+        chunks = _split_message(content or "")
+        if not chunks:
+            return
+        url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
+        headers = self._auth_headers()
+        for i, chunk in enumerate(chunks):
+            payload: dict[str, Any] = {"content": chunk}
+            if i == 0 and reply_to:
+                payload["message_reference"] = {"message_id": reply_to}
+                payload["allowed_mentions"] = {"replied_user": False}
+            if not await self._send_payload(url, headers, payload):
+                break
+
+    async def _send_text_with_embeds(
+        self, channel_id: str, structured: StructuredReply, reply_to: str | None = None
+    ) -> None:
+        """Send text message with optional image embeds."""
+        chunks = _split_message(structured.markdown or "")
+        if not chunks:
+            chunks = [" "]  # avoid empty message
+
+        url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
+        headers = self._auth_headers()
+
+        for i, chunk in enumerate(chunks):
+            payload: dict[str, Any] = {"content": chunk}
+            if i == 0:
+                if reply_to:
+                    payload["message_reference"] = {"message_id": reply_to}
+                    payload["allowed_mentions"] = {"replied_user": False}
+                # Only first chunk gets embeds
+                if structured.image_urls:
+                    payload["embeds"] = [
+                        {"image": {"url": u}} for u in structured.image_urls
+                    ]
+            if not await self._send_payload(url, headers, payload):
+                break
+
+    async def _send_rich_message(
+        self, channel_id: str, structured: StructuredReply,
+        owner_id: str, reply_to: str | None = None
+    ) -> str | None:
+        """Send a message with Components V2 or simple buttons.
+
+        Returns the created message ID, or None on failure.
+        """
+        payload = build_message_payload(structured, owner_id)
+        if reply_to:
+            payload["message_reference"] = {"message_id": reply_to}
+            payload["allowed_mentions"] = {"replied_user": False}
+
+        url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
+        headers = self._auth_headers()
+
+        # Try sending with components
+        msg_id = await self._send_payload_return_id(url, headers, payload)
+        if msg_id:
+            if owner_id:
+                self._interaction_owners[msg_id] = owner_id
+            return msg_id
+
+        # Fallback: retry without components
+        logger.warning("Components V2 send failed, retrying without components")
+        fallback: dict[str, Any] = {"content": structured.markdown or " "}
+        if reply_to:
+            fallback["message_reference"] = {"message_id": reply_to}
+            fallback["allowed_mentions"] = {"replied_user": False}
+        if structured.image_urls:
+            fallback["embeds"] = [
+                {"image": {"url": u}} for u in structured.image_urls
+            ]
+        await self._send_payload(url, headers, fallback)
+        return None
+
+    async def _handle_surface_directives(
+        self, channel_id: str, session_id: str,
+        owner_id: str, structured: StructuredReply
+    ) -> None:
+        """Route surface directives to create/edit/delete Discord messages."""
+        for directive in structured.surface_directives:
+            key = (session_id, directive.surface_id)
+
+            if directive.type == "deletesurface":
+                msg_id = self._surface_messages.pop(key, None)
+                if msg_id:
+                    await self._delete_message(channel_id, msg_id)
+                    self._interaction_owners.pop(msg_id, None)
+
+            elif directive.type in ("updatecomponents", "updatedatamodel"):
+                existing_msg_id = self._surface_messages.get(key)
+                if existing_msg_id:
+                    # Edit existing message
+                    payload = build_message_payload(structured, owner_id)
+                    success = await self._edit_message(
+                        channel_id, existing_msg_id, payload
+                    )
+                    if not success:
+                        # Fallback: edit without components
+                        fallback = {"content": structured.markdown or " "}
+                        await self._edit_message(
+                            channel_id, existing_msg_id, fallback
+                        )
+                else:
+                    # No existing message — create new
+                    msg_id = await self._send_rich_message(
+                        channel_id, structured, owner_id
+                    )
+                    if msg_id:
+                        self._surface_messages[key] = msg_id
+
+            elif directive.type == "createsurface":
+                # Create new surface message
+                msg_id = await self._send_rich_message(
+                    channel_id, structured, owner_id
+                )
+                if msg_id:
+                    self._surface_messages[key] = msg_id
+
+    # ------------------------------------------------------------------
+    # REST helpers
+    # ------------------------------------------------------------------
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bot {self.config.token}"}
 
     async def _send_payload(
         self, url: str, headers: dict[str, str], payload: dict[str, Any]
@@ -143,6 +339,83 @@ class DiscordChannel(BaseChannel):
                 else:
                     await asyncio.sleep(1)
         return False
+
+    async def _send_payload_return_id(
+        self, url: str, headers: dict[str, str], payload: dict[str, Any]
+    ) -> str | None:
+        """Send payload and return the created message ID."""
+        for attempt in range(3):
+            try:
+                response = await self._http.post(url, headers=headers, json=payload)
+                if response.status_code == 429:
+                    data = response.json()
+                    retry_after = float(data.get("retry_after", 1.0))
+                    logger.warning("Discord rate limited, retrying in {}s", retry_after)
+                    await asyncio.sleep(retry_after)
+                    continue
+                if response.status_code >= 400:
+                    logger.warning(
+                        "Discord API error {}: {}", response.status_code,
+                        response.text[:500]
+                    )
+                    return None
+                data = response.json()
+                return data.get("id")
+            except Exception as e:
+                if attempt == 2:
+                    logger.error("Error sending Discord message: {}", e)
+                else:
+                    await asyncio.sleep(1)
+        return None
+
+    async def _edit_message(
+        self, channel_id: str, message_id: str, payload: dict[str, Any]
+    ) -> bool:
+        """Edit an existing Discord message via PATCH."""
+        url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}"
+        headers = self._auth_headers()
+        for attempt in range(3):
+            try:
+                response = await self._http.patch(url, headers=headers, json=payload)
+                if response.status_code == 429:
+                    data = response.json()
+                    retry_after = float(data.get("retry_after", 1.0))
+                    await asyncio.sleep(retry_after)
+                    continue
+                if response.status_code >= 400:
+                    logger.warning(
+                        "Discord edit error {}: {}", response.status_code,
+                        response.text[:500]
+                    )
+                    return False
+                return True
+            except Exception as e:
+                if attempt == 2:
+                    logger.error("Error editing Discord message: {}", e)
+                else:
+                    await asyncio.sleep(1)
+        return False
+
+    async def _delete_message(self, channel_id: str, message_id: str) -> bool:
+        """Delete a Discord message."""
+        url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}"
+        headers = self._auth_headers()
+        try:
+            response = await self._http.delete(url, headers=headers)
+            if response.status_code >= 400:
+                logger.warning(
+                    "Discord delete error {}: {}", response.status_code,
+                    response.text[:200]
+                )
+                return False
+            return True
+        except Exception as e:
+            logger.error("Error deleting Discord message: {}", e)
+            return False
+
+    # ------------------------------------------------------------------
+    # Gateway: connection lifecycle
+    # ------------------------------------------------------------------
 
     async def _gateway_loop(self) -> None:
         """Main gateway loop: identify, heartbeat, dispatch events."""
@@ -173,6 +446,8 @@ class DiscordChannel(BaseChannel):
                 logger.info("Discord gateway READY")
             elif op == 0 and event_type == "MESSAGE_CREATE":
                 await self._handle_message_create(payload)
+            elif op == 0 and event_type == "INTERACTION_CREATE":
+                asyncio.create_task(self._handle_interaction_create(payload))
             elif op == 7:
                 # RECONNECT: exit loop to reconnect
                 logger.info("Discord gateway requested reconnect")
@@ -218,6 +493,10 @@ class DiscordChannel(BaseChannel):
 
         self._heartbeat_task = asyncio.create_task(heartbeat_loop())
 
+    # ------------------------------------------------------------------
+    # Inbound: message handling
+    # ------------------------------------------------------------------
+
     async def _handle_message_create(self, payload: dict[str, Any]) -> None:
         """Handle incoming Discord messages."""
         author = payload.get("author") or {}
@@ -260,20 +539,206 @@ class DiscordChannel(BaseChannel):
                 content_parts.append(f"[attachment: {filename} - download failed]")
 
         reply_to = (payload.get("referenced_message") or {}).get("id")
+        guild_id = payload.get("guild_id")
+        thread_id = None
+        # Check if this is a thread
+        if payload.get("thread") or (
+            payload.get("channel_type") in (10, 11, 12)  # PUBLIC_THREAD, PRIVATE_THREAD, ANNOUNCEMENT_THREAD
+        ):
+            thread_id = channel_id
+
+        session_id = get_session_id(guild_id, channel_id, sender_id, thread_id)
+
+        # Store last user message for "rerun" action
+        user_content = "\n".join(p for p in content_parts if p) or "[empty message]"
+        self._last_user_messages[session_id] = user_content
+
+        # Handle /reset command
+        if content.strip().lower() == "/reset":
+            clear_session_surfaces(session_id, self._surface_states)
+            # Clean up surface messages
+            to_remove = [k for k in self._surface_messages if k[0] == session_id]
+            for k in to_remove:
+                msg_id = self._surface_messages.pop(k, None)
+                if msg_id:
+                    await self._delete_message(channel_id, msg_id)
+                    self._interaction_owners.pop(msg_id, None)
 
         await self._start_typing(channel_id)
 
         await self._handle_message(
             sender_id=sender_id,
             chat_id=channel_id,
-            content="\n".join(p for p in content_parts if p) or "[empty message]",
+            content=user_content,
             media=media_paths,
             metadata={
                 "message_id": str(payload.get("id", "")),
-                "guild_id": payload.get("guild_id"),
+                "guild_id": guild_id,
                 "reply_to": reply_to,
+                "owner_id": sender_id,
+                "session_id": session_id,
             },
         )
+
+    # ------------------------------------------------------------------
+    # Interactions: button/select callbacks
+    # ------------------------------------------------------------------
+
+    async def _handle_interaction_create(self, payload: dict[str, Any]) -> None:
+        """Handle Discord interaction (button click, select menu)."""
+        interaction_type = payload.get("type")
+        if interaction_type != 3:  # MESSAGE_COMPONENT
+            return
+
+        interaction_id = payload.get("id")
+        interaction_token = payload.get("token")
+        if not interaction_id or not interaction_token:
+            return
+
+        # Immediately ACK the interaction (deferred update)
+        await self._ack_interaction(interaction_id, interaction_token)
+
+        # Extract interaction details
+        comp_data = payload.get("data") or {}
+        custom_id = comp_data.get("custom_id") or ""
+        component_type = comp_data.get("component_type", 0)
+
+        owner_id, action, payload_hash = _decode_custom_id(custom_id)
+
+        # Owner-only enforcement
+        user = payload.get("member", {}).get("user") or payload.get("user") or {}
+        actor_id = str(user.get("id", ""))
+
+        if owner_id and actor_id != owner_id:
+            # Send ephemeral rejection
+            await self._send_followup(
+                interaction_token,
+                "⛔ Only the original user can interact with these controls.",
+                ephemeral=True,
+            )
+            return
+
+        channel_id = str(payload.get("channel_id", ""))
+        guild_id = payload.get("guild_id")
+
+        # Build action context
+        if component_type == 3:  # StringSelect
+            selected_values = comp_data.get("values", [])
+            action_payload = json.dumps({
+                "selected": selected_values,
+                "payload": payload_hash or "",
+            })
+        else:
+            action_payload = payload_hash
+
+        # Route actions
+        if action == "rerun":
+            # Re-prompt agent with last user message
+            session_id = get_session_id(guild_id, channel_id, actor_id)
+            last_msg = self._last_user_messages.get(session_id, "")
+            if last_msg:
+                await self._start_typing(channel_id)
+                await self._handle_message(
+                    sender_id=actor_id,
+                    chat_id=channel_id,
+                    content=last_msg,
+                    metadata={
+                        "guild_id": guild_id,
+                        "owner_id": actor_id,
+                        "session_id": session_id,
+                        "interaction_rerun": True,
+                    },
+                )
+        elif action:
+            # Build action prompt and re-prompt agent
+            session_id = get_session_id(guild_id, channel_id, actor_id)
+
+            # Build surface state summary
+            state_summary = {}
+            for (sid, surf_id), state in self._surface_states.items():
+                if sid == session_id:
+                    state_summary[surf_id] = {
+                        "data_model": state.data_model,
+                        "markdown_preview": state.rendered.markdown[:200],
+                    }
+
+            action_prompt = (
+                f"UI Action executed: {action}\n"
+                f"Payload: {action_payload or 'none'}\n"
+                f"Current surface state: {json.dumps(state_summary, ensure_ascii=False)}\n"
+                f"Generate a response for this action."
+            )
+
+            await self._start_typing(channel_id)
+            await self._handle_message(
+                sender_id=actor_id,
+                chat_id=channel_id,
+                content=action_prompt,
+                metadata={
+                    "guild_id": guild_id,
+                    "owner_id": actor_id,
+                    "session_id": session_id,
+                    "interaction_action": action,
+                },
+            )
+
+    async def _ack_interaction(self, interaction_id: str, token: str) -> None:
+        """Send an immediate ACK (deferred update) to Discord."""
+        url = f"{DISCORD_API_BASE}/interactions/{interaction_id}/{token}/callback"
+        headers = self._auth_headers()
+        # Type 6 = DEFERRED_UPDATE_MESSAGE (no visible response)
+        payload = {"type": 6}
+        try:
+            response = await self._http.post(url, headers=headers, json=payload)
+            if response.status_code >= 400:
+                logger.warning("Interaction ACK failed: {}", response.text[:200])
+        except Exception as e:
+            logger.error("Error ACKing interaction: {}", e)
+
+    async def _send_followup(
+        self, token: str, content: str, ephemeral: bool = False
+    ) -> None:
+        """Send a followup message to an interaction."""
+        url = f"{DISCORD_API_BASE}/webhooks/{self._app_id}/{token}"
+        headers = self._auth_headers()
+        payload: dict[str, Any] = {"content": content}
+        if ephemeral:
+            payload["flags"] = 64  # EPHEMERAL
+        try:
+            await self._http.post(url, headers=headers, json=payload)
+        except Exception as e:
+            logger.error("Error sending followup: {}", e)
+
+    @property
+    def _app_id(self) -> str:
+        """Get the application ID (extracted from token or cached)."""
+        # The bot token contains the application ID as the first segment
+        # Format: base64(app_id).timestamp.hmac
+        if not hasattr(self, "_cached_app_id"):
+            try:
+                import base64
+                token_part = self.config.token.split(".")[0]
+                # Add padding if needed
+                padding = 4 - len(token_part) % 4
+                if padding != 4:
+                    token_part += "=" * padding
+                self._cached_app_id = base64.b64decode(token_part).decode()
+            except Exception:
+                self._cached_app_id = ""
+        return self._cached_app_id
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _session_id_from_metadata(self, metadata: dict[str, Any]) -> str:
+        """Extract or build a session ID from outbound message metadata."""
+        if "session_id" in metadata:
+            return metadata["session_id"]
+        guild_id = metadata.get("guild_id")
+        chat_id = metadata.get("chat_id", "")
+        owner_id = metadata.get("owner_id", "")
+        return get_session_id(guild_id, chat_id, owner_id)
 
     async def _start_typing(self, channel_id: str) -> None:
         """Start periodic typing indicator for a channel."""
@@ -281,7 +746,7 @@ class DiscordChannel(BaseChannel):
 
         async def typing_loop() -> None:
             url = f"{DISCORD_API_BASE}/channels/{channel_id}/typing"
-            headers = {"Authorization": f"Bot {self.config.token}"}
+            headers = self._auth_headers()
             while self._running:
                 try:
                     await self._http.post(url, headers=headers)

--- a/nanobot/channels/discord_a2ui.py
+++ b/nanobot/channels/discord_a2ui.py
@@ -1,0 +1,543 @@
+"""A2UI (Agent-to-UI) engine for Discord Components V2.
+
+Parses structured JSON envelopes from agent output and manages stateful
+surfaces with data-binding and template re-rendering.  This module is
+Discord-agnostic — it only cares about parsing and state.  The actual
+Discord REST rendering lives in discord_renderer.py.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MAX_A2UI_ENVELOPES = 8
+_MAX_UI_BUTTONS = 3
+_MAX_OUTPUT_IMAGES = 4
+_MAX_OUTPUT_FILES = 4
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ButtonIntent:
+    """A single button to render."""
+
+    label: str  # Max 80 chars
+    style: str  # primary|secondary|success|danger|link
+    action: str | None = None  # Callback action name
+    url: str | None = None  # Required for link style
+    payload: str | None = None  # Arbitrary payload string
+
+
+@dataclass(frozen=True)
+class UiIntent:
+    """Simple button-based UI intent."""
+
+    buttons: tuple[ButtonIntent, ...] = ()
+
+
+@dataclass(frozen=True)
+class SurfaceDirective:
+    """Instruction to create/update/delete a surface message."""
+
+    type: str  # createsurface|updatecomponents|updatedatamodel|deletesurface
+    surface_id: str
+
+
+@dataclass(frozen=True)
+class StructuredReply:
+    """Parsed agent reply with rich content."""
+
+    markdown: str  # Rendered text content
+    ui_intent: UiIntent | None = None
+    image_urls: tuple[str, ...] = ()
+    file_paths: tuple[str, ...] = ()
+    a2ui_components: tuple[dict[str, Any], ...] = ()  # Raw component dicts
+    surface_directives: tuple[SurfaceDirective, ...] = ()
+
+
+@dataclass
+class SurfaceState:
+    """Mutable state for a live A2UI surface."""
+
+    rendered: StructuredReply
+    template_components: tuple[dict[str, Any], ...]
+    data_model: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction
+# ---------------------------------------------------------------------------
+
+_FENCED_JSON_RE = re.compile(r"```(?:json)?\s*\n?(\{[\s\S]*?\})\s*```", re.IGNORECASE)
+_MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*\]\((https?://[^)]+)\)")
+
+
+def _extract_json_object_text(raw: str) -> str | None:
+    """Try to extract a JSON object string from raw text.
+
+    Strategy 1: entire string is a JSON object (starts with { ends with }).
+    Strategy 2: fenced ```json ... ``` block.
+    """
+    stripped = raw.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        return stripped
+    m = _FENCED_JSON_RE.search(raw)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _normalize_image_url(value: Any) -> str | None:
+    """Validate and normalise an image URL."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    url = value.strip()
+    if not url.startswith(("http://", "https://")):
+        return None
+    return url
+
+
+def _extract_markdown_images(text: str) -> list[str]:
+    """Pull ![alt](url) image URLs from markdown text."""
+    return [u for u in _MARKDOWN_IMAGE_RE.findall(text) if _normalize_image_url(u)]
+
+
+# ---------------------------------------------------------------------------
+# A2UI envelope extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_a2ui_messages(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract valid A2UI envelopes from a parsed JSON payload."""
+    candidates = payload.get("a2ui")
+    if not isinstance(candidates, list):
+        candidates = payload.get("messages")
+    if not isinstance(candidates, list):
+        return []
+    messages: list[dict[str, Any]] = []
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        msg_type = str(item.get("type", "")).strip()
+        if not msg_type:
+            continue
+        messages.append(item)
+        if len(messages) >= _MAX_A2UI_ENVELOPES:
+            break
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Data-binding engine
+# ---------------------------------------------------------------------------
+
+_DATA_BIND_RE = re.compile(r"\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}")
+
+
+def _lookup_data_value(data_model: dict[str, Any], dotpath: str) -> Any:
+    """Walk a dot-separated path through nested dicts."""
+    current: Any = data_model
+    for key in dotpath.split("."):
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            return None
+    return current
+
+
+def _bind_text(text: str, data_model: dict[str, Any]) -> str:
+    """Replace {{path}} placeholders in text with data model values."""
+
+    def _repl(match: re.Match) -> str:
+        value = _lookup_data_value(data_model, match.group(1))
+        if value is None:
+            return ""
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, ensure_ascii=False)
+        return str(value)
+
+    return _DATA_BIND_RE.sub(_repl, text)
+
+
+def _bind_component(component: Any, data_model: dict[str, Any]) -> Any:
+    """Recursively bind data model values into a component tree."""
+    if isinstance(component, str):
+        return _bind_text(component, data_model)
+    if isinstance(component, list):
+        return [_bind_component(item, data_model) for item in component]
+    if isinstance(component, dict):
+        return {k: _bind_component(v, data_model) for k, v in component.items()}
+    return component
+
+
+# ---------------------------------------------------------------------------
+# Component → StructuredReply rendering
+# ---------------------------------------------------------------------------
+
+_BUTTON_STYLES = {"primary", "secondary", "success", "danger", "link"}
+
+
+def _component_type(comp: dict[str, Any]) -> str:
+    return str(comp.get("type", "")).strip().lower()
+
+
+def _render_from_components(
+    components: list[dict[str, Any]],
+) -> StructuredReply:
+    """Walk the component tree (BFS) and extract markdown, buttons, images."""
+    markdown_parts: list[str] = []
+    buttons: list[ButtonIntent] = []
+    image_urls: list[str] = []
+
+    queue = list(components)
+    while queue:
+        comp = queue.pop(0)
+        if not isinstance(comp, dict):
+            continue
+        ctype = _component_type(comp)
+
+        if ctype in ("text", "textdisplay", "markdown"):
+            md = comp.get("markdown") or comp.get("content") or ""
+            if md:
+                markdown_parts.append(str(md))
+        elif ctype in ("button", "action"):
+            label = str(comp.get("label", "")).strip()[:80]
+            style = str(comp.get("style", "secondary")).lower()
+            if style not in _BUTTON_STYLES:
+                style = "secondary"
+            url = _normalize_image_url(comp.get("url"))
+            action = (comp.get("action") or "").strip() or None
+            payload = (comp.get("payload") or "").strip() or None
+            # Auto-detect link buttons
+            if url is not None and action is None:
+                style = "link"
+            if style == "link" and not url:
+                continue  # skip invalid link button
+            if label and len(buttons) < _MAX_UI_BUTTONS:
+                buttons.append(ButtonIntent(
+                    label=label, style=style, action=action,
+                    url=url, payload=payload,
+                ))
+        elif ctype in ("image", "img"):
+            url = _normalize_image_url(comp.get("url"))
+            if url and len(image_urls) < _MAX_OUTPUT_IMAGES:
+                image_urls.append(url)
+        elif ctype in ("media_gallery", "mediagallery"):
+            for item in (comp.get("items") or []):
+                url = _normalize_image_url(
+                    item.get("url") if isinstance(item, dict) else None
+                )
+                if url and len(image_urls) < _MAX_OUTPUT_IMAGES:
+                    image_urls.append(url)
+
+        # Recurse into children
+        for key in ("components", "children", "items"):
+            children = comp.get(key)
+            if isinstance(children, list):
+                queue.extend(children)
+
+        # Section accessory
+        accessory = comp.get("accessory")
+        if isinstance(accessory, dict):
+            queue.append(accessory)
+
+    return StructuredReply(
+        markdown="\n\n".join(markdown_parts),
+        ui_intent=UiIntent(buttons=tuple(buttons)) if buttons else None,
+        image_urls=tuple(image_urls),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Simple (non-A2UI) JSON parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_simple_ui_intent(payload: dict[str, Any]) -> UiIntent | None:
+    """Parse ui_intent.buttons from simple JSON shape."""
+    ui_raw = payload.get("ui_intent")
+    if not isinstance(ui_raw, dict):
+        return None
+    buttons_raw = ui_raw.get("buttons")
+    if not isinstance(buttons_raw, list):
+        return None
+    buttons: list[ButtonIntent] = []
+    for b in buttons_raw:
+        if not isinstance(b, dict):
+            continue
+        label = str(b.get("label", "")).strip()[:80]
+        if not label:
+            continue
+        style = str(b.get("style", "secondary")).lower()
+        if style not in _BUTTON_STYLES:
+            style = "secondary"
+        url = _normalize_image_url(b.get("url"))
+        action = (b.get("action") or "").strip() or None
+        payload_str = (b.get("payload") or "").strip() or None
+        if url and not action:
+            style = "link"
+        if style == "link" and not url:
+            continue
+        buttons.append(ButtonIntent(
+            label=label, style=style, action=action,
+            url=url, payload=payload_str,
+        ))
+        if len(buttons) >= _MAX_UI_BUTTONS:
+            break
+    return UiIntent(buttons=tuple(buttons)) if buttons else None
+
+
+def _parse_image_urls(payload: dict[str, Any]) -> tuple[str, ...]:
+    """Extract validated image URLs from JSON payload."""
+    raw = payload.get("images")
+    if not isinstance(raw, list):
+        return ()
+    urls = []
+    for item in raw:
+        url = _normalize_image_url(item)
+        if url and len(urls) < _MAX_OUTPUT_IMAGES:
+            urls.append(url)
+    return tuple(urls)
+
+
+def _parse_file_paths(payload: dict[str, Any]) -> tuple[str, ...]:
+    """Extract file paths from JSON payload."""
+    paths: list[str] = []
+    for key in ("files", "file_paths", "attachments"):
+        raw = payload.get(key)
+        if not isinstance(raw, list):
+            continue
+        for item in raw:
+            if isinstance(item, str) and item.strip():
+                paths.append(item.strip())
+            elif isinstance(item, dict):
+                p = item.get("path")
+                if isinstance(p, str) and p.strip():
+                    paths.append(p.strip())
+            if len(paths) >= _MAX_OUTPUT_FILES:
+                break
+        if paths:
+            break
+    return tuple(paths[:_MAX_OUTPUT_FILES])
+
+
+# ---------------------------------------------------------------------------
+# A2UI envelope processing (surface state machine)
+# ---------------------------------------------------------------------------
+
+
+def _process_a2ui_envelopes(
+    envelopes: list[dict[str, Any]],
+    session_id: str,
+    surfaces: dict[tuple[str, str], SurfaceState],
+) -> StructuredReply | None:
+    """Process A2UI envelopes against the surface state store.
+
+    Returns a StructuredReply for the *last* createSurface/updateComponents/
+    updateDataModel envelope, or None if only deleteSurface envelopes.
+    """
+    last_reply: StructuredReply | None = None
+    directives: list[SurfaceDirective] = []
+
+    for env in envelopes:
+        env_type = str(env.get("type", "")).strip().lower()
+        surface_id = str(env.get("surfaceId", env.get("surface_id", ""))).strip()
+        if not surface_id:
+            continue
+        key = (session_id, surface_id)
+
+        if env_type == "createsurface":
+            raw_components = env.get("components")
+            if not isinstance(raw_components, list):
+                raw_components = []
+            data_model = env.get("dataModel") or env.get("data_model") or {}
+            if not isinstance(data_model, dict):
+                data_model = {}
+
+            template = tuple(raw_components)
+            bound = [_bind_component(c, data_model) for c in raw_components]
+            rendered = _render_from_components(bound)
+            rendered = StructuredReply(
+                markdown=rendered.markdown,
+                ui_intent=rendered.ui_intent,
+                image_urls=rendered.image_urls,
+                file_paths=rendered.file_paths,
+                a2ui_components=tuple(bound),
+                surface_directives=(SurfaceDirective(type="createsurface", surface_id=surface_id),),
+            )
+            surfaces[key] = SurfaceState(
+                rendered=rendered,
+                template_components=template,
+                data_model=data_model,
+            )
+            directives.append(SurfaceDirective(type="createsurface", surface_id=surface_id))
+            last_reply = rendered
+
+        elif env_type == "updatecomponents":
+            raw_components = env.get("components")
+            if not isinstance(raw_components, list):
+                continue
+            existing = surfaces.get(key)
+            data_model = existing.data_model if existing else {}
+
+            template = tuple(raw_components)
+            bound = [_bind_component(c, data_model) for c in raw_components]
+            rendered = _render_from_components(bound)
+            rendered = StructuredReply(
+                markdown=rendered.markdown,
+                ui_intent=rendered.ui_intent,
+                image_urls=rendered.image_urls,
+                file_paths=rendered.file_paths,
+                a2ui_components=tuple(bound),
+                surface_directives=(SurfaceDirective(type="updatecomponents", surface_id=surface_id),),
+            )
+            surfaces[key] = SurfaceState(
+                rendered=rendered,
+                template_components=template,
+                data_model=data_model,
+            )
+            directives.append(SurfaceDirective(type="updatecomponents", surface_id=surface_id))
+            last_reply = rendered
+
+        elif env_type == "updatedatamodel":
+            new_model = env.get("dataModel") or env.get("data_model") or {}
+            if not isinstance(new_model, dict):
+                continue
+            existing = surfaces.get(key)
+            if not existing:
+                continue
+
+            bound = [_bind_component(c, new_model) for c in existing.template_components]
+            rendered = _render_from_components(bound)
+            rendered = StructuredReply(
+                markdown=rendered.markdown,
+                ui_intent=rendered.ui_intent,
+                image_urls=rendered.image_urls,
+                file_paths=rendered.file_paths,
+                a2ui_components=tuple(bound),
+                surface_directives=(SurfaceDirective(type="updatedatamodel", surface_id=surface_id),),
+            )
+            existing.rendered = rendered
+            existing.data_model = new_model
+            directives.append(SurfaceDirective(type="updatedatamodel", surface_id=surface_id))
+            last_reply = rendered
+
+        elif env_type == "deletesurface":
+            surfaces.pop(key, None)
+            directives.append(SurfaceDirective(type="deletesurface", surface_id=surface_id))
+
+    if not directives:
+        return None
+
+    # Build a combined reply with all directives
+    if last_reply is not None:
+        return StructuredReply(
+            markdown=last_reply.markdown,
+            ui_intent=last_reply.ui_intent,
+            image_urls=last_reply.image_urls,
+            file_paths=last_reply.file_paths,
+            a2ui_components=last_reply.a2ui_components,
+            surface_directives=tuple(directives),
+        )
+    # Only delete directives — return empty reply with directives
+    return StructuredReply(
+        markdown="",
+        surface_directives=tuple(directives),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def structured_reply_from_text(
+    raw_reply: str,
+    session_id: str,
+    surfaces: dict[tuple[str, str], SurfaceState],
+) -> StructuredReply:
+    """Parse raw agent reply text into a StructuredReply.
+
+    Routes through A2UI envelope pipeline or simple JSON/plain-text path.
+    """
+    if not raw_reply or not raw_reply.strip():
+        return StructuredReply(markdown="")
+
+    text = raw_reply.strip()
+
+    # Try to extract JSON
+    json_text = _extract_json_object_text(text)
+    if json_text:
+        try:
+            payload = json.loads(json_text)
+        except (json.JSONDecodeError, ValueError):
+            payload = None
+
+        if isinstance(payload, dict):
+            # Check for A2UI envelopes first
+            a2ui_msgs = _extract_a2ui_messages(payload)
+            if a2ui_msgs:
+                result = _process_a2ui_envelopes(a2ui_msgs, session_id, surfaces)
+                if result is not None:
+                    return result
+
+            # Simple JSON path
+            markdown = str(payload.get("markdown", "")).strip() or text
+            ui_intent = _parse_simple_ui_intent(payload)
+            image_urls = list(_parse_image_urls(payload))
+            file_paths = _parse_file_paths(payload)
+
+            # Merge markdown images after JSON-specified ones
+            for url in _extract_markdown_images(markdown):
+                if url not in image_urls and len(image_urls) < _MAX_OUTPUT_IMAGES:
+                    image_urls.append(url)
+
+            return StructuredReply(
+                markdown=markdown,
+                ui_intent=ui_intent,
+                image_urls=tuple(image_urls),
+                file_paths=file_paths,
+            )
+
+    # Plain text path
+    image_urls = _extract_markdown_images(text)
+    return StructuredReply(
+        markdown=text,
+        image_urls=tuple(image_urls[:_MAX_OUTPUT_IMAGES]),
+    )
+
+
+def clear_session_surfaces(
+    session_id: str,
+    surfaces: dict[tuple[str, str], SurfaceState],
+) -> None:
+    """Remove all surface states for a given session."""
+    to_remove = [k for k in surfaces if k[0] == session_id]
+    for k in to_remove:
+        del surfaces[k]
+
+
+def get_session_id(
+    guild_id: str | None,
+    channel_id: str,
+    user_id: str,
+    thread_id: str | None = None,
+) -> str:
+    """Build a session ID following the deepbot pattern."""
+    if thread_id:
+        return f"thread:{thread_id}:user:{user_id}"
+    if guild_id:
+        return f"guild:{guild_id}:channel:{channel_id}:user:{user_id}"
+    return f"dm:{user_id}"

--- a/nanobot/channels/discord_renderer.py
+++ b/nanobot/channels/discord_renderer.py
@@ -1,0 +1,453 @@
+"""Discord REST API renderer for Components V2.
+
+Builds JSON payloads for the Discord REST API from A2UI StructuredReply
+objects.  No discord.py library — everything is raw JSON matching the
+Discord API v10 component specification.
+
+Discord Component Types (integer IDs):
+  1  = ActionRow
+  2  = Button
+  3  = StringSelect
+  9  = Section
+ 10  = TextDisplay
+ 11  = Thumbnail
+ 12  = MediaGallery
+ 14  = Separator
+ 17  = Container
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from loguru import logger
+
+from nanobot.channels.discord_a2ui import (
+    StructuredReply,
+    SurfaceDirective,
+    _component_type,
+    _normalize_image_url,
+)
+
+# ---------------------------------------------------------------------------
+# Discord component type IDs
+# ---------------------------------------------------------------------------
+
+ACTION_ROW = 1
+BUTTON = 2
+STRING_SELECT = 3
+SECTION = 9
+TEXT_DISPLAY = 10
+THUMBNAIL = 11
+MEDIA_GALLERY = 12
+SEPARATOR = 14
+CONTAINER = 17
+
+# Discord button style IDs
+BUTTON_STYLE_MAP = {
+    "primary": 1,
+    "secondary": 2,
+    "success": 3,
+    "danger": 4,
+    "link": 5,
+}
+
+_MAX_LAYOUT_ITEMS = 25
+
+# Top-level component types that can appear directly in the components array
+_LAYOUT_TOP_LEVEL_TYPES = {
+    "text", "textdisplay", "markdown", "separator", "thumbnail",
+    "media_gallery", "mediagallery", "container", "section",
+    "button", "action", "select", "string_select",
+}
+
+
+# ---------------------------------------------------------------------------
+# custom_id encoding
+# ---------------------------------------------------------------------------
+
+
+def _encode_custom_id(
+    owner_id: str,
+    action: str | None,
+    payload: str | None,
+) -> str:
+    """Encode a custom_id for a button/select interaction.
+
+    Format: a2ui:{owner_id}:{action}:{payload_hash}
+    Max 100 chars (Discord limit).
+    """
+    action_str = action or "_"
+    payload_hash = ""
+    if payload:
+        payload_hash = hashlib.sha256(payload.encode()).hexdigest()[:8]
+    raw = f"a2ui:{owner_id}:{action_str}:{payload_hash}"
+    return raw[:100]
+
+
+def _decode_custom_id(custom_id: str) -> tuple[str, str | None, str | None]:
+    """Decode owner_id, action, payload_hash from custom_id.
+
+    Returns (owner_id, action, payload_hash).
+    """
+    if not custom_id.startswith("a2ui:"):
+        return ("", None, None)
+    parts = custom_id.split(":", 3)
+    owner_id = parts[1] if len(parts) > 1 else ""
+    action = parts[2] if len(parts) > 2 else None
+    payload_hash = parts[3] if len(parts) > 3 else None
+    if action == "_":
+        action = None
+    return (owner_id, action, payload_hash or None)
+
+
+# ---------------------------------------------------------------------------
+# Component builders
+# ---------------------------------------------------------------------------
+
+
+def _build_text_display(comp: dict[str, Any]) -> dict[str, Any]:
+    """Build a TextDisplay (type 10) component."""
+    content = comp.get("markdown") or comp.get("content") or ""
+    return {"type": TEXT_DISPLAY, "content": str(content)}
+
+
+def _build_button(comp: dict[str, Any], owner_id: str) -> dict[str, Any]:
+    """Build a Button (type 2) component."""
+    label = str(comp.get("label", "")).strip()[:80]
+    style_str = str(comp.get("style", "secondary")).lower()
+    url = _normalize_image_url(comp.get("url"))
+    action = (comp.get("action") or "").strip() or None
+    payload = (comp.get("payload") or "").strip() or None
+
+    # Auto-detect link buttons
+    if url is not None and action is None:
+        style_str = "link"
+
+    style_id = BUTTON_STYLE_MAP.get(style_str, 2)  # default secondary
+
+    button: dict[str, Any] = {
+        "type": BUTTON,
+        "label": label or "Button",
+        "style": style_id,
+    }
+
+    if style_id == 5:  # link
+        if not url:
+            return {}  # invalid link button
+        button["url"] = url
+    else:
+        button["custom_id"] = _encode_custom_id(owner_id, action, payload)
+
+    return button
+
+
+def _build_select(comp: dict[str, Any], owner_id: str) -> dict[str, Any]:
+    """Build a StringSelect (type 3) component."""
+    action = (comp.get("action") or "").strip() or "_"
+    payload = (comp.get("payload") or "").strip() or None
+    placeholder = str(comp.get("placeholder", ""))[:150] or None
+    disabled = bool(comp.get("disabled", False))
+    min_values = int(comp.get("min_values", 1))
+    max_values = int(comp.get("max_values", 1))
+
+    options = []
+    for raw in (comp.get("options") or []):
+        if not isinstance(raw, dict):
+            continue
+        label = str(raw.get("label", ""))[:100]
+        if not label:
+            continue
+        value = str(raw.get("value", label))[:100]
+        desc = str(raw.get("description", ""))[:100] or None
+        default = bool(raw.get("default", False))
+        opt: dict[str, Any] = {"label": label, "value": value}
+        if desc:
+            opt["description"] = desc
+        if default:
+            opt["default"] = True
+        options.append(opt)
+
+    if not options:
+        return {}
+
+    select: dict[str, Any] = {
+        "type": STRING_SELECT,
+        "custom_id": _encode_custom_id(owner_id, action, payload),
+        "options": options[:25],  # Discord max 25 options
+        "min_values": min_values,
+        "max_values": min(max_values, len(options)),
+        "disabled": disabled,
+    }
+    if placeholder:
+        select["placeholder"] = placeholder
+
+    return select
+
+
+def _build_thumbnail(comp: dict[str, Any]) -> dict[str, Any]:
+    """Build a Thumbnail (type 11) component."""
+    url = _normalize_image_url(comp.get("url"))
+    if not url:
+        return {}
+    thumb: dict[str, Any] = {
+        "type": THUMBNAIL,
+        "media": {"url": url},
+    }
+    desc = comp.get("description")
+    if desc:
+        thumb["description"] = str(desc)[:256]
+    return thumb
+
+
+def _build_media_gallery(comp: dict[str, Any]) -> dict[str, Any]:
+    """Build a MediaGallery (type 12) component."""
+    items = []
+    for raw in (comp.get("items") or []):
+        if not isinstance(raw, dict):
+            continue
+        url = _normalize_image_url(raw.get("url"))
+        if not url:
+            continue
+        item: dict[str, Any] = {"media": {"url": url}}
+        desc = raw.get("description")
+        if desc:
+            item["description"] = str(desc)[:256]
+        items.append(item)
+        if len(items) >= 10:
+            break
+    if not items:
+        return {}
+    return {"type": MEDIA_GALLERY, "items": items}
+
+
+def _build_separator() -> dict[str, Any]:
+    """Build a Separator (type 14) component."""
+    return {"type": SEPARATOR}
+
+
+def _build_section(comp: dict[str, Any], owner_id: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Build a Section (type 9) component and any promoted selects.
+
+    Discord doesn't allow selects inside sections, so selects found in
+    section children are "promoted" to separate ActionRows that follow
+    the section.
+
+    Returns (section_dict, promoted_action_rows).
+    """
+    children_raw = comp.get("components") or comp.get("children") or []
+    accessory_raw = comp.get("accessory")
+
+    section_components = []
+    promoted: list[dict[str, Any]] = []
+
+    for child in children_raw:
+        if not isinstance(child, dict):
+            continue
+        ctype = _component_type(child)
+        if ctype in ("select", "string_select"):
+            # Promote to ActionRow after section
+            select = _build_select(child, owner_id)
+            if select:
+                promoted.append({"type": ACTION_ROW, "components": [select]})
+        elif ctype in ("text", "textdisplay", "markdown"):
+            section_components.append(_build_text_display(child))
+        if len(section_components) >= 3:
+            break
+
+    section: dict[str, Any] = {"type": SECTION}
+    if section_components:
+        section["components"] = section_components
+
+    # Build accessory (button or thumbnail)
+    if isinstance(accessory_raw, dict):
+        acc_type = _component_type(accessory_raw)
+        if acc_type in ("button", "action"):
+            btn = _build_button(accessory_raw, owner_id)
+            if btn:
+                section["accessory"] = btn
+        elif acc_type == "thumbnail":
+            thumb = _build_thumbnail(accessory_raw)
+            if thumb:
+                section["accessory"] = thumb
+
+    return section, promoted
+
+
+def _build_container(comp: dict[str, Any], owner_id: str) -> dict[str, Any]:
+    """Build a Container (type 17) component with recursive children."""
+    children_raw = comp.get("components") or comp.get("children") or []
+    children = []
+    for child in children_raw:
+        if not isinstance(child, dict):
+            continue
+        built = _build_single_component(child, owner_id)
+        if isinstance(built, list):
+            children.extend(built)
+        elif built:
+            children.append(built)
+    if not children:
+        return {}
+    return {"type": CONTAINER, "components": children}
+
+
+def _build_single_component(
+    comp: dict[str, Any], owner_id: str
+) -> dict[str, Any] | list[dict[str, Any]] | None:
+    """Build a single component, returning either a dict or list (for sections with promoted selects)."""
+    ctype = _component_type(comp)
+
+    if ctype in ("text", "textdisplay", "markdown"):
+        return _build_text_display(comp)
+    elif ctype in ("button", "action"):
+        btn = _build_button(comp, owner_id)
+        if btn:
+            return {"type": ACTION_ROW, "components": [btn]}
+        return None
+    elif ctype in ("select", "string_select"):
+        sel = _build_select(comp, owner_id)
+        if sel:
+            return {"type": ACTION_ROW, "components": [sel]}
+        return None
+    elif ctype == "section":
+        section, promoted = _build_section(comp, owner_id)
+        result = [section]
+        result.extend(promoted)
+        return result
+    elif ctype == "container":
+        cont = _build_container(comp, owner_id)
+        return cont if cont else None
+    elif ctype == "separator":
+        return _build_separator()
+    elif ctype == "thumbnail":
+        return _build_thumbnail(comp)
+    elif ctype in ("media_gallery", "mediagallery"):
+        return _build_media_gallery(comp)
+    else:
+        logger.debug("Unknown A2UI component type: {}", ctype)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Top-level payload builders
+# ---------------------------------------------------------------------------
+
+
+def build_components_v2_payload(
+    a2ui_components: tuple[dict[str, Any], ...] | list[dict[str, Any]],
+    owner_id: str,
+) -> list[dict[str, Any]]:
+    """Build the top-level components array for a Components V2 message.
+
+    Returns a list of Discord component dicts ready for the REST API
+    `components` field.
+    """
+    if not a2ui_components:
+        return []
+
+    components: list[dict[str, Any]] = []
+
+    for comp in a2ui_components:
+        if not isinstance(comp, dict):
+            continue
+        ctype = _component_type(comp)
+        if ctype not in _LAYOUT_TOP_LEVEL_TYPES:
+            continue
+
+        built = _build_single_component(comp, owner_id)
+        if isinstance(built, list):
+            for item in built:
+                if item:
+                    components.append(item)
+                    if len(components) >= _MAX_LAYOUT_ITEMS:
+                        break
+        elif built:
+            components.append(built)
+
+        if len(components) >= _MAX_LAYOUT_ITEMS:
+            break
+
+    return components
+
+
+def build_image_embeds(image_urls: tuple[str, ...] | list[str]) -> list[dict[str, Any]]:
+    """Build image embeds for the embeds field."""
+    embeds = []
+    for url in image_urls:
+        if url:
+            embeds.append({"image": {"url": url}})
+    return embeds
+
+
+def build_simple_buttons_payload(
+    buttons: tuple,  # tuple[ButtonIntent, ...]
+    owner_id: str,
+) -> list[dict[str, Any]]:
+    """Build a standard ActionRow with buttons (non-A2UI simple path)."""
+    if not buttons:
+        return []
+    button_dicts = []
+    for bi in buttons:
+        style_id = BUTTON_STYLE_MAP.get(bi.style, 2)
+        btn: dict[str, Any] = {
+            "type": BUTTON,
+            "label": bi.label,
+            "style": style_id,
+        }
+        if style_id == 5:  # link
+            if not bi.url:
+                continue
+            btn["url"] = bi.url
+        else:
+            btn["custom_id"] = _encode_custom_id(owner_id, bi.action, bi.payload)
+        button_dicts.append(btn)
+    if not button_dicts:
+        return []
+    return [{"type": ACTION_ROW, "components": button_dicts}]
+
+
+def build_message_payload(
+    structured: StructuredReply,
+    owner_id: str,
+) -> dict[str, Any]:
+    """Build a complete Discord message payload from a StructuredReply.
+
+    Returns a dict suitable for POST /channels/{id}/messages.
+    The `flags` field is set to 32768 (IS_COMPONENTS_V2) when using
+    Components V2 layout.
+    """
+    payload: dict[str, Any] = {}
+
+    has_a2ui = bool(structured.a2ui_components)
+
+    if has_a2ui:
+        # Components V2 path — content must be omitted
+        components = build_components_v2_payload(
+            structured.a2ui_components, owner_id
+        )
+        if components:
+            payload["components"] = components
+            payload["flags"] = 32768  # IS_COMPONENTS_V2
+            # Content is forbidden with Components V2
+        else:
+            # Fallback to text if component building failed
+            payload["content"] = structured.markdown or " "
+    elif structured.ui_intent and structured.ui_intent.buttons:
+        # Simple buttons path
+        payload["content"] = structured.markdown or " "
+        components = build_simple_buttons_payload(
+            structured.ui_intent.buttons, owner_id
+        )
+        if components:
+            payload["components"] = components
+    else:
+        # Plain text path
+        payload["content"] = structured.markdown or " "
+
+    # Image embeds (only for non-Components V2, or as supplementary)
+    if structured.image_urls and not has_a2ui:
+        payload["embeds"] = build_image_embeds(structured.image_urls)
+
+    return payload

--- a/workspace/A2UI.md
+++ b/workspace/A2UI.md
@@ -1,0 +1,57 @@
+# A2UI — Agent-to-UI Response Format
+
+You can optionally return structured JSON to render rich Discord UI (Components V2).
+
+## Response Formats
+
+### Plain Text
+Just respond with normal Markdown text.
+
+### Simple JSON (buttons + images)
+```
+{"markdown":"Your message text","ui_intent":{"buttons":[{"label":"Retry","style":"primary","action":"rerun"}]},"images":["https://example.com/img.png"]}
+```
+
+### A2UI (stateful UI surfaces)
+```
+{"a2ui":[{"type":"createSurface","surfaceId":"main","components":[...]}]}
+```
+
+## A2UI Envelope Types
+
+| Type | Purpose |
+|------|---------|
+| `createSurface` | Create a new UI surface with `components` and optional `dataModel` |
+| `updateComponents` | Replace components on an existing surface |
+| `updateDataModel` | Replace the data model (re-renders template with new data) |
+| `deleteSurface` | Remove a surface message |
+
+## Component Types
+
+- **text** — Static text: `{"type":"text","markdown":"# Hello"}`
+- **button** — Interactive button: `{"type":"button","label":"Click","style":"primary","action":"do_thing"}`
+- **select** — Dropdown menu: `{"type":"select","action":"pick","options":[{"label":"A","value":"a"}]}`
+- **section** — Layout with text + accessory (button/thumbnail): `{"type":"section","components":[...],"accessory":{...}}`
+- **container** — Grouping container: `{"type":"container","components":[...]}`
+- **separator** — Visual divider: `{"type":"separator"}`
+- **thumbnail** — Thumbnail image: `{"type":"thumbnail","url":"https://..."}`
+- **media_gallery** — Image gallery: `{"type":"media_gallery","items":[{"url":"https://..."}]}`
+
+## Button Styles
+`primary` | `secondary` | `success` | `danger` | `link`
+- `link` style requires `url` field and has no callback
+- Other styles use `action` field for callbacks
+
+## Data Model Templates
+Use `{{path.to.value}}` syntax in text components. The data model is bound when rendering:
+```
+{"type":"createSurface","surfaceId":"main","dataModel":{"name":"Alice","score":42},"components":[{"type":"text","markdown":"Hello {{name}}! Score: {{score}}"}]}
+```
+
+## Rules
+- Do NOT wrap JSON in markdown code fences
+- Do NOT use markdown tables in Discord (use bullet lists instead)
+- Max 3 buttons per reply
+- Max 4 images per reply
+- Apply envelopes in array order
+- `updateDataModel` is full replacement, not merge


### PR DESCRIPTION
## Summary

Adds **A2UI (Agent-to-UI)** support to the Discord channel, enabling the agent to return structured JSON that renders as native **Discord Components V2** (rich text, buttons, thumbnails, media galleries, sections, and stateful surfaces).

Previously, if the agent returned A2UI JSON, it was displayed as raw text in Discord. Now the channel adapter parses A2UI envelopes, binds data models to templates, and sends proper Components V2 payloads via the Discord REST API.

## Changes

### New Files
| File | Description |
|------|-------------|
| `nanobot/channels/discord_a2ui.py` | Core A2UI engine: JSON extraction, envelope parsing, data binding (`{{path}}` templates), component rendering, and surface state machine |
| `nanobot/channels/discord_renderer.py` | Discord REST payload builder: converts `StructuredReply` → Components V2 JSON (text_display, buttons, thumbnails, media_gallery, separator, section, container) |
| `workspace/A2UI.md` | Bootstrap prompt teaching the agent the A2UI response format |

### Modified Files
| File | Description |
|------|-------------|
| `nanobot/channels/discord.py` | Rewritten with full A2UI pipeline in `send()`: parse → route surface directives → build Components V2 payload → send via REST with fallback. Adds interaction dispatch for button/select callbacks via Gateway |
| `nanobot/agent/context.py` | Added `A2UI.md` to `BOOTSTRAP_FILES` |

## Architecture

```
Agent Response (JSON)
    ↓
structured_reply_from_text()     ← discord_a2ui.py
    ↓
StructuredReply (parsed)
    ↓
build_message_payload()          ← discord_renderer.py
    ↓
Discord REST API (Components V2)
    ↓ fallback on 4xx
Plain markdown text
```

## A2UI Response Formats

The agent can return:
1. **Plain text** — sent as-is
2. **Simple JSON** — `{"text": ..., "buttons": [...], "images": [...]}`
3. **Full A2UI** — `{"a2ui": [{"type": "createSurface", ...}]}` with data binding, components, and surface lifecycle

## Testing

- 76 unit tests (38 engine + 38 renderer) — all passing
- Covers JSON extraction, data binding, component rendering, surface state machine, payload assembly, custom_id encoding, and style mapping