### PR TITLE
feat(telegram): add group mention policy and sender-aware context

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,10 @@ Connect nanobot to your favorite chat platform.
     "telegram": {
       "enabled": true,
       "token": "YOUR_BOT_TOKEN",
-      "allowFrom": ["YOUR_USER_ID"]
+      "allowFrom": ["YOUR_USER_ID"],
+      "groupPolicy": "mention",
+      "groupHistoryOnMention": 8,
+      "mentionByReply": true
     }
   }
 }
@@ -194,6 +197,12 @@ Connect nanobot to your favorite chat platform.
 
 > You can find your **User ID** in Telegram settings. It is shown as `@yourUserId`.
 > Copy this value **without the `@` symbol** and paste it into the config file.
+>
+> `groupPolicy` controls group behavior:
+> - `open`: process every group message
+> - `mention`: only process when `@YourBotName` is mentioned (or when replying to the bot if `mentionByReply` is true)
+>
+> `groupHistoryOnMention` prepends recent non-mention group messages when a mention finally triggers the bot.
 
 
 **3. Run**

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+
 from loguru import logger
 from telegram import BotCommand, Update, ReplyParameters
 from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
@@ -126,6 +127,9 @@ class TelegramChannel(BaseChannel):
         self._app: Application | None = None
         self._chat_ids: dict[str, int] = {}  # Map sender_id to chat_id for replies
         self._typing_tasks: dict[str, asyncio.Task] = {}  # chat_id -> typing loop task
+        self._bot_username: str = ""
+        self._bot_user_id: int | None = None
+        self._group_history: dict[str, list[str]] = {}  # chat_id -> buffered group lines
     
     async def start(self) -> None:
         """Start the Telegram bot with long polling."""
@@ -165,6 +169,8 @@ class TelegramChannel(BaseChannel):
         
         # Get bot info and register command menu
         bot_info = await self._app.bot.get_me()
+        self._bot_username = bot_info.username or ""
+        self._bot_user_id = bot_info.id
         logger.info("Telegram bot @{} connected", bot_info.username)
         
         try:
@@ -308,6 +314,97 @@ class TelegramChannel(BaseChannel):
         sid = str(user.id)
         return f"{sid}|{user.username}" if user.username else sid
 
+    def _group_policy(self) -> str:
+        """Resolve group handling policy."""
+        policy = (self.config.group_policy or "open").strip().lower()
+        if policy in {"open", "mention"}:
+            return policy
+        logger.warning("Invalid Telegram group_policy={}, falling back to open", self.config.group_policy)
+        return "open"
+
+    @staticmethod
+    def _is_group_chat(message) -> bool:
+        return getattr(message.chat, "type", "") != "private"
+
+    def _is_reply_to_bot(self, message) -> bool:
+        if not self.config.mention_by_reply:
+            return False
+        if self._bot_user_id is None:
+            return False
+        reply = getattr(message, "reply_to_message", None)
+        from_user = getattr(reply, "from_user", None) if reply else None
+        return bool(from_user and int(getattr(from_user, "id", 0)) == int(self._bot_user_id))
+
+    def _is_mentioned(self, message, text: str) -> bool:
+        """Check whether the bot is explicitly invoked in a group message."""
+        username = self._bot_username.strip().lstrip("@")
+        if username:
+            pattern = rf"(?<!\w)@{re.escape(username)}(?!\w)"
+            if re.search(pattern, text or "", flags=re.IGNORECASE):
+                return True
+        return self._is_reply_to_bot(message)
+
+    def _strip_bot_mention(self, text: str) -> str:
+        """Remove @botname from text so the model sees only user intent."""
+        username = self._bot_username.strip().lstrip("@")
+        if not text or not username:
+            return text
+        pattern = rf"(?<!\w)@{re.escape(username)}(?!\w)"
+        text = re.sub(pattern, " ", text, flags=re.IGNORECASE)
+        text = re.sub(r"[ \t]{2,}", " ", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip()
+
+    @staticmethod
+    def _sender_label(user) -> str:
+        first_name = (getattr(user, "first_name", "") or "").strip()
+        last_name = (getattr(user, "last_name", "") or "").strip()
+        username = (getattr(user, "username", "") or "").strip()
+        user_id = str(getattr(user, "id", "unknown"))
+        name = " ".join([p for p in (first_name, last_name) if p]).strip()
+        if not name:
+            name = f"@{username}" if username else f"user:{user_id}"
+        if username:
+            return f"{name} (@{username}, id:{user_id})"
+        return f"{name} (id:{user_id})"
+
+    def _format_group_line(self, user, content: str) -> str:
+        text = (content or "").strip() or "[empty message]"
+        return f"{self._sender_label(user)}: {text}"
+
+    @staticmethod
+    def _group_preview(message, raw_text: str) -> str:
+        if raw_text.strip():
+            return raw_text.strip()
+        if message.photo:
+            return "[sent a photo]"
+        if message.voice:
+            return "[sent a voice message]"
+        if message.audio:
+            return "[sent an audio message]"
+        if message.document:
+            return "[sent a file]"
+        return "[sent a message]"
+
+    def _append_group_history(self, chat_id: str, line: str) -> None:
+        limit = max(0, int(self.config.group_history_on_mention))
+        if limit <= 0:
+            return
+        history = self._group_history.setdefault(chat_id, [])
+        history.append(line)
+        if len(history) > limit:
+            del history[:-limit]
+
+    def _pop_group_history(self, chat_id: str) -> list[str]:
+        return self._group_history.pop(chat_id, [])
+
+    def _build_group_content(self, user, content: str, history_lines: list[str]) -> str:
+        current = self._format_group_line(user, content)
+        if not history_lines:
+            return current
+        history = "\n".join(history_lines)
+        return f"Recent group messages before mention:\n{history}\n\nCurrent message:\n{current}"
+
     async def _forward_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Forward slash commands to the bus for unified handling in AgentLoop."""
         if not update.message or not update.effective_user:
@@ -325,21 +422,49 @@ class TelegramChannel(BaseChannel):
         
         message = update.message
         user = update.effective_user
+        if self._bot_user_id is not None and int(user.id) == int(self._bot_user_id):
+            return
+
         chat_id = message.chat_id
+        str_chat_id = str(chat_id)
+        is_group = self._is_group_chat(message)
+        group_policy = self._group_policy()
+
         sender_id = self._sender_id(user)
         
         # Store chat_id for replies
         self._chat_ids[sender_id] = chat_id
+
+        raw_text_parts: list[str] = []
+        if message.text:
+            raw_text_parts.append(message.text)
+        if message.caption:
+            raw_text_parts.append(message.caption)
+        raw_text = "\n".join(raw_text_parts).strip()
+
+        was_mentioned = is_group and self._is_mentioned(message, raw_text)
+        history_lines: list[str] = []
+        if is_group and group_policy == "mention":
+            if not was_mentioned:
+                preview = self._group_preview(message, raw_text)
+                self._append_group_history(str_chat_id, self._format_group_line(user, preview))
+                logger.debug(
+                    "Skip Telegram group message (not mentioned) chat_id={} sender={}",
+                    str_chat_id,
+                    sender_id,
+                )
+                return
+            history_lines = self._pop_group_history(str_chat_id)
         
         # Build content from text and/or media
-        content_parts = []
-        media_paths = []
-        
-        # Text content
-        if message.text:
-            content_parts.append(message.text)
-        if message.caption:
-            content_parts.append(message.caption)
+        content_parts: list[str] = []
+        media_paths: list[str] = []
+
+        text_content = raw_text
+        if is_group and was_mentioned:
+            text_content = self._strip_bot_mention(text_content)
+        if text_content:
+            content_parts.append(text_content)
         
         # Handle media files
         media_file = None
@@ -393,11 +518,11 @@ class TelegramChannel(BaseChannel):
                 content_parts.append(f"[{media_type}: download failed]")
         
         content = "\n".join(content_parts) if content_parts else "[empty message]"
+        if is_group:
+            content = self._build_group_content(user, content, history_lines)
         
         logger.debug("Telegram message from {}: {}...", sender_id, content[:50])
-        
-        str_chat_id = str(chat_id)
-        
+
         # Start typing indicator before processing
         self._start_typing(str_chat_id)
         
@@ -412,7 +537,10 @@ class TelegramChannel(BaseChannel):
                 "user_id": user.id,
                 "username": user.username,
                 "first_name": user.first_name,
-                "is_group": message.chat.type != "private"
+                "is_group": is_group,
+                "chat_type": message.chat.type,
+                "was_mentioned": was_mentioned,
+                "group_policy": group_policy,
             }
         )
     

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -29,6 +29,9 @@ class TelegramConfig(Base):
     allow_from: list[str] = Field(default_factory=list)  # Allowed user IDs or usernames
     proxy: str | None = None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
     reply_to_message: bool = False  # If true, bot replies quote the original message
+    group_policy: str = "open"  # "open" or "mention"
+    group_history_on_mention: int = 8  # Number of recent group messages to prepend on mention (0 to disable)
+    mention_by_reply: bool = True  # In groups, treat replies to bot messages as mention
 
 
 class FeishuConfig(Base):

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -1,0 +1,182 @@
+from types import SimpleNamespace
+
+import pytest
+
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.telegram import TelegramChannel
+from nanobot.config.schema import TelegramConfig
+
+
+def _make_update(
+    *,
+    text: str = "",
+    chat_type: str = "group",
+    chat_id: int = -10001,
+    user_id: int = 123,
+    username: str = "alice",
+    first_name: str = "Alice",
+    reply_to_user_id: int | None = None,
+):
+    user = SimpleNamespace(id=user_id, username=username, first_name=first_name, last_name="")
+    reply_to = None
+    if reply_to_user_id is not None:
+        reply_to = SimpleNamespace(from_user=SimpleNamespace(id=reply_to_user_id))
+    message = SimpleNamespace(
+        chat_id=chat_id,
+        chat=SimpleNamespace(type=chat_type),
+        text=text,
+        caption=None,
+        photo=[],
+        voice=None,
+        audio=None,
+        document=None,
+        reply_to_message=reply_to,
+        message_id=42,
+    )
+    return SimpleNamespace(message=message, effective_user=user)
+
+
+@pytest.mark.asyncio
+async def test_group_mention_policy_buffers_and_flushes_history(monkeypatch) -> None:
+    cfg = TelegramConfig(
+        enabled=True,
+        token="token",
+        group_policy="mention",
+        group_history_on_mention=8,
+        mention_by_reply=True,
+    )
+    channel = TelegramChannel(cfg, MessageBus())
+    channel._bot_username = "nanobot"
+    channel._bot_user_id = 999
+
+    monkeypatch.setattr(channel, "_start_typing", lambda _chat_id: None)
+
+    captured: list[dict] = []
+
+    async def _capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(channel, "_handle_message", _capture)
+
+    await channel._on_message(
+        _make_update(text="hello everyone", user_id=101, username="alice", first_name="Alice"),
+        None,
+    )
+    assert captured == []
+
+    await channel._on_message(
+        _make_update(text="@nanobot what should we do?", user_id=202, username="bob", first_name="Bob"),
+        None,
+    )
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["chat_id"] == "-10001"
+    assert "Recent group messages before mention:" in payload["content"]
+    assert "Alice (@alice, id:101): hello everyone" in payload["content"]
+    assert "Current message:" in payload["content"]
+    assert "Bob (@bob, id:202): what should we do?" in payload["content"]
+    assert payload["metadata"]["was_mentioned"] is True
+    assert payload["metadata"]["group_policy"] == "mention"
+
+
+@pytest.mark.asyncio
+async def test_group_open_policy_includes_sender_identity(monkeypatch) -> None:
+    cfg = TelegramConfig(enabled=True, token="token", group_policy="open")
+    channel = TelegramChannel(cfg, MessageBus())
+    channel._bot_username = "nanobot"
+    channel._bot_user_id = 999
+
+    monkeypatch.setattr(channel, "_start_typing", lambda _chat_id: None)
+
+    captured: list[dict] = []
+
+    async def _capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(channel, "_handle_message", _capture)
+
+    await channel._on_message(
+        _make_update(text="status update", user_id=303, username="carol", first_name="Carol"),
+        None,
+    )
+
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["content"] == "Carol (@carol, id:303): status update"
+    assert payload["metadata"]["is_group"] is True
+    assert payload["metadata"]["group_policy"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_private_chat_not_affected_by_group_mention_policy(monkeypatch) -> None:
+    cfg = TelegramConfig(enabled=True, token="token", group_policy="mention")
+    channel = TelegramChannel(cfg, MessageBus())
+    channel._bot_username = "nanobot"
+    channel._bot_user_id = 999
+
+    monkeypatch.setattr(channel, "_start_typing", lambda _chat_id: None)
+
+    captured: list[dict] = []
+
+    async def _capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(channel, "_handle_message", _capture)
+
+    await channel._on_message(
+        _make_update(
+            text="hello from dm",
+            chat_type="private",
+            chat_id=777,
+            user_id=404,
+            username="dave",
+            first_name="Dave",
+        ),
+        None,
+    )
+
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["chat_id"] == "777"
+    assert payload["content"] == "hello from dm"
+    assert payload["metadata"]["is_group"] is False
+    assert payload["metadata"]["was_mentioned"] is False
+
+
+@pytest.mark.asyncio
+async def test_group_reply_to_bot_counts_as_mention(monkeypatch) -> None:
+    cfg = TelegramConfig(
+        enabled=True,
+        token="token",
+        group_policy="mention",
+        group_history_on_mention=8,
+        mention_by_reply=True,
+    )
+    channel = TelegramChannel(cfg, MessageBus())
+    channel._bot_username = "nanobot"
+    channel._bot_user_id = 999
+
+    monkeypatch.setattr(channel, "_start_typing", lambda _chat_id: None)
+
+    captured: list[dict] = []
+
+    async def _capture(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(channel, "_handle_message", _capture)
+
+    await channel._on_message(
+        _make_update(
+            text="agree",
+            user_id=505,
+            username="erin",
+            first_name="Erin",
+            reply_to_user_id=999,
+        ),
+        None,
+    )
+
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["metadata"]["was_mentioned"] is True
+    assert payload["content"] == "Erin (@erin, id:505): agree"


### PR DESCRIPTION
  This PR improves the Telegram channel behavior in group chats by making speaker identity explicit and adding a
  configurable mention-based trigger mode to avoid unnecessary LLM activations.

Written by Codex but used successfully, so treat with care...

What this adds

  - Adds sender-aware formatting for forwarded group messages (name/username/id prefix) so multi-user context is
    clearer.
  - Adds group_policy in Telegram config:
      - open (default): process every group message.
      - mention: only process when the bot is explicitly mentioned (or replied to, if enabled).
  - Adds mention-mode context buffering:
      - Non-mention group messages are buffered up to group_history_on_mention.
      - When a valid mention/reply arrives, buffered context is prepended before processing.
  - Keeps private chat behavior unchanged (no mention gating).
  - Updates docs and schema for new Telegram config fields.

  New config fields

  - group_policy: str = "open" (open or mention)
  - group_history_on_mention: int = 8
  - mention_by_reply: bool = True

  Why

  - Without this, the bot in a Telegram group activates after every message, and writes an answer too. This is unnecessary, impractical in fact, and consumes tokens. 
  - Without this patch, the bot is lost with writer attribution in multi-user groups.
  
  Validation

  - Added targeted Telegram channel tests covering:
      - open vs mention policy behavior
      - mention/reply trigger paths
      - buffered history prepend on mention
      - private chat unaffected behavior
  - WARNING: these tests are written by Codex (5.3-codex) and have never been run afaik. 
  - BUT: I have used this feature successfully in Telegram, in groups and in private chat. 
  