### PR TITLE
fix: prevent cron job from scheduling new jobs (feedback loop)

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -14,11 +14,16 @@ class CronTool(Tool):
         self._cron = cron_service
         self._channel = ""
         self._chat_id = ""
+        self._in_cron_context = False
 
     def set_context(self, channel: str, chat_id: str) -> None:
         """Set the current session context for delivery."""
         self._channel = channel
         self._chat_id = chat_id
+
+    def set_cron_context(self, active: bool) -> None:
+        """Mark whether the tool is executing inside a cron job callback."""
+        self._in_cron_context = active
 
     @property
     def name(self) -> str:
@@ -72,6 +77,8 @@ class CronTool(Tool):
         **kwargs: Any,
     ) -> str:
         if action == "add":
+            if self._in_cron_context:
+                return "Error: cannot schedule new jobs from within a cron job execution"
             return self._add_job(message, every_seconds, cron_expr, tz, at)
         elif action == "list":
             return self._list_jobs()

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -296,6 +296,7 @@ def gateway(
     # Set cron callback (needs agent)
     async def on_cron_job(job: CronJob) -> str | None:
         """Execute a cron job through the agent."""
+        from nanobot.agent.tools.cron import CronTool
         from nanobot.agent.tools.message import MessageTool
         reminder_note = (
             "[Scheduled Task] Timer finished.\n\n"
@@ -303,12 +304,20 @@ def gateway(
             f"Scheduled instruction: {job.payload.message}"
         )
 
-        response = await agent.process_direct(
-            reminder_note,
-            session_key=f"cron:{job.id}",
-            channel=job.payload.channel or "cli",
-            chat_id=job.payload.to or "direct",
-        )
+        # Prevent the agent from scheduling new cron jobs during execution
+        cron_tool = agent.tools.get("cron")
+        if isinstance(cron_tool, CronTool):
+            cron_tool.set_cron_context(True)
+        try:
+            response = await agent.process_direct(
+                reminder_note,
+                session_key=f"cron:{job.id}",
+                channel=job.payload.channel or "cli",
+                chat_id=job.payload.to or "direct",
+            )
+        finally:
+            if isinstance(cron_tool, CronTool):
+                cron_tool.set_cron_context(False)
 
         message_tool = agent.tools.get("message")
         if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:


### PR DESCRIPTION
## Summary

- Adds `_in_cron_context` flag to `CronTool` to track when executing inside a cron job
- Blocks `cron add` operations during cron execution, returning a clear error message
- Sets the flag in `on_cron_job` callback with proper cleanup via `try/finally`

## Problem

When a cron job executes, it calls `process_direct()` which gives the agent full access to all tools, including the cron tool itself. If the original scheduled message resembles a scheduling instruction (e.g., "Remind me in 10 seconds"), the agent interprets the cron payload as a new user request and calls `cron({"action": "add", ...})`, creating an infinite recursion:

```
1. Cron fires → process_direct("⏰ 1 min test")
2. Agent processes → sees "remind" instruction → calls cron.add()
3. New cron job fires → process_direct("⏰ 1 min test")
4. → infinite loop
```

This was reported with Telegram but affects all channels.

## Fix

Guard the `CronTool.execute()` method with a context flag:

```python
if action == "add" and self._in_cron_context:
    return "Error: cannot schedule new jobs from within a cron job execution"
```

The flag is set before `process_direct()` and cleared in a `finally` block:

```python
cron_tool.set_cron_context(True)
try:
    response = await agent.process_direct(...)
finally:
    cron_tool.set_cron_context(False)
```

`list` and `remove` actions remain available during cron execution — only `add` is blocked.

## Test plan

- [ ] Verify cron jobs execute normally without feedback loop
- [ ] Verify agent cannot schedule new jobs during cron execution
- [ ] Verify `cron list` and `cron remove` still work during execution
- [ ] Verify the flag is properly reset even if the agent errors

Fixes #1441