### PR TITLE
fix: add SIGTERM, SIGHUP handling and ignore SIGPIPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.worktrees/
 .assets
 .env
 *.pyc

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -501,12 +501,17 @@ def agent(
         else:
             cli_channel, cli_chat_id = "cli", session_id
 
-        def _exit_on_sigint(signum, frame):
+        def _handle_signal(signum, frame):
+            sig_name = signal.Signals(signum).name
             _restore_terminal()
-            console.print("\nGoodbye!")
-            os._exit(0)
+            console.print(f"\nReceived {sig_name}, goodbye!")
+            sys.exit(0)
 
-        signal.signal(signal.SIGINT, _exit_on_sigint)
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+        signal.signal(signal.SIGHUP, _handle_signal)
+        # Ignore SIGPIPE to prevent silent process termination when writing to closed pipes
+        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
         async def run_interactive():
             bus_task = asyncio.create_task(agent_loop.run())


### PR DESCRIPTION
## Summary

- Add handler for SIGTERM to prevent "Terminated" message on Linux
- Add handler for SIGHUP for terminal closure handling
- Ignore SIGPIPE to prevent silent process termination when writing to closed pipes
- Change `os._exit(0)` to `sys.exit(0)` for proper cleanup (flush logs, close connections)

Fixes #1365

## Root Cause

The original code only handled SIGINT (Ctrl+C). On Linux, complex tasks could trigger subprocesses that send SIGTERM to the parent process, causing silent "Terminated" output without any cleanup.

## Test Plan

- [x] Start `nanobot agent` in one terminal
- [x] Send `kill -TERM <pid>` from another terminal
- [x] Verify output shows "Received SIGTERM, goodbye!" instead of "Terminated"

🤖 Generated with [Claude Code](https://claude.com/claude-code)