### PR TITLE
feat: enhance Feishu channel with message replies and reaction management

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -42,7 +42,7 @@ class FeishuConfig(Base):
     encrypt_key: str = ""  # Encrypt Key for event subscription (optional)
     verification_token: str = ""  # Verification Token for event subscription (optional)
     allow_from: list[str] = Field(default_factory=list)  # Allowed user open_ids
-    react_emoji: str = "THUMBSUP"  # Emoji type for message reactions (e.g. THUMBSUP, OK, DONE, SMILE)
+    react_emoji: str = "OnIt"  # Emoji type for message reactions (e.g. THUMBSUP, OK, DONE, SMILE)
 
 
 class DingTalkConfig(Base):


### PR DESCRIPTION
  🚀 Overview
  This PR enhances the Feishu (Lark) channel by implementing native message reply (quoting) functionality and improving the lifecycle management of message reactions. These changes make interactions more
  intuitive by directly linking bot responses to user queries and providing better visual feedback during processing.

  🛠 Key Changes


  1. Native Message Replies
   - Integrated ReplyMessageRequest and ReplyMessageRequestBody from the Feishu SDK.
   - Updated the send logic to use the reply API when a message_id is present in the message metadata. This allows the bot to "quote" the original user message instead of just sending a new message in the chat.  


  2. Advanced Reaction Management
   - Reaction Tracking: Implemented a _reaction_ids cache to map message_id to its active reaction_id.
   - Automatic Cleanup: Added DeleteMessageReactionRequest support to remove "processing" reactions (e.g., "OnIt") once the final response is delivered.
   - Improved Feedback: The bot now adds a reaction when it starts processing and removes it upon completion, providing a cleaner UI experience.


  3. Configurable Interaction Styles
   - Updated the default react_emoji from THUMBSUP to OnIt in nanobot/config/schema.py to better reflect the bot's active status.
   - Support for dynamic emoji selection from configuration.


  4. Code Refactoring & Optimization
   - Refactored _send_message_sync to handle both new messages and replies seamlessly.
   - Optimized threading logic for reaction additions and removals using run_in_executor.


  💡 Why this is needed?
   - Contextual Clarity: Replying to messages ensures users know exactly which prompt the bot is responding to, especially in busy group chats.
   - Polished UX: Managing reactions (adding then removing) provides a professional "thinking" indicator without cluttering the chat history with permanent emojis.


  🧪 How to Test
   1. Send a Message: Send a query to the bot via Feishu.
   2. Observe Reaction: Verify that an "OnIt" (or configured) emoji appears on your message immediately.                                                                                                          
   3. Check Reply: Confirm the bot's response is a "Reply" that quotes your original message.                                                                                                                     
   4. Verify Cleanup: Ensure the "OnIt" emoji is removed from your original message once the bot finishes sending the final response.