### PR TITLE
Add gigachat provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ Config file: `~/.nanobot/config.json`
 | `groq` | LLM + **Voice transcription** (Whisper) | [console.groq.com](https://console.groq.com) |
 | `gemini` | LLM (Gemini direct) | [aistudio.google.com](https://aistudio.google.com) |
 | `minimax` | LLM (MiniMax direct) | [platform.minimaxi.com](https://platform.minimaxi.com) |
+| `gigachat` | LLM (GigaChat direct) | [https://developers.sber.ru/docs/ru/gigachat/api/reference/rest/gigachat-api](https://developers.sber.ru/docs/ru/gigachat/api/reference/rest/gigachat-api) |
 | `aihubmix` | LLM (API gateway, access to all models) | [aihubmix.com](https://aihubmix.com) |
 | `siliconflow` | LLM (SiliconFlow/硅基流动) | [siliconflow.cn](https://siliconflow.cn) |
 | `volcengine` | LLM (VolcEngine/火山引擎) | [volcengine.com](https://www.volcengine.com) |

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -221,6 +221,7 @@ class ProvidersConfig(Base):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
+    gigachat: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动) API gateway
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎) API gateway

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -355,6 +355,25 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         model_overrides=(),
     ),
 
+    # GigaChat
+    ProviderSpec(
+        name="gigachat",
+        keywords=("gigachat", "GigaChat-Pro"),
+        env_key="GIGACHAT_CREDENTIALS",
+        display_name="GigaChat",
+        litellm_prefix="gigachat",
+        skip_prefixes=("gigachat/"),
+        env_extras=(("SSL_VERIFY","False"),), #required accirding to litellm docs
+        is_gateway=False,
+        is_local=False,
+        is_oauth=True,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="",
+        default_api_base="",
+        strip_model_prefix=False,
+        model_overrides=(),
+    ),
+
     # === Local deployment (matched by config key, NOT by api_base) =========
 
     # vLLM / any OpenAI-compatible local server.


### PR DESCRIPTION
Gigachat is fully supported by LiteLLM
https://docs.litellm.ai/docs/providers/gigachat

So, this PR adds a provider according to public instruction, with a tweak required for GigaChat - deactivates SSL