### PR TITLE
fix: merge consecutive user messages to prevent API errors

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -112,11 +112,20 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         chat_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
+        runtime_ctx = self._build_runtime_context(channel, chat_id)
+        user_content = self._build_user_content(current_message, media)
+
+        # Merge runtime context and user content into a single user message
+        # to avoid consecutive same-role messages that some providers reject.
+        if isinstance(user_content, str):
+            merged = f"{runtime_ctx}\n\n{user_content}"
+        else:
+            merged = [{"type": "text", "text": runtime_ctx}] + user_content
+
         return [
             {"role": "system", "content": self.build_system_prompt(skill_names)},
             *history,
-            {"role": "user", "content": self._build_runtime_context(channel, chat_id)},
-            {"role": "user", "content": self._build_user_content(current_message, media)},
+            {"role": "user", "content": merged},
         ]
 
     def _build_user_content(self, text: str, media: list[str] | None) -> str | list[dict[str, Any]]:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -464,14 +464,23 @@ class AgentLoop:
                 entry["content"] = content[:self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
             elif role == "user":
                 if isinstance(content, str) and content.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
-                    continue
+                    # Strip the runtime-context prefix, keep only the user text.
+                    parts = content.split("\n\n", 1)
+                    if len(parts) > 1 and parts[1].strip():
+                        entry["content"] = parts[1]
+                    else:
+                        continue
                 if isinstance(content, list):
-                    entry["content"] = [
-                        {"type": "text", "text": "[image]"} if (
-                            c.get("type") == "image_url"
-                            and c.get("image_url", {}).get("url", "").startswith("data:image/")
-                        ) else c for c in content
-                    ]
+                    filtered = []
+                    for c in content:
+                        if c.get("type") == "text" and isinstance(c.get("text"), str) and c["text"].startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
+                            continue  # Strip runtime context from multimodal messages
+                        if (c.get("type") == "image_url"
+                                and c.get("image_url", {}).get("url", "").startswith("data:image/")):
+                            filtered.append({"type": "text", "text": "[image]"})
+                        else:
+                            filtered.append(c)
+                    entry["content"] = filtered
             entry.setdefault("timestamp", datetime.now().isoformat())
             session.messages.append(entry)
         session.updated_at = datetime.now()


### PR DESCRIPTION
## Summary

- Merges runtime context and user content into a single `{"role": "user"}` message in `build_messages()` to avoid consecutive same-role messages
- Updates `_save_turn()` to strip the runtime context prefix from the merged message when persisting to session history
- Handles both plain text and multimodal (image) content correctly

## Problem

`ContextBuilder.build_messages()` produces two consecutive `role: user` messages:

```python
return [
    {"role": "system", "content": ...},
    *history,
    {"role": "user", "content": self._build_runtime_context(...)},  # runtime ctx
    {"role": "user", "content": self._build_user_content(...)},     # actual message
]
```

Some LLM providers (Minimax, Dashscope/Qwen) strictly validate message format and reject consecutive messages from the same role with:

```
Invalid type for 'messages.[0].content': expected one of a string or array of objects, but got an object instead.
```

OpenAI and Anthropic are more lenient and accept this, which is why the bug only surfaces with stricter providers.

## Fix

Merge the two user messages into one before sending:

```python
if isinstance(user_content, str):
    merged = f"{runtime_ctx}\n\n{user_content}"
else:
    merged = [{"type": "text", "text": runtime_ctx}] + user_content
```

## Test plan

- [ ] Verify text-only messages work with Minimax/Dashscope providers
- [ ] Verify multimodal messages (image + text) still work correctly
- [ ] Verify session history saves user content without runtime context prefix
- [ ] Verify existing OpenAI/Anthropic providers continue to work

Fixes #1414
Fixes #1344