### PR TITLE
Added Environment Variable to allow overriding default model timeout for commodity (HOME use) GPU card as of slower reponses

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -37,6 +37,7 @@ class LiteLLMProvider(LLMProvider):
         # provider_name (from config key) is the primary signal;
         # api_key / api_base are fallback for auto-detection.
         self._gateway = find_gateway(provider_name, api_key, api_base)
+        self.llm_timeout = int(os.getenv("LLM_TIMEOUT", 600))
         
         # Configure environment variables
         if api_key:
@@ -136,6 +137,9 @@ class LiteLLMProvider(LLMProvider):
         
         # Apply model-specific overrides (e.g. kimi-k2.5 temperature)
         self._apply_model_overrides(model, kwargs)
+
+        # Add timeout for LLM
+            kwargs["timeout"] = self.llm_timeout
         
         # Pass api_key directly — more reliable than env vars alone
         if self.api_key:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -37,7 +37,10 @@ class LiteLLMProvider(LLMProvider):
         # provider_name (from config key) is the primary signal;
         # api_key / api_base are fallback for auto-detection.
         self._gateway = find_gateway(provider_name, api_key, api_base)
-        self.llm_timeout = int(os.getenv("LLM_TIMEOUT", 600))
+        try:
+            self.llm_timeout = int(os.getenv("LLM_TIMEOUT", 600))
+        except ValueError:
+            self.llm_timeout = 600  # Fallback to default if env var is not a number
         
         # Configure environment variables
         if api_key:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -139,7 +139,7 @@ class LiteLLMProvider(LLMProvider):
         self._apply_model_overrides(model, kwargs)
 
         # Add timeout for LLM
-            kwargs["timeout"] = self.llm_timeout
+        kwargs["timeout"] = self.llm_timeout
         
         # Pass api_key directly — more reliable than env vars alone
         if self.api_key:


### PR DESCRIPTION
Added Environment Variable to allow overriding default model timeout for commodity (HOME use) GPU card as of slower reponses

New environment Vairable LLM_TIMEOUT, which defaults to 600 (the factory default of litellm), user can override it if they are using say, CPU or slower GPUs in order to allow the agent being able to process their request, even in a very slow manner. 