### PR TITLE
feat(config): add subagent LLM configuration support

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -49,14 +49,10 @@ class AgentLoop:
     def __init__(
         self,
         bus: MessageBus,
-        provider: LLMProvider,
         workspace: Path,
-        model: str | None = None,
+        agent_config: dict,
         max_iterations: int = 40,
-        temperature: float = 0.1,
-        max_tokens: int = 4096,
         memory_window: int = 100,
-        reasoning_effort: str | None = None,
         brave_api_key: str | None = None,
         web_proxy: str | None = None,
         exec_config: ExecToolConfig | None = None,
@@ -65,18 +61,19 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        subagent_config: dict | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
         self.channels_config = channels_config
-        self.provider = provider
+        self.provider = agent_config["provider"]
         self.workspace = workspace
-        self.model = model or provider.get_default_model()
+        self.model = agent_config["model"]
         self.max_iterations = max_iterations
-        self.temperature = temperature
-        self.max_tokens = max_tokens
+        self.temperature = agent_config["temperature"]
+        self.max_tokens = agent_config["max_tokens"]
         self.memory_window = memory_window
-        self.reasoning_effort = reasoning_effort
+        self.reasoning_effort = agent_config.get("reasoning_effort")
         self.brave_api_key = brave_api_key
         self.web_proxy = web_proxy
         self.exec_config = exec_config or ExecToolConfig()
@@ -86,14 +83,17 @@ class AgentLoop:
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
+
+        # Build subagent config with fallbacks to main agent settings
+        sub = subagent_config or {}
         self.subagents = SubagentManager(
-            provider=provider,
+            provider=sub.get("provider", self.provider),
             workspace=workspace,
             bus=bus,
-            model=self.model,
-            temperature=self.temperature,
-            max_tokens=self.max_tokens,
-            reasoning_effort=reasoning_effort,
+            model=sub.get("model", self.model),
+            temperature=sub.get("temperature", self.temperature),
+            max_tokens=sub.get("max_tokens", self.max_tokens),
+            reasoning_effort=sub.get("reasoning_effort", self.reasoning_effort),
             brave_api_key=brave_api_key,
             web_proxy=web_proxy,
             exec_config=self.exec_config,

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -6,6 +6,7 @@ import select
 import signal
 import sys
 from pathlib import Path
+from typing import TypedDict
 
 import typer
 from prompt_toolkit import PromptSession
@@ -198,15 +199,29 @@ def onboard():
 
 
 
-def _make_provider(config: Config):
-    """Create the appropriate LLM provider from config."""
+class AgentRuntimeConfig(TypedDict):
+    """Runtime configuration for an agent (main or subagent)."""
+    provider: object  # LLMProvider, use object to avoid circular import
+    model: str
+    max_tokens: int
+    temperature: float
+    reasoning_effort: str | None
+
+
+def _create_provider(config: Config, model: str, provider: str | None = None):
+    """Create LLM provider for given model. Raises error if no API key.
+
+    Args:
+        config: Config object
+        model: Model name
+        provider: Provider override (e.g., "zhipu", "dashscope"). None or "auto" means auto-detect.
+    """
     from nanobot.providers.custom_provider import CustomProvider
     from nanobot.providers.litellm_provider import LiteLLMProvider
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
 
-    model = config.agents.defaults.model
-    provider_name = config.get_provider_name(model)
-    p = config.get_provider(model)
+    provider_name = config.get_provider_name(model, provider)
+    p = config.get_provider(model, provider)
 
     # OpenAI Codex (OAuth)
     if provider_name == "openai_codex" or model.startswith("openai-codex/"):
@@ -216,7 +231,7 @@ def _make_provider(config: Config):
     if provider_name == "custom":
         return CustomProvider(
             api_key=p.api_key if p else "no-key",
-            api_base=config.get_api_base(model) or "http://localhost:8000/v1",
+            api_base=config.get_api_base(model, provider) or "http://localhost:8000/v1",
             default_model=model,
         )
 
@@ -229,11 +244,36 @@ def _make_provider(config: Config):
 
     return LiteLLMProvider(
         api_key=p.api_key if p else None,
-        api_base=config.get_api_base(model),
+        api_base=config.get_api_base(model, provider),
         default_model=model,
         extra_headers=p.extra_headers if p else None,
         provider_name=provider_name,
     )
+
+
+def _get_agent_config(config: Config, agent_cfg, shared_provider=None) -> AgentRuntimeConfig:
+    """Build runtime config for an agent.
+
+    Args:
+        config: Full config object
+        agent_cfg: AgentDefaults object (main or subagent)
+        shared_provider: Existing provider to reuse if same provider type
+    """
+    # Reuse provider if same provider type (model can differ)
+    main_provider_name = config.get_provider_name(config.agents.defaults.model, config.agents.defaults.provider)
+    agent_provider_name = config.get_provider_name(agent_cfg.model, agent_cfg.provider)
+    if shared_provider and agent_provider_name == main_provider_name:
+        provider = shared_provider
+    else:
+        provider = _create_provider(config, agent_cfg.model, agent_cfg.provider)
+
+    return {
+        "provider": provider,
+        "model": agent_cfg.model,
+        "max_tokens": agent_cfg.max_tokens,
+        "temperature": agent_cfg.temperature,
+        "reasoning_effort": agent_cfg.reasoning_effort,
+    }
 
 
 # ============================================================================
@@ -265,8 +305,11 @@ def gateway(
     config = load_config()
     sync_workspace_templates(config.workspace_path)
     bus = MessageBus()
-    provider = _make_provider(config)
     session_manager = SessionManager(config.workspace_path)
+
+    # Get agent configs (main + subagent)
+    main_cfg = _get_agent_config(config, config.agents.defaults)
+    sub_cfg = _get_agent_config(config, config.agents.subagent or config.agents.defaults, shared_provider=main_cfg["provider"])
 
     # Create cron service first (callback set after agent creation)
     cron_store_path = get_data_dir() / "cron" / "jobs.json"
@@ -275,14 +318,10 @@ def gateway(
     # Create agent with cron service
     agent = AgentLoop(
         bus=bus,
-        provider=provider,
         workspace=config.workspace_path,
-        model=config.agents.defaults.model,
-        temperature=config.agents.defaults.temperature,
-        max_tokens=config.agents.defaults.max_tokens,
+        agent_config=main_cfg,
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
-        reasoning_effort=config.agents.defaults.reasoning_effort,
         brave_api_key=config.tools.web.search.api_key or None,
         web_proxy=config.tools.web.proxy or None,
         exec_config=config.tools.exec,
@@ -291,6 +330,7 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_config=sub_cfg,
     )
 
     # Set cron callback (needs agent)
@@ -380,7 +420,7 @@ def gateway(
     hb_cfg = config.gateway.heartbeat
     heartbeat = HeartbeatService(
         workspace=config.workspace_path,
-        provider=provider,
+        provider=main_cfg["provider"],
         model=agent.model,
         on_execute=on_heartbeat_execute,
         on_notify=on_heartbeat_notify,
@@ -445,7 +485,10 @@ def agent(
     sync_workspace_templates(config.workspace_path)
 
     bus = MessageBus()
-    provider = _make_provider(config)
+
+    # Get agent configs (main + subagent)
+    main_cfg = _get_agent_config(config, config.agents.defaults)
+    sub_cfg = _get_agent_config(config, config.agents.subagent or config.agents.defaults, shared_provider=main_cfg["provider"])
 
     # Create cron service for tool usage (no callback needed for CLI unless running)
     cron_store_path = get_data_dir() / "cron" / "jobs.json"
@@ -458,14 +501,10 @@ def agent(
 
     agent_loop = AgentLoop(
         bus=bus,
-        provider=provider,
         workspace=config.workspace_path,
-        model=config.agents.defaults.model,
-        temperature=config.agents.defaults.temperature,
-        max_tokens=config.agents.defaults.max_tokens,
+        agent_config=main_cfg,
         max_iterations=config.agents.defaults.max_tool_iterations,
         memory_window=config.agents.defaults.memory_window,
-        reasoning_effort=config.agents.defaults.reasoning_effort,
         brave_api_key=config.tools.web.search.api_key or None,
         web_proxy=config.tools.web.proxy or None,
         exec_config=config.tools.exec,
@@ -473,6 +512,7 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_config=sub_cfg,
     )
 
     # Show spinner when logs are off (no output to miss); skip when logs are on

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -234,6 +234,7 @@ class AgentsConfig(Base):
     """Agent configuration."""
 
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
+    subagent: AgentDefaults | None = None  # If None, uses defaults
 
 
 class ProviderConfig(Base):
@@ -336,11 +337,17 @@ class Config(BaseSettings):
         """Get expanded workspace path."""
         return Path(self.agents.defaults.workspace).expanduser()
 
-    def _match_provider(self, model: str | None = None) -> tuple["ProviderConfig | None", str | None]:
-        """Match provider config and its registry name. Returns (config, spec_name)."""
+    def _match_provider(self, model: str | None = None, provider: str | None = None) -> tuple["ProviderConfig | None", str | None]:
+        """Match provider config and its registry name. Returns (config, spec_name).
+
+        Args:
+            model: Model name to match
+            provider: Provider override (e.g., "zhipu", "dashscope"). "auto" or None means auto-detect.
+        """
         from nanobot.providers.registry import PROVIDERS
 
-        forced = self.agents.defaults.provider
+        # Use provided provider if not "auto", otherwise use defaults.provider
+        forced = provider if provider and provider != "auto" else self.agents.defaults.provider
         if forced != "auto":
             p = getattr(self.providers, forced, None)
             return (p, forced) if p else (None, None)
@@ -378,26 +385,26 @@ class Config(BaseSettings):
                 return p, spec.name
         return None, None
 
-    def get_provider(self, model: str | None = None) -> ProviderConfig | None:
+    def get_provider(self, model: str | None = None, provider: str | None = None) -> ProviderConfig | None:
         """Get matched provider config (api_key, api_base, extra_headers). Falls back to first available."""
-        p, _ = self._match_provider(model)
+        p, _ = self._match_provider(model, provider)
         return p
 
-    def get_provider_name(self, model: str | None = None) -> str | None:
+    def get_provider_name(self, model: str | None = None, provider: str | None = None) -> str | None:
         """Get the registry name of the matched provider (e.g. "deepseek", "openrouter")."""
-        _, name = self._match_provider(model)
+        _, name = self._match_provider(model, provider)
         return name
 
-    def get_api_key(self, model: str | None = None) -> str | None:
+    def get_api_key(self, model: str | None = None, provider: str | None = None) -> str | None:
         """Get API key for the given model. Falls back to first available key."""
-        p = self.get_provider(model)
+        p = self.get_provider(model, provider)
         return p.api_key if p else None
 
-    def get_api_base(self, model: str | None = None) -> str | None:
+    def get_api_base(self, model: str | None = None, provider: str | None = None) -> str | None:
         """Get API base URL for the given model. Applies default URLs for known gateways."""
         from nanobot.providers.registry import find_by_name
 
-        p, name = self._match_provider(model)
+        p, name = self._match_provider(model, provider)
         if p and p.api_base:
             return p.api_base
         # Only gateways get a default api_base here. Standard providers


### PR DESCRIPTION
## Summary

Allow subagent to use independent LLM configuration. Main agent typically needs stronger LLM for coordination, while subagent can use cheaper models to save tokens.

- Add subagent field to AgentsConfig
- Subagent uses its own provider field; falls back to defaults if not configured
- Add AgentRuntimeConfig TypedDict for type safety
- Refactor AgentLoop to accept agent_config and subagent_config dicts
- Add provider parameter to get_provider_name/get_provider/get_api_base methods

## Example config

```json
{
  "agents": {
    "defaults": {
      "workspace": "~/.nanobot/workspace",
      "model": "glm-5",
      "provider": "zhipu",
      "maxTokens": 8192,
      "temperature": 0.1,
      "maxToolIterations": 40,
      "memoryWindow": 100,
      "reasoningEffort": null
    },
    "subagent": {
      "workspace": "~/.nanobot/workspace",
      "model": "qwen3.5-plus",
      "provider": "dashscope",
      "maxTokens": 8192,
      "temperature": 0.1,
      "maxToolIterations": 40,
      "memoryWindow": 100,
      "reasoningEffort": null
    }
  }
}
```

## Test plan

- [x] Test with subagent config using different provider
- [x] Test without subagent config (uses defaults)
- [x] Test provider reuse when same provider type