### PR TITLE
Fix: Telegram channel crash when proxy is configured

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -140,10 +140,14 @@ class TelegramChannel(BaseChannel):
         self._running = True
 
         # Build the application with larger connection pool to avoid pool-timeout on long runs
-        req = HTTPXRequest(connection_pool_size=16, pool_timeout=5.0, connect_timeout=30.0, read_timeout=30.0)
+        req = HTTPXRequest(
+            connection_pool_size=16,
+            pool_timeout=5.0,
+            connect_timeout=30.0,
+            read_timeout=30.0,
+            proxy=self.config.proxy if self.config.proxy else None,
+        )
         builder = Application.builder().token(self.config.token).request(req).get_updates_request(req)
-        if self.config.proxy:
-            builder = builder.proxy(self.config.proxy).get_updates_proxy(self.config.proxy)
         self._app = builder.build()
         self._app.add_error_handler(self._on_error)
 


### PR DESCRIPTION
Currently, the `TelegramChannel` implementation fails with `ValueError: The parameter 'proxy' may only be set, if no request instance was set.` when a proxy is provided in the configuration. 

This is because the code attempts to set the proxy on the `ApplicationBuilder` while also providing a custom `HTTPXRequest` instance, which is not allowed in `python-telegram-bot`. 

This PR moves the proxy configuration directly into the `HTTPXRequest` initialization, resolving the startup crash.