### PR TITLE
feat(governance): integrate edictum into nanobot tool execution

### DIFF
--- a/nanobot/agent/governance.py
+++ b/nanobot/agent/governance.py
@@ -1,0 +1,191 @@
+"""Edictum governance integration for nanobot agents."""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from nanobot.agent.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+try:
+    from edictum import Edictum, EdictumDenied, Principal
+
+    HAS_EDICTUM = True
+except ImportError:
+    HAS_EDICTUM = False
+
+
+class GovernedToolRegistry:
+    """Drop-in wrapper for nanobot's ToolRegistry with edictum governance.
+
+    Intercepts execute() calls, runs them through the Edictum pipeline,
+    and handles deny/approve/allow paths. All other ToolRegistry methods
+    delegate directly to the inner registry.
+    """
+
+    def __init__(
+        self,
+        inner: "ToolRegistry",
+        guard: "Edictum",
+        *,
+        session_id: str | None = None,
+        principal: "Principal | None" = None,
+        principal_resolver: Callable | None = None,
+    ) -> None:
+        self._inner = inner
+        self._guard = guard
+        self._session_id = session_id or str(uuid.uuid4())
+        self._principal = principal
+        self._principal_resolver = principal_resolver
+
+    # --- Delegate all ToolRegistry methods to inner ---
+
+    def register(self, tool: Any) -> None:
+        return self._inner.register(tool)
+
+    def unregister(self, name: str) -> None:
+        return self._inner.unregister(name)
+
+    def get(self, name: str) -> Any:
+        return self._inner.get(name)
+
+    def has(self, name: str) -> bool:
+        return self._inner.has(name)
+
+    def get_definitions(self) -> list[dict[str, Any]]:
+        return self._inner.get_definitions()
+
+    @property
+    def tool_names(self) -> list[str]:
+        return self._inner.tool_names
+
+    def __len__(self) -> int:
+        return len(self._inner)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._inner
+
+    async def execute(self, name: str, params: dict[str, Any]) -> str:
+        """Execute a tool with governance checks.
+
+        Uses guard.run() which handles the full governance pipeline:
+        pre-checks, approval flow, tool execution, post-checks, audit.
+
+        On deny: returns "[DENIED] reason" string (nanobot expects string results).
+        On approval timeout/deny: returns "[DENIED] Approval denied: reason".
+        On error: returns "[ERROR] message" and logs the exception.
+        """
+
+        async def tool_callable(**kwargs: Any) -> str:
+            return await self._inner.execute(name, kwargs)
+
+        try:
+            result = await self._guard.run(
+                tool_name=name,
+                args=params,
+                tool_callable=tool_callable,
+                session_id=self._session_id,
+                principal=self._principal,
+            )
+            return str(result)
+        except EdictumDenied as e:
+            logger.info("Tool call denied: %s — %s", name, e.reason)
+            return f"[DENIED] {e.reason}"
+        except Exception:
+            logger.exception("Governance error for tool %s", name)
+            return f"[ERROR] Governance check failed for {name}"
+
+    def set_principal(self, principal: Any) -> None:
+        """Update principal for subsequent calls."""
+        self._principal = principal
+
+    def for_subagent(
+        self,
+        *,
+        inner: "ToolRegistry | None" = None,
+        session_id: str | None = None,
+    ) -> GovernedToolRegistry:
+        """Create a child GovernedToolRegistry for a sub-agent.
+
+        Shares the same guard but can wrap a different inner registry
+        (e.g. the subagent's own ToolRegistry) and gets its own session.
+        """
+        return GovernedToolRegistry(
+            inner=inner if inner is not None else self._inner,
+            guard=self._guard,
+            session_id=session_id or str(uuid.uuid4()),
+            principal=self._principal,
+            principal_resolver=self._principal_resolver,
+        )
+
+
+def principal_from_message(message: Any) -> "Principal":
+    """Map a nanobot InboundMessage to an edictum Principal."""
+    return Principal(
+        user_id=f"{message.channel}:{message.sender_id}",
+        role="user",
+        claims={
+            "channel": message.channel,
+            "chat_id": message.chat_id,
+        },
+    )
+
+
+def create_governed_registry(
+    inner: "ToolRegistry",
+    *,
+    contract_path: str | None = None,
+    template: str = "nanobot-agent",
+    server_url: str | None = None,
+    api_key: str | None = None,
+    agent_id: str = "nanobot",
+    mode: str = "enforce",
+) -> GovernedToolRegistry:
+    """Factory function to create a GovernedToolRegistry with edictum config.
+
+    Two modes:
+    1. Local: Load contracts from YAML file or template (no server needed)
+    2. Server: Connect to edictum-server for approval queue + audit
+    """
+    if not HAS_EDICTUM:
+        raise ImportError(
+            "edictum is not installed. Install with: pip install 'nanobot-ai[governance]'"
+        )
+
+    approval_backend = None
+    audit_sink = None
+
+    if server_url and api_key:
+        from edictum.server import (
+            EdictumServerClient,
+            ServerApprovalBackend,
+            ServerAuditSink,
+        )
+
+        client = EdictumServerClient(
+            base_url=server_url,
+            api_key=api_key,
+            agent_id=agent_id,
+        )
+        approval_backend = ServerApprovalBackend(client)
+        audit_sink = ServerAuditSink(client)
+
+    if contract_path:
+        guard = Edictum.from_yaml(
+            contract_path,
+            mode=mode,
+            approval_backend=approval_backend,
+            audit_sink=audit_sink,
+        )
+    else:
+        guard = Edictum.from_template(
+            template,
+            mode=mode,
+            approval_backend=approval_backend,
+            audit_sink=audit_sink,
+        )
+
+    return GovernedToolRegistry(inner=inner, guard=guard)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -60,6 +60,7 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        edictum_config: dict | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -100,6 +101,21 @@ class AgentLoop:
         self._consolidation_tasks: set[asyncio.Task] = set()  # Strong refs to in-flight tasks
         self._consolidation_locks: dict[str, asyncio.Lock] = {}
         self._register_default_tools()
+
+        # Wrap with edictum governance if configured
+        if edictum_config:
+            from nanobot.agent.governance import create_governed_registry
+
+            self.tools = create_governed_registry(
+                self.tools,
+                contract_path=edictum_config.get("contract_path"),
+                template=edictum_config.get("template", "nanobot-agent"),
+                server_url=edictum_config.get("server_url"),
+                api_key=edictum_config.get("api_key"),
+                agent_id=edictum_config.get("agent_id", "nanobot"),
+                mode=edictum_config.get("mode", "enforce"),
+            )
+            self.subagents._governed_tools = self.tools
 
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
@@ -378,6 +394,12 @@ class AgentLoop:
 
             _task = asyncio.create_task(_consolidate_and_unlock())
             self._consolidation_tasks.add(_task)
+
+        # Set governance principal from message sender
+        if hasattr(self.tools, "set_principal"):
+            from nanobot.agent.governance import principal_from_message
+
+            self.tools.set_principal(principal_from_message(msg))
 
         self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
         if message_tool := self.tools.get("message"):

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -49,6 +49,7 @@ class SubagentManager:
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
+        self._governed_tools = None  # Set by AgentLoop when governance is active
     
     async def spawn(
         self,
@@ -114,7 +115,11 @@ class SubagentManager:
             ))
             tools.register(WebSearchTool(api_key=self.brave_api_key))
             tools.register(WebFetchTool())
-            
+
+            # Propagate governance from parent if available
+            if self._governed_tools is not None:
+                tools = self._governed_tools.for_subagent(inner=tools)
+
             # Build messages with subagent-specific prompt
             system_prompt = self._build_subagent_prompt(task)
             messages: list[dict[str, Any]] = [

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -302,6 +302,18 @@ def gateway(
     cron_store_path = get_data_dir() / "cron" / "jobs.json"
     cron = CronService(cron_store_path)
     
+    # Build edictum governance config if enabled
+    edictum_config = None
+    if config.edictum.enabled:
+        edictum_config = {
+            "mode": config.edictum.mode,
+            "template": config.edictum.template,
+            "contract_path": config.edictum.contract_path,
+            "server_url": config.edictum.server_url,
+            "api_key": config.edictum.api_key,
+            "agent_id": config.edictum.agent_id,
+        }
+
     # Create agent with cron service
     agent = AgentLoop(
         bus=bus,
@@ -319,6 +331,7 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        edictum_config=edictum_config,
     )
     
     # Set cron callback (needs agent)
@@ -457,6 +470,17 @@ def agent(
     else:
         logger.disable("nanobot")
     
+    edictum_config = None
+    if config.edictum.enabled:
+        edictum_config = {
+            "mode": config.edictum.mode,
+            "template": config.edictum.template,
+            "contract_path": config.edictum.contract_path,
+            "server_url": config.edictum.server_url,
+            "api_key": config.edictum.api_key,
+            "agent_id": config.edictum.agent_id,
+        }
+
     agent_loop = AgentLoop(
         bus=bus,
         provider=provider,
@@ -472,8 +496,9 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        edictum_config=edictum_config,
     )
-    
+
     # Show spinner when logs are off (no output to miss); skip when logs are on
     def _thinking_ctx():
         if logs:
@@ -948,6 +973,17 @@ def cron_run(
     config = load_config()
     provider = _make_provider(config)
     bus = MessageBus()
+    edictum_config = None
+    if config.edictum.enabled:
+        edictum_config = {
+            "mode": config.edictum.mode,
+            "template": config.edictum.template,
+            "contract_path": config.edictum.contract_path,
+            "server_url": config.edictum.server_url,
+            "api_key": config.edictum.api_key,
+            "agent_id": config.edictum.agent_id,
+        }
+
     agent_loop = AgentLoop(
         bus=bus,
         provider=provider,
@@ -962,6 +998,7 @@ def cron_run(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        edictum_config=edictum_config,
     )
 
     store_path = get_data_dir() / "cron" / "jobs.json"

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -274,6 +274,18 @@ class ToolsConfig(Base):
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
 
+class EdictumConfig(Base):
+    """Edictum governance configuration."""
+
+    enabled: bool = False
+    mode: str = "enforce"  # enforce | observe
+    template: str = "nanobot-agent"  # Built-in template name
+    contract_path: str | None = None  # Custom YAML contract file (overrides template)
+    server_url: str | None = None  # edictum-server URL for HITL + audit
+    api_key: str | None = None  # API key for edictum-server
+    agent_id: str = "nanobot"  # Agent identifier
+
+
 class Config(BaseSettings):
     """Root configuration for nanobot."""
 
@@ -282,6 +294,7 @@ class Config(BaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    edictum: EdictumConfig = Field(default_factory=EdictumConfig)
 
     @property
     def workspace_path(self) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+governance = [
+    "edictum[server,yaml]>=0.10.0",
+]
 dev = [
     "pytest>=9.0.0,<10.0.0",
     "pytest-asyncio>=1.3.0,<2.0.0",

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -1,0 +1,312 @@
+"""Tests for edictum governance integration."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.bus.events import InboundMessage
+
+# --- Helpers ---
+
+
+class EchoTool(Tool):
+    """Simple tool that echoes input for testing."""
+
+    @property
+    def name(self) -> str:
+        return "echo"
+
+    @property
+    def description(self) -> str:
+        return "Echo input"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        return kwargs.get("text", "")
+
+
+def _make_registry() -> ToolRegistry:
+    """Create a ToolRegistry with an echo tool registered."""
+    reg = ToolRegistry()
+    reg.register(EchoTool())
+    return reg
+
+
+def _make_mock_guard(*, result: str = "ok", deny: bool = False, error: bool = False) -> MagicMock:
+    """Create a mock Edictum guard."""
+    guard = MagicMock()
+    if deny:
+        exc = type("EdictumDenied", (Exception,), {"reason": "not allowed"})()
+        guard.run = AsyncMock(side_effect=exc)
+    elif error:
+        guard.run = AsyncMock(side_effect=RuntimeError("guard broke"))
+    else:
+        guard.run = AsyncMock(return_value=result)
+    return guard
+
+
+# --- Test: Delegation ---
+
+
+def test_governed_registry_delegates():
+    """GovernedToolRegistry delegates register/has/get/tool_names to inner."""
+    from nanobot.agent.governance import GovernedToolRegistry
+
+    inner = _make_registry()
+    guard = _make_mock_guard()
+    governed = GovernedToolRegistry(inner=inner, guard=guard)
+
+    assert governed.has("echo")
+    assert not governed.has("missing")
+    assert governed.get("echo") is not None
+    assert governed.get("missing") is None
+    assert "echo" in governed.tool_names
+    assert len(governed) == 1
+    assert "echo" in governed
+
+    defs = governed.get_definitions()
+    assert len(defs) == 1
+    assert defs[0]["function"]["name"] == "echo"
+
+
+# --- Test: Execute allowed ---
+
+
+async def test_governed_execute_allowed():
+    """Tool executes normally when governance allows."""
+    from nanobot.agent.governance import GovernedToolRegistry
+
+    inner = _make_registry()
+    guard = _make_mock_guard(result="hello world")
+    governed = GovernedToolRegistry(inner=inner, guard=guard)
+
+    result = await governed.execute("echo", {"text": "hello world"})
+    assert result == "hello world"
+    guard.run.assert_awaited_once()
+
+    call_kwargs = guard.run.call_args.kwargs
+    assert call_kwargs["tool_name"] == "echo"
+    assert call_kwargs["args"] == {"text": "hello world"}
+
+
+# --- Test: Execute denied ---
+
+
+async def test_governed_execute_denied():
+    """Returns [DENIED] string when governance denies."""
+    from nanobot.agent.governance import GovernedToolRegistry
+
+    inner = _make_registry()
+    mock_denied = type("EdictumDenied", (Exception,), {"reason": "dangerous operation"})
+
+    guard = MagicMock()
+    guard.run = AsyncMock(side_effect=mock_denied("denied"))
+
+    with patch("nanobot.agent.governance.EdictumDenied", mock_denied):
+        governed = GovernedToolRegistry(inner=inner, guard=guard)
+        result = await governed.execute("echo", {"text": "hello"})
+
+    assert result.startswith("[DENIED]")
+    assert "dangerous operation" in result
+
+
+# --- Test: Execute error (graceful degradation) ---
+
+
+async def test_graceful_degradation():
+    """Governance error returns [ERROR] message."""
+    from nanobot.agent.governance import GovernedToolRegistry
+
+    inner = _make_registry()
+    guard = _make_mock_guard(error=True)
+    governed = GovernedToolRegistry(inner=inner, guard=guard)
+
+    result = await governed.execute("echo", {"text": "hello"})
+    assert result.startswith("[ERROR]")
+    assert "echo" in result
+
+
+# --- Test: principal_from_message ---
+
+
+def test_principal_from_message():
+    """Maps InboundMessage fields to edictum Principal correctly."""
+    mock_principal = MagicMock()
+    with patch("nanobot.agent.governance.Principal", return_value=mock_principal) as mock_cls:
+        from nanobot.agent.governance import principal_from_message
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user123",
+            chat_id="chat456",
+            content="hello",
+        )
+        principal_from_message(msg)
+
+        mock_cls.assert_called_once_with(
+            user_id="telegram:user123",
+            role="user",
+            claims={"channel": "telegram", "chat_id": "chat456"},
+        )
+
+
+# --- Test: for_subagent ---
+
+
+def test_for_subagent():
+    """for_subagent creates child with own session but shared guard."""
+    from nanobot.agent.governance import GovernedToolRegistry
+
+    inner = _make_registry()
+    guard = _make_mock_guard()
+    parent = GovernedToolRegistry(inner=inner, guard=guard, session_id="parent-session")
+
+    child = parent.for_subagent()
+    assert child._guard is guard
+    assert child._session_id != "parent-session"
+    assert child._inner is inner
+
+
+def test_for_subagent_with_custom_inner():
+    """for_subagent can wrap a different inner registry."""
+    from nanobot.agent.governance import GovernedToolRegistry
+
+    inner1 = _make_registry()
+    inner2 = ToolRegistry()
+    guard = _make_mock_guard()
+
+    parent = GovernedToolRegistry(inner=inner1, guard=guard)
+    child = parent.for_subagent(inner=inner2)
+
+    assert child._inner is inner2
+    assert child._guard is guard
+
+
+# --- Test: set_principal ---
+
+
+def test_set_principal():
+    """set_principal updates the principal for subsequent calls."""
+    from nanobot.agent.governance import GovernedToolRegistry
+
+    inner = _make_registry()
+    guard = _make_mock_guard()
+    governed = GovernedToolRegistry(inner=inner, guard=guard)
+
+    assert governed._principal is None
+    mock_principal = MagicMock()
+    governed.set_principal(mock_principal)
+    assert governed._principal is mock_principal
+
+
+# --- Test: create_governed_registry (local) ---
+
+
+def test_create_governed_registry_local():
+    """Factory creates GovernedToolRegistry with template (no server)."""
+    from nanobot.agent.governance import GovernedToolRegistry
+
+    mock_edictum = MagicMock()
+    mock_guard = MagicMock()
+    mock_edictum.from_template.return_value = mock_guard
+
+    with patch("nanobot.agent.governance.HAS_EDICTUM", True), patch(
+        "nanobot.agent.governance.Edictum", mock_edictum
+    ):
+        from nanobot.agent.governance import create_governed_registry
+
+        inner = _make_registry()
+        result = create_governed_registry(inner, template="nanobot-agent", mode="enforce")
+
+        assert isinstance(result, GovernedToolRegistry)
+        mock_edictum.from_template.assert_called_once_with(
+            "nanobot-agent",
+            mode="enforce",
+            approval_backend=None,
+            audit_sink=None,
+        )
+
+
+# --- Test: create_governed_registry raises without edictum ---
+
+
+def test_create_governed_registry_no_edictum():
+    """Factory raises ImportError when edictum is not installed."""
+    with patch("nanobot.agent.governance.HAS_EDICTUM", False):
+        from nanobot.agent.governance import create_governed_registry
+
+        inner = _make_registry()
+        with pytest.raises(ImportError, match="edictum is not installed"):
+            create_governed_registry(inner)
+
+
+# --- Test: EdictumConfig schema ---
+
+
+def test_config_schema():
+    """EdictumConfig validates correctly."""
+    from nanobot.config.schema import EdictumConfig
+
+    cfg = EdictumConfig(enabled=True, mode="observe")
+    assert cfg.enabled is True
+    assert cfg.mode == "observe"
+    assert cfg.template == "nanobot-agent"
+    assert cfg.contract_path is None
+    assert cfg.server_url is None
+    assert cfg.api_key is None
+    assert cfg.agent_id == "nanobot"
+
+
+def test_config_schema_defaults():
+    """EdictumConfig has sane defaults."""
+    from nanobot.config.schema import EdictumConfig
+
+    cfg = EdictumConfig()
+    assert cfg.enabled is False
+    assert cfg.mode == "enforce"
+
+
+def test_disabled_config():
+    """edictum.enabled=false means default Config has governance disabled."""
+    from nanobot.config.schema import Config
+
+    c = Config()
+    assert c.edictum.enabled is False
+
+
+def test_config_with_edictum_enabled():
+    """Config accepts edictum section."""
+    from nanobot.config.schema import Config
+
+    c = Config(edictum={"enabled": True, "mode": "observe"})
+    assert c.edictum.enabled is True
+    assert c.edictum.mode == "observe"
+
+
+# --- Test: register/unregister through governed ---
+
+
+def test_governed_register_unregister():
+    """register and unregister pass through to inner."""
+    from nanobot.agent.governance import GovernedToolRegistry
+
+    inner = ToolRegistry()
+    guard = _make_mock_guard()
+    governed = GovernedToolRegistry(inner=inner, guard=guard)
+
+    assert not governed.has("echo")
+    governed.register(EchoTool())
+    assert governed.has("echo")
+    governed.unregister("echo")
+    assert not governed.has("echo")


### PR DESCRIPTION
## Summary

- Wrap nanobot's `ToolRegistry` with `GovernedToolRegistry` — a drop-in that intercepts `execute()` to run edictum contract checks, approval flows, and audit logging
- Wire governance into `AgentLoop`, `SubagentManager`, and all 3 CLI entry points (`gateway`, `agent`, `cron run`) via config-driven `edictum_config` dict
- Add `EdictumConfig` to config schema with enforce/observe modes, template/YAML contract support, and optional server connection
- `edictum` is an optional dependency (`pip install nanobot-ai[governance]`) — graceful `ImportError` handling when not installed

## Files changed (7)

| File | Action |
|------|--------|
| `nanobot/agent/governance.py` | **NEW** — `GovernedToolRegistry`, `principal_from_message()`, `create_governed_registry()` |
| `nanobot/agent/loop.py` | EDIT — `edictum_config` param, wrap tools, set principal per message |
| `nanobot/agent/subagent.py` | EDIT — propagate governance to child agents |
| `nanobot/config/schema.py` | EDIT — `EdictumConfig` model |
| `nanobot/cli/commands.py` | EDIT — pass edictum config to all `AgentLoop` instantiations |
| `pyproject.toml` | EDIT — `[governance]` optional dependency extra |
| `tests/test_governance.py` | **NEW** — 15 tests (delegation, deny, error, subagent, config) |

## Test plan

- [x] `pytest tests/test_governance.py -v` — 15/15 pass
- [x] `pytest tests/ -v` — 87/87 pass, 0 regressions
- [x] `ruff check` — clean on new/modified files
- [ ] Manual: `nanobot gateway` with `edictum.enabled: false` (default) — no behavior change
- [ ] Manual: `nanobot gateway` with `edictum.enabled: true` + edictum installed — governance active