### PR TITLE
feat(qq): bot can send and receive images and files

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -449,57 +449,54 @@ class QQChannel(BaseChannel):
 
     async def _on_message(self, data: C2CMessage | GroupMessage, is_group: bool = False) -> None:
         """Parse inbound message, download attachments, and publish to the bus."""
-        try:
-            if data.id in self._processed_ids:
-                return
-            self._processed_ids.append(data.id)
+        if data.id in self._processed_ids:
+            return
+        self._processed_ids.append(data.id)
 
-            if is_group:
-                chat_id = data.group_openid
-                user_id = data.author.member_openid
-                self._chat_type_cache[chat_id] = "group"
-            else:
-                chat_id = str(
-                    getattr(data.author, "id", None)
-                    or getattr(data.author, "user_openid", "unknown")
-                )
-                user_id = chat_id
-                self._chat_type_cache[chat_id] = "c2c"
-
-            content = (data.content or "").strip()
-
-            # the data used by tests don't contain attachments property
-            # so we use getattr with a default of [] to avoid AttributeError in tests
-            attachments = getattr(data, "attachments", None) or []
-            media_paths, recv_lines, att_meta = await self._handle_attachments(attachments)
-
-            # Compose content that always contains actionable saved paths
-            if recv_lines:
-                tag = (
-                    "[Image]"
-                    if any(_is_image_name(Path(p).name) for p in media_paths)
-                    else "[File]"
-                )
-                file_block = "Received files:\n" + "\n".join(recv_lines)
-                content = (
-                    f"{content}\n\n{file_block}".strip() if content else f"{tag}\n{file_block}"
-                )
-
-            if not content and not media_paths:
-                return
-
-            await self._handle_message(
-                sender_id=user_id,
-                chat_id=chat_id,
-                content=content,
-                media=media_paths if media_paths else None,
-                metadata={
-                    "message_id": data.id,
-                    "attachments": att_meta,
-                },
+        if is_group:
+            chat_id = data.group_openid
+            user_id = data.author.member_openid
+            self._chat_type_cache[chat_id] = "group"
+        else:
+            chat_id = str(
+                getattr(data.author, "id", None)
+                or getattr(data.author, "user_openid", "unknown")
             )
-        except Exception:
-            logger.exception("Error handling QQ message")
+            user_id = chat_id
+            self._chat_type_cache[chat_id] = "c2c"
+
+        content = (data.content or "").strip()
+
+        # the data used by tests don't contain attachments property
+        # so we use getattr with a default of [] to avoid AttributeError in tests
+        attachments = getattr(data, "attachments", None) or []
+        media_paths, recv_lines, att_meta = await self._handle_attachments(attachments)
+
+        # Compose content that always contains actionable saved paths
+        if recv_lines:
+            tag = (
+                "[Image]"
+                if any(_is_image_name(Path(p).name) for p in media_paths)
+                else "[File]"
+            )
+            file_block = "Received files:\n" + "\n".join(recv_lines)
+            content = (
+                f"{content}\n\n{file_block}".strip() if content else f"{tag}\n{file_block}"
+            )
+
+        if not content and not media_paths:
+            return
+
+        await self._handle_message(
+            sender_id=user_id,
+            chat_id=chat_id,
+            content=content,
+            media=media_paths if media_paths else None,
+            metadata={
+                "message_id": data.id,
+                "attachments": att_meta,
+            },
+        )
 
     async def _handle_attachments(
         self,

--- a/tests/test_qq_channel.py
+++ b/tests/test_qq_channel.py
@@ -34,6 +34,7 @@ async def test_on_group_message_routes_to_group_chat_id() -> None:
         content="hello",
         group_openid="group123",
         author=SimpleNamespace(member_openid="user1"),
+        attachments=[],
     )
 
     await channel._on_message(data, is_group=True)


### PR DESCRIPTION
Fixes #1662, #2226. Thanks @Litbay

QQ supports 4 types of media contents (images, audios, videos, other files). Images are sent as images, but all types will be sent as raw files.

 Files uploaded from QQ are also saved to local and sent to LLM for further handling. Sent files are saved under `~/.nanobot/media/qq`

<img width="895" height="867" alt="image" src="https://github.com/user-attachments/assets/f25c9aa2-6889-415b-b1cd-04e424196ae0" />



<img width="1324" height="643" alt="image" src="https://github.com/user-attachments/assets/9e239326-bc61-4fb8-bd87-8738a60fc4b5" />

