### PR TITLE
feat(session): add session export, import, search and stats commands

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -598,6 +598,192 @@ def agent(
 
 
 # ============================================================================
+# Session Commands
+# ============================================================================
+
+session_app = typer.Typer(help="Manage conversation sessions")
+app.add_typer(session_app, name="session")
+
+
+@session_app.command("list")
+def session_list():
+    """List all conversation sessions."""
+    from nanobot.config.loader import load_config
+    from nanobot.session.manager import SessionManager
+
+    config = load_config()
+    manager = SessionManager(config.workspace_path)
+    sessions = manager.list_sessions()
+
+    if not sessions:
+        console.print("[dim]No sessions found.[/dim]")
+        return
+
+    table = Table(title="Conversation Sessions")
+    table.add_column("Session Key", style="cyan")
+    table.add_column("Created", style="green")
+    table.add_column("Last Updated", style="yellow")
+
+    for s in sessions:
+        created = s.get("created_at", "unknown")[:19].replace("T", " ") if s.get("created_at") else "unknown"
+        updated = s.get("updated_at", "unknown")[:19].replace("T", " ") if s.get("updated_at") else "unknown"
+        table.add_row(s["key"], created, updated)
+
+    console.print(table)
+
+
+@session_app.command("export")
+def session_export(
+    key: str = typer.Argument(..., help="Session key (e.g., 'cli:direct', 'telegram:123456')"),
+    output: str = typer.Option(None, "--output", "-o", help="Output file path (optional)"),
+):
+    """Export a session to a JSON file."""
+    from nanobot.config.loader import load_config
+    from nanobot.session.manager import SessionManager
+
+    config = load_config()
+    manager = SessionManager(config.workspace_path)
+
+    try:
+        output_path = Path(output) if output else None
+        exported_path = manager.export_session(key, output_path)
+        console.print(f"[green]✓[/green] Session exported to: [cyan]{exported_path}[/cyan]")
+    except Exception as e:
+        console.print(f"[red]Error exporting session:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@session_app.command("import")
+def session_import(
+    file: str = typer.Argument(..., help="Path to exported JSON file"),
+    key: str = typer.Option(None, "--key", "-k", help="New session key (optional, uses original if not set)"),
+):
+    """Import a session from a JSON file."""
+    from nanobot.config.loader import load_config
+    from nanobot.session.manager import SessionManager
+
+    config = load_config()
+    manager = SessionManager(config.workspace_path)
+
+    try:
+        input_path = Path(file)
+        if not input_path.exists():
+            console.print(f"[red]File not found:[/red] {file}")
+            raise typer.Exit(1)
+
+        session = manager.import_session(input_path, key)
+        console.print(f"[green]✓[/green] Session imported with key: [cyan]{session.key}[/cyan]")
+        console.print(f"  [dim]{len(session.messages)} messages loaded[/dim]")
+    except Exception as e:
+        console.print(f"[red]Error importing session:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@session_app.command("stats")
+def session_stats(
+    key: str = typer.Argument(..., help="Session key (e.g., 'cli:direct')"),
+):
+    """Show statistics for a session."""
+    from nanobot.config.loader import load_config
+    from nanobot.session.manager import SessionManager
+
+    config = load_config()
+    manager = SessionManager(config.workspace_path)
+
+    try:
+        stats = manager.get_session_stats(key)
+
+        table = Table(title=f"Session Stats: {key}")
+        table.add_column("Metric", style="cyan")
+        table.add_column("Value", style="green")
+
+        table.add_row("Total Messages", str(stats["total_messages"]))
+        table.add_row("User Messages", str(stats["user_messages"]))
+        table.add_row("Assistant Messages", str(stats["assistant_messages"]))
+        table.add_row("Tool Calls", str(stats["tool_calls"]))
+        table.add_row("Tool Results", str(stats["tool_results"]))
+        table.add_row("Unconsolidated", str(stats["unconsolidated_messages"]))
+        table.add_row("Created", stats["created_at"][:19].replace("T", " "))
+        table.add_row("Last Updated", stats["updated_at"][:19].replace("T", " "))
+
+        console.print(table)
+    except Exception as e:
+        console.print(f"[red]Error getting stats:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@session_app.command("search")
+def session_search(
+    query: str = typer.Argument(..., help="Search query"),
+    case_sensitive: bool = typer.Option(False, "--case-sensitive", help="Case-sensitive search"),
+    limit: int = typer.Option(10, "--limit", "-n", help="Maximum results to show"),
+):
+    """Search through all sessions for messages containing the query."""
+    from nanobot.config.loader import load_config
+    from nanobot.session.manager import SessionManager
+
+    config = load_config()
+    manager = SessionManager(config.workspace_path)
+
+    try:
+        results = manager.search_sessions(query, case_sensitive)
+
+        if not results:
+            console.print(f"[dim]No results found for '{query}'[/dim]")
+            return
+
+        console.print(f"\n[green]Found {len(results)} results for '{query}':[/green]\n")
+
+        for i, r in enumerate(results[:limit], 1):
+            timestamp = r.get("timestamp", "unknown")[:19].replace("T", " ") if r.get("timestamp") else "unknown"
+            console.print(f"[cyan]{i}.[/cyan] [bold]{r['session_key']}[/bold] | {timestamp} | [dim]{r['role']}[/dim]")
+            console.print(f"   {r['content']}")
+            console.print()
+
+        if len(results) > limit:
+            console.print(f"[dim]... and {len(results) - limit} more results[/dim]")
+
+    except Exception as e:
+        console.print(f"[red]Error searching sessions:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@session_app.command("delete")
+def session_delete(
+    key: str = typer.Argument(..., help="Session key to delete"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+):
+    """Delete a session."""
+    from nanobot.config.loader import load_config
+    from nanobot.session.manager import SessionManager
+
+    config = load_config()
+    manager = SessionManager(config.workspace_path)
+
+    # Check if session exists
+    session = manager.get_or_create(key)
+    if not session.messages and session.key not in manager._cache:
+        console.print(f"[yellow]Session '{key}' not found.[/yellow]")
+        raise typer.Exit(1)
+
+    if not force:
+        confirm = typer.confirm(f"Delete session '{key}' with {len(session.messages)} messages?")
+        if not confirm:
+            console.print("Cancelled.")
+            return
+
+    try:
+        path = manager._get_session_path(key)
+        if path.exists():
+            path.unlink()
+        manager._cache.pop(key, None)
+        console.print(f"[green]✓[/green] Session '{key}' deleted.")
+    except Exception as e:
+        console.print(f"[red]Error deleting session:[/red] {e}")
+        raise typer.Exit(1)
+
+
+# ============================================================================
 # Channel Commands
 # ============================================================================
 

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -210,3 +210,150 @@ class SessionManager:
                 continue
 
         return sorted(sessions, key=lambda x: x.get("updated_at", ""), reverse=True)
+
+    def export_session(self, key: str, output_path: Path | None = None) -> Path:
+        """
+        Export a session to a JSON file.
+
+        Args:
+            key: Session key (channel:chat_id).
+            output_path: Optional output path. Defaults to workspace/exports/<key>.json
+
+        Returns:
+            Path to the exported file.
+        """
+        session = self.get_or_create(key)
+
+        # Determine output path
+        target_path: Path
+        if output_path is None:
+            exports_dir = ensure_dir(self.workspace / "exports")
+            safe_key = safe_filename(key.replace(":", "_"))
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            target_path = exports_dir / f"{safe_key}_{timestamp}.json"
+        else:
+            target_path = output_path
+
+        export_data = {
+            "version": 1,
+            "exported_at": datetime.now().isoformat(),
+            "session": {
+                "key": session.key,
+                "created_at": session.created_at.isoformat(),
+                "updated_at": session.updated_at.isoformat(),
+                "metadata": session.metadata,
+                "last_consolidated": session.last_consolidated,
+                "messages": session.messages
+            }
+        }
+
+        with open(target_path, "w", encoding="utf-8") as f:
+            json.dump(export_data, f, ensure_ascii=False, indent=2)
+
+        return target_path
+
+    def import_session(self, input_path: Path, target_key: str | None = None) -> Session:
+        """
+        Import a session from a JSON file.
+
+        Args:
+            input_path: Path to the exported JSON file.
+            target_key: Optional new key for the session. Uses original if not provided.
+
+        Returns:
+            The imported session.
+        """
+        with open(input_path, encoding="utf-8") as f:
+            export_data = json.load(f)
+
+        session_data = export_data.get("session", {})
+        key = target_key or session_data.get("key", f"imported:{datetime.now().timestamp()}")
+
+        session = Session(
+            key=key,
+            messages=session_data.get("messages", []),
+            metadata=session_data.get("metadata", {}),
+            last_consolidated=session_data.get("last_consolidated", 0)
+        )
+
+        if "created_at" in session_data:
+            session.created_at = datetime.fromisoformat(session_data["created_at"])
+
+        self.save(session)
+        self._cache[key] = session
+
+        return session
+
+    def search_sessions(self, query: str, case_sensitive: bool = False) -> list[dict[str, Any]]:
+        """
+        Search across all sessions for messages containing the query.
+
+        Args:
+            query: Search string.
+            case_sensitive: Whether to match case.
+
+        Returns:
+            List of results with session key, message, and timestamp.
+        """
+        results = []
+        query_cmp = query if case_sensitive else query.lower()
+
+        for session_info in self.list_sessions():
+            key = session_info["key"]
+            session = self.get_or_create(key)
+
+            for msg in session.messages:
+                content = msg.get("content", "")
+                if not isinstance(content, str):
+                    continue
+
+                content_cmp = content if case_sensitive else content.lower()
+
+                if query_cmp in content_cmp:
+                    results.append({
+                        "session_key": key,
+                        "role": msg.get("role", "unknown"),
+                        "content": content[:200] + "..." if len(content) > 200 else content,
+                        "timestamp": msg.get("timestamp", ""),
+                        "full_message": msg
+                    })
+
+        return sorted(results, key=lambda x: x.get("timestamp", ""), reverse=True)
+
+    def get_session_stats(self, key: str) -> dict[str, Any]:
+        """
+        Get statistics for a session.
+
+        Args:
+            key: Session key.
+
+        Returns:
+            Dictionary with message counts, tool usage, etc.
+        """
+        session = self.get_or_create(key)
+
+        stats = {
+            "key": key,
+            "total_messages": len(session.messages),
+            "user_messages": 0,
+            "assistant_messages": 0,
+            "tool_calls": 0,
+            "tool_results": 0,
+            "created_at": session.created_at.isoformat(),
+            "updated_at": session.updated_at.isoformat(),
+            "unconsolidated_messages": len(session.messages) - session.last_consolidated
+        }
+
+        for msg in session.messages:
+            role = msg.get("role", "")
+            if role == "user":
+                stats["user_messages"] += 1
+            elif role == "assistant":
+                stats["assistant_messages"] += 1
+
+            if "tool_calls" in msg:
+                stats["tool_calls"] += len(msg["tool_calls"])
+            if "tool_call_id" in msg:
+                stats["tool_results"] += 1
+
+        return stats


### PR DESCRIPTION
Add comprehensive session management features:

- Export sessions to JSON files with metadata
- Import sessions from exported JSON files
- Search across all sessions for specific content
- View detailed session statistics (message counts, tool usage)
- Delete sessions with confirmation

New CLI commands:
  nanobot session list    - List all sessions
  nanobot session export  - Export a session
  nanobot session import  - Import a session
  nanobot session stats   - Show session statistics
  nanobot session search  - Search session content
  nanobot session delete  - Delete a session