### PR TITLE
fix(message-tool): propagate channel routing metadata to outbound messages

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -144,7 +144,7 @@ class AgentLoop:
         """Update context for all tools that need routing info."""
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
-                message_tool.set_context(channel, chat_id, message_id)
+                message_tool.set_context(channel, chat_id, message_id, metadata)
 
         if spawn_tool := self.tools.get("spawn"):
             if isinstance(spawn_tool, SpawnTool):

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -22,11 +22,14 @@ class MessageTool(Tool):
         self._default_message_id = default_message_id
         self._sent_in_turn: bool = False
 
-    def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
+    _ROUTING_KEYS = ("slack", "discord", "feishu", "mochat", "dingtalk")
+
+    def set_context(self, channel: str, chat_id: str, message_id: str | None = None, metadata: dict | None = None) -> None:
         """Set the current message context."""
         self._default_channel = channel
         self._default_chat_id = chat_id
         self._default_message_id = message_id
+        self._metadata = metadata
 
     def set_send_callback(self, callback: Callable[[OutboundMessage], Awaitable[None]]) -> None:
         """Set the callback for sending messages."""
@@ -89,14 +92,14 @@ class MessageTool(Tool):
         if not self._send_callback:
             return "Error: Message sending not configured"
 
+        routing = {k: self._metadata[k] for k in self._ROUTING_KEYS
+                   if self._metadata and k in self._metadata}
         msg = OutboundMessage(
             channel=channel,
             chat_id=chat_id,
             content=content,
             media=media or [],
-            metadata={
-                "message_id": message_id,
-            }
+            metadata={**routing, "message_id": message_id},
         )
 
         try:


### PR DESCRIPTION
MessageTool was constructing OutboundMessage without channel-specific metadata (e.g. slack.thread_ts), causing replies to land in the main channel instead of the originating thread.