### PR TITLE
fix: merge runtime context into user message to avoid consecutive user messages

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -112,11 +112,22 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         chat_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
+        runtime_ctx = self._build_runtime_context(channel, chat_id)
+        user_content = self._build_user_content(current_message, media)
+
+        # Merge runtime context into user message to avoid consecutive user messages.
+        # Some providers (e.g., MiniMax) reject consecutive messages with the same role.
+        if isinstance(user_content, str):
+            merged_content = f"{runtime_ctx}\n\n{user_content}"
+        else:
+            # user_content is a list of multimodal content blocks.
+            # Prepend runtime context as a text block.
+            merged_content = [{"type": "text", "text": runtime_ctx}] + user_content
+
         return [
             {"role": "system", "content": self.build_system_prompt(skill_names)},
             *history,
-            {"role": "user", "content": self._build_runtime_context(channel, chat_id)},
-            {"role": "user", "content": self._build_user_content(current_message, media)},
+            {"role": "user", "content": merged_content},
         ]
 
     def _build_user_content(self, text: str, media: list[str] | None) -> str | list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

Fixes #1414

This PR addresses content format issues that cause API errors with certain providers.

## Investigation Results (2026-03-02)

### Actual Testing

**Test Environment:**
- MiniMax M2.5 via Anthropic-compatible API (`https://api.minimaxi.com/anthropic`)
- DeepSeek R1 via proxy (`https://api.openai-proxy.org/v1`)

**Test Cases and Results:**

| Test Case | MiniMax Anthropic | DeepSeek via Proxy |
|-----------|-------------------|-------------------|
| `content = object` (dict) | 200 OK | 400 Error |
| `content = [object]` (array) | 200 OK | 200 OK |
| `content = string` | 200 OK | 200 OK |
| consecutive user messages | 200 OK | 200 OK |

**Key Findings:**

1. **Original error could NOT be fully reproduced** - MiniMax M2.5 Anthropic endpoint accepted all test cases including consecutive user messages

2. **`content = object` format issue confirmed** - DeepSeek via proxy rejects `content` being a plain dict/object, requires string or array

3. **Issue #1344 reports identical error** - DashScope (阿里云百炼) reports the same error message, suggesting multiple providers have this restriction

4. **litellm limitation** - [litellm#18834](https://github.com/BerriAI/litellm/issues/18834): litellm does not properly support MiniMax Anthropic endpoint (uses `/v1/chat/completions` instead of `/v1/messages`)

### What This PR Changes

The original `ContextBuilder.build_messages()` generates:

```python
[
    {"role": "system", "content": "..."},
    {"role": "user", "content": "[Runtime Context]..."},  # runtime context
    {"role": "user", "content": "actual user message"},   # separate message
]
```

This PR merges them:

```python
[
    {"role": "system", "content": "..."},
    {"role": "user", "content": "[Runtime Context]...\n\nactual user message"},
]
```

### Why This Change Is Still Valuable

1. **Reduces message count** - Fewer messages = fewer tokens
2. **Semantically cleaner** - Runtime context is metadata for the user message, not a separate turn
3. **May help with strict providers** - While MiniMax M2.5 accepts consecutive messages, other providers/models may not

### Known Related Issues

| Issue | Provider | Description |
|-------|----------|-------------|
| [nanobot#1344](https://github.com/HKUDS/nanobot/issues/1344) | DashScope | Same error message |
| [litellm#18834](https://github.com/BerriAI/litellm/issues/18834) | MiniMax | litellm uses wrong endpoint |
| [litellm#7972](https://github.com/BerriAI/litellm/issues/7972) | DeepSeek R1 | Rejects consecutive same-role messages |

### Caveats

- **Could NOT reproduce original #1414 error** with MiniMax M2.5 Anthropic endpoint
- The fix may not directly resolve #1414 if the root cause is elsewhere (possibly litellm's endpoint handling)
- nanobot already has `_sanitize_empty_content` that converts `content = dict` to `content = [dict]`

## Files Changed

- `nanobot/agent/context.py`: Modified `ContextBuilder.build_messages()` to merge runtime context into user content