### PR TITLE
fix(provider): force gateway routing for LiteLLM calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ poetry.lock
 .pytest_cache/
 botpy.log
 tests/
+plan/

--- a/README.md
+++ b/README.md
@@ -863,6 +863,47 @@ Use `toolTimeout` to override the default 30s per-call timeout for slow servers:
 
 MCP tools are automatically discovered and registered on startup. The LLM can use them alongside built-in tools — no extra configuration needed.
 
+### Mobile App Automation (Maestro)
+
+nanobot can use [Maestro](https://docs.maestro.dev/) for Android/iOS UI automation via MCP.
+
+**1) Bootstrap workspace + MCP config**
+
+```bash
+nanobot mobile setup
+```
+
+This command:
+- creates `mobile/flows`, `mobile/apps`, and `reports/mobile/*` under your workspace
+- creates a sample flow `mobile/flows/smoke.yaml`
+- configures `tools.mcpServers.maestro` as `maestro mcp`
+
+**2) Validate device + run flow**
+
+```bash
+maestro devices
+maestro test mobile/flows/smoke.yaml
+nanobot mobile run --suite smoke --platform android
+# force MCP mode (requires tools.mcpServers.maestro)
+nanobot mobile run --mode mcp --mcp-server maestro
+```
+
+`nanobot mobile run` stores:
+- per-flow stdout/stderr logs in `reports/mobile/runs/<run-id>/`
+- Maestro outputs (screenshots/debug artifacts) in `reports/mobile/artifacts/<run-id>/<flow-id>/`
+- latest structured summary in `reports/mobile/summary-latest.json`
+
+**3) Let nanobot drive Maestro tools**
+
+After starting `nanobot agent` or `nanobot gateway`, the agent can call Maestro MCP tools such as:
+- `maestro_list_devices`
+- `maestro_run_flow_files`
+- `maestro_take_screenshot`
+
+For Telegram/CLI natural-language commands, nanobot can detect supported mobile-test intents and generate/run Maestro flows automatically.
+
+> Install Maestro CLI first if missing: `curl -fsSL "https://get.maestro.mobile.dev" | bash`
+
 
 
 
@@ -892,6 +933,9 @@ MCP tools are automatically discovered and registered on startup. The LLM can us
 | `nanobot provider login openai-codex` | OAuth login for providers |
 | `nanobot channels login` | Link WhatsApp (scan QR) |
 | `nanobot channels status` | Show channel status |
+| `nanobot mobile setup` | Scaffold mobile testing workspace + Maestro MCP config |
+| `nanobot mobile run` | Run mobile flow files and persist run summary/log artifacts |
+| `nanobot mobile status` | Show mobile testing + Maestro MCP status |
 
 Interactive mode exits: `exit`, `quit`, `/exit`, `/quit`, `:q`, or `Ctrl+D`.
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
+import shutil
 import weakref
 from contextlib import AsyncExitStack
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
@@ -45,6 +48,8 @@ class AgentLoop:
     """
 
     _TOOL_RESULT_MAX_CHARS = 500
+    _MOBILE_SHORTCUT_TIMEOUT_S = 120
+    _APP_ID_RE = re.compile(r"(?<![A-Za-z0-9_])[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+(?![A-Za-z0-9_])")
 
     def __init__(
         self,
@@ -171,6 +176,347 @@ class AgentLoop:
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
+    @classmethod
+    def _extract_mobile_transfer_app_id(cls, content: str) -> str | None:
+        """Detect 'open app and go to transfer page' intent from plain text."""
+        text = (content or "").strip()
+        if not text:
+            return None
+        lowered = text.lower()
+        has_open = any(k in text for k in ("打开", "启动")) or any(k in lowered for k in ("open", "launch", "start"))
+        has_transfer = any(k in text for k in ("转账", "转帳")) or any(k in lowered for k in ("transfer", "send"))
+        if not (has_open and has_transfer):
+            return None
+        matched = cls._APP_ID_RE.search(text)
+        return matched.group(0) if matched else None
+
+    @staticmethod
+    def _extract_selected_token_symbol(content: str) -> str | None:
+        """Extract token symbol from user command, e.g. '选择ETH' / 'select ETH'."""
+        text = (content or "").strip()
+        if not text:
+            return None
+        lowered = text.lower()
+        if "地址" in text or "address" in lowered:
+            return None
+        patterns = [
+            r"(?:选择|选中|切换到)\s*([A-Za-z][A-Za-z0-9._-]{1,15})",
+            r"(?:select|choose|pick)\s+([A-Za-z][A-Za-z0-9._-]{1,15})",
+        ]
+        for pattern in patterns:
+            m = re.search(pattern, text, flags=re.IGNORECASE)
+            if not m:
+                continue
+            symbol = re.sub(r"[^A-Za-z0-9_]", "", m.group(1).upper())
+            if symbol:
+                return symbol
+        return None
+
+    @staticmethod
+    def _extract_address_network(content: str) -> str | None:
+        """
+        Extract address-network selection from text:
+        e.g. '选择Ethereum地址' / 'select ethereum address'
+        """
+        text = (content or "").strip()
+        if not text:
+            return None
+        patterns = [
+            r"(?:选择|选中|切换到)\s*([A-Za-z][A-Za-z0-9._-]{1,20})\s*地址",
+            r"(?:select|choose|pick)\s+([A-Za-z][A-Za-z0-9._-]{1,20})\s+address",
+        ]
+        for pattern in patterns:
+            m = re.search(pattern, text, flags=re.IGNORECASE)
+            if not m:
+                continue
+            token = re.sub(r"[^A-Za-z0-9._-]", "", m.group(1)).strip()
+            if token:
+                return token
+        return None
+
+    @staticmethod
+    def _extract_input_payload(content: str) -> str | None:
+        """Extract input payload from text, e.g. '输入0x11111' / 'input 0x11111'."""
+        text = (content or "").strip()
+        if not text:
+            return None
+        patterns = [
+            r"(?:输入|填入|粘贴)\s*([^\s，,。；;]+)",
+            r"(?:input|type|enter)\s+([^\s，,。；;]+)",
+        ]
+        for pattern in patterns:
+            m = re.search(pattern, text, flags=re.IGNORECASE)
+            if not m:
+                continue
+            payload = m.group(1).strip()
+            if payload:
+                return payload
+        return None
+
+    @staticmethod
+    def _yaml_quote(value: str) -> str:
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f"\"{escaped}\""
+
+    @staticmethod
+    def _split_instruction_segments(content: str) -> list[str]:
+        """Split natural-language command into ordered segments."""
+        text = (content or "").strip()
+        if not text:
+            return []
+        return [seg.strip() for seg in re.split(r"[，,。；;、\n]+", text) if seg.strip()]
+
+    @classmethod
+    def _build_mobile_flow_from_instruction(cls, app_id: str, instruction: str) -> tuple[list[str], str]:
+        """
+        Build Maestro flow lines from instruction semantics instead of fixed script.
+
+        Supported action segments:
+        - enter transfer page
+        - select token symbol (e.g. ETH/USDT)
+        """
+        segments = cls._split_instruction_segments(instruction)
+        transfer_opened = False
+        screenshot_idx = 0
+        action_desc: list[str] = []
+
+        flow_lines = [
+            f"appId: {app_id}",
+            "---",
+            "- launchApp",
+        ]
+        action_desc.append("打开应用")
+
+        def _append_open_transfer() -> None:
+            nonlocal transfer_opened
+            if transfer_opened:
+                return
+            flow_lines.extend(
+                [
+                    "- assertVisible:",
+                    '    id: "FunctionBar.转账"',
+                    "- tapOn:",
+                    '    id: "FunctionBar.转账"',
+                    "- assertVisible:",
+                    '    id: "modal-header-close-button"',
+                ]
+            )
+            transfer_opened = True
+            action_desc.append("进入转账页面")
+
+        for seg in segments:
+            lowered = seg.lower()
+            if ("转账" in seg) or ("transfer" in lowered):
+                _append_open_transfer()
+
+            if selected_token := cls._extract_selected_token_symbol(seg):
+                _append_open_transfer()
+                token_id = f"TokenSelectModal.TokenSymbol.{selected_token}"
+                flow_lines.extend(
+                    [
+                        "- assertVisible:",
+                        f'    id: "{token_id}"',
+                        "- tapOn:",
+                        f'    id: "{token_id}"',
+                    ]
+                )
+                action_desc.append(f"选择{selected_token}")
+
+            if addr_network := cls._extract_address_network(seg):
+                flow_lines.extend(
+                    [
+                        "- tapOn:",
+                        f"    text: {cls._yaml_quote(addr_network)}",
+                    ]
+                )
+                action_desc.append(f"选择{addr_network}地址")
+
+            if payload := cls._extract_input_payload(seg):
+                flow_lines.append(f"- inputText: {cls._yaml_quote(payload)}")
+                action_desc.append(f"输入{payload}")
+
+            if any(k in seg for k in ("截图", "截屏", "屏幕截图")) or any(k in lowered for k in ("screenshot", "screen shot", "snapshot")):
+                screenshot_idx += 1
+                flow_lines.append(f"- takeScreenshot: shot-{screenshot_idx:02d}")
+                action_desc.append("截图")
+
+            if ("返回" in seg) or ("回退" in seg) or ("back" in lowered):
+                flow_lines.append("- back")
+                action_desc.append("返回")
+
+        flow_lines.append("")
+        if len(action_desc) <= 1:
+            target_desc = action_desc[0]
+        else:
+            target_desc = "，".join(action_desc[1:])
+        return flow_lines, target_desc
+
+    @staticmethod
+    def _classify_mobile_failure(stdout_text: str, stderr_text: str) -> str:
+        """Classify failure reason into user-facing categories."""
+        combined = f"{stdout_text}\n{stderr_text}"
+        text = combined.lower()
+        if "not enough devices connected" in text or "0 devices connected" in text:
+            return "未检测到可用设备"
+        if re.search(r"launch app .*?\.\.\. failed", text) or "unable to launch app" in text:
+            return "应用启动失败"
+        if m := re.search(r"assert that (.+?)\.\.\. failed", combined, flags=re.IGNORECASE):
+            detail = m.group(1).strip()
+            return f"页面断言失败（{detail}）"
+        if m := re.search(r"tap on (.+?)\.\.\. failed", combined, flags=re.IGNORECASE):
+            detail = m.group(1).strip()
+            return f"点击失败（{detail}）"
+        if m := re.search(r"input text (.+?)\.\.\. failed", combined, flags=re.IGNORECASE):
+            detail = m.group(1).strip()
+            return f"输入失败（{detail}）"
+        if "assert" in text and "failed" in text:
+            return "页面断言失败"
+        if "timeout" in text or "timed out" in text:
+            return "执行超时"
+        return "Maestro执行失败"
+
+    @staticmethod
+    def _summarize_mobile_result(final_content: str) -> str:
+        """Build a short completion notification for remote channels."""
+        content = (final_content or "").strip()
+        run_id_match = re.search(r"runId:\s*([^\n]+)", content)
+        run_id = run_id_match.group(1).strip() if run_id_match else ""
+        reason_match = re.search(r"reason:\s*([^\n]+)", content)
+        reason = reason_match.group(1).strip() if reason_match else ""
+        success = content.startswith("已完成移动自动化测试")
+        if success:
+            base = "移动自动化任务已结束：成功。"
+            return f"{base}\nrunId: {run_id}" if run_id else base
+        base = f"移动自动化任务已结束：失败。{reason}" if reason else "移动自动化任务已结束：失败。"
+        return f"{base}\nrunId: {run_id}" if run_id else base
+
+    async def _run_mobile_transfer_shortcut(
+        self,
+        app_id: str,
+        *,
+        instruction: str,
+        expose_paths: bool = True,
+        timeout_s: int | None = None,
+        on_progress: Callable[[str], Awaitable[None]] | None = None,
+    ) -> str:
+        """
+        Generate and run Maestro flow from explicit user command:
+        launch app -> open transfer -> optional token selection.
+        """
+        if shutil.which("maestro") is None:
+            return (
+                "检测到移动测试指令，但未找到 maestro CLI。"
+                "请先安装 maestro（curl -fsSL \"https://get.maestro.mobile.dev\" | bash）。"
+            )
+
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        app_slug = re.sub(r"[^a-z0-9]+", "-", app_id.lower()).strip("-") or "app"
+        run_id = f"intent-{stamp}-{app_slug[:24]}"
+
+        flow_dir = self.workspace / "mobile" / "flows" / "generated"
+        run_dir = self.workspace / "reports" / "mobile" / "runs" / run_id
+        artifact_dir = self.workspace / "reports" / "mobile" / "artifacts" / run_id / "transfer"
+        maestro_home = self.workspace / ".maestro-home"
+        flow_dir.mkdir(parents=True, exist_ok=True)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        maestro_home.mkdir(parents=True, exist_ok=True)
+
+        flow_lines, target_desc = self._build_mobile_flow_from_instruction(app_id, instruction)
+
+        flow_file = flow_dir / f"{run_id}.yaml"
+        log_file = run_dir / "transfer.log"
+        flow_file.write_text("\n".join(flow_lines), encoding="utf-8")
+        timeout = timeout_s or self._MOBILE_SHORTCUT_TIMEOUT_S
+        if on_progress:
+            await on_progress(f"已生成脚本，准备执行：{target_desc}（timeout={timeout}s）")
+
+        cmd = ["maestro", "test", str(flow_file), "--test-output-dir", str(artifact_dir)]
+        env = dict(os.environ)
+        env["HOME"] = str(maestro_home)
+        existing_opts = env.get("MAESTRO_OPTS", "").strip()
+        user_home_opt = f"-Duser.home={maestro_home}"
+        env["MAESTRO_OPTS"] = f"{existing_opts} {user_home_opt}".strip()
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(self.workspace),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            log_file.write_text(
+                f"$ {' '.join(cmd)}\n\n[timeout] execution exceeded {timeout}s\n",
+                encoding="utf-8",
+            )
+            if on_progress:
+                await on_progress(f"执行超时：{timeout}s")
+            if not expose_paths:
+                return (
+                    f"移动自动化执行超时（{timeout}s）。\n"
+                    f"app: {app_id}\n"
+                    f"runId: {run_id}\n"
+                    "详情日志已保存到本地服务器（已脱敏，不返回本地目录路径）。"
+                )
+            return (
+                f"移动自动化执行超时（{timeout}s）。\n"
+                f"flow: {flow_file}\nlog: {log_file}\nartifact: {artifact_dir}"
+            )
+
+        stdout_text = (stdout_bytes or b"").decode("utf-8", errors="replace")
+        stderr_text = (stderr_bytes or b"").decode("utf-8", errors="replace")
+        log_file.write_text(
+            f"$ {' '.join(cmd)}\n\nSTDOUT:\n{stdout_text}\n\nSTDERR:\n{stderr_text}\n",
+            encoding="utf-8",
+        )
+
+        if proc.returncode == 0:
+            if on_progress:
+                await on_progress("执行完成：通过")
+            if not expose_paths:
+                return (
+                    "已完成移动自动化测试。\n"
+                    f"app: {app_id}\n"
+                    f"target: {target_desc}\n"
+                    f"runId: {run_id}\n"
+                    "执行证据已保存到本地服务器（已脱敏，不返回本地目录路径）。"
+                )
+            return (
+                "已完成移动自动化测试。\n"
+                f"app: {app_id}\n"
+                f"target: {target_desc}\n"
+                f"flow: {flow_file}\n"
+                f"log: {log_file}\n"
+                f"artifact: {artifact_dir}"
+            )
+
+        reason = self._classify_mobile_failure(stdout_text, stderr_text)
+        if on_progress:
+            await on_progress(f"执行失败：{reason}")
+        tail = "\n".join((stdout_text + "\n" + stderr_text).strip().splitlines()[-20:])
+        if not expose_paths:
+            return (
+                "移动自动化测试执行失败。\n"
+                f"app: {app_id}\n"
+                f"reason: {reason}\n"
+                f"runId: {run_id}\n"
+                "详情日志已保存到本地服务器（已脱敏，不返回本地目录路径）。"
+            )
+        return (
+            "移动自动化测试执行失败。\n"
+            f"app: {app_id}\n"
+            f"reason: {reason}\n"
+            f"flow: {flow_file}\n"
+            f"log: {log_file}\n"
+            f"artifact: {artifact_dir}\n"
+            "最后输出:\n"
+            f"{tail}"
+        )
+
     async def _run_agent_loop(
         self,
         initial_messages: list[dict],
@@ -250,7 +596,6 @@ class AgentLoop:
     async def run(self) -> None:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
         self._running = True
-        await self._connect_mcp()
         logger.info("Agent loop started")
 
         while self._running:
@@ -327,6 +672,7 @@ class AgentLoop:
         """Process a single inbound message and return the response."""
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
+            await self._connect_mcp()
             channel, chat_id = (msg.chat_id.split(":", 1) if ":" in msg.chat_id
                                 else ("cli", msg.chat_id))
             logger.info("Processing system message from {}", msg.sender_id)
@@ -384,6 +730,42 @@ class AgentLoop:
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
                                   content="🐈 nanobot commands:\n/new — Start a new conversation\n/stop — Stop the current task\n/help — Show available commands")
 
+        async def _shortcut_progress(content: str, *, final: bool = False) -> None:
+            if on_progress:
+                await on_progress(content)
+                return
+            meta = dict(msg.metadata or {})
+            if not final:
+                meta["_progress"] = True
+            await self.bus.publish_outbound(
+                OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta)
+            )
+
+        if app_id := self._extract_mobile_transfer_app_id(msg.content):
+            await _shortcut_progress(f"Detected mobile transfer intent for {app_id}; running Maestro flow.")
+            expose_paths = msg.channel in {"cli", "system"}
+            final_content = await self._run_mobile_transfer_shortcut(
+                app_id,
+                instruction=msg.content,
+                expose_paths=expose_paths,
+                timeout_s=self._MOBILE_SHORTCUT_TIMEOUT_S,
+                on_progress=_shortcut_progress,
+            )
+            now = datetime.now().isoformat()
+            completion_notice = self._summarize_mobile_result(final_content)
+            await _shortcut_progress(completion_notice, final=True)
+            session.messages.append({"role": "user", "content": msg.content, "timestamp": now})
+            session.messages.append({"role": "assistant", "content": final_content, "timestamp": now})
+            self.sessions.save(session)
+            if msg.channel not in {"cli", "system"}:
+                return None
+            return OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content=final_content,
+                metadata=msg.metadata or {},
+            )
+
         unconsolidated = len(session.messages) - session.last_consolidated
         if (unconsolidated >= self.memory_window and session.key not in self._consolidating):
             self._consolidating.add(session.key)
@@ -406,6 +788,8 @@ class AgentLoop:
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()
+
+        await self._connect_mcp()
 
         history = session.get_history(max_messages=self.memory_window)
         initial_messages = self.context.build_messages(
@@ -483,7 +867,6 @@ class AgentLoop:
         on_progress: Callable[[str], Awaitable[None]] | None = None,
     ) -> str:
         """Process a message directly (for CLI or cron usage)."""
-        await self._connect_mcp()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
         response = await self._process_message(msg, session_key=session_key, on_progress=on_progress)
         return response.content if response else ""

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -213,10 +213,21 @@ class ChannelManager:
                 
                 channel = self.channels.get(msg.channel)
                 if channel:
-                    try:
-                        await channel.send(msg)
-                    except Exception as e:
-                        logger.error("Error sending to {}: {}", msg.channel, e)
+                    max_retries = 3
+                    for attempt in range(1, max_retries + 1):
+                        try:
+                            await channel.send(msg)
+                            break
+                        except Exception as e:
+                            if attempt >= max_retries:
+                                logger.error("Error sending to {} after {} attempts: {}", msg.channel, attempt, e)
+                            else:
+                                delay = 0.5 * attempt
+                                logger.warning(
+                                    "Send to {} failed (attempt {}/{}): {}. Retrying in {:.1f}s",
+                                    msg.channel, attempt, max_retries, e, delay,
+                                )
+                                await asyncio.sleep(delay)
                 else:
                     logger.warning("Unknown channel: {}", msg.channel)
                     

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -267,8 +267,10 @@ class TelegramChannel(BaseChannel):
                 )
 
         # Send text content
+        had_text_send_error = False
         if msg.content and msg.content != "[empty message]":
             for chunk in _split_message(msg.content):
+                sent = False
                 try:
                     html = _markdown_to_telegram_html(chunk)
                     await self._app.bot.send_message(
@@ -277,6 +279,7 @@ class TelegramChannel(BaseChannel):
                         parse_mode="HTML",
                         reply_parameters=reply_params
                     )
+                    sent = True
                 except Exception as e:
                     logger.warning("HTML parse failed, falling back to plain text: {}", e)
                     try:
@@ -285,8 +288,19 @@ class TelegramChannel(BaseChannel):
                             text=chunk,
                             reply_parameters=reply_params
                         )
+                        sent = True
                     except Exception as e2:
-                        logger.error("Error sending Telegram message: {}", e2)
+                        logger.warning("Error sending Telegram message with reply params: {}", e2)
+                        # Last fallback: send without reply params to avoid reply-thread errors.
+                        try:
+                            await self._app.bot.send_message(chat_id=chat_id, text=chunk)
+                            sent = True
+                        except Exception as e3:
+                            logger.error("Error sending Telegram message without reply params: {}", e3)
+                if not sent:
+                    had_text_send_error = True
+        if had_text_send_error:
+            raise RuntimeError("Failed to send one or more Telegram text chunks")
     
     async def _on_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /start command."""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1,11 +1,13 @@
 """CLI commands for nanobot."""
 
 import asyncio
+import json
 import os
 import signal
 from pathlib import Path
 import select
 import sys
+from typing import Any
 
 import typer
 from rich.console import Console
@@ -965,6 +967,605 @@ def cron_run(
             _print_agent_response(result_holder[0], render_markdown=True)
     else:
         console.print(f"[red]Failed to run job {job_id}[/red]")
+
+
+# ============================================================================
+# Mobile Testing Commands
+# ============================================================================
+
+mobile_app = typer.Typer(help="Manage mobile app automation setup")
+app.add_typer(mobile_app, name="mobile")
+
+
+def _mobile_layout(workspace: Path) -> dict[str, Path]:
+    """Return canonical workspace paths for mobile automation."""
+    mobile_root = workspace / "mobile"
+    reports_root = workspace / "reports" / "mobile"
+    return {
+        "mobile_root": mobile_root,
+        "apps_dir": mobile_root / "apps",
+        "flows_dir": mobile_root / "flows",
+        "artifacts_dir": reports_root / "artifacts",
+        "runs_dir": reports_root / "runs",
+        "summary_file": reports_root / "summary-latest.json",
+        "sample_flow": mobile_root / "flows" / "smoke.yaml",
+    }
+
+
+def _write_if_missing(path: Path, content: str) -> bool:
+    """Create a file only when absent. Returns True if created."""
+    if path.exists():
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def _mobile_slug(name: str) -> str:
+    """Build a safe filename token from a flow name."""
+    cleaned = "".join(ch if (ch.isalnum() or ch in "-_.") else "-" for ch in name)
+    cleaned = cleaned.strip("-._")
+    return cleaned or "flow"
+
+
+def _resolve_mobile_flows(
+    workspace: Path,
+    flows_dir: Path,
+    selected_flows: list[str] | None,
+    pattern: str,
+) -> list[Path]:
+    """Resolve flow file paths from explicit args or glob pattern."""
+    candidates: list[Path] = []
+    if selected_flows:
+        for raw in selected_flows:
+            p = Path(raw).expanduser()
+            if not p.is_absolute():
+                p = workspace / p
+            candidates.append(p.resolve())
+    else:
+        patterns = [p.strip() for p in pattern.split(",") if p.strip()]
+        if not patterns:
+            patterns = ["*.yaml", "*.yml"]
+        for pat in patterns:
+            candidates.extend(sorted(flows_dir.glob(pat)))
+    seen: set[Path] = set()
+    flows: list[Path] = []
+    for p in candidates:
+        rp = p.resolve()
+        if rp not in seen:
+            seen.add(rp)
+            flows.append(rp)
+    return flows
+
+
+def _mobile_mcp_run_tool_name(tool_names: list[str], server_name: str) -> str | None:
+    """Pick preferred Maestro MCP run tool from registered names."""
+    preferred = (
+        f"mcp_{server_name}_run_flow_files",
+        f"mcp_{server_name}_run_flow",
+    )
+    for name in preferred:
+        if name in tool_names:
+            return name
+    return None
+
+
+def _mobile_build_mcp_payload_candidates(
+    schema: dict[str, Any],
+    flow_path: Path,
+    flow_output_dir: Path,
+    suite: str,
+    platform: str,
+) -> list[dict[str, Any]]:
+    """Build multiple payload candidates to tolerate MCP schema variants."""
+    props = schema.get("properties", {}) if isinstance(schema, dict) else {}
+    required = schema.get("required", []) if isinstance(schema, dict) else []
+    flow = str(flow_path)
+    out_dir = str(flow_output_dir)
+    candidates: list[dict[str, Any]] = []
+
+    def _append(payload: dict[str, Any]) -> None:
+        if payload not in candidates:
+            candidates.append(payload)
+
+    # 1) Schema-driven required payload (best effort)
+    auto_payload: dict[str, Any] = {}
+    unresolved = False
+    for key in required if isinstance(required, list) else []:
+        key_lower = str(key).lower()
+        key_schema = props.get(key, {}) if isinstance(props, dict) else {}
+        key_type = key_schema.get("type") if isinstance(key_schema, dict) else None
+
+        if any(token in key_lower for token in ("flow", "file", "path")):
+            auto_payload[key] = [flow] if key_type == "array" else flow
+        elif any(token in key_lower for token in ("output", "artifact", "report")):
+            auto_payload[key] = out_dir
+        elif "suite" in key_lower and suite:
+            auto_payload[key] = suite
+        elif "platform" in key_lower and platform:
+            auto_payload[key] = platform
+        else:
+            unresolved = True
+            break
+
+    if not unresolved:
+        _append(auto_payload)
+
+    # 2) Common cross-version payload names
+    fallback_payloads = [
+        {"flow_files": [flow], "test_output_dir": out_dir},
+        {"flowFiles": [flow], "testOutputDir": out_dir},
+        {"flows": [flow], "test_output_dir": out_dir},
+        {"files": [flow], "output_dir": out_dir},
+        {"flow": flow, "test_output_dir": out_dir},
+        {"flowFile": flow, "testOutputDir": out_dir},
+        {"file": flow, "outputDir": out_dir},
+        {"path": flow, "output_dir": out_dir},
+    ]
+
+    for payload in fallback_payloads:
+        if suite:
+            payload.setdefault("suite", suite)
+            payload.setdefault("test_suite", suite)
+        if platform:
+            payload.setdefault("platform", platform)
+        _append(payload)
+
+    return candidates
+
+
+async def _mobile_run_with_mcp(
+    config: Config,
+    server_name: str,
+    flows: list[Path],
+    artifacts_dir: Path,
+    run_dir: Path,
+    suite: str,
+    platform: str,
+    continue_on_fail: bool,
+) -> tuple[list[dict[str, Any]], list[Path], list[Path], str]:
+    """Run flows via Maestro MCP tool wrappers."""
+    from contextlib import AsyncExitStack
+    from nanobot.agent.tools.mcp import connect_mcp_servers
+    from nanobot.agent.tools.registry import ToolRegistry
+
+    mcp_cfg = config.tools.mcp_servers.get(server_name)
+    if not mcp_cfg:
+        raise RuntimeError(f"MCP server '{server_name}' not configured")
+
+    registry = ToolRegistry()
+    async with AsyncExitStack() as stack:
+        await connect_mcp_servers({server_name: mcp_cfg}, registry, stack)
+        run_tool = _mobile_mcp_run_tool_name(registry.tool_names, server_name)
+        if not run_tool:
+            raise RuntimeError(
+                f"No runnable mobile test tool found on MCP server '{server_name}'. "
+                f"Expected one of: run_flow_files, run_flow"
+            )
+
+        tool = registry.get(run_tool)
+        schema = tool.parameters if tool else {}
+        results: list[dict[str, Any]] = []
+        logs: list[Path] = []
+        output_dirs: list[Path] = []
+
+        for idx, flow_path in enumerate(flows, 1):
+            label = _mobile_slug(flow_path.stem)
+            flow_output_dir = artifacts_dir / f"{idx:02d}-{label}"
+            flow_output_dir.mkdir(parents=True, exist_ok=True)
+            output_dirs.append(flow_output_dir)
+            log_file = run_dir / f"{idx:02d}-{label}.log"
+
+            candidates = _mobile_build_mcp_payload_candidates(
+                schema=schema,
+                flow_path=flow_path,
+                flow_output_dir=flow_output_dir,
+                suite=suite,
+                platform=platform,
+            )
+
+            selected_payload: dict[str, Any] = {}
+            selected_result = "Error: no MCP payload candidates were generated"
+            success = False
+            for payload in candidates:
+                out = await registry.execute(run_tool, payload)
+                selected_payload = payload
+                selected_result = out
+                if not (isinstance(out, str) and out.startswith("Error")):
+                    success = True
+                    break
+
+            log_file.write_text(
+                (
+                    f"Tool: {run_tool}\n"
+                    f"Flow: {flow_path}\n"
+                    f"Payload: {json.dumps(selected_payload, ensure_ascii=False)}\n\n"
+                    f"Result:\n{selected_result}\n"
+                ),
+                encoding="utf-8",
+            )
+            logs.append(log_file)
+            results.append(
+                {
+                    "flow": str(flow_path),
+                    "status": "passed" if success else "failed",
+                    "exitCode": 0 if success else 1,
+                    "logFile": str(log_file),
+                    "artifactDir": str(flow_output_dir),
+                }
+            )
+
+            if not success and not continue_on_fail:
+                break
+
+        return results, logs, output_dirs, run_tool
+
+
+@mobile_app.command("setup")
+def mobile_setup(
+    maestro_command: str = typer.Option(
+        "maestro",
+        "--maestro-command",
+        help="Maestro CLI executable name or absolute path",
+    ),
+    tool_timeout: int = typer.Option(
+        180,
+        "--tool-timeout",
+        min=10,
+        help="MCP tool timeout in seconds",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Overwrite existing maestro MCP config if present",
+    ),
+):
+    """Initialize workspace layout and Maestro MCP config for mobile automation."""
+    import shutil
+    from nanobot.config.loader import load_config, save_config
+    from nanobot.config.schema import MCPServerConfig
+
+    config = load_config()
+    workspace = config.workspace_path
+    sync_workspace_templates(workspace)
+
+    layout = _mobile_layout(workspace)
+    created_dirs: list[Path] = []
+    for key in ("apps_dir", "flows_dir", "artifacts_dir", "runs_dir"):
+        path = layout[key]
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+            created_dirs.append(path)
+
+    sample_flow_created = _write_if_missing(
+        layout["sample_flow"],
+        """appId: com.example.app
+---
+- launchApp
+- assertVisible: "Home"
+""",
+    )
+
+    summary_created = _write_if_missing(
+        layout["summary_file"],
+        """{
+  "runId": "",
+  "status": "not-started",
+  "platform": "",
+  "suite": "",
+  "startedAt": "",
+  "finishedAt": "",
+  "artifacts": []
+}
+""",
+    )
+
+    existing = config.tools.mcp_servers.get("maestro")
+    updated_mcp = False
+
+    if existing and not force:
+        console.print("[yellow]maestro MCP config already exists. Use --force to overwrite.[/yellow]")
+    else:
+        env = existing.env if existing else {}
+        config.tools.mcp_servers["maestro"] = MCPServerConfig(
+            command=maestro_command,
+            args=["mcp"],
+            env=env,
+            tool_timeout=tool_timeout,
+        )
+        save_config(config)
+        updated_mcp = True
+
+    console.print(f"{__logo__} Mobile automation setup complete\n")
+    console.print(f"Workspace: [cyan]{workspace}[/cyan]")
+
+    if created_dirs:
+        for path in created_dirs:
+            console.print(f"  [green]✓[/green] Created dir: {path}")
+    else:
+        console.print("  [dim]No new directories created[/dim]")
+
+    console.print(
+        f"  {'[green]✓[/green]' if sample_flow_created else '[dim]•[/dim]'} "
+        f"Sample flow: {layout['sample_flow']}"
+    )
+    console.print(
+        f"  {'[green]✓[/green]' if summary_created else '[dim]•[/dim]'} "
+        f"Summary file: {layout['summary_file']}"
+    )
+
+    if updated_mcp:
+        console.print(
+            f"  [green]✓[/green] Configured MCP server 'maestro' => "
+            f"`{maestro_command} mcp` (toolTimeout={tool_timeout}s)"
+        )
+    else:
+        console.print("  [dim]• MCP config unchanged[/dim]")
+
+    if shutil.which(maestro_command) is None:
+        console.print("\n[yellow]Maestro CLI not found on PATH.[/yellow]")
+        console.print("Install: [cyan]curl -fsSL \"https://get.maestro.mobile.dev\" | bash[/cyan]")
+        console.print("or: [cyan]brew tap mobile-dev-inc/tap && brew install maestro[/cyan]")
+
+    console.print("\nNext steps:")
+    console.print("  1. Start simulator/emulator (or run: [cyan]maestro start-device --platform android[/cyan])")
+    console.print("  2. Adjust appId and assertions in [cyan]mobile/flows/smoke.yaml[/cyan]")
+    console.print("  3. Run locally: [cyan]maestro test mobile/flows/smoke.yaml[/cyan]")
+    console.print("  4. Ask agent to run MCP tools after launching [cyan]nanobot agent[/cyan] or [cyan]nanobot gateway[/cyan]")
+
+
+@mobile_app.command("run")
+def mobile_run(
+    flow: list[str] | None = typer.Option(
+        None,
+        "--flow",
+        "-f",
+        help="Specific flow files to run (repeatable, relative to workspace or absolute).",
+    ),
+    pattern: str = typer.Option(
+        "*.yaml,*.yml",
+        "--pattern",
+        help="Glob pattern(s) under mobile/flows when --flow is not provided. Comma-separated supported.",
+    ),
+    suite: str = typer.Option(
+        "default",
+        "--suite",
+        help="Suite label written into run summary.",
+    ),
+    platform: str = typer.Option(
+        "",
+        "--platform",
+        help="Optional platform label for summary (android/ios).",
+    ),
+    continue_on_fail: bool = typer.Option(
+        True,
+        "--continue-on-fail/--fail-fast",
+        help="Continue running remaining flows after a failure.",
+    ),
+    mode: str = typer.Option(
+        "auto",
+        "--mode",
+        help="Execution mode: auto, local, or mcp.",
+    ),
+    mcp_server: str = typer.Option(
+        "maestro",
+        "--mcp-server",
+        help="MCP server name from tools.mcpServers (used in mcp/auto mode).",
+    ),
+    maestro_command: str = typer.Option(
+        "maestro",
+        "--maestro-command",
+        help="Maestro CLI executable name or absolute path.",
+    ),
+):
+    """Run mobile flow files and persist summary/report artifacts."""
+    import shutil
+    import subprocess
+    import uuid
+    from datetime import datetime
+    from nanobot.config.loader import load_config
+
+    config = load_config()
+    workspace = config.workspace_path
+    layout = _mobile_layout(workspace)
+    flows = _resolve_mobile_flows(workspace, layout["flows_dir"], flow, pattern)
+    mode = mode.lower().strip()
+
+    if not flows:
+        console.print(f"[red]No flow files found.[/red] pattern={pattern}, flows_dir={layout['flows_dir']}")
+        raise typer.Exit(1)
+
+    missing = [str(p) for p in flows if not p.exists()]
+    if missing:
+        console.print(f"[red]Flow file not found:[/red] {missing[0]}")
+        raise typer.Exit(1)
+
+    if mode not in {"auto", "local", "mcp"}:
+        console.print(f"[red]Invalid mode:[/red] {mode}. Use auto/local/mcp.")
+        raise typer.Exit(1)
+
+    has_mcp = mcp_server in config.tools.mcp_servers
+    use_mcp = mode == "mcp" or (mode == "auto" and has_mcp)
+
+    if mode == "mcp" and not has_mcp:
+        console.print(f"[red]MCP server not configured:[/red] {mcp_server}")
+        console.print("Configure it in ~/.nanobot/config.json under tools.mcpServers")
+        raise typer.Exit(1)
+
+    if not use_mcp and shutil.which(maestro_command) is None:
+        console.print(f"[red]Maestro CLI not found:[/red] {maestro_command}")
+        console.print('Install: [cyan]curl -fsSL "https://get.maestro.mobile.dev" | bash[/cyan]')
+        raise typer.Exit(1)
+
+    run_id = datetime.now().strftime("%Y%m%d-%H%M%S") + "-" + uuid.uuid4().hex[:8]
+    started_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    run_dir = layout["runs_dir"] / run_id
+    artifacts_dir = layout["artifacts_dir"] / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    def _rel(path: Path) -> str:
+        try:
+            return str(path.relative_to(workspace))
+        except ValueError:
+            return str(path)
+
+    results: list[dict[str, object]] = []
+    logs: list[Path] = []
+    output_dirs: list[Path] = []
+    exec_mode = "mcp" if use_mcp else "local"
+    console.print(f"Execution mode: [cyan]{exec_mode}[/cyan]")
+
+    if use_mcp:
+        try:
+            raw_results, logs, output_dirs, run_tool = asyncio.run(
+                _mobile_run_with_mcp(
+                    config=config,
+                    server_name=mcp_server,
+                    flows=flows,
+                    artifacts_dir=artifacts_dir,
+                    run_dir=run_dir,
+                    suite=suite,
+                    platform=platform,
+                    continue_on_fail=continue_on_fail,
+                )
+            )
+            console.print(f"MCP tool: [cyan]{run_tool}[/cyan]")
+            for item in raw_results:
+                status = str(item.get("status", "failed"))
+                symbol = "[green]✓[/green]" if status == "passed" else "[red]✗[/red]"
+                flow_name = Path(str(item.get("flow", ""))).name
+                console.print(f"{symbol} {flow_name} ({status})")
+                results.append(
+                    {
+                        "flow": _rel(Path(str(item.get("flow", "")))),
+                        "status": status,
+                        "exitCode": int(item.get("exitCode", 1)),
+                        "logFile": _rel(Path(str(item.get("logFile", "")))),
+                        "artifactDir": _rel(Path(str(item.get("artifactDir", "")))),
+                    }
+                )
+        except Exception as e:
+            if mode == "auto":
+                console.print(f"[yellow]MCP execution failed in auto mode, fallback to local: {e}[/yellow]")
+                use_mcp = False
+            else:
+                console.print(f"[red]MCP execution failed:[/red] {e}")
+                raise typer.Exit(1)
+
+    if not use_mcp:
+        for idx, flow_path in enumerate(flows, 1):
+            label = _mobile_slug(flow_path.stem)
+            log_file = run_dir / f"{idx:02d}-{label}.log"
+            flow_output_dir = artifacts_dir / f"{idx:02d}-{label}"
+            flow_output_dir.mkdir(parents=True, exist_ok=True)
+            cmd = [maestro_command, "test", str(flow_path), "--test-output-dir", str(flow_output_dir)]
+            proc = subprocess.run(
+                cmd,
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+            )
+            log_file.write_text(
+                f"$ {' '.join(cmd)}\n\nSTDOUT:\n{proc.stdout or ''}\n\nSTDERR:\n{proc.stderr or ''}\n",
+                encoding="utf-8",
+            )
+            logs.append(log_file)
+            output_dirs.append(flow_output_dir)
+            status = "passed" if proc.returncode == 0 else "failed"
+            results.append(
+                {
+                    "flow": _rel(flow_path),
+                    "status": status,
+                    "exitCode": proc.returncode,
+                    "logFile": _rel(log_file),
+                    "artifactDir": _rel(flow_output_dir),
+                }
+            )
+
+            symbol = "[green]✓[/green]" if status == "passed" else "[red]✗[/red]"
+            console.print(f"{symbol} {flow_path.name} ({status}) -> {log_file.name}")
+            if proc.returncode != 0 and not continue_on_fail:
+                console.print("[yellow]Fail-fast enabled; stopping remaining flows.[/yellow]")
+                break
+
+    passed = sum(1 for item in results if item["status"] == "passed")
+    failed = len(results) - passed
+    finished_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    summary = {
+        "runId": run_id,
+        "status": "passed" if failed == 0 else "failed",
+        "platform": platform,
+        "suite": suite,
+        "startedAt": started_at,
+        "finishedAt": finished_at,
+        "requestedFlows": len(flows),
+        "executedFlows": len(results),
+        "passedFlows": passed,
+        "failedFlows": failed,
+        "executionMode": "mcp" if use_mcp else "local",
+        "mcpServer": mcp_server if use_mcp else "",
+        "flows": results,
+        "artifacts": (
+            [{"type": "log", "path": _rel(p)} for p in logs]
+            + [{"type": "maestro-output-dir", "path": _rel(p)} for p in output_dirs]
+        ),
+    }
+
+    run_summary = run_dir / "summary.json"
+    run_summary.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    layout["summary_file"].parent.mkdir(parents=True, exist_ok=True)
+    layout["summary_file"].write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    table = Table(title=f"Mobile Run Summary ({run_id})")
+    table.add_column("Suite", style="cyan")
+    table.add_column("Requested")
+    table.add_column("Executed")
+    table.add_column("Passed", style="green")
+    table.add_column("Failed", style="red")
+    table.add_row(suite, str(len(flows)), str(len(results)), str(passed), str(failed))
+    console.print()
+    console.print(table)
+    console.print(f"Summary: [cyan]{layout['summary_file']}[/cyan]")
+    console.print(f"Run dir: [cyan]{run_dir}[/cyan]")
+
+    if failed > 0:
+        raise typer.Exit(1)
+
+
+@mobile_app.command("status")
+def mobile_status():
+    """Show mobile automation workspace and maestro MCP status."""
+    from nanobot.config.loader import load_config, get_config_path
+
+    config_path = get_config_path()
+    config = load_config()
+    workspace = config.workspace_path
+    layout = _mobile_layout(workspace)
+    maestro = config.tools.mcp_servers.get("maestro")
+    cwd = Path.cwd()
+
+    table = Table(title="Mobile Automation Status")
+    table.add_column("Item", style="cyan")
+    table.add_column("Value", style="yellow")
+
+    table.add_row("Config", str(config_path))
+    table.add_row("Workspace", str(workspace))
+    if not str(workspace).startswith(str(cwd)):
+        table.add_row("Workspace scope", f"outside current cwd ({cwd})")
+    table.add_row("Flows dir", str(layout["flows_dir"]))
+    table.add_row("Apps dir", str(layout["apps_dir"]))
+    table.add_row("Reports dir", str(layout["runs_dir"].parent))
+    table.add_row("Sample flow exists", "✓" if layout["sample_flow"].exists() else "✗")
+
+    if maestro:
+        cmd = " ".join([maestro.command, *maestro.args]).strip()
+        table.add_row("MCP maestro", f"✓ {cmd}")
+        table.add_row("MCP toolTimeout", f"{maestro.tool_timeout}s")
+    else:
+        table.add_row("MCP maestro", "✗ not configured")
+
+    console.print(table)
 
 
 # ============================================================================

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -208,6 +208,11 @@ class LiteLLMProvider(LLMProvider):
             "max_tokens": max_tokens,
             "temperature": temperature,
         }
+
+        # In gateway mode (for example OpenRouter), force provider routing in LiteLLM.
+        # This avoids model-keyword mis-detection (e.g. "gemini" in model name).
+        if self._gateway and self._gateway.name:
+            kwargs["custom_llm_provider"] = self._gateway.name
         
         # Apply model-specific overrides (e.g. kimi-k2.5 temperature)
         self._apply_model_overrides(model, kwargs)

--- a/nanobot/skills/README.md
+++ b/nanobot/skills/README.md
@@ -23,3 +23,4 @@ The skill format and metadata structure follow OpenClaw's conventions to maintai
 | `tmux` | Remote-control tmux sessions |
 | `clawhub` | Search and install skills from ClawHub registry |
 | `skill-creator` | Create new skills |
+| `mobile-testing` | Mobile app automation with Maestro |

--- a/nanobot/skills/mobile-testing/SKILL.md
+++ b/nanobot/skills/mobile-testing/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: mobile-testing
+description: "Plan and run mobile App automated tests with Maestro. Use for Android/iOS flow automation, smoke/regression checks, and evidence collection."
+metadata: {"nanobot":{"requires":{"bins":["maestro"]},"install":[{"id":"maestro-curl","kind":"shell","command":"curl -fsSL \"https://get.maestro.mobile.dev\" | bash","bins":["maestro"],"label":"Install Maestro CLI"},{"id":"maestro-brew","kind":"brew","formula":"maestro","bins":["maestro"],"label":"Install Maestro CLI (brew tap required)"}]}}
+---
+
+# Mobile Testing
+
+Use this skill when the user asks to automate testing for iOS/Android apps with Maestro.
+
+## Default Workflow
+
+1. Confirm target platform (`android` or `ios`) and app package/bundle id.
+2. Ensure workspace scaffold exists (recommended once): `nanobot mobile setup`.
+3. Edit or create flows under `mobile/flows/`.
+4. Run test:
+```bash
+nanobot mobile run --suite smoke --platform android
+# prefer MCP execution when configured:
+nanobot mobile run --mode mcp --mcp-server maestro
+# or single flow:
+maestro test mobile/flows/<flow>.yaml
+```
+5. Save artifacts in:
+- `reports/mobile/runs/<run-id>/`
+- `reports/mobile/artifacts/<run-id>/<flow-id>/` (via Maestro `--test-output-dir`)
+6. Update `reports/mobile/summary-latest.json` with run status and artifact paths.
+
+## With MCP (Recommended)
+
+If Maestro MCP is configured (`tools.mcpServers.maestro`), prefer MCP tools for execution and result retrieval.
+
+Typical MCP tool names from Maestro:
+- `maestro_list_devices`
+- `maestro_start_device`
+- `maestro_run_flow_files`
+- `maestro_run_test_suite`
+- `maestro_take_screenshot`
+- `maestro_inspect_view_hierarchy`
+- `maestro_stop_device`
+
+Use them to keep execution deterministic and tool-native in the agent loop.
+
+## Flow Authoring Rules
+
+- Keep one user journey per flow file.
+- Use stable selectors (text/resource-id/accessibility id).
+- For flaky steps, add explicit waits and robust assertions.
+- Name flow files by intent, for example:
+  - `login-smoke.yaml`
+  - `checkout-regression.yaml`
+  - `settings-permission.yaml`
+
+## Report Contract
+
+After each run, produce a concise summary with:
+- `runId`
+- `status` (`passed`/`failed`)
+- `platform`
+- `suite`
+- `startedAt` / `finishedAt`
+- artifact list (screenshots, logs, videos)
+
+Store this summary in `reports/mobile/summary-latest.json`.


### PR DESCRIPTION
## Summary
- force `custom_llm_provider` in gateway mode before calling LiteLLM
- prevent provider keyword mis-detection when model names include keywords like `gemini`
- keep existing model/api_key/api_base flow unchanged

## Root Cause
LiteLLM provider inference can be influenced by model keywords. In gateway scenarios (e.g. OpenRouter + Gemini model names), requests could be routed as direct Gemini calls and fail with `Missing gemini_api_key` even when OpenRouter is configured.

## Fix
When `self._gateway` is detected, explicitly set:
- `custom_llm_provider = self._gateway.name`

in `LiteLLMProvider.chat()` so routing follows configured gateway instead of keyword inference.

## Validation
- verified gateway-mode call payload includes `custom_llm_provider=openrouter`
- reproduced user scenario and confirmed routing no longer requests `GEMINI_API_KEY`
