### PR TITLE
feat: add Anthropic extended thinking support alongside reasoning_effort

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -31,6 +31,14 @@ if TYPE_CHECKING:
     from nanobot.config.schema import ChannelsConfig, ExecToolConfig
     from nanobot.cron.service import CronService
 
+# Token budgets for Anthropic extended thinking mode.
+# Used when reasoning_effort is set and the model supports thinking dicts.
+THINKING_BUDGETS: dict[str, int] = {
+    "low": 2_048,
+    "medium": 8_192,
+    "high": 32_768,
+}
+
 
 class AgentLoop:
     """
@@ -188,6 +196,23 @@ class AgentLoop:
         final_content = None
         tools_used: list[str] = []
 
+        # Dual thinking mode: Anthropic models use a thinking dict with token
+        # budgets; other models use the simpler reasoning_effort string.
+        thinking: dict | None = None
+        effective_reasoning = self.reasoning_effort
+        effective_temperature = self.temperature
+        effective_max_tokens = self.max_tokens
+
+        if self.reasoning_effort and self.reasoning_effort in THINKING_BUDGETS:
+            model_lower = self.model.lower()
+            if "claude" in model_lower or "anthropic" in model_lower:
+                budget = THINKING_BUDGETS[self.reasoning_effort]
+                thinking = {"type": "enabled", "budget_tokens": budget}
+                effective_max_tokens = self.max_tokens + budget
+                # Anthropic requires temperature=1 when thinking is enabled
+                effective_temperature = 1
+                effective_reasoning = None  # Don't pass both
+
         while iteration < self.max_iterations:
             iteration += 1
 
@@ -195,9 +220,10 @@ class AgentLoop:
                 messages=messages,
                 tools=self.tools.get_definitions(),
                 model=self.model,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                reasoning_effort=self.reasoning_effort,
+                temperature=effective_temperature,
+                max_tokens=effective_max_tokens,
+                reasoning_effort=effective_reasoning,
+                thinking=thinking,
             )
 
             if response.has_tool_calls:

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -90,17 +90,20 @@ class LLMProvider(ABC):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        thinking: dict | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request.
-        
+
         Args:
             messages: List of message dicts with 'role' and 'content'.
             tools: Optional list of tool definitions.
             model: Model identifier (provider-specific).
             max_tokens: Maximum tokens in response.
             temperature: Sampling temperature.
-        
+            reasoning_effort: Thinking level for supported models ("low"/"medium"/"high").
+            thinking: Anthropic extended thinking config, e.g. {"type": "enabled", "budget_tokens": 10000}.
+
         Returns:
             LLMResponse with content and/or tool calls.
         """

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -19,7 +19,7 @@ class CustomProvider(LLMProvider):
 
     async def chat(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
                    model: str | None = None, max_tokens: int = 4096, temperature: float = 0.7,
-                   reasoning_effort: str | None = None) -> LLMResponse:
+                   reasoning_effort: str | None = None, thinking: dict | None = None) -> LLMResponse:
         kwargs: dict[str, Any] = {
             "model": model or self.default_model,
             "messages": self._sanitize_empty_content(messages),

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -59,6 +59,8 @@ class LiteLLMProvider(LLMProvider):
         litellm.suppress_debug_info = True
         # Drop unsupported parameters for providers (e.g., gpt-5 rejects some params)
         litellm.drop_params = True
+        # Let LiteLLM translate provider-specific params (e.g. Anthropic thinking)
+        litellm.modify_params = True
 
     def _setup_env(self, api_key: str, api_base: str | None, model: str) -> None:
         """Set environment variables based on detected provider."""
@@ -177,6 +179,7 @@ class LiteLLMProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        thinking: dict | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request via LiteLLM.
@@ -223,10 +226,13 @@ class LiteLLMProvider(LLMProvider):
         if self.extra_headers:
             kwargs["extra_headers"] = self.extra_headers
         
-        if reasoning_effort:
+        if thinking:
+            kwargs["thinking"] = thinking
+            kwargs["drop_params"] = True
+        elif reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
             kwargs["drop_params"] = True
-        
+
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -32,6 +32,7 @@ class OpenAICodexProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        thinking: dict | None = None,
     ) -> LLMResponse:
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)


### PR DESCRIPTION
## Summary

Adds dual-mode thinking support so that Anthropic models can use extended thinking (via `thinking` dict with token budgets) while other models continue using `reasoning_effort`.

Currently, `reasoning_effort` is passed through to LiteLLM, which works for OpenAI o-series, DeepSeek, etc. However, Anthropic's extended thinking requires:
1. A `thinking` dict parameter (e.g. `{"type": "enabled", "budget_tokens": 8192}`)
2. `litellm.modify_params = True` for LiteLLM to translate this correctly
3. `temperature=1` (required by Anthropic when thinking is enabled)

This PR adds auto-detection: when `reasoning_effort` is set to "low"/"medium"/"high" and the model is an Anthropic/Claude model, it automatically converts to the appropriate `thinking` dict. For non-Anthropic models, `reasoning_effort` is passed through as before.

### Changes

- **`providers/base.py`**: Add `thinking: dict | None = None` parameter to abstract `chat()` method
- **`providers/litellm_provider.py`**: Add `thinking` parameter, set `litellm.modify_params = True`, pass `thinking` dict to kwargs (takes priority over `reasoning_effort`)
- **`providers/custom_provider.py`**: Add `thinking` parameter to signature
- **`providers/openai_codex_provider.py`**: Add `thinking` parameter to signature
- **`agent/loop.py`**: Add `THINKING_BUDGETS` mapping and dual-mode detection in `_run_agent_loop()`

### How it works

```python
# In _run_agent_loop(), before the iteration loop:
if self.reasoning_effort and self.reasoning_effort in THINKING_BUDGETS:
    model_lower = self.model.lower()
    if "claude" in model_lower or "anthropic" in model_lower:
        # Anthropic: use thinking dict with token budget
        budget = THINKING_BUDGETS[self.reasoning_effort]
        thinking = {"type": "enabled", "budget_tokens": budget}
        effective_max_tokens = self.max_tokens + budget
        effective_temperature = 1  # Required by Anthropic API
    else:
        # Others: use reasoning_effort string as-is
        pass
```

### Token budgets

| Level | Budget |
|-------|--------|
| low | 2,048 tokens |
| medium | 8,192 tokens |
| high | 32,768 tokens |

## Test plan

- [x] All existing tests pass (100/100)
- [ ] Test with Anthropic model + `reasoning_effort: "high"` — should use thinking dict
- [ ] Test with OpenAI model + `reasoning_effort: "high"` — should use reasoning_effort string
- [ ] Test with no reasoning_effort — no thinking/reasoning params sent