### PR TITLE
feat: replace Brave Search with Firecrawl Search API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ poetry.lock
 .pytest_cache/
 botpy.log
 tests/
+
+# Utility / scratch scripts
+set_api_key.py
+test_firecrawl_standalone.py
+fix_web.py
+patch_web.py
+core_agent_lines.sh


### PR DESCRIPTION
Brave Search API is now paid. This replaces the web_search tool backend with Firecrawl Search API (https://firecrawl.dev).

Changes:
- WebSearchTool: POST to api.firecrawl.dev/v2/search with Bearer auth
- Config: api_key field now accepts Firecrawl API key
- Env fallback: FIRECRAWL_API_KEY instead of BRAVE_API_KEY
- Renamed brave_api_key parameter to firecrawl_api_key throughout