### PR TITLE
feat(discord): Add proxy support for HTTP and WebSocket connections

### DIFF
--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -62,12 +62,21 @@ class DiscordChannel(BaseChannel):
             return
 
         self._running = True
-        self._http = httpx.AsyncClient(timeout=30.0)
+        # Configure HTTP client with proxy if provided
+        http_kwargs: dict[str, Any] = {"timeout": 30.0}
+        if self.config.proxy:
+            http_kwargs["proxy"] = self.config.proxy
+        self._http = httpx.AsyncClient(**http_kwargs)
+
+        # Configure WebSocket connection with proxy if provided
+        ws_kwargs: dict[str, Any] = {}
+        if self.config.proxy:
+            ws_kwargs["proxy"] = self.config.proxy
 
         while self._running:
             try:
                 logger.info("Connecting to Discord gateway...")
-                async with websockets.connect(self.config.gateway_url) as ws:
+                async with websockets.connect(self.config.gateway_url, **ws_kwargs) as ws:
                     self._ws = ws
                     await self._gateway_loop()
             except asyncio.CancelledError:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -62,6 +62,7 @@ class DiscordConfig(Base):
     allow_from: list[str] = Field(default_factory=list)  # Allowed user IDs
     gateway_url: str = "wss://gateway.discord.gg/?v=10&encoding=json"
     intents: int = 37377  # GUILDS + GUILD_MESSAGES + DIRECT_MESSAGES + MESSAGE_CONTENT
+    proxy: str | None = None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
 
 
 class MatrixConfig(Base):


### PR DESCRIPTION

## Summary

Add optional proxy configuration to the Discord channel, enabling connectivity in network-restricted environments via HTTP or SOCKS5 proxies.

## Changes

- `nanobot/config/schema.py`: Add optional `proxy` field to `DiscordConfig`, accepting an HTTP/SOCKS5 proxy URL (defaults to `None`)
- `nanobot/channels/discord.py`: Apply the configured proxy to both `httpx.AsyncClient` (REST requests) and `websockets.connect` (Gateway WebSocket connection) when `proxy` is set

## Motivation

Some users cannot reach Discord directly due to network restrictions and require a proxy to establish a connection. Previously, the Discord channel hardcoded its HTTP client and WebSocket connection with no way to configure a proxy, making it unusable for these users.

## Testing

Add a `proxy` field to the Discord section in `config.yaml` and verify:

```yaml
discord:
  proxy: "http://127.0.0.1:7890"   # or socks5://127.0.0.1:1080
```

- [x] Bot connects to Discord Gateway and sends/receives messages correctly when proxy is configured
- [x] Omitting `proxy` (default `None`) preserves existing behavior with no regression
- [x] Connection failure is logged properly when the proxy is unreachable