### PR TITLE
fix(feishu): media_dir hardcode

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -715,7 +715,10 @@ class FeishuChannel(BaseChannel):
             (file_path, content_text) - file_path is None if download failed
         """
         loop = asyncio.get_running_loop()
-        media_dir = Path.home() / ".nanobot" / "media"
+        if self.config.media_dir:
+            media_dir = Path(self.config.media_dir)
+        else:
+            media_dir = Path.home() / ".nanobot" / "media"
         media_dir.mkdir(parents=True, exist_ok=True)
 
         data, filename = None, None

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -47,6 +47,7 @@ class FeishuConfig(Base):
     react_emoji: str = (
         "THUMBSUP"  # Emoji type for message reactions (e.g. THUMBSUP, OK, DONE, SMILE)
     )
+    media_dir: str = ""  # Directory to save media files (default: ~/.nanobot/media)
 
 
 class DingTalkConfig(Base):


### PR DESCRIPTION
# The directory media_dir  in Feishu is hardcoded, which makes it inconvenient for file interactions.
1. Add media_dir to FeishuConfig in nanobot/config/schema.py:38-50
   - Add new field: media_dir: str = "" with description
2. Update _download_and_save_media in nanobot/channels/feishu.py:705-748
   - Change line 718 from hardcoded Path.home() / ".nanobot" / "media" to use self.config.media_dir
   - If media_dir is empty, fallback to default path

