### PR TITLE
Add OpenCode Zen provider support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -213,6 +213,7 @@ class ProvidersConfig(Base):
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
+    opencode: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenCode Zen API gateway
     deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
     groq: ProviderConfig = Field(default_factory=ProviderConfig)
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -103,6 +103,24 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         supports_prompt_caching=True,
     ),
 
+    # OpenCode Zen: global gateway, keys start with "sk-Y"
+    ProviderSpec(
+        name="opencode",
+        keywords=("opencode",),
+        env_key="OPENCODE_API_KEY",
+        display_name="OpenCode Zen",
+        litellm_prefix="openai",            # opencode/big-pickle → openai/big-pickle (OpenAI-compatible)
+        skip_prefixes=("openai/", "opencode/"),
+        env_extras=(),
+        is_gateway=True,
+        is_local=False,
+        detect_by_key_prefix="sk-Y",
+        detect_by_base_keyword="opencode.ai",
+        default_api_base="https://opencode.ai/zen/v1",
+        strip_model_prefix=True,            # opencode/big-pickle → big-pickle → openai/big-pickle
+        model_overrides=(),
+    ),
+
     # AiHubMix: global gateway, OpenAI-compatible interface.
     # strip_model_prefix=True: it doesn't understand "anthropic/claude-3",
     # so we strip to bare "claude-3" then re-prefix as "openai/claude-3".


### PR DESCRIPTION
Adds [OpenCode Zen](https://opencode.ai/zen) as an LLM provider.

Motivation: quality free models (e.g., big-pickle) with generous rate limits, better than OpenRouter from my experience.

Changes:
- Add OpenCode Zen ProviderSpec to registry.py
- Add opencode provider config to schema.py

The provider routes through OpenAI-compatible API at opencode.ai/zen/v1

Tested with local installation, was able to use my zen api key with the `opencode/big-pickle` model