### PR TITLE
feat(usage): add usage.jsonl tool call, LLM call, and turn logging

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 import weakref
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -14,6 +15,7 @@ from loguru import logger
 
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.memory import MemoryStore
+from nanobot.agent.usage import UsageLog
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
@@ -85,6 +87,7 @@ class AgentLoop:
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
+        self.usage_log = UsageLog(workspace)
         self.tools = ToolRegistry()
         self.subagents = SubagentManager(
             provider=provider,
@@ -180,6 +183,7 @@ class AgentLoop:
     async def _run_agent_loop(
         self,
         initial_messages: list[dict],
+        session_key: str = "",
         on_progress: Callable[..., Awaitable[None]] | None = None,
     ) -> tuple[str | None, list[str], list[dict]]:
         """Run the agent iteration loop. Returns (final_content, tools_used, messages)."""
@@ -198,6 +202,14 @@ class AgentLoop:
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
                 reasoning_effort=self.reasoning_effort,
+            )
+            self.usage_log.log_llm_call(
+                session_key, iteration,
+                sys_chars=len((messages[0].get("content") or "") if messages else ""),
+                hist_chars=sum(len(m.get("content") or "") for m in messages[1:]),
+                tool_definitions=len(self.tools.get_definitions()),
+                prompt_tokens=response.usage.get("prompt_tokens") if response.usage else None,
+                completion_tokens=response.usage.get("completion_tokens") if response.usage else None,
             )
 
             if response.has_tool_calls:
@@ -228,7 +240,13 @@ class AgentLoop:
                     tools_used.append(tool_call.name)
                     args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
                     logger.info("Tool call: {}({})", tool_call.name, args_str[:200])
+                    _t0 = time.monotonic()
                     result = await self.tools.execute(tool_call.name, tool_call.arguments)
+                    self.usage_log.log_tool_call(
+                        session_key, tool_call.name, tool_call.arguments,
+                        int((time.monotonic() - _t0) * 1000),
+                        not result.startswith("Error"),
+                    )
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
@@ -347,7 +365,8 @@ class AgentLoop:
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
             )
-            final_content, _, all_msgs = await self._run_agent_loop(messages)
+            final_content, tools_used, all_msgs = await self._run_agent_loop(messages, session_key=key)
+            self.usage_log.log_turn(key, tools_used)
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
             return OutboundMessage(channel=channel, chat_id=chat_id,
@@ -432,9 +451,10 @@ class AgentLoop:
                 channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
             ))
 
-        final_content, _, all_msgs = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
+        final_content, tools_used, all_msgs = await self._run_agent_loop(
+            initial_messages, session_key=key, on_progress=on_progress or _bus_progress,
         )
+        self.usage_log.log_turn(key, tools_used)
 
         if final_content is None:
             final_content = "I've completed processing but have no response to give."

--- a/nanobot/agent/usage.py
+++ b/nanobot/agent/usage.py
@@ -1,0 +1,85 @@
+"""Usage log: append-only JSONL record of tool calls and agent turns."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class UsageLog:
+    """Writes usage.jsonl at the workspace root.
+
+    Three event types:
+      tool_call — one record per tool execution, with timing and ok flag.
+      llm_call  — one record per LLM provider call, with token and context stats.
+      turn      — one record per agent turn, summarising tools used.
+
+    Failures are silently swallowed — usage logging must never break the agent.
+    """
+
+    def __init__(self, workspace: Path):
+        self._file = workspace / "usage.jsonl"
+
+    def _write(self, record: dict[str, Any]) -> None:
+        try:
+            with open(self._file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except Exception:
+            pass
+
+    def log_tool_call(
+        self,
+        session: str,
+        tool: str,
+        args: dict[str, Any] | None,
+        duration_ms: int,
+        ok: bool,
+    ) -> None:
+        """Record a single tool execution."""
+        # First string arg value — enough to identify target (path, query, command)
+        # without storing full content.
+        arg = next((v for v in (args or {}).values() if isinstance(v, str)), None)
+        self._write({
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "event": "tool_call",
+            "session": session,
+            "tool": tool,
+            "arg": arg,
+            "duration_ms": duration_ms,
+            "ok": ok,
+        })
+
+    def log_llm_call(
+        self,
+        session: str,
+        iteration: int,
+        sys_chars: int,
+        hist_chars: int,
+        tool_definitions: int,
+        prompt_tokens: int | None,
+        completion_tokens: int | None,
+    ) -> None:
+        """Record a single LLM provider call with context size and token usage."""
+        self._write({
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "event": "llm_call",
+            "session": session,
+            "iteration": iteration,
+            "sys_chars": sys_chars,
+            "hist_chars": hist_chars,
+            "tool_definitions": tool_definitions,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+        })
+
+    def log_turn(self, session: str, tools_used: list[str]) -> None:
+        """Record a completed agent turn."""
+        self._write({
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "event": "turn",
+            "session": session,
+            "tools": tools_used,
+            "tool_calls": len(tools_used),
+        })


### PR DESCRIPTION
- Add UsageLog (nanobot/agent/usage.py): append-only JSONL at workspace/usage.jsonl with three event types:
  - tool_call: session, tool, first string arg, duration_ms, ok flag
  - llm_call: session, iteration, sys_chars, hist_chars, tool_definitions, prompt_tokens, completion_tokens
  - turn: session, tools list, tool_calls count
- Wire into AgentLoop: UsageLog instantiated in __init__; tool execution wrapped with time.monotonic() timing; log_llm_call after every provider.chat() call; log_turn at both _process_message call sites
- Failures silently swallowed — never breaks the agent