### PR TITLE
feat: add exponential backoff retry for LLM API rate limits (fixes #1558)

### DIFF
--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -9,6 +9,7 @@ import json_repair
 from openai import AsyncOpenAI
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.providers.retry import with_retry
 
 
 class CustomProvider(LLMProvider):
@@ -37,7 +38,7 @@ class CustomProvider(LLMProvider):
         if tools:
             kwargs.update(tools=tools, tool_choice="auto")
         try:
-            return self._parse(await self._client.chat.completions.create(**kwargs))
+            return self._parse(await with_retry(self._client.chat.completions.create, **kwargs))
         except Exception as e:
             return LLMResponse(content=f"Error: {e}", finish_reason="error")
 

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -11,6 +11,7 @@ from litellm import acompletion
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.providers.registry import find_by_model, find_gateway
+from nanobot.providers.retry import with_retry
 
 # Standard chat-completion message keys.
 _ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content"})
@@ -242,7 +243,7 @@ class LiteLLMProvider(LLMProvider):
             kwargs["tool_choice"] = "auto"
 
         try:
-            response = await acompletion(**kwargs)
+            response = await with_retry(acompletion, **kwargs)
             return self._parse_response(response)
         except Exception as e:
             # Return error as content for graceful handling

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -12,6 +12,7 @@ from loguru import logger
 from oauth_cli_kit import get_token as get_codex_token
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.providers.retry import with_retry
 
 DEFAULT_CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_ORIGINATOR = "nanobot"
@@ -62,12 +63,16 @@ class OpenAICodexProvider(LLMProvider):
 
         try:
             try:
-                content, tool_calls, finish_reason = await _request_codex(url, headers, body, verify=True)
+                content, tool_calls, finish_reason = await with_retry(
+                    _request_codex, url, headers, body, verify=True,
+                )
             except Exception as e:
                 if "CERTIFICATE_VERIFY_FAILED" not in str(e):
                     raise
                 logger.warning("SSL certificate verification failed for Codex API; retrying with verify=False")
-                content, tool_calls, finish_reason = await _request_codex(url, headers, body, verify=False)
+                content, tool_calls, finish_reason = await with_retry(
+                    _request_codex, url, headers, body, verify=False,
+                )
             return LLMResponse(
                 content=content,
                 tool_calls=tool_calls,

--- a/nanobot/providers/retry.py
+++ b/nanobot/providers/retry.py
@@ -1,0 +1,136 @@
+"""Exponential backoff retry for LLM API rate limits.
+
+Provides a generic async retry wrapper that detects HTTP 429 / rate-limit
+errors from any provider and retries with exponential backoff.
+
+No new dependencies — uses only the Python stdlib and logging via loguru.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, TypeVar
+
+from loguru import logger
+
+T = TypeVar("T")
+
+# Default retry parameters
+DEFAULT_MAX_RETRIES = 5
+DEFAULT_INITIAL_DELAY = 1.0  # seconds
+DEFAULT_BACKOFF_FACTOR = 2.0
+DEFAULT_MAX_DELAY = 60.0  # cap per-retry delay
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """Detect whether an exception represents an HTTP 429 / rate-limit error.
+
+    Works across providers (LiteLLM, OpenAI SDK, httpx, generic HTTP errors)
+    without importing provider-specific exception classes at module level.
+    """
+    # Check for status_code attribute (httpx.HTTPStatusError, litellm exceptions,
+    # openai exceptions all expose this).
+    status = getattr(exc, "status_code", None)
+    if status == 429:
+        return True
+
+    # Some wrappers nest the real status in .status or .http_status
+    for attr in ("status", "http_status"):
+        code = getattr(exc, attr, None)
+        if code == 429:
+            return True
+
+    # Fallback: inspect the string representation for common rate-limit signals.
+    err_str = str(exc).lower()
+    rate_limit_keywords = ("rate limit", "rate_limit", "ratelimit", "429", "too many requests", "quota exceeded")
+    return any(kw in err_str for kw in rate_limit_keywords)
+
+
+def _extract_retry_after(exc: Exception) -> float | None:
+    """Try to extract a Retry-After value (in seconds) from the exception.
+
+    Many HTTP libraries attach the response or headers to the exception object.
+    """
+    # httpx / openai / litellm often attach a .response attribute
+    response = getattr(exc, "response", None)
+    if response is not None:
+        headers = getattr(response, "headers", None) or {}
+        retry_after = headers.get("Retry-After") or headers.get("retry-after")
+        if retry_after is not None:
+            try:
+                return float(retry_after)
+            except (ValueError, TypeError):
+                pass
+
+    # Some wrappers store headers directly
+    headers = getattr(exc, "headers", None) or {}
+    retry_after = headers.get("Retry-After") or headers.get("retry-after")
+    if retry_after is not None:
+        try:
+            return float(retry_after)
+        except (ValueError, TypeError):
+            pass
+
+    return None
+
+
+async def with_retry(
+    fn: Callable[..., Awaitable[T]],
+    *args: Any,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    initial_delay: float = DEFAULT_INITIAL_DELAY,
+    backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+    max_delay: float = DEFAULT_MAX_DELAY,
+    **kwargs: Any,
+) -> T:
+    """Call *fn* with exponential backoff retry on rate-limit errors.
+
+    Args:
+        fn: The async callable to invoke.
+        *args: Positional arguments forwarded to *fn*.
+        max_retries: Maximum number of retry attempts (default 5).
+        initial_delay: Initial wait in seconds before first retry (default 1).
+        backoff_factor: Multiplier applied each retry (default 2 → 1s, 2s, 4s, 8s, 16s).
+        max_delay: Cap on per-retry delay in seconds (default 60).
+        **kwargs: Keyword arguments forwarded to *fn*.
+
+    Returns:
+        The result of *fn* on success.
+
+    Raises:
+        The original exception if all retries are exhausted or if the error
+        is not a rate-limit error.
+    """
+    delay = initial_delay
+
+    for attempt in range(max_retries + 1):
+        try:
+            return await fn(*args, **kwargs)
+        except Exception as exc:
+            if not _is_rate_limit_error(exc):
+                raise
+
+            if attempt >= max_retries:
+                logger.error(
+                    "Rate limit: all {} retries exhausted. Raising original error.",
+                    max_retries,
+                )
+                raise
+
+            # Prefer Retry-After header if available
+            retry_after = _extract_retry_after(exc)
+            wait = min(retry_after if retry_after is not None else delay, max_delay)
+
+            logger.warning(
+                "Rate limit hit (attempt {}/{}). Retrying in {:.1f}s{}...",
+                attempt + 1,
+                max_retries,
+                wait,
+                f" (Retry-After: {retry_after:.0f}s)" if retry_after is not None else "",
+            )
+
+            await asyncio.sleep(wait)
+            delay = min(delay * backoff_factor, max_delay)
+
+    # Should not be reached, but satisfies type checker
+    raise RuntimeError("with_retry: unreachable")  # pragma: no cover

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,49 @@
+## feat: add exponential backoff retry for LLM API rate limits
+
+Fixes #1558
+
+### Problem
+
+When an LLM provider returns a rate limit error (HTTP 429), nanobot stops immediately without retrying. This is especially painful during high-traffic periods or when using shared API keys, as a single transient 429 kills the entire agent loop.
+
+### Solution
+
+Added a generic, provider-agnostic exponential backoff retry mechanism in `nanobot/providers/retry.py` and integrated it into all three LLM providers.
+
+**Retry behavior:**
+- Detects 429 / rate-limit errors from any provider (LiteLLM, OpenAI SDK, httpx, generic HTTP errors)
+- Initial delay: 1s, exponential growth: 1s → 2s → 4s → 8s → 16s
+- Maximum 5 retry attempts
+- Honors `Retry-After` response header when present (takes priority over calculated delay)
+- Per-retry delay capped at 60s
+- Logs a warning on each retry so users know what's happening
+- Raises the original exception if all retries are exhausted (preserves existing error handling)
+
+**Detection strategy:**
+- Checks `status_code`, `status`, `http_status` attributes on exceptions (covers litellm, openai, httpx)
+- Falls back to string matching for wrapped/custom errors (`"rate limit"`, `"429"`, `"too many requests"`, `"quota exceeded"`)
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `nanobot/providers/retry.py` | **New** — generic async `with_retry()` utility with rate-limit detection |
+| `nanobot/providers/litellm_provider.py` | Wrap `acompletion()` call with `with_retry()` |
+| `nanobot/providers/custom_provider.py` | Wrap OpenAI SDK call with `with_retry()` |
+| `nanobot/providers/openai_codex_provider.py` | Wrap `_request_codex()` calls with `with_retry()` |
+
+### Design decisions
+
+- **No new dependencies** — uses only `asyncio` and `loguru` (already in the project)
+- **Provider-agnostic** — detection works across all exception types without importing provider-specific classes
+- **Minimal invasion** — single `with_retry()` wrapper around existing API calls; no structural changes
+- **Composable** — `with_retry()` accepts configurable `max_retries`, `initial_delay`, `backoff_factor`, and `max_delay` for future customization
+- **Non-rate-limit errors pass through** — only 429/rate-limit errors trigger retry; all other exceptions propagate immediately
+
+### Example log output
+
+```
+WARNING | Rate limit hit (attempt 1/5). Retrying in 1.0s...
+WARNING | Rate limit hit (attempt 2/5). Retrying in 2.0s...
+WARNING | Rate limit hit (attempt 3/5). Retrying in 4.0s (Retry-After: 3s)...
+```


### PR DESCRIPTION
## feat: add exponential backoff retry for LLM API rate limits

Fixes #1558

### Problem

When an LLM provider returns a rate limit error (HTTP 429), nanobot stops immediately without retrying. This is especially painful during high-traffic periods or when using shared API keys, as a single transient 429 kills the entire agent loop.

### Solution

Added a generic, provider-agnostic exponential backoff retry mechanism in `nanobot/providers/retry.py` and integrated it into all three LLM providers.

**Retry behavior:**
- Detects 429 / rate-limit errors from any provider (LiteLLM, OpenAI SDK, httpx, generic HTTP errors)
- Initial delay: 1s, exponential growth: 1s → 2s → 4s → 8s → 16s
- Maximum 5 retry attempts
- Honors `Retry-After` response header when present (takes priority over calculated delay)
- Per-retry delay capped at 60s
- Logs a warning on each retry so users know what's happening
- Raises the original exception if all retries are exhausted (preserves existing error handling)

**Detection strategy:**
- Checks `status_code`, `status`, `http_status` attributes on exceptions (covers litellm, openai, httpx)
- Falls back to string matching for wrapped/custom errors (`"rate limit"`, `"429"`, `"too many requests"`, `"quota exceeded"`)

### Files changed

| File | Change |
|------|--------|
| `nanobot/providers/retry.py` | **New** — generic async `with_retry()` utility with rate-limit detection |
| `nanobot/providers/litellm_provider.py` | Wrap `acompletion()` call with `with_retry()` |
| `nanobot/providers/custom_provider.py` | Wrap OpenAI SDK call with `with_retry()` |
| `nanobot/providers/openai_codex_provider.py` | Wrap `_request_codex()` calls with `with_retry()` |

### Design decisions

- **No new dependencies** — uses only `asyncio` and `loguru` (already in the project)
- **Provider-agnostic** — detection works across all exception types without importing provider-specific classes
- **Minimal invasion** — single `with_retry()` wrapper around existing API calls; no structural changes
- **Composable** — `with_retry()` accepts configurable `max_retries`, `initial_delay`, `backoff_factor`, and `max_delay` for future customization
- **Non-rate-limit errors pass through** — only 429/rate-limit errors trigger retry; all other exceptions propagate immediately

### Example log output

```
WARNING | Rate limit hit (attempt 1/5). Retrying in 1.0s...
WARNING | Rate limit hit (attempt 2/5). Retrying in 2.0s...
WARNING | Rate limit hit (attempt 3/5). Retrying in 4.0s (Retry-After: 3s)...
```
