### PR TITLE
fix: preserve unknown config keys when saving to prevent data loss

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -46,6 +46,10 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
     """
     Save configuration to file.
 
+    Preserves unknown top-level keys that exist in the current file but
+    are not part of the Config schema (e.g. manually added providers),
+    so round-tripping through Pydantic doesn't silently drop them.
+
     Args:
         config: Configuration to save.
         config_path: Optional path to save to. Uses default if not provided.
@@ -54,6 +58,18 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
     data = config.model_dump(by_alias=True)
+
+    # Merge: preserve keys from existing file that Pydantic doesn't know about
+    if path.exists():
+        try:
+            with open(path, encoding="utf-8") as f:
+                existing = json.load(f)
+            if isinstance(existing, dict):
+                # existing keys not in serialized data are preserved
+                merged = {**existing, **data}
+                data = merged
+        except (json.JSONDecodeError, OSError):
+            pass  # file corrupt or unreadable, overwrite entirely
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Problem

`save_config()` serializes via `config.model_dump(by_alias=True)`, which only includes fields known to the Pydantic `Config` model. Any manually added keys (e.g. custom provider configurations like `openai-codex`) are silently dropped when the config is saved back (#1023, Bug 2).

## Fix

Before writing, read the existing config file and merge the Pydantic-serialized data on top. This preserves unknown top-level keys that exist in the file but aren't part of the schema.

## Changes

- `nanobot/config/loader.py`: `save_config()` now reads + merges before writing
- Gracefully handles corrupt/missing existing file (falls back to overwrite)

Relates to #1023