### PR TITLE
fix: hide reasoning_content from user progress updates

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -202,9 +202,10 @@ class AgentLoop:
 
             if response.has_tool_calls:
                 if on_progress:
+                    # Only show stripped content and thinking blocks in progress, not reasoning_content
+                    # reasoning_content is internal thinking and should not be shown to users
                     thoughts = [
                         self._strip_think(response.content),
-                        response.reasoning_content,
                         *(
                             f"Thinking [{b.get('signature', '...')}]:\n{b.get('thought', '...')}"
                             for b in (response.thinking_blocks or [])


### PR DESCRIPTION
# Fix: Hide reasoning_content from user progress updates

## Problem

The `reasoning_content` field (internal model reasoning) was being included in the `thoughts` list sent to users via `on_progress` callbacks. This caused internal thinking content to appear in QQ channel messages and other user-facing outputs, which was confusing and not intended for end users.

## Solution

- Removed `response.reasoning_content` from the `thoughts` list in `_run_agent_loop`
- Added comments explaining that `reasoning_content` is internal thinking and should not be shown to users
- Now only `_strip_think(response.content)` and `thinking_blocks` are displayed in progress updates

## Changes

- **`nanobot/agent/loop.py`**: Removed `response.reasoning_content` from the `thoughts` list (line 207)

## Testing

- Verified that `reasoning_content` is no longer included in progress updates
- Confirmed that `thinking_blocks` and stripped content still display correctly
- Syntax check passed

## Related

Fixes issue where internal reasoning content was visible to users in chat channels.
