### PR TITLE
fix: delete media files after processing to prevent unbounded disk growth

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -411,6 +411,14 @@ class AgentLoop:
             channel=msg.channel, chat_id=msg.chat_id,
         )
 
+        # Media files have been encoded to base64 by build_messages;
+        # delete them from disk so ~/.nanobot/media/ doesn't grow unbounded.
+        for media_path in (msg.media or []):
+            try:
+                Path(media_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
             meta = dict(msg.metadata or {})
             meta["_progress"] = True

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -411,14 +411,6 @@ class AgentLoop:
             channel=msg.channel, chat_id=msg.chat_id,
         )
 
-        # Media files have been encoded to base64 by build_messages;
-        # delete them from disk so ~/.nanobot/media/ doesn't grow unbounded.
-        for media_path in (msg.media or []):
-            try:
-                Path(media_path).unlink(missing_ok=True)
-            except OSError:
-                pass
-
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
             meta = dict(msg.metadata or {})
             meta["_progress"] = True
@@ -430,6 +422,20 @@ class AgentLoop:
         final_content, _, all_msgs = await self._run_agent_loop(
             initial_messages, on_progress=on_progress or _bus_progress,
         )
+
+        # Media files were encoded to base64 by build_messages above and
+        # may also have been referenced by tool calls during the agent loop.
+        # Clean up now that all processing is done so ~/.nanobot/media/
+        # doesn't grow unbounded.  Only delete files inside the expected
+        # media directory for safety.
+        media_dir = Path.home() / ".nanobot" / "media"
+        for media_path in (msg.media or []):
+            try:
+                p = Path(media_path).resolve()
+                p.relative_to(media_dir)
+                p.unlink(missing_ok=True)
+            except (OSError, ValueError):
+                pass
 
         if final_content is None:
             final_content = "I've completed processing but have no response to give."


### PR DESCRIPTION
## Summary

- Media files downloaded by Telegram, Discord, and Feishu channels to `~/.nanobot/media/` are never cleaned up, causing unbounded disk growth
- After `build_messages` encodes images to base64 in memory, the on-disk files are no longer needed
- This PR deletes media files immediately after message construction in the agent loop — a single cleanup point that covers all channels

## Details

The media lifecycle:
1. Channel downloads file to `~/.nanobot/media/` (telegram.py, discord.py, feishu.py)
2. Path is passed via message bus to agent loop
3. `context.build_messages` → `_build_user_content` reads files and encodes images to base64
4. **Files are no longer needed** ← cleanup happens here now

The cleanup is intentionally simple: iterate `msg.media`, call `Path.unlink(missing_ok=True)`, silently ignore errors. This avoids complexity (no background tasks, no TTL, no config) while fully solving the leak.

## Test plan

- [ ] Send photo/voice/document to Telegram bot, verify response works normally
- [ ] Verify `~/.nanobot/media/` does not accumulate files after processing
- [ ] Send attachment via Discord, verify same behavior
- [ ] Verify non-media messages (text only) are unaffected

Closes #896