### PR TITLE
feat: Add vision provider support for multi-modal image recognition

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -272,12 +272,28 @@ def gateway(
     cron_store_path = get_data_dir() / "cron" / "jobs.json"
     cron = CronService(cron_store_path)
 
+    # Create vision provider if vision model is configured
+    vision_provider = None
+    vision_model = getattr(config.agents.defaults, "vision_model", None)
+    if vision_model and hasattr(config.providers, "vision") and config.providers.vision.api_key:
+        from nanobot.providers.litellm_provider import LiteLLMProvider
+
+        vision_cfg = config.providers.vision
+        vision_provider = LiteLLMProvider(
+            api_key=vision_cfg.api_key,
+            api_base=vision_cfg.api_base,
+            default_model=vision_model,
+            provider_name=None,
+        )
+
     # Create agent with cron service
     agent = AgentLoop(
         bus=bus,
         provider=provider,
         workspace=config.workspace_path,
         model=config.agents.defaults.model,
+        vision_model=vision_model,
+        vision_provider=vision_provider,
         temperature=config.agents.defaults.temperature,
         max_tokens=config.agents.defaults.max_tokens,
         max_iterations=config.agents.defaults.max_tool_iterations,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -263,6 +263,7 @@ class ProvidersConfig(Base):
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎) API gateway
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig)  # Github Copilot (OAuth)
+    vision: ProviderConfig = Field(default_factory=ProviderConfig)  # Vision model provider for multi-modal (e.g., "qwen3-vl-plus")
 
 
 class HeartbeatConfig(Base):


### PR DESCRIPTION
## Summary
This PR adds vision provider configuration support for multi-modal image recognition in nanobot.

## Changes
- Added `vision` provider configuration field in `config/schema.py`
- Updated `gateway()` function in `cli/commands.py` to initialize `vision_provider` when `vision_model` is configured
- Enables using different API endpoints for vision models vs text-only models

## Motivation
Users may want to use different API providers/endpoints for:
- Text conversations (e.g., custom provider with dashscope API)
- Image recognition (e.g., dedicated vision provider with iflow API)

This implementation allows configuring a separate `vision` provider in config.json:
```json
{
  "providers": {
    "custom": { "apiKey": "...", "apiBase": "https://dashscope.aliyuncs.com/v1" },
    "vision": { "apiKey": "...", "apiBase": "https://apis.iflow.cn/v1" }
  },
  "agents": {
    "defaults": { "visionModel": "qwen3-vl-plus" }
  }
}
```

## Related Issue
Related to #223 (Multi-Modal Support: Images, Voice, and Video)

This implements Phase 1 (Vision) configuration support for the gateway mode, complementing the existing Feishu image download support (commit 49cc0c5).