### PR TITLE
feat(agent): improve long-workflow context retention

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -32,6 +32,14 @@ class ContextBuilder:
         if bootstrap:
             parts.append(bootstrap)
 
+        pinned = self.memory.get_pinned_context()
+        if pinned:
+            parts.append(f"# Pinned Context\n\n{pinned}")
+
+        workflow = self._load_workflow()
+        if workflow:
+            parts.append(f"# Current Workflow\n\n{workflow}")
+
         memory = self.memory.get_memory_context()
         if memory:
             parts.append(f"# Memory\n\n{memory}")
@@ -69,7 +77,9 @@ You are nanobot, a helpful AI assistant.
 ## Workspace
 Your workspace is at: {workspace_path}
 - Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)
+- Pinned context: {workspace_path}/memory/PINNED.md (always-injected task-critical rules)
 - History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
+- Workflow tracker: {workspace_path}/WORKFLOW.md (current long-task status and next action)
 - Custom skills: {workspace_path}/skills/{{skill-name}}/SKILL.md
 
 ## nanobot Guidelines
@@ -102,6 +112,13 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
                 parts.append(f"## {filename}\n\n{content}")
 
         return "\n\n".join(parts) if parts else ""
+
+    def _load_workflow(self) -> str:
+        """Load the current workflow tracker if present."""
+        workflow_file = self.workspace / "WORKFLOW.md"
+        if workflow_file.exists():
+            return workflow_file.read_text(encoding="utf-8").strip()
+        return ""
 
     def build_messages(
         self,

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -49,11 +49,19 @@ class MemoryStore:
         self.memory_dir = ensure_dir(workspace / "memory")
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.history_file = self.memory_dir / "HISTORY.md"
+        self.pinned_file = self.memory_dir / "PINNED.md"
+
+    @staticmethod
+    def _read_file(path: Path) -> str:
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+        return ""
 
     def read_long_term(self) -> str:
-        if self.memory_file.exists():
-            return self.memory_file.read_text(encoding="utf-8")
-        return ""
+        return self._read_file(self.memory_file)
+
+    def read_pinned(self) -> str:
+        return self._read_file(self.pinned_file)
 
     def write_long_term(self, content: str) -> None:
         self.memory_file.write_text(content, encoding="utf-8")
@@ -65,6 +73,9 @@ class MemoryStore:
     def get_memory_context(self) -> str:
         long_term = self.read_long_term()
         return f"## Long-term Memory\n{long_term}" if long_term else ""
+
+    def get_pinned_context(self) -> str:
+        return self.read_pinned().strip()
 
     async def consolidate(
         self,

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -31,6 +31,9 @@ class Session:
     metadata: dict[str, Any] = field(default_factory=dict)
     last_consolidated: int = 0  # Number of messages already consolidated to files
 
+    _RECENT_TOOL_RESULT_COUNT = 2
+    _OLDER_TOOL_RESULT_MAX_CHARS = 180
+
     def add_message(self, role: str, content: str, **kwargs: Any) -> None:
         """Add a message to the session."""
         msg = {
@@ -53,14 +56,42 @@ class Session:
                 sliced = sliced[i:]
                 break
 
+        tool_indices = [i for i, m in enumerate(sliced) if m.get("role") == "tool"]
+        detailed_tool_start = (
+            tool_indices[-self._RECENT_TOOL_RESULT_COUNT]
+            if len(tool_indices) > self._RECENT_TOOL_RESULT_COUNT
+            else len(sliced)
+        )
+
         out: list[dict[str, Any]] = []
-        for m in sliced:
+        for idx, m in enumerate(sliced):
             entry: dict[str, Any] = {"role": m["role"], "content": m.get("content", "")}
             for k in ("tool_calls", "tool_call_id", "name"):
                 if k in m:
                     entry[k] = m[k]
+            if entry["role"] == "tool":
+                entry["content"] = self._prune_tool_content(
+                    content=entry.get("content", ""),
+                    tool_name=entry.get("name"),
+                    keep_detail=idx >= detailed_tool_start,
+                )
             out.append(entry)
         return out
+
+    @classmethod
+    def _prune_tool_content(cls, content: Any, tool_name: str | None, keep_detail: bool) -> Any:
+        """Reduce stale tool output while preserving recent detailed results."""
+        if keep_detail or not isinstance(content, str):
+            return content
+
+        compact = " ".join(content.split())
+        if len(compact) > cls._OLDER_TOOL_RESULT_MAX_CHARS:
+            compact = compact[:cls._OLDER_TOOL_RESULT_MAX_CHARS].rstrip() + "..."
+
+        label = tool_name or "tool"
+        if compact:
+            return f"[older tool result pruned: {label}] {compact}"
+        return f"[older tool result pruned: {label}]"
 
     def clear(self) -> None:
         """Clear all messages and reset session to initial state."""

--- a/nanobot/templates/WORKFLOW.md
+++ b/nanobot/templates/WORKFLOW.md
@@ -1,0 +1,23 @@
+# Workflow
+
+Keep this file short and current during long-running tasks.
+
+## Goal
+
+- Describe the task outcome you are driving toward.
+
+## Current Status
+
+- Record the latest confirmed state.
+
+## Next Step
+
+- Write the very next action to take.
+
+## Completed
+
+- Move finished milestones here.
+
+## Notes
+
+- Add only details that still matter for future turns.

--- a/nanobot/templates/memory/PINNED.md
+++ b/nanobot/templates/memory/PINNED.md
@@ -1,0 +1,11 @@
+# Pinned Context
+
+Use this file for durable, task-critical rules that must stay visible in every long workflow.
+
+## Active Rules
+
+- Add stable constraints or must-follow rules here.
+
+## Project Notes
+
+- Add only facts that are too important to drop from context.

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -102,7 +102,9 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
         if item.name.endswith(".md"):
             _write(item, workspace / item.name)
     _write(tpl / "memory" / "MEMORY.md", workspace / "memory" / "MEMORY.md")
+    _write(tpl / "memory" / "PINNED.md", workspace / "memory" / "PINNED.md")
     _write(None, workspace / "memory" / "HISTORY.md")
+    _write(tpl / "WORKFLOW.md", workspace / "WORKFLOW.md")
     (workspace / "skills").mkdir(exist_ok=True)
 
     if added and not silent:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -19,7 +19,7 @@ def mock_paths():
     """Mock config/workspace paths for test isolation."""
     with patch("nanobot.config.loader.get_config_path") as mock_cp, \
          patch("nanobot.config.loader.save_config") as mock_sc, \
-         patch("nanobot.config.loader.load_config") as mock_lc, \
+         patch("nanobot.config.loader.load_config"), \
          patch("nanobot.utils.helpers.get_workspace_path") as mock_ws:
 
         base_dir = Path("./test_onboard_data")
@@ -53,6 +53,8 @@ def test_onboard_fresh_install(mock_paths):
     assert config_file.exists()
     assert (workspace_dir / "AGENTS.md").exists()
     assert (workspace_dir / "memory" / "MEMORY.md").exists()
+    assert (workspace_dir / "memory" / "PINNED.md").exists()
+    assert (workspace_dir / "WORKFLOW.md").exists()
 
 
 def test_onboard_existing_config_refresh(mock_paths):

--- a/tests/test_long_workflow_context.py
+++ b/tests/test_long_workflow_context.py
@@ -1,0 +1,84 @@
+"""Tests for first-phase long-workflow anti-forgetting support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nanobot.agent.context import ContextBuilder
+from nanobot.session.manager import Session
+from nanobot.utils.helpers import sync_workspace_templates
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    return workspace
+
+
+def test_sync_workspace_templates_adds_pinned_and_workflow(tmp_path: Path) -> None:
+    workspace = _make_workspace(tmp_path)
+
+    added = sync_workspace_templates(workspace, silent=True)
+
+    assert "memory/PINNED.md" in added
+    assert "WORKFLOW.md" in added
+    assert (workspace / "memory" / "PINNED.md").exists()
+    assert (workspace / "WORKFLOW.md").exists()
+
+
+def test_system_prompt_includes_pinned_and_workflow_context(tmp_path: Path) -> None:
+    workspace = _make_workspace(tmp_path)
+    (workspace / "memory").mkdir()
+    (workspace / "memory" / "PINNED.md").write_text(
+        "# Pinned\n- Always verify before claiming success.\n",
+        encoding="utf-8",
+    )
+    (workspace / "WORKFLOW.md").write_text(
+        "# Workflow\nCurrent step: implement pruning.\nNext step: run tests.\n",
+        encoding="utf-8",
+    )
+
+    prompt = ContextBuilder(workspace).build_system_prompt()
+
+    assert "# Pinned Context" in prompt
+    assert "Always verify before claiming success." in prompt
+    assert "# Current Workflow" in prompt
+    assert "Current step: implement pruning." in prompt
+    assert "Next step: run tests." in prompt
+
+
+def test_get_history_prunes_older_tool_output_but_keeps_recent_detail() -> None:
+    session = Session(key="cli:test")
+    tool_payload = "line\n" * 120
+
+    for idx in range(5):
+        session.messages.extend([
+            {"role": "user", "content": f"user-{idx}"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": f"call-{idx}",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": f"call-{idx}",
+                "name": "read_file",
+                "content": f"tool-{idx}\n{tool_payload}",
+            },
+            {"role": "assistant", "content": f"done-{idx}"},
+        ])
+
+    history = session.get_history(max_messages=40)
+    tool_messages = [m for m in history if m["role"] == "tool"]
+
+    assert len(tool_messages) == 5
+    assert tool_messages[0]["content"].startswith("[older tool result pruned: read_file]")
+    assert "tool-0" in tool_messages[0]["content"]
+    assert tool_messages[-1]["content"].startswith("tool-4\nline\nline")
+    assert "[older tool result pruned" not in tool_messages[-1]["content"]


### PR DESCRIPTION
## Summary

Inspired in part by Anthropic's context management write-up:
https://claude.com/blog/context-management

This PR implements a deliberately small first phase for improving long-workflow stability in nanobot.

It adds:
- pinned long-lived task rules via `memory/PINNED.md`
- explicit long-task progress tracking via `WORKFLOW.md`
- lightweight pruning of older tool outputs in session history

## Changes

- inject `memory/PINNED.md` into the system prompt
- inject `WORKFLOW.md` into the system prompt
- create both files during workspace template sync / onboard
- prune older tool results in `Session.get_history()` while keeping recent tool output detailed
- add tests covering template creation, prompt injection, and tool-result pruning

## Non-goals

- LanceDB or external memory stores
- token-aware dynamic context editing
- complex harnesses
- broad architecture refactors

## Validation

Automated:
- `/Users/kaijimima1234/Desktop/nanobot/venv/bin/python -m pytest -q tests/test_context_prompt_cache.py tests/test_consolidate_offset.py tests/test_memory_consolidation_types.py tests/test_long_workflow_context.py tests/test_commands.py`
- `64 passed in 3.13s`
- `uvx ruff check nanobot/agent/memory.py nanobot/agent/context.py nanobot/session/manager.py nanobot/utils/helpers.py tests/test_long_workflow_context.py tests/test_commands.py`
- `All checks passed!`

Manual smoke:
- verified `onboard` creates `memory/PINNED.md` and `WORKFLOW.md`
- ran an 8-turn `AgentLoop + read_file` smoke flow
- confirmed pinned/workflow content enters the system prompt
- confirmed older tool outputs are pruned while recent outputs remain detailed
