### PR TITLE
feat(dingtalk): add support for group chat messages

### DIFF
--- a/nanobot/channels/dingtalk.py
+++ b/nanobot/channels/dingtalk.py
@@ -315,7 +315,7 @@ class DingTalkChannel(BaseChannel):
             payload = {
                 "robotCode": self.config.client_id,
                 "openConversationId": chat_id[6:],  # Remove "group:" prefix,
-                "msgKey": "msg_key",
+                "msgKey": msg_key,
                 "msgParam": json.dumps(msg_param, ensure_ascii=False),
             }
         else:


### PR DESCRIPTION
## Summary
- Add support for DingTalk group chat messages, enabling the bot to receive and respond in group conversations
- Automatically detect message type (group vs private) based on `conversationType` field
- Use appropriate API endpoints for each message type:
  - Group chat: `/v1.0/robot/groupMessages/send`
  - Private chat: `/v1.0/robot/oToMessages/batchSend`
- Group chat replies now mention the original sender for better context. But in reality, there is no @ effect; it's just text. DingTalk's official documentation has interface explanations.

<img width="703" height="622" alt="image" src="https://github.com/user-attachments/assets/ae53ec9c-8250-498b-a1c4-e5ffb9b696a5" />


> https://open.dingtalk.com/document/development/the-robot-sends-a-group-message

<img width="981" height="463" alt="image" src="https://github.com/user-attachments/assets/58592b3c-7527-4f23-a615-07101ca1d3a4" />


## Changes
- **Receive**: Detect `conversationType` from incoming messages and prefix group chat IDs with `group:` for routing
- **Send**: Route messages to the correct DingTalk API based on the `group:` prefix in `chat_id`
- **Mention**: Automatically append `@{sender_name}` in group chat responses

Resolves #1045 