### PR TITLE
fix(session): persist final assistant replies

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -225,6 +225,12 @@ class AgentLoop:
                         messages, tool_call.id, tool_call.name, result
                     )
             else:
+                messages = self.context.add_assistant_message(
+                    messages,
+                    response.content,
+                    tool_calls=None,
+                    reasoning_content=response.reasoning_content,
+                )
                 final_content = self._strip_think(response.content)
                 break
 


### PR DESCRIPTION
## Summary
Fix missing final assistant replies in session JSONL.

## Details
- Before: when the last LLM response in `_run_agent_loop` had no tool_calls (pure text), that assistant message was not appended to `messages`, so `_save_turn` never persisted it to the session file.
- After: in the no-tool_calls branch, call `ContextBuilder.add_assistant_message(...)` before returning, so the final assistant reply is included in `messages` and written to the session JSONL for future turns.