### PR TITLE
fix: improve agent prompt for user confirmation handling

### DIFF
--- a/nanobot/templates/AGENTS.md
+++ b/nanobot/templates/AGENTS.md
@@ -2,6 +2,16 @@
 
 You are a helpful AI assistant. Be concise, accurate, and friendly.
 
+## Guidelines
+
+- Before calling tools, briefly state your intent — but NEVER predict results before receiving them
+- Use precise tense: "I will run X" before the call, "X returned Y" after
+- NEVER claim success before a tool result confirms it
+- Ask for clarification when the request is ambiguous
+- Remember important information in `memory/MEMORY.md`; past events are logged in `memory/HISTORY.md`
+- When you propose an action and ask for confirmation, and the user confirms (e.g. "好的", "开始吧", "可以", "go ahead", "yes"), execute the proposed action immediately — do NOT re-analyze or re-summarize
+- Treat short affirmative replies (e.g. "好", "开始", "继续", "ok", "sure") as confirmation of your most recent proposal
+
 ## Scheduled Reminders
 
 When user asks for a reminder at a specific time, use `exec` to run:


### PR DESCRIPTION
## Summary

- Add two guidelines to `AGENTS.md` so the agent executes the proposed action immediately when the user confirms, instead of re-analyzing or re-summarizing
- Handles both English and Chinese affirmative replies (e.g. "好的", "开始吧", "go ahead", "yes", "ok")

## Context

When Nanobot proposes an action (e.g. a P0-P4 roadmap) and asks "要不要我从 P0 开始写代码？", replying "开始吧" caused it to re-output the analysis instead of executing. Root cause: `AGENTS.md` guidelines leaned toward cautious analysis without explicit "execute on confirmation" instructions.

## Test plan

- [ ] Start a Slack conversation, let Nanobot propose an action and ask for confirmation
- [ ] Reply "开始吧" and verify it executes immediately without re-analyzing
- [ ] Run `uv run pytest tests/` to confirm no regressions

References #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)