### PR TITLE
cron: honor external jobs.json updates during timer ticks

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -226,6 +226,8 @@ class CronService:
 
     async def _on_timer(self) -> None:
         """Handle timer tick - run due jobs."""
+        # Pick up external CLI/file changes before deciding due jobs.
+        self._load_store()
         if not self._store:
             return
 

--- a/tests/test_cron_service.py
+++ b/tests/test_cron_service.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from nanobot.cron.service import CronService
@@ -28,3 +30,30 @@ def test_add_job_accepts_valid_timezone(tmp_path) -> None:
 
     assert job.schedule.tz == "America/Vancouver"
     assert job.state.next_run_at_ms is not None
+
+
+@pytest.mark.asyncio
+async def test_running_service_honors_external_disable(tmp_path) -> None:
+    store_path = tmp_path / "cron" / "jobs.json"
+    called: list[str] = []
+
+    async def on_job(job) -> None:
+        called.append(job.id)
+
+    service = CronService(store_path, on_job=on_job)
+    job = service.add_job(
+        name="external-disable",
+        schedule=CronSchedule(kind="every", every_ms=200),
+        message="hello",
+    )
+    await service.start()
+    try:
+        external = CronService(store_path)
+        updated = external.enable_job(job.id, enabled=False)
+        assert updated is not None
+        assert updated.enabled is False
+
+        await asyncio.sleep(0.35)
+        assert called == []
+    finally:
+        service.stop()


### PR DESCRIPTION
## Summary
- reload cron store at the start of each timer tick before evaluating due jobs
- prevent stale in-memory schedules from overwriting external CLI/file updates
- add async regression test to ensure a running service respects an external disable

## Root cause
`CronService` only checked for external `jobs.json` changes inside `_load_store()`, but `_on_timer()` used cached `_store` directly and then saved it back. This allowed a running gateway to execute and persist stale job states after external edits.

## Verification
- `uv run pytest tests/test_cron_service.py -q` (3 passed)
