### PR TITLE
fix: cron multi-instance stale cache causes job loss

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -74,10 +74,7 @@ class CronService:
         self._running = False
     
     def _load_store(self) -> CronStore:
-        """Load jobs from disk."""
-        if self._store:
-            return self._store
-        
+        """Load jobs from disk (always re-reads to avoid stale cache across instances)."""
         if self.store_path.exists():
             try:
                 data = json.loads(self.store_path.read_text(encoding="utf-8"))

--- a/tests/test_cron_service.py
+++ b/tests/test_cron_service.py
@@ -28,3 +28,47 @@ def test_add_job_accepts_valid_timezone(tmp_path) -> None:
 
     assert job.schedule.tz == "America/Vancouver"
     assert job.state.next_run_at_ms is not None
+
+
+def test_multi_instance_list_sees_jobs_from_other_instance(tmp_path) -> None:
+    """Instance B should see jobs added by instance A (no stale cache)."""
+    store_path = tmp_path / "cron" / "jobs.json"
+    schedule = CronSchedule(kind="every", every_ms=60_000)
+
+    service_a = CronService(store_path)
+    service_b = CronService(store_path)
+
+    # Prime service_b cache
+    assert service_b.list_jobs(include_disabled=True) == []
+
+    # A adds a job
+    service_a.add_job(name="from_a", schedule=schedule, message="hello")
+
+    # B should see it without restart
+    jobs_b = service_b.list_jobs(include_disabled=True)
+    assert [j.name for j in jobs_b] == ["from_a"]
+
+
+def test_multi_instance_remove_does_not_clobber_other_jobs(tmp_path) -> None:
+    """Removing a job from instance B must not drop unrelated jobs added by A."""
+    store_path = tmp_path / "cron" / "jobs.json"
+    schedule = CronSchedule(kind="every", every_ms=60_000)
+
+    service_a = CronService(store_path)
+    service_b = CronService(store_path)
+
+    first = service_a.add_job(name="first", schedule=schedule, message="first")
+
+    # Prime service_b cache with snapshot containing only "first"
+    assert [j.name for j in service_b.list_jobs(include_disabled=True)] == ["first"]
+
+    # A adds a second job
+    service_a.add_job(name="second", schedule=schedule, message="second")
+
+    # B removes the first job — must not clobber "second"
+    assert service_b.remove_job(first.id) is True
+
+    # Fresh reader should still see "second"
+    reloaded = CronService(store_path)
+    names = [j.name for j in reloaded.list_jobs(include_disabled=True)]
+    assert names == ["second"]


### PR DESCRIPTION
## Summary

Fixes inter-instance cache staleness in `CronService` — multiple instances sharing the same `jobs.json` now always see each other's changes.

## Problem (#1033)

Each channel (CLI, Discord, Feishu, etc.) spawns its own `CronService` instance with its own `_store` cache. `_load_store()` only reads from disk once, then returns the cached version forever:

```python
def _load_store(self) -> CronStore:
    if self._store:
        return self._store  # ← stale after first load
```

This causes:
1. Channel B never sees jobs created by Channel A
2. Channel B's `remove_job()` writes back its stale snapshot, **silently clobbering** jobs added by Channel A

## Fix

Remove the in-memory cache check — `_load_store()` now always re-reads from disk:

```python
def _load_store(self) -> CronStore:
    """Load jobs from disk (always re-reads to avoid stale cache across instances)."""
    if self.store_path.exists():
        ...
```

Performance impact is negligible — `jobs.json` is typically a few KB at most.

## Changes

| File | Change |
|------|--------|
| `nanobot/cron/service.py` | Remove stale cache check in `_load_store()` (-4 lines, +1 line) |
| `tests/test_cron_service.py` | Add 2 regression tests from issue reproducer |

## Tests

Two new tests based on the reproducer in the issue:

1. `test_multi_instance_list_sees_jobs_from_other_instance` — instance B sees jobs added by A
2. `test_multi_instance_remove_does_not_clobber_other_jobs` — B's remove doesn't drop A's unrelated jobs

All 78 tests pass.

Closes #1033