### PR TITLE
feat(channels): add MQTT channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Connect nanobot to your favorite chat platform.
 | **Slack** | Bot token + App-Level token |
 | **Email** | IMAP/SMTP credentials |
 | **QQ** | App ID + App Secret |
+| **MQTT** | MQTT broker (localhost or remote) |
 
 <details>
 <summary><b>Telegram</b> (Recommended)</summary>
@@ -639,6 +640,92 @@ Give nanobot its own email account. It polls **IMAP** for incoming mail and repl
 ```bash
 nanobot gateway
 ```
+
+</details>
+
+<details>
+<summary><b>MQTT</b></summary>
+
+Connect nanobot to any MQTT broker for IoT device communication, custom integrations, or low-bandwidth environments.
+
+**1. Set up an MQTT broker**
+
+You need an MQTT broker. Options:
+- **Local**: `docker run -it -p 1883:1883 eclipse-mosquitto`
+- **Cloud**: [Mosquitto](https://mosquitto.org/), [EMQX](https://www.emqx.io/), [HiveMQ](https://www.hivemq.com/), or any public broker
+
+**2. Configure**
+
+```json
+{
+  "channels": {
+    "mqtt": {
+      "enabled": true,
+      "host": "localhost",
+      "port": 1883,
+      "username": "",
+      "password": "",
+      "useTls": false,
+      "subscribeTopics": [
+        {"topic": "nanobot/+/inbox", "qos": 1}
+      ],
+      "publishTopicTemplate": "nanobot/{chat_id}/outbox",
+      "payloadFormat": "json",
+      "allowFrom": ["*"]
+    }
+  }
+}
+```
+
+**3. Test**
+
+```bash
+# Terminal 1: Subscribe to responses
+mosquitto_sub -h localhost -t "nanobot/+/outbox" -v
+
+# Terminal 2: Send a message
+mosquitto_pub -h localhost -t "nanobot/user123/inbox" -m '{"content": "Hello!"}'
+
+# Terminal 3: Run nanobot
+nanobot gateway
+```
+
+**Configuration options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `host` | `localhost` | MQTT broker hostname |
+| `port` | `1883` | MQTT broker port (use `8883` for TLS) |
+| `username` | `""` | MQTT username (optional) |
+| `password` | `""` | MQTT password (optional) |
+| `useTls` | `false` | Enable TLS/SSL |
+| `tlsInsecure` | `false` | Skip certificate verification (dev only) |
+| `subscribeTopics` | `[{"topic": "nanobot/+/inbox", "qos": 1}]` | Topics to subscribe (supports `+` and `#` wildcards) |
+| `publishTopicTemplate` | `nanobot/{chat_id}/outbox` | Outbound topic template (`{chat_id}` replaced with sender) |
+| `payloadFormat` | `json` | Message format: `json` or `text` |
+| `will.enabled` | `true` | Enable Last Will Testament (LWT) |
+| `will.topic` | `nanobot/status` | LWT topic |
+| `will.payload` | `offline` | LWT message on disconnect |
+| `birthEnabled` | `true` | Publish birth message on connect |
+| `birthTopic` | `nanobot/status` | Birth message topic |
+| `birthPayload` | `online` | Birth message content |
+| `reconnectMinDelay` | `1.0` | Minimum reconnection delay (seconds) |
+| `reconnectMaxDelay` | `60.0` | Maximum reconnection delay (seconds) |
+
+**Message format (JSON):**
+```json
+{
+  "content": "Your message here",
+  "metadata": {
+    "custom_field": "value"
+  }
+}
+```
+
+**Topic patterns:**
+- Inbound: `nanobot/{sender_id}/inbox` — the `{sender_id}` is extracted and used as `chat_id`
+- Outbound: `nanobot/{chat_id}/outbox` — responses are published here
+- Wildcards: `+` matches single level, `#` matches multiple levels
 
 </details>
 

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -149,6 +149,18 @@ class ChannelManager:
             except ImportError as e:
                 logger.warning("Matrix channel not available: {}", e)
 
+        # MQTT channel
+        if self.config.channels.mqtt.enabled:
+            try:
+                from nanobot.channels.mqtt import MQTTChannel
+                self.channels["mqtt"] = MQTTChannel(
+                    self.config.channels.mqtt,
+                    self.bus,
+                )
+                logger.info("MQTT channel enabled")
+            except ImportError as e:
+                logger.warning("MQTT channel not available: {}", e)
+
         self._validate_allow_from()
 
     def _validate_allow_from(self) -> None:

--- a/nanobot/channels/mqtt.py
+++ b/nanobot/channels/mqtt.py
@@ -1,0 +1,290 @@
+"""MQTT channel implementation using aiomqtt."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import ssl
+from typing import Any
+
+from aiomqtt import Client, MqttError, Will
+from loguru import logger
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import MQTTConfig
+
+
+class MQTTChannel(BaseChannel):
+    """
+    MQTT channel using aiomqtt for async-native MQTT communication.
+
+    Supports:
+    - Bidirectional messaging via pub/sub topics
+    - TLS/SSL secure connections
+    - Username/password authentication
+    - QoS levels 0, 1, 2
+    - Last Will Testament (LWT)
+    - Birth messages
+    - JSON and text payload formats
+    - Exponential backoff reconnection
+    """
+
+    name = "mqtt"
+
+    # Default topic pattern for extracting sender_id
+    # Matches: nanobot/{sender_id}/inbox or any single-level wildcard
+    DEFAULT_TOPIC_PATTERN = re.compile(r"^nanobot/([^/]+)/inbox$")
+
+    def __init__(self, config: MQTTConfig, bus: MessageBus):
+        super().__init__(config, bus)
+        self.config: MQTTConfig = config
+        self._client: Client | None = None
+        self._running = False
+        self._reconnect_delay = config.reconnect_min_delay
+        self._topic_pattern = self.DEFAULT_TOPIC_PATTERN
+
+    def _build_tls_context(self) -> ssl.SSLContext | None:
+        """Build TLS context for secure connections."""
+        if not self.config.use_tls:
+            return None
+
+        context = ssl.create_default_context()
+
+        if self.config.tls_ca_certs:
+            context.load_verify_locations(cafile=self.config.tls_ca_certs)
+
+        if self.config.tls_insecure:
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+            logger.warning("MQTT TLS certificate verification disabled")
+
+        return context
+
+    def _build_will(self) -> Will | None:
+        """Build Last Will Testament (LWT) message."""
+        if not self.config.will.enabled:
+            return None
+
+        return Will(
+            topic=self.config.will.topic,
+            payload=self.config.will.payload,
+            qos=self.config.will.qos,
+            retain=self.config.will.retain,
+        )
+
+    def _parse_topic(self, topic: str) -> tuple[str, str] | None:
+        """
+        Extract sender_id and chat_id from topic path.
+
+        Returns (sender_id, chat_id) or None if topic doesn't match pattern.
+        """
+        match = self._topic_pattern.match(topic)
+        if match:
+            sender_id = match.group(1)
+            return sender_id, sender_id
+        return None
+
+    def _build_publish_topic(self, chat_id: str) -> str:
+        """Build outbound topic from template."""
+        return self.config.publish_topic_template.replace("{chat_id}", chat_id)
+
+    def _decode_payload(self, payload: bytes, topic: str) -> tuple[str, dict[str, Any]]:
+        """
+        Decode MQTT payload to content and metadata.
+
+        Returns (content, metadata) tuple.
+        """
+        try:
+            text = payload.decode("utf-8")
+        except UnicodeDecodeError:
+            logger.warning("Failed to decode MQTT payload as UTF-8 from topic: {}", topic)
+            return "", {"raw": True, "decode_error": True}
+
+        if self.config.payload_format == "json":
+            try:
+                data = json.loads(text)
+                if isinstance(data, dict):
+                    content = data.get("content", "")
+                    metadata = data.get("metadata", {})
+                    if not isinstance(metadata, dict):
+                        metadata = {"raw_metadata": metadata}
+                    return content, metadata
+                return str(data), {}
+            except json.JSONDecodeError:
+                # Fall back to plain text
+                return text, {"json_parse_error": True}
+
+        # Plain text format
+        return text, {}
+
+    def _encode_payload(self, content: str, metadata: dict[str, Any] | None = None) -> bytes:
+        """Encode message content to MQTT payload."""
+        if self.config.payload_format == "json":
+            data = {"content": content}
+            if metadata:
+                # Filter out internal metadata
+                filtered = {k: v for k, v in metadata.items() if not k.startswith("_")}
+                if filtered:
+                    data["metadata"] = filtered
+            return json.dumps(data, ensure_ascii=False).encode("utf-8")
+
+        return content.encode("utf-8")
+
+    async def _publish_birth_message(self, client: Client) -> None:
+        """Publish birth message to indicate online status."""
+        if not self.config.birth_enabled:
+            return
+
+        try:
+            await client.publish(
+                topic=self.config.birth_topic,
+                payload=self.config.birth_payload,
+                qos=self.config.birth_qos,
+                retain=self.config.birth_retain,
+            )
+            logger.debug("Published MQTT birth message to {}", self.config.birth_topic)
+        except MqttError as e:
+            logger.warning("Failed to publish birth message: {}", e)
+
+    async def _handle_mqtt_message(self, topic: str, payload: bytes) -> None:
+        """Process an incoming MQTT message."""
+        parsed = self._parse_topic(topic)
+        if not parsed:
+            logger.debug("MQTT message from unmatched topic: {}", topic)
+            return
+
+        sender_id, chat_id = parsed
+        content, metadata = self._decode_payload(payload, topic)
+        metadata["mqtt_topic"] = topic
+
+        if not content:
+            logger.debug("Empty MQTT message from {} on topic {}", sender_id, topic)
+            return
+
+        logger.debug("MQTT message from {}: {}...", sender_id, content[:50])
+
+        await self._handle_message(
+            sender_id=sender_id,
+            chat_id=chat_id,
+            content=content,
+            media=[],
+            metadata=metadata,
+        )
+
+    async def _message_loop(self, client: Client) -> None:
+        """Process incoming MQTT messages."""
+        async for message in client.messages:
+            if not self._running:
+                break
+
+            try:
+                await self._handle_mqtt_message(
+                    topic=str(message.topic),
+                    payload=message.payload,
+                )
+            except Exception as e:
+                logger.error("Error processing MQTT message: {}", e)
+
+    async def _exponential_backoff(self) -> None:
+        """Wait with exponential backoff before reconnecting."""
+        logger.info("Reconnecting to MQTT in {:.1f} seconds...", self._reconnect_delay)
+        await asyncio.sleep(self._reconnect_delay)
+        self._reconnect_delay = min(
+            self._reconnect_delay * 2,
+            self.config.reconnect_max_delay,
+        )
+
+    async def start(self) -> None:
+        """Start the MQTT client and begin listening for messages."""
+        if not self.config.host:
+            logger.error("MQTT broker host not configured")
+            return
+
+        self._running = True
+        logger.info(
+            "Starting MQTT channel ({}:{})...",
+            self.config.host,
+            self.config.port,
+        )
+
+        while self._running:
+            try:
+                await self._run_client()
+            except MqttError as e:
+                if not self._running:
+                    break
+                logger.error("MQTT connection error: {}", e)
+                await self._exponential_backoff()
+            except Exception as e:
+                if not self._running:
+                    break
+                logger.error("Unexpected MQTT error: {}", e)
+                await self._exponential_backoff()
+
+    async def _run_client(self) -> None:
+        """Run the MQTT client connection loop."""
+        tls_context = self._build_tls_context()
+        will = self._build_will()
+
+        client_kwargs: dict[str, Any] = {
+            "hostname": self.config.host,
+            "port": self.config.port,
+            "identifier": self.config.client_id or None,
+            "keepalive": self.config.keepalive,
+            "clean_session": self.config.clean_session,
+        }
+
+        if self.config.username:
+            client_kwargs["username"] = self.config.username
+        if self.config.password:
+            client_kwargs["password"] = self.config.password
+        if tls_context:
+            client_kwargs["tls_context"] = tls_context
+        if will:
+            client_kwargs["will"] = will
+
+        async with Client(**client_kwargs) as client:
+            self._client = client
+            self._reconnect_delay = self.config.reconnect_min_delay
+
+            logger.info("MQTT connected to {}:{}", self.config.host, self.config.port)
+
+            # Subscribe to configured topics
+            for topic_config in self.config.subscribe_topics:
+                await client.subscribe(topic_config.topic, qos=topic_config.qos)
+                logger.debug("MQTT subscribed to: {} (QoS {})", topic_config.topic, topic_config.qos)
+
+            # Publish birth message
+            await self._publish_birth_message(client)
+
+            # Process messages
+            await self._message_loop(client)
+
+    async def stop(self) -> None:
+        """Stop the MQTT client."""
+        logger.info("Stopping MQTT channel...")
+        self._running = False
+        self._client = None
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Send a message through MQTT."""
+        if not self._client:
+            logger.warning("MQTT client not connected, cannot send message")
+            return
+
+        topic = self._build_publish_topic(msg.chat_id)
+        payload = self._encode_payload(msg.content, msg.metadata)
+
+        try:
+            await self._client.publish(
+                topic=topic,
+                payload=payload,
+                qos=self.config.publish_qos,
+                retain=self.config.retain_outbound,
+            )
+            logger.debug("MQTT published to {}: {}...", topic, msg.content[:50] if msg.content else "[empty]")
+        except MqttError as e:
+            logger.error("Failed to publish MQTT message to {}: {}", topic, e)

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -199,6 +199,72 @@ class QQConfig(Base):
     )  # Allowed user openids (empty = public access)
 
 
+class MQTTTopicConfig(Base):
+    """Configuration for a single MQTT topic subscription."""
+
+    topic: str = "nanobot/+/inbox"  # Topic pattern (supports + and # wildcards)
+    qos: int = 1  # QoS level: 0 (at most once), 1 (at least once), 2 (exactly once)
+
+
+class MQTTWillConfig(Base):
+    """Last Will and Testament (LWT) configuration for MQTT."""
+
+    enabled: bool = True
+    topic: str = "nanobot/status"  # Topic for will message
+    payload: str = "offline"  # Message published on unexpected disconnect
+    qos: int = 1
+    retain: bool = True
+
+
+class MQTTConfig(Base):
+    """MQTT channel configuration using aiomqtt."""
+
+    enabled: bool = False
+
+    # Connection settings
+    host: str = "localhost"  # MQTT broker hostname
+    port: int = 1883  # MQTT broker port (8883 for TLS)
+    client_id: str = ""  # Optional client ID (auto-generated if empty)
+
+    # Authentication
+    username: str = ""  # MQTT username (optional)
+    password: str = ""  # MQTT password (optional)
+
+    # TLS/SSL settings
+    use_tls: bool = False  # Enable TLS/SSL (default True for port 8883)
+    tls_insecure: bool = False  # Skip certificate verification (dev only)
+
+    # Session settings
+    clean_session: bool = True  # Start with a clean session
+    keepalive: int = 60  # Keepalive interval in seconds
+
+    # Topic configuration
+    subscribe_topics: list[MQTTTopicConfig] = Field(
+        default_factory=lambda: [MQTTTopicConfig()]
+    )
+    publish_topic_template: str = "nanobot/{chat_id}/outbox"
+    publish_qos: int = 1
+    retain_outbound: bool = False
+
+    # Last Will Testament (LWT)
+    will: MQTTWillConfig = Field(default_factory=MQTTWillConfig)
+
+    # Birth message (published on connect)
+    birth_enabled: bool = True
+    birth_topic: str = "nanobot/status"
+    birth_payload: str = "online"
+    birth_qos: int = 1
+    birth_retain: bool = True
+
+    # Message format
+    payload_format: Literal["json", "text"] = "json"
+
+    # Reconnection settings
+    reconnect_min_delay: float = 1.0
+    reconnect_max_delay: float = 60.0
+
+    # Access control
+    allow_from: list[str] = Field(default_factory=list)
 
 
 class ChannelsConfig(Base):
@@ -216,6 +282,7 @@ class ChannelsConfig(Base):
     slack: SlackConfig = Field(default_factory=SlackConfig)
     qq: QQConfig = Field(default_factory=QQConfig)
     matrix: MatrixConfig = Field(default_factory=MatrixConfig)
+    mqtt: MQTTConfig = Field(default_factory=MQTTConfig)
 
 
 class AgentDefaults(Base):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "json-repair>=0.57.0,<1.0.0",
     "chardet>=3.0.2,<6.0.0",
     "openai>=2.8.0",
+    "aiomqtt>=2.3.0,<3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -105,3 +106,10 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "ruff>=0.15.5",
+]

--- a/tests/test_mqtt_channel.py
+++ b/tests/test_mqtt_channel.py
@@ -1,0 +1,296 @@
+"""Unit tests for MQTT channel implementation."""
+
+import json
+import pytest
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.mqtt import MQTTChannel
+from nanobot.config.schema import MQTTConfig, MQTTTopicConfig, MQTTWillConfig
+
+
+def _make_config(**overrides) -> MQTTConfig:
+    """Create a test MQTT configuration."""
+    defaults = {
+        "enabled": True,
+        "host": "localhost",
+        "port": 1883,
+        "allow_from": ["*"],
+    }
+    defaults.update(overrides)
+    return MQTTConfig(**defaults)
+
+
+class TestTopicParsing:
+    """Tests for MQTT topic parsing."""
+
+    def test_parse_valid_topic(self) -> None:
+        """Valid topic extracts sender_id correctly."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        result = channel._parse_topic("nanobot/user123/inbox")
+        assert result is not None
+        sender_id, chat_id = result
+        assert sender_id == "user123"
+        assert chat_id == "user123"
+
+    def test_parse_topic_with_dashes(self) -> None:
+        """Topic with dashes in sender_id works."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        result = channel._parse_topic("nanobot/user-abc-123/inbox")
+        assert result is not None
+        assert result[0] == "user-abc-123"
+
+    def test_parse_topic_with_underscores(self) -> None:
+        """Topic with underscores in sender_id works."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        result = channel._parse_topic("nanobot/user_abc_123/inbox")
+        assert result is not None
+        assert result[0] == "user_abc_123"
+
+    def test_parse_topic_with_special_chars(self) -> None:
+        """Topic with special characters in sender_id works."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        result = channel._parse_topic("nanobot/device@home/inbox")
+        assert result is not None
+        assert result[0] == "device@home"
+
+    def test_parse_invalid_topic_wrong_prefix(self) -> None:
+        """Invalid topic prefix returns None."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        result = channel._parse_topic("other/user123/inbox")
+        assert result is None
+
+    def test_parse_invalid_topic_wrong_suffix(self) -> None:
+        """Invalid topic suffix returns None."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        result = channel._parse_topic("nanobot/user123/outbox")
+        assert result is None
+
+    def test_parse_invalid_topic_too_many_levels(self) -> None:
+        """Topic with too many levels returns None."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        result = channel._parse_topic("nanobot/org/user123/inbox")
+        assert result is None
+
+    def test_parse_invalid_topic_too_few_levels(self) -> None:
+        """Topic with too few levels returns None."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        result = channel._parse_topic("nanobot/user123")
+        assert result is None
+
+
+class TestPayloadDecoding:
+    """Tests for MQTT payload decoding."""
+
+    def test_decode_json_payload(self) -> None:
+        """JSON payload decodes correctly."""
+        channel = MQTTChannel(_make_config(payload_format="json"), MessageBus())
+        payload = json.dumps({"content": "Hello", "metadata": {"key": "value"}}).encode()
+        content, metadata = channel._decode_payload(payload, "nanobot/test/inbox")
+        assert content == "Hello"
+        assert metadata == {"key": "value"}
+
+    def test_decode_json_payload_without_metadata(self) -> None:
+        """JSON payload without metadata works."""
+        channel = MQTTChannel(_make_config(payload_format="json"), MessageBus())
+        payload = json.dumps({"content": "Hello"}).encode()
+        content, metadata = channel._decode_payload(payload, "nanobot/test/inbox")
+        assert content == "Hello"
+        assert metadata == {}
+
+    def test_decode_json_payload_plain_string(self) -> None:
+        """JSON payload with plain string value works."""
+        channel = MQTTChannel(_make_config(payload_format="json"), MessageBus())
+        payload = json.dumps("Just a string").encode()
+        content, metadata = channel._decode_payload(payload, "nanobot/test/inbox")
+        assert content == "Just a string"
+        assert metadata == {}
+
+    def test_decode_json_invalid_falls_back(self) -> None:
+        """Invalid JSON falls back to plain text."""
+        channel = MQTTChannel(_make_config(payload_format="json"), MessageBus())
+        payload = b"Not valid JSON"
+        content, metadata = channel._decode_payload(payload, "nanobot/test/inbox")
+        assert content == "Not valid JSON"
+        assert metadata.get("json_parse_error") is True
+
+    def test_decode_text_payload(self) -> None:
+        """Text payload decodes as-is."""
+        channel = MQTTChannel(_make_config(payload_format="text"), MessageBus())
+        payload = b"Plain text message"
+        content, metadata = channel._decode_payload(payload, "nanobot/test/inbox")
+        assert content == "Plain text message"
+        assert metadata == {}
+
+    def test_decode_unicode_payload(self) -> None:
+        """Unicode payload decodes correctly."""
+        channel = MQTTChannel(_make_config(payload_format="text"), MessageBus())
+        payload = "你好世界 🌍".encode("utf-8")
+        content, metadata = channel._decode_payload(payload, "nanobot/test/inbox")
+        assert content == "你好世界 🌍"
+        assert metadata == {}
+
+    def test_decode_invalid_utf8(self) -> None:
+        """Invalid UTF-8 returns empty content with error flag."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        payload = b"\xff\xfe invalid utf-8"
+        content, metadata = channel._decode_payload(payload, "nanobot/test/inbox")
+        assert content == ""
+        assert metadata.get("decode_error") is True
+        assert metadata.get("raw") is True
+
+
+class TestPayloadEncoding:
+    """Tests for MQTT payload encoding."""
+
+    def test_encode_json_payload(self) -> None:
+        """JSON payload encodes correctly."""
+        channel = MQTTChannel(_make_config(payload_format="json"), MessageBus())
+        payload = channel._encode_payload("Hello", {"key": "value"})
+        data = json.loads(payload)
+        assert data["content"] == "Hello"
+        assert data["metadata"] == {"key": "value"}
+
+    def test_encode_json_filters_internal_metadata(self) -> None:
+        """Internal metadata (starting with _) is filtered out."""
+        channel = MQTTChannel(_make_config(payload_format="json"), MessageBus())
+        payload = channel._encode_payload("Hello", {"_internal": "secret", "public": "value"})
+        data = json.loads(payload)
+        assert "_internal" not in data.get("metadata", {})
+        assert data["metadata"]["public"] == "value"
+
+    def test_encode_json_no_metadata(self) -> None:
+        """JSON payload without metadata works."""
+        channel = MQTTChannel(_make_config(payload_format="json"), MessageBus())
+        payload = channel._encode_payload("Hello")
+        data = json.loads(payload)
+        assert data["content"] == "Hello"
+        assert "metadata" not in data
+
+    def test_encode_text_payload(self) -> None:
+        """Text payload encodes as-is."""
+        channel = MQTTChannel(_make_config(payload_format="text"), MessageBus())
+        payload = channel._encode_payload("Hello", {"key": "value"})
+        assert payload == b"Hello"
+
+    def test_encode_unicode_payload(self) -> None:
+        """Unicode payload encodes correctly."""
+        channel = MQTTChannel(_make_config(payload_format="json"), MessageBus())
+        payload = channel._encode_payload("你好世界 🌍")
+        data = json.loads(payload)
+        assert data["content"] == "你好世界 🌍"
+
+
+class TestTopicBuilding:
+    """Tests for outbound topic building."""
+
+    def test_build_publish_topic_default(self) -> None:
+        """Default template builds correctly."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        topic = channel._build_publish_topic("user123")
+        assert topic == "nanobot/user123/outbox"
+
+    def test_build_publish_topic_custom_template(self) -> None:
+        """Custom template builds correctly."""
+        config = _make_config(publish_topic_template="mybot/{chat_id}/reply")
+        channel = MQTTChannel(config, MessageBus())
+        topic = channel._build_publish_topic("user123")
+        assert topic == "mybot/user123/reply"
+
+    def test_build_publish_topic_special_chars(self) -> None:
+        """Topic with special characters in chat_id works."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        topic = channel._build_publish_topic("device@home")
+        assert topic == "nanobot/device@home/outbox"
+
+
+class TestAccessControl:
+    """Tests for access control (inherited from BaseChannel)."""
+
+    def test_allow_all(self) -> None:
+        """Wildcard allows all senders."""
+        channel = MQTTChannel(_make_config(allow_from=["*"]), MessageBus())
+        assert channel.is_allowed("anyone") is True
+        assert channel.is_allowed("user123") is True
+
+    def test_allow_specific(self) -> None:
+        """Specific allowlist works."""
+        channel = MQTTChannel(_make_config(allow_from=["user123", "user456"]), MessageBus())
+        assert channel.is_allowed("user123") is True
+        assert channel.is_allowed("user456") is True
+        assert channel.is_allowed("user789") is False
+
+    def test_empty_allowlist_denies_all(self) -> None:
+        """Empty allowlist denies all."""
+        channel = MQTTChannel(_make_config(allow_from=[]), MessageBus())
+        assert channel.is_allowed("anyone") is False
+
+
+    def test_pipe_separated_sender_id(self) -> None:
+        """Pipe-separated sender_id matches any part."""
+        channel = MQTTChannel(_make_config(allow_from=["user123"]), MessageBus())
+        # sender_id can be "id|username" format
+        assert channel.is_allowed("user123|myname") is True
+        assert channel.is_allowed("other|user123") is True
+
+
+class TestConfigurationDefaults:
+    """Tests for configuration defaults."""
+
+    def test_default_subscribe_topics(self) -> None:
+        """Default subscribe topics are set."""
+        config = MQTTConfig()
+        assert len(config.subscribe_topics) == 1
+        assert config.subscribe_topics[0].topic == "nanobot/+/inbox"
+        assert config.subscribe_topics[0].qos == 1
+
+    def test_default_connection_settings(self) -> None:
+        """Default connection settings are correct."""
+        config = MQTTConfig()
+        assert config.host == "localhost"
+        assert config.port == 1883
+        assert config.keepalive == 60
+        assert config.clean_session is True
+
+    def test_default_will_settings(self) -> None:
+        """Default will settings are correct."""
+        config = MQTTConfig()
+        assert config.will.enabled is True
+        assert config.will.topic == "nanobot/status"
+        assert config.will.payload == "offline"
+
+    def test_default_reconnect_settings(self) -> None:
+        """Default reconnect settings are correct."""
+        config = MQTTConfig()
+        assert config.reconnect_min_delay == 1.0
+        assert config.reconnect_max_delay == 60.0
+
+
+@pytest.mark.asyncio
+class TestAsyncOperations:
+    """Async tests for MQTT channel."""
+
+    async def test_send_without_client_returns_early(self) -> None:
+        """Send without connected client returns early without error."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        channel._client = None
+
+        # Should not raise an exception
+        await channel.send(OutboundMessage(
+            channel="mqtt",
+            chat_id="user123",
+            content="Test message",
+        ))
+
+        # Verify state unchanged
+        assert channel._client is None
+
+    async def test_stop_sets_running_false(self) -> None:
+        """Stop sets running flag to False."""
+        channel = MQTTChannel(_make_config(), MessageBus())
+        channel._running = True
+
+        await channel.stop()
+
+        assert channel._running is False
+        assert channel._client is None


### PR DESCRIPTION
Add aiomqtt-based MQTT channel for IoT device communication and custom integrations.

Features:
- Async-native implementation using aiomqtt library
- Bidirectional messaging via pub/sub topics
- JSON and text payload formats
- TLS/SSL secure connections
- Username/password authentication
- QoS levels 0, 1, 2 support
- Last Will Testament (LWT) for presence indication
- Birth message on connect
- Exponential backoff reconnection
- Configurable topic patterns with wildcards

Configuration:
- MQTTConfig, MQTTTopicConfig, MQTTWillConfig in schema.py
- Default topics: nanobot/+/inbox (subscribe), nanobot/{chat_id}/outbox (publish)

Files:
- nanobot/channels/mqtt.py: MQTTChannel implementation
- nanobot/config/schema.py: Configuration classes
- nanobot/channels/manager.py: Channel registration
- tests/test_mqtt_channel.py: 33 unit tests
- README.md: Documentation