### PR TITLE
ToolRegistry.execute() catches Exception, but asyncio.CancelledError

### DIFF
--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -1,5 +1,6 @@
 """Tool registry for dynamic tool management."""
 
+import asyncio
 from typing import Any
 
 from nanobot.agent.tools.base import Tool
@@ -55,6 +56,8 @@ class ToolRegistry:
             if isinstance(result, str) and result.startswith("Error"):
                 return result + _HINT
             return result
+        except asyncio.CancelledError:
+            raise  # Let /stop cancellation propagate
         except Exception as e:
             return f"Error executing {name}: {str(e)}" + _HINT
 


### PR DESCRIPTION
## What
Add explicit `asyncio.CancelledError` handling in `ToolRegistry.execute()`.

## Why
`ToolRegistry.execute()` wraps tool calls in `try/except Exception`, but 
`asyncio.CancelledError` inherits from `BaseException` (not `Exception`) 
since Python 3.9. This means task cancellations from `/stop` escape the 
handler without being properly propagated.

This is the registry-level counterpart to the MCP tool-level fix in PR #1728.

## How
- Add `except asyncio.CancelledError: raise` before the `except Exception` handler
- Ensures `/stop` cancellations propagate correctly through tool execution

## Testing
1. Start a long-running tool call (e.g. shell command)
2. Send `/stop` → should cancel cleanly
3. Normal tool errors should still return error messages to the LLM

## Acknowledgment
Fix identified and developed with assistance from Claude Opus 4.6