### PR TITLE
fix(web_search): use resolved Brave API key in request headers

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -80,7 +80,7 @@ class WebSearchTool(Tool):
                 r = await client.get(
                     "https://api.search.brave.com/res/v1/web/search",
                     params={"q": query, "count": n},
-                    headers={"Accept": "application/json", "X-Subscription-Token": api_key},
+                    headers={"Accept": "application/json", "X-Subscription-Token": self.api_key},
                     timeout=10.0
                 )
                 r.raise_for_status()


### PR DESCRIPTION
### Problem
`WebSearchTool` resolves the Brave key via `self.api_key`, but the request header still referenced `api_key` as a local variable.  
At runtime, this causes `web_search` calls to fail even when `tools.web.search.apiKey` is correctly configured.

### Solution
Use the instance property in the request header so the resolved key is actually passed to Brave Search.

```python
headers={"Accept": "application/json", "X-Subscription-Token": self.api_key}
```

### Changes
File Change
nanobot/agent/tools/web.py 1-line fix — replace undefined local api_key with self.api_key in WebSearchTool.execute()

This is a standalone fix that restores web search behavior and matches the intended runtime key-resolution logic.