### PR TITLE
fix(whatsapp): allow fromMe messages so linked-device owner can chat …

### DIFF
--- a/bridge/src/whatsapp.ts
+++ b/bridge/src/whatsapp.ts
@@ -110,8 +110,7 @@ export class WhatsAppClient {
       if (type !== 'notify') return;
 
       for (const msg of messages) {
-        // Skip own messages
-        if (msg.key.fromMe) continue;
+        console.log(`[DEBUG] msg: fromMe=${msg.key.fromMe}, jid=${msg.key.remoteJid}, hasMessage=${!!msg.message}`);
 
         // Skip status updates
         if (msg.key.remoteJid === 'status@broadcast') continue;

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -94,6 +94,7 @@ class WhatsAppChannel(BaseChannel):
 
     async def _handle_bridge_message(self, raw: str) -> None:
         """Handle a message from the bridge."""
+        logger.debug("Bridge raw message: {}", raw[:200])
         try:
             data = json.loads(raw)
         except json.JSONDecodeError:


### PR DESCRIPTION
…with bot

WhatsApp linked devices see the owner's outgoing messages as fromMe=true. The bridge was unconditionally skipping these, preventing the account owner from interacting with the bot. Remove the fromMe gate and add debug logging to both bridge and Python channel for easier troubleshooting.