### PR TITLE
fix(agent): Empty Message Filtering

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -45,6 +45,7 @@ class AgentLoop:
     """
 
     _TOOL_RESULT_MAX_CHARS = 500
+    _EMPTY_ASSISTANT_CONTENT = "(empty)"
 
     def __init__(
         self,
@@ -177,6 +178,36 @@ class AgentLoop:
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
+    @staticmethod
+    def _stringify_message_content(content: Any) -> str:
+        """Convert non-string message content into a safe string payload."""
+        try:
+            return json.dumps(content, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(content)
+
+    def _normalize_messages_for_provider(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Normalize message content shape before sending to any provider."""
+        normalized: list[dict[str, Any]] = []
+        for msg in messages:
+            clean = dict(msg)
+            role = clean.get("role")
+            content = clean.get("content")
+
+            if role == "assistant":
+                if content is None:
+                    clean["content"] = self._EMPTY_ASSISTANT_CONTENT
+                elif not isinstance(content, str):
+                    clean["content"] = self._stringify_message_content(content)
+            elif role == "tool":
+                if not isinstance(content, str):
+                    clean["content"] = self._stringify_message_content(content)
+            elif content is None and role in {"system", "user"}:
+                clean["content"] = ""
+
+            normalized.append(clean)
+        return normalized
+
     async def _run_agent_loop(
         self,
         initial_messages: list[dict],
@@ -191,6 +222,7 @@ class AgentLoop:
         while iteration < self.max_iterations:
             iteration += 1
 
+            messages = self._normalize_messages_for_provider(messages)
             response = await self.provider.chat(
                 messages=messages,
                 tools=self.tools.get_definitions(),
@@ -455,7 +487,7 @@ class AgentLoop:
     def _save_turn(self, session: Session, messages: list[dict], skip: int) -> None:
         """Save new-turn messages into session, truncating large tool results."""
         from datetime import datetime
-        for m in messages[skip:]:
+        for m in self._normalize_messages_for_provider(messages[skip:]):
             entry = dict(m)
             role, content = entry.get("role"), entry.get("content")
             if role == "assistant" and not content and not entry.get("tool_calls"):

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -45,7 +45,7 @@ class AgentLoop:
     """
 
     _TOOL_RESULT_MAX_CHARS = 500
-    _EMPTY_ASSISTANT_CONTENT = "(empty)"
+    _EMPTY_PROVIDER_CONTENT = " "
 
     def __init__(
         self,
@@ -195,15 +195,27 @@ class AgentLoop:
             content = clean.get("content")
 
             if role == "assistant":
+                has_tool_calls = bool(clean.get("tool_calls"))
                 if content is None:
-                    clean["content"] = self._EMPTY_ASSISTANT_CONTENT
+                    if has_tool_calls:
+                        clean["content"] = self._EMPTY_PROVIDER_CONTENT
+                    else:
+                        continue
+                elif isinstance(content, str):
+                    if not content:
+                        if has_tool_calls:
+                            clean["content"] = self._EMPTY_PROVIDER_CONTENT
+                        else:
+                            continue
                 elif not isinstance(content, str):
                     clean["content"] = self._stringify_message_content(content)
             elif role == "tool":
-                if not isinstance(content, str):
+                if content is None or content == "":
+                    clean["content"] = self._EMPTY_PROVIDER_CONTENT
+                elif not isinstance(content, str):
                     clean["content"] = self._stringify_message_content(content)
             elif content is None and role in {"system", "user"}:
-                clean["content"] = ""
+                clean["content"] = self._EMPTY_PROVIDER_CONTENT
 
             normalized.append(clean)
         return normalized
@@ -487,13 +499,23 @@ class AgentLoop:
     def _save_turn(self, session: Session, messages: list[dict], skip: int) -> None:
         """Save new-turn messages into session, truncating large tool results."""
         from datetime import datetime
-        for m in self._normalize_messages_for_provider(messages[skip:]):
+        for m in messages[skip:]:
+            # Filter empty assistant messages BEFORE normalization so they don't
+            # get converted into placeholder text and pollute session history.
+            if m.get("role") == "assistant" and not m.get("content") and not m.get("tool_calls"):
+                continue
+
             entry = dict(m)
             role, content = entry.get("role"), entry.get("content")
-            if role == "assistant" and not content and not entry.get("tool_calls"):
-                continue  # skip empty assistant messages — they poison session context
-            if role == "tool" and isinstance(content, str) and len(content) > self._TOOL_RESULT_MAX_CHARS:
-                entry["content"] = content[:self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
+            if role == "assistant" and content is not None and not isinstance(content, str):
+                entry["content"] = self._stringify_message_content(content)
+                content = entry["content"]
+            if role == "tool":
+                if not isinstance(content, str):
+                    entry["content"] = self._stringify_message_content(content)
+                    content = entry["content"]
+                if len(content) > self._TOOL_RESULT_MAX_CHARS:
+                    entry["content"] = content[:self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
             elif role == "user":
                 if isinstance(content, str) and content.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
                     continue


### PR DESCRIPTION
# Fix persistent 400 errors caused by session message contamination: Add unified message normalization at the framework layer.

## Background and Problem
If historical messages in the same session contain structures that do not meet strict provider requirements (e.g., an `assistant` message with `tool_calls` and `content=None`, or `tool.content` being a non-string value), subsequent requests may keep triggering 400 errors.

This issue causes repeated failures after session contamination and affects the stability of multi-turn conversations.

## Problem Identification
- `Session.get_history()` directly replays historical messages into the next round of context.
- `AgentLoop._run_agent_loop()` lacks unified message validation before calling `provider.chat(...)`.
- The existing protection mainly ensures that **error responses are not persisted to the database**, which cannot cover the scenario where **the history is already contaminated but requests continue to be sent**.

## Solution (Current Change)
This fix is implemented only at the framework layer, without adding custom cleaning logic at the provider level.

Coverage points:
1. Contaminated history is cleaned by the unified layer before being sent to the provider.
2. Two consecutive turns in the same session no longer enter a permanent 400 loop.
**Related issues** ： #1396 

## Scope of Impact
Only the following file is involved:
 - `nanobot/agent/loop.py`

## Risks
- Normalization is applied at the framework layer. If a provider requires special formatting in the future, the unified rules should be extended carefully instead of adding duplicate logic at lower layers.