### PR TITLE
feat(codex): 在 openai_codex 中同时支持 OAuth 与自定义 Responses 模式

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -208,9 +208,13 @@ def _make_provider(config: Config):
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
 
-    # OpenAI Codex (OAuth)
+    # OpenAI Codex (OAuth or direct Responses API via api_key/api_base)
     if provider_name == "openai_codex" or model.startswith("openai-codex/"):
-        return OpenAICodexProvider(default_model=model)
+        return OpenAICodexProvider(
+            default_model=model,
+            api_key=p.api_key if p else None,
+            api_base=p.api_base if p else None,
+        )
 
     # Custom: direct OpenAI-compatible endpoint, bypasses LiteLLM
     if provider_name == "custom":

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -1,5 +1,6 @@
 """Configuration schema using Pydantic."""
 
+import re
 from pathlib import Path
 from typing import Literal
 
@@ -342,8 +343,9 @@ class Config(BaseSettings):
 
         forced = self.agents.defaults.provider
         if forced != "auto":
-            p = getattr(self.providers, forced, None)
-            return (p, forced) if p else (None, None)
+            canonical_forced = _canonical_provider_name(forced)
+            p = getattr(self.providers, canonical_forced, None)
+            return (p, canonical_forced) if p else (None, None)
 
         model_lower = (model or self.agents.defaults.model).lower()
         model_normalized = model_lower.replace("-", "_")
@@ -410,3 +412,9 @@ class Config(BaseSettings):
         return None
 
     model_config = ConfigDict(env_prefix="NANOBOT_", env_nested_delimiter="__")
+
+
+def _canonical_provider_name(name: str) -> str:
+    """Normalize provider aliases like openaiCodex/openai-codex to openai_codex."""
+    collapsed = re.sub(r"(?<!^)(?=[A-Z])", "_", name).replace("-", "_")
+    return collapsed.lower()

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -14,14 +14,20 @@ from oauth_cli_kit import get_token as get_codex_token
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 
 DEFAULT_CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
+DEFAULT_RESPONSES_URL = "https://api.openai.com/v1/responses"
 DEFAULT_ORIGINATOR = "nanobot"
 
 
 class OpenAICodexProvider(LLMProvider):
-    """Use Codex OAuth to call the Responses API."""
+    """Use Codex OAuth or custom Responses API to call the Responses endpoint."""
 
-    def __init__(self, default_model: str = "openai-codex/gpt-5.1-codex"):
-        super().__init__(api_key=None, api_base=None)
+    def __init__(
+        self,
+        default_model: str = "openai-codex/gpt-5.1-codex",
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ):
+        super().__init__(api_key=api_key, api_base=api_base)
         self.default_model = default_model
 
     async def chat(
@@ -36,8 +42,14 @@ class OpenAICodexProvider(LLMProvider):
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)
 
-        token = await asyncio.to_thread(get_codex_token)
-        headers = _build_headers(token.account_id, token.access)
+        use_custom_responses = bool(self.api_base or self.api_key)
+        if use_custom_responses:
+            headers = _build_custom_headers(self.api_key)
+            url = _build_responses_url(self.api_base)
+        else:
+            token = await asyncio.to_thread(get_codex_token)
+            headers = _build_headers(token.account_id, token.access)
+            url = DEFAULT_CODEX_URL
 
         body: dict[str, Any] = {
             "model": _strip_model_prefix(model),
@@ -57,8 +69,6 @@ class OpenAICodexProvider(LLMProvider):
 
         if tools:
             body["tools"] = _convert_tools(tools)
-
-        url = DEFAULT_CODEX_URL
 
         try:
             try:
@@ -99,6 +109,30 @@ def _build_headers(account_id: str, token: str) -> dict[str, str]:
         "accept": "text/event-stream",
         "content-type": "application/json",
     }
+
+
+def _build_custom_headers(api_key: str | None) -> dict[str, str]:
+    headers = {
+        "accept": "text/event-stream",
+        "content-type": "application/json",
+        "User-Agent": "nanobot (python)",
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _build_responses_url(api_base: str | None) -> str:
+    base = (api_base or "").strip()
+    if not base:
+        return DEFAULT_RESPONSES_URL
+
+    base = base.rstrip("/")
+    if base.endswith("/responses"):
+        return base
+    if base.endswith("/v1"):
+        return f"{base}/responses"
+    return f"{base}/v1/responses"
 
 
 async def _request_codex(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -114,6 +114,13 @@ def test_config_matches_openai_codex_with_hyphen_prefix():
     assert config.get_provider_name() == "openai_codex"
 
 
+def test_config_forced_provider_accepts_camel_case_alias():
+    config = Config()
+    config.agents.defaults.provider = "openaiCodex"
+
+    assert config.get_provider_name("openai-codex/gpt-5.1-codex") == "openai_codex"
+
+
 def test_find_by_model_prefers_explicit_prefix_over_generic_codex_keyword():
     spec = find_by_model("github-copilot/gpt-5.3-codex")
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,7 +8,11 @@ from typer.testing import CliRunner
 from nanobot.cli.commands import app
 from nanobot.config.schema import Config
 from nanobot.providers.litellm_provider import LiteLLMProvider
-from nanobot.providers.openai_codex_provider import _strip_model_prefix
+from nanobot.providers.openai_codex_provider import (
+    OpenAICodexProvider,
+    _build_responses_url,
+    _strip_model_prefix,
+)
 from nanobot.providers.registry import find_by_model
 
 runner = CliRunner()
@@ -128,3 +132,24 @@ def test_litellm_provider_canonicalizes_github_copilot_hyphen_prefix():
 def test_openai_codex_strip_prefix_supports_hyphen_and_underscore():
     assert _strip_model_prefix("openai-codex/gpt-5.1-codex") == "gpt-5.1-codex"
     assert _strip_model_prefix("openai_codex/gpt-5.1-codex") == "gpt-5.1-codex"
+
+
+def test_openai_codex_build_responses_url_supports_common_api_base_styles():
+    assert _build_responses_url("https://example.com/responses") == "https://example.com/responses"
+    assert _build_responses_url("https://example.com/v1") == "https://example.com/v1/responses"
+    assert _build_responses_url("https://example.com") == "https://example.com/v1/responses"
+
+
+def test_make_provider_passes_openai_codex_api_credentials():
+    from nanobot.cli.commands import _make_provider
+
+    config = Config()
+    config.agents.defaults.model = "openai-codex/gpt-5.1-codex"
+    config.providers.openai_codex.api_key = "test-key"
+    config.providers.openai_codex.api_base = "https://example.com/v1"
+
+    provider = _make_provider(config)
+
+    assert isinstance(provider, OpenAICodexProvider)
+    assert provider.api_key == "test-key"
+    assert provider.api_base == "https://example.com/v1"


### PR DESCRIPTION
## 概要
本 PR 以“最小侵入”的方式为 `openai_codex` 增加双模式运行能力：

- **自定义 Responses 模式**：当 `providers.openai_codex.api_base` 或 `api_key` 存在时启用
- **OAuth 模式（原行为）**：当两者都不存在时保持不变

Closes #1549。

## 背景与动机
当前 `openai_codex` 在运行时是 OAuth-only 行为。即使用户在 `openai_codex` 下配置了 `api_base` / `api_key`，仍会强制调用 `get_codex_token()`，导致非 OAuth 场景失败。

本改动不引入新 provider、不改现有配置结构，仅在已有 provider 内做受控分流。

## 具体改动
1. `OpenAICodexProvider` 构造函数新增参数：`api_key`、`api_base`
2. 在 `chat()` 中按配置分流：
   - 自定义模式：使用 `Authorization: Bearer <api_key>`（若有），并使用由 `api_base` 推导出的 `/responses` URL
   - OAuth 模式：保留现有 `get_codex_token()`、headers 和 Codex URL
3. 新增 `_build_responses_url()` 兼容处理：
   - 已为 `.../responses`：原样使用
   - 以 `.../v1` 结尾：拼接 `.../v1/responses`
   - 其他 base：拼接 `.../v1/responses`
4. 在 `_make_provider()` 中创建 `OpenAICodexProvider` 时透传 `p.api_key` / `p.api_base`
5. 补充测试：
   - URL 构建兼容性
   - provider 工厂是否正确透传 codex 配置
6. 额外修复（本分支后续提交）：
   - 兼容 `agents.defaults.provider` 的别名写法（如 `openaiCodex` / `openai-codex`），统一规范化到 `openai_codex`

## 兼容性说明
- 默认 OAuth 用户无感：未配置 `api_base/api_key` 时行为不变。
- 不修改配置 schema，不新增命令。
- 仅扩展 `openai_codex` 的运行时能力。

## 验证情况
- 已补充单测用例（见 `tests/test_commands.py`）。
- 已通过 `python3 -m compileall` 对改动文件的语法检查。
- 当前环境未安装 pytest dev 依赖，完整测试建议在 CI / 本地安装 dev 依赖后执行。
