### PR TITLE
feat(channels): add python_call channel for programmatic access

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Connect nanobot to your favorite chat platform.
 | **Slack** | Bot token + App-Level token |
 | **Email** | IMAP/SMTP credentials |
 | **QQ** | App ID + App Secret |
+| **Python Call** | Just `enabled: true` (programmatic access) |
 
 <details>
 <summary><b>Telegram</b> (Recommended)</summary>
@@ -692,6 +693,17 @@ async def chat(msg: str, user_id: str):
     reply = await channel.call(msg, sender_id=user_id, session_id=user_id, timeout=60.0)
     return {"reply": reply}
 ```
+
+**`call()` parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `content` | Message text to send |
+| `sender_id` | Caller identifier (default `"python_caller"`) |
+| `session_id` | Stable session ID for conversation persistence |
+| `metadata` | Config overrides (e.g. `system_prompt`, `model`) |
+| `media` | List of media URLs to attach |
+| `timeout` | Max seconds to wait (`None` = wait forever) |
 
 > See [`examples/python_call_examples.py`](examples/python_call_examples.py) for more patterns — multi-agent pipelines, timeout handling, CI testing, and more.
 

--- a/README.md
+++ b/README.md
@@ -642,6 +642,61 @@ nanobot gateway
 
 </details>
 
+<details>
+<summary><b>Python Call (Programmatic Access)</b></summary>
+
+Use nanobot as an **async function** from any Python code — no webhooks, no message queues, just `await`.
+
+**1. Enable**
+
+```json
+{
+  "channels": {
+    "python_call": {
+      "enabled": true
+    }
+  }
+}
+```
+
+**2. Usage**
+
+```python
+channel = manager.get_channel("python_call")
+
+# One-off call
+response = await channel.call("What is 2 + 2?", timeout=30.0)
+
+# Persistent session (agent remembers prior messages)
+await channel.call("My name is Alice.", session_id="alice", timeout=30.0)
+reply = await channel.call("What's my name?", session_id="alice", timeout=30.0)
+
+# Config overrides via metadata
+response = await channel.call(
+    "Translate to French",
+    session_id="translator",
+    metadata={"system_prompt": "You are a French translator."},
+    timeout=30.0,
+)
+
+# Batch processing
+tasks = [channel.call(f"Summarize: {doc}", session_id=f"doc-{i}", timeout=60.0) for i, doc in enumerate(docs)]
+results = await asyncio.gather(*tasks)
+```
+
+**3. Embed in a web app (FastAPI)**
+
+```python
+@app.post("/chat")
+async def chat(msg: str, user_id: str):
+    reply = await channel.call(msg, sender_id=user_id, session_id=user_id, timeout=60.0)
+    return {"reply": reply}
+```
+
+> See [`examples/python_call_examples.py`](examples/python_call_examples.py) for more patterns — multi-agent pipelines, timeout handling, CI testing, and more.
+
+</details>
+
 ## 🌐 Agent Social Network
 
 🐈 nanobot is capable of linking to the agent social network (agent community). **Just send one message and your nanobot joins automatically!**

--- a/examples/python_call_examples.py
+++ b/examples/python_call_examples.py
@@ -1,0 +1,286 @@
+"""
+Python Call Channel — Usage Examples
+=====================================
+
+The ``python_call`` channel lets you interact with nanobot programmatically
+from any Python code.  Think of it as turning the agent into an async function:
+no webhooks, no message queues — just ``await``.
+
+Enable it in ``~/.nanobot/config.json``:
+
+    {
+      "channels": {
+        "python_call": {
+          "enabled": true
+        }
+      }
+    }
+
+Then use any of the patterns below.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+# ---------------------------------------------------------------------------
+# Helper: get the python_call channel from a running nanobot gateway
+# ---------------------------------------------------------------------------
+
+
+async def get_channel():
+    """
+    Boot nanobot and return the python_call channel.
+
+    In production you would typically start the gateway separately
+    (``nanobot gateway``) and obtain the channel from the running
+    ChannelManager.  This helper is a self-contained shortcut for
+    examples and scripts.
+    """
+    from nanobot.channels.manager import ChannelManager
+    from nanobot.config.loader import load_config
+
+    config = load_config()
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    manager = ChannelManager(config, bus)
+    await manager.start_all()
+    channel = manager.get_channel("python_call")
+    return channel, manager
+
+
+# ===================================================================
+# Example 1 — One-off call (no session persistence)
+# ===================================================================
+
+
+async def example_one_off():
+    """Send a single message and get a response."""
+    channel, manager = await get_channel()
+    try:
+        response = await channel.call("What is 2 + 2?", timeout=30.0)
+        print("Agent:", response)
+    finally:
+        await manager.stop_all()
+
+
+# ===================================================================
+# Example 2 — Persistent session (conversation history preserved)
+# ===================================================================
+
+
+async def example_session():
+    """
+    Use ``session_id`` to keep conversation context across calls.
+    The agent will remember prior messages within the same session.
+    """
+    channel, manager = await get_channel()
+    try:
+        await channel.call(
+            "My name is Alice.",
+            session_id="alice",
+            timeout=30.0,
+        )
+        reply = await channel.call(
+            "What is my name?",
+            session_id="alice",
+            timeout=30.0,
+        )
+        print("Agent:", reply)  # Should mention "Alice"
+    finally:
+        await manager.stop_all()
+
+
+# ===================================================================
+# Example 3 — Config overrides via metadata
+# ===================================================================
+
+
+async def example_metadata_override():
+    """
+    Pass ``metadata`` to override agent config on the fly —
+    e.g. a custom system prompt or model.
+    """
+    channel, manager = await get_channel()
+    try:
+        response = await channel.call(
+            "Hello, how are you?",
+            session_id="translator",
+            metadata={"system_prompt": "You are a French translator. Reply only in French."},
+            timeout=30.0,
+        )
+        print("Agent (French):", response)
+    finally:
+        await manager.stop_all()
+
+
+# ===================================================================
+# Example 4 — Embed in a web app (FastAPI)
+# ===================================================================
+
+"""
+from fastapi import FastAPI
+
+app = FastAPI()
+channel = None
+
+@app.on_event("startup")
+async def startup():
+    global channel
+    channel, _ = await get_channel()
+
+@app.post("/chat")
+async def chat(msg: str, user_id: str = "anonymous"):
+    reply = await channel.call(
+        msg,
+        sender_id=user_id,
+        session_id=user_id,   # each user gets their own session
+        timeout=60.0,
+    )
+    return {"reply": reply}
+"""
+
+
+# ===================================================================
+# Example 5 — Batch processing with asyncio.gather
+# ===================================================================
+
+
+async def example_batch():
+    """Process multiple inputs concurrently."""
+    channel, manager = await get_channel()
+    try:
+        documents = [
+            "Python is a programming language.",
+            "Rust is a systems programming language.",
+            "Go is designed for concurrency.",
+        ]
+        tasks = [
+            channel.call(
+                f"Summarize in one sentence: {doc}",
+                session_id=f"batch-{i}",
+                timeout=60.0,
+            )
+            for i, doc in enumerate(documents)
+        ]
+        results = await asyncio.gather(*tasks)
+        for doc, summary in zip(documents, results):
+            print(f"  {doc[:30]}... -> {summary}")
+    finally:
+        await manager.stop_all()
+
+
+# ===================================================================
+# Example 6 — Multi-agent chaining (pipeline)
+# ===================================================================
+
+
+async def example_pipeline():
+    """
+    Chain multiple agent calls where the output of one becomes
+    the input of the next — like Unix pipes.
+    """
+    channel, manager = await get_channel()
+    try:
+        # Step 1: translate
+        translation = await channel.call(
+            "今天天气真好",
+            session_id="translator",
+            metadata={"system_prompt": "Translate the input to English. Reply with only the translation."},
+            timeout=30.0,
+        )
+        print("Translation:", translation)
+
+        # Step 2: review
+        review = await channel.call(
+            f"Is this translation accurate? Original: '今天天气真好', Translation: '{translation}'",
+            session_id="reviewer",
+            metadata={"system_prompt": "You are a translation reviewer. Reply with a brief assessment."},
+            timeout=30.0,
+        )
+        print("Review:", review)
+    finally:
+        await manager.stop_all()
+
+
+# ===================================================================
+# Example 7 — Timeout handling
+# ===================================================================
+
+
+async def example_timeout():
+    """Gracefully handle agent timeouts."""
+    channel, manager = await get_channel()
+    try:
+        try:
+            response = await channel.call(
+                "Write a very long essay about the universe.",
+                timeout=5.0,  # short timeout for demo
+            )
+            print("Agent:", response)
+        except asyncio.TimeoutError:
+            print("Agent did not respond in time — try a longer timeout or simpler prompt.")
+    finally:
+        await manager.stop_all()
+
+
+# ===================================================================
+# Example 8 — Testing in CI / pytest
+# ===================================================================
+
+"""
+import pytest
+
+@pytest.fixture
+async def channel():
+    ch, manager = await get_channel()
+    yield ch
+    await manager.stop_all()
+
+@pytest.mark.asyncio
+async def test_greeting(channel):
+    reply = await channel.call("Hello!", timeout=10.0)
+    assert len(reply) > 0
+
+@pytest.mark.asyncio
+async def test_math(channel):
+    reply = await channel.call("What is 1 + 1? Reply with just the number.", timeout=10.0)
+    assert "2" in reply
+"""
+
+
+# ===================================================================
+# Run all examples
+# ===================================================================
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Example 1: One-off call")
+    print("=" * 60)
+    asyncio.run(example_one_off())
+
+    print("\n" + "=" * 60)
+    print("Example 2: Persistent session")
+    print("=" * 60)
+    asyncio.run(example_session())
+
+    print("\n" + "=" * 60)
+    print("Example 3: Metadata override (French translator)")
+    print("=" * 60)
+    asyncio.run(example_metadata_override())
+
+    print("\n" + "=" * 60)
+    print("Example 5: Batch processing")
+    print("=" * 60)
+    asyncio.run(example_batch())
+
+    print("\n" + "=" * 60)
+    print("Example 6: Multi-agent pipeline")
+    print("=" * 60)
+    asyncio.run(example_pipeline())
+
+    print("\n" + "=" * 60)
+    print("Example 7: Timeout handling")
+    print("=" * 60)
+    asyncio.run(example_timeout())

--- a/examples/python_call_examples.py
+++ b/examples/python_call_examples.py
@@ -37,12 +37,11 @@ async def get_channel():
     ChannelManager.  This helper is a self-contained shortcut for
     examples and scripts.
     """
+    from nanobot.bus.queue import MessageBus
     from nanobot.channels.manager import ChannelManager
     from nanobot.config.loader import load_config
 
     config = load_config()
-    from nanobot.bus.queue import MessageBus
-
     bus = MessageBus()
     manager = ChannelManager(config, bus)
     await manager.start_all()
@@ -120,15 +119,19 @@ async def example_metadata_override():
 # ===================================================================
 
 """
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
-app = FastAPI()
 channel = None
 
-@app.on_event("startup")
-async def startup():
+@asynccontextmanager
+async def lifespan(app):
     global channel
-    channel, _ = await get_channel()
+    channel, manager = await get_channel()
+    yield
+    await manager.stop_all()
+
+app = FastAPI(lifespan=lifespan)
 
 @app.post("/chat")
 async def chat(msg: str, user_id: str = "anonymous"):
@@ -271,16 +274,16 @@ if __name__ == "__main__":
     asyncio.run(example_metadata_override())
 
     print("\n" + "=" * 60)
-    print("Example 5: Batch processing")
+    print("Example 4: Batch processing")
     print("=" * 60)
     asyncio.run(example_batch())
 
     print("\n" + "=" * 60)
-    print("Example 6: Multi-agent pipeline")
+    print("Example 5: Multi-agent pipeline")
     print("=" * 60)
     asyncio.run(example_pipeline())
 
     print("\n" + "=" * 60)
-    print("Example 7: Timeout handling")
+    print("Example 6: Timeout handling")
     print("=" * 60)
     asyncio.run(example_timeout())

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -151,12 +151,15 @@ class ChannelManager:
 
         # Python call channel
         if self.config.channels.python_call.enabled:
-            from nanobot.channels.python_call import PythonCallChannel
-            self.channels["python_call"] = PythonCallChannel(
-                self.config.channels.python_call,
-                self.bus,
-            )
-            logger.info("Python call channel enabled")
+            try:
+                from nanobot.channels.python_call import PythonCallChannel
+                self.channels["python_call"] = PythonCallChannel(
+                    self.config.channels.python_call,
+                    self.bus,
+                )
+                logger.info("Python call channel enabled")
+            except ImportError as e:
+                logger.warning("Python call channel not available: {}", e)
 
         self._validate_allow_from()
 

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -149,6 +149,15 @@ class ChannelManager:
             except ImportError as e:
                 logger.warning("Matrix channel not available: {}", e)
 
+        # Python call channel
+        if self.config.channels.python_call.enabled:
+            from nanobot.channels.python_call import PythonCallChannel
+            self.channels["python_call"] = PythonCallChannel(
+                self.config.channels.python_call,
+                self.bus,
+            )
+            logger.info("Python call channel enabled")
+
         self._validate_allow_from()
 
     def _validate_allow_from(self) -> None:

--- a/nanobot/channels/python_call.py
+++ b/nanobot/channels/python_call.py
@@ -34,8 +34,16 @@ class PythonCallChannel(BaseChannel):
             metadata={"system_prompt": "You are a translator."},
         )
 
+        # With timeout (raises asyncio.TimeoutError if agent doesn't reply)
+        response = await channel.call("Hello", timeout=30.0)
+
     Each ``call()`` publishes an inbound message to the bus, then waits for
     the corresponding outbound reply (matched by ``chat_id``).
+
+    .. warning::
+        When *timeout* is not set (the default), ``call()`` blocks
+        indefinitely until the agent replies.  Always consider setting a
+        timeout in production code.
     """
 
     name = "python_call"
@@ -128,6 +136,9 @@ class PythonCallChannel(BaseChannel):
         if chat_id is not None and session_id is not None:
             raise ValueError("chat_id and session_id are mutually exclusive")
 
+        if timeout is not None and timeout <= 0:
+            raise ValueError(f"timeout must be positive, got {timeout}")
+
         # Resolve the effective chat_id
         if session_id is not None:
             effective_chat_id = f"session-{session_id}"
@@ -137,6 +148,13 @@ class PythonCallChannel(BaseChannel):
             effective_chat_id = f"session-{self.config.default_session_id}"
         else:
             effective_chat_id = f"pycall-{uuid.uuid4().hex[:12]}"
+
+        logger.debug(
+            "python_call: call from {} chat_id={} content={}...",
+            sender_id,
+            effective_chat_id,
+            content[:50],
+        )
 
         loop = asyncio.get_running_loop()
         fut: asyncio.Future[str] = loop.create_future()
@@ -153,7 +171,15 @@ class PythonCallChannel(BaseChannel):
             )
 
             if timeout is not None:
-                return await asyncio.wait_for(fut, timeout=timeout)
-            return await fut
+                result = await asyncio.wait_for(fut, timeout=timeout)
+            else:
+                result = await fut
+
+            logger.debug(
+                "python_call: response for chat_id={} len={}",
+                effective_chat_id,
+                len(result),
+            )
+            return result
         finally:
             self._pending.pop(effective_chat_id, None)

--- a/nanobot/channels/python_call.py
+++ b/nanobot/channels/python_call.py
@@ -1,0 +1,123 @@
+"""Python call channel for programmatic access to nanobot."""
+
+import asyncio
+import uuid
+from typing import Any
+
+from loguru import logger
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import PythonCallConfig
+
+
+class PythonCallChannel(BaseChannel):
+    """
+    Channel that allows Python code to interact with nanobot programmatically.
+
+    Usage::
+
+        channel = manager.get_channel("python_call")
+        response = await channel.call("Hello, nanobot!")
+
+    Each ``call()`` publishes an inbound message to the bus, then waits for
+    the corresponding outbound reply (matched by ``chat_id``).
+    """
+
+    name = "python_call"
+
+    def __init__(self, config: PythonCallConfig, bus: MessageBus):
+        super().__init__(config, bus)
+        self.config: PythonCallConfig = config
+        # Pending futures keyed by chat_id, waiting for outbound responses
+        self._pending: dict[str, asyncio.Future[str]] = {}
+
+    async def start(self) -> None:
+        """Mark the channel as running (no persistent connection needed)."""
+        self._running = True
+        logger.info("Python call channel started")
+
+    async def stop(self) -> None:
+        """Stop the channel and cancel any pending calls."""
+        self._running = False
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.cancel()
+        self._pending.clear()
+        logger.info("Python call channel stopped")
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """
+        Handle an outbound message from the agent.
+
+        If the ``chat_id`` matches a pending call, resolve its future so that
+        ``call()`` returns the response.  Progress messages (metadata
+        ``_progress``) are silently ignored.
+        """
+        if msg.metadata.get("_progress"):
+            return
+
+        fut = self._pending.get(msg.chat_id)
+        if fut and not fut.done():
+            fut.set_result(msg.content)
+        else:
+            logger.debug(
+                "python_call: no pending future for chat_id={}", msg.chat_id
+            )
+
+    async def call(
+        self,
+        content: str,
+        *,
+        sender_id: str = "python_caller",
+        chat_id: str | None = None,
+        media: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> str:
+        """
+        Send a message to the agent and wait for its response.
+
+        Args:
+            content: The message text to send.
+            sender_id: Identifier for the caller (default ``"python_caller"``).
+            chat_id: Optional chat identifier.  A unique id is generated when
+                     omitted so that concurrent calls don't collide.
+            media: Optional list of media URLs to attach.
+            metadata: Optional extra metadata forwarded to the agent.
+            timeout: Maximum seconds to wait for the agent's reply.
+                     ``None`` means wait indefinitely.
+
+        Returns:
+            The agent's text response.
+
+        Raises:
+            asyncio.TimeoutError: If *timeout* is set and the agent does not
+                reply in time.
+            RuntimeError: If the channel is not running.
+        """
+        if not self._running:
+            raise RuntimeError("python_call channel is not running")
+
+        if chat_id is None:
+            chat_id = f"pycall-{uuid.uuid4().hex[:12]}"
+
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[str] = loop.create_future()
+        self._pending[chat_id] = fut
+
+        try:
+            await self._handle_message(
+                sender_id=sender_id,
+                chat_id=chat_id,
+                content=content,
+                media=media,
+                metadata=metadata,
+            )
+
+            if timeout is not None:
+                return await asyncio.wait_for(fut, timeout=timeout)
+            return await fut
+        finally:
+            self._pending.pop(chat_id, None)

--- a/nanobot/channels/python_call.py
+++ b/nanobot/channels/python_call.py
@@ -19,7 +19,20 @@ class PythonCallChannel(BaseChannel):
     Usage::
 
         channel = manager.get_channel("python_call")
+
+        # One-off call (no session persistence)
         response = await channel.call("Hello, nanobot!")
+
+        # Persistent session (conversation history preserved across calls)
+        response1 = await channel.call("My name is Alice", session_id="alice")
+        response2 = await channel.call("What's my name?", session_id="alice")
+
+        # Config overrides via metadata
+        response = await channel.call(
+            "Translate to French",
+            session_id="translator",
+            metadata={"system_prompt": "You are a translator."},
+        )
 
     Each ``call()`` publishes an inbound message to the bus, then waits for
     the corresponding outbound reply (matched by ``chat_id``).
@@ -72,6 +85,8 @@ class PythonCallChannel(BaseChannel):
         *,
         sender_id: str = "python_caller",
         chat_id: str | None = None,
+        session_id: str | None = None,
+        session_key: str | None = None,
         media: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
         timeout: float | None = None,
@@ -84,8 +99,17 @@ class PythonCallChannel(BaseChannel):
             sender_id: Identifier for the caller (default ``"python_caller"``).
             chat_id: Optional chat identifier.  A unique id is generated when
                      omitted so that concurrent calls don't collide.
+            session_id: Stable session identifier for conversation persistence.
+                        When provided, the same ``session_id`` across multiple
+                        calls keeps conversation history (the agent remembers
+                        prior messages).  Mutually exclusive with ``chat_id``.
+            session_key: Optional session key override passed to the bus.
+                         Allows custom session scoping (e.g. sharing a session
+                         across different chat_ids).
             media: Optional list of media URLs to attach.
-            metadata: Optional extra metadata forwarded to the agent.
+            metadata: Optional extra metadata forwarded to the agent.  Config
+                      overrides can be passed here (e.g. ``system_prompt``,
+                      ``model``).
             timeout: Maximum seconds to wait for the agent's reply.
                      ``None`` means wait indefinitely.
 
@@ -96,28 +120,40 @@ class PythonCallChannel(BaseChannel):
             asyncio.TimeoutError: If *timeout* is set and the agent does not
                 reply in time.
             RuntimeError: If the channel is not running.
+            ValueError: If both *chat_id* and *session_id* are provided.
         """
         if not self._running:
             raise RuntimeError("python_call channel is not running")
 
-        if chat_id is None:
-            chat_id = f"pycall-{uuid.uuid4().hex[:12]}"
+        if chat_id is not None and session_id is not None:
+            raise ValueError("chat_id and session_id are mutually exclusive")
+
+        # Resolve the effective chat_id
+        if session_id is not None:
+            effective_chat_id = f"session-{session_id}"
+        elif chat_id is not None:
+            effective_chat_id = chat_id
+        elif self.config.default_session_id:
+            effective_chat_id = f"session-{self.config.default_session_id}"
+        else:
+            effective_chat_id = f"pycall-{uuid.uuid4().hex[:12]}"
 
         loop = asyncio.get_running_loop()
         fut: asyncio.Future[str] = loop.create_future()
-        self._pending[chat_id] = fut
+        self._pending[effective_chat_id] = fut
 
         try:
             await self._handle_message(
                 sender_id=sender_id,
-                chat_id=chat_id,
+                chat_id=effective_chat_id,
                 content=content,
                 media=media,
                 metadata=metadata,
+                session_key=session_key,
             )
 
             if timeout is not None:
                 return await asyncio.wait_for(fut, timeout=timeout)
             return await fut
         finally:
-            self._pending.pop(chat_id, None)
+            self._pending.pop(effective_chat_id, None)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -707,6 +707,14 @@ def channels_status():
         em_config
     )
 
+    # Python Call
+    pc = config.channels.python_call
+    table.add_row(
+        "Python Call",
+        "✓" if pc.enabled else "✗",
+        "programmatic API"
+    )
+
     console.print(table)
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -221,6 +221,7 @@ class PythonCallConfig(Base):
 
     enabled: bool = False
     allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Default allow all for programmatic use
+    default_session_id: str = ""  # When set, all calls without explicit session_id/chat_id use this session
 
 
 class ChannelsConfig(Base):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -216,6 +216,13 @@ class MatrixConfig(Base):
     allow_room_mentions: bool = False
 
 
+class PythonCallConfig(Base):
+    """Python call channel configuration for programmatic access."""
+
+    enabled: bool = False
+    allow_from: list[str] = Field(default_factory=lambda: ["*"])  # Default allow all for programmatic use
+
+
 class ChannelsConfig(Base):
     """Configuration for chat channels."""
 
@@ -231,6 +238,7 @@ class ChannelsConfig(Base):
     slack: SlackConfig = Field(default_factory=SlackConfig)
     qq: QQConfig = Field(default_factory=QQConfig)
     matrix: MatrixConfig = Field(default_factory=MatrixConfig)
+    python_call: PythonCallConfig = Field(default_factory=PythonCallConfig)
 
 
 class AgentDefaults(Base):

--- a/tests/test_python_call_channel.py
+++ b/tests/test_python_call_channel.py
@@ -385,6 +385,54 @@ async def test_metadata_passed_through(channel, bus):
 
 
 @pytest.mark.asyncio
+async def test_media_passed_through(channel, bus):
+    """Media URLs are forwarded to the bus message."""
+    await channel.start()
+
+    async def fake_agent():
+        msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+        assert msg.media == ["https://example.com/image.png"]
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="python_call",
+                chat_id=msg.chat_id,
+                content="got media",
+            )
+        )
+
+    async def dispatch_outbound():
+        msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+        await channel.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    result = await asyncio.wait_for(
+        channel.call("check this", media=["https://example.com/image.png"]),
+        timeout=3,
+    )
+    assert result == "got media"
+
+    await agent_task
+    await dispatch_task
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_call_negative_timeout(channel):
+    """call() raises ValueError for non-positive timeout."""
+    await channel.start()
+
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        await channel.call("hello", timeout=-1)
+
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        await channel.call("hello", timeout=0)
+
+    await channel.stop()
+
+
+@pytest.mark.asyncio
 async def test_explicit_session_id_overrides_default(bus):
     """Explicit session_id takes precedence over config default_session_id."""
     config = PythonCallConfig(

--- a/tests/test_python_call_channel.py
+++ b/tests/test_python_call_channel.py
@@ -1,0 +1,226 @@
+"""Tests for the Python call channel."""
+
+import asyncio
+
+import pytest
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.python_call import PythonCallChannel
+from nanobot.config.schema import PythonCallConfig
+
+
+@pytest.fixture
+def bus():
+    return MessageBus()
+
+
+@pytest.fixture
+def channel(bus):
+    config = PythonCallConfig(enabled=True, allow_from=["*"])
+    return PythonCallChannel(config, bus)
+
+
+@pytest.mark.asyncio
+async def test_start_stop(channel):
+    """Channel can start and stop."""
+    assert not channel.is_running
+    await channel.start()
+    assert channel.is_running
+    await channel.stop()
+    assert not channel.is_running
+
+
+@pytest.mark.asyncio
+async def test_call_returns_agent_response(channel, bus):
+    """call() publishes inbound and resolves when outbound arrives."""
+    await channel.start()
+
+    async def fake_agent():
+        """Simulate the agent: consume inbound, publish outbound."""
+        msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+        assert msg.channel == "python_call"
+        assert msg.content == "ping"
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="python_call",
+                chat_id=msg.chat_id,
+                content="pong",
+            )
+        )
+
+    # The channel.send() is called by the ChannelManager dispatcher;
+    # simulate that here by bridging outbound to channel.send().
+    async def dispatch_outbound():
+        msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+        await channel.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    result = await asyncio.wait_for(channel.call("ping"), timeout=3)
+    assert result == "pong"
+
+    await agent_task
+    await dispatch_task
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_call_with_custom_chat_id(channel, bus):
+    """call() with explicit chat_id uses that id."""
+    await channel.start()
+
+    async def fake_agent():
+        msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+        assert msg.chat_id == "my-session"
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="python_call",
+                chat_id="my-session",
+                content="ok",
+            )
+        )
+
+    async def dispatch_outbound():
+        msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+        await channel.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    result = await asyncio.wait_for(
+        channel.call("hi", chat_id="my-session"), timeout=3
+    )
+    assert result == "ok"
+
+    await agent_task
+    await dispatch_task
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_call_timeout(channel):
+    """call() raises TimeoutError when no reply comes."""
+    await channel.start()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await channel.call("hello", timeout=0.1)
+
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_call_not_running(channel):
+    """call() raises RuntimeError when channel is not running."""
+    with pytest.raises(RuntimeError, match="not running"):
+        await channel.call("hello")
+
+
+@pytest.mark.asyncio
+async def test_progress_messages_ignored(channel, bus):
+    """Progress outbound messages do not resolve the pending future."""
+    await channel.start()
+
+    async def fake_agent():
+        msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+        # Send a progress message first
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="python_call",
+                chat_id=msg.chat_id,
+                content="thinking...",
+                metadata={"_progress": True},
+            )
+        )
+        # Then the real reply
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="python_call",
+                chat_id=msg.chat_id,
+                content="done",
+            )
+        )
+
+    async def dispatch_outbound():
+        for _ in range(2):
+            msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+            await channel.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    result = await asyncio.wait_for(channel.call("work"), timeout=3)
+    assert result == "done"
+
+    await agent_task
+    await dispatch_task
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls(channel, bus):
+    """Multiple concurrent calls are matched correctly by chat_id."""
+    await channel.start()
+
+    async def fake_agent():
+        for _ in range(2):
+            msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+            await bus.publish_outbound(
+                OutboundMessage(
+                    channel="python_call",
+                    chat_id=msg.chat_id,
+                    content=f"reply-to-{msg.content}",
+                )
+            )
+
+    async def dispatch_outbound():
+        for _ in range(2):
+            msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+            await channel.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    r1, r2 = await asyncio.gather(
+        channel.call("a", chat_id="id-a"),
+        channel.call("b", chat_id="id-b"),
+    )
+    assert r1 == "reply-to-a"
+    assert r2 == "reply-to-b"
+
+    await agent_task
+    await dispatch_task
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_pending(channel, bus):
+    """Stopping the channel cancels pending call futures."""
+    await channel.start()
+
+    call_task = asyncio.create_task(channel.call("hello", chat_id="pending-id"))
+    # Let the call publish inbound
+    await asyncio.sleep(0.05)
+
+    await channel.stop()
+
+    with pytest.raises((asyncio.CancelledError, RuntimeError)):
+        await call_task
+
+
+@pytest.mark.asyncio
+async def test_access_denied(bus):
+    """call() from a non-allowed sender does not produce inbound messages."""
+    config = PythonCallConfig(enabled=True, allow_from=["allowed-user"])
+    ch = PythonCallChannel(config, bus)
+    await ch.start()
+
+    # This call uses sender_id="python_caller" which is not in allow_from
+    # _handle_message will deny access, so the inbound queue stays empty
+    # and the call will time out.
+    with pytest.raises(asyncio.TimeoutError):
+        await ch.call("hello", timeout=0.2)
+
+    assert bus.inbound_size == 0
+    await ch.stop()

--- a/tests/test_python_call_channel.py
+++ b/tests/test_python_call_channel.py
@@ -224,3 +224,198 @@ async def test_access_denied(bus):
 
     assert bus.inbound_size == 0
     await ch.stop()
+
+
+@pytest.mark.asyncio
+async def test_session_id_produces_stable_chat_id(channel, bus):
+    """session_id maps to a deterministic chat_id for session persistence."""
+    await channel.start()
+
+    received_chat_ids = []
+
+    async def fake_agent():
+        for _ in range(2):
+            msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+            received_chat_ids.append(msg.chat_id)
+            await bus.publish_outbound(
+                OutboundMessage(
+                    channel="python_call",
+                    chat_id=msg.chat_id,
+                    content="ok",
+                )
+            )
+
+    async def dispatch_outbound():
+        for _ in range(2):
+            msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+            await channel.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    await asyncio.wait_for(
+        channel.call("msg1", session_id="alice"), timeout=3
+    )
+    await asyncio.wait_for(
+        channel.call("msg2", session_id="alice"), timeout=3
+    )
+
+    # Both calls should use the same chat_id
+    assert received_chat_ids[0] == received_chat_ids[1] == "session-alice"
+
+    await agent_task
+    await dispatch_task
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_session_id_and_chat_id_mutually_exclusive(channel):
+    """Providing both session_id and chat_id raises ValueError."""
+    await channel.start()
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        await channel.call("hi", chat_id="x", session_id="y")
+
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_default_session_id_from_config(bus):
+    """When config has default_session_id, calls use it as chat_id."""
+    config = PythonCallConfig(
+        enabled=True, allow_from=["*"], default_session_id="default"
+    )
+    ch = PythonCallChannel(config, bus)
+    await ch.start()
+
+    async def fake_agent():
+        msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+        assert msg.chat_id == "session-default"
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="python_call",
+                chat_id=msg.chat_id,
+                content="ok",
+            )
+        )
+
+    async def dispatch_outbound():
+        msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+        await ch.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    result = await asyncio.wait_for(ch.call("hello"), timeout=3)
+    assert result == "ok"
+
+    await agent_task
+    await dispatch_task
+    await ch.stop()
+
+
+@pytest.mark.asyncio
+async def test_session_key_override(channel, bus):
+    """session_key is passed through to the bus message."""
+    await channel.start()
+
+    async def fake_agent():
+        msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+        assert msg.session_key_override == "custom:shared-session"
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="python_call",
+                chat_id=msg.chat_id,
+                content="ok",
+            )
+        )
+
+    async def dispatch_outbound():
+        msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+        await channel.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    result = await asyncio.wait_for(
+        channel.call("hi", session_key="custom:shared-session"), timeout=3
+    )
+    assert result == "ok"
+
+    await agent_task
+    await dispatch_task
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_metadata_passed_through(channel, bus):
+    """Metadata (including config overrides) is forwarded to the bus."""
+    await channel.start()
+
+    async def fake_agent():
+        msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+        assert msg.metadata.get("system_prompt") == "You are a translator."
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="python_call",
+                chat_id=msg.chat_id,
+                content="translated",
+            )
+        )
+
+    async def dispatch_outbound():
+        msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+        await channel.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    result = await asyncio.wait_for(
+        channel.call(
+            "hello",
+            metadata={"system_prompt": "You are a translator."},
+        ),
+        timeout=3,
+    )
+    assert result == "translated"
+
+    await agent_task
+    await dispatch_task
+    await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_id_overrides_default(bus):
+    """Explicit session_id takes precedence over config default_session_id."""
+    config = PythonCallConfig(
+        enabled=True, allow_from=["*"], default_session_id="default"
+    )
+    ch = PythonCallChannel(config, bus)
+    await ch.start()
+
+    async def fake_agent():
+        msg = await asyncio.wait_for(bus.consume_inbound(), timeout=2)
+        assert msg.chat_id == "session-override"
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="python_call",
+                chat_id=msg.chat_id,
+                content="ok",
+            )
+        )
+
+    async def dispatch_outbound():
+        msg = await asyncio.wait_for(bus.consume_outbound(), timeout=2)
+        await ch.send(msg)
+
+    agent_task = asyncio.create_task(fake_agent())
+    dispatch_task = asyncio.create_task(dispatch_outbound())
+
+    result = await asyncio.wait_for(
+        ch.call("hi", session_id="override"), timeout=3
+    )
+    assert result == "ok"
+
+    await agent_task
+    await dispatch_task
+    await ch.stop()


### PR DESCRIPTION
Add a new channel that allows Python code to interact with nanobot programmatically via `await channel.call("message")`. Each call publishes an inbound message and waits for the matching outbound reply, supporting concurrent calls, timeouts, and access control.