### PR TITLE
fix: prefix group chat messages with sender name on Telegram

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -402,9 +402,16 @@ class TelegramChannel(BaseChannel):
                 content_parts.append(f"[{media_type}: download failed]")
         
         content = "\n".join(content_parts) if content_parts else "[empty message]"
-        
+
+        # In group chats, prefix content with sender name so the LLM can
+        # attribute messages to individual users.
+        is_group = message.chat.type != "private"
+        if is_group:
+            display_name = user.first_name or user.username or str(user.id)
+            content = f"[{display_name}]: {content}"
+
         logger.debug("Telegram message from {}: {}...", sender_id, content[:50])
-        
+
         str_chat_id = str(chat_id)
 
         # Telegram media groups: buffer briefly, forward as one aggregated turn.

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -403,8 +403,8 @@ class TelegramChannel(BaseChannel):
         
         content = "\n".join(content_parts) if content_parts else "[empty message]"
 
-        # In group chats, prefix content with sender name so the LLM can
-        # attribute messages to individual users.
+        # In non-private chats (group/supergroup/channel), prefix content with
+        # sender name so the LLM can attribute messages to individual users.
         is_group = message.chat.type != "private"
         if is_group:
             display_name = user.first_name or user.username or str(user.id)
@@ -450,7 +450,7 @@ class TelegramChannel(BaseChannel):
                 "user_id": user.id,
                 "username": user.username,
                 "first_name": user.first_name,
-                "is_group": message.chat.type != "private"
+                "is_group": is_group
             }
         )
     


### PR DESCRIPTION
## Summary

- In Telegram group chats, all messages arrive as plain text with no sender attribution
- The LLM cannot tell who said what — it sees a flat stream of anonymous messages
- This PR prefixes group message content with `[DisplayName]: ` using the fallback chain `first_name` → `username` → `user_id`
- Consistent with the pattern already used by the WhatsApp bridge
- Private DMs are unaffected

### Before
```
User A sends "Hello" → LLM sees: "Hello"
User B sends "Hi" → LLM sees: "Hi"
```

### After
```
User A sends "Hello" → LLM sees: "[Alice]: Hello"
User B sends "Hi" → LLM sees: "[Bob]: Hi"
```

## Test plan

- [ ] Send messages from multiple users in a Telegram group, verify each has sender prefix
- [ ] Send a private DM, verify no prefix is added
- [ ] Verify media messages (photo, voice) also include sender prefix in groups

Closes #1091