### PR TITLE
fix(cli): return same-target message tool replies in direct mode

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -8,7 +8,7 @@ import re
 import weakref
 from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from loguru import logger
 
@@ -506,4 +506,11 @@ class AgentLoop:
         await self._connect_mcp()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
         response = await self._process_message(msg, session_key=session_key, on_progress=on_progress)
-        return response.content if response else ""
+        if response:
+            return response.content
+
+        message_tool = self.tools.get("message")
+        if isinstance(message_tool, MessageTool) and message_tool._last_same_target_message:
+            return message_tool._last_same_target_message.content
+
+        return ""

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -21,6 +21,7 @@ class MessageTool(Tool):
         self._default_chat_id = default_chat_id
         self._default_message_id = default_message_id
         self._sent_in_turn: bool = False
+        self._last_same_target_message: OutboundMessage | None = None
 
     def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
         """Set the current message context."""
@@ -35,6 +36,7 @@ class MessageTool(Tool):
     def start_turn(self) -> None:
         """Reset per-turn send tracking."""
         self._sent_in_turn = False
+        self._last_same_target_message = None
 
     @property
     def name(self) -> str:
@@ -103,6 +105,7 @@ class MessageTool(Tool):
             await self._send_callback(msg)
             if channel == self._default_channel and chat_id == self._default_chat_id:
                 self._sent_in_turn = True
+                self._last_same_target_message = msg
             media_info = f" with {len(media)} attachments" if media else ""
             return f"Message sent to {channel}:{chat_id}{media_info}"
         except Exception as e:

--- a/tests/test_message_tool_suppress.py
+++ b/tests/test_message_tool_suppress.py
@@ -86,6 +86,34 @@ class TestMessageToolSuppressLogic:
         assert result is not None
         assert "Hello" in result.content
 
+    @pytest.mark.asyncio
+    async def test_process_direct_returns_same_target_message_content(self, tmp_path: Path) -> None:
+        loop = _make_loop(tmp_path)
+        tool_call = ToolCallRequest(
+            id="call1",
+            name="message",
+            arguments={"content": "Hello from tool", "channel": "cli", "chat_id": "direct"},
+        )
+        calls = iter([
+            LLMResponse(content="", tool_calls=[tool_call]),
+            LLMResponse(content="Done", tool_calls=[]),
+        ])
+        loop.provider.chat = AsyncMock(side_effect=lambda *a, **kw: next(calls))
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        async def _silent(*_args, **_kwargs) -> None:
+            pass
+
+        response = await loop.process_direct(
+            "Hello",
+            channel="cli",
+            chat_id="direct",
+            on_progress=_silent,
+        )
+
+        assert response == "Hello from tool"
+        assert loop.bus.outbound_size == 1
+
     async def test_progress_hides_internal_reasoning(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)
         tool_call = ToolCallRequest(id="call1", name="read_file", arguments={"path": "foo.txt"})
@@ -128,5 +156,7 @@ class TestMessageToolTurnTracking:
     def test_start_turn_resets(self) -> None:
         tool = MessageTool()
         tool._sent_in_turn = True
+        tool._last_same_target_message = OutboundMessage(channel="cli", chat_id="direct", content="Hello")
         tool.start_turn()
         assert not tool._sent_in_turn
+        assert tool._last_same_target_message is None


### PR DESCRIPTION
Fixes #1243

## Summary
- keep track of same-target `message` tool deliveries within a turn
- let `process_direct()` return that delivered content when the normal final outbound is suppressed
- add regression coverage for direct mode and turn reset

## Why
Suppressing the final outbound is correct for bus-driven channels because the `message` tool has already delivered the reply. But `process_direct()` is a request/response API: in `nanobot agent -m`, there is no outbound consumer, so suppressing the reply also suppresses the only user-visible answer.

This keeps the no-duplicate behavior for channel flows while making direct mode return the content it already sent to the same target.

## Testing
- `/Users/monolith/Desktop/nanobot-repo-cli-direct/.venv/bin/python -m pytest tests/test_message_tool_suppress.py -q`
- `uv run --python /Users/monolith/Desktop/nanobot-repo-cli-direct/.venv/bin/python ruff check nanobot/agent/loop.py nanobot/agent/tools/message.py tests/test_message_tool_suppress.py`