### PR TITLE
fix(session): keep history truncation coherent for tool calls

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -42,19 +42,65 @@ class Session:
         self.messages.append(msg)
         self.updated_at = datetime.now()
 
+    @staticmethod
+    def _is_history_slice_coherent(messages: list[dict[str, Any]]) -> bool:
+        """Validate tool-call/tool-result adjacency in a history slice."""
+        declared_ids: set[str] = set()
+        pending_ids: set[str] | None = None
+
+        for m in messages:
+            role = m.get("role")
+
+            if role == "assistant" and m.get("tool_calls"):
+                if pending_ids:
+                    return False
+                ids = {
+                    str(tc.get("id"))
+                    for tc in (m.get("tool_calls") or [])
+                    if isinstance(tc, dict) and tc.get("id")
+                }
+                if not ids:
+                    return False
+                declared_ids.update(ids)
+                pending_ids = set(ids)
+                continue
+
+            if role == "tool":
+                tool_call_id = str(m.get("tool_call_id") or "")
+                if not tool_call_id:
+                    return False
+                if tool_call_id not in declared_ids:
+                    return False
+                if not pending_ids or tool_call_id not in pending_ids:
+                    return False
+                pending_ids.remove(tool_call_id)
+                if not pending_ids:
+                    pending_ids = None
+                continue
+
+            # Any non-tool message closes the tool result phase.
+            if pending_ids:
+                return False
+
+        return not pending_ids
+
+    @classmethod
+    def _trim_to_coherent_history(cls, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Drop the smallest broken prefix caused by tail truncation."""
+        if cls._is_history_slice_coherent(messages):
+            return messages
+
+        for start in range(1, len(messages)):
+            candidate = messages[start:]
+            if cls._is_history_slice_coherent(candidate):
+                return candidate
+        return []
+    
     def get_history(self, max_messages: int = 500) -> list[dict[str, Any]]:
-        """Return unconsolidated messages for LLM input, aligned to a user turn."""
-        unconsolidated = self.messages[self.last_consolidated:]
-        sliced = unconsolidated[-max_messages:]
-
-        # Drop leading non-user messages to avoid orphaned tool_result blocks
-        for i, m in enumerate(sliced):
-            if m.get("role") == "user":
-                sliced = sliced[i:]
-                break
-
+        """Get recent messages in LLM format, preserving tool metadata."""
+        recent = self._trim_to_coherent_history(self.messages[-max_messages:])
         out: list[dict[str, Any]] = []
-        for m in sliced:
+        for m in recent:
             entry: dict[str, Any] = {"role": m["role"], "content": m.get("content", "")}
             for k in ("tool_calls", "tool_call_id", "name"):
                 if k in m:

--- a/tests/test_session_history_coherence.py
+++ b/tests/test_session_history_coherence.py
@@ -1,0 +1,62 @@
+from nanobot.session.manager import Session
+
+
+def test_get_history_preserves_tool_metadata() -> None:
+    session = Session(key="cli:direct")
+    session.add_message("user", "check repo status")
+    session.add_message(
+        "assistant",
+        "",
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{\"command\":\"git status --short\"}"},
+            }
+        ],
+    )
+    session.add_message(
+        "tool",
+        " M README.md",
+        tool_call_id="call_1",
+        name="exec",
+    )
+    session.add_message("assistant", "Working tree has local changes.")
+
+    history = session.get_history(max_messages=10)
+
+    assert history[0] == {"role": "user", "content": "check repo status"}
+    assert history[1]["tool_calls"][0]["function"]["name"] == "exec"
+    assert history[2]["tool_call_id"] == "call_1"
+    assert history[2]["name"] == "exec"
+
+
+def test_get_history_drops_orphan_tool_results_after_truncation() -> None:
+    session = Session(key="feishu:test")
+
+    for i in range(4):
+        session.add_message("user", f"u{i}")
+        session.add_message("assistant", f"a{i}")
+
+    session.add_message(
+        "assistant",
+        "",
+        tool_calls=[
+            {
+                "id": "call_orphan",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{\"path\":\"x\"}"},
+            }
+        ],
+    )
+    session.add_message("tool", "file-content", tool_call_id="call_orphan", name="read_file")
+    session.add_message("assistant", "summary after tool")
+
+    session.add_message("user", "new question")
+    session.add_message("assistant", "new answer")
+
+    history = session.get_history(max_messages=4)
+
+    assert [m["role"] for m in history] == ["assistant", "user", "assistant"]
+    assert history[0]["content"] == "summary after tool"
+    assert all(m.get("role") != "tool" for m in history)


### PR DESCRIPTION
## Summary
- trim truncated history to a tool-call/tool-result coherent slice before returning Session.get_history()
- preserve existing tool metadata behavior while avoiding orphan tool messages
- add regression tests for normal tool metadata retention and orphan-tool truncation

## Why
When max_messages truncates the session tail, the slice can begin with a tool message whose parent assistant tool_calls message was cut off. Some strict providers reject this invalid sequence.

## Testing
- uv run --extra dev pytest tests/test_session_history_coherence.py
