### PR TITLE
feat: add model parameter to subagent spawn

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -56,6 +56,7 @@ class SubagentManager:
         label: str | None = None,
         origin_channel: str = "cli",
         origin_chat_id: str = "direct",
+        model: str | None = None,
     ) -> str:
         """
         Spawn a subagent to execute a task in the background.
@@ -65,12 +66,15 @@ class SubagentManager:
             label: Optional human-readable label for the task.
             origin_channel: The channel to announce results to.
             origin_chat_id: The chat ID to announce results to.
+            model: Optional model override for this subagent. If not provided,
+                   uses the SubagentManager's default model.
         
         Returns:
             Status message indicating the subagent was started.
         """
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
+        effective_model = model or self.model
         
         origin = {
             "channel": origin_channel,
@@ -79,7 +83,7 @@ class SubagentManager:
         
         # Create background task
         bg_task = asyncio.create_task(
-            self._run_subagent(task_id, task, display_label, origin)
+            self._run_subagent(task_id, task, display_label, origin, effective_model)
         )
         self._running_tasks[task_id] = bg_task
         
@@ -95,9 +99,10 @@ class SubagentManager:
         task: str,
         label: str,
         origin: dict[str, str],
+        model: str,
     ) -> None:
         """Execute the subagent task and announce the result."""
-        logger.info("Subagent [{}] starting task: {}", task_id, label)
+        logger.info("Subagent [{}] starting task: {} (model: {})", task_id, label, model)
         
         try:
             # Build subagent tools (no message tool, no spawn tool)
@@ -133,7 +138,7 @@ class SubagentManager:
                 response = await self.provider.chat(
                     messages=messages,
                     tools=tools.get_definitions(),
-                    model=self.model,
+                    model=model,
                     temperature=self.temperature,
                     max_tokens=self.max_tokens,
                 )

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -35,7 +35,9 @@ class SpawnTool(Tool):
         return (
             "Spawn a subagent to handle a task in the background. "
             "Use this for complex or time-consuming tasks that can run independently. "
-            "The subagent will complete the task and report back when done."
+            "The subagent will complete the task and report back when done. "
+            "Optionally specify a 'model' to use a different LLM for this subagent "
+            "(e.g., use a more capable model for complex tasks)."
         )
     
     @property
@@ -51,15 +53,20 @@ class SpawnTool(Tool):
                     "type": "string",
                     "description": "Optional short label for the task (for display)",
                 },
+                "model": {
+                    "type": "string",
+                    "description": "Optional model override for this subagent (e.g., 'openrouter/anthropic/claude-3.5-sonnet' for complex tasks)",
+                },
             },
             "required": ["task"],
         }
     
-    async def execute(self, task: str, label: str | None = None, **kwargs: Any) -> str:
+    async def execute(self, task: str, label: str | None = None, model: str | None = None, **kwargs: Any) -> str:
         """Spawn a subagent to execute the given task."""
         return await self._manager.spawn(
             task=task,
             label=label,
             origin_channel=self._origin_channel,
             origin_chat_id=self._origin_chat_id,
+            model=model,
         )


### PR DESCRIPTION
## Summary

- Add optional `model` parameter to `SubagentManager.spawn()` and `SpawnTool.execute()`
- Subagents can now use a different LLM than the default agent model

## Motivation

Without this change, all subagents inherit the parent agent's default model. This makes cost-aware routing impossible — every task, regardless of complexity, uses the same LLM.

With the [intelligent-router](https://github.com/steipete/clawhub-skills/tree/main/skills/intelligent-router) skill, tasks can be classified by complexity (SIMPLE/COMPLEX) and routed to appropriate models. For example:

- Simple tasks (greetings, lookups) → free local vLLM model
- Complex tasks (debugging, architecture) → Claude Sonnet via OpenRouter

But the router can only recommend a model — it had no way to pass that recommendation to `spawn()`. This PR closes that gap.

## Changes

- **`nanobot/agent/subagent.py`**: `spawn()` and `_run_subagent()` accept an optional `model` parameter. Falls back to the manager's default model when not provided.
- **`nanobot/agent/tools/spawn.py`**: Exposes `model` as an optional parameter in the tool schema so the LLM can specify which model a subagent should use.

## Backward Compatibility

Fully backward-compatible. The `model` parameter is optional and defaults to the existing behavior when omitted.

## Test plan

- [ ] Spawn subagent without `model` parameter — should use default model (no change)
- [ ] Spawn subagent with `model` parameter — should use the specified model
- [ ] Verify tool schema includes `model` in the spawn tool definition


🤖 Generated with [Claude Code](https://claude.com/claude-code)