### PR TITLE
feat(feishu): support configurable API domain for feishu

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -286,6 +286,7 @@ class FeishuChannel(BaseChannel):
             .app_id(self.config.app_id) \
             .app_secret(self.config.app_secret) \
             .log_level(lark.LogLevel.INFO) \
+            .domain(self.config.domain) \
             .build()
         
         # Create event handler (only register message receive, ignore other events)
@@ -301,7 +302,8 @@ class FeishuChannel(BaseChannel):
             self.config.app_id,
             self.config.app_secret,
             event_handler=event_handler,
-            log_level=lark.LogLevel.INFO
+            log_level=lark.LogLevel.INFO,
+            domain=self.config.domain
         )
         
         # Start WebSocket client in a separate thread with reconnect loop

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -43,6 +43,7 @@ class FeishuConfig(Base):
     verification_token: str = ""  # Verification Token for event subscription (optional)
     allow_from: list[str] = Field(default_factory=list)  # Allowed user open_ids
     react_emoji: str = "THUMBSUP"  # Emoji type for message reactions (e.g. THUMBSUP, OK, DONE, SMILE)
+    domain: str = "https://open.feishu.cn"  # Feishu domain, default is https://open.feishu.cn
 
 
 class DingTalkConfig(Base):


### PR DESCRIPTION
## Description
This PR adds support for configuring a custom Feishu API domain, which is useful for enterprises that use self-hosted or customized Feishu endpoints.

## Changes
- Added domain field to FeishuConfig with default value https://open.feishu.cn
- Updated Feishu SDK client initialization to use the configurable domain for both OpenAPI and WebSocket connections