### PR TITLE
feat(cron): propagate channel metadata through cron jobs

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -140,7 +140,9 @@ class AgentLoop:
         finally:
             self._mcp_connecting = False
 
-    def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
+    def _set_tool_context(
+        self, channel: str, chat_id: str, message_id: str | None = None, metadata: dict | None = None
+    ) -> None:
         """Update context for all tools that need routing info."""
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
@@ -152,7 +154,7 @@ class AgentLoop:
 
         if cron_tool := self.tools.get("cron"):
             if isinstance(cron_tool, CronTool):
-                cron_tool.set_context(channel, chat_id)
+                cron_tool.set_context(channel, chat_id, metadata)
 
     @staticmethod
     def _strip_think(text: str | None) -> str | None:
@@ -307,7 +309,7 @@ class AgentLoop:
             logger.info("Processing system message from {}", msg.sender_id)
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
-            self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
+            self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"), msg.metadata)
             history = session.get_history(max_messages=self.memory_window)
             messages = self.context.build_messages(
                 history=history,
@@ -379,7 +381,7 @@ class AgentLoop:
             _task = asyncio.create_task(_consolidate_and_unlock())
             self._consolidation_tasks.add(_task)
 
-        self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
+        self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"), msg.metadata)
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -14,11 +14,13 @@ class CronTool(Tool):
         self._cron = cron_service
         self._channel = ""
         self._chat_id = ""
+        self._metadata: dict | None = None
     
-    def set_context(self, channel: str, chat_id: str) -> None:
+    def set_context(self, channel: str, chat_id: str, metadata: dict | None = None) -> None:
         """Set the current session context for delivery."""
         self._channel = channel
         self._chat_id = chat_id
+        self._metadata = metadata
     
     @property
     def name(self) -> str:
@@ -61,6 +63,10 @@ class CronTool(Tool):
                 "job_id": {
                     "type": "string",
                     "description": "Job ID (for remove)"
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Channel-specific metadata (e.g. {\"slack\": {\"thread_ts\": \"...\"}})"
                 }
             },
             "required": ["action"]
@@ -75,10 +81,11 @@ class CronTool(Tool):
         tz: str | None = None,
         at: str | None = None,
         job_id: str | None = None,
+        metadata: dict | None = None,
         **kwargs: Any
     ) -> str:
         if action == "add":
-            return self._add_job(message, every_seconds, cron_expr, tz, at)
+            return self._add_job(message, every_seconds, cron_expr, tz, at, metadata=metadata)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
@@ -92,6 +99,7 @@ class CronTool(Tool):
         cron_expr: str | None,
         tz: str | None,
         at: str | None,
+        metadata: dict | None = None,
     ) -> str:
         if not message:
             return "Error: message is required for add"
@@ -121,6 +129,14 @@ class CronTool(Tool):
         else:
             return "Error: either every_seconds, cron_expr, or at is required"
         
+        # Merge explicit metadata with session context metadata
+        effective_metadata = self._metadata
+        if metadata is not None:
+            if effective_metadata is not None:
+                effective_metadata = {**effective_metadata, **metadata}
+            else:
+                effective_metadata = metadata
+
         job = self._cron.add_job(
             name=message[:30],
             schedule=schedule,
@@ -129,6 +145,7 @@ class CronTool(Tool):
             channel=self._channel,
             to=self._chat_id,
             delete_after_run=delete_after,
+            metadata=effective_metadata,
         )
         return f"Created job '{job.name}' (id: {job.id})"
     

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -335,7 +335,8 @@ def gateway(
             await bus.publish_outbound(OutboundMessage(
                 channel=job.payload.channel or "cli",
                 chat_id=job.payload.to,
-                content=response or ""
+                content=response or "",
+                metadata=job.payload.metadata or {},
             ))
         return response
     cron.on_job = on_cron_job
@@ -838,15 +839,29 @@ def cron_add(
     deliver: bool = typer.Option(False, "--deliver", "-d", help="Deliver response to channel"),
     to: str = typer.Option(None, "--to", help="Recipient for delivery"),
     channel: str = typer.Option(None, "--channel", help="Channel for delivery (e.g. 'telegram', 'whatsapp')"),
+    metadata: str | None = typer.Option(None, "--metadata", help="Channel metadata as JSON (e.g. '{\"slack\": {\"thread_ts\": \"...\"}}')")
 ):
     """Add a scheduled job."""
     from nanobot.config.loader import get_data_dir
     from nanobot.cron.service import CronService
     from nanobot.cron.types import CronSchedule
     
+    import json as _json
+
     if tz and not cron_expr:
         console.print("[red]Error: --tz can only be used with --cron[/red]")
         raise typer.Exit(1)
+
+    parsed_metadata: dict | None = None
+    if metadata is not None:
+        try:
+            parsed_metadata = _json.loads(metadata)
+        except _json.JSONDecodeError as e:
+            console.print(f"[red]Error: Invalid JSON for --metadata: {e}[/red]")
+            raise typer.Exit(1) from e
+        if not isinstance(parsed_metadata, dict):
+            console.print("[red]Error: --metadata must be a JSON object[/red]")
+            raise typer.Exit(1)
 
     # Determine schedule type
     if every:
@@ -872,6 +887,7 @@ def cron_add(
             deliver=deliver,
             to=to,
             channel=channel,
+            metadata=parsed_metadata,
         )
     except ValueError as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -100,6 +100,7 @@ class CronService:
                             deliver=j["payload"].get("deliver", False),
                             channel=j["payload"].get("channel"),
                             to=j["payload"].get("to"),
+                            metadata=j["payload"].get("metadata"),
                         ),
                         state=CronJobState(
                             next_run_at_ms=j.get("state", {}).get("nextRunAtMs"),
@@ -147,6 +148,7 @@ class CronService:
                         "deliver": j.payload.deliver,
                         "channel": j.payload.channel,
                         "to": j.payload.to,
+                        "metadata": j.payload.metadata,
                     },
                     "state": {
                         "nextRunAtMs": j.state.next_run_at_ms,
@@ -283,6 +285,7 @@ class CronService:
         channel: str | None = None,
         to: str | None = None,
         delete_after_run: bool = False,
+        metadata: dict | None = None,
     ) -> CronJob:
         """Add a new job."""
         store = self._load_store()
@@ -300,6 +303,7 @@ class CronService:
                 deliver=deliver,
                 channel=channel,
                 to=to,
+                metadata=metadata,
             ),
             state=CronJobState(next_run_at_ms=_compute_next_run(schedule, now)),
             created_at_ms=now,

--- a/nanobot/cron/types.py
+++ b/nanobot/cron/types.py
@@ -27,6 +27,8 @@ class CronPayload:
     deliver: bool = False
     channel: str | None = None  # e.g. "whatsapp"
     to: str | None = None  # e.g. phone number
+    # Channel-specific metadata (e.g. thread_ts for Slack)
+    metadata: dict | None = None
 
 
 @dataclass


### PR DESCRIPTION
Pass channel-specific metadata (e.g. Slack thread_ts) from the originating message through to cron job payloads, so scheduled responses are delivered back to the correct thread or context.

The changes add a metadata field to CronPayload, thread it through CronTool, CronService, the agent loop's
_set_tool_context, the CLI's cron add command (--metadata flag), and the gateway's outbound publish.