### PR TITLE
feat(config): add `cursor` and `gh` CLI API keys via config

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -58,8 +58,6 @@ class AgentLoop:
         max_tokens: int = 4096,
         memory_window: int = 100,
         brave_api_key: str | None = None,
-        cursor_api_key: str | None = None,
-        gh_api_key: str | None = None,
         exec_config: ExecToolConfig | None = None,
         cron_service: CronService | None = None,
         restrict_to_workspace: bool = False,
@@ -77,8 +75,6 @@ class AgentLoop:
         self.max_tokens = max_tokens
         self.memory_window = memory_window
         self.brave_api_key = brave_api_key
-        self.cursor_api_key = cursor_api_key
-        self.gh_api_key = gh_api_key
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -26,8 +26,10 @@ from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import LLMProvider
 from nanobot.session.manager import Session, SessionManager
 
+from nanobot.config.schema import ExecToolConfig
+
 if TYPE_CHECKING:
-    from nanobot.config.schema import ChannelsConfig, ExecToolConfig
+    from nanobot.config.schema import ChannelsConfig
     from nanobot.cron.service import CronService
 
 
@@ -56,6 +58,8 @@ class AgentLoop:
         max_tokens: int = 4096,
         memory_window: int = 100,
         brave_api_key: str | None = None,
+        cursor_api_key: str | None = None,
+        gh_api_key: str | None = None,
         exec_config: ExecToolConfig | None = None,
         cron_service: CronService | None = None,
         restrict_to_workspace: bool = False,
@@ -63,7 +67,6 @@ class AgentLoop:
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
     ):
-        from nanobot.config.schema import ExecToolConfig
         self.bus = bus
         self.channels_config = channels_config
         self.provider = provider
@@ -74,6 +77,8 @@ class AgentLoop:
         self.max_tokens = max_tokens
         self.memory_window = memory_window
         self.brave_api_key = brave_api_key
+        self.cursor_api_key = cursor_api_key
+        self.gh_api_key = gh_api_key
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -113,6 +113,15 @@ def _is_exit_command(command: str) -> bool:
     return command.lower() in EXIT_COMMANDS
 
 
+def _should_show_progress(channels_config, tool_hint: bool) -> bool:
+    """Return True if progress or tool hint should be shown per channels config."""
+    if not channels_config:
+        return True
+    if tool_hint:
+        return channels_config.send_tool_hints
+    return channels_config.send_progress
+
+
 async def _read_interactive_input_async() -> str:
     """Read user input using prompt_toolkit (handles paste, history, display).
 
@@ -284,6 +293,8 @@ def gateway(
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
         brave_api_key=config.tools.web.search.api_key or None,
+        cursor_api_key=config.tools.cursor.api_key or None,
+        gh_api_key=config.tools.gh.api_key or None,
         exec_config=config.tools.exec,
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
@@ -291,7 +302,7 @@ def gateway(
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
     )
-    
+
     # Set cron callback (needs agent)
     async def on_cron_job(job: CronJob) -> str | None:
         """Execute a cron job through the agent."""
@@ -442,13 +453,15 @@ def agent(
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
         brave_api_key=config.tools.web.search.api_key or None,
+        cursor_api_key=config.tools.cursor.api_key or None,
+        gh_api_key=config.tools.gh.api_key or None,
         exec_config=config.tools.exec,
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
     )
-    
+
     # Show spinner when logs are off (no output to miss); skip when logs are on
     def _thinking_ctx():
         if logs:
@@ -458,10 +471,7 @@ def agent(
         return console.status("[dim]nanobot is thinking...[/dim]", spinner="dots")
 
     async def _cli_progress(content: str, *, tool_hint: bool = False) -> None:
-        ch = agent_loop.channels_config
-        if ch and tool_hint and not ch.send_tool_hints:
-            return
-        if ch and not tool_hint and not ch.send_progress:
+        if not _should_show_progress(agent_loop.channels_config, tool_hint):
             return
         console.print(f"  [dim]↳ {content}[/dim]")
 
@@ -504,12 +514,7 @@ def agent(
                         msg = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
                         if msg.metadata.get("_progress"):
                             is_tool_hint = msg.metadata.get("_tool_hint", False)
-                            ch = agent_loop.channels_config
-                            if ch and is_tool_hint and not ch.send_tool_hints:
-                                pass
-                            elif ch and not is_tool_hint and not ch.send_progress:
-                                pass
-                            else:
+                            if _should_show_progress(agent_loop.channels_config, is_tool_hint):
                                 console.print(f"  [dim]↳ {msg.content}[/dim]")
                         elif not turn_done.is_set():
                             if msg.content:
@@ -933,6 +938,8 @@ def cron_run(
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
         brave_api_key=config.tools.web.search.api_key or None,
+        cursor_api_key=config.tools.cursor.api_key or None,
+        gh_api_key=config.tools.gh.api_key or None,
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
@@ -1007,6 +1014,9 @@ def status():
             else:
                 has_key = bool(p.api_key)
                 console.print(f"{spec.label}: {'[green]✓[/green]' if has_key else '[dim]not set[/dim]'}")
+
+        console.print(f"Cursor CLI: {'[green]✓[/green]' if config.tools.cursor.api_key else '[dim]not set[/dim]'}")
+        console.print(f"gh CLI: {'[green]✓[/green]' if config.tools.gh.api_key else '[dim]not set[/dim]'}")
 
 
 # ============================================================================

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -208,6 +208,14 @@ def onboard():
 
 
 
+def _inject_cli_env(config: Config) -> None:
+    """Inject GH_TOKEN and CURSOR_API_KEY into os.environ for subprocess inheritance."""
+    if config.tools.gh.api_key:
+        os.environ["GH_TOKEN"] = config.tools.gh.api_key
+    if config.tools.cursor.api_key:
+        os.environ["CURSOR_API_KEY"] = config.tools.cursor.api_key
+
+
 def _make_provider(config: Config):
     """Create the appropriate LLM provider from config."""
     from nanobot.providers.litellm_provider import LiteLLMProvider
@@ -273,6 +281,7 @@ def gateway(
     console.print(f"{__logo__} Starting nanobot gateway on port {port}...")
     
     config = load_config()
+    _inject_cli_env(config)
     sync_workspace_templates(config.workspace_path)
     bus = MessageBus()
     provider = _make_provider(config)
@@ -293,8 +302,6 @@ def gateway(
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
         brave_api_key=config.tools.web.search.api_key or None,
-        cursor_api_key=config.tools.cursor.api_key or None,
-        gh_api_key=config.tools.gh.api_key or None,
         exec_config=config.tools.exec,
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
@@ -429,6 +436,7 @@ def agent(
     from loguru import logger
     
     config = load_config()
+    _inject_cli_env(config)
     sync_workspace_templates(config.workspace_path)
     
     bus = MessageBus()
@@ -453,8 +461,6 @@ def agent(
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
         brave_api_key=config.tools.web.search.api_key or None,
-        cursor_api_key=config.tools.cursor.api_key or None,
-        gh_api_key=config.tools.gh.api_key or None,
         exec_config=config.tools.exec,
         cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
@@ -926,6 +932,8 @@ def cron_run(
     logger.disable("nanobot")
 
     config = load_config()
+    _inject_cli_env(config)
+
     provider = _make_provider(config)
     bus = MessageBus()
     agent_loop = AgentLoop(
@@ -938,8 +946,6 @@ def cron_run(
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
         brave_api_key=config.tools.web.search.api_key or None,
-        cursor_api_key=config.tools.cursor.api_key or None,
-        gh_api_key=config.tools.gh.api_key or None,
         exec_config=config.tools.exec,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
 
@@ -72,9 +72,9 @@ class MatrixConfig(Base):
     access_token: str = ""
     user_id: str = ""  # @bot:matrix.org
     device_id: str = ""
-    e2ee_enabled: bool = True # Enable Matrix E2EE support (encryption + encrypted room handling).
-    sync_stop_grace_seconds: int = 2 # Max seconds to wait for sync_forever to stop gracefully before cancellation fallback.
-    max_media_bytes: int = 20 * 1024 * 1024 # Max attachment size accepted for Matrix media handling (inbound + outbound).
+    e2ee_enabled: bool = True  # Enable Matrix E2EE support (encryption + encrypted room handling)
+    sync_stop_grace_seconds: int = 2  # Max seconds to wait for sync_forever to stop gracefully before cancellation fallback
+    max_media_bytes: int = 20 * 1024 * 1024  # Max attachment size for Matrix media (inbound + outbound)
     allow_from: list[str] = Field(default_factory=list)
     group_policy: Literal["open", "mention", "allowlist"] = "open"
     group_allow_from: list[str] = Field(default_factory=list)
@@ -184,20 +184,6 @@ class QQConfig(Base):
     secret: str = ""  # 机器人密钥 (AppSecret) from q.qq.com
     allow_from: list[str] = Field(default_factory=list)  # Allowed user openids (empty = public access)
 
-class MatrixConfig(Base):
-    """Matrix (Element) channel configuration."""
-    enabled: bool = False
-    homeserver: str = "https://matrix.org"
-    access_token: str = ""
-    user_id: str = ""                       # e.g. @bot:matrix.org
-    device_id: str = ""
-    e2ee_enabled: bool = True               # end-to-end encryption support
-    sync_stop_grace_seconds: int = 2        # graceful sync_forever shutdown timeout
-    max_media_bytes: int = 20 * 1024 * 1024 # inbound + outbound attachment limit
-    allow_from: list[str] = Field(default_factory=list)
-    group_policy: Literal["open", "mention", "allowlist"] = "open"
-    group_allow_from: list[str] = Field(default_factory=list)
-    allow_room_mentions: bool = False
 
 class ChannelsConfig(Base):
     """Configuration for chat channels."""
@@ -286,6 +272,18 @@ class WebSearchConfig(Base):
     max_results: int = 5
 
 
+class CursorConfig(Base):
+    """Cursor CLI configuration."""
+
+    api_key: str = ""  # Cursor API key from https://cursor.com/dashboard
+
+
+class GhConfig(Base):
+    """GitHub CLI configuration."""
+
+    api_key: str = ""  # GH token for gh auth
+
+
 class WebToolsConfig(Base):
     """Web tools configuration."""
 
@@ -315,6 +313,8 @@ class ToolsConfig(Base):
 
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
+    cursor: CursorConfig = Field(default_factory=CursorConfig)
+    gh: GhConfig = Field(default_factory=GhConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 

--- a/tests/test_cursor_gh_config_env.py
+++ b/tests/test_cursor_gh_config_env.py
@@ -1,0 +1,77 @@
+"""Tests for Cursor and gh API keys via config (feat/cursor-gh-variables)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from nanobot.cli.commands import app
+from nanobot.config.schema import Config
+
+runner = CliRunner()
+
+
+def test_config_has_cursor_and_gh_tools_config():
+    """ToolsConfig has cursor and gh fields with api_key, default empty."""
+    config = Config()
+    assert hasattr(config.tools, "cursor")
+    assert hasattr(config.tools, "gh")
+    assert hasattr(config.tools.cursor, "api_key")
+    assert hasattr(config.tools.gh, "api_key")
+    assert config.tools.cursor.api_key == ""
+    assert config.tools.gh.api_key == ""
+
+
+def test_config_loads_cursor_gh_from_json():
+    """Config loads tools.cursor.apiKey and tools.gh.apiKey from JSON (camelCase)."""
+    config = Config.model_validate(
+        {
+            "tools": {
+                "cursor": {"apiKey": "cursor-key-123"},
+                "gh": {"apiKey": "gh-token-456"},
+            }
+        }
+    )
+    assert config.tools.cursor.api_key == "cursor-key-123"
+    assert config.tools.gh.api_key == "gh-token-456"
+
+
+def test_agent_loop_stores_cursor_and_gh_api_keys():
+    """AgentLoop stores cursor_api_key and gh_api_key on self when passed."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=Path("/tmp/test"),
+        model="test-model",
+        cursor_api_key="cursor-secret",
+        gh_api_key="gh-secret",
+    )
+    assert loop.cursor_api_key == "cursor-secret"
+    assert loop.gh_api_key == "gh-secret"
+
+
+def test_status_shows_cursor_and_gh_cli(tmp_path):
+    """Status command shows Cursor CLI and gh CLI lines."""
+    config_file = tmp_path / "config.json"
+    config_file.touch()
+    with (
+        patch("nanobot.config.loader.get_config_path") as mock_cp,
+        patch("nanobot.config.loader.load_config") as mock_lc,
+    ):
+        mock_cp.return_value = config_file
+        config = Config()
+        config.tools.cursor.api_key = "cursor-key"
+        config.tools.gh.api_key = ""
+        mock_lc.return_value = config
+
+        result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 0
+        assert "Cursor CLI" in result.stdout
+        assert "gh CLI" in result.stdout

--- a/tests/test_cursor_gh_config_env.py
+++ b/tests/test_cursor_gh_config_env.py
@@ -1,7 +1,8 @@
 """Tests for Cursor and gh API keys via config (feat/cursor-gh-variables)."""
 
+import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
@@ -36,24 +37,20 @@ def test_config_loads_cursor_gh_from_json():
     assert config.tools.gh.api_key == "gh-token-456"
 
 
-def test_agent_loop_stores_cursor_and_gh_api_keys():
-    """AgentLoop stores cursor_api_key and gh_api_key on self when passed."""
-    from nanobot.agent.loop import AgentLoop
-    from nanobot.bus.queue import MessageBus
+def test_inject_cli_env_sets_gh_token_and_cursor_api_key():
+    """_inject_cli_env sets GH_TOKEN and CURSOR_API_KEY in os.environ."""
+    from nanobot.cli.commands import _inject_cli_env
 
-    bus = MessageBus()
-    provider = MagicMock()
-    provider.get_default_model.return_value = "test-model"
-    loop = AgentLoop(
-        bus=bus,
-        provider=provider,
-        workspace=Path("/tmp/test"),
-        model="test-model",
-        cursor_api_key="cursor-secret",
-        gh_api_key="gh-secret",
+    config = Config.model_validate(
+        {"tools": {"cursor": {"apiKey": "cursor-secret"}, "gh": {"apiKey": "gh-secret"}}}
     )
-    assert loop.cursor_api_key == "cursor-secret"
-    assert loop.gh_api_key == "gh-secret"
+    try:
+        _inject_cli_env(config)
+        assert os.environ.get("GH_TOKEN") == "gh-secret"
+        assert os.environ.get("CURSOR_API_KEY") == "cursor-secret"
+    finally:
+        os.environ.pop("GH_TOKEN", None)
+        os.environ.pop("CURSOR_API_KEY", None)
 
 
 def test_status_shows_cursor_and_gh_cli(tmp_path):


### PR DESCRIPTION
# Goal
For coding workflows, `nanobot` can use `Claude` or `Codex`, but not `cursor`. This PR sets up the config to allow users to do that. We do not bake in the `cursor` nor the `gh` CLI tool, that is still up to the user to install, but this PR makes setting the keys aligned with how secrets are already handled in `nanobot`.

## Problem
Tools that run in subprocesses (e.g. ExecTool spawning cursor or gh) need CURSOR_API_KEY and GH_TOKEN in the environment. Currently there is no way to configure these keys in nanobot config, so users must set them manually in the shell before running the agent.

## Solution
Add CursorConfig and GhConfig to the schema (mirroring WebSearchConfig/brave_api_key pattern). Inject GH_TOKEN and CURSOR_API_KEY into os.environ at process startup via `_inject_cli_env(config)`, called after load_config in gateway, agent, and cron run. ExecTool subprocesses inherit them (env=None, so they get parent env). No changes to AgentLoop, ExecTool, or SubagentManager. Add Cursor CLI and gh CLI status lines to `nanobot status`.

Config keys: `tools.cursor.apiKey`, `tools.gh.apiKey` (camelCase via existing alias).

## Use Case
Users running nanobot can install and use `cursor` or `gh` CLI from agent tool calls can add their API keys to `~/.nanobot/config.json` and have them available without manual env setup. `nanobot status` shows whether keys are configured.

## Test coverage
- tests/test_cursor_gh_config_env.py: schema defaults, JSON loading, _inject_cli_env sets GH_TOKEN/CURSOR_API_KEY in os.environ, status output
- All 99 tests pass (excluding test_matrix_channel which requires matrix extra)

## QOL (`nanobot/cli/commands.py`)
Introduces _should_show_progress() to centralize when progress and tool hints are shown in the CLI.