### PR TITLE
feat: add config option to disable exec/shell tool

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -106,11 +106,12 @@ class AgentLoop:
         allowed_dir = self.workspace if self.restrict_to_workspace else None
         for cls in (ReadFileTool, WriteFileTool, EditFileTool, ListDirTool):
             self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
-        self.tools.register(ExecTool(
-            working_dir=str(self.workspace),
-            timeout=self.exec_config.timeout,
-            restrict_to_workspace=self.restrict_to_workspace,
-        ))
+        if self.exec_config.enabled:
+            self.tools.register(ExecTool(
+                working_dir=str(self.workspace),
+                timeout=self.exec_config.timeout,
+                restrict_to_workspace=self.restrict_to_workspace,
+            ))
         self.tools.register(WebSearchTool(api_key=self.brave_api_key))
         self.tools.register(WebFetchTool())
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -107,11 +107,12 @@ class SubagentManager:
             tools.register(WriteFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
             tools.register(EditFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
             tools.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ExecTool(
-                working_dir=str(self.workspace),
-                timeout=self.exec_config.timeout,
-                restrict_to_workspace=self.restrict_to_workspace,
-            ))
+            if self.exec_config.enabled:
+                tools.register(ExecTool(
+                    working_dir=str(self.workspace),
+                    timeout=self.exec_config.timeout,
+                    restrict_to_workspace=self.restrict_to_workspace,
+                ))
             tools.register(WebSearchTool(api_key=self.brave_api_key))
             tools.register(WebFetchTool())
             

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -251,6 +251,7 @@ class WebToolsConfig(Base):
 class ExecToolConfig(Base):
     """Shell exec tool configuration."""
 
+    enabled: bool = True
     timeout: int = 60
 
 

--- a/tests/test_exec_tool_config.py
+++ b/tests/test_exec_tool_config.py
@@ -1,0 +1,48 @@
+"""Tests for exec tool enable/disable configuration (issue #1013)."""
+
+from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
+
+from nanobot.config.schema import ExecToolConfig
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.tools.shell import ExecTool
+
+
+def _make_agent_loop(exec_enabled: bool) -> AgentLoop:
+    """Create an AgentLoop with minimal mocks for tool registration testing."""
+    bus = MagicMock()
+    bus.publish_outbound = AsyncMock()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    config = ExecToolConfig(enabled=exec_enabled)
+    return AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=Path("/tmp/nanobot-test"),
+        exec_config=config,
+    )
+
+
+def test_exec_tool_registered_by_default() -> None:
+    loop = _make_agent_loop(exec_enabled=True)
+    tool_names = [t.name for t in loop.tools._tools.values()]
+    assert "exec" in tool_names
+
+
+def test_exec_tool_not_registered_when_disabled() -> None:
+    loop = _make_agent_loop(exec_enabled=False)
+    tool_names = [t.name for t in loop.tools._tools.values()]
+    assert "exec" not in tool_names
+
+
+def test_exec_config_enabled_defaults_to_true() -> None:
+    config = ExecToolConfig()
+    assert config.enabled is True
+
+
+def test_other_tools_still_registered_when_exec_disabled() -> None:
+    loop = _make_agent_loop(exec_enabled=False)
+    tool_names = [t.name for t in loop.tools._tools.values()]
+    assert "read_file" in tool_names
+    assert "write_file" in tool_names
+    assert "list_dir" in tool_names


### PR DESCRIPTION
Closes #1013

## Summary

- Add `enabled: bool = True` field to `ExecToolConfig` in `schema.py`
- Gate `ExecTool` registration on `exec_config.enabled` in both `AgentLoop` and `SubagentManager`
- Default is `True` (backward-compatible — no behavior change for existing users)

## Usage

```json
{
  "tools": {
    "exec": {
      "enabled": false
    }
  }
}
```

When `enabled` is `false`, the `exec` tool is not registered for any agent. All other tools (filesystem, web, message, spawn, cron) remain available.

## Test plan

- [x] New tests in `tests/test_exec_tool_config.py` (4 tests, all passing)
- [x] Existing test suite unaffected (no regressions)
- [x] Verified `ExecToolConfig()` defaults to `enabled=True`
- [x] Verified exec tool absent from registry when disabled
- [x] Verified other tools still registered when exec disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)