### PR TITLE
Fix/memory consolidation timeout

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio 
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -111,14 +112,14 @@ class MemoryStore:
 {chr(10).join(lines)}"""
 
         try:
-            response = await provider.chat(
+            response = await syncio.wait_for(provider.chat(
                 messages=[
                     {"role": "system", "content": "You are a memory consolidation agent. Call the save_memory tool with your consolidation of the conversation."},
                     {"role": "user", "content": prompt},
                 ],
                 tools=_SAVE_MEMORY_TOOL,
                 model=model,
-            )
+            ), timeout=120
 
             if not response.has_tool_calls:
                 logger.warning("Memory consolidation: LLM did not call save_memory, skipping")
@@ -152,6 +153,9 @@ class MemoryStore:
             session.last_consolidated = 0 if archive_all else len(session.messages) - keep_count
             logger.info("Memory consolidation done: {} messages, last_consolidated={}", len(session.messages), session.last_consolidated)
             return True
+        except asyncio.TimeoutError:
+            logger.warning("Memory consolidation timed out afther 120s")
+            return False 
         except Exception:
             logger.exception("Memory consolidation failed")
             return False

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -34,7 +34,7 @@ class MCPToolWrapper(Tool):
     def parameters(self) -> dict[str, Any]:
         return self._parameters
 
-    async def execute(self, **kwargs: Any) -> str:
+async def execute(self, **kwargs: Any) -> str:
         from mcp import types
         try:
             result = await asyncio.wait_for(
@@ -44,13 +44,24 @@ class MCPToolWrapper(Tool):
         except asyncio.TimeoutError:
             logger.warning("MCP tool '{}' timed out after {}s", self._name, self._tool_timeout)
             return f"(MCP tool call timed out after {self._tool_timeout}s)"
+        except asyncio.CancelledError:
+            # MCP SDK's anyio cancel scopes can leak CancelledError on timeout/failure.
+            # Re-raise only if our task was externally cancelled (e.g. /stop).
+            task = asyncio.current_task()
+            if task is not None and task.cancelling() > 0:
+                raise
+            logger.warning("MCP tool '{}' was cancelled by server/SDK", self._name)
+            return f"(MCP tool call was cancelled)"
+        except Exception as exc:
+            logger.warning("MCP tool '{}' failed: {}: {}", self._name, type(exc).__name__, exc)
+            return f"(MCP tool call failed: {type(exc).__name__})"
         parts = []
         for block in result.content:
             if isinstance(block, types.TextContent):
                 parts.append(block.text)
             else:
                 parts.append(str(block))
-        return "\n".join(parts) or "(no output)"
+        return "\n".join(parts) or "(no output)
 
 
 async def connect_mcp_servers(


### PR DESCRIPTION
## What
Add a 120-second timeout to the LLM call in memory consolidation.

## Why
`MemoryStore.consolidate()` calls `provider.chat()` without any timeout.
If the LLM provider hangs or responds very slowly, the consolidation
task blocks indefinitely. This holds the session's consolidation lock
and keeps the session key in the `_consolidating` set permanently,
preventing all future memory consolidations for that session.

## How
- Wrap `provider.chat()` with `asyncio.wait_for(..., timeout=120)`
- Add `asyncio.TimeoutError` handler that logs a warning and returns `False`
- 120 seconds is generous for a summarization task; most complete in under 30s

## Testing
1. Configure a provider with a very slow or unreachable endpoint
2. Trigger memory consolidation (send enough messages to exceed `memory_window`)
3. Verify consolidation times out after 120s and returns gracefully
4. Verify subsequent consolidations can still run (lock is released)

## Acknowledgment
Fix identified and developed with assistance from Claude Opus 4.6