### PR TITLE
fix: send Telegram message with manual cron job execution

### DIFF
--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from loguru import logger
 
-from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.config.schema import Config
@@ -16,28 +15,29 @@ from nanobot.config.schema import Config
 class ChannelManager:
     """
     Manages chat channels and coordinates message routing.
-    
+
     Responsibilities:
     - Initialize enabled channels (Telegram, WhatsApp, etc.)
     - Start/stop channels
     - Route outbound messages
     """
-    
+
     def __init__(self, config: Config, bus: MessageBus):
         self.config = config
         self.bus = bus
         self.channels: dict[str, BaseChannel] = {}
         self._dispatch_task: asyncio.Task | None = None
-        
+
         self._init_channels()
-    
+
     def _init_channels(self) -> None:
         """Initialize channels based on config."""
-        
+
         # Telegram channel
         if self.config.channels.telegram.enabled:
             try:
                 from nanobot.channels.telegram import TelegramChannel
+
                 self.channels["telegram"] = TelegramChannel(
                     self.config.channels.telegram,
                     self.bus,
@@ -46,11 +46,12 @@ class ChannelManager:
                 logger.info("Telegram channel enabled")
             except ImportError as e:
                 logger.warning("Telegram channel not available: {}", e)
-        
+
         # WhatsApp channel
         if self.config.channels.whatsapp.enabled:
             try:
                 from nanobot.channels.whatsapp import WhatsAppChannel
+
                 self.channels["whatsapp"] = WhatsAppChannel(
                     self.config.channels.whatsapp, self.bus
                 )
@@ -62,17 +63,19 @@ class ChannelManager:
         if self.config.channels.discord.enabled:
             try:
                 from nanobot.channels.discord import DiscordChannel
+
                 self.channels["discord"] = DiscordChannel(
                     self.config.channels.discord, self.bus
                 )
                 logger.info("Discord channel enabled")
             except ImportError as e:
                 logger.warning("Discord channel not available: {}", e)
-        
+
         # Feishu channel
         if self.config.channels.feishu.enabled:
             try:
                 from nanobot.channels.feishu import FeishuChannel
+
                 self.channels["feishu"] = FeishuChannel(
                     self.config.channels.feishu, self.bus
                 )
@@ -96,6 +99,7 @@ class ChannelManager:
         if self.config.channels.dingtalk.enabled:
             try:
                 from nanobot.channels.dingtalk import DingTalkChannel
+
                 self.channels["dingtalk"] = DingTalkChannel(
                     self.config.channels.dingtalk, self.bus
                 )
@@ -107,6 +111,7 @@ class ChannelManager:
         if self.config.channels.email.enabled:
             try:
                 from nanobot.channels.email import EmailChannel
+
                 self.channels["email"] = EmailChannel(
                     self.config.channels.email, self.bus
                 )
@@ -118,6 +123,7 @@ class ChannelManager:
         if self.config.channels.slack.enabled:
             try:
                 from nanobot.channels.slack import SlackChannel
+
                 self.channels["slack"] = SlackChannel(
                     self.config.channels.slack, self.bus
                 )
@@ -129,6 +135,7 @@ class ChannelManager:
         if self.config.channels.qq.enabled:
             try:
                 from nanobot.channels.qq import QQChannel
+
                 self.channels["qq"] = QQChannel(
                     self.config.channels.qq,
                     self.bus,
@@ -136,11 +143,19 @@ class ChannelManager:
                 logger.info("QQ channel enabled")
             except ImportError as e:
                 logger.warning("QQ channel not available: {}", e)
-    
-    async def _start_channel(self, name: str, channel: BaseChannel) -> None:
+
+    async def _start_channel(
+        self,
+        name: str,
+        channel: BaseChannel,
+        send_only: bool = False,
+    ) -> None:
         """Start a channel and log any exceptions."""
         try:
-            await channel.start()
+            if send_only and name == "telegram":
+                await channel.start(send_only=True)
+            else:
+                await channel.start()
         except Exception as e:
             logger.error("Failed to start channel {}: {}", name, e)
 
@@ -149,23 +164,63 @@ class ChannelManager:
         if not self.channels:
             logger.warning("No channels enabled")
             return
-        
+
         # Start outbound dispatcher
         self._dispatch_task = asyncio.create_task(self._dispatch_outbound())
-        
+
         # Start channels
         tasks = []
         for name, channel in self.channels.items():
             logger.info("Starting {} channel...", name)
-            tasks.append(asyncio.create_task(self._start_channel(name, channel)))
-        
+            tasks.append(
+                asyncio.create_task(self._start_channel(name, channel))
+            )
+
         # Wait for all to complete (they should run forever)
         await asyncio.gather(*tasks, return_exceptions=True)
-    
+
+    async def start_for_cron_job(self) -> None:
+        """
+        Start channels and outbound dispatcher for ephemeral use (e.g. cron run).
+        Non-blocking: starts tasks in background and returns after a short init delay.
+        Call stop_for_cron_job() when done.
+        """
+        if not self.channels:
+            logger.warning("No channels enabled")
+            return
+
+        self._dispatch_task = asyncio.create_task(self._dispatch_outbound())
+        for name, channel in self.channels.items():
+            logger.info("Starting {} channel for cron job...", name)
+            asyncio.create_task(
+                self._start_channel(name, channel, send_only=True)
+            )
+
+        await asyncio.sleep(5)
+
+    async def stop_for_cron_job(self, drain_timeout: float = 15.0) -> None:
+        """
+        Stop channels after a cron job run.
+        Waits for the outbound queue to drain so all messages are delivered
+        before tearing down. Call this after start_for_cron_job().
+        """
+        if self._dispatch_task:
+            elapsed = 0.0
+            poll_interval = 0.2
+            while self.bus.outbound_size > 0 and elapsed < drain_timeout:
+                await asyncio.sleep(poll_interval)
+                elapsed += poll_interval
+            if self.bus.outbound_size > 0:
+                logger.warning(
+                    "Outbound queue not empty after {:.0f}s",
+                    drain_timeout,
+                )
+        await self.stop_all()
+
     async def stop_all(self) -> None:
         """Stop all channels and the dispatcher."""
         logger.info("Stopping all channels...")
-        
+
         # Stop dispatcher
         if self._dispatch_task:
             self._dispatch_task.cancel()
@@ -173,7 +228,7 @@ class ChannelManager:
                 await self._dispatch_task
             except asyncio.CancelledError:
                 pass
-        
+
         # Stop all channels
         for name, channel in self.channels.items():
             try:
@@ -181,24 +236,28 @@ class ChannelManager:
                 logger.info("Stopped {} channel", name)
             except Exception as e:
                 logger.error("Error stopping {}: {}", name, e)
-    
+
     async def _dispatch_outbound(self) -> None:
         """Dispatch outbound messages to the appropriate channel."""
         logger.info("Outbound dispatcher started")
-        
+
         while True:
             try:
                 msg = await asyncio.wait_for(
-                    self.bus.consume_outbound(),
-                    timeout=1.0
+                    self.bus.consume_outbound(), timeout=1.0
                 )
-                
                 if msg.metadata.get("_progress"):
-                    if msg.metadata.get("_tool_hint") and not self.config.channels.send_tool_hints:
+                    if (
+                        msg.metadata.get("_tool_hint")
+                        and not self.config.channels.send_tool_hints
+                    ):
                         continue
-                    if not msg.metadata.get("_tool_hint") and not self.config.channels.send_progress:
+                    if (
+                        not msg.metadata.get("_tool_hint")
+                        and not self.config.channels.send_progress
+                    ):
                         continue
-                
+
                 channel = self.channels.get(msg.channel)
                 if channel:
                     try:
@@ -207,26 +266,23 @@ class ChannelManager:
                         logger.error("Error sending to {}: {}", msg.channel, e)
                 else:
                     logger.warning("Unknown channel: {}", msg.channel)
-                    
+
             except asyncio.TimeoutError:
                 continue
             except asyncio.CancelledError:
                 break
-    
+
     def get_channel(self, name: str) -> BaseChannel | None:
         """Get a channel by name."""
         return self.channels.get(name)
-    
+
     def get_status(self) -> dict[str, Any]:
         """Get status of all channels."""
         return {
-            name: {
-                "enabled": True,
-                "running": channel.is_running
-            }
+            name: {"enabled": True, "running": channel.is_running}
             for name, channel in self.channels.items()
         }
-    
+
     @property
     def enabled_channels(self) -> list[str]:
         """Get list of enabled channel names."""

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import re
+
 from loguru import logger
-from telegram import BotCommand, Update, ReplyParameters
-from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
+from telegram import BotCommand, ReplyParameters, Update
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 from telegram.request import HTTPXRequest
 
 from nanobot.bus.events import OutboundMessage
@@ -21,60 +28,70 @@ def _markdown_to_telegram_html(text: str) -> str:
     """
     if not text:
         return ""
-    
+
     # 1. Extract and protect code blocks (preserve content from other processing)
     code_blocks: list[str] = []
+
     def save_code_block(m: re.Match) -> str:
         code_blocks.append(m.group(1))
         return f"\x00CB{len(code_blocks) - 1}\x00"
-    
-    text = re.sub(r'```[\w]*\n?([\s\S]*?)```', save_code_block, text)
-    
+
+    text = re.sub(r"```[\w]*\n?([\s\S]*?)```", save_code_block, text)
+
     # 2. Extract and protect inline code
     inline_codes: list[str] = []
+
     def save_inline_code(m: re.Match) -> str:
         inline_codes.append(m.group(1))
         return f"\x00IC{len(inline_codes) - 1}\x00"
-    
-    text = re.sub(r'`([^`]+)`', save_inline_code, text)
-    
+
+    text = re.sub(r"`([^`]+)`", save_inline_code, text)
+
     # 3. Headers # Title -> just the title text
-    text = re.sub(r'^#{1,6}\s+(.+)$', r'\1', text, flags=re.MULTILINE)
-    
+    text = re.sub(r"^#{1,6}\s+(.+)$", r"\1", text, flags=re.MULTILINE)
+
     # 4. Blockquotes > text -> just the text (before HTML escaping)
-    text = re.sub(r'^>\s*(.*)$', r'\1', text, flags=re.MULTILINE)
-    
+    text = re.sub(r"^>\s*(.*)$", r"\1", text, flags=re.MULTILINE)
+
     # 5. Escape HTML special characters
     text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-    
+
     # 6. Links [text](url) - must be before bold/italic to handle nested cases
-    text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', text)
-    
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', text)
+
     # 7. Bold **text** or __text__
-    text = re.sub(r'\*\*(.+?)\*\*', r'<b>\1</b>', text)
-    text = re.sub(r'__(.+?)__', r'<b>\1</b>', text)
-    
+    text = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", text)
+    text = re.sub(r"__(.+?)__", r"<b>\1</b>", text)
+
     # 8. Italic _text_ (avoid matching inside words like some_var_name)
-    text = re.sub(r'(?<![a-zA-Z0-9])_([^_]+)_(?![a-zA-Z0-9])', r'<i>\1</i>', text)
-    
+    text = re.sub(
+        r"(?<![a-zA-Z0-9])_([^_]+)_(?![a-zA-Z0-9])", r"<i>\1</i>", text
+    )
+
     # 9. Strikethrough ~~text~~
-    text = re.sub(r'~~(.+?)~~', r'<s>\1</s>', text)
-    
+    text = re.sub(r"~~(.+?)~~", r"<s>\1</s>", text)
+
     # 10. Bullet lists - item -> • item
-    text = re.sub(r'^[-*]\s+', '• ', text, flags=re.MULTILINE)
-    
+    text = re.sub(r"^[-*]\s+", "• ", text, flags=re.MULTILINE)
+
     # 11. Restore inline code with HTML tags
     for i, code in enumerate(inline_codes):
         # Escape HTML in code content
-        escaped = code.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        escaped = (
+            code.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        )
         text = text.replace(f"\x00IC{i}\x00", f"<code>{escaped}</code>")
-    
+
     # 12. Restore code blocks with HTML tags
     for i, code in enumerate(code_blocks):
         # Escape HTML in code content
-        escaped = code.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-        text = text.replace(f"\x00CB{i}\x00", f"<pre><code>{escaped}</code></pre>")
-    
+        escaped = (
+            code.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        )
+        text = text.replace(
+            f"\x00CB{i}\x00", f"<pre><code>{escaped}</code></pre>"
+        )
+
     return text
 
 
@@ -88,9 +105,9 @@ def _split_message(content: str, max_len: int = 4000) -> list[str]:
             chunks.append(content)
             break
         cut = content[:max_len]
-        pos = cut.rfind('\n')
+        pos = cut.rfind("\n")
         if pos == -1:
-            pos = cut.rfind(' ')
+            pos = cut.rfind(" ")
         if pos == -1:
             pos = max_len
         chunks.append(content[:pos])
@@ -101,19 +118,19 @@ def _split_message(content: str, max_len: int = 4000) -> list[str]:
 class TelegramChannel(BaseChannel):
     """
     Telegram channel using long polling.
-    
+
     Simple and reliable - no webhook/public IP needed.
     """
-    
+
     name = "telegram"
-    
+
     # Commands registered with Telegram's command menu
     BOT_COMMANDS = [
         BotCommand("start", "Start the bot"),
         BotCommand("new", "Start a new conversation"),
         BotCommand("help", "Show available commands"),
     ]
-    
+
     def __init__(
         self,
         config: TelegramConfig,
@@ -124,80 +141,102 @@ class TelegramChannel(BaseChannel):
         self.config: TelegramConfig = config
         self.groq_api_key = groq_api_key
         self._app: Application | None = None
-        self._chat_ids: dict[str, int] = {}  # Map sender_id to chat_id for replies
-        self._typing_tasks: dict[str, asyncio.Task] = {}  # chat_id -> typing loop task
-    
-    async def start(self) -> None:
-        """Start the Telegram bot with long polling."""
+        self._chat_ids: dict[
+            str, int
+        ] = {}  # Map sender_id to chat_id for replies
+        self._typing_tasks: dict[
+            str, asyncio.Task
+        ] = {}  # chat_id -> typing loop task
+        self._send_only: bool = False
+
+    async def start(self, send_only: bool = False) -> None:
+        """
+        Start the Telegram bot.
+        If send_only=True, initializes for sending only (no polling).
+        Use when another instance (e.g. gateway) already polls - avoids getUpdates conflict.
+        """
         if not self.config.token:
             logger.error("Telegram bot token not configured")
             return
-        
+
         self._running = True
-        
-        # Build the application with larger connection pool to avoid pool-timeout on long runs
-        req = HTTPXRequest(connection_pool_size=16, pool_timeout=5.0, connect_timeout=30.0, read_timeout=30.0)
-        builder = Application.builder().token(self.config.token).request(req).get_updates_request(req)
+        self._send_only = send_only
+
+        req = HTTPXRequest(
+            connection_pool_size=16,
+            pool_timeout=5.0,
+            connect_timeout=30.0,
+            read_timeout=30.0,
+        )
+        builder = (
+            Application.builder()
+            .token(self.config.token)
+            .request(req)
+            .get_updates_request(req)
+        )
         if self.config.proxy:
-            builder = builder.proxy(self.config.proxy).get_updates_proxy(self.config.proxy)
+            builder = builder.proxy(self.config.proxy).get_updates_proxy(
+                self.config.proxy
+            )
         self._app = builder.build()
         self._app.add_error_handler(self._on_error)
-        
-        # Add command handlers
-        self._app.add_handler(CommandHandler("start", self._on_start))
-        self._app.add_handler(CommandHandler("new", self._forward_command))
-        self._app.add_handler(CommandHandler("help", self._on_help))
-        
-        # Add message handler for text, photos, voice, documents
-        self._app.add_handler(
-            MessageHandler(
-                (filters.TEXT | filters.PHOTO | filters.VOICE | filters.AUDIO | filters.Document.ALL) 
-                & ~filters.COMMAND, 
-                self._on_message
+
+        if not send_only:
+            self._app.add_handler(CommandHandler("start", self._on_start))
+            self._app.add_handler(CommandHandler("new", self._forward_command))
+            self._app.add_handler(CommandHandler("help", self._on_help))
+            self._app.add_handler(
+                MessageHandler(
+                    (
+                        filters.TEXT
+                        | filters.PHOTO
+                        | filters.VOICE
+                        | filters.AUDIO
+                        | filters.Document.ALL
+                    )
+                    & ~filters.COMMAND,
+                    self._on_message,
+                )
             )
-        )
-        
-        logger.info("Starting Telegram bot (polling mode)...")
-        
-        # Initialize and start polling
+
         await self._app.initialize()
         await self._app.start()
-        
-        # Get bot info and register command menu
+
         bot_info = await self._app.bot.get_me()
-        logger.info("Telegram bot @{} connected", bot_info.username)
-        
-        try:
-            await self._app.bot.set_my_commands(self.BOT_COMMANDS)
-            logger.debug("Telegram bot commands registered")
-        except Exception as e:
-            logger.warning("Failed to register bot commands: {}", e)
-        
-        # Start polling (this runs until stopped)
-        await self._app.updater.start_polling(
-            allowed_updates=["message"],
-            drop_pending_updates=True  # Ignore old messages on startup
+        logger.info(
+            "Telegram bot @{} connected ({})",
+            bot_info.username,
+            "send-only" if send_only else "polling",
         )
-        
-        # Keep running until stopped
-        while self._running:
-            await asyncio.sleep(1)
-    
+
+        if not send_only:
+            try:
+                await self._app.bot.set_my_commands(self.BOT_COMMANDS)
+                logger.debug("Telegram bot commands registered")
+            except Exception as e:
+                logger.warning("Failed to register bot commands: {}", e)
+            await self._app.updater.start_polling(
+                allowed_updates=["message"],
+                drop_pending_updates=True,
+            )
+            while self._running:
+                await asyncio.sleep(1)
+
     async def stop(self) -> None:
         """Stop the Telegram bot."""
         self._running = False
-        
-        # Cancel all typing indicators
+
         for chat_id in list(self._typing_tasks):
             self._stop_typing(chat_id)
-        
+
         if self._app:
             logger.info("Stopping Telegram bot...")
-            await self._app.updater.stop()
+            if not self._send_only:
+                await self._app.updater.stop()
             await self._app.stop()
             await self._app.shutdown()
             self._app = None
-    
+
     @staticmethod
     def _get_media_type(path: str) -> str:
         """Guess media type from file extension."""
@@ -230,11 +269,11 @@ class TelegramChannel(BaseChannel):
             if reply_to_message_id:
                 reply_params = ReplyParameters(
                     message_id=reply_to_message_id,
-                    allow_sending_without_reply=True
+                    allow_sending_without_reply=True,
                 )
 
         # Send media files
-        for media_path in (msg.media or []):
+        for media_path in msg.media or []:
             try:
                 media_type = self._get_media_type(media_path)
                 sender = {
@@ -242,12 +281,18 @@ class TelegramChannel(BaseChannel):
                     "voice": self._app.bot.send_voice,
                     "audio": self._app.bot.send_audio,
                 }.get(media_type, self._app.bot.send_document)
-                param = "photo" if media_type == "photo" else media_type if media_type in ("voice", "audio") else "document"
-                with open(media_path, 'rb') as f:
+                param = (
+                    "photo"
+                    if media_type == "photo"
+                    else media_type
+                    if media_type in ("voice", "audio")
+                    else "document"
+                )
+                with open(media_path, "rb") as f:
                     await sender(
-                        chat_id=chat_id, 
+                        chat_id=chat_id,
                         **{param: f},
-                        reply_parameters=reply_params
+                        reply_parameters=reply_params,
                     )
             except Exception as e:
                 filename = media_path.rsplit("/", 1)[-1]
@@ -255,7 +300,7 @@ class TelegramChannel(BaseChannel):
                 await self._app.bot.send_message(
                     chat_id=chat_id,
                     text=f"[Failed to send: {filename}]",
-                    reply_parameters=reply_params
+                    reply_parameters=reply_params,
                 )
 
         # Send text content
@@ -264,23 +309,27 @@ class TelegramChannel(BaseChannel):
                 try:
                     html = _markdown_to_telegram_html(chunk)
                     await self._app.bot.send_message(
-                        chat_id=chat_id, 
-                        text=html, 
+                        chat_id=chat_id,
+                        text=html,
                         parse_mode="HTML",
-                        reply_parameters=reply_params
+                        reply_parameters=reply_params,
                     )
                 except Exception as e:
-                    logger.warning("HTML parse failed, falling back to plain text: {}", e)
+                    logger.warning(
+                        "HTML parse failed, falling back to plain text: {}", e
+                    )
                     try:
                         await self._app.bot.send_message(
-                            chat_id=chat_id, 
+                            chat_id=chat_id,
                             text=chunk,
-                            reply_parameters=reply_params
+                            reply_parameters=reply_params,
                         )
                     except Exception as e2:
                         logger.error("Error sending Telegram message: {}", e2)
-    
-    async def _on_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+
+    async def _on_start(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Handle /start command."""
         if not update.message or not update.effective_user:
             return
@@ -292,7 +341,9 @@ class TelegramChannel(BaseChannel):
             "Type /help to see available commands."
         )
 
-    async def _on_help(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def _on_help(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Handle /help command, bypassing ACL so all users can access it."""
         if not update.message:
             return
@@ -308,7 +359,9 @@ class TelegramChannel(BaseChannel):
         sid = str(user.id)
         return f"{sid}|{user.username}" if user.username else sid
 
-    async def _forward_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def _forward_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Forward slash commands to the bus for unified handling in AgentLoop."""
         if not update.message or not update.effective_user:
             return
@@ -317,34 +370,36 @@ class TelegramChannel(BaseChannel):
             chat_id=str(update.message.chat_id),
             content=update.message.text,
         )
-    
-    async def _on_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+
+    async def _on_message(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Handle incoming messages (text, photos, voice, documents)."""
         if not update.message or not update.effective_user:
             return
-        
+
         message = update.message
         user = update.effective_user
         chat_id = message.chat_id
         sender_id = self._sender_id(user)
-        
+
         # Store chat_id for replies
         self._chat_ids[sender_id] = chat_id
-        
+
         # Build content from text and/or media
         content_parts = []
         media_paths = []
-        
+
         # Text content
         if message.text:
             content_parts.append(message.text)
         if message.caption:
             content_parts.append(message.caption)
-        
+
         # Handle media files
         media_file = None
         media_type = None
-        
+
         if message.photo:
             media_file = message.photo[-1]  # Largest photo
             media_type = "image"
@@ -357,50 +412,66 @@ class TelegramChannel(BaseChannel):
         elif message.document:
             media_file = message.document
             media_type = "file"
-        
+
         # Download media if present
         if media_file and self._app:
             try:
                 file = await self._app.bot.get_file(media_file.file_id)
-                ext = self._get_extension(media_type, getattr(media_file, 'mime_type', None))
-                
+                ext = self._get_extension(
+                    media_type, getattr(media_file, "mime_type", None)
+                )
+
                 # Save to workspace/media/
                 from pathlib import Path
+
                 media_dir = Path.home() / ".nanobot" / "media"
                 media_dir.mkdir(parents=True, exist_ok=True)
-                
+
                 file_path = media_dir / f"{media_file.file_id[:16]}{ext}"
                 await file.download_to_drive(str(file_path))
-                
+
                 media_paths.append(str(file_path))
-                
+
                 # Handle voice transcription
                 if media_type == "voice" or media_type == "audio":
-                    from nanobot.providers.transcription import GroqTranscriptionProvider
-                    transcriber = GroqTranscriptionProvider(api_key=self.groq_api_key)
+                    from nanobot.providers.transcription import (
+                        GroqTranscriptionProvider,
+                    )
+
+                    transcriber = GroqTranscriptionProvider(
+                        api_key=self.groq_api_key
+                    )
                     transcription = await transcriber.transcribe(file_path)
                     if transcription:
-                        logger.info("Transcribed {}: {}...", media_type, transcription[:50])
-                        content_parts.append(f"[transcription: {transcription}]")
+                        logger.info(
+                            "Transcribed {}: {}...",
+                            media_type,
+                            transcription[:50],
+                        )
+                        content_parts.append(
+                            f"[transcription: {transcription}]"
+                        )
                     else:
                         content_parts.append(f"[{media_type}: {file_path}]")
                 else:
                     content_parts.append(f"[{media_type}: {file_path}]")
-                    
+
                 logger.debug("Downloaded {} to {}", media_type, file_path)
             except Exception as e:
                 logger.error("Failed to download media: {}", e)
                 content_parts.append(f"[{media_type}: download failed]")
-        
-        content = "\n".join(content_parts) if content_parts else "[empty message]"
-        
+
+        content = (
+            "\n".join(content_parts) if content_parts else "[empty message]"
+        )
+
         logger.debug("Telegram message from {}: {}...", sender_id, content[:50])
-        
+
         str_chat_id = str(chat_id)
-        
+
         # Start typing indicator before processing
         self._start_typing(str_chat_id)
-        
+
         # Forward to the message bus
         await self._handle_message(
             sender_id=sender_id,
@@ -412,34 +483,40 @@ class TelegramChannel(BaseChannel):
                 "user_id": user.id,
                 "username": user.username,
                 "first_name": user.first_name,
-                "is_group": message.chat.type != "private"
-            }
+                "is_group": message.chat.type != "private",
+            },
         )
-    
+
     def _start_typing(self, chat_id: str) -> None:
         """Start sending 'typing...' indicator for a chat."""
         # Cancel any existing typing task for this chat
         self._stop_typing(chat_id)
-        self._typing_tasks[chat_id] = asyncio.create_task(self._typing_loop(chat_id))
-    
+        self._typing_tasks[chat_id] = asyncio.create_task(
+            self._typing_loop(chat_id)
+        )
+
     def _stop_typing(self, chat_id: str) -> None:
         """Stop the typing indicator for a chat."""
         task = self._typing_tasks.pop(chat_id, None)
         if task and not task.done():
             task.cancel()
-    
+
     async def _typing_loop(self, chat_id: str) -> None:
         """Repeatedly send 'typing' action until cancelled."""
         try:
             while self._app:
-                await self._app.bot.send_chat_action(chat_id=int(chat_id), action="typing")
+                await self._app.bot.send_chat_action(
+                    chat_id=int(chat_id), action="typing"
+                )
                 await asyncio.sleep(4)
         except asyncio.CancelledError:
             pass
         except Exception as e:
             logger.debug("Typing indicator stopped for {}: {}", chat_id, e)
-    
-    async def _on_error(self, update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+
+    async def _on_error(
+        self, update: object, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Log polling / handler errors instead of silently swallowing them."""
         logger.error("Telegram error: {}", context.error)
 
@@ -447,11 +524,20 @@ class TelegramChannel(BaseChannel):
         """Get file extension based on media type."""
         if mime_type:
             ext_map = {
-                "image/jpeg": ".jpg", "image/png": ".png", "image/gif": ".gif",
-                "audio/ogg": ".ogg", "audio/mpeg": ".mp3", "audio/mp4": ".m4a",
+                "image/jpeg": ".jpg",
+                "image/png": ".png",
+                "image/gif": ".gif",
+                "audio/ogg": ".ogg",
+                "audio/mpeg": ".mp3",
+                "audio/mp4": ".m4a",
             }
             if mime_type in ext_map:
                 return ext_map[mime_type]
-        
-        type_map = {"image": ".jpg", "voice": ".ogg", "audio": ".mp3", "file": ""}
+
+        type_map = {
+            "image": ".jpg",
+            "voice": ".ogg",
+            "audio": ".mp3",
+            "file": "",
+        }
         return type_map.get(media_type, "")

--- a/tests/test_channel_manager_send_only.py
+++ b/tests/test_channel_manager_send_only.py
@@ -1,0 +1,114 @@
+"""Tests for ChannelManager send_only behavior (Telegram send_only mode)."""
+
+import pytest
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.channels.manager import ChannelManager
+from nanobot.config.schema import Config
+
+
+class RecordingChannel(BaseChannel):
+    """Channel that records start() and send() calls for testing."""
+
+    name = "recording"
+
+    def __init__(self, bus: MessageBus, channel_name: str = "recording"):
+        super().__init__(object(), bus)
+        self.channel_name = channel_name
+        self.start_calls: list[tuple[tuple, dict]] = []
+
+    async def start(self, *args: object, **kwargs: object) -> None:
+        self.start_calls.append((args, dict(kwargs)))
+        self._running = True
+
+    async def stop(self) -> None:
+        self._running = False
+
+    async def send(self, msg: OutboundMessage) -> None:
+        pass
+
+
+@pytest.fixture
+def bus() -> MessageBus:
+    return MessageBus()
+
+
+@pytest.fixture
+def recording_telegram(bus: MessageBus) -> RecordingChannel:
+    return RecordingChannel(bus, "telegram")
+
+
+@pytest.fixture
+def recording_discord(bus: MessageBus) -> RecordingChannel:
+    return RecordingChannel(bus, "discord")
+
+
+@pytest.fixture
+def manager(bus: MessageBus) -> ChannelManager:
+    return ChannelManager(Config(), bus)
+
+
+@pytest.mark.asyncio
+async def test_start_channel_send_only_telegram_calls_start_with_send_only(
+    manager: ChannelManager,
+    recording_telegram: RecordingChannel,
+) -> None:
+    manager.channels["telegram"] = recording_telegram
+
+    await manager._start_channel("telegram", recording_telegram, send_only=True)
+
+    assert len(recording_telegram.start_calls) == 1
+    _, kwargs = recording_telegram.start_calls[0]
+    assert kwargs == {"send_only": True}
+
+
+@pytest.mark.asyncio
+async def test_start_channel_send_only_non_telegram_calls_start_without_args(
+    manager: ChannelManager,
+    recording_discord: RecordingChannel,
+) -> None:
+    manager.channels["discord"] = recording_discord
+
+    await manager._start_channel("discord", recording_discord, send_only=True)
+
+    assert len(recording_discord.start_calls) == 1
+    _, kwargs = recording_discord.start_calls[0]
+    assert kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_start_channel_no_send_only_calls_start_without_args(
+    manager: ChannelManager,
+    recording_telegram: RecordingChannel,
+) -> None:
+    manager.channels["telegram"] = recording_telegram
+
+    await manager._start_channel(
+        "telegram", recording_telegram, send_only=False
+    )
+
+    assert len(recording_telegram.start_calls) == 1
+    _, kwargs = recording_telegram.start_calls[0]
+    assert kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_start_for_cron_job_passes_send_only_to_all_channels(
+    manager: ChannelManager,
+    recording_telegram: RecordingChannel,
+    recording_discord: RecordingChannel,
+) -> None:
+    manager.channels = {
+        "telegram": recording_telegram,
+        "discord": recording_discord,
+    }
+
+    await manager.start_for_cron_job()
+
+    assert len(recording_telegram.start_calls) == 1
+    assert recording_telegram.start_calls[0][1] == {"send_only": True}
+
+    assert len(recording_discord.start_calls) == 1
+    assert recording_discord.start_calls[0][1] == {}

--- a/tests/test_telegram_send_only.py
+++ b/tests/test_telegram_send_only.py
@@ -1,0 +1,172 @@
+"""Tests for TelegramChannel send_only behavior (Telegram send_only mode)."""
+
+import asyncio
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.telegram import TelegramChannel
+from nanobot.config.schema import TelegramConfig
+
+
+@pytest.fixture
+def bus() -> MessageBus:
+    return MessageBus()
+
+
+@dataclass
+class _MockAppTracker:
+    add_handler_calls: list = field(default_factory=list)
+    start_polling_called: list = field(default_factory=list)
+    updater_stop_called: list = field(default_factory=list)
+
+
+def _make_mock_app(tracker: _MockAppTracker) -> MagicMock:
+    mock_app = MagicMock()
+    mock_app.add_handler = MagicMock()
+    mock_app.add_error_handler = MagicMock()
+    mock_app.initialize = AsyncMock()
+    mock_app.start = AsyncMock()
+    mock_app.stop = AsyncMock()
+    mock_app.shutdown = AsyncMock()
+
+    mock_bot = MagicMock()
+    mock_bot.get_me = AsyncMock(return_value=MagicMock(username="test_bot"))
+    mock_bot.set_my_commands = AsyncMock()
+    mock_app.bot = mock_bot
+
+    async def track_start_polling(**kw: object) -> None:
+        tracker.start_polling_called.append(True)
+
+    async def track_updater_stop() -> None:
+        tracker.updater_stop_called.append(True)
+
+    mock_updater = MagicMock()
+    mock_updater.start_polling = AsyncMock(side_effect=track_start_polling)
+    mock_updater.stop = AsyncMock(side_effect=track_updater_stop)
+    mock_app.updater = mock_updater
+
+    def track_add_handler(handler: object) -> None:
+        tracker.add_handler_calls.append(("add_handler", handler))
+
+    mock_app.add_handler.side_effect = track_add_handler
+    return mock_app
+
+
+def _make_mock_builder(mock_app: MagicMock) -> MagicMock:
+    mock_builder = MagicMock()
+    mock_builder.token.return_value = mock_builder
+    mock_builder.request.return_value = mock_builder
+    mock_builder.get_updates_request.return_value = mock_builder
+    mock_builder.build.return_value = mock_app
+    return mock_builder
+
+
+@pytest.fixture
+def telegram_config() -> TelegramConfig:
+    return TelegramConfig(token="fake-token-for-testing", enabled=True)
+
+
+@pytest.fixture
+def mock_telegram_env() -> tuple[MagicMock, MagicMock, _MockAppTracker]:
+    tracker = _MockAppTracker()
+    mock_app = _make_mock_app(tracker)
+    mock_builder = _make_mock_builder(mock_app)
+    return mock_app, mock_builder, tracker
+
+
+@pytest.mark.asyncio
+async def test_start_send_only_sets_flag(
+    bus: MessageBus,
+    telegram_config: TelegramConfig,
+    mock_telegram_env: tuple[MagicMock, MagicMock, _MockAppTracker],
+) -> None:
+    _, mock_builder, _ = mock_telegram_env
+    channel = TelegramChannel(telegram_config, bus)
+
+    with patch("nanobot.channels.telegram.Application") as MockApp:  # noqa: N806
+        MockApp.builder.return_value = mock_builder
+        await channel.start(send_only=True)
+
+    assert channel._send_only is True
+
+
+@pytest.mark.asyncio
+async def test_start_send_only_skips_handlers_and_polling(
+    bus: MessageBus,
+    telegram_config: TelegramConfig,
+    mock_telegram_env: tuple[MagicMock, MagicMock, _MockAppTracker],
+) -> None:
+    mock_app, mock_builder, tracker = mock_telegram_env
+    channel = TelegramChannel(telegram_config, bus)
+
+    with patch("nanobot.channels.telegram.Application") as MockApp:  # noqa: N806
+        MockApp.builder.return_value = mock_builder
+        await channel.start(send_only=True)
+
+    handler_calls = [
+        c for c in tracker.add_handler_calls if c[0] == "add_handler"
+    ]
+    assert len(handler_calls) == 0
+    assert len(tracker.start_polling_called) == 0
+
+
+@pytest.mark.asyncio
+async def test_start_normal_adds_handlers_and_polls(
+    bus: MessageBus,
+    telegram_config: TelegramConfig,
+    mock_telegram_env: tuple[MagicMock, MagicMock, _MockAppTracker],
+) -> None:
+    mock_app, mock_builder, tracker = mock_telegram_env
+    channel = TelegramChannel(telegram_config, bus)
+
+    with patch("nanobot.channels.telegram.Application") as MockApp:  # noqa: N806
+        MockApp.builder.return_value = mock_builder
+        start_task = asyncio.create_task(channel.start(send_only=False))
+        await asyncio.sleep(0.1)
+        channel._running = False
+        await start_task
+
+    handler_calls = [
+        c for c in tracker.add_handler_calls if c[0] == "add_handler"
+    ]
+    assert len(handler_calls) == 4
+    assert len(tracker.start_polling_called) == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_send_only_skips_updater_stop(
+    bus: MessageBus,
+    telegram_config: TelegramConfig,
+    mock_telegram_env: tuple[MagicMock, MagicMock, _MockAppTracker],
+) -> None:
+    mock_app, mock_builder, tracker = mock_telegram_env
+    channel = TelegramChannel(telegram_config, bus)
+
+    with patch("nanobot.channels.telegram.Application") as MockApp:  # noqa: N806
+        MockApp.builder.return_value = mock_builder
+        await channel.start(send_only=True)
+        await channel.stop()
+
+    assert len(tracker.updater_stop_called) == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_normal_calls_updater_stop(
+    bus: MessageBus,
+    telegram_config: TelegramConfig,
+    mock_telegram_env: tuple[MagicMock, MagicMock, _MockAppTracker],
+) -> None:
+    mock_app, mock_builder, tracker = mock_telegram_env
+    channel = TelegramChannel(telegram_config, bus)
+
+    with patch("nanobot.channels.telegram.Application") as MockApp:  # noqa: N806
+        MockApp.builder.return_value = mock_builder
+        start_task = asyncio.create_task(channel.start(send_only=False))
+        await asyncio.sleep(0.1)
+        await channel.stop()
+        await start_task
+
+    assert len(tracker.updater_stop_called) == 1


### PR DESCRIPTION
## Description

## Summary

Adds a `send_only` option to the Telegram channel so cron job runs can deliver messages without starting a second polling connection. This enables commands like:

```bash
docker exec nanobot-gateway nanobot cron run <job_id>
```

to send the agent response to Telegram.

## Problem

- Running a cron job manually did not deliver messages to Telegram.
- Without `send_only` param, a single bot cannot open two Telegram polling connections (one for the main app, one for the cron run).
- Cron runs need a send-only channel that does not register handlers or start polling.

## Solution

- **ChannelManager**: `_start_channel` accepts `send_only`; when true and channel is Telegram, passes `send_only=True` to `channel.start()`. 
    - Added `start_for_cron_job()` and `stop_for_cron_job()` for ephemeral channel use.
- **TelegramChannel**: `start(send_only=True)` initializes for sending only (no handlers, no polling). Skips `updater.stop()` on teardown when in send_only mode.

We add the `send_only` param so that the original Telegram setup does not break and polling can still occur in core channel implementation.

## Changes

- `nanobot/channels/manager.py`: send_only param, start_for_cron_job, stop_for_cron_job
- `nanobot/channels/telegram.py`: send_only support in start/stop
- `tests/test_channel_manager_send_only.py`, `tests/test_telegram_send_only.py`

## Testing

```bash
uv run pytest tests/test_channel_manager_send_only.py tests/test_telegram_send_only.py -v
```