### PR TITLE
Fix onboard command to respect workspace config setting

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -158,7 +158,7 @@ def onboard():
     """Initialize nanobot configuration and workspace."""
     from nanobot.config.loader import get_config_path, load_config, save_config
     from nanobot.config.schema import Config
-    from nanobot.utils.helpers import get_workspace_path
+    from nanobot.utils.helpers import ensure_dir
     
     config_path = get_config_path()
     
@@ -175,15 +175,14 @@ def onboard():
             save_config(config)
             console.print(f"[green]✓[/green] Config refreshed at {config_path} (existing values preserved)")
     else:
-        save_config(Config())
+        config = Config()
+        save_config(config)
         console.print(f"[green]✓[/green] Created config at {config_path}")
     
-    # Create workspace
-    workspace = get_workspace_path()
+    # Create workspace - use config's workspace_path to respect user settings
+    workspace = ensure_dir(config.workspace_path)
     
-    if not workspace.exists():
-        workspace.mkdir(parents=True, exist_ok=True)
-        console.print(f"[green]✓[/green] Created workspace at {workspace}")
+    console.print(f"[green]✓[/green] Workspace ready at {workspace}")
     
     # Create default bootstrap files
     _create_workspace_templates(workspace)


### PR DESCRIPTION
## Description

Fixes #1133 - Workspace path in onboard command ignores config setting

## Problem

The onboard command was using get_workspace_path() which always returns the default ~/.nanobot/workspace, ignoring any custom workspace path defined in the config file.

This caused:
- Configuration inconsistency - user-defined workspace paths do not take effect
- Potential security concerns when restrictedToWorkdir is enabled

## Solution

Use config.workspace_path property instead of get_workspace_path() to respect user-defined workspace paths.

## Changes

- Replace get_workspace_path() with config.workspace_path
- Import ensure_dir helper instead
- Simplify workspace creation (ensure_dir handles existence check)