### PR TITLE
fix(feishu): isolate lark ws Client event loop from main asyncio loop

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -290,16 +290,28 @@ class FeishuChannel(BaseChannel):
             log_level=lark.LogLevel.INFO
         )
 
-        # Start WebSocket client in a separate thread with reconnect loop
+        # Start WebSocket client in a separate thread with reconnect loop.
+        # A dedicated event loop is created for this thread so that lark_oapi's
+        # module-level `loop = asyncio.get_event_loop()` picks up an idle loop
+        # instead of the already-running main asyncio loop, which would cause
+        # "This event loop is already running" errors.
         def run_ws():
-            while self._running:
-                try:
-                    self._ws_client.start()
-                except Exception as e:
-                    logger.warning("Feishu WebSocket error: {}", e)
-                if self._running:
-                    import time
-                    time.sleep(5)
+            import time
+            import lark_oapi.ws.client as _lark_ws_client
+            ws_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(ws_loop)
+            # Patch the module-level loop used by lark's ws Client.start()
+            _lark_ws_client.loop = ws_loop
+            try:
+                while self._running:
+                    try:
+                        self._ws_client.start()
+                    except Exception as e:
+                        logger.warning("Feishu WebSocket error: {}", e)
+                    if self._running:
+                        time.sleep(5)
+            finally:
+                ws_loop.close()
 
         self._ws_thread = threading.Thread(target=run_ws, daemon=True)
         self._ws_thread.start()


### PR DESCRIPTION
## Problem

Commit 0209ad5 moved `import lark_oapi as lark` inside `start()` (lazy import) to suppress DeprecationWarnings. This introduced a regression: the import now happens **after** the main asyncio loop is already running, so `lark_oapi`'s module-level initialization captures the running main loop:

```python
# lark_oapi/ws/client.py (module level)
loop = asyncio.get_event_loop()  # ← now returns the running main loop
```

When the WebSocket thread calls `loop.run_until_complete()` inside `Client.start()`, Python raises:

```
RuntimeWarning: This event loop is already running
RuntimeWarning: coroutine 'Client._disconnect' was never awaited
RuntimeWarning: coroutine 'Client._connect' was never awaited
```

## Fix

In `run_ws()`, create a dedicated event loop with `asyncio.new_event_loop()` and patch `lark_oapi.ws.client.loop` to use it before calling `Client.start()`. The loop is closed on thread exit.

```python
def run_ws():
    ws_loop = asyncio.new_event_loop()
    asyncio.set_event_loop(ws_loop)
    import lark_oapi.ws.client as _lark_ws_client
    _lark_ws_client.loop = ws_loop  # redirect lark's module-level loop
    try:
        while self._running:
            ...
    finally:
        ws_loop.close()
```

This ensures `Client.start()`'s `loop.run_until_complete()` calls operate on an idle, thread-local loop — completely isolated from the main asyncio loop.