### PR TITLE
Refactor: Replace `message_id` with generic `metadata` in tool contexts

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -152,12 +152,12 @@ class AgentLoop:
         finally:
             self._mcp_connecting = False
 
-    def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
+    def _set_tool_context(self, channel: str, chat_id: str, metadata: dict | None = None) -> None:
         """Update context for all tools that need routing info."""
         for name in ("message", "spawn", "cron"):
             if tool := self.tools.get(name):
                 if hasattr(tool, "set_context"):
-                    tool.set_context(channel, chat_id, *([message_id] if name == "message" else []))
+                    tool.set_context(channel, chat_id, metadata=metadata)
 
     @staticmethod
     def _strip_think(text: str | None) -> str | None:
@@ -341,7 +341,7 @@ class AgentLoop:
             logger.info("Processing system message from {}", msg.sender_id)
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
-            self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
+            self._set_tool_context(channel, chat_id, metadata=msg.metadata)
             history = session.get_history(max_messages=self.memory_window)
             messages = self.context.build_messages(
                 history=history,
@@ -411,7 +411,7 @@ class AgentLoop:
             _task = asyncio.create_task(_consolidate_and_unlock())
             self._consolidation_tasks.add(_task)
 
-        self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
+        self._set_tool_context(msg.channel, msg.chat_id, metadata=msg.metadata)
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -17,7 +17,7 @@ class CronTool(Tool):
         self._chat_id = ""
         self._in_cron_context: ContextVar[bool] = ContextVar("cron_in_context", default=False)
 
-    def set_context(self, channel: str, chat_id: str) -> None:
+    def set_context(self, channel: str, chat_id: str, **kwargs) -> None:
         """Set the current session context for delivery."""
         self._channel = channel
         self._chat_id = chat_id

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -14,19 +14,19 @@ class MessageTool(Tool):
         send_callback: Callable[[OutboundMessage], Awaitable[None]] | None = None,
         default_channel: str = "",
         default_chat_id: str = "",
-        default_message_id: str | None = None,
+        metadata: dict | None = None,
     ):
         self._send_callback = send_callback
         self._default_channel = default_channel
         self._default_chat_id = default_chat_id
-        self._default_message_id = default_message_id
+        self._default_metadata = metadata or {}
         self._sent_in_turn: bool = False
 
-    def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
+    def set_context(self, channel: str, chat_id: str, metadata: dict | None = None, **kwargs) -> None:
         """Set the current message context."""
         self._default_channel = channel
         self._default_chat_id = chat_id
-        self._default_message_id = message_id
+        self._default_metadata = metadata or {}
 
     def set_send_callback(self, callback: Callable[[OutboundMessage], Awaitable[None]]) -> None:
         """Set the callback for sending messages."""
@@ -75,13 +75,13 @@ class MessageTool(Tool):
         content: str,
         channel: str | None = None,
         chat_id: str | None = None,
-        message_id: str | None = None,
         media: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
         **kwargs: Any
     ) -> str:
         channel = channel or self._default_channel
         chat_id = chat_id or self._default_chat_id
-        message_id = message_id or self._default_message_id
+        metadata = metadata or self._default_metadata
 
         if not channel or not chat_id:
             return "Error: No target channel/chat specified"
@@ -94,9 +94,7 @@ class MessageTool(Tool):
             chat_id=chat_id,
             content=content,
             media=media or [],
-            metadata={
-                "message_id": message_id,
-            }
+            metadata=metadata,
         )
 
         try:

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -17,7 +17,7 @@ class SpawnTool(Tool):
         self._origin_chat_id = "direct"
         self._session_key = "cli:direct"
 
-    def set_context(self, channel: str, chat_id: str) -> None:
+    def set_context(self, channel: str, chat_id: str, **kwargs) -> None:
         """Set the origin context for subagent announcements."""
         self._origin_channel = channel
         self._origin_chat_id = chat_id


### PR DESCRIPTION
## 描述
本 PR 重构了从 `AgentLoop` 向底层工具（`MessageTool`、`CronTool`、`SpawnTool`）传递消息上下文的方式。

之前，代码仅显式提取了 `message_id` 并传递给工具。当我们需要特定平台的其他扩展信息或路由配置时，这种硬编码的方式极大地限制了扩展性。本次更新改为传递完整的 `metadata` 字典，确保各个工具（尤其是 `MessageTool`）能够获取到输入消息的所有上下文信息。

## 主要更改
* **`agent/loop.py`**: 更新了 `_set_tool_context` 方法，现在接收并传递 `metadata: dict`，而不是特定的 `message_id`。
* **`agent/tools/message.py`**: 
  * 更新了 `__init__` 和 `set_context` 方法，使用 `metadata` 替代了 `default_message_id` 参数。
  * 现在构建 `OutboundMessage` 时会附带完整的 `metadata`，保留了所有的原始上下文（其中自然也包含了原本的 `message_id`，并且为未来支持诸如 thread ID、UI 状态等扩展留出了空间）。
* **`agent/tools/cron.py` & `agent/tools/spawn.py`**: 更新了 `set_context` 方法的签名，增加了 `**kwargs` 参数以对齐新的通用接口，提升了代码的向前兼容性。

## 影响范围
* **扩展性提升**: 未来如果需要在消息的元数据中增加任何新字段，它们都会自动流转到各个工具和发出的消息中，无需再频繁修改 `AgentLoop` 的方法签名。
* **非破坏性更新**: 原有的 `message_id` 依然会被成功传递，因为它现在被完整保留在了 `metadata` 字典内。原有功能不受影响。

---

## Description
This PR refactors how message context is passed from the `AgentLoop` to the underlying tools (`MessageTool`, `CronTool`, `SpawnTool`). 

Previously, only `message_id` was explicitly extracted from the incoming message and passed to the tools. This limits extensibility when other platform-specific metadata or routing information is required. This update passes the entire `metadata` dictionary, ensuring that tools (especially `MessageTool`) have access to all context from the incoming message.

## Key Changes
* **`agent/loop.py`**: Updated `_set_tool_context` to accept and pass `metadata: dict` instead of a specific `message_id`.
* **`agent/tools/message.py`**: 
  * Updated `__init__` and `set_context` to manage `metadata` instead of `default_message_id`.
  * Now attaches the full `metadata` payload to the `OutboundMessage`, preserving all original context (which naturally includes `message_id` but allows for future additions like thread IDs, UI states, etc.).
* **`agent/tools/cron.py` & `agent/tools/spawn.py`**: Updated the `set_context` method signatures to accept `**kwargs`, aligning with the new generic interface and improving forward compatibility.

## Impact
* **Extensibility**: Any new fields added to a message's metadata will now automatically flow through to the tools and outbound messages without requiring changes to the `AgentLoop` signature.
* **Non-breaking**: The `message_id` is still successfully propagated because it is preserved inside the `metadata` dict.


