### PR TITLE
fix(cron): stop sending Telegram messages on every cron job run

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -61,6 +61,10 @@ class CronTool(Tool):
                 "job_id": {
                     "type": "string",
                     "description": "Job ID (for remove)"
+                },
+                "deliver": {
+                    "type": "boolean",
+                    "description": "If true, automatically send the agent's response to the user after every run. Use for reminder-type jobs where notification is the whole point. For monitoring/recurring tasks where you should only report important findings, omit this and use the message tool explicitly when something is worth reporting."
                 }
             },
             "required": ["action"]
@@ -75,10 +79,11 @@ class CronTool(Tool):
         tz: str | None = None,
         at: str | None = None,
         job_id: str | None = None,
+        deliver: bool = False,
         **kwargs: Any
     ) -> str:
         if action == "add":
-            return self._add_job(message, every_seconds, cron_expr, tz, at)
+            return self._add_job(message, every_seconds, cron_expr, tz, at, deliver)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
@@ -92,6 +97,7 @@ class CronTool(Tool):
         cron_expr: str | None,
         tz: str | None,
         at: str | None,
+        deliver: bool = False,
     ) -> str:
         if not message:
             return "Error: message is required for add"
@@ -125,7 +131,7 @@ class CronTool(Tool):
             name=message[:30],
             schedule=schedule,
             message=message,
-            deliver=True,
+            deliver=deliver,
             channel=self._channel,
             to=self._chat_id,
             delete_after_run=delete_after,

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -324,11 +324,15 @@ def gateway(
     # Set cron callback (needs agent)
     async def on_cron_job(job: CronJob) -> str | None:
         """Execute a cron job through the agent."""
+        async def _silent(*_args, **_kwargs):
+            pass
+
         response = await agent.process_direct(
             job.payload.message,
             session_key=f"cron:{job.id}",
             channel=job.payload.channel or "cli",
             chat_id=job.payload.to or "direct",
+            on_progress=_silent,  # suppress: cron should not push progress to external channels
         )
         if job.payload.deliver and job.payload.to:
             from nanobot.bus.events import OutboundMessage

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -43,17 +43,18 @@ class Session:
         self.updated_at = datetime.now()
 
     def get_history(self, max_messages: int = 500) -> list[dict[str, Any]]:
-        """Get recent messages in LLM format, preserving tool metadata."""
-        sliced = self.messages[-max_messages:]
-        # If the slice boundary fell inside a tool_use/tool_result pair, the
-        # assistant message with tool_calls was cut off but its tool result
-        # messages are still present. Drop those orphaned leading tool messages
-        # so the API never sees a tool_result without a matching tool_use.
-        start = 0
-        while start < len(sliced) and sliced[start].get("role") == "tool":
-            start += 1
+        """Return unconsolidated messages for LLM input, aligned to a user turn."""
+        unconsolidated = self.messages[self.last_consolidated:]
+        sliced = unconsolidated[-max_messages:]
+
+        # Drop leading non-user messages to avoid orphaned tool_result blocks
+        for i, m in enumerate(sliced):
+            if m.get("role") == "user":
+                sliced = sliced[i:]
+                break
+
         out: list[dict[str, Any]] = []
-        for m in sliced[start:]:
+        for m in sliced:
             entry: dict[str, Any] = {"role": m["role"], "content": m.get("content", "")}
             for k in ("tool_calls", "tool_call_id", "name"):
                 if k in m:

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -44,8 +44,16 @@ class Session:
     
     def get_history(self, max_messages: int = 500) -> list[dict[str, Any]]:
         """Get recent messages in LLM format, preserving tool metadata."""
+        sliced = self.messages[-max_messages:]
+        # If the slice boundary fell inside a tool_use/tool_result pair, the
+        # assistant message with tool_calls was cut off but its tool result
+        # messages are still present. Drop those orphaned leading tool messages
+        # so the API never sees a tool_result without a matching tool_use.
+        start = 0
+        while start < len(sliced) and sliced[start].get("role") == "tool":
+            start += 1
         out: list[dict[str, Any]] = []
-        for m in self.messages[-max_messages:]:
+        for m in sliced[start:]:
             entry: dict[str, Any] = {"role": m["role"], "content": m.get("content", "")}
             for k in ("tool_calls", "tool_call_id", "name"):
                 if k in m:

--- a/nanobot/templates/AGENTS.md
+++ b/nanobot/templates/AGENTS.md
@@ -10,13 +10,12 @@ You are a helpful AI assistant. Be concise, accurate, and friendly.
 - Ask for clarification when the request is ambiguous
 - Remember important information in `memory/MEMORY.md`; past events are logged in `memory/HISTORY.md`
 
-## Scheduled Reminders
+## Scheduled Reminders and Cron Jobs
 
-When user asks for a reminder at a specific time, use `exec` to run:
-```
-nanobot cron add --name "reminder" --message "Your message" --at "YYYY-MM-DDTHH:MM:SS" --deliver --to "USER_ID" --channel "CHANNEL"
-```
-Get USER_ID and CHANNEL from the current session (e.g., `8281248569` and `telegram` from `telegram:8281248569`).
+Use the `cron` tool to schedule jobs. The `deliver` parameter controls whether the agent's response is automatically sent to the user after every run:
+
+- **Set `deliver=true`** for reminder-type jobs where the notification IS the point (e.g. "remind me at 9am to take my medication"). The response will be sent to the user automatically.
+- **Omit `deliver` (default false)** for monitoring/recurring tasks (e.g. "check my server every hour"). The job runs silently. Use the `message` tool explicitly inside the job's response only when something important is found — do NOT send a message if everything is fine and there's nothing to act on.
 
 **Do NOT just write reminders to MEMORY.md** — that won't trigger actual notifications.
 


### PR DESCRIPTION
CronTool hardcoded deliver=True, causing every agent-scheduled cron job to send a response to the user's channel after each run — even for monitoring tasks where nothing important happened. This produced noisy messages every few minutes saying everything was fine.

Fix: make deliver a proper parameter (defaulting to False) so the agent can choose. Update AGENTS.md to guide the agent: set deliver=true only for reminder-type jobs where notification is the purpose; for monitoring tasks, stay silent and use the message tool explicitly only when something important is found.