### PR TITLE
feat(telegram): add /model command for dynamic model switching

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -42,6 +42,7 @@ class AgentLoop:
     4. Executes tool calls
     5. Sends responses back
     """
+    _SESSION_MODEL_KEY = "preferred_model"
 
     def __init__(
         self,
@@ -174,6 +175,7 @@ class AgentLoop:
     async def _run_agent_loop(
         self,
         initial_messages: list[dict],
+        model: str | None = None,
         on_progress: Callable[..., Awaitable[None]] | None = None,
     ) -> tuple[str | None, list[str], list[dict]]:
         """Run the agent iteration loop. Returns (final_content, tools_used, messages)."""
@@ -181,6 +183,7 @@ class AgentLoop:
         iteration = 0
         final_content = None
         tools_used: list[str] = []
+        selected_model = model or self.model
 
         while iteration < self.max_iterations:
             iteration += 1
@@ -188,7 +191,7 @@ class AgentLoop:
             response = await self.provider.chat(
                 messages=messages,
                 tools=self.tools.get_definitions(),
-                model=self.model,
+                model=selected_model,
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
             )
@@ -236,6 +239,43 @@ class AgentLoop:
             )
 
         return final_content, tools_used, messages
+
+    def _session_model(self, session: Session) -> str:
+        """Return the model for this session, falling back to the default."""
+        model = session.metadata.get(self._SESSION_MODEL_KEY)
+        if isinstance(model, str) and model.strip():
+            return model.strip()
+        return self.model
+
+    def _handle_model_command(
+        self,
+        session: Session,
+        msg: InboundMessage,
+        requested_model: str | None,
+    ) -> OutboundMessage:
+        """Handle model selection/status commands."""
+        current_model = self._session_model(session)
+        requested = (requested_model or "").strip()
+
+        if not requested:
+            return OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content=(
+                    f"Current model: `{current_model}`\n"
+                    "Use `/model <name>` to switch models for this chat."
+                ),
+                metadata=msg.metadata or {},
+            )
+
+        session.metadata[self._SESSION_MODEL_KEY] = requested
+        self.sessions.save(session)
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content=f"Model switched to `{requested}` for this chat.",
+            metadata=msg.metadata or {},
+        )
 
     async def run(self) -> None:
         """Run the agent loop, processing messages from the bus."""
@@ -313,7 +353,10 @@ class AgentLoop:
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
             )
-            final_content, _, all_msgs = await self._run_agent_loop(messages)
+            final_content, _, all_msgs = await self._run_agent_loop(
+                messages,
+                model=self._session_model(session),
+            )
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
             return OutboundMessage(channel=channel, chat_id=chat_id,
@@ -325,8 +368,14 @@ class AgentLoop:
         key = session_key or msg.session_key
         session = self.sessions.get_or_create(key)
 
+        if msg.metadata.get("system_command") == "set_model":
+            raw_model = msg.metadata.get("model")
+            requested_model = raw_model if isinstance(raw_model, str) else None
+            return self._handle_model_command(session, msg, requested_model)
+
         # Slash commands
-        cmd = msg.content.strip().lower()
+        raw_cmd = msg.content.strip()
+        cmd = raw_cmd.lower()
         if cmd == "/new":
             lock = self._get_consolidation_lock(session.key)
             self._consolidating.add(session.key)
@@ -335,6 +384,7 @@ class AgentLoop:
                     snapshot = session.messages[session.last_consolidated:]
                     if snapshot:
                         temp = Session(key=session.key)
+                        temp.metadata = dict(session.metadata)
                         temp.messages = list(snapshot)
                         if not await self._consolidate_memory(temp, archive_all=True):
                             return OutboundMessage(
@@ -358,7 +408,10 @@ class AgentLoop:
                                   content="New session started.")
         if cmd == "/help":
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
-                                  content="🐈 nanobot commands:\n/new — Start a new conversation\n/help — Show available commands")
+                                  content="🐈 nanobot commands:\n/new — Start a new conversation\n/model — Show or switch model for this chat\n/help — Show available commands")
+        model_match = re.match(r"^/model(?:@\w+)?(?:\s+(.+))?$", raw_cmd, re.IGNORECASE)
+        if model_match:
+            return self._handle_model_command(session, msg, model_match.group(1))
 
         unconsolidated = len(session.messages) - session.last_consolidated
         if (unconsolidated >= self.memory_window and session.key not in self._consolidating):
@@ -401,7 +454,9 @@ class AgentLoop:
             ))
 
         final_content, _, all_msgs = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
+            initial_messages,
+            model=self._session_model(session),
+            on_progress=on_progress or _bus_progress,
         )
 
         if final_content is None:
@@ -440,7 +495,7 @@ class AgentLoop:
     async def _consolidate_memory(self, session, archive_all: bool = False) -> bool:
         """Delegate to MemoryStore.consolidate(). Returns True on success."""
         return await MemoryStore(self.workspace).consolidate(
-            session, self.provider, self.model,
+            session, self.provider, self._session_model(session),
             archive_all=archive_all, memory_window=self.memory_window,
         )
 

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -111,6 +111,7 @@ class TelegramChannel(BaseChannel):
     BOT_COMMANDS = [
         BotCommand("start", "Start the bot"),
         BotCommand("new", "Start a new conversation"),
+        BotCommand("model", "Show or switch model for this chat"),
         BotCommand("help", "Show available commands"),
     ]
     
@@ -146,6 +147,7 @@ class TelegramChannel(BaseChannel):
         # Add command handlers
         self._app.add_handler(CommandHandler("start", self._on_start))
         self._app.add_handler(CommandHandler("new", self._forward_command))
+        self._app.add_handler(CommandHandler("model", self._on_model))
         self._app.add_handler(CommandHandler("help", self._on_help))
         
         # Add message handler for text, photos, voice, documents
@@ -299,6 +301,7 @@ class TelegramChannel(BaseChannel):
         await update.message.reply_text(
             "🐈 nanobot commands:\n"
             "/new — Start a new conversation\n"
+            "/model [name] — Show or switch model for this chat\n"
             "/help — Show available commands"
         )
 
@@ -316,6 +319,27 @@ class TelegramChannel(BaseChannel):
             sender_id=self._sender_id(update.effective_user),
             chat_id=str(update.message.chat_id),
             content=update.message.text,
+        )
+
+    async def _on_model(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /model command by sending a structured command to AgentLoop."""
+        if not update.message or not update.effective_user:
+            return
+
+        sender_id = self._sender_id(update.effective_user)
+        chat_id = str(update.message.chat_id)
+        raw_text = update.message.text or "/model"
+        requested_model = " ".join(context.args).strip() if context.args else None
+
+        await self._handle_message(
+            sender_id=sender_id,
+            chat_id=chat_id,
+            content=raw_text,
+            metadata={
+                "message_id": update.message.message_id,
+                "system_command": "set_model",
+                "model": requested_model,
+            },
         )
     
     async def _on_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
This PR adds a new model command to the Telegram channel, allowing users to dynamically switch LLM models per session. The selected model is persisted in session metadata