### PR TITLE
fix: break Discord typing loop on persistent HTTP failure

### DIFF
--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -285,8 +285,11 @@ class DiscordChannel(BaseChannel):
             while self._running:
                 try:
                     await self._http.post(url, headers=headers)
-                except Exception:
-                    pass
+                except asyncio.CancelledError:
+                    return
+                except Exception as e:
+                    logger.debug("Discord typing indicator failed for {}: {}", channel_id, e)
+                    return
                 await asyncio.sleep(8)
 
         self._typing_tasks[channel_id] = asyncio.create_task(typing_loop())


### PR DESCRIPTION
## Summary

- The Discord typing indicator loop catches all exceptions with bare `except: pass`
- If the HTTP client has a permanent failure (closed, auth error, network down), the loop spins every 8 seconds doing nothing until the channel is explicitly stopped
- This wastes resources and floods logs silently
- Fix: log the error at debug level and exit the loop, letting the task clean up naturally

## Test plan

- [ ] Verify typing indicator appears normally during message processing
- [ ] Verify typing indicator stops after response is sent
- [ ] Verify that if Discord API returns persistent errors, the typing loop exits cleanly instead of spinning