### PR TITLE
Use instance variable for API key in web.py

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -80,7 +80,7 @@ class WebSearchTool(Tool):
                 r = await client.get(
                     "https://api.search.brave.com/res/v1/web/search",
                     params={"q": query, "count": n},
-                    headers={"Accept": "application/json", "X-Subscription-Token": api_key},
+                    headers={"Accept": "application/json", "X-Subscription-Token": self.api_key},
                     timeout=10.0
                 )
                 r.raise_for_status()


### PR DESCRIPTION
What does this PR do?
Fixes a NameError in the WebSearchTool when making requests to the Brave Search API.

Why is it needed?
The tool was incorrectly referencing api_key as a local variable when constructing the headers for the HTTP request. Since api_key is passed during initialization and stored as an instance attribute, this PR updates the reference to self.api_key so the tool can successfully authenticate.

How to test:
Configure a Brave Search API key and trigger a web search using the agent. The request will now succeed instead of throwing an undefined variable exception.