### PR TITLE
fix(qq): add msg_seq to prevent message deduplication error

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -56,7 +56,7 @@ class QQChannel(BaseChannel):
         self.config: QQConfig = config
         self._client: "botpy.Client | None" = None
         self._processed_ids: deque = deque(maxlen=1000)
-        self._msg_seq: int = 1  # Message sequence to avoid QQ API deduplication
+        self._msg_seq: int = 1  # 消息序列号，避免被 QQ API 去重
 
     async def start(self) -> None:
         """Start the QQ bot."""
@@ -103,11 +103,13 @@ class QQChannel(BaseChannel):
             return
         try:
             msg_id = msg.metadata.get("message_id")
+            self._msg_seq += 1  # 递增序列号
             await self._client.api.post_c2c_message(
                 openid=msg.chat_id,
                 msg_type=0,
                 content=msg.content,
                 msg_id=msg_id,
+                msg_seq=self._msg_seq,  # 添加序列号避免去重
             )
         except Exception as e:
             logger.error("Error sending QQ message: {}", e)
@@ -134,3 +136,4 @@ class QQChannel(BaseChannel):
             )
         except Exception:
             logger.exception("Error handling QQ message")
+


### PR DESCRIPTION

## PR Description

### 🐛 Problem

When sending multiple messages through QQ channel, the QQ API returns error `40054005`:
<img width="1090" height="105" alt="image" src="https://github.com/user-attachments/assets/fa871b57-f036-4412-8246-f15ebda4c97f" />


```
消息被去重，请检查请求msgseq
(Message deduplicated, please check msgseq)
```

This happens because the `post_c2c_message` API requires an incrementing `msg_seq` parameter to distinguish different messages.

### ✅ Solution

Add a `_msg_seq` counter to `QQChannel` class and pass it to `post_c2c_message()` API call.

### 📝 Changes

```diff
class QQChannel(BaseChannel):
    def __init__(self, config: QQConfig, bus: MessageBus):
        super().__init__(config, bus)
        self.config: QQConfig = config
        self._client: "botpy.Client | None" = None
        self._processed_ids: deque = deque(maxlen=1000)
+       self._msg_seq: int = 1  # Message sequence to avoid QQ API deduplication

    async def send(self, msg: OutboundMessage) -> None:
        """Send a message through QQ."""
        if not self._client:
            logger.warning("QQ client not initialized")
            return
        try:
            msg_id = msg.metadata.get("message_id")
+           self._msg_seq += 1  # Increment sequence number
            await self._client.api.post_c2c_message(
                openid=msg.chat_id,
                msg_type=0,
                content=msg.content,
                msg_id=msg_id,
+               msg_seq=self._msg_seq,  # Add sequence to avoid deduplication
            )
        except Exception as e:
            logger.error("Error sending QQ message: {}", e)
```

### 🧪 Testing

- Tested with consecutive messages to QQ bot
- Before: Second message fails with `40054005` error
- After: All messages sent successfully

### 📚 Reference

- [QQ Bot API Documentation](https://bot.q.qq.com/wiki/develop/api-v2/)
- Error code `40054005`: Message deduplication triggered when `msg_seq` is missing or repeated

