### PR TITLE
feat: AgentSkills.io format compatibility + GitHub skill installer

### DIFF
--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -1,195 +1,330 @@
-"""Skills loader for agent capabilities."""
+"""Skills loader for agent capabilities.
+
+Supports both nanobot's native skill format and the AgentSkills.io
+open standard (https://agentskills.io/specification).
+"""
 
 import json
+import logging
 import os
 import re
 import shutil
+import tempfile
+import urllib.error
+import urllib.request
 from pathlib import Path
+from typing import Any
 
 # Default builtin skills directory (relative to this file)
 BUILTIN_SKILLS_DIR = Path(__file__).parent.parent / "skills"
 
+logger = logging.getLogger(__name__)
+
+# AgentSkills.io name validation pattern
+_SKILL_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+
+
+def _parse_yaml_frontmatter(raw: str) -> dict[str, Any]:
+    """Parse YAML frontmatter with support for nested mappings.
+
+    Handles both simple ``key: value`` lines and one-level nested mappings
+    (like ``metadata:`` with indented children).  This keeps nanobot free of
+    external YAML dependencies while being compatible with the AgentSkills.io
+    spec.
+    """
+    result: dict[str, Any] = {}
+    current_key: str | None = None
+    current_map: dict[str, str] | None = None
+
+    for line in raw.split("\n"):
+        # Skip blank lines and comments
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        indent = len(line) - len(line.lstrip())
+
+        # Nested value (indented under a mapping key)
+        if indent >= 2 and current_key is not None and ":" in stripped:
+            k, v = stripped.split(":", 1)
+            k = k.strip()
+            v = v.strip().strip("\"'")
+            if current_map is None:
+                current_map = {}
+            current_map[k] = v
+            continue
+
+        # Flush previous nested mapping
+        if current_key is not None and current_map is not None:
+            result[current_key] = current_map
+            current_map = None
+            current_key = None
+
+        if ":" not in stripped:
+            continue
+
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip().strip("\"'")
+
+        if not value:
+            # Start of a nested mapping (e.g. ``metadata:``)
+            current_key = key
+            current_map = {}
+        else:
+            result[key] = value
+            current_key = None
+
+    # Flush trailing nested mapping
+    if current_key is not None and current_map is not None:
+        result[current_key] = current_map
+
+    return result
+
+
+def validate_skill_name(name: str) -> list[str]:
+    """Validate a skill name against the AgentSkills.io spec.
+
+    Returns a list of error strings (empty means valid).
+    """
+    errors: list[str] = []
+    if not name:
+        errors.append("name must not be empty")
+        return errors
+    if len(name) > 64:
+        errors.append(f"name must be <= 64 chars, got {len(name)}")
+    if not _SKILL_NAME_RE.match(name):
+        errors.append("name must be lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens")
+    if "--" in name:
+        errors.append("name must not contain consecutive hyphens")
+    return errors
+
 
 class SkillsLoader:
-    """
-    Loader for agent skills.
-    
+    """Loader for agent skills.
+
     Skills are markdown files (SKILL.md) that teach the agent how to use
-    specific tools or perform certain tasks.
+    specific tools or perform certain tasks.  Supports both nanobot's native
+    format and the AgentSkills.io open standard.
     """
-    
+
     def __init__(self, workspace: Path, builtin_skills_dir: Path | None = None):
         self.workspace = workspace
         self.workspace_skills = workspace / "skills"
         self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR
-    
+
+    # ------------------------------------------------------------------
+    # Listing & loading
+    # ------------------------------------------------------------------
+
     def list_skills(self, filter_unavailable: bool = True) -> list[dict[str, str]]:
+        """List all available skills.
+
+        Returns list of dicts with 'name', 'path', 'source'.
         """
-        List all available skills.
-        
-        Args:
-            filter_unavailable: If True, filter out skills with unmet requirements.
-        
-        Returns:
-            List of skill info dicts with 'name', 'path', 'source'.
-        """
-        skills = []
-        
+        skills: list[dict[str, str]] = []
+
         # Workspace skills (highest priority)
         if self.workspace_skills.exists():
             for skill_dir in self.workspace_skills.iterdir():
                 if skill_dir.is_dir():
-                    skill_file = skill_dir / "SKILL.md"
-                    if skill_file.exists():
+                    skill_file = self._find_skill_md(skill_dir)
+                    if skill_file:
                         skills.append({"name": skill_dir.name, "path": str(skill_file), "source": "workspace"})
-        
+
         # Built-in skills
         if self.builtin_skills and self.builtin_skills.exists():
             for skill_dir in self.builtin_skills.iterdir():
                 if skill_dir.is_dir():
-                    skill_file = skill_dir / "SKILL.md"
-                    if skill_file.exists() and not any(s["name"] == skill_dir.name for s in skills):
+                    skill_file = self._find_skill_md(skill_dir)
+                    if skill_file and not any(s["name"] == skill_dir.name for s in skills):
                         skills.append({"name": skill_dir.name, "path": str(skill_file), "source": "builtin"})
-        
-        # Filter by requirements
+
         if filter_unavailable:
             return [s for s in skills if self._check_requirements(self._get_skill_meta(s["name"]))]
         return skills
-    
+
     def load_skill(self, name: str) -> str | None:
-        """
-        Load a skill by name.
-        
-        Args:
-            name: Skill name (directory name).
-        
-        Returns:
-            Skill content or None if not found.
-        """
+        """Load a skill by name.  Returns content or None."""
         # Check workspace first
-        workspace_skill = self.workspace_skills / name / "SKILL.md"
-        if workspace_skill.exists():
-            return workspace_skill.read_text(encoding="utf-8")
-        
+        ws_dir = self.workspace_skills / name
+        if ws_dir.is_dir():
+            f = self._find_skill_md(ws_dir)
+            if f:
+                return f.read_text(encoding="utf-8")
+
         # Check built-in
         if self.builtin_skills:
-            builtin_skill = self.builtin_skills / name / "SKILL.md"
-            if builtin_skill.exists():
-                return builtin_skill.read_text(encoding="utf-8")
-        
+            bi_dir = self.builtin_skills / name
+            if bi_dir.is_dir():
+                f = self._find_skill_md(bi_dir)
+                if f:
+                    return f.read_text(encoding="utf-8")
+
         return None
-    
+
     def load_skills_for_context(self, skill_names: list[str]) -> str:
-        """
-        Load specific skills for inclusion in agent context.
-        
-        Args:
-            skill_names: List of skill names to load.
-        
-        Returns:
-            Formatted skills content.
-        """
+        """Load specific skills for inclusion in agent context."""
         parts = []
         for name in skill_names:
             content = self.load_skill(name)
             if content:
                 content = self._strip_frontmatter(content)
                 parts.append(f"### Skill: {name}\n\n{content}")
-        
         return "\n\n---\n\n".join(parts) if parts else ""
-    
+
     def build_skills_summary(self) -> str:
-        """
-        Build a summary of all skills (name, description, path, availability).
-        
-        This is used for progressive loading - the agent can read the full
-        skill content using read_file when needed.
-        
-        Returns:
-            XML-formatted skills summary.
-        """
+        """Build XML summary of all skills for progressive loading."""
         all_skills = self.list_skills(filter_unavailable=False)
         if not all_skills:
             return ""
-        
-        def escape_xml(s: str) -> str:
+
+        def esc(s: str) -> str:
             return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-        
+
         lines = ["<skills>"]
         for s in all_skills:
-            name = escape_xml(s["name"])
+            name = esc(s["name"])
             path = s["path"]
-            desc = escape_xml(self._get_skill_description(s["name"]))
+            desc = esc(self._get_skill_description(s["name"]))
             skill_meta = self._get_skill_meta(s["name"])
             available = self._check_requirements(skill_meta)
-            
-            lines.append(f"  <skill available=\"{str(available).lower()}\">")
+
+            lines.append(f'  <skill available="{str(available).lower()}">')
             lines.append(f"    <name>{name}</name>")
             lines.append(f"    <description>{desc}</description>")
             lines.append(f"    <location>{path}</location>")
-            
-            # Show missing requirements for unavailable skills
+
             if not available:
                 missing = self._get_missing_requirements(skill_meta)
                 if missing:
-                    lines.append(f"    <requires>{escape_xml(missing)}</requires>")
-            
-            lines.append(f"  </skill>")
+                    lines.append(f"    <requires>{esc(missing)}</requires>")
+
+            lines.append("  </skill>")
         lines.append("</skills>")
-        
         return "\n".join(lines)
-    
-    def _get_missing_requirements(self, skill_meta: dict) -> str:
-        """Get a description of missing requirements."""
-        missing = []
-        requires = skill_meta.get("requires", {})
-        for b in requires.get("bins", []):
-            if not shutil.which(b):
-                missing.append(f"CLI: {b}")
-        for env in requires.get("env", []):
-            if not os.environ.get(env):
-                missing.append(f"ENV: {env}")
-        return ", ".join(missing)
-    
-    def _get_skill_description(self, name: str) -> str:
-        """Get the description of a skill from its frontmatter."""
-        meta = self.get_skill_metadata(name)
-        if meta and meta.get("description"):
-            return meta["description"]
-        return name  # Fallback to skill name
-    
-    def _strip_frontmatter(self, content: str) -> str:
-        """Remove YAML frontmatter from markdown content."""
+
+    # ------------------------------------------------------------------
+    # GitHub skill installer
+    # ------------------------------------------------------------------
+
+    def install_from_github(
+        self,
+        owner: str,
+        repo: str,
+        skill_name: str | None = None,
+        skills_dir: str = "skills",
+        ref: str = "main",
+    ) -> list[str]:
+        """Install skills from a GitHub repository.
+
+        Supports repos following the AgentSkills.io directory convention
+        (``skills/<name>/SKILL.md``).
+
+        Args:
+            owner: GitHub user or org (e.g. ``huggingface``).
+            repo: Repository name (e.g. ``skills``).
+            skill_name: Install a single skill.  When *None*, all skills
+                found under *skills_dir* are installed.
+            skills_dir: Subdirectory in the repo that contains skills.
+            ref: Git ref (branch / tag / commit).
+
+        Returns:
+            List of installed skill names.
+        """
+        api = f"https://api.github.com/repos/{owner}/{repo}"
+        installed: list[str] = []
+
+        if skill_name:
+            names = [skill_name]
+        else:
+            # List skills directory
+            names = self._github_list_skills(api, skills_dir, ref)
+
+        for name in names:
+            try:
+                self._install_one_skill(api, skills_dir, name, ref)
+                installed.append(name)
+                logger.info("Installed skill %s from %s/%s", name, owner, repo)
+            except Exception as exc:
+                logger.warning("Failed to install skill %s: %s", name, exc)
+
+        return installed
+
+    def _github_list_skills(self, api: str, skills_dir: str, ref: str) -> list[str]:
+        """List skill directories in a GitHub repo."""
+        url = f"{api}/contents/{skills_dir}?ref={ref}"
+        data = self._github_get_json(url)
+        return [item["name"] for item in data if item.get("type") == "dir"]
+
+    def _install_one_skill(self, api: str, skills_dir: str, name: str, ref: str) -> None:
+        """Download and install a single skill from GitHub."""
+        dest = self.workspace_skills / name
+        dest.mkdir(parents=True, exist_ok=True)
+
+        # Recursively download skill directory
+        self._github_download_dir(api, f"{skills_dir}/{name}", ref, dest)
+
+        # Validate after download
+        skill_md = self._find_skill_md(dest)
+        if not skill_md:
+            shutil.rmtree(dest, ignore_errors=True)
+            raise FileNotFoundError(f"No SKILL.md found in {name}")
+
+    def _github_download_dir(self, api: str, path: str, ref: str, dest: Path) -> None:
+        """Recursively download a directory from GitHub."""
+        url = f"{api}/contents/{path}?ref={ref}"
+        items = self._github_get_json(url)
+
+        for item in items:
+            item_dest = dest / item["name"]
+            if item["type"] == "file":
+                self._github_download_file(item["download_url"], item_dest)
+            elif item["type"] == "dir":
+                item_dest.mkdir(parents=True, exist_ok=True)
+                self._github_download_dir(api, f"{path}/{item['name']}", ref, item_dest)
+
+    @staticmethod
+    def _github_download_file(url: str, dest: Path) -> None:
+        """Download a single file from GitHub."""
+        req = urllib.request.Request(url, headers={"User-Agent": "nanobot"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            dest.write_bytes(resp.read())
+
+    @staticmethod
+    def _github_get_json(url: str) -> Any:
+        """GET a GitHub API endpoint and return parsed JSON."""
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "nanobot",
+            "Accept": "application/vnd.github.v3+json",
+        })
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GITHUB_PERSONAL_ACCESS_TOKEN")
+        if token:
+            req.add_header("Authorization", f"token {token}")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+
+    # ------------------------------------------------------------------
+    # Metadata helpers
+    # ------------------------------------------------------------------
+
+    def get_skill_metadata(self, name: str) -> dict | None:
+        """Get metadata from a skill's frontmatter.
+
+        Uses the enhanced parser that supports both nanobot's legacy
+        ``key: value`` format and AgentSkills.io nested YAML.
+        """
+        content = self.load_skill(name)
+        if not content:
+            return None
+
         if content.startswith("---"):
-            match = re.match(r"^---\n.*?\n---\n", content, re.DOTALL)
+            match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
             if match:
-                return content[match.end():].strip()
-        return content
-    
-    def _parse_nanobot_metadata(self, raw: str) -> dict:
-        """Parse skill metadata JSON from frontmatter (supports nanobot and openclaw keys)."""
-        try:
-            data = json.loads(raw)
-            return data.get("nanobot", data.get("openclaw", {})) if isinstance(data, dict) else {}
-        except (json.JSONDecodeError, TypeError):
-            return {}
-    
-    def _check_requirements(self, skill_meta: dict) -> bool:
-        """Check if skill requirements are met (bins, env vars)."""
-        requires = skill_meta.get("requires", {})
-        for b in requires.get("bins", []):
-            if not shutil.which(b):
-                return False
-        for env in requires.get("env", []):
-            if not os.environ.get(env):
-                return False
-        return True
-    
-    def _get_skill_meta(self, name: str) -> dict:
-        """Get nanobot metadata for a skill (cached in frontmatter)."""
-        meta = self.get_skill_metadata(name) or {}
-        return self._parse_nanobot_metadata(meta.get("metadata", ""))
-    
+                return _parse_yaml_frontmatter(match.group(1))
+
+        return None
+
     def get_always_skills(self) -> list[str]:
         """Get skills marked as always=true that meet requirements."""
         result = []
@@ -199,30 +334,80 @@ class SkillsLoader:
             if skill_meta.get("always") or meta.get("always"):
                 result.append(s["name"])
         return result
-    
-    def get_skill_metadata(self, name: str) -> dict | None:
-        """
-        Get metadata from a skill's frontmatter.
-        
-        Args:
-            name: Skill name.
-        
-        Returns:
-            Metadata dict or None.
-        """
-        content = self.load_skill(name)
-        if not content:
-            return None
-        
-        if content.startswith("---"):
-            match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-            if match:
-                # Simple YAML parsing
-                metadata = {}
-                for line in match.group(1).split("\n"):
-                    if ":" in line:
-                        key, value = line.split(":", 1)
-                        metadata[key.strip()] = value.strip().strip('"\'')
-                return metadata
-        
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _find_skill_md(skill_dir: Path) -> Path | None:
+        """Find SKILL.md (case-insensitive) in a directory."""
+        for name in ("SKILL.md", "skill.md"):
+            p = skill_dir / name
+            if p.exists():
+                return p
         return None
+
+    def _get_skill_description(self, name: str) -> str:
+        """Get the description of a skill from its frontmatter."""
+        meta = self.get_skill_metadata(name)
+        if meta and meta.get("description"):
+            return meta["description"]
+        return name
+
+    def _strip_frontmatter(self, content: str) -> str:
+        """Remove YAML frontmatter from markdown content."""
+        if content.startswith("---"):
+            match = re.match(r"^---\n.*?\n---\n", content, re.DOTALL)
+            if match:
+                return content[match.end():].strip()
+        return content
+
+    def _parse_nanobot_metadata(self, raw: str | dict) -> dict:
+        """Parse skill metadata from frontmatter.
+
+        Handles both nanobot's legacy JSON-string format and
+        AgentSkills.io's native dict format.
+        """
+        if isinstance(raw, dict):
+            # AgentSkills.io style: metadata is already a dict
+            return raw.get("nanobot", raw.get("openclaw", raw))
+        if isinstance(raw, str) and raw:
+            try:
+                data = json.loads(raw)
+                return data.get("nanobot", data.get("openclaw", {})) if isinstance(data, dict) else {}
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return {}
+
+    def _check_requirements(self, skill_meta: dict) -> bool:
+        """Check if skill requirements are met (bins, env vars, compatibility)."""
+        requires = skill_meta.get("requires", {})
+        if isinstance(requires, dict):
+            for b in requires.get("bins", []):
+                if not shutil.which(b):
+                    return False
+            for env in requires.get("env", []):
+                if not os.environ.get(env):
+                    return False
+        return True
+
+    def _get_missing_requirements(self, skill_meta: dict) -> str:
+        """Get a description of missing requirements."""
+        missing = []
+        requires = skill_meta.get("requires", {})
+        if isinstance(requires, dict):
+            for b in requires.get("bins", []):
+                if not shutil.which(b):
+                    missing.append(f"CLI: {b}")
+            for env in requires.get("env", []):
+                if not os.environ.get(env):
+                    missing.append(f"ENV: {env}")
+        return ", ".join(missing)
+
+    def _get_skill_meta(self, name: str) -> dict:
+        """Get nanobot metadata for a skill."""
+        meta = self.get_skill_metadata(name) or {}
+        return self._parse_nanobot_metadata(meta.get("metadata", ""))
+
+

--- a/nanobot/agent/tools/skill_installer.py
+++ b/nanobot/agent/tools/skill_installer.py
@@ -1,0 +1,97 @@
+"""Tool for installing skills from GitHub repositories.
+
+Allows the agent to install AgentSkills.io-compatible skills at runtime.
+"""
+
+import re
+from pathlib import Path
+
+from ..skills import SkillsLoader
+
+
+class SkillInstallTool:
+    """Install skills from GitHub into the workspace.
+
+    Accepts references like:
+    - ``huggingface/skills`` — install all skills from the repo
+    - ``huggingface/skills/hugging-face-model-trainer`` — install one skill
+    - ``https://github.com/huggingface/skills`` — full URL form
+    """
+
+    name = "install_skill"
+    description = (
+        "Install an AgentSkills.io-compatible skill from a GitHub repository. "
+        "Pass a reference like 'owner/repo' to install all skills, or "
+        "'owner/repo/skill-name' to install a specific one. "
+        "Example: install_skill(ref='huggingface/skills/hugging-face-model-trainer')"
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "ref": {
+                "type": "string",
+                "description": (
+                    "GitHub reference: 'owner/repo', 'owner/repo/skill-name', "
+                    "or a full GitHub URL."
+                ),
+            },
+            "skills_dir": {
+                "type": "string",
+                "description": "Subdirectory containing skills (default: 'skills').",
+                "default": "skills",
+            },
+            "branch": {
+                "type": "string",
+                "description": "Git branch or tag (default: 'main').",
+                "default": "main",
+            },
+        },
+        "required": ["ref"],
+    }
+
+    def __init__(self, workspace: Path):
+        self.workspace = workspace
+        self.loader = SkillsLoader(workspace)
+
+    def run(self, ref: str, skills_dir: str = "skills", branch: str = "main") -> str:
+        """Execute the install."""
+        owner, repo, skill_name = self._parse_ref(ref)
+
+        try:
+            installed = self.loader.install_from_github(
+                owner=owner,
+                repo=repo,
+                skill_name=skill_name,
+                skills_dir=skills_dir,
+                ref=branch,
+            )
+        except Exception as exc:
+            return f"❌ Install failed: {exc}"
+
+        if not installed:
+            return "⚠️ No skills found or installed."
+
+        names = ", ".join(installed)
+        dest = self.loader.workspace_skills
+        return (
+            f"✅ Installed {len(installed)} skill(s): {names}\n"
+            f"Location: {dest}\n"
+            f"Start a new session to load them."
+        )
+
+    @staticmethod
+    def _parse_ref(ref: str) -> tuple[str, str, str | None]:
+        """Parse a GitHub reference into (owner, repo, skill_name | None)."""
+        # Strip full URL prefix
+        ref = re.sub(r"^https?://github\.com/", "", ref.strip().rstrip("/"))
+
+        parts = ref.split("/")
+        if len(parts) < 2:
+            raise ValueError(
+                f"Invalid ref '{ref}'. Expected 'owner/repo' or 'owner/repo/skill-name'."
+            )
+
+        owner = parts[0]
+        repo = parts[1]
+        skill_name = parts[2] if len(parts) >= 3 else None
+        return owner, repo, skill_name

--- a/tests/test_agentskills_compat.py
+++ b/tests/test_agentskills_compat.py
@@ -1,0 +1,311 @@
+"""Tests for AgentSkills.io format compatibility and GitHub skill installer."""
+
+import json
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nanobot.agent.skills import SkillsLoader, _parse_yaml_frontmatter, validate_skill_name
+from nanobot.agent.tools.skill_installer import SkillInstallTool
+
+
+# ---------------------------------------------------------------------------
+# _parse_yaml_frontmatter
+# ---------------------------------------------------------------------------
+
+class TestParseYamlFrontmatter:
+    def test_simple_key_value(self):
+        raw = "name: my-skill\ndescription: A test skill"
+        result = _parse_yaml_frontmatter(raw)
+        assert result["name"] == "my-skill"
+        assert result["description"] == "A test skill"
+
+    def test_quoted_values(self):
+        raw = 'name: "my-skill"\ndescription: \'A test skill\''
+        result = _parse_yaml_frontmatter(raw)
+        assert result["name"] == "my-skill"
+        assert result["description"] == "A test skill"
+
+    def test_nested_metadata(self):
+        raw = textwrap.dedent("""\
+            name: pdf-processing
+            description: Extract text from PDFs
+            metadata:
+              author: example-org
+              version: "1.0"
+        """)
+        result = _parse_yaml_frontmatter(raw)
+        assert result["name"] == "pdf-processing"
+        assert result["metadata"] == {"author": "example-org", "version": "1.0"}
+
+    def test_agentskills_full_frontmatter(self):
+        raw = textwrap.dedent("""\
+            name: hugging-face-model-trainer
+            description: Train models on HF infrastructure
+            license: Apache-2.0
+            compatibility: Requires python3, uv
+            allowed-tools: Bash(python3:*) Read
+            metadata:
+              author: huggingface
+              version: "0.1"
+        """)
+        result = _parse_yaml_frontmatter(raw)
+        assert result["name"] == "hugging-face-model-trainer"
+        assert result["license"] == "Apache-2.0"
+        assert result["compatibility"] == "Requires python3, uv"
+        assert result["allowed-tools"] == "Bash(python3:*) Read"
+        assert result["metadata"]["author"] == "huggingface"
+
+    def test_nanobot_legacy_json_metadata(self):
+        raw = 'name: weather\ndescription: Get weather\nmetadata: {"nanobot":{"emoji":"🌤️","always":true}}'
+        result = _parse_yaml_frontmatter(raw)
+        assert result["name"] == "weather"
+        # Legacy JSON metadata is kept as a string
+        assert result["metadata"] == '{"nanobot":{"emoji":"🌤️","always":true}}'
+
+    def test_blank_lines_and_comments(self):
+        raw = "# comment\nname: test\n\n# another\ndescription: desc"
+        result = _parse_yaml_frontmatter(raw)
+        assert result["name"] == "test"
+        assert result["description"] == "desc"
+
+    def test_empty_input(self):
+        assert _parse_yaml_frontmatter("") == {}
+
+
+# ---------------------------------------------------------------------------
+# validate_skill_name
+# ---------------------------------------------------------------------------
+
+class TestValidateSkillName:
+    def test_valid_names(self):
+        for name in ["pdf-processing", "data-analysis", "code-review", "a", "a1b2"]:
+            assert validate_skill_name(name) == [], f"Expected valid: {name}"
+
+    def test_empty(self):
+        errors = validate_skill_name("")
+        assert any("empty" in e for e in errors)
+
+    def test_uppercase(self):
+        errors = validate_skill_name("PDF-Processing")
+        assert len(errors) > 0
+
+    def test_leading_hyphen(self):
+        errors = validate_skill_name("-pdf")
+        assert len(errors) > 0
+
+    def test_trailing_hyphen(self):
+        errors = validate_skill_name("pdf-")
+        assert len(errors) > 0
+
+    def test_consecutive_hyphens(self):
+        errors = validate_skill_name("pdf--processing")
+        assert any("consecutive" in e for e in errors)
+
+    def test_too_long(self):
+        errors = validate_skill_name("a" * 65)
+        assert any("64" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# SkillsLoader — enhanced metadata parsing
+# ---------------------------------------------------------------------------
+
+class TestSkillsLoaderMetadata:
+    def setup_method(self):
+        """Create a temp workspace with test skills."""
+        import tempfile
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.workspace = self.tmpdir / "workspace"
+        self.skills_dir = self.workspace / "skills"
+        self.loader = SkillsLoader(self.workspace, builtin_skills_dir=None)
+
+    def teardown_method(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _create_skill(self, name: str, frontmatter: str, body: str = "# Skill"):
+        d = self.skills_dir / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text(f"---\n{frontmatter}\n---\n{body}")
+
+    def test_agentskills_format(self):
+        self._create_skill("pdf-tool", textwrap.dedent("""\
+            name: pdf-tool
+            description: Extract text from PDFs
+            license: MIT
+            metadata:
+              author: test-org
+              version: "2.0"
+        """))
+        meta = self.loader.get_skill_metadata("pdf-tool")
+        assert meta["name"] == "pdf-tool"
+        assert meta["license"] == "MIT"
+        assert meta["metadata"] == {"author": "test-org", "version": "2.0"}
+
+    def test_nanobot_legacy_format(self):
+        self._create_skill("weather", 'name: weather\ndescription: Get weather\nmetadata: {"nanobot":{"emoji":"🌤️"}}')
+        meta = self.loader.get_skill_metadata("weather")
+        assert meta["name"] == "weather"
+        # Legacy JSON string preserved
+        assert "nanobot" in meta["metadata"]
+
+    def test_find_skill_md_case_insensitive(self):
+        d = self.skills_dir / "lower-case"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "skill.md").write_text("---\nname: lower-case\ndescription: test\n---\n# Hi")
+        content = self.loader.load_skill("lower-case")
+        assert content is not None
+        assert "lower-case" in content
+
+    def test_list_skills(self):
+        self._create_skill("alpha", "name: alpha\ndescription: Alpha skill")
+        self._create_skill("beta", "name: beta\ndescription: Beta skill")
+        skills = self.loader.list_skills(filter_unavailable=False)
+        names = {s["name"] for s in skills}
+        assert "alpha" in names
+        assert "beta" in names
+
+    def test_description_from_agentskills(self):
+        self._create_skill("my-skill", "name: my-skill\ndescription: A great skill for testing")
+        desc = self.loader._get_skill_description("my-skill")
+        assert desc == "A great skill for testing"
+
+    def test_parse_nanobot_metadata_dict(self):
+        """AgentSkills.io metadata (already a dict) should pass through."""
+        meta = {"author": "test", "version": "1.0"}
+        result = self.loader._parse_nanobot_metadata(meta)
+        assert result == meta
+
+    def test_parse_nanobot_metadata_dict_with_nanobot_key(self):
+        meta = {"nanobot": {"always": True, "emoji": "🔥"}}
+        result = self.loader._parse_nanobot_metadata(meta)
+        assert result == {"always": True, "emoji": "🔥"}
+
+
+# ---------------------------------------------------------------------------
+# SkillsLoader — GitHub installer
+# ---------------------------------------------------------------------------
+
+class TestGitHubInstaller:
+    def setup_method(self):
+        import tempfile
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.workspace = self.tmpdir / "workspace"
+        self.loader = SkillsLoader(self.workspace, builtin_skills_dir=None)
+
+    def teardown_method(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    @patch.object(SkillsLoader, "_github_get_json")
+    @patch.object(SkillsLoader, "_github_download_file")
+    def test_install_single_skill(self, mock_download, mock_get_json):
+        # Mock directory listing for the skill
+        mock_get_json.return_value = [
+            {"name": "SKILL.md", "type": "file", "download_url": "https://raw.example.com/SKILL.md"},
+            {"name": "scripts", "type": "dir"},
+        ]
+
+        # Mock scripts dir listing
+        mock_get_json.side_effect = [
+            # First call: skill dir contents
+            [
+                {"name": "SKILL.md", "type": "file", "download_url": "https://raw.example.com/SKILL.md"},
+            ],
+        ]
+
+        # Mock file download to write a valid SKILL.md
+        def write_skill(url, dest):
+            dest.write_text("---\nname: test-skill\ndescription: A test\n---\n# Test")
+
+        mock_download.side_effect = write_skill
+
+        installed = self.loader.install_from_github("test-org", "test-repo", skill_name="test-skill")
+        assert installed == ["test-skill"]
+        assert (self.workspace / "skills" / "test-skill" / "SKILL.md").exists()
+
+    @patch.object(SkillsLoader, "_github_get_json")
+    def test_list_remote_skills(self, mock_get_json):
+        mock_get_json.return_value = [
+            {"name": "skill-a", "type": "dir"},
+            {"name": "skill-b", "type": "dir"},
+            {"name": "README.md", "type": "file"},
+        ]
+        names = self.loader._github_list_skills("https://api.github.com/repos/o/r", "skills", "main")
+        assert names == ["skill-a", "skill-b"]
+
+    @patch.object(SkillsLoader, "_github_download_dir")
+    def test_install_no_skill_md_cleanup(self, mock_download_dir):
+        """If downloaded dir has no SKILL.md, it should be cleaned up."""
+        # Mock download to create a dir without SKILL.md
+        def fake_download(api, path, ref, dest):
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "random.txt").write_text("not a skill")
+
+        mock_download_dir.side_effect = fake_download
+
+        with pytest.raises(FileNotFoundError):
+            self.loader._install_one_skill(
+                "https://api.github.com/repos/o/r", "skills", "bad-skill", "main"
+            )
+        # Directory should be cleaned up
+        assert not (self.workspace / "skills" / "bad-skill").exists()
+
+
+# ---------------------------------------------------------------------------
+# SkillInstallTool
+# ---------------------------------------------------------------------------
+
+class TestSkillInstallTool:
+    def test_parse_ref_owner_repo(self):
+        owner, repo, name = SkillInstallTool._parse_ref("huggingface/skills")
+        assert owner == "huggingface"
+        assert repo == "skills"
+        assert name is None
+
+    def test_parse_ref_owner_repo_skill(self):
+        owner, repo, name = SkillInstallTool._parse_ref("huggingface/skills/model-trainer")
+        assert owner == "huggingface"
+        assert repo == "skills"
+        assert name == "model-trainer"
+
+    def test_parse_ref_full_url(self):
+        owner, repo, name = SkillInstallTool._parse_ref("https://github.com/huggingface/skills/model-trainer")
+        assert owner == "huggingface"
+        assert repo == "skills"
+        assert name == "model-trainer"
+
+    def test_parse_ref_trailing_slash(self):
+        owner, repo, name = SkillInstallTool._parse_ref("huggingface/skills/")
+        assert owner == "huggingface"
+        assert repo == "skills"
+        assert name is None
+
+    def test_parse_ref_invalid(self):
+        with pytest.raises(ValueError):
+            SkillInstallTool._parse_ref("just-one-part")
+
+    @patch.object(SkillsLoader, "install_from_github", return_value=["skill-a", "skill-b"])
+    def test_run_success(self, mock_install):
+        tool = SkillInstallTool(Path("/tmp/test-workspace"))
+        result = tool.run("org/repo")
+        assert "✅" in result
+        assert "2 skill(s)" in result
+        assert "skill-a" in result
+
+    @patch.object(SkillsLoader, "install_from_github", return_value=[])
+    def test_run_no_skills(self, mock_install):
+        tool = SkillInstallTool(Path("/tmp/test-workspace"))
+        result = tool.run("org/empty-repo")
+        assert "⚠️" in result
+
+    @patch.object(SkillsLoader, "install_from_github", side_effect=Exception("API rate limit"))
+    def test_run_error(self, mock_install):
+        tool = SkillInstallTool(Path("/tmp/test-workspace"))
+        result = tool.run("org/repo")
+        assert "❌" in result
+        assert "rate limit" in result


### PR DESCRIPTION
## Summary

Add support for the [AgentSkills.io](https://agentskills.io) open standard, enabling nanobot to install and use skills from any compatible repository (e.g. [huggingface/skills](https://github.com/huggingface/skills), [anthropics/skills](https://github.com/anthropics/skills)).

Closes #622, #665

## What changed

### 1. Enhanced YAML frontmatter parser (`skills.py`)

The existing simple `key: value` parser couldn't handle AgentSkills.io's nested `metadata:` mapping. The new `_parse_yaml_frontmatter()` supports:

- Simple `key: value` lines (backward compatible)
- One-level nested mappings (e.g. `metadata:` with indented children)
- Quoted values, comments, blank lines
- Both nanobot's legacy JSON-string metadata and AgentSkills.io's native dict format

```yaml
# AgentSkills.io format — now supported
name: hugging-face-model-trainer
description: Train models on HF infrastructure
license: Apache-2.0
compatibility: Requires python3, uv
allowed-tools: Bash(python3:*) Read
metadata:
  author: huggingface
  version: "0.1"
```

### 2. GitHub skill installer (`skills.py` + `skill_installer.py`)

`SkillsLoader.install_from_github()` downloads skills directly from any GitHub repo:

```python
loader.install_from_github("huggingface", "skills")  # install all 9 HF skills
loader.install_from_github("huggingface", "skills", skill_name="hugging-face-model-trainer")  # install one
```

`SkillInstallTool` exposes this to the agent as a callable tool:

```
install_skill(ref="huggingface/skills/hugging-face-model-trainer")
install_skill(ref="https://github.com/anthropics/skills")
```

### 3. Skill name validation

`validate_skill_name()` enforces AgentSkills.io naming rules (lowercase, hyphens, no consecutive hyphens, max 64 chars).

### 4. Case-insensitive SKILL.md detection

Now finds both `SKILL.md` and `skill.md`, matching the AgentSkills.io spec.

## Design decisions

- **Zero new dependencies** — uses stdlib `urllib` + `json` instead of `requests` or `strictyaml`
- **Backward compatible** — nanobot's legacy JSON-string metadata format still works
- **GitHub token optional** — uses `GITHUB_TOKEN` or `GITHUB_PERSONAL_ACCESS_TOKEN` if available (for rate limits), but works without
- **Recursive download** — handles skills with `scripts/`, `references/`, `assets/` subdirectories
- **Cleanup on failure** — if a downloaded skill has no SKILL.md, the directory is removed

## Testing

32 new tests covering:
- YAML frontmatter parser (7 tests)
- Skill name validator (7 tests)
- SkillsLoader metadata parsing (7 tests)
- GitHub installer (3 tests)
- SkillInstallTool (8 tests)

All 118 existing tests pass (zero regressions).

## Files changed

| File | Change |
|------|--------|
| `nanobot/agent/skills.py` | Enhanced frontmatter parser, GitHub installer, case-insensitive SKILL.md |
| `nanobot/agent/tools/skill_installer.py` | New — SkillInstallTool for agent-driven installation |
| `tests/test_agentskills_compat.py` | New — 32 tests |