### PR TITLE
refactor: streamline subagent prompt by reusing ContextBuilder and SkillsLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ⚡️ Delivers core agent functionality in just **~4,000** lines of code — **99% smaller** than Clawdbot's 430k+ lines.
 
-📏 Real-time line count: **3,922 lines** (run `bash core_agent_lines.sh` to verify anytime)
+📏 Real-time line count: **3,927 lines** (run `bash core_agent_lines.sh` to verify anytime)
 
 ## 📢 News
 


### PR DESCRIPTION
## Summary

Streamline `_build_subagent_prompt` in `subagent.py` — from 36 lines to 21 lines.

- **Remove unused `task` parameter** — `task` was passed to `_build_subagent_prompt` but never referenced in the prompt string; it's already sent as a separate user message
- **Reuse `ContextBuilder._build_runtime_context()`** — eliminates duplicated `datetime.now()` + `time.strftime` logic
- **Remove redundant "What You Can Do" / "What You Cannot Do" sections** — tool definitions already convey available capabilities
- **Integrate `SkillsLoader`** — subagent now dynamically discovers workspace skills instead of hardcoding a path hint
- **Compress rules** — 4 verbose rules condensed to 2 sentences with identical semantics