### PR TITLE
fix(context): detect image MIME type from magic bytes instead of file extension

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -12,6 +12,19 @@ from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
 
 
+def _detect_image_mime(data: bytes) -> str | None:
+    """Detect image MIME type from magic bytes, ignoring file extension."""
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
 class ContextBuilder:
     """Builds the context (system prompt + messages) for the agent."""
 
@@ -136,10 +149,14 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         images = []
         for path in media:
             p = Path(path)
-            mime, _ = mimetypes.guess_type(path)
-            if not p.is_file() or not mime or not mime.startswith("image/"):
+            if not p.is_file():
                 continue
-            b64 = base64.b64encode(p.read_bytes()).decode()
+            raw = p.read_bytes()
+            # Detect real MIME type from magic bytes; fallback to filename guess
+            mime = _detect_image_mime(raw) or mimetypes.guess_type(path)[0]
+            if not mime or not mime.startswith("image/"):
+                continue
+            b64 = base64.b64encode(raw).decode()
             images.append({"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}})
 
         if not images:


### PR DESCRIPTION
## Problem

When downloading images from Feishu, the file extension may not match the actual image format:
- Feishu API may return incorrect `file_name` (e.g., `.jpg` for PNG images)
- Fallback logic hardcodes `.jpg` extension
- `mimetypes.guess_type()` relies on file extension → returns wrong MIME type
- Anthropic API validates image format and rejects mismatched MIME types

Error example:
```
Error code: 400 - image was specified using image/jpeg but appears to be image/png
```

## Solution

Added `_detect_image_mime()` function to detect actual image format using magic bytes:
- PNG: `\x89PNG\r\n\x1a\n`
- JPEG: `\xff\xd8\xff`
- GIF: `GIF87a` / `GIF89a`
- WEBP: `RIFF....WEBP`

Falls back to `mimetypes.guess_type()` if magic bytes detection fails.

## Testing

Tested with Feishu images that have mismatched extensions.