### PR TITLE
Preserve reasoning_content in message sanitization for thinking models

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -59,6 +59,7 @@ class AgentLoop:
         restrict_to_workspace: bool = False,
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
+        show_tool_progress: bool = True,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -73,6 +74,7 @@ class AgentLoop:
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
+        self.show_tool_progress = show_tool_progress
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
@@ -353,7 +355,7 @@ class AgentLoop:
             ))
 
         final_content, tools_used = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
+            initial_messages, on_progress=on_progress or (_bus_progress if self.show_tool_progress else None),
         )
 
         if final_content is None:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -368,6 +368,7 @@ def gateway(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
+        show_tool_progress=config.agents.defaults.show_tool_progress,
     )
     
     # Set cron callback (needs agent)
@@ -484,6 +485,7 @@ def agent(
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
+        show_tool_progress=config.agents.defaults.show_tool_progress,
     )
     
     # Show spinner when logs are off (no output to miss); skip when logs are on
@@ -934,6 +936,7 @@ def cron_run(
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
+        show_tool_progress=config.agents.defaults.show_tool_progress,
     )
 
     store_path = get_data_dir() / "cron" / "jobs.json"

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -188,6 +188,7 @@ class AgentDefaults(Base):
     temperature: float = 0.7
     max_tool_iterations: int = 20
     memory_window: int = 50
+    show_tool_progress: bool = True
 
 
 class AgentsConfig(Base):

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -13,7 +13,7 @@ from nanobot.providers.registry import find_by_model, find_gateway
 
 
 # Standard OpenAI chat-completion message keys; extras (e.g. reasoning_content) are stripped for strict providers.
-_ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name"})
+_ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content"})
 
 
 class LiteLLMProvider(LLMProvider):

--- a/tests/test_reasoning_content.py
+++ b/tests/test_reasoning_content.py
@@ -1,0 +1,116 @@
+"""Tests for reasoning_content preservation in message sanitization.
+
+Kimi K2.5 and DeepSeek-R1 return reasoning_content in assistant messages.
+When the model uses thinking/reasoning mode with tool calls, the API requires
+reasoning_content to be echoed back in subsequent requests. Stripping it
+causes: "thinking is enabled but reasoning_content is missing in assistant
+tool call message".
+"""
+
+from nanobot.providers.litellm_provider import LiteLLMProvider
+from nanobot.agent.context import ContextBuilder
+from pathlib import Path
+
+
+def test_sanitize_preserves_reasoning_content() -> None:
+    """reasoning_content must survive _sanitize_messages for thinking models."""
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is 2+2?"},
+        {
+            "role": "assistant",
+            "content": "The answer is 4.",
+            "reasoning_content": "Let me think... 2+2=4",
+        },
+    ]
+    sanitized = LiteLLMProvider._sanitize_messages(messages)
+    assistant_msg = sanitized[2]
+    assert assistant_msg["reasoning_content"] == "Let me think... 2+2=4"
+
+
+def test_sanitize_preserves_reasoning_content_with_tool_calls() -> None:
+    """reasoning_content on assistant tool-call messages must be preserved.
+
+    This is the exact scenario that triggers the Kimi error — the assistant
+    returns reasoning_content alongside tool_calls, and the next request
+    must include both.
+    """
+    messages = [
+        {"role": "user", "content": "Search for nanobot"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "I should search the web for nanobot info.",
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": '{"query": "nanobot"}'},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_123",
+            "name": "web_search",
+            "content": "nanobot is an AI assistant",
+        },
+    ]
+    sanitized = LiteLLMProvider._sanitize_messages(messages)
+    assistant_msg = sanitized[1]
+    assert "reasoning_content" in assistant_msg
+    assert assistant_msg["reasoning_content"] == "I should search the web for nanobot info."
+    assert "tool_calls" in assistant_msg
+
+
+def test_sanitize_still_strips_unknown_keys() -> None:
+    """Non-standard keys other than reasoning_content should still be stripped."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "hello",
+            "some_random_field": "should be removed",
+            "another_unknown": 42,
+        },
+    ]
+    sanitized = LiteLLMProvider._sanitize_messages(messages)
+    assert "some_random_field" not in sanitized[0]
+    assert "another_unknown" not in sanitized[0]
+    assert sanitized[0]["content"] == "hello"
+
+
+def test_sanitize_handles_missing_reasoning_content() -> None:
+    """Messages without reasoning_content should work as before (no regression)."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "thanks"},
+    ]
+    sanitized = LiteLLMProvider._sanitize_messages(messages)
+    assert len(sanitized) == 3
+    assert "reasoning_content" not in sanitized[1]
+    assert sanitized[1]["content"] == "hello"
+
+
+def test_context_builder_adds_reasoning_content() -> None:
+    """ContextBuilder.add_assistant_message should include reasoning_content."""
+    builder = ContextBuilder(Path("/tmp"))
+    messages: list = []
+
+    tool_calls = [
+        {"id": "call_1", "type": "function", "function": {"name": "exec", "arguments": "{}"}}
+    ]
+    messages = builder.add_assistant_message(
+        messages, "running command", tool_calls, reasoning_content="Let me run this command."
+    )
+    assert len(messages) == 1
+    assert messages[0]["reasoning_content"] == "Let me run this command."
+    assert messages[0]["tool_calls"] == tool_calls
+
+
+def test_context_builder_omits_reasoning_content_when_none() -> None:
+    """When reasoning_content is None, it should not appear in the message."""
+    builder = ContextBuilder(Path("/tmp"))
+    messages: list = []
+    messages = builder.add_assistant_message(messages, "hello", reasoning_content=None)
+    assert "reasoning_content" not in messages[0]


### PR DESCRIPTION
## Summary
- Fixes a crash with Kimi K2.5 (and DeepSeek-R1) where stripping `reasoning_content` from assistant messages caused: *"thinking is enabled but reasoning_content is missing in assistant tool call message"*
- The root cause was `_ALLOWED_MSG_KEYS` in `litellm_provider.py` excluding `reasoning_content`, so it was dropped on every outgoing request replay
- Also adds an `AgentDefaults.show_tool_progress` config flag (default: `true`) to allow operators to suppress mid-turn tool progress callbacks

## Changes
- `nanobot/providers/litellm_provider.py` — add `"reasoning_content"` to `_ALLOWED_MSG_KEYS`
- `nanobot/config/schema.py` — add `show_tool_progress: bool = True` to `AgentDefaults`
- `nanobot/agent/loop.py` — respect `show_tool_progress` flag when wiring progress callbacks
- `nanobot/cli/commands.py` — pass `show_tool_progress` from config to `AgentLoop` in gateway, agent, and cron commands
- `tests/test_reasoning_content.py` — 6 tests covering the exact Kimi error scenario (assistant with `reasoning_content` + `tool_calls`), unknown-key stripping, and `ContextBuilder` integration

## Test plan
- [x] All 69 tests pass (`pytest tests/ -q`)
- [x] Targeted tests cover the exact Kimi/DeepSeek-R1 error scenario