### PR TITLE
feat: add async event injection mechanism for user interruption

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -86,13 +86,18 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
     @staticmethod
     def _get_event_handling_directive() -> str:
         """Get the event handling directive for system prompt."""
-        return """## Event Handling
+        return """## Follow-up Questions
 
-If you receive a <SYS_EVENT> message during tool execution:
-1. IMMEDIATELY acknowledge the event
-2. The event content ALWAYS takes priority over your current task
-3. Respond naturally to the event
-4. Decide whether to continue your previous task or switch to the new request
+If you see a user message starting with "[User followed up]:":
+1. This means the user sent an additional message while you were still processing their previous request
+2. Treat it as a natural conversation continuation
+3. Respond to ALL the user's questions/requests from this conversation, not just the follow-up
+4. If you already started answering the previous question, acknowledge that and then address the follow-up
+
+Example:
+- User asked: "What's your name?"
+- User followed up: "What time is it?"
+- You should answer: "I'm nanobot, an AI assistant. It's currently [time], and I'm here to help you with both questions!"
 """
 
     @staticmethod

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -88,16 +88,18 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         """Get the event handling directive for system prompt."""
         return """## Follow-up Questions
 
-If you see a user message starting with "[User followed up]:":
-1. This means the user sent an additional message while you were still processing their previous request
-2. Treat it as a natural conversation continuation
-3. Respond to ALL the user's questions/requests from this conversation, not just the follow-up
-4. If you already started answering the previous question, acknowledge that and then address the follow-up
+Sometimes users may send additional messages before you finish responding. These will be appended to their previous message with a "[Follow-up]:" marker.
+
+When you see a user message containing "[Follow-up]:":
+1. Understand that the user sent multiple messages in quick succession
+2. Address ALL parts of their message - both the original question and the follow-up
+3. Treat it as a natural multi-part question, not separate conversations
 
 Example:
-- User asked: "What's your name?"
-- User followed up: "What time is it?"
-- You should answer: "I'm nanobot, an AI assistant. It's currently [time], and I'm here to help you with both questions!"
+- User's message appears as: "What's your name?\n\n[Follow-up]: What time is it?"
+- You should answer: "I'm nanobot, an AI assistant. It's currently [time]. How can I help you today?"
+
+This ensures users feel heard even when they send multiple messages quickly.
 """
 
     @staticmethod

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -22,10 +22,13 @@ class ContextBuilder:
         self.workspace = workspace
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
-
-    def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
+    
+    def build_system_prompt(self, skill_names: list[str] | None = None, enable_event_handling: bool = False) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
         parts = [self._get_identity()]
+
+        if enable_event_handling:
+            parts.append(self._get_event_handling_directive())
 
         bootstrap = self._load_bootstrap_files()
         if bootstrap:
@@ -81,6 +84,18 @@ Your workspace is at: {workspace_path}
 Reply directly with text for conversations. Only use the 'message' tool to send to a specific chat channel."""
 
     @staticmethod
+    def _get_event_handling_directive() -> str:
+        """Get the event handling directive for system prompt."""
+        return """## Event Handling
+
+If you receive a <SYS_EVENT> message during tool execution:
+1. IMMEDIATELY acknowledge the event
+2. The event content ALWAYS takes priority over your current task
+3. Respond naturally to the event
+4. Decide whether to continue your previous task or switch to the new request
+"""
+
+    @staticmethod
     def _build_runtime_context(channel: str | None, chat_id: str | None) -> str:
         """Build untrusted runtime metadata block for injection before the user message."""
         now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
@@ -110,6 +125,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         media: list[str] | None = None,
         channel: str | None = None,
         chat_id: str | None = None,
+        enable_event_handling: bool = False,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
         runtime_ctx = self._build_runtime_context(channel, chat_id)
@@ -123,7 +139,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
 
         return [
-            {"role": "system", "content": self.build_system_prompt(skill_names)},
+            {"role": "system", "content": self.build_system_prompt(skill_names, enable_event_handling=enable_event_handling)},
             *history,
             {"role": "user", "content": merged},
         ]

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -198,12 +198,23 @@ class AgentLoop:
                 return False
             event = await self.bus.check_events(session_key)
             if event:
-                # Inject as user message (follow-up question), not system event
-                # This ensures LLM treats it as a natural conversation continuation
-                messages.append({
-                    "role": "user",
-                    "content": f"[User followed up]: {event}"
-                })
+                # Append to the last user message instead of creating a new one
+                # This avoids consecutive user messages which confuse LLM
+                last_user_idx = None
+                for i in range(len(messages) - 1, -1, -1):
+                    if messages[i].get("role") == "user":
+                        last_user_idx = i
+                        break
+                
+                if last_user_idx is not None:
+                    # Append to existing user message
+                    messages[last_user_idx]["content"] += f"\n\n[Follow-up]: {event}"
+                else:
+                    # Fallback: create new user message (shouldn't happen in normal flow)
+                    messages.append({
+                        "role": "user",
+                        "content": f"[Follow-up]: {event}"
+                    })
                 return True
             return False
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -244,11 +244,11 @@ class AgentLoop:
                     thinking_blocks=response.thinking_blocks,
                 )
 
-                # Execute each tool, checking for events before each one
+                # Execute each tool, checking for events before and after each one
                 for i, tool_call in enumerate(response.tool_calls):
                     if await inject_event():
                         # Event received: cancel this and all remaining tools
-                        logger.info("Event received during tool execution, cancelling remaining tools")
+                        logger.info("Event received before tool execution, cancelling current and remaining tools")
                         for tc in response.tool_calls[i:]:
                             messages.append({
                                 "role": "tool",
@@ -265,6 +265,18 @@ class AgentLoop:
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
+
+                    if await inject_event():
+                        # Event received: cancel all remaining tools
+                        logger.info("Event received after tool execution, cancelling remaining tools (current tool completed)")
+                        for tc in response.tool_calls[i+1:]:
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": tc.id,
+                                "name": tc.name,
+                                "content": "CANCELLED: User interrupted"
+                            })
+                        break
             else:
                 clean = self._strip_think(response.content)
                 # Don't persist error responses to session history — they can

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -190,6 +190,10 @@ class AgentLoop:
         messages = initial_messages
         iteration = 0
         final_content = None
+        
+        # Track the index of the current request's user message
+        # This ensures follow-up events are appended to the correct message, not historical ones
+        current_user_msg_idx = len(messages) - 1 if messages and messages[-1].get("role") == "user" else None
         tools_used: list[str] = []
 
         async def inject_event() -> bool:
@@ -198,19 +202,26 @@ class AgentLoop:
                 return False
             event = await self.bus.check_events(session_key)
             if event:
-                # Append to the last user message instead of creating a new one
-                # This avoids consecutive user messages which confuse LLM
-                last_user_idx = None
-                for i in range(len(messages) - 1, -1, -1):
-                    if messages[i].get("role") == "user":
-                        last_user_idx = i
-                        break
+                # Prefer the current request's user message if available
+                target_idx = current_user_msg_idx
                 
-                if last_user_idx is not None:
+                # Fallback: find last user message in history (shouldn't happen in normal flow)
+                if target_idx is None:
+                    for i in range(len(messages) - 1, -1, -1):
+                        if messages[i].get("role") == "user":
+                            target_idx = i
+                            break
+                
+                if target_idx is not None:
                     # Append to existing user message
-                    messages[last_user_idx]["content"] += f"\n\n[Follow-up]: {event}"
+                    original_content = messages[target_idx]["content"]
+                    original_preview = original_content[:50] + "..." if len(original_content) > 50 else original_content
+                    messages[target_idx]["content"] += f"\n\n[Follow-up]: {event}"
+                    logger.info("Appended follow-up to user message {}: \"{}\" + \"[Follow-up]: {}\"", 
+                               target_idx, original_preview, event[:50])
                 else:
                     # Fallback: create new user message (shouldn't happen in normal flow)
+                    logger.warning("No user message found in history, creating new message for follow-up: {}", event[:50])
                     messages.append({
                         "role": "user",
                         "content": f"[Follow-up]: {event}"
@@ -301,18 +312,18 @@ class AgentLoop:
                     logger.error("LLM returned error: {}", (clean or "")[:200])
                     final_content = clean or "Sorry, I encountered an error calling the AI model."
                     break
+
+                # Check for events BEFORE adding assistant message to history
+                # If user sent follow-up while LLM was generating, append it and re-generate
+                # This prevents creating two separate assistant responses
+                if await inject_event():
+                    continue
+
                 messages = self.context.add_assistant_message(
                     messages, clean, reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
                 )
                 final_content = clean
-
-                # Check for events before returning final response
-                # If user interrupted while LLM was generating response,
-                # combine both in the next iteration (like humans do)
-                if await inject_event():
-                    continue
-
                 break
 
         if final_content is None and iteration >= self.max_iterations:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -198,9 +198,11 @@ class AgentLoop:
                 return False
             event = await self.bus.check_events(session_key)
             if event:
+                # Inject as user message (follow-up question), not system event
+                # This ensures LLM treats it as a natural conversation continuation
                 messages.append({
-                    "role": "system",
-                    "content": f"<SYS_EVENT type=\"user_interrupt\">{event}</SYS_EVENT>"
+                    "role": "user",
+                    "content": f"[User followed up]: {event}"
                 })
                 return True
             return False

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -205,10 +205,46 @@ class AgentLoop:
                 return True
             return False
 
+        def cancel_remaining_tools(start_idx: int, current_cancelled: bool) -> None:
+            """Cancel remaining tools by adding CANCELLED messages."""
+            reason = "before tool execution" if current_cancelled else "after tool execution (current tool completed)"
+            logger.info(f"Event received {reason}, cancelling {'current and ' if current_cancelled else ''}remaining tools")
+
+            for tc in response.tool_calls[start_idx:]:
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "name": tc.name,
+                    "content": "CANCELLED: User interrupted"
+                })
+
+        async def execute_tool_calls() -> bool:
+            """Execute tool calls with event checking. Returns True if should break."""
+            nonlocal messages
+            for i, tool_call in enumerate(response.tool_calls):
+                # Check before tool execution
+                if await inject_event():
+                    cancel_remaining_tools(i, current_cancelled=True)
+                    return True
+
+                # Execute tool
+                tools_used.append(tool_call.name)
+                args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
+                logger.info("Tool call: {}({})", tool_call.name, args_str[:200])
+                result = await self.tools.execute(tool_call.name, tool_call.arguments)
+                messages = self.context.add_tool_result(
+                    messages, tool_call.id, tool_call.name, result
+                )
+
+                # Check after tool execution
+                if await inject_event():
+                    cancel_remaining_tools(i + 1, current_cancelled=False)
+                    return True
+
+            return False
+
         while iteration < self.max_iterations:
             iteration += 1
-
-            # Check for user events before LLM call
             await inject_event()
 
             response = await self.provider.chat(
@@ -244,43 +280,10 @@ class AgentLoop:
                     thinking_blocks=response.thinking_blocks,
                 )
 
-                # Execute each tool, checking for events before and after each one
-                for i, tool_call in enumerate(response.tool_calls):
-                    if await inject_event():
-                        # Event received: cancel this and all remaining tools
-                        logger.info("Event received before tool execution, cancelling current and remaining tools")
-                        for tc in response.tool_calls[i:]:
-                            messages.append({
-                                "role": "tool",
-                                "tool_call_id": tc.id,
-                                "name": tc.name,
-                                "content": "CANCELLED: User interrupted"
-                            })
-                        break
-
-                    tools_used.append(tool_call.name)
-                    args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
-                    logger.info("Tool call: {}({})", tool_call.name, args_str[:200])
-                    result = await self.tools.execute(tool_call.name, tool_call.arguments)
-                    messages = self.context.add_tool_result(
-                        messages, tool_call.id, tool_call.name, result
-                    )
-
-                    if await inject_event():
-                        # Event received: cancel all remaining tools
-                        logger.info("Event received after tool execution, cancelling remaining tools (current tool completed)")
-                        for tc in response.tool_calls[i+1:]:
-                            messages.append({
-                                "role": "tool",
-                                "tool_call_id": tc.id,
-                                "name": tc.name,
-                                "content": "CANCELLED: User interrupted"
-                            })
-                        break
+                if await execute_tool_calls():
+                    continue
             else:
                 clean = self._strip_think(response.content)
-                # Don't persist error responses to session history — they can
-                # poison the context and cause permanent 400 loops (#1303).
                 if response.finish_reason == "error":
                     logger.error("LLM returned error: {}", (clean or "")[:200])
                     final_content = clean or "Sorry, I encountered an error calling the AI model."
@@ -290,6 +293,13 @@ class AgentLoop:
                     thinking_blocks=response.thinking_blocks,
                 )
                 final_content = clean
+
+                # Check for events before returning final response
+                # If user interrupted while LLM was generating response,
+                # combine both in the next iteration (like humans do)
+                if await inject_event():
+                    continue
+
                 break
 
         if final_content is None and iteration >= self.max_iterations:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -65,6 +65,7 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        enable_event_handling: bool = False,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -82,6 +83,7 @@ class AgentLoop:
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
+        self.enable_event_handling = enable_event_handling
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
@@ -108,7 +110,8 @@ class AgentLoop:
         self._consolidating: set[str] = set()  # Session keys with consolidation in progress
         self._consolidation_tasks: set[asyncio.Task] = set()  # Strong refs to in-flight tasks
         self._consolidation_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
-        self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
+        self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks (all scheduled tasks)
+        self._processing_tasks: set[str] = set()  # Session keys currently being processed
         self._processing_lock = asyncio.Lock()
         self._register_default_tools()
 
@@ -181,6 +184,7 @@ class AgentLoop:
         self,
         initial_messages: list[dict],
         on_progress: Callable[..., Awaitable[None]] | None = None,
+        session_key: str | None = None,
     ) -> tuple[str | None, list[str], list[dict]]:
         """Run the agent iteration loop. Returns (final_content, tools_used, messages)."""
         messages = initial_messages
@@ -188,8 +192,24 @@ class AgentLoop:
         final_content = None
         tools_used: list[str] = []
 
+        async def inject_event() -> bool:
+            """Check for and inject pending events. Returns True if event was found."""
+            if not session_key:
+                return False
+            event = await self.bus.check_events(session_key)
+            if event:
+                messages.append({
+                    "role": "system",
+                    "content": f"<SYS_EVENT type=\"user_interrupt\">{event}</SYS_EVENT>"
+                })
+                return True
+            return False
+
         while iteration < self.max_iterations:
             iteration += 1
+
+            # Check for user events before LLM call
+            await inject_event()
 
             response = await self.provider.chat(
                 messages=messages,
@@ -224,7 +244,20 @@ class AgentLoop:
                     thinking_blocks=response.thinking_blocks,
                 )
 
-                for tool_call in response.tool_calls:
+                # Execute each tool, checking for events before each one
+                for i, tool_call in enumerate(response.tool_calls):
+                    if await inject_event():
+                        # Event received: cancel this and all remaining tools
+                        logger.info("Event received during tool execution, cancelling remaining tools")
+                        for tc in response.tool_calls[i:]:
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": tc.id,
+                                "name": tc.name,
+                                "content": "CANCELLED: User interrupted"
+                            })
+                        break
+
                     tools_used.append(tool_call.name)
                     args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
                     logger.info("Tool call: {}({})", tool_call.name, args_str[:200])
@@ -271,9 +304,15 @@ class AgentLoop:
             if msg.content.strip().lower() == "/stop":
                 await self._handle_stop(msg)
             else:
+                # If a task is already processing this session, publish as interrupt event
+                if self.enable_event_handling and msg.session_key in self._processing_tasks:
+                    await self.bus.publish_event(msg.session_key, msg.content)
+                    logger.info("Published interrupt event for session {}", msg.session_key)
+                    continue  # In-flight task will handle the event, keep processing other messages
+
                 task = asyncio.create_task(self._dispatch(msg))
                 self._active_tasks.setdefault(msg.session_key, []).append(task)
-                task.add_done_callback(lambda t, k=msg.session_key: self._active_tasks.get(k, []) and self._active_tasks[k].remove(t) if t in self._active_tasks.get(k, []) else None)
+                task.add_done_callback(lambda t, k=msg.session_key: self._cleanup_task(k, t))
 
     async def _handle_stop(self, msg: InboundMessage) -> None:
         """Cancel all active tasks and subagents for the session."""
@@ -291,27 +330,41 @@ class AgentLoop:
             channel=msg.channel, chat_id=msg.chat_id, content=content,
         ))
 
+    def _cleanup_task(self, session_key: str, task: asyncio.Task) -> None:
+        """Remove a completed task from the active tasks tracking."""
+        tasks = self._active_tasks.get(session_key)
+        if tasks and task in tasks:
+            tasks.remove(task)
+            if not tasks:
+                del self._active_tasks[session_key]
+
     async def _dispatch(self, msg: InboundMessage) -> None:
         """Process a message under the global lock."""
-        async with self._processing_lock:
-            try:
-                response = await self._process_message(msg)
-                if response is not None:
-                    await self.bus.publish_outbound(response)
-                elif msg.channel == "cli":
+        # Mark this session as being processed
+        self._processing_tasks.add(msg.session_key)
+        try:
+            async with self._processing_lock:
+                try:
+                    response = await self._process_message(msg)
+                    if response is not None:
+                        await self.bus.publish_outbound(response)
+                    elif msg.channel == "cli":
+                        await self.bus.publish_outbound(OutboundMessage(
+                            channel=msg.channel, chat_id=msg.chat_id,
+                            content="", metadata=msg.metadata or {},
+                        ))
+                except asyncio.CancelledError:
+                    logger.info("Task cancelled for session {}", msg.session_key)
+                    raise
+                except Exception:
+                    logger.exception("Error processing message for session {}", msg.session_key)
                     await self.bus.publish_outbound(OutboundMessage(
                         channel=msg.channel, chat_id=msg.chat_id,
-                        content="", metadata=msg.metadata or {},
+                        content="Sorry, I encountered an error.",
                     ))
-            except asyncio.CancelledError:
-                logger.info("Task cancelled for session {}", msg.session_key)
-                raise
-            except Exception:
-                logger.exception("Error processing message for session {}", msg.session_key)
-                await self.bus.publish_outbound(OutboundMessage(
-                    channel=msg.channel, chat_id=msg.chat_id,
-                    content="Sorry, I encountered an error.",
-                ))
+        finally:
+            # Always remove from processing set when done
+            self._processing_tasks.discard(msg.session_key)
 
     async def close_mcp(self) -> None:
         """Close MCP connections."""
@@ -326,6 +379,18 @@ class AgentLoop:
         """Stop the agent loop."""
         self._running = False
         logger.info("Agent loop stopping")
+
+    def _get_consolidation_lock(self, session_key: str) -> asyncio.Lock:
+        lock = self._consolidation_locks.get(session_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._consolidation_locks[session_key] = lock
+        return lock
+
+    def _prune_consolidation_lock(self, session_key: str, lock: asyncio.Lock) -> None:
+        """Drop lock entry if no longer in use."""
+        if not lock.locked():
+            self._consolidation_locks.pop(session_key, None)
 
     async def _process_message(
         self,
@@ -346,8 +411,9 @@ class AgentLoop:
             messages = self.context.build_messages(
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
+                enable_event_handling=self.enable_event_handling,
             )
-            final_content, _, all_msgs = await self._run_agent_loop(messages)
+            final_content, _, all_msgs = await self._run_agent_loop(messages, session_key=key)
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
             return OutboundMessage(channel=channel, chat_id=chat_id,
@@ -422,6 +488,7 @@ class AgentLoop:
             current_message=msg.content,
             media=msg.media if msg.media else None,
             channel=msg.channel, chat_id=msg.chat_id,
+            enable_event_handling=self.enable_event_handling,
         )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
@@ -433,7 +500,7 @@ class AgentLoop:
             ))
 
         final_content, _, all_msgs = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
+            initial_messages, on_progress=on_progress or _bus_progress, session_key=key,
         )
 
         if final_content is None:

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -64,4 +64,8 @@ class MessageBus:
             except asyncio.QueueEmpty:
                 break
 
+        # Clean up empty queues to prevent memory leak
+        if queue.empty():
+            self._event_channels.pop(session_key, None)
+
         return "\n".join(f"- {e}" for e in events) if events else None

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -16,6 +16,7 @@ class MessageBus:
     def __init__(self):
         self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue()
         self.outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
+        self._event_channels: dict[str, asyncio.Queue[dict]] = {}
 
     async def publish_inbound(self, msg: InboundMessage) -> None:
         """Publish a message from a channel to the agent."""
@@ -42,3 +43,25 @@ class MessageBus:
     def outbound_size(self) -> int:
         """Number of pending outbound messages."""
         return self.outbound.qsize()
+
+    async def publish_event(self, session_key: str, content: str) -> None:
+        """Publish an event to a specific session's event channel."""
+        if session_key not in self._event_channels:
+            self._event_channels[session_key] = asyncio.Queue()
+        await self._event_channels[session_key].put(content)
+
+    async def check_events(self, session_key: str) -> str | None:
+        """Non-blocking check for accumulated events. Returns formatted string or None."""
+        queue = self._event_channels.get(session_key)
+        if not queue:
+            return None
+
+        # Drain all available events without blocking
+        events = []
+        while not queue.empty():
+            try:
+                events.append(queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+
+        return "\n".join(f"- {e}" for e in events) if events else None

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -291,6 +291,7 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        enable_event_handling=config.agents.defaults.enable_event_handling,
     )
 
     # Set cron callback (needs agent)
@@ -473,6 +474,7 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        enable_event_handling=config.agents.defaults.enable_event_handling,
     )
 
     # Show spinner when logs are off (no output to miss); skip when logs are on

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -227,6 +227,7 @@ class AgentDefaults(Base):
     temperature: float = 0.1
     max_tool_iterations: int = 40
     memory_window: int = 100
+    enable_event_handling: bool = False  # Enable async event injection for task interruption
     reasoning_effort: str | None = None  # low / medium / high — enables LLM thinking mode
 
 

--- a/tests/test_event_injection.py
+++ b/tests/test_event_injection.py
@@ -1,0 +1,394 @@
+"""Tests for async event injection mechanism."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_messagebus_event_channel_creation():
+    """Test that event channels are created on demand."""
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    session_key = "telegram:12345"
+
+    # Publish an event
+    await bus.publish_event(session_key, "User sent: stop")
+
+    # Event channel should exist
+    assert session_key in bus._event_channels
+
+    # Check event retrieval
+    event = await bus.check_events(session_key)
+    assert event == "- User sent: stop"
+
+    # Second check should return None (queue empty)
+    event2 = await bus.check_events(session_key)
+    assert event2 is None
+
+
+@pytest.mark.asyncio
+async def test_messagebus_event_accumulation():
+    """Test that multiple events are accumulated and returned together."""
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    session_key = "discord:67890"
+
+    await bus.publish_event(session_key, "First message")
+    await bus.publish_event(session_key, "Second message")
+    await bus.publish_event(session_key, "Third message")
+
+    events = await bus.check_events(session_key)
+    assert events == "- First message\n- Second message\n- Third message"
+
+    # Queue should be empty after retrieval
+    assert await bus.check_events(session_key) is None
+
+
+@pytest.mark.asyncio
+async def test_messagebus_non_blocking_check():
+    """Test that check_events doesn't block when no events."""
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    session_key = "test:key"
+
+    # Should return immediately with None
+    start = asyncio.get_event_loop().time()
+    event = await bus.check_events(session_key)
+    elapsed = asyncio.get_event_loop().time() - start
+
+    assert event is None
+    assert elapsed < 0.01  # Should be nearly instant
+
+
+def test_system_prompt_includes_event_handling():
+    """Test that system prompt includes event handling instructions when enabled."""
+    from unittest.mock import MagicMock, patch
+    from nanobot.agent.context import ContextBuilder
+
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with patch("nanobot.agent.context.MemoryStore"), \
+         patch("nanobot.agent.context.SkillsLoader"):
+        builder = ContextBuilder(workspace)
+
+    prompt = builder.build_system_prompt(enable_event_handling=True)
+
+    assert "Event Handling" in prompt
+    assert "<SYS_EVENT>" in prompt
+    assert "IMMEDIATELY acknowledge" in prompt
+    assert "ALWAYS takes priority" in prompt
+    assert "type=\"user_interrupt\"" not in prompt  # Directive uses generic tag
+
+
+def test_system_prompt_no_event_handling_by_default():
+    """Test that event handling is NOT included by default."""
+    from unittest.mock import MagicMock, patch
+    from nanobot.agent.context import ContextBuilder
+
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with patch("nanobot.agent.context.MemoryStore"), \
+         patch("nanobot.agent.context.SkillsLoader"):
+        builder = ContextBuilder(workspace)
+
+    prompt = builder.build_system_prompt()
+
+    # Should not contain event handling by default
+    assert "Event Handling" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_checks_events_before_llm():
+    """Test that agent loop checks for events before calling LLM."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    # Mock LLM response with no tool calls
+    mock_response = MagicMock()
+    mock_response.has_tool_calls = False
+    mock_response.content = "Hello"
+    provider.chat = AsyncMock(return_value=mock_response)
+
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    # Properly mock ContextBuilder and its instance
+    mock_ctx = MagicMock()
+    # add_assistant_message should modify and return the messages list
+    mock_ctx.add_assistant_message.side_effect = lambda msgs, c, tc=None, **kw: msgs + [{"role": "assistant", "content": c}]
+    MockCtx = MagicMock(return_value=mock_ctx)
+
+    with patch("nanobot.agent.loop.ContextBuilder", MockCtx), \
+         patch("nanobot.agent.loop.SessionManager"), \
+         patch("nanobot.agent.loop.SubagentManager"):
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+
+    # Publish an event before running loop
+    await bus.publish_event("test:key", "User interrupt")
+
+    # Run loop with event callback
+    final_content, _, messages = await loop._run_agent_loop(
+        initial_messages=[{"role": "user", "content": "test"}],
+        on_progress=None,
+        session_key="test:key",
+    )
+
+    # Event should have been injected as a system message with <SYS_EVENT> tag
+    assert any("<SYS_EVENT" in m.get("content", "") and "User interrupt" in m.get("content", "") for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_cancels_tools_on_event():
+    """Test that pending tool calls are cancelled when event arrives."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    # Mock LLM response with tool calls
+    mock_response = MagicMock()
+    mock_response.has_tool_calls = True
+    mock_response.content = "Let me search"
+    mock_response.reasoning_content = None
+    mock_tool = MagicMock()
+    mock_tool.id = "call_123"
+    mock_tool.name = "web_search"
+    mock_tool.arguments = {"query": "test"}
+    mock_response.tool_calls = [mock_tool]
+
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SessionManager"), \
+         patch("nanobot.agent.loop.SubagentManager"), \
+         patch("nanobot.agent.loop.ToolRegistry") as MockRegistry:
+        mock_registry = MagicMock()
+        mock_registry.get_definitions.return_value = []
+
+        # Mock tools.execute to track if it was called
+        mock_execute = AsyncMock(return_value="result")
+        mock_registry.execute = mock_execute
+        MockRegistry.return_value = mock_registry
+
+        # Create chat mock that publishes event during call
+        async def chat_with_event(*args, **kwargs):
+            # Publish event when LLM is called (simulating user interrupt)
+            await bus.publish_event("test:key", "Stop now")
+            return mock_response
+
+        provider.chat = AsyncMock(side_effect=chat_with_event)
+
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+
+    final_content, tools_used, messages = await loop._run_agent_loop(
+        initial_messages=[{"role": "user", "content": "test"}],
+        session_key="test:key",
+    )
+
+    # Tools should not be executed (event cancelled them)
+    assert tools_used == []
+    # execute should not have been called
+    mock_execute.assert_not_called()
+
+
+def test_event_handling_config_default():
+    """Test that event handling is disabled by default."""
+    from nanobot.config.schema import AgentDefaults
+
+    config = AgentDefaults()
+    assert config.enable_event_handling is False
+
+
+def test_event_handling_config_enabled():
+    """Test that event handling can be enabled via config."""
+    from nanobot.config.schema import AgentDefaults
+
+    config = AgentDefaults(enable_event_handling=True)
+    assert config.enable_event_handling is True
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_event_injection():
+    """Test complete flow: user message -> event -> LLM response."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.events import InboundMessage
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+
+    # Mock provider that simulates task interruption
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    # First call: LLM decides to use a tool
+    response1 = MagicMock()
+    response1.has_tool_calls = True
+    response1.content = "I'll search for that"
+    response1.reasoning_content = None
+    tool1 = MagicMock()
+    tool1.id = "call_1"
+    tool1.name = "web_search"
+    tool1.arguments = {"query": "python sorting"}
+    response1.tool_calls = [tool1]
+
+    # After event: LLM acknowledges and switches
+    response2 = MagicMock()
+    response2.has_tool_calls = False
+    response2.content = "I'll stop searching and help you with the stock price instead."
+    response2.reasoning_content = None
+
+    provider.chat = AsyncMock(side_effect=[response1, response2])
+
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with patch("nanobot.agent.loop.ContextBuilder") as MockCtx, \
+         patch("nanobot.agent.loop.SubagentManager"), \
+         patch("nanobot.agent.loop.ToolRegistry") as MockRegistry:
+        mock_ctx = MagicMock()
+        mock_ctx.build_messages.return_value = [
+            {"role": "system", "content": "You are nanobot"},
+            {"role": "user", "content": "Search for python sorting algorithms"}
+        ]
+        mock_ctx.add_assistant_message.side_effect = lambda msgs, c, tc=None, **kw: msgs + [{"role": "assistant", "content": c, "tool_calls": tc}]
+        mock_ctx.add_tool_result.side_effect = lambda msgs, tid, tn, res: msgs + [{"role": "tool", "tool_call_id": tid, "name": tn, "content": res}]
+        MockCtx.return_value = mock_ctx
+
+        mock_registry = MagicMock()
+        mock_registry.get_definitions.return_value = [
+            {"type": "function", "function": {"name": "web_search", "parameters": {}}}
+        ]
+        mock_registry.execute = AsyncMock(return_value="Search results...")
+        MockRegistry.return_value = mock_registry
+
+        # Mock session manager properly
+        mock_session = MagicMock()
+        mock_session.messages = []
+        mock_session.last_consolidated = 0
+        mock_session.key = "test:c1"
+        mock_session.get_history.return_value = []
+
+        mock_session_manager = MagicMock()
+        mock_session_manager.get_or_create.return_value = mock_session
+
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace,
+                        session_manager=mock_session_manager, enable_event_handling=True)
+
+    # Start processing a message
+    msg = InboundMessage(channel="test", sender_id="u1", chat_id="c1", content="Search for python sorting")
+
+    # In background, publish an interrupt event
+    async def interrupt_later():
+        await asyncio.sleep(0.01)  # Wait for loop to start
+        await bus.publish_event("test:c1", "Never mind, check AAPL stock price instead")
+
+    asyncio.create_task(interrupt_later())
+
+    # Process message
+    response = await loop._process_message(msg, session_key="test:c1")
+
+    # LLM should have acknowledged the event
+    assert response is not None
+    # The final response should mention the event (stock price)
+    # Note: Since provider.chat is mocked with side_effect, the final response
+    # comes from response2 which mentions "stock price"
+
+
+@pytest.mark.asyncio
+async def test_no_event_overhead():
+    """Test that event checking adds negligible overhead when no events."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    import time
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    mock_response = MagicMock()
+    mock_response.has_tool_calls = False
+    mock_response.content = "Response"
+    provider.chat = AsyncMock(return_value=mock_response)
+
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SessionManager"), \
+         patch("nanobot.agent.loop.SubagentManager"):
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+
+    start = time.perf_counter()
+    for _ in range(100):
+        await loop._run_agent_loop(
+            initial_messages=[{"role": "user", "content": "test"}],
+            session_key="test:key",
+        )
+    elapsed = time.perf_counter() - start
+
+    # 100 iterations should be fast (< 1 second)
+    assert elapsed < 1.0, f"Event checking overhead too high: {elapsed}s for 100 iterations"
+
+
+@pytest.mark.asyncio
+async def test_event_published_when_active_task_exists():
+    """Test that events are published when user sends message during task execution."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.chat = AsyncMock(return_value=MagicMock(
+        has_tool_calls=False,
+        content="Response"
+    ))
+
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SessionManager"), \
+         patch("nanobot.agent.loop.SubagentManager"):
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace, enable_event_handling=True)
+
+    # Simulate a message currently being processed (has acquired processing lock)
+    # This is the key difference: _processing_tasks tracks tasks actually executing
+    session_key = "test:channel"
+    loop._processing_tasks.add(session_key)
+
+    # Verify _processing_tasks correctly identifies processing state
+    assert session_key in loop._processing_tasks
+    assert "nonexistent" not in loop._processing_tasks
+
+    # Simulate the event publishing code from _process_message
+    if loop.enable_event_handling and session_key in loop._processing_tasks:
+        await bus.publish_event(session_key, "Interrupt message")
+
+    # Verify event was published
+    event = await bus.check_events(session_key)
+    assert event is not None
+    assert "Interrupt message" in event
+
+    # After processing completes, task is removed from _processing_tasks
+    loop._processing_tasks.discard(session_key)
+    assert session_key not in loop._processing_tasks

--- a/tests/test_event_injection.py
+++ b/tests/test_event_injection.py
@@ -80,9 +80,9 @@ def test_system_prompt_includes_event_handling():
     prompt = builder.build_system_prompt(enable_event_handling=True)
 
     assert "Follow-up Questions" in prompt
-    assert "[User followed up]:" in prompt
-    assert "natural conversation continuation" in prompt
-    assert "Respond to ALL" in prompt
+    assert "[Follow-up]:" in prompt
+    assert "natural multi-part question" in prompt
+    assert "Address ALL" in prompt
 
 
 def test_system_prompt_no_event_handling_by_default():
@@ -144,7 +144,7 @@ async def test_agent_loop_checks_events_before_llm():
         session_key="test:key",
     )
 
-    assert any(m.get("role") == "user" and "[User followed up]:" in m.get("content", "") and "User interrupt" in m.get("content", "") for m in messages)
+    assert any(m.get('role') == 'user' and m.get('content', '') == 'test\n\n[Follow-up]: - User interrupt' for m in messages)
 
 @pytest.mark.asyncio
 async def test_agent_loop_cancels_tools_on_event():

--- a/tests/test_event_injection.py
+++ b/tests/test_event_injection.py
@@ -79,11 +79,10 @@ def test_system_prompt_includes_event_handling():
 
     prompt = builder.build_system_prompt(enable_event_handling=True)
 
-    assert "Event Handling" in prompt
-    assert "<SYS_EVENT>" in prompt
-    assert "IMMEDIATELY acknowledge" in prompt
-    assert "ALWAYS takes priority" in prompt
-    assert "type=\"user_interrupt\"" not in prompt  # Directive uses generic tag
+    assert "Follow-up Questions" in prompt
+    assert "[User followed up]:" in prompt
+    assert "natural conversation continuation" in prompt
+    assert "Respond to ALL" in prompt
 
 
 def test_system_prompt_no_event_handling_by_default():
@@ -145,9 +144,7 @@ async def test_agent_loop_checks_events_before_llm():
         session_key="test:key",
     )
 
-    # Event should have been injected as a system message with <SYS_EVENT> tag
-    assert any("<SYS_EVENT" in m.get("content", "") and "User interrupt" in m.get("content", "") for m in messages)
-
+    assert any(m.get("role") == "user" and "[User followed up]:" in m.get("content", "") and "User interrupt" in m.get("content", "") for m in messages)
 
 @pytest.mark.asyncio
 async def test_agent_loop_cancels_tools_on_event():

--- a/tests/test_event_injection.py
+++ b/tests/test_event_injection.py
@@ -475,3 +475,87 @@ async def test_event_during_tool_execution_result_preserved():
     assert results == ["result_1", "result_2"], f"Wrong results: {results}"
 
 
+
+@pytest.mark.asyncio
+async def test_event_before_final_response_combined():
+    """Test event arriving just before final response (no tool calls).
+
+    Human behavior: when about to reply but get interrupted, 
+    combine both instead of ignoring the interruption.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with patch("nanobot.agent.loop.ContextBuilder") as MockCtx, \
+         patch("nanobot.agent.loop.SessionManager"), \
+         patch("nanobot.agent.loop.SubagentManager"), \
+         patch("nanobot.agent.loop.ToolRegistry") as MockRegistry:
+        mock_ctx = MagicMock()
+        mock_ctx.build_messages.return_value = [
+            {"role": "system", "content": "You are nanobot"},
+            {"role": "user", "content": "What's the capital of France?"}
+        ]
+
+        mock_registry = MagicMock()
+        mock_registry.get_definitions.return_value = []
+        MockRegistry.return_value = mock_registry
+
+        # Patch check_events to return event on 2nd call (after first LLM response)
+        check_event_calls = [0]
+
+        async def mock_check_events(session_key):
+            check_event_calls[0] += 1
+            if check_event_calls[0] == 2:
+                # Return event on second call
+                return "Also tell me about Germany!"
+            return None
+
+        bus.check_events = mock_check_events
+
+        async def mock_chat(*args, **kwargs):
+            if provider.chat.call_count == 0:
+                return MagicMock(
+                    has_tool_calls=False,
+                    content="The capital of France is Paris.",
+                    reasoning_content=None,
+                    finish_reason="stop"
+                )
+            else:
+                return MagicMock(
+                    has_tool_calls=False,
+                    content="Paris is France's capital. Germany's capital is Berlin.",
+                    reasoning_content=None,
+                    finish_reason="stop"
+                )
+
+        provider.chat = AsyncMock(side_effect=mock_chat)
+
+        mock_ctx.add_assistant_message = MagicMock(
+            side_effect=lambda msgs, c, tc=None, **kw: 
+                msgs + [{"role": "assistant", "content": c, "tool_calls": tc}]
+        )
+        MockCtx.return_value = mock_ctx
+
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+
+        final_content, tools_used, messages = await loop._run_agent_loop(
+            initial_messages=[{"role": "user", "content": "What's the capital of France?"}],
+            session_key="test:key",
+        )
+
+        # check_events should be called multiple times
+        assert check_event_calls[0] >= 2, f"Expected at least 2 event checks, got {check_event_calls[0]}"
+        
+        # Should call LLM twice because event was detected before break
+        assert provider.chat.call_count == 2, \
+            f"Expected 2 LLM calls (initial + after event), got {provider.chat.call_count}"
+        assert "Paris" in final_content
+        assert "Berlin" in final_content or "Germany" in final_content

--- a/tests/test_event_injection.py
+++ b/tests/test_event_injection.py
@@ -392,3 +392,86 @@ async def test_event_published_when_active_task_exists():
     # After processing completes, task is removed from _processing_tasks
     loop._processing_tasks.discard(session_key)
     assert session_key not in loop._processing_tasks
+
+
+
+
+@pytest.mark.asyncio
+async def test_event_during_tool_execution_result_preserved():
+    """Test Bug 1: tool result preserved when event arrives during execution.
+    
+    Key point: if tool completes execution, its result should be preserved
+    even if an event arrived during execution. The event only cancels REMAINING tools.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    mock_response = MagicMock()
+    mock_response.has_tool_calls = True
+    mock_response.content = "Processing"
+    mock_response.reasoning_content = None
+    
+    tools = []
+    for i in range(1, 4):
+        tc = MagicMock()
+        tc.id = f"call_{i}"
+        tc.name = "test_tool"
+        tc.arguments = {"index": i}
+        tools.append(tc)
+    
+    mock_response.tool_calls = tools
+
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SessionManager"), \
+         patch("nanobot.agent.loop.SubagentManager"), \
+         patch("nanobot.agent.loop.ToolRegistry") as MockRegistry:
+        mock_registry = MagicMock()
+        mock_registry.get_definitions.return_value = []
+        
+        results = []
+        
+        async def mock_execute(name, args):
+            idx = args["index"]
+            # Event arrives during second tool execution
+            if idx == 2:
+                await bus.publish_event("test:key", "Stop!")
+            results.append(f"result_{idx}")
+            return f"result_{idx}"
+        
+        mock_registry.execute = AsyncMock(side_effect=mock_execute)
+        MockRegistry.return_value = mock_registry
+        
+        # LLM returns tool calls first, then final response
+        final_response = MagicMock()
+        final_response.has_tool_calls = False
+        final_response.content = "Interrupted"
+        final_response.reasoning_content = None
+        final_response.finish_reason = "stop"
+        
+        provider.chat = AsyncMock(side_effect=[mock_response, final_response])
+
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+
+    final_content, tools_used, _ = await loop._run_agent_loop(
+        initial_messages=[{"role": "user", "content": "test"}],
+        session_key="test:key",
+    )
+
+    # Key assertions:
+    # 1. First two tools executed (third was cancelled)
+    assert tools_used == ["test_tool", "test_tool"], \
+        f"Expected first 2 tools to execute, got: {tools_used}"
+    
+    # 2. Both completed successfully and returned results
+    assert len(results) == 2, f"Expected 2 results, got {len(results)}"
+    assert results == ["result_1", "result_2"], f"Wrong results: {results}"
+
+


### PR DESCRIPTION
# feat: Async Event Injection for User Interruption
**Before**:
<img width="686" height="380" alt="image" src="https://github.com/user-attachments/assets/995266b1-8b66-4ceb-a044-9bdcceb58ee9" />
**now**:
<img width="820" height="387" alt="image" src="https://github.com/user-attachments/assets/c90ffbfc-d60c-48d3-bd38-91d93fdaea8a" /><details>
<summary>log</summary>

```log
Feb 26 16:57:17 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:17.873 | INFO
  | nanobot.agent.loop:run:280 - Agent loop started
Feb 26 16:57:29 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:29.131 | DEBUG
  | nanobot.channels.feishu:_add_reaction_sync:353 - Added THUMBSUP reaction to message xxx 
Feb 26 16:57:29 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:29.131 | INFO
  | nanobot.agent.loop:_process_message:407 - Processing message from feishu:xxx: 写一个快速排序算法，运行一下告诉我结果然后删掉你写的脚本
Feb 26 16:57:34 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:34.681 | INFO
  | nanobot.agent.loop:_run_agent_loop:258 - Tool call: write_file({"path": ".nanobot/workspace/quicksort.py", "content": "#!/usr/bin/env python3\ndef quicksort(arr):\n    if len(arr) <= 1:\n        return arr\n    pivot = arr[len(arr) // 2]\n    le)
Feb 26 16:57:36 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:36.078 | INFO
  | nanobot.agent.loop:_run_agent_loop:258 - Tool call: exec({"command": "python3 .nanobot/workspace/quicksort.py"})
Feb 26 16:57:38 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:38.148 | DEBUG
  | nanobot.channels.feishu:_add_reaction_sync:353 - Added THUMBSUP reaction to message 
Feb 26 16:57:38 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:38.149 | INFO
  | nanobot.agent.loop:run:294 - Published interrupt event for session feishu xxx:
Feb 26 16:57:38 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:38.260 | INFO
  | nanobot.agent.loop:_run_agent_loop:246 - Event received during tool execution, cancelling remaining tools
Feb 26 16:57:40 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:40.666 | INFO
  | nanobot.agent.loop:_process_message:496 - Response to feishu:xxx: 今天是星期四。
Feb 26 16:57:41 iZbp17cdwauhcjtoqny51sZ nanobot[21590]: 2026-02-26 16:57:41.311 | DEBUG
  | nanobot.channels.feishu:_send_message_sync:613 - Feishu interactive message sent to xxx
```
</details>

# feat: Async Event Injection for User Interruption

Users can interrupt tasks during tool execution. Events route through session queues and inject at LLM/tool checkpoints.

## Lightweight
<details>
<summary>git diff message</summary>

```shell
❯ git diff HEAD~1 --stat
 nanobot/agent/context.py      |  20 ++-
 nanobot/agent/loop.py         |  97 ++++++++---
 nanobot/bus/queue.py          |  23 +++
 nanobot/cli/commands.py       |   3 +
 nanobot/config/schema.py      |   1 +
 tests/test_event_injection.py | 388 ++++++++++++++++++++++++++++++++++++++++++
 6 files changed, 509 insertions(+), 23 deletions(-)
```
</details>

- Zero dependencies: `asyncio.Queue` only, `get_nowait()` non-blocking
- Opt-in: `enable_event_handling: false` by default

## Implementation

**MessageBus** - Event publish/check:
```python
async def publish_event(self, session_key: str, content: str) -> None:
    if session_key not in self._event_channels:
        self._event_channels[session_key] = asyncio.Queue()
    await self._event_channels[session_key].put(content)

async def check_events(self, session_key: str) -> str | None:
    queue = self._event_channels.get(session_key)
    if not queue: return None
    events = []
    while not queue.empty():
        try: events.append(queue.get_nowait())
        except asyncio.QueueEmpty: break
    return "\n".join(f"- {e}" for e in events) if events else None
```

**AgentLoop** - Three checkpoints:
1. Before LLM - inject `<SYS_EVENT>` system messages
2. Before each tool - cancel remaining tools on event
3. Message routing - publish as event when task active, prevent duplicates

## Usage

```
User: "Write quicksort, run it, delete the script"
LLM: [exec write_file -> exec -> rm]
User: "Never mind, what day is it?"  # During exec
LLM: [Cancels rm] "It's Thursday."
```

Enable: `{"agents": {"defaults": {"enable_event_handling": true}}}`

## Testing & Limitations

- 28 tests pass (12 event + 7 cancellation + 9 CLI)
- Events checked between tools only (cannot interrupt running tool)
- Same-session messages serialized by `_processing_lock`
Refer #1181
