### PR TITLE
fix: Add reasoning_content support for Moonshot Kimi and other reasoning models

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -150,12 +150,33 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         content: str | None,
         tool_calls: list[dict[str, Any]] | None = None,
         reasoning_content: str | None = None,
+        model: str | None = None,
     ) -> list[dict[str, Any]]:
         """Add an assistant message to the message list."""
         msg: dict[str, Any] = {"role": "assistant", "content": content}
         if tool_calls:
             msg["tool_calls"] = tool_calls
+        
+        # For reasoning models (e.g., Moonshot Kimi k2.5, DeepSeek-R1), if any previous
+        # assistant message had reasoning_content, all subsequent assistant messages must
+        # also include it (even if None/empty) to satisfy the API requirements.
+        # Check if this is a reasoning model or if previous messages had reasoning_content
+        is_reasoning_model = model and any(
+            keyword in model.lower() for keyword in ("kimi", "reason", "deepseek-r1", "deepseek-reason")
+        )
+        has_previous_reasoning = any(
+            m.get("role") == "assistant" and "reasoning_content" in m
+            for m in messages
+        )
+        
+        # Include reasoning_content if provided, or if this is a reasoning model and
+        # previous messages had it, or if this message has tool_calls and is a reasoning model
         if reasoning_content is not None:
             msg["reasoning_content"] = reasoning_content
+        elif (is_reasoning_model or has_previous_reasoning) and tool_calls:
+            # For reasoning models with tool calls, include empty reasoning_content if not provided
+            # This ensures API compatibility (some models require the field to be present)
+            msg["reasoning_content"] = ""
+        
         messages.append(msg)
         return messages

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -214,6 +214,7 @@ class AgentLoop:
                 messages = self.context.add_assistant_message(
                     messages, response.content, tool_call_dicts,
                     reasoning_content=response.reasoning_content,
+                    model=self.model,
                 )
 
                 for tool_call in response.tool_calls:
@@ -234,6 +235,7 @@ class AgentLoop:
                     break
                 messages = self.context.add_assistant_message(
                     messages, clean, reasoning_content=response.reasoning_content,
+                    model=self.model,
                 )
                 final_content = clean
                 break

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -140,11 +140,16 @@ class SubagentManager:
                         }
                         for tc in response.tool_calls
                     ]
-                    messages.append({
+                    msg = {
                         "role": "assistant",
                         "content": response.content or "",
                         "tool_calls": tool_call_dicts,
-                    })
+                    }
+                    # Include reasoning_content for reasoning models (e.g., Moonshot Kimi, DeepSeek-R1)
+                    # Even if None, some models require this field to be present
+                    if response.reasoning_content is not None:
+                        msg["reasoning_content"] = response.reasoning_content
+                    messages.append(msg)
                     
                     # Execute tools
                     for tool_call in response.tool_calls:


### PR DESCRIPTION
Fixes #1313

## Problem
When using reasoning models like Moonshot Kimi k2.5 with tool calling enabled, the request fails with:
\\\
Error calling LLM: litellm.BadRequestError: MoonshotException - thinking is enabled but reasoning_content is missing in assistant tool call message at index 2
\\\

The API requires that all assistant messages with tool_calls include the \easoning_content\ field, even if it's empty.

## Solution
This PR adds proper \easoning_content\ handling for reasoning models:

1. **subagent.py**: Adds \easoning_content\ to assistant messages with tool calls
2. **context.py**: Enhances \dd_assistant_message\ to automatically detect reasoning models and include \easoning_content\ when needed
   - Detects reasoning models by checking model name for keywords: 'kimi', 'reason', 'deepseek-r1', etc.
   - Checks if previous messages had \easoning_content\ to ensure consistency
   - For reasoning models with tool calls, includes empty \easoning_content\ if not provided
3. **loop.py**: Passes model name to \dd_assistant_message\ for reasoning model detection

## Testing
This fix ensures compatibility with Moonshot Kimi k2.5 and other reasoning models that require the \easoning_content\ field to be present in all assistant messages with tool calls.