### PR TITLE
docs: fix allowFrom description for post-v0.1.4.post3 behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ pip install nanobot-ai[matrix]
 
 | Option | Description |
 |--------|-------------|
-| `allowFrom` | User IDs allowed to interact. Empty = all senders. |
+| `allowFrom` | User IDs allowed to interact. Empty = deny all; use `["*"]` to allow all. |
 | `groupPolicy` | `open` (default), `mention`, or `allowlist`. |
 | `groupAllowFrom` | Room allowlist (used when policy is `allowlist`). |
 | `allowRoomMentions` | Accept `@room` mentions in mention mode. |
@@ -881,7 +881,7 @@ MCP tools are automatically discovered and registered on startup. The LLM can us
 |--------|---------|-------------|
 | `tools.restrictToWorkspace` | `false` | When `true`, restricts **all** agent tools (shell, file read/write/edit, list) to the workspace directory. Prevents path traversal and out-of-scope access. |
 | `tools.exec.pathAppend` | `""` | Extra directories to append to `PATH` when running shell commands (e.g. `/usr/sbin` for `ufw`). |
-| `channels.*.allowFrom` | `[]` (allow all) | Whitelist of user IDs. Empty = allow everyone; non-empty = only listed users can interact. |
+| `channels.*.allowFrom` | `[]` (deny all) | Whitelist of user IDs. Empty = deny all; use `["*"]` to allow all; otherwise only listed users can interact. |
 
 
 ## CLI Reference


### PR DESCRIPTION
## Summary
- Matrix options table: clarify that empty `allowFrom` = deny all; use `["*"]` to allow all.
- Security table: update `channels.*.allowFrom` row to match current default (empty = deny all; use `["*"]` to allow all).

## Motivation
README and Security tip already state that in post-v0.1.4.post3 empty `allowFrom` denies all, but the Matrix and Security tables still said "Empty = all senders" / "Empty = allow everyone". This aligns the tables with the actual behavior.

Made with [Cursor](https://cursor.com)