### PR TITLE
fix: propagate session affinity for vLLM cache locality

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ Run your own model with vLLM or any OpenAI-compatible server, then add to config
 
 **1. Start the server** (example):
 ```bash
-vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000
+vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000 --enable-prefix-caching
 ```
 
 **2. Add to config** (partial — merge into `~/.nanobot/config.json`):
@@ -780,6 +780,9 @@ vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000
   }
 }
 ```
+
+> Recommended for distributed vLLM workers: keep sticky routing by session so each chat keeps hitting the same worker cache.
+> nanobot sends `x-session-affinity` derived from session ID on model requests.
 
 </details>
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -181,6 +181,7 @@ class AgentLoop:
         self,
         initial_messages: list[dict],
         on_progress: Callable[..., Awaitable[None]] | None = None,
+        session_id: str | None = None,
     ) -> tuple[str | None, list[str], list[dict]]:
         """Run the agent iteration loop. Returns (final_content, tools_used, messages)."""
         messages = initial_messages
@@ -198,6 +199,7 @@ class AgentLoop:
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
                 reasoning_effort=self.reasoning_effort,
+                session_id=session_id,
             )
 
             if response.has_tool_calls:
@@ -356,7 +358,7 @@ class AgentLoop:
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
             )
-            final_content, _, all_msgs = await self._run_agent_loop(messages)
+            final_content, _, all_msgs = await self._run_agent_loop(messages, session_id=key)
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
             return OutboundMessage(channel=channel, chat_id=chat_id,
@@ -442,7 +444,7 @@ class AgentLoop:
             ))
 
         final_content, _, all_msgs = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
+            initial_messages, on_progress=on_progress or _bus_progress, session_id=key,
         )
 
         if final_content is None:

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -35,7 +35,6 @@ class AzureOpenAIProvider(LLMProvider):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.api_version = "2024-10-21"
-        self._default_affinity = uuid.uuid4().hex
         
         # Validate required parameters
         if not api_key:
@@ -64,11 +63,10 @@ class AzureOpenAIProvider(LLMProvider):
 
     def _build_headers(self, session_id: str | None = None) -> dict[str, str]:
         """Build headers for Azure OpenAI API with api-key header."""
-        affinity = self._session_affinity(session_id) or self._default_affinity
         return {
             "Content-Type": "application/json",
             "api-key": self.api_key,  # Azure OpenAI uses api-key header, not Authorization
-            "x-session-affinity": affinity,  # Stable per session when available
+            "x-session-affinity": uuid.uuid4().hex,  # For cache locality
         }
 
     @staticmethod

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -35,6 +35,7 @@ class AzureOpenAIProvider(LLMProvider):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.api_version = "2024-10-21"
+        self._default_affinity = uuid.uuid4().hex
         
         # Validate required parameters
         if not api_key:
@@ -61,12 +62,13 @@ class AzureOpenAIProvider(LLMProvider):
         )
         return f"{url}?api-version={self.api_version}"
 
-    def _build_headers(self) -> dict[str, str]:
+    def _build_headers(self, session_id: str | None = None) -> dict[str, str]:
         """Build headers for Azure OpenAI API with api-key header."""
+        affinity = self._session_affinity(session_id) or self._default_affinity
         return {
             "Content-Type": "application/json",
             "api-key": self.api_key,  # Azure OpenAI uses api-key header, not Authorization
-            "x-session-affinity": uuid.uuid4().hex,  # For cache locality
+            "x-session-affinity": affinity,  # Stable per session when available
         }
 
     @staticmethod
@@ -118,6 +120,7 @@ class AzureOpenAIProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        session_id: str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request to Azure OpenAI.
@@ -135,7 +138,7 @@ class AzureOpenAIProvider(LLMProvider):
         """
         deployment_name = model or self.default_model
         url = self._build_chat_url(deployment_name)
-        headers = self._build_headers()
+        headers = self._build_headers(session_id=session_id)
         payload = self._prepare_request_payload(
             deployment_name, messages, tools, max_tokens, temperature, reasoning_effort
         )

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+import hashlib
 from typing import Any
 
 
@@ -101,6 +102,13 @@ class LLMProvider(ABC):
             sanitized.append(clean)
         return sanitized
 
+    @staticmethod
+    def _session_affinity(session_id: str | None) -> str | None:
+        """Build a stable, provider-safe affinity key from a session ID."""
+        if not session_id:
+            return None
+        return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:32]
+
     @abstractmethod
     async def chat(
         self,
@@ -110,6 +118,7 @@ class LLMProvider(ABC):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        session_id: str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request.
@@ -120,6 +129,7 @@ class LLMProvider(ABC):
             model: Model identifier (provider-specific).
             max_tokens: Maximum tokens in response.
             temperature: Sampling temperature.
+            session_id: Stable session identifier used for backend sticky routing.
         
         Returns:
             LLMResponse with content and/or tool calls.

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import uuid
 from typing import Any
 
 import json_repair
@@ -16,22 +15,22 @@ class CustomProvider(LLMProvider):
     def __init__(self, api_key: str = "no-key", api_base: str = "http://localhost:8000/v1", default_model: str = "default"):
         super().__init__(api_key, api_base)
         self.default_model = default_model
-        # Keep affinity stable for this provider instance to improve backend cache locality.
         self._client = AsyncOpenAI(
             api_key=api_key,
             base_url=api_base,
-            default_headers={"x-session-affinity": uuid.uuid4().hex},
         )
 
     async def chat(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
                    model: str | None = None, max_tokens: int = 4096, temperature: float = 0.7,
-                   reasoning_effort: str | None = None) -> LLMResponse:
+                   reasoning_effort: str | None = None, session_id: str | None = None) -> LLMResponse:
         kwargs: dict[str, Any] = {
             "model": model or self.default_model,
             "messages": self._sanitize_empty_content(messages),
             "max_tokens": max(1, max_tokens),
             "temperature": temperature,
         }
+        if affinity := self._session_affinity(session_id):
+            kwargs["extra_headers"] = {"x-session-affinity": affinity}
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
         if tools:
@@ -58,4 +57,3 @@ class CustomProvider(LLMProvider):
 
     def get_default_model(self) -> str:
         return self.default_model
-

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -164,7 +164,8 @@ class LiteLLMProvider(LLMProvider):
     def _build_extra_headers(self, session_id: str | None) -> dict[str, str] | None:
         """Merge user headers with a stable session-affinity key for sticky routing."""
         headers = dict(self.extra_headers)
-        affinity = self._session_affinity(session_id)
+        # Inject affinity only for vLLM path where cache-aware sticky routing is documented.
+        affinity = self._session_affinity(session_id) if self._is_vllm else None
         if affinity:
             headers.setdefault("x-session-affinity", affinity)
         return headers or None

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -49,6 +49,8 @@ class LiteLLMProvider(LLMProvider):
         # provider_name (from config key) is the primary signal;
         # api_key / api_base are fallback for auto-detection.
         self._gateway = find_gateway(provider_name, api_key, api_base)
+        self._is_vllm = self._gateway is not None and self._gateway.name == "vllm"
+        self._vllm_notice_emitted = False
 
         # Configure environment variables
         if api_key:
@@ -159,6 +161,24 @@ class LiteLLMProvider(LLMProvider):
                     kwargs.update(overrides)
                     return
 
+    def _build_extra_headers(self, session_id: str | None) -> dict[str, str] | None:
+        """Merge user headers with a stable session-affinity key for sticky routing."""
+        headers = dict(self.extra_headers)
+        affinity = self._session_affinity(session_id)
+        if affinity:
+            headers.setdefault("x-session-affinity", affinity)
+        return headers or None
+
+    def _emit_vllm_cache_guidance_once(self) -> None:
+        """Emit one-time vLLM guidance for prefix caching and sticky routing."""
+        if self._vllm_notice_emitted or not self._is_vllm:
+            return
+        self._vllm_notice_emitted = True
+        logger.warning(
+            "vLLM provider detected. Ensure --enable-prefix-caching is enabled and route the same session "
+            "to the same worker (nanobot sends x-session-affinity when session_id is available)."
+        )
+
     @staticmethod
     def _extra_msg_keys(original_model: str, resolved_model: str) -> frozenset[str]:
         """Return provider-specific extra keys to preserve in request messages."""
@@ -214,6 +234,7 @@ class LiteLLMProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        session_id: str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request via LiteLLM.
@@ -231,6 +252,7 @@ class LiteLLMProvider(LLMProvider):
         original_model = model or self.default_model
         model = self._resolve_model(original_model)
         extra_msg_keys = self._extra_msg_keys(original_model, model)
+        self._emit_vllm_cache_guidance_once()
 
         if self._supports_cache_control(original_model):
             messages, tools = self._apply_cache_control(messages, tools)
@@ -257,9 +279,9 @@ class LiteLLMProvider(LLMProvider):
         if self.api_base:
             kwargs["api_base"] = self.api_base
 
-        # Pass extra headers (e.g. APP-Code for AiHubMix)
-        if self.extra_headers:
-            kwargs["extra_headers"] = self.extra_headers
+        # Pass extra headers (e.g. APP-Code for AiHubMix, x-session-affinity for sticky routing)
+        if headers := self._build_extra_headers(session_id):
+            kwargs["extra_headers"] = headers
         
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -32,6 +32,7 @@ class OpenAICodexProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        session_id: str | None = None,
     ) -> LLMResponse:
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)

--- a/tests/test_azure_openai_provider.py
+++ b/tests/test_azure_openai_provider.py
@@ -80,22 +80,6 @@ def test_build_headers():
     assert "x-session-affinity" in headers
 
 
-def test_build_headers_stable_per_session_id():
-    """Session ID should map to a stable affinity key for sticky routing."""
-    provider = AzureOpenAIProvider(
-        api_key="test-api-key-123",
-        api_base="https://test-resource.openai.azure.com",
-        default_model="gpt-4o",
-    )
-
-    headers_a1 = provider._build_headers(session_id="cli:room-a")
-    headers_a2 = provider._build_headers(session_id="cli:room-a")
-    headers_b = provider._build_headers(session_id="cli:room-b")
-
-    assert headers_a1["x-session-affinity"] == headers_a2["x-session-affinity"]
-    assert headers_a1["x-session-affinity"] != headers_b["x-session-affinity"]
-
-
 def test_prepare_request_payload():
     """Test request payload preparation with Azure OpenAI 2024-10-21 compliance."""
     provider = AzureOpenAIProvider(

--- a/tests/test_azure_openai_provider.py
+++ b/tests/test_azure_openai_provider.py
@@ -80,6 +80,22 @@ def test_build_headers():
     assert "x-session-affinity" in headers
 
 
+def test_build_headers_stable_per_session_id():
+    """Session ID should map to a stable affinity key for sticky routing."""
+    provider = AzureOpenAIProvider(
+        api_key="test-api-key-123",
+        api_base="https://test-resource.openai.azure.com",
+        default_model="gpt-4o",
+    )
+
+    headers_a1 = provider._build_headers(session_id="cli:room-a")
+    headers_a2 = provider._build_headers(session_id="cli:room-a")
+    headers_b = provider._build_headers(session_id="cli:room-b")
+
+    assert headers_a1["x-session-affinity"] == headers_a2["x-session-affinity"]
+    assert headers_a1["x-session-affinity"] != headers_b["x-session-affinity"]
+
+
 def test_prepare_request_payload():
     """Test request payload preparation with Azure OpenAI 2024-10-21 compliance."""
     provider = AzureOpenAIProvider(

--- a/tests/test_session_affinity.py
+++ b/tests/test_session_affinity.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse
+from nanobot.providers.litellm_provider import LiteLLMProvider
+
+
+def _fake_litellm_response(content: str = "ok"):
+    message = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+@pytest.mark.asyncio
+async def test_litellm_vllm_injects_stable_session_affinity_header():
+    provider = LiteLLMProvider(
+        api_key="dummy",
+        api_base="http://localhost:8000/v1",
+        default_model="meta-llama/Llama-3.1-8B-Instruct",
+        provider_name="vllm",
+    )
+    messages = [{"role": "user", "content": "hello"}]
+    fake_resp = _fake_litellm_response()
+
+    with patch("nanobot.providers.litellm_provider.acompletion", new=AsyncMock(return_value=fake_resp)) as mock_complete:
+        await provider.chat(messages, session_id="cli:room-a")
+        await provider.chat(messages, session_id="cli:room-a")
+        await provider.chat(messages, session_id="cli:room-b")
+
+    h1 = mock_complete.call_args_list[0].kwargs["extra_headers"]["x-session-affinity"]
+    h2 = mock_complete.call_args_list[1].kwargs["extra_headers"]["x-session-affinity"]
+    h3 = mock_complete.call_args_list[2].kwargs["extra_headers"]["x-session-affinity"]
+
+    assert h1 == h2
+    assert h1 != h3
+
+
+@pytest.mark.asyncio
+async def test_litellm_vllm_merges_user_headers_with_session_affinity():
+    provider = LiteLLMProvider(
+        api_key="dummy",
+        api_base="http://localhost:8000/v1",
+        default_model="meta-llama/Llama-3.1-8B-Instruct",
+        provider_name="vllm",
+        extra_headers={"X-App-Code": "abc123"},
+    )
+    messages = [{"role": "user", "content": "hello"}]
+    fake_resp = _fake_litellm_response()
+
+    with patch("nanobot.providers.litellm_provider.acompletion", new=AsyncMock(return_value=fake_resp)) as mock_complete:
+        await provider.chat(messages, session_id="cli:room-a")
+
+    headers = mock_complete.call_args.kwargs["extra_headers"]
+    assert headers["X-App-Code"] == "abc123"
+    assert "x-session-affinity" in headers
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_passes_session_key_to_provider(tmp_path):
+    provider = Mock()
+    provider.get_default_model.return_value = "test-model"
+    provider.chat = AsyncMock(return_value=LLMResponse(content="ok"))
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        memory_window=10,
+    )
+
+    result = await loop.process_direct("hello", session_key="cli:room-a")
+
+    assert result == "ok"
+    assert provider.chat.call_args.kwargs["session_id"] == "cli:room-a"


### PR DESCRIPTION
## Current Problem
In distributed/self-hosted vLLM setups, the same session may be served by different workers. This reduces prefix-cache locality and causes latency/cost jitter.

## Approach
Make nanobot expose a stable session routing hint in the vLLM path, and document deployment expectations clearly.

## Documentation-Backed Boundaries
### Supported by official docs
- vLLM prefix caching + flags: [Prefix Caching](https://docs.vllm.ai/en/stable/design/prefix_caching/), [Engine Args](https://docs.vllm.ai/en/stable/configuration/engine_args/), [Cache Config API](https://docs.vllm.ai/en/stable/api/vllm/config/cache/)
- vLLM session/prefix-aware routing patterns: [Prefix-aware Routing](https://docs.vllm.ai/projects/production-stack/en/latest/use_cases/prefix-aware-routing.html), [Router Logic (session key in headers)](https://docs.vllm.ai/projects/production-stack/en/vllm-stack-0.1.1/dev_guide/dev_api/router-logic.html)
- LiteLLM header forwarding / vLLM route support: [vLLM Provider](https://docs.litellm.ai/docs/providers/vllm), [Forward Client Headers](https://docs.litellm.ai/docs/proxy/forward_client_headers), [Anthropic `extra_headers` example](https://docs.litellm.ai/docs/providers/anthropic)
- OpenAI Python SDK per-request `extra_headers`: [openai-python README](https://github.com/openai/openai-python/blob/main/README.md), [Responses resource (`extra_headers`)](https://github.com/openai/openai-python/blob/main/src/openai/resources/responses/responses.py)

### Not officially documented
- Azure OpenAI `x-session-affinity` semantics: [Azure OpenAI latest](https://learn.microsoft.com/en-us/azure/foundry/openai/latest), [Azure OpenAI reference](https://learn.microsoft.com/en-us/azure/foundry/openai/reference)
- OpenAI Responses/Codex session-affinity routing headers: [Responses create](https://platform.openai.com/docs/api-reference/responses/create), [GPT-5.1-Codex model page](https://platform.openai.com/docs/models/gpt-5.1-codex)

So this PR keeps behavior changes only in documented paths and avoids undocumented provider-specific claims.

## What Changed
- Added optional `session_id` to provider interface for consistent internal calls.
- `AgentLoop` forwards session key into provider chat calls.
- LiteLLM provider:
  - injects stable `x-session-affinity` only for vLLM path
  - preserves user-defined headers
  - emits one-time vLLM guidance for prefix caching + sticky routing
- Custom provider (OpenAI-compatible endpoint path):
  - sends per-request `x-session-affinity` when `session_id` is available
- Azure/Codex:
  - no new undocumented affinity semantics
  - Codex keeps signature compatibility only
- README:
  - vLLM startup example now explicitly includes `--enable-prefix-caching`
  - adds sticky-routing note for distributed workers

## Validation
Executed:
- `.venv/bin/pytest -q tests/test_session_affinity.py tests/test_azure_openai_provider.py tests/test_commands.py::test_litellm_provider_canonicalizes_github_copilot_hyphen_prefix tests/test_loop_save_turn.py tests/test_task_cancel.py tests/test_consolidate_offset.py`

Result: `69 passed`.

Closes #1645.