### PR TITLE
fix(codex): stabilize prompt_cache_key and include model/tools fingerprint

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -34,25 +34,31 @@ class OpenAICodexProvider(LLMProvider):
     ) -> LLMResponse:
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)
+        model_name = _strip_model_prefix(model)
+        converted_tools = _convert_tools(tools) if tools else None
 
         token = await asyncio.to_thread(get_codex_token)
         headers = _build_headers(token.account_id, token.access)
 
         body: dict[str, Any] = {
-            "model": _strip_model_prefix(model),
+            "model": model_name,
             "store": False,
             "stream": True,
             "instructions": system_prompt,
             "input": input_items,
             "text": {"verbosity": "medium"},
             "include": ["reasoning.encrypted_content"],
-            "prompt_cache_key": _prompt_cache_key(messages),
+            "prompt_cache_key": _prompt_cache_key(
+                messages,
+                model=model_name,
+                tools=converted_tools,
+            ),
             "tool_choice": "auto",
             "parallel_tool_calls": True,
         }
 
-        if tools:
-            body["tools"] = _convert_tools(tools)
+        if converted_tools:
+            body["tools"] = converted_tools
 
         url = DEFAULT_CODEX_URL
 
@@ -217,8 +223,44 @@ def _split_tool_call_id(tool_call_id: Any) -> tuple[str, str | None]:
     return "call_0", None
 
 
-def _prompt_cache_key(messages: list[dict[str, Any]]) -> str:
-    raw = json.dumps(messages, ensure_ascii=True, sort_keys=True)
+_RUNTIME_CONTEXT_TAG_PREFIX = "[Runtime Context"
+_RUNTIME_TIME_LINE_PREFIX = "Current Time:"
+_RUNTIME_TIME_CANONICAL_LINE = "Current Time: <normalized>"
+
+
+def _normalize_runtime_context(content: str) -> str:
+    """Normalize volatile runtime metadata so prompt cache keys stay stable."""
+    lines = content.splitlines()
+    if not lines:
+        return content
+    if not lines[0].strip().startswith(_RUNTIME_CONTEXT_TAG_PREFIX):
+        return content
+    return "\n".join(
+        _RUNTIME_TIME_CANONICAL_LINE if line.startswith(_RUNTIME_TIME_LINE_PREFIX) else line
+        for line in lines
+    )
+
+
+def _prompt_cache_key(
+    messages: list[dict[str, Any]],
+    *,
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+) -> str:
+    normalized_messages: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") != "user" or not isinstance(msg.get("content"), str):
+            normalized_messages.append(msg)
+            continue
+        normalized_messages.append({**msg, "content": _normalize_runtime_context(msg["content"])})
+
+    payload: dict[str, Any] = {"messages": normalized_messages}
+    if model is not None:
+        payload["model"] = model
+    if tools is not None:
+        payload["tools"] = tools
+
+    raw = json.dumps(payload, ensure_ascii=True, sort_keys=True)
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import datetime as datetime_module
 
 from nanobot.agent.context import ContextBuilder
+from nanobot.providers.openai_codex_provider import _prompt_cache_key
 
 
 class _FakeDatetime(real_datetime):
@@ -64,3 +65,41 @@ def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
 
     assert messages[-1]["role"] == "user"
     assert messages[-1]["content"] == "Return exactly: OK"
+
+
+def test_codex_prompt_cache_key_ignores_runtime_clock_line() -> None:
+    """Changing only runtime Current Time should not change prompt_cache_key."""
+    tag = ContextBuilder._RUNTIME_CONTEXT_TAG
+
+    m1 = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "user",
+            "content": f"{tag}\nCurrent Time: 2026-02-27 10:00 (Friday)\nChannel: cli\nChat ID: direct",
+        },
+        {"role": "user", "content": "Summarize latest logs"},
+    ]
+    m2 = [
+        {"role": "system", "content": "sys"},
+        {
+            "role": "user",
+            "content": f"{tag}\nCurrent Time: 2026-02-27 10:01 (Friday)\nChannel: cli\nChat ID: direct",
+        },
+        {"role": "user", "content": "Summarize latest logs"},
+    ]
+
+    assert _prompt_cache_key(m1) == _prompt_cache_key(m2)
+
+
+def test_codex_prompt_cache_key_includes_model_and_tools() -> None:
+    """Different model/tools should produce a different prompt_cache_key."""
+    messages = [{"role": "system", "content": "sys"}, {"role": "user", "content": "hello"}]
+    tools_a = [{"type": "function", "name": "read_file", "parameters": {"type": "object"}}]
+    tools_b = [{"type": "function", "name": "write_file", "parameters": {"type": "object"}}]
+
+    k1 = _prompt_cache_key(messages, model="gpt-5.1-codex", tools=tools_a)
+    k2 = _prompt_cache_key(messages, model="gpt-5.1-codex-mini", tools=tools_a)
+    k3 = _prompt_cache_key(messages, model="gpt-5.1-codex", tools=tools_b)
+
+    assert k1 != k2
+    assert k1 != k3


### PR DESCRIPTION
## Summary
- stabilize Codex `prompt_cache_key` by normalizing volatile runtime `Current Time` line
- include `model` and `tools` fingerprints in key generation to avoid cross-context key collisions
- add tests for runtime-time invariance and model/tools key differentiation

## Why
Previously key generation hashed raw `messages` only. Runtime clock changes caused frequent key churn and poor cache hit probability.

## Benchmark (local key-collision proxy)
Synthetic 200-request check (same request except runtime clock line):
- before: `unique_keys=200`, `hit_rate_proxy=0.0`
- after: `unique_keys=1`, `hit_rate_proxy=0.995`

## Test Plan
- [x] `PYTHONPATH=. /home/rickthemad4/.venvs/nanobot/bin/pytest -q tests/test_context_prompt_cache.py tests/test_commands.py`
- [ ] full `pytest -q` (currently blocked by unrelated baseline collection issues in this environment: `tests/test_heartbeat_service.py`, `tests/test_matrix_channel.py`)

## Scope
Changes only affect `OpenAICodexProvider` path; non-Codex providers are untouched.