### PR TITLE
fix(codex): add actionable error for deactivated_workspace (402)

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -311,6 +311,12 @@ def _map_finish_reason(status: str | None) -> str:
 
 
 def _friendly_error(status_code: int, raw: str) -> str:
+    raw_lower = raw.lower()
     if status_code == 429:
         return "ChatGPT usage quota exceeded or rate limit triggered. Please try again later."
+    if status_code == 402 and "deactivated_workspace" in raw_lower:
+        return (
+            "Codex workspace is deactivated (HTTP 402: deactivated_workspace). "
+            "Switch to an active ChatGPT workspace and run `nanobot provider login openai-codex` again."
+        )
     return f"HTTP {status_code}: {raw}"


### PR DESCRIPTION
 ## Summary

  This PR improves OpenAI Codex error handling for workspace-related failures.

  When Codex returns HTTP 402 with deactivated_workspace, nanobot now surfaces a clear, actionable message instead of a raw HTTP error payload.

  ## What Changed

  - Updated Codex provider error mapping in openai_codex_provider.py:311.
  - Added a user-facing recovery hint for this specific failure:
      - switch to an active ChatGPT workspace
      - re-run nanobot provider login openai-codex

  ## Why

  Users previously saw a low-level error like:
  Error calling Codex: HTTP 402: {"detail":{"code":"deactivated_workspace"}}

  That message is technically correct but not actionable. This change makes recovery steps explicit and reduces troubleshooting time.

  ## Scope

  - Functional change only in Codex error messaging.
  - No API contract changes.
  - No behavior changes for unrelated error paths.