### PR TITLE
fix(agent): avoid persisting runtime context metadata into history

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -472,8 +472,6 @@ class AgentLoop:
                 and isinstance(entry.get("content"), str)
                 and entry["content"].startswith(ContextBuilder._RUNTIME_CONTEXT_TAG)
             ):
-                # Runtime metadata is injected per-turn for model context only; do not persist it
-                # into long-lived session history to avoid semantic drift and repetitive replies.
                 continue
             if entry.get("role") == "user" and isinstance(entry.get("content"), list):
                 entry["content"] = [


### PR DESCRIPTION
Fixes #1176

Problem
Since v0.1.4.post2, runtime context metadata is injected as a separate user message each turn. When this metadata is persisted into session history, non-user runtime text can accumulate in long-lived context and increase the chance of repeated carry-over content in later replies.

What changed
In AgentLoop._save_turn(), user messages that are runtime metadata blocks (tagged with ContextBuilder._RUNTIME_CONTEXT_TAG) are skipped during persistence.

This keeps runtime metadata available for the current turn only, while preserving normal session history behavior for:
- real user messages
- assistant messages
- tool messages/results

Scope
- Single-file change in nanobot/agent/loop.py
- No changes to runtime-context injection behavior for current-turn reasoning
- No changes to tool execution flow or channel routing