### PR TITLE
feat(qq): send messages using markdown payload

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -113,16 +113,16 @@ class QQChannel(BaseChannel):
             if msg_type == "group":
                 await self._client.api.post_group_message(
                     group_openid=msg.chat_id,
-                    msg_type=0,
-                    content=msg.content,
+                    msg_type=2,
+                    markdown={"content": msg.content},
                     msg_id=msg_id,
                     msg_seq=self._msg_seq,
                 )
             else:
                 await self._client.api.post_c2c_message(
                     openid=msg.chat_id,
-                    msg_type=0,
-                    content=msg.content,
+                    msg_type=2,
+                    markdown={"content": msg.content},
                     msg_id=msg_id,
                     msg_seq=self._msg_seq,
                 )


### PR DESCRIPTION
## Summary
Use QQ markdown messages in `nanobot/channels/qq.py` instead of plain text messages.

## Changes
- switch `msg_type` from `0` to `2`
- replace `content=msg.content` with `markdown={"content": msg.content}`

## Why
This improves rendering of:
- markdown tables
- code blocks
- links
- lists

on QQ clients.

## Notes
This is a minimal change and keeps the implementation simple.