### PR TITLE
feat(cli): add DingTalk, QQ, and Email to channels status output

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -668,6 +668,33 @@ def channels_status():
         slack_config
     )
 
+    # DingTalk
+    dt = config.channels.dingtalk
+    dt_config = f"client_id: {dt.client_id[:10]}..." if dt.client_id else "[dim]not configured[/dim]"
+    table.add_row(
+        "DingTalk",
+        "✓" if dt.enabled else "✗",
+        dt_config
+    )
+
+    # QQ
+    qq = config.channels.qq
+    qq_config = f"app_id: {qq.app_id[:10]}..." if qq.app_id else "[dim]not configured[/dim]"
+    table.add_row(
+        "QQ",
+        "✓" if qq.enabled else "✗",
+        qq_config
+    )
+
+    # Email
+    em = config.channels.email
+    em_config = em.imap_host if em.imap_host else "[dim]not configured[/dim]"
+    table.add_row(
+        "Email",
+        "✓" if em.enabled else "✗",
+        em_config
+    )
+
     console.print(table)
 
 


### PR DESCRIPTION
## Summary
This PR adds DingTalk, QQ, and Email channels to the `nanobot channels status` command output. These channels were implemented but missing from the CLI status display.
## Changes
- Added DingTalk status display (shows `client_id` prefix if configured)
- Added QQ status display (shows `app_id` prefix if configured)
- Added Email status display (shows `imap_host` if configured)
## Before
<img width="1408" height="484" alt="image" src="https://github.com/user-attachments/assets/5bcffbed-f81a-461b-9f56-e58b94be41af" />

## After
<img width="1414" height="574" alt="image" src="https://github.com/user-attachments/assets/6e424200-0ac3-4b27-ae67-8fc00935b90e" />
