### PR TITLE
fix(shell): kill entire process group on timeout to reap child processes 

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -133,10 +133,26 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         if not media:
             return text
 
+        # Fallback MIME types by file extension
+        _EXT_TO_MIME = {
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".png": "image/png",
+            ".gif": "image/gif",
+            ".webp": "image/webp",
+            ".bmp": "image/bmp",
+            ".tiff": "image/tiff",
+            ".tif": "image/tiff",
+        }
+
         images = []
         for path in media:
             p = Path(path)
             mime, _ = mimetypes.guess_type(path)
+            # Fallback to extension-based detection if mimetypes fails
+            if not mime:
+                ext = p.suffix.lower()
+                mime = _EXT_TO_MIME.get(ext)
             if not p.is_file() or not mime or not mime.startswith("image/"):
                 continue
             b64 = base64.b64encode(p.read_bytes()).decode()

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -3,6 +3,8 @@
 import asyncio
 import os
 import re
+import signal
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -74,23 +76,34 @@ class ExecTool(Tool):
             env["PATH"] = env.get("PATH", "") + os.pathsep + self.path_append
 
         try:
-            process = await asyncio.create_subprocess_shell(
-                command,
+            kwargs: dict = dict(
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
                 env=env,
             )
-            
+            # Create a new session so all child processes share a process group
+            # that we can kill atomically on timeout.
+            if sys.platform != "win32":
+                kwargs["start_new_session"] = True
+
+            process = await asyncio.create_subprocess_shell(command, **kwargs)
+
             try:
                 stdout, stderr = await asyncio.wait_for(
                     process.communicate(),
                     timeout=self.timeout
                 )
             except asyncio.TimeoutError:
-                process.kill()
-                # Wait for the process to fully terminate so pipes are
-                # drained and file descriptors are released.
+                # Kill the entire process group to ensure child processes
+                # (e.g. npx, node) are also terminated.
+                if sys.platform != "win32":
+                    try:
+                        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+                    except ProcessLookupError:
+                        process.kill()
+                else:
+                    process.kill()
                 try:
                     await asyncio.wait_for(process.wait(), timeout=5.0)
                 except asyncio.TimeoutError:

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -1,10 +1,12 @@
 """Feishu/Lark channel implementation using lark-oapi SDK with WebSocket long connection."""
 
 import asyncio
+import importlib.util
 import json
 import os
 import re
 import threading
+import time
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any
@@ -15,8 +17,6 @@ from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.config.schema import FeishuConfig
-
-import importlib.util
 
 FEISHU_AVAILABLE = importlib.util.find_spec("lark_oapi") is not None
 
@@ -275,11 +275,21 @@ class FeishuChannel(BaseChannel):
             .build()
 
         # Create event handler (only register message receive, ignore other events)
+        # Register no-op handlers for other events to suppress SDK error logs
+        def _noop(*args, **kwargs) -> None:
+            pass
+
         event_handler = lark.EventDispatcherHandler.builder(
             self.config.encrypt_key or "",
             self.config.verification_token or "",
         ).register_p2_im_message_receive_v1(
             self._on_message_sync
+        ).register_p2_im_message_message_read_v1(
+            _noop
+        ).register_p2_im_message_reaction_created_v1(
+            _noop
+        ).register_p2_im_chat_access_event_bot_p2p_chat_entered_v1(
+            _noop
         ).build()
 
         # Create WebSocket client for long connection
@@ -296,7 +306,6 @@ class FeishuChannel(BaseChannel):
         # instead of the already-running main asyncio loop, which would cause
         # "This event loop is already running" errors.
         def run_ws():
-            import time
             import lark_oapi.ws.client as _lark_ws_client
             ws_loop = asyncio.new_event_loop()
             asyncio.set_event_loop(ws_loop)
@@ -319,9 +328,20 @@ class FeishuChannel(BaseChannel):
         logger.info("Feishu bot started with WebSocket long connection")
         logger.info("No public IP required - using WebSocket to receive events")
 
-        # Keep running until stopped
+        # Keep running until stopped; check thread liveness every 5 minutes
+        THREAD_CHECK_INTERVAL = 300
+        last_thread_check = time.time()
+
         while self._running:
-            await asyncio.sleep(1)
+            await asyncio.sleep(60)
+            now = time.time()
+            if now - last_thread_check >= THREAD_CHECK_INTERVAL:
+                last_thread_check = now
+                if self._ws_thread and not self._ws_thread.is_alive():
+                    logger.error("Feishu WebSocket thread died, restarting...")
+                    self._ws_thread = threading.Thread(target=run_ws, daemon=True)
+                    self._ws_thread.start()
+                    logger.info("Feishu WebSocket thread restarted")
 
     async def stop(self) -> None:
         """


### PR DESCRIPTION
  ## Summary            
                                                                                                                                                                  
  - Use `os.killpg` to kill the entire process group on timeout instead of only the direct subprocess                                                             
  - Start subprocess with `start_new_session=True` so all descendants (e.g. npx, node) share the same process group                                               
  - Fall back to `process.kill()` if `ProcessLookupError` is raised                                                                                               
  - Windows behavior unchanged                                                                                                                                    
                                                                                                                                                                  
  ## Problem                                                                                                                                                      
                                                                                                                                                                  
  Previously, only the direct subprocess was killed on timeout, leaving its child processes (e.g. node spawned by npx) as orphans still consuming resources.

  ## Test plan

  - [ ] Run a command that spawns child processes (e.g. `npx ...`), trigger timeout, verify all child processes are terminated
  - [ ] Verify existing behavior is unchanged on Windows