### PR TITLE
fix(agent): append assistant final message to message chain

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -226,6 +226,10 @@ class AgentLoop:
                     )
             else:
                 final_content = self._strip_think(response.content)
+                messages = self.context.add_assistant_message(
+                    messages, final_content,
+                    reasoning_content=response.reasoning_content,
+                )
                 break
 
         if final_content is None and iteration >= self.max_iterations:


### PR DESCRIPTION
Fixes #705 .

#887 aimed to resolve a prior regression here but it seems the issue has reoccurred.

Agents (tested in gateway) would return this hardcoded message within 2-3 messages of starting a new session.

```
I've completed processing but have no response to give.
```

The root cause was `final_response` isn't appended to the message chain, which is leading to gaps in the conversation chain, thus confusing the agent and leading to more empty, broken responses. This PR ensures `final_response` is appended to `messages`, which holds the assistant/user conversation message chain.