### PR TITLE
docs :: Add tip for configuring Z.ai Coding Plan credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ Config file: `~/.nanobot/config.json`
 > [!TIP]
 > - **Groq** provides free voice transcription via Whisper. If configured, Telegram voice messages will be automatically transcribed.
 > - **Zhipu Coding Plan**: If you're on Zhipu's coding plan, set `"apiBase": "https://open.bigmodel.cn/api/coding/paas/v4"` in your zhipu provider config.
+> - **Z.ai Coding Plan**: If you're on Z.ai's coding plan, set `"apiBase": "https://api.z.ai/api/anthropic"` in the zhipu provider config.
 > - **MiniMax (Mainland China)**: If your API key is from MiniMax's mainland China platform (minimaxi.com), set `"apiBase": "https://api.minimaxi.com/v1"` in your minimax provider config.
 > - **VolcEngine Coding Plan**: If you're on VolcEngine's coding plan, set `"apiBase": "https://ark.cn-beijing.volces.com/api/coding/v3"` in your volcengine provider config.
 
@@ -599,7 +600,7 @@ Config file: `~/.nanobot/config.json`
 | `volcengine` | LLM (VolcEngine/火山引擎) | [volcengine.com](https://www.volcengine.com) |
 | `dashscope` | LLM (Qwen) | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
 | `moonshot` | LLM (Moonshot/Kimi) | [platform.moonshot.cn](https://platform.moonshot.cn) |
-| `zhipu` | LLM (Zhipu GLM) | [open.bigmodel.cn](https://open.bigmodel.cn) |
+| `zhipu` | LLM (Zhipu GLM / z.ai gateway) | [open.bigmodel.cn](https://open.bigmodel.cn) · [z.ai](https://z.ai) |
 | `vllm` | LLM (local, any OpenAI-compatible server) | — |
 | `openai_codex` | LLM (Codex, OAuth) | `nanobot provider login openai-codex` |
 | `github_copilot` | LLM (GitHub Copilot, OAuth) | `nanobot provider login github-copilot` |


### PR DESCRIPTION
While Zhipu and Z.ai are the same provider entity, they provide two different coding plans (Zhipu coding plan and z.ai coding plan). An API key for the z.ai coding plan does not work with the Zhipu endpoint.

I recently set up nanobot with the Z.ai coding plan credentials. I used the Zhipu provider section in `~/.nanobot/config.json`, but pointed it to the claude code compatible endpoint from z.ai (https://api.z.ai/api/anthropic) with a correstonding API key and it worked correctly.

You can see the reference of the setup here: https://docs.z.ai/devpack/tool/claude#manual-configuration

<img width="785" height="775" alt="image" src="https://github.com/user-attachments/assets/50b66fa9-ee6b-438f-b2c4-136a9bf738d0" />


This PR adds a tip for any future users who want to configure `nanobot` with z.ai credentials. 