### PR TITLE
feat: add generic bidirectional webhook channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ Connect nanobot to your favorite chat platform.
 | **Slack** | Bot token + App-Level token |
 | **Email** | IMAP/SMTP credentials |
 | **QQ** | App ID + App Secret |
+| **Webhook** | Local HTTP access + connector endpoint (`127.0.0.1:19400`) |
+
+> Webhook channel defaults:
+> - Inbound route: `POST /v1/inbound`
+> - Outbound route: `POST /v1/outbound`
+> - Connector forward target: `http://127.0.0.1:19400/v1/outbound`
 
 <details>
 <summary><b>Telegram</b> (Recommended)</summary>

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -136,6 +136,18 @@ class ChannelManager:
                 logger.info("QQ channel enabled")
             except ImportError as e:
                 logger.warning("QQ channel not available: {}", e)
+
+        # Webhook channel
+        if self.config.channels.webhook.enabled:
+            try:
+                from nanobot.channels.webhook import WebhookChannel
+                self.channels["webhook"] = WebhookChannel(
+                    self.config.channels.webhook,
+                    self.bus,
+                )
+                logger.info("Webhook channel enabled")
+            except ImportError as e:
+                logger.warning("Webhook channel not available: {}", e)
     
     async def _start_channel(self, name: str, channel: BaseChannel) -> None:
         """Start a channel and log any exceptions."""

--- a/nanobot/channels/webhook.py
+++ b/nanobot/channels/webhook.py
@@ -1,0 +1,391 @@
+"""Generic bidirectional webhook channel implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+import httpx
+from loguru import logger
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import WebhookConfig
+
+
+class _WebhookRequestHandler(BaseHTTPRequestHandler):
+    """HTTP handler that delegates route processing to WebhookChannel."""
+
+    channel: "WebhookChannel"
+
+    def do_POST(self) -> None:
+        self._handle()
+
+    def do_GET(self) -> None:
+        self._handle()
+
+    def do_PUT(self) -> None:
+        self._handle()
+
+    def do_DELETE(self) -> None:
+        self._handle()
+
+    def do_PATCH(self) -> None:
+        self._handle()
+
+    def do_HEAD(self) -> None:
+        self._handle()
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        logger.debug("Webhook HTTP {} - {}", self.address_string(), fmt % args)
+
+    def _handle(self) -> None:
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            content_length = 0
+        body = self.rfile.read(content_length) if content_length > 0 else b""
+        remote_addr = f"{self.client_address[0]}:{self.client_address[1]}"
+
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                self.channel.handle_http_request(
+                    method=self.command,
+                    path=self.path,
+                    headers=dict(self.headers.items()),
+                    body=body,
+                    remote_addr=remote_addr,
+                ),
+                self.channel.loop,
+            )
+            status, response_body = future.result(timeout=30)
+        except Exception as e:
+            logger.error("Webhook request handling failed: {}", e)
+            status = HTTPStatus.INTERNAL_SERVER_ERROR
+            response_body = {"error": "Internal server error"}
+
+        payload = json.dumps(response_body, ensure_ascii=False).encode("utf-8")
+        self.send_response(int(status))
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(payload)
+
+
+class WebhookChannel(BaseChannel):
+    """Bidirectional local webhook channel."""
+
+    name = "webhook"
+
+    def __init__(self, config: WebhookConfig, bus: MessageBus):
+        super().__init__(config, bus)
+        self.config: WebhookConfig = config
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._server: ThreadingHTTPServer | None = None
+        self._server_thread: threading.Thread | None = None
+        self._webhook_path = self._normalize_path(self.config.webhook_path, "/v1/inbound")
+        self._send_path = self._normalize_path(self.config.send_path, "/v1/outbound")
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        if self._loop is None:
+            raise RuntimeError("Webhook event loop is not initialized")
+        return self._loop
+
+    async def start(self) -> None:
+        """Start webhook HTTP server."""
+        if self._running:
+            return
+
+        host = (self.config.webhook_host or "127.0.0.1").strip() or "127.0.0.1"
+        port = int(self.config.webhook_port or 18794)
+        self._webhook_path = self._normalize_path(self.config.webhook_path, "/v1/inbound")
+        self._send_path = self._normalize_path(self.config.send_path, "/v1/outbound")
+        self._loop = asyncio.get_running_loop()
+
+        handler_cls = self._build_handler_class()
+
+        try:
+            self._server = ThreadingHTTPServer((host, port), handler_cls)
+            self._server.daemon_threads = True
+        except OSError as e:
+            logger.error("Failed to start webhook channel server: {}", e)
+            return
+
+        self._server_thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="nanobot-webhook-server",
+            daemon=True,
+        )
+        self._server_thread.start()
+        self._running = True
+        logger.info(
+            "Webhook channel listening on http://{}:{}{} and http://{}:{}{}",
+            host,
+            port,
+            self._webhook_path,
+            host,
+            port,
+            self._send_path,
+        )
+
+        try:
+            while self._running:
+                await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            await self.stop()
+            raise
+
+    async def stop(self) -> None:
+        """Stop webhook HTTP server."""
+        self._running = False
+
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+
+        if self._server_thread and self._server_thread.is_alive():
+            self._server_thread.join(timeout=5)
+        self._server_thread = None
+
+        logger.info("Webhook channel stopped")
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Forward outbound message from nanobot to the local connector."""
+        to_value = str(msg.metadata.get("to") or msg.chat_id).strip()
+        peer_value = str(msg.metadata.get("peer") or "").strip()
+        content_value = str(msg.content or "")
+
+        if not to_value or not content_value.strip():
+            logger.warning("Webhook outbound send skipped: missing to/content")
+            return
+
+        payload: dict[str, str] = {
+            "to": to_value,
+            "content": content_value,
+        }
+        if peer_value:
+            payload["peer"] = peer_value
+
+        status, response = await self._forward_to_connector(payload)
+        if status >= HTTPStatus.BAD_REQUEST:
+            logger.error("Webhook outbound send failed: status={} error={}", status, response.get("error"))
+
+    async def handle_http_request(
+        self,
+        method: str,
+        path: str,
+        headers: Mapping[str, Any],
+        body: bytes,
+        remote_addr: str,
+    ) -> tuple[int, dict[str, Any]]:
+        """Handle an incoming HTTP request for inbound/outbound routes."""
+        route_path = urlsplit(path).path
+
+        if route_path == self._webhook_path:
+            return await self._handle_inbound(method, headers, body, remote_addr)
+        if route_path == self._send_path:
+            return await self._handle_send(method, headers, body)
+        return HTTPStatus.NOT_FOUND, {"error": "Route not found"}
+
+    async def _handle_inbound(
+        self,
+        method: str,
+        headers: Mapping[str, Any],
+        body: bytes,
+        remote_addr: str,
+    ) -> tuple[int, dict[str, Any]]:
+        if method != "POST":
+            return HTTPStatus.METHOD_NOT_ALLOWED, {"error": "Method not allowed"}
+        if not self._is_json_content_type(headers):
+            return HTTPStatus.BAD_REQUEST, {"error": "Content-Type must be application/json"}
+        if not self._is_authorized(headers):
+            return HTTPStatus.FORBIDDEN, {"error": "Invalid token"}
+
+        payload = self._decode_json_body(body)
+        if payload is None:
+            return HTTPStatus.BAD_REQUEST, {"error": "Invalid JSON payload"}
+
+        sender_id = self._resolve_sender_id(headers, remote_addr)
+        if not self.is_allowed(sender_id):
+            return HTTPStatus.FORBIDDEN, {"error": "Sender not allowed"}
+
+        chat_id = self._resolve_chat_id(headers, sender_id)
+        content, payload_json = self._resolve_payload_content(payload)
+
+        metadata: dict[str, Any] = {
+            "platform": "webhook",
+            "delivery_protocol": "webhook",
+            "payload_json": payload_json,
+            "content_type": self._header(headers, "Content-Type"),
+            "request_id": self._header(headers, "x-request-id"),
+            "sender_id": sender_id,
+            "chat_id": chat_id,
+        }
+        for header_name in (
+            "x-clawdentity-agent-did",
+            "x-clawdentity-to-agent-did",
+            "x-clawdentity-verified",
+        ):
+            value = self._header(headers, header_name)
+            if value:
+                metadata[header_name.replace("-", "_")] = value
+
+        await self._handle_message(
+            sender_id=sender_id,
+            chat_id=chat_id,
+            content=content,
+            metadata=metadata,
+        )
+        return HTTPStatus.ACCEPTED, {"status": "accepted"}
+
+    async def _handle_send(
+        self,
+        method: str,
+        headers: Mapping[str, Any],
+        body: bytes,
+    ) -> tuple[int, dict[str, Any]]:
+        if method != "POST":
+            return HTTPStatus.METHOD_NOT_ALLOWED, {"error": "Method not allowed"}
+        if not self._is_json_content_type(headers):
+            return HTTPStatus.BAD_REQUEST, {"error": "Content-Type must be application/json"}
+        if not self._is_authorized(headers):
+            return HTTPStatus.FORBIDDEN, {"error": "Invalid token"}
+
+        payload = self._decode_json_body(body)
+        if not isinstance(payload, dict):
+            return HTTPStatus.BAD_REQUEST, {"error": "Invalid JSON payload"}
+
+        to_value = str(payload.get("to", "")).strip()
+        content_value = payload.get("content")
+        peer_value = payload.get("peer")
+
+        if not to_value:
+            return HTTPStatus.BAD_REQUEST, {"error": "Missing required field: to"}
+        if not isinstance(content_value, str) or not content_value.strip():
+            return HTTPStatus.BAD_REQUEST, {"error": "Missing required field: content"}
+
+        outbound_payload: dict[str, str] = {
+            "to": to_value,
+            "content": content_value,
+        }
+        if isinstance(peer_value, str) and peer_value.strip():
+            outbound_payload["peer"] = peer_value.strip()
+
+        status, response = await self._forward_to_connector(outbound_payload)
+        if status >= HTTPStatus.BAD_REQUEST:
+            return status, response
+        return HTTPStatus.ACCEPTED, {"status": "accepted"}
+
+    async def _forward_to_connector(self, payload: dict[str, str]) -> tuple[int, dict[str, Any]]:
+        connector_url = str(self.config.connector_url or "").strip()
+        if not connector_url:
+            return HTTPStatus.INTERNAL_SERVER_ERROR, {"error": "connector_url is not configured"}
+
+        timeout_s = float(self.config.connector_timeout_seconds or 10.0)
+        timeout_s = max(0.1, timeout_s)
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout_s) as client:
+                response = await client.post(connector_url, json=payload)
+        except httpx.HTTPError as e:
+            logger.error("Webhook connector forward failed: {}", e)
+            return HTTPStatus.BAD_GATEWAY, {"error": "Failed to reach connector endpoint"}
+
+        if response.status_code // 100 != 2:
+            logger.warning(
+                "Webhook connector rejected outbound message: status={} body={}",
+                response.status_code,
+                response.text[:300],
+            )
+            return HTTPStatus.BAD_GATEWAY, {"error": "Connector rejected outbound message"}
+
+        return HTTPStatus.ACCEPTED, {"status": "accepted"}
+
+    @staticmethod
+    def _normalize_path(value: str, default: str) -> str:
+        path = (value or "").strip() or default
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return path
+
+    @staticmethod
+    def _header(headers: Mapping[str, Any], name: str) -> str:
+        lookup = name.lower()
+        for key, value in headers.items():
+            if str(key).lower() == lookup and value is not None:
+                return str(value).strip()
+        return ""
+
+    def _is_json_content_type(self, headers: Mapping[str, Any]) -> bool:
+        content_type = self._header(headers, "Content-Type").lower()
+        media_type = content_type.split(";", 1)[0].strip()
+        return media_type == "application/json"
+
+    def _is_authorized(self, headers: Mapping[str, Any]) -> bool:
+        expected = str(self.config.token or "")
+        if not expected:
+            return True
+        return self._resolve_auth_token(headers) == expected
+
+    def _resolve_auth_token(self, headers: Mapping[str, Any]) -> str:
+        token = self._header(headers, "x-webhook-token")
+        if token:
+            return token
+
+        authorization = self._header(headers, "Authorization")
+        if authorization.lower().startswith("bearer "):
+            return authorization[7:].strip()
+        return authorization
+
+    @staticmethod
+    def _decode_json_body(body: bytes) -> Any | None:
+        try:
+            return json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return None
+
+    def _resolve_sender_id(self, headers: Mapping[str, Any], remote_addr: str) -> str:
+        for key in ("x-webhook-sender-id", "x-clawdentity-agent-did"):
+            value = self._header(headers, key)
+            if value:
+                return value
+        host = remote_addr.strip()
+        if host.startswith("[") and "]" in host:
+            return host[1 : host.index("]")]
+        if ":" in host:
+            return host.rsplit(":", 1)[0]
+        return host or "webhook"
+
+    def _resolve_chat_id(self, headers: Mapping[str, Any], sender_id: str) -> str:
+        for key in ("x-webhook-chat-id", "x-clawdentity-to-agent-did"):
+            value = self._header(headers, key)
+            if value:
+                return value
+        return sender_id
+
+    @staticmethod
+    def _resolve_payload_content(payload: Any) -> tuple[str, str]:
+        payload_json = json.dumps(payload, ensure_ascii=False)
+        if isinstance(payload, dict):
+            for key in ("content", "text", "message"):
+                value = payload.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value, payload_json
+        return payload_json, payload_json
+
+    def _build_handler_class(self) -> type[_WebhookRequestHandler]:
+        outer = self
+
+        class Handler(_WebhookRequestHandler):
+            channel = outer
+
+        return Handler

--- a/nanobot/channels/webhook.py
+++ b/nanobot/channels/webhook.py
@@ -233,7 +233,6 @@ class WebhookChannel(BaseChannel):
         for header_name in (
             "x-clawdentity-agent-did",
             "x-clawdentity-to-agent-did",
-            "x-clawdentity-verified",
         ):
             value = self._header(headers, header_name)
             if value:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -165,6 +165,20 @@ class QQConfig(Base):
     allow_from: list[str] = Field(default_factory=list)  # Allowed user openids (empty = public access)
 
 
+class WebhookConfig(Base):
+    """Generic webhook channel configuration."""
+
+    enabled: bool = False
+    webhook_host: str = "127.0.0.1"
+    webhook_port: int = 18794
+    webhook_path: str = "/v1/inbound"
+    send_path: str = "/v1/outbound"
+    connector_url: str = "http://127.0.0.1:19400/v1/outbound"
+    connector_timeout_seconds: float = 10.0
+    token: str = ""
+    allow_from: list[str] = Field(default_factory=list)
+
+
 class ChannelsConfig(Base):
     """Configuration for chat channels."""
 
@@ -177,6 +191,7 @@ class ChannelsConfig(Base):
     email: EmailConfig = Field(default_factory=EmailConfig)
     slack: SlackConfig = Field(default_factory=SlackConfig)
     qq: QQConfig = Field(default_factory=QQConfig)
+    webhook: WebhookConfig = Field(default_factory=WebhookConfig)
 
 
 class AgentDefaults(Base):

--- a/tests/test_webhook_channel.py
+++ b/tests/test_webhook_channel.py
@@ -1,0 +1,153 @@
+import asyncio
+
+import pytest
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.webhook import WebhookChannel
+from nanobot.config.schema import WebhookConfig
+
+
+def _make_channel(*, token: str = "") -> WebhookChannel:
+    cfg = WebhookConfig(
+        enabled=True,
+        webhook_host="127.0.0.1",
+        webhook_port=18794,
+        webhook_path="/v1/inbound",
+        send_path="/v1/outbound",
+        connector_url="http://127.0.0.1:19400/v1/outbound",
+        token=token,
+    )
+    return WebhookChannel(cfg, MessageBus())
+
+
+@pytest.mark.asyncio
+async def test_inbound_route_publishes_message_to_bus() -> None:
+    channel = _make_channel()
+
+    status, response = await channel.handle_http_request(
+        method="POST",
+        path="/v1/inbound",
+        headers={
+            "Content-Type": "application/json",
+            "x-webhook-sender-id": "did:example:sender",
+            "x-webhook-chat-id": "did:example:receiver",
+        },
+        body=b'{"content":"hello"}',
+        remote_addr="127.0.0.1:4567",
+    )
+
+    assert status == 202
+    assert response == {"status": "accepted"}
+
+    inbound = await asyncio.wait_for(channel.bus.consume_inbound(), timeout=1)
+    assert inbound.channel == "webhook"
+    assert inbound.sender_id == "did:example:sender"
+    assert inbound.chat_id == "did:example:receiver"
+    assert inbound.content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_outbound_route_forwards_to_connector(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = _make_channel()
+    captured: dict[str, str] = {}
+
+    async def fake_forward(payload: dict[str, str]) -> tuple[int, dict[str, str]]:
+        captured.update(payload)
+        return 202, {"status": "accepted"}
+
+    monkeypatch.setattr(channel, "_forward_to_connector", fake_forward)
+
+    status, response = await channel.handle_http_request(
+        method="POST",
+        path="/v1/outbound",
+        headers={"Content-Type": "application/json"},
+        body=b'{"to":"did:example:peer","content":"ping","peer":"alice"}',
+        remote_addr="127.0.0.1:4567",
+    )
+
+    assert status == 202
+    assert response == {"status": "accepted"}
+    assert captured == {
+        "to": "did:example:peer",
+        "content": "ping",
+        "peer": "alice",
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_uses_connector_forwarding(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = _make_channel()
+    captured: dict[str, str] = {}
+
+    async def fake_forward(payload: dict[str, str]) -> tuple[int, dict[str, str]]:
+        captured.update(payload)
+        return 202, {"status": "accepted"}
+
+    monkeypatch.setattr(channel, "_forward_to_connector", fake_forward)
+
+    await channel.send(
+        OutboundMessage(
+            channel="webhook",
+            chat_id="did:example:peer",
+            content="hello from nanobot",
+            metadata={"peer": "bob"},
+        )
+    )
+
+    assert captured == {
+        "to": "did:example:peer",
+        "content": "hello from nanobot",
+        "peer": "bob",
+    }
+
+
+@pytest.mark.asyncio
+async def test_token_auth_is_optional_but_enforced_when_configured() -> None:
+    channel = _make_channel(token="secret-token")
+
+    status, _ = await channel.handle_http_request(
+        method="POST",
+        path="/v1/inbound",
+        headers={"Content-Type": "application/json"},
+        body=b'{"content":"hello"}',
+        remote_addr="127.0.0.1:4567",
+    )
+    assert status == 403
+
+    status, response = await channel.handle_http_request(
+        method="POST",
+        path="/v1/inbound",
+        headers={
+            "Content-Type": "application/json",
+            "x-webhook-token": "secret-token",
+            "x-webhook-sender-id": "did:example:sender",
+        },
+        body=b'{"content":"hello"}',
+        remote_addr="127.0.0.1:4567",
+    )
+    assert status == 202
+    assert response == {"status": "accepted"}
+
+
+@pytest.mark.asyncio
+async def test_outbound_route_requires_to_and_content_fields() -> None:
+    channel = _make_channel()
+
+    status, _ = await channel.handle_http_request(
+        method="POST",
+        path="/v1/outbound",
+        headers={"Content-Type": "application/json"},
+        body=b'{"content":"hello"}',
+        remote_addr="127.0.0.1:4567",
+    )
+    assert status == 400
+
+    status, _ = await channel.handle_http_request(
+        method="POST",
+        path="/v1/outbound",
+        headers={"Content-Type": "application/json"},
+        body=b'{"to":"did:example:peer"}',
+        remote_addr="127.0.0.1:4567",
+    )
+    assert status == 400

--- a/tests/test_webhook_channel.py
+++ b/tests/test_webhook_channel.py
@@ -1,5 +1,7 @@
 import asyncio
+import contextlib
 
+import httpx
 import pytest
 
 from nanobot.bus.events import OutboundMessage
@@ -8,15 +10,21 @@ from nanobot.channels.webhook import WebhookChannel
 from nanobot.config.schema import WebhookConfig
 
 
-def _make_channel(*, token: str = "") -> WebhookChannel:
+def _make_channel(
+    *,
+    token: str = "",
+    allow_from: list[str] | None = None,
+    webhook_port: int = 18794,
+) -> WebhookChannel:
     cfg = WebhookConfig(
         enabled=True,
         webhook_host="127.0.0.1",
-        webhook_port=18794,
+        webhook_port=webhook_port,
         webhook_path="/v1/inbound",
         send_path="/v1/outbound",
         connector_url="http://127.0.0.1:19400/v1/outbound",
         token=token,
+        allow_from=list(allow_from or []),
     )
     return WebhookChannel(cfg, MessageBus())
 
@@ -128,6 +136,110 @@ async def test_token_auth_is_optional_but_enforced_when_configured() -> None:
     )
     assert status == 202
     assert response == {"status": "accepted"}
+
+
+@pytest.mark.asyncio
+async def test_bearer_auth_token_is_enforced_when_configured() -> None:
+    channel = _make_channel(token="secret-token")
+
+    status, response = await channel.handle_http_request(
+        method="POST",
+        path="/v1/inbound",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer secret-token",
+            "x-webhook-sender-id": "did:example:sender",
+        },
+        body=b'{"content":"hello"}',
+        remote_addr="127.0.0.1:4567",
+    )
+    assert status == 202
+    assert response == {"status": "accepted"}
+
+    status, _ = await channel.handle_http_request(
+        method="POST",
+        path="/v1/inbound",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer wrong-token",
+            "x-webhook-sender-id": "did:example:sender",
+        },
+        body=b'{"content":"hello"}',
+        remote_addr="127.0.0.1:4567",
+    )
+    assert status == 403
+
+
+@pytest.mark.asyncio
+async def test_inbound_route_enforces_allow_from_sender_ids() -> None:
+    channel = _make_channel(allow_from=["did:example:allowed"])
+
+    status, response = await channel.handle_http_request(
+        method="POST",
+        path="/v1/inbound",
+        headers={
+            "Content-Type": "application/json",
+            "x-webhook-sender-id": "did:example:allowed",
+        },
+        body=b'{"content":"hello"}',
+        remote_addr="127.0.0.1:4567",
+    )
+    assert status == 202
+    assert response == {"status": "accepted"}
+
+    status, response = await channel.handle_http_request(
+        method="POST",
+        path="/v1/inbound",
+        headers={
+            "Content-Type": "application/json",
+            "x-webhook-sender-id": "did:example:blocked",
+        },
+        body=b'{"content":"hello"}',
+        remote_addr="127.0.0.1:4567",
+    )
+    assert status == 403
+    assert response == {"error": "Sender not allowed"}
+
+
+@pytest.mark.asyncio
+async def test_webhook_server_start_and_stop_lifecycle() -> None:
+    channel = _make_channel(webhook_port=0)
+    start_task = asyncio.create_task(channel.start())
+
+    base_url = ""
+    for _ in range(40):
+        if channel._server is None:
+            await asyncio.sleep(0.05)
+            continue
+        host, port = channel._server.server_address
+        base_url = f"http://{host}:{port}"
+        try:
+            async with httpx.AsyncClient(timeout=0.5) as client:
+                response = await client.get(f"{base_url}/v1/inbound")
+            if response.status_code == 405:
+                break
+        except httpx.HTTPError:
+            pass
+        await asyncio.sleep(0.05)
+    else:
+        if not start_task.done():
+            start_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await start_task
+        pytest.fail("webhook server did not start listening in time")
+
+    await channel.stop()
+    await asyncio.wait_for(start_task, timeout=2)
+
+    for _ in range(40):
+        try:
+            async with httpx.AsyncClient(timeout=0.5) as client:
+                await client.get(f"{base_url}/v1/inbound")
+        except httpx.HTTPError:
+            break
+        await asyncio.sleep(0.05)
+    else:
+        pytest.fail("webhook server is still accepting connections after stop")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds a new generic **bidirectional webhook** channel for NanoBot.

The channel runs a local HTTP server with two routes on the same port:
- `POST /v1/inbound`: receives inbound relay messages and publishes them to NanoBot's message bus.
- `POST /v1/outbound`: accepts outbound payloads (`to`, `content`, `peer`) and forwards them to the local connector.

Default connector forward target:
- `http://127.0.0.1:19400/v1/outbound`

## What is Clawdentity?
[Clawdentity](https://github.com/vrknetha/clawdentity) is an open identity and messaging protocol for AI agents.

In this PR, Clawdentity is one **consumer** of the generic webhook channel. The same channel can also be used for:
- home automation webhooks
- CI/CD notifications
- inter-agent messaging bridges
- internal event fan-in pipelines

## Changes
- Added `WebhookChannel` (`nanobot/channels/webhook.py`) with bidirectional HTTP handling.
- Added `channels.webhook` config (`nanobot/config/schema.py`).
- Registered webhook channel in manager (`nanobot/channels/manager.py`).
- Updated README channel table and defaults.

## Request Validation / Auth
- Both routes require `POST` + `Content-Type: application/json` + valid JSON.
- Optional token auth via `x-webhook-token` or `Authorization` header.
- Optional sender allowlist via `allow_from` for inbound route.

## Validation
- `./.venv/bin/pip3 install -e ".[dev]"`
- `./.venv/bin/python -m pytest tests/test_webhook_channel.py`
- Result: `5 passed`
