### PR TITLE
Fix web_search: use self.api_key instead of undefined api_key

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -80,7 +80,7 @@ class WebSearchTool(Tool):
                 r = await client.get(
                     "https://api.search.brave.com/res/v1/web/search",
                     params={"q": query, "count": n},
-                    headers={"Accept": "application/json", "X-Subscription-Token": api_key},
+                    headers={"Accept": "application/json", "X-Subscription-Token": self.api_key},
                     timeout=10.0
                 )
                 r.raise_for_status()


### PR DESCRIPTION
## Description

Fixes #1130 - web_search broken: api_key not defined in web.py

## Problem

The web_search tool was failing because the execute method referenced  instead of , causing a NameError when making the Brave Search API call.

## Solution

Changed  to  on line 83.

## Changes

- Fixed typo in  line 83