### PR TITLE
feat(providers): add Fireworks AI as a dedicated gateway provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ Config file: `~/.nanobot/config.json`
 | `groq` | LLM + **Voice transcription** (Whisper) | [console.groq.com](https://console.groq.com) |
 | `gemini` | LLM (Gemini direct) | [aistudio.google.com](https://aistudio.google.com) |
 | `minimax` | LLM (MiniMax direct) | [platform.minimax.io](https://platform.minimax.io) |
+| `fireworks` | LLM (Fireworks AI gateway) | [fireworks.ai](https://fireworks.ai) |
 | `aihubmix` | LLM (API gateway, access to all models) | [aihubmix.com](https://aihubmix.com) |
 | `siliconflow` | LLM (SiliconFlow/硅基流动) | [siliconflow.cn](https://siliconflow.cn) |
 | `volcengine` | LLM (VolcEngine/火山引擎) | [volcengine.com](https://www.volcengine.com) |

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -219,6 +219,7 @@ class ProvidersConfig(Base):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
+    fireworks: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动) API gateway
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎) API gateway

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -159,6 +159,27 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         model_overrides=(),
     ),
 
+    # Fireworks AI: gateway hosting models from many providers.
+    # User writes fireworks/deepseek-v3 → strip to deepseek-v3 → fireworks_ai/deepseek-v3.
+    ProviderSpec(
+        name="fireworks",
+        keywords=("fireworks",),
+        env_key="FIREWORKS_AI_API_KEY",
+        display_name="Fireworks AI",
+        litellm_prefix="fireworks_ai",
+        skip_prefixes=(),
+        env_extras=(),
+        is_gateway=True,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="fireworks",
+        default_api_base="https://api.fireworks.ai/inference/v1",
+        strip_model_prefix=True,
+        model_overrides=(),
+        supports_prompt_caching=True,
+        stream=True,
+    ),
+
     # === Standard providers (matched by model-name keywords) ===============
 
     # Anthropic: LiteLLM recognizes "claude-*" natively, no prefix needed.


### PR DESCRIPTION
## Summary
- Add Fireworks AI as a first-class gateway provider (`is_gateway=True`, `strip_model_prefix=True`)
- Fireworks hosts models from many vendors (DeepSeek, Llama, MiniMax, etc.), so gateway treatment prevents model-name keyword clashes (e.g. `deepseek-v3` being routed to the DeepSeek provider)
- Users write `fireworks/deepseek-v3` → resolved to `fireworks_ai/deepseek-v3` for LiteLLM

## Test plan
- [ ] `nanobot onboard` — confirm `fireworks` section appears in `~/.nanobot/config.json`
- [ ] Set `apiKey` under `providers.fireworks` and `model` to `fireworks/deepseek-v3`
- [ ] `nanobot agent -m "hello"` — confirm LiteLLM routes to `fireworks_ai/deepseek-v3`
- [ ] `nanobot status` — confirm "Fireworks AI" appears with key status

> **Note:** This PR depends on #992 for the `stream=True` support in `LiteLLMProvider` (Fireworks requires streaming for `max_tokens > 4096`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)