### PR TITLE
feat: extract PDF text content in Feishu channel

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -588,7 +588,17 @@ class FeishuChannel(BaseChannel):
             file_path = media_dir / filename
             file_path.write_bytes(data)
             logger.debug("Downloaded {} to {}", msg_type, file_path)
-            return str(file_path), f"[{msg_type}: {filename}]"
+
+            # Extract text from PDF files
+            content_text = f"[{msg_type}: {filename}]"
+            if file_path.suffix.lower() == ".pdf":
+                from nanobot.utils.pdf import extract_pdf_text
+
+                pdf_text = extract_pdf_text(file_path)
+                if pdf_text:
+                    content_text += f"\n\n{pdf_text}"
+
+            return str(file_path), content_text
 
         return None, f"[{msg_type}: download failed]"
 

--- a/nanobot/utils/pdf.py
+++ b/nanobot/utils/pdf.py
@@ -1,0 +1,49 @@
+"""PDF text extraction utility."""
+
+from pathlib import Path
+
+from loguru import logger
+
+try:
+    from pypdf import PdfReader
+
+    PYPDF_AVAILABLE = True
+except ImportError:
+    PYPDF_AVAILABLE = False
+    PdfReader = None
+
+
+def extract_pdf_text(file_path: str | Path, max_chars: int = 50000) -> str | None:
+    """Extract text content from a PDF file.
+
+    Args:
+        file_path: Path to the PDF file.
+        max_chars: Maximum characters to extract (default 50k to avoid huge payloads).
+
+    Returns:
+        Extracted text or None if extraction failed or pypdf is not installed.
+    """
+    if not PYPDF_AVAILABLE:
+        logger.debug("pypdf not installed, skipping PDF text extraction")
+        return None
+
+    try:
+        reader = PdfReader(str(file_path))
+        pages = []
+        total = 0
+        for i, page in enumerate(reader.pages):
+            text = page.extract_text()
+            if text:
+                text = text.strip()
+                if total + len(text) > max_chars:
+                    text = text[: max_chars - total]
+                    pages.append(f"[Page {i + 1}]\n{text}\n...(truncated)")
+                    break
+                pages.append(f"[Page {i + 1}]\n{text}")
+                total += len(text)
+        if not pages:
+            return None
+        return "\n\n".join(pages)
+    except Exception as e:
+        logger.warning("Failed to extract text from PDF {}: {}", file_path, e)
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "prompt-toolkit>=3.0.50,<4.0.0",
     "mcp>=1.26.0,<2.0.0",
     "json-repair>=0.57.0,<1.0.0",
+    "pypdf>=5.0.0,<6.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_pdf_extraction.py
+++ b/tests/test_pdf_extraction.py
@@ -1,0 +1,112 @@
+"""Tests for PDF text extraction utility."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestExtractPdfText:
+    """Tests for extract_pdf_text function."""
+
+    def test_returns_none_when_pypdf_not_available(self):
+        with patch("nanobot.utils.pdf.PYPDF_AVAILABLE", False):
+            from nanobot.utils.pdf import extract_pdf_text
+
+            result = extract_pdf_text("/fake/path.pdf")
+            assert result is None
+
+    def test_returns_none_for_nonexistent_file(self):
+        from nanobot.utils.pdf import extract_pdf_text
+
+        result = extract_pdf_text("/nonexistent/file.pdf")
+        assert result is None
+
+    def test_extracts_text_from_pdf(self):
+        from nanobot.utils.pdf import extract_pdf_text
+
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = "Hello World"
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_page]
+
+        with patch("nanobot.utils.pdf.PdfReader", return_value=mock_reader):
+            with patch("nanobot.utils.pdf.PYPDF_AVAILABLE", True):
+                result = extract_pdf_text("/fake/path.pdf")
+                assert result is not None
+                assert "Hello World" in result
+                assert "[Page 1]" in result
+
+    def test_extracts_multiple_pages(self):
+        from nanobot.utils.pdf import extract_pdf_text
+
+        pages = []
+        for i in range(3):
+            p = MagicMock()
+            p.extract_text.return_value = f"Page {i + 1} content"
+            pages.append(p)
+        mock_reader = MagicMock()
+        mock_reader.pages = pages
+
+        with patch("nanobot.utils.pdf.PdfReader", return_value=mock_reader):
+            with patch("nanobot.utils.pdf.PYPDF_AVAILABLE", True):
+                result = extract_pdf_text("/fake/path.pdf")
+                assert "[Page 1]" in result
+                assert "[Page 2]" in result
+                assert "[Page 3]" in result
+
+    def test_truncates_at_max_chars(self):
+        from nanobot.utils.pdf import extract_pdf_text
+
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = "A" * 1000
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_page, mock_page]
+
+        with patch("nanobot.utils.pdf.PdfReader", return_value=mock_reader):
+            with patch("nanobot.utils.pdf.PYPDF_AVAILABLE", True):
+                result = extract_pdf_text("/fake/path.pdf", max_chars=500)
+                assert "truncated" in result
+
+    def test_skips_empty_pages(self):
+        from nanobot.utils.pdf import extract_pdf_text
+
+        empty_page = MagicMock()
+        empty_page.extract_text.return_value = ""
+        text_page = MagicMock()
+        text_page.extract_text.return_value = "Real content"
+        mock_reader = MagicMock()
+        mock_reader.pages = [empty_page, text_page]
+
+        with patch("nanobot.utils.pdf.PdfReader", return_value=mock_reader):
+            with patch("nanobot.utils.pdf.PYPDF_AVAILABLE", True):
+                result = extract_pdf_text("/fake/path.pdf")
+                assert "Real content" in result
+                assert "[Page 2]" in result
+
+    def test_returns_none_for_all_empty_pages(self):
+        from nanobot.utils.pdf import extract_pdf_text
+
+        empty_page = MagicMock()
+        empty_page.extract_text.return_value = ""
+        mock_reader = MagicMock()
+        mock_reader.pages = [empty_page]
+
+        with patch("nanobot.utils.pdf.PdfReader", return_value=mock_reader):
+            with patch("nanobot.utils.pdf.PYPDF_AVAILABLE", True):
+                result = extract_pdf_text("/fake/path.pdf")
+                assert result is None
+
+    def test_handles_extract_text_returning_none(self):
+        from nanobot.utils.pdf import extract_pdf_text
+
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = None
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_page]
+
+        with patch("nanobot.utils.pdf.PdfReader", return_value=mock_reader):
+            with patch("nanobot.utils.pdf.PYPDF_AVAILABLE", True):
+                result = extract_pdf_text("/fake/path.pdf")
+                assert result is None


### PR DESCRIPTION
## Summary

When a PDF file is received via Feishu, the agent currently only sees `[file: xxx.pdf]` and cannot read the PDF content. This PR adds automatic PDF text extraction so the agent can understand PDF content inline.

## Changes

- **`nanobot/utils/pdf.py`** — New shared utility `extract_pdf_text()` using `pypdf`
  - Page-by-page extraction with `[Page N]` markers
  - `max_chars` limit (default 50k) to avoid huge payloads
  - Graceful fallback: returns `None` if pypdf not installed or extraction fails
- **`nanobot/channels/feishu.py`** — Integrate PDF extraction in `_download_and_save_media`
  - After downloading a `.pdf` file, extract text and append to content
  - Zero behavior change for non-PDF files
- **`pyproject.toml`** — Add `pypdf>=5.0.0,<6.0.0` dependency
- **`tests/test_pdf_extraction.py`** — 8 unit tests covering normal/edge cases

## Example

Before:
```
[file: 申请退费所需材料.pdf]
```

After:
```
[file: 申请退费所需材料.pdf]

[Page 1]
一、当事人可自愿选择是否同意预留银行账户用于办理诉讼费退费...

[Page 2]
诉讼费退还账户确认书...
```

## Testing

- 8 new tests, 86 total tests pass (excluding pre-existing heartbeat import error)