### PR TITLE
fix: add missed `openai` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "prompt-toolkit>=3.0.50,<4.0.0",
     "mcp>=1.26.0,<2.0.0",
     "json-repair>=0.57.0,<1.0.0",
+    "openai>=2.8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The `openai` package is currently directly dependent in this repository, but it does not appear in `pyproject.toml`. Instead, it is indirectly imported via `litellm`.

https://github.com/HKUDS/nanobot/blob/c05cb2ef64ce8eaa0257e1ae677a64ea7309f243/nanobot/providers/custom_provider.py#L8

uv.lock:
```
[[package]]
name = "litellm"
version = "1.82.0"
source = { registry = "https://pypi.org/simple" }
dependencies = [
    { name = "aiohttp" },
    { name = "click" },
    { name = "fastuuid" },
    { name = "httpx" },
    { name = "importlib-metadata" },
    { name = "jinja2" },
    { name = "jsonschema" },
    { name = "openai" },
    { name = "pydantic" },
    { name = "python-dotenv" },
    { name = "tiktoken" },
    { name = "tokenizers" },
]
```