### PR TITLE
feat(feishu): streaming card output with Card Kit API

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -14,6 +14,7 @@ from loguru import logger
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
+from nanobot.channels.feishu_streaming import FeishuStreamingCard
 from nanobot.config.schema import FeishuConfig
 
 import importlib.util
@@ -252,6 +253,7 @@ class FeishuChannel(BaseChannel):
         self._ws_thread: threading.Thread | None = None
         self._processed_message_ids: OrderedDict[str, None] = OrderedDict()  # Ordered dedup cache
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._streaming_cards: dict[str, FeishuStreamingCard] = {}  # chat_id -> active streaming card
 
     async def start(self) -> None:
         """Start the Feishu bot with WebSocket long connection."""
@@ -658,7 +660,11 @@ class FeishuChannel(BaseChannel):
             return False
 
     async def send(self, msg: OutboundMessage) -> None:
-        """Send a message through Feishu, including media (images/files) if present."""
+        """Send a message through Feishu, including media (images/files) if present.
+
+        Supports streaming card mode: progress messages are streamed into a
+        single updating card, and the final message closes the card.
+        """
         if not self._client:
             logger.warning("Feishu client not initialized")
             return
@@ -666,27 +672,43 @@ class FeishuChannel(BaseChannel):
         try:
             receive_id_type = "chat_id" if msg.chat_id.startswith("oc_") else "open_id"
             loop = asyncio.get_running_loop()
+            is_progress = msg.metadata.get("_progress", False)
 
+            # --- Streaming card handling ---
+            if is_progress and msg.content and msg.content.strip():
+                # Start or update a streaming card for this chat
+                card = self._streaming_cards.get(msg.chat_id)
+                if card is None:
+                    card = FeishuStreamingCard(
+                        self.config.app_id, self.config.app_secret, self._client
+                    )
+                    started = await loop.run_in_executor(
+                        None, card.start_sync, msg.chat_id, receive_id_type
+                    )
+                    if started:
+                        self._streaming_cards[msg.chat_id] = card
+                    else:
+                        # Fallback: send as regular card message
+                        card = None
+
+                if card and card.is_active:
+                    await loop.run_in_executor(None, card.update_sync, msg.content)
+                    return  # Don't send as separate message
+
+            # --- Final message: close streaming card if active ---
+            active_card = self._streaming_cards.pop(msg.chat_id, None)
+            if active_card and active_card.is_active and msg.content and msg.content.strip():
+                # Close the streaming card with final content
+                await loop.run_in_executor(None, active_card.close_sync, msg.content)
+
+                # Still send media files if any
+                for file_path in msg.media:
+                    await self._send_media_file(loop, receive_id_type, msg.chat_id, file_path)
+                return
+
+            # --- Regular (non-streaming) send ---
             for file_path in msg.media:
-                if not os.path.isfile(file_path):
-                    logger.warning("Media file not found: {}", file_path)
-                    continue
-                ext = os.path.splitext(file_path)[1].lower()
-                if ext in self._IMAGE_EXTS:
-                    key = await loop.run_in_executor(None, self._upload_image_sync, file_path)
-                    if key:
-                        await loop.run_in_executor(
-                            None, self._send_message_sync,
-                            receive_id_type, msg.chat_id, "image", json.dumps({"image_key": key}, ensure_ascii=False),
-                        )
-                else:
-                    key = await loop.run_in_executor(None, self._upload_file_sync, file_path)
-                    if key:
-                        media_type = "audio" if ext in self._AUDIO_EXTS else "file"
-                        await loop.run_in_executor(
-                            None, self._send_message_sync,
-                            receive_id_type, msg.chat_id, media_type, json.dumps({"file_key": key}, ensure_ascii=False),
-                        )
+                await self._send_media_file(loop, receive_id_type, msg.chat_id, file_path)
 
             if msg.content and msg.content.strip():
                 elements = self._build_card_elements(msg.content)
@@ -699,6 +721,30 @@ class FeishuChannel(BaseChannel):
 
         except Exception as e:
             logger.error("Error sending Feishu message: {}", e)
+
+    async def _send_media_file(
+        self, loop: asyncio.AbstractEventLoop, receive_id_type: str, chat_id: str, file_path: str
+    ) -> None:
+        """Upload and send a single media file."""
+        if not os.path.isfile(file_path):
+            logger.warning("Media file not found: {}", file_path)
+            return
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext in self._IMAGE_EXTS:
+            key = await loop.run_in_executor(None, self._upload_image_sync, file_path)
+            if key:
+                await loop.run_in_executor(
+                    None, self._send_message_sync,
+                    receive_id_type, chat_id, "image", json.dumps({"image_key": key}, ensure_ascii=False),
+                )
+        else:
+            key = await loop.run_in_executor(None, self._upload_file_sync, file_path)
+            if key:
+                media_type = "audio" if ext in self._AUDIO_EXTS else "file"
+                await loop.run_in_executor(
+                    None, self._send_message_sync,
+                    receive_id_type, chat_id, media_type, json.dumps({"file_key": key}, ensure_ascii=False),
+                )
 
     def _on_message_sync(self, data: "P2ImMessageReceiveV1") -> None:
         """

--- a/nanobot/channels/feishu_streaming.py
+++ b/nanobot/channels/feishu_streaming.py
@@ -1,0 +1,250 @@
+"""Feishu Streaming Card - Card Kit streaming API for real-time text output.
+
+Uses the Feishu Card Kit API to create streaming cards that update in real-time,
+giving users immediate visual feedback as the bot generates its response.
+
+API Reference:
+- Create card: POST /cardkit/v1/cards
+- Update element: PUT /cardkit/v1/cards/{card_id}/elements/{element_id}/content
+- Update settings: PATCH /cardkit/v1/cards/{card_id}/settings
+"""
+
+import json
+import time
+from typing import Any
+
+import requests
+from loguru import logger
+
+
+# Token cache (keyed by app_id)
+_token_cache: dict[str, dict[str, Any]] = {}
+
+API_BASE = "https://open.feishu.cn/open-apis"
+
+
+def _get_tenant_token(app_id: str, app_secret: str) -> str:
+    """Get or refresh tenant access token with caching."""
+    cached = _token_cache.get(app_id)
+    if cached and cached["expires_at"] > time.time() + 60:
+        return cached["token"]
+
+    resp = requests.post(
+        f"{API_BASE}/auth/v3/tenant_access_token/internal",
+        json={"app_id": app_id, "app_secret": app_secret},
+        timeout=10,
+    )
+    data = resp.json()
+    if data.get("code") != 0 or not data.get("tenant_access_token"):
+        raise RuntimeError(f"Failed to get tenant token: {data.get('msg', 'unknown error')}")
+
+    token = data["tenant_access_token"]
+    _token_cache[app_id] = {
+        "token": token,
+        "expires_at": time.time() + data.get("expire", 7200),
+    }
+    return token
+
+
+def _truncate_summary(text: str, max_len: int = 50) -> str:
+    """Create a short summary for the card."""
+    if not text:
+        return ""
+    clean = text.replace("\n", " ").strip()
+    return clean if len(clean) <= max_len else clean[: max_len - 3] + "..."
+
+
+class FeishuStreamingCard:
+    """Manages a single streaming card session.
+
+    Lifecycle:
+    1. start() - Create card entity + send card message
+    2. update() - Update card content (throttled)
+    3. close() - Final update + disable streaming mode
+    """
+
+    def __init__(self, app_id: str, app_secret: str, client: Any):
+        self.app_id = app_id
+        self.app_secret = app_secret
+        self._client = client  # lark_oapi Client for sending messages
+        self._card_id: str | None = None
+        self._message_id: str | None = None
+        self._sequence: int = 0
+        self._current_text: str = ""
+        self._closed: bool = False
+        self._last_update_time: float = 0
+        self._pending_text: str | None = None
+        self._update_throttle_ms: int = 150  # Max ~6 updates/sec
+
+    @property
+    def is_active(self) -> bool:
+        return self._card_id is not None and not self._closed
+
+    def _auth_headers(self) -> dict[str, str]:
+        token = _get_tenant_token(self.app_id, self.app_secret)
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    def start_sync(self, receive_id: str, receive_id_type: str = "chat_id") -> bool:
+        """Create streaming card and send it. Returns True on success."""
+        if self._card_id:
+            return True
+
+        card_json = {
+            "schema": "2.0",
+            "config": {
+                "streaming_mode": True,
+                "summary": {"content": "[Generating...]"},
+                "streaming_config": {
+                    "print_frequency_ms": {"default": 50},
+                    "print_step": {"default": 2},
+                },
+            },
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": "\u23f3 Thinking...",
+                        "element_id": "content",
+                    }
+                ],
+            },
+        }
+
+        try:
+            # Step 1: Create card entity via Card Kit API
+            create_resp = requests.post(
+                f"{API_BASE}/cardkit/v1/cards",
+                headers=self._auth_headers(),
+                json={"type": "card_json", "data": json.dumps(card_json)},
+                timeout=10,
+            )
+            create_data = create_resp.json()
+            if create_data.get("code") != 0 or not create_data.get("data", {}).get("card_id"):
+                logger.error("Failed to create streaming card: {}", create_data.get("msg"))
+                return False
+
+            self._card_id = create_data["data"]["card_id"]
+
+            # Step 2: Send card message via IM API
+            from lark_oapi.api.im.v1 import CreateMessageRequest, CreateMessageRequestBody
+
+            content = json.dumps(
+                {"type": "card", "data": {"card_id": self._card_id}},
+                ensure_ascii=False,
+            )
+            request = (
+                CreateMessageRequest.builder()
+                .receive_id_type(receive_id_type)
+                .request_body(
+                    CreateMessageRequestBody.builder()
+                    .receive_id(receive_id)
+                    .msg_type("interactive")
+                    .content(content)
+                    .build()
+                )
+                .build()
+            )
+            response = self._client.im.v1.message.create(request)
+            if not response.success() or not response.data:
+                logger.error(
+                    "Failed to send streaming card message: code={}, msg={}",
+                    response.code,
+                    response.msg,
+                )
+                self._card_id = None
+                return False
+
+            self._message_id = response.data.message_id
+            logger.debug(
+                "Streaming card started: card_id={}, message_id={}",
+                self._card_id,
+                self._message_id,
+            )
+            return True
+
+        except Exception as e:
+            logger.error("Error starting streaming card: {}", e)
+            self._card_id = None
+            return False
+
+    def update_sync(self, text: str) -> None:
+        """Update the card content. Throttled to avoid rate limits."""
+        if not self._card_id or self._closed:
+            return
+
+        now = time.time() * 1000
+        if now - self._last_update_time < self._update_throttle_ms:
+            self._pending_text = text
+            return
+
+        self._pending_text = None
+        self._last_update_time = now
+        self._do_update(text)
+
+    def _do_update(self, text: str) -> None:
+        """Actually send the content update to the Card Kit API."""
+        if not self._card_id:
+            return
+
+        self._sequence += 1
+        self._current_text = text
+
+        try:
+            requests.put(
+                f"{API_BASE}/cardkit/v1/cards/{self._card_id}/elements/content/content",
+                headers=self._auth_headers(),
+                json={
+                    "content": text,
+                    "sequence": self._sequence,
+                    "uuid": f"s_{self._card_id}_{self._sequence}",
+                },
+                timeout=10,
+            )
+        except Exception as e:
+            logger.debug("Streaming card update failed: {}", e)
+
+    def flush_pending_sync(self) -> None:
+        """Flush any pending throttled update."""
+        if self._pending_text and not self._closed:
+            self._do_update(self._pending_text)
+            self._pending_text = None
+
+    def close_sync(self, final_text: str | None = None) -> None:
+        """Finalize the card: send last content update, then disable streaming mode."""
+        if not self._card_id or self._closed:
+            return
+
+        self._closed = True
+        text = final_text or self._pending_text or self._current_text
+
+        # Send final content if it differs
+        if text and text != self._current_text:
+            self._do_update(text)
+
+        # Disable streaming mode
+        self._sequence += 1
+        try:
+            requests.patch(
+                f"{API_BASE}/cardkit/v1/cards/{self._card_id}/settings",
+                headers=self._auth_headers(),
+                json={
+                    "settings": json.dumps(
+                        {
+                            "config": {
+                                "streaming_mode": False,
+                                "summary": {"content": _truncate_summary(text or "")},
+                            },
+                        }
+                    ),
+                    "sequence": self._sequence,
+                    "uuid": f"c_{self._card_id}_{self._sequence}",
+                },
+                timeout=10,
+            )
+        except Exception as e:
+            logger.debug("Streaming card close failed: {}", e)
+
+        logger.debug("Streaming card closed: card_id={}", self._card_id)


### PR DESCRIPTION
# feat(feishu): streaming card output with Card Kit API

## Problem

Currently, the bot's response only appears after the entire generation is complete. For long responses, users stare at a blank screen for 10-30+ seconds with no feedback. Modern AI chat interfaces (ChatGPT, Claude) stream text incrementally, and users expect the same from Feishu bots.

## Solution

Implement real-time streaming card output using Feishu's Card Kit API:

### How it works

```
User sends message
    ↓
First progress chunk arrives
    ↓
Create streaming card (POST /cardkit/v1/cards)
    → schema 2.0, streaming_mode: true
    → element_id: "content" for updates
    ↓
Send card message (POST /im/v1/messages)
    → msg_type: "interactive"
    → content: {type: "card", data: {card_id: "..."}}
    ↓
Progress updates arrive
    ↓
Update card content (PUT /cardkit/v1/cards/{id}/elements/content/content)
    → Throttled to ~6 updates/sec
    ↓
Final response arrives
    ↓
Close streaming (PATCH /cardkit/v1/cards/{id}/settings)
    → streaming_mode: false
    → summary with truncated text
```

### Key features

- **Throttled updates** (150ms min interval) to respect API rate limits
- **Tenant access token caching** with automatic refresh
- **Graceful fallback** — if streaming card creation fails, falls back to regular card messages
- **Pending update flush** — throttled updates are flushed on close to avoid data loss
- **Clean architecture** — new `feishu_streaming.py` module, minimal changes to existing `feishu.py`

### Files

- **New:** `nanobot/channels/feishu_streaming.py` — `FeishuStreamingCard` class with full Card Kit API integration
- **Modified:** `nanobot/channels/feishu.py` — `send()` method refactored to detect progress messages and route to streaming cards

### Integration with existing architecture

The agent loop already publishes progress messages via `_bus_progress()` with `metadata._progress = True`. The channel manager forwards these to `channel.send()`. This PR detects progress messages in `send()` and routes them to streaming cards instead of sending separate messages.

## Testing

1. Send a message that triggers a long response → card appears immediately with "⏳ Thinking..."
2. Text streams in incrementally → card updates in real-time
3. Response completes → streaming mode disabled, card shows final content
4. Send a short response → no streaming card (only final message sent as regular card)
5. Card creation fails (e.g., API error) → falls back to regular card messages

## Dependencies

- `requests` (already available in Python stdlib ecosystem, commonly installed)
- No new pip dependencies required beyond existing `lark-oapi`

## References

- [Feishu Card Kit API](https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/cardkit-v1/card/create)
- Inspired by [OpenClaw's streaming-card.ts](https://github.com/nicepkg/openclaw) implementation
