### PR TITLE
feat: configurable subagent max iterations

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -65,6 +65,7 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        subagent_max_iterations: int = 15,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -98,6 +99,7 @@ class AgentLoop:
             web_proxy=web_proxy,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            default_max_iterations=subagent_max_iterations,
         )
 
         self._running = False

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -34,6 +34,7 @@ class SubagentManager:
         web_proxy: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
+        default_max_iterations: int = 15,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.provider = provider
@@ -47,6 +48,7 @@ class SubagentManager:
         self.web_proxy = web_proxy
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
+        self.default_max_iterations = default_max_iterations
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
 
@@ -116,7 +118,7 @@ class SubagentManager:
             ]
 
             # Run agent loop (limited iterations)
-            max_iterations = 15
+            max_iterations = self.default_max_iterations
             iteration = 0
             final_result: str | None = None
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -291,6 +291,7 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_max_iterations=config.agents.defaults.subagent_max_iterations,
     )
 
     # Set cron callback (needs agent)
@@ -463,6 +464,7 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_max_iterations=config.agents.defaults.subagent_max_iterations,
     )
 
     # Show spinner when logs are off (no output to miss); skip when logs are on
@@ -957,6 +959,7 @@ def cron_run(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_max_iterations=config.agents.defaults.subagent_max_iterations,
     )
 
     store_path = get_data_dir() / "cron" / "jobs.json"

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -225,6 +225,7 @@ class AgentDefaults(Base):
     max_tokens: int = 8192
     temperature: float = 0.1
     max_tool_iterations: int = 40
+    subagent_max_iterations: int = 15
     memory_window: int = 100
     reasoning_effort: str | None = None  # low / medium / high — enables LLM thinking mode
 


### PR DESCRIPTION
## Summary
- Add `agents.defaults.subagentMaxIterations` config option (default 15)
- Replaces the hardcoded `max_iterations = 15` in `SubagentManager`
- Threads the value through `AgentLoop` constructor and all three CLI entry points (`gateway`, `agent`, `cron_run`)

## Test plan
- [ ] Verify default behavior unchanged (15 iterations)
- [ ] Set `agents.defaults.subagentMaxIterations: 5` and verify subagents stop after 5 iterations
- [ ] Verify the setting works across gateway, agent, and cron-run commands