### PR TITLE
Fixes CLI input/output conflict when subagents are running in the background.

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -171,10 +171,28 @@ class AgentLoop:
         """Format tool calls as concise hint, e.g. 'web_search("query")'."""
         def _fmt(tc):
             args = (tc.arguments[0] if isinstance(tc.arguments, list) else tc.arguments) or {}
-            val = next(iter(args.values()), None) if isinstance(args, dict) else None
+            if not isinstance(args, dict):
+                return tc.name
+
+            # For file operations, prefer showing the file path over content
+            if tc.name in ("write_file", "edit_file", "read_file"):
+                path = args.get("path", "")
+                if path:
+                    return f'{tc.name}("{path}")'
+
+            val = next(iter(args.values()), None)
             if not isinstance(val, str):
                 return tc.name
-            return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
+
+            # Replace newlines for cleaner display (avoid multi-line hints)
+            if "\n" in val:
+                # For multi-line content, show byte/char count instead
+                return f'{tc.name}("<{len(val)} chars>")'
+
+            # Truncate if too long
+            if len(val) > 40:
+                val = val[:40] + "…"
+            return f'{tc.name}("{val}")'
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
     async def _run_agent_loop(
@@ -228,7 +246,14 @@ class AgentLoop:
                     tools_used.append(tool_call.name)
                     args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
                     logger.info("Tool call: {}({})", tool_call.name, args_str[:200])
-                    result = await self.tools.execute(tool_call.name, tool_call.arguments)
+
+                    # Execute tool and handle ToolResult (separate display vs LLM content)
+                    result, _ = await self.tools.execute(
+                        tool_call.name,
+                        tool_call.arguments,
+                        on_progress=on_progress,
+                    )
+
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
@@ -424,10 +449,18 @@ class AgentLoop:
             channel=msg.channel, chat_id=msg.chat_id,
         )
 
-        async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
+        async def _bus_progress(content: str, *, tool_hint: bool = False, display_type: str = "text") -> None:
+            """Publish progress message to bus.
+
+            Args:
+                content: The content to display.
+                tool_hint: If True, this is a tool call hint.
+                display_type: Type of content (text/diff/raw) for rendering.
+            """
             meta = dict(msg.metadata or {})
             meta["_progress"] = True
             meta["_tool_hint"] = tool_hint
+            meta["_display_type"] = display_type
             await self.bus.publish_outbound(OutboundMessage(
                 channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
             ))

--- a/nanobot/agent/tools/base.py
+++ b/nanobot/agent/tools/base.py
@@ -1,7 +1,26 @@
 """Base class for agent tools."""
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any
+
+
+@dataclass
+class ToolResult:
+    """
+    Result of tool execution with separate content for LLM and display for user.
+
+    This separation allows tools to provide rich, formatted output to users
+    while keeping the LLM context clean with concise information.
+
+    Attributes:
+        content: The result content sent to the LLM (included in context).
+        display: Formatted content displayed directly to the user (not sent to LLM).
+        display_type: Type of display content for rendering (e.g., 'text', 'diff', 'raw').
+    """
+    content: str  # Sent to LLM (included in context)
+    display: str | None = None  # Displayed to user only (not in context)
+    display_type: str = "text"  # Rendering hint: text/diff/raw/etc.
 
 
 class Tool(ABC):
@@ -40,7 +59,7 @@ class Tool(ABC):
         pass
 
     @abstractmethod
-    async def execute(self, **kwargs: Any) -> str:
+    async def execute(self, **kwargs: Any) -> str | ToolResult:
         """
         Execute the tool with given parameters.
 
@@ -48,7 +67,8 @@ class Tool(ABC):
             **kwargs: Tool-specific parameters.
 
         Returns:
-            String result of the tool execution.
+            String result of the tool execution, or ToolResult for separate
+            LLM content and user display.
         """
         pass
 

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -1,10 +1,15 @@
 """File system tools: read, write, edit."""
 
 import difflib
+import re
+from io import StringIO
 from pathlib import Path
 from typing import Any
 
-from nanobot.agent.tools.base import Tool
+from rich.console import Console
+from rich.text import Text
+
+from nanobot.agent.tools.base import Tool, ToolResult
 
 
 def _resolve_path(
@@ -99,16 +104,57 @@ class WriteFileTool(Tool):
             "required": ["path", "content"],
         }
 
-    async def execute(self, path: str, content: str, **kwargs: Any) -> str:
+    async def execute(self, path: str, content: str, **kwargs: Any) -> str | ToolResult:
         try:
             file_path = _resolve_path(path, self._workspace, self._allowed_dir)
             file_path.parent.mkdir(parents=True, exist_ok=True)
             file_path.write_text(content, encoding="utf-8")
-            return f"Successfully wrote {len(content)} bytes to {file_path}"
+
+            # Generate content preview for user display
+            preview = self._format_content_preview(content, str(file_path))
+
+            return ToolResult(
+                content=f"Successfully wrote {len(content)} bytes to {file_path}",
+                display=preview,
+                display_type="write_preview",
+            )
         except PermissionError as e:
             return f"Error: {e}"
         except Exception as e:
             return f"Error writing file: {str(e)}"
+
+    def _format_content_preview(self, content: str, path: str, max_lines: int = 20) -> str:
+        """
+        Format a preview of written file content.
+
+        Args:
+            content: The content that was written.
+            path: File path for display.
+            max_lines: Maximum number of lines to preview.
+
+        Returns:
+            Formatted preview string.
+        """
+        lines = content.splitlines(keepends=False)
+        total_lines = len(lines)
+
+        preview = []
+        preview.append(f"Wrote {len(content)} bytes to {path}")
+
+        if total_lines == 0:
+            preview.append("(empty file)")
+        elif total_lines <= max_lines:
+            # Show all content with line numbers
+            for i, line in enumerate(lines, 1):
+                preview.append(f" {i:>4}   {line}")
+        else:
+            # Show first max_lines with indicator
+            preview.append(f"--- Content preview (first {max_lines} of {total_lines} lines) ---")
+            for i in range(max_lines):
+                preview.append(f" {i+1:>4}   {lines[i]}")
+            preview.append(f"... ({total_lines - max_lines} more lines)")
+
+        return "\n".join(preview) + "\n"
 
 
 class EditFileTool(Tool):
@@ -138,7 +184,7 @@ class EditFileTool(Tool):
             "required": ["path", "old_text", "new_text"],
         }
 
-    async def execute(self, path: str, old_text: str, new_text: str, **kwargs: Any) -> str:
+    async def execute(self, path: str, old_text: str, new_text: str, **kwargs: Any) -> str | ToolResult:
         try:
             file_path = _resolve_path(path, self._workspace, self._allowed_dir)
             if not file_path.exists():
@@ -154,14 +200,94 @@ class EditFileTool(Tool):
             if count > 1:
                 return f"Warning: old_text appears {count} times. Please provide more context to make it unique."
 
+            old_lines = content.splitlines(keepends=True)
             new_content = content.replace(old_text, new_text, 1)
+            new_lines = new_content.splitlines(keepends=True)
             file_path.write_text(new_content, encoding="utf-8")
 
-            return f"Successfully edited {file_path}"
+            # Generate colored diff for user display
+            diff_display = self._format_colored_diff(old_lines, new_lines, str(file_path))
+
+            return ToolResult(
+                content=f"Successfully edited {file_path}",
+                display=diff_display,
+                display_type="diff",
+            )
         except PermissionError as e:
             return f"Error: {e}"
         except Exception as e:
             return f"Error editing file: {str(e)}"
+
+    def _format_colored_diff(self, old_lines: list[str], new_lines: list[str], path: str) -> str:
+        """
+        Format diff with ANSI colors for terminal display.
+
+        Format:
+        - Line numbers on left
+        - + for added lines (green background)
+        - - for removed lines (red background)
+        - Space for unchanged lines (no color)
+
+        Args:
+            old_lines: Original file lines.
+            new_lines: Modified file lines.
+            path: File path for display.
+
+        Returns:
+            Formatted diff string with ANSI color codes.
+        """
+        # ANSI color codes - using darker/muted background colors
+        RESET = "\x1b[0m"
+        # Darker red background (RGB: 100, 0, 0) for removed lines
+        RED_BG = "\x1b[48;2;100;0;0m"
+        # Darker green background (RGB: 0, 100, 0) for added lines
+        GREEN_BG = "\x1b[48;2;0;100;0m"
+        BOLD = "\x1b[1m"  # Bold for header
+
+        # Generate unified diff
+        diff = list(difflib.unified_diff(old_lines, new_lines, lineterm=""))
+
+        if not diff:
+            return "No changes to display\n"
+
+        lines = []
+        lines.append(f"{BOLD}Diff: {path}{RESET}\n")
+
+        # Track line numbers for old and new files
+        old_line_num = 0
+        new_line_num = 0
+
+        for line in diff:
+            if line.startswith("@@"):
+                # Parse hunk header to get line numbers, but don't display it
+                match = re.search(r"-(\d+)", line)
+                if match:
+                    old_line_num = int(match.group(1)) - 1  # Will increment before use
+                match = re.search(r"\+(\d+)", line)
+                if match:
+                    new_line_num = int(match.group(1)) - 1  # Will increment before use
+                # Skip the @@ header line
+            elif line.startswith("---") or line.startswith("+++"):
+                # Skip file header lines
+                continue
+            elif line.startswith("-"):
+                # Removed line - show with old line number and red background
+                old_line_num += 1
+                content = line[1:].rstrip("\n")
+                lines.append(f"{RED_BG} {old_line_num:>4} - {content}{RESET}\n")
+            elif line.startswith("+"):
+                # Added line - show with new line number and green background
+                new_line_num += 1
+                content = line[1:].rstrip("\n")
+                lines.append(f"{GREEN_BG} {new_line_num:>4} + {content}{RESET}\n")
+            elif line.startswith(" "):
+                # Unchanged line - increment both, show without color
+                old_line_num += 1
+                new_line_num += 1
+                content = line[1:].rstrip("\n")
+                lines.append(f" {old_line_num:>4}   {content}\n")
+
+        return "".join(lines)
 
     @staticmethod
     def _not_found_message(old_text: str, content: str, path: str) -> str:

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -1,6 +1,7 @@
 """File system tools: read, write, edit."""
 
 import difflib
+import os
 import re
 from io import StringIO
 from pathlib import Path
@@ -223,10 +224,11 @@ class EditFileTool(Tool):
         Format diff with ANSI colors for terminal display.
 
         Format:
-        - Line numbers on left
+        - Line numbers on left (colored: red for removed, green for added)
         - + for added lines (green background)
         - - for removed lines (red background)
         - Space for unchanged lines (no color)
+        - Background colors extend to full terminal width
 
         Args:
             old_lines: Original file lines.
@@ -236,13 +238,24 @@ class EditFileTool(Tool):
         Returns:
             Formatted diff string with ANSI color codes.
         """
-        # ANSI color codes - using darker/muted background colors
+        # ANSI color codes - using very dark background colors
         RESET = "\x1b[0m"
-        # Darker red background (RGB: 100, 0, 0) for removed lines
-        RED_BG = "\x1b[48;2;100;0;0m"
-        # Darker green background (RGB: 0, 100, 0) for added lines
-        GREEN_BG = "\x1b[48;2;0;100;0m"
+        # Very dark red background (RGB: 50, 0, 0) for removed lines
+        RED_BG = "\x1b[48;2;50;0;0m"
+        # Very dark green background (RGB: 0, 50, 0) for added lines
+        GREEN_BG = "\x1b[48;2;0;50;0m"
+        # Red foreground for line numbers (removed lines)
+        RED_FG = "\x1b[38;2;255;100;100m"
+        # Green foreground for line numbers (added lines)
+        GREEN_FG = "\x1b[38;2;100;255;100m"
         BOLD = "\x1b[1m"  # Bold for header
+
+        # Get terminal width for full-line background
+        try:
+            terminal_width = os.get_terminal_size().columns
+        except OSError:
+            # Fallback if terminal size cannot be determined
+            terminal_width = 100
 
         # Generate unified diff
         diff = list(difflib.unified_diff(old_lines, new_lines, lineterm=""))
@@ -250,8 +263,13 @@ class EditFileTool(Tool):
         if not diff:
             return "No changes to display\n"
 
+        # Count added and removed lines
+        added_count = sum(1 for line in diff if line.startswith("+"))
+        removed_count = sum(1 for line in diff if line.startswith("-"))
+
         lines = []
-        lines.append(f"{BOLD}Diff: {path}{RESET}\n")
+        lines.append(f"{BOLD}Update: {path}{RESET}\n")
+        lines.append(f"  ↳ Added {added_count} line{'s' if added_count != 1 else ''}, removed {removed_count} line{'s' if removed_count != 1 else ''}\n")
 
         # Track line numbers for old and new files
         old_line_num = 0
@@ -260,32 +278,43 @@ class EditFileTool(Tool):
         for line in diff:
             if line.startswith("@@"):
                 # Parse hunk header to get line numbers, but don't display it
+                # Format: @@ -old_start,old_count +new_start,new_count @@
                 match = re.search(r"-(\d+)", line)
                 if match:
-                    old_line_num = int(match.group(1)) - 1  # Will increment before use
+                    old_line_num = int(match.group(1))  # Current position in old file
                 match = re.search(r"\+(\d+)", line)
                 if match:
-                    new_line_num = int(match.group(1)) - 1  # Will increment before use
+                    new_line_num = int(match.group(1))  # Current position in new file
                 # Skip the @@ header line
             elif line.startswith("---") or line.startswith("+++"):
                 # Skip file header lines
                 continue
             elif line.startswith("-"):
                 # Removed line - show with old line number and red background
-                old_line_num += 1
+                # The old_line_num represents the line number in the original file
                 content = line[1:].rstrip("\n")
-                lines.append(f"{RED_BG} {old_line_num:>4} - {content}{RESET}\n")
+                visible_prefix = f" {old_line_num:>4} - {content}"
+                remaining = max(0, terminal_width - len(visible_prefix))
+                lines.append(f"{RED_BG} {RED_FG}{old_line_num:>4}{RESET}{RED_BG} - {content}{' ' * remaining}{RESET}\n")
+                # Move to next line in old file after displaying
+                old_line_num += 1
             elif line.startswith("+"):
                 # Added line - show with new line number and green background
-                new_line_num += 1
+                # The new_line_num represents the line number in the new file
                 content = line[1:].rstrip("\n")
-                lines.append(f"{GREEN_BG} {new_line_num:>4} + {content}{RESET}\n")
+                visible_prefix = f" {new_line_num:>4} + {content}"
+                remaining = max(0, terminal_width - len(visible_prefix))
+                lines.append(f"{GREEN_BG} {GREEN_FG}{new_line_num:>4}{RESET}{GREEN_BG} + {content}{' ' * remaining}{RESET}\n")
+                # Move to next line in new file after displaying
+                new_line_num += 1
             elif line.startswith(" "):
-                # Unchanged line - increment both, show without color
+                # Unchanged line - exists in both files
+                # Show new_line_num since we're viewing the modified file
+                content = line[1:].rstrip("\n")
+                lines.append(f" {new_line_num:>4}   {content}\n")
+                # Move to next line in both files
                 old_line_num += 1
                 new_line_num += 1
-                content = line[1:].rstrip("\n")
-                lines.append(f" {old_line_num:>4}   {content}\n")
 
         return "".join(lines)
 

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -1,8 +1,8 @@
 """Tool registry for dynamic tool management."""
 
-from typing import Any
+from typing import Any, Callable
 
-from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.base import Tool, ToolResult
 
 
 class ToolRegistry:
@@ -35,24 +35,60 @@ class ToolRegistry:
         """Get all tool definitions in OpenAI format."""
         return [tool.to_schema() for tool in self._tools.values()]
 
-    async def execute(self, name: str, params: dict[str, Any]) -> str:
-        """Execute a tool by name with given parameters."""
+    async def execute(
+        self,
+        name: str,
+        params: dict[str, Any],
+        on_progress: Callable[..., Any] | None = None,
+    ) -> tuple[str, str | None]:
+        """
+        Execute a tool by name with given parameters.
+
+        Args:
+            name: Tool name to execute.
+            params: Tool parameters.
+            on_progress: Optional callback for display content (display_content, display_type).
+
+        Returns:
+            Tuple of (content_for_llm, display_for_user).
+            - content_for_llm: Sent to LLM and included in context.
+            - display_for_user: Optional formatted content for user display (deprecated, use on_progress).
+        """
         _HINT = "\n\n[Analyze the error above and try a different approach.]"
 
         tool = self._tools.get(name)
         if not tool:
-            return f"Error: Tool '{name}' not found. Available: {', '.join(self.tool_names)}"
+            content = f"Error: Tool '{name}' not found. Available: {', '.join(self.tool_names)}"
+            return content + _HINT, None
 
         try:
             errors = tool.validate_params(params)
             if errors:
-                return f"Error: Invalid parameters for tool '{name}': " + "; ".join(errors) + _HINT
+                content = f"Error: Invalid parameters for tool '{name}': " + "; ".join(errors) + _HINT
+                return content, None
+
             result = await tool.execute(**params)
-            if isinstance(result, str) and result.startswith("Error"):
-                return result + _HINT
-            return result
+
+            # Handle ToolResult with separate LLM content and user display
+            if isinstance(result, ToolResult):
+                if result.display and on_progress:
+                    # Send display content through callback (not to LLM)
+                    # Pass display_type as keyword argument for compatibility with existing callbacks
+                    await on_progress(result.display, display_type=result.display_type)
+                # Return only content for LLM context
+                if isinstance(result.content, str) and result.content.startswith("Error"):
+                    return result.content + _HINT, None
+                return result.content, None
+
+            # Backward compatibility: direct string return
+            result_str = str(result)
+            if result_str.startswith("Error"):
+                return result_str + _HINT, None
+            return result_str, None
+
         except Exception as e:
-            return f"Error executing {name}: {str(e)}" + _HINT
+            content = f"Error executing {name}: {str(e)}" + _HINT
+            return content, None
 
     @property
     def tool_names(self) -> list[str]:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -483,13 +483,25 @@ def agent(
         # Animated spinner is safe to use with prompt_toolkit input handling
         return console.status("[dim]nanobot is thinking...[/dim]", spinner="dots")
 
-    async def _cli_progress(content: str, *, tool_hint: bool = False) -> None:
+    async def _cli_progress(content: str, *, tool_hint: bool = False, display_type: str = "text") -> None:
+        """Display progress content from tool execution.
+
+        Args:
+            content: The content to display.
+            tool_hint: If True, this is a tool call hint (e.g., "edit_file(...)").
+            display_type: Type of content for rendering (text/diff/raw/etc.).
+        """
         ch = agent_loop.channels_config
         if ch and tool_hint and not ch.send_tool_hints:
             return
         if ch and not tool_hint and not ch.send_progress:
             return
-        console.print(f"  [dim]↳ {content}[/dim]")
+
+        # For diff and write_preview types, use print() directly for better formatting control
+        if display_type in ("diff", "write_preview"):
+            print(content, end="")
+        else:
+            console.print(f"  [dim]↳ {content}[/dim]")
 
     if message:
         # Single message mode — direct call, no bus needed
@@ -530,11 +542,15 @@ def agent(
                         msg = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
                         if msg.metadata.get("_progress"):
                             is_tool_hint = msg.metadata.get("_tool_hint", False)
+                            display_type = msg.metadata.get("_display_type", "text")
                             ch = agent_loop.channels_config
                             if ch and is_tool_hint and not ch.send_tool_hints:
                                 pass
                             elif ch and not is_tool_hint and not ch.send_progress:
                                 pass
+                            elif display_type in ("diff", "write_preview"):
+                                # For these types, use print() for better formatting control
+                                print(msg.content, end="")
                             else:
                                 console.print(f"  [dim]↳ {msg.content}[/dim]")
                         elif not turn_done.is_set():


### PR DESCRIPTION
  Problem

  When the main LLM spawns a subagent, it returns immediately, causing turn_done to be set quickly. However, the subagent continues
  running in the background and outputs progress messages. The CLI incorrectly allows new user input before the subagent completes
  its work, resulting in garbled command line display where the "You:" prompt mixes with subagent output.

  Root Cause

  The CLI loop checks if the turn is done but doesn't account for:
  1. Subagents still running in the background
  2. Subagent result messages (system messages) being processed by the main LLM to generate summaries

  Solution

  Introduce a pending background task counter in MessageBus:

  1. bus/queue.py: Add _pending_background counter with increment_background(), decrement_background(), and has_pending_background
  property
  2. spawn.py: Call increment_background() when spawning a subagent
  3. loop.py: Call decrement_background() after processing system messages (subagent results)
  4. commands.py: Check bus.has_pending_background before accepting new user input

  This ensures the CLI waits for all subagents to complete and for the main LLM to finish generating summaries before allowing new
  input.