### PR TITLE
fix(agent): show all tool arguments in progress hint

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -163,12 +163,23 @@ class AgentLoop:
 
     @staticmethod
     def _tool_hint(tool_calls: list) -> str:
-        """Format tool calls as concise hint, e.g. 'web_search("query")'."""
-        def _fmt(tc):
-            val = next(iter(tc.arguments.values()), None) if tc.arguments else None
-            if not isinstance(val, str):
-                return tc.name
-            return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
+        """Format tool calls as concise hint with all arguments, e.g. 'exec(command="ls", working_dir="/tmp")'."""
+        _max_val = 40
+
+        def _fmt_val(val: Any) -> str:
+            if val is None:
+                return "None"
+            s = val if isinstance(val, str) else repr(val)
+            if len(s) > _max_val:
+                return s[:_max_val] + "…"
+            return s
+
+        def _fmt(tc) -> str:
+            if not tc.arguments:
+                return tc.name + "()"
+            parts = [f'{k}={_fmt_val(v)}' for k, v in tc.arguments.items()]
+            return f"{tc.name}({', '.join(parts)})"
+
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
     async def _run_agent_loop(

--- a/tests/test_tool_hint.py
+++ b/tests/test_tool_hint.py
@@ -1,0 +1,68 @@
+"""Tests for AgentLoop._tool_hint formatting of tool calls."""
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.providers.base import ToolCallRequest
+
+
+def test_tool_hint_no_arguments():
+    """Tool with no arguments shows name()."""
+    calls = [ToolCallRequest(id="1", name="list_dir", arguments={})]
+    assert AgentLoop._tool_hint(calls) == "list_dir()"
+
+
+def test_tool_hint_single_argument():
+    """Tool with one argument shows name(arg=value)."""
+    calls = [
+        ToolCallRequest(id="1", name="web_search", arguments={"query": "weather Berlin"})
+    ]
+    assert AgentLoop._tool_hint(calls) == 'web_search(query=weather Berlin)'
+
+
+def test_tool_hint_multiple_arguments():
+    """Tool with multiple arguments shows all (e.g. exec with command and working_dir)."""
+    calls = [
+        ToolCallRequest(
+            id="1",
+            name="exec",
+            arguments={"command": "ls -la", "working_dir": "/tmp"},
+        )
+    ]
+    hint = AgentLoop._tool_hint(calls)
+    assert "exec(" in hint
+    assert "command=ls -la" in hint
+    assert "working_dir=/tmp" in hint
+
+
+def test_tool_hint_long_value_truncated():
+    """Long string values are truncated with ellipsis."""
+    long_query = "x" * 50
+    calls = [
+        ToolCallRequest(id="1", name="web_search", arguments={"query": long_query})
+    ]
+    hint = AgentLoop._tool_hint(calls)
+    assert "…" in hint
+    assert len(hint) < 60
+
+
+def test_tool_hint_multiple_calls():
+    """Multiple tool calls are comma-separated."""
+    calls = [
+        ToolCallRequest(id="1", name="read_file", arguments={"path": "a.txt"}),
+        ToolCallRequest(id="2", name="read_file", arguments={"path": "b.txt"}),
+    ]
+    hint = AgentLoop._tool_hint(calls)
+    assert "read_file(path=a.txt)" in hint
+    assert "read_file(path=b.txt)" in hint
+    assert hint.count(", ") >= 1
+
+
+def test_tool_hint_non_string_value():
+    """Non-string argument values use repr (e.g. numbers, bool)."""
+    calls = [
+        ToolCallRequest(id="1", name="fake_tool", arguments={"count": 3, "flag": True})
+    ]
+    hint = AgentLoop._tool_hint(calls)
+    assert "count=3" in hint or "3" in hint
+    assert "flag=True" in hint or "True" in hint


### PR DESCRIPTION
## What
Progress/tool hints now show all arguments per tool call (e.g. `exec(command=ls, working_dir=/tmp)`) instead of only the first argument value.

## Why
When `sendToolHints` is enabled, users see what the agent is doing; multi-argument tools (e.g. `exec` with `command` and `working_dir`) were only showing one value before.

## How
- Updated `_tool_hint()` in `nanobot/agent/loop.py` to format all `tc.arguments` with truncation for long values.
- Added `tests/test_tool_hint.py` (6 cases: no args, single, multiple, long value, multiple calls, non-string values).

Tested locally and on device; existing tests pass.