### PR TITLE
feat(custom-provider): add x-session-affinity header for prompt caching

### DIFF
--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 import json_repair
@@ -15,7 +16,11 @@ class CustomProvider(LLMProvider):
     def __init__(self, api_key: str = "no-key", api_base: str = "http://localhost:8000/v1", default_model: str = "default"):
         super().__init__(api_key, api_base)
         self.default_model = default_model
-        self._client = AsyncOpenAI(api_key=api_key, base_url=api_base)
+        self._client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=api_base,
+            default_headers={"x-session-affinity": uuid.uuid4().hex},
+        )
 
     async def chat(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
                    model: str | None = None, max_tokens: int = 4096, temperature: float = 0.7,


### PR DESCRIPTION
## Summary
- Add `x-session-affinity` header (random UUID per client instance) to `CustomProvider` requests
- Improves prompt cache hit rates with providers that support session affinity by routing requests to the same backend

## Test plan
- [ ] Verify CustomProvider sends `x-session-affinity` header on requests
- [ ] Verify the header value is stable across requests from the same client instance