### PR TITLE
fix(github copilot tool calls): GitHub Copilot tool_calls not working (multi-choice response)

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -8,6 +8,7 @@ from typing import Any
 import json_repair
 import litellm
 from litellm import acompletion
+from loguru import logger
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.providers.registry import find_by_model, find_gateway
@@ -255,20 +256,37 @@ class LiteLLMProvider(LLMProvider):
         """Parse LiteLLM response into our standard format."""
         choice = response.choices[0]
         message = choice.message
+        content = message.content
+        finish_reason = choice.finish_reason
+
+        # Some providers (e.g. GitHub Copilot) split content and tool_calls
+        # across multiple choices. Merge them so tool_calls are not lost.
+        raw_tool_calls = []
+        for ch in response.choices:
+            msg = ch.message
+            if hasattr(msg, "tool_calls") and msg.tool_calls:
+                raw_tool_calls.extend(msg.tool_calls)
+                if ch.finish_reason in ("tool_calls", "stop"):
+                    finish_reason = ch.finish_reason
+            if not content and msg.content:
+                content = msg.content
+
+        if len(response.choices) > 1:
+            logger.debug("LiteLLM response has {} choices, merged {} tool_calls",
+                         len(response.choices), len(raw_tool_calls))
 
         tool_calls = []
-        if hasattr(message, "tool_calls") and message.tool_calls:
-            for tc in message.tool_calls:
-                # Parse arguments from JSON string if needed
-                args = tc.function.arguments
-                if isinstance(args, str):
-                    args = json_repair.loads(args)
+        for tc in raw_tool_calls:
+            # Parse arguments from JSON string if needed
+            args = tc.function.arguments
+            if isinstance(args, str):
+                args = json_repair.loads(args)
 
-                tool_calls.append(ToolCallRequest(
-                    id=_short_tool_id(),
-                    name=tc.function.name,
-                    arguments=args,
-                ))
+            tool_calls.append(ToolCallRequest(
+                id=_short_tool_id(),
+                name=tc.function.name,
+                arguments=args,
+            ))
 
         usage = {}
         if hasattr(response, "usage") and response.usage:
@@ -282,9 +300,9 @@ class LiteLLMProvider(LLMProvider):
         thinking_blocks = getattr(message, "thinking_blocks", None) or None
         
         return LLMResponse(
-            content=message.content,
+            content=content,
             tool_calls=tool_calls,
-            finish_reason=choice.finish_reason or "stop",
+            finish_reason=finish_reason or "stop",
             usage=usage,
             reasoning_content=reasoning_content,
             thinking_blocks=thinking_blocks,


### PR DESCRIPTION
## Problem

When using `github_copilot/` models, the agent never executes tool calls. The LLM says it will use a tool but then returns the text response without actually calling any tools.

the following are agent logs before fix.
```
You: 2026-03-04 13:46:54.861 | INFO     | nanobot.agent.loop:run:263 - Agent loop started
You: give me the results
2026-03-04 13:48:09.386 | INFO     | nanobot.agent.loop:_process_message:357 - Processing message from cli:user: give me the results
13:48:09 - LiteLLM:WARNING: authenticator.py:99 - API key expired, refreshing
2026-03-04 13:48:13.680 | DEBUG    | nanobot.providers.litellm_provider:_parse_response:260 - LiteLLM raw response: finish_reason=tool_calls, content=I'm so sorry for all the delays! Let me actually do it now!, tool_calls=None
2026-03-04 13:48:13.682 | INFO     | nanobot.agent.loop:_process_message:449 - Response to cli:user: I'm so sorry for all the delays! Let me actually do it now!

🐈 nanobot
I'm so sorry for all the delays! Let me actually do it now!

You: directly give me the results
2026-03-04 13:48:36.458 | INFO     | nanobot.agent.loop:_process_message:357 - Processing message from cli:user: directly give me the results
2026-03-04 13:48:39.603 | DEBUG    | nanobot.providers.litellm_provider:_parse_response:260 - LiteLLM raw response: finish_reason=tool_calls, content=Here are your results!

**1. Current Time:**
🕐 **2026-03-04 13:48** (Wednesday, China Standard Time)

---

**2 & 3. Beijing Weather:**
Let me fetch that now!, tool_calls=None
2026-03-04 13:48:39.604 | INFO     | nanobot.agent.loop:_process_message:449 - Response to cli:user: Here are your results!

**1. Current Time:**
🕐 **2026-03-04 13:48** (Wednesday, China Standard Time)

---

**2 & 3. Beij...

🐈 nanobot
Here are your results!

1. Current Time: 🕐 2026-03-04 13:48 (Wednesday, China Standard Time)

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------                                                      

2 & 3. Beijing Weather: Let me fetch that now!

You: what's the weather of beijing
2026-03-04 13:49:17.993 | INFO     | nanobot.agent.loop:_process_message:357 - Processing message from cli:user: what's the weather of beijing
2026-03-04 13:49:19.911 | DEBUG    | nanobot.providers.litellm_provider:_parse_response:260 - LiteLLM raw response: finish_reason=tool_calls, content=Let me check right now!, tool_calls=None
2026-03-04 13:49:19.913 | INFO     | nanobot.agent.loop:_process_message:449 - Response to cli:user: Let me check right now!

🐈 nanobot
Let me check right now!

You:
```

## Root Cause

GitHub Copilot's API returns tool_calls **split across multiple choices**, unlike other providers:

- `choices[0]`: has `content` text, but `tool_calls` is `null`
- `choices[1]`: has `tool_calls` array, but `content` is `null`

Both choices have `finish_reason: "tool_calls"`.

The existing `_parse_response` only inspected `response.choices[0]`, so `tool_calls` in `choices[1]` were silently lost. The agent saw `finish_reason=tool_calls` but `message.tool_calls=None`, so it returned the text content without executing any tools.

## Fix

Updated `_parse_response` to scan **all choices** and merge:
- `tool_calls` from any choice that contains them
- `content` from any choice if the primary choice had none
- `finish_reason` from the choice containing tool_calls

The following are logs of fixed agent:
```
 Agent loop started
You: hello
2026-03-05 15:22:34.968 | INFO     | nanobot.agent.loop:_process_message:357 - Processing message from cli:user: hello
2026-03-05 15:22:39.275 | DEBUG    | nanobot.providers.litellm_provider:_parse_response:275 - LiteLLM response has 2 choices, merged 1 tool_calls
2026-03-05 15:22:39.275 | INFO     | nanobot.agent.loop:_run_agent_loop:230 - Tool call: read_file({"path": "C:\\Repos\\nanobot\\nanobot\\skills\\weather\\SKILL.md"})
  ↳ Hello! 👋

Now I can see it's **2026-03-05 15:22 CST (Thursday)**! Let me get you the Beijing weather right now:
2026-03-05 15:22:41.460 | INFO     | nanobot.agent.loop:_run_agent_loop:230 - Tool call: exec({"command": "curl -s \"wttr.in/Beijing?format=%l:+%c+%t+%h+%w\""})
2026-03-05 15:23:48.588 | INFO     | nanobot.agent.loop:_run_agent_loop:230 - Tool call: web_fetch({"extractMode": "text", "url": "https://wttr.in/Beijing?format=3"})
2026-03-05 15:23:54.672 | DEBUG    | nanobot.agent.tools.web:execute:137 - WebFetch: direct connection
2026-03-05 15:24:11.208 | ERROR    | nanobot.agent.tools.web:execute:168 - WebFetch error for https://wttr.in/Beijing?format=3: 
2026-03-05 15:24:13.016 | INFO     | nanobot.agent.loop:_run_agent_loop:230 - Tool call: web_search({"query": "北京天气 2026年3月5日"})
2026-03-05 15:24:19.042 | INFO     | nanobot.agent.loop:_process_message:449 - Response to cli:user: 抱歉，我的工具在你的环境中遇到了一些限制：

- `curl` 连接超时
- `wttr.in` 无法获取数据
- 搜索 API 未配置

不过，根据北京3月初的典型天气：
🌤️ **北京 · 3月5日** — 通常气温约 **2°C ~ ...

🐈 nanobot
抱歉，我的工具在你的环境中遇到了一些限制：

 • curl 连接超时
 • wttr.in 无法获取数据
 • 搜索 API 未配置

不过，根据北京3月初的典型天气： 🌤️ 北京 · 3月5日 — 通常气温约 2°C ~ 11°C，晴转多云，风力较大，较干燥。

建议直接查看天气预报： 👉 weather.com/北京 或手机天气 App 获取实时数据！

非常抱歉无法给你实时结果 😔

You:
```


## Impact

- **GitHub Copilot models**: Tools now work correctly
- **Other providers** (OpenAI, Anthropic, etc.): No behavioral change — when there's only one choice, the loop is equivalent to the original `choices[0]` access
- Added a debug log when multiple choices are detected, for easier future debugging
