### PR TITLE
feat(exec): per-call timeout, env_strip, and output truncation

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -115,6 +115,8 @@ class AgentLoop:
             timeout=self.exec_config.timeout,
             restrict_to_workspace=self.restrict_to_workspace,
             path_append=self.exec_config.path_append,
+            max_output_chars=self.exec_config.max_output_chars,
+            env_strip=self.exec_config.env_strip,
         ))
         self.tools.register(WebSearchTool(api_key=self.brave_api_key))
         self.tools.register(WebFetchTool())

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -100,6 +100,8 @@ class SubagentManager:
                 timeout=self.exec_config.timeout,
                 restrict_to_workspace=self.restrict_to_workspace,
                 path_append=self.exec_config.path_append,
+                max_output_chars=self.exec_config.max_output_chars,
+                env_strip=self.exec_config.env_strip,
             ))
             tools.register(WebSearchTool(api_key=self.brave_api_key))
             tools.register(WebFetchTool())

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -297,6 +297,12 @@ class ExecToolConfig(Base):
 
     timeout: int = 60
     path_append: str = ""
+    max_output_chars: int = 10000
+    env_strip: list[str] = Field(default_factory=lambda: [
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+    ])
 
 
 class MCPServerConfig(Base):

--- a/nanobot/templates/TOOLS.md
+++ b/nanobot/templates/TOOLS.md
@@ -5,9 +5,9 @@ This file documents non-obvious constraints and usage patterns.
 
 ## exec — Safety Limits
 
-- Commands have a configurable timeout (default 60s)
+- Commands have a configurable timeout (default 60s); pass `timeout` per-call to override (max 1800s)
 - Dangerous commands are blocked (rm -rf, format, dd, shutdown, etc.)
-- Output is truncated at 10,000 characters
+- Output is truncated at 10,000 characters; use file output (`-o` or `>`) for long results
 - `restrictToWorkspace` config can limit file access to the workspace
 
 ## cron — Scheduled Reminders

--- a/tests/test_exec_tool.py
+++ b/tests/test_exec_tool.py
@@ -1,0 +1,93 @@
+"""Tests for ExecTool env_strip, per-call timeout, and max_output_chars."""
+
+import os
+
+import pytest
+
+from nanobot.agent.tools.shell import ExecTool
+
+
+class TestEnvStrip:
+    @pytest.mark.asyncio
+    async def test_env_strip_removes_keys(self):
+        """API keys listed in env_strip must not leak to child processes."""
+        os.environ["ANTHROPIC_API_KEY"] = "sk-test-secret"
+        try:
+            tool = ExecTool(env_strip=["ANTHROPIC_API_KEY"])
+            result = await tool.execute("echo $ANTHROPIC_API_KEY")
+            assert "sk-test-secret" not in result
+        finally:
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+
+    @pytest.mark.asyncio
+    async def test_env_strip_empty_preserves_env(self):
+        """An empty env_strip list should not remove any variables."""
+        os.environ["TEST_NANOBOT_VAR"] = "keep-me"
+        try:
+            tool = ExecTool(env_strip=[])
+            result = await tool.execute("echo $TEST_NANOBOT_VAR")
+            assert "keep-me" in result
+        finally:
+            os.environ.pop("TEST_NANOBOT_VAR", None)
+
+
+class TestPerCallTimeout:
+    @pytest.mark.asyncio
+    async def test_per_call_timeout_overrides_default(self):
+        """A per-call timeout should override the instance default."""
+        tool = ExecTool(timeout=60)
+        # sleep 5 with a 1-second per-call timeout should time out
+        result = await tool.execute("sleep 5", timeout=1)
+        assert "timed out" in result
+        assert "1 seconds" in result
+
+    @pytest.mark.asyncio
+    async def test_per_call_timeout_fallback_to_default(self):
+        """Without per-call timeout, the instance default is used."""
+        tool = ExecTool(timeout=1)
+        result = await tool.execute("sleep 5")
+        assert "timed out" in result
+        assert "1 seconds" in result
+
+    @pytest.mark.asyncio
+    async def test_per_call_timeout_succeeds_within_limit(self):
+        """A fast command should succeed with a generous per-call timeout."""
+        tool = ExecTool(timeout=1)  # tight default
+        result = await tool.execute("echo ok", timeout=10)
+        assert "ok" in result
+        assert "timed out" not in result
+
+    def test_timeout_parameter_in_schema(self):
+        """The timeout parameter should be exposed in the JSON schema."""
+        tool = ExecTool()
+        props = tool.parameters["properties"]
+        assert "timeout" in props
+        assert props["timeout"]["type"] == "integer"
+        assert props["timeout"]["minimum"] == 1
+        assert props["timeout"]["maximum"] == 1800
+
+    def test_timeout_validation_rejects_out_of_range(self):
+        """Parameter validation should reject timeout outside [1, 1800]."""
+        tool = ExecTool()
+        errors = tool.validate_params({"command": "echo hi", "timeout": 0})
+        assert any("must be >= 1" in e for e in errors)
+        errors = tool.validate_params({"command": "echo hi", "timeout": 9999})
+        assert any("must be <= 1800" in e for e in errors)
+
+
+class TestMaxOutputChars:
+    @pytest.mark.asyncio
+    async def test_max_output_chars_truncation(self):
+        """Output exceeding max_output_chars must be truncated."""
+        tool = ExecTool(max_output_chars=50)
+        result = await tool.execute("python3 -c \"print('A' * 200)\"")
+        assert "truncated" in result
+        assert len(result.split("\n... (truncated")[0]) <= 50
+
+    @pytest.mark.asyncio
+    async def test_max_output_chars_no_truncation(self):
+        """Short output should not be truncated."""
+        tool = ExecTool(max_output_chars=10000)
+        result = await tool.execute("echo hello")
+        assert "truncated" not in result
+        assert "hello" in result


### PR DESCRIPTION
## Summary

- **Per-call timeout**: ExecTool now exposes a `timeout` parameter (1–1800s) in the JSON schema so the LLM can request longer timeouts for heavy tasks (e.g. coding agents) without changing the instance default
- **env_strip**: Strips sensitive env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`) from child processes to prevent credential leaks
- **Configurable output truncation**: `max_output_chars` is now configurable via `ExecToolConfig` (default 10,000 chars)
- **Tests**: 9 tests covering env_strip, per-call timeout (override, fallback, success path), schema validation, and output truncation
- **Docs**: Updated `templates/TOOLS.md` to document per-call timeout and file output hint

## Test plan

- [x] `pytest tests/test_exec_tool.py -v` — 9/9 passed
- [x] Full test suite (111/111 passed, excluding 2 pre-existing collection errors)
- [x] Parameter validation rejects `timeout` outside [1, 1800] range

🤖 Generated with [Claude Code](https://claude.com/claude-code)