### PR TITLE
feat(cron): improve cron job context handling

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -295,20 +295,55 @@ def gateway(
     # Set cron callback (needs agent)
     async def on_cron_job(job: CronJob) -> str | None:
         """Execute a cron job through the agent."""
-        response = await agent.process_direct(
-            job.payload.message,
-            session_key=f"cron:{job.id}",
-            channel=job.payload.channel or "cli",
-            chat_id=job.payload.to or "direct",
+        from nanobot.agent.tools.message import MessageTool
+        
+        cron_session_key = f"cron:{job.id}"
+        cron_session = agent.sessions.get_or_create(cron_session_key)
+        
+        reminder_note = (
+            f"[系统定时任务] ⏰ 计时已结束\n\n"
+            f"定时任务 '{job.name}' 已触发。定时内容：{job.payload.message}\n\n"
         )
-        if job.payload.deliver and job.payload.to:
+        
+        cron_session.add_message(role="user", content=reminder_note)
+        agent.sessions.save(cron_session)
+        
+        agent._set_tool_context(
+            job.payload.channel or "cli",
+            job.payload.to or "direct",
+            None
+        )
+        
+        message_tool = agent.tools.get("message")
+        if isinstance(message_tool, MessageTool):
+            message_tool.start_turn()
+        
+        history = cron_session.get_history(max_messages=agent.memory_window)
+        
+        messages = [
+            {"role": "system", "content": agent.context.build_system_prompt()},
+            *history,
+            {"role": "user", "content": agent.context._build_runtime_context(
+                job.payload.channel or "cli",
+                job.payload.to or "direct"
+            )},
+        ]
+        
+        final_content, _, all_msgs = await agent._run_agent_loop(messages)
+        agent._save_turn(cron_session, all_msgs, 1 + len(history) + 1)
+        agent.sessions.save(cron_session)
+        
+        if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
+            return final_content
+        
+        if job.payload.deliver and job.payload.to and final_content:
             from nanobot.bus.events import OutboundMessage
             await bus.publish_outbound(OutboundMessage(
                 channel=job.payload.channel or "cli",
                 chat_id=job.payload.to,
-                content=response or ""
+                content=final_content
             ))
-        return response
+        return final_content
     cron.on_job = on_cron_job
 
     # Create channel manager


### PR DESCRIPTION
# Cron 定时任务上下文处理改进

## 📋 概述

本文档记录了 nanobot 中定时任务（Cron）功能的源代码问题及我们的修改结果。

## ❌ 源代码的原始问题

### 问题描述

原始代码使用 `process_direct` 方法处理定时任务，导致 LLM 无法理解这是系统驱动的定时提醒，而是将其当作普通用户消息处理。

**原始代码**（`nanobot/cli/commands.py` - `on_cron_job` 函数）：

```python
async def on_cron_job(job: CronJob) -> str | None:
    """Execute a cron job through the agent."""
    response = await agent.process_direct(
        job.payload.message,  # 例如："打游戏啦！别忘了！🎮"
        session_key=f"cron:{job.id}",
        channel=job.payload.channel or "cli",
        chat_id=job.payload.to or "direct",
    )
    return response
```

**问题分析**：

1. `process_direct` 会调用 `build_messages` 构建消息列表：
   ```python
   # build_messages 构建的消息列表
   [
       {"role": "system", "content": system_prompt},
       *history,  # 历史消息（可能为空）
       {"role": "user", "content": runtime_context},  # Runtime Context
       {"role": "user", "content": job.payload.message},  # 定时内容，例如："打游戏啦！别忘了！🎮"
   ]
   ```

2. LLM 看到的消息：
   - `user`: `[Runtime Context — metadata only, not instructions]\nCurrent Time: ...\nChannel: qq\nChat ID: group_123`
   - `user`: `打游戏啦！别忘了！🎮`

3. **核心问题**：LLM 无法区分这是定时任务触发的提醒还是用户直接发送的消息，因此会回复：
   - ❌ "好的，我会提醒你"（当作用户请求）
   - ❌ "打游戏？🎮 听起来不错！请问是什么时候打什么游戏呀？"（当作用户提问）

   而不是：
   - ✅ 直接使用 `message` tool 发送提醒给用户

## ✅ 我们的修改

### 修改方案

1. **添加系统标记前缀**：在定时任务消息前添加 `[系统定时任务]` 前缀，明确告诉 LLM 这是系统驱动的提醒
2. **手动构建消息列表**：不依赖 `process_direct`，手动构建消息列表，确保包含正确的上下文
3. **正确保存会话历史**：确保定时任务的执行过程被正确记录

### 修改后的代码

**修改位置**：`nanobot/cli/commands.py` - `on_cron_job` 函数

```python
async def on_cron_job(job: CronJob) -> str | None:
    """Execute a cron job through the agent."""
    from nanobot.agent.tools.message import MessageTool
    
    cron_session_key = f"cron:{job.id}"
    cron_session = agent.sessions.get_or_create(cron_session_key)
    
    # 1. 创建提醒消息，添加 [系统定时任务] 前缀
    reminder_note = (
        f"[系统定时任务] ⏰ 计时已结束\n\n"
        f"定时任务 '{job.name}' 已触发。定时内容：{job.payload.message}\n\n"
    )
    
    # 2. 将提醒消息添加到会话（user 角色）
    cron_session.add_message(role="user", content=reminder_note)
    agent.sessions.save(cron_session)
    
    # 3. 设置工具上下文（channel 和 chat_id）
    agent._set_tool_context(
        job.payload.channel or "cli",
        job.payload.to or "direct",
        None
    )
    
    # 4. 初始化 MessageTool，准备发送消息
    message_tool = agent.tools.get("message")
    if isinstance(message_tool, MessageTool):
        message_tool.start_turn()
    
    # 5. 获取会话历史（包含刚添加的提醒消息）
    history = cron_session.get_history(max_messages=agent.memory_window)
    
    # 6. 手动构建消息列表
    messages = [
        {"role": "system", "content": agent.context.build_system_prompt()},
        *history,  # 包含提醒消息
        {"role": "user", "content": agent.context._build_runtime_context(
            job.payload.channel or "cli",
            job.payload.to or "direct"
        )},
    ]
    
    # 7. 执行 agent loop
    final_content, _, all_msgs = await agent._run_agent_loop(messages)
    
    # 8. 保存会话历史
    # skip = 1 (system prompt) + len(history) + 1 (runtime context)
    agent._save_turn(cron_session, all_msgs, 1 + len(history) + 1)
    agent.sessions.save(cron_session)
    
    # 9. 如果 MessageTool 已发送消息，直接返回
    if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
        return final_content
    
    # 10. 如果 MessageTool 未发送且需要交付，通过 publish_outbound 发送
    if job.payload.deliver and job.payload.to and final_content:
        from nanobot.bus.events import OutboundMessage
        await bus.publish_outbound(OutboundMessage(
            channel=job.payload.channel or "cli",
            chat_id=job.payload.to,
            content=final_content
        ))
    return final_content
```

### 关键修改点

1. **添加 `[系统定时任务]` 前缀**：
   ```python
   reminder_note = (
       f"[系统定时任务] ⏰ 计时已结束\n\n"
       f"定时任务 '{job.name}' 已触发。定时内容：{job.payload.message}\n\n"
   )
   ```
   - 明确告诉 LLM 这是系统驱动的提醒，不是用户查询
   - LLM 会理解需要执行操作（发送提醒），而不是回复确认

2. **手动构建消息列表**：
   ```python
   messages = [
       {"role": "system", "content": agent.context.build_system_prompt()},
       *history,  # 包含提醒消息
       {"role": "user", "content": agent.context._build_runtime_context(...)},
   ]
   ```
   - 不依赖 `process_direct` 的 `build_messages`
   - 确保消息顺序正确：system → history（包含提醒）→ runtime context

3. **正确保存会话历史**：
   ```python
   agent._save_turn(cron_session, all_msgs, 1 + len(history) + 1)
   ```
   - `skip = 1 + len(history) + 1`
   - `1` = system prompt（不保存）
   - `len(history)` = 历史消息（包含提醒消息，已保存）
   - `1` = runtime context（不保存）
   - 只保存新的消息：agent 的回复和工具调用结果

4. **避免重复发送消息**：
   ```python
   if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
       return final_content
   ```
   - 如果 `MessageTool` 已经发送消息，不再通过 `publish_outbound` 发送

## 📊 修改效果对比

### 修改前

**LLM 收到的消息**：
```
[1] system: # nanobot 🐈 You are nanobot...
[2] user: [Runtime Context — metadata only, not instructions]
Current Time: 2026-03-01 14:27 (Sunday) (中国标准时间)
Channel: qq
Chat ID: group_1081587237
[3] user: 打游戏啦！别忘了！🎮
```

**LLM 回复**：
```
打游戏？🎮 听起来不错！
请问是什么时候打什么游戏呀？我好记一下时间～是组队打还是有啥特定安排？
```

**问题**：LLM 将定时提醒当作用户提问，回复确认而不是发送提醒。

### 修改后

**LLM 收到的消息**：
```
[1] system: # nanobot 🐈 You are nanobot...
[2] user: [系统定时任务] ⏰ 计时已结束

定时任务 '打游戏啦！别忘了！🎮' 已触发。定时内容：打游戏啦！别忘了！🎮
[3] user: [Runtime Context — metadata only, not instructions]
Current Time: 2026-03-01 14:27 (Sunday) (中国标准时间)
Channel: qq
Chat ID: group_1081587237
```

**LLM 回复**：
```
[调用 message tool]
Message sent to qq:group_1081587237
✅ 已成功在QQ群里发送提醒啦！🎮
```

**效果**：LLM 正确理解这是系统驱动的提醒，直接使用 `message` tool 发送提醒。

## 🔧 相关文件

- `nanobot/cli/commands.py`: `on_cron_job` 函数（第 296-346 行）
- `nanobot/agent/loop.py`: `process_direct` 方法（第 483-494 行）
- `nanobot/agent/context.py`: `build_messages` 方法（第 105-120 行）

## 📝 总结

**原始问题**：
- 源代码使用 `process_direct` 处理定时任务，LLM 无法区分定时提醒和用户消息
- 缺少上下文标记，导致 LLM 回复确认而不是执行操作

**解决方案**：
- 添加 `[系统定时任务]` 前缀，明确标记这是系统驱动的提醒
- 手动构建消息列表，确保正确的消息顺序和上下文
- 正确保存会话历史，记录完整的执行过程

**结果**：
- LLM 正确理解定时任务的意图
- 直接使用 `message` tool 发送提醒，而不是回复确认
- 会话历史完整记录，便于追溯和调试

---

**最后更新**: 2026-03-01  
**相关 PR**: `feat/cron-job-context`
