### PR TITLE
feat(skills): support cron in skill frontmatter for scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,36 @@ nanobot/
 └── cli/            # 🖥️ Commands
 ```
 
+## Skills
+
+Skills are markdown files (SKILL.md) that teach the agent specific capabilities. Place them in `~/.nanobot/workspace/skills/<skill-name>/SKILL.md`.
+
+### Skill Frontmatter
+
+Skills support YAML frontmatter with optional fields:
+
+```yaml
+---
+name: my-skill
+description: What this skill does
+cron: "0 2 * * *"     # Optional: auto-register as scheduled task
+---
+```
+
+### Scheduled Skills (cron)
+
+Add a `cron` field to automatically run a skill on a schedule:
+
+```yaml
+---
+name: daily-report
+description: Generate daily report
+cron: "0 9 * * *"     # Every day at 9:00 AM
+---
+```
+
+The skill will be automatically registered when the agent starts. The job name matches the skill name, preventing duplicate registrations.
+
 ## 🤝 Contribute & Roadmap
 
 PRs welcome! The codebase is intentionally small and readable. 🤗

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -269,6 +269,7 @@ class AgentLoop:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
         self._running = True
         await self._connect_mcp()
+        await self.context.skills.run_init_hooks(self)
         logger.info("Agent loop started")
 
         while self._running:

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -1,10 +1,13 @@
 """Skills loader for agent capabilities."""
 
+import importlib.util
 import json
 import os
 import re
 import shutil
 from pathlib import Path
+
+from loguru import logger
 
 # Default builtin skills directory (relative to this file)
 BUILTIN_SKILLS_DIR = Path(__file__).parent.parent / "skills"
@@ -226,3 +229,57 @@ class SkillsLoader:
                 return metadata
 
         return None
+
+    def get_cron_skills(self) -> list[dict]:
+        """
+        Get skills that have cron schedules defined in frontmatter.
+
+        Returns:
+            List of dicts with 'name' and 'cron' (schedule expression).
+        """
+        result = []
+        for s in self.list_skills(filter_unavailable=True):
+            meta = self.get_skill_metadata(s["name"])
+            if meta and meta.get("cron"):
+                result.append({
+                    "name": s["name"],
+                    "cron": meta["cron"],
+                })
+        return result
+
+    def register_cron_jobs(self, cron_service) -> None:
+        """
+        Register cron jobs for skills with cron in frontmatter.
+
+        Args:
+            cron_service: The CronService instance.
+        """
+        if not cron_service:
+            return
+
+        from nanobot.cron.types import CronSchedule
+
+        existing_names = {job.name for job in cron_service.list_jobs()}
+
+        for skill in self.get_cron_skills():
+            job_name = skill["name"]
+            if job_name in existing_names:
+                continue
+
+            schedule = CronSchedule(kind="cron", expr=skill["cron"], tz=None)
+            cron_service.add_job(
+                name=job_name,
+                schedule=schedule,
+                message=f"Run skill '{job_name}' scheduled task",
+            )
+            logger.info(f"Registered cron job for skill '{job_name}': {skill['cron']}")
+
+    async def run_init_hooks(self, agent_loop) -> None:
+        """
+        Run initialization for skills (register cron jobs, etc).
+
+        Args:
+            agent_loop: The AgentLoop instance.
+        """
+        # Register cron jobs from skill frontmatter
+        self.register_cron_jobs(agent_loop.cron_service)

--- a/nanobot/skills/README.md
+++ b/nanobot/skills/README.md
@@ -5,8 +5,22 @@ This directory contains built-in skills that extend nanobot's capabilities.
 ## Skill Format
 
 Each skill is a directory containing a `SKILL.md` file with:
-- YAML frontmatter (name, description, metadata)
+- YAML frontmatter (name, description, optional cron schedule, metadata)
 - Markdown instructions for the agent
+
+### Scheduled Skills
+
+Add a `cron` field to frontmatter to auto-register the skill as a scheduled task:
+
+```yaml
+---
+name: daily-report
+description: Generate daily report
+cron: "0 9 * * *"
+---
+```
+
+The job will be registered at startup using the skill name (prevents duplicates).
 
 ## Attribution
 
@@ -17,9 +31,12 @@ The skill format and metadata structure follow OpenClaw's conventions to maintai
 
 | Skill | Description |
 |-------|-------------|
+| `clawhub` | Search and install skills from ClawHub registry |
+| `cron` | Schedule reminders and recurring tasks |
+| `dream` | Daily memory consolidation - backup, extract info, clean history |
 | `github` | Interact with GitHub using the `gh` CLI |
-| `weather` | Get weather info using wttr.in and Open-Meteo |
+| `memory` | Two-layer memory system with grep-based recall |
+| `skill-creator` | Create new skills |
 | `summarize` | Summarize URLs, files, and YouTube videos |
 | `tmux` | Remote-control tmux sessions |
-| `clawhub` | Search and install skills from ClawHub registry |
-| `skill-creator` | Create new skills |
+| `weather` | Get weather info using wttr.in and Open-Meteo |

--- a/nanobot/skills/dream/SKILL.md
+++ b/nanobot/skills/dream/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: dream
+description: Daily memory consolidation - backup memory, extract important info to MEMORY.md, clean old history.
+cron: "0 2 * * *"
+metadata: {"nanobot":{"emoji":"🌙"}}
+---
+
+# Dream - Memory Consolidation Skill
+
+## Purpose
+
+Mimics human sleep dreaming to consolidate memories:
+- Backup current memory files
+- Extract important information from recent HISTORY to MEMORY.md
+- Clean up old history entries (keep 7 days)
+- Review and prune MEMORY.md to prevent bloat
+- Push a brief summary to notification channel
+
+## Schedule
+
+Runs automatically at 2:00 AM daily via cron.
+
+## How It Works
+
+Agent executes the consolidation workflow:
+1. Backup MEMORY.md and HISTORY.md to `memory/backups/`
+2. Analyze last 7 days of HISTORY.md
+3. Extract important info to MEMORY.md (see guidelines below)
+4. **Review MEMORY.md and remove outdated/temporary info**
+5. Clean up old HISTORY entries (keep 7 days)
+6. Send brief summary to notification channel
+
+## What Belongs in MEMORY.md (Long-term Memory)
+
+- User identity (name, contact info, relationships)
+- Stable preferences (communication style, language, timezone)
+- API keys and credentials
+- Server/infrastructure configuration
+- Active skills and their cron job IDs
+- Known bugs with workarounds
+- Ongoing project references (repo URLs, not detailed notes)
+
+## What Does NOT Belong in MEMORY.md
+
+- Debugging session notes (temporary, will become stale)
+- PR/code review details (track in GitHub, not memory)
+- Research notes on libraries/tools (temporary exploration)
+- Step-by-step procedures (belongs in SKILL.md)
+- Repeated information (deduplicate first)
+- Time-sensitive info (dates, versions that will expire)
+
+## MEMORY.md Maintenance Rules
+
+1. **One line per fact**: Avoid multi-paragraph explanations
+2. **No duplication**: If info exists, don't add it again
+3. **Prune outdated info**: Remove anything no longer relevant
+4. **Reference, don't copy**: Link to SKILL.md for detailed procedures
+5. **Review monthly**: Check if accumulated info is still needed


### PR DESCRIPTION
Skills support YAML frontmatter with optional fields:

```yaml
---
name: my-skill
description: What this skill does
cron: "0 2 * * *"     # Optional: auto-register as scheduled task
---
```

### Scheduled Skills (cron)

Add a `cron` field to automatically run a skill on a schedule:

```yaml
---
name: daily-report
description: Generate daily report
cron: "0 9 * * *"     # Every day at 9:00 AM
---
```

The skill will be automatically registered when the agent starts. The job name matches the skill name, preventing duplicate registrations.

