### PR TITLE
fix(lark): Remove non-existent stop() call on Lark ws.Client when enable lark channel 

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -311,8 +311,8 @@ class FeishuChannel(BaseChannel):
                     self._ws_client.start()
                 except Exception as e:
                     logger.warning("Feishu WebSocket error: {}", e)
-                    if self._running:
-                        import time; time.sleep(5)
+                if self._running:
+                    import time; time.sleep(5)
         
         self._ws_thread = threading.Thread(target=run_ws, daemon=True)
         self._ws_thread.start()


### PR DESCRIPTION
### What type of PR is this?
- Bug fix

### What does this PR do?
Removes the invalid call to `lark.ws.Client.stop()`, this method does not exist in the Lark WebSocket client implementation, leading to runtime exceptions. 
<img width="2404" height="238" alt="image" src="https://github.com/user-attachments/assets/7846e9ec-7404-4b98-88ac-dadbafbd411d" />

The Lark.ws.Client manages its lifecycle via a private `_running` boolean flag. As no public `stop()` method is exposed for graceful shutdown, the client instance will be destroyed naturally when the program exits.

