### PR TITLE
feat: hot-reload config on each message dispatch

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -112,6 +112,48 @@ class AgentLoop:
         self._processing_lock = asyncio.Lock()
         self._register_default_tools()
 
+        # Hot-reload: track config file mtime to detect changes
+        self._config_mtime: float = self._get_config_mtime()
+
+    # ------------------------------------------------------------------
+    # Hot-reload: detect config changes and rebuild provider on the fly
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_config_mtime() -> float:
+        """Return mtime of config.json, or 0 if it doesn't exist."""
+        from nanobot.config.loader import get_config_path
+        p = get_config_path()
+        try:
+            return p.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    async def _maybe_reload_config(self) -> None:
+        """Check if config.json changed; if so, rebuild provider and update model."""
+        mtime = self._get_config_mtime()
+        if mtime == self._config_mtime:
+            return
+
+        try:
+            from nanobot.config.loader import load_config
+            from nanobot.cli.commands import _make_provider
+            config = load_config()
+            new_model = config.agents.defaults.model
+            new_provider = _make_provider(config)
+            self.provider = new_provider
+            self.model = new_model
+            self.subagents.provider = new_provider
+            self.subagents.model = new_model
+            self._config_mtime = mtime
+            logger.info(
+                "Config hot-reloaded: model={}, provider={}",
+                new_model,
+                type(new_provider).__name__,
+            )
+        except Exception:
+            logger.exception("Failed to hot-reload config, keeping existing provider")
+
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
         allowed_dir = self.workspace if self.restrict_to_workspace else None
@@ -294,6 +336,7 @@ class AgentLoop:
     async def _dispatch(self, msg: InboundMessage) -> None:
         """Process a message under the global lock."""
         async with self._processing_lock:
+            await self._maybe_reload_config()
             try:
                 response = await self._process_message(msg)
                 if response is not None:


### PR DESCRIPTION
## Summary

Reload `config.json` automatically when it changes, without restarting the gateway process. Inspired by how CoPaw handles per-request config loading.

## Problem

Currently, nanobot reads `config.json` once at startup and pins the provider/model in memory for the entire lifetime of the process. Changing the model or API key requires a full restart, which is disruptive — especially when running as a long-lived gateway.

## Solution

Track the `mtime` of `~/.nanobot/config.json`. Before each message is dispatched, check if the file changed. If so, rebuild the provider and update the model in-place.

### Key design decisions

- **mtime-based detection** — `os.stat()` is a single syscall, essentially free. No polling loop or inotify dependency needed. This is the same pattern already used in #1371 (cron `jobs.json` hot-reload, merged).
- **Called inside `_processing_lock`** — the reload happens while holding the processing lock, so concurrent requests cannot observe a half-updated state.
- **Safe fallback** — if `load_config()` or `_make_provider()` raises, the exception is logged and the existing provider is kept. The bot stays alive.
- **Subagents updated too** — `subagents.provider` and `subagents.model` are updated atomically alongside the main agent.

## Changes

```
nanobot/agent/loop.py
  + _config_mtime: float               # tracked in __init__
  + _get_config_mtime() -> float       # stat() helper, returns 0 on missing file  
  + _maybe_reload_config()             # mtime diff → rebuild provider
  _dispatch(): call _maybe_reload_config() before _process_message()
```

## Behavior

| Action | Before | After |
|--------|--------|-------|
| Change model in config.json | Requires restart | Takes effect on next message |
| Change API key | Requires restart | Takes effect on next message |
| Config file unchanged | — | No overhead (single stat() call) |
| Config reload fails | — | Logs error, keeps existing provider |

## Testing

1. Start gateway
2. Send a message — note which model responds
3. Edit `~/.nanobot/config.json`, change `agents.defaults.model`
4. Send another message — new model responds immediately, no restart needed
<img width="1027" height="119" alt="image" src="https://github.com/user-attachments/assets/fb3e3565-065e-4e8e-9ad0-9c987399293d" />
