### PR TITLE
feat(providers): add Venice.ai provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ Config file: `~/.nanobot/config.json`
 | `groq` | LLM + **Voice transcription** (Whisper) | [console.groq.com](https://console.groq.com) |
 | `gemini` | LLM (Gemini direct) | [aistudio.google.com](https://aistudio.google.com) |
 | `minimax` | LLM (MiniMax direct) | [platform.minimaxi.com](https://platform.minimaxi.com) |
+| `venice` | LLM (Venice.ai gateway) | [venice.ai](https://venice.ai) |
 | `aihubmix` | LLM (API gateway, access to all models) | [aihubmix.com](https://aihubmix.com) |
 | `siliconflow` | LLM (SiliconFlow/硅基流动) | [siliconflow.cn](https://siliconflow.cn) |
 | `volcengine` | LLM (VolcEngine/火山引擎) | [volcengine.com](https://www.volcengine.com) |

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -219,6 +219,7 @@ class ProvidersConfig(Base):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
+    venice: ProviderConfig = Field(default_factory=ProviderConfig)  # Venice.ai gateway
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动) API gateway
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎) API gateway

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -159,6 +159,24 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         model_overrides=(),
     ),
 
+    # Venice.ai: privacy-focused gateway hosting open-source models.
+    ProviderSpec(
+        name="venice",
+        keywords=("venice",),
+        env_key="VENICE_API_KEY",
+        display_name="Venice.ai",
+        litellm_prefix="openai",            # OpenAI-compatible, no native LiteLLM support
+        skip_prefixes=(),
+        env_extras=(),
+        is_gateway=True,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="venice",
+        default_api_base="https://api.venice.ai/api/v1",
+        strip_model_prefix=True,
+        model_overrides=(),
+    ),
+
     # === Standard providers (matched by model-name keywords) ===============
 
     # Anthropic: LiteLLM recognizes "claude-*" natively, no prefix needed.


### PR DESCRIPTION
## Summary

- Add Venice.ai as a gateway provider (`is_gateway=True`, `strip_model_prefix=True`)