### PR TITLE
Fix: Convert skills summary from XML to Markdown to prevent tool-call syntax pollution with DeepSeek models

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -46,7 +46,7 @@ class ContextBuilder:
             parts.append(f"""# Skills
 
 The following skills extend your capabilities. To use a skill, read its SKILL.md file using the read_file tool.
-Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
+Skills marked as unavailable need dependencies installed first - you can try installing them with apt/brew.
 
 {skills_summary}""")
 

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -46,7 +46,7 @@ class ContextBuilder:
             parts.append(f"""# Skills
 
 The following skills extend your capabilities. To use a skill, read its SKILL.md file using the read_file tool.
-Skills marked as unavailable need dependencies installed first - you can try installing them with apt/brew.
+Skills with `available: false` need dependencies installed first - you can try installing them with apt/brew.
 
 {skills_summary}""")
 

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -106,38 +106,34 @@ class SkillsLoader:
         skill content using read_file when needed.
 
         Returns:
-            XML-formatted skills summary.
+            Markdown-formatted skills summary.
         """
         all_skills = self.list_skills(filter_unavailable=False)
         if not all_skills:
             return ""
 
-        def escape_xml(s: str) -> str:
-            return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
-        lines = ["<skills>"]
+        lines = []
         for s in all_skills:
-            name = escape_xml(s["name"])
+            name = s["name"]
             path = s["path"]
-            desc = escape_xml(self._get_skill_description(s["name"]))
+            desc = self._get_skill_description(s["name"])
             skill_meta = self._get_skill_meta(s["name"])
             available = self._check_requirements(skill_meta)
 
-            lines.append(f"  <skill available=\"{str(available).lower()}\">")
-            lines.append(f"    <name>{name}</name>")
-            lines.append(f"    <description>{desc}</description>")
-            lines.append(f"    <location>{path}</location>")
+            lines.append(f"- **{name}**")
+            lines.append(f"  - available: {str(available).lower()}")
+            lines.append(f"  - description: {desc}")
+            lines.append(f"  - location: {path}")
 
             # Show missing requirements for unavailable skills
             if not available:
                 missing = self._get_missing_requirements(skill_meta)
                 if missing:
-                    lines.append(f"    <requires>{escape_xml(missing)}</requires>")
+                    lines.append(f"  - requires: {missing}")
 
-            lines.append("  </skill>")
-        lines.append("</skills>")
+            lines.append("")
 
-        return "\n".join(lines)
+        return "\n".join(lines).strip()
 
     def _get_missing_requirements(self, skill_meta: dict) -> str:
         """Get a description of missing requirements."""


### PR DESCRIPTION
### Problem

When using DeepSeek-V3 (or DeepSeek-V3-0324) as the underlying model, the system prompt's skills summary is formatted as XML:

```XML
<skills>
  <skill available="true">
    <name>github</name>
    <description>Interact with GitHub using the `gh` CLI.</description>
    <location>/path/to/SKILL.md</location>
  </skill>
</skills>
```
DeepSeek models express tool calls using a special XML-like syntax in their responses (e.g. <｜DSML｜function_calls>). The presence of XML in the system prompt contaminates the model's parsing context, causing it to misinterpret or corrupt its own tool-call response syntax. This leads to broken or malformed tool invocations when using DeepSeek models.
<img width="561" height="277" alt="image" src="https://github.com/user-attachments/assets/92a8a623-f97a-4283-8528-3b53207bb90c" />


### Solution

Replace the XML-formatted skills summary with a Markdown bullet-list format:

```Markdown
- **github**
  - available: true
  - description: Interact with GitHub using the `gh` CLI.
  - location: /path/to/SKILL.md
```

### Changes made:

nanobot/agent/skills.py — SkillsLoader.build_skills_summary(): Replaces XML tags and XML escaping with a plain Markdown bullet list.
nanobot/agent/context.py — ContextBuilder.build_system_prompt(): Updates the description text (removes the available="false" XML attribute reference) to match the new Markdown format.

### Impact

✅ Fixes the tool-call syntax pollution issue when using DeepSeek models.
✅ No side effects for other models (GPT-4, Claude, etc.) — Markdown is universally well-understood by all LLMs as a way to structure information in system prompts.
✅ No changes to the skills loading or availability-checking logic.from XML to Markdown format