### PR TITLE
fix(feishu): convert audio type to file for API compatibility

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -530,6 +530,10 @@ class FeishuChannel(BaseChannel):
         self, message_id: str, file_key: str, resource_type: str = "file"
     ) -> tuple[bytes | None, str | None]:
         """Download a file/audio/media from a Feishu message by message_id and file_key."""
+        # Feishu API only accepts 'image' or 'file' as type parameter
+        # Convert 'audio' to 'file' for API compatibility
+        if resource_type == "audio":
+            resource_type = "file"
         try:
             request = (
                 GetMessageResourceRequest.builder()


### PR DESCRIPTION
## Summary

Fixes voice message download failure in Feishu channel by converting the `audio` resource type to `file` before calling Feishu's GetMessageResource API.

## Problem

Feishu's GetMessageResource API only accepts `image` or `file` as the `type` parameter. When downloading voice messages, nanobot was passing `audio` which caused the API to reject the request with an error like `[audio: download failed]`.

## Solution

Added type conversion in `_download_file_sync` method to convert `audio` to `file` before making the API call. This allows voice messages to be downloaded and transcribed successfully.

## Testing

- Tested with voice messages in Feishu
- Voice messages are now successfully downloaded and transcribed using local ASR (Qwen3-ASR)
- No impact on image or file downloads

## Changes

- Modified `nanobot/channels/feishu.py`: Added 4 lines to convert `audio` type to `file` in `_download_file_sync` method