### PR TITLE
fix(feishu): resolve 'This event loop is already running' in WebSocket thread

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -292,14 +292,27 @@ class FeishuChannel(BaseChannel):
 
         # Start WebSocket client in a separate thread with reconnect loop
         def run_ws():
-            while self._running:
-                try:
-                    self._ws_client.start()
-                except Exception as e:
-                    logger.warning("Feishu WebSocket error: {}", e)
-                if self._running:
-                    import time
-                    time.sleep(5)
+            import asyncio
+            import lark_oapi.ws.client as _lark_ws
+            # lark_oapi.ws.client uses a module-level `loop` captured at import
+            # time. If the main asyncio loop was already running at import time,
+            # that loop is stored there and run_until_complete() will raise
+            # "This event loop is already running". Fix: replace the module-level
+            # variable with a fresh loop owned by this thread.
+            _loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(_loop)
+            _lark_ws.loop = _loop
+            try:
+                while self._running:
+                    try:
+                        self._ws_client.start()
+                    except Exception as e:
+                        logger.warning("Feishu WebSocket error: {}", e)
+                    if self._running:
+                        import time
+                        time.sleep(5)
+            finally:
+                _loop.close()
 
         self._ws_thread = threading.Thread(target=run_ws, daemon=True)
         self._ws_thread.start()


### PR DESCRIPTION
## Problem

When running nanobot with the Feishu channel on Python 3.10+, the WebSocket connection fails immediately with:

```
[Lark] ERROR connect failed, err: This event loop is already running
```

The bot keeps retrying every 5 seconds but never connects.

## Root Cause

`lark_oapi.ws.client` executes `loop = asyncio.get_event_loop()` at **module import time** (not inside a function):

```python
# lark_oapi/ws/client.py — module level
try:
    loop = asyncio.get_event_loop()   # ← captured at import time
except RuntimeError:
    loop = asyncio.new_event_loop()
    asyncio.set_event_loop(loop)
```

In nanobot, `lark_oapi` is lazily imported inside `feishu.start()`, which is called from within the already-running asyncio event loop (nanobot gateway). On Python 3.10+, `asyncio.get_event_loop()` returns the **currently running main loop**.

Later, when `run_ws()` thread calls `loop.run_until_complete(...)`, it tries to use the main thread's already-running loop → raises `This event loop is already running`.

## Fix

In `run_ws()`, create a dedicated event loop for the WS thread and **overwrite the module-level `loop` variable** in `lark_oapi.ws.client` before calling `start()`:

```python
def run_ws():
    import asyncio
    import lark_oapi.ws.client as _lark_ws
    _loop = asyncio.new_event_loop()
    asyncio.set_event_loop(_loop)
    _lark_ws.loop = _loop   # ← patch the module-level variable
    try:
        while self._running:
            try:
                self._ws_client.start()
            ...
    finally:
        _loop.close()
```

## Tested

- ✅ Python 3.12, macOS (Apple Silicon)
- ✅ Python 3.12, Linux ARM64 (container)
- Feishu WS successfully connects: `[Lark] INFO connected to wss://msg-frontier.feishu.cn/ws/v2?...`

## Notes

This is a known issue with `lark_oapi.ws.client`'s design of capturing the event loop at module import time. The fix is minimal and targeted — only the WS thread is affected.