### PR TITLE
refactor(memory): decouple history logging from memory consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1186,6 +1186,36 @@ nanobot/
 └── cli/            # 🖥️ Commands
 ```
 
+## Skills
+
+Skills are markdown files (SKILL.md) that teach the agent specific capabilities. Place them in `~/.nanobot/workspace/skills/<skill-name>/SKILL.md`.
+
+### Skill Frontmatter
+
+Skills support YAML frontmatter with optional fields:
+
+```yaml
+---
+name: my-skill
+description: What this skill does
+cron: "0 2 * * *"     # Optional: auto-register as scheduled task
+---
+```
+
+### Scheduled Skills (cron)
+
+Add a `cron` field to automatically run a skill on a schedule:
+
+```yaml
+---
+name: daily-report
+description: Generate daily report
+cron: "0 9 * * *"     # Every day at 9:00 AM
+---
+```
+
+The skill will be automatically registered when the agent starts. The job name matches the skill name, preventing duplicate registrations.
+
 ## 🤝 Contribute & Roadmap
 
 PRs welcome! The codebase is intentionally small and readable. 🤗

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -260,6 +260,7 @@ class AgentLoop:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
         self._running = True
         await self._connect_mcp()
+        await self.context.skills.run_init_hooks(self)
         logger.info("Agent loop started")
 
         while self._running:

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -15,12 +15,12 @@ if TYPE_CHECKING:
     from nanobot.session.manager import Session
 
 
-_SAVE_MEMORY_TOOL = [
+_SAVE_HISTORY_TOOL = [
     {
         "type": "function",
         "function": {
-            "name": "save_memory",
-            "description": "Save the memory consolidation result to persistent storage.",
+            "name": "save_history",
+            "description": "Save a summary of the conversation to HISTORY.md for grep-searchable logs.",
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -29,13 +29,8 @@ _SAVE_MEMORY_TOOL = [
                         "description": "A paragraph (2-5 sentences) summarizing key events/decisions/topics. "
                         "Start with [YYYY-MM-DD HH:MM]. Include detail useful for grep search.",
                     },
-                    "memory_update": {
-                        "type": "string",
-                        "description": "Full updated long-term memory as markdown. Include all existing "
-                        "facts plus new ones. Return unchanged if nothing new.",
-                    },
                 },
-                "required": ["history_entry", "memory_update"],
+                "required": ["history_entry"],
             },
         },
     }
@@ -43,7 +38,11 @@ _SAVE_MEMORY_TOOL = [
 
 
 class MemoryStore:
-    """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
+    """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log).
+
+    MEMORY.md is maintained by the dream skill (scheduled task).
+    consolidate() only writes to HISTORY.md to avoid output truncation issues.
+    """
 
     def __init__(self, workspace: Path):
         self.memory_dir = ensure_dir(workspace / "memory")
@@ -74,15 +73,14 @@ class MemoryStore:
         *,
         archive_all: bool = False,
         memory_window: int = 50,
-        max_tokens: int = 16384,
     ) -> bool:
-        """Consolidate old messages into MEMORY.md + HISTORY.md via LLM tool call.
+        """Consolidate old messages into HISTORY.md via LLM tool call.
+
+        Only writes to HISTORY.md. MEMORY.md is maintained by the dream skill
+        which runs as a scheduled task and can use file editing tools to
+        incrementally update without output truncation issues.
 
         Returns True on success (including no-op), False on failure.
-
-        Args:
-            max_tokens: Maximum tokens for LLM response. Default 16384 to accommodate
-                        large memory_update output (existing memory + new content).
         """
         if archive_all:
             old_messages = session.messages
@@ -106,11 +104,7 @@ class MemoryStore:
             tools = f" [tools: {', '.join(m['tools_used'])}]" if m.get("tools_used") else ""
             lines.append(f"[{m.get('timestamp', '?')[:16]}] {m['role'].upper()}{tools}: {m['content']}")
 
-        current_memory = self.read_long_term()
-        prompt = f"""Process this conversation and call the save_memory tool with your consolidation.
-
-## Current Long-term Memory
-{current_memory or "(empty)"}
+        prompt = f"""Summarize this conversation and call the save_history tool.
 
 ## Conversation to Process
 {chr(10).join(lines)}"""
@@ -118,25 +112,22 @@ class MemoryStore:
         try:
             response = await provider.chat(
                 messages=[
-                    {"role": "system", "content": "You are a memory consolidation agent. Call the save_memory tool with your consolidation of the conversation."},
+                    {"role": "system", "content": "You are a memory consolidation agent. Call the save_history tool with a brief summary of the conversation."},
                     {"role": "user", "content": prompt},
                 ],
-                tools=_SAVE_MEMORY_TOOL,
+                tools=_SAVE_HISTORY_TOOL,
                 model=model,
-                max_tokens=max_tokens,
             )
 
             # Safety check: reject if LLM response was truncated due to token limit
-            # This prevents memory corruption from incomplete tool call arguments
             if response.finish_reason == "length":
                 logger.warning(
-                    "Memory consolidation rejected: LLM response truncated (finish_reason='length'). "
-                    f"Current max_tokens={max_tokens}. Consider increasing it further."
+                    "Memory consolidation rejected: LLM response truncated (finish_reason='length')."
                 )
                 return False
 
             if not response.has_tool_calls:
-                logger.warning("Memory consolidation: LLM did not call save_memory, skipping")
+                logger.warning("Memory consolidation: LLM did not call save_history, skipping")
                 return False
 
             args = response.tool_calls[0].arguments
@@ -158,11 +149,6 @@ class MemoryStore:
                 if not isinstance(entry, str):
                     entry = json.dumps(entry, ensure_ascii=False)
                 self.append_history(entry)
-            if update := args.get("memory_update"):
-                if not isinstance(update, str):
-                    update = json.dumps(update, ensure_ascii=False)
-                if update != current_memory:
-                    self.write_long_term(update)
 
             session.last_consolidated = 0 if archive_all else len(session.messages) - keep_count
             logger.info("Memory consolidation done: {} messages, last_consolidated={}", len(session.messages), session.last_consolidated)

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -74,10 +74,15 @@ class MemoryStore:
         *,
         archive_all: bool = False,
         memory_window: int = 50,
+        max_tokens: int = 16384,
     ) -> bool:
         """Consolidate old messages into MEMORY.md + HISTORY.md via LLM tool call.
 
         Returns True on success (including no-op), False on failure.
+
+        Args:
+            max_tokens: Maximum tokens for LLM response. Default 16384 to accommodate
+                        large memory_update output (existing memory + new content).
         """
         if archive_all:
             old_messages = session.messages
@@ -118,7 +123,17 @@ class MemoryStore:
                 ],
                 tools=_SAVE_MEMORY_TOOL,
                 model=model,
+                max_tokens=max_tokens,
             )
+
+            # Safety check: reject if LLM response was truncated due to token limit
+            # This prevents memory corruption from incomplete tool call arguments
+            if response.finish_reason == "length":
+                logger.warning(
+                    "Memory consolidation rejected: LLM response truncated (finish_reason='length'). "
+                    f"Current max_tokens={max_tokens}. Consider increasing it further."
+                )
+                return False
 
             if not response.has_tool_calls:
                 logger.warning("Memory consolidation: LLM did not call save_memory, skipping")

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -259,11 +259,12 @@ class SkillsLoader:
 
         from nanobot.cron.types import CronSchedule
 
-        existing_names = {job.name for job in cron_service.list_jobs()}
+        existing_names = {job.name for job in cron_service.list_jobs(include_disabled=True)}
 
         for skill in self.get_cron_skills():
             job_name = skill["name"]
             if job_name in existing_names:
+                logger.debug(f"{job_name} has registered")
                 continue
 
             schedule = CronSchedule(kind="cron", expr=skill["cron"], tz=None)

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -1,10 +1,13 @@
 """Skills loader for agent capabilities."""
 
+import importlib.util
 import json
 import os
 import re
 import shutil
 from pathlib import Path
+
+from loguru import logger
 
 # Default builtin skills directory (relative to this file)
 BUILTIN_SKILLS_DIR = Path(__file__).parent.parent / "skills"
@@ -226,3 +229,57 @@ class SkillsLoader:
                 return metadata
 
         return None
+
+    def get_cron_skills(self) -> list[dict]:
+        """
+        Get skills that have cron schedules defined in frontmatter.
+
+        Returns:
+            List of dicts with 'name' and 'cron' (schedule expression).
+        """
+        result = []
+        for s in self.list_skills(filter_unavailable=True):
+            meta = self.get_skill_metadata(s["name"])
+            if meta and meta.get("cron"):
+                result.append({
+                    "name": s["name"],
+                    "cron": meta["cron"],
+                })
+        return result
+
+    def register_cron_jobs(self, cron_service) -> None:
+        """
+        Register cron jobs for skills with cron in frontmatter.
+
+        Args:
+            cron_service: The CronService instance.
+        """
+        if not cron_service:
+            return
+
+        from nanobot.cron.types import CronSchedule
+
+        existing_names = {job.name for job in cron_service.list_jobs()}
+
+        for skill in self.get_cron_skills():
+            job_name = skill["name"]
+            if job_name in existing_names:
+                continue
+
+            schedule = CronSchedule(kind="cron", expr=skill["cron"], tz=None)
+            cron_service.add_job(
+                name=job_name,
+                schedule=schedule,
+                message=f"Run skill '{job_name}' scheduled task",
+            )
+            logger.info(f"Registered cron job for skill '{job_name}': {skill['cron']}")
+
+    async def run_init_hooks(self, agent_loop) -> None:
+        """
+        Run initialization for skills (register cron jobs, etc).
+
+        Args:
+            agent_loop: The AgentLoop instance.
+        """
+        # Register cron jobs from skill frontmatter
+        self.register_cron_jobs(agent_loop.cron_service)

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -51,7 +51,11 @@ class SkillsLoader:
             for skill_dir in self.builtin_skills.iterdir():
                 if skill_dir.is_dir():
                     skill_file = skill_dir / "SKILL.md"
-                    if skill_file.exists() and not any(s["name"] == skill_dir.name for s in skills):
+                    if skill_file.exists():
+                        if any(s["name"] == skill_dir.name for s in skills):
+                            # Workspace skill overrides builtin
+                            logger.warning(f"Skill '{skill_dir.name}' in workspace overrides builtin skill")
+                            continue
                         skills.append({"name": skill_dir.name, "path": str(skill_file), "source": "builtin"})
 
         # Filter by requirements
@@ -216,7 +220,10 @@ class SkillsLoader:
         content = self.load_skill(name)
         if not content:
             return None
+        return self._parse_frontmatter(content)
 
+    def _parse_frontmatter(self, content: str) -> dict | None:
+        """Parse YAML frontmatter from skill content."""
         if content.startswith("---"):
             match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
             if match:
@@ -227,12 +234,14 @@ class SkillsLoader:
                         key, value = line.split(":", 1)
                         metadata[key.strip()] = value.strip().strip('"\'')
                 return metadata
-
         return None
 
     def get_cron_skills(self) -> list[dict]:
         """
         Get skills that have cron schedules defined in frontmatter.
+
+        If a workspace skill overrides a builtin skill, the cron field from
+        builtin is preserved unless workspace skill explicitly overrides it.
 
         Returns:
             List of dicts with 'name' and 'cron' (schedule expression).
@@ -240,12 +249,35 @@ class SkillsLoader:
         result = []
         for s in self.list_skills(filter_unavailable=True):
             meta = self.get_skill_metadata(s["name"])
-            if meta and meta.get("cron"):
+            cron_expr = meta.get("cron") if meta else None
+
+            # If workspace skill overrides builtin but doesn't have cron,
+            # check if builtin has cron and use it (with warning)
+            if not cron_expr and s["source"] == "workspace":
+                builtin_meta = self._get_builtin_skill_metadata(s["name"])
+                if builtin_meta and builtin_meta.get("cron"):
+                    logger.warning(
+                        f"Skill '{s['name']}' in workspace overrides builtin but missing cron field. "
+                        f"Using builtin cron: {builtin_meta['cron']}"
+                    )
+                    cron_expr = builtin_meta["cron"]
+
+            if cron_expr:
                 result.append({
                     "name": s["name"],
-                    "cron": meta["cron"],
+                    "cron": cron_expr,
                 })
         return result
+
+    def _get_builtin_skill_metadata(self, name: str) -> dict | None:
+        """Get metadata from builtin skill (used when workspace overrides)."""
+        if not self.builtin_skills:
+            return None
+        builtin_file = self.builtin_skills / name / "SKILL.md"
+        if not builtin_file.exists():
+            return None
+        content = builtin_file.read_text(encoding="utf-8")
+        return self._parse_frontmatter(content)
 
     def register_cron_jobs(self, cron_service) -> None:
         """

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -298,6 +298,12 @@ class CronService:
         _validate_schedule_for_add(schedule)
         now = _now_ms()
 
+        # Validate cron expression can compute next run
+        if schedule.kind == "cron" and schedule.expr:
+            next_run = _compute_next_run(schedule, now)
+            if next_run is None:
+                raise ValueError(f"Invalid cron expression: {schedule.expr}")
+
         job = CronJob(
             id=str(uuid.uuid4())[:8],
             name=name,

--- a/nanobot/skills/README.md
+++ b/nanobot/skills/README.md
@@ -5,8 +5,22 @@ This directory contains built-in skills that extend nanobot's capabilities.
 ## Skill Format
 
 Each skill is a directory containing a `SKILL.md` file with:
-- YAML frontmatter (name, description, metadata)
+- YAML frontmatter (name, description, optional cron schedule, metadata)
 - Markdown instructions for the agent
+
+### Scheduled Skills
+
+Add a `cron` field to frontmatter to auto-register the skill as a scheduled task:
+
+```yaml
+---
+name: daily-report
+description: Generate daily report
+cron: "0 9 * * *"
+---
+```
+
+The job will be registered at startup using the skill name (prevents duplicates).
 
 ## Attribution
 
@@ -17,9 +31,12 @@ The skill format and metadata structure follow OpenClaw's conventions to maintai
 
 | Skill | Description |
 |-------|-------------|
+| `clawhub` | Search and install skills from ClawHub registry |
+| `cron` | Schedule reminders and recurring tasks |
+| `dream` | Daily memory consolidation - backup, extract info, clean history |
 | `github` | Interact with GitHub using the `gh` CLI |
-| `weather` | Get weather info using wttr.in and Open-Meteo |
+| `memory` | Two-layer memory system with grep-based recall |
+| `skill-creator` | Create new skills |
 | `summarize` | Summarize URLs, files, and YouTube videos |
 | `tmux` | Remote-control tmux sessions |
-| `clawhub` | Search and install skills from ClawHub registry |
-| `skill-creator` | Create new skills |
+| `weather` | Get weather info using wttr.in and Open-Meteo |

--- a/nanobot/skills/dream/SKILL.md
+++ b/nanobot/skills/dream/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: dream
+description: Daily memory consolidation - backup memory, extract important info to MEMORY.md, clean old history.
+cron: "0 2 * * *"
+metadata: {"nanobot":{"emoji":"🌙"}}
+---
+
+# Dream - Memory Consolidation Skill
+
+## Purpose
+
+Mimics human sleep dreaming to consolidate memories:
+- Backup current memory files
+- Extract important information from recent HISTORY to MEMORY.md
+- Clean up old history entries (keep 7 days)
+- Review and prune MEMORY.md to prevent bloat
+- Push a brief summary to notification channel
+
+## Schedule
+
+Runs automatically at 2:00 AM daily via cron.
+
+## How It Works
+
+Agent executes the consolidation workflow:
+1. Backup MEMORY.md and HISTORY.md to `memory/backups/`
+2. Analyze last 7 days of HISTORY.md
+3. Extract important info to MEMORY.md (see guidelines below)
+4. **Review MEMORY.md and remove outdated/temporary info**
+5. Clean up old HISTORY entries (keep 7 days)
+6. Send brief summary to notification channel
+
+## What Belongs in MEMORY.md (Long-term Memory)
+
+- User identity (name, contact info, relationships)
+- Stable preferences (communication style, language, timezone)
+- API keys and credentials
+- Server/infrastructure configuration
+- Active skills and their cron job IDs
+- Known bugs with workarounds
+- Ongoing project references (repo URLs, not detailed notes)
+
+## What Does NOT Belong in MEMORY.md
+
+- Debugging session notes (temporary, will become stale)
+- PR/code review details (track in GitHub, not memory)
+- Research notes on libraries/tools (temporary exploration)
+- Step-by-step procedures (belongs in SKILL.md)
+- Repeated information (deduplicate first)
+- Time-sensitive info (dates, versions that will expire)
+
+## MEMORY.md Maintenance Rules
+
+1. **One line per fact**: Avoid multi-paragraph explanations
+2. **No duplication**: If info exists, don't add it again
+3. **Prune outdated info**: Remove anything no longer relevant
+4. **Reference, don't copy**: Link to SKILL.md for detailed procedures
+5. **Review monthly**: Check if accumulated info is still needed

--- a/tests/test_memory_consolidation_types.py
+++ b/tests/test_memory_consolidation_types.py
@@ -26,17 +26,16 @@ def _make_session(message_count: int = 30, memory_window: int = 50):
     return session
 
 
-def _make_tool_response(history_entry, memory_update):
-    """Create an LLMResponse with a save_memory tool call."""
+def _make_tool_response(history_entry):
+    """Create an LLMResponse with a save_history tool call."""
     return LLMResponse(
         content=None,
         tool_calls=[
             ToolCallRequest(
                 id="call_1",
-                name="save_memory",
+                name="save_history",
                 arguments={
                     "history_entry": history_entry,
-                    "memory_update": memory_update,
                 },
             )
         ],
@@ -54,7 +53,6 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat = AsyncMock(
             return_value=_make_tool_response(
                 history_entry="[2026-01-01] User discussed testing.",
-                memory_update="# Memory\nUser likes testing.",
             )
         )
         session = _make_session(message_count=60)
@@ -64,7 +62,6 @@ class TestMemoryConsolidationTypeHandling:
         assert result is True
         assert store.history_file.exists()
         assert "[2026-01-01] User discussed testing." in store.history_file.read_text()
-        assert "User likes testing." in store.memory_file.read_text()
 
     @pytest.mark.asyncio
     async def test_dict_arguments_serialized_to_json(self, tmp_path: Path) -> None:
@@ -74,7 +71,6 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat = AsyncMock(
             return_value=_make_tool_response(
                 history_entry={"timestamp": "2026-01-01", "summary": "User discussed testing."},
-                memory_update={"facts": ["User likes testing"], "topics": ["testing"]},
             )
         )
         session = _make_session(message_count=60)
@@ -86,10 +82,6 @@ class TestMemoryConsolidationTypeHandling:
         history_content = store.history_file.read_text()
         parsed = json.loads(history_content.strip())
         assert parsed["summary"] == "User discussed testing."
-
-        memory_content = store.memory_file.read_text()
-        parsed_mem = json.loads(memory_content)
-        assert "User likes testing" in parsed_mem["facts"]
 
     @pytest.mark.asyncio
     async def test_string_arguments_as_raw_json(self, tmp_path: Path) -> None:
@@ -103,10 +95,9 @@ class TestMemoryConsolidationTypeHandling:
             tool_calls=[
                 ToolCallRequest(
                     id="call_1",
-                    name="save_memory",
+                    name="save_history",
                     arguments=json.dumps({
                         "history_entry": "[2026-01-01] User discussed testing.",
-                        "memory_update": "# Memory\nUser likes testing.",
                     }),
                 )
             ],
@@ -121,7 +112,7 @@ class TestMemoryConsolidationTypeHandling:
 
     @pytest.mark.asyncio
     async def test_no_tool_call_returns_false(self, tmp_path: Path) -> None:
-        """When LLM doesn't use the save_memory tool, return False."""
+        """When LLM doesn't use the save_history tool, return False."""
         store = MemoryStore(tmp_path)
         provider = AsyncMock()
         provider.chat = AsyncMock(
@@ -158,10 +149,9 @@ class TestMemoryConsolidationTypeHandling:
             tool_calls=[
                 ToolCallRequest(
                     id="call_1",
-                    name="save_memory",
+                    name="save_history",
                     arguments=[{
                         "history_entry": "[2026-01-01] User discussed testing.",
-                        "memory_update": "# Memory\nUser likes testing.",
                     }],
                 )
             ],
@@ -173,7 +163,6 @@ class TestMemoryConsolidationTypeHandling:
 
         assert result is True
         assert "User discussed testing." in store.history_file.read_text()
-        assert "User likes testing." in store.memory_file.read_text()
 
     @pytest.mark.asyncio
     async def test_list_arguments_empty_list_returns_false(self, tmp_path: Path) -> None:
@@ -186,7 +175,7 @@ class TestMemoryConsolidationTypeHandling:
             tool_calls=[
                 ToolCallRequest(
                     id="call_1",
-                    name="save_memory",
+                    name="save_history",
                     arguments=[],
                 )
             ],
@@ -209,7 +198,7 @@ class TestMemoryConsolidationTypeHandling:
             tool_calls=[
                 ToolCallRequest(
                     id="call_1",
-                    name="save_memory",
+                    name="save_history",
                     arguments=["string", "content"],
                 )
             ],
@@ -220,3 +209,28 @@ class TestMemoryConsolidationTypeHandling:
         result = await store.consolidate(session, provider, "test-model", memory_window=50)
 
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_truncated_response_returns_false(self, tmp_path: Path) -> None:
+        """When LLM response is truncated (finish_reason='length'), return False."""
+        store = MemoryStore(tmp_path)
+        provider = AsyncMock()
+
+        response = LLMResponse(
+            content=None,
+            tool_calls=[
+                ToolCallRequest(
+                    id="call_1",
+                    name="save_history",
+                    arguments={"history_entry": "[2026-01-01] Truncated..."},
+                )
+            ],
+            finish_reason="length",  # Response was truncated
+        )
+        provider.chat = AsyncMock(return_value=response)
+        session = _make_session(message_count=60)
+
+        result = await store.consolidate(session, provider, "test-model", memory_window=50)
+
+        assert result is False
+        assert not store.history_file.exists()


### PR DESCRIPTION
## Problem

When LLM's response is truncated (due to `max_tokens` limit), the `memory_update` field may contain incomplete content. This causes `MEMORY.md` to be overwritten with truncated data, resulting in permanent data loss.

## Evidence

This bug occurred in production on 2026-03-06 at 23:08:51 CST:

Journal logs:
```
Mar 06 23:07:20 nanobot[162239]: Memory consolidation: 74 to consolidate, 50 keep
Mar 06 23:08:51 nanobot[162239]: Memory consolidation done: 1099 messages, last_consolidated=1049
```
MEMORY.md after corruption:
```
➜  ~ stat /home/chengyongru/.nanobot/workspace/memory/MEMORY.md
  File: /home/chengyongru/.nanobot/workspace/memory/MEMORY.md
  Size: 171             Blocks: 8          IO Block: 4096   regular file
Device: 254,3   Inode: 428594      Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1001/chengyongru)   Gid: ( 1001/chengyongru)
Access: 2026-03-06 23:08:51.587827651 +0800
Modify: 2026-03-06 23:08:51.323826093 +0800
Change: 2026-03-06 23:08:51.323826093 +0800
 Birth: 2026-02-26 01:20:48.903428545 +0800
 ```
Backup comparison:

Corrupted: 171 bytes
Backup (healthy): 10,180 bytes
---

## Root Cause Analysis

The consolidate function required LLM to output complete `memory_update` (existing memory + new content), which could be very long (10KB+). This exceeded typical `max_tokens` limits (4K-16K), causing truncation.

---

## Solution: Separate consolidate and dream

### Changes

1. **consolidate() now only writes HISTORY.md**
   - Removed `memory_update` from tool definition
   - Output is small (~500 tokens), no truncation risk

2. **Added dream skill** 
   - Runs daily at 2AM via cron
   - Backs up memory files
   - Extracts important info from HISTORY.md to MEMORY.md
   - Cleans old history entries (keep 7 days)
   - Prunes MEMORY.md to prevent bloat

### Benefits

| Aspect | Before | After |
|--------|--------|-------|
| consolidate output | `history_entry` + `memory_update` (10KB+) | `history_entry` only (~500 tokens) |
| Truncation risk | High | None |
| MEMORY.md update | During consolidate (rushed) | During dream (background) |
| Memory maintenance | None | Daily pruning via dream |

---

## References

- [OpenAI: Handling finish_reason: length](https://community.openai.com/t/tips-for-handling-finish-reason-length-with-json/806445)
- [Claude Code Issue #1261: Memory Truncation](https://github.com/anthropics/claude-code/issues/1261)