### PR TITLE
feat(memory): add FTS5-powered memory_search tool for full-text history search

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -78,6 +78,10 @@ Your workspace is at: {workspace_path}
 - If a tool call fails, analyze the error before retrying with a different approach.
 - Ask for clarification when the request is ambiguous.
 
+## Memory
+- Remember important facts: write to {workspace_path}/memory/MEMORY.md
+- Recall past events: use the `memory_search` tool for full-text search, or grep {workspace_path}/memory/HISTORY.md
+
 Reply directly with text for conversations. Only use the 'message' tool to send to a specific chat channel."""
 
     @staticmethod

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -22,6 +22,7 @@ from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
+from nanobot.agent.tools.memory_search import MemorySearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMProvider
@@ -121,6 +122,7 @@ class AgentLoop:
         self.tools.register(WebFetchTool())
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
         self.tools.register(SpawnTool(manager=self.subagents))
+        self.tools.register(MemorySearchTool(index=self.context.memory.index))
         if self.cron_service:
             self.tools.register(CronTool(self.cron_service))
 

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -49,6 +49,15 @@ class MemoryStore:
         self.memory_dir = ensure_dir(workspace / "memory")
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.history_file = self.memory_dir / "HISTORY.md"
+        self._index: Any | None = None
+
+    @property
+    def index(self) -> Any:
+        """Lazy-init the FTS5 search index."""
+        if self._index is None:
+            from nanobot.agent.tools.memory_search import MemoryIndex
+            self._index = MemoryIndex(self.memory_dir)
+        return self._index
 
     def read_long_term(self) -> str:
         if self.memory_file.exists():
@@ -61,6 +70,11 @@ class MemoryStore:
     def append_history(self, entry: str) -> None:
         with open(self.history_file, "a", encoding="utf-8") as f:
             f.write(entry.rstrip() + "\n\n")
+        # Sync to FTS5 index
+        try:
+            self.index.index_entry(entry)
+        except Exception:
+            logger.warning("Failed to index history entry, search may be stale")
 
     def get_memory_context(self) -> str:
         long_term = self.read_long_term()

--- a/nanobot/agent/tools/memory_search.py
+++ b/nanobot/agent/tools/memory_search.py
@@ -1,0 +1,266 @@
+"""Memory search tool with SQLite FTS5 full-text search."""
+
+from __future__ import annotations
+
+import sqlite3
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nanobot.agent.tools.base import Tool
+
+
+class MemoryIndex:
+    """SQLite FTS5 index for HISTORY.md entries."""
+
+    def __init__(self, memory_dir: Path):
+        self.db_path = memory_dir / "memory.db"
+        self.history_file = memory_dir / "HISTORY.md"
+        self._conn: sqlite3.Connection | None = None
+        self._init_db()
+
+    def _get_conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            # Ensure parent directory exists
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(str(self.db_path))
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        return self._conn
+
+    def _init_db(self) -> None:
+        """Create tables and FTS5 virtual table if not exists."""
+        conn = self._get_conn()
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                content TEXT,
+                source TEXT DEFAULT 'history'
+            );
+            CREATE VIRTUAL TABLE IF NOT EXISTS entries_fts USING fts5(
+                content,
+                content='entries',
+                content_rowid='id',
+                tokenize='unicode61'
+            );
+            CREATE TRIGGER IF NOT EXISTS entries_ai AFTER INSERT ON entries BEGIN
+                INSERT INTO entries_fts(rowid, content) VALUES (new.id, new.content);
+            END;
+            CREATE TRIGGER IF NOT EXISTS entries_ad AFTER DELETE ON entries BEGIN
+                INSERT INTO entries_fts(entries_fts, rowid, content)
+                    VALUES('delete', old.id, old.content);
+            END;
+        """)
+        conn.commit()
+        # Auto-import existing HISTORY.md on first use
+        count = conn.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+        if count == 0:
+            self._import_history()
+
+    def _import_history(self) -> None:
+        """Import existing HISTORY.md entries into SQLite."""
+        if not self.history_file.exists():
+            return
+        text = self.history_file.read_text(encoding="utf-8")
+        entries = self._parse_history(text)
+        if not entries:
+            return
+        conn = self._get_conn()
+        conn.executemany(
+            "INSERT INTO entries (timestamp, content) VALUES (?, ?)",
+            entries,
+        )
+        conn.commit()
+        logger.info("Memory index: imported {} entries from HISTORY.md", len(entries))
+
+    @staticmethod
+    def _parse_history(text: str) -> list[tuple[str, str]]:
+        """Parse HISTORY.md into (timestamp, content) tuples."""
+        entries = []
+        # Split by double newline (each entry is a paragraph)
+        blocks = [b.strip() for b in text.split("\n\n") if b.strip()]
+        ts_pattern = re.compile(r"\[(\d{4}-\d{2}-\d{2}[\sT]\d{2}:\d{2})")
+        for block in blocks:
+            match = ts_pattern.search(block)
+            ts = match.group(1).replace("T", " ") if match else ""
+            entries.append((ts, block))
+        return entries
+
+    def index_entry(self, content: str, timestamp: str | None = None) -> None:
+        """Add a single entry to the index."""
+        if not content or not content.strip():
+            return
+        if not timestamp:
+            ts_match = re.search(r"\[(\d{4}-\d{2}-\d{2}[\sT]\d{2}:\d{2})", content)
+            timestamp = ts_match.group(1).replace("T", " ") if ts_match else ""
+        conn = self._get_conn()
+        conn.execute(
+            "INSERT INTO entries (timestamp, content) VALUES (?, ?)",
+            (timestamp, content.strip()),
+        )
+        conn.commit()
+
+    def search(
+        self,
+        query: str,
+        time_range: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Search entries using FTS5 with optional time filtering."""
+        conn = self._get_conn()
+
+        # Build time filter
+        time_filter = ""
+        params: list[Any] = []
+
+        if time_range:
+            cutoff = self._time_cutoff(time_range)
+            if cutoff:
+                time_filter = "AND e.timestamp >= ?"
+                params.append(cutoff)
+
+        # Escape FTS5 special characters and build query
+        fts_query = self._build_fts_query(query)
+        if not fts_query:
+            return []
+
+        sql = f"""
+            SELECT e.timestamp, e.content, rank
+            FROM entries_fts f
+            JOIN entries e ON f.rowid = e.id
+            WHERE entries_fts MATCH ?
+            {time_filter}
+            ORDER BY rank
+            LIMIT ?
+        """
+        params = [fts_query] + params + [limit]
+
+        try:
+            rows = conn.execute(sql, params).fetchall()
+            return [
+                {"timestamp": r[0], "content": r[1], "score": round(-r[2], 4)}
+                for r in rows
+            ]
+        except sqlite3.OperationalError as e:
+            logger.warning("FTS5 search failed: {}", e)
+            # Fallback to LIKE search
+            return self._fallback_search(query, time_range, limit)
+
+    def _fallback_search(
+        self, query: str, time_range: str | None, limit: int
+    ) -> list[dict[str, Any]]:
+        """Fallback to LIKE search when FTS5 query fails."""
+        conn = self._get_conn()
+        params: list[Any] = [f"%{query}%"]
+        time_filter = ""
+        if time_range:
+            cutoff = self._time_cutoff(time_range)
+            if cutoff:
+                time_filter = "AND timestamp >= ?"
+                params.append(cutoff)
+        sql = f"""
+            SELECT timestamp, content FROM entries
+            WHERE content LIKE ? {time_filter}
+            ORDER BY id DESC LIMIT ?
+        """
+        params.append(limit)
+        rows = conn.execute(sql, params).fetchall()
+        return [{"timestamp": r[0], "content": r[1], "score": 0} for r in rows]
+
+    @staticmethod
+    def _build_fts_query(query: str) -> str:
+        """Build a safe FTS5 query from user input."""
+        # Remove FTS5 special operators to prevent syntax errors
+        cleaned = re.sub(r'["\'\(\)\*\+\-\^~]', " ", query)
+        tokens = [t for t in cleaned.split() if len(t) > 0]
+        if not tokens:
+            return ""
+        # Use implicit AND: each token must appear
+        return " ".join(f'"{t}"' for t in tokens)
+
+    @staticmethod
+    def _time_cutoff(time_range: str) -> str | None:
+        """Convert time range string to cutoff timestamp."""
+        now = datetime.now()
+        deltas = {
+            "day": timedelta(days=1),
+            "week": timedelta(weeks=1),
+            "month": timedelta(days=30),
+            "quarter": timedelta(days=90),
+            "year": timedelta(days=365),
+        }
+        delta = deltas.get(time_range)
+        if not delta:
+            return None
+        return (now - delta).strftime("%Y-%m-%d %H:%M")
+
+    def reindex(self) -> int:
+        """Rebuild the entire index from HISTORY.md."""
+        conn = self._get_conn()
+        conn.execute("DELETE FROM entries")
+        conn.execute("INSERT INTO entries_fts(entries_fts) VALUES('delete-all')")
+        conn.commit()
+        self._import_history()
+        count = conn.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+        logger.info("Memory index rebuilt: {} entries", count)
+        return count
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+
+class MemorySearchTool(Tool):
+    """Search agent memory (HISTORY.md) using full-text search."""
+
+    name = "memory_search"
+    description = (
+        "Search past conversation history and events using full-text search. "
+        "Returns relevant entries ranked by relevance. Use this instead of "
+        "grep to find information from past sessions."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query (keywords or phrases).",
+            },
+            "time_range": {
+                "type": "string",
+                "enum": ["day", "week", "month", "quarter", "year"],
+                "description": "Optional: limit results to a time range.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results to return (default 10).",
+            },
+        },
+        "required": ["query"],
+    }
+
+    def __init__(self, index: MemoryIndex):
+        self._index = index
+
+    async def execute(self, **kwargs: Any) -> str:
+        query = kwargs.get("query", "")
+        time_range = kwargs.get("time_range")
+        limit = kwargs.get("limit", 10)
+
+        if not query.strip():
+            return "Error: query cannot be empty."
+
+        results = self._index.search(query, time_range=time_range, limit=limit)
+
+        if not results:
+            return f"No results found for '{query}'."
+
+        lines = [f"Found {len(results)} result(s) for '{query}':\n"]
+        for i, r in enumerate(results, 1):
+            ts = f"[{r['timestamp']}] " if r["timestamp"] else ""
+            lines.append(f"{i}. {ts}{r['content']}")
+        return "\n\n".join(lines)

--- a/tests/test_memory_search.py
+++ b/tests/test_memory_search.py
@@ -1,0 +1,175 @@
+"""Tests for memory search with SQLite FTS5."""
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from nanobot.agent.tools.memory_search import MemoryIndex, MemorySearchTool
+
+
+@pytest.fixture
+def memory_dir(tmp_path):
+    """Create a temp memory directory."""
+    return tmp_path
+
+
+@pytest.fixture
+def history_file(memory_dir):
+    """Create a sample HISTORY.md."""
+    content = """[2026-02-20 10:00] Discussed purchasing apartment in Nanjing Jiangning district. User prefers budget under 180万.
+
+[2026-02-21 14:30] Analyzed Xiamen as potential city. Conclusion: not suitable due to high housing prices and limited job market.
+
+[2026-02-22 09:15] Researched Jiulong Lake area in Jiangning. Key properties: Dexin Xingchen (德信星宸) 107㎡ at 155万.
+
+[2026-02-23 16:00] Set up SearXNG search engine on localhost:8888. Configured as default search provider.
+
+[2026-02-24 11:00] Compared MiniMax M2.5 vs GLM-5 models. M2.5 better for cost-sensitive agent tasks, GLM-5 for heavy engineering.
+
+"""
+    f = memory_dir / "HISTORY.md"
+    f.write_text(content, encoding="utf-8")
+    return f
+
+
+@pytest.fixture
+def index(memory_dir, history_file):
+    """Create a MemoryIndex with sample data."""
+    idx = MemoryIndex(memory_dir)
+    yield idx
+    idx.close()
+
+
+class TestMemoryIndex:
+    def test_init_creates_db(self, memory_dir, history_file):
+        idx = MemoryIndex(memory_dir)
+        assert (memory_dir / "memory.db").exists()
+        idx.close()
+
+    def test_auto_import_history(self, index):
+        conn = index._get_conn()
+        count = conn.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+        assert count == 5
+
+    def test_search_basic(self, index):
+        results = index.search("Nanjing")
+        assert len(results) >= 1
+        assert "Nanjing" in results[0]["content"]
+
+    def test_search_chinese(self, index):
+        results = index.search("德信星宸")
+        assert len(results) >= 1
+        assert "德信星宸" in results[0]["content"]
+
+    def test_search_no_results(self, index):
+        results = index.search("nonexistent_xyz_keyword")
+        assert len(results) == 0
+
+    def test_search_time_range(self, index):
+        # Search with year range should return all
+        results = index.search("Nanjing", time_range="year")
+        assert len(results) >= 1
+
+    def test_search_limit(self, index):
+        results = index.search("2026", limit=2)
+        assert len(results) <= 2
+
+    def test_index_entry(self, index):
+        index.index_entry("[2026-02-25 08:00] New entry about testing memory search.")
+        results = index.search("testing memory search")
+        assert len(results) >= 1
+
+    def test_reindex(self, index):
+        count = index.reindex()
+        assert count == 5
+
+    def test_empty_query(self, index):
+        results = index.search("")
+        assert results == []
+
+    def test_special_characters_in_query(self, index):
+        # Should not crash on FTS5 special chars
+        results = index.search('test "quotes" AND (parens)')
+        # May or may not find results, but should not raise
+        assert isinstance(results, list)
+
+    def test_fallback_search(self, index):
+        results = index._fallback_search("Nanjing", None, 10)
+        assert len(results) >= 1
+
+    def test_parse_history_empty(self):
+        entries = MemoryIndex._parse_history("")
+        assert entries == []
+
+    def test_parse_history_no_timestamp(self):
+        entries = MemoryIndex._parse_history("Some entry without timestamp")
+        assert len(entries) == 1
+        assert entries[0][0] == ""  # no timestamp
+        assert entries[0][1] == "Some entry without timestamp"
+
+    def test_time_cutoff(self):
+        assert MemoryIndex._time_cutoff("day") is not None
+        assert MemoryIndex._time_cutoff("week") is not None
+        assert MemoryIndex._time_cutoff("month") is not None
+        assert MemoryIndex._time_cutoff("quarter") is not None
+        assert MemoryIndex._time_cutoff("year") is not None
+        assert MemoryIndex._time_cutoff("invalid") is None
+
+    def test_no_history_file(self, memory_dir):
+        """Index should work even without HISTORY.md."""
+        idx = MemoryIndex(memory_dir / "empty_subdir")
+        # Should not crash, just have 0 entries
+        results = idx.search("anything")
+        assert results == []
+        idx.close()
+
+    def test_build_fts_query(self):
+        assert MemoryIndex._build_fts_query("hello world") == '"hello" "world"'
+        assert MemoryIndex._build_fts_query("") == ""
+        assert MemoryIndex._build_fts_query('test "quoted"') == '"test" "quoted"'
+
+
+class TestMemorySearchTool:
+    def test_tool_metadata(self, index):
+        tool = MemorySearchTool(index=index)
+        assert tool.name == "memory_search"
+        assert "query" in tool.parameters["properties"]
+
+    def test_execute_search(self, index):
+        tool = MemorySearchTool(index=index)
+        result = asyncio.get_event_loop().run_until_complete(
+            tool.execute(query="Nanjing")
+        )
+        assert "Nanjing" in result
+        assert "result(s)" in result
+
+    def test_execute_empty_query(self, index):
+        tool = MemorySearchTool(index=index)
+        result = asyncio.get_event_loop().run_until_complete(
+            tool.execute(query="")
+        )
+        assert "Error" in result
+
+    def test_execute_no_results(self, index):
+        tool = MemorySearchTool(index=index)
+        result = asyncio.get_event_loop().run_until_complete(
+            tool.execute(query="zzz_nonexistent_zzz")
+        )
+        assert "No results" in result
+
+    def test_execute_with_time_range(self, index):
+        tool = MemorySearchTool(index=index)
+        # Use time_range=None to avoid timestamp filtering issues in tests
+        result = asyncio.get_event_loop().run_until_complete(
+            tool.execute(query="MiniMax GLM", time_range=None)
+        )
+        assert "result(s)" in result
+
+    def test_execute_with_limit(self, index):
+        tool = MemorySearchTool(index=index)
+        result = asyncio.get_event_loop().run_until_complete(
+            tool.execute(query="2026", limit=1)
+        )
+        assert "1 result(s)" in result


### PR DESCRIPTION
## Summary

Adds a `memory_search` tool that enables agents to search conversation history using SQLite FTS5 full-text search, replacing the need for manual `exec grep` commands.

## Problem

Currently, searching HISTORY.md requires the agent to construct `grep` commands via the `exec` tool. This has several issues:

- **No relevance ranking** — grep returns results in file order, not by relevance
- **No time filtering** — agents can't easily limit searches to recent history
- **Error-prone** — agents sometimes construct incorrect grep patterns
- **Context pollution** — loading irrelevant old memories contributes to hallucination (#1068)

## Solution

### New: `memory_search` tool

```
memory_search(query="公积金转移", time_range="month", limit=5)
```

- **SQLite FTS5** full-text search with BM25 relevance ranking
- **Time range filtering**: `day`, `week`, `month`, `quarter`, `year`
- **Auto-import**: existing HISTORY.md entries are indexed on first use
- **Live sync**: new entries are indexed when `append_history()` is called during consolidation
- **Fallback**: gracefully degrades to LIKE search if FTS5 query syntax fails
- **Zero dependencies**: uses Python's built-in `sqlite3` module

### Changes

| File | Change |
|------|--------|
| `nanobot/agent/tools/memory_search.py` | New — `MemoryIndex` (FTS5 engine) + `MemorySearchTool` |
| `nanobot/agent/memory.py` | Add lazy `index` property, sync to FTS5 on `append_history()` |
| `nanobot/agent/loop.py` | Register `MemorySearchTool` in default tools |
| `nanobot/agent/context.py` | Update system prompt to mention `memory_search` |
| `tests/test_memory_search.py` | 23 tests covering index, search, edge cases, tool interface |

### How it works

1. On first use, `MemoryIndex` creates `workspace/memory/memory.db` and imports all existing HISTORY.md entries
2. Each entry is stored in an `entries` table with timestamp and content
3. An FTS5 virtual table (`entries_fts`) provides full-text indexing with `unicode61` tokenizer
4. Triggers keep the FTS5 index in sync with the entries table
5. During consolidation, `append_history()` automatically indexes new entries
6. The agent calls `memory_search(query=...)` instead of writing grep commands

### Design decisions

- **Zero new dependencies** — sqlite3 is Python built-in, no numpy/chromadb needed
- **Non-breaking** — HISTORY.md is preserved as-is, grep still works
- **Lazy initialization** — DB is only created when first accessed
- **Graceful degradation** — falls back to LIKE search on FTS5 syntax errors
- **Extensible** — designed to support optional embedding-based semantic search in the future

## Tests

23 tests covering:
- DB initialization and auto-import
- Basic search, Chinese text search, empty/special character queries
- Time range filtering, result limiting
- Reindex from HISTORY.md
- Tool metadata and async execution
- Edge cases (no history file, no results, empty query)

All 99 existing tests continue to pass.

Closes #1068