### PR TITLE
fix: kill subprocess on CancelledError in ExecTool

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -96,6 +96,14 @@ class ExecTool(Tool):
                 except asyncio.TimeoutError:
                     pass
                 return f"Error: Command timed out after {self.timeout} seconds"
+            except BaseException:
+                # CancelledError or other — kill subprocess before propagating
+                process.kill()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5.0)
+                except (asyncio.TimeoutError, BaseException):
+                    pass
+                raise
             
             output_parts = []
             


### PR DESCRIPTION
## Problem

When a running task is cancelled (e.g. via `asyncio.Task.cancel()`), the subprocess spawned by `ExecTool` is orphaned. This happens because `CancelledError` inherits from `BaseException` in Python 3.9+, so the existing `except Exception` handler doesn't catch it.

## Solution

Add a `BaseException` handler after the timeout handler that:
1. Calls `process.kill()` to terminate the subprocess
2. Waits up to 5s for cleanup (`process.wait()`)
3. Re-raises the original exception

```python
except BaseException:
    process.kill()
    try:
        await asyncio.wait_for(process.wait(), timeout=5.0)
    except (asyncio.TimeoutError, BaseException):
        pass
    raise
```

## Changes

| File | Change |
|------|--------|
| `nanobot/agent/tools/shell.py` | +8 lines — BaseException handler kills subprocess before propagating |

This is a standalone fix that prevents orphan processes regardless of how the cancellation is triggered.