### PR TITLE
Modify Feishu bot permissions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Uses **WebSocket** long connection — no public IP required.
 **1. Create a Feishu bot**
 - Visit [Feishu Open Platform](https://open.feishu.cn/app)
 - Create a new app → Enable **Bot** capability
-- **Permissions**: Add `im:message` (send messages)
+- **Permissions**: Add `im:message` (send messages) and `im:message.p2p_msg:readonly` (receive messages)
 - **Events**: Add `im.message.receive_v1` (receive messages)
   - Select **Long Connection** mode (requires running nanobot first to establish connection)
 - Get **App ID** and **App Secret** from "Credentials & Basic Info"


### PR DESCRIPTION
Updated permissions for Feishu bot setup instructions.

`im:message.p2p_msg:readonly` is mandatory otherwise messages cannot be received