### PR TITLE
fix(codex): pass reasoning_effort to Codex API

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -52,6 +52,9 @@ class OpenAICodexProvider(LLMProvider):
             "parallel_tool_calls": True,
         }
 
+        if reasoning_effort:
+            body["reasoning"] = {"effort": reasoning_effort}
+
         if tools:
             body["tools"] = _convert_tools(tools)
 


### PR DESCRIPTION
## Summary
- The OpenAI Codex provider accepts `reasoning_effort` as a parameter but silently discards it
- This wires it through as `{"reasoning": {"effort": "..."}}` in the request body so the `reasoningEffort` config option actually takes effect

## Test plan
- Set `reasoningEffort` to `"low"`, `"medium"`, or `"high"` in config
- Verify the Codex API receives the `reasoning` field in the request body
- Confirm responses reflect the requested reasoning effort level

🐈 Generated with [Claude Code](https://claude.com/claude-code)