### PR TITLE
fix(feishu): use msg_type "media" for mp4 video files

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -474,6 +474,7 @@ class FeishuChannel(BaseChannel):
 
     _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".ico", ".tiff", ".tif"}
     _AUDIO_EXTS = {".opus"}
+    _VIDEO_EXTS = {".mp4", ".mov", ".avi"}
     _FILE_TYPE_MAP = {
         ".opus": "opus", ".mp4": "mp4", ".pdf": "pdf", ".doc": "doc", ".docx": "doc",
         ".xls": "xls", ".xlsx": "xls", ".ppt": "ppt", ".pptx": "ppt",
@@ -682,7 +683,12 @@ class FeishuChannel(BaseChannel):
                 else:
                     key = await loop.run_in_executor(None, self._upload_file_sync, file_path)
                     if key:
-                        media_type = "audio" if ext in self._AUDIO_EXTS else "file"
+                        # Use msg_type "media" for audio/video so users can play inline;
+                        # "file" for everything else (documents, archives, etc.)
+                        if ext in self._AUDIO_EXTS or ext in self._VIDEO_EXTS:
+                            media_type = "media"
+                        else:
+                            media_type = "file"
                         await loop.run_in_executor(
                             None, self._send_message_sync,
                             receive_id_type, msg.chat_id, media_type, json.dumps({"file_key": key}, ensure_ascii=False),


### PR DESCRIPTION
# fix(feishu): use msg_type "media" for mp4 video files

## Problem

When the bot sends an mp4 video file, it uses `msg_type: "file"`, which means users have to download the file to play it. Feishu supports inline video playback, but only when `msg_type` is `"media"`.

## Solution

- Add `_VIDEO_EXTS` constant: `{".mp4", ".mov", ".avi"}`
- When sending files, check if the extension is in `_AUDIO_EXTS` or `_VIDEO_EXTS` → use `msg_type: "media"`
- Otherwise → use `msg_type: "file"` (documents, archives, etc.)

The `upload_file` API already correctly sets `file_type="mp4"` via the existing `_FILE_TYPE_MAP`, so only the send `msg_type` needed fixing.

## Before / After

| | Before | After |
|---|---|---|
| mp4 | `msg_type: "file"` (download only) | `msg_type: "media"` (inline playback ▶️) |
| opus | `msg_type: "audio"` ❌ | `msg_type: "media"` ✅ |
| pdf | `msg_type: "file"` ✅ | `msg_type: "file"` ✅ |

Note: This also fixes opus audio which was using `"audio"` — Feishu requires `"media"` for both audio and video.

## Testing

- Send an mp4 video → should play inline in Feishu chat
- Send a PDF → should still show as downloadable file
- Send an opus audio → should play inline
