### PR TITLE
fix: preserve reasoning_content in messages for thinking-enabled models

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -12,8 +12,9 @@ from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.providers.registry import find_by_model, find_gateway
 
 
-# Standard OpenAI chat-completion message keys; extras (e.g. reasoning_content) are stripped for strict providers.
-_ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name"})
+# Standard OpenAI chat-completion message keys plus reasoning_content for
+# thinking-enabled models (Kimi k2.5, DeepSeek-R1, etc.).
+_ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content"})
 
 
 class LiteLLMProvider(LLMProvider):


### PR DESCRIPTION
## Problem

When using Moonshot Kimi k2.5 (or similar thinking-enabled models), assistant messages containing tool calls must include `reasoning_content`. However, `_sanitize_messages()` strips it because it's not in `_ALLOWED_MSG_KEYS`, causing:

```
litellm.BadRequestError: MoonshotException - thinking is enabled but reasoning_content is missing in assistant tool call message
```

## Fix

Add `reasoning_content` to `_ALLOWED_MSG_KEYS`. When the key is absent from a message it's simply not included (dict comprehension filters by `k in _ALLOWED_MSG_KEYS` AND `k in msg`), so this is a no-op for non-thinking models.

## Changes

- `nanobot/providers/litellm_provider.py`: Add `reasoning_content` to the allowed keys set

Fixes #1014