### PR TITLE
feat: fallback model support for transient LLM failures

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -203,22 +203,27 @@ def _setup_all_provider_envs(config: Config) -> None:
     """Set environment variables for every configured provider.
 
     This is necessary so that fallback models from other providers can
-    authenticate via LiteLLM's env-var resolution.
+    authenticate via LiteLLM's env-var resolution.  Iterates the central
+    registry so newly-added providers are picked up automatically.
     """
     import os
-    from nanobot.providers.registry import find_by_name
+    from nanobot.providers.registry import PROVIDERS
 
-    for spec_name in (
-        "anthropic", "openai", "openrouter", "deepseek", "groq", "zhipu",
-        "dashscope", "gemini", "moonshot", "minimax", "aihubmix",
-        "siliconflow", "volcengine", "vllm",
-    ):
-        p = getattr(config.providers, spec_name, None)
+    for spec in PROVIDERS:
+        if not spec.env_key or spec.is_oauth or spec.is_direct:
+            continue
+        p = getattr(config.providers, spec.name, None)
         if not p or not p.api_key:
             continue
-        spec = find_by_name(spec_name)
-        if spec and spec.env_key:
-            os.environ.setdefault(spec.env_key, p.api_key)
+
+        os.environ.setdefault(spec.env_key, p.api_key)
+
+        # Resolve env_extras (e.g. ZHIPUAI_API_KEY, MOONSHOT_API_BASE)
+        effective_base = getattr(p, "api_base", None) or spec.default_api_base
+        for env_name, env_val in spec.env_extras:
+            resolved = env_val.replace("{api_key}", p.api_key)
+            resolved = resolved.replace("{api_base}", effective_base)
+            os.environ.setdefault(env_name, resolved)
 
 
 def _make_provider(config: Config):

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -199,6 +199,28 @@ def onboard():
 
 
 
+def _setup_all_provider_envs(config: Config) -> None:
+    """Set environment variables for every configured provider.
+
+    This is necessary so that fallback models from other providers can
+    authenticate via LiteLLM's env-var resolution.
+    """
+    import os
+    from nanobot.providers.registry import find_by_name
+
+    for spec_name in (
+        "anthropic", "openai", "openrouter", "deepseek", "groq", "zhipu",
+        "dashscope", "gemini", "moonshot", "minimax", "aihubmix",
+        "siliconflow", "volcengine", "vllm",
+    ):
+        p = getattr(config.providers, spec_name, None)
+        if not p or not p.api_key:
+            continue
+        spec = find_by_name(spec_name)
+        if spec and spec.env_key:
+            os.environ.setdefault(spec.env_key, p.api_key)
+
+
 def _make_provider(config: Config):
     """Create the appropriate LLM provider from config."""
     from nanobot.providers.litellm_provider import LiteLLMProvider
@@ -228,12 +250,19 @@ def _make_provider(config: Config):
         console.print("Set one in ~/.nanobot/config.json under providers section")
         raise typer.Exit(1)
 
+    # Ensure all configured providers have their env vars set so that
+    # fallback models from different providers can authenticate.
+    fallbacks = config.agents.defaults.fallbacks
+    if fallbacks:
+        _setup_all_provider_envs(config)
+
     return LiteLLMProvider(
         api_key=p.api_key if p else None,
         api_base=config.get_api_base(model),
         default_model=model,
         extra_headers=p.extra_headers if p else None,
         provider_name=provider_name,
+        fallbacks=fallbacks,
     )
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -222,6 +222,7 @@ class AgentDefaults(Base):
     workspace: str = "~/.nanobot/workspace"
     model: str = "anthropic/claude-opus-4-5"
     provider: str = "auto"  # Provider name (e.g. "anthropic", "openrouter") or "auto" for auto-detection
+    fallbacks: list[str] = Field(default_factory=list)  # Fallback models tried on transient LLM failures
     max_tokens: int = 8192
     temperature: float = 0.1
     max_tool_iterations: int = 40

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -207,39 +207,43 @@ class LiteLLMProvider(LLMProvider):
         original_model = model or self.default_model
         model = self._resolve_model(original_model)
 
+        # Keep originals for fallback retries (cache_control may not be
+        # supported by fallback providers).
+        raw_messages, raw_tools = messages, tools
+
         if self._supports_cache_control(original_model):
             messages, tools = self._apply_cache_control(messages, tools)
 
         # Clamp max_tokens to at least 1 — negative or zero values cause
         # LiteLLM to reject the request with "max_tokens must be at least 1".
         max_tokens = max(1, max_tokens)
-        
+
         kwargs: dict[str, Any] = {
             "model": model,
             "messages": self._sanitize_messages(self._sanitize_empty_content(messages)),
             "max_tokens": max_tokens,
             "temperature": temperature,
         }
-        
+
         # Apply model-specific overrides (e.g. kimi-k2.5 temperature)
         self._apply_model_overrides(model, kwargs)
-        
+
         # Pass api_key directly — more reliable than env vars alone
         if self.api_key:
             kwargs["api_key"] = self.api_key
-        
+
         # Pass api_base for custom endpoints
         if self.api_base:
             kwargs["api_base"] = self.api_base
-        
+
         # Pass extra headers (e.g. APP-Code for AiHubMix)
         if self.extra_headers:
             kwargs["extra_headers"] = self.extra_headers
-        
+
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
-        
+
         try:
             response = await acompletion(**kwargs)
             return self._parse_response(response)
@@ -249,7 +253,9 @@ class LiteLLMProvider(LLMProvider):
                     content=f"Error calling LLM: {str(e)}",
                     finish_reason="error",
                 )
-            return await self._try_fallbacks(e, messages, tools, max_tokens, temperature)
+            return await self._try_fallbacks(
+                e, raw_messages, raw_tools, max_tokens, temperature,
+            )
         except Exception as e:
             # Return error as content for graceful handling
             return LLMResponse(
@@ -265,23 +271,29 @@ class LiteLLMProvider(LLMProvider):
         max_tokens: int,
         temperature: float,
     ) -> LLMResponse:
-        """Try fallback models after a transient error on the primary model."""
-        sanitized = self._sanitize_messages(self._sanitize_empty_content(messages))
+        """Try fallback models after a transient error on the primary model.
 
+        Receives the *raw* (pre-cache_control) messages/tools so that
+        cache_control is only injected when the fallback provider supports it.
+        """
         for fb_model in self._fallbacks:
             resolved = self._resolve_model(fb_model)
             logger.warning("Primary model failed ({}), trying fallback: {}", original_error, fb_model)
 
+            fb_msgs, fb_tools = messages, tools
+            if self._supports_cache_control(fb_model):
+                fb_msgs, fb_tools = self._apply_cache_control(fb_msgs, fb_tools)
+
             fb_kwargs: dict[str, Any] = {
                 "model": resolved,
-                "messages": sanitized,
+                "messages": self._sanitize_messages(self._sanitize_empty_content(fb_msgs)),
                 "max_tokens": max_tokens,
                 "temperature": temperature,
             }
             self._apply_model_overrides(resolved, fb_kwargs)
 
-            if tools:
-                fb_kwargs["tools"] = tools
+            if fb_tools:
+                fb_kwargs["tools"] = fb_tools
                 fb_kwargs["tool_choice"] = "auto"
 
             try:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import litellm
 from litellm import acompletion
+from loguru import logger
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.providers.registry import find_by_model, find_gateway
@@ -24,26 +25,37 @@ def _short_tool_id() -> str:
     return "".join(secrets.choice(_ALNUM) for _ in range(9))
 
 
+# Transient errors that should trigger fallback model retry.
+_TRANSIENT_ERRORS = (
+    litellm.Timeout,
+    litellm.ServiceUnavailableError,
+    litellm.InternalServerError,
+    litellm.RateLimitError,
+)
+
+
 class LiteLLMProvider(LLMProvider):
     """
     LLM provider using LiteLLM for multi-provider support.
-    
+
     Supports OpenRouter, Anthropic, OpenAI, Gemini, MiniMax, and many other providers through
     a unified interface.  Provider-specific logic is driven by the registry
     (see providers/registry.py) — no if-elif chains needed here.
     """
-    
+
     def __init__(
-        self, 
-        api_key: str | None = None, 
+        self,
+        api_key: str | None = None,
         api_base: str | None = None,
         default_model: str = "anthropic/claude-opus-4-5",
         extra_headers: dict[str, str] | None = None,
         provider_name: str | None = None,
+        fallbacks: list[str] | None = None,
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
+        self._fallbacks = fallbacks or []
         
         # Detect gateway / local deployment.
         # provider_name (from config key) is the primary signal;
@@ -231,6 +243,13 @@ class LiteLLMProvider(LLMProvider):
         try:
             response = await acompletion(**kwargs)
             return self._parse_response(response)
+        except _TRANSIENT_ERRORS as e:
+            if not self._fallbacks:
+                return LLMResponse(
+                    content=f"Error calling LLM: {str(e)}",
+                    finish_reason="error",
+                )
+            return await self._try_fallbacks(e, messages, tools, max_tokens, temperature)
         except Exception as e:
             # Return error as content for graceful handling
             return LLMResponse(
@@ -238,6 +257,46 @@ class LiteLLMProvider(LLMProvider):
                 finish_reason="error",
             )
     
+    async def _try_fallbacks(
+        self,
+        original_error: Exception,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+        temperature: float,
+    ) -> LLMResponse:
+        """Try fallback models after a transient error on the primary model."""
+        sanitized = self._sanitize_messages(self._sanitize_empty_content(messages))
+
+        for fb_model in self._fallbacks:
+            resolved = self._resolve_model(fb_model)
+            logger.warning("Primary model failed ({}), trying fallback: {}", original_error, fb_model)
+
+            fb_kwargs: dict[str, Any] = {
+                "model": resolved,
+                "messages": sanitized,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+            self._apply_model_overrides(resolved, fb_kwargs)
+
+            if tools:
+                fb_kwargs["tools"] = tools
+                fb_kwargs["tool_choice"] = "auto"
+
+            try:
+                response = await acompletion(**fb_kwargs)
+                logger.info("Fallback model {} succeeded", fb_model)
+                return self._parse_response(response)
+            except Exception as fb_err:
+                logger.warning("Fallback model {} also failed: {}", fb_model, fb_err)
+                continue
+
+        return LLMResponse(
+            content=f"All models failed. Primary error: {original_error}",
+            finish_reason="error",
+        )
+
     def _parse_response(self, response: Any) -> LLMResponse:
         """Parse LiteLLM response into our standard format."""
         choice = response.choices[0]


### PR DESCRIPTION
## Summary

Resolves #1121 — when the primary model fails with a transient error (timeout, rate limit, 503, 500), nanobot now automatically retries with user-configured fallback models.

### Changes

- **`config/schema.py`**: Added `fallbacks` field to `AgentDefaults` — a list of model names to try when the primary model fails transiently
- **`cli/commands.py`**: Added `_setup_all_provider_envs()` to set env vars for all configured providers, so fallback models from different providers can authenticate via LiteLLM
- **`providers/litellm_provider.py`**:
  - Defined `_TRANSIENT_ERRORS` tuple (Timeout, ServiceUnavailable, InternalServer, RateLimitError)
  - Added `fallbacks` parameter to provider constructor
  - Modified `chat()` to catch transient errors separately and delegate to `_try_fallbacks()`
  - Implemented `_try_fallbacks()` — iterates through fallback models, resolving names and applying overrides, logging each attempt

### Usage

```json
{
  "agents": {
    "defaults": {
      "model": "anthropic/claude-sonnet-4-5",
      "fallbacks": ["openai/gpt-4o", "deepseek/deepseek-chat"]
    }
  },
  "providers": {
    "anthropic": { "api_key": "sk-ant-..." },
    "openai": { "api_key": "sk-..." },
    "deepseek": { "api_key": "sk-..." }
  }
}
```

If Claude times out or returns 429/500/503, nanobot will automatically try GPT-4o, then DeepSeek, before returning an error.