### PR TITLE
Refactor context prompt templates and add runtime context tests

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -12,6 +12,48 @@ from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
 from nanobot.utils.helpers import detect_image_mime
 
+# ---------------------------------------------------------------------------
+# Prompt templates
+# ---------------------------------------------------------------------------
+
+_IDENTITY_TEMPLATE = """\
+# nanobot 🐈
+
+You are nanobot, a helpful AI assistant.
+
+## Runtime
+{runtime}
+
+## Workspace
+Your workspace is at: {workspace}
+- Long-term memory: {workspace}/memory/MEMORY.md (write important facts here)
+- History log: {workspace}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
+- Custom skills: {workspace}/skills/{{skill-name}}/SKILL.md
+
+## nanobot Guidelines
+- State intent before tool calls, but NEVER predict or claim results before receiving them.
+- Before modifying a file, read it first. Do not assume files or directories exist.
+- After writing or editing a file, re-read it if accuracy matters.
+- If a tool call fails, analyze the error before retrying with a different approach.
+- Ask for clarification when the request is ambiguous.
+
+Reply directly with text for conversations. Only use the 'message' tool to send to a specific chat channel.\
+"""
+
+_SKILLS_SECTION_TEMPLATE = """\
+# Skills
+
+The following skills extend your capabilities. To use a skill, read its SKILL.md file using the read_file tool.
+Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
+
+{skills_summary}\
+"""
+
+_RUNTIME_CONTEXT_TEMPLATE = "{tag}\nCurrent Time: {now} ({tz})"
+_RUNTIME_CONTEXT_CHANNEL_TEMPLATE = "{tag}\nCurrent Time: {now} ({tz})\nChannel: {channel}\nChat ID: {chat_id}"
+
+# ---------------------------------------------------------------------------
+
 
 class ContextBuilder:
     """Builds the context (system prompt + messages) for the agent."""
@@ -44,12 +86,7 @@ class ContextBuilder:
 
         skills_summary = self.skills.build_skills_summary()
         if skills_summary:
-            parts.append(f"""# Skills
-
-The following skills extend your capabilities. To use a skill, read its SKILL.md file using the read_file tool.
-Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
-
-{skills_summary}""")
+            parts.append(_SKILLS_SECTION_TEMPLATE.format(skills_summary=skills_summary))
 
         return "\n\n---\n\n".join(parts)
 
@@ -58,38 +95,18 @@ Skills with available="false" need dependencies installed first - you can try in
         workspace_path = str(self.workspace.expanduser().resolve())
         system = platform.system()
         runtime = f"{'macOS' if system == 'Darwin' else system} {platform.machine()}, Python {platform.python_version()}"
-
-        return f"""# nanobot 🐈
-
-You are nanobot, a helpful AI assistant.
-
-## Runtime
-{runtime}
-
-## Workspace
-Your workspace is at: {workspace_path}
-- Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)
-- History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
-- Custom skills: {workspace_path}/skills/{{skill-name}}/SKILL.md
-
-## nanobot Guidelines
-- State intent before tool calls, but NEVER predict or claim results before receiving them.
-- Before modifying a file, read it first. Do not assume files or directories exist.
-- After writing or editing a file, re-read it if accuracy matters.
-- If a tool call fails, analyze the error before retrying with a different approach.
-- Ask for clarification when the request is ambiguous.
-
-Reply directly with text for conversations. Only use the 'message' tool to send to a specific chat channel."""
+        return _IDENTITY_TEMPLATE.format(runtime=runtime, workspace=workspace_path)
 
     @staticmethod
     def _build_runtime_context(channel: str | None, chat_id: str | None) -> str:
         """Build untrusted runtime metadata block for injection before the user message."""
         now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
         tz = time.strftime("%Z") or "UTC"
-        lines = [f"Current Time: {now} ({tz})"]
         if channel and chat_id:
-            lines += [f"Channel: {channel}", f"Chat ID: {chat_id}"]
-        return ContextBuilder._RUNTIME_CONTEXT_TAG + "\n" + "\n".join(lines)
+            return _RUNTIME_CONTEXT_CHANNEL_TEMPLATE.format(
+                tag=ContextBuilder._RUNTIME_CONTEXT_TAG, now=now, tz=tz, channel=channel, chat_id=chat_id
+            )
+        return _RUNTIME_CONTEXT_TEMPLATE.format(tag=ContextBuilder._RUNTIME_CONTEXT_TAG, now=now, tz=tz)
 
     def _load_bootstrap_files(self) -> str:
         """Load all bootstrap files from workspace."""

--- a/tests/test_context_prompt_cache.py
+++ b/tests/test_context_prompt_cache.py
@@ -63,3 +63,21 @@ def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
     assert "Channel: cli" in user_content
     assert "Chat ID: direct" in user_content
     assert "Return exactly: OK" in user_content
+
+
+def test_runtime_context_tag_and_channel_fields_are_consistent() -> None:
+    """Runtime context should always start with the class tag and only include channel metadata when complete."""
+    base_runtime = ContextBuilder._build_runtime_context(channel=None, chat_id=None)
+    assert base_runtime.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG + "\n")
+    assert "Channel:" not in base_runtime
+    assert "Chat ID:" not in base_runtime
+
+    missing_chat_id = ContextBuilder._build_runtime_context(channel="cli", chat_id=None)
+    assert missing_chat_id.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG + "\n")
+    assert "Channel:" not in missing_chat_id
+    assert "Chat ID:" not in missing_chat_id
+
+    complete = ContextBuilder._build_runtime_context(channel="cli", chat_id="direct")
+    assert complete.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG + "\n")
+    assert "Channel: cli" in complete
+    assert "Chat ID: direct" in complete


### PR DESCRIPTION
## Summary
This PR refactors ContextBuilder prompt construction to use module-level template constants, and adds focused tests around runtime context behavior.

## Changes
* Moved large inline prompt strings in [context.py](app://-/index.html#) into reusable constants:
  * identity/system prompt template
  * skills section template
  * runtime context templates
* Kept runtime context tag compatibility via ContextBuilder._RUNTIME_CONTEXT_TAG so existing logic (e.g. session filtering in loop) remains stable.
* Added unit test in [test_context_prompt_cache.py](app://-/index.html#):
  * verifies runtime context always starts with the runtime tag
  * verifies Channel/Chat ID fields are included only when both are present

## Why
* Improves readability and maintainability of [context.py](app://-/index.html#)
* Prevents regressions in runtime context formatting and tag usage

## Validation
* Ran: [test_context_prompt_cache.py](app://-/index.html#)
* Result: 3 passed