### PR TITLE
fix(litellm): convert image Data URIs to Anthropic source.base64 format

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -178,6 +178,54 @@ class LiteLLMProvider(LLMProvider):
             sanitized.append(clean)
         return sanitized
 
+    @staticmethod
+    def _is_anthropic_model(original_model: str, resolved_model: str) -> bool:
+        """Return True when the target provider is Anthropic."""
+        spec = find_by_model(original_model) or find_by_model(resolved_model)
+        return (
+            (spec is not None and spec.name == "anthropic")
+            or "claude" in original_model.lower()
+            or resolved_model.startswith("anthropic/")
+        )
+
+    @staticmethod
+    def _convert_images_for_anthropic(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Convert OpenAI-style image_url Data URIs to Anthropic's source.base64 format.
+
+        LiteLLM translates HTTP image URLs automatically, but leaves Data URIs
+        (data:<mime>;base64,<data>) in the OpenAI image_url format, which
+        Anthropic rejects with a 400 invalid_request_error.
+        """
+        result = []
+        for msg in messages:
+            content = msg.get("content")
+            if not isinstance(content, list):
+                result.append(msg)
+                continue
+            new_content = []
+            for block in content:
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") == "image_url"
+                    and isinstance(block.get("image_url"), dict)
+                ):
+                    url = block["image_url"].get("url", "")
+                    if url.startswith("data:") and ";base64," in url:
+                        header, data = url.split(";base64,", 1)
+                        media_type = header[len("data:"):]
+                        new_content.append({
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": media_type,
+                                "data": data,
+                            },
+                        })
+                        continue
+                new_content.append(block)
+            result.append({**msg, "content": new_content})
+        return result
+
     async def chat(
         self,
         messages: list[dict[str, Any]],
@@ -206,6 +254,9 @@ class LiteLLMProvider(LLMProvider):
 
         if self._supports_cache_control(original_model):
             messages, tools = self._apply_cache_control(messages, tools)
+
+        if self._is_anthropic_model(original_model, model):
+            messages = self._convert_images_for_anthropic(messages)
 
         # Clamp max_tokens to at least 1 — negative or zero values cause
         # LiteLLM to reject the request with "max_tokens must be at least 1".

--- a/tests/test_litellm_provider_image.py
+++ b/tests/test_litellm_provider_image.py
@@ -1,0 +1,134 @@
+"""Tests for Anthropic image format conversion in LiteLLMProvider."""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.providers.litellm_provider import LiteLLMProvider
+
+
+# ---------------------------------------------------------------------------
+# _convert_images_for_anthropic
+# ---------------------------------------------------------------------------
+
+def _jpeg_data_uri(data: str = "abc123") -> str:
+    return f"data:image/jpeg;base64,{data}"
+
+
+def _png_data_uri(data: str = "xyz789") -> str:
+    return f"data:image/png;base64,{data}"
+
+
+def test_converts_jpeg_data_uri_to_anthropic_format():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _jpeg_data_uri("FAKEDATA")}},
+                {"type": "text", "text": "What is in this image?"},
+            ],
+        }
+    ]
+    result = LiteLLMProvider._convert_images_for_anthropic(messages)
+    assert len(result) == 1
+    content = result[0]["content"]
+    assert content[0] == {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/jpeg",
+            "data": "FAKEDATA",
+        },
+    }
+    assert content[1] == {"type": "text", "text": "What is in this image?"}
+
+
+def test_converts_png_data_uri_to_anthropic_format():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _png_data_uri("PNGDATA")}},
+            ],
+        }
+    ]
+    result = LiteLLMProvider._convert_images_for_anthropic(messages)
+    img = result[0]["content"][0]
+    assert img["source"]["media_type"] == "image/png"
+    assert img["source"]["data"] == "PNGDATA"
+
+
+def test_leaves_http_image_url_unchanged():
+    """HTTP URLs should pass through unchanged so litellm handles them."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "https://example.com/photo.jpg"}},
+            ],
+        }
+    ]
+    result = LiteLLMProvider._convert_images_for_anthropic(messages)
+    assert result[0]["content"][0] == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/photo.jpg"},
+    }
+
+
+def test_leaves_string_content_messages_unchanged():
+    messages = [{"role": "user", "content": "Hello"}]
+    result = LiteLLMProvider._convert_images_for_anthropic(messages)
+    assert result == messages
+
+
+def test_leaves_non_image_blocks_unchanged():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "No images here"},
+            ],
+        }
+    ]
+    result = LiteLLMProvider._convert_images_for_anthropic(messages)
+    assert result[0]["content"] == [{"type": "text", "text": "No images here"}]
+
+
+def test_handles_multiple_images_in_one_message():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _jpeg_data_uri("DATA1")}},
+                {"type": "image_url", "image_url": {"url": _png_data_uri("DATA2")}},
+                {"type": "text", "text": "Compare them"},
+            ],
+        }
+    ]
+    result = LiteLLMProvider._convert_images_for_anthropic(messages)
+    content = result[0]["content"]
+    assert content[0]["source"]["data"] == "DATA1"
+    assert content[1]["source"]["data"] == "DATA2"
+    assert content[2]["type"] == "text"
+
+
+def test_does_not_mutate_original_messages():
+    original_block = {"type": "image_url", "image_url": {"url": _jpeg_data_uri("DATA")}}
+    messages = [{"role": "user", "content": [original_block]}]
+    LiteLLMProvider._convert_images_for_anthropic(messages)
+    # Original block untouched
+    assert messages[0]["content"][0]["type"] == "image_url"
+
+
+# ---------------------------------------------------------------------------
+# _is_anthropic_model
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("original,resolved,expected", [
+    ("claude-sonnet-4-5", "anthropic/claude-sonnet-4-5", True),
+    ("anthropic/claude-opus-4-5", "anthropic/claude-opus-4-5", True),
+    ("gpt-4o", "openai/gpt-4o", False),
+    ("gemini/gemini-pro", "gemini/gemini-pro", False),
+])
+def test_is_anthropic_model(original, resolved, expected):
+    assert LiteLLMProvider._is_anthropic_model(original, resolved) == expected


### PR DESCRIPTION
## Problem

When sending images to Anthropic (Claude) models via LiteLLM, the agent builds image content blocks using the OpenAI `image_url` format with Data URIs:

```json
{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
```

LiteLLM automatically translates **HTTP image URLs** to Anthropic's native format, but it leaves **Data URIs** (inline base64) in OpenAI format. Anthropic rejects these with a 400 error:

```
invalid_request_error: ***.source.base64: The image was specified using the image/jpeg media type...
```

## Fix

Added `_convert_images_for_anthropic()` to `LiteLLMProvider` that rewrites `image_url` Data URI blocks into Anthropic's native `source.base64` structure before the LiteLLM call:

```json
{
  "type": "image",
  "source": {"type": "base64", "media_type": "image/jpeg", "data": "..."}
}
```

HTTP URLs are left unchanged (LiteLLM handles them). The conversion is only applied when the target model is detected as Anthropic/Claude.

## Tests

11 new unit tests covering: JPEG/PNG conversion, HTTP URL pass-through, string-content messages, multi-image messages, and immutability of the original message list.