### PR TITLE
fix: correct Windows Terminal syntax for new tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ poetry.lock
 .pytest_cache/
 botpy.log
 tests/
+nanobot_venv/

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -44,7 +44,9 @@ class ExecTool(Tool):
     
     @property
     def description(self) -> str:
-        return "Execute a shell command and return its output. Use with caution."
+        return ("Execute a shell command and return its output. Use with caution. "
+                "On Windows, when using 'wt nt' to open a new tab, do NOT quote the entire nested "
+                "command as a single argument; instead use 'wt nt cmd /c \"command\"'.")
     
     @property
     def parameters(self) -> dict[str, Any]:

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -44,7 +44,9 @@ class ExecTool(Tool):
     
     @property
     def description(self) -> str:
-        return "Execute a shell command and return its output. Use with caution."
+        return ("Execute a shell command and return its output. Use with caution. "
+                "On Windows, when using 'wt nt' to open a new tab, do NOT quote the entire nested "
+                "command; use 'wt nt cmd /c \"command\"' or 'wt nt powershell -Command \"command\"'.")
     
     @property
     def parameters(self) -> dict[str, Any]:

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -46,7 +46,8 @@ class ExecTool(Tool):
     def description(self) -> str:
         return ("Execute a shell command and return its output. Use with caution. "
                 "On Windows, when using 'wt nt' to open a new tab, do NOT quote the entire nested "
-                "command; use 'wt nt cmd /c \"command\"' or 'wt nt powershell -Command \"command\"'.")
+                "command; use 'wt nt cmd /c \"command\"' or 'wt nt powershell -Command \"Start-Process 'C:\\Path\\To\\App.exe'\"'. "
+                "CRITICAL: Always quote paths with spaces inside PowerShell command strings.")
     
     @property
     def parameters(self) -> dict[str, Any]:

--- a/nanobot/templates/TOOLS.md
+++ b/nanobot/templates/TOOLS.md
@@ -13,3 +13,12 @@ This file documents non-obvious constraints and usage patterns.
 ## cron — Scheduled Reminders
 
 - Please refer to cron skill for usage.
+## Windows Terminal (wt.exe) Usage Patterns
+
+When opening a new tab or pane on Windows, follow these syntax rules to avoid "File not found" (0x80070002) errors:
+- **DO NOT** quote the entire command as a single argument: `wt nt "npm install"` (WRONG)
+- **DO** wrap in a shell (cmd or powershell) for complex commands or PowerShell cmdlets:
+  - `wt nt cmd /c "npm install -g vercel"` (CORRECT)
+  - `wt nt powershell -Command "Start-Process 'C:\Path\To\App.exe'"` (CORRECT)
+- **DO** use separate arguments for simple executables: `wt nt npm install -g vercel` (CORRECT) or `wt nt "C:\Path\To\App.exe"` (CORRECT)
+- Use `wt -w 0 nt ...` to ensure it opens in the current terminal window.

--- a/nanobot/templates/TOOLS.md
+++ b/nanobot/templates/TOOLS.md
@@ -19,6 +19,6 @@ When opening a new tab or pane on Windows, follow these syntax rules to avoid "F
 - **DO NOT** quote the entire command as a single argument: `wt nt "npm install"` (WRONG)
 - **DO** wrap in a shell (cmd or powershell) for complex commands or PowerShell cmdlets:
   - `wt nt cmd /c "npm install -g vercel"` (CORRECT)
-  - `wt nt powershell -Command "Start-Process 'C:\Path\To\App.exe'"` (CORRECT)
+  - `wt nt powershell -Command "Start-Process 'C:\Program Files\App\App.exe'"` (CORRECT - **ALWAYS** quote paths with spaces inside PowerShell strings)
 - **DO** use separate arguments for simple executables: `wt nt npm install -g vercel` (CORRECT) or `wt nt "C:\Path\To\App.exe"` (CORRECT)
 - Use `wt -w 0 nt ...` to ensure it opens in the current terminal window.

--- a/nanobot/templates/TOOLS.md
+++ b/nanobot/templates/TOOLS.md
@@ -13,3 +13,10 @@ This file documents non-obvious constraints and usage patterns.
 ## cron — Scheduled Reminders
 
 - Please refer to cron skill for usage.
+## Windows Terminal (wt.exe) Usage Patterns
+
+When opening a new tab or pane on Windows, follow these syntax rules to avoid "File not found" errors:
+- **DO NOT** quote the entire command as a single argument: `wt nt "npm install"` (WRONG)
+- **DO** wrap in a shell (cmd or powershell) for complex commands: `wt nt cmd /c "npm install -g vercel"` (CORRECT)
+- **DO** use separate arguments for simple commands: `wt nt npm install -g vercel` (CORRECT)
+- Use `wt -w 0 nt ...` to ensure it opens in the current terminal window.


### PR DESCRIPTION
## Summary
- Fixed `0x80070002` (File not found) errors when nanobot uses `wt nt` on Windows.
- Updated `ExecTool` description to explicitly warn against quoting the entire nested command.
- Added detailed Windows Terminal usage patterns to `TOOLS.md` template to guide the AI towards the `cmd /c` pattern.

## Why
On Windows, `wt nt "command"` fails because Windows Terminal interprets the entire string as a filename. The correct approach is `wt nt cmd /c \"command\"` or passing arguments unquoted. This change ensures the AI understands this requirement.