### PR TITLE
Improve agent loop session concurrency

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -8,7 +8,7 @@ import re
 import weakref
 from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from loguru import logger
 
@@ -108,8 +108,8 @@ class AgentLoop:
         self._consolidating: set[str] = set()  # Session keys with consolidation in progress
         self._consolidation_tasks: set[asyncio.Task] = set()  # Strong refs to in-flight tasks
         self._consolidation_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+        self._session_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
         self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
-        self._processing_lock = asyncio.Lock()
         self._register_default_tools()
 
     def _register_default_tools(self) -> None:
@@ -291,27 +291,57 @@ class AgentLoop:
             channel=msg.channel, chat_id=msg.chat_id, content=content,
         ))
 
+    def _resolve_session_key(self, msg: InboundMessage, session_key: str | None = None) -> str:
+        """Resolve the canonical session key for both chat and system messages."""
+        if session_key:
+            return session_key
+        if msg.channel == "system":
+            if ":" in msg.chat_id:
+                channel, chat_id = msg.chat_id.split(":", 1)
+                return f"{channel}:{chat_id}"
+            return f"cli:{msg.chat_id}"
+        return msg.session_key
+
+    def _get_session_lock(self, session_key: str) -> asyncio.Lock:
+        """Return the lock guarding a single conversation session."""
+        lock = self._session_locks.get(session_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._session_locks[session_key] = lock
+        return lock
+
+    async def _process_with_session_lock(
+        self,
+        msg: InboundMessage,
+        session_key: str | None = None,
+        on_progress: Callable[[str], Awaitable[None]] | None = None,
+    ) -> OutboundMessage | None:
+        """Serialize processing within one session while allowing other sessions to run."""
+        key = self._resolve_session_key(msg, session_key=session_key)
+        async with self._get_session_lock(key):
+            return await self._process_message(msg, session_key=key, on_progress=on_progress)
+
     async def _dispatch(self, msg: InboundMessage) -> None:
-        """Process a message under the global lock."""
-        async with self._processing_lock:
-            try:
-                response = await self._process_message(msg)
-                if response is not None:
-                    await self.bus.publish_outbound(response)
-                elif msg.channel == "cli":
-                    await self.bus.publish_outbound(OutboundMessage(
-                        channel=msg.channel, chat_id=msg.chat_id,
-                        content="", metadata=msg.metadata or {},
-                    ))
-            except asyncio.CancelledError:
-                logger.info("Task cancelled for session {}", msg.session_key)
-                raise
-            except Exception:
-                logger.exception("Error processing message for session {}", msg.session_key)
+        """Process a message under a per-session lock."""
+        key = self._resolve_session_key(msg)
+        try:
+            response = await self._process_with_session_lock(msg, session_key=key)
+            if response is not None:
+                await self.bus.publish_outbound(response)
+            elif msg.channel == "cli":
                 await self.bus.publish_outbound(OutboundMessage(
                     channel=msg.channel, chat_id=msg.chat_id,
-                    content="Sorry, I encountered an error.",
+                    content="", metadata=msg.metadata or {},
                 ))
+        except asyncio.CancelledError:
+            logger.info("Task cancelled for session {}", key)
+            raise
+        except Exception:
+            logger.exception("Error processing message for session {}", key)
+            await self.bus.publish_outbound(OutboundMessage(
+                channel=msg.channel, chat_id=msg.chat_id,
+                content="Sorry, I encountered an error.",
+            ))
 
     async def close_mcp(self) -> None:
         """Close MCP connections."""
@@ -356,7 +386,7 @@ class AgentLoop:
         preview = msg.content[:80] + "..." if len(msg.content) > 80 else msg.content
         logger.info("Processing message from {}:{}: {}", msg.channel, msg.sender_id, preview)
 
-        key = session_key or msg.session_key
+        key = self._resolve_session_key(msg, session_key=session_key)
         session = self.sessions.get_or_create(key)
 
         # Slash commands
@@ -505,5 +535,9 @@ class AgentLoop:
         """Process a message directly (for CLI or cron usage)."""
         await self._connect_mcp()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
-        response = await self._process_message(msg, session_key=session_key, on_progress=on_progress)
+        response = await self._process_with_session_lock(
+            msg,
+            session_key=session_key,
+            on_progress=on_progress,
+        )
         return response.content if response else ""

--- a/tests/test_task_cancel.py
+++ b/tests/test_task_cancel.py
@@ -21,8 +21,8 @@ def _make_loop():
 
     with patch("nanobot.agent.loop.ContextBuilder"), \
          patch("nanobot.agent.loop.SessionManager"), \
-         patch("nanobot.agent.loop.SubagentManager") as MockSubMgr:
-        MockSubMgr.return_value.cancel_by_session = AsyncMock(return_value=0)
+         patch("nanobot.agent.loop.SubagentManager") as mock_sub_mgr:
+        mock_sub_mgr.return_value.cancel_by_session = AsyncMock(return_value=0)
         loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
     return loop, bus
 
@@ -104,7 +104,7 @@ class TestDispatch:
         assert out.content == "hi"
 
     @pytest.mark.asyncio
-    async def test_processing_lock_serializes(self):
+    async def test_session_lock_serializes_same_session(self):
         from nanobot.bus.events import InboundMessage, OutboundMessage
 
         loop, bus = _make_loop()
@@ -123,6 +123,59 @@ class TestDispatch:
         t1 = asyncio.create_task(loop._dispatch(msg1))
         t2 = asyncio.create_task(loop._dispatch(msg2))
         await asyncio.gather(t1, t2)
+        assert order == ["start-a", "end-a", "start-b", "end-b"]
+
+    @pytest.mark.asyncio
+    async def test_session_lock_allows_different_sessions_in_parallel(self):
+        from nanobot.bus.events import InboundMessage, OutboundMessage
+
+        loop, bus = _make_loop()
+        order = []
+        started = 0
+        both_started = asyncio.Event()
+
+        async def mock_process(m, **kwargs):
+            nonlocal started
+            order.append(f"start-{m.content}")
+            started += 1
+            if started == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=0.2)
+            order.append(f"end-{m.content}")
+            return OutboundMessage(channel="test", chat_id=m.chat_id, content=m.content)
+
+        loop._process_message = mock_process
+        msg1 = InboundMessage(channel="test", sender_id="u1", chat_id="c1", content="a")
+        msg2 = InboundMessage(channel="test", sender_id="u1", chat_id="c2", content="b")
+
+        await asyncio.gather(
+            asyncio.create_task(loop._dispatch(msg1)),
+            asyncio.create_task(loop._dispatch(msg2)),
+        )
+
+        assert order[:2] == ["start-a", "start-b"] or order[:2] == ["start-b", "start-a"]
+
+    @pytest.mark.asyncio
+    async def test_process_direct_serializes_same_session(self):
+        from nanobot.bus.events import OutboundMessage
+
+        loop, bus = _make_loop()
+        order = []
+
+        async def mock_process(m, **kwargs):
+            order.append(f"start-{m.content}")
+            await asyncio.sleep(0.05)
+            order.append(f"end-{m.content}")
+            return OutboundMessage(channel="test", chat_id="c1", content=m.content)
+
+        loop._process_message = mock_process
+
+        result_a, result_b = await asyncio.gather(
+            loop.process_direct("a", session_key="test:c1", channel="test", chat_id="c1"),
+            loop.process_direct("b", session_key="test:c1", channel="test", chat_id="c1"),
+        )
+
+        assert (result_a, result_b) == ("a", "b")
         assert order == ["start-a", "end-a", "start-b", "end-b"]
 
 


### PR DESCRIPTION
## Summary
- replace the global `AgentLoop` processing lock with per-session locks
- serialize work within one session while allowing different sessions to run concurrently
- route `process_direct()` through the same session-locking path and add regression tests

## Validation
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_task_cancel.py -q`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_context_editor.py tests/test_heartbeat_service.py tests/test_cron_service.py -q`
- `uv run --with ruff python -m ruff check nanobot/agent/loop.py tests/test_task_cancel.py`