### PR TITLE
fix: implement groupPolicy filtering for Telegram channel

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -126,6 +126,7 @@ class TelegramChannel(BaseChannel):
         self.config: TelegramConfig = config
         self.groq_api_key = groq_api_key
         self._app: Application | None = None
+        self._bot_username: str | None = None  # Stored on startup for mention detection
         self._chat_ids: dict[str, int] = {}  # Map sender_id to chat_id for replies
         self._typing_tasks: dict[str, asyncio.Task] = {}  # chat_id -> typing loop task
         self._media_group_buffers: dict[str, dict] = {}
@@ -169,6 +170,7 @@ class TelegramChannel(BaseChannel):
 
         # Get bot info and register command menu
         bot_info = await self._app.bot.get_me()
+        self._bot_username = bot_info.username
         logger.info("Telegram bot @{} connected", bot_info.username)
 
         try:
@@ -328,6 +330,31 @@ class TelegramChannel(BaseChannel):
             content=update.message.text,
         )
 
+    def _should_respond_in_group(self, message) -> bool:
+        """Check whether the bot should respond to a group message based on group_policy."""
+        policy = self.config.group_policy
+
+        if policy == "open":
+            return True
+
+        if policy == "allowlist":
+            return str(message.chat_id) in self.config.group_allow_from
+
+        # policy == "mention"
+        # Check if the message is a reply to one of the bot's messages
+        if message.reply_to_message and message.reply_to_message.from_user:
+            if message.reply_to_message.from_user.is_bot and self._bot_username:
+                if message.reply_to_message.from_user.username == self._bot_username:
+                    return True
+
+        # Check if the bot is @mentioned in the text
+        if self._bot_username:
+            text = message.text or message.caption or ""
+            if f"@{self._bot_username}" in text:
+                return True
+
+        return False
+
     async def _on_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming messages (text, photos, voice, documents)."""
         if not update.message or not update.effective_user:
@@ -337,6 +364,10 @@ class TelegramChannel(BaseChannel):
         user = update.effective_user
         chat_id = message.chat_id
         sender_id = self._sender_id(user)
+
+        # Apply group policy filter for non-private chats
+        if message.chat.type != "private" and not self._should_respond_in_group(message):
+            return
 
         # Store chat_id for replies
         self._chat_ids[sender_id] = chat_id

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -31,6 +31,8 @@ class TelegramConfig(Base):
     allow_from: list[str] = Field(default_factory=list)  # Allowed user IDs or usernames
     proxy: str | None = None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
     reply_to_message: bool = False  # If true, bot replies quote the original message
+    group_policy: Literal["open", "mention", "allowlist"] = "mention"  # Group message policy
+    group_allow_from: list[str] = Field(default_factory=list)  # Allowed group chat IDs (for allowlist policy)
 
 
 class FeishuConfig(Base):


### PR DESCRIPTION
## Summary

- Adds `group_policy` and `group_allow_from` configuration fields to `TelegramConfig`
- Implements `_should_respond_in_group()` with three policies: `open`, `mention`, `allowlist`
- Stores bot username on startup for @mention detection
- Filters group messages in `_on_message` before processing

## Problem

The Telegram channel completely lacks group policy support. The `_on_message` method forwards every group message to `_handle_message` without checking if the bot was mentioned or if the message is a reply. This means the bot responds to **every single message** in group chats, regardless of the `groupPolicy` configuration.

Other channels (Slack, Matrix, Mochat) already have proper group policy filtering. Telegram was the only major channel missing this feature.

## Implementation

Following the Slack channel's pattern:

**Config** (`schema.py`):
```python
group_policy: Literal["open", "mention", "allowlist"] = "mention"
group_allow_from: list[str] = Field(default_factory=list)
```

Default is `"mention"` — safe default that prevents the bot from flooding group chats.

**Filter logic** (`telegram.py`):
- `"open"` — respond to all group messages
- `"mention"` — only respond when `@botname` is in the text or the message is a reply to the bot
- `"allowlist"` — only respond in group chats whose chat_id is in `group_allow_from`

Private (DM) conversations are unaffected.

## Test plan

- [ ] Verify bot still responds to all DMs (private chats)
- [ ] Verify `"mention"` policy: bot ignores group messages without @mention
- [ ] Verify `"mention"` policy: bot responds when @mentioned in group
- [ ] Verify `"mention"` policy: bot responds when message replies to bot's message
- [ ] Verify `"open"` policy: bot responds to all group messages
- [ ] Verify `"allowlist"` policy: bot only responds in listed group IDs

Fixes #1380