### PR TITLE
feat(memory): add optional skill memory and query-aware retrieval

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -24,7 +24,7 @@ class ContextBuilder:
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
 
-    def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
+    def build_system_prompt(self, skill_names: list[str] | None = None, *, current_message: str = "") -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
         parts = [self._get_identity()]
 
@@ -32,7 +32,7 @@ class ContextBuilder:
         if bootstrap:
             parts.append(bootstrap)
 
-        memory = self.memory.get_memory_context()
+        memory = self.memory.get_memory_context(query=current_message)
         if memory:
             parts.append(f"# Memory\n\n{memory}")
 
@@ -70,6 +70,7 @@ You are nanobot, a helpful AI assistant.
 Your workspace is at: {workspace_path}
 - Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)
 - History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
+- Learned skills: {workspace_path}/memory/SKILLS.jsonl (auto-extracted reusable workflow patterns)
 - Custom skills: {workspace_path}/skills/{{skill-name}}/SKILL.md
 
 ## nanobot Guidelines
@@ -124,7 +125,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
 
         return [
-            {"role": "system", "content": self.build_system_prompt(skill_names)},
+            {"role": "system", "content": self.build_system_prompt(skill_names, current_message=current_message)},
             *history,
             {"role": "user", "content": merged},
         ]

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -34,6 +35,18 @@ _SAVE_MEMORY_TOOL = [
                         "description": "Full updated long-term memory as markdown. Include all existing "
                         "facts plus new ones. Return unchanged if nothing new.",
                     },
+                    "skill": {
+                        "type": "string",
+                        "description": (
+                            "If the conversation contains a successful multi-step task using tools, "
+                            "extract a REUSABLE workflow template as JSON: "
+                            '{"task": "abstract task description (generalized, no specific names/paths)", '
+                            '"steps": ["generalized step 1", "generalized step 2", ...], '
+                            '"tools": ["tool_name_1", "tool_name_2", ...], '
+                            '"tags": ["lowercase_keyword1", "lowercase_keyword2", ...]}. '
+                            "Return empty string if no reusable multi-step workflow was found."
+                        ),
+                    },
                 },
                 "required": ["history_entry", "memory_update"],
             },
@@ -43,12 +56,13 @@ _SAVE_MEMORY_TOOL = [
 
 
 class MemoryStore:
-    """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
+    """Three-layer memory: MEMORY.md (facts) + HISTORY.md (event log) + SKILLS.jsonl (workflow patterns)."""
 
     def __init__(self, workspace: Path):
         self.memory_dir = ensure_dir(workspace / "memory")
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.history_file = self.memory_dir / "HISTORY.md"
+        self.skills_file = self.memory_dir / "SKILLS.jsonl"
 
     def read_long_term(self) -> str:
         if self.memory_file.exists():
@@ -62,9 +76,94 @@ class MemoryStore:
         with open(self.history_file, "a", encoding="utf-8") as f:
             f.write(entry.rstrip() + "\n\n")
 
-    def get_memory_context(self) -> str:
+    # ── Skill Memory ──────────────────────────────────────────────
+
+    def load_skills(self) -> list[dict]:
+        """Load all skills from SKILLS.jsonl."""
+        if not self.skills_file.exists():
+            return []
+        skills = []
+        for line in self.skills_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    skills.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        return skills
+
+    def save_skill(self, skill: dict) -> None:
+        """Append a skill to SKILLS.jsonl after deduplication check."""
+        if self._is_duplicate_skill(skill):
+            logger.info("Skill extraction: duplicate skill '{}', skipping", skill.get("task", ""))
+            return
+        skill.setdefault("recorded", datetime.now().isoformat()[:16])
+        with open(self.skills_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(skill, ensure_ascii=False) + "\n")
+        logger.info("Skill saved: {}", skill.get("task", ""))
+
+    def _is_duplicate_skill(self, new_skill: dict) -> bool:
+        """Check if a similar skill already exists (Jaccard similarity on tags > 0.5)."""
+        new_tags = {t.lower() for t in new_skill.get("tags", [])}
+        if not new_tags:
+            return False
+        for skill in self.load_skills():
+            existing_tags = {t.lower() for t in skill.get("tags", [])}
+            if not existing_tags:
+                continue
+            jaccard = len(new_tags & existing_tags) / len(new_tags | existing_tags)
+            if jaccard > 0.5:
+                return True
+        return False
+
+    def find_relevant_skills(self, query: str, top_k: int = 3) -> list[dict]:
+        """Find skills relevant to a query via keyword overlap on tags + task."""
+        skills = self.load_skills()
+        if not skills:
+            return []
+        query_tokens = set(query.lower().split())
+        scored = []
+        for skill in skills:
+            skill_tokens: set[str] = set()
+            for tag in skill.get("tags", []):
+                skill_tokens.update(tag.lower().split())
+            skill_tokens.update(skill.get("task", "").lower().split())
+            score = len(query_tokens & skill_tokens)
+            if score > 0:
+                scored.append((score, skill))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [s[1] for s in scored[:top_k]]
+
+    def get_skills_context(self, query: str = "", top_k: int = 3) -> str:
+        """Build a formatted skills string for prompt injection."""
+        skills = self.find_relevant_skills(query, top_k) if query else self.load_skills()[-top_k:]
+        if not skills:
+            return ""
+        logger.info(
+            "Skill retrieval: query='{}' -> {} skill(s) injected: {}",
+            query[:60],
+            len(skills),
+            [s.get("task", "?") for s in skills],
+        )
+        parts = []
+        for s in skills:
+            steps = "\n".join(f"  {i + 1}. {step}" for i, step in enumerate(s.get("steps", [])))
+            tools = ", ".join(s.get("tools", []))
+            parts.append(f"### {s.get('task', 'Untitled')}\n- Tools: {tools}\n- Steps:\n{steps}")
+        return "\n\n".join(parts)
+
+    # ── Context ───────────────────────────────────────────────────
+
+    def get_memory_context(self, query: str = "") -> str:
+        """Build the full memory context block (long-term facts + relevant skills)."""
+        parts = []
         long_term = self.read_long_term()
-        return f"## Long-term Memory\n{long_term}" if long_term else ""
+        if long_term:
+            parts.append(f"## Long-term Memory\n{long_term}")
+        skills_ctx = self.get_skills_context(query)
+        if skills_ctx:
+            parts.append(f"## Learned Skills\nReusable workflow patterns from past tasks:\n\n{skills_ctx}")
+        return "\n\n".join(parts)
 
     async def consolidate(
         self,
@@ -102,18 +201,32 @@ class MemoryStore:
             lines.append(f"[{m.get('timestamp', '?')[:16]}] {m['role'].upper()}{tools}: {m['content']}")
 
         current_memory = self.read_long_term()
+        existing_skills = self.load_skills()
+        skills_summary = "\n".join(f"- {s.get('task', '?')}" for s in existing_skills) if existing_skills else "(none)"
         prompt = f"""Process this conversation and call the save_memory tool with your consolidation.
 
 ## Current Long-term Memory
 {current_memory or "(empty)"}
 
+## Existing Skills (avoid duplicates)
+{skills_summary}
+
 ## Conversation to Process
-{chr(10).join(lines)}"""
+{chr(10).join(lines)}
+
+If the conversation contains a successful multi-step task using tools, also extract a reusable skill in the 'skill' field — generalize specific details into abstract, reusable patterns. Skip if trivial or conversational."""
 
         try:
             response = await provider.chat(
                 messages=[
-                    {"role": "system", "content": "You are a memory consolidation agent. Call the save_memory tool with your consolidation of the conversation."},
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a memory consolidation agent. Call the save_memory tool with your consolidation. "
+                            "If the conversation contains a successful multi-step task, also extract a reusable skill — "
+                            "generalize specific details into abstract, reusable workflow patterns."
+                        ),
+                    },
                     {"role": "user", "content": prompt},
                 ],
                 tools=_SAVE_MEMORY_TOOL,
@@ -148,6 +261,17 @@ class MemoryStore:
                     update = json.dumps(update, ensure_ascii=False)
                 if update != current_memory:
                     self.write_long_term(update)
+
+            if skill_json := args.get("skill"):
+                if isinstance(skill_json, str) and skill_json.strip():
+                    try:
+                        skill = json.loads(skill_json)
+                        if isinstance(skill, dict) and skill.get("task") and skill.get("steps"):
+                            self.save_skill(skill)
+                    except json.JSONDecodeError:
+                        logger.debug("Skill extraction: invalid JSON, skipping")
+                elif isinstance(skill_json, dict) and skill_json.get("task") and skill_json.get("steps"):
+                    self.save_skill(skill_json)
 
             session.last_consolidated = 0 if archive_all else len(session.messages) - keep_count
             logger.info("Memory consolidation done: {} messages, last_consolidated={}", len(session.messages), session.last_consolidated)

--- a/nanobot/skills/memory/SKILL.md
+++ b/nanobot/skills/memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory
-description: Two-layer memory system with grep-based recall.
+description: Three-layer memory system with skill extraction and grep-based recall.
 always: true
 ---
 
@@ -10,6 +10,7 @@ always: true
 
 - `memory/MEMORY.md` — Long-term facts (preferences, project context, relationships). Always loaded into your context.
 - `memory/HISTORY.md` — Append-only event log. NOT loaded into context. Search it with grep. Each entry starts with [YYYY-MM-DD HH:MM].
+- `memory/SKILLS.jsonl` — Learned workflow patterns auto-extracted from successful multi-step tasks. Relevant skills are loaded into your context based on the current query.
 
 ## Search Past Events
 
@@ -26,6 +27,10 @@ Write important facts immediately using `edit_file` or `write_file`:
 - Project context ("The API uses OAuth2")
 - Relationships ("Alice is the project lead")
 
+## Learned Skills
+
+When you see a relevant skill in your context under "Learned Skills", use it as a reference to guide your approach. Skills are abstract workflow templates — adapt specific steps to the current task.
+
 ## Auto-consolidation
 
-Old conversations are automatically summarized and appended to HISTORY.md when the session grows large. Long-term facts are extracted to MEMORY.md. You don't need to manage this.
+Old conversations are automatically summarized and appended to HISTORY.md when the session grows large. Long-term facts are extracted to MEMORY.md. Successful multi-step workflows are extracted to SKILLS.jsonl. You don't need to manage this.


### PR DESCRIPTION
## Summary
- Introduce an optional skill memory layer via `memory/SKILLS.jsonl` for reusable workflow patterns.
- Add skill extraction during memory consolidation, including JSON validation and tag-based deduplication.
- Inject query-relevant learned skills into runtime context via `ContextBuilder` and `MemoryStore.get_memory_context(query=...)`.
- Update memory skill documentation to reflect the learned-skills behavior.

## Why
When facing new tasks, the agent still needs to re-plan similar workflows
instead of learning from previously completed tasks.

Inspired by the [*Agent Workflow Memory* paper (ICML 2025)](https://icml.cc/virtual/2025/poster/45496), this change
introduces a mechanism for storing and retrieving learnable workflow skills.

This enables the agent to retain generalized task-solving patterns and
learn from and reuse them in future queries, improving both consistency
and efficiency.

## Changes
- `nanobot/agent/memory.py`
  - Add skill schema support in `save_memory` tool output.
  - Add `SKILLS.jsonl` load/save/find/dedup logic.
  - Include learned-skills context in memory context generation.
- `nanobot/agent/context.py`
  - Pass current user message into system-prompt memory retrieval for query-aware skill injection.
  - Update system prompt docs with `SKILLS.jsonl`.
- `nanobot/skills/memory/SKILL.md`
  - Document the updated memory model and learned-skills usage.

## Test Plan
- [x] Run a conversation with a successful multi-step tool workflow and verify a new entry appears in `memory/SKILLS.jsonl`.
- [x] Verify duplicate-like skills are skipped by the tag-overlap dedup logic.
- [x] Verify relevant learned skills appear in prompt context for matching user queries.
- [x] Verify normal memory consolidation still updates `MEMORY.md` and `HISTORY.md` as expected.