### PR TITLE
feat: add HTTP health endpoint on gateway port 18790

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -449,6 +449,10 @@ def gateway(
     console.print(f"[green]✓[/green] Heartbeat: every {hb_cfg.interval_s}s")
 
     async def run():
+        # Start ClawLink identity HTTP server for network discovery
+        from nanobot.web.server import start_http_server
+        http_server = await start_http_server(host=config.gateway.host, port=port)
+
         try:
             await cron.start()
             await heartbeat.start()
@@ -459,6 +463,9 @@ def gateway(
         except KeyboardInterrupt:
             console.print("\nShutting down...")
         finally:
+            if http_server is not None:
+                http_server.close()
+                await http_server.wait_closed()
             await agent.close_mcp()
             heartbeat.stop()
             cron.stop()

--- a/nanobot/web/server.py
+++ b/nanobot/web/server.py
@@ -1,0 +1,100 @@
+"""Minimal async HTTP server for ClawLink identity and health endpoints.
+
+Uses only the Python standard library (asyncio) — no extra dependencies.
+
+The ClawLink Protocol (https://github.com/SilverstreamsAI/ClawNexus) allows
+discovery tools to identify running AI framework instances on the network.
+Responding to ``/.well-known/claw-identity.json`` lets NanoBot be
+auto-discovered by any ClawLink-compatible scanner (e.g. ClawNexus).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from nanobot import __version__
+
+logger = logging.getLogger(__name__)
+
+IDENTITY_PAYLOAD = json.dumps({
+    "implementation": "nanobot",
+    "version": __version__,
+    "protocol": "clawlink/1.0",
+}).encode()
+
+HEALTH_PAYLOAD = json.dumps({
+    "status": "ok",
+    "framework": "nanobot",
+    "version": __version__,
+}).encode()
+
+NOT_FOUND_PAYLOAD = json.dumps({"error": "Not Found"}).encode()
+
+
+def _http_response(status: int, phrase: str, body: bytes) -> bytes:
+    """Build a minimal HTTP/1.1 response."""
+    return (
+        f"HTTP/1.1 {status} {phrase}\r\n"
+        f"Content-Type: application/json\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        f"Connection: close\r\n"
+        f"\r\n"
+    ).encode() + body
+
+
+_ROUTES: dict[str, tuple[int, str, bytes]] = {
+    "/.well-known/claw-identity.json": (200, "OK", IDENTITY_PAYLOAD),
+    "/health": (200, "OK", HEALTH_PAYLOAD),
+}
+
+
+async def _handle_client(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    """Handle a single HTTP request."""
+    try:
+        request_line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+        if not request_line:
+            return
+
+        parts = request_line.decode("utf-8", errors="replace").strip().split()
+        method = parts[0] if parts else ""
+        path = parts[1] if len(parts) > 1 else ""
+
+        if method == "GET" and path in _ROUTES:
+            status, phrase, body = _ROUTES[path]
+            writer.write(_http_response(status, phrase, body))
+        else:
+            writer.write(_http_response(404, "Not Found", NOT_FOUND_PAYLOAD))
+
+        await writer.drain()
+    except (asyncio.TimeoutError, ConnectionError, OSError):
+        pass
+    finally:
+        writer.close()
+
+
+async def start_http_server(
+    host: str = "0.0.0.0",
+    port: int = 18790,
+) -> asyncio.Server | None:
+    """Start the ClawLink identity HTTP server.
+
+    Returns the server instance, or *None* if the port is unavailable.
+    """
+    try:
+        server = await asyncio.start_server(_handle_client, host, port)
+        logger.info("HTTP server listening on %s:%d", host, port)
+        return server
+    except OSError as exc:
+        logger.warning(
+            "Could not start HTTP server on %s:%d (%s) — skipping",
+            host,
+            port,
+            exc,
+        )
+        return None


### PR DESCRIPTION
## Summary

Implements an actual HTTP listener on the gateway port (18790) that has been declared but never bound — resolving #510 and providing the foundation for #1118.

- **Zero new dependencies** — uses only Python stdlib (`asyncio.start_server`)
- Serves `/health` → `{ "status": "ok", "framework": "nanobot", "version": "..." }`
- Serves `/.well-known/claw-identity.json` → [ClawLink Protocol](https://github.com/SilverstreamsAI/ClawNexus) identity (open standard for AI instance discovery)
- Binds to existing `GatewayConfig.host`/`port` (default `0.0.0.0:18790`)
- Graceful port conflict handling (logs warning, does not crash)
- Integrated into `gateway` command startup/shutdown lifecycle

## Motivation

- **#510**: `nanobot gateway` prints "Starting on port 18790" but nothing actually listens — this fixes that
- **#1118**: HTTP server is the prerequisite for incoming webhooks
- **Docker**: `Dockerfile` already `EXPOSE`s 18790, `docker-compose.yml` already maps it — now something actually responds
- **HEALTHCHECK**: Enables `docker-compose` health checks (`curl http://localhost:18790/health`)

## Changes

| File | Change |
|------|--------|
| `nanobot/web/__init__.py` | New module |
| `nanobot/web/server.py` | Minimal async HTTP server (~100 lines, stdlib only) |
| `nanobot/cli/commands.py` | Wire `start_http_server()` into `gateway` startup + shutdown |

## Comparison with other approaches

| | This PR | #722 (FastAPI) | #1650 (Web UI) |
|---|---------|---------------|----------------|
| New dependencies | **0** | fastapi + uvicorn | multiple |
| Scope | Health + identity | Full REST API | Full Web UI |
| Risk | Minimal | Medium | High |

This PR is intentionally minimal — it fills the port placeholder and provides a foundation. A full REST API (#722) or Web UI (#1650) can build on top of this later.

## Test plan

- [ ] `nanobot gateway` → verify `ss -tuln | grep 18790` shows LISTEN
- [ ] `curl http://localhost:18790/health` → `{ "status": "ok", "framework": "nanobot" }`
- [ ] `curl http://localhost:18790/.well-known/claw-identity.json` → identity JSON
- [ ] `curl http://localhost:18790/nonexistent` → 404
- [ ] Start with port already in use → graceful warning, no crash