### PR TITLE
fix(agent): let background direct runs opt out of implicit bus progress

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -8,7 +8,7 @@ import re
 import weakref
 from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from loguru import logger
 
@@ -331,7 +331,8 @@ class AgentLoop:
         self,
         msg: InboundMessage,
         session_key: str | None = None,
-        on_progress: Callable[[str], Awaitable[None]] | None = None,
+        on_progress: Callable[..., Awaitable[None]] | None = None,
+        emit_progress: bool = True,
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
         # System messages: parse origin from chat_id ("channel:chat_id")
@@ -432,8 +433,12 @@ class AgentLoop:
                 channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
             ))
 
+        progress_handler = on_progress
+        if progress_handler is None and emit_progress:
+            progress_handler = _bus_progress
+
         final_content, _, all_msgs = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
+            initial_messages, on_progress=progress_handler,
         )
 
         if final_content is None:
@@ -500,10 +505,16 @@ class AgentLoop:
         session_key: str = "cli:direct",
         channel: str = "cli",
         chat_id: str = "direct",
-        on_progress: Callable[[str], Awaitable[None]] | None = None,
+        on_progress: Callable[..., Awaitable[None]] | None = None,
+        emit_progress: bool = True,
     ) -> str:
         """Process a message directly (for CLI or cron usage)."""
         await self._connect_mcp()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
-        response = await self._process_message(msg, session_key=session_key, on_progress=on_progress)
+        response = await self._process_message(
+            msg,
+            session_key=session_key,
+            on_progress=on_progress,
+            emit_progress=emit_progress,
+        )
         return response.content if response else ""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 # Force UTF-8 encoding for Windows console
 if sys.platform == "win32":
-    import locale
     if sys.stdout.encoding != "utf-8":
         os.environ["PYTHONIOENCODING"] = "utf-8"
         # Re-open stdout/stderr with UTF-8 encoding
@@ -212,8 +211,8 @@ def onboard():
 
 def _make_provider(config: Config):
     """Create the appropriate LLM provider from config."""
-    from nanobot.providers.openai_codex_provider import OpenAICodexProvider
     from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+    from nanobot.providers.openai_codex_provider import OpenAICodexProvider
 
     model = config.agents.defaults.model
     provider_name = config.get_provider_name(model)
@@ -239,7 +238,7 @@ def _make_provider(config: Config):
             console.print("Set them in ~/.nanobot/config.json under providers.azure_openai section")
             console.print("Use the model field to specify the deployment name.")
             raise typer.Exit(1)
-        
+
         return AzureOpenAIProvider(
             api_key=p.api_key,
             api_base=p.api_base,
@@ -348,6 +347,7 @@ def gateway(
                 session_key=f"cron:{job.id}",
                 channel=job.payload.channel or "cli",
                 chat_id=job.payload.to or "direct",
+                emit_progress=False,
             )
         finally:
             if isinstance(cron_tool, CronTool) and cron_token is not None:

--- a/tests/test_message_tool_suppress.py
+++ b/tests/test_message_tool_suppress.py
@@ -115,6 +115,61 @@ class TestMessageToolSuppressLogic:
             ('read_file("foo.txt")', True),
         ]
 
+    @pytest.mark.asyncio
+    async def test_process_direct_can_disable_default_bus_progress(self, tmp_path: Path) -> None:
+        loop = _make_loop(tmp_path)
+        tool_call = ToolCallRequest(id="call1", name="read_file", arguments={"path": "foo.txt"})
+        calls = iter([
+            LLMResponse(content="Visible<think>hidden</think>", tool_calls=[tool_call]),
+            LLMResponse(content="Done", tool_calls=[]),
+        ])
+        loop.provider.chat = AsyncMock(side_effect=lambda *a, **kw: next(calls))
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.tools.execute = AsyncMock(return_value="ok")
+
+        response = await loop.process_direct(
+            "Scan the file",
+            session_key="cron:job1",
+            channel="telegram",
+            chat_id="chat123",
+            emit_progress=False,
+        )
+
+        assert response == "Done"
+        assert loop.bus.outbound_size == 0
+
+    @pytest.mark.asyncio
+    async def test_process_direct_keeps_explicit_progress_callback(self, tmp_path: Path) -> None:
+        loop = _make_loop(tmp_path)
+        tool_call = ToolCallRequest(id="call1", name="read_file", arguments={"path": "foo.txt"})
+        calls = iter([
+            LLMResponse(content="Visible<think>hidden</think>", tool_calls=[tool_call]),
+            LLMResponse(content="Done", tool_calls=[]),
+        ])
+        loop.provider.chat = AsyncMock(side_effect=lambda *a, **kw: next(calls))
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.tools.execute = AsyncMock(return_value="ok")
+
+        progress: list[tuple[str, bool]] = []
+
+        async def on_progress(content: str, *, tool_hint: bool = False) -> None:
+            progress.append((content, tool_hint))
+
+        response = await loop.process_direct(
+            "Scan the file",
+            session_key="cron:job1",
+            channel="telegram",
+            chat_id="chat123",
+            on_progress=on_progress,
+            emit_progress=False,
+        )
+
+        assert response == "Done"
+        assert progress == [
+            ("Visible", False),
+            ('read_file("foo.txt")', True),
+        ]
+
 
 class TestMessageToolTurnTracking:
 


### PR DESCRIPTION
Fixes #954
Related to #1500

## Summary
- add an explicit `emit_progress` switch to direct processing
- only attach the default bus progress publisher when that switch is enabled
- disable implicit progress streaming for cron-triggered background turns

## Why
`process_direct()` currently falls back to `_bus_progress()` whenever a caller does not provide a progress callback. That makes background turns noisy by construction: cron uses `process_direct()` without a callback, so internal tool/status messages get published into the user channel even when nobody asked for foreground progress.

The fix keeps explicit progress callbacks working, but stops treating background execution as chat-visible by default.

## Testing
- `/Users/monolith/Desktop/nanobot-repo-progress-mode/.venv/bin/python -m pytest tests/test_message_tool_suppress.py`
- `uv run --python /Users/monolith/Desktop/nanobot-repo-progress-mode/.venv/bin/python ruff check nanobot/agent/loop.py nanobot/cli/commands.py tests/test_message_tool_suppress.py`