### PR TITLE
fix: handle list-type tool arguments in _tool_hint

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -163,7 +163,10 @@ class AgentLoop:
     def _tool_hint(tool_calls: list) -> str:
         """Format tool calls as concise hint, e.g. 'web_search("query")'."""
         def _fmt(tc):
-            val = next(iter(tc.arguments.values()), None) if tc.arguments else None
+            args = tc.arguments
+            if isinstance(args, list) and args:
+                args = args[0]
+            val = next(iter(args.values()), None) if isinstance(args, dict) and args else None
             if not isinstance(val, str):
                 return tc.name
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'


### PR DESCRIPTION
Some models (e.g., Kimi K2.5 via OpenRouter) return tool call arguments as a list instead of a dict. This caused an AttributeError when trying to call .values() on the list such as ask Kimi to generate the html file.

The fix checks if arguments is a list and extracts the first element before accessing .values().
