### PR TITLE
(feat) Local transcription support

### DIFF
--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -38,10 +38,16 @@ class ChannelManager:
         if self.config.channels.telegram.enabled:
             try:
                 from nanobot.channels.telegram import TelegramChannel
+
+                # Fallback to legacy Groq api_key if transcription-specific key is not set
+                transcription_config = self.config.transcription
+                if not transcription_config.api_key and transcription_config.provider == "groq":
+                    transcription_config.api_key = self.config.providers.groq.api_key
+
                 self.channels["telegram"] = TelegramChannel(
                     self.config.channels.telegram,
                     self.bus,
-                    groq_api_key=self.config.providers.groq.api_key,
+                    transcription_config=transcription_config,
                 )
                 logger.info("Telegram channel enabled")
             except ImportError as e:

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -178,6 +178,10 @@ class TelegramChannel(BaseChannel):
         self._media_group_buffers: dict[str, dict] = {}
         self._media_group_tasks: dict[str, asyncio.Task] = {}
 
+        # Eagerly instantiate transcriber to allow preloading (if enabled)
+        from nanobot.providers.transcription import get_transcription_provider
+        self._transcriber = get_transcription_provider(self.transcription_config)
+
     async def start(self) -> None:
         """Start the Telegram bot with long polling."""
         if not self.config.token:
@@ -185,6 +189,10 @@ class TelegramChannel(BaseChannel):
             return
 
         self._running = True
+
+        # Trigger transcription warmup (e.g. for MLX models)
+        if self._transcriber:
+            await self._transcriber.preload()
 
         # Build the application with larger connection pool to avoid pool-timeout on long runs
         req = HTTPXRequest(connection_pool_size=16, pool_timeout=5.0, connect_timeout=30.0, read_timeout=30.0)
@@ -459,12 +467,9 @@ class TelegramChannel(BaseChannel):
 
                 # Handle voice transcription
                 if media_type == "voice" or media_type == "audio":
-                    from nanobot.providers.transcription import get_transcription_provider
-                    transcriber = get_transcription_provider(self.transcription_config)
-                    
                     transcription = None
-                    if transcriber:
-                        transcription = await transcriber.transcribe(file_path)
+                    if self._transcriber:
+                        transcription = await self._transcriber.transcribe(file_path)
                         
                     if transcription:
                         logger.info("Transcribed {}: {}...", media_type, transcription[:50])

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -15,7 +15,7 @@ from telegram.request import HTTPXRequest
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
-from nanobot.config.schema import TelegramConfig
+from nanobot.config.schema import TelegramConfig, TranscriptionConfig
 from nanobot.utils.helpers import split_message
 
 TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
@@ -167,11 +167,11 @@ class TelegramChannel(BaseChannel):
         self,
         config: TelegramConfig,
         bus: MessageBus,
-        groq_api_key: str = "",
+        transcription_config: TranscriptionConfig | None = None,
     ):
         super().__init__(config, bus)
         self.config: TelegramConfig = config
-        self.groq_api_key = groq_api_key
+        self.transcription_config = transcription_config
         self._app: Application | None = None
         self._chat_ids: dict[str, int] = {}  # Map sender_id to chat_id for replies
         self._typing_tasks: dict[str, asyncio.Task] = {}  # chat_id -> typing loop task
@@ -459,9 +459,13 @@ class TelegramChannel(BaseChannel):
 
                 # Handle voice transcription
                 if media_type == "voice" or media_type == "audio":
-                    from nanobot.providers.transcription import GroqTranscriptionProvider
-                    transcriber = GroqTranscriptionProvider(api_key=self.groq_api_key)
-                    transcription = await transcriber.transcribe(file_path)
+                    from nanobot.providers.transcription import get_transcription_provider
+                    transcriber = get_transcription_provider(self.transcription_config)
+                    
+                    transcription = None
+                    if transcriber:
+                        transcription = await transcriber.transcribe(file_path)
+                        
                     if transcription:
                         logger.info("Transcribed {}: {}...", media_type, transcription[:50])
                         content_parts.append(f"[transcription: {transcription}]")

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -329,6 +329,16 @@ class ToolsConfig(Base):
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
 
+class TranscriptionConfig(Base):
+    """Transcription configuration."""
+
+    enabled: bool = True
+    provider: str = "groq"  # groq, openai, or any litellm provider
+    model: str = "whisper-large-v3"
+    api_key: str = ""
+    api_base: str | None = None
+
+
 class Config(BaseSettings):
     """Root configuration for nanobot."""
 
@@ -337,6 +347,7 @@ class Config(BaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    transcription: TranscriptionConfig = Field(default_factory=TranscriptionConfig)
 
     @property
     def workspace_path(self) -> Path:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -337,6 +337,7 @@ class TranscriptionConfig(Base):
     model: str = "whisper-large-v3"
     api_key: str = ""
     api_base: str | None = None
+    preload: bool = False
 
 
 class Config(BaseSettings):

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -1,64 +1,131 @@
-"""Voice transcription provider using Groq."""
+"""Voice transcription providers using LiteLLM and local backends."""
+
+from __future__ import annotations
 
 import os
+from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Any
 
-import httpx
+from litellm import atranscription
 from loguru import logger
 
+from nanobot.config.schema import TranscriptionConfig
 
-class GroqTranscriptionProvider:
+
+class TranscriptionProvider(ABC):
+    """Base class for transcription providers."""
+
+    @abstractmethod
+    async def transcribe(self, file_path: str | Path) -> str:
+        """Transcribe an audio file."""
+        pass
+
+
+class LiteLLMTranscriptionProvider(TranscriptionProvider):
     """
-    Voice transcription provider using Groq's Whisper API.
-
-    Groq offers extremely fast transcription with a generous free tier.
+    Transcription provider using LiteLLM.
+    Supports OpenAI, Groq, and local OpenAI-compatible endpoints.
     """
 
-    def __init__(self, api_key: str | None = None):
-        self.api_key = api_key or os.environ.get("GROQ_API_KEY")
-        self.api_url = "https://api.groq.com/openai/v1/audio/transcriptions"
+    def __init__(
+        self,
+        model: str = "whisper-large-v3",
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ):
+        self.model = model
+        self.api_key = api_key
+        self.api_base = api_base
 
     async def transcribe(self, file_path: str | Path) -> str:
-        """
-        Transcribe an audio file using Groq.
-
-        Args:
-            file_path: Path to the audio file.
-
-        Returns:
-            Transcribed text.
-        """
-        if not self.api_key:
-            logger.warning("Groq API key not configured for transcription")
-            return ""
-
+        """Transcribe an audio file using LiteLLM."""
         path = Path(file_path)
         if not path.exists():
             logger.error("Audio file not found: {}", file_path)
             return ""
 
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "file": open(path, "rb"),
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+
         try:
-            async with httpx.AsyncClient() as client:
-                with open(path, "rb") as f:
-                    files = {
-                        "file": (path.name, f),
-                        "model": (None, "whisper-large-v3"),
-                    }
-                    headers = {
-                        "Authorization": f"Bearer {self.api_key}",
-                    }
-
-                    response = await client.post(
-                        self.api_url,
-                        headers=headers,
-                        files=files,
-                        timeout=60.0
-                    )
-
-                    response.raise_for_status()
-                    data = response.json()
-                    return data.get("text", "")
-
+            response = await atranscription(**kwargs)
+            return response.get("text", "")
         except Exception as e:
-            logger.error("Groq transcription error: {}", e)
+            logger.error("LiteLLM transcription error: {}", e)
             return ""
+        finally:
+            if "file" in kwargs:
+                kwargs["file"].close()
+
+
+class MLXTranscriptionProvider(TranscriptionProvider):
+    """
+    Local transcription using mlx-whisper (highly optimized for Apple Silicon).
+    """
+
+    def __init__(self, model: str = "mlx-community/whisper-large-v3-mlx"):
+        self.model = model
+        try:
+            import mlx_whisper
+            self._mlx = mlx_whisper
+        except ImportError:
+            self._mlx = None
+            logger.warning("mlx-whisper not installed. Run: pip install mlx-whisper")
+
+    async def transcribe(self, file_path: str | Path) -> str:
+        if not self._mlx:
+            return ""
+        
+        path = str(Path(file_path).absolute())
+        try:
+            # mlx_whisper.transcribe is synchronous; run in thread
+            import asyncio
+            from functools import partial
+            loop = asyncio.get_event_loop()
+            result = await loop.run_in_executor(
+                None, 
+                partial(self._mlx.transcribe, path, path_or_hf_repo=self.model)
+            )
+            return result.get("text", "").strip()
+        except Exception as e:
+            logger.error("MLX transcription error: {}", e)
+            return ""
+
+
+class GroqTranscriptionProvider(LiteLLMTranscriptionProvider):
+    """Legacy wrapper for Groq transcription."""
+
+    def __init__(self, api_key: str | None = None):
+        super().__init__(
+            model="whisper-large-v3",
+            api_key=api_key,
+        )
+
+
+def get_transcription_provider(config: TranscriptionConfig | None) -> TranscriptionProvider | None:
+    """Factory to create a transcription provider based on config."""
+    if not config or not config.enabled:
+        return None
+
+    p = config.provider.lower()
+    
+    if p == "mlx":
+        return MLXTranscriptionProvider(model=config.model)
+    
+    # Default to LiteLLM for everything else (groq, openai, local servers)
+    model = config.model
+    if "/" not in model and p not in ["openai", "custom"]:
+        model = f"{p}/{model}"
+
+    return LiteLLMTranscriptionProvider(
+        model=model,
+        api_key=config.api_key,
+        api_base=config.api_base,
+    )

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import os
+import asyncio
 from abc import ABC, abstractmethod
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -18,19 +19,23 @@ class TranscriptionProvider(ABC):
 
     @abstractmethod
     async def transcribe(self, file_path: str | Path) -> str:
-        """Transcribe an audio file."""
+        """Transcribe an audio file and return the text."""
+        pass
+
+    async def preload(self) -> None:
+        """Optional: eagerly load model weights into memory before first use."""
         pass
 
 
 class LiteLLMTranscriptionProvider(TranscriptionProvider):
     """
-    Transcription provider using LiteLLM.
-    Supports OpenAI, Groq, and local OpenAI-compatible endpoints.
+    Cloud/remote transcription via LiteLLM.
+    Supports Groq, OpenAI, and any other LiteLLM-compatible endpoint.
     """
 
     def __init__(
         self,
-        model: str = "whisper-large-v3",
+        model: str,
         api_key: str | None = None,
         api_base: str | None = None,
     ):
@@ -39,16 +44,12 @@ class LiteLLMTranscriptionProvider(TranscriptionProvider):
         self.api_base = api_base
 
     async def transcribe(self, file_path: str | Path) -> str:
-        """Transcribe an audio file using LiteLLM."""
         path = Path(file_path)
         if not path.exists():
             logger.error("Audio file not found: {}", file_path)
             return ""
 
-        kwargs: dict[str, Any] = {
-            "model": self.model,
-            "file": open(path, "rb"),
-        }
+        kwargs: dict[str, Any] = {"model": self.model, "file": open(path, "rb")}
         if self.api_key:
             kwargs["api_key"] = self.api_key
         if self.api_base:
@@ -61,17 +62,23 @@ class LiteLLMTranscriptionProvider(TranscriptionProvider):
             logger.error("LiteLLM transcription error: {}", e)
             return ""
         finally:
-            if "file" in kwargs:
-                kwargs["file"].close()
+            kwargs["file"].close()
 
 
 class MLXTranscriptionProvider(TranscriptionProvider):
     """
-    Local transcription using mlx-whisper (highly optimized for Apple Silicon).
+    Local transcription using mlx-whisper, optimised for Apple Silicon.
+
+    The model is loaded lazily on first use. If `preload=True`, it is instead
+    loaded eagerly in the background (via `preload()`) so the first real
+    transcription is instantaneous.
     """
 
-    def __init__(self, model: str = "mlx-community/whisper-large-v3-mlx"):
+    def __init__(self, model: str = "mlx-community/whisper-large-v3-mlx", preload: bool = False):
         self.model = model
+        self._do_preload = preload
+        self._preload_task: asyncio.Task | None = None
+
         try:
             import mlx_whisper
             self._mlx = mlx_whisper
@@ -79,19 +86,38 @@ class MLXTranscriptionProvider(TranscriptionProvider):
             self._mlx = None
             logger.warning("mlx-whisper not installed. Run: pip install mlx-whisper")
 
+    async def preload(self) -> None:
+        """Start loading the model into memory in a background task."""
+        if not self._do_preload or not self._mlx or self._preload_task:
+            return
+        logger.info("MLX: preloading model in background: {}", self.model)
+        self._preload_task = asyncio.create_task(self._load_model())
+
+    async def _load_model(self) -> None:
+        """Load model weights through ModelHolder so transcribe() reuses the cache."""
+        try:
+            import mlx.core as mx
+            from mlx_whisper.transcribe import ModelHolder
+
+            await asyncio.get_event_loop().run_in_executor(
+                None, partial(ModelHolder.get_model, self.model, mx.float16)
+            )
+            logger.info("MLX: model resident in memory: {}", self.model)
+        except Exception as e:
+            logger.warning("MLX: preload failed: {}", e)
+
     async def transcribe(self, file_path: str | Path) -> str:
         if not self._mlx:
             return ""
-        
+
+        # If preloading is in-flight, finish that first — no double load
+        if self._preload_task and not self._preload_task.done():
+            await self._preload_task
+
         path = str(Path(file_path).absolute())
         try:
-            # mlx_whisper.transcribe is synchronous; run in thread
-            import asyncio
-            from functools import partial
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(
-                None, 
-                partial(self._mlx.transcribe, path, path_or_hf_repo=self.model)
+            result = await asyncio.get_event_loop().run_in_executor(
+                None, partial(self._mlx.transcribe, path, path_or_hf_repo=self.model)
             )
             return result.get("text", "").strip()
         except Exception as e:
@@ -99,33 +125,23 @@ class MLXTranscriptionProvider(TranscriptionProvider):
             return ""
 
 
-class GroqTranscriptionProvider(LiteLLMTranscriptionProvider):
-    """Legacy wrapper for Groq transcription."""
-
-    def __init__(self, api_key: str | None = None):
-        super().__init__(
-            model="whisper-large-v3",
-            api_key=api_key,
-        )
-
-
 def get_transcription_provider(config: TranscriptionConfig | None) -> TranscriptionProvider | None:
-    """Factory to create a transcription provider based on config."""
+    """Factory: create the right transcription provider from config."""
     if not config or not config.enabled:
         return None
 
     p = config.provider.lower()
-    
+
     if p == "mlx":
-        return MLXTranscriptionProvider(model=config.model)
-    
-    # Default to LiteLLM for everything else (groq, openai, local servers)
+        return MLXTranscriptionProvider(model=config.model, preload=config.preload)
+
+    # Everything else goes through LiteLLM (groq, openai, azure, deepgram, …)
     model = config.model
-    if "/" not in model and p not in ["openai", "custom"]:
+    if "/" not in model and p not in ("openai", "custom"):
         model = f"{p}/{model}"
 
     return LiteLLMTranscriptionProvider(
         model=model,
-        api_key=config.api_key,
+        api_key=config.api_key or None,
         api_base=config.api_base,
     )


### PR DESCRIPTION
This PR generalizes TranscriptionProvider and adds support for any openai-compatible transcription provider.

This also implements MLXTranscriptionProvider for macs (needs mlx-whisper to work).

The old Groq behavior and key routing works exactly as it used to, if transcription settings are not configured.

## Usage:

Add to your config:

```
"transcription": {
    "enabled": true,
    "provider": "openai",
    "model": "whisper-1",
    "apiBase": "http://localhost:port/v1 OR CLOUD URL",
    "apiKey": "..."
  }
```

## mlx-whisper:

```
"transcription": {
    "enabled": true,
    "provider": "mlx",
    "model": "mlx-community/whisper-large-v3-mlx"
  }
```

and `pip install mlx-whisper`

The mlx-whisper implementation also supports model preloading (add `"preload": true` to transcription config)
