### PR TITLE
feat(systemd): support service cli interface for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,12 @@ MCP tools are automatically discovered and registered on startup. The LLM can us
 | `nanobot provider login openai-codex` | OAuth login for providers |
 | `nanobot channels login` | Link WhatsApp (scan QR) |
 | `nanobot channels status` | Show channel status |
+| `nanobot service install` | Install as systemd service (Linux) |
+| `nanobot service uninstall` | Uninstall systemd service |
+| `nanobot service status` | Show service status |
+| `nanobot service logs` | View service logs |
+| `nanobot service logs --follow` | Follow logs in real-time |
+| `nanobot service restart` | Restart the service |
 
 Interactive mode exits: `exit`, `quit`, `/exit`, `/quit`, `:q`, or `Ctrl+D`.
 
@@ -975,48 +981,25 @@ docker run -v ~/.nanobot:/root/.nanobot --rm nanobot status
 
 Run the gateway as a systemd user service so it starts automatically and restarts on failure.
 
-**1. Find the nanobot binary path:**
-
 ```bash
-which nanobot   # e.g. /home/user/.local/bin/nanobot
+# Install and start the service
+nanobot service install
+
+# Check service status
+nanobot service status
+
+# View logs
+nanobot service logs
+
+# Follow logs in real-time
+nanobot service logs --follow
+
+# Restart the service
+nanobot service restart
+
+# Uninstall the service
+nanobot service uninstall
 ```
-
-**2. Create the service file** at `~/.config/systemd/user/nanobot-gateway.service` (replace `ExecStart` path if needed):
-
-```ini
-[Unit]
-Description=Nanobot Gateway
-After=network.target
-
-[Service]
-Type=simple
-ExecStart=%h/.local/bin/nanobot gateway
-Restart=always
-RestartSec=10
-NoNewPrivileges=yes
-ProtectSystem=strict
-ReadWritePaths=%h
-
-[Install]
-WantedBy=default.target
-```
-
-**3. Enable and start:**
-
-```bash
-systemctl --user daemon-reload
-systemctl --user enable --now nanobot-gateway
-```
-
-**Common operations:**
-
-```bash
-systemctl --user status nanobot-gateway        # check status
-systemctl --user restart nanobot-gateway       # restart after config changes
-journalctl --user -u nanobot-gateway -f        # follow logs
-```
-
-If you edit the `.service` file itself, run `systemctl --user daemon-reload` before restarting.
 
 > **Note:** User services only run while you are logged in. To keep the gateway running after logout, enable lingering:
 >

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1016,6 +1016,10 @@ def status():
 provider_app = typer.Typer(help="Manage providers")
 app.add_typer(provider_app, name="provider")
 
+# Service management (Linux systemd)
+from nanobot.cli.service import app as service_app
+app.add_typer(service_app, name="service")
+
 
 _LOGIN_HANDLERS: dict[str, callable] = {}
 

--- a/nanobot/cli/service.py
+++ b/nanobot/cli/service.py
@@ -1,0 +1,312 @@
+"""System service management for nanobot (Linux systemd)."""
+
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+from rich.console import Console
+from rich.table import Table
+import typer
+
+from nanobot import __logo__
+
+console = Console()
+
+# Service name constant - can be parameterized later for multi-instance support
+SERVICE_NAME = "nanobot"
+SERVICE_DESCRIPTION = "Nanobot AI Assistant Gateway"
+
+# Paths
+SYSTEMD_USER_DIR = Path.home() / ".config" / "systemd" / "user"
+
+
+def get_service_file_path() -> Path:
+    """Get the systemd service file path."""
+    return SYSTEMD_USER_DIR / f"{SERVICE_NAME}.service"
+
+
+def get_nanobot_executable() -> str:
+    """Get the path to the nanobot executable."""
+    # Try to find nanobot in PATH
+    nanobot_path = shutil.which("nanobot")
+    if nanobot_path:
+        return nanobot_path
+
+    # Fallback: use python -m nanobot
+    python_path = shutil.which("python3") or shutil.which("python")
+    if python_path:
+        return f"{python_path} -m nanobot"
+
+    raise RuntimeError("Cannot find nanobot executable")
+
+
+def generate_service_unit() -> str:
+    """Generate systemd service unit content."""
+    try:
+        exec_path = get_nanobot_executable()
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    # Check if it's a simple path or needs shell invocation
+    if " " in exec_path:
+        # python -m nanobot style - needs shell
+        exec_start = f"/bin/bash -c '{exec_path} gateway'"
+    else:
+        exec_start = f"{exec_path} gateway"
+
+    return f"""[Unit]
+Description={SERVICE_DESCRIPTION}
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={exec_start}
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def check_linux_systemd() -> bool:
+    """Check if we're on Linux with systemd available."""
+    if platform.system() != "Linux":
+        console.print("[red]Error: Service management is only supported on Linux.[/red]")
+        return False
+
+    # Check if systemctl exists
+    if not shutil.which("systemctl"):
+        console.print("[red]Error: systemctl not found. Is systemd installed?[/red]")
+        return False
+
+    return True
+
+
+def run_systemctl_user(args: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    """Run a systemctl --user command."""
+    cmd = ["systemctl", "--user"] + args
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def check_linger_enabled() -> bool:
+    """Check if linger is enabled for the current user."""
+    user = os.environ.get("USER", "")
+    if not user:
+        return False
+
+    linger_file = Path(f"/var/lib/systemd/linger/{user}")
+    return linger_file.exists()
+
+
+def install_service() -> None:
+    """Install nanobot as a systemd user service."""
+    if not check_linux_systemd():
+        raise typer.Exit(1)
+
+    service_path = get_service_file_path()
+
+    # Check if already installed
+    if service_path.exists():
+        console.print(f"[yellow]Service already installed at {service_path}[/yellow]")
+        if not typer.confirm("Reinstall?"):
+            return
+
+    # Create systemd user directory
+    SYSTEMD_USER_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Generate and write service file
+    service_content = generate_service_unit()
+    service_path.write_text(service_content)
+    console.print(f"[green]✓[/green] Created service file: {service_path}")
+
+    # Reload systemd
+    console.print("Reloading systemd daemon...")
+    try:
+        run_systemctl_user(["daemon-reload"])
+        console.print("[green]✓[/green] Daemon reloaded")
+    except subprocess.CalledProcessError as e:
+        console.print(f"[red]Failed to reload daemon: {e.stderr}[/red]")
+        raise typer.Exit(1)
+
+    # Enable and start service
+    console.print("Enabling and starting service...")
+    try:
+        run_systemctl_user(["enable", "--now", SERVICE_NAME])
+        console.print(f"[green]✓[/green] Service '{SERVICE_NAME}' enabled and started")
+    except subprocess.CalledProcessError as e:
+        console.print(f"[red]Failed to enable/start service: {e.stderr}[/red]")
+        raise typer.Exit(1)
+
+    # Check linger
+    if not check_linger_enabled():
+        console.print()
+        console.print("[yellow]⚠ Linger is not enabled.[/yellow]")
+        console.print("  Without linger, the service will stop when you log out.")
+        console.print(f"  To enable linger, run: [cyan]loginctl enable-linger $USER[/cyan]")
+    else:
+        console.print("[green]✓[/green] Linger is enabled (service will run at boot)")
+
+    console.print()
+    console.print(f"{__logo__} Service installed successfully!")
+    console.print(f"  Check status: [cyan]nanobot service status[/cyan]")
+    console.print(f"  View logs:    [cyan]nanobot service logs[/cyan]")
+
+
+def uninstall_service() -> None:
+    """Uninstall the nanobot systemd user service."""
+    if not check_linux_systemd():
+        raise typer.Exit(1)
+
+    service_path = get_service_file_path()
+
+    if not service_path.exists():
+        console.print(f"[yellow]Service not installed (no file at {service_path})[/yellow]")
+
+        # Try to disable anyway in case it's registered but file is missing
+        try:
+            run_systemctl_user(["disable", SERVICE_NAME], check=False)
+            run_systemctl_user(["stop", SERVICE_NAME], check=False)
+        except Exception:
+            pass
+        return
+
+    # Stop and disable
+    console.print("Stopping and disabling service...")
+    try:
+        run_systemctl_user(["stop", SERVICE_NAME], check=False)
+        run_systemctl_user(["disable", SERVICE_NAME], check=False)
+        console.print("[green]✓[/green] Service stopped and disabled")
+    except subprocess.CalledProcessError as e:
+        console.print(f"[yellow]Warning: {e.stderr}[/yellow]")
+
+    # Remove service file
+    service_path.unlink()
+    console.print(f"[green]✓[/green] Removed service file: {service_path}")
+
+    # Reload daemon
+    try:
+        run_systemctl_user(["daemon-reload"])
+        console.print("[green]✓[/green] Daemon reloaded")
+    except subprocess.CalledProcessError as e:
+        console.print(f"[yellow]Warning: Failed to reload daemon: {e.stderr}[/yellow]")
+
+    console.print()
+    console.print(f"{__logo__} Service uninstalled.")
+
+
+def service_status() -> None:
+    """Show the status of the nanobot service."""
+    if not check_linux_systemd():
+        raise typer.Exit(1)
+
+    service_path = get_service_file_path()
+
+    # Check if service file exists
+    if not service_path.exists():
+        console.print(f"[yellow]Service not installed[/yellow]")
+        console.print(f"  Run [cyan]nanobot service install[/cyan] to install")
+        return
+
+    # Get service status
+    result = run_systemctl_user(["status", SERVICE_NAME], check=False)
+
+    # Also check is-active and is-enabled
+    active_result = run_systemctl_user(["is-active", SERVICE_NAME], check=False)
+    enabled_result = run_systemctl_user(["is-enabled", SERVICE_NAME], check=False)
+
+    is_active = active_result.returncode == 0
+    is_enabled = enabled_result.returncode == 0
+    linger_enabled = check_linger_enabled()
+
+    # Display status table
+    table = Table(title=f"{SERVICE_NAME} Service Status")
+    table.add_column("Property", style="cyan")
+    table.add_column("Value")
+
+    table.add_row("Service File", str(service_path))
+    table.add_row("Active", "[green]active[/green]" if is_active else "[red]inactive[/red]")
+    table.add_row("Enabled", "[green]yes[/green]" if is_enabled else "[dim]no[/dim]")
+    table.add_row("Linger", "[green]enabled[/green]" if linger_enabled else "[yellow]disabled[/yellow]")
+
+    console.print(table)
+
+    # Show last few log lines if active
+    if is_active:
+        console.print()
+        console.print("[dim]Recent logs:[/dim]")
+        logs_result = subprocess.run(
+            ["journalctl", "--user", "-u", SERVICE_NAME, "-n", "5", "--no-pager"],
+            capture_output=True,
+            text=True,
+        )
+        if logs_result.stdout.strip():
+            for line in logs_result.stdout.strip().split("\n"):
+                console.print(f"  [dim]{line}[/dim]")
+
+
+def service_logs(follow: bool = False, lines: int = 50) -> None:
+    """View nanobot service logs."""
+    if not check_linux_systemd():
+        raise typer.Exit(1)
+
+    service_path = get_service_file_path()
+    if not service_path.exists():
+        console.print(f"[yellow]Service not installed[/yellow]")
+        raise typer.Exit(1)
+
+    cmd = ["journalctl", "--user", "-u", SERVICE_NAME, "-n", str(lines)]
+    if follow:
+        cmd.append("-f")
+
+    # Use exec to replace current process for follow mode
+    if follow:
+        os.execvp("journalctl", cmd)
+    else:
+        subprocess.run(cmd)
+
+
+def restart_service() -> None:
+    """Restart the nanobot service."""
+    if not check_linux_systemd():
+        raise typer.Exit(1)
+
+    service_path = get_service_file_path()
+    if not service_path.exists():
+        console.print(f"[red]Service not installed[/red]")
+        raise typer.Exit(1)
+
+    try:
+        run_systemctl_user(["restart", SERVICE_NAME])
+        console.print(f"[green]✓[/green] Service restarted")
+    except subprocess.CalledProcessError as e:
+        console.print(f"[red]Failed to restart service: {e.stderr}[/red]")
+        raise typer.Exit(1)
+
+
+# Create typer app for service commands
+app = typer.Typer(help="Manage nanobot system service (Linux)")
+
+app.command(name="install")(install_service)
+app.command(name="uninstall")(uninstall_service)
+app.command(name="status")(service_status)
+
+
+@app.command(name="logs")
+def logs_cmd(
+    follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
+    lines: int = typer.Option(50, "--lines", "-n", help="Number of lines to show"),
+):
+    """View nanobot service logs."""
+    service_logs(follow=follow, lines=lines)
+
+
+@app.command(name="restart")
+def restart_cmd():
+    """Restart the nanobot service."""
+    restart_service()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,324 @@
+"""Tests for nanobot.cli.service module."""
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from nanobot.cli.service import (
+    SERVICE_NAME,
+    SYSTEMD_USER_DIR,
+    check_linger_enabled,
+    check_linux_systemd,
+    generate_service_unit,
+    get_nanobot_executable,
+    get_service_file_path,
+)
+from nanobot.cli.service import app as service_app
+
+runner = CliRunner()
+
+
+class TestServicePaths:
+    """Test path-related functions."""
+
+    def test_get_service_file_path(self):
+        """Service file should be in ~/.config/systemd/user/."""
+        path = get_service_file_path()
+        assert path == SYSTEMD_USER_DIR / f"{SERVICE_NAME}.service"
+        # Check path components (works on both Windows and Linux)
+        assert path.parent.name == "user"
+        assert path.parent.parent.name == "systemd"
+        assert path.parent.parent.parent.name == ".config"
+        assert path.name == "nanobot.service"
+
+
+class TestGetNanobotExecutable:
+    """Test nanobot executable detection."""
+
+    def test_finds_nanobot_in_path(self):
+        """Should find nanobot if it exists in PATH."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.return_value = "/usr/bin/nanobot"
+            result = get_nanobot_executable()
+            assert result == "/usr/bin/nanobot"
+
+    def test_fallback_to_python_module(self):
+        """Should fallback to python -m nanobot if nanobot not in PATH."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            # First call (nanobot) returns None, second (python3) returns path
+            mock_which.side_effect = [None, "/usr/bin/python3"]
+            result = get_nanobot_executable()
+            assert result == "/usr/bin/python3 -m nanobot"
+
+    def test_fallback_to_python(self):
+        """Should try python if python3 not found."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.side_effect = [None, None, "/usr/bin/python"]
+            result = get_nanobot_executable()
+            assert result == "/usr/bin/python -m nanobot"
+
+    def test_raises_if_nothing_found(self):
+        """Should raise if no executable found."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.return_value = None
+            with pytest.raises(RuntimeError, match="Cannot find nanobot"):
+                get_nanobot_executable()
+
+
+class TestGenerateServiceUnit:
+    """Test systemd service unit generation."""
+
+    def test_basic_structure(self):
+        """Generated unit should have all required sections."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.return_value = "/usr/bin/nanobot"
+            unit = generate_service_unit()
+
+        assert "[Unit]" in unit
+        assert "[Service]" in unit
+        assert "[Install]" in unit
+
+    def test_contains_description(self):
+        """Unit should have a description."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.return_value = "/usr/bin/nanobot"
+            unit = generate_service_unit()
+
+        assert "Description=" in unit
+        assert "Nanobot" in unit
+
+    def test_exec_start_with_simple_path(self):
+        """ExecStart should use direct path when found in PATH."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.return_value = "/usr/bin/nanobot"
+            unit = generate_service_unit()
+
+        assert "ExecStart=/usr/bin/nanobot gateway" in unit
+
+    def test_exec_start_with_python_module(self):
+        """ExecStart should use bash -c for python -m style."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.side_effect = [None, "/usr/bin/python3"]
+            unit = generate_service_unit()
+
+        assert "ExecStart=/bin/bash -c '/usr/bin/python3 -m nanobot gateway'" in unit
+
+    def test_restart_policy(self):
+        """Unit should have restart-on-failure policy."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.return_value = "/usr/bin/nanobot"
+            unit = generate_service_unit()
+
+        assert "Restart=on-failure" in unit
+        assert "RestartSec=5" in unit
+
+    def test_logging_to_journal(self):
+        """Unit should log to journald."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.return_value = "/usr/bin/nanobot"
+            unit = generate_service_unit()
+
+        assert "StandardOutput=journal" in unit
+        assert "StandardError=journal" in unit
+
+    def test_install_target(self):
+        """Unit should be wanted by default.target."""
+        with patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_which.return_value = "/usr/bin/nanobot"
+            unit = generate_service_unit()
+
+        assert "WantedBy=default.target" in unit
+
+
+class TestCheckLinuxSystemd:
+    """Test Linux/systemd availability check."""
+
+    def test_returns_false_on_non_linux(self):
+        """Should return False on non-Linux platforms."""
+        with patch("nanobot.cli.service.platform.system") as mock_system:
+            mock_system.return_value = "Windows"
+            result = check_linux_systemd()
+            assert result is False
+
+    def test_returns_false_if_no_systemctl(self):
+        """Should return False if systemctl not found."""
+        with patch("nanobot.cli.service.platform.system") as mock_system, \
+             patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_system.return_value = "Linux"
+            mock_which.return_value = None
+            result = check_linux_systemd()
+            assert result is False
+
+    def test_returns_true_on_linux_with_systemd(self):
+        """Should return True on Linux with systemctl."""
+        with patch("nanobot.cli.service.platform.system") as mock_system, \
+             patch("nanobot.cli.service.shutil.which") as mock_which:
+            mock_system.return_value = "Linux"
+            mock_which.return_value = "/usr/bin/systemctl"
+            result = check_linux_systemd()
+            assert result is True
+
+
+class TestCheckLingerEnabled:
+    """Test linger status check."""
+
+    def test_returns_false_if_no_user_env(self):
+        """Should return False if USER env var not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove USER from environment
+            os.environ.pop("USER", None)
+            result = check_linger_enabled()
+            assert result is False
+
+    def test_returns_false_if_linger_file_missing(self):
+        """Should return False if linger file doesn't exist."""
+        with patch.dict(os.environ, {"USER": "testuser"}), \
+             patch("nanobot.cli.service.Path.exists") as mock_exists:
+            mock_exists.return_value = False
+            result = check_linger_enabled()
+            assert result is False
+
+    def test_returns_true_if_linger_file_exists(self):
+        """Should return True if linger file exists."""
+        with patch.dict(os.environ, {"USER": "testuser"}), \
+             patch("nanobot.cli.service.Path.exists") as mock_exists:
+            mock_exists.return_value = True
+            result = check_linger_enabled()
+            assert result is True
+
+
+class TestServiceCommands:
+    """Test CLI commands."""
+
+    def test_status_shows_not_installed_on_non_linux(self):
+        """Status command should show error on non-Linux."""
+        with patch("nanobot.cli.service.check_linux_systemd") as mock_check:
+            mock_check.return_value = False
+            result = runner.invoke(service_app, ["status"])
+            # Should exit with error on non-Linux
+            assert result.exit_code != 0 or "only supported on Linux" in result.stdout
+
+    def test_install_rejected_on_non_linux(self):
+        """Install command should be rejected on non-Linux."""
+        with patch("nanobot.cli.service.check_linux_systemd") as mock_check:
+            mock_check.return_value = False
+            result = runner.invoke(service_app, ["install"])
+            assert result.exit_code != 0
+            # Just check exit code is non-zero (error occurred)
+            # The error message goes to console via rich, not captured in stdout
+
+    def test_uninstall_rejected_on_non_linux(self):
+        """Uninstall command should be rejected on non-Linux."""
+        with patch("nanobot.cli.service.check_linux_systemd") as mock_check:
+            mock_check.return_value = False
+            result = runner.invoke(service_app, ["uninstall"])
+            assert result.exit_code != 0
+
+    def test_restart_rejected_on_non_linux(self):
+        """Restart command should be rejected on non-Linux."""
+        with patch("nanobot.cli.service.check_linux_systemd") as mock_check:
+            mock_check.return_value = False
+            result = runner.invoke(service_app, ["restart"])
+            assert result.exit_code != 0
+
+    def test_logs_rejected_on_non_linux(self):
+        """Logs command should be rejected on non-Linux."""
+        with patch("nanobot.cli.service.check_linux_systemd") as mock_check:
+            mock_check.return_value = False
+            result = runner.invoke(service_app, ["logs"])
+            assert result.exit_code != 0
+
+
+class TestServiceInstall:
+    """Test service installation."""
+
+    def test_install_creates_service_file(self, tmp_path):
+        """Install should create systemd service file."""
+        service_dir = tmp_path / ".config" / "systemd" / "user"
+        service_file = service_dir / "nanobot.service"
+
+        with patch("nanobot.cli.service.check_linux_systemd") as mock_check, \
+             patch("nanobot.cli.service.SYSTEMD_USER_DIR", service_dir), \
+             patch("nanobot.cli.service.get_service_file_path") as mock_path, \
+             patch("nanobot.cli.service.shutil.which") as mock_which, \
+             patch("nanobot.cli.service.run_systemctl_user") as mock_run, \
+             patch("nanobot.cli.service.check_linger_enabled") as mock_linger:
+
+            mock_check.return_value = True
+            mock_path.return_value = service_file
+            mock_which.return_value = "/usr/bin/nanobot"
+            mock_run.return_value = MagicMock(returncode=0)
+            mock_linger.return_value = True
+
+            result = runner.invoke(service_app, ["install"])
+
+            assert result.exit_code == 0
+            assert service_file.exists()
+            content = service_file.read_text()
+            assert "[Unit]" in content
+            assert "[Service]" in content
+
+    def test_install_shows_linger_warning(self, tmp_path):
+        """Install should warn if linger is not enabled."""
+        service_dir = tmp_path / ".config" / "systemd" / "user"
+        service_file = service_dir / "nanobot.service"
+
+        with patch("nanobot.cli.service.check_linux_systemd") as mock_check, \
+             patch("nanobot.cli.service.SYSTEMD_USER_DIR", service_dir), \
+             patch("nanobot.cli.service.get_service_file_path") as mock_path, \
+             patch("nanobot.cli.service.shutil.which") as mock_which, \
+             patch("nanobot.cli.service.run_systemctl_user") as mock_run, \
+             patch("nanobot.cli.service.check_linger_enabled") as mock_linger:
+
+            mock_check.return_value = True
+            mock_path.return_value = service_file
+            mock_which.return_value = "/usr/bin/nanobot"
+            mock_run.return_value = MagicMock(returncode=0)
+            mock_linger.return_value = False
+
+            result = runner.invoke(service_app, ["install"])
+
+            assert "Linger is not enabled" in result.stdout
+
+
+class TestServiceUninstall:
+    """Test service uninstallation."""
+
+    def test_uninstall_removes_service_file(self, tmp_path):
+        """Uninstall should remove the service file."""
+        service_dir = tmp_path / ".config" / "systemd" / "user"
+        service_dir.mkdir(parents=True)
+        service_file = service_dir / "nanobot.service"
+        service_file.write_text("[Unit]\nDescription=Test\n")
+
+        with patch("nanobot.cli.service.check_linux_systemd") as mock_check, \
+             patch("nanobot.cli.service.get_service_file_path") as mock_path, \
+             patch("nanobot.cli.service.run_systemctl_user") as mock_run:
+
+            mock_check.return_value = True
+            mock_path.return_value = service_file
+            mock_run.return_value = MagicMock(returncode=0)
+
+            result = runner.invoke(service_app, ["uninstall"])
+
+            assert result.exit_code == 0
+            assert not service_file.exists()
+
+    def test_uninstall_handles_missing_service(self):
+        """Uninstall should handle case where service is not installed."""
+        with patch("nanobot.cli.service.check_linux_systemd") as mock_check, \
+             patch("nanobot.cli.service.get_service_file_path") as mock_path, \
+             patch("nanobot.cli.service.run_systemctl_user") as mock_run:
+
+            mock_check.return_value = True
+            mock_path.return_value = Path("/nonexistent/nanobot.service")
+            mock_run.return_value = MagicMock(returncode=0)
+
+            result = runner.invoke(service_app, ["uninstall"])
+
+            assert "Service not installed" in result.stdout


### PR DESCRIPTION
```sh
(base) ➜  ~ nanobot service install
Service already installed at /home/xxx/.config/systemd/user/nanobot.service
Reinstall? [y/N]: y
✓ Created service file: /home/xxx/.config/systemd/user/nanobot.service
Reloading systemd daemon...
✓ Daemon reloaded
Enabling and starting service...
✓ Service 'nanobot' enabled and started
✓ Linger is enabled (service will run at boot)

🐈 Service installed successfully!
  Check status: nanobot service status
  View logs:    nanobot service logs
(base) ➜  ~ nanobot service status
                     nanobot Service Status
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Property     ┃ Value                                          ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ Service File │ /home/xxx/.config/systemd/user/nanobot.service │
│ Active       │ active                                         │
│ Enabled      │ yes                                            │
│ Linger       │ enabled                                        │
└──────────────┴────────────────────────────────────────────────┘

Recent logs:
  Feb 27 00:46:25 xxxxx systemd[303]: nanobot.service: Main process exited,
code=exited, status=1/FAILURE
  Feb 27 00:46:25 xxxxx systemd[303]: nanobot.service: Failed with result
'exit-code'.
  Feb 27 00:46:31 xxxxx systemd[303]: nanobot.service: Scheduled restart job,
restart counter is at 3.
  Feb 27 00:46:31 xxxxx systemd[303]: Stopped Nanobot AI Assistant Gateway.
  Feb 27 00:46:31 xxxxx systemd[303]: Started Nanobot AI Assistant Gateway.

(base) ➜  ~ nanobot service logs
Feb 27 00:45:38 xxxxx nanobot[1511]: Set one in ~/.nanobot/config.json under p>
Feb 27 00:45:37 xxxxx systemd[303]: nanobot.service: Main process exited, code>
Feb 27 00:45:37 xxxxx systemd[303]: nanobot.service: Failed with result 'exit->
Feb 27 00:45:42 xxxxx systemd[303]: nanobot.service: Scheduled restart job, re>
Feb 27 00:45:42 xxxxx systemd[303]: Stopped Nanobot AI Assistant Gateway.
Feb 27 00:45:42 xxxxx systemd[303]: Started Nanobot AI Assistant Gateway.
Feb 27 00:45:43 xxxxx nanobot[1522]: 🐈 Starting nanobot gateway on port 18790>
Feb 27 00:45:43 xxxxx nanobot[1522]: Error: No API key configured.
Feb 27 00:45:43 xxxxx nanobot[1522]: Set one in ~/.nanobot/config.json under p>
Feb 27 00:45:43 xxxxx systemd[303]: nanobot.service: Main process exited, code>
Feb 27 00:45:43 xxxxx systemd[303]: nanobot.service: Failed with result 'exit->
Feb 27 00:45:49 xxxxx systemd[303]: nanobot.service: Scheduled restart job, re>
Feb 27 00:45:49 xxxxx systemd[303]: Stopped Nanobot AI Assistant Gateway.
Feb 27 00:45:49 xxxxx systemd[303]: Started Nanobot AI Assistant Gateway.
Feb 27 00:45:54 xxxxx nanobot[1529]: 00:45:54 - LiteLLM:WARNING: get_model_cos>
Feb 27 00:45:55 xxxxx nanobot[1529]: 🐈 Starting nanobot gateway on port 18790>
Feb 27 00:45:55 xxxxx nanobot[1529]: Error: No API key configured.
Feb 27 00:45:55 xxxxx nanobot[1529]: Set one in ~/.nanobot/config.json under p>
Feb 27 00:45:55 xxxxx systemd[303]: nanobot.service: Main process exited, code>
Feb 27 00:45:55 xxxxx systemd[303]: nanobot.service: Failed with result 'exit->
Feb 27 00:46:00 xxxxx systemd[303]: nanobot.service: Scheduled restart job, re>
Feb 27 00:46:00 xxxxx systemd[303]: Stopped Nanobot AI Assistant Gateway.
Feb 27 00:46:00 xxxxx systemd[303]: Started Nanobot AI Assistant Gateway.
Feb 27 00:46:09 xxxxx systemd[303]: Stopping Nanobot AI Assistant Gateway...
Feb 27 00:46:09 xxxxx systemd[303]: Stopped Nanobot AI Assistant Gateway.
Feb 27 00:46:09 xxxxx systemd[303]: Started Nanobot AI Assistant Gateway.
Feb 27 00:46:10 xxxxx nanobot[1551]: 🐈 Starting nanobot gateway on port 18790>
Feb 27 00:46:10 xxxxx nanobot[1551]: Error: No API key configured.
Feb 27 00:46:10 xxxxx nanobot[1551]: Set one in ~/.nanobot/config.json under p>
Feb 27 00:46:11 xxxxx systemd[303]: nanobot.service: Main process exited, code>
Feb 27 00:46:11 xxxxx systemd[303]: nanobot.service: Failed with result 'exit->
Feb 27 00:46:16 xxxxx systemd[303]: nanobot.service: Scheduled restart job, re>
Feb 27 00:46:16 xxxxx systemd[303]: Stopped Nanobot AI Assistant Gateway.
Feb 27 00:46:16 xxxxx systemd[303]: Started Nanobot AI Assistant Gateway.
Feb 27 00:46:18 xxxxx nanobot[1559]: 🐈 Starting nanobot gateway on port 18790>
Feb 27 00:46:18 xxxxx nanobot[1559]: Error: No API key configured.
Feb 27 00:46:18 xxxxx nanobot[1559]: Set one in ~/.nanobot/config.json under p>
Feb 27 00:46:18 xxxxx systemd[303]: nanobot.service: Main process exited, code>
Feb 27 00:46:18 xxxxx systemd[303]: nanobot.service: Failed with result 'exit->
Feb 27 00:46:24 xxxxx systemd[303]: nanobot.service: Scheduled restart job, re>
Feb 27 00:46:24 xxxxx systemd[303]: Stopped Nanobot AI Assistant Gateway.
Feb 27 00:46:24 xxxxx systemd[303]: Started Nanobot AI Assistant Gateway.
Feb 27 00:46:25 xxxxx nanobot[1572]: 🐈 Starting nanobot gateway on port 18790>
Feb 27 00:46:25 xxxxx nanobot[1572]: Error: No API key configured.
(base) ➜  ~ nanobot service restart
✓ Service restarted
```