### PR TITLE
fix: remove overly broad "codex" keyword from openai_codex provider

### DIFF
--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -201,7 +201,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
     # OpenAI Codex: uses OAuth, not API key.
     ProviderSpec(
         name="openai_codex",
-        keywords=("openai-codex", "codex"),
+        keywords=("openai-codex",),
         env_key="",                         # OAuth-based, no API key
         display_name="OpenAI Codex",
         litellm_prefix="",                  # Not routed through LiteLLM


### PR DESCRIPTION
## Summary

Closes #1311 — the bare keyword `"codex"` in the `openai_codex` provider spec causes false positive matches when a model name happens to contain "codex" (e.g. `gpt-5.3-codex` on a custom provider). This incorrectly routes the request through the OAuth-based OpenAI Codex provider, producing "OAuth credentials not found" errors.

### Change

Removed `"codex"` from `openai_codex.keywords`, keeping only the explicit `"openai-codex"` prefix. Auto-detection now requires the canonical prefix to match, preventing false positives on model names that incidentally contain "codex".

Users explicitly setting `provider: "openai_codex"` or using the `openai-codex/` model prefix are unaffected.