### PR TITLE
Fix assistant messages without tool calls not being saved to session history

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -225,7 +225,16 @@ class AgentLoop:
                         messages, tool_call.id, tool_call.name, result
                     )
             else:
-                final_content = self._strip_think(response.content)
+                clean = self._strip_think(response.content)
+                if on_progress and clean:
+                    await on_progress(clean)
+                messages = self.context.add_assistant_message(
+                    messages,
+                    clean,
+                    tool_calls=None,
+                    reasoning_content=response.reasoning_content,
+                )
+                final_content = clean
                 break
 
         if final_content is None and iteration >= self.max_iterations:


### PR DESCRIPTION
Fix assistant messages without tool calls not being saved to session history
===========================================================================

## Summary

This PR fixes an issue in the agent loop where assistant messages that do **not** invoke any tools are never persisted into the session history (`session.messages`). As a result, conversations where the model responds purely in natural language (no `tool_calls`) are missing the assistant side in the stored JSONL, which breaks traceability and downstream analysis.

Upstream repository: https://github.com/HKUDS/nanobot

## Problem

Currently, `AgentLoop._run_agent_loop` only appends an assistant message to the `messages` list when the response includes `tool_calls`. In the no-tool branch, it only sets `final_content` and exits:

```python
else:
    final_content = self._strip_think(response.content)
    break
```

Later, `_process_message` calls:

```python
final_content, _, all_msgs = await self._run_agent_loop(...)
self._save_turn(session, all_msgs, 1 + len(history))
```

and `_save_turn` only writes `messages[skip:]` (system + old history are skipped). Since the no-tool branch never appended an assistant message, `messages[skip:]` contains only:

- the new user message, and
- any tool results (if present, but in this case there are none),

so the assistant’s natural-language reply is **lost** from `session.messages`.

This means:

- Session JSONL files contain user turns and tool outputs, but **omit** plain assistant replies.
- It is hard to build a fully traceable, replayable testing environment, because you cannot reconstruct what the model actually said when it didn’t call tools.

## Changes

In `nanobot/agent/loop.py`, inside `_run_agent_loop`:

- In the `else` branch where `response.has_tool_calls` is `False`:
  - Strip `<think>...</think>` blocks using `_strip_think`.
  - Optionally send the cleaned content to the `on_progress` callback (for consistent streaming behavior).
  - Append an assistant message to `messages` via `ContextBuilder.add_assistant_message`, **without** any `tool_calls`.
  - Set `final_content` to the cleaned text and `break`.

The new logic looks like this:

```python
else:
    clean = self._strip_think(response.content)
    if on_progress and clean:
        await on_progress(clean)
    messages = self.context.add_assistant_message(
        messages,
        clean,
        tool_calls=None,
        reasoning_content=response.reasoning_content,
    )
    final_content = clean
    break
```

This mirrors the existing behavior in the tool-call branch, but for the no-tool case.

## Behavior Impact

- **Before**:
  - `session.messages` for a turn with no tool calls contained:
    - the new `user` message only.
  - The assistant’s reply was not stored and could not be inspected later from the JSONL.

- **After**:
  - `session.messages` for a turn with no tool calls now contains:
    - the new `user` message, and
    - a corresponding `assistant` message with the final text reply.
  - Tool-calling behavior is unchanged.
  - Progress callbacks (`on_progress`) now receive the final text in both tool and no-tool paths, for more consistent streaming.

This makes the conversation history complete and much more suitable for:

- traceable / reproducible testing,
- debugging agent behavior,
- building higher-level “experience” and evaluation mechanisms on top of the stored traces.

## Testing

Manual testing steps:

1. Start the agent and send a prompt that should **not** require any tool calls (e.g. a simple self-introduction or explanation).
2. After the reply, open the corresponding session file under `~/.nanobot/workspace/sessions/*.jsonl`.
3. Observe that the last turn now includes:
   - the `user` message,
   - and a matching `assistant` message containing the natural-language reply.

Previously, only the `user` message would appear for such turns.

<img width="1407" height="1176" alt="bb00b19e15f41f0c427edf0ae67adff1" src="https://github.com/user-attachments/assets/ad740320-349f-4850-a425-1c7cec6ed0ab" />
wrong: line 41 - 44
right: line 45 - 46


## Future Work

I plan to build on this change by:

- Adding a lightweight, structured execution trace layer (e.g. JSONL traces) on top of `session.messages` to support **traceable, reproducible testing**.
- Experimenting with context/experience mechanisms that leverage these complete histories to evaluate context changes and token efficiency over time.

