### PR TITLE
fix: allow read-only access to builtin skills when restrictToWorkspace is enabled

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -16,6 +16,7 @@ from nanobot.agent.context import ContextBuilder
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
+from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.registry import ToolRegistry
@@ -109,7 +110,11 @@ class AgentLoop:
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
         allowed_dir = self.workspace if self.restrict_to_workspace else None
-        for cls in (ReadFileTool, WriteFileTool, EditFileTool, ListDirTool):
+        # Builtin skills live outside workspace; allow read-only access even when restricted
+        extra_read_dirs = [BUILTIN_SKILLS_DIR] if allowed_dir and BUILTIN_SKILLS_DIR.exists() else None
+        for cls in (ReadFileTool, ListDirTool):
+            self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir, extra_read_dirs=extra_read_dirs))
+        for cls in (WriteFileTool, EditFileTool):
             self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
         self.tools.register(ExecTool(
             working_dir=str(self.workspace),

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -11,6 +11,7 @@ from loguru import logger
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMProvider
+from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.filesystem import ReadFileTool, WriteFileTool, EditFileTool, ListDirTool
 from nanobot.agent.tools.shell import ExecTool
@@ -91,10 +92,11 @@ class SubagentManager:
             # Build subagent tools (no message tool, no spawn tool)
             tools = ToolRegistry()
             allowed_dir = self.workspace if self.restrict_to_workspace else None
-            tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
+            extra_read_dirs = [BUILTIN_SKILLS_DIR] if allowed_dir and BUILTIN_SKILLS_DIR.exists() else None
+            tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir, extra_read_dirs=extra_read_dirs))
             tools.register(WriteFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
             tools.register(EditFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir))
+            tools.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir, extra_read_dirs=extra_read_dirs))
             tools.register(ExecTool(
                 working_dir=str(self.workspace),
                 timeout=self.exec_config.timeout,

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -7,26 +7,45 @@ from typing import Any
 from nanobot.agent.tools.base import Tool
 
 
-def _resolve_path(path: str, workspace: Path | None = None, allowed_dir: Path | None = None) -> Path:
-    """Resolve path against workspace (if relative) and enforce directory restriction."""
+def _resolve_path(
+    path: str,
+    workspace: Path | None = None,
+    allowed_dir: Path | None = None,
+    extra_read_dirs: list[Path] | None = None,
+) -> Path:
+    """Resolve path against workspace (if relative) and enforce directory restriction.
+
+    Args:
+        path: The raw path string.
+        workspace: Default base for relative paths.
+        allowed_dir: Primary allowed directory (e.g. workspace).
+        extra_read_dirs: Additional directories that are allowed (read-only use-case).
+    """
     p = Path(path).expanduser()
     if not p.is_absolute() and workspace:
         p = workspace / p
     resolved = p.resolve()
     if allowed_dir:
-        try:
-            resolved.relative_to(allowed_dir.resolve())
-        except ValueError:
-            raise PermissionError(f"Path {path} is outside allowed directory {allowed_dir}")
+        allowed_dirs = [allowed_dir.resolve()]
+        if extra_read_dirs:
+            allowed_dirs.extend(d.resolve() for d in extra_read_dirs)
+        for ad in allowed_dirs:
+            try:
+                resolved.relative_to(ad)
+                return resolved
+            except ValueError:
+                continue
+        raise PermissionError(f"Path {path} is outside allowed directory {allowed_dir}")
     return resolved
 
 
 class ReadFileTool(Tool):
     """Tool to read file contents."""
 
-    def __init__(self, workspace: Path | None = None, allowed_dir: Path | None = None):
+    def __init__(self, workspace: Path | None = None, allowed_dir: Path | None = None, extra_read_dirs: list[Path] | None = None):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
+        self._extra_read_dirs = extra_read_dirs
 
     @property
     def name(self) -> str:
@@ -51,7 +70,7 @@ class ReadFileTool(Tool):
     
     async def execute(self, path: str, **kwargs: Any) -> str:
         try:
-            file_path = _resolve_path(path, self._workspace, self._allowed_dir)
+            file_path = _resolve_path(path, self._workspace, self._allowed_dir, self._extra_read_dirs)
             if not file_path.exists():
                 return f"Error: File not found: {path}"
             if not file_path.is_file():
@@ -196,9 +215,10 @@ class EditFileTool(Tool):
 class ListDirTool(Tool):
     """Tool to list directory contents."""
 
-    def __init__(self, workspace: Path | None = None, allowed_dir: Path | None = None):
+    def __init__(self, workspace: Path | None = None, allowed_dir: Path | None = None, extra_read_dirs: list[Path] | None = None):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
+        self._extra_read_dirs = extra_read_dirs
 
     @property
     def name(self) -> str:
@@ -223,7 +243,7 @@ class ListDirTool(Tool):
     
     async def execute(self, path: str, **kwargs: Any) -> str:
         try:
-            dir_path = _resolve_path(path, self._workspace, self._allowed_dir)
+            dir_path = _resolve_path(path, self._workspace, self._allowed_dir, self._extra_read_dirs)
             if not dir_path.exists():
                 return f"Error: Directory not found: {path}"
             if not dir_path.is_dir():

--- a/tests/test_builtin_skills_restrict.py
+++ b/tests/test_builtin_skills_restrict.py
@@ -1,0 +1,145 @@
+"""Tests for builtin skills access when restrictToWorkspace is enabled."""
+
+import pytest
+from pathlib import Path
+
+from nanobot.agent.tools.filesystem import _resolve_path, ReadFileTool, ListDirTool, WriteFileTool, EditFileTool
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Create a temporary workspace directory."""
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    return ws
+
+
+@pytest.fixture
+def builtin_skills_dir(tmp_path):
+    """Create a temporary builtin skills directory (outside workspace)."""
+    skills = tmp_path / "package" / "skills"
+    skills.mkdir(parents=True)
+    skill_dir = skills / "memory"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Memory Skill\nBuiltin skill content.")
+    return skills
+
+
+class TestResolvePathExtraReadDirs:
+    """Test _resolve_path with extra_read_dirs parameter."""
+
+    def test_allowed_dir_blocks_outside_path(self, workspace):
+        """Path outside workspace is blocked when allowed_dir is set."""
+        outside = workspace.parent / "outside.txt"
+        outside.touch()
+        with pytest.raises(PermissionError, match="outside allowed directory"):
+            _resolve_path(str(outside), workspace=workspace, allowed_dir=workspace)
+
+    def test_extra_read_dirs_allows_builtin_path(self, workspace, builtin_skills_dir):
+        """Path in extra_read_dirs is allowed even with allowed_dir set."""
+        skill_file = builtin_skills_dir / "memory" / "SKILL.md"
+        result = _resolve_path(
+            str(skill_file),
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_read_dirs=[builtin_skills_dir],
+        )
+        assert result == skill_file.resolve()
+
+    def test_extra_read_dirs_still_blocks_other_paths(self, workspace, builtin_skills_dir):
+        """Paths not in workspace or extra_read_dirs are still blocked."""
+        other = workspace.parent / "other.txt"
+        other.touch()
+        with pytest.raises(PermissionError, match="outside allowed directory"):
+            _resolve_path(
+                str(other),
+                workspace=workspace,
+                allowed_dir=workspace,
+                extra_read_dirs=[builtin_skills_dir],
+            )
+
+    def test_workspace_path_still_works_with_extra_dirs(self, workspace, builtin_skills_dir):
+        """Workspace paths still work when extra_read_dirs is set."""
+        ws_file = workspace / "test.md"
+        ws_file.touch()
+        result = _resolve_path(
+            str(ws_file),
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_read_dirs=[builtin_skills_dir],
+        )
+        assert result == ws_file.resolve()
+
+    def test_no_allowed_dir_ignores_extra_read_dirs(self, workspace, builtin_skills_dir):
+        """When allowed_dir is None, any path is allowed (no restriction)."""
+        outside = workspace.parent / "anywhere.txt"
+        outside.touch()
+        result = _resolve_path(str(outside), workspace=workspace, allowed_dir=None, extra_read_dirs=[builtin_skills_dir])
+        assert result == outside.resolve()
+
+    def test_extra_read_dirs_none_behaves_as_before(self, workspace):
+        """When extra_read_dirs is None, behavior is unchanged."""
+        outside = workspace.parent / "blocked.txt"
+        outside.touch()
+        with pytest.raises(PermissionError):
+            _resolve_path(str(outside), workspace=workspace, allowed_dir=workspace, extra_read_dirs=None)
+
+
+class TestReadFileToolExtraReadDirs:
+    """Test ReadFileTool with extra_read_dirs for builtin skills."""
+
+    @pytest.mark.asyncio
+    async def test_read_builtin_skill(self, workspace, builtin_skills_dir):
+        """ReadFileTool can read builtin skill files when extra_read_dirs is set."""
+        tool = ReadFileTool(workspace=workspace, allowed_dir=workspace, extra_read_dirs=[builtin_skills_dir])
+        skill_path = str(builtin_skills_dir / "memory" / "SKILL.md")
+        result = await tool.execute(path=skill_path)
+        assert "Memory Skill" in result
+        assert "Error" not in result
+
+    @pytest.mark.asyncio
+    async def test_read_builtin_skill_blocked_without_extra(self, workspace, builtin_skills_dir):
+        """ReadFileTool blocks builtin skill files without extra_read_dirs."""
+        tool = ReadFileTool(workspace=workspace, allowed_dir=workspace)
+        skill_path = str(builtin_skills_dir / "memory" / "SKILL.md")
+        result = await tool.execute(path=skill_path)
+        assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_read_workspace_file(self, workspace, builtin_skills_dir):
+        """ReadFileTool can still read workspace files."""
+        (workspace / "notes.md").write_text("hello")
+        tool = ReadFileTool(workspace=workspace, allowed_dir=workspace, extra_read_dirs=[builtin_skills_dir])
+        result = await tool.execute(path=str(workspace / "notes.md"))
+        assert result == "hello"
+
+
+class TestWriteFileToolNoExtraReadDirs:
+    """Ensure WriteFileTool does NOT get extra_read_dirs (write stays restricted)."""
+
+    @pytest.mark.asyncio
+    async def test_write_outside_workspace_blocked(self, workspace, builtin_skills_dir):
+        """WriteFileTool cannot write to builtin skills directory."""
+        tool = WriteFileTool(workspace=workspace, allowed_dir=workspace)
+        target = str(builtin_skills_dir / "memory" / "hack.md")
+        result = await tool.execute(path=target, content="hacked")
+        assert "Error" in result
+
+
+class TestListDirToolExtraReadDirs:
+    """Test ListDirTool with extra_read_dirs."""
+
+    @pytest.mark.asyncio
+    async def test_list_builtin_skills_dir(self, workspace, builtin_skills_dir):
+        """ListDirTool can list builtin skills directory."""
+        tool = ListDirTool(workspace=workspace, allowed_dir=workspace, extra_read_dirs=[builtin_skills_dir])
+        result = await tool.execute(path=str(builtin_skills_dir))
+        assert "memory" in result
+        assert "Error" not in result
+
+    @pytest.mark.asyncio
+    async def test_list_builtin_blocked_without_extra(self, workspace, builtin_skills_dir):
+        """ListDirTool blocks builtin skills directory without extra_read_dirs."""
+        tool = ListDirTool(workspace=workspace, allowed_dir=workspace)
+        result = await tool.execute(path=str(builtin_skills_dir))
+        assert "Error" in result


### PR DESCRIPTION
## Problem

When `restrictToWorkspace: true` is set, all filesystem tools restrict access to the workspace directory. However, **builtin skills** (shipped inside the nanobot Python package) live outside the workspace. This means agents cannot `read_file` on builtin skill SKILL.md files — they get a `PermissionError`.

Reported in #1138.

## Solution

Added an `extra_read_dirs` parameter to `_resolve_path()`, `ReadFileTool`, and `ListDirTool`. When `restrictToWorkspace` is enabled, the builtin skills directory (`BUILTIN_SKILLS_DIR`) is passed as an additional allowed **read-only** path.

- **ReadFileTool** / **ListDirTool** — can read builtin skill files ✅
- **WriteFileTool** / **EditFileTool** — remain strictly restricted to workspace ✅ (no `extra_read_dirs`)

## Changes

| File | Change |
|------|--------|
| `filesystem.py` | `_resolve_path()` accepts `extra_read_dirs` list; checks all allowed dirs |
| `loop.py` | Passes `BUILTIN_SKILLS_DIR` as extra read dir for read-only tools |
| `subagent.py` | Same treatment for subagent tool registration |
| `test_builtin_skills_restrict.py` | 12 tests covering all scenarios |

## Testing

- 12 new tests, all passing
- 90 total tests, zero regressions

Closes #1138