### PR TITLE
feat(heartbeat): Ability to force heartbeat channel

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -345,18 +345,24 @@ def gateway(
 
     def _pick_heartbeat_target() -> tuple[str, str]:
         """Pick a routable channel/chat target for heartbeat-triggered messages."""
+        # Use explicitly configured target if set.
+        hb = config.gateway.heartbeat
+        if hb.channel and hb.chat_id:
+            return hb.channel, hb.chat_id
+
+        # Fallback: pick the most recently updated non-internal session.
         enabled = set(channels.enabled_channels)
-        # Prefer the most recently updated non-internal session on an enabled channel.
         for item in session_manager.list_sessions():
             key = item.get("key") or ""
             if ":" not in key:
                 continue
-            channel, chat_id = key.split(":", 1)
+            parts = key.split(":")
+            channel = parts[0]
+            chat_id = parts[1] if len(parts) >= 2 else ""
             if channel in {"cli", "system"}:
                 continue
             if channel in enabled and chat_id:
                 return channel, chat_id
-        # Fallback keeps prior behavior but remains explicit.
         return "cli", "direct"
 
     # Create heartbeat service

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -233,6 +233,8 @@ class HeartbeatConfig(Base):
 
     enabled: bool = True
     interval_s: int = 30 * 60  # 30 minutes
+    channel: str = ""  # Target channel type (e.g. "slack")
+    chat_id: str = ""  # Target chat ID (e.g. Slack channel ID)
 
 
 class GatewayConfig(Base):


### PR DESCRIPTION
Heartbeat currently sends responses to the most recently used channel. Which can be wild.

Add explicit channel/chat_id config to HeartbeatConfig so user can choose to force the heartbeat to target a configured channel instead of guessing from session history. Fall back to session discovery with corrected key parsing (extract only the channel ID part).