### PR TITLE
fix(web): use self.api_key instead of undefined api_key

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -80,7 +80,7 @@ class WebSearchTool(Tool):
                 r = await client.get(
                     "https://api.search.brave.com/res/v1/web/search",
                     params={"q": query, "count": n},
-                    headers={"Accept": "application/json", "X-Subscription-Token": api_key},
+                    headers={"Accept": "application/json", "X-Subscription-Token": self.api_key},
                     timeout=10.0
                 )
                 r.raise_for_status()


### PR DESCRIPTION
## Summary

- In `WebSearchTool.execute`, the `X-Subscription-Token` header was referencing `api_key` (a bare name that doesn't exist in the local scope) instead of `self.api_key` (the property that resolves the key from config or environment).
- This caused a `NameError: name 'api_key' is not defined` whenever `web_search` was invoked, even when the API key was properly configured.

## Fix

```python
# Before
headers={"Accept": "application/json", "X-Subscription-Token": api_key},

# After
headers={"Accept": "application/json", "X-Subscription-Token": self.api_key},
```

Made with [Cursor](https://cursor.com)