### PR TITLE
feat: improve debug prompt logging format for better readability

### DIFF
--- a/PR_debug_prompt_format.md
+++ b/PR_debug_prompt_format.md
@@ -1,0 +1,104 @@
+Improve debug prompt logging format for better readability
+================================================================
+
+## Summary
+
+This PR improves the debug prompt logging mechanism in `LiteLLMProvider` to output human-readable, well-formatted text logs instead of JSONL. The logs now clearly show the full prompt (messages + tools) sent to the LLM in each call, making it much easier to debug and understand what context the model receives.
+
+Upstream repository: https://github.com/HKUDS/nanobot
+
+## Problem
+
+Previously, the debug prompt logging (if implemented) would likely output raw JSON, which:
+- Is hard to read when messages contain long system prompts, HTML fragments, or truncated content
+- Causes syntax highlighting issues in editors when JSON contains unclosed quotes (e.g., from truncated HTML like `<img src="https://img.shields.io`)
+- Makes it difficult to quickly scan what was actually sent to the LLM
+
+## Changes
+
+### 1. Added `_debug_log_prompt` method
+
+A new method in `LiteLLMProvider` that:
+- Formats the full prompt (messages + tools) in a human-readable text format
+- Writes to `~/.nanobot/debug/prompts.log` (using `.log` extension instead of `.jsonl` to avoid JSON syntax highlighting issues)
+- Only keeps the **most recent** LLM call (overwrites the file each time) to avoid disk bloat
+
+### 2. Format improvements
+
+The log format includes:
+- **Header**: Timestamp and model name
+- **Messages section**: Each message numbered `[1]`, `[2]`, etc., with:
+  - Role and tool_calls hint (e.g., `[3] assistant (tool_calls: exec, read_file):`)
+  - Content indented with 4 spaces for readability
+  - Proper handling of both string and structured content
+- **Tools section**: List of all tool definitions with names and descriptions
+
+### 3. Integration
+
+The method is called in `chat()` right before sending the request to LiteLLM, ensuring we capture exactly what gets sent to the provider.
+
+## Behavior Impact
+
+- **Before**: No debug prompt logging (or raw JSON that's hard to read)
+- **After**: 
+  - Each LLM call writes a clean, readable log to `~/.nanobot/debug/prompts.log`
+  - The file always contains only the **latest** call (overwrites on each new call)
+  - Format is optimized for human reading, with clear sections and indentation
+  - No JSON syntax highlighting issues even when content contains unclosed quotes or HTML fragments
+
+## Example Output
+
+```
+================================================================================
+2026-02-26T11:28:17.941640  model=minimax/MiniMax-M2.5
+
+=== MESSAGES ===
+
+[1] system:
+    # nanobot 🐈
+    
+    You are nanobot, a helpful AI assistant.
+    ...
+
+[2] user:
+    比较openclaw和nanobot
+    
+    [Runtime Context]
+    Current Time: 2026-02-26 11:28 (Thursday) (中国标准时间)
+    Channel: cli
+    Chat ID: direct
+
+[3] assistant (tool_calls: web_fetch):
+    
+    让我获取更多信息来比较这两个项目：
+
+=== TOOLS (definitions) ===
+- read_file: Read the contents of a file at the given path.
+- write_file: Write content to a file at the given path. Creates parent directories if needed.
+- exec: Execute a shell command and return its output. Use with caution.
+...
+```
+
+## Testing
+
+1. Run any `nanobot agent` command that triggers an LLM call
+2. Check `~/.nanobot/debug/prompts.log`
+3. Verify:
+   - The file contains a well-formatted, readable log
+   - All messages are numbered and indented
+   - Tool definitions are listed at the end
+   - The file is overwritten on each new call (only latest call is kept)
+
+## Benefits
+
+- **Better debugging**: Developers can quickly see exactly what prompt was sent to the LLM
+- **No syntax highlighting issues**: Using `.log` extension avoids JSON parsing problems
+- **Clean format**: Indentation and sections make it easy to scan
+- **Minimal disk usage**: Only keeps the latest call, not a growing history
+
+## Future Work
+
+This debug logging can be extended to:
+- Support keeping a configurable number of recent calls (e.g., last 5)
+- Add token counting and cost estimation
+- Include response metadata (tokens used, finish reason, etc.)

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -3,6 +3,8 @@
 import json
 import json_repair
 import os
+from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import litellm
@@ -164,6 +166,65 @@ class LiteLLMProvider(LLMProvider):
             sanitized.append(clean)
         return sanitized
 
+    def _debug_log_prompt(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> None:
+        """Persist the latest full prompt for local debugging（仅保留最近一条调用）."""
+        try:
+            base = Path.home() / ".nanobot" / "debug"
+            base.mkdir(parents=True, exist_ok=True)
+            # 这里已经不是 JSONL，而是纯文本调试日志，所以用 .log 更直观，
+            # 也避免编辑器按 JSON 高亮导致因未闭合的 `"` 看起来「全文件乱掉」。
+            path = base / "prompts.log"
+
+            ts = datetime.now().isoformat()
+            lines: list[str] = []
+            sep = "=" * 80
+            lines.append(f"{sep}\n")
+            lines.append(f"{ts}  model={model}\n\n")
+            lines.append("=== MESSAGES ===\n\n")
+
+            for idx, msg in enumerate(messages, start=1):
+                role = msg.get("role", "?")
+                content = msg.get("content")
+                tool_calls = msg.get("tool_calls")
+                tc_hint = ""
+                if tool_calls:
+                    names = [tc.get("function", {}).get("name", "") for tc in tool_calls]
+                    names = [n for n in names if n]
+                    if names:
+                        tc_hint = f" (tool_calls: {', '.join(names)})"
+                lines.append(f"[{idx}] {role}{tc_hint}:\n")
+                # 内容按行缩进，避免整体视觉混在一起
+                if isinstance(content, str):
+                    for line in str(content).splitlines():
+                        lines.append(f"    {line}\n")
+                else:
+                    pretty = json.dumps(content, ensure_ascii=False, indent=2)
+                    for line in pretty.splitlines():
+                        lines.append(f"    {line}\n")
+                lines.append("\n")
+
+            # Tools summary（工具定义）
+            lines.append("=== TOOLS (definitions) ===\n")
+            for t in tools or []:
+                fn = t.get("function", {})
+                name = fn.get("name", "")
+                desc = fn.get("description", "")
+                lines.append(f"- {name}: {desc}\n")
+            lines.append("\n")
+
+            # 只保留最近一次调用：直接覆盖写入
+            text = "".join(lines)
+            with path.open("w", encoding="utf-8") as f:
+                f.write(text)
+        except Exception:
+            # Debug logging必须不能影响正常执行
+            return
+
     async def chat(
         self,
         messages: list[dict[str, Any]],
@@ -187,6 +248,9 @@ class LiteLLMProvider(LLMProvider):
         """
         original_model = model or self.default_model
         model = self._resolve_model(original_model)
+
+        # Debug: record the full prompt (system + history + user + tools) for this call.
+        self._debug_log_prompt(original_model, messages, tools)
 
         if self._supports_cache_control(original_model):
             messages, tools = self._apply_cache_control(messages, tools)


### PR DESCRIPTION
- Add _debug_log_prompt method to LiteLLMProvider
- Output human-readable text format instead of JSONL
- Use .log extension to avoid JSON syntax highlighting issues
- Only keep the most recent LLM call (overwrites on each call)
- Format includes numbered messages with indentation and tool definitions
- Makes debugging much easier by showing exactly what prompt was sent to LLM
[prompts.log](https://github.com/user-attachments/files/25563440/prompts.log)
About 1000 lines in max