### PR TITLE
refactor(context): simplify runtime-context merge logic

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -102,6 +102,16 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
 
         return "\n\n".join(parts) if parts else ""
 
+    def _merge_runtime_context(
+        self,
+        runtime_ctx: str,
+        user_content: str | list[dict[str, Any]],
+    ) -> str | list[dict[str, Any]]:
+        """Merge runtime metadata into the current user message content."""
+        if isinstance(user_content, str):
+            return f"{runtime_ctx}\n\n{user_content}"
+        return [{"type": "text", "text": runtime_ctx}, *user_content]
+
     def build_messages(
         self,
         history: list[dict[str, Any]],
@@ -114,18 +124,12 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         """Build the complete message list for an LLM call."""
         runtime_ctx = self._build_runtime_context(channel, chat_id)
         user_content = self._build_user_content(current_message, media)
-
-        # Merge runtime context and user content into a single user message
-        # to avoid consecutive same-role messages that some providers reject.
-        if isinstance(user_content, str):
-            merged = f"{runtime_ctx}\n\n{user_content}"
-        else:
-            merged = [{"type": "text", "text": runtime_ctx}] + user_content
+        merged_content = self._merge_runtime_context(runtime_ctx, user_content)
 
         return [
             {"role": "system", "content": self.build_system_prompt(skill_names)},
             *history,
-            {"role": "user", "content": merged},
+            {"role": "user", "content": merged_content},
         ]
 
     def _build_user_content(self, text: str, media: list[str] | None) -> str | list[dict[str, Any]]:

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -39,8 +39,8 @@ def test_system_prompt_stays_stable_when_clock_changes(tmp_path, monkeypatch) ->
     assert prompt1 == prompt2
 
 
-def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
-    """Runtime metadata should be a separate user message before the actual user message."""
+def test_runtime_context_is_merged_into_untrusted_user_message(tmp_path) -> None:
+    """Runtime metadata should be merged into the current user message payload."""
     workspace = _make_workspace(tmp_path)
     builder = ContextBuilder(workspace)
 
@@ -54,13 +54,11 @@ def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
     assert messages[0]["role"] == "system"
     assert "## Current Session" not in messages[0]["content"]
 
-    assert messages[-2]["role"] == "user"
-    runtime_content = messages[-2]["content"]
-    assert isinstance(runtime_content, str)
-    assert ContextBuilder._RUNTIME_CONTEXT_TAG in runtime_content
-    assert "Current Time:" in runtime_content
-    assert "Channel: cli" in runtime_content
-    assert "Chat ID: direct" in runtime_content
-
     assert messages[-1]["role"] == "user"
-    assert messages[-1]["content"] == "Return exactly: OK"
+    merged_content = messages[-1]["content"]
+    assert isinstance(merged_content, str)
+    assert ContextBuilder._RUNTIME_CONTEXT_TAG in merged_content
+    assert "Current Time:" in merged_content
+    assert "Channel: cli" in merged_content
+    assert "Chat ID: direct" in merged_content
+    assert "Return exactly: OK" in merged_content


### PR DESCRIPTION
## Summary
- extract runtime-context merge into a dedicated helper (`_merge_runtime_context`)
- keep message-shape behavior unchanged (runtime metadata remains merged into the current user message)
- align/refresh context prompt cache test assertion with current merged-message behavior

## Why
PR #1417 logic is functionally fine but can be made simpler and easier to read/maintain by removing inline branching from `build_messages`.

## Behavior
No functional change intended:
- string user content -> `runtime_ctx + "\n\n" + user text`
- multimodal user content -> prepend runtime text block to content array

## Test
- `uv run pytest -q tests/test_context_prompt_cache.py`

Both tests pass locally.
