### PR TITLE
feat: Subagent Profiles — configurable tools, skills, model per profile

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -63,6 +63,7 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        subagent_profiles: dict | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -92,6 +93,8 @@ class AgentLoop:
             brave_api_key=brave_api_key,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            profiles=subagent_profiles or {},
+            skills_loader=self.context.skills,
         )
 
         self._running = False

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -17,9 +17,30 @@ from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.web import WebSearchTool, WebFetchTool
 
 
+# Mapping of tool names to their classes and required init kwargs
+_TOOL_BUILDERS: dict[str, type] = {
+    "read_file": ReadFileTool,
+    "write_file": WriteFileTool,
+    "edit_file": EditFileTool,
+    "list_dir": ListDirTool,
+    "exec": ExecTool,
+    "web_search": WebSearchTool,
+    "web_fetch": WebFetchTool,
+}
+
+
 class SubagentManager:
-    """Manages background subagent execution."""
-    
+    """
+    Manages background subagent execution.
+
+    Subagents are lightweight agent instances that run in the background
+    to handle specific tasks. They share the same LLM provider but have
+    isolated context and a focused system prompt.
+
+    When subagent_profiles are configured, each profile can specify its own
+    tools, skills, model, and iteration limits.
+    """
+
     def __init__(
         self,
         provider: LLMProvider,
@@ -31,6 +52,8 @@ class SubagentManager:
         brave_api_key: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
+        profiles: dict | None = None,
+        skills_loader: Any | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.provider = provider
@@ -42,93 +65,176 @@ class SubagentManager:
         self.brave_api_key = brave_api_key
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
+        self._profiles = profiles or {}
+        self._skills_loader = skills_loader
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
-        self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
-    
+
+    def get_profile_names(self) -> list[str]:
+        """Return available profile names."""
+        return list(self._profiles.keys())
+
+    def get_profiles_description(self) -> str:
+        """Return a formatted description of available profiles for the LLM."""
+        if not self._profiles:
+            return ""
+        lines = []
+        for name, profile in self._profiles.items():
+            desc = profile.description or "No description"
+            tools_info = ", ".join(profile.tools) if profile.tools else "all tools"
+            lines.append(f"- {name}: {desc} (tools: {tools_info})")
+        return "\n".join(lines)
+
+    def _resolve_profile(self, profile_name: str | None) -> "SubagentProfile | None":
+        """Resolve a profile by name, returning None for default behavior."""
+        if not profile_name or not self._profiles:
+            return None
+        profile = self._profiles.get(profile_name)
+        if profile is None:
+            logger.warning("Unknown subagent profile '{}', falling back to default", profile_name)
+        return profile
+
     async def spawn(
         self,
         task: str,
         label: str | None = None,
+        profile: str | None = None,
         origin_channel: str = "cli",
         origin_chat_id: str = "direct",
         session_key: str | None = None,
     ) -> str:
-        """Spawn a subagent to execute a task in the background."""
+        """
+        Spawn a subagent to execute a task in the background.
+
+        Args:
+            task: The task description for the subagent.
+            label: Optional human-readable label for the task.
+            profile: Optional profile name for specialized behavior.
+            origin_channel: The channel to announce results to.
+            origin_chat_id: The chat ID to announce results to.
+
+        Returns:
+            Status message indicating the subagent was started.
+        """
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
-        origin = {"channel": origin_channel, "chat_id": origin_chat_id}
+        resolved_profile = self._resolve_profile(profile)
+
+        origin = {
+            "channel": origin_channel,
+            "chat_id": origin_chat_id,
+        }
 
         bg_task = asyncio.create_task(
-            self._run_subagent(task_id, task, display_label, origin)
+            self._run_subagent(task_id, task, display_label, origin, resolved_profile)
         )
         self._running_tasks[task_id] = bg_task
-        if session_key:
-            self._session_tasks.setdefault(session_key, set()).add(task_id)
+        bg_task.add_done_callback(lambda _: self._running_tasks.pop(task_id, None))
 
-        def _cleanup(_: asyncio.Task) -> None:
-            self._running_tasks.pop(task_id, None)
-            if session_key and (ids := self._session_tasks.get(session_key)):
-                ids.discard(task_id)
-                if not ids:
-                    del self._session_tasks[session_key]
-
-        bg_task.add_done_callback(_cleanup)
-        
-        logger.info("Spawned subagent [{}]: {}", task_id, display_label)
+        profile_info = f" [profile: {profile}]" if profile else ""
+        logger.info("Spawned subagent [{}]{}: {}", task_id, profile_info, display_label)
         return f"Subagent [{display_label}] started (id: {task_id}). I'll notify you when it completes."
-    
+
+    def _build_tools_for_profile(self, profile: "SubagentProfile | None") -> ToolRegistry:
+        """Build a ToolRegistry based on the profile's tool allow/deny lists."""
+        tools = ToolRegistry()
+        allowed_dir = self.workspace if self.restrict_to_workspace else None
+
+        # Determine which tool names to register
+        if profile and profile.tools:
+            # Explicit allow list
+            tool_names = set(profile.tools)
+        else:
+            # All tools by default
+            tool_names = set(_TOOL_BUILDERS.keys())
+
+        # Apply deny list
+        if profile and profile.disallowed_tools:
+            tool_names -= set(profile.disallowed_tools)
+
+        # Register tools
+        for name in tool_names:
+            if name not in _TOOL_BUILDERS:
+                logger.warning("Unknown tool '{}' in subagent profile, skipping", name)
+                continue
+            cls = _TOOL_BUILDERS[name]
+            if cls in (ReadFileTool, WriteFileTool, EditFileTool, ListDirTool):
+                tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
+            elif cls is ExecTool:
+                tools.register(ExecTool(
+                    working_dir=str(self.workspace),
+                    timeout=self.exec_config.timeout,
+                    restrict_to_workspace=self.restrict_to_workspace,
+                ))
+            elif cls is WebSearchTool:
+                tools.register(WebSearchTool(api_key=self.brave_api_key))
+            elif cls is WebFetchTool:
+                tools.register(WebFetchTool())
+
+        return tools
+
+    def _load_skills_content(self, skill_names: list[str]) -> str:
+        """Load skill content for injection into the subagent system prompt."""
+        if not skill_names or not self._skills_loader:
+            return ""
+        parts = []
+        for name in skill_names:
+            content = self._skills_loader.load_skill(name)
+            if content:
+                parts.append(f"### Skill: {name}\n\n{content}")
+            else:
+                logger.warning("Skill '{}' not found for subagent profile", name)
+        if not parts:
+            return ""
+        return "\n# Skills\n\n" + "\n\n---\n\n".join(parts)
+
     async def _run_subagent(
         self,
         task_id: str,
         task: str,
         label: str,
         origin: dict[str, str],
+        profile: "SubagentProfile | None" = None,
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
-        
+
         try:
-            # Build subagent tools (no message tool, no spawn tool)
-            tools = ToolRegistry()
-            allowed_dir = self.workspace if self.restrict_to_workspace else None
-            tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(WriteFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(EditFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ExecTool(
-                working_dir=str(self.workspace),
-                timeout=self.exec_config.timeout,
-                restrict_to_workspace=self.restrict_to_workspace,
-                path_append=self.exec_config.path_append,
-            ))
-            tools.register(WebSearchTool(api_key=self.brave_api_key))
-            tools.register(WebFetchTool())
-            
-            # Build messages with subagent-specific prompt
-            system_prompt = self._build_subagent_prompt(task)
+            # Build tools based on profile
+            tools = self._build_tools_for_profile(profile)
+
+            # Resolve model/temperature/max_tokens from profile or defaults
+            model = (profile.model if profile and profile.model else None) or self.model
+            temperature = (profile.temperature if profile and profile.temperature is not None else None) or self.temperature
+            max_tokens = (profile.max_tokens if profile and profile.max_tokens is not None else None) or self.max_tokens
+            max_iterations = profile.max_iterations if profile else 15
+
+            # Build system prompt with optional skills
+            skills_content = ""
+            if profile and profile.skills:
+                skills_content = self._load_skills_content(profile.skills)
+            system_prompt = self._build_subagent_prompt(task, profile, skills_content)
+
             messages: list[dict[str, Any]] = [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": task},
             ]
-            
-            # Run agent loop (limited iterations)
-            max_iterations = 15
+
+            # Run agent loop
             iteration = 0
             final_result: str | None = None
-            
+
             while iteration < max_iterations:
                 iteration += 1
-                
+
                 response = await self.provider.chat(
                     messages=messages,
                     tools=tools.get_definitions(),
-                    model=self.model,
-                    temperature=self.temperature,
-                    max_tokens=self.max_tokens,
+                    model=model,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
                 )
-                
+
                 if response.has_tool_calls:
-                    # Add assistant message with tool calls
                     tool_call_dicts = [
                         {
                             "id": tc.id,
@@ -145,8 +251,7 @@ class SubagentManager:
                         "content": response.content or "",
                         "tool_calls": tool_call_dicts,
                     })
-                    
-                    # Execute tools
+
                     for tool_call in response.tool_calls:
                         args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
                         logger.debug("Subagent [{}] executing: {} with arguments: {}", task_id, tool_call.name, args_str)
@@ -160,18 +265,18 @@ class SubagentManager:
                 else:
                     final_result = response.content
                     break
-            
+
             if final_result is None:
                 final_result = "Task completed but no final response was generated."
-            
+
             logger.info("Subagent [{}] completed successfully", task_id)
             await self._announce_result(task_id, label, task, final_result, origin, "ok")
-            
+
         except Exception as e:
             error_msg = f"Error: {str(e)}"
             logger.error("Subagent [{}] failed: {}", task_id, e)
             await self._announce_result(task_id, label, task, error_msg, origin, "error")
-    
+
     async def _announce_result(
         self,
         task_id: str,
@@ -183,7 +288,7 @@ class SubagentManager:
     ) -> None:
         """Announce the subagent result to the main agent via the message bus."""
         status_text = "completed successfully" if status == "ok" else "failed"
-        
+
         announce_content = f"""[Subagent '{label}' {status_text}]
 
 Task: {task}
@@ -192,24 +297,32 @@ Result:
 {result}
 
 Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not mention technical details like "subagent" or task IDs."""
-        
-        # Inject as system message to trigger main agent
+
         msg = InboundMessage(
             channel="system",
             sender_id="subagent",
             chat_id=f"{origin['channel']}:{origin['chat_id']}",
             content=announce_content,
         )
-        
+
         await self.bus.publish_inbound(msg)
         logger.debug("Subagent [{}] announced result to {}:{}", task_id, origin['channel'], origin['chat_id'])
-    
-    def _build_subagent_prompt(self, task: str) -> str:
+
+    def _build_subagent_prompt(
+        self,
+        task: str,
+        profile: "SubagentProfile | None" = None,
+        skills_content: str = "",
+    ) -> str:
         """Build a focused system prompt for the subagent."""
         from datetime import datetime
         import time as _time
         now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
         tz = _time.strftime("%Z") or "UTC"
+
+        role_section = ""
+        if profile and profile.description:
+            role_section = f"\n## Role\n{profile.description}\n"
 
         return f"""# Subagent
 
@@ -217,7 +330,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
 {now} ({tz})
 
 You are a subagent spawned by the main agent to complete a specific task.
-
+{role_section}
 ## Rules
 1. Stay focused - complete only the assigned task, nothing else
 2. Your final response will be reported back to the main agent
@@ -238,7 +351,7 @@ You are a subagent spawned by the main agent to complete a specific task.
 ## Workspace
 Your workspace is at: {self.workspace}
 Skills are available at: {self.workspace}/skills/ (read SKILL.md files as needed)
-
+{skills_content}
 When you have completed the task, provide a clear summary of your findings or actions."""
     
     async def cancel_by_session(self, session_key: str) -> int:

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -37,7 +37,7 @@ class SpawnTool(Tool):
     
     @property
     def parameters(self) -> dict[str, Any]:
-        return {
+        params: dict[str, Any] = {
             "type": "object",
             "properties": {
                 "task": {
@@ -51,12 +51,23 @@ class SpawnTool(Tool):
             },
             "required": ["task"],
         }
-    
-    async def execute(self, task: str, label: str | None = None, **kwargs: Any) -> str:
+        # Expose available profiles in the schema so the LLM knows what's available
+        profile_names = self._manager.get_profile_names()
+        if profile_names:
+            profiles_desc = self._manager.get_profiles_description()
+            params["properties"]["profile"] = {
+                "type": "string",
+                "description": f"Optional subagent profile to use. Available profiles:\n{profiles_desc}",
+                "enum": profile_names,
+            }
+        return params
+
+    async def execute(self, task: str, label: str | None = None, profile: str | None = None, **kwargs: Any) -> str:
         """Spawn a subagent to execute the given task."""
         return await self._manager.spawn(
             task=task,
             label=label,
+            profile=profile,
             origin_channel=self._origin_channel,
             origin_chat_id=self._origin_chat_id,
             session_key=self._session_key,

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -290,6 +290,7 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_profiles=config.agents.subagent_profiles,
     )
     
     # Set cron callback (needs agent)
@@ -447,6 +448,7 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_profiles=config.agents.subagent_profiles,
     )
     
     # Show spinner when logs are off (no output to miss); skip when logs are on
@@ -937,6 +939,7 @@ def cron_run(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_profiles=config.agents.subagent_profiles,
     )
 
     store_path = get_data_dir() / "cron" / "jobs.json"

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -228,10 +228,24 @@ class AgentDefaults(Base):
     memory_window: int = 100
 
 
+class SubagentProfile(Base):
+    """Configuration for a named subagent profile."""
+
+    description: str = ""  # Helps the LLM decide which profile to use
+    tools: list[str] = Field(default_factory=list)  # Tool allow list (empty = all tools)
+    disallowed_tools: list[str] = Field(default_factory=list)  # Tool deny list
+    skills: list[str] = Field(default_factory=list)  # Skills to inject into system prompt
+    model: str | None = None  # Model override (None = inherit from parent)
+    temperature: float | None = None  # Temperature override
+    max_tokens: int | None = None  # Max tokens override
+    max_iterations: int = 15  # Iteration limit for this profile
+
+
 class AgentsConfig(Base):
     """Agent configuration."""
 
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
+    subagent_profiles: dict[str, SubagentProfile] = Field(default_factory=dict)
 
 
 class ProviderConfig(Base):

--- a/tests/test_subagent_profiles.py
+++ b/tests/test_subagent_profiles.py
@@ -1,0 +1,255 @@
+"""Tests for subagent profiles feature."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from pathlib import Path
+
+from nanobot.config.schema import SubagentProfile, AgentsConfig
+from nanobot.agent.subagent import SubagentManager, _TOOL_BUILDERS
+from nanobot.agent.tools.spawn import SpawnTool
+
+
+# ── Schema Tests ──
+
+
+class TestSubagentProfileSchema:
+    """Test SubagentProfile configuration model."""
+
+    def test_default_profile(self):
+        p = SubagentProfile()
+        assert p.tools == []
+        assert p.disallowed_tools == []
+        assert p.skills == []
+        assert p.model is None
+        assert p.temperature is None
+        assert p.max_tokens is None
+        assert p.max_iterations == 15
+        assert p.description == ""
+
+    def test_custom_profile(self):
+        p = SubagentProfile(
+            description="Web researcher",
+            tools=["web_search", "web_fetch"],
+            disallowed_tools=["exec"],
+            skills=["summarize"],
+            model="anthropic/claude-haiku-4-5",
+            temperature=0.3,
+            max_iterations=10,
+        )
+        assert p.description == "Web researcher"
+        assert p.tools == ["web_search", "web_fetch"]
+        assert p.disallowed_tools == ["exec"]
+        assert p.skills == ["summarize"]
+        assert p.model == "anthropic/claude-haiku-4-5"
+        assert p.temperature == 0.3
+        assert p.max_iterations == 10
+
+    def test_agents_config_with_profiles(self):
+        ac = AgentsConfig(
+            subagent_profiles={
+                "researcher": SubagentProfile(tools=["web_search"]),
+                "coder": SubagentProfile(tools=["read_file", "write_file", "exec"]),
+            }
+        )
+        assert len(ac.subagent_profiles) == 2
+        assert "researcher" in ac.subagent_profiles
+        assert "coder" in ac.subagent_profiles
+
+    def test_agents_config_empty_profiles_backward_compat(self):
+        ac = AgentsConfig()
+        assert ac.subagent_profiles == {}
+
+    def test_camel_case_alias(self):
+        """Ensure camelCase config keys work (JSON config compat)."""
+        ac = AgentsConfig.model_validate({
+            "subagentProfiles": {
+                "researcher": {"tools": ["web_search"], "maxIterations": 10}
+            }
+        })
+        assert "researcher" in ac.subagent_profiles
+        assert ac.subagent_profiles["researcher"].max_iterations == 10
+
+
+# ── SubagentManager Tests ──
+
+
+class TestSubagentManager:
+    """Test SubagentManager profile-related methods."""
+
+    def _make_manager(self, profiles=None):
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        bus = MagicMock()
+        return SubagentManager(
+            provider=provider,
+            workspace=Path("/tmp/test-workspace"),
+            bus=bus,
+            profiles=profiles or {},
+        )
+
+    def test_get_profile_names_empty(self):
+        mgr = self._make_manager()
+        assert mgr.get_profile_names() == []
+
+    def test_get_profile_names(self):
+        profiles = {
+            "researcher": SubagentProfile(description="Research"),
+            "coder": SubagentProfile(description="Code"),
+        }
+        mgr = self._make_manager(profiles)
+        names = mgr.get_profile_names()
+        assert set(names) == {"researcher", "coder"}
+
+    def test_get_profiles_description(self):
+        profiles = {
+            "researcher": SubagentProfile(
+                description="Web research",
+                tools=["web_search", "web_fetch"],
+            ),
+        }
+        mgr = self._make_manager(profiles)
+        desc = mgr.get_profiles_description()
+        assert "researcher" in desc
+        assert "Web research" in desc
+        assert "web_search" in desc
+
+    def test_resolve_profile_none(self):
+        mgr = self._make_manager({"researcher": SubagentProfile()})
+        assert mgr._resolve_profile(None) is None
+        assert mgr._resolve_profile("") is None
+
+    def test_resolve_profile_found(self):
+        p = SubagentProfile(description="test")
+        mgr = self._make_manager({"researcher": p})
+        assert mgr._resolve_profile("researcher") is p
+
+    def test_resolve_profile_unknown_returns_none(self):
+        mgr = self._make_manager({"researcher": SubagentProfile()})
+        assert mgr._resolve_profile("nonexistent") is None
+
+    def test_build_tools_no_profile_gets_all(self):
+        mgr = self._make_manager()
+        tools = mgr._build_tools_for_profile(None)
+        registered = {t.name for t in tools._tools.values()}
+        assert registered == set(_TOOL_BUILDERS.keys())
+
+    def test_build_tools_with_allow_list(self):
+        p = SubagentProfile(tools=["web_search", "web_fetch"])
+        mgr = self._make_manager()
+        tools = mgr._build_tools_for_profile(p)
+        registered = {t.name for t in tools._tools.values()}
+        assert registered == {"web_search", "web_fetch"}
+
+    def test_build_tools_with_deny_list(self):
+        p = SubagentProfile(disallowed_tools=["exec", "web_search"])
+        mgr = self._make_manager()
+        tools = mgr._build_tools_for_profile(p)
+        registered = {t.name for t in tools._tools.values()}
+        assert "exec" not in registered
+        assert "web_search" not in registered
+        assert "read_file" in registered
+
+    def test_build_tools_allow_and_deny(self):
+        """Deny list takes precedence over allow list."""
+        p = SubagentProfile(
+            tools=["web_search", "web_fetch", "exec"],
+            disallowed_tools=["exec"],
+        )
+        mgr = self._make_manager()
+        tools = mgr._build_tools_for_profile(p)
+        registered = {t.name for t in tools._tools.values()}
+        assert registered == {"web_search", "web_fetch"}
+
+    def test_build_tools_unknown_tool_skipped(self):
+        p = SubagentProfile(tools=["web_search", "nonexistent_tool"])
+        mgr = self._make_manager()
+        tools = mgr._build_tools_for_profile(p)
+        registered = {t.name for t in tools._tools.values()}
+        assert registered == {"web_search"}
+
+    def test_build_subagent_prompt_default(self):
+        mgr = self._make_manager()
+        prompt = mgr._build_subagent_prompt("do something")
+        assert "Subagent" in prompt
+        assert str(mgr.workspace) in prompt
+
+    def test_build_subagent_prompt_with_profile_description(self):
+        p = SubagentProfile(description="Expert web researcher")
+        mgr = self._make_manager()
+        prompt = mgr._build_subagent_prompt("do something", profile=p)
+        assert "Expert web researcher" in prompt
+
+    def test_load_skills_content_no_loader(self):
+        mgr = self._make_manager()
+        assert mgr._load_skills_content(["summarize"]) == ""
+
+    def test_load_skills_content_with_loader(self):
+        loader = MagicMock()
+        loader.load_skill.return_value = "# Summarize\nSummarize stuff."
+        mgr = self._make_manager()
+        mgr._skills_loader = loader
+        content = mgr._load_skills_content(["summarize"])
+        assert "Summarize" in content
+        assert "### Skill: summarize" in content
+        loader.load_skill.assert_called_once_with("summarize")
+
+    def test_load_skills_content_missing_skill(self):
+        loader = MagicMock()
+        loader.load_skill.return_value = None
+        mgr = self._make_manager()
+        mgr._skills_loader = loader
+        content = mgr._load_skills_content(["nonexistent"])
+        assert content == ""
+
+
+# ── SpawnTool Tests ──
+
+
+class TestSpawnToolProfiles:
+    """Test SpawnTool profile parameter exposure."""
+
+    def test_parameters_no_profiles(self):
+        mgr = MagicMock()
+        mgr.get_profile_names.return_value = []
+        tool = SpawnTool(manager=mgr)
+        params = tool.parameters
+        assert "profile" not in params["properties"]
+
+    def test_parameters_with_profiles(self):
+        mgr = MagicMock()
+        mgr.get_profile_names.return_value = ["researcher", "coder"]
+        mgr.get_profiles_description.return_value = "- researcher: Web research\n- coder: Code"
+        tool = SpawnTool(manager=mgr)
+        params = tool.parameters
+        assert "profile" in params["properties"]
+        assert params["properties"]["profile"]["enum"] == ["researcher", "coder"]
+
+    @pytest.mark.asyncio
+    async def test_execute_passes_profile(self):
+        mgr = MagicMock()
+        mgr.spawn = AsyncMock(return_value="started")
+        tool = SpawnTool(manager=mgr)
+        tool.set_context("feishu", "chat123")
+        result = await tool.execute(task="research AI", profile="researcher")
+        mgr.spawn.assert_called_once_with(
+            task="research AI",
+            label=None,
+            profile="researcher",
+            origin_channel="feishu",
+            origin_chat_id="chat123",
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_no_profile(self):
+        mgr = MagicMock()
+        mgr.spawn = AsyncMock(return_value="started")
+        tool = SpawnTool(manager=mgr)
+        tool.set_context("cli", "direct")
+        result = await tool.execute(task="do stuff")
+        mgr.spawn.assert_called_once_with(
+            task="do stuff",
+            label=None,
+            profile=None,
+            origin_channel="cli",
+            origin_chat_id="direct",
+        )


### PR DESCRIPTION
## Summary

Implements #1012. Adds support for named subagent profiles, allowing each profile to define its own tools, skills, model, and iteration limits.

## Problem

Currently all subagents are "jack of all trades" — same model, same tools, no skills, fixed 15 iterations. There's no way to spawn a specialized subagent (e.g. a researcher with only web tools, or a coder with only file/exec tools).

## Solution

Introduce `SubagentProfile` configuration that lets users define specialized subagent profiles:

```json
{
  "agents": {
    "subagentProfiles": {
      "researcher": {
        "description": "Web research and information gathering",
        "tools": ["web_search", "web_fetch", "read_file", "write_file"],
        "skills": ["summarize", "searxng"],
        "model": "anthropic/claude-haiku-4-5",
        "maxIterations": 10
      },
      "coder": {
        "description": "Code writing and debugging",
        "tools": ["read_file", "write_file", "edit_file", "exec", "list_dir"],
        "disallowedTools": [],
        "skills": ["test-driven-development"],
        "maxIterations": 20
      }
    }
  }
}
```

The LLM can then spawn specialized subagents:
```
spawn(task="research AI trends", profile="researcher")
```

## Design Decisions

Surveyed 6 frameworks (Claude Code, OpenAI Agents SDK, AutoGen, LangGraph, CrewAI, OpenClaw) before implementation:

- **Tools allow/deny list** — inspired by Claude Code's `tools` + `disallowedTools`
- **Profile description for LLM routing** — inspired by Claude Code's description-driven auto-routing
- **Agent as Tool pattern** — nanobot's spawn is essentially this (OpenAI SDK, AutoGen)
- **Per-profile model override** — common across all frameworks
- **No handoff mode** — nanobot's architecture is single-agent + spawn, not multi-agent chat

## Changes

| File | Lines | What |
|------|-------|------|
| `config/schema.py` | +14 | `SubagentProfile` model, `subagent_profiles` field on `AgentsConfig` |
| `agent/tools/spawn.py` | +17 | Optional `profile` param, expose available profiles in tool schema |
| `agent/subagent.py` | +155/-60 | Profile-aware tool building, skill injection, model/temp override |
| `agent/loop.py` | +3 | Pass profiles + skills_loader to SubagentManager |
| `cli/commands.py` | +3 | Wire `subagent_profiles` in all 3 AgentLoop instantiation sites |
| `tests/test_subagent_profiles.py` | +255 | 25 tests covering schema, tool filtering, skill loading, spawn |

## Backward Compatibility

- No profile specified → behavior identical to before
- Empty `subagentProfiles` → same as no profiles
- Unknown profile name → warning log + fallback to default
- `tools: []` (empty list) → all tools (not zero tools)

## Tests

25 new tests, 97 total passing (72 existing + 25 new, zero regression).

Closes #1012