### PR TITLE
Move current time to the end of the system prompt

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -67,15 +67,20 @@ The following skills extend your capabilities. To use a skill, read its SKILL.md
 Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
 
 {skills_summary}""")
-        
-        return "\n\n---\n\n".join(parts)
-    
-    def _get_identity(self) -> str:
-        """Get the core identity section."""
+
+        # Add current date/time
         from datetime import datetime
         import time as _time
         now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
         tz = _time.strftime("%Z") or "UTC"
+        parts.append(f"""
+## Current Time
+{now} ({tz})""")
+       
+        return "\n\n---\n\n".join(parts)
+    
+    def _get_identity(self) -> str:
+        """Get the core identity section."""
         workspace_path = str(self.workspace.expanduser().resolve())
         system = platform.system()
         runtime = f"{'macOS' if system == 'Darwin' else system} {platform.machine()}, Python {platform.python_version()}"
@@ -83,9 +88,6 @@ Skills with available="false" need dependencies installed first - you can try in
         return f"""# nanobot 🐈
 
 You are nanobot, a helpful AI assistant. 
-
-## Current Time
-{now} ({tz})
 
 ## Runtime
 {runtime}


### PR DESCRIPTION
This is a very simple change, which moves the date/time string to the end of the system prompt.

Many modern LLM providers use implicit cache. This tries to match a request to the previous requests up to the first diverging token. When a match is found, a previously saved cache is used and the cost per token for that part is much lower. By moving the date/time string to the end of the prompt, a significantly longer portion of the request can be matched, and therefore saving token cost.