### PR TITLE
feat: LLM fallback chain on retriable errors (Timeout/503/502/429)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -24,7 +24,7 @@ from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
-from nanobot.providers.base import LLMProvider
+from nanobot.providers.base import LLMProvider, LLMResponse
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
@@ -52,6 +52,7 @@ class AgentLoop:
         provider: LLMProvider,
         workspace: Path,
         model: str | None = None,
+        fallbacks: list[str] | None = None,
         max_iterations: int = 40,
         temperature: float = 0.1,
         max_tokens: int = 4096,
@@ -70,6 +71,7 @@ class AgentLoop:
         self.provider = provider
         self.workspace = workspace
         self.model = model or provider.get_default_model()
+        self.fallbacks = fallbacks or []
         self.max_iterations = max_iterations
         self.temperature = temperature
         self.max_tokens = max_tokens
@@ -171,6 +173,46 @@ class AgentLoop:
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
+    async def _call_with_fallback(
+        self,
+        messages: list[dict],
+    ) -> LLMResponse:
+        """Call the primary model; on retriable errors, try fallback models in order."""
+        response = await self.provider.chat(
+            messages=messages,
+            tools=self.tools.get_definitions(),
+            model=self.model,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+
+        if response.finish_reason != "retriable_error" or not self.fallbacks:
+            return response
+
+        primary_error = response.content
+        logger.warning("Primary model {} failed: {}. Trying fallbacks...", self.model, primary_error)
+
+        for fallback_model in self.fallbacks:
+            logger.info("Trying fallback model: {}", fallback_model)
+            response = await self.provider.chat(
+                messages=messages,
+                tools=self.tools.get_definitions(),
+                model=fallback_model,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+            )
+            if response.finish_reason != "retriable_error":
+                logger.info("Fallback model {} succeeded", fallback_model)
+                return response
+            logger.warning("Fallback model {} also failed: {}", fallback_model, response.content)
+
+        # All fallbacks exhausted — return the original error
+        logger.error("All fallback models exhausted. Returning primary error.")
+        return LLMResponse(
+            content=primary_error,
+            finish_reason="error",
+        )
+
     async def _run_agent_loop(
         self,
         initial_messages: list[dict],
@@ -185,13 +227,7 @@ class AgentLoop:
         while iteration < self.max_iterations:
             iteration += 1
 
-            response = await self.provider.chat(
-                messages=messages,
-                tools=self.tools.get_definitions(),
-                model=self.model,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-            )
+            response = await self._call_with_fallback(messages)
 
             if response.has_tool_calls:
                 if on_progress:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -279,6 +279,7 @@ def gateway(
         provider=provider,
         workspace=config.workspace_path,
         model=config.agents.defaults.model,
+        fallbacks=config.agents.defaults.fallbacks,
         temperature=config.agents.defaults.temperature,
         max_tokens=config.agents.defaults.max_tokens,
         max_iterations=config.agents.defaults.max_tool_iterations,
@@ -435,6 +436,7 @@ def agent(
     agent_loop = AgentLoop(
         bus=bus,
         provider=provider,
+        fallbacks=config.agents.defaults.fallbacks,
         workspace=config.workspace_path,
         model=config.agents.defaults.model,
         temperature=config.agents.defaults.temperature,
@@ -926,6 +928,7 @@ def cron_run(
     agent_loop = AgentLoop(
         bus=bus,
         provider=provider,
+        fallbacks=config.agents.defaults.fallbacks,
         workspace=config.workspace_path,
         model=config.agents.defaults.model,
         temperature=config.agents.defaults.temperature,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -222,6 +222,7 @@ class AgentDefaults(Base):
     workspace: str = "~/.nanobot/workspace"
     model: str = "anthropic/claude-opus-4-5"
     provider: str = "auto"  # Provider name (e.g. "anthropic", "openrouter") or "auto" for auto-detection
+    fallbacks: list[str] = Field(default_factory=list)
     max_tokens: int = 8192
     temperature: float = 0.1
     max_tool_iterations: int = 40

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -231,8 +231,21 @@ class LiteLLMProvider(LLMProvider):
         try:
             response = await acompletion(**kwargs)
             return self._parse_response(response)
+        except (
+            litellm.Timeout,
+            litellm.ServiceUnavailableError,
+            litellm.InternalServerError,
+            litellm.APIConnectionError,
+            litellm.RateLimitError,
+            litellm.BadGatewayError,
+        ) as e:
+            # Retriable errors — signal the agent loop to try fallback models
+            return LLMResponse(
+                content=f"Error calling LLM: {str(e)}",
+                finish_reason="retriable_error",
+            )
         except Exception as e:
-            # Return error as content for graceful handling
+            # Non-retriable errors (auth, bad request, etc.)
             return LLMResponse(
                 content=f"Error calling LLM: {str(e)}",
                 finish_reason="error",

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -1,0 +1,227 @@
+"""Tests for LLM fallback chain on retriable errors."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.providers.base import LLMProvider, LLMResponse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeProvider(LLMProvider):
+    """Provider that returns pre-configured responses per model."""
+
+    def __init__(self, responses: dict[str, LLMResponse]):
+        super().__init__()
+        self._responses = responses
+        self.calls: list[str] = []  # track which models were called
+
+    async def chat(self, messages, tools=None, model=None, max_tokens=4096, temperature=0.7):
+        model = model or "primary"
+        self.calls.append(model)
+        return self._responses.get(model, LLMResponse(content="unknown model", finish_reason="error"))
+
+    def get_default_model(self):
+        return "primary"
+
+
+def _ok_response(text: str = "OK") -> LLMResponse:
+    return LLMResponse(content=text, finish_reason="stop")
+
+
+def _retriable_error(msg: str = "503 Service Unavailable") -> LLMResponse:
+    return LLMResponse(content=f"Error calling LLM: {msg}", finish_reason="retriable_error")
+
+
+def _fatal_error(msg: str = "401 Unauthorized") -> LLMResponse:
+    return LLMResponse(content=f"Error calling LLM: {msg}", finish_reason="error")
+
+
+def _make_agent_loop(provider, fallbacks=None, tmp_path=None):
+    """Create a minimal AgentLoop for testing."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    workspace = tmp_path or Path("/tmp/test-workspace")
+    workspace.mkdir(parents=True, exist_ok=True)
+    bus = MessageBus()
+
+    return AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=workspace,
+        model="primary",
+        fallbacks=fallbacks or [],
+        max_iterations=5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCallWithFallback:
+    """Tests for AgentLoop._call_with_fallback."""
+
+    @pytest.mark.asyncio
+    async def test_primary_succeeds_no_fallback_tried(self, tmp_path):
+        """When primary model succeeds, no fallback should be attempted."""
+        provider = FakeProvider({"primary": _ok_response("hello")})
+        agent = _make_agent_loop(provider, fallbacks=["fallback-1"], tmp_path=tmp_path)
+
+        resp = await agent._call_with_fallback([{"role": "user", "content": "hi"}])
+
+        assert resp.content == "hello"
+        assert resp.finish_reason == "stop"
+        assert provider.calls == ["primary"]
+
+    @pytest.mark.asyncio
+    async def test_primary_fails_fallback_succeeds(self, tmp_path):
+        """When primary returns retriable error, first working fallback should be used."""
+        provider = FakeProvider({
+            "primary": _retriable_error(),
+            "fallback-1": _ok_response("from fallback"),
+        })
+        agent = _make_agent_loop(provider, fallbacks=["fallback-1"], tmp_path=tmp_path)
+
+        resp = await agent._call_with_fallback([{"role": "user", "content": "hi"}])
+
+        assert resp.content == "from fallback"
+        assert resp.finish_reason == "stop"
+        assert provider.calls == ["primary", "fallback-1"]
+
+    @pytest.mark.asyncio
+    async def test_primary_and_first_fallback_fail_second_succeeds(self, tmp_path):
+        """Should try fallbacks in order until one succeeds."""
+        provider = FakeProvider({
+            "primary": _retriable_error(),
+            "fallback-1": _retriable_error("also down"),
+            "fallback-2": _ok_response("third time's the charm"),
+        })
+        agent = _make_agent_loop(
+            provider, fallbacks=["fallback-1", "fallback-2"], tmp_path=tmp_path
+        )
+
+        resp = await agent._call_with_fallback([{"role": "user", "content": "hi"}])
+
+        assert resp.content == "third time's the charm"
+        assert provider.calls == ["primary", "fallback-1", "fallback-2"]
+
+    @pytest.mark.asyncio
+    async def test_all_models_fail_returns_primary_error(self, tmp_path):
+        """When all models fail, should return the primary error."""
+        provider = FakeProvider({
+            "primary": _retriable_error("primary down"),
+            "fallback-1": _retriable_error("fallback down"),
+        })
+        agent = _make_agent_loop(provider, fallbacks=["fallback-1"], tmp_path=tmp_path)
+
+        resp = await agent._call_with_fallback([{"role": "user", "content": "hi"}])
+
+        assert "primary down" in resp.content
+        assert resp.finish_reason == "error"
+        assert provider.calls == ["primary", "fallback-1"]
+
+    @pytest.mark.asyncio
+    async def test_non_retriable_error_no_fallback(self, tmp_path):
+        """Non-retriable errors (auth, bad request) should NOT trigger fallback."""
+        provider = FakeProvider({
+            "primary": _fatal_error("401 Unauthorized"),
+            "fallback-1": _ok_response("should not reach"),
+        })
+        agent = _make_agent_loop(provider, fallbacks=["fallback-1"], tmp_path=tmp_path)
+
+        resp = await agent._call_with_fallback([{"role": "user", "content": "hi"}])
+
+        assert "401 Unauthorized" in resp.content
+        assert resp.finish_reason == "error"
+        assert provider.calls == ["primary"]  # fallback NOT tried
+
+    @pytest.mark.asyncio
+    async def test_no_fallbacks_configured(self, tmp_path):
+        """When no fallbacks configured, retriable error is returned as-is."""
+        provider = FakeProvider({"primary": _retriable_error()})
+        agent = _make_agent_loop(provider, fallbacks=[], tmp_path=tmp_path)
+
+        resp = await agent._call_with_fallback([{"role": "user", "content": "hi"}])
+
+        assert resp.finish_reason == "retriable_error"
+        assert provider.calls == ["primary"]
+
+
+class TestLiteLLMProviderRetriableErrors:
+    """Tests for retriable vs non-retriable error classification in LiteLLMProvider."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_retriable(self):
+        """litellm.Timeout should produce retriable_error finish_reason."""
+        import litellm
+        from nanobot.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(api_key="test-key", default_model="test/model")
+        with patch("nanobot.providers.litellm_provider.acompletion") as mock:
+            mock.side_effect = litellm.Timeout(
+                message="Connection timed out",
+                model="test/model",
+                llm_provider="test",
+            )
+            resp = await provider.chat([{"role": "user", "content": "hi"}])
+
+        assert resp.finish_reason == "retriable_error"
+        assert "timed out" in resp.content.lower() or "Timeout" in resp.content
+
+    @pytest.mark.asyncio
+    async def test_service_unavailable_is_retriable(self):
+        """litellm.ServiceUnavailableError should produce retriable_error."""
+        import litellm
+        from nanobot.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(api_key="test-key", default_model="test/model")
+        with patch("nanobot.providers.litellm_provider.acompletion") as mock:
+            mock.side_effect = litellm.ServiceUnavailableError(
+                message="503 Service Unavailable",
+                model="test/model",
+                llm_provider="test",
+            )
+            resp = await provider.chat([{"role": "user", "content": "hi"}])
+
+        assert resp.finish_reason == "retriable_error"
+
+    @pytest.mark.asyncio
+    async def test_auth_error_is_not_retriable(self):
+        """litellm.AuthenticationError should produce regular error, not retriable."""
+        import litellm
+        from nanobot.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(api_key="test-key", default_model="test/model")
+        with patch("nanobot.providers.litellm_provider.acompletion") as mock:
+            mock.side_effect = litellm.AuthenticationError(
+                message="Invalid API key",
+                model="test/model",
+                llm_provider="test",
+            )
+            resp = await provider.chat([{"role": "user", "content": "hi"}])
+
+        assert resp.finish_reason == "error"
+
+
+class TestSchemaFallbacks:
+    """Tests for fallbacks field in AgentDefaults."""
+
+    def test_default_fallbacks_empty(self):
+        from nanobot.config.schema import AgentDefaults
+        defaults = AgentDefaults()
+        assert defaults.fallbacks == []
+
+    def test_fallbacks_from_config(self):
+        from nanobot.config.schema import AgentDefaults
+        defaults = AgentDefaults(fallbacks=["model-a", "model-b"])
+        assert defaults.fallbacks == ["model-a", "model-b"]


### PR DESCRIPTION
## Problem

When the primary model returns a `litellm.Timeout` or `litellm.ServiceUnavailableError` (e.g. Gemini 503 after 600 seconds), the configured fallback models are not triggered. The agent simply returns an error to the user instead of retrying with the next model in the fallback chain.

Closes #1121

## Solution

### 1. `AgentDefaults` — new `fallbacks` field
```json
"agents": {
  "defaults": {
    "model": "gemini/gemini-3.1-pro-preview",
    "fallbacks": [
      "vllm/mlx-community/Qwen3-14B-4bit",
      "openrouter/meta-llama/llama-3.3-70b-instruct"
    ]
  }
}
```

### 2. `LiteLLMProvider.chat()` — distinguish retriable vs non-retriable errors
- **Retriable** (`finish_reason="retriable_error"`): `Timeout`, `ServiceUnavailableError`, `InternalServerError`, `APIConnectionError`, `RateLimitError`, `BadGatewayError`
- **Non-retriable** (`finish_reason="error"`): `AuthenticationError`, `BadRequestError`, etc.

### 3. `AgentLoop._call_with_fallback()` — ordered fallback chain
On retriable error from primary model, tries each fallback model in order. If all fail, returns the original primary error. Non-retriable errors skip fallback entirely.

## Changes
| File | Change |
|------|--------|
| `nanobot/config/schema.py` | +`fallbacks: list[str]` field |
| `nanobot/providers/litellm_provider.py` | Classify retriable vs non-retriable exceptions |
| `nanobot/agent/loop.py` | +`_call_with_fallback()` method, import `LLMResponse` |
| `nanobot/cli/commands.py` | Pass `fallbacks` to all 3 `AgentLoop` instances |
| `tests/test_llm_fallback.py` | 11 tests covering fallback chain, error classification, schema |

## Testing
- 11 new tests, 89 total tests pass (1 pre-existing skip)
- Covers: primary success, single fallback, chained fallback, all-fail, non-retriable skip, no-fallbacks-configured, litellm exception classification

## Backward Compatible
- `fallbacks` defaults to `[]` — zero behavior change for existing users
- No new dependencies