### PR TITLE
fix: advance last_consolidated on consolidation failure to prevent re…

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -154,4 +154,7 @@ class MemoryStore:
             return True
         except Exception:
             logger.exception("Memory consolidation failed")
+            if not archive_all:
+                session.last_consolidated = len(session.messages) - keep_count
+                logger.info("Memory consolidation failed: advancing last_consolidated to {} to prevent retry storm", session.last_consolidated)
             return False


### PR DESCRIPTION
…try storm

**Root cause analysis of `loop.py` / `memory.py`:**

When memory consolidation fails (LLM timeout or error), `last_consolidated` was not updated, causing the next trigger to retry an ever-growing batch. This leads to unbounded message accumulation and cascading LLM timeouts.

Specifically:
- `last_consolidated` is only updated on **success** — if the LLM call fails, it stays at the old position
- The trigger condition `len(session.messages) > self.memory_window` keeps firing every message once exceeded
- Result: 76 → 240 message accumulation observed in a single session, causing downstream LLM timeouts on the main agent loop

**Fix:** In the `except` block of `_consolidate_memory`, advance `last_consolidated` to the current position even on failure, matching the success-path logic. The `if not archive_all` guard ensures the `/new` command path is unaffected.

Note: concurrency guards (`self._consolidating` set + task lock) were already in place in `loop.py`.

Fixes #1174