### PR TITLE
chore: refine platform policy and memory SKILL docs

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -58,6 +58,32 @@ Skills with available="false" need dependencies installed first - you can try in
         system = platform.system()
         runtime = f"{'macOS' if system == 'Darwin' else system} {platform.machine()}, Python {platform.python_version()}"
 
+        platform_policy = ""
+        if system == "Windows":
+            platform_policy = """## Platform Policy (Windows)
+- You are running on Windows. Shell commands executed via the `exec` tool run under the default Windows shell (PowerShell or cmd.exe) unless you explicitly invoke another shell.
+- Prefer UTF-8 for file I/O and command output. If terminal output is garbled/mojibake, retry with:
+  - PowerShell: `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; <command>`
+  - cmd.exe: `chcp 65001 >NUL & <command>`
+- Do NOT assume GNU tools like `grep`, `sed`, `awk` exist. Prefer Windows built-ins:
+  - Search text: `findstr /i "keyword" path\\to\\file`
+  - List files: `dir`
+  - Show file: `type path\\to\\file`
+- When in doubt, prefer the file tools (`read_file`, `list_dir`) over shell for portability and reliability.
+"""
+        elif system == "Darwin":
+            platform_policy = """## Platform Policy (macOS)
+- You are running on macOS. Prefer POSIX tools and UTF-8.
+- Use forward-slash paths. Prefer `ls`, `cat`, `grep`, `find` for filesystem and text operations.
+- When in doubt, prefer the file tools (`read_file`, `list_dir`) over shell for portability and reproducibility.
+"""
+        else:
+            platform_policy = """## Platform Policy (Linux)
+- You are running on Linux. Prefer POSIX tools and UTF-8.
+- Use forward-slash paths. Prefer `ls`, `cat`, `grep`, `find` for filesystem and text operations.
+- When in doubt, prefer the file tools (`read_file`, `list_dir`) over shell for portability and reproducibility.
+"""
+
         return f"""# nanobot 🐈
 
 You are nanobot, a helpful AI assistant.
@@ -70,6 +96,8 @@ Your workspace is at: {workspace_path}
 - Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)
 - History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
 - Custom skills: {workspace_path}/skills/{{skill-name}}/SKILL.md
+
+{platform_policy}
 
 ## nanobot Guidelines
 - State intent before tool calls, but NEVER predict or claim results before receiving them.

--- a/nanobot/skills/memory/SKILL.md
+++ b/nanobot/skills/memory/SKILL.md
@@ -9,15 +9,20 @@ always: true
 ## Structure
 
 - `memory/MEMORY.md` — Long-term facts (preferences, project context, relationships). Always loaded into your context.
-- `memory/HISTORY.md` — Append-only event log. NOT loaded into context. Search it with grep. Each entry starts with [YYYY-MM-DD HH:MM].
+- `memory/HISTORY.md` — Append-only event log. NOT loaded into context. Search it with grep-style tools or in-memory filters. Each entry starts with [YYYY-MM-DD HH:MM].
 
 ## Search Past Events
 
-```bash
-grep -i "keyword" memory/HISTORY.md
-```
+**Recommended approach (cross-platform):**
+- Use `read_file` to read `memory/HISTORY.md`, then search in-memory
+- This is the most reliable and portable method on all platforms
 
-Use the `exec` tool to run grep. Combine patterns: `grep -iE "meeting|deadline" memory/HISTORY.md`
+**Alternative (if you need command-line search):**
+- **Linux/macOS:** `grep -i "keyword" memory/HISTORY.md`
+- **Windows:** `findstr /i "keyword" memory\HISTORY.md`
+- **Python (cross-platform):** `python -c "import re; content=open('memory/HISTORY.md', encoding='utf-8').read(); print('\n'.join([l for l in content.split('\n') if 'keyword' in l.lower()][-20:]))"`
+
+Use the `exec` tool to run these commands. For complex searches, prefer `read_file` + in-memory filtering.
 
 ## When to Update MEMORY.md
 


### PR DESCRIPTION
### Summary

This PR tightens up the platform-specific guidance and memory search instructions in nanobot’s system prompt and skills:

- Clarifies the Platform Policy (Windows/macOS/Linux) sections in the core system prompt.
- Documents how to search `memory/HISTORY.md` in a cross-platform way, with explicit Windows examples.

### Changes

1. Platform policy in `nanobot/agent/context.py`
   - Clarifies how `exec` behaves on Windows (default shell, UTF-8 recommendations).
   - For Windows, prefers built-ins like `findstr`, `dir`, `type` instead of assuming GNU tools (`grep`, `sed`, `awk`).
   - For macOS/Linux, recommends POSIX tools (`ls`, `cat`, `grep`, `find`) while still preferring `read_file` / `list_dir` when possible for portability and reproducibility.

2. HISTORY.md search guidance in `nanobot/skills/memory/SKILL.md`
   - Explains that `memory/HISTORY.md` is an append-only, grep-friendly log and is not automatically loaded into normal context.
   - Recommends `read_file` + in-memory search as the most reliable and portable approach.
   - Provides Linux/macOS `grep` and Windows `findstr` examples for quick command-line lookup.

### Rationale

- Aligns the platform prompt more closely with Lobster-style explicit platform policies.
- Makes HISTORY.md usage clearer, especially for Windows users who may not have GNU tools installed by default.