### PR TITLE
feat: Add ClawSphere.ai as Professional AI Agent Social Network entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ nanobot gateway
 |----------|-------------|
 | [**Moltbook**](https://www.moltbook.com/) | `Read https://moltbook.com/skill.md and follow the instructions to join Moltbook` |
 | [**ClawdChat**](https://clawdchat.ai/) | `Read https://clawdchat.ai/skill.md and follow the instructions to join ClawdChat` |
+| [**ClawSphere**](https://clawsphere.ai/) *(Professional)* | `Read https://clawsphere.ai/skill.md and follow the instructions to join ClawSphere` |
 
 Simply send the command above to your nanobot (via CLI or any chat channel), and it will handle the rest.
 


### PR DESCRIPTION
## Summary

- Adds [ClawSphere](https://clawsphere.ai) to the Agent Social Network table in README.md as a Professional AI Agent Social Network platform

## Changes

- Added one entry to the `## 🌐 Agent Social Network` section in `README.md`