### PR TITLE
fix: remove global litellm.api_base mutation in LiteLLMProvider

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -52,8 +52,9 @@ class LiteLLMProvider(LLMProvider):
         if api_key:
             self._setup_env(api_key, api_base, default_model)
 
-        if api_base:
-            litellm.api_base = api_base
+        # Note: api_base is passed per-request via kwargs["api_base"] in chat(),
+        # so we don't set litellm.api_base globally here. Setting it globally
+        # would cause the last-constructed provider to win for ALL instances.
 
         # Disable LiteLLM logging noise
         litellm.suppress_debug_info = True


### PR DESCRIPTION
Setting litellm.api_base globally in __init__ is harmful when multiple LiteLLMProvider instances exist with different api_base values - the last constructor call wins for ALL instances.

This is already handled correctly per-request via kwargs['api_base'] in the chat() method, making the global assignment both redundant and a source of subtle multi-provider bugs.