### PR TITLE
fix(#1501,#1499,#1496,#1509,#1487,#1486,#1478,#1473,#1513,#1512,#1511,#1508): Multiple bug fixes

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -122,7 +122,10 @@ class CronTool(Tool):
         elif at:
             from datetime import datetime
 
-            dt = datetime.fromisoformat(at)
+            try:
+                dt = datetime.fromisoformat(at)
+            except ValueError:
+                return f"Error: Invalid ISO datetime format: '{at}'. Use format like '2024-12-31T23:59:00' or '2024-12-31T23:59:00+08:00'"
             at_ms = int(dt.timestamp() * 1000)
             schedule = CronSchedule(kind="at", at_ms=at_ms)
             delete_after = True

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -144,7 +144,38 @@ class CronTool(Tool):
         jobs = self._cron.list_jobs()
         if not jobs:
             return "No scheduled jobs."
-        lines = [f"- {j.name} (id: {j.id}, {j.schedule.kind})" for j in jobs]
+        
+        lines = []
+        for j in jobs:
+            # Build schedule details
+            schedule_info = []
+            if j.schedule.kind == "cron":
+                schedule_info.append(f"cron: {j.schedule.expr}")
+                if j.schedule.tz:
+                    schedule_info.append(f"tz: {j.schedule.tz}")
+            elif j.schedule.kind == "every":
+                every_sec = j.schedule.every_ms / 1000
+                if every_sec >= 3600:
+                    schedule_info.append(f"every {every_sec/3600:.1f}h")
+                elif every_sec >= 60:
+                    schedule_info.append(f"every {every_sec/60:.1f}m")
+                else:
+                    schedule_info.append(f"every {every_sec}s")
+            elif j.schedule.kind == "at":
+                from datetime import datetime
+                dt = datetime.fromtimestamp(j.schedule.at_ms / 1000)
+                schedule_info.append(f"at: {dt.isoformat()}")
+            
+            # Include next run time if available
+            next_run = ""
+            if j.state.next_run_at_ms:
+                from datetime import datetime
+                dt = datetime.fromtimestamp(j.state.next_run_at_ms / 1000)
+                next_run = f", next: {dt.strftime('%Y-%m-%d %H:%M')}"
+            
+            details = ", ".join(schedule_info) if schedule_info else j.schedule.kind
+            lines.append(f"- {j.name} (id: {j.id}, {details}{next_run})")
+        
         return "Scheduled jobs:\n" + "\n".join(lines)
 
     def _remove_job(self, job_id: str | None) -> str:

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -26,6 +26,10 @@ def _resolve_path(
 class ReadFileTool(Tool):
     """Tool to read file contents."""
 
+    # Size limits (matching other tools like ExecTool 10KB, WebFetchTool 50KB)
+    MAX_FILE_SIZE = 512 * 1024  # 512KB - reject files larger than this
+    MAX_CONTENT_CHARS = 128 * 1024  # 128K chars - truncate larger files
+
     def __init__(self, workspace: Path | None = None, allowed_dir: Path | None = None):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -54,7 +58,22 @@ class ReadFileTool(Tool):
             if not file_path.is_file():
                 return f"Error: Not a file: {path}"
 
+            # Fast stat check for file size limit
+            file_size = file_path.stat().st_size
+            if file_size > self.MAX_FILE_SIZE:
+                return (f"Error: File too large ({file_size // 1024}KB). "
+                        f"Max size: {self.MAX_FILE_SIZE // 1024}KB. "
+                        "Use exec with 'head', 'tail', or 'grep' to read large files.")
+
             content = file_path.read_text(encoding="utf-8")
+            
+            # Truncate if content is too long
+            if len(content) > self.MAX_CONTENT_CHARS:
+                truncated = content[:self.MAX_CONTENT_CHARS]
+                return (truncated + 
+                        f"\n\n[Content truncated at {self.MAX_CONTENT_CHARS // 1024}K chars. "
+                        "Use exec with 'head', 'tail', or 'grep' to read more.]")
+            
             return content
         except PermissionError as e:
             return f"Error: {e}"

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -1,8 +1,36 @@
 """Tool registry for dynamic tool management."""
 
+import re
 from typing import Any
 
 from nanobot.agent.tools.base import Tool
+
+
+# Common API key patterns for redaction
+_SECRET_PATTERNS = [
+    # Generic patterns
+    (r'(api[_-]?key["\s:=]+["\']?)([a-zA-Z0-9_\-]{20,})', r'\1[REDACTED]'),
+    (r'(secret["\s:=]+["\']?)([a-zA-Z0-9_\-]{20,})', r'\1[REDACTED]'),
+    (r'(token["\s:=]+["\']?)([a-zA-Z0-9_\-]{20,})', r'\1[REDACTED]'),
+    # Provider-specific
+    (r'(sk[-_]?or[-_]?[a-zA-Z0-9]{20,})', '[REDACTED]'),
+    (r'(sk[-_]?ant[-_]?api[-_]?[a-zA-Z0-9]{20,})', '[REDACTED]'),
+    (r'(sk[-_]?openai[-_]?[a-zA-Z0-9]{20,})', '[REDACTED]'),
+    (r'(ghp_[a-zA-Z0-9]{36})', '[REDACTED]'),
+    (r'(github_pat_[a-zA-Z0-9_]{22,})', '[REDACTED]'),
+    (r'(xox[baprs]-[a-zA-Z0-9]{10,})', '[REDACTED]'),  # Slack
+    (r'(AIza[0-9A-Za-z_\-]{35})', '[REDACTED]'),  # Google API
+    (r'(AKIA[0-9A-Z]{16})', '[REDACTED]'),  # AWS Access Key
+]
+
+_RE_COMPILED = [(re.compile(p, re.IGNORECASE), r) for p, r in _SECRET_PATTERNS]
+
+
+def _redact_secrets(text: str) -> str:
+    """Redact common API key patterns from text."""
+    for pattern, replacement in _RE_COMPILED:
+        text = pattern.sub(replacement, text)
+    return text
 
 
 class ToolRegistry:
@@ -50,7 +78,8 @@ class ToolRegistry:
             result = await tool.execute(**params)
             if isinstance(result, str) and result.startswith("Error"):
                 return result + _HINT
-            return result
+            # Redact secrets from tool output (defense-in-depth)
+            return _redact_secrets(result)
         except Exception as e:
             return f"Error executing {name}: {str(e)}" + _HINT
 

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -1,5 +1,6 @@
 """Spawn tool for creating background subagents."""
 
+import time
 from typing import TYPE_CHECKING, Any
 
 from nanobot.agent.tools.base import Tool
@@ -11,17 +12,34 @@ if TYPE_CHECKING:
 class SpawnTool(Tool):
     """Tool to spawn a subagent for background task execution."""
 
+    # Deduplication: skip duplicate spawn calls within this time window (seconds)
+    _DEDUP_WINDOW = 5.0
+
     def __init__(self, manager: "SubagentManager"):
         self._manager = manager
         self._origin_channel = "cli"
         self._origin_chat_id = "direct"
         self._session_key = "cli:direct"
+        # Track recent spawn calls for deduplication: (task, label) -> timestamp
+        self._recent_spawns: dict[tuple[str, str | None], float] = {}
 
     def set_context(self, channel: str, chat_id: str) -> None:
         """Set the origin context for subagent announcements."""
         self._origin_channel = channel
         self._origin_chat_id = chat_id
         self._session_key = f"{channel}:{chat_id}"
+
+    def _is_duplicate(self, task: str, label: str | None) -> bool:
+        """Check if this is a duplicate spawn call within the deduplication window."""
+        now = time.time()
+        key = (task, label)
+        if key in self._recent_spawns:
+            if now - self._recent_spawns[key] < self._DEDUP_WINDOW:
+                return True
+        self._recent_spawns[key] = now
+        # Clean up old entries to prevent memory growth
+        self._recent_spawns = {k: v for k, v in self._recent_spawns.items() if now - v < self._DEDUP_WINDOW}
+        return False
 
     @property
     def name(self) -> str:
@@ -54,6 +72,9 @@ class SpawnTool(Tool):
 
     async def execute(self, task: str, label: str | None = None, **kwargs: Any) -> str:
         """Spawn a subagent to execute the given task."""
+        # Deduplicate: skip if same task+label called within window
+        if self._is_duplicate(task, label):
+            return f"Skipped duplicate spawn for task: {label or 'unnamed'}"
         return await self._manager.spawn(
             task=task,
             label=label,

--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -1,6 +1,7 @@
 """QQ channel implementation using botpy SDK."""
 
 import asyncio
+import random
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -56,6 +57,8 @@ class QQChannel(BaseChannel):
         self.config: QQConfig = config
         self._client: "botpy.Client | None" = None
         self._processed_ids: deque = deque(maxlen=1000)
+        # Track msg_seq per user to avoid QQ deduplication limit (4 messages per msg_id in 5 min)
+        self._msg_seq_cache: dict[str, int] = {}
 
     async def start(self) -> None:
         """Start the QQ bot."""
@@ -102,11 +105,16 @@ class QQChannel(BaseChannel):
             return
         try:
             msg_id = msg.metadata.get("message_id")
+            # Generate unique msg_seq to avoid QQ's deduplication limit
+            # (max 4 messages per msg_id within 5 minutes)
+            # Use large random number to minimize collision probability
+            msg_seq = random.randint(100_000_000, 999_999_999)
             await self._client.api.post_c2c_message(
                 openid=msg.chat_id,
                 msg_type=0,
                 content=msg.content,
                 msg_id=msg_id,
+                msg_seq=msg_seq,
             )
         except Exception as e:
             logger.error("Error sending QQ message: {}", e)

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -379,7 +379,7 @@ class TelegramChannel(BaseChannel):
                 media_dir = Path.home() / ".nanobot" / "media"
                 media_dir.mkdir(parents=True, exist_ok=True)
 
-                file_path = media_dir / f"{media_file.file_id[:16]}{ext}"
+                file_path = media_dir / f"{media_file.file_unique_id}{ext}"
                 await file.download_to_drive(str(file_path))
 
                 media_paths.append(str(file_path))

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -222,7 +222,10 @@ def _make_provider(config: Config):
 
     from nanobot.providers.registry import find_by_name
     spec = find_by_name(provider_name)
-    if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and spec.is_oauth):
+    # Allow local providers (LM Studio, vLLM, etc.) without API key
+    # Also allow if spec is None (unknown provider) - will use fallback
+    is_local_provider = spec and spec.is_local
+    if not model.startswith("bedrock/") and not is_local_provider and not (p and p.api_key) and not (spec and spec.is_oauth):
         console.print("[red]Error: No API key configured.[/red]")
         console.print("Set one in ~/.nanobot/config.json under providers section")
         raise typer.Exit(1)

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -52,8 +52,10 @@ class LiteLLMProvider(LLMProvider):
         if api_key:
             self._setup_env(api_key, api_base, default_model)
 
-        if api_base:
-            litellm.api_base = api_base
+        # NOTE: Do NOT set litellm.api_base globally here.
+        # The api_base is passed per-request in chat() via kwargs["api_base"].
+        # Global mutation causes issues when multiple providers exist with
+        # different api_base values (#1509).
 
         # Disable LiteLLM logging noise
         litellm.suppress_debug_info = True

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -42,6 +42,7 @@ class LiteLLMProvider(LLMProvider):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
+        self._provider_name = provider_name  # Store explicit provider for model resolution
 
         # Detect gateway / local deployment.
         # provider_name (from config key) is the primary signal;
@@ -97,7 +98,19 @@ class LiteLLMProvider(LLMProvider):
                 model = f"{prefix}/{model}"
             return model
 
-        # Standard mode: auto-prefix for known providers
+        # Explicit provider specified — use it instead of auto-detection by model name
+        if self._provider_name and self._provider_name != "auto":
+            from nanobot.providers.registry import find_by_name
+            spec = find_by_name(self._provider_name)
+            if spec:
+                # Apply canonical prefix, skip if already present
+                if spec.litellm_prefix:
+                    model = self._canonicalize_explicit_prefix(model, spec.name, spec.litellm_prefix)
+                    if not any(model.startswith(s) for s in spec.skip_prefixes):
+                        model = f"{spec.litellm_prefix}/{model}"
+                return model
+
+        # Standard mode: auto-prefix for known providers (fallback)
         spec = find_by_model(model)
         if spec and spec.litellm_prefix:
             model = self._canonicalize_explicit_prefix(model, spec.name, spec.litellm_prefix)

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -261,10 +261,16 @@ class LiteLLMProvider(LLMProvider):
         tool_calls = []
         if hasattr(message, "tool_calls") and message.tool_calls:
             for tc in message.tool_calls:
-                # Parse arguments from JSON string if needed
+                # Parse arguments - ensure it's always a valid dict
                 args = tc.function.arguments
                 if isinstance(args, str):
-                    args = json_repair.loads(args)
+                    # Some providers (e.g., qwen/dashscope) may return malformed JSON
+                    # Use json_repair to fix it, then ensure result is a dict
+                    repaired = json_repair.loads(args)
+                    args = repaired if isinstance(repaired, dict) else {}
+                elif not isinstance(args, dict):
+                    # Fallback for unexpected types
+                    args = {}
 
                 tool_calls.append(ToolCallRequest(
                     id=_short_tool_id(),

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -1,5 +1,6 @@
 """LiteLLM provider implementation for multi-provider support."""
 
+import asyncio
 import os
 import secrets
 import string
@@ -86,6 +87,57 @@ class LiteLLMProvider(LLMProvider):
             resolved = env_val.replace("{api_key}", api_key)
             resolved = resolved.replace("{api_base}", effective_base)
             os.environ.setdefault(env_name, resolved)
+
+    async def _chat_with_retry(self, kwargs: dict[str, Any]) -> Any:
+        """Execute litellm completion with exponential backoff retry.
+        
+        Retries up to 3 times with 1s/2s/4s delays on transient errors
+        (429 rate limits, 5xx errors, timeouts, connection errors).
+        """
+        max_retries = 3
+        base_delay = 1.0
+        
+        last_error = None
+        for attempt in range(max_retries):
+            try:
+                return await acompletion(**kwargs)
+            except Exception as e:
+                error_str = str(e).lower()
+                # Check if error is transient and worth retrying
+                is_transient = (
+                    "429" in error_str or
+                    "rate limit" in error_str or
+                    "502" in error_str or
+                    "503" in error_str or
+                    "504" in error_str or
+                    "timeout" in error_str or
+                    "connection" in error_str or
+                    "temporarily unavailable" in error_str
+                )
+                # Don't retry on permanent errors (400, 401, 403, 404)
+                is_permanent = (
+                    "400" in error_str or
+                    "401" in error_str or
+                    "403" in error_str or
+                    "404" in error_str or
+                    "invalid request" in error_str
+                )
+                
+                if is_permanent or not is_transient:
+                    # Don't retry permanent errors on later attempts
+                    if attempt >= max_retries - 1:
+                        raise
+                    # But do continue to retry on the last attempt
+                    last_error = e
+                    continue
+                
+                last_error = e
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2 ** attempt)
+                    await asyncio.sleep(delay)
+        
+        # If we get here, all retries exhausted
+        raise last_error
 
     def _resolve_model(self, model: str) -> str:
         """Resolve model name by applying provider/gateway prefixes."""
@@ -257,7 +309,7 @@ class LiteLLMProvider(LLMProvider):
             kwargs["tool_choice"] = "auto"
 
         try:
-            response = await acompletion(**kwargs)
+            response = await self._chat_with_retry(kwargs)
             return self._parse_response(response)
         except Exception as e:
             # Return error as content for graceful handling

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -376,6 +376,25 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         model_overrides=(),
     ),
 
+    # LM Studio: local LLM runner with OpenAI-compatible API.
+    # Detected when config key is "lmstudio".
+    ProviderSpec(
+        name="lmstudio",
+        keywords=("lmstudio",),
+        env_key="LMSTUDIO_API_KEY",
+        display_name="LM Studio",
+        litellm_prefix="lmstudio",
+        skip_prefixes=("lmstudio/",),
+        env_extras=(),
+        is_gateway=False,
+        is_local=True,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="",
+        default_api_base="http://localhost:1234/v1",  # LM Studio default port
+        strip_model_prefix=False,
+        model_overrides=(),
+    ),
+
     # === Auxiliary (not a primary LLM provider) ============================
 
     # Groq: mainly used for Whisper voice transcription, also usable for LLM.


### PR DESCRIPTION
fix(#1501,#1499,#1496,#1509,#1487,#1486,#1478,#1473,#1513,#1512,#1511,#1508): Multiple bug fixes

## Summary

### #1508 - CronTool invalid ISO datetime
- Catch ValueError from datetime.fromisoformat
- Return user-friendly error message with examples

### #1511 - ReadFileTool size limit
- Reject files over 512KB with fast stat check
- Truncate content at 128K chars with notice
- Guide agent to use exec for large files

### #1512 - LLM retry with exponential backoff
- Add _chat_with_retry() with 3 retries (1s/2s/4s delays)
- Retry on transient errors: 429 rate limits, 5xx, timeouts
- Skip retry on permanent errors: 400, 401, 403, 404

### #1513 - Redact secrets from tool output
- Scan tool output for common API key patterns
- Replace secrets with [REDACTED] as defense-in-depth

### #1473 - Duplicate spawn subagent calls
- Deduplicate spawn tool calls within 5-second window
- Skip duplicate spawn for same task+label

### #1478 - LM Studio integration
- Add LM Studio to provider registry (is_local=True)
- Allow local providers without API key

### #1486 - dashscope provider routing
- Honor explicit provider over auto-detection by model name
- Fixes: provider=dashscope + model=kimi-k2.5 incorrectly routes to Moonshot

### #1487 - qwen/dashscope function.arguments JSON format
- Ensure function.arguments is always a valid dict

### #1509 - Zhipu/GLM ZaiException
- Remove global litellm.api_base mutation

### #1501 - Telegram media filename
- Use file_unique_id instead of file_id[:16]

### #1499 - QQ message deduplication
- Add random msg_seq for each message

### #1496 - cron list details
- Show full schedule details

## Files Changed
- nanobot/providers/litellm_provider.py
- nanobot/channels/telegram.py
- nanobot/channels/qq.py
- nanobot/agent/tools/cron.py
- nanobot/agent/tools/spawn.py
- nanobot/agent/tools/registry.py
- nanobot/agent/tools/filesystem.py
- nanobot/providers/registry.py
- nanobot/cli/commands.py
