### PR TITLE
cli: fail fast when explicit model provider is not configured

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -279,6 +279,31 @@ This file stores important information that should persist across sessions.
     skills_dir.mkdir(exist_ok=True)
 
 
+def _ensure_explicit_model_provider_configured(config: Config, model: str) -> None:
+    """Fail fast when model explicitly targets a provider without credentials."""
+    if model.startswith("bedrock/") or "/" not in model:
+        return
+
+    from nanobot.providers.registry import find_by_name
+
+    prefix = model.split("/", 1)[0].lower().replace("-", "_")
+    spec = find_by_name(prefix)
+    if not spec:
+        return
+
+    provider_cfg = getattr(config.providers, spec.name, None)
+    has_auth = spec.is_oauth or bool(provider_cfg and provider_cfg.api_key)
+    if has_auth:
+        return
+
+    console.print(f"[red]Error: Model '{model}' requires provider '{spec.name}'.[/red]")
+    console.print(
+        f"Set [cyan]providers.{spec.name}.apiKey[/cyan] in ~/.nanobot/config.json, "
+        "or switch to a model backed by a configured provider."
+    )
+    raise typer.Exit(1)
+
+
 def _make_provider(config: Config):
     """Create the appropriate LLM provider from config."""
     from nanobot.providers.litellm_provider import LiteLLMProvider
@@ -286,6 +311,7 @@ def _make_provider(config: Config):
     from nanobot.providers.custom_provider import CustomProvider
 
     model = config.agents.defaults.model
+    _ensure_explicit_model_provider_configured(config, model)
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,9 +3,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
-from nanobot.cli.commands import app
+from nanobot.cli.commands import (
+    _ensure_explicit_model_provider_configured,
+    _make_provider,
+    app,
+)
 from nanobot.config.schema import Config
 from nanobot.providers.litellm_provider import LiteLLMProvider
 from nanobot.providers.openai_codex_provider import _strip_model_prefix
@@ -128,3 +133,37 @@ def test_litellm_provider_canonicalizes_github_copilot_hyphen_prefix():
 def test_openai_codex_strip_prefix_supports_hyphen_and_underscore():
     assert _strip_model_prefix("openai-codex/gpt-5.1-codex") == "gpt-5.1-codex"
     assert _strip_model_prefix("openai_codex/gpt-5.1-codex") == "gpt-5.1-codex"
+
+
+def test_explicit_provider_model_requires_its_own_api_key():
+    config = Config()
+    config.agents.defaults.model = "anthropic/claude-opus-4-5"
+    config.providers.zhipu.api_key = "zhipu-key"
+
+    with pytest.raises(typer.Exit):
+        _ensure_explicit_model_provider_configured(config, config.agents.defaults.model)
+
+
+def test_explicit_provider_model_passes_when_key_is_set():
+    config = Config()
+    config.agents.defaults.model = "anthropic/claude-opus-4-5"
+    config.providers.anthropic.api_key = "anthropic-key"
+
+    _ensure_explicit_model_provider_configured(config, config.agents.defaults.model)
+
+
+def test_model_without_explicit_prefix_skips_strict_provider_check():
+    config = Config()
+    config.agents.defaults.model = "claude-opus-4-5"
+    config.providers.openrouter.api_key = "sk-or-v1-test"
+
+    _ensure_explicit_model_provider_configured(config, config.agents.defaults.model)
+
+
+def test_make_provider_fails_fast_on_explicit_prefix_mismatch():
+    config = Config()
+    config.agents.defaults.model = "anthropic/claude-opus-4-5"
+    config.providers.zhipu.api_key = "zhipu-key"
+
+    with pytest.raises(typer.Exit):
+        _make_provider(config)


### PR DESCRIPTION
## Summary

This PR adds a fail-fast precheck in CLI startup to catch explicit model/provider mismatches early.

Before this change, configs like `model=anthropic/...` with only `providers.zhipu.apiKey` set could fail later at runtime with a less actionable provider error.
Now the CLI exits early with a clear configuration message.

## What changed

- Added `_ensure_explicit_model_provider_configured(config, model)` in `nanobot/cli/commands.py`.
- Wired the precheck into `_make_provider(...)` before provider construction.
- Added tests in `tests/test_commands.py` for:
  - explicit provider mismatch -> exits early
  - explicit provider match -> passes
  - model without explicit provider prefix -> no strict block
  - `_make_provider` fail-fast behavior

## Why this approach

- Keeps behavior unchanged for normal fallback flows.
- Adds guardrails only when users explicitly select a provider-prefixed model.
- Improves startup error clarity and reduces support/debug time.

## Validation

### Automated tests

```bash
python -m pytest -q tests/test_commands.py
python -m pytest -q
```

### A/B manual verification

Use your local launcher (`nanobot`, `nb`, or a full executable path).
Below, `<nanobot_cmd>` means whichever command works in your environment.

#### Scenario A (guard case): explicit provider mismatch should fail fast

Config setup:
- `agents.defaults.model = anthropic/claude-opus-4-5`
- only `providers.zhipu.apiKey` is set

Command:

```bash
<nanobot_cmd> agent -m "hi"
```

Expected:
- immediate config error:
  - `Model 'anthropic/...' requires provider 'anthropic'`
  - prompt to set `providers.anthropic.apiKey` or switch model

<img width="908" height="75" alt="image" src="https://github.com/user-attachments/assets/9e556ab1-3f87-4dc7-a2f9-c1282e2def02" />


#### Scenario B (happy path): matched provider should proceed normally

Config setup:
- `agents.defaults.model = glm-4.7-flash`
- `providers.zhipu.apiKey` is set

Command:

```bash
<nanobot_cmd> agent -m "Please reply with exactly: startup test passed" --logs
```

Expected:
- normal response from model (for example: `startup test passed`)

<img width="921" height="195" alt="image" src="https://github.com/user-attachments/assets/0411a2d4-a53f-4af8-9b2e-fc7f6d6de0a8" />

## Notes

- No API/schema changes.
- No behavior change for users who do not use explicit provider-prefixed models.
