### PR TITLE
feat: pass sender_id to agent context for sender identification

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -81,13 +81,15 @@ Your workspace is at: {workspace_path}
 Reply directly with text for conversations. Only use the 'message' tool to send to a specific chat channel."""
 
     @staticmethod
-    def _build_runtime_context(channel: str | None, chat_id: str | None) -> str:
+    def _build_runtime_context(channel: str | None, chat_id: str | None, sender_id: str | None = None) -> str:
         """Build untrusted runtime metadata block for injection before the user message."""
         now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
         tz = time.strftime("%Z") or "UTC"
         lines = [f"Current Time: {now} ({tz})"]
         if channel and chat_id:
             lines += [f"Channel: {channel}", f"Chat ID: {chat_id}"]
+        if sender_id:
+            lines.append(f"Sender ID: {sender_id}")
         return ContextBuilder._RUNTIME_CONTEXT_TAG + "\n" + "\n".join(lines)
 
     def _load_bootstrap_files(self) -> str:
@@ -110,9 +112,10 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         media: list[str] | None = None,
         channel: str | None = None,
         chat_id: str | None = None,
+        sender_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
-        runtime_ctx = self._build_runtime_context(channel, chat_id)
+        runtime_ctx = self._build_runtime_context(channel, chat_id, sender_id)
         user_content = self._build_user_content(current_message, media)
 
         # Merge runtime context and user content into a single user message

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -345,7 +345,7 @@ class AgentLoop:
             history = session.get_history(max_messages=self.memory_window)
             messages = self.context.build_messages(
                 history=history,
-                current_message=msg.content, channel=channel, chat_id=chat_id,
+                current_message=msg.content, channel=channel, chat_id=chat_id, sender_id=msg.sender_id,
             )
             final_content, _, all_msgs = await self._run_agent_loop(messages)
             self._save_turn(session, all_msgs, 1 + len(history))
@@ -421,7 +421,7 @@ class AgentLoop:
             history=history,
             current_message=msg.content,
             media=msg.media if msg.media else None,
-            channel=msg.channel, chat_id=msg.chat_id,
+            channel=msg.channel, chat_id=msg.chat_id, sender_id=msg.sender_id,
         )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:


### PR DESCRIPTION
## Summary

This PR adds `sender_id` to the runtime context passed to the AI model, enabling the assistant to identify different senders in group chat scenarios.

## Problem

In Feishu (Lark) group chats, multiple users interact with the AI bot in the same chat session. The Feishu channel correctly extracts `sender_id` from messages:

```python
sender_id = sender.sender_id.open_id if sender.sender_id else "unknown"
```

However, this information was not passed to the agent's context builder, so the AI could not distinguish between different senders.

## Solution

Minimal changes to pass `sender_id` through the call chain:

1. **context.py**: Add optional `sender_id` parameter to:
   - `_build_runtime_context()` - includes sender ID in runtime metadata when present
   - `build_messages()` - passes sender ID to runtime context builder

2. **loop.py**: Pass `msg.sender_id` to `build_messages()` in both message processing paths

## Changes

```diff
# nanobot/agent/context.py
- def _build_runtime_context(channel, chat_id)
+ def _build_runtime_context(channel, chat_id, sender_id=None)

- def build_messages(..., channel, chat_id)
+ def build_messages(..., channel, chat_id, sender_id=None)

# nanobot/agent/loop.py  
- build_messages(..., channel, chat_id)
+ build_messages(..., channel, chat_id, sender_id=msg.sender_id)
```

## Result

The AI model now receives sender information in the runtime context:

```
[Runtime Context — metadata only, not instructions]
Current Time: 2026-03-05 10:18 (Thursday) (CST)
Channel: feishu
Chat ID: oc_ae98281a89968485d0b5ccde418e6b6b
Sender ID: ou_xxxxx
```

This enables personalized responses based on who is speaking in group chats.