### PR TITLE
feat: add inline keyboard support for Telegram messages

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -65,6 +65,25 @@ class MessageTool(Tool):
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Optional: list of file paths to attach (images, audio, documents)"
+                },
+                "callback_id": {
+                    "type": "string",
+                    "description": "Optional: logical ID to group callback buttons (auto-generated if not provided)"
+                },
+                "inline_buttons": {
+                    "type": "array",
+                    "description": "Optional: inline buttons for Telegram. Format: [{\"id\": \"btn\", \"label\": \"Label\", \"data\": \"instructions\", \"metadata\": {...}}] or [{\"label\": \"Link\", \"url\": \"https://...\"}]",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string", "description": "Button identifier for callback"},
+                            "label": {"type": "string", "description": "Button text shown to user"},
+                            "data": {"type": "string", "description": "Instructions for the agent when button is clicked"},
+                            "metadata": {"type": "object", "description": "Additional structured data"},
+                            "url": {"type": "string", "description": "URL for link buttons (no callback)"}
+                        },
+                        "required": ["label"]
+                    }
                 }
             },
             "required": ["content"]
@@ -77,6 +96,8 @@ class MessageTool(Tool):
         chat_id: str | None = None,
         message_id: str | None = None,
         media: list[str] | None = None,
+        callback_id: str | None = None,
+        inline_buttons: list[dict] | None = None,
         **kwargs: Any
     ) -> str:
         channel = channel or self._default_channel
@@ -89,20 +110,26 @@ class MessageTool(Tool):
         if not self._send_callback:
             return "Error: Message sending not configured"
 
+        # Build metadata
+        metadata: dict[str, Any] = {"message_id": message_id}
+        if callback_id:
+            metadata["callback_id"] = callback_id
+        if inline_buttons:
+            metadata["inline_buttons"] = inline_buttons
+
         msg = OutboundMessage(
             channel=channel,
             chat_id=chat_id,
             content=content,
             media=media or [],
-            metadata={
-                "message_id": message_id,
-            }
+            metadata=metadata
         )
 
         try:
             await self._send_callback(msg)
             self._sent_in_turn = True
             media_info = f" with {len(media)} attachments" if media else ""
-            return f"Message sent to {channel}:{chat_id}{media_info}"
+            buttons_info = f" with {len(inline_buttons)} inline buttons" if inline_buttons else ""
+            return f"Message sent to {channel}:{chat_id}{media_info}{buttons_info}"
         except Exception as e:
             return f"Error sending message: {str(e)}"

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -557,6 +557,11 @@ class TelegramChannel(BaseChannel):
         query = update.callback_query
         await query.answer()
         
+        # Check if message still exists (may have been deleted)
+        if not query.message:
+            logger.warning("Callback query received but message was deleted")
+            return
+        
         # Parse callback_data: "callback_id:button_id"
         parts = query.data.split(":", 1)
         if len(parts) != 2:

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import re
+from uuid import uuid4
 from loguru import logger
-from telegram import BotCommand, Update, ReplyParameters
-from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
+from telegram import BotCommand, Update, ReplyParameters, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import Application, CommandHandler, MessageHandler, CallbackQueryHandler, filters, ContextTypes
 from telegram.request import HTTPXRequest
 
 from nanobot.bus.events import OutboundMessage
@@ -127,6 +128,7 @@ class TelegramChannel(BaseChannel):
         self._app: Application | None = None
         self._chat_ids: dict[str, int] = {}  # Map sender_id to chat_id for replies
         self._typing_tasks: dict[str, asyncio.Task] = {}  # chat_id -> typing loop task
+        self._pending_callbacks: dict[str, dict] = {}  # callback_id -> {buttons, message_ids}
     
     async def start(self) -> None:
         """Start the Telegram bot with long polling."""
@@ -158,6 +160,9 @@ class TelegramChannel(BaseChannel):
             )
         )
         
+        # Add callback query handler for inline button clicks
+        self._app.add_handler(CallbackQueryHandler(self._on_callback_query))
+        
         logger.info("Starting Telegram bot (polling mode)...")
         
         # Initialize and start polling
@@ -176,7 +181,7 @@ class TelegramChannel(BaseChannel):
         
         # Start polling (this runs until stopped)
         await self._app.updater.start_polling(
-            allowed_updates=["message"],
+            allowed_updates=["message", "callback_query"],
             drop_pending_updates=True  # Ignore old messages on startup
         )
         
@@ -234,6 +239,18 @@ class TelegramChannel(BaseChannel):
                     allow_sending_without_reply=True
                 )
 
+        # Build inline keyboard from metadata
+        reply_markup = None
+        callback_id = None
+        inline_buttons = msg.metadata.get("inline_buttons")
+        if inline_buttons:
+            # Get or generate callback_id
+            callback_id = msg.metadata.get("callback_id")
+            if not callback_id:
+                callback_id = uuid4().hex[:8]
+            reply_markup = self._build_inline_keyboard(inline_buttons, callback_id)
+            logger.debug("Sending message with inline keyboard: {} callback_id={}", inline_buttons, callback_id)
+
         # Send media files
         for media_path in (msg.media or []):
             try:
@@ -256,7 +273,8 @@ class TelegramChannel(BaseChannel):
                 await self._app.bot.send_message(
                     chat_id=chat_id,
                     text=f"[Failed to send: {filename}]",
-                    reply_parameters=reply_params
+                    reply_parameters=reply_params,
+                    reply_markup=reply_markup
                 )
 
         # Send text content
@@ -264,20 +282,27 @@ class TelegramChannel(BaseChannel):
             for chunk in _split_message(msg.content):
                 try:
                     html = _markdown_to_telegram_html(chunk)
-                    await self._app.bot.send_message(
+                    sent_msg = await self._app.bot.send_message(
                         chat_id=chat_id, 
                         text=html, 
                         parse_mode="HTML",
-                        reply_parameters=reply_params
+                        reply_parameters=reply_params,
+                        reply_markup=reply_markup
                     )
+                    # Store button definitions for callback handling
+                    if inline_buttons and sent_msg:
+                        self._store_callback(callback_id, inline_buttons, sent_msg.message_id)
                 except Exception as e:
                     logger.warning("HTML parse failed, falling back to plain text: {}", e)
                     try:
-                        await self._app.bot.send_message(
+                        sent_msg = await self._app.bot.send_message(
                             chat_id=chat_id, 
                             text=chunk,
-                            reply_parameters=reply_params
+                            reply_parameters=reply_params,
+                            reply_markup=reply_markup
                         )
+                        if inline_buttons and sent_msg:
+                            self._store_callback(callback_id, inline_buttons, sent_msg.message_id)
                     except Exception as e2:
                         logger.error("Error sending Telegram message: {}", e2)
     
@@ -457,3 +482,109 @@ class TelegramChannel(BaseChannel):
         
         type_map = {"image": ".jpg", "voice": ".ogg", "audio": ".mp3", "file": ""}
         return type_map.get(media_type, "")
+
+    def _build_inline_keyboard(self, buttons: list[dict], callback_id: str) -> InlineKeyboardMarkup | None:
+        """Build InlineKeyboardMarkup from button definitions.
+        
+        Button format:
+        [
+            {"id": "btn_id", "label": "Button Text", "data": "instructions", "metadata": {...}},
+            {"label": "URL Button", "url": "https://example.com"}
+        ]
+        Or with rows:
+        [
+            [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+            [{"label": "Website", "url": "https://example.com"}]
+        ]
+        """
+        if not buttons:
+            return None
+        
+        keyboard: list[list[InlineKeyboardButton]] = []
+        
+        for item in buttons:
+            if isinstance(item, list):
+                row = []
+                for btn in item:
+                    row.append(self._create_button(btn, callback_id))
+                keyboard.append(row)
+            elif isinstance(item, dict):
+                keyboard.append([self._create_button(item, callback_id)])
+        
+        return InlineKeyboardMarkup(inline_keyboard=keyboard) if keyboard else None
+    
+    def _create_button(self, btn: dict, callback_id: str) -> InlineKeyboardButton:
+        """Create an InlineKeyboardButton from a dict."""
+        text = btn.get("label", btn.get("text", ""))
+        
+        if "url" in btn:
+            return InlineKeyboardButton(text=text, url=btn["url"])
+        else:
+            # Callback button: encode as "callback_id:button_id"
+            button_id = btn.get("id", text.lower().replace(" ", "_"))
+            callback_data = f"{callback_id}:{button_id}"
+            return InlineKeyboardButton(text=text, callback_data=callback_data)
+
+    def _store_callback(self, callback_id: str, buttons: list[dict], message_id: int) -> None:
+        """Store button definitions for callback handling."""
+        if callback_id not in self._pending_callbacks:
+            self._pending_callbacks[callback_id] = {
+                "buttons": {},
+                "message_ids": []
+            }
+        
+        # Store each button by its id
+        for item in buttons:
+            if isinstance(item, list):
+                for btn in item:
+                    if isinstance(btn, dict) and "id" in btn:
+                        self._pending_callbacks[callback_id]["buttons"][btn["id"]] = btn
+            elif isinstance(item, dict) and "id" in item:
+                self._pending_callbacks[callback_id]["buttons"][item["id"]] = item
+        
+        self._pending_callbacks[callback_id]["message_ids"].append(message_id)
+        logger.debug("Stored callback {} with message_id={}", callback_id, message_id)
+
+    def _get_callback(self, callback_id: str, button_id: str) -> dict | None:
+        """Retrieve button definition for a callback."""
+        cb = self._pending_callbacks.get(callback_id)
+        if cb:
+            return cb["buttons"].get(button_id)
+        return None
+
+    async def _on_callback_query(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle inline button clicks."""
+        query = update.callback_query
+        await query.answer()
+        
+        # Parse callback_data: "callback_id:button_id"
+        parts = query.data.split(":", 1)
+        if len(parts) != 2:
+            logger.warning("Invalid callback_data format: {}", query.data)
+            return
+        
+        callback_id, button_id = parts
+        button_def = self._get_callback(callback_id, button_id)
+        
+        if not button_def:
+            logger.warning("Callback not found: {} / {}", callback_id, button_id)
+            button_def = {"id": button_id, "label": query.data}
+        
+        # Build metadata for agent
+        sender_id = self._sender_id(query.from_user)
+        chat_id = str(query.message.chat_id)
+        
+        await self._handle_message(
+            sender_id=sender_id,
+            chat_id=chat_id,
+            content="",
+            metadata={
+                "event_type": "callback_query",
+                "callback_id": callback_id,
+                "button": button_def,
+                "message_id": query.message.message_id,
+                "user_id": query.from_user.id,
+                "username": query.from_user.username,
+                "first_name": query.from_user.first_name,
+            }
+        )

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -575,6 +575,17 @@ class TelegramChannel(BaseChannel):
             logger.warning("Callback not found: {} / {}", callback_id, button_id)
             button_def = {"id": button_id, "label": query.data}
         
+        # Build content for agent
+        button_label = button_def.get("label", button_id)
+        button_data = button_def.get("data", "")
+        button_meta = button_def.get("metadata", {})
+        
+        content = f"[CALLBACK] Button clicked: \"{button_label}\" (id: {button_id})"
+        if button_data:
+            content += f"\nInstruction: {button_data}"
+        if button_meta:
+            content += f"\nData: {button_meta}"
+        
         # Build metadata for agent
         sender_id = self._sender_id(query.from_user)
         chat_id = str(query.message.chat_id)
@@ -582,7 +593,7 @@ class TelegramChannel(BaseChannel):
         await self._handle_message(
             sender_id=sender_id,
             chat_id=chat_id,
-            content="",
+            content=content,
             metadata={
                 "event_type": "callback_query",
                 "callback_id": callback_id,


### PR DESCRIPTION
## Summary

This PR adds native inline keyboard support for Telegram messages, allowing nanobot to send messages with interactive buttons and receive callbacks when users click them.

## Motivation

Enables richer user interactions through:
- Confirmation dialogs (Yes/No, Approve/Reject)
- Quick action buttons for reminders/tasks
- URL links alongside messages
- Multi-row button layouts

## Changes

### `nanobot/channels/telegram.py`
- Added `CallbackQueryHandler` for receiving button click callbacks
- Added `_pending_callbacks` in-memory storage for button definitions
- Added `callback_query` to `allowed_updates` in polling
- Added `_store_callback()`, `_get_callback()`, `_on_callback_query()` methods
- Updated `_build_inline_keyboard()` and `_create_button()` for new button format
- Added null check for deleted messages in callback handler

### `nanobot/agent/tools/message.py`
- Added `inline_buttons` parameter for defining interactive buttons
- Added `callback_id` parameter for grouping buttons across messages

### `workspace/TOOLS.md`
- Documented the `message` tool with new parameters
- Added inline buttons section with usage examples
- Added callback handling documentation for the agent

## Usage

### Sending a message with inline buttons

```python
message(
    content="Reminder: Drink water!",
    channel="telegram",
    chat_id="6176528759",
    callback_id="reminder_001",
    inline_buttons=[
        {"id": "done", "label": "✅ Done", "data": "Mark this as completed"},
        {"id": "snooze", "label": "⏰ Snooze", "data": "Remind me in 10 minutes"}
    ]
)
```

### Button format

```python
# Callback button (triggers callback to agent)
{"id": "approve", "label": "✅ Approve", "data": "Instructions", "metadata": {...}}

# URL button (opens link, no callback)
{"label": "Help", "url": "https://example.com"}

# Row layouts (multiple buttons per row)
[
    [{"id": "yes", "label": "Yes"}, {"id": "no", "label": "No"}],
    [{"label": "Help", "url": "..."}]
]
```

### Receiving callbacks

When a user clicks a button, the agent receives an InboundMessage with:
- `content`: structured message indicating which button was clicked
- `metadata.event_type`: `"callback_query"`
- `metadata.callback_id`: the group identifier
- `metadata.button`: `{id, label, data, metadata}`

The agent should check `metadata.event_type == "callback_query"` to handle button clicks.

## callback_id Design

The `callback_id` is a **message-level** identifier that groups buttons:
- Multiple messages can share the same `callback_id` (e.g., recurring reminders)
- Each button has its own `id` within the group
- Telegram receives `callback_data` as `"callback_id:button_id"` (fits in 64 bytes)
- If not provided, a short UUID is auto-generated

## Tested

Working in production on a personal nanobot instance.