### PR TITLE
Add CrowPay skill — payment service for AI agents

### DIFF
--- a/nanobot/skills/crow/SKILL.md
+++ b/nanobot/skills/crow/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: crow
+description: Agent payment service via CrowPay — gives your agent a wallet to pay for APIs and services. Use this skill whenever the agent needs to handle HTTP 402 Payment Required responses, pay for an API, buy credits or subscriptions, pay a merchant with a credit card, set up an agent wallet, or manage spending rules. Also use when the user mentions CrowPay, Crow, agent payments, USDC, x402, or buying anything on the internet for the agent — even if they don't say "Crow" by name.
+---
+
+# Crow — Agent Payment Service
+
+Crow gives your AI agent a wallet to pay for APIs and services autonomously — within spending rules set by the wallet owner. All interaction is via **curl / HTTP requests** to `https://api.crowpay.ai`.
+
+Two payment methods:
+- **x402 (USDC on Base)** — for APIs that return HTTP 402 Payment Required
+- **Credit card (Stripe)** — for merchants, subscriptions, API credits
+
+**Dashboard:** https://crowpay.ai/dashboard
+
+## When to Use This Skill
+
+- Agent gets an HTTP `402 Payment Required` response
+- Agent needs to pay for an API, buy credits, or pay a merchant
+- User wants to set up an agent wallet with spending rules
+- User asks about CrowPay, Crow, or agent payments
+- User wants their agent to buy something on the internet
+
+---
+
+## Setup — Get a Wallet and API Key
+
+```bash
+curl -X POST https://api.crowpay.ai/setup \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Response:
+```json
+{
+  "apiKey": "crow_sk_abc123...",
+  "walletAddress": "0x1234...abcd",
+  "claimUrl": "https://crowpay.ai/claim/xyz789",
+  "fundingInstructions": "Send USDC on Base to 0x1234...abcd"
+}
+```
+
+**Three things to do after setup:**
+1. **Save the `apiKey` immediately** — it is shown only once and cannot be retrieved later
+2. Tell the user to visit the `claimUrl` to create their account and set spending rules
+3. Fund the wallet: send USDC on Base to `walletAddress`, or add a credit card in the dashboard
+
+All subsequent requests need this header:
+```
+X-API-Key: crow_sk_abc123...
+```
+
+---
+
+## Decision Tree
+
+```
+Agent needs to pay for something?
+│
+├── Got an HTTP 402 from an API? (x402 / USDC)
+│   │
+│   └── curl POST /authorize  ← pass the full 402 response body
+│       ├── 200 → Got signed payload. Retry original request with payment-signature header.
+│       ├── 202 → Needs human approval. Poll GET /authorize/status every 3s.
+│       └── 403 → Spending rules blocked it. Tell the user.
+│
+└── Paying a merchant with credit card?
+    │
+    └── curl POST /authorize/card  ← pass amount, merchant, reason
+        ├── 200 → Got sptToken. Use it to pay via Stripe.
+        ├── 202 → Needs human approval. Poll GET /authorize/status every 3s.
+        └── 403 → Spending rules blocked it. Tell the user.
+```
+
+---
+
+## Endpoints
+
+### POST /setup — Create wallet + API key
+
+No auth required.
+
+```bash
+curl -X POST https://api.crowpay.ai/setup \
+  -H "Content-Type: application/json" \
+  -d '{"network": "eip155:8453"}'
+```
+
+`network` is optional (defaults to Base mainnet). Response contains `apiKey`, `walletAddress`, `claimUrl`.
+
+---
+
+### POST /authorize — Pay for an x402 API (USDC)
+
+When you hit an API and get a `402 Payment Required` response, forward the entire response body to Crow:
+
+```bash
+curl -X POST https://api.crowpay.ai/authorize \
+  -H "X-API-Key: crow_sk_abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "paymentRequired": {
+      "x402Version": 2,
+      "resource": {"url": "https://api.example.com/v1/data"},
+      "accepts": [{
+        "scheme": "exact",
+        "network": "eip155:8453",
+        "amount": "1000000",
+        "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        "payTo": "0xRecipientAddress",
+        "maxTimeoutSeconds": 60,
+        "extra": {"name": "USDC", "version": "2"}
+      }]
+    },
+    "merchant": "ExampleAPI",
+    "reason": "Fetching data for user task",
+    "platform": "Claude MCP",
+    "service": "Premium data API"
+  }'
+```
+
+**Required fields:**
+- `paymentRequired` — the full 402 response body from the API
+- `merchant` — name of the service (wallet owner sees this)
+- `reason` — why the payment is needed (wallet owner sees this)
+
+**Optional context fields (recommended):**
+- `platform` — which agent/platform is making the request (e.g. "Claude MCP", "LangChain")
+- `service` — what service/product the payment is for (e.g. "Weather API call", "Premium data")
+
+**200 → Auto-approved.** Response is a signed payment payload. To retry the original request:
+```bash
+# Base64-encode the entire response and put it in the payment-signature header
+PAYMENT=$(echo '<full JSON response>' | base64)
+curl https://api.example.com/v1/data -H "payment-signature: $PAYMENT"
+```
+
+**202 → Needs human approval.** Response contains `approvalId`. Poll for status (see below).
+
+**403 → Denied.** Spending rules blocked it. Do not retry with same params.
+
+See `references/x402-flow.md` for the complete end-to-end walkthrough.
+
+---
+
+### POST /authorize/card — Pay a merchant with credit card
+
+```bash
+curl -X POST https://api.crowpay.ai/authorize/card \
+  -H "X-API-Key: crow_sk_abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amountCents": 1000,
+    "merchant": "OpenAI",
+    "reason": "GPT-4 API credits",
+    "platform": "Claude MCP",
+    "service": "GPT-4 API credits"
+  }'
+```
+
+**Required fields:**
+- `amountCents` — amount in cents (`1000` = $10.00)
+- `merchant` — merchant name
+- `reason` — why the payment is needed
+
+**Optional fields:**
+- `currency` — defaults to `"usd"`
+- `paymentMethodId` — specific card to use (uses default card if omitted)
+- `merchantStripeAccount` — Stripe Connect account ID if applicable
+- `platform` — which agent/platform is making the request (e.g. "Claude MCP", "LangChain")
+- `service` — what service/product the payment is for (e.g. "GPT-4 credits", "API subscription")
+
+**200 → Auto-approved:**
+```json
+{"approved": true, "sptToken": "spt_...", "transactionId": "..."}
+```
+Use the `sptToken` to pay the merchant. Expires in 1 hour.
+
+**202 → Needs human approval.** Poll for status.
+
+**403 → Denied.** Spending rules blocked it.
+
+See `references/card-payments.md` for full details.
+
+---
+
+### GET /authorize/status — Poll for approval
+
+```bash
+curl "https://api.crowpay.ai/authorize/status?id=APPROVAL_ID" \
+  -H "X-API-Key: crow_sk_abc123..."
+```
+
+Poll every **3 seconds**. Do not poll faster.
+
+| Status in response | What to do |
+|--------------------|------------|
+| `"pending"` | Keep polling |
+| `"signing"` | Keep polling (approved, generating payload) |
+| Response has `payload` field | Done — use the signed payload to pay |
+| Response has `sptToken` field | Done — use token for card payment |
+| `"denied"` | Stop. Owner rejected the payment. |
+| `"timeout"` | Stop. Approval window expired. |
+| `"failed"` | Stop. Error during signing. |
+
+---
+
+### POST /settle — Report x402 settlement
+
+After the x402 facilitator settles your payment on-chain, report it. Idempotent — safe to call multiple times.
+
+```bash
+curl -X POST https://api.crowpay.ai/settle \
+  -H "X-API-Key: crow_sk_abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"transactionId": "...", "txHash": "0x..."}'
+```
+
+Not needed for card payments (Stripe webhooks handle this automatically).
+
+---
+
+## Key Numbers
+
+| Type | Format | Example | Dollar value |
+|------|--------|---------|-------------|
+| USDC (x402) | Atomic units, 6 decimals | `1000000` | $1.00 |
+| USDC (x402) | Atomic units, 6 decimals | `100000` | $0.10 |
+| Card | Cents | `100` | $1.00 |
+| Card | Cents | `1000` | $10.00 |
+
+- **Network:** Base mainnet (`eip155:8453`)
+- **USDC contract:** `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+
+## Default Spending Rules
+
+Auto-created when wallet is claimed:
+- Per-transaction limit: **$25**
+- Daily limit: **$50**
+- Auto-approve threshold: **$5** (above this → human must approve)
+
+Owners customize these in the dashboard.
+
+## References
+
+For deeper walkthroughs with complete curl examples and all edge cases:
+
+- `references/api-reference.md` — Complete API reference: every endpoint, every field, every response code with curl examples
+- `references/x402-flow.md` — End-to-end 402 payment walkthrough with curl
+- `references/card-payments.md` — Credit card payment walkthrough with curl
+- `references/error-handling.md` — All error codes, retry strategy, polling best practices
+
+## Finding Services to Pay For
+
+Use [Nightmarket](https://nightmarket.ai) to discover paid APIs your agent can call. Every Nightmarket service uses x402 — Crow handles the payments automatically.
+
+Install the Nightmarket skill:
+```
+npx skills add https://github.com/Fallomai/skills --skill nightmarket
+```

--- a/nanobot/skills/crow/references/api-reference.md
+++ b/nanobot/skills/crow/references/api-reference.md
@@ -1,0 +1,370 @@
+# Crow API Reference
+
+Complete reference for all Crow endpoints. Base URL: `https://api.crowpay.ai`
+
+## Authentication
+
+All endpoints except `POST /setup` require:
+```
+X-API-Key: crow_sk_...
+```
+
+---
+
+## POST /setup
+
+Create a new agent wallet and API key.
+
+```bash
+curl -X POST https://api.crowpay.ai/setup \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+### Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `network` | string | No | CAIP-2 network ID. Defaults to `"eip155:8453"` (Base mainnet) |
+
+### Responses
+
+**200 OK**
+```json
+{
+  "apiKey": "crow_sk_abc123def456...",
+  "walletAddress": "0x1234567890abcdef1234567890abcdef12345678",
+  "claimUrl": "https://crowpay.ai/claim/xyz789",
+  "fundingInstructions": "Send USDC on Base to 0x1234..."
+}
+```
+
+**429 Too Many Requests** — IP-based rate limit. Wait and retry.
+
+---
+
+## POST /authorize
+
+Check spending rules and sign an EIP-3009 USDC payment authorization for x402 protocol.
+
+```bash
+curl -X POST https://api.crowpay.ai/authorize \
+  -H "X-API-Key: crow_sk_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "paymentRequired": {"x402Version":2,"resource":{"url":"..."},"accepts":[{"scheme":"exact","network":"eip155:8453","amount":"1000000","asset":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","payTo":"0x...","maxTimeoutSeconds":60,"extra":{"name":"USDC","version":"2"}}]},
+    "merchant": "ServiceName",
+    "reason": "Why this payment is needed"
+  }'
+```
+
+### Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `paymentRequired` | object | Yes | The full HTTP 402 response body from the x402 API |
+| `merchant` | string | Yes | Human-readable name of the service. Wallet owner sees this. |
+| `reason` | string | Yes | Why the payment is needed. Wallet owner sees this. |
+| `walletAddress` | string | No | Specific wallet to use. Defaults to API key's wallet. |
+| `platform` | string | No | Which agent/platform is making the request (e.g. "Claude MCP", "LangChain"). Wallet owner sees this. |
+| `service` | string | No | What service/product the payment is for (e.g. "Weather API", "Premium data"). Wallet owner sees this. |
+
+### paymentRequired format
+
+This is the standard x402 v2 PaymentRequired object:
+
+```json
+{
+  "x402Version": 2,
+  "resource": {
+    "url": "https://api.example.com/v1/endpoint",
+    "description": "Optional description"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "amount": "1000000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0xRecipientAddress",
+      "maxTimeoutSeconds": 60,
+      "extra": {
+        "name": "USDC",
+        "version": "2"
+      }
+    }
+  ]
+}
+```
+
+### Responses
+
+**200 OK — Auto-approved**
+
+The signed payment payload. Use this to retry the original request.
+
+```json
+{
+  "x402Version": 2,
+  "resource": {"url": "https://api.example.com/v1/endpoint"},
+  "accepted": {
+    "scheme": "exact",
+    "network": "eip155:8453",
+    "amount": "1000000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "0xRecipientAddress",
+    "maxTimeoutSeconds": 60,
+    "extra": {"name": "USDC", "version": "2"}
+  },
+  "payload": {
+    "signature": "0xabc123...",
+    "authorization": {
+      "from": "0xYourWallet",
+      "to": "0xRecipient",
+      "value": "1000000",
+      "validAfter": "1740672089",
+      "validBefore": "1740672154",
+      "nonce": "0xrandomnonce..."
+    }
+  }
+}
+```
+
+To retry the original request with payment:
+```bash
+PAYMENT=$(echo '{"x402Version":2,...}' | base64 -w0)
+curl https://api.example.com/v1/endpoint \
+  -H "payment-signature: $PAYMENT"
+```
+
+**202 Accepted — Pending human approval**
+```json
+{
+  "status": "pending",
+  "approvalId": "abc123",
+  "expiresAt": 1740672200,
+  "message": "Payment requires human approval. Poll GET /authorize/status?id=abc123"
+}
+```
+
+**400 Bad Request**
+- `Missing required fields: paymentRequired, merchant, reason`
+- `No compatible payment option` — wallet doesn't support the requested network/asset
+
+**401 Unauthorized**
+- `Missing X-API-Key header`
+- `Invalid API key or wallet not found`
+- `Wallet not claimed — claim your wallet first`
+
+**403 Forbidden**
+- `Payment denied` with `reason` field explaining why (e.g., "Exceeds per-transaction limit of $25.00")
+
+### Spending rules checked
+
+1. Per-transaction limit
+2. Merchant blacklist
+3. Merchant whitelist (if configured)
+4. Daily spending limit
+5. Auto-approve threshold (above threshold → 202 pending)
+
+---
+
+## POST /authorize/card
+
+Request a credit card payment. Returns a Stripe Shared Payment Token.
+
+```bash
+curl -X POST https://api.crowpay.ai/authorize/card \
+  -H "X-API-Key: crow_sk_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amountCents": 1000,
+    "merchant": "OpenAI",
+    "reason": "GPT-4 API credits"
+  }'
+```
+
+### Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amountCents` | integer | Yes | Amount in cents. `1000` = $10.00. Must be positive. |
+| `merchant` | string | Yes | Merchant name. Wallet owner sees this. |
+| `reason` | string | Yes | Why the payment is needed. Wallet owner sees this. |
+| `currency` | string | No | Defaults to `"usd"` |
+| `paymentMethodId` | string | No | Specific card ID. Uses default card if omitted. |
+| `merchantStripeAccount` | string | No | Stripe Connect account ID if applicable |
+| `platform` | string | No | Which agent/platform is making the request (e.g. "Claude MCP", "LangChain"). Wallet owner sees this. |
+| `service` | string | No | What service/product the payment is for (e.g. "GPT-4 credits", "API subscription"). Wallet owner sees this. |
+
+### Responses
+
+**200 OK — Auto-approved**
+```json
+{
+  "approved": true,
+  "sptToken": "spt_abc123...",
+  "transactionId": "txn_xyz789"
+}
+```
+
+The `sptToken` is a Stripe Shared Payment Token. Use it to pay the merchant via Stripe. Expires in 1 hour.
+
+**202 Accepted — Pending human approval**
+```json
+{
+  "status": "pending",
+  "approvalId": "abc123",
+  "expiresAt": 1740672200,
+  "message": "Payment requires human approval. Poll GET /authorize/status?id=abc123"
+}
+```
+
+**400 Bad Request**
+- `amountCents must be a positive integer`
+- `Missing required fields: merchant, reason`
+- `No payment methods configured. Add a card first.`
+
+**401 Unauthorized** — Invalid or missing API key.
+
+**403 Forbidden**
+- `Payment denied` with reason
+- `Payment method not found or not owned by you`
+
+### Default card spending rules
+
+Created automatically when a card is added:
+
+| Rule | Default |
+|------|---------|
+| Daily limit | $50 |
+| Per-transaction limit | $25 |
+| Auto-approve threshold | $5 |
+
+---
+
+## GET /authorize/status
+
+Poll for the status of a pending approval (works for both x402 and card payments).
+
+```bash
+curl "https://api.crowpay.ai/authorize/status?id=APPROVAL_ID" \
+  -H "X-API-Key: crow_sk_..."
+```
+
+### Query parameters
+
+| Param | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | The `approvalId` from a 202 response |
+
+Poll every **3 seconds**. Do not poll faster.
+
+### Responses
+
+**Still pending:**
+```json
+{"status": "pending"}
+```
+
+**Approved — signing in progress:**
+```json
+{"status": "signing"}
+```
+
+**Approved — x402 payload ready:**
+```json
+{
+  "x402Version": 2,
+  "resource": {"url": "..."},
+  "accepted": {"scheme": "exact", "...": "..."},
+  "payload": {
+    "signature": "0x...",
+    "authorization": {"from": "0x...", "to": "0x...", "value": "1000000", "...": "..."}
+  }
+}
+```
+
+**Approved — card token ready:**
+```json
+{
+  "approved": true,
+  "sptToken": "spt_...",
+  "transactionId": "..."
+}
+```
+
+**Denied:**
+```json
+{"status": "denied", "reason": "Denied by wallet owner"}
+```
+
+**Timed out:**
+```json
+{"status": "timeout", "reason": "Approval window expired"}
+```
+
+**Failed:**
+```json
+{"status": "failed", "reason": "Payment provisioning failed"}
+```
+
+**400** — Missing `id` query parameter.
+**403** — Approval belongs to a different wallet.
+**404** — Approval not found.
+
+---
+
+## POST /settle
+
+Report that an x402 payment settled on-chain. Idempotent — safe to call multiple times.
+
+```bash
+curl -X POST https://api.crowpay.ai/settle \
+  -H "X-API-Key: crow_sk_..." \
+  -H "Content-Type: application/json" \
+  -d '{"transactionId": "txn_xyz789", "txHash": "0xabcdef..."}'
+```
+
+### Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `transactionId` | string | Yes | Transaction ID from the authorize response |
+| `txHash` | string | Yes | On-chain transaction hash |
+
+### Responses
+
+**200 OK**
+```json
+{"success": true}
+```
+
+Or if already settled:
+```json
+{"success": true, "alreadySettled": true}
+```
+
+**400** — Missing `transactionId` or `txHash`.
+**403** — Transaction belongs to a different wallet.
+**404** — Transaction not found.
+**422** — Transaction is in wrong state (e.g., still pending approval).
+
+Not needed for card payments — Stripe webhooks handle settlement automatically.
+
+---
+
+## CORS
+
+All endpoints (except `/stripe/webhook`) support CORS with `Access-Control-Allow-Origin: *`. OPTIONS preflight requests return 204.
+
+## Constants
+
+| Constant | Value |
+|----------|-------|
+| Base URL | `https://api.crowpay.ai` |
+| USDC contract (Base mainnet) | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Network (CAIP-2) | `eip155:8453` |
+| USDC decimals | 6 |
+| $1.00 in USDC atomic units | `1000000` |
+| $1.00 in card cents | `100` |

--- a/nanobot/skills/crow/references/card-payments.md
+++ b/nanobot/skills/crow/references/card-payments.md
@@ -1,0 +1,124 @@
+# Credit Card Payments — End-to-End with curl
+
+Pay merchants with a credit card using Stripe Shared Payment Tokens (SPTs). Use this when there's no 402 involved — e.g., paying for SaaS, API credits, subscriptions.
+
+## Prerequisites
+
+- Wallet must be claimed (user visited `claimUrl` from `/setup`)
+- A credit card must be added in the dashboard at https://crowpay.ai/dashboard
+- Card spending rules are auto-created when a card is added
+
+## Step 1: Request a card payment
+
+```bash
+curl -X POST https://api.crowpay.ai/authorize/card \
+  -H "X-API-Key: crow_sk_abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amountCents": 500,
+    "merchant": "OpenAI",
+    "reason": "GPT-4 API credits for code review task",
+    "platform": "Claude MCP",
+    "service": "GPT-4 API credits"
+  }'
+```
+
+### All request fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `amountCents` | integer | Yes | — | Amount in cents. `500` = $5.00. Must be positive. |
+| `merchant` | string | Yes | — | Merchant name (wallet owner sees this) |
+| `reason` | string | Yes | — | Why the payment is needed (wallet owner sees this) |
+| `currency` | string | No | `"usd"` | Currency code |
+| `paymentMethodId` | string | No | default card | ID of a specific card to charge |
+| `merchantStripeAccount` | string | No | — | Stripe Connect account ID if applicable |
+| `platform` | string | No | — | Which agent/platform is making the request (e.g. "Claude MCP") |
+| `service` | string | No | — | What service/product the payment is for (e.g. "GPT-4 credits") |
+
+## Step 2a: If 200 — Auto-approved
+
+Amount is within the auto-approve threshold (default $5):
+
+```json
+{
+  "approved": true,
+  "sptToken": "spt_abc123def456...",
+  "transactionId": "txn_xyz789"
+}
+```
+
+The `sptToken` is a Stripe Shared Payment Token. Use it to pay the merchant through Stripe's payment API. The token expires in **1 hour**.
+
+## Step 2b: If 202 — Needs human approval
+
+Amount exceeds auto-approve threshold:
+
+```json
+{
+  "status": "pending",
+  "approvalId": "approval_abc123",
+  "expiresAt": 1740672200,
+  "message": "Payment requires human approval. Poll GET /authorize/status?id=approval_abc123"
+}
+```
+
+Poll every 3 seconds:
+
+```bash
+curl "https://api.crowpay.ai/authorize/status?id=approval_abc123" \
+  -H "X-API-Key: crow_sk_abc123..."
+```
+
+When approved, response will contain `sptToken`:
+
+```json
+{
+  "approved": true,
+  "sptToken": "spt_abc123def456...",
+  "transactionId": "txn_xyz789"
+}
+```
+
+If `"denied"`, `"timeout"`, or `"failed"` — stop and inform the user.
+
+## Step 2c: If 403 — Denied
+
+Spending rules blocked the payment:
+
+```json
+{
+  "error": "Payment denied",
+  "reason": "Exceeds daily limit of $50.00"
+}
+```
+
+Do not retry with same params. Tell the user.
+
+## Default card spending rules
+
+Created automatically when a card is added:
+
+| Rule | Default |
+|------|---------|
+| Daily limit | $50 (5000 cents) |
+| Per-transaction limit | $25 (2500 cents) |
+| Auto-approve threshold | $5 (500 cents) |
+
+Owners can customize all limits in the dashboard under the "Rules" tab.
+
+## Settlement
+
+Card payments are tracked automatically via Stripe webhooks — no need to call `/settle`.
+
+- `shared_payment.issued_token.used` → transaction marked as settled
+- `shared_payment.issued_token.deactivated` → transaction marked as failed
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `amountCents must be a positive integer` | Invalid amount | Use a positive integer in cents |
+| `Missing required fields: merchant, reason` | Body incomplete | Add both fields |
+| `No payment methods configured` | No card added | User needs to add card in dashboard |
+| `Payment method not found or not owned by you` | Bad `paymentMethodId` | Omit it to use default card |

--- a/nanobot/skills/crow/references/error-handling.md
+++ b/nanobot/skills/crow/references/error-handling.md
@@ -1,0 +1,151 @@
+# Error Handling
+
+All Crow API errors return JSON:
+
+```json
+{
+  "error": "Short error message",
+  "reason": "Detailed explanation (on 403s)",
+  "details": "Technical details (on 500s)"
+}
+```
+
+## Status Codes
+
+| Status | Meaning | Retry? | Action |
+|--------|---------|--------|--------|
+| 200 | Success | — | Proceed |
+| 202 | Pending approval | Poll | Poll `/authorize/status` every 3s |
+| 400 | Bad request | No | Fix the request |
+| 401 | Unauthorized | No | Check API key |
+| 403 | Denied by rules | No | Inform user, do not retry same params |
+| 404 | Not found | No | Check the ID |
+| 422 | Invalid state | No | Transaction is in wrong state |
+| 429 | Rate limited | Yes | Wait, then retry with backoff |
+| 500 | Server error | Yes | Retry with exponential backoff |
+
+## Errors by Endpoint
+
+### POST /setup
+
+| Error | Cause |
+|-------|-------|
+| 429 `Rate limit exceeded` | Too many setup calls from this IP |
+
+### POST /authorize
+
+| Status | Error | Cause |
+|--------|-------|-------|
+| 400 | `Missing required fields: paymentRequired, merchant, reason` | Request body incomplete |
+| 400 | `No compatible payment option` | Wallet doesn't support requested network/asset |
+| 401 | `Missing X-API-Key header` | No API key provided |
+| 401 | `Invalid API key or wallet not found` | Key is wrong or revoked |
+| 401 | `Wallet not claimed` | User hasn't visited the claim URL |
+| 403 | `Payment denied` | Spending rules blocked it (check `reason` field) |
+
+### POST /authorize/card
+
+| Status | Error | Cause |
+|--------|-------|-------|
+| 400 | `amountCents must be a positive integer` | Invalid amount |
+| 400 | `Missing required fields: merchant, reason` | Request body incomplete |
+| 400 | `No payment methods configured` | No card in dashboard |
+| 403 | `Payment denied` | Spending rules blocked it (check `reason` field) |
+| 403 | `Payment method not found or not owned by you` | Bad `paymentMethodId` |
+
+### GET /authorize/status
+
+| Status | Error | Cause |
+|--------|-------|-------|
+| 400 | `Missing id query parameter` | No `?id=` in URL |
+| 403 | `Forbidden` | Approval belongs to a different wallet |
+| 404 | `Approval not found` | Invalid approval ID |
+
+### POST /settle
+
+| Status | Error | Cause |
+|--------|-------|-------|
+| 400 | `Missing transactionId or txHash` | Request body incomplete |
+| 403 | `Forbidden` | Transaction belongs to a different wallet |
+| 404 | `Transaction not found` | Invalid transaction ID |
+| 422 | `Cannot settle transaction with status: ...` | Wrong state (e.g., still pending approval) |
+
+## Retry Strategy
+
+For retryable errors (429, 5xx), use exponential backoff:
+
+```bash
+# Simple retry with backoff
+for i in 1 2 3; do
+  response=$(curl -s -w "\n%{http_code}" -X POST https://api.crowpay.ai/authorize \
+    -H "X-API-Key: crow_sk_..." \
+    -H "Content-Type: application/json" \
+    -d '...')
+
+  status_code=$(echo "$response" | tail -1)
+  body=$(echo "$response" | head -1)
+
+  if [ "$status_code" -lt 500 ] && [ "$status_code" -ne 429 ]; then
+    echo "$body"
+    break
+  fi
+
+  sleep $((i * 2))
+done
+```
+
+## Polling Best Practices
+
+When polling `/authorize/status`:
+- Poll every **3 seconds** — not faster
+- Set a max timeout (e.g., 5 minutes) to avoid infinite loops
+- The `expiresAt` timestamp in the 202 response tells you when the approval window closes
+- Handle all terminal states: `denied`, `timeout`, `failed`
+
+```bash
+# Poll loop
+APPROVAL_ID="abc123"
+MAX_ATTEMPTS=100  # 5 minutes at 3s intervals
+
+for i in $(seq 1 $MAX_ATTEMPTS); do
+  response=$(curl -s "https://api.crowpay.ai/authorize/status?id=$APPROVAL_ID" \
+    -H "X-API-Key: crow_sk_...")
+
+  status=$(echo "$response" | jq -r '.status // empty')
+
+  # Check for signed payload (x402)
+  if echo "$response" | jq -e '.payload' > /dev/null 2>&1; then
+    echo "Approved! Got payment payload."
+    echo "$response"
+    break
+  fi
+
+  # Check for SPT token (card)
+  if echo "$response" | jq -e '.sptToken' > /dev/null 2>&1; then
+    echo "Approved! Got SPT token."
+    echo "$response"
+    break
+  fi
+
+  # Terminal states
+  case "$status" in
+    denied|timeout|failed)
+      echo "Payment $status: $(echo "$response" | jq -r '.reason')"
+      break
+      ;;
+    pending|signing)
+      sleep 3
+      ;;
+  esac
+done
+```
+
+## Constants
+
+| Constant | Value |
+|----------|-------|
+| USDC contract (Base) | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Network (CAIP-2) | `eip155:8453` |
+| USDC decimals | 6 |
+| $1.00 in USDC atomic units | `1000000` |
+| $1.00 in card cents | `100` |

--- a/nanobot/skills/crow/references/x402-flow.md
+++ b/nanobot/skills/crow/references/x402-flow.md
@@ -1,0 +1,170 @@
+# x402 Payment Flow — End-to-End with curl
+
+Step-by-step guide for handling HTTP 402 Payment Required responses using Crow.
+
+## Overview
+
+x402 is a protocol where APIs return HTTP 402 with payment details. You forward the 402 body to Crow, Crow checks spending rules and signs a USDC authorization, and you retry the original request with the signed payment.
+
+## Step 1: Call an API and get a 402
+
+```bash
+curl -i https://api.example.com/v1/data
+```
+
+Response:
+```
+HTTP/1.1 402 Payment Required
+Content-Type: application/json
+
+{
+  "x402Version": 2,
+  "resource": {"url": "https://api.example.com/v1/data", "description": "Premium data"},
+  "accepts": [{
+    "scheme": "exact",
+    "network": "eip155:8453",
+    "amount": "500000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "0xMerchantAddress",
+    "maxTimeoutSeconds": 60,
+    "extra": {"name": "USDC", "version": "2"}
+  }]
+}
+```
+
+This means: "Pay $0.50 USDC on Base to access this endpoint."
+
+## Step 2: Forward the 402 to Crow
+
+Pass the **entire 402 response body** as `paymentRequired`, and add a clear `merchant` name and `reason`:
+
+```bash
+curl -X POST https://api.crowpay.ai/authorize \
+  -H "X-API-Key: crow_sk_abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "paymentRequired": {
+      "x402Version": 2,
+      "resource": {"url": "https://api.example.com/v1/data", "description": "Premium data"},
+      "accepts": [{
+        "scheme": "exact",
+        "network": "eip155:8453",
+        "amount": "500000",
+        "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        "payTo": "0xMerchantAddress",
+        "maxTimeoutSeconds": 60,
+        "extra": {"name": "USDC", "version": "2"}
+      }]
+    },
+    "merchant": "ExampleAPI",
+    "reason": "Fetching premium data for user analysis",
+    "platform": "Claude MCP",
+    "service": "Premium data API"
+  }'
+```
+
+The wallet owner sees the `merchant` and `reason` when approving, so make them descriptive.
+
+## Step 3a: If 200 — Auto-approved
+
+Crow checked spending rules and $0.50 is within the auto-approve threshold. You get a signed payment payload:
+
+```json
+{
+  "x402Version": 2,
+  "resource": {"url": "https://api.example.com/v1/data"},
+  "accepted": {"scheme": "exact", "network": "eip155:8453", "amount": "500000", "...": "..."},
+  "payload": {
+    "signature": "0xabc123...",
+    "authorization": {
+      "from": "0xYourWallet",
+      "to": "0xMerchantAddress",
+      "value": "500000",
+      "validAfter": "1740672089",
+      "validBefore": "1740672154",
+      "nonce": "0xrandomnonce..."
+    }
+  }
+}
+```
+
+Retry your original request with this payload base64-encoded in the `payment-signature` header:
+
+```bash
+# Save the full Crow response to a variable
+CROW_RESPONSE='{"x402Version":2,"resource":{"url":"https://api.example.com/v1/data"},"accepted":{...},"payload":{...}}'
+
+# Base64-encode it
+PAYMENT=$(echo -n "$CROW_RESPONSE" | base64 -w0)
+
+# Retry the original request
+curl https://api.example.com/v1/data \
+  -H "payment-signature: $PAYMENT"
+```
+
+The x402 facilitator on the API side verifies the signature and settles the USDC transfer on-chain.
+
+## Step 3b: If 202 — Needs human approval
+
+The amount exceeds the auto-approve threshold. The wallet owner gets a notification and must approve in their dashboard.
+
+```json
+{
+  "status": "pending",
+  "approvalId": "approval_abc123",
+  "expiresAt": 1740672200,
+  "message": "Payment requires human approval. Poll GET /authorize/status?id=approval_abc123"
+}
+```
+
+Poll every 3 seconds:
+
+```bash
+# Poll for status
+curl "https://api.crowpay.ai/authorize/status?id=approval_abc123" \
+  -H "X-API-Key: crow_sk_abc123..."
+```
+
+Keep polling while status is `"pending"` or `"signing"`.
+
+When the response contains a `payload` field, use it the same way as step 3a — base64-encode and retry.
+
+If status is `"denied"`, `"timeout"`, or `"failed"` — stop. The payment was not approved.
+
+## Step 3c: If 403 — Denied
+
+Spending rules blocked this payment. The response tells you why:
+
+```json
+{
+  "error": "Payment denied",
+  "reason": "Exceeds per-transaction limit of $25.00"
+}
+```
+
+Do **not** retry with the same parameters. Tell the user.
+
+## Step 4: Report settlement
+
+After the x402 facilitator settles the payment on-chain:
+
+```bash
+curl -X POST https://api.crowpay.ai/settle \
+  -H "X-API-Key: crow_sk_abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transactionId": "txn_xyz789",
+    "txHash": "0xabcdef1234567890..."
+  }'
+```
+
+This is idempotent — safe to call multiple times.
+
+## Key details
+
+- USDC amounts are in **atomic units** with 6 decimals: `1000000` = $1.00, `500000` = $0.50
+- Network is always Base mainnet: `eip155:8453`
+- USDC contract: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+- Crow signs EIP-3009 `TransferWithAuthorization` — the facilitator settles on-chain
+- The wallet's private key never leaves Crow's server
+- Default auto-approve threshold is $5 — owner can change this in dashboard


### PR DESCRIPTION
## What this adds

A new **CrowPay** (Crow) skill that gives nanobot agents the ability to pay for APIs and services autonomously — within spending rules set by the wallet owner.

### How it works

[CrowPay](https://crowpay.ai) provides managed wallets for AI agents with built-in spending rules, human approval workflows, and audit trails. It supports two payment methods:

- **x402 (USDC on Base)** — for APIs that return HTTP 402 Payment Required (like [Nightmarket](https://nightmarket.ai) services)
- **Credit card (Stripe)** — for merchants, subscriptions, and API credits

The agent interacts entirely via HTTP requests to `https://api.crowpay.ai`. No wallet private keys are ever exposed to the agent.

### Skill contents

- **SKILL.md** — main skill doc with setup, decision tree, and all endpoint docs
- **references/api-reference.md** — complete API reference with every field and response code
- **references/x402-flow.md** — end-to-end 402 payment walkthrough with curl
- **references/card-payments.md** — credit card payment walkthrough
- **references/error-handling.md** — all error codes, retry strategy, polling best practices

### Why this is useful for nanobot

Agents often need to pay for external services — API calls, credits, subscriptions. Without a payment skill, the agent has to ask the user to handle every transaction manually. CrowPay lets the agent handle payments autonomously while the wallet owner maintains control through configurable spending rules and approval thresholds.

Default rules auto-approve transactions under $5, require human approval for larger amounts, and enforce daily limits. All customizable via the dashboard.

### Integration

Follows the same `nanobot/skills/` directory structure and SKILL.md format as existing skills. Zero configuration needed.