### PR TITLE
fix the feishu interactive message text cannot be extracted

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -89,8 +89,9 @@ def _extract_interactive_content(content: dict) -> list[str]:
         elif isinstance(title, str):
             parts.append(f"title: {title}")
 
-    for element in content.get("elements", []) if isinstance(content.get("elements"), list) else []:
-        parts.extend(_extract_element_content(element))
+    for elements in content.get("elements", []) if isinstance(content.get("elements"), list) else []:
+        for element in elements:
+            parts.extend(_extract_element_content(element))
 
     card = content.get("card", {})
     if card:


### PR DESCRIPTION
The official Feishu documentation shows its interactive message structure as follows:
https://open.feishu.cn/document/server-docs/im-v1/message-content-description/message_content#3ea4c2d5
```json
{
    "title": "卡片标题",
    "elements": [
        [
            {
                "tag": "button",
                "text": "主按钮",
                "type": "primary"
            },
            {
                "tag": "button",
                "text": "次按钮",
                "type": "default"
            },
            {
                "tag": "button",
                "text": "危险按钮",
                "type": "danger"
            }
        ],
        [
            {
                "tag": "a",
                "href": "https://www.feishu.cn",
                "text": "飞书"
            },
            {
                "tag": "text",
                "text": "整合即时沟通、日历、音视频会议、云文档、云盘、工作台等功能于一体，成就组织和个人，"
            },
            {
                "tag": "at",
                "user_id": "@_user_1",
                "user_name": ""
            },
            {
                "tag": "text",
                "text": "更高效、更愉悦。"
            }
        ],
       ...
    ]
}
```

Therefore, the element text extraction needs to be modified to:
```py
    for elements in content.get("elements", []) if isinstance(content.get("elements"), list) else []:
        for element in elements:
            parts.extend(_extract_element_content(element))
```
Previously it was:
```py
    for element in content.get("elements", []) if isinstance(content.get("elements"), list) else []:
        parts.extend(_extract_element_content(element))
```