### PR TITLE
feat(transport): add serve mode + websocket contract to decouple adapters from agent core

### DIFF
--- a/nanobot/bus/__init__.py
+++ b/nanobot/bus/__init__.py
@@ -1,6 +1,13 @@
 """Message bus module for decoupled channel-agent communication."""
 
+from nanobot.bus.backends import BusBackend, InMemoryBusBackend
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
 
-__all__ = ["MessageBus", "InboundMessage", "OutboundMessage"]
+__all__ = [
+    "BusBackend",
+    "InMemoryBusBackend",
+    "MessageBus",
+    "InboundMessage",
+    "OutboundMessage",
+]

--- a/nanobot/bus/backends.py
+++ b/nanobot/bus/backends.py
@@ -1,0 +1,66 @@
+"""Message bus backend implementations."""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+
+
+class BusBackend(ABC):
+    """Abstract backend for inbound/outbound message transport."""
+
+    @abstractmethod
+    async def publish_inbound(self, msg: InboundMessage) -> None:
+        pass
+
+    @abstractmethod
+    async def consume_inbound(self) -> InboundMessage:
+        pass
+
+    @abstractmethod
+    async def publish_outbound(self, msg: OutboundMessage) -> None:
+        pass
+
+    @abstractmethod
+    async def consume_outbound(self) -> OutboundMessage:
+        pass
+
+    @property
+    @abstractmethod
+    def inbound_size(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def outbound_size(self) -> int:
+        pass
+
+
+class InMemoryBusBackend(BusBackend):
+    """Default in-process asyncio queue backend."""
+
+    def __init__(self):
+        self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue()
+        self.outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
+
+    async def publish_inbound(self, msg: InboundMessage) -> None:
+        await self.inbound.put(msg)
+
+    async def consume_inbound(self) -> InboundMessage:
+        return await self.inbound.get()
+
+    async def publish_outbound(self, msg: OutboundMessage) -> None:
+        await self.outbound.put(msg)
+
+    async def consume_outbound(self) -> OutboundMessage:
+        return await self.outbound.get()
+
+    @property
+    def inbound_size(self) -> int:
+        return self.inbound.qsize()
+
+    @property
+    def outbound_size(self) -> int:
+        return self.outbound.qsize()

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -1,7 +1,6 @@
 """Async message queue for decoupled channel-agent communication."""
 
-import asyncio
-
+from nanobot.bus.backends import BusBackend, InMemoryBusBackend
 from nanobot.bus.events import InboundMessage, OutboundMessage
 
 
@@ -13,32 +12,31 @@ class MessageBus:
     them and pushes responses to the outbound queue.
     """
 
-    def __init__(self):
-        self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue()
-        self.outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
+    def __init__(self, backend: BusBackend | None = None):
+        self.backend: BusBackend = backend or InMemoryBusBackend()
 
     async def publish_inbound(self, msg: InboundMessage) -> None:
         """Publish a message from a channel to the agent."""
-        await self.inbound.put(msg)
+        await self.backend.publish_inbound(msg)
 
     async def consume_inbound(self) -> InboundMessage:
         """Consume the next inbound message (blocks until available)."""
-        return await self.inbound.get()
+        return await self.backend.consume_inbound()
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """Publish a response from the agent to channels."""
-        await self.outbound.put(msg)
+        await self.backend.publish_outbound(msg)
 
     async def consume_outbound(self) -> OutboundMessage:
         """Consume the next outbound message (blocks until available)."""
-        return await self.outbound.get()
+        return await self.backend.consume_outbound()
 
     @property
     def inbound_size(self) -> int:
         """Number of pending inbound messages."""
-        return self.inbound.qsize()
+        return self.backend.inbound_size
 
     @property
     def outbound_size(self) -> int:
         """Number of pending outbound messages."""
-        return self.outbound.qsize()
+        return self.backend.outbound_size

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -409,6 +409,104 @@ def gateway(
     asyncio.run(run())
 
 
+@app.command()
+def serve(
+    host: str = typer.Option("127.0.0.1", "--host", help="Transport gateway host"),
+    port: int = typer.Option(18791, "--port", "-p", help="Transport gateway port"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
+):
+    """Start WebSocket transport gateway for external app adapters."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.agent.tools.message import MessageTool
+    from nanobot.bus.events import OutboundMessage
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.loader import get_data_dir, load_config
+    from nanobot.cron.service import CronService
+    from nanobot.cron.types import CronJob
+    from nanobot.session.manager import SessionManager
+    from nanobot.transport.ws_gateway import WebSocketGateway
+
+    if verbose:
+        import logging
+        logging.basicConfig(level=logging.DEBUG)
+
+    console.print(f"{__logo__} Starting transport gateway on ws://{host}:{port}...")
+
+    config = load_config()
+    sync_workspace_templates(config.workspace_path)
+    bus = MessageBus()
+    provider = _make_provider(config)
+    session_manager = SessionManager(config.workspace_path)
+
+    cron_store_path = get_data_dir() / "cron" / "jobs.json"
+    cron = CronService(cron_store_path)
+
+    agent = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=config.workspace_path,
+        model=config.agents.defaults.model,
+        temperature=config.agents.defaults.temperature,
+        max_tokens=config.agents.defaults.max_tokens,
+        max_iterations=config.agents.defaults.max_tool_iterations,
+        memory_window=config.agents.defaults.memory_window,
+        reasoning_effort=config.agents.defaults.reasoning_effort,
+        brave_api_key=config.tools.web.search.api_key or None,
+        web_proxy=config.tools.web.proxy or None,
+        exec_config=config.tools.exec,
+        cron_service=cron,
+        restrict_to_workspace=config.tools.restrict_to_workspace,
+        session_manager=session_manager,
+        mcp_servers=config.tools.mcp_servers,
+        channels_config=config.channels,
+    )
+
+    async def on_cron_job(job: CronJob) -> str | None:
+        reminder_note = (
+            "[Scheduled Task] Timer finished.\n\n"
+            f"Task '{job.name}' has been triggered.\n"
+            f"Scheduled instruction: {job.payload.message}"
+        )
+
+        response = await agent.process_direct(
+            reminder_note,
+            session_key=f"cron:{job.id}",
+            channel=job.payload.channel or "transport",
+            chat_id=job.payload.to or "direct",
+        )
+
+        message_tool = agent.tools.get("message")
+        if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
+            return response
+
+        if job.payload.deliver and job.payload.to and response:
+            await bus.publish_outbound(OutboundMessage(
+                channel=job.payload.channel or "transport",
+                chat_id=job.payload.to,
+                content=response,
+            ))
+        return response
+
+    cron.on_job = on_cron_job
+
+    ws_gateway = WebSocketGateway(bus=bus, host=host, port=port)
+
+    async def run():
+        try:
+            await cron.start()
+            await ws_gateway.start()
+            await agent.run()
+        except KeyboardInterrupt:
+            console.print("\nShutting down...")
+        finally:
+            await agent.close_mcp()
+            cron.stop()
+            await ws_gateway.stop()
+            agent.stop()
+
+    asyncio.run(run())
+
+
 
 
 # ============================================================================

--- a/nanobot/transport/__init__.py
+++ b/nanobot/transport/__init__.py
@@ -1,0 +1,15 @@
+"""Transport interfaces for external adapter integration."""
+
+from nanobot.transport.contracts import (
+    AttachmentRef,
+    InboundTransportMessage,
+    OutboundTransportEvent,
+    OutboundTransportMessage,
+)
+
+__all__ = [
+    "AttachmentRef",
+    "InboundTransportMessage",
+    "OutboundTransportMessage",
+    "OutboundTransportEvent",
+]

--- a/nanobot/transport/contracts.py
+++ b/nanobot/transport/contracts.py
@@ -1,0 +1,126 @@
+"""Transport-level message contracts for external adapters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+
+
+class AttachmentRef(BaseModel):
+    """Attachment reference used by external adapters."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str | None = None  # Optional adapter-side identifier for dedup/tracing.
+    type: Literal["image", "audio", "video", "file"] | None = None  # High-level attachment kind.
+    mime_type: str | None = None  # Specific media type, e.g. "image/png", "audio/mpeg".
+    url: str | None = None  # Remote source (HTTP/S, object storage, CDN).
+    local_path: str | None = None  # Local source path (same host/container as gateway).
+    size_bytes: int | None = None
+    sha256: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class InboundTransportMessage(BaseModel):
+    """Inbound payload accepted from external adapters."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    message_id: str | None = None
+    session_key: str | None = None
+    channel: str
+    chat_id: str
+    sender_id: str
+    content: str = ""
+    media: list[str] = Field(default_factory=list)
+    attachments: list[AttachmentRef] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def _collect_media_refs(self) -> list[str]:
+        refs = list(self.media)
+        for att in self.attachments:
+            # Prefer local_path over url when both are provided.
+            if att.local_path:
+                refs.append(att.local_path)
+            elif att.url:
+                refs.append(att.url)
+        # preserve order while deduplicating
+        return list(dict.fromkeys(refs))
+
+    def to_bus_message(self) -> InboundMessage:
+        metadata = dict(self.metadata)
+        if self.message_id:
+            metadata.setdefault("message_id", self.message_id)
+        if self.attachments:
+            metadata["attachments"] = [a.model_dump(mode="json") for a in self.attachments]
+        return InboundMessage(
+            channel=self.channel,
+            sender_id=self.sender_id,
+            chat_id=self.chat_id,
+            content=self.content,
+            media=self._collect_media_refs(),
+            metadata=metadata,
+            session_key_override=self.session_key,
+        )
+
+
+class OutboundTransportMessage(BaseModel):
+    """Outbound payload emitted to external adapters."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    channel: str
+    chat_id: str
+    content: str
+    reply_to: str | None = None
+    media: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def from_bus_message(cls, msg: OutboundMessage) -> "OutboundTransportMessage":
+        return cls(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content=msg.content,
+            reply_to=msg.reply_to,
+            media=list(msg.media or []),
+            metadata=dict(msg.metadata or {}),
+        )
+
+
+TransportEventType = Literal[
+    "message.started",
+    "message.delta",
+    "message.completed",
+    "message.failed",
+    "tool.started",
+    "tool.finished",
+]
+
+
+class OutboundTransportEvent(BaseModel):
+    """Event envelope for streaming outbound events."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    event_id: str = Field(default_factory=lambda: str(uuid4()))
+    event_type: TransportEventType
+    timestamp: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    message: OutboundTransportMessage
+
+    @classmethod
+    def from_bus_message(cls, msg: OutboundMessage) -> "OutboundTransportEvent":
+        metadata = msg.metadata or {}
+        if metadata.get("_progress"):
+            event_type: TransportEventType = "message.delta"
+        else:
+            event_type = "message.completed"
+        return cls(
+            event_type=event_type,
+            message=OutboundTransportMessage.from_bus_message(msg),
+        )

--- a/nanobot/transport/ws_gateway.py
+++ b/nanobot/transport/ws_gateway.py
@@ -1,0 +1,164 @@
+"""WebSocket gateway for external adapter integration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from loguru import logger
+from pydantic import ValidationError
+from websockets.asyncio.server import Server, serve
+from websockets.exceptions import ConnectionClosed
+
+from nanobot.bus.queue import MessageBus
+from nanobot.transport.contracts import InboundTransportMessage, OutboundTransportEvent
+
+
+class WebSocketGateway:
+    """Bidirectional adapter gateway over WebSocket."""
+
+    def __init__(self, bus: MessageBus, host: str = "127.0.0.1", port: int = 18791):
+        self.bus = bus
+        self.host = host
+        self.port = port
+        self._server: Server | None = None
+        self._dispatch_task: asyncio.Task | None = None
+        self._running = False
+        self._clients: set[Any] = set()
+        self._subscriptions: dict[Any, set[str]] = {}
+
+    async def start(self) -> None:
+        """Start gateway and outbound dispatcher."""
+        if self._running:
+            return
+        self._running = True
+        self._server = await serve(self._handle_client, self.host, self.port)
+        self._dispatch_task = asyncio.create_task(self._dispatch_outbound())
+        logger.info("WebSocket gateway listening on ws://{}:{}", self.host, self.port)
+
+    async def stop(self) -> None:
+        """Stop gateway and close all active connections."""
+        self._running = False
+        if self._dispatch_task:
+            self._dispatch_task.cancel()
+            try:
+                await self._dispatch_task
+            except asyncio.CancelledError:
+                pass
+            self._dispatch_task = None
+
+        for ws in list(self._clients):
+            try:
+                await ws.close()
+            except Exception:
+                pass
+
+        self._clients.clear()
+        self._subscriptions.clear()
+
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle_client(self, websocket) -> None:
+        self._clients.add(websocket)
+        self._subscriptions[websocket] = set()
+        await self._send(websocket, {"type": "welcome", "version": 1})
+
+        try:
+            async for raw in websocket:
+                await self._handle_frame(websocket, raw)
+        except ConnectionClosed:
+            pass
+        finally:
+            self._clients.discard(websocket)
+            self._subscriptions.pop(websocket, None)
+
+    async def _handle_frame(self, websocket, raw: str) -> None:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            await self._send(websocket, {"type": "error", "error": "invalid_json"})
+            return
+
+        frame_type = payload.get("type")
+        if frame_type == "ping":
+            await self._send(websocket, {"type": "pong"})
+            return
+
+        if frame_type == "subscribe":
+            channels = payload.get("channels")
+            self._subscriptions[websocket] = self._normalize_channels(channels)
+            await self._send(
+                websocket,
+                {
+                    "type": "subscribed",
+                    "channels": sorted(self._subscriptions[websocket]),
+                },
+            )
+            return
+
+        if frame_type == "inbound":
+            body = payload.get("message", payload)
+            try:
+                inbound = InboundTransportMessage.model_validate(body)
+            except ValidationError as e:
+                await self._send(
+                    websocket,
+                    {"type": "error", "error": "invalid_inbound", "details": e.errors()},
+                )
+                return
+
+            await self.bus.publish_inbound(inbound.to_bus_message())
+            await self._send(
+                websocket,
+                {"type": "ack", "message_id": inbound.message_id or ""},
+            )
+            return
+
+        await self._send(websocket, {"type": "error", "error": "unsupported_type"})
+
+    def _normalize_channels(self, channels: Any) -> set[str]:
+        if not isinstance(channels, Iterable) or isinstance(channels, (str, bytes)):
+            return set()
+        out = set()
+        for item in channels:
+            if isinstance(item, str) and item.strip():
+                out.add(item.strip())
+        return out
+
+    async def _dispatch_outbound(self) -> None:
+        while self._running:
+            try:
+                msg = await asyncio.wait_for(self.bus.consume_outbound(), timeout=1.0)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+            event = OutboundTransportEvent.from_bus_message(msg).model_dump(mode="json")
+            frame = {"type": "outbound", "event": event}
+
+            dead_clients: list[Any] = []
+            for ws in self._clients:
+                subs = self._subscriptions.get(ws, set())
+                if subs and msg.channel not in subs:
+                    continue
+                try:
+                    await self._send(ws, frame)
+                except ConnectionClosed:
+                    dead_clients.append(ws)
+                except Exception as e:
+                    logger.warning("Failed to send outbound frame: {}", e)
+                    dead_clients.append(ws)
+
+            for ws in dead_clients:
+                self._clients.discard(ws)
+                self._subscriptions.pop(ws, None)
+
+    @staticmethod
+    async def _send(websocket, payload: dict[str, Any]) -> None:
+        await websocket.send(json.dumps(payload, ensure_ascii=False))

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -1,8 +1,15 @@
+import asyncio
+import json
 from typing import Any
 
 from nanobot.agent.tools.base import Tool
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.shell import ExecTool
+from nanobot.bus.backends import InMemoryBusBackend
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.transport.contracts import InboundTransportMessage, OutboundTransportEvent
+from nanobot.transport.ws_gateway import WebSocketGateway
 
 
 class SampleTool(Tool):
@@ -106,3 +113,188 @@ def test_exec_extract_absolute_paths_captures_posix_absolute_paths() -> None:
     paths = ExecTool._extract_absolute_paths(cmd)
     assert "/tmp/data.txt" in paths
     assert "/tmp/out.txt" in paths
+
+
+async def test_message_bus_uses_default_inmemory_backend() -> None:
+    bus = MessageBus()
+
+    inbound = InboundMessage(channel="cli", sender_id="u1", chat_id="c1", content="hello")
+    await bus.publish_inbound(inbound)
+    received_in = await bus.consume_inbound()
+    assert received_in.content == "hello"
+
+    outbound = OutboundMessage(channel="cli", chat_id="c1", content="world")
+    await bus.publish_outbound(outbound)
+    received_out = await bus.consume_outbound()
+    assert received_out.content == "world"
+
+
+async def test_message_bus_accepts_explicit_backend() -> None:
+    backend = InMemoryBusBackend()
+    bus = MessageBus(backend=backend)
+
+    msg = InboundMessage(channel="telegram", sender_id="u2", chat_id="c2", content="x")
+    await bus.publish_inbound(msg)
+    consumed = await backend.consume_inbound()
+    assert consumed.channel == "telegram"
+
+
+def test_inbound_contract_converts_to_bus_message() -> None:
+    inbound = InboundTransportMessage.model_validate(
+        {
+            "message_id": "msg-1",
+            "session_key": "telegram:chat-1:thread-2",
+            "channel": "telegram",
+            "chat_id": "chat-1",
+            "sender_id": "user-1",
+            "content": "hello",
+            "media": ["/tmp/a.png"],
+            "attachments": [
+                {"type": "image", "url": "https://example.com/x.png"},
+                {"type": "file", "local_path": "/tmp/doc.pdf"},
+            ],
+            "metadata": {"thread_id": "2"},
+        }
+    )
+
+    msg = inbound.to_bus_message()
+    assert msg.channel == "telegram"
+    assert msg.session_key == "telegram:chat-1:thread-2"
+    assert msg.metadata["message_id"] == "msg-1"
+    assert msg.metadata["thread_id"] == "2"
+    assert len(msg.media) == 3
+
+
+def test_outbound_event_maps_progress_to_delta() -> None:
+    outbound = OutboundMessage(
+        channel="telegram",
+        chat_id="chat-1",
+        content="thinking...",
+        metadata={"_progress": True},
+    )
+
+    event = OutboundTransportEvent.from_bus_message(outbound)
+    assert event.event_type == "message.delta"
+    assert event.message.channel == "telegram"
+
+
+def test_outbound_event_maps_final_to_completed() -> None:
+    outbound = OutboundMessage(
+        channel="telegram",
+        chat_id="chat-1",
+        content="done",
+    )
+
+    event = OutboundTransportEvent.from_bus_message(outbound)
+    assert event.event_type == "message.completed"
+
+
+class _FakeWebSocket:
+    def __init__(self):
+        self.sent: list[dict[str, Any]] = []
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(json.loads(payload))
+
+
+def test_ws_gateway_normalize_channels() -> None:
+    bus = MessageBus()
+    gateway = WebSocketGateway(bus=bus)
+
+    assert gateway._normalize_channels("telegram") == set()
+    assert gateway._normalize_channels(None) == set()
+    assert gateway._normalize_channels([" telegram ", "telegram", "", 1, "cli"]) == {"telegram", "cli"}
+
+
+async def test_ws_gateway_handle_frame_ping() -> None:
+    bus = MessageBus()
+    gateway = WebSocketGateway(bus=bus)
+    ws = _FakeWebSocket()
+
+    await gateway._handle_frame(ws, json.dumps({"type": "ping"}))
+    assert ws.sent[-1] == {"type": "pong"}
+
+
+async def test_ws_gateway_handle_frame_subscribe_and_invalid_json() -> None:
+    bus = MessageBus()
+    gateway = WebSocketGateway(bus=bus)
+    ws = _FakeWebSocket()
+    gateway._subscriptions[ws] = set()
+
+    await gateway._handle_frame(ws, "not-json")
+    assert ws.sent[-1]["type"] == "error"
+    assert ws.sent[-1]["error"] == "invalid_json"
+
+    await gateway._handle_frame(
+        ws,
+        json.dumps({"type": "subscribe", "channels": ["telegram", " cli ", "telegram"]}),
+    )
+    assert gateway._subscriptions[ws] == {"telegram", "cli"}
+    assert ws.sent[-1] == {"type": "subscribed", "channels": ["cli", "telegram"]}
+
+
+async def test_ws_gateway_handle_frame_inbound_and_invalid_inbound() -> None:
+    bus = MessageBus()
+    gateway = WebSocketGateway(bus=bus)
+    ws = _FakeWebSocket()
+
+    await gateway._handle_frame(
+        ws,
+        json.dumps({"type": "inbound", "message": {"channel": "web"}}),
+    )
+    assert ws.sent[-1]["type"] == "error"
+    assert ws.sent[-1]["error"] == "invalid_inbound"
+
+    payload = {
+        "type": "inbound",
+        "message": {
+            "message_id": "m-1",
+            "session_key": "web:user-1",
+            "channel": "web",
+            "chat_id": "user-1",
+            "sender_id": "user-1",
+            "content": "hello",
+        },
+    }
+    await gateway._handle_frame(ws, json.dumps(payload))
+    inbound = await bus.consume_inbound()
+    assert inbound.session_key == "web:user-1"
+    assert inbound.content == "hello"
+    assert ws.sent[-1] == {"type": "ack", "message_id": "m-1"}
+
+
+async def test_ws_gateway_dispatch_outbound_respects_subscriptions() -> None:
+    bus = MessageBus()
+    gateway = WebSocketGateway(bus=bus)
+    ws_all = _FakeWebSocket()
+    ws_telegram = _FakeWebSocket()
+
+    gateway._clients = {ws_all, ws_telegram}
+    gateway._subscriptions = {
+        ws_all: set(),
+        ws_telegram: {"telegram"},
+    }
+    gateway._running = True
+
+    task = asyncio.create_task(gateway._dispatch_outbound())
+    try:
+        await bus.publish_outbound(
+            OutboundMessage(channel="web", chat_id="user-1", content="hello")
+        )
+
+        for _ in range(20):
+            if ws_all.sent:
+                break
+            await asyncio.sleep(0.01)
+
+        assert len(ws_all.sent) == 1
+        assert ws_all.sent[0]["type"] == "outbound"
+        assert ws_all.sent[0]["event"]["message"]["channel"] == "web"
+        assert ws_telegram.sent == []
+    finally:
+        gateway._running = False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass


### PR DESCRIPTION
## Summary
This PR introduces a new **transport/serve path** so external clients (web UI, custom chat adapters, etc.) can communicate with nanobot through a stable WebSocket contract, instead of requiring in-repo channel integrations.

Core idea:
- `nanobot serve` runs the agent backend and exposes a WebSocket gateway.
- External frontends/adapters push inbound messages and subscribe to outbound events.
- The core agent logic remains focused on runtime behavior (context, tools, sessions, providers), while integration-specific UI/channel logic can evolve outside this repo.

---

## Why this change

I’ve seen multiple PRs trying to add ChatGPT-like web UI and other chat app integrations directly into this repository. At the same time, many issues are integration-specific (Telegram/Slack/Matrix/etc.), which consumes maintainer bandwidth and mixes concerns in the core codebase.

This PR moves toward a cleaner modular split:

1. **Backend (this repo)**  
   Focus on agent runtime, tool execution, memory/session, scheduling, and model providers.

2. **Frontend / channel adapters (outside this repo or as separate modules)**  
   Focus on UX, platform APIs, and integration details.

By adding a common contract/protocol between FE and BE, we can standardize integration points and reduce coupling.

---

## What’s included

### 1) Bus backend abstraction
- Added `BusBackend` interface and default `InMemoryBusBackend`.
- `MessageBus` now depends on backend abstraction instead of hardcoded queues.

Files:
- `nanobot/bus/backends.py`
- `nanobot/bus/queue.py`
- `nanobot/bus/__init__.py`

### 2) Transport contracts
- Added transport-level message/event models for adapter-facing protocol:
  - `AttachmentRef`
  - `InboundTransportMessage`
  - `OutboundTransportMessage`
  - `OutboundTransportEvent`

Files:
- `nanobot/transport/contracts.py`
- `nanobot/transport/__init__.py`

### 3) WebSocket gateway
- Added `WebSocketGateway`:
  - accepts `inbound` frames
  - supports `subscribe` channel filtering
  - emits `outbound` events (`message.delta` / `message.completed`, etc.)
  - handles ack/error/ping-pong

File:
- `nanobot/transport/ws_gateway.py`

### 4) New CLI mode: `serve`
- Added `nanobot serve` command to run:
  - agent loop
  - cron service
  - websocket gateway
- This provides a backend endpoint for web UI / external adapters.

File:
- `nanobot/cli/commands.py`

### 5) Unit tests
- Added transport-focused unit tests for:
  - bus backend behavior
  - contract mapping
  - websocket frame handling and outbound dispatch filtering

File:
- `tests/test_tool_validation.py`

---

## Practical impact

With this PR, a local web UI can do:

1. Connect to `ws://127.0.0.1:18791`
2. Send standardized `inbound` messages
3. Receive streamed `outbound` events

This makes “ChatGPT-style web UI” integration straightforward **without embedding frontend code into core backend repo**.

---

## Design intent

This is not a full extraction of all built-in channels yet.  
It is a foundational step toward:
- clearer FE/BE boundaries,
- modular integration strategy,
- lower maintenance overhead in core,
- and a leaner, more backend-focused repository over time.

---

## Notes

- Existing gateway/channel flow remains available.
- `serve` is additive, not a breaking replacement.
- The transport contract can become the long-term standard integration interface for external UIs and chat adapters.
