### PR TITLE
fix(web_search): resolve NameError when Brave API key is configured

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -80,7 +80,7 @@ class WebSearchTool(Tool):
                 r = await client.get(
                     "https://api.search.brave.com/res/v1/web/search",
                     params={"q": query, "count": n},
-                    headers={"Accept": "application/json", "X-Subscription-Token": api_key},
+                    headers={"Accept": "application/json", "X-Subscription-Token": self.api_key},
                     timeout=10.0
                 )
                 r.raise_for_status()


### PR DESCRIPTION
Fixes #1212

Problem
WebSearchTool.execute() used an undefined local variable api_key when building the Brave request header, causing NameError and breaking web_search.

Solution
Use self.api_key (the existing resolved API key property) for the X-Subscription-Token request header.

Change scope
- Single-line fix in nanobot/agent/tools/web.py
- No behavior changes outside web_search header construction