### PR TITLE
feat: support NANOBOT_HOME env var for custom data directory

### DIFF
--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -236,7 +236,8 @@ class DiscordChannel(BaseChannel):
 
         content_parts = [content] if content else []
         media_paths: list[str] = []
-        media_dir = Path.home() / ".nanobot" / "media"
+        from nanobot.utils.helpers import get_data_path
+        media_dir = get_data_path() / "media"
 
         for attachment in payload.get("attachments") or []:
             url = attachment.get("url")

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -541,7 +541,8 @@ class FeishuChannel(BaseChannel):
             (file_path, content_text) - file_path is None if download failed
         """
         loop = asyncio.get_running_loop()
-        media_dir = Path.home() / ".nanobot" / "media"
+        from nanobot.utils.helpers import get_data_path
+        media_dir = get_data_path() / "media"
         media_dir.mkdir(parents=True, exist_ok=True)
 
         data, filename = None, None

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -364,9 +364,9 @@ class TelegramChannel(BaseChannel):
                 file = await self._app.bot.get_file(media_file.file_id)
                 ext = self._get_extension(media_type, getattr(media_file, 'mime_type', None))
                 
-                # Save to workspace/media/
-                from pathlib import Path
-                media_dir = Path.home() / ".nanobot" / "media"
+                # Save to data/media/
+                from nanobot.utils.helpers import get_data_path
+                media_dir = get_data_path() / "media"
                 media_dir.mkdir(parents=True, exist_ok=True)
                 
                 file_path = media_dir / f"{media_file.file_id[:16]}{ext}"

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -87,7 +87,8 @@ def _init_prompt_session() -> None:
     except Exception:
         pass
 
-    history_file = Path.home() / ".nanobot" / "history" / "cli_history"
+    from nanobot.utils.helpers import get_data_path
+    history_file = get_data_path() / "history" / "cli_history"
     history_file.parent.mkdir(parents=True, exist_ok=True)
 
     _PROMPT_SESSION = PromptSession(
@@ -190,7 +191,7 @@ def onboard():
     
     console.print(f"\n{__logo__} nanobot is ready!")
     console.print("\nNext steps:")
-    console.print("  1. Add your API key to [cyan]~/.nanobot/config.json[/cyan]")
+    console.print(f"  1. Add your API key to [cyan]{config_path}[/cyan]")
     console.print("     Get one at: https://openrouter.ai/keys")
     console.print("  2. Chat: [cyan]nanobot agent -m \"Hello!\"[/cyan]")
     console.print("\n[dim]Want Telegram/WhatsApp? See: https://github.com/HKUDS/nanobot#-chat-apps[/dim]")
@@ -255,7 +256,8 @@ def _make_provider(config: Config):
     spec = find_by_name(provider_name)
     if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and spec.is_oauth):
         console.print("[red]Error: No API key configured.[/red]")
-        console.print("Set one in ~/.nanobot/config.json under providers section")
+        from nanobot.config.loader import get_config_path as _gcp
+        console.print(f"Set one in {_gcp()} under providers section")
         raise typer.Exit(1)
 
     return LiteLLMProvider(
@@ -704,7 +706,8 @@ def _get_bridge_dir() -> Path:
     import subprocess
     
     # User's bridge location
-    user_bridge = Path.home() / ".nanobot" / "bridge"
+    from nanobot.utils.helpers import get_data_path as _gdp
+    user_bridge = _gdp() / "bridge"
     
     # Check if already built
     if (user_bridge / "dist" / "index.js").exists():

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -8,7 +8,8 @@ from nanobot.config.schema import Config
 
 def get_config_path() -> Path:
     """Get the default configuration file path."""
-    return Path.home() / ".nanobot" / "config.json"
+    from nanobot.utils.helpers import get_data_path
+    return get_data_path() / "config.json"
 
 
 def get_data_dir() -> Path:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -184,7 +184,7 @@ class ChannelsConfig(Base):
 class AgentDefaults(Base):
     """Default agent configuration."""
 
-    workspace: str = "~/.nanobot/workspace"
+    workspace: str = ""
     model: str = "anthropic/claude-opus-4-5"
     max_tokens: int = 8192
     temperature: float = 0.1
@@ -286,7 +286,11 @@ class Config(BaseSettings):
     @property
     def workspace_path(self) -> Path:
         """Get expanded workspace path."""
-        return Path(self.agents.defaults.workspace).expanduser()
+        ws = self.agents.defaults.workspace
+        if ws:
+            return Path(ws).expanduser()
+        from nanobot.utils.helpers import get_workspace_path
+        return get_workspace_path()
 
     def _match_provider(self, model: str | None = None) -> tuple["ProviderConfig | None", str | None]:
         """Match provider config and its registry name. Returns (config, spec_name)."""

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -1,6 +1,7 @@
 """Utility functions for nanobot."""
 
 from pathlib import Path
+import os
 from datetime import datetime
 
 
@@ -11,7 +12,10 @@ def ensure_dir(path: Path) -> Path:
 
 
 def get_data_path() -> Path:
-    """Get the nanobot data directory (~/.nanobot)."""
+    """Get the nanobot data directory (env: NANOBOT_HOME, default: ~/.nanobot)."""
+    home = os.environ.get("NANOBOT_HOME")
+    if home:
+        return ensure_dir(Path(home).expanduser().resolve())
     return ensure_dir(Path.home() / ".nanobot")
 
 
@@ -28,7 +32,7 @@ def get_workspace_path(workspace: str | None = None) -> Path:
     if workspace:
         path = Path(workspace).expanduser()
     else:
-        path = Path.home() / ".nanobot" / "workspace"
+        path = get_data_path() / "workspace"
     return ensure_dir(path)
 
 


### PR DESCRIPTION
## Summary

Allow overriding the default `~/.nanobot` data directory by setting the `NANOBOT_HOME` environment variable.

## Motivation

- **Enterprise deployments**: Keep config inside the project directory for version control and team sharing
- **Docker/CI**: Use project-local data directories instead of home directory
- **Multi-instance**: Run multiple nanobot instances with isolated data

## Usage

```bash
export NANOBOT_HOME=/path/to/project/.nanobot
nanobot onboard   # creates config.json, workspace/ under NANOBOT_HOME
nanobot agent     # all data stored under NANOBOT_HOME
```

When `NANOBOT_HOME` is not set, behavior is **identical** to before (`~/.nanobot`).

## Changes

| File | Change |
|------|--------|
| `utils/helpers.py` | `get_data_path()` reads `NANOBOT_HOME` env var; `get_workspace_path()` fallback uses `get_data_path()` |
| `config/loader.py` | `get_config_path()` derives from `get_data_path()` |
| `config/schema.py` | Workspace default empty string, `workspace_path` property falls back dynamically |
| `cli/commands.py` | 4 hardcoded paths now use `get_data_path()` |
| `channels/{telegram,discord,feishu}.py` | `media_dir` uses `get_data_path()` |

**7 files, 28 insertions, 14 deletions.** Zero new files, zero new dependencies.

## Backward Compatibility

- Default behavior unchanged when `NANOBOT_HOME` is unset
- Existing configs with explicit `workspace` paths continue to work
- Legacy session migration path (`~/.nanobot/sessions`) intentionally unchanged (migration source must always point to old location)
