### PR TITLE
feat: add LLM_LOGGING env var for request/response debug logging

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 import secrets
 import string
+import time
 from typing import Any
 
 import json_repair
@@ -61,6 +62,9 @@ class LiteLLMProvider(LLMProvider):
         litellm.suppress_debug_info = True
         # Drop unsupported parameters for providers (e.g., gpt-5 rejects some params)
         litellm.drop_params = True
+
+        self._llm_logging = os.environ.get("LLM_LOGGING", "").lower() == "true"
+        self._llm_log_truncate = int(os.environ.get("LLM_LOG_TRUNCATE", "500"))
 
     def _setup_env(self, api_key: str, api_base: str | None, model: str) -> None:
         """Set environment variables based on detected provider."""
@@ -270,7 +274,59 @@ class LiteLLMProvider(LLMProvider):
             kwargs["tool_choice"] = "auto"
 
         try:
+            if self._llm_logging:
+                logger.info(
+                    "LLM request: model={} messages={} tools={}",
+                    model,
+                    len(kwargs["messages"]),
+                    len(tools) if tools else 0,
+                )
+                for msg in kwargs["messages"]:
+                    role = msg.get("role", "?")
+                    content = msg.get("content") or ""
+                    if isinstance(content, list):
+                        content = " ".join(b.get("text", "") for b in content if isinstance(b, dict))
+                    text = str(content).replace("\n", "\\n")
+                    if self._llm_log_truncate >= 0:
+                        text = text[:self._llm_log_truncate]
+                    logger.info("  [{}] {}", role, text)
+
+            t0 = time.monotonic()
             response = await acompletion(**kwargs)
+            elapsed = time.monotonic() - t0
+
+            if self._llm_logging:
+                usage = response.usage
+                choice = response.choices[0]
+                content = getattr(choice.message, "content", None) or ""
+                tool_calls = getattr(choice.message, "tool_calls", None) or []
+                cached_tokens = 0
+                if usage:
+                    # OpenAI format
+                    details = getattr(usage, "prompt_tokens_details", None)
+                    cached_tokens = getattr(details, "cached_tokens", 0) or 0
+                    # Anthropic format
+                    if not cached_tokens:
+                        cached_tokens = getattr(usage, "cache_read_input_tokens", 0) or 0
+                cache_created = getattr(usage, "cache_creation_input_tokens", 0) if usage else 0
+                logger.info(
+                    "LLM response: model={} tokens={}+{}={} cached={} cache_created={} duration={:.2f}s finish={} tools={}",
+                    model,
+                    usage.prompt_tokens if usage else "?",
+                    usage.completion_tokens if usage else "?",
+                    usage.total_tokens if usage else "?",
+                    cached_tokens,
+                    cache_created,
+                    elapsed,
+                    choice.finish_reason,
+                    [tc.function.name for tc in tool_calls],
+                )
+                if content:
+                    text = str(content).replace("\n", "\\n")
+                    if self._llm_log_truncate >= 0:
+                        text = text[:self._llm_log_truncate]
+                    logger.info("  [assistant] {}", text)
+
             return self._parse_response(response)
         except Exception as e:
             # Return error as content for graceful handling


### PR DESCRIPTION
When LLM_LOGGING=true, logs each request (model, message count, tool count, per-message content) and each response (token usage, cache hits, duration, finish reason, tool calls) at INFO level via loguru.

LLM_LOG_TRUNCATE controls message content truncation (default 500 chars, -1 disables truncation). Supports cached token reporting for both OpenAI (prompt_tokens_details.cached_tokens) and Anthropic (cache_read_input_tokens / cache_creation_input_tokens) formats.