### PR TITLE
fix: resolve empty message crash loop and context repetition bug

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -404,9 +404,13 @@ class AgentLoop:
                 message_tool.start_turn()
 
         history = session.get_history(max_messages=self.memory_window)
+        
+        # FIX: Anchor the model's attention to stop it from re-answering old history
+        wrapped_content = f"--- END OF HISTORY ---\n\nCURRENT USER REQUEST (Answer ONLY this, do NOT answer previous questions again):\n{msg.content}"
+        
         initial_messages = self.context.build_messages(
             history=history,
-            current_message=msg.content,
+            current_message=wrapped_content,
             media=msg.media if msg.media else None,
             channel=msg.channel, chat_id=msg.chat_id,
         )

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -267,8 +267,10 @@ class TelegramChannel(BaseChannel):
                 )
 
         # Send text content
-        if msg.content and msg.content != "[empty message]":
+        if msg.content and msg.content != "[empty message]" and msg.content.strip():
             for chunk in _split_message(msg.content):
+                if not chunk.strip():
+                    continue
                 try:
                     html = _markdown_to_telegram_html(chunk)
                     await self._app.bot.send_message(

--- a/tests/test_history_wrapper.py
+++ b/tests/test_history_wrapper.py
@@ -1,0 +1,118 @@
+"""Tests for the ephemeral history-boundary wrapper in AgentLoop._process_message.
+
+Verifies that:
+  - The LLM receives the "END OF HISTORY" wrapped version of the user message.
+  - The wrapper is NOT persisted into session history; only the original content is saved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse
+
+
+_WRAPPER_MARKER = "--- END OF HISTORY ---"
+
+
+def _make_loop(tmp_path: Path) -> AgentLoop:
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    return AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model", memory_window=10)
+
+
+class TestEphemeralHistoryWrapper:
+    """Wrapper must be visible to the LLM but absent from persisted session history."""
+
+    @pytest.mark.asyncio
+    async def test_llm_receives_wrapped_content(self, tmp_path: Path) -> None:
+        """The provider.chat call must contain the boundary wrapper in the last user message."""
+        loop = _make_loop(tmp_path)
+        loop.provider.chat = AsyncMock(
+            return_value=LLMResponse(content="pong", tool_calls=[])
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        msg = InboundMessage(channel="cli", sender_id="user", chat_id="direct", content="ping")
+        await loop._process_message(msg)
+
+        call_kwargs = loop.provider.chat.call_args
+        assert call_kwargs is not None
+        messages_sent = call_kwargs.kwargs.get("messages") or call_kwargs.args[0]
+
+        # Find the last user message (current request)
+        user_msgs = [m for m in messages_sent if m.get("role") == "user"]
+        last_user = user_msgs[-1]
+        content = last_user.get("content", "")
+        if isinstance(content, list):
+            text_parts = [c.get("text", "") for c in content if c.get("type") == "text"]
+            content = " ".join(text_parts)
+
+        assert _WRAPPER_MARKER in content, (
+            "LLM should receive the ephemeral 'END OF HISTORY' boundary wrapper."
+        )
+        assert "ping" in content
+
+    @pytest.mark.asyncio
+    async def test_wrapper_not_persisted_in_session_history(self, tmp_path: Path) -> None:
+        """Session history must store the plain original message, never the wrapper text."""
+        loop = _make_loop(tmp_path)
+        loop.provider.chat = AsyncMock(
+            return_value=LLMResponse(content="pong", tool_calls=[])
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        msg = InboundMessage(channel="cli", sender_id="user", chat_id="direct", content="ping")
+        await loop._process_message(msg)
+
+        session = loop.sessions.get("cli:direct")
+        assert session is not None
+
+        for entry in session.messages:
+            content = entry.get("content", "")
+            if isinstance(content, str):
+                assert _WRAPPER_MARKER not in content, (
+                    f"Ephemeral wrapper must not be persisted in session history. "
+                    f"Found in: {content[:120]}"
+                )
+            elif isinstance(content, list):
+                for part in content:
+                    text = part.get("text", "") if isinstance(part, dict) else ""
+                    assert _WRAPPER_MARKER not in text, (
+                        "Ephemeral wrapper must not be persisted in session history."
+                    )
+
+    @pytest.mark.asyncio
+    async def test_original_content_is_persisted(self, tmp_path: Path) -> None:
+        """The original user message content must appear in session history."""
+        loop = _make_loop(tmp_path)
+        loop.provider.chat = AsyncMock(
+            return_value=LLMResponse(content="pong", tool_calls=[])
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        msg = InboundMessage(channel="cli", sender_id="user", chat_id="direct", content="ping")
+        await loop._process_message(msg)
+
+        session = loop.sessions.get("cli:direct")
+        assert session is not None
+
+        user_entries = [e for e in session.messages if e.get("role") == "user"]
+        plain_texts = []
+        for e in user_entries:
+            c = e.get("content", "")
+            if isinstance(c, str):
+                plain_texts.append(c)
+            elif isinstance(c, list):
+                plain_texts.extend(p.get("text", "") for p in c if isinstance(p, dict))
+
+        assert any("ping" in t and _WRAPPER_MARKER not in t for t in plain_texts), (
+            "Original 'ping' content should be persisted in session history without the wrapper."
+        )

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -1,0 +1,92 @@
+"""Tests for the Telegram channel's whitespace-guard in the send() method.
+
+Verifies that:
+  - Whitespace-only msg.content does not trigger any Telegram API calls.
+  - Whitespace-only chunks produced by _split_message are silently skipped.
+  - Normal non-empty content still results in the expected API calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.telegram import TelegramChannel
+from nanobot.config.schema import TelegramConfig
+
+
+def _make_channel() -> TelegramChannel:
+    config = TelegramConfig(enabled=True, token="fake-token")
+    bus = MessageBus()
+    channel = TelegramChannel(config=config, bus=bus)
+
+    # Inject a fully-mocked Application so send() can run without a real bot.
+    mock_bot = MagicMock()
+    mock_bot.send_message = AsyncMock()
+    mock_app = MagicMock()
+    mock_app.bot = mock_bot
+    channel._app = mock_app
+
+    return channel
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_content_does_not_call_send_message() -> None:
+    """A message whose content is only whitespace must never hit the Telegram API."""
+    channel = _make_channel()
+
+    for whitespace in ["   ", "\t", "\n", "\r\n", "  \n  "]:
+        channel._app.bot.send_message.reset_mock()
+        msg = OutboundMessage(channel="telegram", chat_id="123456", content=whitespace)
+        await channel.send(msg)
+        channel._app.bot.send_message.assert_not_called(), (
+            f"send_message should NOT be called for whitespace-only content {whitespace!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_empty_message_sentinel_does_not_call_send_message() -> None:
+    """The '[empty message]' sentinel value must never trigger a Telegram API call."""
+    channel = _make_channel()
+    msg = OutboundMessage(channel="telegram", chat_id="123456", content="[empty message]")
+    await channel.send(msg)
+    channel._app.bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_empty_string_does_not_call_send_message() -> None:
+    """Empty string content must not trigger a Telegram API call."""
+    channel = _make_channel()
+    msg = OutboundMessage(channel="telegram", chat_id="123456", content="")
+    await channel.send(msg)
+    channel._app.bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_normal_content_does_call_send_message() -> None:
+    """A message with real text content must result in exactly one send_message call."""
+    channel = _make_channel()
+    msg = OutboundMessage(channel="telegram", chat_id="123456", content="Hello, world!")
+    await channel.send(msg)
+    channel._app.bot.send_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_whitespace_chunk_skipped_within_multi_chunk_message() -> None:
+    """Individual whitespace-only chunks inside a larger message must be silently skipped."""
+    from unittest.mock import patch
+
+    channel = _make_channel()
+
+    # Patch _split_message to inject a whitespace chunk between real ones.
+    with patch("nanobot.channels.telegram._split_message", return_value=["Hello", "   ", "World"]):
+        msg = OutboundMessage(channel="telegram", chat_id="123456", content="Hello   World")
+        await channel.send(msg)
+
+    # Only 2 real chunks ("Hello" and "World") should generate API calls; the "   " is skipped.
+    assert channel._app.bot.send_message.call_count == 2, (
+        "Expected exactly 2 send_message calls (whitespace chunk must be skipped)."
+    )


### PR DESCRIPTION
## Description
This PR addresses two edge-case bugs that occur during long conversations or when using specific API providers (like Moonshot/Kimi K2.5) that have massive context windows and occasionally return empty text blocks alongside tool calls.

### 1. Telegram Empty Message Crash Loop
**The Bug:** When the LLM outputs an empty string or whitespace-only chunk, the `python-telegram-bot` library attempts to send it, resulting in a Telegram API exception. This causes the bot loop to crash and the platform to retry the request, creating a duplicate-reply loop.
**The Fix:** Added `.strip()` validation in `channels/telegram.py` before markdown parsing and message dispatching to ensure the bot silently ignores empty chunks instead of crashing.

### 2. Context History Repetition
**The Bug:** When `HISTORY.md` is fed into the context builder, models with very large context windows sometimes lose attention and interpret older user messages in the history as pending instructions, attempting to answer them again.
**The Fix:** Updated the prompt construction in `agent/loop.py` to wrap the `msg.content` with a clear delimiter and strict system instruction, anchoring the model's attention exclusively to the latest user request.

## Changes Made
- **`nanobot/channels/telegram.py`**: Added `and msg.content.strip()` and `if not chunk.strip(): continue` to the message splitting loop.
- **`nanobot/agent/loop.py`**: Wrapped the `current_message` variable in a strict `--- END OF HISTORY ---` boundary before passing it to `self.context.build_messages`.

## Testing
- [x] Verified the Telegram channel gracefully drops empty chunks without throwing exceptions.
- [x] Verified the LLM accurately responds only to the latest user query without hallucinating answers to previous conversation turns.
- [x] Tested locally using the Moonshot (Kimi K2.5) API.