### PR TITLE
fix: prevent session poisoning from null/error LLM responses

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -224,6 +224,12 @@ class AgentLoop:
                     )
             else:
                 clean = self._strip_think(response.content)
+                # Don't persist error responses to session history — they can
+                # poison the context and cause permanent 400 loops (#1303).
+                if response.finish_reason == "error":
+                    logger.error("LLM returned error: {}", (clean or "")[:200])
+                    final_content = clean or "Sorry, I encountered an error calling the AI model."
+                    break
                 messages = self.context.add_assistant_message(
                     messages, clean, reasoning_content=response.reasoning_content,
                 )

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -51,6 +51,14 @@ class LLMProvider(ABC):
         for msg in messages:
             content = msg.get("content")
 
+            # None content on a plain assistant message (no tool_calls) crashes
+            # providers with "invalid message content type: <nil>".
+            if content is None and msg.get("role") == "assistant" and not msg.get("tool_calls"):
+                clean = dict(msg)
+                clean["content"] = "(empty)"
+                result.append(clean)
+                continue
+
             if isinstance(content, str) and not content:
                 clean = dict(msg)
                 clean["content"] = None if (msg.get("role") == "assistant" and msg.get("tool_calls")) else "(empty)"


### PR DESCRIPTION
## Summary

Closes #1303 — when an LLM returns `content: null` on a plain assistant message (without `tool_calls`), the null response gets saved to session history. On the next request, this corrupts the context and causes a permanent 400 error loop.

### Changes

- **`providers/base.py`** — `_sanitize_empty_content()`: added handling for `content is None` on assistant messages without `tool_calls`, replacing it with `"(empty)"`. This matches the existing pattern for empty-string content.

- **`agent/loop.py`** — `_run_agent_loop()`: when the LLM response has `finish_reason="error"`, the error text is returned to the user but **not appended to the message history**. This prevents error strings from being persisted in session files where they would be replayed on every subsequent request.

### Root cause

`_sanitize_empty_content()` handled `content: None` only for assistant messages **with** `tool_calls` (where `None` is valid per the API spec). Plain assistant messages with `None` content fell through unmodified, causing providers to reject the history with:

```
Error code: 400 - {'error': {'message': 'invalid message content type: <nil>'}}
```

The error response was then saved as a normal message, creating a permanent poison loop.