### PR TITLE
fix(cron): auto-reload jobs.json when modified externally

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -68,13 +68,19 @@ class CronService:
         on_job: Callable[[CronJob], Coroutine[Any, Any, str | None]] | None = None
     ):
         self.store_path = store_path
-        self.on_job = on_job  # Callback to execute job, returns response text
+        self.on_job = on_job
         self._store: CronStore | None = None
+        self._last_mtime: float = 0.0
         self._timer_task: asyncio.Task | None = None
         self._running = False
     
     def _load_store(self) -> CronStore:
-        """Load jobs from disk."""
+        """Load jobs from disk. Reloads automatically if file was modified externally."""
+        if self._store and self.store_path.exists():
+            mtime = self.store_path.stat().st_mtime
+            if mtime != self._last_mtime:
+                logger.info("Cron: jobs.json modified externally, reloading")
+                self._store = None
         if self._store:
             return self._store
         
@@ -163,6 +169,7 @@ class CronService:
         }
         
         self.store_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        self._last_mtime = self.store_path.stat().st_mtime
     
     async def start(self) -> None:
         """Start the cron service."""


### PR DESCRIPTION
## Summary

Fix a data-loss bug where CLI operations (`nanobot cron add/remove`) are silently overwritten by the running gateway process.

**Root cause**: `CronService` caches `jobs.json` in memory on first load and never checks if the file was modified externally. When the gateway's timer tick fires, it calls `_save_store()` which writes the stale in-memory state back to disk — overwriting any changes made by the CLI, `edit_file`, or manual edits.

**Fix**: Track file `mtime` and compare on every `_load_store()` call. If the file was modified externally, discard the in-memory cache and reload from disk. After each `_save_store()`, update the tracked mtime to avoid false positives.

+4 lines, zero new dependencies.