### PR TITLE
feat(subagent): control plane MVP (list/kill)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -318,7 +318,8 @@ class AgentLoop:
         session = self.sessions.get_or_create(key)
 
         # Slash commands
-        cmd = msg.content.strip().lower()
+        raw_cmd = msg.content.strip()
+        cmd = raw_cmd.lower()
         if cmd == "/new":
             lock = self._get_consolidation_lock(session.key)
             self._consolidating.add(session.key)
@@ -348,9 +349,51 @@ class AgentLoop:
             self.sessions.invalidate(session.key)
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
                                   content="New session started.")
+        if cmd in {"/subagent list", "/subagent ls", "/subagents"}:
+            running = self.subagents.list_running()
+            if not running:
+                return OutboundMessage(
+                    channel=msg.channel,
+                    chat_id=msg.chat_id,
+                    content="No running subagents.",
+                )
+
+            lines = ["Running subagents:"]
+            for item in running:
+                lines.append(
+                    f"- {item['id']} | {item['label']} | {item['status']} | started {item['started_at']}"
+                )
+            return OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content="\n".join(lines),
+            )
+        if cmd.startswith("/subagent kill"):
+            parts = raw_cmd.split(maxsplit=2)
+            if len(parts) < 3 or not parts[2].strip():
+                return OutboundMessage(
+                    channel=msg.channel,
+                    chat_id=msg.chat_id,
+                    content="Usage: /subagent kill <id>",
+                )
+            _, status_text = await self.subagents.kill(parts[2].strip())
+            return OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content=status_text,
+            )
         if cmd == "/help":
-            return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
-                                  content="🐈 nanobot commands:\n/new — Start a new conversation\n/help — Show available commands")
+            return OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content=(
+                    "🐈 nanobot commands:\n"
+                    "/new — Start a new conversation\n"
+                    "/help — Show available commands\n"
+                    "/subagent list — List running subagents\n"
+                    "/subagent kill <id> — Cancel a running subagent"
+                ),
+            )
 
         if len(session.messages) > self.memory_window and session.key not in self._consolidating:
             self._consolidating.add(session.key)

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +50,7 @@ class SubagentManager:
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
+        self._task_meta: dict[str, dict[str, str]] = {}
     
     async def spawn(
         self,
@@ -71,6 +73,7 @@ class SubagentManager:
         """
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
+        started_at = datetime.now(timezone.utc).isoformat()
         
         origin = {
             "channel": origin_channel,
@@ -82,10 +85,19 @@ class SubagentManager:
             self._run_subagent(task_id, task, display_label, origin)
         )
         self._running_tasks[task_id] = bg_task
-        
+        self._task_meta[task_id] = {
+            "label": display_label,
+            "task": task,
+            "started_at": started_at,
+        }
+
         # Cleanup when done
-        bg_task.add_done_callback(lambda _: self._running_tasks.pop(task_id, None))
-        
+        def _cleanup(_: asyncio.Task[None]) -> None:
+            self._running_tasks.pop(task_id, None)
+            self._task_meta.pop(task_id, None)
+
+        bg_task.add_done_callback(_cleanup)
+
         logger.info("Spawned subagent [{}]: {}", task_id, display_label)
         return f"Subagent [{display_label}] started (id: {task_id}). I'll notify you when it completes."
     
@@ -254,4 +266,55 @@ When you have completed the task, provide a clear summary of your findings or ac
     
     def get_running_count(self) -> int:
         """Return the number of currently running subagents."""
-        return len(self._running_tasks)
+        return len(self.list_running())
+
+    def list_running(self) -> list[dict[str, str]]:
+        """List currently running subagents and their metadata."""
+        running: list[dict[str, str]] = []
+        stale_ids: list[str] = []
+
+        for task_id, bg_task in self._running_tasks.items():
+            if bg_task.done():
+                stale_ids.append(task_id)
+                continue
+
+            meta = self._task_meta.get(task_id, {})
+            running.append({
+                "id": task_id,
+                "label": meta.get("label", ""),
+                "task": meta.get("task", ""),
+                "status": "running",
+                "started_at": meta.get("started_at", ""),
+            })
+
+        for task_id in stale_ids:
+            self._running_tasks.pop(task_id, None)
+            self._task_meta.pop(task_id, None)
+
+        running.sort(key=lambda item: item.get("started_at", ""))
+        return running
+
+    async def kill(self, task_id: str) -> tuple[bool, str]:
+        """Cancel a running subagent by task id."""
+        bg_task = self._running_tasks.get(task_id)
+        if bg_task is None:
+            return False, f"Subagent [{task_id}] not found."
+
+        if bg_task.done():
+            self._running_tasks.pop(task_id, None)
+            self._task_meta.pop(task_id, None)
+            return False, f"Subagent [{task_id}] is already finished."
+
+        bg_task.cancel()
+        try:
+            await bg_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.warning("Subagent [{}] raised while cancelling: {}", task_id, e)
+        finally:
+            self._running_tasks.pop(task_id, None)
+            self._task_meta.pop(task_id, None)
+
+        logger.info("Cancelled subagent [{}]", task_id)
+        return True, f"Subagent [{task_id}] cancelled."

--- a/tests/test_subagent_control.py
+++ b/tests/test_subagent_control.py
@@ -1,0 +1,151 @@
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.subagent import SubagentManager
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse
+
+
+def _make_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.chat = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+    return provider
+
+
+def _make_manager(tmp_path: Path) -> SubagentManager:
+    return SubagentManager(
+        provider=_make_provider(),
+        workspace=tmp_path,
+        bus=MessageBus(),
+        model="test-model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_subagent_list_returns_empty_when_no_tasks(tmp_path: Path) -> None:
+    manager = _make_manager(tmp_path)
+    assert manager.list_running() == []
+
+
+@pytest.mark.asyncio
+async def test_subagent_list_includes_running_tasks(tmp_path: Path) -> None:
+    manager = _make_manager(tmp_path)
+    task_id = "abc12345"
+    sleeper = asyncio.create_task(asyncio.sleep(60))
+    manager._running_tasks[task_id] = sleeper
+    manager._task_meta[task_id] = {
+        "label": "demo",
+        "task": "do work",
+        "started_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    try:
+        running = manager.list_running()
+        assert len(running) == 1
+        assert running[0]["id"] == task_id
+        assert running[0]["label"] == "demo"
+        assert running[0]["status"] == "running"
+    finally:
+        sleeper.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await sleeper
+
+
+@pytest.mark.asyncio
+async def test_subagent_kill_success(tmp_path: Path) -> None:
+    manager = _make_manager(tmp_path)
+    task_id = "deadbeef"
+    sleeper = asyncio.create_task(asyncio.sleep(60))
+    manager._running_tasks[task_id] = sleeper
+    manager._task_meta[task_id] = {
+        "label": "demo",
+        "task": "do work",
+        "started_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    ok, message = await manager.kill(task_id)
+
+    assert ok is True
+    assert "cancel" in message.lower()
+    assert task_id not in manager._running_tasks
+    assert task_id not in manager._task_meta
+
+
+@pytest.mark.asyncio
+async def test_subagent_kill_nonexistent_task(tmp_path: Path) -> None:
+    manager = _make_manager(tmp_path)
+    ok, message = await manager.kill("missing")
+    assert ok is False
+    assert "not found" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_subagent_kill_handles_race_with_completed_task(tmp_path: Path) -> None:
+    manager = _make_manager(tmp_path)
+    task_id = "facefeed"
+    done_task = asyncio.create_task(asyncio.sleep(0))
+    manager._running_tasks[task_id] = done_task
+    manager._task_meta[task_id] = {
+        "label": "demo",
+        "task": "do work",
+        "started_at": "2026-01-01T00:00:00+00:00",
+    }
+    await done_task
+
+    ok, message = await manager.kill(task_id)
+
+    assert ok is False
+    assert "already" in message.lower()
+    assert task_id not in manager._running_tasks
+    assert task_id not in manager._task_meta
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_subagent_list_command_bypasses_model(tmp_path: Path) -> None:
+    bus = MessageBus()
+    provider = _make_provider()
+    loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+
+    response = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="user", chat_id="test", content="/subagent list")
+    )
+
+    assert response is not None
+    assert "No running subagents" in response.content
+    provider.chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_subagent_kill_nonexistent_bypasses_model(tmp_path: Path) -> None:
+    bus = MessageBus()
+    provider = _make_provider()
+    loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+
+    response = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="user", chat_id="test", content="/subagent kill missing")
+    )
+
+    assert response is not None
+    assert "not found" in response.content.lower()
+    provider.chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_subagent_kill_requires_id(tmp_path: Path) -> None:
+    bus = MessageBus()
+    provider = _make_provider()
+    loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+
+    response = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="user", chat_id="test", content="/subagent kill")
+    )
+
+    assert response is not None
+    assert "usage: /subagent kill <id>" in response.content.lower()
+    provider.chat.assert_not_called()


### PR DESCRIPTION
## Summary

Implements a minimal subagent control-plane MVP for #1006.

This PR adds:
- list running subagents
- kill subagent by id

## What is included

- Manager-level control primitives:
  - `list_running()`
  - `kill(task_id)`
- Slash commands routed on the bus path:
  - `/subagent list`
  - `/subagent kill <id>`
- `/help` updates for new control commands
- Tests for list/kill behavior and command routing

## Scope

- bus-first compatible
- no direct-call-only path introduced
- existing `spawn` flow remains unchanged

## Out of scope

- steer/intervene with follow-up guidance to running subagents
- human-in-the-loop approval workflow
- persistence/history UI for subagent lifecycle

## Validation

Local test runs passed:
- `tests/test_subagent_control.py`
- `tests/test_cli_input.py`
- `tests/test_consolidate_offset.py`
- `tests/test_commands.py`
- `tests/test_cron_commands.py`
- `tests/test_cron_service.py`

## Status

- [x] Implement manager-level list/kill primitives
- [x] Wire slash command entry points
- [x] Add tests for list/kill and race cases
- [ ] Await maintainer review and feedback

Closes #1006