### PR TITLE
feat: add skill status command

### DIFF
--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import platform
 import re
 import shutil
 from pathlib import Path
@@ -55,6 +56,43 @@ class SkillsLoader:
         if filter_unavailable:
             return [s for s in skills if self._check_requirements(self._get_skill_meta(s["name"]))]
         return skills
+
+    def list_skills_with_status(self) -> list[dict[str, str]]:
+        """List skills with availability status and details."""
+        skills = self.list_skills(filter_unavailable=False)
+        results: list[dict[str, str]] = []
+
+        for skill in skills:
+            name = skill["name"]
+            meta = self.get_skill_metadata(name) or {}
+            skill_meta = self._parse_nanobot_metadata(meta.get("metadata", ""))
+
+            missing = self._get_missing_requirements(skill_meta)
+            runtime = self._get_skill_runtime(skill_meta, meta)
+            os_issue = self._check_os_support(skill_meta)
+
+            if missing:
+                status = "error"
+                detail = missing
+            elif os_issue:
+                status = "error"
+                detail = os_issue
+            elif runtime and self._is_runtime_unsupported(runtime):
+                status = "error"
+                detail = f"runtime: {runtime}"
+            else:
+                status = "ready"
+                detail = "ok"
+
+            results.append({
+                "name": name,
+                "path": skill["path"],
+                "source": skill["source"],
+                "status": status,
+                "details": detail,
+            })
+
+        return results
     
     def load_skill(self, name: str) -> str | None:
         """
@@ -150,6 +188,45 @@ class SkillsLoader:
             if not os.environ.get(env):
                 missing.append(f"ENV: {env}")
         return ", ".join(missing)
+
+    def _get_skill_runtime(self, skill_meta: dict, raw_meta: dict) -> str | None:
+        """Return declared runtime from metadata or frontmatter."""
+        runtime = skill_meta.get("runtime") if isinstance(skill_meta, dict) else None
+        if runtime:
+            return str(runtime).strip().lower()
+        raw_runtime = raw_meta.get("runtime")
+        if raw_runtime:
+            return str(raw_runtime).strip().lower()
+        return None
+
+    def _is_runtime_unsupported(self, runtime: str) -> bool:
+        """Return True if runtime is unsupported by nanobot."""
+        return runtime in {"typescript", "ts", "deno"}
+
+    def _check_os_support(self, skill_meta: dict) -> str | None:
+        """Return OS compatibility issue if current OS is unsupported."""
+        if not isinstance(skill_meta, dict):
+            return None
+        allowed = skill_meta.get("os")
+        if not allowed:
+            return None
+        if isinstance(allowed, str):
+            allowed_list = [allowed]
+        else:
+            allowed_list = list(allowed)
+        allowed_list = [str(item).strip().lower() for item in allowed_list if str(item).strip()]
+        if not allowed_list:
+            return None
+        current = platform.system().lower()
+        if current.startswith("darwin"):
+            current = "darwin"
+        elif current.startswith("linux"):
+            current = "linux"
+        elif current.startswith("win"):
+            current = "windows"
+        if current not in allowed_list:
+            return f"os: {current} not supported"
+        return None
     
     def _get_skill_description(self, name: str) -> str:
         """Get the description of a skill from its frontmatter."""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1010,6 +1010,51 @@ def status():
 
 
 # ============================================================================
+# Skill Commands
+# ============================================================================
+
+
+skill_app = typer.Typer(help="Manage skills")
+app.add_typer(skill_app, name="skill")
+
+
+@skill_app.command("status")
+def skill_status(
+    as_json: bool = typer.Option(False, "--json", help="Output JSON"),
+):
+    """Show installed skill status."""
+    from nanobot.config.loader import load_config
+    from nanobot.agent.skills import SkillsLoader
+
+    config = load_config()
+    loader = SkillsLoader(config.workspace_path)
+    skills = loader.list_skills_with_status()
+
+    if as_json:
+        console.print_json(data=skills)
+        return
+
+    table = Table(title="Skill Status")
+    table.add_column("Skill", style="cyan")
+    table.add_column("Status")
+    table.add_column("Source", style="yellow")
+    table.add_column("Details")
+
+    for skill in skills:
+        status = skill["status"]
+        if status == "ready":
+            status_text = "[green]ready[/green]"
+        elif status == "warning":
+            status_text = "[yellow]warning[/yellow]"
+        else:
+            status_text = "[red]error[/red]"
+        table.add_row(skill["name"], status_text, skill["source"], skill["details"])
+
+    console.print(table)
+
+
+
+# ============================================================================
 # OAuth Login
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Add `nanobot skill status` CLI command to help users quickly diagnose which skills are ready and which have issues.

## Motivation

After installing skills (especially from ClawHub), users often encounter "skill unavailable" without knowing why. This command surfaces the root cause — missing dependencies, unsupported OS, or incompatible runtime — so users can fix issues themselves or let nanobot assist.

Related: #1238 (AgentSkills.io compat + GitHub skill installer)

## Changes

### `nanobot/agent/skills.py`
- `list_skills_with_status()` — iterates all installed skills, checks availability, returns structured status list
- `_get_skill_runtime()` — extracts declared runtime from skill metadata/frontmatter
- `_is_runtime_unsupported()` — flags unsupported runtimes (e.g. `typescript`, `deno`)
- `_check_os_support()` — validates current OS against skill's allowed OS list (darwin/linux/windows)

### `nanobot/cli/commands.py`
- New `skill` subcommand group via `typer.Typer`
- `nanobot skill status` — displays a Rich table with skill name, status, source, and details
- `--json` flag for machine-readable output

## Usage

```bash
# Table view
nanobot skill status

# JSON output (for scripting)
nanobot skill status --json
```

## Screenshot

<img width="774" height="404" alt="image" src="https://github.com/user-attachments/assets/c50e1218-dd48-468d-be28-f148709d7dbe" />

## Status Legend

| Status | Meaning |
|--------|---------|
| 🟢 ready | Skill is fully functional |
| 🔴 error | Missing requirements, unsupported OS, or incompatible runtime |
