### PR TITLE
Fix: Add sender name context to DingTalk messages

### DIFF
--- a/nanobot/channels/dingtalk.py
+++ b/nanobot/channels/dingtalk.py
@@ -425,10 +425,14 @@ class DingTalkChannel(BaseChannel):
         """
         try:
             logger.info("DingTalk inbound: {} from {}", content, sender_name)
+
+            # Prepend sender context so the agent knows who is speaking
+            content_with_context = f"[from: {sender_name}]\n{content}"
+
             await self._handle_message(
                 sender_id=sender_id,
                 chat_id=sender_id,  # For private chat, chat_id == sender_id
-                content=str(content),
+                content=content_with_context,
                 metadata={
                     "sender_name": sender_name,
                     "platform": "dingtalk",


### PR DESCRIPTION
# Fix: Add sender name context to DingTalk messages

## Summary

This PR fixes an issue where the agent could not identify the sender's display name when receiving DingTalk messages. The agent only saw the `staffId` (e.g., `123456`) but not the sender's actual name (e.g., `张三`).

## Changes

- Modified `DingTalkChannel._on_message()` to prepend sender name to message content
- Format: `[from: {sender_name}]\n{content}`
- Aligns with existing Telegram channel implementation for sender context

## Before

Agent receives:
```
1
```

Metadata contains sender name, but agent doesn't see it in the conversation.

## After

Agent receives:
```
[from: 张三 🦌]
1
```

Agent can now identify who is speaking.

## Implementation details

The fix follows the same pattern used in the Telegram channel (`telegram.py:730-743`) where sender context is prepended to help the agent understand who is speaking, especially useful in multi-user scenarios.

## Testing

- [x] Tested with DingTalk bot receiving messages
- [x] Verified sender name appears in agent's context
- [x] No breaking changes to existing functionality

## Related Issues

Fixes #1418

---

**Note**: This is a simple, non-breaking change that improves agent context awareness across all DingTalk conversations.
