### PR TITLE
fix(memory): force tool_choice in consolidation to prevent silent memory loss

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -118,6 +118,8 @@ class MemoryStore:
                 ],
                 tools=_SAVE_MEMORY_TOOL,
                 model=model,
+                max_tokens=16384,
+                tool_choice={"type": "function", "function": {"name": "save_memory"}},
             )
 
             if not response.has_tool_calls:

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -88,6 +88,7 @@ class AzureOpenAIProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: str | dict | None = None,
     ) -> dict[str, Any]:
         """Prepare the request payload with Azure OpenAI 2024-10-21 compliance."""
         payload: dict[str, Any] = {
@@ -106,7 +107,7 @@ class AzureOpenAIProvider(LLMProvider):
 
         if tools:
             payload["tools"] = tools
-            payload["tool_choice"] = "auto"
+            payload["tool_choice"] = tool_choice or "auto"
 
         return payload
 
@@ -118,6 +119,7 @@ class AzureOpenAIProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: str | dict | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request to Azure OpenAI.
@@ -137,7 +139,7 @@ class AzureOpenAIProvider(LLMProvider):
         url = self._build_chat_url(deployment_name)
         headers = self._build_headers()
         payload = self._prepare_request_payload(
-            deployment_name, messages, tools, max_tokens, temperature, reasoning_effort
+            deployment_name, messages, tools, max_tokens, temperature, reasoning_effort, tool_choice
         )
 
         try:

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -110,6 +110,7 @@ class LLMProvider(ABC):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: str | dict | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request.
@@ -120,6 +121,8 @@ class LLMProvider(ABC):
             model: Model identifier (provider-specific).
             max_tokens: Maximum tokens in response.
             temperature: Sampling temperature.
+            tool_choice: Tool choice strategy ("auto", "required", or specific tool dict).
+                         If None, defaults to provider behavior (typically "auto").
         
         Returns:
             LLMResponse with content and/or tool calls.

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -25,7 +25,7 @@ class CustomProvider(LLMProvider):
 
     async def chat(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
                    model: str | None = None, max_tokens: int = 4096, temperature: float = 0.7,
-                   reasoning_effort: str | None = None) -> LLMResponse:
+                   reasoning_effort: str | None = None, tool_choice: str | dict | None = None) -> LLMResponse:
         kwargs: dict[str, Any] = {
             "model": model or self.default_model,
             "messages": self._sanitize_empty_content(messages),
@@ -35,7 +35,7 @@ class CustomProvider(LLMProvider):
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
         if tools:
-            kwargs.update(tools=tools, tool_choice="auto")
+            kwargs.update(tools=tools, tool_choice=tool_choice or "auto")
         try:
             return self._parse(await self._client.chat.completions.create(**kwargs))
         except Exception as e:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -214,6 +214,7 @@ class LiteLLMProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: str | dict | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request via LiteLLM.
@@ -267,7 +268,7 @@ class LiteLLMProvider(LLMProvider):
         
         if tools:
             kwargs["tools"] = tools
-            kwargs["tool_choice"] = "auto"
+            kwargs["tool_choice"] = tool_choice or "auto"
 
         try:
             response = await acompletion(**kwargs)

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -32,6 +32,7 @@ class OpenAICodexProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: str | dict | None = None,
     ) -> LLMResponse:
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)
@@ -48,7 +49,7 @@ class OpenAICodexProvider(LLMProvider):
             "text": {"verbosity": "medium"},
             "include": ["reasoning.encrypted_content"],
             "prompt_cache_key": _prompt_cache_key(messages),
-            "tool_choice": "auto",
+            "tool_choice": tool_choice or "auto",
             "parallel_tool_calls": True,
         }
 


### PR DESCRIPTION
## Problem

During memory consolidation, the LLM is called with `tool_choice="auto"`, which allows the model to respond with plain text instead of calling the `save_memory` tool. When this happens, the consolidation **silently fails** — old messages are still trimmed from the session, but neither `HISTORY.md` nor `MEMORY.md` gets updated.

### Impact

- **Permanent memory loss**: Conversation history and learned facts are irreversibly discarded without being persisted.
- **Silent failure**: The only indication is a `WARNING` log line (`"LLM did not call save_memory, skipping"`), which is easy to miss. The function returns `False` but the caller does not retry.
- **Higher failure rate on capable models**: Larger models (e.g. Claude Opus, GPT-4) are more prone to this because they tend to produce analytical text responses before (or instead of) invoking tools when `tool_choice` is `"auto"`.
- **Compounding effect**: Since consolidation runs periodically, each failure loses a batch of messages. Over long sessions, this can result in a completely empty or severely degraded memory file.

### Root Cause

In `memory.py`, the `consolidate()` method calls `provider.chat()` without specifying `tool_choice`, defaulting to `"auto"`. The system prompt says _"Call the save_memory tool"_, but with `tool_choice="auto"`, the model is free to ignore this instruction and respond with plain text — which it frequently does.

A secondary issue: `max_tokens` defaults to `4096`, which can be insufficient when `MEMORY.md` grows large (the tool must return the full updated memory content). If the output is truncated mid-JSON, the tool call parsing fails silently.

## Solution

### 1. Add `tool_choice` parameter to all providers

Added an optional `tool_choice: str | dict | None = None` parameter to `LLMProvider.chat()` (base class) and all concrete implementations:

- `litellm_provider.py`
- `azure_openai_provider.py`
- `custom_provider.py`
- `openai_codex_provider.py`

When `tool_choice` is `None` (the default), behavior falls back to `"auto"` — **no change to normal conversation flow**.

### 2. Force `save_memory` in consolidation

In `memory.py`, the consolidation call now specifies:

```python
tool_choice={"type": "function", "function": {"name": "save_memory"}},
max_tokens=16384,
```

This guarantees the model will call `save_memory` and has sufficient output budget to return the full memory content.

## Files Changed

| File | Change |
|------|--------|
| `nanobot/providers/base.py` | Add `tool_choice` param to abstract `chat()` |
| `nanobot/providers/litellm_provider.py` | Accept and forward `tool_choice` |
| `nanobot/providers/azure_openai_provider.py` | Accept and forward `tool_choice` |
| `nanobot/providers/custom_provider.py` | Accept and forward `tool_choice` |
| `nanobot/providers/openai_codex_provider.py` | Accept and forward `tool_choice` |
| `nanobot/agent/memory.py` | Set `tool_choice` and `max_tokens` in consolidation |

## Backward Compatibility

Fully backward compatible. The `tool_choice` parameter defaults to `None`, which preserves the existing `"auto"` behavior for all callers that do not explicitly pass it.