### PR TITLE
feat: add consolidation_model for cheaper memory consolidation

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -65,6 +65,7 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        consolidation_model: str | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -72,6 +73,7 @@ class AgentLoop:
         self.provider = provider
         self.workspace = workspace
         self.model = model or provider.get_default_model()
+        self.consolidation_model = consolidation_model or self.model
         self.max_iterations = max_iterations
         self.temperature = temperature
         self.max_tokens = max_tokens
@@ -479,7 +481,7 @@ class AgentLoop:
     async def _consolidate_memory(self, session, archive_all: bool = False) -> bool:
         """Delegate to MemoryStore.consolidate(). Returns True on success."""
         return await MemoryStore(self.workspace).consolidate(
-            session, self.provider, self.model,
+            session, self.provider, self.consolidation_model,
             archive_all=archive_all, memory_window=self.memory_window,
         )
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -291,6 +291,7 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        consolidation_model=config.agents.defaults.consolidation_model,
     )
 
     # Set cron callback (needs agent)
@@ -371,7 +372,7 @@ def gateway(
     heartbeat = HeartbeatService(
         workspace=config.workspace_path,
         provider=provider,
-        model=agent.model,
+        model=agent.consolidation_model or agent.model,
         on_execute=on_heartbeat_execute,
         on_notify=on_heartbeat_notify,
         interval_s=hb_cfg.interval_s,
@@ -463,6 +464,7 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        consolidation_model=config.agents.defaults.consolidation_model,
     )
 
     # Show spinner when logs are off (no output to miss); skip when logs are on
@@ -957,6 +959,7 @@ def cron_run(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        consolidation_model=config.agents.defaults.consolidation_model,
     )
 
     store_path = get_data_dir() / "cron" / "jobs.json"

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -222,6 +222,7 @@ class AgentDefaults(Base):
     workspace: str = "~/.nanobot/workspace"
     model: str = "anthropic/claude-opus-4-5"
     provider: str = "auto"  # Provider name (e.g. "anthropic", "openrouter") or "auto" for auto-detection
+    consolidation_model: str | None = None  # Model for memory consolidation (defaults to main model)
     max_tokens: int = 8192
     temperature: float = 0.1
     max_tool_iterations: int = 40


### PR DESCRIPTION
## Summary

Adds a `consolidation_model` field to `AgentDefaults` so memory consolidation and heartbeat skip/run decisions can route to a cheaper model than the main agent model.

**Use case:** When running an expensive orchestrator model (e.g. Opus) as the main agent, memory consolidation doesn't need that level of capability. This field lets users configure a cheaper model (e.g. Sonnet, Haiku) for consolidation, saving significant cost on long-running sessions.

**Behavior:**
- `consolidation_model: null` (default) → uses the main agent model (no change from current behavior)
- `consolidation_model: "openai/sonnet-4-5"` → consolidation and heartbeat decisions use the specified model

## Changes

- `nanobot/config/schema.py`: Add `consolidation_model: str | None = None` to `AgentDefaults`
- `nanobot/agent/loop.py`: Accept `consolidation_model` param in `AgentLoop.__init__()`, use in `_consolidate_memory()`
- `nanobot/cli/commands.py`: Pass `consolidation_model` from config in all 3 `AgentLoop` instantiation sites (gateway, agent, cron_run) + use for `HeartbeatService` model

## Config example

```yaml
agents:
  defaults:
    model: anthropic/claude-opus-4-5
    consolidationModel: anthropic/claude-sonnet-4-5  # cheaper model for memory ops
```