### PR TITLE
fix(cli): use workspace cron store in agent mode

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -471,7 +471,7 @@ def agent(
 
     from nanobot.agent.loop import AgentLoop
     from nanobot.bus.queue import MessageBus
-    from nanobot.config.loader import get_data_dir, load_config
+    from nanobot.config.loader import load_config
     from nanobot.cron.service import CronService
 
     config = load_config()
@@ -481,7 +481,7 @@ def agent(
     provider = _make_provider(config)
 
     # Create cron service for tool usage (no callback needed for CLI unless running)
-    cron_store_path = get_data_dir() / "cron" / "jobs.json"
+    cron_store_path = config.workspace_path / "cron" / "jobs.json"
     cron = CronService(cron_store_path)
 
     if logs:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -128,3 +128,34 @@ def test_litellm_provider_canonicalizes_github_copilot_hyphen_prefix():
 def test_openai_codex_strip_prefix_supports_hyphen_and_underscore():
     assert _strip_model_prefix("openai-codex/gpt-5.1-codex") == "gpt-5.1-codex"
     assert _strip_model_prefix("openai_codex/gpt-5.1-codex") == "gpt-5.1-codex"
+
+
+def test_agent_uses_workspace_cron_store(tmp_path):
+    config = Config()
+    config.agents.defaults.workspace = str(tmp_path / "workspace")
+    observed: dict[str, Path] = {}
+
+    class DummyCronService:
+        def __init__(self, store_path):
+            observed["store_path"] = store_path
+
+    class DummyAgentLoop:
+        def __init__(self, **kwargs):
+            self.channels_config = kwargs["channels_config"]
+
+        async def process_direct(self, message, session_id, on_progress=None):
+            return "ok"
+
+        async def close_mcp(self):
+            return None
+
+    with patch("nanobot.config.loader.load_config", return_value=config), \
+         patch("nanobot.cli.commands.sync_workspace_templates"), \
+         patch("nanobot.bus.queue.MessageBus"), \
+         patch("nanobot.cron.service.CronService", DummyCronService), \
+         patch("nanobot.agent.loop.AgentLoop", DummyAgentLoop), \
+         patch("nanobot.cli.commands._make_provider", return_value=object()):
+        result = runner.invoke(app, ["agent", "--message", "hello", "--logs", "--no-markdown"])
+
+    assert result.exit_code == 0
+    assert observed["store_path"] == config.workspace_path / "cron" / "jobs.json"


### PR DESCRIPTION
Summary
- Use the workspace-scoped cron store in `nanobot agent`
- Add a regression test for the CLI agent cron store path

Problem
Cron jobs created in CLI agent mode were stored in `~/.nanobot/cron/jobs.json` while gateway mode used `~/.nanobot/workspace/cron/jobs.json`, so jobs were not shared across modes.

Changes
- nanobot/cli/commands.py: align `agent()` cron storage with the workspace-scoped `jobs.json` path used by `gateway()`
- tests/test_commands.py: add a regression test that would fail under the old `get_data_dir()` path
Fixes #1649
