### PR TITLE
feat(web): add retry mechanism with backoff for web search

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -11,6 +11,7 @@ import httpx
 from loguru import logger
 
 from nanobot.agent.tools.base import Tool
+from nanobot.utils.helpers import retry_with_backoff
 
 # Shared constants
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36"
@@ -76,9 +77,17 @@ class WebSearchTool(Tool):
                 "(or export BRAVE_API_KEY), then restart the gateway."
             )
 
-        try:
-            n = min(max(count or self.max_results, 1), 10)
-            logger.debug("WebSearch: {}", "proxy enabled" if self.proxy else "direct connection")
+        n = min(max(count or self.max_results, 1), 10)
+        logger.debug("WebSearch: {}", "proxy enabled" if self.proxy else "direct connection")
+
+        def should_retry(e: Exception) -> bool:
+            if isinstance(e, httpx.ProxyError):
+                return False
+            if isinstance(e, httpx.HTTPStatusError):
+                return e.response.status_code >= 500 or e.response.status_code == 429
+            return isinstance(e, (httpx.TimeoutException, httpx.ConnectError, httpx.RemoteProtocolError))
+
+        async def _search() -> str:
             async with httpx.AsyncClient(proxy=self.proxy) as client:
                 r = await client.get(
                     "https://api.search.brave.com/res/v1/web/search",
@@ -98,6 +107,12 @@ class WebSearchTool(Tool):
                 if desc := item.get("description"):
                     lines.append(f"   {desc}")
             return "\n".join(lines)
+
+        try:
+            return await retry_with_backoff(_search, max_retries=3, should_retry=should_retry)
+        except httpx.HTTPStatusError as e:
+            logger.error("WebSearch HTTP error: {}", e)
+            return f"HTTP error: {e}"
         except httpx.ProxyError as e:
             logger.error("WebSearch proxy error: {}", e)
             return f"Proxy error: {e}"

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -1,8 +1,12 @@
 """Utility functions for nanobot."""
 
+import asyncio
 import re
 from datetime import datetime
 from pathlib import Path
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
 
 
 def detect_image_mime(data: bytes) -> str | None:
@@ -110,3 +114,43 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
         for name in added:
             Console().print(f"  [dim]Created {name}[/dim]")
     return added
+
+
+async def retry_with_backoff(
+    func: Callable[[], T],
+    max_retries: int = 3,
+    should_retry: Callable[[Exception], bool] | None = None,
+) -> T:
+    """
+    Retry an async function with exponential backoff.
+
+    Args:
+        func: Async function to retry.
+        max_retries: Maximum number of retry attempts.
+        should_retry: Optional function to determine if an exception should be retried.
+                     Returns True to retry, False to raise immediately.
+
+    Returns:
+        Result of the function call.
+
+    Raises:
+        Exception: The last exception if all retries fail.
+    """
+    import httpx
+    from loguru import logger
+
+    for attempt in range(max_retries):
+        try:
+            return await func()
+        except Exception as e:
+            if should_retry and not should_retry(e):
+                raise
+
+            if attempt == max_retries - 1:
+                raise
+
+            backoff = 2 ** attempt
+            logger.warning("Retry attempt {}/{} after {}s: {}", attempt + 1, max_retries, backoff, type(e).__name__)
+            await asyncio.sleep(backoff)
+
+    raise RuntimeError("Unexpected error in retry_with_backoff")


### PR DESCRIPTION
Implement retry_with_backoff utility function to handle transient failures in web requests. The WebSearchTool now uses this to automatically retry on network errors and server issues (500, 429) while avoiding retries for proxy errors. This improves reliability of web search operations.