### PR TITLE
fix(qq): disable botpy file log to fix read-only filesystem error

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -31,7 +31,13 @@ def _make_bot_class(channel: "QQChannel") -> "type[botpy.Client]":
 
     class _Bot(botpy.Client):
         def __init__(self):
-            super().__init__(intents=intents)
+            # Disable botpy's default file handler (TimedRotatingFileHandler).
+            # By default botpy writes "botpy.log" to the process cwd, which
+            # fails under systemd with ProtectSystem=strict (read-only root fs).
+            # nanobot already handles logging via loguru, so the file handler is
+            # redundant.  ext_handlers=False keeps console output but suppresses
+            # the file log.  See: https://github.com/HKUDS/nanobot/issues/1343
+            super().__init__(intents=intents, ext_handlers=False)
 
         async def on_ready(self):
             logger.info("QQ bot ready: {}", self.robot.name)


### PR DESCRIPTION
## Summary

Fixes #1343

When nanobot is run as a systemd service with `ProtectSystem=strict` (a common hardening option), the process working directory is set to the read-only root filesystem (`/`). botpy's `Client` constructor defaults to `ext_handlers=True`, which installs a `TimedRotatingFileHandler` that tries to write `botpy.log` to `os.getcwd()`. This raises:

```
[Errno 30] Read-only file system: '/botpy.log'
```

…and prevents the QQ channel from starting.

## Root Cause

In `botpy/logging.py`, `DEFAULT_FILE_HANDLER` sets:

```python
"filename": os.path.join(os.getcwd(), "%(name)s.log")
```

When `botpy.Client.__init__` is called with the default `ext_handlers=True`, this handler is installed and attempts to open `/botpy.log` for writing — which fails on a read-only root filesystem.

## Fix

Pass `ext_handlers=False` when constructing the botpy `Client` subclass inside `_make_bot_class`. This suppresses the file handler while keeping console output intact. Since nanobot already handles all log output through loguru, botpy's file handler is fully redundant.

## Changes

- `nanobot/channels/qq.py`: pass `ext_handlers=False` to `super().__init__()` in the internal `_Bot` subclass

---
🤖 Generated with Claude Code