### PR TITLE
feat: Claude Code CLI OAuth login + Anthropic API proxy

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -1,0 +1,408 @@
+---
+name: setup
+description: Run initial nanobot setup. Use when user wants to install, configure providers, set up chat channels, or deploy the gateway. Triggers on "setup", "install", "configure nanobot", "onboard", or first-time setup requests.
+---
+
+# nanobot Setup
+
+Run setup steps automatically. Only pause when user action is required (OAuth login, pasting tokens, scanning QR codes). Use `AskUserQuestion` for all user-facing choices.
+
+**Principle:** When something is broken or missing, fix it. Don't tell the user to go fix it themselves unless it genuinely requires their manual action (e.g. running `claude setup-token` in another terminal, scanning a QR code). If a dependency is missing, install it. If a config is wrong, fix it. Ask the user for permission when needed, then do the work.
+
+**Config editing:** Always read `~/.nanobot/config.json` first, merge changes into existing config, write back. Never overwrite unrelated settings.
+
+**Secrets policy:** OAuth tokens must NEVER be collected in chat — direct the user to run the auth command in another terminal. API keys and channel tokens CAN be collected via `AskUserQuestion` since they are user-provided credentials the user explicitly wants to configure.
+
+**Idempotent:** Check state before each step. Skip what's already done, offer to reconfigure if user wants.
+
+## 1. Prerequisites
+
+Check requirements and fix what's missing:
+
+```bash
+python3 --version   # Need >= 3.11
+docker --version    # Need Docker for containerized deploy
+which nanobot       # Check if nanobot CLI is installed
+```
+
+- **Python < 3.11 or missing:** Inform user, suggest install method for their OS.
+- **Docker missing/not running:**
+  - Not installed: `AskUserQuestion: Docker is needed for containerized deployment. Install it?`
+    - Linux: `curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker $USER`
+    - macOS: `brew install --cask docker`
+  - Installed but not running: start it (`sudo systemctl start docker` on Linux, `open -a Docker` on macOS). Wait 15s, re-check with `docker info`.
+- **nanobot not installed:** Check if we're in the nanobot repo directory.
+  - In repo: `pip install -e .` (editable install for development)
+  - Not in repo: `pip install nanobot-ai` or `uv tool install nanobot-ai`
+
+## 2. Onboard
+
+Run `nanobot onboard` to create config and workspace.
+
+```bash
+nanobot onboard
+```
+
+- If config already exists, choose "N" (refresh, keep existing values).
+- If fresh install, it creates `~/.nanobot/config.json` and `~/.nanobot/workspace/`.
+- Verify config exists after: `cat ~/.nanobot/config.json`
+
+## 3. Provider Authentication
+
+`AskUserQuestion: Which LLM provider do you want to use?`
+
+Options:
+- **Claude Code CLI (OAuth)** — Uses your Claude Code subscription. No API key needed.
+- **OpenRouter** — Access to all models. Needs API key from openrouter.ai.
+- **Anthropic** — Claude direct. Needs API key from console.anthropic.com.
+- **Other** — Any provider from the supported list.
+
+### Claude Code CLI (OAuth)
+
+Claude Code uses OAuth — no API key or `providers` config entry needed. The token is read from the `CLAUDE_CODE_OAUTH_TOKEN` env var at runtime. The `providers.claude_code` section in config only has `enabled` (default: true) and an optional `model` override.
+
+1. Check if `claude` CLI is installed: `which claude`
+   - Not installed: inform user to install Claude Code CLI first (https://docs.anthropic.com/en/docs/claude-code)
+2. Check if token already exists: `echo $CLAUDE_CODE_OAUTH_TOKEN`
+   - If set, confirm with user: keep existing token or re-authenticate?
+3. If no token: tell user to run `claude setup-token` **in another terminal** and come back when done.
+   - **Do NOT collect the token in chat.**
+   - `claude setup-token` prints a token starting with `sk-ant-oat...`
+   - After user confirms they ran it, verify the token is accessible.
+4. **Wire up the env var for nanobot to read it:**
+   - **For Docker:** Ensure `docker-compose.yml` has `env_file: .env` in the gateway service. If not, add it. Then add the token to `.env` in the project root:
+     ```bash
+     echo "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-..." >> .env
+     ```
+     Make sure `.env` is in `.gitignore` (never commit secrets).
+   - **For local/systemd:** Add to shell profile (`~/.bashrc` or `~/.zshrc`):
+     ```bash
+     export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-..."
+     ```
+     Then `source ~/.bashrc` (or restart shell).
+   - Verify: `echo $CLAUDE_CODE_OAUTH_TOKEN | head -c 10` should show `sk-ant-oat`
+5. `AskUserQuestion: Which Claude model?` Options: claude-sonnet-4-20250514 (recommended, fast), claude-opus-4-5-20250414 (most capable).
+6. Set model in config — read config, merge (only the model, no provider entry needed):
+   ```json
+   {
+     "agents": {
+       "defaults": {
+         "model": "claude-code/claude-sonnet-4-20250514"
+       }
+     }
+   }
+   ```
+
+### OpenRouter
+
+1. `AskUserQuestion: What is your OpenRouter API key?` (get one at https://openrouter.ai/keys)
+2. Read current config, merge the key:
+   ```json
+   {
+     "providers": {
+       "openrouter": {
+         "apiKey": "sk-or-v1-xxx"
+       }
+     }
+   }
+   ```
+3. `AskUserQuestion: Which model?` Suggest `anthropic/claude-sonnet-4-20250514` as default.
+
+### Anthropic (direct)
+
+1. Same pattern: user provides API key, write to config under `providers.anthropic.apiKey`.
+2. Model: `claude-sonnet-4-20250514` default.
+
+### Other providers
+
+For any other provider in the supported list (deepseek, gemini, groq, minimax, etc.):
+1. Ask for API key
+2. Write to appropriate config field: `providers.<name>.apiKey`
+3. Ask for model name or suggest a default
+
+## 4. Channel Setup
+
+`AskUserQuestion: Which chat channel(s) do you want to connect?`
+
+Options: Telegram (recommended), Discord, WhatsApp, Slack, Feishu, DingTalk, Email, QQ, Mochat, None (CLI only for now)
+
+### Telegram
+
+1. Tell user: Open Telegram, search `@BotFather`, send `/newbot`, follow prompts, copy the token.
+2. `AskUserQuestion: What is your Telegram bot token?` — Write to config.
+3. `AskUserQuestion: What is your Telegram User ID?` (find in Telegram settings, without `@`)
+4. Write to config:
+   ```json
+   {
+     "channels": {
+       "telegram": {
+         "enabled": true,
+         "token": "BOT_TOKEN",
+         "allowFrom": ["USER_ID"]
+       }
+     }
+   }
+   ```
+
+### Discord
+
+1. Tell user: Go to https://discord.com/developers/applications, create app, add bot, enable MESSAGE CONTENT INTENT, copy bot token.
+2. Tell user: Enable Developer Mode in Discord settings, right-click avatar, Copy User ID.
+3. Collect bot token and user ID via `AskUserQuestion`.
+4. Write to config:
+   ```json
+   {
+     "channels": {
+       "discord": {
+         "enabled": true,
+         "token": "BOT_TOKEN",
+         "allowFrom": ["USER_ID"]
+       }
+     }
+   }
+   ```
+5. Remind user to invite the bot: OAuth2 > URL Generator > Scopes: `bot` > Permissions: `Send Messages`, `Read Message History`.
+
+### WhatsApp
+
+1. Requires Node.js >= 18. Check: `node --version`. Install if missing:
+   - Linux: `curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs`
+   - macOS: `brew install node@22`
+2. Tell user they'll need two terminals:
+   - Terminal 1: `nanobot channels login` (scan QR with WhatsApp > Linked Devices)
+   - Terminal 2: `nanobot gateway`
+3. `AskUserQuestion: What is your phone number?` (format: +1234567890)
+4. Write to config:
+   ```json
+   {
+     "channels": {
+       "whatsapp": {
+         "enabled": true,
+         "allowFrom": ["+1234567890"]
+       }
+     }
+   }
+   ```
+
+### Slack
+
+1. Tell user to create a Slack app at https://api.slack.com/apps (from scratch).
+2. Guide: Socket Mode ON > generate App-Level Token (`xapp-...`), add bot scopes (`chat:write`, `reactions:write`, `app_mentions:read`), subscribe to events (`message.im`, `message.channels`, `app_mention`), enable Messages Tab, install to workspace, copy Bot Token (`xoxb-...`).
+3. Collect bot token and app token via `AskUserQuestion`.
+4. Write to config:
+   ```json
+   {
+     "channels": {
+       "slack": {
+         "enabled": true,
+         "botToken": "xoxb-...",
+         "appToken": "xapp-...",
+         "groupPolicy": "mention"
+       }
+     }
+   }
+   ```
+
+### Feishu
+
+1. Tell user: Visit https://open.feishu.cn/app, create app, enable Bot, add `im:message` permission, add `im.message.receive_v1` event with Long Connection mode, get App ID and App Secret, publish app.
+2. Collect App ID and App Secret via `AskUserQuestion`.
+3. Write to config (`encryptKey` and `verificationToken` are optional for Long Connection mode):
+   ```json
+   {
+     "channels": {
+       "feishu": {
+         "enabled": true,
+         "appId": "cli_xxx",
+         "appSecret": "xxx",
+         "encryptKey": "",
+         "verificationToken": "",
+         "allowFrom": []
+       }
+     }
+   }
+   ```
+
+### DingTalk
+
+1. Tell user: Visit https://open-dev.dingtalk.com/, create app, add Robot capability, toggle Stream Mode ON, get AppKey and AppSecret.
+2. Collect credentials via `AskUserQuestion`.
+3. Write to config:
+   ```json
+   {
+     "channels": {
+       "dingtalk": {
+         "enabled": true,
+         "clientId": "APP_KEY",
+         "clientSecret": "APP_SECRET"
+       }
+     }
+   }
+   ```
+
+### Email
+
+1. Tell user to create a dedicated email account (e.g. Gmail with App Password: enable 2-Step Verification, then create an App Password at https://myaccount.google.com/apppasswords).
+2. Collect IMAP/SMTP settings and allowed sender addresses via `AskUserQuestion`.
+3. Write to config:
+   ```json
+   {
+     "channels": {
+       "email": {
+         "enabled": true,
+         "consentGranted": true,
+         "imapHost": "imap.gmail.com",
+         "imapPort": 993,
+         "imapUsername": "my-nanobot@gmail.com",
+         "imapPassword": "your-app-password",
+         "smtpHost": "smtp.gmail.com",
+         "smtpPort": 587,
+         "smtpUsername": "my-nanobot@gmail.com",
+         "smtpPassword": "your-app-password",
+         "fromAddress": "my-nanobot@gmail.com",
+         "allowFrom": ["your-real-email@gmail.com"]
+       }
+     }
+   }
+   ```
+
+### QQ
+
+1. Tell user: Visit https://q.qq.com, register as developer, create bot, get AppID and AppSecret.
+2. Tell user to set up sandbox for testing.
+3. Collect credentials via `AskUserQuestion`.
+4. Write to config:
+   ```json
+   {
+     "channels": {
+       "qq": {
+         "enabled": true,
+         "appId": "APP_ID",
+         "secret": "APP_SECRET"
+       }
+     }
+   }
+   ```
+
+### Mochat
+
+1. Simplest option — tell user they can ask nanobot itself to set it up:
+   > Send this to nanobot: `Read https://raw.githubusercontent.com/HKUDS/MoChat/refs/heads/main/skills/nanobot/skill.md and register on MoChat. My Email account is xxx@xxx Bind me as your owner and DM me on MoChat.`
+2. Or collect `claw_token` and `agent_user_id` manually and write to config:
+   ```json
+   {
+     "channels": {
+       "mochat": {
+         "enabled": true,
+         "base_url": "https://mochat.io",
+         "socket_url": "https://mochat.io",
+         "socket_path": "/socket.io",
+         "claw_token": "claw_xxx",
+         "agent_user_id": "6982abcdef",
+         "sessions": ["*"],
+         "panels": ["*"],
+         "reply_delay_mode": "non-mention",
+         "reply_delay_ms": 120000
+       }
+     }
+   }
+   ```
+
+## 5. Deploy
+
+`AskUserQuestion: How do you want to run nanobot?`
+
+Options:
+- **Docker (recommended)** — containerized, auto-restart
+- **Local** — run directly with `nanobot gateway`
+- **systemd service** — run as a background Linux service
+
+### Docker
+
+```bash
+docker compose up -d --build nanobot-gateway
+```
+
+Verify:
+```bash
+docker compose ps
+docker compose logs --tail 20 nanobot-gateway
+```
+
+If build fails: read logs, diagnose, fix, retry.
+
+### Local
+
+```bash
+nanobot gateway
+```
+
+Note: this runs in foreground. Suggest Docker or systemd for persistent deployment.
+
+### systemd service (Linux)
+
+1. Find nanobot path: `which nanobot`
+2. Create `~/.config/systemd/user/nanobot-gateway.service` (replace ExecStart path if needed):
+   ```ini
+   [Unit]
+   Description=Nanobot Gateway
+   After=network.target
+
+   [Service]
+   Type=simple
+   ExecStart=%h/.local/bin/nanobot gateway
+   Restart=always
+   RestartSec=10
+   NoNewPrivileges=yes
+   ProtectSystem=strict
+   ReadWritePaths=%h
+
+   [Install]
+   WantedBy=default.target
+   ```
+3. Enable and start:
+   ```bash
+   systemctl --user daemon-reload
+   systemctl --user enable --now nanobot-gateway
+   ```
+4. User services only run while logged in. For unattended operation:
+   ```bash
+   loginctl enable-linger $USER
+   ```
+
+## 6. Verify
+
+Run verification checks:
+
+```bash
+nanobot status
+```
+
+For Docker:
+```bash
+docker compose ps
+docker compose logs --tail 30 nanobot-gateway
+```
+
+Check for:
+- Provider shows as configured (API key or OAuth token detected)
+- Channels show as enabled
+- Gateway is running and accepting connections
+- No errors in logs
+
+If something is wrong, diagnose and fix. Common issues:
+- **Provider not detected:** Check config.json has the right key under `providers`.
+- **Channel failing:** Check token/credentials are correct, bot has required permissions.
+- **Gateway won't start:** Check port 18790 is free, Docker is running.
+
+Tell user to test by sending a message in their configured channel.
+
+## Troubleshooting
+
+**`claude setup-token` didn't set the env var:** The token may need to be exported. Check `~/.claude/` for credential files. The user may need to restart their shell or source the profile.
+
+**Docker build fails:** Run `docker compose build --no-cache nanobot-gateway` for a clean build.
+
+**Gateway crashes on startup:** Check `docker compose logs nanobot-gateway`. Usually a config issue — missing required fields or invalid JSON.
+
+**Bot doesn't respond:** Check `allowFrom` — if set, only listed user IDs can interact. Empty list means allow everyone.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .assets
 .env
+.mcp.json
 *.pyc
 dist/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ venv/
 __pycache__/
 poetry.lock
 .pytest_cache/
+.worktrees/
 botpy.log
 tests/

--- a/README.md
+++ b/README.md
@@ -603,6 +603,37 @@ Config file: `~/.nanobot/config.json`
 | `vllm` | LLM (local, any OpenAI-compatible server) | — |
 | `openai_codex` | LLM (Codex, OAuth) | `nanobot provider login openai-codex` |
 | `github_copilot` | LLM (GitHub Copilot, OAuth) | `nanobot provider login github-copilot` |
+| `claude_code` | LLM (Claude Code CLI, OAuth) | `claude setup-token` via Claude Code CLI |
+
+<details>
+<summary><b>Claude Code CLI (OAuth)</b></summary>
+
+Uses your existing Claude Code CLI OAuth token to access Anthropic models. Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and logged in.
+
+**1. Login via Claude Code CLI:**
+```bash
+claude setup-token
+```
+
+**2. Set model** (merge into `~/.nanobot/config.json`):
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "claude-code/claude-sonnet-4-20250514"
+    }
+  }
+}
+```
+
+**3. Chat:**
+```bash
+nanobot agent -m "Hello!"
+```
+
+> The Claude Code provider auto-detects your OAuth token — no API key needed. It also exposes a local Anthropic-compatible proxy, so other tools can use it too.
+
+</details>
 
 <details>
 <summary><b>OpenAI Codex (OAuth)</b></summary>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ x-common-config: &common-config
   build:
     context: .
     dockerfile: Dockerfile
+  env_file:
+    - path: .env
+      required: false
   volumes:
     - ~/.nanobot:/root/.nanobot
 

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -1,6 +1,7 @@
 """MCP client: connects to MCP servers and wraps their tools as native nanobot tools."""
 
 import asyncio
+import os
 from contextlib import AsyncExitStack
 from typing import Any
 
@@ -63,8 +64,14 @@ async def connect_mcp_servers(
     for name, cfg in mcp_servers.items():
         try:
             if cfg.command:
+                # Resolve ${VAR} references in env values from os.environ
+                resolved_env = None
+                if cfg.env:
+                    resolved_env = {
+                        k: os.path.expandvars(v) for k, v in cfg.env.items()
+                    }
                 params = StdioServerParameters(
-                    command=cfg.command, args=cfg.args, env=cfg.env or None
+                    command=cfg.command, args=cfg.args, env=resolved_env
                 )
                 read, write = await stack.enter_async_context(stdio_client(params))
             elif cfg.url:

--- a/nanobot/api/__init__.py
+++ b/nanobot/api/__init__.py
@@ -1,0 +1,1 @@
+"""Anthropic Messages API proxy module."""

--- a/nanobot/api/anthropic_format.py
+++ b/nanobot/api/anthropic_format.py
@@ -1,0 +1,321 @@
+"""Anthropic <-> LiteLLM (OpenAI) format conversion.
+
+Converts between the Anthropic Messages API format and the OpenAI/LiteLLM
+chat completion format so the proxy can serve Anthropic-format requests
+using any LiteLLM-supported backend.
+"""
+
+import json
+from typing import Any, AsyncIterator
+
+# Anthropic stop_reason -> OpenAI finish_reason
+_STOP_REASON_MAP = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "content_filter": "end_turn",
+}
+
+# OpenAI finish_reason -> Anthropic stop_reason (reverse)
+_FINISH_REASON_MAP = {v: k for k, v in _STOP_REASON_MAP.items()}
+
+
+def anthropic_request_to_litellm(body: dict[str, Any]) -> dict[str, Any]:
+    """Convert an Anthropic Messages API request to LiteLLM (OpenAI) format.
+
+    Handles: system, messages (text/image/tool_use/tool_result), tools, stop_sequences.
+    """
+    litellm_messages: list[dict[str, Any]] = []
+
+    # System prompt
+    system = body.get("system")
+    if isinstance(system, str) and system:
+        litellm_messages.append({"role": "system", "content": system})
+    elif isinstance(system, list):
+        text_parts = [b["text"] for b in system if b.get("type") == "text"]
+        if text_parts:
+            litellm_messages.append({"role": "system", "content": "\n\n".join(text_parts)})
+
+    # Messages
+    for msg in body.get("messages", []):
+        role = msg.get("role")
+        content = msg.get("content")
+
+        if role == "assistant":
+            if isinstance(content, str):
+                litellm_messages.append({"role": "assistant", "content": content})
+            elif isinstance(content, list):
+                text_parts = []
+                tool_calls = []
+                for block in content:
+                    btype = block.get("type")
+                    if btype == "text":
+                        text_parts.append(block["text"])
+                    elif btype == "tool_use":
+                        tool_calls.append({
+                            "id": block.get("id", ""),
+                            "type": "function",
+                            "function": {
+                                "name": block.get("name", ""),
+                                "arguments": json.dumps(block.get("input", {})),
+                            },
+                        })
+                assistant_msg: dict[str, Any] = {"role": "assistant"}
+                assistant_msg["content"] = "\n".join(text_parts) if text_parts else None
+                if tool_calls:
+                    assistant_msg["tool_calls"] = tool_calls
+                litellm_messages.append(assistant_msg)
+            continue
+
+        if role == "user":
+            if isinstance(content, str):
+                litellm_messages.append({"role": "user", "content": content})
+            elif isinstance(content, list):
+                user_parts: list[dict[str, Any]] = []
+                tool_results: list[dict[str, Any]] = []
+                for block in content:
+                    btype = block.get("type")
+                    if btype == "text":
+                        user_parts.append({"type": "text", "text": block["text"]})
+                    elif btype == "image":
+                        source = block.get("source", {})
+                        if source.get("type") == "base64":
+                            url = f"data:{source['media_type']};base64,{source['data']}"
+                            user_parts.append({
+                                "type": "image_url",
+                                "image_url": {"url": url},
+                            })
+                    elif btype == "tool_result":
+                        # Tool results become separate messages
+                        result_content = block.get("content", "")
+                        if isinstance(result_content, list):
+                            result_content = "\n".join(
+                                b.get("text", "") for b in result_content if b.get("type") == "text"
+                            )
+                        tool_results.append({
+                            "role": "tool",
+                            "tool_call_id": block.get("tool_use_id", ""),
+                            "content": result_content,
+                        })
+                # Add tool results first (they relate to previous assistant turn)
+                litellm_messages.extend(tool_results)
+                # Then add user content if any
+                if user_parts:
+                    if len(user_parts) == 1 and user_parts[0].get("type") == "text":
+                        litellm_messages.append({"role": "user", "content": user_parts[0]["text"]})
+                    else:
+                        litellm_messages.append({"role": "user", "content": user_parts})
+            continue
+
+        # Pass through other roles
+        litellm_messages.append(msg)
+
+    result: dict[str, Any] = {
+        "model": body.get("model", ""),
+        "messages": litellm_messages,
+        "max_tokens": body.get("max_tokens", 4096),
+    }
+
+    if "temperature" in body:
+        result["temperature"] = body["temperature"]
+
+    # stop_sequences -> stop
+    if "stop_sequences" in body:
+        result["stop"] = body["stop_sequences"]
+
+    # Tools
+    if "tools" in body:
+        openai_tools = []
+        for tool in body["tools"]:
+            openai_tools.append({
+                "type": "function",
+                "function": {
+                    "name": tool.get("name", ""),
+                    "description": tool.get("description", ""),
+                    "parameters": tool.get("input_schema", {"type": "object", "properties": {}}),
+                },
+            })
+        result["tools"] = openai_tools
+        result["tool_choice"] = "auto"
+
+    if body.get("stream"):
+        result["stream"] = True
+
+    return result
+
+
+def litellm_response_to_anthropic(response: Any, model: str = "") -> dict[str, Any]:
+    """Convert a LiteLLM response object to Anthropic Messages API format."""
+    choice = response.choices[0]
+    message = choice.message
+
+    content_blocks: list[dict[str, Any]] = []
+
+    if message.content:
+        content_blocks.append({"type": "text", "text": message.content})
+
+    if hasattr(message, "tool_calls") and message.tool_calls:
+        for tc in message.tool_calls:
+            args = tc.function.arguments
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    args = {}
+            content_blocks.append({
+                "type": "tool_use",
+                "id": tc.id,
+                "name": tc.function.name,
+                "input": args,
+            })
+
+    # Map finish reason
+    finish = choice.finish_reason or "stop"
+    stop_reason = _STOP_REASON_MAP.get(finish, "end_turn")
+
+    usage = response.usage if hasattr(response, "usage") and response.usage else None
+
+    return {
+        "id": getattr(response, "id", "msg_proxy"),
+        "type": "message",
+        "role": "assistant",
+        "model": model or getattr(response, "model", ""),
+        "content": content_blocks,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": usage.prompt_tokens if usage else 0,
+            "output_tokens": usage.completion_tokens if usage else 0,
+        },
+    }
+
+
+async def generate_sse_events(
+    stream: AsyncIterator,
+    model: str = "",
+) -> AsyncIterator[str]:
+    """Convert LiteLLM streaming chunks to Anthropic SSE event sequence.
+
+    Yields SSE-formatted strings: "event: <type>\\ndata: <json>\\n\\n"
+    """
+    # message_start
+    yield _sse("message_start", {
+        "type": "message_start",
+        "message": {
+            "id": "msg_proxy",
+            "type": "message",
+            "role": "assistant",
+            "model": model,
+            "content": [],
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        },
+    })
+
+    block_index = 0
+    in_text_block = False
+    in_tool_block = False
+    current_tool_id = ""
+    current_tool_name = ""
+
+    async for chunk in stream:
+        if not hasattr(chunk, "choices") or not chunk.choices:
+            continue
+
+        delta = chunk.choices[0].delta
+        finish_reason = chunk.choices[0].finish_reason
+
+        # Text content
+        text = getattr(delta, "content", None)
+        if text:
+            if not in_text_block:
+                yield _sse("content_block_start", {
+                    "type": "content_block_start",
+                    "index": block_index,
+                    "content_block": {"type": "text", "text": ""},
+                })
+                in_text_block = True
+
+            yield _sse("content_block_delta", {
+                "type": "content_block_delta",
+                "index": block_index,
+                "delta": {"type": "text_delta", "text": text},
+            })
+
+        # Tool calls
+        tool_calls = getattr(delta, "tool_calls", None)
+        if tool_calls:
+            for tc in tool_calls:
+                fn = getattr(tc, "function", None)
+                if not fn:
+                    continue
+
+                # New tool call starts
+                if fn.name:
+                    # Close previous blocks
+                    if in_text_block:
+                        yield _sse("content_block_stop", {
+                            "type": "content_block_stop",
+                            "index": block_index,
+                        })
+                        block_index += 1
+                        in_text_block = False
+
+                    if in_tool_block:
+                        yield _sse("content_block_stop", {
+                            "type": "content_block_stop",
+                            "index": block_index,
+                        })
+                        block_index += 1
+
+                    current_tool_id = tc.id or ""
+                    current_tool_name = fn.name
+                    yield _sse("content_block_start", {
+                        "type": "content_block_start",
+                        "index": block_index,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": current_tool_id,
+                            "name": current_tool_name,
+                            "input": {},
+                        },
+                    })
+                    in_tool_block = True
+
+                # Tool arguments delta
+                if fn.arguments:
+                    yield _sse("content_block_delta", {
+                        "type": "content_block_delta",
+                        "index": block_index,
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": fn.arguments,
+                        },
+                    })
+
+        # Stream finished
+        if finish_reason:
+            if in_text_block:
+                yield _sse("content_block_stop", {
+                    "type": "content_block_stop",
+                    "index": block_index,
+                })
+            if in_tool_block:
+                yield _sse("content_block_stop", {
+                    "type": "content_block_stop",
+                    "index": block_index,
+                })
+
+            stop_reason = _STOP_REASON_MAP.get(finish_reason, "end_turn")
+            yield _sse("message_delta", {
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                "usage": {"output_tokens": 0},
+            })
+            yield _sse("message_stop", {"type": "message_stop"})
+
+
+def _sse(event: str, data: dict[str, Any]) -> str:
+    """Format an SSE event string."""
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"

--- a/nanobot/api/auth.py
+++ b/nanobot/api/auth.py
@@ -1,0 +1,23 @@
+"""Simple API key authentication for the proxy server."""
+
+from aiohttp import web
+
+
+def check_auth(request: web.Request, required_key: str) -> str | None:
+    """Validate the request against the required API key.
+
+    Returns None if authorized, or an error message string if not.
+    """
+    if not required_key:
+        return None  # empty key = accept all requests
+
+    # Accept "Authorization: Bearer <key>"
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer ") and auth_header[7:] == required_key:
+        return None
+
+    # Accept "x-api-key: <key>"
+    if request.headers.get("x-api-key", "") == required_key:
+        return None
+
+    return "Invalid API key"

--- a/nanobot/api/claude_direct.py
+++ b/nanobot/api/claude_direct.py
@@ -1,0 +1,74 @@
+"""Direct Anthropic API client using OAuth token.
+
+Used by the proxy server in OAuth mode to forward requests directly
+to the Anthropic Messages API with Claude Code headers.
+"""
+
+from typing import Any
+
+import httpx
+from loguru import logger
+
+ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+
+CLAUDE_CODE_HEADERS = {
+    "anthropic-version": "2023-06-01",
+    "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14",
+}
+
+CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
+
+
+def inject_system_prompt(body: dict[str, Any]) -> dict[str, Any]:
+    """Ensure the required Claude Code system prompt is present."""
+    system = body.get("system")
+
+    if system is None:
+        body["system"] = CLAUDE_CODE_SYSTEM_PREFIX
+    elif isinstance(system, str):
+        if CLAUDE_CODE_SYSTEM_PREFIX not in system:
+            body["system"] = [
+                {"type": "text", "text": CLAUDE_CODE_SYSTEM_PREFIX},
+                {"type": "text", "text": system},
+            ]
+    elif isinstance(system, list):
+        has_prefix = any(
+            b.get("type") == "text" and CLAUDE_CODE_SYSTEM_PREFIX in b.get("text", "")
+            for b in system
+        )
+        if not has_prefix:
+            body["system"] = [
+                {"type": "text", "text": CLAUDE_CODE_SYSTEM_PREFIX},
+            ] + system
+
+    return body
+
+
+async def send_to_anthropic(
+    body: dict[str, Any],
+    token: str,
+    stream: bool = False,
+) -> httpx.Response:
+    """Send a request to the Anthropic Messages API.
+
+    For streaming requests, returns the response with stream open (caller must close).
+    For non-streaming, returns the complete response.
+    """
+    body = inject_system_prompt(body)
+
+    headers = {
+        **CLAUDE_CODE_HEADERS,
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    if stream:
+        body["stream"] = True
+        client = httpx.AsyncClient(timeout=300)
+        req = client.build_request("POST", ANTHROPIC_API_URL, json=body, headers=headers)
+        resp = await client.send(req, stream=True)
+        resp._client = client  # attach for cleanup
+        return resp
+
+    async with httpx.AsyncClient(timeout=300) as client:
+        return await client.post(ANTHROPIC_API_URL, json=body, headers=headers)

--- a/nanobot/api/handlers.py
+++ b/nanobot/api/handlers.py
@@ -1,0 +1,144 @@
+"""HTTP handlers for the Anthropic Messages API proxy."""
+
+import json
+from typing import Any
+
+from aiohttp import web
+from loguru import logger
+
+from nanobot.api.auth import check_auth
+from nanobot.api.claude_direct import send_to_anthropic
+from nanobot.providers.claude_code_auth import is_oauth_token
+
+
+class MessagesHandler:
+    """Handler for /v1/messages requests.
+
+    Two modes:
+    - OAuth mode: forward directly to Anthropic API with Claude Code headers
+    - LiteLLM mode: convert Anthropic -> OpenAI format, call via LiteLLM, convert back
+    """
+
+    def __init__(self, proxy_config: Any, litellm_kwargs: dict[str, Any]):
+        self._proxy_config = proxy_config
+        self._litellm_kwargs = litellm_kwargs
+
+        api_key = litellm_kwargs.get("api_key", "")
+        if api_key and is_oauth_token(api_key):
+            self._oauth_token: str | None = api_key
+        else:
+            self._oauth_token = None
+
+        self._model_map: dict[str, str] = {}
+        if hasattr(proxy_config, "model_map"):
+            self._model_map = proxy_config.model_map or {}
+
+    def _remap_model(self, model: str) -> str:
+        """Apply model name remapping from config."""
+        return self._model_map.get(model, model)
+
+    async def handle_messages(self, request: web.Request) -> web.StreamResponse:
+        """Handle POST /v1/messages."""
+        # Auth check
+        required_key = getattr(self._proxy_config, "api_key", "")
+        auth_err = check_auth(request, required_key)
+        if auth_err:
+            return web.json_response({"error": {"type": "authentication_error", "message": auth_err}}, status=401)
+
+        try:
+            body = await request.json()
+        except json.JSONDecodeError:
+            return web.json_response(
+                {"error": {"type": "invalid_request_error", "message": "Invalid JSON body"}},
+                status=400,
+            )
+
+        # Apply model remapping
+        if "model" in body:
+            body["model"] = self._remap_model(body["model"])
+
+        is_stream = body.get("stream", False)
+
+        if self._oauth_token:
+            return await self._handle_oauth(body, is_stream)
+        return await self._handle_litellm(body, is_stream)
+
+    async def _handle_oauth(self, body: dict[str, Any], stream: bool) -> web.StreamResponse:
+        """Forward request directly to Anthropic API (OAuth path)."""
+        try:
+            resp = await send_to_anthropic(body, self._oauth_token, stream=stream)
+
+            if not stream:
+                data = resp.json()
+                return web.json_response(data, status=resp.status_code)
+
+            # Streaming: pipe SSE from Anthropic directly
+            response = web.StreamResponse(
+                status=resp.status_code,
+                headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+            )
+            await response.prepare(request=None)  # aiohttp quirk
+
+            try:
+                async for line in resp.aiter_lines():
+                    await response.write(f"{line}\n".encode())
+            finally:
+                await resp.aclose()
+                if hasattr(resp, "_client"):
+                    await resp._client.aclose()
+
+            return response
+
+        except Exception as e:
+            logger.error("OAuth proxy error: {}", e)
+            return web.json_response(
+                {"error": {"type": "api_error", "message": str(e)}},
+                status=502,
+            )
+
+    async def _handle_litellm(self, body: dict[str, Any], stream: bool) -> web.StreamResponse:
+        """Convert Anthropic -> LiteLLM, call LLM, convert back."""
+        from litellm import acompletion
+
+        from nanobot.api.anthropic_format import (
+            anthropic_request_to_litellm,
+            generate_sse_events,
+            litellm_response_to_anthropic,
+        )
+
+        litellm_req = anthropic_request_to_litellm(body)
+        model = litellm_req.pop("model", "") or self._litellm_kwargs.get("model", "")
+
+        kwargs = {
+            **self._litellm_kwargs,
+            **litellm_req,
+            "model": model,
+        }
+        # Don't pass api_key twice
+        if "api_key" not in kwargs and self._litellm_kwargs.get("api_key"):
+            kwargs["api_key"] = self._litellm_kwargs["api_key"]
+
+        try:
+            if stream:
+                kwargs["stream"] = True
+                response = await acompletion(**kwargs)
+
+                sse_response = web.StreamResponse(
+                    headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+                )
+                await sse_response.prepare(request=None)
+
+                async for event_str in generate_sse_events(response, model=model):
+                    await sse_response.write(event_str.encode())
+
+                return sse_response
+            else:
+                response = await acompletion(**kwargs)
+                anthropic_resp = litellm_response_to_anthropic(response, model=model)
+                return web.json_response(anthropic_resp)
+        except Exception as e:
+            logger.error("LiteLLM proxy error: {}", e)
+            return web.json_response(
+                {"error": {"type": "api_error", "message": str(e)}},
+                status=502,
+            )

--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -1,0 +1,47 @@
+"""aiohttp-based Anthropic Messages API proxy server."""
+
+from aiohttp import web
+from loguru import logger
+
+from nanobot.api.handlers import MessagesHandler
+
+
+class ProxyServer:
+    """Lightweight proxy server exposing Anthropic Messages API endpoints."""
+
+    def __init__(self, host: str, port: int, handler: MessagesHandler):
+        self.host = host
+        self.port = port
+        self.handler = handler
+        self._runner: web.AppRunner | None = None
+
+    def _create_app(self) -> web.Application:
+        app = web.Application()
+        app.router.add_post("/v1/messages", self.handler.handle_messages)
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/", self._handle_root)
+        return app
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        return web.json_response({"status": "ok"})
+
+    async def _handle_root(self, request: web.Request) -> web.Response:
+        return web.json_response({
+            "service": "nanobot-proxy",
+            "endpoints": ["/v1/messages", "/health"],
+        })
+
+    async def start(self) -> None:
+        """Start the proxy server (non-blocking)."""
+        app = self._create_app()
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, self.port)
+        await site.start()
+        logger.info("Proxy server started on {}:{}", self.host, self.port)
+
+    async def stop(self) -> None:
+        """Stop the proxy server."""
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -193,6 +193,7 @@ def onboard():
     console.print("\nNext steps:")
     console.print("  1. Add your API key to [cyan]~/.nanobot/config.json[/cyan]")
     console.print("     Get one at: https://openrouter.ai/keys")
+    console.print("     [dim]Or use Claude Code CLI: [cyan]claude setup-token[/cyan] (no API key needed)[/dim]")
     console.print("  2. Chat: [cyan]nanobot agent -m \"Hello!\"[/cyan]")
     console.print("\n[dim]Want Telegram/WhatsApp? See: https://github.com/HKUDS/nanobot#-chat-apps[/dim]")
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1076,6 +1076,17 @@ def status():
                 has_key = bool(p.api_key)
                 console.print(f"{spec.label}: {'[green]✓[/green]' if has_key else '[dim]not set[/dim]'}")
 
+        # MCP servers
+        mcp_servers = config.tools.mcp_servers
+        if mcp_servers:
+            console.print()
+            console.print(f"MCP Servers: {len(mcp_servers)}")
+            for name, cfg in mcp_servers.items():
+                if cfg.command:
+                    console.print(f"  [green]●[/green] {name} [dim]({cfg.command} {' '.join(cfg.args)})[/dim]")
+                elif cfg.url:
+                    console.print(f"  [green]●[/green] {name} [dim]({cfg.url})[/dim]")
+
 
 # ============================================================================
 # OAuth Login

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -6,6 +6,7 @@ import signal
 from pathlib import Path
 import select
 import sys
+from typing import Any
 
 import typer
 from rich.console import Console
@@ -230,7 +231,10 @@ def _create_workspace_templates(workspace: Path):
 
 
 def _make_provider(config: Config):
-    """Create the appropriate LLM provider from config."""
+    """Create the appropriate LLM provider from config.
+
+    Priority: explicit API key > Claude Code OAuth > error.
+    """
     from nanobot.providers.litellm_provider import LiteLLMProvider
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
     from nanobot.providers.custom_provider import CustomProvider
@@ -253,18 +257,33 @@ def _make_provider(config: Config):
 
     from nanobot.providers.registry import find_by_name
     spec = find_by_name(provider_name)
-    if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and spec.is_oauth):
-        console.print("[red]Error: No API key configured.[/red]")
-        console.print("Set one in ~/.nanobot/config.json under providers section")
-        raise typer.Exit(1)
 
-    return LiteLLMProvider(
-        api_key=p.api_key if p else None,
-        api_base=config.get_api_base(model),
-        default_model=model,
-        extra_headers=p.extra_headers if p else None,
-        provider_name=provider_name,
-    )
+    # If we have an explicit API key, use LiteLLM
+    if (p and p.api_key) or model.startswith("bedrock/") or (spec and spec.is_oauth):
+        return LiteLLMProvider(
+            api_key=p.api_key if p else None,
+            api_base=config.get_api_base(model),
+            default_model=model,
+            extra_headers=p.extra_headers if p else None,
+            provider_name=provider_name,
+        )
+
+    # Fallback: Claude Code CLI OAuth token
+    cc_config = config.providers.claude_code
+    if cc_config.enabled:
+        from nanobot.providers.claude_code_auth import get_claude_code_token
+
+        oauth_token = get_claude_code_token()
+        if oauth_token:
+            from nanobot.providers.claude_code_provider import ClaudeCodeProvider
+
+            cc_model = cc_config.model or model
+            return ClaudeCodeProvider(oauth_token=oauth_token, default_model=cc_model)
+
+    console.print("[red]Error: No API key configured.[/red]")
+    console.print("  1. Run [cyan]claude setup-token[/cyan] and export CLAUDE_CODE_OAUTH_TOKEN")
+    console.print("  2. Or set a key in ~/.nanobot/config.json under providers section")
+    raise typer.Exit(1)
 
 
 # ============================================================================
@@ -1015,12 +1034,22 @@ def status():
         from nanobot.providers.registry import PROVIDERS
 
         console.print(f"Model: {config.agents.defaults.model}")
-        
+
+        # Claude Code CLI status
+        if config.providers.claude_code.enabled:
+            import os
+
+            cc_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+            cc_status = "[green]✓ token set[/green]" if cc_token else "[yellow]CLAUDE_CODE_OAUTH_TOKEN not set[/yellow]"
+            console.print(f"Claude Code CLI: {cc_status}")
+
         # Check API keys from registry
         for spec in PROVIDERS:
             p = getattr(config.providers, spec.name, None)
             if p is None:
                 continue
+            if spec.name == "claude_code":
+                continue  # Handled above with explicit env var check
             if spec.is_oauth:
                 console.print(f"{spec.label}: [green]✓ (OAuth)[/green]")
             elif spec.is_local:
@@ -1115,6 +1144,57 @@ def _login_github_copilot() -> None:
     except Exception as e:
         console.print(f"[red]Authentication error: {e}[/red]")
         raise typer.Exit(1)
+
+
+@app.command(hidden=True)
+def proxy(
+    port: int = typer.Option(18790, "--port", "-p", help="Proxy port"),
+    host: str = typer.Option("0.0.0.0", "--host", "-H", help="Proxy host"),
+    model: str = typer.Option(None, "--model", "-m", help="Override default model"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
+):
+    """Start standalone Anthropic Messages API proxy (internal)."""
+    from nanobot.config.loader import load_config
+
+    if verbose:
+        import logging
+        logging.basicConfig(level=logging.DEBUG)
+
+    config = load_config()
+    provider = _make_provider(config)
+
+    litellm_kwargs: dict[str, Any] = {}
+    if hasattr(provider, "api_key") and provider.api_key:
+        litellm_kwargs["api_key"] = provider.api_key
+    if hasattr(provider, "api_base") and provider.api_base:
+        litellm_kwargs["api_base"] = provider.api_base
+    if model:
+        litellm_kwargs["model"] = model
+    elif hasattr(provider, "default_model"):
+        litellm_kwargs["model"] = provider.default_model
+
+    from nanobot.api.handlers import MessagesHandler
+    from nanobot.api.server import ProxyServer
+
+    handler = MessagesHandler(proxy_config=config.gateway.proxy, litellm_kwargs=litellm_kwargs)
+    server = ProxyServer(host=host, port=port, handler=handler)
+
+    console.print(f"{__logo__} Starting API proxy on http://{host}:{port}")
+    console.print(f"  Endpoints: POST /v1/messages, GET /health")
+    console.print(f"  Connect Claude Code CLI:")
+    console.print(f"    [green]ANTHROPIC_BASE_URL=http://localhost:{port} claude[/green]")
+
+    async def run():
+        await server.start()
+        try:
+            while True:
+                await asyncio.sleep(3600)
+        except KeyboardInterrupt:
+            console.print("\nShutting down proxy...")
+        finally:
+            await server.stop()
+
+    asyncio.run(run())
 
 
 if __name__ == "__main__":

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -248,6 +248,19 @@ def _make_provider(config: Config):
     if provider_name == "openai_codex" or model.startswith("openai-codex/"):
         return OpenAICodexProvider(default_model=model)
 
+    # Claude Code CLI (OAuth)
+    if provider_name == "claude_code" or model.startswith("claude-code/"):
+        from nanobot.providers.claude_code_auth import get_claude_code_token
+        from nanobot.providers.claude_code_provider import ClaudeCodeProvider
+
+        oauth_token = get_claude_code_token()
+        if oauth_token:
+            cc_model = config.providers.claude_code.model or model
+            return ClaudeCodeProvider(oauth_token=oauth_token, default_model=cc_model)
+        console.print("[red]Error: CLAUDE_CODE_OAUTH_TOKEN not set.[/red]")
+        console.print("  Run [cyan]claude setup-token[/cyan] and export the token.")
+        raise typer.Exit(1)
+
     # Custom: direct OpenAI-compatible endpoint, bypasses LiteLLM
     if provider_name == "custom":
         return CustomProvider(

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -1,6 +1,7 @@
 """Configuration loading utilities."""
 
 import json
+import os
 from pathlib import Path
 
 from nanobot.config.schema import Config
@@ -9,6 +10,34 @@ from nanobot.config.schema import Config
 def get_config_path() -> Path:
     """Get the default configuration file path."""
     return Path.home() / ".nanobot" / "config.json"
+
+
+def load_dotenv(env_path: Path | None = None) -> None:
+    """Load KEY=VALUE pairs from .env into os.environ (skip existing).
+
+    Search order (first found wins per variable):
+    1. Explicit *env_path* if given
+    2. CWD / .env
+    3. ~/.nanobot/.env
+    """
+    candidates = (
+        [env_path] if env_path else [
+            Path.cwd() / ".env",
+            Path.home() / ".nanobot" / ".env",
+        ]
+    )
+    for path in candidates:
+        if not path.exists():
+            continue
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                key = key.strip()
+                value = value.strip().strip("\"'")
+                os.environ.setdefault(key, value)
 
 
 def get_data_dir() -> Path:
@@ -27,6 +56,7 @@ def load_config(config_path: Path | None = None) -> Config:
     Returns:
         Loaded configuration object.
     """
+    load_dotenv()
     path = config_path or get_config_path()
 
     if path.exists():

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -185,7 +185,7 @@ class AgentDefaults(Base):
     """Default agent configuration."""
 
     workspace: str = "~/.nanobot/workspace"
-    model: str = "anthropic/claude-opus-4-5"
+    model: str = "anthropic/claude-opus-4-6"
     max_tokens: int = 8192
     temperature: float = 0.1
     max_tool_iterations: int = 40
@@ -206,9 +206,26 @@ class ProviderConfig(Base):
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
 
 
+class ClaudeCodeConfig(Base):
+    """Claude Code CLI OAuth authentication."""
+
+    enabled: bool = True   # Auto-detect Claude Code CLI login
+    model: str = ""        # Override model. Empty = use agents.defaults.model
+
+
+class ProxyConfig(Base):
+    """Anthropic API proxy configuration."""
+
+    enabled: bool = True
+    api_key: str = ""      # If set, require in Authorization header. Empty = accept any.
+    model_map: dict[str, str] = Field(default_factory=dict)  # Remap incoming model names
+    default_model: str = ""  # Override default model. Empty = use agents.defaults.model
+
+
 class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
+    claude_code: ClaudeCodeConfig = Field(default_factory=ClaudeCodeConfig)
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -233,6 +250,7 @@ class GatewayConfig(Base):
 
     host: str = "0.0.0.0"
     port: int = 18790
+    proxy: ProxyConfig = Field(default_factory=ProxyConfig)
 
 
 class WebSearchConfig(Base):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -323,14 +323,14 @@ class Config(BaseSettings):
         for spec in PROVIDERS:
             p = getattr(self.providers, spec.name, None)
             if p and model_prefix and normalized_prefix == spec.name:
-                if spec.is_oauth or p.api_key:
+                if spec.is_oauth or getattr(p, "api_key", None):
                     return p, spec.name
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
             p = getattr(self.providers, spec.name, None)
             if p and any(_kw_matches(kw) for kw in spec.keywords):
-                if spec.is_oauth or p.api_key:
+                if spec.is_oauth or getattr(p, "api_key", None):
                     return p, spec.name
 
         # Fallback: gateways first, then others (follows registry order)

--- a/nanobot/providers/claude_code_auth.py
+++ b/nanobot/providers/claude_code_auth.py
@@ -1,0 +1,26 @@
+"""Claude Code CLI OAuth token from environment.
+
+Token is set via: claude setup-token
+Env var: CLAUDE_CODE_OAUTH_TOKEN
+"""
+
+import os
+
+from loguru import logger
+
+
+def get_claude_code_token() -> str | None:
+    """Get Claude Code OAuth token from CLAUDE_CODE_OAUTH_TOKEN env var.
+
+    Users obtain this token by running: claude setup-token
+    """
+    token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+    if token:
+        logger.debug("Using Claude Code OAuth token from CLAUDE_CODE_OAUTH_TOKEN")
+        return token
+    return None
+
+
+def is_oauth_token(token: str) -> bool:
+    """Check if a token is a Claude Code OAuth token (vs regular API key)."""
+    return token.startswith("sk-ant-oat")

--- a/nanobot/providers/claude_code_provider.py
+++ b/nanobot/providers/claude_code_provider.py
@@ -1,0 +1,243 @@
+"""LLM provider that calls Anthropic API directly using Claude Code OAuth token."""
+
+import json
+from typing import Any
+
+import httpx
+import json_repair
+from loguru import logger
+
+from nanobot.api.claude_direct import (
+    ANTHROPIC_API_URL,
+    CLAUDE_CODE_HEADERS,
+    CLAUDE_CODE_SYSTEM_PREFIX,
+)
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+
+# Tool name remapping — OAuth API rejects some nanobot tool names
+_TOOL_NAME_TO_API: dict[str, str] = {
+    "read_file": "ReadFile",
+}
+_TOOL_NAME_FROM_API: dict[str, str] = {v: k for k, v in _TOOL_NAME_TO_API.items()}
+
+# Map Anthropic stop_reason -> OpenAI-style finish_reason
+_FINISH_MAP = {"end_turn": "stop", "tool_use": "tool_calls", "max_tokens": "length"}
+
+
+class ClaudeCodeProvider(LLMProvider):
+    """Provider that uses Claude Code CLI OAuth token to call Anthropic API directly."""
+
+    def __init__(self, oauth_token: str, default_model: str = "claude-sonnet-4-5-20250929"):
+        super().__init__(api_key=oauth_token)
+        self.oauth_token = oauth_token
+        self.default_model = default_model
+        # Strip provider prefix if present (e.g. "anthropic/claude-sonnet-4-5" -> "claude-sonnet-4-5")
+        if "/" in self.default_model:
+            self.default_model = self.default_model.split("/", 1)[1]
+
+    def _build_body(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> dict[str, Any]:
+        """Convert OpenAI-style messages/tools to Anthropic Messages API format."""
+        system_parts: list[str] = [CLAUDE_CODE_SYSTEM_PREFIX]
+        anthropic_messages: list[dict[str, Any]] = []
+
+        for msg in messages:
+            role = msg["role"]
+            content = msg.get("content")
+
+            if role == "system":
+                if isinstance(content, str) and content:
+                    system_parts.append(content)
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            system_parts.append(block["text"])
+                continue
+
+            if role == "assistant":
+                blocks: list[dict[str, Any]] = []
+                if content:
+                    blocks.append({"type": "text", "text": content})
+                # Convert tool_calls to Anthropic tool_use blocks
+                for tc in msg.get("tool_calls") or []:
+                    fn = tc.get("function", {})
+                    args = fn.get("arguments", "{}")
+                    if isinstance(args, str):
+                        args = json_repair.loads(args)
+                    name = fn.get("name", "")
+                    blocks.append({
+                        "type": "tool_use",
+                        "id": tc.get("id", ""),
+                        "name": _TOOL_NAME_TO_API.get(name, name),
+                        "input": args,
+                    })
+                if blocks:
+                    anthropic_messages.append({"role": "assistant", "content": blocks})
+                continue
+
+            if role == "tool":
+                # Tool result message
+                anthropic_messages.append({
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": msg.get("tool_call_id", ""),
+                        "content": content or "",
+                    }],
+                })
+                continue
+
+            # user message
+            if isinstance(content, str):
+                anthropic_messages.append({"role": "user", "content": content})
+            elif isinstance(content, list):
+                # Convert image_url blocks to Anthropic format
+                blocks = []
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "image_url":
+                        url = item["image_url"]["url"]
+                        if url.startswith("data:"):
+                            # data:image/png;base64,ABC... -> media_type + data
+                            header, data = url.split(",", 1)
+                            media_type = header.split(":")[1].split(";")[0]
+                            blocks.append({
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": media_type,
+                                    "data": data,
+                                },
+                            })
+                        else:
+                            blocks.append({"type": "text", "text": f"[image: {url}]"})
+                    elif isinstance(item, dict) and item.get("type") == "text":
+                        blocks.append({"type": "text", "text": item["text"]})
+                    else:
+                        blocks.append(item)
+                anthropic_messages.append({"role": "user", "content": blocks})
+            elif content is not None:
+                anthropic_messages.append({"role": "user", "content": str(content)})
+
+        # Build system as array of content blocks
+        system_blocks = [{"type": "text", "text": part} for part in system_parts]
+
+        body: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max(1, max_tokens),
+            "temperature": temperature,
+            "system": system_blocks,
+            "messages": anthropic_messages,
+        }
+
+        # Convert OpenAI tool definitions to Anthropic format
+        if tools:
+            anthropic_tools = []
+            for tool_def in tools:
+                fn = tool_def.get("function", tool_def)
+                name = fn.get("name", "")
+                anthropic_tools.append({
+                    "name": _TOOL_NAME_TO_API.get(name, name),
+                    "description": fn.get("description", ""),
+                    "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+                })
+            body["tools"] = anthropic_tools
+
+        return body
+
+    async def _send_request(self, body: dict[str, Any]) -> httpx.Response:
+        """Send request to Anthropic API."""
+        async with httpx.AsyncClient(timeout=300) as client:
+            return await client.post(
+                ANTHROPIC_API_URL,
+                headers={
+                    **CLAUDE_CODE_HEADERS,
+                    "Authorization": f"Bearer {self.oauth_token}",
+                    "Content-Type": "application/json",
+                },
+                json=body,
+            )
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+    ) -> LLMResponse:
+        """Send a chat completion request to Anthropic API using OAuth token."""
+        resolved_model = model or self.default_model
+        if "/" in resolved_model:
+            resolved_model = resolved_model.split("/", 1)[1]
+
+        messages = self._sanitize_empty_content(messages)
+        body = self._build_body(messages, tools, resolved_model, max_tokens, temperature)
+
+        try:
+            resp = await self._send_request(body)
+
+            if resp.status_code == 401:
+                logger.error("Claude Code OAuth token rejected (401). Run: claude setup-token")
+                return LLMResponse(
+                    content="OAuth token expired or invalid. Run `claude setup-token` to get a new one.",
+                    finish_reason="error",
+                )
+
+            if resp.status_code != 200:
+                error_text = resp.text
+                logger.error("Anthropic API error {}: {}", resp.status_code, error_text[:500])
+                return LLMResponse(
+                    content=f"Error calling Anthropic API: {resp.status_code} - {error_text[:300]}",
+                    finish_reason="error",
+                )
+
+            return self._parse_response(resp.json())
+        except Exception as e:
+            logger.error("Claude Code provider error: {}", e)
+            return LLMResponse(
+                content=f"Error calling LLM: {e}",
+                finish_reason="error",
+            )
+
+    def _parse_response(self, data: dict[str, Any]) -> LLMResponse:
+        """Parse Anthropic API response into LLMResponse."""
+        content_text: list[str] = []
+        tool_calls: list[ToolCallRequest] = []
+
+        for block in data.get("content", []):
+            if block.get("type") == "text":
+                content_text.append(block["text"])
+            elif block.get("type") == "tool_use":
+                name = block.get("name", "")
+                tool_calls.append(ToolCallRequest(
+                    id=block.get("id", ""),
+                    name=_TOOL_NAME_FROM_API.get(name, name),
+                    arguments=block.get("input", {}),
+                ))
+
+        stop_reason = data.get("stop_reason", "end_turn")
+        finish_reason = _FINISH_MAP.get(stop_reason, "stop")
+
+        usage_data = data.get("usage", {})
+        usage = {
+            "prompt_tokens": usage_data.get("input_tokens", 0),
+            "completion_tokens": usage_data.get("output_tokens", 0),
+            "total_tokens": usage_data.get("input_tokens", 0) + usage_data.get("output_tokens", 0),
+        }
+
+        return LLMResponse(
+            content="\n".join(content_text) if content_text else None,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            usage=usage,
+        )
+
+    def get_default_model(self) -> str:
+        """Get the default model."""
+        return self.default_model

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -29,7 +29,7 @@ class LiteLLMProvider(LLMProvider):
         self, 
         api_key: str | None = None, 
         api_base: str | None = None,
-        default_model: str = "anthropic/claude-opus-4-5",
+        default_model: str = "anthropic/claude-opus-4-6",
         extra_headers: dict[str, str] | None = None,
         provider_name: str | None = None,
     ):

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -236,6 +236,26 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         is_oauth=True,                      # OAuth-based authentication
     ),
 
+    # Claude Code CLI: uses OAuth token from `claude setup-token`, bypasses LiteLLM.
+    ProviderSpec(
+        name="claude_code",
+        keywords=("claude-code",),
+        env_key="CLAUDE_CODE_OAUTH_TOKEN",
+        display_name="Claude Code CLI",
+        litellm_prefix="",
+        skip_prefixes=(),
+        env_extras=(),
+        is_gateway=False,
+        is_local=False,
+        detect_by_key_prefix="sk-ant-oat",
+        detect_by_base_keyword="",
+        default_api_base="https://api.anthropic.com/v1",
+        strip_model_prefix=False,
+        model_overrides=(),
+        is_oauth=True,
+        is_direct=True,
+    ),
+
     # DeepSeek: needs "deepseek/" prefix for LiteLLM routing.
     ProviderSpec(
         name="deepseek",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "prompt-toolkit>=3.0.50,<4.0.0",
     "mcp>=1.26.0,<2.0.0",
     "json-repair>=0.57.0,<1.0.0",
+    "aiohttp>=3.9.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_api_format.py
+++ b/tests/test_api_format.py
@@ -1,0 +1,274 @@
+"""Tests for Anthropic <-> LiteLLM format conversion."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.api.anthropic_format import (
+    anthropic_request_to_litellm,
+    litellm_response_to_anthropic,
+)
+
+
+# ── Request conversion ──────────────────────────────────────────────
+
+
+class TestAnthropicRequestToLitellm:
+    def test_basic_user_message(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        result = anthropic_request_to_litellm(body)
+
+        assert result["model"] == "claude-sonnet-4-5-20250929"
+        assert result["max_tokens"] == 1024
+        assert len(result["messages"]) == 1
+        assert result["messages"][0] == {"role": "user", "content": "Hello"}
+
+    def test_system_string(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "system": "You are helpful.",
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+        result = anthropic_request_to_litellm(body)
+
+        assert result["messages"][0] == {"role": "system", "content": "You are helpful."}
+        assert result["messages"][1] == {"role": "user", "content": "Hi"}
+
+    def test_system_array(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "system": [
+                {"type": "text", "text": "Part 1"},
+                {"type": "text", "text": "Part 2"},
+            ],
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+        result = anthropic_request_to_litellm(body)
+
+        assert result["messages"][0]["role"] == "system"
+        assert "Part 1" in result["messages"][0]["content"]
+        assert "Part 2" in result["messages"][0]["content"]
+
+    def test_assistant_with_tool_use(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "user", "content": "Read the file"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "I'll read that."},
+                        {
+                            "type": "tool_use",
+                            "id": "call_123",
+                            "name": "read_file",
+                            "input": {"path": "/tmp/test.txt"},
+                        },
+                    ],
+                },
+            ],
+        }
+        result = anthropic_request_to_litellm(body)
+
+        assistant_msg = result["messages"][1]
+        assert assistant_msg["role"] == "assistant"
+        assert assistant_msg["content"] == "I'll read that."
+        assert len(assistant_msg["tool_calls"]) == 1
+        tc = assistant_msg["tool_calls"][0]
+        assert tc["id"] == "call_123"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "read_file"
+        assert json.loads(tc["function"]["arguments"]) == {"path": "/tmp/test.txt"}
+
+    def test_tool_result(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_123",
+                            "content": "file contents here",
+                        },
+                    ],
+                },
+            ],
+        }
+        result = anthropic_request_to_litellm(body)
+
+        tool_msg = result["messages"][0]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "call_123"
+        assert tool_msg["content"] == "file contents here"
+
+    def test_tool_definitions(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather data",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            ],
+        }
+        result = anthropic_request_to_litellm(body)
+
+        assert len(result["tools"]) == 1
+        tool = result["tools"][0]
+        assert tool["type"] == "function"
+        assert tool["function"]["name"] == "get_weather"
+        assert tool["function"]["description"] == "Get weather data"
+        assert tool["function"]["parameters"]["properties"]["city"]["type"] == "string"
+
+    def test_stop_sequences(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stop_sequences": ["\n\nHuman:"],
+        }
+        result = anthropic_request_to_litellm(body)
+        assert result["stop"] == ["\n\nHuman:"]
+
+    def test_image_content(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is this?"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "iVBOR...",
+                            },
+                        },
+                    ],
+                },
+            ],
+        }
+        result = anthropic_request_to_litellm(body)
+
+        user_msg = result["messages"][0]
+        assert user_msg["role"] == "user"
+        assert isinstance(user_msg["content"], list)
+        assert user_msg["content"][0] == {"type": "text", "text": "What is this?"}
+        img = user_msg["content"][1]
+        assert img["type"] == "image_url"
+        assert img["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_stream_passthrough(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "stream": True,
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+        result = anthropic_request_to_litellm(body)
+        assert result["stream"] is True
+
+    def test_temperature_passthrough(self):
+        body = {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 1024,
+            "temperature": 0.5,
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+        result = anthropic_request_to_litellm(body)
+        assert result["temperature"] == 0.5
+
+
+# ── Response conversion ─────────────────────────────────────────────
+
+
+def _make_response(content=None, tool_calls=None, finish_reason="stop", model="claude-test"):
+    """Helper to build a mock LiteLLM response."""
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+    return SimpleNamespace(id="chatcmpl-test", choices=[choice], usage=usage, model=model)
+
+
+class TestLitellmResponseToAnthropic:
+    def test_text_response(self):
+        resp = _make_response(content="Hello there!")
+        result = litellm_response_to_anthropic(resp, model="claude-sonnet-4-5-20250929")
+
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["model"] == "claude-sonnet-4-5-20250929"
+        assert len(result["content"]) == 1
+        assert result["content"][0] == {"type": "text", "text": "Hello there!"}
+        assert result["stop_reason"] == "end_turn"
+        assert result["usage"]["input_tokens"] == 10
+        assert result["usage"]["output_tokens"] == 20
+
+    def test_tool_call_response(self):
+        tc = SimpleNamespace(
+            id="call_abc",
+            function=SimpleNamespace(name="get_weather", arguments='{"city": "London"}'),
+        )
+        resp = _make_response(content=None, tool_calls=[tc], finish_reason="tool_calls")
+        result = litellm_response_to_anthropic(resp)
+
+        assert len(result["content"]) == 1
+        block = result["content"][0]
+        assert block["type"] == "tool_use"
+        assert block["id"] == "call_abc"
+        assert block["name"] == "get_weather"
+        assert block["input"] == {"city": "London"}
+        assert result["stop_reason"] == "tool_use"
+
+    def test_text_and_tool_response(self):
+        tc = SimpleNamespace(
+            id="call_xyz",
+            function=SimpleNamespace(name="search", arguments='{"q": "test"}'),
+        )
+        resp = _make_response(content="Let me search.", tool_calls=[tc], finish_reason="tool_calls")
+        result = litellm_response_to_anthropic(resp)
+
+        assert len(result["content"]) == 2
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][1]["type"] == "tool_use"
+
+    def test_stop_reason_mapping(self):
+        for oai_reason, anthropic_reason in [
+            ("stop", "end_turn"),
+            ("length", "max_tokens"),
+            ("tool_calls", "tool_use"),
+            ("content_filter", "end_turn"),
+        ]:
+            resp = _make_response(content="x", finish_reason=oai_reason)
+            result = litellm_response_to_anthropic(resp)
+            assert result["stop_reason"] == anthropic_reason, f"Failed for {oai_reason}"
+
+    def test_no_usage(self):
+        message = SimpleNamespace(content="hi", tool_calls=None)
+        choice = SimpleNamespace(message=message, finish_reason="stop")
+        resp = SimpleNamespace(id="test", choices=[choice], usage=None, model="test")
+        result = litellm_response_to_anthropic(resp)
+
+        assert result["usage"]["input_tokens"] == 0
+        assert result["usage"]["output_tokens"] == 0

--- a/tests/test_claude_code_auth.py
+++ b/tests/test_claude_code_auth.py
@@ -1,0 +1,28 @@
+import os
+from unittest.mock import patch
+
+from nanobot.providers.claude_code_auth import get_claude_code_token, is_oauth_token
+
+
+def test_get_token_returns_env_var():
+    with patch.dict(os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test123"}):
+        assert get_claude_code_token() == "sk-ant-oat01-test123"
+
+
+def test_get_token_returns_none_when_unset():
+    with patch.dict(os.environ, {}, clear=True):
+        assert get_claude_code_token() is None
+
+
+def test_get_token_returns_none_for_empty_string():
+    with patch.dict(os.environ, {"CLAUDE_CODE_OAUTH_TOKEN": ""}):
+        assert get_claude_code_token() is None
+
+
+def test_is_oauth_token_true():
+    assert is_oauth_token("sk-ant-oat01-abc") is True
+
+
+def test_is_oauth_token_false():
+    assert is_oauth_token("sk-ant-api03-abc") is False
+    assert is_oauth_token("") is False

--- a/tests/test_claude_code_provider.py
+++ b/tests/test_claude_code_provider.py
@@ -1,0 +1,27 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from nanobot.providers.claude_code_provider import ClaudeCodeProvider
+
+
+@pytest.mark.asyncio
+async def test_401_returns_error_with_setup_token_hint():
+    """On 401, provider should return error message suggesting claude setup-token."""
+    provider = ClaudeCodeProvider(oauth_token="sk-ant-oat01-expired")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+    mock_resp.text = "Unauthorized"
+
+    with patch.object(provider, "_send_request", new_callable=AsyncMock, return_value=mock_resp):
+        result = await provider.chat(messages=[{"role": "user", "content": "hi"}])
+
+    assert result.finish_reason == "error"
+    assert "setup-token" in result.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_no_refresh_token_method():
+    """_refresh_token should no longer exist."""
+    provider = ClaudeCodeProvider(oauth_token="sk-ant-oat01-test")
+    assert not hasattr(provider, "_refresh_token")

--- a/tests/test_registry_claude_code.py
+++ b/tests/test_registry_claude_code.py
@@ -1,0 +1,10 @@
+from nanobot.providers.registry import find_by_name
+
+
+def test_claude_code_in_registry():
+    spec = find_by_name("claude_code")
+    assert spec is not None
+    assert spec.is_oauth is True
+    assert spec.is_direct is True
+    assert spec.env_key == "CLAUDE_CODE_OAUTH_TOKEN"
+    assert spec.display_name == "Claude Code CLI"

--- a/tests/test_shared_constants.py
+++ b/tests/test_shared_constants.py
@@ -1,0 +1,16 @@
+def test_provider_and_direct_share_constants():
+    """Ensure ClaudeCodeProvider uses the same constants as claude_direct."""
+    from nanobot.api.claude_direct import (
+        ANTHROPIC_API_URL,
+        CLAUDE_CODE_HEADERS,
+        CLAUDE_CODE_SYSTEM_PREFIX,
+    )
+    from nanobot.providers.claude_code_provider import (
+        ANTHROPIC_API_URL as PROVIDER_URL,
+        CLAUDE_CODE_HEADERS as PROVIDER_HEADERS,
+        CLAUDE_CODE_SYSTEM_PREFIX as PROVIDER_PREFIX,
+    )
+
+    assert PROVIDER_URL is ANTHROPIC_API_URL
+    assert PROVIDER_HEADERS is CLAUDE_CODE_HEADERS
+    assert PROVIDER_PREFIX is CLAUDE_CODE_SYSTEM_PREFIX


### PR DESCRIPTION
## Summary

- **Claude Code CLI OAuth**: nanobot reads `CLAUDE_CODE_OAUTH_TOKEN` env var (from `claude setup-token`) to authenticate with Anthropic API directly — no separate API key needed. Users with a Claude Max/Pro subscription run `claude setup-token` once, export the token, and `nanobot agent` works out of the box.
- **Anthropic Messages API proxy**: internal proxy server (`nanobot proxy`) that translates between Anthropic Messages API format and LiteLLM, enabling external Anthropic-compatible clients to route through any configured backend.
- **DRY OAuth architecture**: `is_oauth_token()` consolidated to single source, Anthropic constants shared between provider and proxy, `claude_code` added to provider registry with `is_oauth=True, is_direct=True`.

### How it works

```
claude setup-token (browser OAuth, produces 1-year token)
        |
export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
        |
nanobot reads env var → ClaudeCodeProvider
        |
Direct Anthropic API calls with Claude Code headers
```

### New files

| File | Purpose |
|---|---|
| `nanobot/providers/claude_code_auth.py` | Read OAuth token from `CLAUDE_CODE_OAUTH_TOKEN` env var |
| `nanobot/providers/claude_code_provider.py` | LLMProvider that calls Anthropic API directly with OAuth |
| `nanobot/api/` | Anthropic Messages API proxy (format conversion, auth, SSE streaming, server) |
| `tests/test_*.py` | 9 new tests for auth, provider, format conversion, registry |

### Config

Auto-detection is enabled by default. To disable:

```json
{
  "providers": {
    "claude_code": { "enabled": false }
  }
}
```

Priority: explicit API key > Claude Code OAuth > error with instructions.

### Usage

```bash
# One-time: get long-lived token
claude setup-token
export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...

# Then just use nanobot normally
nanobot agent -m "Hello!"
nanobot status   # shows "Claude Code CLI: ✓ token set"
```

## Test plan

- [x] `pytest tests/` — all 96 tests pass
- [x] `nanobot status` — shows Claude Code CLI token status
- [x] No duplicate `is_oauth_token()` definitions (single source in `claude_code_auth.py`)
- [x] Constants shared between provider and proxy (identity-checked in tests)
- [x] 401 returns actionable error: "Run `claude setup-token` to get a new one"
- [x] `claude_code` ProviderSpec in registry with correct flags
- [x] No circular import dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)