### PR TITLE
feat(skills): add claude-code and codex delegation skills

### DIFF
--- a/nanobot/skills/claude-code/SKILL.md
+++ b/nanobot/skills/claude-code/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: claude-code
+description: "Delegate tasks to Claude Code (Opus) for architecture, refactoring, and code review."
+metadata: {"nanobot":{"emoji":"🤖","requires":{"bins":["claude"]}}}
+---
+
+# Claude Code Skill
+
+Delegate complex tasks to Claude Code in non-interactive mode. Best for architecture, refactoring, and code review.
+
+## When to use
+
+- **Architecture / design** — system design, API design, module decomposition
+- **Refactoring** — large-scale restructuring across multiple files
+- **Code review** — deep analysis with contextual understanding
+
+For template generation, batch operations, or test scaffolding, prefer the `codex` skill.
+
+## Non-interactive execution (exec tool)
+
+Always use `-p` (prompt) mode. Redirect stdout to a file to avoid output truncation on long responses (Claude Code has no `-o` flag).
+
+```bash
+# Basic: result to file (avoids truncation)
+OUT=$(mktemp /tmp/claude-XXXXXX.txt)
+cd <project_dir> && claude -p "<prompt>" --output-format text > "$OUT" 2>&1
+cat "$OUT"
+
+# Full-auto mode (skips permission prompts)
+OUT=$(mktemp /tmp/claude-XXXXXX.txt)
+cd <project_dir> && claude -p "<prompt>" --output-format text --dangerously-skip-permissions > "$OUT" 2>&1
+cat "$OUT"
+```
+
+**Important:** Request a longer `timeout` (e.g. 300–600s) via the exec tool's `timeout` parameter — Claude Code tasks often take several minutes.
+
+## Output formats
+
+| Flag | Use case |
+|------|----------|
+| `--output-format text` | Human-readable, good for review results |
+| `--output-format json` | Structured output, good for parsing |
+
+## Environment notes
+
+- `env_strip` automatically clears `ANTHROPIC_API_KEY` — Claude Code uses OAuth, not the API key
+- Config: `~/.claude/settings.json`
+- Auth: claude.ai OAuth (already logged in)
+- Default permission mode: `bypassPermissions` (configured in settings.json)

--- a/nanobot/skills/codex/SKILL.md
+++ b/nanobot/skills/codex/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: codex
+description: "Delegate tasks to Codex CLI for template generation, batch operations, and test scaffolding."
+metadata: {"nanobot":{"emoji":"⚡","requires":{"bins":["codex"]}}}
+---
+
+# Codex Skill
+
+Delegate tasks to Codex CLI in non-interactive mode. Best for template generation, batch operations, and test scaffolding.
+
+## When to use
+
+- **Template / boilerplate generation** — scaffolding new files, components, configs
+- **Batch operations** — repetitive changes across many files
+- **Test scaffolding** — generating test stubs and fixtures
+
+For architecture, refactoring, or code review, prefer the `claude-code` skill.
+
+## Non-interactive execution (exec tool)
+
+Use `exec --full-auto` mode. Use `-o` to write the final response to a file — this avoids output truncation when results are long.
+
+```bash
+# Basic: result to file (avoids truncation)
+codex exec --full-auto -C <project_dir> -o /tmp/codex-result.txt "<prompt>"
+cat /tmp/codex-result.txt
+
+# With JSON event stream (for progress monitoring)
+codex exec --full-auto --json -C <project_dir> "<prompt>"
+
+# Specify sandbox mode
+codex exec --full-auto -s workspace-write -C <project_dir> -o /tmp/codex-result.txt "<prompt>"
+```
+
+**Important:** Request a longer `timeout` (e.g. 300–600s) via the exec tool's `timeout` parameter — Codex tasks often take several minutes.
+
+## Key flags
+
+| Flag | Purpose |
+|------|---------|
+| `--full-auto` | Auto-approve + workspace-write sandbox |
+| `-o <file>` | Write final message to file (avoids truncation) |
+| `--json` | JSONL event stream to stdout |
+| `-C <dir>` | Working directory |
+| `-s <sandbox>` | Sandbox mode override |
+
+## Environment notes
+
+- Config: `~/.codex/config.toml`
+- Model: gpt-5.3-codex
+- MCP servers: playwright, pyright


### PR DESCRIPTION
## Summary

- **claude-code skill**: Delegates tasks to Claude Code (Opus) in non-interactive `-p` mode, using stdout redirection to avoid output truncation. Best for architecture, refactoring, and code review. Gated by `requires.bins: ["claude"]`
- **codex skill**: Delegates tasks to Codex CLI via `exec --full-auto`, using `-o` for file output. Best for template generation, batch operations, and test scaffolding. Gated by `requires.bins: ["codex"]`

Both skills document the exec tool's `timeout` parameter for long-running agent tasks and include cross-references for selection guidance.

## Test plan

- [x] Skills discovered by `SkillsLoader.list_skills()` with correct `available` status
- [x] Skills appear in `build_skills_summary()` XML output
- [x] `shutil.which` availability gating works (available=True when binary exists, False otherwise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)