### PR TITLE
feat(cli): Support set channel in Agent CLI

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -140,7 +140,9 @@ class AgentLoop:
         finally:
             self._mcp_connecting = False
 
-    def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
+    def _set_tool_context(
+        self, channel: str, chat_id: str, message_id: str | None = None, metadata: dict | None = None
+    ) -> None:
         """Update context for all tools that need routing info."""
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
@@ -152,7 +154,7 @@ class AgentLoop:
 
         if cron_tool := self.tools.get("cron"):
             if isinstance(cron_tool, CronTool):
-                cron_tool.set_context(channel, chat_id)
+                cron_tool.set_context(channel, chat_id, metadata)
 
     @staticmethod
     def _strip_think(text: str | None) -> str | None:
@@ -307,7 +309,7 @@ class AgentLoop:
             logger.info("Processing system message from {}", msg.sender_id)
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
-            self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
+            self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"), msg.metadata)
             history = session.get_history(max_messages=self.memory_window)
             messages = self.context.build_messages(
                 history=history,
@@ -379,7 +381,7 @@ class AgentLoop:
             _task = asyncio.create_task(_consolidate_and_unlock())
             self._consolidation_tasks.add(_task)
 
-        self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
+        self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"), msg.metadata)
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -14,11 +14,13 @@ class CronTool(Tool):
         self._cron = cron_service
         self._channel = ""
         self._chat_id = ""
+        self._metadata: dict | None = None
     
-    def set_context(self, channel: str, chat_id: str) -> None:
+    def set_context(self, channel: str, chat_id: str, metadata: dict | None = None) -> None:
         """Set the current session context for delivery."""
         self._channel = channel
         self._chat_id = chat_id
+        self._metadata = metadata
     
     @property
     def name(self) -> str:
@@ -61,6 +63,10 @@ class CronTool(Tool):
                 "job_id": {
                     "type": "string",
                     "description": "Job ID (for remove)"
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Channel-specific metadata (e.g. {\"slack\": {\"thread_ts\": \"...\"}})"
                 }
             },
             "required": ["action"]
@@ -75,10 +81,11 @@ class CronTool(Tool):
         tz: str | None = None,
         at: str | None = None,
         job_id: str | None = None,
+        metadata: dict | None = None,
         **kwargs: Any
     ) -> str:
         if action == "add":
-            return self._add_job(message, every_seconds, cron_expr, tz, at)
+            return self._add_job(message, every_seconds, cron_expr, tz, at, metadata=metadata)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
@@ -92,6 +99,7 @@ class CronTool(Tool):
         cron_expr: str | None,
         tz: str | None,
         at: str | None,
+        metadata: dict | None = None,
     ) -> str:
         if not message:
             return "Error: message is required for add"
@@ -121,6 +129,14 @@ class CronTool(Tool):
         else:
             return "Error: either every_seconds, cron_expr, or at is required"
         
+        # Merge explicit metadata with session context metadata
+        effective_metadata = self._metadata
+        if metadata is not None:
+            if effective_metadata is not None:
+                effective_metadata = {**effective_metadata, **metadata}
+            else:
+                effective_metadata = metadata
+
         job = self._cron.add_job(
             name=message[:30],
             schedule=schedule,
@@ -129,6 +145,7 @@ class CronTool(Tool):
             channel=self._channel,
             to=self._chat_id,
             delete_after_run=delete_after,
+            metadata=effective_metadata,
         )
         return f"Created job '{job.name}' (id: {job.id})"
     

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -57,7 +57,11 @@ class BaseChannel(ABC):
             msg: The message to send.
         """
         pass
-    
+
+    async def init_send(self) -> None:
+        """Initialize minimum state for send() without starting the listener."""
+        pass
+
     def is_allowed(self, sender_id: str) -> bool:
         """
         Check if a sender is allowed to use this bot.

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -30,6 +30,10 @@ class SlackChannel(BaseChannel):
         self._socket_client: SocketModeClient | None = None
         self._bot_user_id: str | None = None
 
+    async def init_send(self) -> None:
+        if not self._web_client and self.config.bot_token:
+            self._web_client = AsyncWebClient(token=self.config.bot_token)
+
     async def start(self) -> None:
         """Start the Slack Socket Mode client."""
         if not self.config.bot_token or not self.config.app_token:

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -126,7 +126,17 @@ class TelegramChannel(BaseChannel):
         self._app: Application | None = None
         self._chat_ids: dict[str, int] = {}  # Map sender_id to chat_id for replies
         self._typing_tasks: dict[str, asyncio.Task] = {}  # chat_id -> typing loop task
-    
+
+    async def init_send(self) -> None:
+        if self._app or not self.config.token:
+            return
+        req = HTTPXRequest(connection_pool_size=4, connect_timeout=30.0, read_timeout=30.0)
+        builder = Application.builder().token(self.config.token).request(req)
+        if self.config.proxy:
+            builder = builder.proxy(self.config.proxy)
+        self._app = builder.build()
+        await self._app.initialize()
+
     async def start(self) -> None:
         """Start the Telegram bot with long polling."""
         if not self.config.token:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -416,12 +416,29 @@ def gateway(
 # ============================================================================
 
 
+async def _init_channel_for_send(config, bus, channel_name):
+    """Instantiate a channel with just enough state to call send()."""
+    if channel_name == "slack":
+        from nanobot.channels.slack import SlackChannel
+        ch = SlackChannel(config.channels.slack, bus)
+    elif channel_name == "telegram":
+        from nanobot.channels.telegram import TelegramChannel
+        ch = TelegramChannel(config.channels.telegram, bus, groq_api_key=config.providers.groq.api_key)
+    else:
+        return None
+    await ch.init_send()
+    return ch
+
+
 @app.command()
 def agent(
     message: str = typer.Option(None, "--message", "-m", help="Message to send to the agent"),
     session_id: str = typer.Option("cli:direct", "--session", "-s", help="Session ID"),
     markdown: bool = typer.Option(True, "--markdown/--no-markdown", help="Render assistant output as Markdown"),
     logs: bool = typer.Option(False, "--logs/--no-logs", help="Show nanobot runtime logs during chat"),
+    channel: str = typer.Option(None, "--channel", help="Deliver response to channel (e.g. 'slack', 'telegram')"),
+    to: str = typer.Option(None, "--to", help="Recipient chat_id for channel delivery"),
+    metadata: str | None = typer.Option(None, "--metadata", help="Channel metadata as JSON (e.g. '{\"slack\": {\"thread_ts\": \"...\"}}')")
 ):
     """Interact with the agent directly."""
     from nanobot.config.loader import load_config, get_data_dir
@@ -429,8 +446,28 @@ def agent(
     from nanobot.agent.loop import AgentLoop
     from nanobot.cron.service import CronService
     from loguru import logger
-    
+
     config = load_config()
+
+    # Validate --channel / --to / --metadata flags
+    if channel and not to:
+        console.print("[red]Error: --channel requires --to[/red]")
+        raise typer.Exit(1)
+    if to and not channel:
+        console.print("[red]Error: --to requires --channel[/red]")
+        raise typer.Exit(1)
+
+    import json as _json
+    parsed_metadata: dict | None = None
+    if metadata is not None:
+        try:
+            parsed_metadata = _json.loads(metadata)
+        except _json.JSONDecodeError as e:
+            console.print(f"[red]Error: Invalid JSON for --metadata: {e}[/red]")
+            raise typer.Exit(1) from e
+        if not isinstance(parsed_metadata, dict):
+            console.print("[red]Error: --metadata must be a JSON object[/red]")
+            raise typer.Exit(1)
     
     bus = MessageBus()
     provider = _make_provider(config)
@@ -481,8 +518,30 @@ def agent(
         # Single message mode — direct call, no bus needed
         async def run_once():
             with _thinking_ctx():
-                response = await agent_loop.process_direct(message, session_id, on_progress=_cli_progress)
+                response = await agent_loop.process_direct(
+                    message,
+                    session_id,
+                    channel=channel or "cli",
+                    chat_id=to or "direct",
+                    on_progress=_cli_progress,
+                )
             _print_agent_response(response, render_markdown=markdown)
+
+            # Deliver to channel if requested
+            if channel and to:
+                from nanobot.bus.events import OutboundMessage
+                ch = await _init_channel_for_send(config, bus, channel)
+                if ch is None:
+                    console.print(f"[red]Error: Unknown channel '{channel}'[/red]")
+                else:
+                    await ch.send(OutboundMessage(
+                        channel=channel,
+                        chat_id=to,
+                        content=response or "",
+                        metadata=parsed_metadata or {},
+                    ))
+                    console.print(f"[green]✓[/green] Delivered to {channel}:{to}")
+
             await agent_loop.close_mcp()
 
         asyncio.run(run_once())

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -335,7 +335,8 @@ def gateway(
             await bus.publish_outbound(OutboundMessage(
                 channel=job.payload.channel or "cli",
                 chat_id=job.payload.to,
-                content=response or ""
+                content=response or "",
+                metadata=job.payload.metadata or {},
             ))
         return response
     cron.on_job = on_cron_job
@@ -838,15 +839,29 @@ def cron_add(
     deliver: bool = typer.Option(False, "--deliver", "-d", help="Deliver response to channel"),
     to: str = typer.Option(None, "--to", help="Recipient for delivery"),
     channel: str = typer.Option(None, "--channel", help="Channel for delivery (e.g. 'telegram', 'whatsapp')"),
+    metadata: str | None = typer.Option(None, "--metadata", help="Channel metadata as JSON (e.g. '{\"slack\": {\"thread_ts\": \"...\"}}')")
 ):
     """Add a scheduled job."""
     from nanobot.config.loader import get_data_dir
     from nanobot.cron.service import CronService
     from nanobot.cron.types import CronSchedule
     
+    import json as _json
+
     if tz and not cron_expr:
         console.print("[red]Error: --tz can only be used with --cron[/red]")
         raise typer.Exit(1)
+
+    parsed_metadata: dict | None = None
+    if metadata is not None:
+        try:
+            parsed_metadata = _json.loads(metadata)
+        except _json.JSONDecodeError as e:
+            console.print(f"[red]Error: Invalid JSON for --metadata: {e}[/red]")
+            raise typer.Exit(1) from e
+        if not isinstance(parsed_metadata, dict):
+            console.print("[red]Error: --metadata must be a JSON object[/red]")
+            raise typer.Exit(1)
 
     # Determine schedule type
     if every:
@@ -872,6 +887,7 @@ def cron_add(
             deliver=deliver,
             to=to,
             channel=channel,
+            metadata=parsed_metadata,
         )
     except ValueError as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -100,6 +100,7 @@ class CronService:
                             deliver=j["payload"].get("deliver", False),
                             channel=j["payload"].get("channel"),
                             to=j["payload"].get("to"),
+                            metadata=j["payload"].get("metadata"),
                         ),
                         state=CronJobState(
                             next_run_at_ms=j.get("state", {}).get("nextRunAtMs"),
@@ -147,6 +148,7 @@ class CronService:
                         "deliver": j.payload.deliver,
                         "channel": j.payload.channel,
                         "to": j.payload.to,
+                        "metadata": j.payload.metadata,
                     },
                     "state": {
                         "nextRunAtMs": j.state.next_run_at_ms,
@@ -283,6 +285,7 @@ class CronService:
         channel: str | None = None,
         to: str | None = None,
         delete_after_run: bool = False,
+        metadata: dict | None = None,
     ) -> CronJob:
         """Add a new job."""
         store = self._load_store()
@@ -300,6 +303,7 @@ class CronService:
                 deliver=deliver,
                 channel=channel,
                 to=to,
+                metadata=metadata,
             ),
             state=CronJobState(next_run_at_ms=_compute_next_run(schedule, now)),
             created_at_ms=now,

--- a/nanobot/cron/types.py
+++ b/nanobot/cron/types.py
@@ -27,6 +27,8 @@ class CronPayload:
     deliver: bool = False
     channel: str | None = None  # e.g. "whatsapp"
     to: str | None = None  # e.g. phone number
+    # Channel-specific metadata (e.g. thread_ts for Slack)
+    metadata: dict | None = None
 
 
 @dataclass


### PR DESCRIPTION
Allow `nanobot agent -m` to deliver responses to a channel (Slack, Telegram) with metadata, reusing the same OutboundMessage path as cron jobs. Adds init_send() to BaseChannel so channels can initialize just enough client state for sending without starting a full listener loop.

Useful for external scripts that need to report to a channel.