### PR TITLE
feat: support explicit provider selection in config

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -186,6 +186,7 @@ class AgentDefaults(Base):
 
     workspace: str = "~/.nanobot/workspace"
     model: str = "anthropic/claude-opus-4-5"
+    provider: str = "auto"  # Provider name (e.g. "anthropic", "openrouter") or "auto" for auto-detection
     max_tokens: int = 8192
     temperature: float = 0.1
     max_tool_iterations: int = 40
@@ -300,6 +301,11 @@ class Config(BaseSettings):
     def _match_provider(self, model: str | None = None) -> tuple["ProviderConfig | None", str | None]:
         """Match provider config and its registry name. Returns (config, spec_name)."""
         from nanobot.providers.registry import PROVIDERS
+
+        forced = self.agents.defaults.provider
+        if forced != "auto":
+            p = getattr(self.providers, forced, None)
+            return (p, forced) if p else (None, None)
 
         model_lower = (model or self.agents.defaults.model).lower()
         model_normalized = model_lower.replace("-", "_")


### PR DESCRIPTION
## Summary

Allow users to explicitly select an LLM provider in `config.json` instead of relying solely on auto-detection.

Adds a `provider` field to `AgentDefaults` (default: `"auto"` for full backward compatibility).

## Motivation

When users configure API keys for multiple providers (e.g. both `anthropic` and `openrouter`), the current auto-detection logic picks the first match based on model name keywords and registry order. This makes it impossible to pin a specific provider — especially for gateway providers like OpenRouter that can serve any model name.

## Design

- **Minimal change**: 1 new field + 4 lines of logic in `_match_provider()`
- **Backward compatible**: `"auto"` (default) preserves the existing auto-detection behavior exactly
- **Fail-safe**: If the user types an invalid provider name, returns `(None, None)` — downstream reports "No API key configured" rather than silently falling back
- **No side effects**: Only affects LLM provider matching; independent paths like Groq voice transcription are untouched

## Usage

```json
"defaults": {
  "model": "claude-sonnet-4-6",
  "provider": "anthropic"
}
```

Valid provider names match `ProvidersConfig` attributes: `anthropic`, `openai`, `openrouter`, `deepseek`, `groq`, `gemini`, `openai_codex`, etc.

## Changed files

- `nanobot/config/schema.py` — add `provider` field to `AgentDefaults`; add early-return branch in `_match_provider()`
