### PR TITLE
feat(command): Add /discard command for non-persistent session resets (new session without consolidation)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -389,9 +389,17 @@ class AgentLoop:
             self.sessions.invalidate(session.key)
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
                                   content="New session started.")
+
+        if cmd == "/discard":
+            session.clear()
+            self.sessions.save(session)
+            self.sessions.invalidate(session.key)
+            return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
+                                  content="Discarded previous session. New session started.")
+        
         if cmd == "/help":
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
-                                  content="🐈 nanobot commands:\n/new — Start a new conversation\n/stop — Stop the current task\n/help — Show available commands")
+                                  content="🐈 nanobot commands:\n/new — Start a new conversation\n/discard — Discard current conversation\n/stop — Stop the current task\n/help — Show available commands")
 
         unconsolidated = len(session.messages) - session.last_consolidated
         if (unconsolidated >= self.memory_window and session.key not in self._consolidating):


### PR DESCRIPTION
## Description

This PR introduces a new slash command, /discard, which allows users to reset their current session immediately without triggering the memory consolidation process.

Unlike /new, which archives the current conversation history and updates the bot's long-term memory before clearing, /discard simply wipes the current session state.

## Use Cases

- Testing/Debugging: Quickly reset the bot's state during development without polluting the memory database with test logs.

- Privacy/Security: When a session contains sensitive information that the user does not want preserved or summarized into the bot's long-term history.

- Topic Switching: When the previous context is irrelevant or "hallucination-heavy" and the user wants a clean slate without carrying over any weight from the last interaction.