### PR TITLE
fix: pass msg_id in QQ C2C reply to avoid proactive message permissio…

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -100,10 +100,12 @@ class QQChannel(BaseChannel):
             logger.warning("QQ client not initialized")
             return
         try:
+            msg_id = msg.metadata.get("message_id")
             await self._client.api.post_c2c_message(
                 openid=msg.chat_id,
                 msg_type=0,
                 content=msg.content,
+                msg_id=msg_id,
             )
         except Exception as e:
             logger.error("Error sending QQ message: {}", e)


### PR DESCRIPTION
…n error

QQ's bot API requires a msg_id (original inbound message ID) to send a passive reply. Without it the request is treated as a proactive message and fails with error 40034102 (无权限). The message_id was already stored in InboundMessage.metadata and forwarded to OutboundMessage, but was never read in send().