### PR TITLE
feat(feishu): make reaction emoji configurable

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -692,7 +692,7 @@ class FeishuChannel(BaseChannel):
             msg_type = message.message_type
 
             # Add reaction
-            await self._add_reaction(message_id, "THUMBSUP")
+            await self._add_reaction(message_id, self.config.react_emoji)
 
             # Parse content
             content_parts = []

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -42,6 +42,7 @@ class FeishuConfig(Base):
     encrypt_key: str = ""  # Encrypt Key for event subscription (optional)
     verification_token: str = ""  # Verification Token for event subscription (optional)
     allow_from: list[str] = Field(default_factory=list)  # Allowed user open_ids
+    react_emoji: str = "THUMBSUP"  # Emoji type for message reactions (e.g. THUMBSUP, OK, DONE, SMILE)
 
 
 class DingTalkConfig(Base):


### PR DESCRIPTION
## Summary

Replace the hardcoded `THUMBSUP` reaction emoji in the Feishu channel with a configurable `react_emoji` field in `FeishuConfig`.

## Changes

- **`nanobot/config/schema.py`**: Add `react_emoji: str = "THUMBSUP"` to `FeishuConfig`
- **`nanobot/channels/feishu.py`**: Use `self.config.react_emoji` instead of hardcoded string

## Motivation

The Feishu channel hardcodes `THUMBSUP` as the reaction emoji for incoming messages. This makes it impossible for users to customize the reaction without modifying source code.

The Slack channel already has a `react_emoji` config field — this PR brings the Feishu channel in line with that pattern.

## Backward Compatibility

Default value is `THUMBSUP`, so existing deployments are unaffected.