### PR TITLE
fix: persist last_consolidated after auto memory consolidation

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -392,7 +392,8 @@ class AgentLoop:
             async def _consolidate_and_unlock():
                 try:
                     async with lock:
-                        await self._consolidate_memory(session)
+                        if await self._consolidate_memory(session):
+                            self.sessions.save(session)
                 finally:
                     self._consolidating.discard(session.key)
                     _task = asyncio.current_task()


### PR DESCRIPTION
## Summary
Fixes #1698

The `last_consolidated` counter was not being updated in the session file after automatic memory consolidation, causing repeated unnecessary consolidation triggers.

## Changes
- Save session to disk after successful auto memory consolidation in `_consolidate_and_unlock()`

## Details
The `/new` command path correctly called `self.sessions.save(session)` after consolidation, but the automatic consolidation path in the agent loop did not. This meant `last_consolidated` was updated in memory but never persisted, so on next load the old value was read back and consolidation would trigger again.

---
Generated by Orbit 🛸