### PR TITLE
Fix: prevent silent discard of final response when message tool is used

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -60,6 +60,7 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        suppress_final_response_if_message_tool: bool = True,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -75,6 +76,7 @@ class AgentLoop:
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
+        self.suppress_final_response_if_message_tool = suppress_final_response_if_message_tool
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
@@ -407,15 +409,24 @@ class AgentLoop:
         if final_content is None:
             final_content = "I've completed processing but have no response to give."
 
-        preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
-        logger.info("Response to {}:{}: {}", msg.channel, msg.sender_id, preview)
-
         self._save_turn(session, all_msgs, 1 + len(history))
         self.sessions.save(session)
 
+        preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
-                return None
+                if self.suppress_final_response_if_message_tool:
+                    logger.info("Response suppressed due to message tool usage in this turn.")
+                    logger.debug(
+                        "Suppressed final response for {}:{}: {}",
+                        msg.channel, msg.sender_id, preview,
+                    )
+                    return None
+                logger.info(
+                    "Message tool was used in this turn, but final response delivery is enabled."
+                )
+
+        logger.info("Sending response to {}:{}: {}", msg.channel, msg.sender_id, preview)
 
         return OutboundMessage(
             channel=msg.channel, chat_id=msg.chat_id, content=final_content,

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -312,6 +312,9 @@ def gateway(
         max_tokens=config.agents.defaults.max_tokens,
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
+        suppress_final_response_if_message_tool=(
+            config.agents.defaults.suppress_final_response_if_message_tool
+        ),
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
         cron_service=cron,
@@ -469,6 +472,9 @@ def agent(
         max_tokens=config.agents.defaults.max_tokens,
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
+        suppress_final_response_if_message_tool=(
+            config.agents.defaults.suppress_final_response_if_message_tool
+        ),
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
         cron_service=cron,
@@ -960,6 +966,9 @@ def cron_run(
         max_tokens=config.agents.defaults.max_tokens,
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
+        suppress_final_response_if_message_tool=(
+            config.agents.defaults.suppress_final_response_if_message_tool
+        ),
         brave_api_key=config.tools.web.search.api_key or None,
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -190,6 +190,7 @@ class AgentDefaults(Base):
     temperature: float = 0.1
     max_tool_iterations: int = 40
     memory_window: int = 100
+    suppress_final_response_if_message_tool: bool = True
 
 
 class AgentsConfig(Base):

--- a/tests/test_agent_loop_message_tool_response.py
+++ b/tests/test_agent_loop_message_tool_response.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.tools.message import MessageTool
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+
+
+def _make_loop(tmp_path: Path, *, suppress: bool = True) -> AgentLoop:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    return AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        suppress_final_response_if_message_tool=suppress,
+    )
+
+
+def _logger_messages(mock: MagicMock) -> list[str]:
+    msgs: list[str] = []
+    for call in mock.call_args_list:
+        if call.args and isinstance(call.args[0], str):
+            msgs.append(call.args[0])
+    return msgs
+
+
+@pytest.mark.asyncio
+async def test_message_tool_usage_suppresses_final_response_with_explicit_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _make_loop(tmp_path, suppress=True)
+
+    async def _fake_run_agent_loop(initial_messages, on_progress=None):
+        message_tool = loop.tools.get("message")
+        assert isinstance(message_tool, MessageTool)
+        message_tool._sent_in_turn = True
+        return "Final answer", [], initial_messages
+
+    monkeypatch.setattr(loop, "_run_agent_loop", _fake_run_agent_loop)
+    info_mock = MagicMock()
+    debug_mock = MagicMock()
+    monkeypatch.setattr("nanobot.agent.loop.logger.info", info_mock)
+    monkeypatch.setattr("nanobot.agent.loop.logger.debug", debug_mock)
+
+    response = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="u1", chat_id="c1", content="hello")
+    )
+
+    assert response is None
+    messages = _logger_messages(info_mock)
+    assert "Response suppressed due to message tool usage in this turn." in messages
+    assert "Sending response to {}:{}: {}" not in messages
+    assert "Response to {}:{}: {}" not in messages
+    assert debug_mock.called
+
+
+@pytest.mark.asyncio
+async def test_message_tool_usage_can_still_send_final_response_when_suppression_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _make_loop(tmp_path, suppress=False)
+
+    async def _fake_run_agent_loop(initial_messages, on_progress=None):
+        message_tool = loop.tools.get("message")
+        assert isinstance(message_tool, MessageTool)
+        message_tool._sent_in_turn = True
+        return "Final answer", [], initial_messages
+
+    monkeypatch.setattr(loop, "_run_agent_loop", _fake_run_agent_loop)
+    info_mock = MagicMock()
+    monkeypatch.setattr("nanobot.agent.loop.logger.info", info_mock)
+
+    response = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="u1", chat_id="c1", content="hello")
+    )
+
+    assert response is not None
+    assert response.content == "Final answer"
+    messages = _logger_messages(info_mock)
+    assert "Response suppressed due to message tool usage in this turn." not in messages
+    assert "Message tool was used in this turn, but final response delivery is enabled." in messages
+    assert "Sending response to {}:{}: {}" in messages
+    assert "Response to {}:{}: {}" not in messages
+
+
+@pytest.mark.asyncio
+async def test_normal_turn_without_message_tool_usage_behaves_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _make_loop(tmp_path, suppress=True)
+
+    async def _fake_run_agent_loop(initial_messages, on_progress=None):
+        return "Final answer", [], initial_messages
+
+    monkeypatch.setattr(loop, "_run_agent_loop", _fake_run_agent_loop)
+    info_mock = MagicMock()
+    monkeypatch.setattr("nanobot.agent.loop.logger.info", info_mock)
+
+    response = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="u1", chat_id="c1", content="hello")
+    )
+
+    assert response is not None
+    assert response.content == "Final answer"
+    messages = _logger_messages(info_mock)
+    assert "Sending response to {}:{}: {}" in messages
+    assert "Response suppressed due to message tool usage in this turn." not in messages
+    assert "Response to {}:{}: {}" not in messages
+


### PR DESCRIPTION
## Summary
Fixes a bug in AgentLoop where the final response generated at the end of a turn could be silently discarded when the message tool was used earlier in the same turn.

Previously, nanobot would log a response preview (Response to ...) and then return None if MessageTool._sent_in_turn was true, causing:

- misleading logs
- no final reply on the original channel
- silent suppression with no explanation

This PR makes suppression explicit, fixes logging order, and adds a config flag to control behavior.

## What changed
- Moved response logging to occur after message-tool suppression decision
- Added explicit suppression log when final response is intentionally not returned
- Added config flag to control behavior:
  - `agents.defaults.suppress_final_response_if_message_tool` (default: true)
- Preserved backward compatibility by keeping suppression enabled by default
- Added unit tests covering suppression/non-suppression/normal flow

## Behavior after this PR
**Default behavior (backward compatible)**
If message tool was used in a turn and suppression is enabled:
- final response is suppressed
- nanobot logs: `Response suppressed due to message tool usage in this turn.`
- no misleading `Response to ...` / send log is emitted

**Optional behavior**
If `agents.defaults.suppress_final_response_if_message_tool = false`:
- nanobot still sends the final response on the original channel
- logs explicitly indicate that message tool was used but final response delivery is enabled

## Why this fix
This resolves a correctness issue where logs claimed a response existed/suggested delivery while the function actually returned None. It also avoids silent failures by making suppression explicit.

## Tests
Added tests for:
- message tool used + suppression enabled -> response suppressed with explicit log
- message tool used + suppression disabled -> final response sent
- no message tool usage -> normal behavior unchanged

Test file:
- `test_agent_loop_message_tool_response.py`

## Notes
- This PR intentionally preserves existing default behavior to avoid breaking workflows that rely on suppressing the final response after message tool usage.
- Existing unrelated local changes (`test_cron_service.py`, `.editorconfig`) were not included in this branch.