### PR TITLE
fix(telegram): added "stop" command handler, fixed stop command

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -197,6 +197,7 @@ class TelegramChannel(BaseChannel):
         # Add command handlers
         self._app.add_handler(CommandHandler("start", self._on_start))
         self._app.add_handler(CommandHandler("new", self._forward_command))
+        self._app.add_handler(CommandHandler("stop", self._forward_command))
         self._app.add_handler(CommandHandler("help", self._on_help))
 
         # Add message handler for text, photos, voice, documents


### PR DESCRIPTION
The "stop" command wasn't registered in telegram.py , thus not getting forwarded and not working.
This PR fixes it.