### PR TITLE
fix(slack): define use_thread variable before use in send()

### DIFF
--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -82,6 +82,7 @@ class SlackChannel(BaseChannel):
             thread_ts = slack_meta.get("thread_ts")
             channel_type = slack_meta.get("channel_type")
             # Only reply in thread for channel/group messages; DMs don't use threads
+            use_thread = thread_ts is not None and channel_type != "im"
             thread_ts_param = thread_ts if use_thread else None
 
             # Slack rejects empty text payloads. Keep media-only messages media-only,


### PR DESCRIPTION
Fixes #1713

The use_thread variable was referenced but never defined, causing a NameError when sending any Slack message.

**Changes**:
- Added `use_thread` variable definition
- Fixes NameError in Slack send() method