### PR TITLE
fix: handle CancelledError in MCP tool calls to prevent process crash

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -34,7 +34,7 @@ class MCPToolWrapper(Tool):
     def parameters(self) -> dict[str, Any]:
         return self._parameters
 
-    async def execute(self, **kwargs: Any) -> str:
+async def execute(self, **kwargs: Any) -> str:
         from mcp import types
         try:
             result = await asyncio.wait_for(
@@ -44,13 +44,24 @@ class MCPToolWrapper(Tool):
         except asyncio.TimeoutError:
             logger.warning("MCP tool '{}' timed out after {}s", self._name, self._tool_timeout)
             return f"(MCP tool call timed out after {self._tool_timeout}s)"
+        except asyncio.CancelledError:
+            # MCP SDK's anyio cancel scopes can leak CancelledError on timeout/failure.
+            # Re-raise only if our task was externally cancelled (e.g. /stop).
+            task = asyncio.current_task()
+            if task is not None and task.cancelling() > 0:
+                raise
+            logger.warning("MCP tool '{}' was cancelled by server/SDK", self._name)
+            return f"(MCP tool call was cancelled)"
+        except Exception as exc:
+            logger.warning("MCP tool '{}' failed: {}: {}", self._name, type(exc).__name__, exc)
+            return f"(MCP tool call failed: {type(exc).__name__})"
         parts = []
         for block in result.content:
             if isinstance(block, types.TextContent):
                 parts.append(block.text)
             else:
                 parts.append(str(block))
-        return "\n".join(parts) or "(no output)"
+        return "\n".join(parts) or "(no output)
 
 
 async def connect_mcp_servers(


### PR DESCRIPTION
## What
Add proper exception handling for `CancelledError` and general `Exception` 
in `MCPToolWrapper.execute()`.

## Why
MCP SDK uses anyio cancel scopes internally. When a tool call times out or 
fails, anyio can produce a `CancelledError` that leaks through `asyncio.wait_for`.

Since `CancelledError` inherits from `BaseException` (not `Exception` in Python 3.9+), 
it escapes both `MCPToolWrapper.execute()` (which only caught `TimeoutError`) and 
`ToolRegistry.execute()` (which only catches `Exception`), propagating up to the 
agent loop dispatch and crashing the process.

The existing `close_mcp()` method already acknowledges this MCP SDK behavior 
by catching `BaseExceptionGroup`.

## How
- Catch `asyncio.CancelledError`: use `task.cancelling()` (Python 3.11+) to 
  distinguish genuine cancellation (/stop) from MCP SDK internal cancellation.
  Re-raise for /stop, return graceful error otherwise.
- Catch `Exception`: return error message to LLM instead of crashing.

## Testing
1. Configure an MCP server with a slow tool
2. Set a short `toolTimeout`
3. Trigger the tool → should return graceful error instead of crashing
4. Use `/stop` during MCP tool execution → should still cancel properly

Related: #1055

## Acknowledgment
Fix identified and developed with assistance from Claude Opus 4.6