### PR TITLE
refactor: use WeakValueDictionary for consolidation locks

### DIFF
--- a/tests/test_consolidate_offset.py
+++ b/tests/test_consolidate_offset.py
@@ -786,10 +786,8 @@ class TestConsolidationDeduplicationGuard:
         )
 
     @pytest.mark.asyncio
-    async def test_new_cleans_up_consolidation_lock_for_invalidated_session(
-        self, tmp_path: Path
-    ) -> None:
-        """/new should remove lock entry for fully invalidated session key."""
+    async def test_new_clears_session_and_responds(self, tmp_path: Path) -> None:
+        """/new clears session and returns confirmation."""
         from nanobot.agent.loop import AgentLoop
         from nanobot.bus.events import InboundMessage
         from nanobot.bus.queue import MessageBus
@@ -801,7 +799,6 @@ class TestConsolidationDeduplicationGuard:
         loop = AgentLoop(
             bus=bus, provider=provider, workspace=tmp_path, model="test-model", memory_window=10
         )
-
         loop.provider.chat = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
         loop.tools.get_definitions = MagicMock(return_value=[])
 
@@ -810,10 +807,6 @@ class TestConsolidationDeduplicationGuard:
             session.add_message("user", f"msg{i}")
             session.add_message("assistant", f"resp{i}")
         loop.sessions.save(session)
-
-        # Ensure lock exists before /new.
-        loop._consolidation_locks.setdefault(session.key, asyncio.Lock())
-        assert session.key in loop._consolidation_locks
 
         async def _ok_consolidate(sess, archive_all: bool = False) -> bool:
             return True
@@ -825,4 +818,4 @@ class TestConsolidationDeduplicationGuard:
 
         assert response is not None
         assert "new session started" in response.content.lower()
-        assert session.key not in loop._consolidation_locks
+        assert loop.sessions.get_or_create("cli:test").messages == []


### PR DESCRIPTION
## Summary

Replace `_consolidation_locks: dict[str, asyncio.Lock]` with `weakref.WeakValueDictionary` so locks are automatically garbage-collected when no task holds a reference.

**Problem:** Two `if not lock.locked(): pop(...)` calls in `loop.py` attempted manual lock cleanup, but had a subtle race condition — a lock could be popped while another coroutine was queued waiting on it, causing a new lock to be created for the same session key. This breaks the serialization guarantee. (See #1255 for detailed analysis.)

**Fix:** `WeakValueDictionary` handles lifecycle automatically. While a task runs, its closure holds a strong reference to the lock; when all tasks complete, the lock is GC'd and the entry disappears. No manual cleanup, no race, no leak.

## Changes

**`nanobot/agent/loop.py`** (+2, -6):
- `_consolidation_locks` type changed from `dict` to `weakref.WeakValueDictionary`
- Removed 2 manual `if not lock.locked(): pop(...)` blocks (in `/new` handler and background consolidation task)

**`tests/test_consolidate_offset.py`** (+3, -9):
- Test renamed to `test_new_clears_session_and_responds`
- Now verifies `/new` clears session messages (business logic) instead of checking manual lock removal (implementation detail)
