### PR TITLE
fix: stabilize prompt prefix for better cache reuse

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -72,10 +72,6 @@ Skills with available="false" need dependencies installed first - you can try in
     
     def _get_identity(self) -> str:
         """Get the core identity section."""
-        from datetime import datetime
-        import time as _time
-        now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
-        tz = _time.strftime("%Z") or "UTC"
         workspace_path = str(self.workspace.expanduser().resolve())
         system = platform.system()
         runtime = f"{'macOS' if system == 'Darwin' else system} {platform.machine()}, Python {platform.python_version()}"
@@ -83,9 +79,6 @@ Skills with available="false" need dependencies installed first - you can try in
         return f"""# nanobot 🐈
 
 You are nanobot, a helpful AI assistant. 
-
-## Current Time
-{now} ({tz})
 
 ## Runtime
 {runtime}
@@ -108,6 +101,34 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
 ## Memory
 - Remember important facts: write to {workspace_path}/memory/MEMORY.md
 - Recall past events: grep {workspace_path}/memory/HISTORY.md"""
+
+    @staticmethod
+    def _build_runtime_context(channel: str | None, chat_id: str | None) -> str:
+        """Build dynamic runtime context and attach it to the tail user message."""
+        from datetime import datetime
+        import time as _time
+
+        now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
+        tz = _time.strftime("%Z") or "UTC"
+        lines = [f"Current Time: {now} ({tz})"]
+        if channel and chat_id:
+            lines.append(f"Channel: {channel}")
+            lines.append(f"Chat ID: {chat_id}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _append_runtime_context(
+        user_content: str | list[dict[str, Any]],
+        runtime_context: str,
+    ) -> str | list[dict[str, Any]]:
+        """Append runtime context at the tail of the user message."""
+        runtime_block = f"[Runtime Context]\n{runtime_context}"
+        if isinstance(user_content, str):
+            return f"{user_content}\n\n{runtime_block}"
+
+        content = list(user_content)
+        content.append({"type": "text", "text": runtime_block})
+        return content
     
     def _load_bootstrap_files(self) -> str:
         """Load all bootstrap files from workspace."""
@@ -148,8 +169,6 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
 
         # System prompt
         system_prompt = self.build_system_prompt(skill_names)
-        if channel and chat_id:
-            system_prompt += f"\n\n## Current Session\nChannel: {channel}\nChat ID: {chat_id}"
         messages.append({"role": "system", "content": system_prompt})
 
         # History
@@ -157,6 +176,10 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
 
         # Current message (with optional image attachments)
         user_content = self._build_user_content(current_message, media)
+        user_content = self._append_runtime_context(
+            user_content=user_content,
+            runtime_context=self._build_runtime_context(channel, chat_id),
+        )
         messages.append({"role": "user", "content": user_content})
 
         return messages

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -1,0 +1,63 @@
+"""Tests for cache-friendly prompt construction."""
+
+from __future__ import annotations
+
+from datetime import datetime as real_datetime
+from pathlib import Path
+import datetime as datetime_module
+
+from nanobot.agent.context import ContextBuilder
+
+
+class _FakeDatetime(real_datetime):
+    current = real_datetime(2026, 2, 24, 13, 59)
+
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        return cls.current
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    return workspace
+
+
+def test_system_prompt_stays_stable_when_clock_changes(tmp_path, monkeypatch) -> None:
+    """System prompt should not change just because wall clock minute changes."""
+    monkeypatch.setattr(datetime_module, "datetime", _FakeDatetime)
+
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    _FakeDatetime.current = real_datetime(2026, 2, 24, 13, 59)
+    prompt1 = builder.build_system_prompt()
+
+    _FakeDatetime.current = real_datetime(2026, 2, 24, 14, 0)
+    prompt2 = builder.build_system_prompt()
+
+    assert prompt1 == prompt2
+
+
+def test_runtime_context_is_appended_to_current_user_message(tmp_path) -> None:
+    """Dynamic runtime details should be added at the tail user message, not system."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    messages = builder.build_messages(
+        history=[],
+        current_message="Return exactly: OK",
+        channel="cli",
+        chat_id="direct",
+    )
+
+    assert messages[0]["role"] == "system"
+    assert "## Current Session" not in messages[0]["content"]
+
+    assert messages[-1]["role"] == "user"
+    user_content = messages[-1]["content"]
+    assert isinstance(user_content, str)
+    assert "Return exactly: OK" in user_content
+    assert "Current Time:" in user_content
+    assert "Channel: cli" in user_content
+    assert "Chat ID: direct" in user_content


### PR DESCRIPTION
## Summary
- Stabilize the system prompt prefix by removing minute-level `Current Time` from system content.
- Move runtime metadata (`Current Time`, `Channel`, `Chat ID`) to the tail of the current user message.
- Add regression tests to ensure cache-friendly prompt construction remains stable.

## Root Cause
`ContextBuilder._get_identity()` injected dynamic wall-clock time into the system prompt each call. Since this field was near the front of the prompt, the prefix changed every minute, reducing prefix-cache reuse opportunities.

## Code Changes
- `nanobot/agent/context.py`
  - Remove dynamic `## Current Time` section from system prompt.
  - Add `_build_runtime_context()` and `_append_runtime_context()`.
  - Append runtime context to the current user message instead of system prompt.
- `tests/test_context_prompt_cache.py`
  - Add test: system prompt remains identical when clock minute changes.
  - Add test: runtime context is appended to user message, not system prompt.

## Reproduction Experiments

### 1) Controlled cache experiment on OpenRouter (`openai/gpt-4.1-mini`)
Purpose: isolate the effect of placing dynamic time near prompt head vs tail.

| Case | prompt_tokens | cached_tokens | cost |
|---|---:|---:|---:|
| static_1 | 3520 | 0 | 0.0014112 |
| static_2 (same prefix) | 3520 | 3328 | 0.0004128 |
| dynamic_1 (time near head) | 3537 | 0 | 0.0014180 |
| dynamic_2 (head time changed by 1 min) | 3537 | 0 | 0.0014180 |
| tail_1 (time at tail) | 3539 | 0 | 0.0014188 |
| tail_2 (tail time changed by 1 min) | 3539 | 3328 | 0.0004204 |

Observation: dynamic time near the head kills cache reuse; moving dynamic time to the tail preserves large prefix reuse.

### 2) End-to-end via nanobot (before vs after)
Method: call nanobot directly 3 times around a minute boundary and capture `build_system_prompt()` hash + provider usage.

Before fix:
- System hash changed at minute rollover:
  - 13:59 -> `513520145d02ab1b`
  - 14:00 -> `701e380a5a9e6eb9`
- `cached_tokens` sequence: `0, 1664, 0`

After fix:
- System hash remains stable across minute rollover:
  - `86a88cee69456b64, 86a88cee69456b64, 86a88cee69456b64`
- `## Current Time` no longer appears in system prompt.
- Runtime context is present in the user message tail.

## Test Plan
- [x] `python -m pytest -q tests/test_context_prompt_cache.py`
- [x] `python -m pytest -q tests/test_commands.py`
- [x] `python -m pytest -q tests/test_consolidate_offset.py`
- [x] `python -m pytest -q`

## Notes
This change targets prefix stability (a prerequisite for cache reuse) while preserving runtime awareness by relocating dynamic context to the current user turn.
