### PR TITLE
feat(provider): support kimi-coding model mapping and endpoint

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -30,6 +30,12 @@ class LiteLLMProvider(LLMProvider):
     a unified interface.  Provider-specific logic is driven by the registry
     (see providers/registry.py) — no if-elif chains needed here.
     """
+    KIMI_CODING_MODEL_PREFIX = "kimi-coding/"
+    KIMI_CODING_DEFAULT_BASE = "https://api.kimi.com/coding"
+    KIMI_CODING_DEFAULT_MODEL = "k2p5"
+    KIMI_CODING_MODEL_ALIASES = {
+        "kimi-for-coding": "k2p5",
+    }
 
     def __init__(
         self,
@@ -95,6 +101,10 @@ class LiteLLMProvider(LLMProvider):
                 model = f"{prefix}/{model}"
             return model
 
+        if self._is_kimi_coding_model_ref(model):
+            model_id = self._normalize_kimi_coding_model_id(model)
+            return f"anthropic/{model_id}"
+
         # Standard mode: auto-prefix for known providers
         spec = find_by_model(model)
         if spec and spec.litellm_prefix:
@@ -103,6 +113,40 @@ class LiteLLMProvider(LLMProvider):
                 model = f"{spec.litellm_prefix}/{model}"
 
         return model
+
+    @classmethod
+    def _is_kimi_coding_model_ref(cls, model: str | None) -> bool:
+        if not model:
+            return False
+        return model.lower().startswith(cls.KIMI_CODING_MODEL_PREFIX)
+
+    @classmethod
+    def _normalize_kimi_coding_model_id(cls, model: str) -> str:
+        suffix = model.split("/", 1)[1].strip() if "/" in model else model.strip()
+        if not suffix:
+            return cls.KIMI_CODING_DEFAULT_MODEL
+        return cls.KIMI_CODING_MODEL_ALIASES.get(suffix.lower(), suffix)
+
+    @classmethod
+    def _normalize_kimi_coding_api_base(cls, api_base: str) -> str:
+        base = api_base.strip().rstrip("/")
+        if base.endswith("/v1"):
+            base = base[:-3]
+        return base or cls.KIMI_CODING_DEFAULT_BASE
+
+    def _resolve_api_base_for_model(self, raw_model: str | None) -> str | None:
+        if not self._is_kimi_coding_model_ref(raw_model):
+            return self.api_base
+
+        base = (self.api_base or "").strip()
+        if not base:
+            return self.KIMI_CODING_DEFAULT_BASE
+
+        lower = base.lower()
+        if "api.moonshot.cn" in lower or "api.moonshot.ai" in lower:
+            return self.KIMI_CODING_DEFAULT_BASE
+
+        return self._normalize_kimi_coding_api_base(base)
 
     @staticmethod
     def _canonicalize_explicit_prefix(model: str, spec_name: str, canonical_prefix: str) -> str:
@@ -216,8 +260,9 @@ class LiteLLMProvider(LLMProvider):
             kwargs["api_key"] = self.api_key
 
         # Pass api_base for custom endpoints
-        if self.api_base:
-            kwargs["api_base"] = self.api_base
+        resolved_api_base = self._resolve_api_base_for_model(original_model)
+        if resolved_api_base:
+            kwargs["api_base"] = resolved_api_base
 
         # Pass extra headers (e.g. APP-Code for AiHubMix)
         if self.extra_headers:

--- a/tests/test_provider_kimi_coding.py
+++ b/tests/test_provider_kimi_coding.py
@@ -1,0 +1,26 @@
+from nanobot.providers.litellm_provider import LiteLLMProvider
+
+
+def test_kimi_coding_model_ref_is_rewritten_to_anthropic_messages() -> None:
+    provider = LiteLLMProvider(default_model="kimi-coding/k2p5")
+
+    assert provider._resolve_model("kimi-coding/k2p5") == "anthropic/k2p5"
+    assert provider._resolve_model("kimi-coding/kimi-for-coding") == "anthropic/k2p5"
+
+
+def test_kimi_coding_api_base_uses_kimi_coding_endpoint_when_moonshot_base_configured() -> None:
+    provider = LiteLLMProvider(
+        default_model="kimi-coding/k2p5",
+        api_base="https://api.moonshot.cn/v1",
+    )
+
+    assert provider._resolve_api_base_for_model("kimi-coding/k2p5") == "https://api.kimi.com/coding"
+
+
+def test_kimi_coding_api_base_strips_trailing_v1() -> None:
+    provider = LiteLLMProvider(
+        default_model="kimi-coding/k2p5",
+        api_base="https://api.kimi.com/coding/v1/",
+    )
+
+    assert provider._resolve_api_base_for_model("kimi-coding/k2p5") == "https://api.kimi.com/coding"


### PR DESCRIPTION
## Summary
- add dedicated handling for models with kimi-coding/ prefix
- map kimi-coding models to anthropic/* transport format expected by the coding endpoint
- resolve API base for kimi-coding models to https://api.kimi.com/coding (and normalize trailing /v1)
- add unit tests for model and endpoint resolution

## Why
Kimi coding endpoints differ from Moonshot chat endpoints. Routing kimi-coding/* through the normal moonshot prefix can produce incorrect model/base combinations.

## Testing
- uv run --project . pytest -q tests/test_provider_kimi_coding.py tests/test_commands.py