### PR TITLE
feat(memory): improve memory with BM25 + temporal decay retrieval

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -23,7 +23,7 @@ class ContextBuilder:
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
 
-    def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
+    def build_system_prompt(self, skill_names: list[str] | None = None, query: str = "") -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
         parts = [self._get_identity()]
 
@@ -31,7 +31,7 @@ class ContextBuilder:
         if bootstrap:
             parts.append(bootstrap)
 
-        memory = self.memory.get_memory_context()
+        memory = self.memory.get_memory_context(query=query)
         if memory:
             parts.append(f"# Memory\n\n{memory}")
 
@@ -67,7 +67,8 @@ You are nanobot, a helpful AI assistant.
 
 ## Workspace
 Your workspace is at: {workspace_path}
-- Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)
+- Semantic memory: {workspace_path}/memory/MEMORY.md (stable facts: preferences, relationships, projects)
+- Episodic memory: {workspace_path}/memory/memory.jsonl (time-bound events and context)
 - History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
 - Custom skills: {workspace_path}/skills/{{skill-name}}/SKILL.md
 
@@ -112,8 +113,9 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         chat_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
+        query = current_message if isinstance(current_message, str) else ""
         return [
-            {"role": "system", "content": self.build_system_prompt(skill_names)},
+            {"role": "system", "content": self.build_system_prompt(skill_names, query=query)},
             *history,
             {"role": "user", "content": self._build_runtime_context(channel, chat_id)},
             {"role": "user", "content": self._build_user_content(current_message, media)},

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import math
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -31,8 +33,24 @@ _SAVE_MEMORY_TOOL = [
                     },
                     "memory_update": {
                         "type": "string",
-                        "description": "Full updated long-term memory as markdown. Include all existing "
-                        "facts plus new ones. Return unchanged if nothing new.",
+                        "description": "Semantic memory — full updated MEMORY.md as markdown. ONLY stable, timeless facts: preferences, relationships, projects, skills."
+                        "NEVER include events, current activities, or anything time-bound. Return current memory unchanged if nothing new."
+                    },
+                    "episodic_memory_update": {
+                        "type": "array",
+                        "description": "Episodic memory — time-bound events, experiences, and context only.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "text": {"type": "string"},
+                                "importance": {
+                                    "type": "string",
+                                    "enum": ["high", "medium", "low"],
+                                    "description": "Retrieval importance: high=critical to remember, medium=useful, low=nice to have.",
+                                },
+                            },
+                            "required": ["text", "importance"],
+                        },
                     },
                 },
                 "required": ["history_entry", "memory_update"],
@@ -41,14 +59,55 @@ _SAVE_MEMORY_TOOL = [
     }
 ]
 
+_DECAY_LAMBDA = {"high": 0.001, "medium": 0.01, "low": 0.1}
+_IMPORTANCE_WEIGHT = {"high": 1.0, "medium": 0.6, "low": 0.3}
+
 
 class MemoryStore:
-    """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
+    """Three-layer memory: MEMORY.md (long-term semantic facts) + memory.jsonl(long-term episodic facts) + HISTORY.md (grep-searchable log)."""
 
     def __init__(self, workspace: Path):
         self.memory_dir = ensure_dir(workspace / "memory")
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.history_file = self.memory_dir / "HISTORY.md"
+        self.episodic_file = self.memory_dir / "memory.jsonl"
+        self._facts: list[dict] = []
+        self._bm25 = None
+        self._mtime: float = 0.0
+        self._sync()
+
+    def _sync(self) -> None:
+        if not self.episodic_file.exists() or (mtime := self.episodic_file.stat().st_mtime) == self._mtime:
+            return
+        self._facts = []
+        for line in self.episodic_file.read_text(encoding="utf-8").splitlines():
+            try:
+                self._facts.append(json.loads(line.strip()))
+            except (json.JSONDecodeError, ValueError):
+                pass
+        try:
+            from rank_bm25 import BM25Okapi
+            self._bm25 = BM25Okapi([m["text"].lower().split() for m in self._facts]) if self._facts else None
+        except ImportError:
+            self._bm25 = None
+        self._mtime = mtime
+
+    def _decay_score(self, fact: dict) -> float:
+        imp = fact.get("importance", "medium")
+        try: age = (datetime.now() - datetime.fromisoformat(fact["created_at"])).days
+        except (KeyError, ValueError): age = 0
+        return _IMPORTANCE_WEIGHT.get(imp, 0.6) * math.exp(-_DECAY_LAMBDA.get(imp, 0.01) * age)
+
+    def retrieve(self, query: str, top_k: int = 5) -> list[dict]:
+        self._sync()
+        if not self._facts:
+            return []
+        if self._bm25 is not None:
+            bm25 = self._bm25.get_scores(query.lower().split())
+            scored = sorted(((bm25[i] * self._decay_score(m), i) for i, m in enumerate(self._facts) if bm25[i] > 0), reverse=True)
+        else:
+            scored = sorted(((self._decay_score(m), i) for i, m in enumerate(self._facts)), reverse=True)
+        return [self._facts[i] for _, i in scored[:top_k]]
 
     def read_long_term(self) -> str:
         if self.memory_file.exists():
@@ -62,9 +121,13 @@ class MemoryStore:
         with open(self.history_file, "a", encoding="utf-8") as f:
             f.write(entry.rstrip() + "\n\n")
 
-    def get_memory_context(self) -> str:
-        long_term = self.read_long_term()
-        return f"## Long-term Memory\n{long_term}" if long_term else ""
+    def get_memory_context(self, query: str = "") -> str:
+        parts = []
+        if lt := self.read_long_term():
+            parts.append(f"## Semantic Memory\n{lt}")
+        if query and (relevant := self.retrieve(query, top_k=5)):
+            parts.append("## Episodic Memory\n" + "\n".join(f"- [{m['importance']}] {m['text']}" for m in relevant))
+        return "\n\n".join(parts) if parts else ""
 
     async def consolidate(
         self,
@@ -75,8 +138,7 @@ class MemoryStore:
         archive_all: bool = False,
         memory_window: int = 50,
     ) -> bool:
-        """Consolidate old messages into MEMORY.md + HISTORY.md via LLM tool call.
-
+        """Consolidate old messages into MEMORY.md(semantic) + memory.jsonl(episodic) + HISTORY.md via LLM tool call.
         Returns True on success (including no-op), False on failure.
         """
         if archive_all:
@@ -113,7 +175,10 @@ class MemoryStore:
         try:
             response = await provider.chat(
                 messages=[
-                    {"role": "system", "content": "You are a memory consolidation agent. Call the save_memory tool with your consolidation of the conversation."},
+                    {"role": "system", "content": "You are a memory consolidation agent. Call the save_memory tool. "
+                     "memory_update: ONLY timeless semantic facts (preferences, relationships, projects, skills) — never events or activities. "
+                     "episodic_memory_update: ONLY episodic entries (events, activities, context) — never stable facts. "
+                     "importance: high=must remember, medium=useful, low=nice to have."},
                     {"role": "user", "content": prompt},
                 ],
                 tools=_SAVE_MEMORY_TOOL,
@@ -141,6 +206,18 @@ class MemoryStore:
                     update = json.dumps(update, ensure_ascii=False)
                 if update != current_memory:
                     self.write_long_term(update)
+            if (facts_list := args.get("episodic_memory_update")) and isinstance(facts_list, list):
+                self._sync()
+                existing = {m["text"].lower() for m in self._facts}
+                memory_lower = (update or "").lower()
+                now = datetime.now().isoformat()
+                entries = [json.dumps({"text": t, "importance": m.get("importance", "medium"), "created_at": now}, ensure_ascii=False)
+                           for m in facts_list if (t := m.get("text", "").strip()) and t.lower() not in existing
+                           and t.lower() not in memory_lower]
+                if entries:
+                    with open(self.episodic_file, "a", encoding="utf-8") as fh:
+                        fh.write("\n".join(entries) + "\n")
+                logger.info("Memory consolidation: appended {} facts", len(entries))
 
             session.last_consolidated = 0 if archive_all else len(session.messages) - keep_count
             logger.info("Memory consolidation done: {} messages, last_consolidated={}", len(session.messages), session.last_consolidated)

--- a/nanobot/skills/memory/SKILL.md
+++ b/nanobot/skills/memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory
-description: Two-layer memory system with grep-based recall.
+description: Semantic + episodic memory system with BM25 + temporal decay ranked recall.
 always: true
 ---
 
@@ -8,7 +8,8 @@ always: true
 
 ## Structure
 
-- `memory/MEMORY.md` — Long-term facts (preferences, project context, relationships). Always loaded into your context.
+- `memory/MEMORY.md` — Long-term semantic memory: stable facts (preferences, relationships, projects). Always loaded into your context.
+- `memory/memory.jsonl` — Long-term episodic memory: time-bound events and context. Top-5 most relevant auto-injected per turn using BM25 + temporal decay ranking.
 - `memory/HISTORY.md` — Append-only event log. NOT loaded into context. Search it with grep. Each entry starts with [YYYY-MM-DD HH:MM].
 
 ## Search Past Events
@@ -21,10 +22,19 @@ Use the `exec` tool to run grep. Combine patterns: `grep -iE "meeting|deadline" 
 
 ## When to Update MEMORY.md
 
-Write important facts immediately using `edit_file` or `write_file`:
+Write semantic facts immediately using `edit_file` or `write_file`:
 - User preferences ("I prefer dark mode")
-- Project context ("The API uses OAuth2")
 - Relationships ("Alice is the project lead")
+
+## When to Update memory.jsonl
+
+Write episodic facts immediately using `edit_file` or `write_file`:
+
+```json
+{"text": "The API uses OAuth2", "importance": "medium", "created_at": "2026-01-01T10:00:00"}
+{"text": "I am traveling next week", "importance": "high", "created_at": "2026-01-01T10:00:00"}
+```
+- `importance` — retrieval priority: `high`=must remember, `medium`=useful, `low`=nice to have
 
 ## Auto-consolidation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "prompt-toolkit>=3.0.50,<4.0.0",
     "mcp>=1.26.0,<2.0.0",
     "json-repair>=0.57.0,<1.0.0",
+    "rank-bm25>=0.2.2,<1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Introducing new memory layer with BM25 + temporal decay retrieval, long-term memory is split into two parts
- Semantic memory (MEMORY.md): stable facts — preferences, relationships, projects
- Episodic memory (memory.jsonl): time-bound events, auto-retrieved each turn
  - Top-5 episodic facts injected per turn via BM25 + decay weighted by importance (high/medium/low)

#### Why?
- Better scaling, less impact on context size. Instead of loading everything, BM25 retrieval picks only the top-5 facts most relevant to the current message are injected. 
- Keeps MEMORY.md clean, Temporary context stays in episodic memory

#### Files Changed
(+90 line, Ran run bash core_agent_lines.sh  - `Core agent is 4,024 lines total.`)
  - nanobot/agent/memory.py — core memory system rewrite
  - nanobot/agent/context.py — per-turn query injection for episodic retrieval
  - nanobot/skills/memory/SKILL.md — updated skill documentation
  - pyproject.toml — added rank-bm25 dependency

