### PR TITLE
fix(telegram): prefix group messages with sender name

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -208,6 +208,14 @@ class TelegramChannel(BaseChannel):
             self._app = None
 
     @staticmethod
+    def _format_group_content(content: str, user, is_group: bool) -> str:
+        """Prefix content with sender name in group chats."""
+        if not is_group:
+            return content
+        name = user.first_name or user.username or str(user.id)
+        return f"[{name}]: {content}"
+
+    @staticmethod
     def _get_media_type(path: str) -> str:
         """Guess media type from file extension."""
         ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
@@ -404,6 +412,9 @@ class TelegramChannel(BaseChannel):
 
         content = "\n".join(content_parts) if content_parts else "[empty message]"
 
+        is_group = message.chat.type != "private"
+        content = self._format_group_content(content, user, is_group)
+
         logger.debug("Telegram message from {}: {}...", sender_id, content[:50])
 
         str_chat_id = str(chat_id)
@@ -418,7 +429,7 @@ class TelegramChannel(BaseChannel):
                     "metadata": {
                         "message_id": message.message_id, "user_id": user.id,
                         "username": user.username, "first_name": user.first_name,
-                        "is_group": message.chat.type != "private",
+                        "is_group": is_group,
                     },
                 }
                 self._start_typing(str_chat_id)
@@ -444,7 +455,7 @@ class TelegramChannel(BaseChannel):
                 "user_id": user.id,
                 "username": user.username,
                 "first_name": user.first_name,
-                "is_group": message.chat.type != "private"
+                "is_group": is_group,
             }
         )
 

--- a/tests/test_telegram_group.py
+++ b/tests/test_telegram_group.py
@@ -1,0 +1,62 @@
+"""Tests for Telegram group sender identification."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.channels.telegram import TelegramChannel
+
+
+class FakeUser:
+    """Minimal Telegram user stub."""
+
+    def __init__(self, user_id: int, first_name: str = "", username: str = ""):
+        self.id = user_id
+        self.first_name = first_name
+        self.username = username
+
+
+# --- _format_group_content ---
+
+
+def test_group_message_prefixed_with_first_name() -> None:
+    user = FakeUser(123, first_name="Andrise")
+    result = TelegramChannel._format_group_content("Bom dia", user, is_group=True)
+    assert result == "[Andrise]: Bom dia"
+
+
+def test_private_message_unchanged() -> None:
+    user = FakeUser(123, first_name="Andrise")
+    result = TelegramChannel._format_group_content("Bom dia", user, is_group=False)
+    assert result == "Bom dia"
+
+
+def test_fallback_to_username_when_no_first_name() -> None:
+    user = FakeUser(123, username="tiktoby")
+    result = TelegramChannel._format_group_content("Hello", user, is_group=True)
+    assert result == "[tiktoby]: Hello"
+
+
+def test_fallback_to_user_id_when_no_name() -> None:
+    user = FakeUser(8501561624)
+    result = TelegramChannel._format_group_content("Hello", user, is_group=True)
+    assert result == "[8501561624]: Hello"
+
+
+def test_group_media_content_prefixed() -> None:
+    user = FakeUser(123, first_name="Toby")
+    content = "Check this\n[image: /home/ubuntu/.nanobot/media/photo.jpg]"
+    result = TelegramChannel._format_group_content(content, user, is_group=True)
+    assert result == f"[Toby]: {content}"
+
+
+def test_group_empty_message_prefixed() -> None:
+    user = FakeUser(123, first_name="Andrei")
+    result = TelegramChannel._format_group_content("[empty message]", user, is_group=True)
+    assert result == "[Andrei]: [empty message]"
+
+
+def test_first_name_takes_priority_over_username() -> None:
+    user = FakeUser(123, first_name="Saimon", username="tiktoby")
+    result = TelegramChannel._format_group_content("Hi", user, is_group=True)
+    assert result == "[Saimon]: Hi"


### PR DESCRIPTION
## Summary

Fixes #1091 — In group chats, the bot cannot distinguish who sent each message because all members share a single session and message content has no sender attribution.

- Add `_format_group_content()` static method to `TelegramChannel` that prefixes content with `[Name]: ` in group chats
- Fallback chain: `first_name` → `username` → `user.id`
- Private (DM) messages are not affected
- Consistent with the pattern already used by the WhatsApp bridge

## Changes

- `nanobot/channels/telegram.py` — add `_format_group_content()` and call it in `_on_message`
- `tests/test_telegram_group.py` — 7 test cases covering group prefix, DM unchanged, fallback chain, media messages

## Test plan

- [x] Group message prefixed with `first_name`
- [x] Private message content unchanged
- [x] Fallback: no first_name → uses username
- [x] Fallback: no first_name or username → uses user ID
- [x] Media content (e.g. `[image: path]`) gets prefixed correctly
- [x] Empty message in group gets prefixed
- [x] first_name takes priority over username
- [x] Full test suite passes (79/79)