### PR TITLE
fix(agent): replace empty final replies with useful fallback content

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -177,6 +177,21 @@ class AgentLoop:
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
+    @staticmethod
+    def _fallback_from_tool_results(messages: list[dict[str, Any]]) -> str | None:
+        """Use the most recent non-empty tool result when the model ends with no text."""
+        for msg in reversed(messages):
+            if msg.get("role") != "tool":
+                continue
+            content = msg.get("content")
+            if not isinstance(content, str):
+                continue
+            text = content.strip()
+            if not text:
+                continue
+            return text[:1000].rstrip() + ("..." if len(text) > 1000 else "")
+        return None
+
     async def _run_agent_loop(
         self,
         initial_messages: list[dict],
@@ -244,7 +259,7 @@ class AgentLoop:
                     messages, clean, reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
                 )
-                final_content = clean
+                final_content = clean or self._fallback_from_tool_results(messages)
                 break
 
         if final_content is None and iteration >= self.max_iterations:
@@ -437,7 +452,7 @@ class AgentLoop:
         )
 
         if final_content is None:
-            final_content = "I've completed processing but have no response to give."
+            final_content = "Task completed."
 
         self._save_turn(session, all_msgs, 1 + len(history))
         self.sessions.save(session)

--- a/tests/test_message_tool_suppress.py
+++ b/tests/test_message_tool_suppress.py
@@ -86,6 +86,38 @@ class TestMessageToolSuppressLogic:
         assert result is not None
         assert "Hello" in result.content
 
+    @pytest.mark.asyncio
+    async def test_empty_final_uses_last_tool_result(self, tmp_path: Path) -> None:
+        loop = _make_loop(tmp_path)
+        tool_call = ToolCallRequest(id="call1", name="read_file", arguments={"path": "foo.txt"})
+        calls = iter([
+            LLMResponse(content="", tool_calls=[tool_call]),
+            LLMResponse(content="", tool_calls=[]),
+        ])
+        loop.provider.chat = AsyncMock(side_effect=lambda *a, **kw: next(calls))
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.tools.execute = AsyncMock(return_value="file contents")
+
+        msg = InboundMessage(channel="cli", sender_id="user1", chat_id="chat123", content="Read")
+        result = await loop._process_message(msg)
+
+        assert result is not None
+        assert result.content == "file contents"
+
+    @pytest.mark.asyncio
+    async def test_empty_final_without_tool_results_returns_task_completed(
+        self, tmp_path: Path
+    ) -> None:
+        loop = _make_loop(tmp_path)
+        loop.provider.chat = AsyncMock(return_value=LLMResponse(content="", tool_calls=[]))
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        msg = InboundMessage(channel="cli", sender_id="user1", chat_id="chat123", content="Hi")
+        result = await loop._process_message(msg)
+
+        assert result is not None
+        assert result.content == "Task completed."
+
     async def test_progress_hides_internal_reasoning(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)
         tool_call = ToolCallRequest(id="call1", name="read_file", arguments={"path": "foo.txt"})


### PR DESCRIPTION
Closes #1710

## Summary
- use the most recent non-empty tool result when the model ends with an empty final assistant message
- replace the generic empty-response fallback with a shorter completion message when there is no tool result to surface
- add regression tests for both paths

## Testing
- `uv run --with pytest --with pytest-asyncio pytest -q tests/test_message_tool_suppress.py`
- `uv run --with pytest --with pytest-asyncio pytest -q tests/test_consolidate_offset.py -k "consolidation_guard_prevents_duplicate_tasks or new_waits_for_inflight_consolidation_and_preserves_messages"`
- `uv run --with ruff ruff check nanobot/agent/loop.py tests/test_message_tool_suppress.py`