### PR TITLE
fix: generate short alphanumeric tool_call_id for Mistral compatibility

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -3,6 +3,8 @@
 import json
 import json_repair
 import os
+import secrets
+import string
 from typing import Any
 
 import litellm
@@ -15,6 +17,11 @@ from nanobot.providers.registry import find_by_model, find_gateway
 # Standard OpenAI chat-completion message keys plus reasoning_content for
 # thinking-enabled models (Kimi k2.5, DeepSeek-R1, etc.).
 _ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content"})
+_ALNUM = string.ascii_letters + string.digits
+
+def _short_tool_id() -> str:
+    """Generate a 9-char alphanumeric ID compatible with all providers (incl. Mistral)."""
+    return "".join(secrets.choice(_ALNUM) for _ in range(9))
 
 
 class LiteLLMProvider(LLMProvider):
@@ -245,7 +252,7 @@ class LiteLLMProvider(LLMProvider):
                     args = json_repair.loads(args)
                 
                 tool_calls.append(ToolCallRequest(
-                    id=tc.id,
+                    id=_short_tool_id(),
                     name=tc.function.name,
                     arguments=args,
                 ))


### PR DESCRIPTION
## Summary

Mistral API requires `tool_call_id` to be exactly 9 alphanumeric characters (`[a-zA-Z0-9]{9}`), but LiteLLM generates OpenAI-style IDs like `chatcmpl-tool-xxxxxxxx`. When these IDs are saved into session history and sent back to Mistral in subsequent turns, the API rejects them with a 400 error.

**Root cause:** nanobot uses `tc.id` from LiteLLM's response directly. LiteLLM normalizes provider-native IDs into its own format, which doesn't satisfy Mistral's strict validation.

**Fix:** Generate our own 9-char alphanumeric `tool_call_id` in `_parse_response`, compatible with all providers (Mistral, OpenAI, Anthropic, etc.). The ID is only used internally to pair `assistant.tool_calls[].id` with `tool.tool_call_id` — providers don't cross-validate ID origin across requests.

## Changes

- `litellm_provider.py`: Added `_short_tool_id()` that generates a 9-char `[a-zA-Z0-9]` ID using `secrets.choice`, replacing `tc.id` in `_parse_response`
