### PR TITLE
feat(cron): support messageFile in cron job payload

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -286,13 +286,16 @@ class CronService:
         self,
         name: str,
         schedule: CronSchedule,
-        message: str,
+        message: str = "",
+        message_file: str | None = None,
         deliver: bool = False,
         channel: str | None = None,
         to: str | None = None,
         delete_after_run: bool = False,
     ) -> CronJob:
         """Add a new job."""
+        if bool(message) == bool(message_file):
+            raise ValueError("Exactly one of message or message_file must be provided")
         store = self._load_store()
         _validate_schedule_for_add(schedule)
         now = _now_ms()
@@ -305,6 +308,7 @@ class CronService:
             payload=CronPayload(
                 kind="agent_turn",
                 message=message,
+                message_file=message_file,
                 deliver=deliver,
                 channel=channel,
                 to=to,

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -104,6 +104,7 @@ class CronService:
                         payload=CronPayload(
                             kind=j["payload"].get("kind", "agent_turn"),
                             message=j["payload"].get("message", ""),
+                            message_file=j["payload"].get("messageFile"),
                             deliver=j["payload"].get("deliver", False),
                             channel=j["payload"].get("channel"),
                             to=j["payload"].get("to"),
@@ -150,7 +151,7 @@ class CronService:
                     },
                     "payload": {
                         "kind": j.payload.kind,
-                        "message": j.payload.message,
+                        **({"messageFile": j.payload.message_file} if j.payload.message_file else {"message": j.payload.message}),
                         "deliver": j.payload.deliver,
                         "channel": j.payload.channel,
                         "to": j.payload.to,

--- a/nanobot/cron/types.py
+++ b/nanobot/cron/types.py
@@ -23,6 +23,7 @@ class CronPayload:
     """What to do when the job runs."""
     kind: Literal["system_event", "agent_turn"] = "agent_turn"
     message: str = ""
+    message_file: str | None = None  # path relative to workspace; overrides message when set
     # Deliver response to channel
     deliver: bool = False
     channel: str | None = None  # e.g. "whatsapp"


### PR DESCRIPTION
Adds a message_file field to CronPayload as an alternative to message, allowing cron job prompts to be stored in workspace-relative files (e.g. prompts/daily.md) instead of inline in jobs.json.

- CronPayload gains message_file: str | None = None
- service.add_job validates that exactly one of message/message_file is set
- Both cron callbacks resolve message_file at runtime via config.workspace_path
- CLI cron add gains --message-file / -f option (mutually exclusive with --message)