### PR TITLE
Make Codex OAuth dependency optional and lazy-loaded

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -232,7 +232,6 @@ def _create_workspace_templates(workspace: Path):
 def _make_provider(config: Config):
     """Create the appropriate LLM provider from config."""
     from nanobot.providers.litellm_provider import LiteLLMProvider
-    from nanobot.providers.openai_codex_provider import OpenAICodexProvider
     from nanobot.providers.custom_provider import CustomProvider
 
     model = config.agents.defaults.model
@@ -241,6 +240,7 @@ def _make_provider(config: Config):
 
     # OpenAI Codex (OAuth)
     if provider_name == "openai_codex" or model.startswith("openai-codex/"):
+        from nanobot.providers.openai_codex_provider import OpenAICodexProvider
         return OpenAICodexProvider(default_model=model)
 
     # Custom: direct OpenAI-compatible endpoint, bypasses LiteLLM

--- a/nanobot/providers/__init__.py
+++ b/nanobot/providers/__init__.py
@@ -2,6 +2,12 @@
 
 from nanobot.providers.base import LLMProvider, LLMResponse
 from nanobot.providers.litellm_provider import LiteLLMProvider
-from nanobot.providers.openai_codex_provider import OpenAICodexProvider
 
-__all__ = ["LLMProvider", "LLMResponse", "LiteLLMProvider", "OpenAICodexProvider"]
+__all__ = ["LLMProvider", "LLMResponse", "LiteLLMProvider"]
+
+try:
+	from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+	__all__.append("OpenAICodexProvider")
+except Exception:
+	# Optional OAuth dependency may not be installed.
+	pass

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -9,8 +9,6 @@ from typing import Any, AsyncGenerator
 
 import httpx
 from loguru import logger
-
-from oauth_cli_kit import get_token as get_codex_token
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 
 DEFAULT_CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
@@ -35,7 +33,7 @@ class OpenAICodexProvider(LLMProvider):
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)
 
-        token = await asyncio.to_thread(get_codex_token)
+        token = await asyncio.to_thread(_get_codex_token)
         headers = _build_headers(token.account_id, token.access)
 
         body: dict[str, Any] = {
@@ -77,6 +75,17 @@ class OpenAICodexProvider(LLMProvider):
 
     def get_default_model(self) -> str:
         return self.default_model
+
+
+def _get_codex_token():
+    try:
+        from oauth_cli_kit import get_token as get_codex_token
+    except ImportError as e:
+        raise RuntimeError(
+            "OpenAI Codex OAuth dependency missing. Install with: pip install 'nanobot-ai[oauth]' "
+            "or pip install oauth-cli-kit"
+        ) from e
+    return get_codex_token()
 
 
 def _strip_model_prefix(model: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nanobot-ai"
 version = "0.1.4.post1"
 description = "A lightweight personal AI assistant framework"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [
     {name = "nanobot contributors"}
@@ -14,6 +14,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.10",
 ]
 
 dependencies = [
@@ -24,7 +25,6 @@ dependencies = [
     "websockets>=16.0,<17.0",
     "websocket-client>=1.9.0,<2.0.0",
     "httpx>=0.28.0,<1.0.0",
-    "oauth-cli-kit>=0.1.3,<1.0.0",
     "loguru>=0.7.3,<1.0.0",
     "readability-lxml>=0.8.4,<1.0.0",
     "rich>=14.0.0,<15.0.0",
@@ -45,6 +45,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+oauth = [
+    "oauth-cli-kit>=0.1.3,<1.0.0",
+]
+
 dev = [
     "pytest>=9.0.0,<10.0.0",
     "pytest-asyncio>=1.3.0,<2.0.0",


### PR DESCRIPTION
- Move OpenAI Codex provider import in CLI provider factory into the codex-only branch to avoid importing optional auth dependencies for other providers.

- Update providers package exports to conditionally include OpenAICodexProvider so package import works even when oauth extras are not installed.

- Replace top-level oauth_cli_kit import in openai_codex_provider with lazy helper _get_codex_token() and raise a clear runtime error with install guidance when dependency is missing.

- Move oauth-cli-kit from core dependencies to optional extras under [project.optional-dependencies].

- Expand Python compatibility metadata from >=3.11 to >=3.10 and add classifier for 3.10.