### PR TITLE
feat(provider): preserve reasoning_details across turns and configure MiniMax reasoning_split via registry

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -154,6 +154,26 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         reasoning_details: Any | None = None,
     ) -> list[dict[str, Any]]:
         """Add an assistant message to the message list."""
+        messages.append(
+            self.build_assistant_message(
+                content=content,
+                tool_calls=tool_calls,
+                reasoning_content=reasoning_content,
+                thinking_blocks=thinking_blocks,
+                reasoning_details=reasoning_details,
+            )
+        )
+        return messages
+
+    @staticmethod
+    def build_assistant_message(
+        content: str | None,
+        tool_calls: list[dict[str, Any]] | None = None,
+        reasoning_content: str | None = None,
+        thinking_blocks: list[dict] | None = None,
+        reasoning_details: Any | None = None,
+    ) -> dict[str, Any]:
+        """Build a normalized assistant message payload."""
         msg: dict[str, Any] = {"role": "assistant", "content": content}
         if tool_calls:
             msg["tool_calls"] = tool_calls
@@ -163,5 +183,4 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
             msg["thinking_blocks"] = thinking_blocks
         if reasoning_details is not None:
             msg["reasoning_details"] = reasoning_details
-        messages.append(msg)
-        return messages
+        return msg

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -151,6 +151,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         tool_calls: list[dict[str, Any]] | None = None,
         reasoning_content: str | None = None,
         thinking_blocks: list[dict] | None = None,
+        reasoning_details: Any | None = None,
     ) -> list[dict[str, Any]]:
         """Add an assistant message to the message list."""
         msg: dict[str, Any] = {"role": "assistant", "content": content}
@@ -160,5 +161,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
             msg["reasoning_content"] = reasoning_content
         if thinking_blocks:
             msg["thinking_blocks"] = thinking_blocks
+        if reasoning_details is not None:
+            msg["reasoning_details"] = reasoning_details
         messages.append(msg)
         return messages

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -45,8 +45,6 @@ class AgentLoop:
     """
 
     _TOOL_RESULT_MAX_CHARS = 500
-    _CHAT_RETRY_MAX = 2
-    _CHAT_RETRY_BASE_DELAY_SECONDS = 0.8
 
     def __init__(
         self,
@@ -179,71 +177,6 @@ class AgentLoop:
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
-    @staticmethod
-    def _is_retryable_error(text: str | None) -> bool:
-        """Return True for transient provider errors that should be retried."""
-        t = (text or "").lower()
-        markers = (
-            "apiconnectionerror",
-            "server disconnected",
-            "timeout",
-            "temporarily unavailable",
-            "rate limit",
-            "429",
-            "connection reset",
-            "network",
-            "econnreset",
-        )
-        return any(marker in t for marker in markers)
-
-    @staticmethod
-    def _friendly_error_message(text: str | None) -> str:
-        """Map low-level provider errors into user-facing messages."""
-        t = (text or "").lower()
-        if any(marker in t for marker in ("401", "unauthorized", "invalid api key")):
-            return "Model authentication failed. Please check your API key."
-        if "rate limit" in t or "429" in t:
-            return "The model is rate-limiting requests. Please try again shortly."
-        if any(marker in t for marker in ("timeout", "apiconnectionerror", "server disconnected", "network")):
-            return "The model connection is unstable right now. Please try again."
-        return "Sorry, I encountered an error calling the AI model."
-
-    async def _chat_with_retry(self, messages: list[dict]) -> tuple[Any, str | None]:
-        """Call provider.chat with retry for transient errors."""
-        last_response = None
-        max_attempts = self._CHAT_RETRY_MAX + 1
-
-        for attempt in range(max_attempts):
-            response = await self.provider.chat(
-                messages=messages,
-                tools=self.tools.get_definitions(),
-                model=self.model,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                reasoning_effort=self.reasoning_effort,
-            )
-            last_response = response
-
-            if response.finish_reason != "error":
-                return response, None
-
-            clean_err = self._strip_think(response.content)
-            logger.warning(
-                "LLM returned error (attempt {}/{}): {}",
-                attempt + 1,
-                max_attempts,
-                (clean_err or "")[:300],
-            )
-
-            if (not self._is_retryable_error(clean_err)) or attempt == self._CHAT_RETRY_MAX:
-                logger.error("LLM failed after retries: {}", (clean_err or "")[:500])
-                return response, self._friendly_error_message(clean_err)
-
-            await asyncio.sleep(self._CHAT_RETRY_BASE_DELAY_SECONDS * (2 ** attempt))
-
-        clean_err = self._strip_think(getattr(last_response, "content", None))
-        return last_response, self._friendly_error_message(clean_err)
-
     async def _run_agent_loop(
         self,
         initial_messages: list[dict],
@@ -258,9 +191,14 @@ class AgentLoop:
         while iteration < self.max_iterations:
             iteration += 1
 
-            response, user_error = await self._chat_with_retry(messages)
-            if user_error:
-                return user_error, tools_used, messages
+            response = await self.provider.chat(
+                messages=messages,
+                tools=self.tools.get_definitions(),
+                model=self.model,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                reasoning_effort=self.reasoning_effort,
+            )
 
             if response.has_tool_calls:
                 if on_progress:
@@ -300,8 +238,8 @@ class AgentLoop:
                 # Don't persist error responses to session history — they can
                 # poison the context and cause permanent 400 loops (#1303).
                 if response.finish_reason == "error":
-                    logger.error("LLM returned error: {}", (clean or "")[:300])
-                    final_content = self._friendly_error_message(clean)
+                    logger.error("LLM returned error: {}", (clean or "")[:200])
+                    final_content = clean or "Sorry, I encountered an error calling the AI model."
                     break
                 messages = self.context.add_assistant_message(
                     messages, clean, reasoning_content=response.reasoning_content,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -45,6 +45,8 @@ class AgentLoop:
     """
 
     _TOOL_RESULT_MAX_CHARS = 500
+    _CHAT_RETRY_MAX = 2
+    _CHAT_RETRY_BASE_DELAY_SECONDS = 0.8
 
     def __init__(
         self,
@@ -177,6 +179,71 @@ class AgentLoop:
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
+    @staticmethod
+    def _is_retryable_error(text: str | None) -> bool:
+        """Return True for transient provider errors that should be retried."""
+        t = (text or "").lower()
+        markers = (
+            "apiconnectionerror",
+            "server disconnected",
+            "timeout",
+            "temporarily unavailable",
+            "rate limit",
+            "429",
+            "connection reset",
+            "network",
+            "econnreset",
+        )
+        return any(marker in t for marker in markers)
+
+    @staticmethod
+    def _friendly_error_message(text: str | None) -> str:
+        """Map low-level provider errors into user-facing messages."""
+        t = (text or "").lower()
+        if any(marker in t for marker in ("401", "unauthorized", "invalid api key")):
+            return "Model authentication failed. Please check your API key."
+        if "rate limit" in t or "429" in t:
+            return "The model is rate-limiting requests. Please try again shortly."
+        if any(marker in t for marker in ("timeout", "apiconnectionerror", "server disconnected", "network")):
+            return "The model connection is unstable right now. Please try again."
+        return "Sorry, I encountered an error calling the AI model."
+
+    async def _chat_with_retry(self, messages: list[dict]) -> tuple[Any, str | None]:
+        """Call provider.chat with retry for transient errors."""
+        last_response = None
+        max_attempts = self._CHAT_RETRY_MAX + 1
+
+        for attempt in range(max_attempts):
+            response = await self.provider.chat(
+                messages=messages,
+                tools=self.tools.get_definitions(),
+                model=self.model,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                reasoning_effort=self.reasoning_effort,
+            )
+            last_response = response
+
+            if response.finish_reason != "error":
+                return response, None
+
+            clean_err = self._strip_think(response.content)
+            logger.warning(
+                "LLM returned error (attempt {}/{}): {}",
+                attempt + 1,
+                max_attempts,
+                (clean_err or "")[:300],
+            )
+
+            if (not self._is_retryable_error(clean_err)) or attempt == self._CHAT_RETRY_MAX:
+                logger.error("LLM failed after retries: {}", (clean_err or "")[:500])
+                return response, self._friendly_error_message(clean_err)
+
+            await asyncio.sleep(self._CHAT_RETRY_BASE_DELAY_SECONDS * (2 ** attempt))
+
+        clean_err = self._strip_think(getattr(last_response, "content", None))
+        return last_response, self._friendly_error_message(clean_err)
+
     async def _run_agent_loop(
         self,
         initial_messages: list[dict],
@@ -191,14 +258,9 @@ class AgentLoop:
         while iteration < self.max_iterations:
             iteration += 1
 
-            response = await self.provider.chat(
-                messages=messages,
-                tools=self.tools.get_definitions(),
-                model=self.model,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                reasoning_effort=self.reasoning_effort,
-            )
+            response, user_error = await self._chat_with_retry(messages)
+            if user_error:
+                return user_error, tools_used, messages
 
             if response.has_tool_calls:
                 if on_progress:
@@ -238,8 +300,8 @@ class AgentLoop:
                 # Don't persist error responses to session history — they can
                 # poison the context and cause permanent 400 loops (#1303).
                 if response.finish_reason == "error":
-                    logger.error("LLM returned error: {}", (clean or "")[:200])
-                    final_content = clean or "Sorry, I encountered an error calling the AI model."
+                    logger.error("LLM returned error: {}", (clean or "")[:300])
+                    final_content = self._friendly_error_message(clean)
                     break
                 messages = self.context.add_assistant_message(
                     messages, clean, reasoning_content=response.reasoning_content,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -222,6 +222,7 @@ class AgentLoop:
                     messages, response.content, tool_call_dicts,
                     reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
+                    reasoning_details=response.reasoning_details,
                 )
 
                 for tool_call in response.tool_calls:
@@ -243,6 +244,7 @@ class AgentLoop:
                 messages = self.context.add_assistant_message(
                     messages, clean, reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
+                    reasoning_details=response.reasoning_details,
                 )
                 final_content = clean
                 break

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from loguru import logger
 
+from nanobot.agent.context import ContextBuilder
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.shell import ExecTool
@@ -145,23 +146,15 @@ class SubagentManager:
                         }
                         for tc in response.tool_calls
                     ]
-                    messages.append({
-                        "role": "assistant",
-                        "content": response.content or "",
-                        "tool_calls": tool_call_dicts,
-                        **(
-                            {"reasoning_content": response.reasoning_content}
-                            if response.reasoning_content is not None else {}
-                        ),
-                        **(
-                            {"thinking_blocks": response.thinking_blocks}
-                            if response.thinking_blocks else {}
-                        ),
-                        **(
-                            {"reasoning_details": response.reasoning_details}
-                            if response.reasoning_details is not None else {}
-                        ),
-                    })
+                    messages.append(
+                        ContextBuilder.build_assistant_message(
+                            content=response.content or "",
+                            tool_calls=tool_call_dicts,
+                            reasoning_content=response.reasoning_content,
+                            thinking_blocks=response.thinking_blocks,
+                            reasoning_details=response.reasoning_details,
+                        )
+                    )
 
                     # Execute tools
                     for tool_call in response.tool_calls:
@@ -223,7 +216,6 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
     
     def _build_subagent_prompt(self) -> str:
         """Build a focused system prompt for the subagent."""
-        from nanobot.agent.context import ContextBuilder
         from nanobot.agent.skills import SkillsLoader
 
         time_ctx = ContextBuilder._build_runtime_context(None, None)

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -149,6 +149,18 @@ class SubagentManager:
                         "role": "assistant",
                         "content": response.content or "",
                         "tool_calls": tool_call_dicts,
+                        **(
+                            {"reasoning_content": response.reasoning_content}
+                            if response.reasoning_content is not None else {}
+                        ),
+                        **(
+                            {"thinking_blocks": response.thinking_blocks}
+                            if response.thinking_blocks else {}
+                        ),
+                        **(
+                            {"reasoning_details": response.reasoning_details}
+                            if response.reasoning_details is not None else {}
+                        ),
                     })
 
                     # Execute tools

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -22,6 +22,7 @@ class LLMResponse:
     usage: dict[str, int] = field(default_factory=dict)
     reasoning_content: str | None = None  # Kimi, DeepSeek-R1 etc.
     thinking_blocks: list[dict] | None = None  # Anthropic extended thinking
+    reasoning_details: Any | None = None  # MiniMax interleaved CoT metadata
     
     @property
     def has_tool_calls(self) -> bool:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -156,7 +156,13 @@ class LiteLLMProvider(LLMProvider):
         if spec:
             for pattern, overrides in spec.model_overrides:
                 if pattern in model_lower:
-                    kwargs.update(overrides)
+                    merged = dict(overrides)
+                    if "extra_body" in merged and isinstance(merged["extra_body"], dict):
+                        base_extra = kwargs.get("extra_body")
+                        extra_body = dict(base_extra) if isinstance(base_extra, dict) else {}
+                        extra_body.update(merged["extra_body"])
+                        merged["extra_body"] = extra_body
+                    kwargs.update(merged)
                     return
 
     @staticmethod

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -13,7 +13,9 @@ from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.providers.registry import find_by_model, find_gateway
 
 # Standard chat-completion message keys.
-_ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content"})
+_ALLOWED_MSG_KEYS = frozenset(
+    {"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content", "reasoning_details"}
+)
 _ANTHROPIC_EXTRA_KEYS = frozenset({"thinking_blocks"})
 _ALNUM = string.ascii_letters + string.digits
 
@@ -280,6 +282,11 @@ class LiteLLMProvider(LLMProvider):
 
         reasoning_content = getattr(message, "reasoning_content", None) or None
         thinking_blocks = getattr(message, "thinking_blocks", None) or None
+        reasoning_details = getattr(message, "reasoning_details", None) or None
+        if reasoning_details is None:
+            psf = getattr(message, "provider_specific_fields", None) or {}
+            if isinstance(psf, dict):
+                reasoning_details = psf.get("reasoning_details")
         
         return LLMResponse(
             content=message.content,
@@ -288,6 +295,7 @@ class LiteLLMProvider(LLMProvider):
             usage=usage,
             reasoning_content=reasoning_content,
             thinking_blocks=thinking_blocks,
+            reasoning_details=reasoning_details,
         )
 
     def get_default_model(self) -> str:

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -352,7 +352,11 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_base_keyword="",
         default_api_base="https://api.minimax.io/v1",
         strip_model_prefix=False,
-        model_overrides=(),
+        model_overrides=(
+            ("minimax-m2.5", {"reasoning_split": True}),
+            ("minimax-m2.1", {"reasoning_split": True}),
+            ("minimax-m2", {"reasoning_split": True}),
+        ),
     ),
 
     # === Local deployment (matched by config key, NOT by api_base) =========

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -353,9 +353,9 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://api.minimax.io/v1",
         strip_model_prefix=False,
         model_overrides=(
-            ("minimax-m2.5", {"reasoning_split": True}),
-            ("minimax-m2.1", {"reasoning_split": True}),
-            ("minimax-m2", {"reasoning_split": True}),
+            ("minimax-m2.5", {"extra_body": {"reasoning_split": True}}),
+            ("minimax-m2.1", {"extra_body": {"reasoning_split": True}}),
+            ("minimax-m2", {"extra_body": {"reasoning_split": True}}),
         ),
     ),
 

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import datetime as datetime_module
 
 from nanobot.agent.context import ContextBuilder
+from nanobot.providers.litellm_provider import LiteLLMProvider
 
 
 class _FakeDatetime(real_datetime):
@@ -64,3 +65,21 @@ def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
 
     assert messages[-1]["role"] == "user"
     assert messages[-1]["content"] == "Return exactly: OK"
+
+
+def test_minimax_model_overrides_enable_reasoning_split_in_extra_body() -> None:
+    provider = LiteLLMProvider(default_model="minimax/MiniMax-M2.5")
+    kwargs: dict[str, object] = {}
+
+    provider._apply_model_overrides("minimax/MiniMax-M2.5", kwargs)
+
+    assert kwargs.get("extra_body") == {"reasoning_split": True}
+
+
+def test_model_overrides_merge_extra_body_and_keep_existing_fields() -> None:
+    provider = LiteLLMProvider(default_model="minimax/MiniMax-M2.5")
+    kwargs: dict[str, object] = {"extra_body": {"foo": "bar"}}
+
+    provider._apply_model_overrides("minimax/MiniMax-M2.5", kwargs)
+
+    assert kwargs.get("extra_body") == {"foo": "bar", "reasoning_split": True}


### PR DESCRIPTION
## Summary
This PR improves reasoning metadata continuity across multi-turn conversations and configures MiniMax interleaved reasoning in a provider-configurable way.

## Changes
- Added `reasoning_details` to provider response model.
- Preserved `reasoning_details` in assistant message history for:
  - main agent loop
  - subagent loop
- Allowed `reasoning_details` through message sanitization in LiteLLM provider.
- Parsed `reasoning_details` from LiteLLM response (`message` and provider-specific fields fallback).
- Moved MiniMax `reasoning_split` enablement to provider registry `model_overrides` for:
  - `minimax-m2.5`
  - `minimax-m2.1`
  - `minimax-m2`

## Why
- Prevent loss of reasoning metadata between turns.
- Keep provider-specific behavior declarative in registry instead of hardcoding in request flow.
- Improve maintainability and extensibility for future provider-specific options.

## Validation
- Ran Python compile checks on touched core files.
- Verified branch contains only 6 changed files relevant to this feature.
