### PR TITLE
feat: add allow_from whitelist support for Feishu channel

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -252,6 +252,7 @@ class FeishuChannel(BaseChannel):
         self._ws_thread: threading.Thread | None = None
         self._processed_message_ids: OrderedDict[str, None] = OrderedDict()  # Ordered dedup cache
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._allowed_users = set(getattr(config, 'allow_from', []) or [])
 
     async def start(self) -> None:
         """Start the Feishu bot with WebSocket long connection."""
@@ -874,6 +875,12 @@ class FeishuChannel(BaseChannel):
             chat_id = message.chat_id
             chat_type = message.chat_type
             msg_type = message.message_type
+
+            # Check whitelist. Empty/blank entries or "*" mean allow all.
+            allowed_users = {user for user in self._allowed_users if user}
+            if "*" not in allowed_users and allowed_users and sender_id not in allowed_users:
+                logger.info(f"User {sender_id} not in whitelist, ignoring message")
+                return
 
             # Add reaction
             await self._add_reaction(message_id, self.config.react_emoji)


### PR DESCRIPTION
## Summary

Implement `allow_from` config option to restrict Feishu bot access to specific users.

## Changes

- Read `allow_from` from config and convert to set for efficient lookup
- Check sender_id against whitelist before processing messages
- Support "*" wildcard to allow all users
- Filter out empty/blank entries
- Log ignored messages for debugging purposes

## Usage

Add to config:
```json
{
  "channels": {
    "feishu": {
      "allowFrom": ["ou_xxxxxxxxxxxxxxxx", "ou_yyyyyyyyyyyyyyyy"]
    }
  }
}
```

Use `["*"]` or leave empty to allow all users.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Handles edge cases (wildcard, empty entries)

---

Reviewed-by: Codex
Author: Qin Liu <lqgy2001@gmail.com>