### PR TITLE
fix(email): allow proactive sends when autoReplyEnabled is false

### DIFF
--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -108,11 +108,6 @@ class EmailChannel(BaseChannel):
             logger.warning("Skip email send: consent_granted is false")
             return
 
-        force_send = bool((msg.metadata or {}).get("force_send"))
-        if not self.config.auto_reply_enabled and not force_send:
-            logger.info("Skip automatic email reply: auto_reply_enabled is false")
-            return
-
         if not self.config.smtp_host:
             logger.warning("Email channel SMTP host not configured")
             return
@@ -120,6 +115,15 @@ class EmailChannel(BaseChannel):
         to_addr = msg.chat_id.strip()
         if not to_addr:
             logger.warning("Email channel missing recipient address")
+            return
+
+        # Determine if this is a reply (recipient has sent us an email before)
+        is_reply = to_addr in self._last_subject_by_chat
+        force_send = bool((msg.metadata or {}).get("force_send"))
+
+        # autoReplyEnabled only controls automatic replies, not proactive sends
+        if is_reply and not self.config.auto_reply_enabled and not force_send:
+            logger.info("Skip automatic email reply to {}: auto_reply_enabled is false", to_addr)
             return
 
         base_subject = self._last_subject_by_chat.get(to_addr, "nanobot reply")


### PR DESCRIPTION
Previously, `autoReplyEnabled=false` would block ALL email sends, including proactive emails triggered from other channels (e.g., asking nanobot on Feishu to send an email).

Now `autoReplyEnabled` only controls automatic replies to incoming emails, not proactive sends. This allows users to disable auto-replies while still being able to ask nanobot to send emails on demand.

Changes:
- Check if recipient is in `_last_subject_by_chat` to determine if it's a reply
- Only skip sending when it's a reply AND auto_reply_enabled is false
- Add test for proactive send with auto_reply_enabled=false
- Update existing test to verify reply behavior

<img width="635" height="117" alt="image" src="https://github.com/user-attachments/assets/cb108ab3-9641-471b-9cf6-253bde70df0f" />
<img width="468" height="389" alt="image" src="https://github.com/user-attachments/assets/4f5c29fa-a7cf-49b8-a9fb-6e6587361216" />
