### PR TITLE
fix(heartbeat): make start idempotent and require exact HEARTBEAT_OK

### DIFF
--- a/tests/test_heartbeat_service.py
+++ b/tests/test_heartbeat_service.py
@@ -1,0 +1,40 @@
+import asyncio
+
+import pytest
+
+from nanobot.heartbeat.service import (
+    HeartbeatService,
+    _is_heartbeat_ok_response,
+)
+
+
+def test_heartbeat_ok_response_requires_exact_token() -> None:
+    assert _is_heartbeat_ok_response("HEARTBEAT_OK")
+    assert _is_heartbeat_ok_response("`HEARTBEAT_OK`")
+    assert _is_heartbeat_ok_response("**HEARTBEAT_OK**")
+
+    assert not _is_heartbeat_ok_response("HEARTBEAT_OK, done")
+    assert not _is_heartbeat_ok_response("done HEARTBEAT_OK")
+    assert not _is_heartbeat_ok_response("HEARTBEAT_NOT_OK")
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent(tmp_path) -> None:
+    async def _on_heartbeat(_: str) -> str:
+        return "HEARTBEAT_OK"
+
+    service = HeartbeatService(
+        workspace=tmp_path,
+        on_heartbeat=_on_heartbeat,
+        interval_s=9999,
+        enabled=True,
+    )
+
+    await service.start()
+    first_task = service._task
+    await service.start()
+
+    assert service._task is first_task
+
+    service.stop()
+    await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- make HeartbeatService.start() idempotent when called repeatedly
- add a strict HEARTBEAT_OK parser that only accepts the exact token (with simple markdown wrappers)
- add regression tests for exact-token matching and idempotent start behavior

## Why
The previous substring check treated responses like "done HEARTBEAT_OK" or "HEARTBEAT_OK, done" as no-op heartbeats, which can hide actual work. Repeated start() calls could also create duplicate heartbeat tasks.

## Testing
- uv run --extra dev pytest tests/test_heartbeat_service.py
