### PR TITLE
feat(provider): add policy-driven retries and fallback model

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -231,6 +231,8 @@ def _make_provider(config: Config):
         api_key=p.api_key if p else None,
         api_base=config.get_api_base(model),
         default_model=model,
+        fallback_model=config.agents.defaults.fallback_model,
+        llm_policy=config.agents.defaults.llm_policy,
         extra_headers=p.extra_headers if p else None,
         provider_name=provider_name,
     )

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -216,17 +216,44 @@ class ChannelsConfig(Base):
     matrix: MatrixConfig = Field(default_factory=MatrixConfig)
 
 
+class RetryPolicyConfig(Base):
+    """Retry behavior for LLM calls."""
+
+    max_retries: int = 4
+    base_delay_sec: float = 0.75
+    max_delay_sec: float = 8.0
+    retryable_status_codes: list[int] = Field(
+        default_factory=lambda: [408, 409, 429, 500, 502, 503, 504]
+    )
+
+
+class FallbackPolicyConfig(Base):
+    """Fallback model behavior when primary call fails."""
+
+    enabled: bool = True
+    retryable_errors_only: bool = True
+
+
+class LLMCallPolicyConfig(Base):
+    """Top-level LLM calling policy."""
+
+    retry: RetryPolicyConfig = Field(default_factory=RetryPolicyConfig)
+    fallback: FallbackPolicyConfig = Field(default_factory=FallbackPolicyConfig)
+
+
 class AgentDefaults(Base):
     """Default agent configuration."""
 
     workspace: str = "~/.nanobot/workspace"
     model: str = "anthropic/claude-opus-4-5"
+    fallback_model: str | None = None
     provider: str = "auto"  # Provider name (e.g. "anthropic", "openrouter") or "auto" for auto-detection
     max_tokens: int = 8192
     temperature: float = 0.1
     max_tool_iterations: int = 40
     memory_window: int = 100
     reasoning_effort: str | None = None  # low / medium / high — enables LLM thinking mode
+    llm_policy: LLMCallPolicyConfig = Field(default_factory=LLMCallPolicyConfig)
 
 
 class AgentsConfig(Base):

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -1,16 +1,21 @@
 """LiteLLM provider implementation for multi-provider support."""
 
+import asyncio
+import json
+import json_repair
 import os
+import random
 import secrets
 import string
 from typing import Any
 
-import json_repair
 import litellm
 from litellm import acompletion
+from loguru import logger
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.providers.registry import find_by_model, find_gateway
+
 
 # Standard OpenAI chat-completion message keys plus reasoning_content for
 # thinking-enabled models (Kimi k2.5, DeepSeek-R1, etc.).
@@ -30,36 +35,45 @@ class LiteLLMProvider(LLMProvider):
     a unified interface.  Provider-specific logic is driven by the registry
     (see providers/registry.py) — no if-elif chains needed here.
     """
+    
+    RETRYABLE_STATUS_CODES = {408, 409, 429, 500, 502, 503, 504}
+    DEFAULT_MAX_RETRIES = 4
+    DEFAULT_RETRY_BASE_DELAY_SEC = 0.75
+    DEFAULT_RETRY_MAX_DELAY_SEC = 8.0
 
     def __init__(
-        self,
-        api_key: str | None = None,
+        self, 
+        api_key: str | None = None, 
         api_base: str | None = None,
         default_model: str = "anthropic/claude-opus-4-5",
+        fallback_model: str | None = None,
+        llm_policy: Any | None = None,
         extra_headers: dict[str, str] | None = None,
         provider_name: str | None = None,
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
+        self.fallback_model = fallback_model.strip() if fallback_model and fallback_model.strip() else None
+        self._llm_policy = self._coerce_policy(llm_policy)
         self.extra_headers = extra_headers or {}
-
+        
         # Detect gateway / local deployment.
         # provider_name (from config key) is the primary signal;
         # api_key / api_base are fallback for auto-detection.
         self._gateway = find_gateway(provider_name, api_key, api_base)
-
+        
         # Configure environment variables
         if api_key:
             self._setup_env(api_key, api_base, default_model)
-
+        
         if api_base:
             litellm.api_base = api_base
-
+        
         # Disable LiteLLM logging noise
         litellm.suppress_debug_info = True
         # Drop unsupported parameters for providers (e.g., gpt-5 rejects some params)
         litellm.drop_params = True
-
+    
     def _setup_env(self, api_key: str, api_base: str | None, model: str) -> None:
         """Set environment variables based on detected provider."""
         spec = self._gateway or find_by_model(model)
@@ -83,7 +97,7 @@ class LiteLLMProvider(LLMProvider):
             resolved = env_val.replace("{api_key}", api_key)
             resolved = resolved.replace("{api_base}", effective_base)
             os.environ.setdefault(env_name, resolved)
-
+    
     def _resolve_model(self, model: str) -> str:
         """Resolve model name by applying provider/gateway prefixes."""
         if self._gateway:
@@ -94,7 +108,7 @@ class LiteLLMProvider(LLMProvider):
             if prefix and not model.startswith(f"{prefix}/"):
                 model = f"{prefix}/{model}"
             return model
-
+        
         # Standard mode: auto-prefix for known providers
         spec = find_by_model(model)
         if spec and spec.litellm_prefix:
@@ -114,6 +128,172 @@ class LiteLLMProvider(LLMProvider):
             return model
         return f"{canonical_prefix}/{remainder}"
 
+    @staticmethod
+    def _coerce_policy(policy: Any) -> dict[str, Any]:
+        """Normalize policy object into a plain dict."""
+        if policy is None:
+            return {}
+        if isinstance(policy, dict):
+            return policy
+        model_dump = getattr(policy, "model_dump", None)
+        if callable(model_dump):
+            try:
+                data = model_dump()
+                if isinstance(data, dict):
+                    return data
+            except Exception:
+                return {}
+        return {}
+
+    def _policy_section(self, key: str) -> dict[str, Any]:
+        section = self._llm_policy.get(key, {})
+        return section if isinstance(section, dict) else {}
+
+    @staticmethod
+    def _parse_bool(value: Any) -> bool | None:
+        if isinstance(value, bool):
+            return value
+        if not isinstance(value, str):
+            return None
+        text = value.strip().lower()
+        if text in {"1", "true", "yes", "on"}:
+            return True
+        if text in {"0", "false", "no", "off"}:
+            return False
+        return None
+
+    def _retryable_status_codes(self) -> set[int]:
+        retry_policy = self._policy_section("retry")
+        from_policy = retry_policy.get("retryable_status_codes")
+        if isinstance(from_policy, list):
+            parsed = {
+                int(v)
+                for v in from_policy
+                if isinstance(v, int) or (isinstance(v, str) and v.isdigit())
+            }
+            if parsed:
+                return parsed
+
+        raw = os.getenv("NANOBOT_LLM_RETRYABLE_STATUS_CODES")
+        if raw:
+            parsed = {
+                int(part.strip())
+                for part in raw.split(",")
+                if part.strip().isdigit()
+            }
+            if parsed:
+                return parsed
+
+        return set(self.RETRYABLE_STATUS_CODES)
+
+    def _retry_settings(self) -> tuple[int, float, float]:
+        """Read retry settings with precedence: config policy > env > defaults."""
+        retry_policy = self._policy_section("retry")
+
+        max_retries = self.DEFAULT_MAX_RETRIES
+        base_delay = self.DEFAULT_RETRY_BASE_DELAY_SEC
+        max_delay = self.DEFAULT_RETRY_MAX_DELAY_SEC
+
+        from_policy_retries = retry_policy.get("max_retries")
+        if isinstance(from_policy_retries, int):
+            max_retries = max(0, from_policy_retries)
+        else:
+            raw_max_retries = os.getenv("NANOBOT_LLM_MAX_RETRIES")
+            if raw_max_retries is not None:
+                try:
+                    max_retries = max(0, int(raw_max_retries))
+                except ValueError:
+                    pass
+
+        from_policy_base = retry_policy.get("base_delay_sec")
+        if isinstance(from_policy_base, (int, float)):
+            base_delay = max(0.0, float(from_policy_base))
+        else:
+            raw_base_delay = os.getenv("NANOBOT_LLM_RETRY_BASE_DELAY_SEC")
+            if raw_base_delay is not None:
+                try:
+                    base_delay = max(0.0, float(raw_base_delay))
+                except ValueError:
+                    pass
+
+        from_policy_max = retry_policy.get("max_delay_sec")
+        if isinstance(from_policy_max, (int, float)):
+            max_delay = max(0.0, float(from_policy_max))
+        else:
+            raw_max_delay = os.getenv("NANOBOT_LLM_RETRY_MAX_DELAY_SEC")
+            if raw_max_delay is not None:
+                try:
+                    max_delay = max(0.0, float(raw_max_delay))
+                except ValueError:
+                    pass
+
+        if max_delay < base_delay:
+            max_delay = base_delay
+
+        return max_retries, base_delay, max_delay
+
+    def _fallback_settings(self) -> tuple[bool, bool]:
+        """Read fallback settings with precedence: config policy > env > defaults."""
+        fallback_policy = self._policy_section("fallback")
+        enabled = True
+        retryable_only = True
+
+        from_policy_enabled = fallback_policy.get("enabled")
+        if isinstance(from_policy_enabled, bool):
+            enabled = from_policy_enabled
+        else:
+            raw_enabled = os.getenv("NANOBOT_LLM_FALLBACK_ENABLED")
+            parsed_enabled = self._parse_bool(raw_enabled)
+            if parsed_enabled is not None:
+                enabled = parsed_enabled
+
+        from_policy_retryable_only = fallback_policy.get("retryable_errors_only")
+        if isinstance(from_policy_retryable_only, bool):
+            retryable_only = from_policy_retryable_only
+        else:
+            raw_retryable_only = os.getenv("NANOBOT_LLM_FALLBACK_RETRYABLE_ONLY")
+            parsed_retryable_only = self._parse_bool(raw_retryable_only)
+            if parsed_retryable_only is not None:
+                retryable_only = parsed_retryable_only
+
+        return enabled, retryable_only
+
+    def _extract_status_code(self, error: Exception) -> int | None:
+        """Extract HTTP status code from provider exception when available."""
+        status_code = getattr(error, "status_code", None)
+        if isinstance(status_code, int):
+            return status_code
+
+        response = getattr(error, "response", None)
+        if response is not None:
+            response_status = getattr(response, "status_code", None)
+            if isinstance(response_status, int):
+                return response_status
+
+        return None
+
+    def _is_retryable_error(self, error: Exception) -> bool:
+        """Decide whether this exception is safe to retry."""
+        status_code = self._extract_status_code(error)
+        if status_code in self._retryable_status_codes():
+            return True
+
+        retryable_error_names = {
+            "RateLimitError",
+            "Timeout",
+            "TimeoutError",
+            "APIConnectionError",
+            "ServiceUnavailableError",
+            "InternalServerError",
+        }
+        return error.__class__.__name__ in retryable_error_names
+
+    def _retry_delay(self, attempt: int, base_delay: float, max_delay: float) -> float:
+        """Exponential backoff with small jitter."""
+        delay = min(max_delay, base_delay * (2 ** attempt))
+        jitter = random.uniform(0.0, min(0.4, delay * 0.2))
+        return delay + jitter
+    
     def _supports_cache_control(self, model: str) -> bool:
         """Return True when the provider supports cache_control on content blocks."""
         if self._gateway is not None:
@@ -156,7 +336,7 @@ class LiteLLMProvider(LLMProvider):
                 if pattern in model_lower:
                     kwargs.update(overrides)
                     return
-
+    
     @staticmethod
     def _sanitize_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Strip non-standard keys and ensure assistant messages have a content key."""
@@ -169,43 +349,23 @@ class LiteLLMProvider(LLMProvider):
             sanitized.append(clean)
         return sanitized
 
-    async def chat(
+    def _build_chat_kwargs(
         self,
+        model: str,
         messages: list[dict[str, Any]],
-        tools: list[dict[str, Any]] | None = None,
-        model: str | None = None,
-        max_tokens: int = 4096,
-        temperature: float = 0.7,
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+        temperature: float,
         reasoning_effort: str | None = None,
-    ) -> LLMResponse:
-        """
-        Send a chat completion request via LiteLLM.
-
-        Args:
-            messages: List of message dicts with 'role' and 'content'.
-            tools: Optional list of tool definitions in OpenAI format.
-            model: Model identifier (e.g., 'anthropic/claude-sonnet-4-5').
-            max_tokens: Maximum tokens in response.
-            temperature: Sampling temperature.
-
-        Returns:
-            LLMResponse with content and/or tool calls.
-        """
-        original_model = model or self.default_model
-        model = self._resolve_model(original_model)
-
-        if self._supports_cache_control(original_model):
-            messages, tools = self._apply_cache_control(messages, tools)
-
-        # Clamp max_tokens to at least 1 — negative or zero values cause
-        # LiteLLM to reject the request with "max_tokens must be at least 1".
-        max_tokens = max(1, max_tokens)
-
+    ) -> dict[str, Any]:
         kwargs: dict[str, Any] = {
             "model": model,
             "messages": self._sanitize_messages(self._sanitize_empty_content(messages)),
             "max_tokens": max_tokens,
             "temperature": temperature,
+            # Keep retry behavior in this class for cross-provider consistency.
+            "num_retries": 0,
+            "max_retries": 0,
         }
 
         # Apply model-specific overrides (e.g. kimi-k2.5 temperature)
@@ -222,30 +382,149 @@ class LiteLLMProvider(LLMProvider):
         # Pass extra headers (e.g. APP-Code for AiHubMix)
         if self.extra_headers:
             kwargs["extra_headers"] = self.extra_headers
-        
+
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
             kwargs["drop_params"] = True
-        
+
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
 
-        try:
-            response = await acompletion(**kwargs)
-            return self._parse_response(response)
-        except Exception as e:
-            # Return error as content for graceful handling
-            return LLMResponse(
-                content=f"Error calling LLM: {str(e)}",
-                finish_reason="error",
-            )
+        return kwargs
 
+    async def _call_with_retries(
+        self,
+        kwargs: dict[str, Any],
+        max_retries: int,
+        base_delay: float,
+        max_delay: float,
+    ) -> tuple[Any | None, Exception | None]:
+        last_error: Exception | None = None
+        model_name = str(kwargs.get("model", "unknown"))
+
+        for attempt in range(max_retries + 1):
+            try:
+                return await acompletion(**kwargs), None
+            except Exception as e:
+                last_error = e
+                if attempt >= max_retries or not self._is_retryable_error(e):
+                    break
+
+                wait_sec = self._retry_delay(
+                    attempt=attempt,
+                    base_delay=base_delay,
+                    max_delay=max_delay,
+                )
+                logger.warning(
+                    "LLM call failed ({err}) model={model}; retry {retry}/{total} in {wait:.2f}s",
+                    err=e.__class__.__name__,
+                    model=model_name,
+                    retry=attempt + 1,
+                    total=max_retries,
+                    wait=wait_sec,
+                )
+                await asyncio.sleep(wait_sec)
+
+        return None, last_error
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+    ) -> LLMResponse:
+        """
+        Send a chat completion request via LiteLLM.
+        
+        Args:
+            messages: List of message dicts with 'role' and 'content'.
+            tools: Optional list of tool definitions in OpenAI format.
+            model: Model identifier (e.g., 'anthropic/claude-sonnet-4-5').
+            max_tokens: Maximum tokens in response.
+            temperature: Sampling temperature.
+        
+        Returns:
+            LLMResponse with content and/or tool calls.
+        """
+        primary_raw_model = model or self.default_model
+        primary_model = self._resolve_model(primary_raw_model)
+        fallback_raw_model = self.fallback_model if self.fallback_model else None
+        fallback_model = self._resolve_model(fallback_raw_model) if fallback_raw_model else None
+
+        if self._supports_cache_control(primary_raw_model):
+            messages, tools = self._apply_cache_control(messages, tools)
+
+        # Clamp max_tokens to at least 1 — negative or zero values cause
+        # LiteLLM to reject the request with "max_tokens must be at least 1".
+        max_tokens = max(1, max_tokens)
+
+        max_retries, base_delay, max_delay = self._retry_settings()
+        primary_kwargs = self._build_chat_kwargs(
+            model=primary_model,
+            messages=messages,
+            tools=tools,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
+        )
+
+        response, primary_error = await self._call_with_retries(
+            kwargs=primary_kwargs,
+            max_retries=max_retries,
+            base_delay=base_delay,
+            max_delay=max_delay,
+        )
+        if response is not None:
+            return self._parse_response(response)
+
+        last_error = primary_error
+
+        fallback_enabled, retryable_only = self._fallback_settings()
+        can_fallback = (
+            fallback_enabled
+            and fallback_model
+            and fallback_model != primary_model
+            and primary_error is not None
+            and (self._is_retryable_error(primary_error) if retryable_only else True)
+        )
+        if can_fallback:
+            logger.warning(
+                "Primary model failed after retries; switching fallback model {fallback}",
+                fallback=fallback_model,
+            )
+            fallback_kwargs = self._build_chat_kwargs(
+                model=fallback_model,
+                messages=messages,
+                tools=tools,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                reasoning_effort=reasoning_effort,
+            )
+            response, fallback_error = await self._call_with_retries(
+                kwargs=fallback_kwargs,
+                max_retries=max_retries,
+                base_delay=base_delay,
+                max_delay=max_delay,
+            )
+            if response is not None:
+                return self._parse_response(response)
+            last_error = fallback_error or primary_error
+
+        # Return error as content for graceful handling.
+        return LLMResponse(
+            content=f"Error calling LLM: {str(last_error) if last_error else 'unknown error'}",
+            finish_reason="error",
+        )
+    
     def _parse_response(self, response: Any) -> LLMResponse:
         """Parse LiteLLM response into our standard format."""
         choice = response.choices[0]
         message = choice.message
-
+        
         tool_calls = []
         if hasattr(message, "tool_calls") and message.tool_calls:
             for tc in message.tool_calls:
@@ -253,13 +532,13 @@ class LiteLLMProvider(LLMProvider):
                 args = tc.function.arguments
                 if isinstance(args, str):
                     args = json_repair.loads(args)
-
+                
                 tool_calls.append(ToolCallRequest(
                     id=_short_tool_id(),
                     name=tc.function.name,
                     arguments=args,
                 ))
-
+        
         usage = {}
         if hasattr(response, "usage") and response.usage:
             usage = {
@@ -267,7 +546,7 @@ class LiteLLMProvider(LLMProvider):
                 "completion_tokens": response.usage.completion_tokens,
                 "total_tokens": response.usage.total_tokens,
             }
-
+        
         reasoning_content = getattr(message, "reasoning_content", None) or None
         thinking_blocks = getattr(message, "thinking_blocks", None) or None
         
@@ -279,7 +558,7 @@ class LiteLLMProvider(LLMProvider):
             reasoning_content=reasoning_content,
             thinking_blocks=thinking_blocks,
         )
-
+    
     def get_default_model(self) -> str:
         """Get the default model."""
         return self.default_model

--- a/tests/test_provider_policy.py
+++ b/tests/test_provider_policy.py
@@ -1,0 +1,45 @@
+from nanobot.providers.litellm_provider import LiteLLMProvider
+
+
+def test_llm_policy_overrides_env(monkeypatch) -> None:
+    monkeypatch.setenv("NANOBOT_LLM_MAX_RETRIES", "9")
+    monkeypatch.setenv("NANOBOT_LLM_RETRY_BASE_DELAY_SEC", "9")
+    monkeypatch.setenv("NANOBOT_LLM_RETRY_MAX_DELAY_SEC", "9")
+    monkeypatch.setenv("NANOBOT_LLM_FALLBACK_ENABLED", "true")
+    monkeypatch.setenv("NANOBOT_LLM_FALLBACK_RETRYABLE_ONLY", "true")
+
+    provider = LiteLLMProvider(
+        default_model="openai/gpt-4o-mini",
+        llm_policy={
+            "retry": {
+                "max_retries": 1,
+                "base_delay_sec": 0.2,
+                "max_delay_sec": 0.4,
+            },
+            "fallback": {
+                "enabled": False,
+                "retryable_errors_only": False,
+            },
+        },
+    )
+
+    assert provider._retry_settings() == (1, 0.2, 0.4)
+    assert provider._fallback_settings() == (False, False)
+
+
+def test_retryable_status_codes_can_be_configured(monkeypatch) -> None:
+    monkeypatch.delenv("NANOBOT_LLM_RETRYABLE_STATUS_CODES", raising=False)
+
+    provider = LiteLLMProvider(
+        default_model="openai/gpt-4o-mini",
+        llm_policy={"retry": {"retryable_status_codes": [418]}},
+    )
+
+    class TeapotError(Exception):
+        status_code = 418
+
+    class InternalError(Exception):
+        status_code = 500
+
+    assert provider._is_retryable_error(TeapotError("teapot"))
+    assert not provider._is_retryable_error(InternalError("internal"))


### PR DESCRIPTION
## Summary
- add configurable LLM retry policy (max retries, backoff, retryable status codes)
- add optional fallback model switching when primary model fails
- wire config into provider creation via agents.defaults.fallback_model and agents.defaults.llm_policy
- add focused policy tests

## Why
Provider failures are not always fatal and should be handled with predictable retries and optional fallback. This improves runtime reliability without changing normal successful paths.

## Testing
- uv run --project . pytest -q tests/test_provider_policy.py tests/test_commands.py