### PR TITLE
feat(CI): add unit-test workflow with coverage gate and README badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    name: Unit Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: |
+          uv sync --extra dev
+          # Matrix tests need nio + HTML sanitizer, but not python-olm/e2e.
+          uv pip install matrix-nio mistune nh3 pytest-cov
+
+      - name: Run unit tests with coverage
+        run: |
+          uv run pytest -q --cov=nanobot --cov-report=term-missing --cov-report=xml --cov-fail-under=35
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-py${{ matrix.python-version }}
+          path: coverage.xml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <h1>nanobot: Ultra-Lightweight Personal AI Assistant</h1>
   <p>
     <a href="https://pypi.org/project/nanobot-ai/"><img src="https://img.shields.io/pypi/v/nanobot-ai" alt="PyPI"></a>
+    <a href="https://github.com/HKUDS/nanobot/actions/workflows/ci.yml"><img src="https://github.com/HKUDS/nanobot/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
     <a href="https://pepy.tech/project/nanobot-ai"><img src="https://static.pepy.tech/badge/nanobot-ai" alt="Downloads"></a>
     <img src="https://img.shields.io/badge/python-≥3.11-blue" alt="Python">
     <img src="https://img.shields.io/badge/license-MIT-green" alt="License">


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions CI pipeline to run Python unit tests on every PR and `main` push, with coverage reporting and a minimum coverage gate. It also adds a CI status badge to the README.

## Changes

1. Added CI workflow
- New file: `.github/workflows/ci.yml`
- Triggers:
  - `pull_request`
  - `push` to `main`
- Matrix:
  - Python `3.11`, `3.12`
- Uses `uv` for environment/dependency setup

2. Added test + coverage execution
- Installs dependencies with:
  - `uv sync --extra dev`
  - `uv pip install matrix-nio mistune nh3 pytest-cov`
- Runs:
  - `pytest -q --cov=nanobot --cov-report=term-missing --cov-report=xml --cov-fail-under=35`
- Uploads `coverage.xml` as workflow artifact per Python version

3. Added README CI badge
- Updated `README.md` to include a badge linking to:
  - `https://github.com/HKUDS/nanobot/actions/workflows/ci.yml`

## Why
- Ensure PRs and `main` commits automatically run unit tests
- Prevent silent test regressions
- Enforce a baseline code coverage floor (`35%`) in CI
- Improve visibility of repository health from the README

## Notes
- Branch protection (required status checks) still needs to be configured in GitHub repository settings by an admin/maintainer.
- Coverage threshold is intentionally conservative as an initial baseline and can be raised over time.
