### PR TITLE
fix(validation): handle None value in string schema validation

### DIFF
--- a/nanobot/agent/tools/base.py
+++ b/nanobot/agent/tools/base.py
@@ -150,9 +150,11 @@ class Tool(ABC):
             if "maximum" in schema and val > schema["maximum"]:
                 errors.append(f"{label} must be <= {schema['maximum']}")
         if t == "string":
-            if "minLength" in schema and len(val) < schema["minLength"]:
+            if val is None:
+                errors.append(f"{label} should be string, got None")
+            elif "minLength" in schema and len(val) < schema["minLength"]:
                 errors.append(f"{label} must be at least {schema['minLength']} chars")
-            if "maxLength" in schema and len(val) > schema["maxLength"]:
+            elif "maxLength" in schema and len(val) > schema["maxLength"]:
                 errors.append(f"{label} must be at most {schema['maxLength']} chars")
         if t == "object":
             props = schema.get("properties", {})


### PR DESCRIPTION
Add check for None value in string validation to prevent TypeError when validating schema. This ensures proper error messaging when None is provided for a string field.