### PR TITLE
feat(agent): log cumulative token usage after each agent loop

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -179,6 +179,7 @@ class AgentLoop:
         iteration = 0
         final_content = None
         tools_used: list[str] = []
+        total_usage: dict[str, int] = {}
 
         while iteration < self.max_iterations:
             iteration += 1
@@ -190,6 +191,9 @@ class AgentLoop:
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
             )
+
+            for key, val in response.usage.items():
+                total_usage[key] = total_usage.get(key, 0) + val
 
             if response.has_tool_calls:
                 if on_progress:
@@ -235,6 +239,14 @@ class AgentLoop:
             final_content = (
                 f"I reached the maximum number of tool call iterations ({self.max_iterations}) "
                 "without completing the task. You can try breaking the task into smaller steps."
+            )
+
+        if total_usage:
+            logger.info(
+                "Token usage — prompt: {}, completion: {}, total: {}",
+                total_usage.get("prompt_tokens", 0),
+                total_usage.get("completion_tokens", 0),
+                total_usage.get("total_tokens", 0),
             )
 
         return final_content, tools_used, messages


### PR DESCRIPTION
## What

Accumulate token usage across all LLM calls within a single agent loop turn, then emit a single `logger.info` line at the end:

```
Token usage — prompt: 1234, completion: 456, total: 1690
```

## Why

`LLMResponse.usage` is already populated by `LiteLLMProvider._parse_response()`, but the data was never surfaced anywhere. Multi-step turns (with tool calls) make multiple LLM calls — summing them gives an accurate per-turn cost signal useful for debugging and cost awareness.

## Changes

- `nanobot/agent/loop.py`: add `total_usage` accumulator in `_run_agent_loop`; log after the loop exits. No behaviour change, no new dependencies.