### PR TITLE
fix(security): remove insecure Codex TLS retry

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -8,7 +8,6 @@ import json
 from typing import Any, AsyncGenerator
 
 import httpx
-from loguru import logger
 
 from oauth_cli_kit import get_token as get_codex_token
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
@@ -57,19 +56,21 @@ class OpenAICodexProvider(LLMProvider):
         url = DEFAULT_CODEX_URL
 
         try:
-            try:
-                content, tool_calls, finish_reason = await _request_codex(url, headers, body, verify=True)
-            except Exception as e:
-                if "CERTIFICATE_VERIFY_FAILED" not in str(e):
-                    raise
-                logger.warning("SSL certificate verification failed for Codex API; retrying with verify=False")
-                content, tool_calls, finish_reason = await _request_codex(url, headers, body, verify=False)
+            content, tool_calls, finish_reason = await _request_codex(url, headers, body)
             return LLMResponse(
                 content=content,
                 tool_calls=tool_calls,
                 finish_reason=finish_reason,
             )
         except Exception as e:
+            if "CERTIFICATE_VERIFY_FAILED" in str(e):
+                return LLMResponse(
+                    content=(
+                        "Error calling Codex: SSL certificate verification failed. "
+                        "TLS verification is required; fix your local CA/certificate chain and retry."
+                    ),
+                    finish_reason="error",
+                )
             return LLMResponse(
                 content=f"Error calling Codex: {str(e)}",
                 finish_reason="error",
@@ -101,9 +102,8 @@ async def _request_codex(
     url: str,
     headers: dict[str, str],
     body: dict[str, Any],
-    verify: bool,
 ) -> tuple[str, list[ToolCallRequest], str]:
-    async with httpx.AsyncClient(timeout=60.0, verify=verify) as client:
+    async with httpx.AsyncClient(timeout=60.0) as client:
         async with client.stream("POST", url, headers=headers, json=body) as response:
             if response.status_code != 200:
                 text = await response.aread()


### PR DESCRIPTION
## Background
The Codex provider currently retries requests with `verify=False` when it detects `CERTIFICATE_VERIFY_FAILED`.

That behavior was introduced with Codex integration and kept through later refactors/bugfixes as a compatibility fallback. Functionally, it turns a trust-chain error into a silent TLS downgrade.

## Security risk
When TLS verification is disabled, the provider can no longer authenticate the peer certificate chain. For this OAuth flow, that increases risk of:
- bearer token/account-header interception on hostile or misconfigured networks
- response tampering by on-path actors
- hard-to-detect MITM in environments with transparent TLS interception

For auth-bearing requests, fail-closed is the safer default than insecure retry.

## What this PR changes
- removes the insecure `verify=False` retry path
- keeps TLS verification enabled for all Codex API calls
- returns a clear, actionable error message when certificate verification fails

## Why this is correct
- aligns with secure-by-default transport behavior
- preserves normal behavior for healthy environments
- avoids silent security downgrades
- keeps external API behavior stable (no public interface changes; only internal request handling)

## Compatibility impact
- **No change** for users with valid local/system trust stores
- users who previously depended on insecure fallback (broken trust chain or TLS interception) will now see an explicit error instead

Recommended remediation for affected users:
1. fix local CA/system trust chain
2. install required corporate root CA into trust store (if enterprise proxying is used)
3. retry once certificate validation is healthy

## Behavior change summary
- before: on `CERTIFICATE_VERIFY_FAILED`, request retried with `verify=False`
- now: no insecure retry; explicit certificate-chain error is returned

## Validation
- `python3 -m py_compile nanobot/providers/openai_codex_provider.py`
- focused provider behavior checks via local import-stub harness:
  - success path unchanged
  - certificate-failure path returns fail-closed guidance
  - generic error path unchanged
- `rg -n "verify=False" nanobot` => no remaining insecure TLS bypass in codebase

## Scope
Single-file change: `nanobot/providers/openai_codex_provider.py`
