### PR TITLE
feat: add configurable LLM retries and clearer error messages

### DIFF
--- a/henryeli_Fix_PR1.md
+++ b/henryeli_Fix_PR1.md
@@ -1,0 +1,59 @@
+# PR: LLM Retries and Improved Error Messages
+
+## Problem
+
+When the LLM backend (e.g. hosted vLLM, local vLLM) returns transient errors like `500 Internal Server Error`, the request fails immediately with an opaque error message such as:
+
+```
+Error calling LLM: litellm.InternalServerError: Hosted_vllmException - {"error":{"message":"500 Internal Server Error: Internal Server Error",...}}
+```
+
+Users get no retries and a technical error string that is not actionable.
+
+## Solution
+
+This PR adds three small, surgical changes:
+
+### 1. Retries for transient errors
+
+- LiteLLM's `num_retries` is now passed to `acompletion()` so transient 500s, rate limits, and connection errors are retried automatically.
+- Default: 2 retries.
+
+### 2. Configurable retries
+
+- New config option: `agents.defaults.llmRetries` (or `llm_retries` in snake_case).
+- Example in `~/.nanobot/config.json`:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "anthropic/claude-opus-4-5",
+      "llmRetries": 2
+    }
+  }
+}
+```
+
+- Set to `0` to disable retries. Default is `2` if omitted.
+
+### 3. Clearer user-facing error message
+
+- When retries are exhausted, the user now sees:
+
+  > The AI model server returned a temporary error. We retried 2 times. Please try again in a moment.
+
+- The raw exception is still logged with `logger.error()` for debugging.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `nanobot/config/schema.py` | Add `llm_retries` to `AgentDefaults` |
+| `nanobot/providers/litellm_provider.py` | Add `num_retries` param, pass to LiteLLM, improve error message |
+| `nanobot/cli/commands.py` | Pass `config.agents.defaults.llm_retries` to `LiteLLMProvider` |
+
+## Backward compatibility
+
+- No breaking changes. Existing configs work without `llmRetries`; default is 2 retries.
+- Existing tests pass; `LiteLLMProvider` calls without `num_retries` use the default.

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -233,6 +233,7 @@ def _make_provider(config: Config):
         default_model=model,
         extra_headers=p.extra_headers if p else None,
         provider_name=provider_name,
+        num_retries=config.agents.defaults.llm_retries,
     )
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -246,6 +246,7 @@ class AgentDefaults(Base):
     max_tool_iterations: int = 40
     memory_window: int = 100
     reasoning_effort: str | None = None  # low / medium / high — enables LLM thinking mode
+    llm_retries: int = 2  # Number of retries for transient LLM errors (500, rate limit, etc.)
 
 
 class AgentsConfig(Base):

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -8,6 +8,7 @@ from typing import Any
 import json_repair
 import litellm
 from litellm import acompletion
+from loguru import logger
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.providers.registry import find_by_model, find_gateway
@@ -38,10 +39,12 @@ class LiteLLMProvider(LLMProvider):
         default_model: str = "anthropic/claude-opus-4-5",
         extra_headers: dict[str, str] | None = None,
         provider_name: str | None = None,
+        num_retries: int = 2,
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
+        self._num_retries = max(0, num_retries)
 
         # Detect gateway / local deployment.
         # provider_name (from config key) is the primary signal;
@@ -241,13 +244,19 @@ class LiteLLMProvider(LLMProvider):
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
 
+        kwargs["num_retries"] = self._num_retries
+
         try:
             response = await acompletion(**kwargs)
             return self._parse_response(response)
         except Exception as e:
-            # Return error as content for graceful handling
+            logger.error("LLM request failed after retries: {}", e)
+            retries_note = f" We retried {self._num_retries} times." if self._num_retries > 0 else ""
             return LLMResponse(
-                content=f"Error calling LLM: {str(e)}",
+                content=(
+                    f"The AI model server returned a temporary error.{retries_note} "
+                    "Please try again in a moment."
+                ),
                 finish_reason="error",
             )
 


### PR DESCRIPTION
- Add llm_retries config (default 2) for transient 500/rate-limit errors
- Show user-friendly error when retries exhausted
- Log raw exception for debugging

