### PR TITLE
feat: concurrent session processing with per-session locking

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -14,6 +14,7 @@ from loguru import logger
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.subagent import SubagentManager
+from nanobot.agent.task_context import current_channel, current_chat_id, current_message_id, message_sent_in_turn
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.message import MessageTool
@@ -99,6 +100,10 @@ class AgentLoop:
         self._consolidating: set[str] = set()  # Session keys with consolidation in progress
         self._consolidation_tasks: set[asyncio.Task] = set()  # Strong refs to in-flight tasks
         self._consolidation_locks: dict[str, asyncio.Lock] = {}
+        # Concurrent session processing
+        self._session_locks: dict[str, asyncio.Lock] = {}  # Per-session serialization
+        self._processing_tasks: set[asyncio.Task] = set()  # Strong refs to in-flight tasks
+        self._concurrency_semaphore = asyncio.Semaphore(5)  # Max concurrent sessions
         self._register_default_tools()
 
     def _register_default_tools(self) -> None:
@@ -141,18 +146,10 @@ class AgentLoop:
             self._mcp_connecting = False
 
     def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
-        """Update context for all tools that need routing info."""
-        if message_tool := self.tools.get("message"):
-            if isinstance(message_tool, MessageTool):
-                message_tool.set_context(channel, chat_id, message_id)
-
-        if spawn_tool := self.tools.get("spawn"):
-            if isinstance(spawn_tool, SpawnTool):
-                spawn_tool.set_context(channel, chat_id)
-
-        if cron_tool := self.tools.get("cron"):
-            if isinstance(cron_tool, CronTool):
-                cron_tool.set_context(channel, chat_id)
+        """Update context for all tools that need routing info (via ContextVar)."""
+        current_channel.set(channel)
+        current_chat_id.set(chat_id)
+        current_message_id.set(message_id)
 
     @staticmethod
     def _strip_think(text: str | None) -> str | None:
@@ -249,6 +246,22 @@ class AgentLoop:
                     self.bus.consume_inbound(),
                     timeout=1.0
                 )
+                task = asyncio.create_task(self._dispatch(msg))
+                self._processing_tasks.add(task)
+                task.add_done_callback(self._processing_tasks.discard)
+            except asyncio.TimeoutError:
+                continue
+
+    async def _dispatch(self, msg: InboundMessage) -> None:
+        """Dispatch a message with per-session locking and concurrency control."""
+        session_key = msg.session_key
+        lock = self._session_locks.get(session_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._session_locks[session_key] = lock
+
+        async with self._concurrency_semaphore:
+            async with lock:
                 try:
                     response = await self._process_message(msg)
                     if response is not None:
@@ -264,8 +277,10 @@ class AgentLoop:
                         chat_id=msg.chat_id,
                         content=f"Sorry, I encountered an error: {str(e)}"
                     ))
-            except asyncio.TimeoutError:
-                continue
+
+        # Prune lock if no longer in use
+        if not lock.locked():
+            self._session_locks.pop(session_key, None)
 
     async def close_mcp(self) -> None:
         """Close MCP connections."""
@@ -414,7 +429,7 @@ class AgentLoop:
         self.sessions.save(session)
 
         if message_tool := self.tools.get("message"):
-            if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
+            if isinstance(message_tool, MessageTool) and message_tool.sent_in_turn:
                 return None
 
         return OutboundMessage(

--- a/nanobot/agent/task_context.py
+++ b/nanobot/agent/task_context.py
@@ -1,0 +1,16 @@
+"""Per-task context variables for concurrent session processing.
+
+Uses Python contextvars so each asyncio.create_task() gets an isolated copy.
+Tools read from these instead of mutable instance attributes, making them
+safe to use across concurrent sessions.
+"""
+
+from contextvars import ContextVar
+
+# Routing context — set by _set_tool_context before each _process_message
+current_channel: ContextVar[str] = ContextVar("current_channel", default="")
+current_chat_id: ContextVar[str] = ContextVar("current_chat_id", default="")
+current_message_id: ContextVar[str | None] = ContextVar("current_message_id", default=None)
+
+# Per-turn state for MessageTool
+message_sent_in_turn: ContextVar[bool] = ContextVar("message_sent_in_turn", default=False)

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from nanobot.agent.task_context import current_channel, current_chat_id
 from nanobot.agent.tools.base import Tool
 from nanobot.cron.service import CronService
 from nanobot.cron.types import CronSchedule
@@ -12,13 +13,11 @@ class CronTool(Tool):
     
     def __init__(self, cron_service: CronService):
         self._cron = cron_service
-        self._channel = ""
-        self._chat_id = ""
     
     def set_context(self, channel: str, chat_id: str) -> None:
-        """Set the current session context for delivery."""
-        self._channel = channel
-        self._chat_id = chat_id
+        """Set the current session context via ContextVar (task-isolated)."""
+        current_channel.set(channel)
+        current_chat_id.set(chat_id)
     
     @property
     def name(self) -> str:
@@ -95,7 +94,9 @@ class CronTool(Tool):
     ) -> str:
         if not message:
             return "Error: message is required for add"
-        if not self._channel or not self._chat_id:
+        channel = current_channel.get()
+        chat_id = current_chat_id.get()
+        if not channel or not chat_id:
             return "Error: no session context (channel/chat_id)"
         if tz and not cron_expr:
             return "Error: tz can only be used with cron_expr"
@@ -126,8 +127,8 @@ class CronTool(Tool):
             schedule=schedule,
             message=message,
             deliver=True,
-            channel=self._channel,
-            to=self._chat_id,
+            channel=channel,
+            to=chat_id,
             delete_after_run=delete_after,
         )
         return f"Created job '{job.name}' (id: {job.id})"

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -2,6 +2,12 @@
 
 from typing import Any, Awaitable, Callable
 
+from nanobot.agent.task_context import (
+    current_channel,
+    current_chat_id,
+    current_message_id,
+    message_sent_in_turn,
+)
 from nanobot.agent.tools.base import Tool
 from nanobot.bus.events import OutboundMessage
 
@@ -17,16 +23,16 @@ class MessageTool(Tool):
         default_message_id: str | None = None,
     ):
         self._send_callback = send_callback
+        # Legacy defaults used only when ContextVar is unset (e.g. tests)
         self._default_channel = default_channel
         self._default_chat_id = default_chat_id
         self._default_message_id = default_message_id
-        self._sent_in_turn: bool = False
 
     def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
-        """Set the current message context."""
-        self._default_channel = channel
-        self._default_chat_id = chat_id
-        self._default_message_id = message_id
+        """Set the current message context via ContextVar (task-isolated)."""
+        current_channel.set(channel)
+        current_chat_id.set(chat_id)
+        current_message_id.set(message_id)
 
     def set_send_callback(self, callback: Callable[[OutboundMessage], Awaitable[None]]) -> None:
         """Set the callback for sending messages."""
@@ -34,7 +40,12 @@ class MessageTool(Tool):
 
     def start_turn(self) -> None:
         """Reset per-turn send tracking."""
-        self._sent_in_turn = False
+        message_sent_in_turn.set(False)
+
+    @property
+    def sent_in_turn(self) -> bool:
+        """Whether a message was sent in the current turn."""
+        return message_sent_in_turn.get()
 
     @property
     def name(self) -> str:
@@ -79,9 +90,9 @@ class MessageTool(Tool):
         media: list[str] | None = None,
         **kwargs: Any
     ) -> str:
-        channel = channel or self._default_channel
-        chat_id = chat_id or self._default_chat_id
-        message_id = message_id or self._default_message_id
+        channel = channel or current_channel.get() or self._default_channel
+        chat_id = chat_id or current_chat_id.get() or self._default_chat_id
+        message_id = message_id or current_message_id.get() or self._default_message_id
 
         if not channel or not chat_id:
             return "Error: No target channel/chat specified"
@@ -101,7 +112,7 @@ class MessageTool(Tool):
 
         try:
             await self._send_callback(msg)
-            self._sent_in_turn = True
+            message_sent_in_turn.set(True)
             media_info = f" with {len(media)} attachments" if media else ""
             return f"Message sent to {channel}:{chat_id}{media_info}"
         except Exception as e:

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -2,6 +2,7 @@
 
 from typing import Any, TYPE_CHECKING
 
+from nanobot.agent.task_context import current_channel, current_chat_id
 from nanobot.agent.tools.base import Tool
 
 if TYPE_CHECKING:
@@ -13,13 +14,11 @@ class SpawnTool(Tool):
     
     def __init__(self, manager: "SubagentManager"):
         self._manager = manager
-        self._origin_channel = "cli"
-        self._origin_chat_id = "direct"
     
     def set_context(self, channel: str, chat_id: str) -> None:
-        """Set the origin context for subagent announcements."""
-        self._origin_channel = channel
-        self._origin_chat_id = chat_id
+        """Set the origin context via ContextVar (task-isolated)."""
+        current_channel.set(channel)
+        current_chat_id.set(chat_id)
     
     @property
     def name(self) -> str:
@@ -55,6 +54,6 @@ class SpawnTool(Tool):
         return await self._manager.spawn(
             task=task,
             label=label,
-            origin_channel=self._origin_channel,
-            origin_chat_id=self._origin_chat_id,
+            origin_channel=current_channel.get() or "cli",
+            origin_chat_id=current_chat_id.get() or "direct",
         )

--- a/tests/test_concurrent_sessions.py
+++ b/tests/test_concurrent_sessions.py
@@ -1,0 +1,332 @@
+"""Tests for concurrent session processing."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.agent.task_context import (
+    current_channel,
+    current_chat_id,
+    current_message_id,
+    message_sent_in_turn,
+)
+from nanobot.agent.tools.message import MessageTool
+from nanobot.agent.tools.spawn import SpawnTool
+from nanobot.agent.tools.cron import CronTool
+from nanobot.bus.events import InboundMessage, OutboundMessage
+
+
+# ---------------------------------------------------------------------------
+# ContextVar isolation tests
+# ---------------------------------------------------------------------------
+
+class TestContextVarIsolation:
+    """Verify ContextVars are isolated across concurrent asyncio tasks."""
+
+    @pytest.mark.asyncio
+    async def test_channel_isolation_across_tasks(self):
+        """Two concurrent tasks setting different channels don't interfere."""
+        results = {}
+
+        async def task_a():
+            current_channel.set("feishu")
+            current_chat_id.set("chat_a")
+            await asyncio.sleep(0.05)  # yield to task_b
+            results["a_channel"] = current_channel.get()
+            results["a_chat"] = current_chat_id.get()
+
+        async def task_b():
+            current_channel.set("slack")
+            current_chat_id.set("chat_b")
+            await asyncio.sleep(0.05)
+            results["b_channel"] = current_channel.get()
+            results["b_chat"] = current_chat_id.get()
+
+        await asyncio.gather(
+            asyncio.create_task(task_a()),
+            asyncio.create_task(task_b()),
+        )
+
+        assert results["a_channel"] == "feishu"
+        assert results["a_chat"] == "chat_a"
+        assert results["b_channel"] == "slack"
+        assert results["b_chat"] == "chat_b"
+
+    @pytest.mark.asyncio
+    async def test_sent_in_turn_isolation(self):
+        """message_sent_in_turn is isolated per task."""
+        results = {}
+
+        async def task_a():
+            message_sent_in_turn.set(True)
+            await asyncio.sleep(0.05)
+            results["a"] = message_sent_in_turn.get()
+
+        async def task_b():
+            message_sent_in_turn.set(False)
+            await asyncio.sleep(0.05)
+            results["b"] = message_sent_in_turn.get()
+
+        await asyncio.gather(
+            asyncio.create_task(task_a()),
+            asyncio.create_task(task_b()),
+        )
+
+        assert results["a"] is True
+        assert results["b"] is False
+
+    @pytest.mark.asyncio
+    async def test_message_id_isolation(self):
+        """current_message_id is isolated per task."""
+        results = {}
+
+        async def task_a():
+            current_message_id.set("msg_111")
+            await asyncio.sleep(0.05)
+            results["a"] = current_message_id.get()
+
+        async def task_b():
+            current_message_id.set("msg_222")
+            await asyncio.sleep(0.05)
+            results["b"] = current_message_id.get()
+
+        await asyncio.gather(
+            asyncio.create_task(task_a()),
+            asyncio.create_task(task_b()),
+        )
+
+        assert results["a"] == "msg_111"
+        assert results["b"] == "msg_222"
+
+
+# ---------------------------------------------------------------------------
+# MessageTool with ContextVar
+# ---------------------------------------------------------------------------
+
+class TestMessageToolContextVar:
+    """MessageTool reads from ContextVar instead of instance attributes."""
+
+    @pytest.mark.asyncio
+    async def test_set_context_uses_contextvar(self):
+        tool = MessageTool(send_callback=AsyncMock())
+        tool.set_context("feishu", "chat_123", "msg_456")
+
+        assert current_channel.get() == "feishu"
+        assert current_chat_id.get() == "chat_123"
+        assert current_message_id.get() == "msg_456"
+
+    @pytest.mark.asyncio
+    async def test_execute_reads_contextvar(self):
+        callback = AsyncMock()
+        tool = MessageTool(send_callback=callback)
+
+        current_channel.set("telegram")
+        current_chat_id.set("tg_user_1")
+
+        result = await tool.execute(content="hello")
+        assert "telegram:tg_user_1" in result
+        callback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_explicit_channel_overrides_contextvar(self):
+        callback = AsyncMock()
+        tool = MessageTool(send_callback=callback)
+
+        current_channel.set("feishu")
+        current_chat_id.set("chat_default")
+
+        result = await tool.execute(content="hello", channel="slack", chat_id="slack_ch")
+        assert "slack:slack_ch" in result
+
+    @pytest.mark.asyncio
+    async def test_start_turn_resets_sent_flag(self):
+        tool = MessageTool(send_callback=AsyncMock())
+        message_sent_in_turn.set(True)
+        tool.start_turn()
+        assert tool.sent_in_turn is False
+
+    @pytest.mark.asyncio
+    async def test_sent_in_turn_property(self):
+        callback = AsyncMock()
+        tool = MessageTool(send_callback=callback)
+        current_channel.set("feishu")
+        current_chat_id.set("chat_1")
+
+        tool.start_turn()
+        assert tool.sent_in_turn is False
+
+        await tool.execute(content="hi")
+        assert tool.sent_in_turn is True
+
+
+# ---------------------------------------------------------------------------
+# SpawnTool with ContextVar
+# ---------------------------------------------------------------------------
+
+class TestSpawnToolContextVar:
+
+    @pytest.mark.asyncio
+    async def test_execute_reads_contextvar(self):
+        manager = MagicMock()
+        manager.spawn = AsyncMock(return_value="Spawned task")
+        tool = SpawnTool(manager=manager)
+
+        current_channel.set("discord")
+        current_chat_id.set("dc_ch_1")
+
+        result = await tool.execute(task="do something")
+        assert result == "Spawned task"
+        manager.spawn.assert_called_once_with(
+            task="do something",
+            label=None,
+            origin_channel="discord",
+            origin_chat_id="dc_ch_1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_defaults_when_contextvar_unset(self):
+        manager = MagicMock()
+        manager.spawn = AsyncMock(return_value="ok")
+        tool = SpawnTool(manager=manager)
+
+        # Reset contextvars
+        current_channel.set("")
+        current_chat_id.set("")
+
+        await tool.execute(task="test")
+        manager.spawn.assert_called_once_with(
+            task="test",
+            label=None,
+            origin_channel="cli",
+            origin_chat_id="direct",
+        )
+
+
+# ---------------------------------------------------------------------------
+# CronTool with ContextVar
+# ---------------------------------------------------------------------------
+
+class TestCronToolContextVar:
+
+    @pytest.mark.asyncio
+    async def test_add_job_reads_contextvar(self):
+        cron_service = MagicMock()
+        job_mock = MagicMock()
+        job_mock.name = "test"
+        job_mock.id = "abc123"
+        cron_service.add_job.return_value = job_mock
+        tool = CronTool(cron_service=cron_service)
+
+        current_channel.set("feishu")
+        current_chat_id.set("feishu_chat")
+
+        result = await tool.execute(
+            action="add", message="remind me", every_seconds=60
+        )
+        assert "abc123" in result
+        cron_service.add_job.assert_called_once()
+        call_kwargs = cron_service.add_job.call_args
+        assert call_kwargs.kwargs.get("channel") == "feishu" or call_kwargs[1].get("channel") == "feishu"
+
+    @pytest.mark.asyncio
+    async def test_add_job_fails_without_context(self):
+        cron_service = MagicMock()
+        tool = CronTool(cron_service=cron_service)
+
+        current_channel.set("")
+        current_chat_id.set("")
+
+        result = await tool.execute(action="add", message="test", every_seconds=60)
+        assert "Error" in result
+
+
+# ---------------------------------------------------------------------------
+# Concurrent dispatch simulation
+# ---------------------------------------------------------------------------
+
+class TestConcurrentDispatch:
+    """Simulate concurrent message processing with session locking."""
+
+    @pytest.mark.asyncio
+    async def test_different_sessions_run_concurrently(self):
+        """Messages from different sessions should overlap in time."""
+        execution_log = []
+
+        async def fake_process(session_key, delay):
+            execution_log.append(f"{session_key}_start")
+            await asyncio.sleep(delay)
+            execution_log.append(f"{session_key}_end")
+
+        sem = asyncio.Semaphore(5)
+        locks: dict[str, asyncio.Lock] = {}
+
+        async def dispatch(session_key, delay):
+            lock = locks.setdefault(session_key, asyncio.Lock())
+            async with sem:
+                async with lock:
+                    await fake_process(session_key, delay)
+
+        await asyncio.gather(
+            asyncio.create_task(dispatch("feishu:chat_a", 0.1)),
+            asyncio.create_task(dispatch("slack:chat_b", 0.1)),
+        )
+
+        # Both should start before either ends (concurrent)
+        assert execution_log.index("feishu:chat_a_start") < execution_log.index("slack:chat_b_end")
+        assert execution_log.index("slack:chat_b_start") < execution_log.index("feishu:chat_a_end")
+
+    @pytest.mark.asyncio
+    async def test_same_session_runs_serially(self):
+        """Messages from the same session should not overlap."""
+        execution_log = []
+
+        async def fake_process(label, delay):
+            execution_log.append(f"{label}_start")
+            await asyncio.sleep(delay)
+            execution_log.append(f"{label}_end")
+
+        lock = asyncio.Lock()
+        sem = asyncio.Semaphore(5)
+
+        async def dispatch(label, delay):
+            async with sem:
+                async with lock:
+                    await fake_process(label, delay)
+
+        await asyncio.gather(
+            asyncio.create_task(dispatch("msg1", 0.1)),
+            asyncio.create_task(dispatch("msg2", 0.1)),
+        )
+
+        # msg1 should end before msg2 starts (serial)
+        assert execution_log.index("msg1_end") < execution_log.index("msg2_start")
+
+    @pytest.mark.asyncio
+    async def test_semaphore_limits_concurrency(self):
+        """Semaphore should cap the number of concurrent tasks."""
+        max_concurrent = 0
+        current_concurrent = 0
+        lock = asyncio.Lock()
+
+        async def tracked_task(i):
+            nonlocal max_concurrent, current_concurrent
+            async with lock:
+                current_concurrent += 1
+                if current_concurrent > max_concurrent:
+                    max_concurrent = current_concurrent
+            await asyncio.sleep(0.05)
+            async with lock:
+                current_concurrent -= 1
+
+        sem = asyncio.Semaphore(3)
+
+        async def dispatch(i):
+            async with sem:
+                await tracked_task(i)
+
+        await asyncio.gather(*[
+            asyncio.create_task(dispatch(i)) for i in range(10)
+        ])
+
+        assert max_concurrent <= 3


### PR DESCRIPTION
Superseded by split PRs:
- #1119 — refactor: migrate tool context to contextvars (pure refactor, no behavior change)
- #1120 — feat: concurrent session dispatch with per-session locking (depends on #1119)