### PR TITLE
fix(feishu): parse post wrapper payload for rich text messages

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -221,18 +221,32 @@ def _extract_post_content(content_json: dict) -> tuple[str, list[str]]:
         text = " ".join(text_parts).strip() if text_parts else None
         return text, image_keys
     
+    # Compatible with both shapes:
+    # 1) {"post": {"zh_cn": {...}}}
+    # 2) {"zh_cn": {...}} or {"title": "...", "content": [...]}
+    post_root = content_json.get("post") if isinstance(content_json, dict) else None
+    if not isinstance(post_root, dict):
+        post_root = content_json if isinstance(content_json, dict) else {}
+
     # Try direct format first
-    if "content" in content_json:
-        text, images = extract_from_lang(content_json)
+    if "content" in post_root:
+        text, images = extract_from_lang(post_root)
         if text or images:
             return text or "", images
     
     # Try localized format
     for lang_key in ("zh_cn", "en_us", "ja_jp"):
-        lang_content = content_json.get(lang_key)
+        lang_content = post_root.get(lang_key)
         text, images = extract_from_lang(lang_content)
         if text or images:
             return text or "", images
+
+    # Fallback: first dict-shaped child
+    for value in post_root.values():
+        if isinstance(value, dict):
+            text, images = extract_from_lang(value)
+            if text or images:
+                return text or "", images
     
     return "", []
 

--- a/tests/test_feishu_post_content.py
+++ b/tests/test_feishu_post_content.py
@@ -1,0 +1,40 @@
+from nanobot.channels.feishu import _extract_post_content
+
+
+def test_extract_post_content_supports_post_wrapper_shape() -> None:
+    payload = {
+        "post": {
+            "zh_cn": {
+                "title": "日报",
+                "content": [
+                    [
+                        {"tag": "text", "text": "完成"},
+                        {"tag": "img", "image_key": "img_1"},
+                    ]
+                ],
+            }
+        }
+    }
+
+    text, image_keys = _extract_post_content(payload)
+
+    assert text == "日报 完成"
+    assert image_keys == ["img_1"]
+
+
+def test_extract_post_content_keeps_direct_shape_behavior() -> None:
+    payload = {
+        "title": "Daily",
+        "content": [
+            [
+                {"tag": "text", "text": "report"},
+                {"tag": "img", "image_key": "img_a"},
+                {"tag": "img", "image_key": "img_b"},
+            ]
+        ],
+    }
+
+    text, image_keys = _extract_post_content(payload)
+
+    assert text == "Daily report"
+    assert image_keys == ["img_a", "img_b"]


### PR DESCRIPTION
## Summary
- Support post payloads wrapped as {"post": {"zh_cn": ...}} in _extract_post_content
- Keep existing direct/localized parsing behavior unchanged
- Add regression tests for wrapped and direct payload shapes

## Why
Feishu post events can arrive with an outer post object. The current parser only checks direct/localized shapes at the top level and can return empty content for valid wrapped payloads.

## Testing
- uv run --project . pytest -q tests/test_feishu_post_content.py