### PR TITLE
feat: add human in loop approval mechanism for executing commands and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,7 +906,69 @@ MCP tools are automatically discovered and registered on startup. The LLM can us
 |--------|---------|-------------|
 | `tools.restrictToWorkspace` | `false` | When `true`, restricts **all** agent tools (shell, file read/write/edit, list) to the workspace directory. Prevents path traversal and out-of-scope access. |
 | `tools.exec.pathAppend` | `""` | Extra directories to append to `PATH` when running shell commands (e.g. `/usr/sbin` for `ufw`). |
+| `tools.exec.requireApproval` | `true` | When `true`, the agent pauses and asks for confirmation before running package-install commands. Set `false` to disable. |
+| `tools.exec.approvalPatterns` | *(see below)* | List of regex patterns for commands that trigger approval. Override to add or remove patterns. |
+| `tools.exec.approvalTimeout` | `300` | Seconds before a pending approval expires automatically (default 5 minutes). |
 | `channels.*.allowFrom` | `[]` (allow all) | Whitelist of user IDs. Empty = allow everyone; non-empty = only listed users can interact. |
+
+### Human-in-the-Loop Command Approval
+
+By default, nanobot intercepts potentially environment-altering commands (package installs, etc.) and asks you before executing them. This prevents the agent from silently modifying your environment.
+
+**How it works:**
+
+1. The agent decides to run a matched command (e.g. `pip install yt-dlp`).
+2. Instead of executing it, nanobot sends you an approval request:
+
+   ```
+   ⚠️ Approval required (#1)
+   Command: `pip install yt-dlp`
+
+   Reply /approve 1 to execute or /deny 1 to reject.
+   ```
+
+3. You reply `/approve 1` to allow or `/deny 1` to cancel.
+4. The agent resumes and continues processing.
+
+The `#id` in the message lets you handle multiple pending approvals in the same session without mixing them up. The approval request shows the exact normalized command that will be executed — what you see is what runs.
+
+**Default patterns that trigger approval** (all package managers):
+```
+pip / pip3 / uv pip / uv add / poetry add / conda / mamba install
+npm / npx / yarn / pnpm / bun install/add
+apt / apt-get / yum / dnf / pacman / brew install
+cargo install  ·  gem install  ·  go install
+```
+
+**Disable approval entirely:**
+```json
+{
+  "tools": {
+    "exec": {
+      "requireApproval": false
+    }
+  }
+}
+```
+
+**Customize which commands require approval:**
+```json
+{
+  "tools": {
+    "exec": {
+      "requireApproval": true,
+      "approvalPatterns": [
+        "\\b(pip|pip3|uv pip)\\s+install\\b",
+        "\\b(npm|yarn)\\s+(install|add)\\b"
+      ],
+      "approvalTimeout": 600
+    }
+  }
+}
+```
+
+> [!NOTE]
+> Approval works the same way across all channels — CLI, Telegram, Discord, Slack, and any other channel. Reply `/approve <id>` or `/deny <id>` as a plain text message. Pending approvals that are not answered within `approvalTimeout` seconds are automatically cancelled.
 
 
 ## 🧩 Multiple Instances

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 import weakref
 from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
@@ -30,6 +32,24 @@ from nanobot.session.manager import Session, SessionManager
 if TYPE_CHECKING:
     from nanobot.config.schema import ChannelsConfig, ExecToolConfig
     from nanobot.cron.service import CronService
+
+
+@dataclass
+class PendingApproval:
+    """A command awaiting user approval."""
+
+    approval_id: int
+    session_key: str
+    channel: str
+    chat_id: str
+    command: str
+    tool_call_id: str
+    tool_name: str
+    created_at: float = field(default_factory=time.time)
+    messages_snapshot: list[dict] = field(default_factory=list)
+    on_progress: Any = None  # Callable or None
+    tools_used: list[str] = field(default_factory=list)
+    iteration: int = 0
 
 
 class AgentLoop:
@@ -110,6 +130,9 @@ class AgentLoop:
         self._consolidation_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
         self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
         self._processing_lock = asyncio.Lock()
+        self._pending_approvals: dict[str, dict[int, PendingApproval]] = {}  # session_key -> {id: pending}
+        self._approval_counter = 0
+        self._approval_timeout = getattr(self.exec_config, "approval_timeout", 300)
         self._register_default_tools()
 
     def _register_default_tools(self) -> None:
@@ -122,6 +145,8 @@ class AgentLoop:
             timeout=self.exec_config.timeout,
             restrict_to_workspace=self.restrict_to_workspace,
             path_append=self.exec_config.path_append,
+            require_approval=getattr(self.exec_config, "require_approval", False),
+            approval_patterns=getattr(self.exec_config, "approval_patterns", []),
         ))
         self.tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
         self.tools.register(WebFetchTool(proxy=self.web_proxy))
@@ -181,6 +206,9 @@ class AgentLoop:
         self,
         initial_messages: list[dict],
         on_progress: Callable[..., Awaitable[None]] | None = None,
+        session_key: str | None = None,
+        channel: str | None = None,
+        chat_id: str | None = None,
     ) -> tuple[str | None, list[str], list[dict]]:
         """Run the agent iteration loop. Returns (final_content, tools_used, messages)."""
         messages = initial_messages
@@ -229,6 +257,41 @@ class AgentLoop:
                     args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
                     logger.info("Tool call: {}({})", tool_call.name, args_str[:200])
                     result = await self.tools.execute(tool_call.name, tool_call.arguments)
+
+                    # Check if the command requires user approval
+                    if isinstance(result, str) and result.startswith(ExecTool.APPROVAL_REQUIRED_PREFIX):
+                        pending_cmd = result[len(ExecTool.APPROVAL_REQUIRED_PREFIX):]
+                        if session_key and channel and chat_id:
+                            self._approval_counter += 1
+                            aid = self._approval_counter
+                            session_pending = self._pending_approvals.setdefault(session_key, {})
+                            session_pending[aid] = PendingApproval(
+                                approval_id=aid,
+                                session_key=session_key,
+                                channel=channel,
+                                chat_id=chat_id,
+                                command=pending_cmd,
+                                tool_call_id=tool_call.id,
+                                tool_name=tool_call.name,
+                                messages_snapshot=list(messages),
+                                on_progress=on_progress,
+                                tools_used=list(tools_used),
+                                iteration=iteration,
+                            )
+                            logger.info("Approval required for command: {} (id={})", pending_cmd, aid)
+                            await self.bus.publish_outbound(OutboundMessage(
+                                channel=channel, chat_id=chat_id,
+                                content=(
+                                    f"⚠️ **Approval required** (#{aid})\n"
+                                    f"Command: `{pending_cmd}`\n\n"
+                                    f"Reply `/approve {aid}` to execute or `/deny {aid}` to reject."
+                                ),
+                            ))
+                            # Return a sentinel so the caller knows the loop is suspended
+                            return "__APPROVAL_PENDING__", tools_used, messages
+                        # Fallback: no session context, just block
+                        result = f"Error: Command requires user approval but no interactive session is available: {pending_cmd}"
+
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
@@ -347,7 +410,11 @@ class AgentLoop:
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
             )
-            final_content, _, all_msgs = await self._run_agent_loop(messages)
+            final_content, _, all_msgs = await self._run_agent_loop(
+                messages, session_key=key, channel=channel, chat_id=chat_id,
+            )
+            if final_content == "__APPROVAL_PENDING__":
+                return None
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
             return OutboundMessage(channel=channel, chat_id=chat_id,
@@ -391,7 +458,14 @@ class AgentLoop:
                                   content="New session started.")
         if cmd == "/help":
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
-                                  content="🐈 nanobot commands:\n/new — Start a new conversation\n/stop — Stop the current task\n/help — Show available commands")
+                                  content="🐈 nanobot commands:\n/new — Start a new conversation\n/stop — Stop the current task\n/approve <id> — Approve a pending command\n/deny <id> — Reject a pending command\n/help — Show available commands")
+
+        # Handle /approve <id> and /deny <id> for pending approval
+        raw_cmd = msg.content.strip()
+        if raw_cmd.lower().startswith("/approve"):
+            return await self._handle_approval(msg, approved=True, raw=raw_cmd)
+        if raw_cmd.lower().startswith("/deny"):
+            return await self._handle_approval(msg, approved=False, raw=raw_cmd)
 
         unconsolidated = len(session.messages) - session.last_consolidated
         if (unconsolidated >= self.memory_window and session.key not in self._consolidating):
@@ -434,7 +508,12 @@ class AgentLoop:
 
         final_content, _, all_msgs = await self._run_agent_loop(
             initial_messages, on_progress=on_progress or _bus_progress,
+            session_key=key, channel=msg.channel, chat_id=msg.chat_id,
         )
+
+        if final_content == "__APPROVAL_PENDING__":
+            # Agent loop is suspended waiting for user approval; don't save yet
+            return None
 
         if final_content is None:
             final_content = "I've completed processing but have no response to give."
@@ -450,6 +529,128 @@ class AgentLoop:
         return OutboundMessage(
             channel=msg.channel, chat_id=msg.chat_id, content=final_content,
             metadata=msg.metadata or {},
+        )
+
+    async def _handle_approval(self, msg: InboundMessage, *, approved: bool, raw: str = "") -> OutboundMessage:
+        """Handle /approve [id] or /deny [id] for a pending command."""
+        key = msg.session_key
+        session_pending = self._pending_approvals.get(key, {})
+
+        if not session_pending:
+            return OutboundMessage(
+                channel=msg.channel, chat_id=msg.chat_id,
+                content="No pending command to approve.",
+            )
+
+        # Parse optional ID from command, e.g. "/approve 3"
+        parts = raw.split()
+        target_id: int | None = None
+        if len(parts) >= 2:
+            try:
+                target_id = int(parts[1])
+            except ValueError:
+                return OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content=f"Invalid approval ID '{parts[1]}'. Use `/approve <id>` or `/deny <id>`.",
+                )
+
+        if target_id is not None:
+            pending = session_pending.pop(target_id, None)
+            if pending is None:
+                ids = ", ".join(f"#{i}" for i in session_pending)
+                return OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content=f"No pending command with ID #{target_id}. Pending: {ids or 'none'}.",
+                )
+        else:
+            # No ID given: only accept if there is exactly one pending
+            if len(session_pending) > 1:
+                ids = ", ".join(f"#{i}: `{p.command}`" for i, p in sorted(session_pending.items()))
+                return OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content=f"Multiple pending commands — please specify an ID:\n{ids}",
+                )
+            target_id, pending = next(iter(session_pending.items()))
+            session_pending.pop(target_id)
+
+        if not session_pending:
+            self._pending_approvals.pop(key, None)
+
+        # Check expiration
+        if time.time() - pending.created_at > self._approval_timeout:
+            return OutboundMessage(
+                channel=msg.channel, chat_id=msg.chat_id,
+                content=f"⏰ Approval #{pending.approval_id} expired. Ask the agent to try again.",
+            )
+
+        if not approved:
+            # Feed a denial result back into the messages so the LLM knows
+            messages = pending.messages_snapshot
+            messages = self.context.add_tool_result(
+                messages, pending.tool_call_id, pending.tool_name,
+                f"Error: User denied execution of command: {pending.command}",
+            )
+            session = self.sessions.get_or_create(key)
+            self._set_tool_context(pending.channel, pending.chat_id)
+
+            final_content, _, all_msgs = await self._run_agent_loop(
+                messages,
+                on_progress=pending.on_progress,
+                session_key=key,
+                channel=pending.channel,
+                chat_id=pending.chat_id,
+            )
+            if final_content == "__APPROVAL_PENDING__":
+                return None
+
+            if final_content is None:
+                final_content = "Command was denied."
+            self._save_turn(session, all_msgs, len(pending.messages_snapshot))
+            self.sessions.save(session)
+            return OutboundMessage(
+                channel=msg.channel, chat_id=msg.chat_id, content=final_content,
+            )
+
+        # Approved: execute the original command directly
+        exec_tool = self.tools.get("exec")
+        if not exec_tool or not isinstance(exec_tool, ExecTool):
+            return OutboundMessage(
+                channel=msg.channel, chat_id=msg.chat_id,
+                content="Error: exec tool not available.",
+            )
+
+        # Temporarily disable approval to avoid re-triggering
+        exec_tool.require_approval = False
+        try:
+            result = await exec_tool.execute(command=pending.command)
+        finally:
+            exec_tool.require_approval = getattr(self.exec_config, "require_approval", True)
+
+        messages = pending.messages_snapshot
+        messages = self.context.add_tool_result(
+            messages, pending.tool_call_id, pending.tool_name, result,
+        )
+
+        session = self.sessions.get_or_create(key)
+        self._set_tool_context(pending.channel, pending.chat_id)
+
+        # Resume the agent loop so it can continue processing
+        final_content, _, all_msgs = await self._run_agent_loop(
+            messages,
+            on_progress=pending.on_progress,
+            session_key=key,
+            channel=pending.channel,
+            chat_id=pending.chat_id,
+        )
+        if final_content == "__APPROVAL_PENDING__":
+            return None
+
+        if final_content is None:
+            final_content = "Command executed and processing complete."
+        self._save_turn(session, all_msgs, len(pending.messages_snapshot))
+        self.sessions.save(session)
+        return OutboundMessage(
+            channel=msg.channel, chat_id=msg.chat_id, content=final_content,
         )
 
     def _save_turn(self, session: Session, messages: list[dict], skip: int) -> None:

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -12,6 +12,9 @@ from nanobot.agent.tools.base import Tool
 class ExecTool(Tool):
     """Tool to execute shell commands."""
 
+    # Sentinel prefix returned by _guard_command when approval is needed
+    APPROVAL_REQUIRED_PREFIX = "APPROVAL_REQUIRED:"
+
     def __init__(
         self,
         timeout: int = 60,
@@ -20,6 +23,8 @@ class ExecTool(Tool):
         allow_patterns: list[str] | None = None,
         restrict_to_workspace: bool = False,
         path_append: str = "",
+        require_approval: bool = False,
+        approval_patterns: list[str] | None = None,
     ):
         self.timeout = timeout
         self.working_dir = working_dir
@@ -37,6 +42,8 @@ class ExecTool(Tool):
         self.allow_patterns = allow_patterns or []
         self.restrict_to_workspace = restrict_to_workspace
         self.path_append = path_append
+        self.require_approval = require_approval
+        self.approval_patterns = approval_patterns or []
 
     @property
     def name(self) -> str:
@@ -134,6 +141,12 @@ class ExecTool(Tool):
         if self.allow_patterns:
             if not any(re.search(p, lower) for p in self.allow_patterns):
                 return "Error: Command blocked by safety guard (not in allowlist)"
+
+        # Check if the command requires user approval
+        if self.require_approval and self.approval_patterns:
+            for pattern in self.approval_patterns:
+                if re.search(pattern, lower):
+                    return f"{self.APPROVAL_REQUIRED_PREFIX}{cmd}"
 
         if self.restrict_to_workspace:
             if "..\\" in cmd or "../" in cmd:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -306,6 +306,16 @@ class ExecToolConfig(Base):
 
     timeout: int = 60
     path_append: str = ""
+    require_approval: bool = True  # Require user approval before running install commands
+    approval_patterns: list[str] = Field(default_factory=lambda: [
+        r"\b(pip|pip3|uv pip|uv add|poetry add|conda|mamba)\s+install\b",
+        r"\b(npm|npx|yarn|pnpm|bun)\s+(install|add|i)\b",
+        r"\b(apt|apt-get|yum|dnf|pacman|brew)\s+install\b",
+        r"\bcargo\s+install\b",
+        r"\bgem\s+install\b",
+        r"\bgo\s+install\b",
+    ])  # Regex patterns for commands that require approval
+    approval_timeout: int = 300  # Seconds before a pending approval expires
 
 
 class MCPServerConfig(Base):

--- a/nanobot/templates/TOOLS.md
+++ b/nanobot/templates/TOOLS.md
@@ -9,6 +9,10 @@ This file documents non-obvious constraints and usage patterns.
 - Dangerous commands are blocked (rm -rf, format, dd, shutdown, etc.)
 - Output is truncated at 10,000 characters
 - `restrictToWorkspace` config can limit file access to the workspace
+- `requireApproval` (default: true) requires user confirmation before running install commands (pip, npm, apt, etc.)
+  - When triggered, the agent pauses and asks: reply `/approve` or `/deny`
+  - Customize patterns via `approvalPatterns` in config
+  - Set `requireApproval: false` to disable
 
 ## cron — Scheduled Reminders
 


### PR DESCRIPTION
This pull request introduces a robust "human-in-the-loop" approval system for potentially environment-altering shell commands (like package installs) executed by the agent. By default, the agent now pauses and requests explicit user confirmation before running such commands, improving safety and transparency. The system is configurable and works seamlessly across all supported channels (CLI, Telegram, Discord, Slack, etc.).

Key changes:

**Command Approval System**

* Added a new approval workflow: when a command matches configured "dangerous" patterns (e.g., package installs), the agent suspends execution and requests user approval via `/approve <id>` or `/deny <id>`. Handles multiple pending approvals, timeouts, and resumes or aborts execution based on user input. [[1]](diffhunk://#diff-463e4e8193e41661c33817f15dadc4749ac6cd7df202f38bf1646a7ebb982375R37-R54) [[2]](diffhunk://#diff-463e4e8193e41661c33817f15dadc4749ac6cd7df202f38bf1646a7ebb982375R260-R294) [[3]](diffhunk://#diff-463e4e8193e41661c33817f15dadc4749ac6cd7df202f38bf1646a7ebb982375R534-R655)
* Introduced the `PendingApproval` dataclass to track commands awaiting approval, including session context, command details, and expiration.
* Extended the agent loop and message processing to support suspending and resuming execution around approvals, including proper session and message state management. [[1]](diffhunk://#diff-463e4e8193e41661c33817f15dadc4749ac6cd7df202f38bf1646a7ebb982375R209-R211) [[2]](diffhunk://#diff-463e4e8193e41661c33817f15dadc4749ac6cd7df202f38bf1646a7ebb982375L350-R417) [[3]](diffhunk://#diff-463e4e8193e41661c33817f15dadc4749ac6cd7df202f38bf1646a7ebb982375R511-R517)

**Configuration and Tooling**

* Updated `ExecTool` and its config schema to support `require_approval`, `approval_patterns`, and `approval_timeout` options. Default patterns cover most package managers, and all are customizable via config. [[1]](diffhunk://#diff-f02708ccf11c07997d39cc475757d5bca264c605792a56b8a9cfd3ce28c75b3cR15-R17) [[2]](diffhunk://#diff-f02708ccf11c07997d39cc475757d5bca264c605792a56b8a9cfd3ce28c75b3cR26-R27) [[3]](diffhunk://#diff-f02708ccf11c07997d39cc475757d5bca264c605792a56b8a9cfd3ce28c75b3cR45-R46) [[4]](diffhunk://#diff-f02708ccf11c07997d39cc475757d5bca264c605792a56b8a9cfd3ce28c75b3cR145-R150) [[5]](diffhunk://#diff-efb49dd5c06433d760183227c9f24fde37bb8373891a9d8e4e62e200eb16501bR309-R318)
* The new approval system is documented in `README.md` and `TOOLS.md`, including usage, configuration, and customization examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R909-R972) [[2]](diffhunk://#diff-6a310d799c39a3eacf2841d474de6be09f44f7031c2d552dd999ac29c6c74e70R12-R15)

**User Experience**

* Added `/approve <id>` and `/deny <id>` commands to the CLI and chat interfaces, with clear feedback and error handling for invalid or expired approvals.
* Approval requests show the exact command to be executed and support multiple simultaneous approvals per session. [[1]](diffhunk://#diff-463e4e8193e41661c33817f15dadc4749ac6cd7df202f38bf1646a7ebb982375R260-R294) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R909-R972)

These changes significantly improve the safety and auditability of agent-driven shell operations, especially in shared or production environments.

<img width="565" height="177" alt="Snipaste_2026-03-08_21-04-01" src="https://github.com/user-attachments/assets/5ed08f9e-07cb-41e8-9d0f-769c537294a7" />
