### PR TITLE
feat(agent): stabilize KV cache via strict half-window batch rollover

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -42,6 +42,9 @@ class AgentLoop:
     4. Executes tool calls
     5. Sends responses back
     """
+    _PROMPT_BASE_INDEX_KEY = "prompt_rollover_base_index"
+    _PROMPT_ROLLOVER_HARD_RATIO = 1.4
+    _PROMPT_ROLLOVER_MIN_HEADROOM = 10
 
     def __init__(
         self,
@@ -327,6 +330,71 @@ class AgentLoop:
         if not lock.locked():
             self._consolidation_locks.pop(session_key, None)
 
+    def _get_prompt_rollover_limits(self) -> tuple[int, int]:
+        """Return (soft_limit, hard_limit) for prompt history without new config knobs."""
+        soft_limit = max(1, self.memory_window)
+        hard_limit = max(
+            soft_limit + self._PROMPT_ROLLOVER_MIN_HEADROOM,
+            int(soft_limit * self._PROMPT_ROLLOVER_HARD_RATIO),
+        )
+        return soft_limit, hard_limit
+
+    def _get_prompt_base_index(self, session: Session) -> int:
+        raw_base = session.metadata.get(self._PROMPT_BASE_INDEX_KEY, session.last_consolidated)
+        try:
+            base = int(raw_base)
+        except (TypeError, ValueError):
+            base = session.last_consolidated
+        base = max(0, session.last_consolidated, base)
+        return min(base, len(session.messages))
+
+    def _maybe_rollover_prompt_history(self, session: Session) -> None:
+        """
+        Batch-roll prompt history by index only (no summary injection).
+
+        This keeps a stable prefix between rollovers and avoids per-turn
+        sliding-window churn once history grows beyond the hard limit.
+        """
+        soft_limit, hard_limit = self._get_prompt_rollover_limits()
+        start_index = self._get_prompt_base_index(session)
+        available = len(session.messages) - start_index
+        if available <= hard_limit:
+            return
+
+        new_base = max(start_index, len(session.messages) - soft_limit)
+        if new_base == start_index:
+            return
+
+        session.metadata[self._PROMPT_BASE_INDEX_KEY] = new_base
+        logger.info(
+            "Prompt rollover: session={} start={} new_base={} kept={}",
+            session.key,
+            start_index,
+            new_base,
+            len(session.messages) - new_base,
+        )
+
+    def _build_prompt_history(self, session: Session) -> list[dict[str, Any]]:
+        start_index = self._get_prompt_base_index(session)
+        sliced = session.messages[start_index:]
+
+        # Avoid starting from orphaned tool/result entries.
+        for i, msg in enumerate(sliced):
+            if msg.get("role") == "user":
+                sliced = sliced[i:]
+                break
+        else:
+            sliced = []
+
+        history: list[dict[str, Any]] = []
+        for msg in sliced:
+            entry: dict[str, Any] = {"role": msg["role"], "content": msg.get("content", "")}
+            for key in ("tool_calls", "tool_call_id", "name"):
+                if key in msg:
+                    entry[key] = msg[key]
+            history.append(entry)
+        return history
+
     async def _process_message(
         self,
         msg: InboundMessage,
@@ -341,8 +409,9 @@ class AgentLoop:
             logger.info("Processing system message from {}", msg.sender_id)
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
+            self._maybe_rollover_prompt_history(session)
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
-            history = session.get_history(max_messages=self.memory_window)
+            history = self._build_prompt_history(session)
             messages = self.context.build_messages(
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
@@ -386,6 +455,7 @@ class AgentLoop:
                 self._prune_consolidation_lock(session.key, lock)
 
             session.clear()
+            session.metadata.pop(self._PROMPT_BASE_INDEX_KEY, None)
             self.sessions.save(session)
             self.sessions.invalidate(session.key)
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
@@ -413,12 +483,13 @@ class AgentLoop:
             _task = asyncio.create_task(_consolidate_and_unlock())
             self._consolidation_tasks.add(_task)
 
+        self._maybe_rollover_prompt_history(session)
         self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()
 
-        history = session.get_history(max_messages=self.memory_window)
+        history = self._build_prompt_history(session)
         initial_messages = self.context.build_messages(
             history=history,
             current_message=msg.content,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -343,6 +343,32 @@ class AgentLoop:
         base = max(0, session.last_consolidated, base)
         return min(base, len(session.messages))
 
+    def _align_prompt_base_to_user_turn(
+        self,
+        session: Session,
+        start_index: int,
+        candidate_base: int,
+    ) -> int:
+        """
+        Align a rollover base index to a user-turn boundary.
+
+        Prefer a user message at/after candidate_base to keep the recent range.
+        If none exists, fall back to the closest user message before candidate_base.
+        """
+        messages = session.messages
+        end = len(messages)
+        base = max(start_index, min(candidate_base, end))
+
+        for idx in range(base, end):
+            if messages[idx].get("role") == "user":
+                return idx
+
+        for idx in range(base - 1, start_index - 1, -1):
+            if messages[idx].get("role") == "user":
+                return idx
+
+        return start_index
+
     def _maybe_rollover_prompt_history(self, session: Session) -> None:
         """
         Batch-roll prompt history by index only (no summary injection).
@@ -356,7 +382,12 @@ class AgentLoop:
         if available <= hard_limit:
             return
 
-        new_base = max(start_index, len(session.messages) - soft_limit)
+        candidate_base = max(start_index, len(session.messages) - soft_limit)
+        new_base = self._align_prompt_base_to_user_turn(
+            session=session,
+            start_index=start_index,
+            candidate_base=candidate_base,
+        )
         if new_base == start_index:
             return
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -348,26 +348,29 @@ class AgentLoop:
         session: Session,
         start_index: int,
         candidate_base: int,
+        hard_limit: int,
     ) -> int:
         """
         Align a rollover base index to a user-turn boundary.
 
         Prefer a user message at/after candidate_base to keep the recent range.
-        If none exists, fall back to the closest user message before candidate_base.
+        If none exists, fall back to the closest prior user inside the hard window.
+        If still none exists, keep candidate_base to preserve strict window bounds.
         """
         messages = session.messages
         end = len(messages)
         base = max(start_index, min(candidate_base, end))
+        hard_window_start = max(start_index, end - hard_limit)
 
         for idx in range(base, end):
             if messages[idx].get("role") == "user":
                 return idx
 
-        for idx in range(base - 1, start_index - 1, -1):
+        for idx in range(base - 1, hard_window_start - 1, -1):
             if messages[idx].get("role") == "user":
                 return idx
 
-        return start_index
+        return base
 
     def _maybe_rollover_prompt_history(self, session: Session) -> None:
         """
@@ -387,6 +390,7 @@ class AgentLoop:
             session=session,
             start_index=start_index,
             candidate_base=candidate_base,
+            hard_limit=hard_limit,
         )
         if new_base == start_index:
             return
@@ -404,13 +408,18 @@ class AgentLoop:
         start_index = self._get_prompt_base_index(session)
         sliced = session.messages[start_index:]
 
-        # Avoid starting from orphaned tool/result entries.
+        # Prefer starting at a user turn; if unavailable, fall back to assistant.
         for i, msg in enumerate(sliced):
             if msg.get("role") == "user":
                 sliced = sliced[i:]
                 break
         else:
-            sliced = []
+            for i, msg in enumerate(sliced):
+                if msg.get("role") == "assistant":
+                    sliced = sliced[i:]
+                    break
+            else:
+                sliced = []
 
         history: list[dict[str, Any]] = []
         for msg in sliced:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -43,8 +43,6 @@ class AgentLoop:
     5. Sends responses back
     """
     _PROMPT_BASE_INDEX_KEY = "prompt_rollover_base_index"
-    _PROMPT_ROLLOVER_HARD_RATIO = 1.4
-    _PROMPT_ROLLOVER_MIN_HEADROOM = 10
 
     def __init__(
         self,
@@ -331,12 +329,9 @@ class AgentLoop:
             self._consolidation_locks.pop(session_key, None)
 
     def _get_prompt_rollover_limits(self) -> tuple[int, int]:
-        """Return (soft_limit, hard_limit) for prompt history without new config knobs."""
-        soft_limit = max(1, self.memory_window)
-        hard_limit = max(
-            soft_limit + self._PROMPT_ROLLOVER_MIN_HEADROOM,
-            int(soft_limit * self._PROMPT_ROLLOVER_HARD_RATIO),
-        )
+        """Return strict half-window rollover limits for prompt history."""
+        hard_limit = max(1, self.memory_window)
+        soft_limit = max(1, hard_limit // 2)
         return soft_limit, hard_limit
 
     def _get_prompt_base_index(self, session: Session) -> int:

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from datetime import datetime as real_datetime
 from pathlib import Path
 import datetime as datetime_module
+from unittest.mock import MagicMock
 
 from nanobot.agent.context import ContextBuilder
+from nanobot.agent.loop import AgentLoop
+from nanobot.session.manager import Session
 
 
 class _FakeDatetime(real_datetime):
@@ -64,3 +67,59 @@ def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
 
     assert messages[-1]["role"] == "user"
     assert messages[-1]["content"] == "Return exactly: OK"
+
+
+class _DummyBus:
+    async def publish_outbound(self, _message):
+        return None
+
+
+def _make_loop(tmp_path: Path, memory_window: int = 100) -> AgentLoop:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "anthropic/claude-sonnet-4-5"
+    return AgentLoop(
+        bus=_DummyBus(),
+        provider=provider,
+        workspace=_make_workspace(tmp_path),
+        memory_window=memory_window,
+    )
+
+
+def _make_session(message_count: int) -> Session:
+    session = Session(key="cli:direct")
+    for i in range(message_count):
+        role = "user" if i % 2 == 0 else "assistant"
+        session.add_message(role, f"{role}-{i}")
+    return session
+
+
+def test_rollover_batches_old_prefix_without_summary(tmp_path: Path) -> None:
+    loop = _make_loop(tmp_path, memory_window=100)
+    session = _make_session(150)
+
+    loop._maybe_rollover_prompt_history(session)
+
+    assert session.metadata["prompt_rollover_base_index"] == 50
+
+    history = loop._build_prompt_history(session)
+    assert len(history) == 100
+    assert history[0]["content"] == "user-50"
+
+
+def test_rollover_does_not_slide_every_turn_before_hard_limit(tmp_path: Path) -> None:
+    loop = _make_loop(tmp_path, memory_window=100)
+    session = _make_session(150)
+
+    loop._maybe_rollover_prompt_history(session)
+
+    for i in range(150, 160):
+        role = "user" if i % 2 == 0 else "assistant"
+        session.add_message(role, f"{role}-{i}")
+
+    loop._maybe_rollover_prompt_history(session)
+
+    assert session.metadata["prompt_rollover_base_index"] == 50
+
+    history = loop._build_prompt_history(session)
+    assert history[0]["content"] == "user-50"
+    assert len(history) == 110

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -143,3 +143,25 @@ def test_rollover_keeps_user_turn_when_tail_has_no_user(tmp_path: Path) -> None:
     history = loop._build_prompt_history(session)
     assert history
     assert history[0]["role"] == "user"
+    assert len(history) <= loop.memory_window
+
+
+def test_rollover_keeps_hard_limit_when_no_user_exists_in_hard_window(tmp_path: Path) -> None:
+    """When no user exists in the hard window, keep bounded assistant/tool tail."""
+    loop = _make_loop(tmp_path, memory_window=100)
+    session = Session(key="cli:direct")
+
+    for i in range(60):
+        role = "user" if i % 2 == 0 else "assistant"
+        session.add_message(role, f"{role}-{i}")
+
+    for i in range(60, 200):
+        role = "assistant" if i % 2 == 0 else "tool"
+        session.add_message(role, f"{role}-{i}")
+
+    loop._maybe_rollover_prompt_history(session)
+
+    history = loop._build_prompt_history(session)
+    assert history
+    assert history[0]["role"] == "assistant"
+    assert len(history) <= loop.memory_window

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -123,3 +123,23 @@ def test_rollover_does_not_slide_every_turn_before_hard_limit(tmp_path: Path) ->
     history = loop._build_prompt_history(session)
     assert history[0]["content"] == "user-100"
     assert len(history) == 60
+
+
+def test_rollover_keeps_user_turn_when_tail_has_no_user(tmp_path: Path) -> None:
+    """Tool-heavy tails should not cause rollover history to become empty."""
+    loop = _make_loop(tmp_path, memory_window=100)
+    session = Session(key="cli:direct")
+
+    for i in range(40):
+        role = "user" if i % 2 == 0 else "assistant"
+        session.add_message(role, f"{role}-{i}")
+
+    for i in range(40, 130):
+        role = "assistant" if i % 2 == 0 else "tool"
+        session.add_message(role, f"{role}-{i}")
+
+    loop._maybe_rollover_prompt_history(session)
+
+    history = loop._build_prompt_history(session)
+    assert history
+    assert history[0]["role"] == "user"

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -99,11 +99,11 @@ def test_rollover_batches_old_prefix_without_summary(tmp_path: Path) -> None:
 
     loop._maybe_rollover_prompt_history(session)
 
-    assert session.metadata["prompt_rollover_base_index"] == 50
+    assert session.metadata["prompt_rollover_base_index"] == 100
 
     history = loop._build_prompt_history(session)
-    assert len(history) == 100
-    assert history[0]["content"] == "user-50"
+    assert len(history) == 50
+    assert history[0]["content"] == "user-100"
 
 
 def test_rollover_does_not_slide_every_turn_before_hard_limit(tmp_path: Path) -> None:
@@ -118,8 +118,8 @@ def test_rollover_does_not_slide_every_turn_before_hard_limit(tmp_path: Path) ->
 
     loop._maybe_rollover_prompt_history(session)
 
-    assert session.metadata["prompt_rollover_base_index"] == 50
+    assert session.metadata["prompt_rollover_base_index"] == 100
 
     history = loop._build_prompt_history(session)
-    assert history[0]["content"] == "user-50"
-    assert len(history) == 110
+    assert history[0]["content"] == "user-100"
+    assert len(history) == 60


### PR DESCRIPTION
## Summary

This PR proposes an alternative to summary-in-prompt compaction:
**batch prompt rollover with strict half-window semantics, without summary injection**.

The goal is to improve KV cache reuse by reducing per-turn prefix churn, while keeping implementation scope minimal.

## Experimental Results (OpenRouter `gpt-4.1-mini`)

This is the key reason for this PR.

A/B setup:
- A: `origin/main`
- B: this PR branch (`draft/batch-rollover-no-summary-v1`)
- same scripted session: 40 turns, `memory_window=50`, `temperature=0`
- model: OpenRouter `openai/gpt-4.1-mini`
- anti-bias: two paired runs with order swap (A→B and B→A)

Paired average results:

| Metric | Main | This PR | Change |
| --- | ---: | ---: | ---: |
| `cached_ratio` | 42.4% | 66.7% | **+24.3 pp** |
| `warm_cached_ratio` | 36.2% | 65.8% | **+29.6 pp** |
| `sum_cost_total` | 0.02665 | 0.01826 | **-31.5%** |
| `warm_sum_cost_total` | 0.02062 | 0.01302 | **-36.9%** |
| `avg_lcp_share_prev` | 0.735 | 0.922 | **+18.7 pp** |

Window-sliding phase only (`turn >= 26`):
- `cached_ratio`: 15.2% -> 61.8% (**+46.6 pp**)
- `cost_total`: **-48.4%**
- `avg_lcp_share_prev`: **+52.2 pp**


### Cost attribution (why the savings are mostly from cache)

Prompt-volume reduction exists, but it is not the dominant factor.
From paired totals:

- `sum_prompt_tokens`: `192,620 -> 178,892` (**-7.1%**)
- `sum_cached_tokens`: `81,664 -> 119,296` (**+46.1%**)
- `cached_ratio`: `42.4% -> 66.7%` (**+24.3 pp**)

Interpretation:
- Only reducing prompt size cannot explain the full cost drop.
- The larger driver is converting uncached prompt tokens into cached prompt tokens.
- This is also consistent with sliding-phase behavior (`turn >= 26`), where cache ratio improves from `15.2%` to `61.8%` and cost drops by `48.4%`.

## Problem

When the history window is full, per-turn sliding changes the history block every turn.
So adjacent requests share less prefix and cache reuse drops.

```mermaid
flowchart TB
  subgraph BEFORE[Before per turn sliding]
    direction TB

    subgraph R1[Round t]
      direction TB
      S1[System]
      subgraph H1[History slots]
        direction LR
        H1A[slot1 H1] --> H1B[slot2 H2] --> H1C[slot3 H3] --> H1D[slot4 H4]
      end
      U1[Current user t]
      S1 --> H1A
      H1D --> U1
    end

    subgraph R2[Round t next]
      direction TB
      S2[System]
      subgraph H2[History slots]
        direction LR
        H2A[slot1 H2] --> H2B[slot2 H3] --> H2C[slot3 H4] --> H2D[slot4 H5]
      end
      U2[Current user t next]
      S2 --> H2A
      H2D --> U2
    end

    DROP[H1 dropped]
    ADD[H5 appended]
    H1A -. drop .-> DROP
    H2D -. add .-> ADD
  end
```

In this shape, `System` is stable, but history slots shift every turn.

## What this PR changes

### 1) Normal rounds between boundaries

Keep one stable history block for multiple rounds.

```mermaid
flowchart TB
  subgraph NORMAL[Normal rounds]
    direction TB

    subgraph N1[Round t]
      direction TB
      NS1[System]
      subgraph NH1[History slots]
        direction LR
        NH1A[slot1 H21] --> NH1B[slot2 H22] --> NH1C[slot3 H23] --> NH1D[slot4 H24]
      end
      NU1[Current user t]
      NS1 --> NH1A
      NH1D --> NU1
    end

    subgraph N2[Round t next]
      direction TB
      NS2[System]
      subgraph NH2[History slots]
        direction LR
        NH2A[slot1 H21] --> NH2B[slot2 H22] --> NH2C[slot3 H23] --> NH2D[slot4 H24]
      end
      NU2[Current user t next]
      NS2 --> NH2A
      NH2D --> NU2
    end
  end
```

### 2) Rollover boundary round

Move base index once, keep only the last half-window as the new stable block.

```mermaid
flowchart TB
  subgraph BOUNDARY[Rollover boundary]
    direction TB

    subgraph B1[Before boundary]
      direction TB
      BS1[System]
      subgraph BH1[History slots]
        direction LR
        BH1A[slot1 H21] --> BH1B[slot2 H22] --> BH1C[slot3 H23] --> BH1D[slot4 H24]
      end
      BU1[Current user]
      BS1 --> BH1A
      BH1D --> BU1
    end

    subgraph B2[After boundary keep last half]
      direction TB
      BS2[System]
      subgraph BH2[History slots]
        direction LR
        BH2A[slot1 H23] --> BH2B[slot2 H24]
      end
      BU2[Current user next]
      BS2 --> BH2A
      BH2B --> BU2
    end
  end
```

## Behavior

- Maintain `prompt_rollover_base_index` in session metadata.
- Build prompt history from this stable base index.
- Use strict half-window thresholds:
  - `hard_limit = memory_window`
  - `soft_limit = memory_window // 2`
- When history from base exceeds hard limit, advance base to keep only the last soft limit.
- Clear rollover base index on `/new`.

## Why this scope

- No summary generation or injection.
- No new config knobs.
- No provider-specific logic.

This keeps the change low-risk and easy to review while directly targeting cache-prefix stability.

## Trade-offs

- At rollover boundaries, older context is dropped in one batch.
- Long-term retention still relies on existing memory consolidation (`MEMORY.md` / `HISTORY.md`).

## Tests

Added or updated in `tests/test_context_prompt_cache.py`:

- `test_rollover_batches_old_prefix_without_summary`
- `test_rollover_does_not_slide_every_turn_before_hard_limit`
