### PR TITLE
feat(agent): stabilize KV cache reuse with batch prompt rollover

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -28,7 +28,11 @@ class ContextBuilder:
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
     
-    def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
+    def build_system_prompt(
+        self,
+        skill_names: list[str] | None = None,
+        session_summary: str | None = None,
+    ) -> str:
         """
         Build the system prompt from bootstrap files, memory, and skills.
         
@@ -70,6 +74,12 @@ The following skills extend your capabilities. To use a skill, read its SKILL.md
 Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
 
 {skills_summary}""")
+
+        if session_summary and session_summary.strip():
+            parts.append(
+                "# Session Summary (Compressed Context)\n\n"
+                + session_summary.strip()
+            )
         
         return "\n\n---\n\n".join(parts)
     
@@ -132,6 +142,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         history: list[dict[str, Any]],
         current_message: str,
         skill_names: list[str] | None = None,
+        session_summary: str | None = None,
         media: list[str] | None = None,
         channel: str | None = None,
         chat_id: str | None = None,
@@ -153,7 +164,10 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         messages = []
 
         # System prompt
-        system_prompt = self.build_system_prompt(skill_names)
+        system_prompt = self.build_system_prompt(
+            skill_names=skill_names,
+            session_summary=session_summary,
+        )
         messages.append({"role": "system", "content": system_prompt})
 
         # History

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import re
 from contextlib import AsyncExitStack
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
@@ -42,6 +43,11 @@ class AgentLoop:
     4. Executes tool calls
     5. Sends responses back
     """
+    _PROMPT_SUMMARY_KEY = "prompt_rollover_summary"
+    _PROMPT_BASE_INDEX_KEY = "prompt_rollover_base_index"
+    _PROMPT_ROLLOVER_HARD_RATIO = 1.4
+    _PROMPT_ROLLOVER_MIN_HEADROOM = 10
+    _SUMMARY_SOURCE_MAX_CHARS = 400
 
     def __init__(
         self,
@@ -294,6 +300,140 @@ class AgentLoop:
         if not lock.locked():
             self._consolidation_locks.pop(session_key, None)
 
+    def _get_prompt_rollover_limits(self) -> tuple[int, int]:
+        """Return (soft_limit, hard_limit) without adding new config knobs."""
+        soft_limit = max(1, self.memory_window)
+        hard_limit = max(
+            soft_limit + self._PROMPT_ROLLOVER_MIN_HEADROOM,
+            int(soft_limit * self._PROMPT_ROLLOVER_HARD_RATIO),
+        )
+        return soft_limit, hard_limit
+
+    def _get_prompt_base_index(self, session: Session) -> int:
+        raw_base = session.metadata.get(self._PROMPT_BASE_INDEX_KEY, session.last_consolidated)
+        try:
+            base = int(raw_base)
+        except (TypeError, ValueError):
+            base = session.last_consolidated
+        base = max(0, session.last_consolidated, base)
+        return min(base, len(session.messages))
+
+    @staticmethod
+    def _serialize_message_for_summary(msg: dict[str, Any], max_chars: int) -> str:
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            text = content
+        else:
+            text = json.dumps(content, ensure_ascii=False)
+        text = text.strip().replace("\n", " ")
+        if len(text) > max_chars:
+            text = text[:max_chars] + "..."
+        role = str(msg.get("role", "unknown")).upper()
+        return f"{role}: {text}"
+
+    async def _update_prompt_rollover_summary(
+        self,
+        existing_summary: str | None,
+        chunk: list[dict[str, Any]],
+    ) -> str | None:
+        lines = [
+            self._serialize_message_for_summary(m, self._SUMMARY_SOURCE_MAX_CHARS)
+            for m in chunk
+            if m.get("content")
+        ]
+        if not lines:
+            return existing_summary.strip() if isinstance(existing_summary, str) else None
+
+        current_summary = (existing_summary or "").strip()
+        source_text = "\n".join(lines)
+        prompt = f"""Update the stable conversation summary.
+
+Existing summary:
+{current_summary or "(empty)"}
+
+New older messages to fold in:
+{source_text}
+
+Return plain text only. Keep it concise and factual. Preserve open tasks, decisions, and user preferences."""
+
+        response = await self.provider.chat(
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You summarize chat history for context compression.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            model=self.model,
+            max_tokens=min(self.max_tokens, 1024),
+            temperature=0.1,
+        )
+
+        if response.finish_reason == "error":
+            return None
+
+        summary = (response.content or "").strip()
+        if not summary:
+            return None
+        return summary[:6000].strip()
+
+    async def _maybe_rollover_prompt_history(self, session: Session) -> None:
+        """Batch-roll old prompt history into a stable summary (avoid per-turn sliding)."""
+        soft_limit, hard_limit = self._get_prompt_rollover_limits()
+        base_index = self._get_prompt_base_index(session)
+        start_index = max(base_index, session.last_consolidated)
+
+        available = len(session.messages) - start_index
+        if available <= hard_limit:
+            return
+
+        new_base = max(start_index, len(session.messages) - soft_limit)
+        chunk = session.messages[start_index:new_base]
+        if not chunk:
+            return
+
+        existing_summary = session.metadata.get(self._PROMPT_SUMMARY_KEY)
+        updated_summary = await self._update_prompt_rollover_summary(existing_summary, chunk)
+        if not updated_summary:
+            return
+
+        session.metadata[self._PROMPT_SUMMARY_KEY] = updated_summary
+        session.metadata[self._PROMPT_BASE_INDEX_KEY] = new_base
+        session.updated_at = datetime.now()
+        logger.info(
+            "Prompt rollover: session={} start={} new_base={} kept={} summarized={}",
+            session.key,
+            start_index,
+            new_base,
+            len(session.messages) - new_base,
+            len(chunk),
+        )
+
+    def _build_prompt_history(self, session: Session) -> tuple[str | None, list[dict[str, Any]]]:
+        base_index = self._get_prompt_base_index(session)
+        start_index = max(base_index, session.last_consolidated)
+        sliced = session.messages[start_index:]
+
+        # Avoid starting from orphaned tool/result entries.
+        for i, m in enumerate(sliced):
+            if m.get("role") == "user":
+                sliced = sliced[i:]
+                break
+        else:
+            sliced = []
+
+        history: list[dict[str, Any]] = []
+        for m in sliced:
+            entry: dict[str, Any] = {"role": m["role"], "content": m.get("content", "")}
+            for key in ("tool_calls", "tool_call_id", "name"):
+                if key in m:
+                    entry[key] = m[key]
+            history.append(entry)
+
+        summary = session.metadata.get(self._PROMPT_SUMMARY_KEY)
+        summary_text = summary.strip() if isinstance(summary, str) else None
+        return summary_text or None, history
+
     async def _process_message(
         self,
         msg: InboundMessage,
@@ -308,10 +448,12 @@ class AgentLoop:
             logger.info("Processing system message from {}", msg.sender_id)
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
+            await self._maybe_rollover_prompt_history(session)
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
-            history = session.get_history(max_messages=self.memory_window)
+            session_summary, history = self._build_prompt_history(session)
             messages = self.context.build_messages(
                 history=history,
+                session_summary=session_summary,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
             )
             final_content, _, all_msgs = await self._run_agent_loop(messages)
@@ -353,6 +495,8 @@ class AgentLoop:
                 self._prune_consolidation_lock(session.key, lock)
 
             session.clear()
+            session.metadata.pop(self._PROMPT_SUMMARY_KEY, None)
+            session.metadata.pop(self._PROMPT_BASE_INDEX_KEY, None)
             self.sessions.save(session)
             self.sessions.invalidate(session.key)
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
@@ -380,14 +524,16 @@ class AgentLoop:
             _task = asyncio.create_task(_consolidate_and_unlock())
             self._consolidation_tasks.add(_task)
 
+        await self._maybe_rollover_prompt_history(session)
         self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()
 
-        history = session.get_history(max_messages=self.memory_window)
+        session_summary, history = self._build_prompt_history(session)
         initial_messages = self.context.build_messages(
             history=history,
+            session_summary=session_summary,
             current_message=msg.content,
             media=msg.media if msg.media else None,
             channel=msg.channel, chat_id=msg.chat_id,
@@ -427,7 +573,6 @@ class AgentLoop:
 
     def _save_turn(self, session: Session, messages: list[dict], skip: int) -> None:
         """Save new-turn messages into session, truncating large tool results."""
-        from datetime import datetime
         for m in messages[skip:]:
             entry = {k: v for k, v in m.items() if k != "reasoning_content"}
             if entry.get("role") == "tool" and isinstance(entry.get("content"), str):

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime as real_datetime
 from pathlib import Path
 import datetime as datetime_module
+from unittest.mock import AsyncMock, MagicMock
 
 from nanobot.agent.context import ContextBuilder
+from nanobot.agent.loop import AgentLoop
+from nanobot.providers.base import LLMResponse
+from nanobot.session.manager import Session
 
 
 class _FakeDatetime(real_datetime):
@@ -64,3 +69,80 @@ def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
 
     assert messages[-1]["role"] == "user"
     assert messages[-1]["content"] == "Return exactly: OK"
+
+
+class _DummyBus:
+    async def publish_outbound(self, _message):
+        return None
+
+
+def _make_loop(tmp_path: Path, memory_window: int = 100) -> tuple[AgentLoop, MagicMock]:
+    workspace = _make_workspace(tmp_path)
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "anthropic/claude-sonnet-4-5"
+    provider.chat = AsyncMock(return_value=LLMResponse(content="updated summary", tool_calls=[]))
+
+    loop = AgentLoop(
+        bus=_DummyBus(),
+        provider=provider,
+        workspace=workspace,
+        memory_window=memory_window,
+    )
+    return loop, provider
+
+
+def _make_session(message_count: int) -> Session:
+    session = Session(key="cli:direct")
+    for i in range(message_count):
+        role = "user" if i % 2 == 0 else "assistant"
+        session.add_message(role, f"{role}-{i}")
+    return session
+
+
+def test_system_prompt_can_include_stable_summary_block(tmp_path: Path) -> None:
+    builder = ContextBuilder(_make_workspace(tmp_path))
+
+    prompt = builder.build_system_prompt(session_summary="Older context summary")
+
+    assert "# Session Summary (Compressed Context)" in prompt
+    assert "Older context summary" in prompt
+
+
+def test_rollover_compacts_old_prefix_in_batches(tmp_path: Path) -> None:
+    loop, provider = _make_loop(tmp_path, memory_window=100)
+    session = _make_session(150)
+
+    asyncio.run(loop._maybe_rollover_prompt_history(session))
+
+    assert session.metadata["prompt_rollover_base_index"] == 50
+    assert session.metadata["prompt_rollover_summary"] == "updated summary"
+    provider.chat.assert_awaited_once()
+
+    summary, history = loop._build_prompt_history(session)
+    assert summary == "updated summary"
+    assert len(history) == 100
+    assert history[0]["content"] == "user-50"
+
+
+def test_rollover_does_not_slide_every_turn_before_hard_limit(tmp_path: Path) -> None:
+    loop, provider = _make_loop(tmp_path, memory_window=100)
+    session = _make_session(150)
+
+    asyncio.run(loop._maybe_rollover_prompt_history(session))
+    provider.chat.reset_mock()
+
+    # Add 10 messages (5 turns): still below hard limit after the first rollover.
+    for i in range(150, 160):
+        role = "user" if i % 2 == 0 else "assistant"
+        session.add_message(role, f"{role}-{i}")
+
+    asyncio.run(loop._maybe_rollover_prompt_history(session))
+
+    # Base index should stay fixed, avoiding per-turn sliding-window churn.
+    assert session.metadata["prompt_rollover_base_index"] == 50
+    provider.chat.assert_not_awaited()
+
+    _, history = loop._build_prompt_history(session)
+    assert history[0]["content"] == "user-50"
+    assert len(history) == 110


### PR DESCRIPTION
## Experiment Comparison (nanobot path, OpenRouter + `openai/gpt-4o-mini`)

Setup:
- Real nanobot message-building/session path (not direct raw API-only calls)
- `memory_window=10`, `turns=16`, same prompt/workspace for both branches
- Metrics: `prompt_tokens`, `cached_tokens`, and LCP proxy (`lcp_share_prev`, closer to `1.0` means a more stable cacheable prefix)

| Variant | warm_avg_prompt_tokens (turn 7-16) | warm_avg_cached_tokens (turn 7-16) | warm_avg_lcp_share_prev (turn 7-16) |
| --- | ---: | ---: | ---: |
| `origin/main` (sliding window) | 8151.9 | 6566.4 | 0.9749 |
| This PR (batch rollover + stable summary) | 8325.4 | 7948.8 | 0.9931 |

Relative deltas (this PR vs baseline):
- `warm_avg_cached_tokens`: **+1382.4** (**+21.1%**)
- `warm_avg_lcp_share_prev`: **+0.0182** (**+1.9%** relative); distance-to-1.0 drops from `0.0251` to `0.0069` (**-72.5%**)
- `warm_avg_prompt_tokens`: **+173.5** (**+2.1%**) due to hysteresis (history is kept longer before rollover)

Observed behavior:
- Baseline: after sliding starts, prefix changes every turn, and `cached_tokens` repeatedly drops to lower plateaus (including occasional zero-hit turns in this run).
- This PR: history grows until hard threshold, then one rollover compaction happens; after that, cache hit recovers and stays high.

## Problem Analysis

Current sliding-window behavior changes the prompt boundary every turn once the window is full.
That causes unstable leading prefix in requests, which reduces cross-turn KV/prefix cache reuse.

In short:
- **Before window fills**: high and stable cache reuse.
- **After window fills (baseline)**: every turn shifts the oldest messages out; prompt prefix churn increases; cache reuse degrades.

## Proposal / Solution

Introduce **batch prompt rollover** with a **stable compressed summary** (no new config knobs in this initial version):

1. Keep a soft/hard hysteresis band derived from `memory_window`:
- `soft_limit = memory_window`
- `hard_limit = max(memory_window + 10, int(memory_window * 1.4))`

2. Only compact when history exceeds `hard_limit`:
- Summarize dropped old chunk into `prompt_rollover_summary`
- Advance `prompt_rollover_base_index`
- Keep recent tail (`soft_limit`) as verbatim history

3. Inject summary into system prompt as a stable block:
- `# Session Summary (Compressed Context)`
- Maintains continuity while avoiding per-turn prefix churn

4. Guardrails:
- Keep summary bounded (`<= 6000` chars)
- Ignore empty summary updates
- Keep base index monotonic and safe vs consolidation index
- Clear rollover metadata on `/new`

## Summary Size Rationale

How the current summary size is chosen:
- We cap persisted summary text at `6000` chars to prevent summary growth from replacing one prompt-bloat problem with another.
- This cap is intentionally conservative for v1: it keeps a stable compressed context block while still allowing key decisions/preferences to accumulate.
- Source messages are also serialized with a per-message cap (`400` chars) before summarization, which reduces outlier tool-output impact.

Why this is a reasonable default:
- In practice, this keeps summary overhead bounded and predictable across turns, improving cache stability.
- It avoids introducing new config knobs in v1 while still enforcing hard guardrails.

Future refinement (if maintainers prefer):
- Replace char-based cap with token-aware budgeting (e.g., summary budget as a fraction of prompt window).
- Add a compaction pass when summary nears budget (e.g., “summary of summaries”) to preserve long-horizon continuity.

## Where Gains Are Largest

This approach is typically more beneficial when:
- Conversations are long enough that sliding would otherwise happen every turn.
- History/tool outputs occupy a large share of prompt tokens (stable system prefix is not dominant).
- Provider/model has meaningful prefix-cache economics and good cache observability.
- Runtime/system layers are stable, so most churn comes from rolling history boundaries.

## Where Gains May Be Smaller

Benefits are usually smaller when:
- Sessions are short and rarely hit the sliding region.
- A very large stable system prompt dominates total prompt tokens.
- Provider cache TTL/eviction/routing variability dominates application-side improvements.

## Code Changes

- `nanobot/agent/loop.py`
  - Added rollover summary/base metadata and helper methods
  - Added batched compaction flow (`_maybe_rollover_prompt_history`)
  - Added rollover-aware prompt history builder (`_build_prompt_history`)
  - Wired system/system-message and normal message processing paths to use summary-aware history
  - Cleared rollover metadata on `/new`

- `nanobot/agent/context.py`
  - Extended `build_system_prompt()` with optional `session_summary`
  - Extended `build_messages()` to pass summary into system prompt

- `tests/test_context_prompt_cache.py`
  - Added coverage for summary block injection
  - Added rollover compaction behavior test
  - Added hysteresis/no-per-turn-sliding-before-hard-limit test

