### PR TITLE
fix(providers): strip thinking_blocks for non-Anthropic providers

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -78,6 +78,15 @@ class LLMProvider(ABC):
                     result.append(clean)
                     continue
 
+            # Defensive: a bare dict as content (e.g. a single content block) is
+            # not valid for any provider — wrap it in a list so the API receives
+            # an array of objects rather than a plain object.
+            if isinstance(content, dict):
+                clean = dict(msg)
+                clean["content"] = [content]
+                result.append(clean)
+                continue
+
             result.append(msg)
         return result
 

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -14,7 +14,13 @@ from nanobot.providers.registry import find_by_model, find_gateway
 
 # Standard OpenAI chat-completion message keys plus reasoning_content for
 # thinking-enabled models (Kimi k2.5, DeepSeek-R1, etc.).
-_ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content", "thinking_blocks"})
+_ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content"})
+
+# Additional keys only valid for Anthropic extended-thinking models.
+# Passing thinking_blocks to non-Anthropic providers (e.g. Dashscope/Qwen) can
+# cause LiteLLM to mangle the content field, resulting in provider errors like
+# "Invalid type for 'messages.[0].content': got an object instead of a string".
+_ANTHROPIC_EXTRA_KEYS = frozenset({"thinking_blocks"})
 _ALNUM = string.ascii_letters + string.digits
 
 def _short_tool_id() -> str:
@@ -158,11 +164,21 @@ class LiteLLMProvider(LLMProvider):
                     return
 
     @staticmethod
-    def _sanitize_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Strip non-standard keys and ensure assistant messages have a content key."""
+    def _sanitize_messages(
+        messages: list[dict[str, Any]],
+        extra_keys: frozenset[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Strip non-standard keys and ensure assistant messages have a content key.
+
+        Args:
+            messages: Raw message list to sanitize.
+            extra_keys: Additional provider-specific keys to preserve (e.g.
+                ``_ANTHROPIC_EXTRA_KEYS`` for models that support thinking_blocks).
+        """
+        allowed = _ALLOWED_MSG_KEYS | (extra_keys or frozenset())
         sanitized = []
         for msg in messages:
-            clean = {k: v for k, v in msg.items() if k in _ALLOWED_MSG_KEYS}
+            clean = {k: v for k, v in msg.items() if k in allowed}
             # Strict providers require "content" even when assistant only has tool_calls
             if clean.get("role") == "assistant" and "content" not in clean:
                 clean["content"] = None
@@ -197,13 +213,20 @@ class LiteLLMProvider(LLMProvider):
         if self._supports_cache_control(original_model):
             messages, tools = self._apply_cache_control(messages, tools)
 
+        # Determine provider-specific extra message keys.
+        # thinking_blocks is an Anthropic-only field: passing it to other providers
+        # (e.g. Dashscope/Qwen) can corrupt the content field and trigger API errors.
+        extra_msg_keys = _ANTHROPIC_EXTRA_KEYS if model.startswith("anthropic/") else None
+
         # Clamp max_tokens to at least 1 — negative or zero values cause
         # LiteLLM to reject the request with "max_tokens must be at least 1".
         max_tokens = max(1, max_tokens)
 
         kwargs: dict[str, Any] = {
             "model": model,
-            "messages": self._sanitize_messages(self._sanitize_empty_content(messages)),
+            "messages": self._sanitize_messages(
+                self._sanitize_empty_content(messages), extra_keys=extra_msg_keys
+            ),
             "max_tokens": max_tokens,
             "temperature": temperature,
         }

--- a/tests/test_thinking_blocks_sanitize.py
+++ b/tests/test_thinking_blocks_sanitize.py
@@ -1,0 +1,123 @@
+"""Tests for thinking_blocks/reasoning_content sanitization in LiteLLM provider.
+
+Regression test for issue #1344: non-Anthropic providers (e.g. Dashscope/Qwen)
+should never receive thinking_blocks in their message payloads, as LiteLLM may
+mangle the content field when it encounters unknown Anthropic-only keys, causing
+provider errors like:
+  "Invalid type for 'messages.[0].content': got an object instead of a string"
+"""
+
+from __future__ import annotations
+
+from nanobot.providers.base import LLMProvider
+from nanobot.providers.litellm_provider import (
+    LiteLLMProvider,
+    _ALLOWED_MSG_KEYS,
+    _ANTHROPIC_EXTRA_KEYS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_messages_with_thinking_blocks() -> list[dict]:
+    """Return a typical message list that includes thinking_blocks (from Anthropic)."""
+    return [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {
+            "role": "assistant",
+            "content": "Let me think about that.",
+            "thinking_blocks": [
+                {"type": "thinking", "thinking": "The user asked a question."},
+            ],
+        },
+        {"role": "user", "content": "What is 2+2?"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_messages tests
+# ---------------------------------------------------------------------------
+
+def test_thinking_blocks_stripped_by_default() -> None:
+    """thinking_blocks must be removed when no extra_keys are passed."""
+    messages = _make_messages_with_thinking_blocks()
+    sanitized = LiteLLMProvider._sanitize_messages(messages)
+
+    for msg in sanitized:
+        assert "thinking_blocks" not in msg, (
+            f"thinking_blocks leaked into sanitized message: {msg}"
+        )
+
+
+def test_thinking_blocks_preserved_for_anthropic() -> None:
+    """thinking_blocks must be kept when _ANTHROPIC_EXTRA_KEYS are passed."""
+    messages = _make_messages_with_thinking_blocks()
+    sanitized = LiteLLMProvider._sanitize_messages(messages, extra_keys=_ANTHROPIC_EXTRA_KEYS)
+
+    assistant_msgs = [m for m in sanitized if m.get("role") == "assistant"]
+    assert len(assistant_msgs) == 1
+    assert "thinking_blocks" in assistant_msgs[0], (
+        "thinking_blocks should be preserved when extra_keys includes it"
+    )
+
+
+def test_standard_keys_always_preserved() -> None:
+    """Core message keys (role, content, tool_calls, …) must survive sanitization."""
+    messages = [
+        {"role": "user", "content": "hello", "unknown_field": "ignored"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "x", "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+            "arbitrary": "should be stripped",
+        },
+    ]
+    sanitized = LiteLLMProvider._sanitize_messages(messages)
+
+    assert sanitized[0] == {"role": "user", "content": "hello"}
+    assert "tool_calls" in sanitized[1]
+    assert "arbitrary" not in sanitized[1]
+
+
+def test_assistant_content_none_added_when_missing() -> None:
+    """Strict providers need content=None on assistant messages that only have tool_calls."""
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "x", "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+        }
+    ]
+    sanitized = LiteLLMProvider._sanitize_messages(messages)
+    assert sanitized[0].get("content") is None
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_empty_content defensive dict handling
+# ---------------------------------------------------------------------------
+
+def test_dict_content_wrapped_in_list() -> None:
+    """A bare dict as content must be wrapped in a list for API compatibility."""
+    messages = [
+        {"role": "user", "content": {"type": "text", "text": "hello"}},
+    ]
+    sanitized = LLMProvider._sanitize_empty_content(messages)
+    assert isinstance(sanitized[0]["content"], list), (
+        "dict content should be wrapped in a list"
+    )
+    assert sanitized[0]["content"] == [{"type": "text", "text": "hello"}]
+
+
+def test_string_content_unchanged() -> None:
+    """Normal string content should pass through _sanitize_empty_content unchanged."""
+    messages = [{"role": "user", "content": "hello"}]
+    sanitized = LLMProvider._sanitize_empty_content(messages)
+    assert sanitized[0]["content"] == "hello"
+
+
+def test_list_content_unchanged_when_non_empty() -> None:
+    """Non-empty list content should pass through unchanged."""
+    messages = [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+    sanitized = LLMProvider._sanitize_empty_content(messages)
+    assert sanitized[0]["content"] == [{"type": "text", "text": "hello"}]


### PR DESCRIPTION
## Summary

Fixes #1344

### Problem

When a user session contains  (from Anthropic extended-thinking mode) and the session history is subsequently replayed to a non-Anthropic provider (e.g. Dashscope/Qwen), LiteLLM may mangle the message's `content` field — converting the thinking block dict directly into `content` — resulting in:

```
litellm.BadRequestError: DashscopeException - Invalid type for 'messages.[0].content':
expected one of a string or array of objects, but got an object instead.
```

This error **persists across turns** because the problematic session history is reloaded on every message, making the bot permanently broken until the session is cleared.

### Root Cause

PR #1330 added `thinking_blocks` to `_ALLOWED_MSG_KEYS`, which means it is now forwarded to **all** providers. `thinking_blocks` is an Anthropic-only field. When LiteLLM encounters it in a message intended for Dashscope/Qwen, it may convert the thinking block object into the `content` field.

### Fix

- Move `thinking_blocks` out of `_ALLOWED_MSG_KEYS` into a new `_ANTHROPIC_EXTRA_KEYS` frozenset.
- Extend `_sanitize_messages()` with an optional `extra_keys` parameter.
- In `chat()`, detect `anthropic/` models and pass `_ANTHROPIC_EXTRA_KEYS`; all other providers have `thinking_blocks` stripped before the API call.
- Add defensive handling in `_sanitize_empty_content()` for bare dict content: wrap it in a list (belt-and-suspenders against similar issues).

### Tests

Added `tests/test_thinking_blocks_sanitize.py` with 7 tests covering:
- `thinking_blocks` stripped by default (non-Anthropic)
- `thinking_blocks` preserved for Anthropic models
- Standard keys always preserved
- Defensive dict-content wrapping in `_sanitize_empty_content`