### PR TITLE
feat(providers): add NanoGPT provider and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ Config file: `~/.nanobot/config.json`
 | `groq` | LLM + **Voice transcription** (Whisper) | [console.groq.com](https://console.groq.com) |
 | `gemini` | LLM (Gemini direct) | [aistudio.google.com](https://aistudio.google.com) |
 | `minimax` | LLM (MiniMax direct) | [platform.minimaxi.com](https://platform.minimaxi.com) |
+| `nanogpt` | LLM (NanoGPT gateway) | [nano-gpt.com](https://nano-gpt.com) |
 | `aihubmix` | LLM (API gateway, access to all models) | [aihubmix.com](https://aihubmix.com) |
 | `siliconflow` | LLM (SiliconFlow/硅基流动) | [siliconflow.cn](https://siliconflow.cn) |
 | `volcengine` | LLM (VolcEngine/火山引擎) | [volcengine.com](https://www.volcengine.com) |

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -263,6 +263,7 @@ class ProvidersConfig(Base):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
+    nanogpt: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -162,6 +162,26 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         strip_model_prefix=False,
         model_overrides=(),
     ),
+
+    # NanoGPT: gateway hosting models from many providers.
+    # User writes nanogpt/openai/gpt-5.2 → strip to openai/gpt-5.2 → nano-gpt/openai/gpt-5.2.
+    ProviderSpec(
+        name="nanogpt",
+        keywords=("nanogpt",),
+        env_key="NANOGPT_API_KEY",
+        display_name="NanoGPT",
+        litellm_prefix="nano-gpt",
+        skip_prefixes=(),
+        env_extras=(),
+        is_gateway=True,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="nano-gpt",
+        default_api_base="https://nano-gpt.com/api/v1",
+        strip_model_prefix=True,
+        model_overrides=(),
+    ),
+
     # === Standard providers (matched by model-name keywords) ===============
     # Anthropic: LiteLLM recognizes "claude-*" natively, no prefix needed.
     ProviderSpec(


### PR DESCRIPTION
Adding support for [NanoGPT](https://nano-gpt.com/). It's listed in LiteLLM [here](https://docs.litellm.ai/docs/providers/nano-gpt).

I believe it is a good addition to the official providers, I personally like NanoGPT for their high level of privacy orientation, affordable subscription to open models etc.