### PR TITLE
ToolRegistry.register() silently overwrites tools with the same name.

### DIFF
--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from loguru import logger
+
 from nanobot.agent.tools.base import Tool
 
 
@@ -17,6 +19,8 @@ class ToolRegistry:
 
     def register(self, tool: Tool) -> None:
         """Register a tool."""
+        if tool.name in self._tools:
+            logger.warning("Tool '{}' already registered, overwriting", tool.name)
         self._tools[tool.name] = tool
 
     def unregister(self, name: str) -> None:


### PR DESCRIPTION
This can happen when multiple MCP servers expose tools with identical names, causing one to disappear without any indication.
Adds a logger.warning() so users can diagnose unexpected tool conflicts.

## What
Add a warning log when registering a tool that overwrites an existing one.

## Why
`ToolRegistry.register()` silently overwrites if a tool with the same 
name already exists. This can happen when multiple MCP servers expose 
tools with identical names — one tool quietly disappears with no 
indication to the user, making debugging very difficult.

## How
- Check if `tool.name` already exists in the registry before overwriting
- Log a warning with the tool name via `loguru.logger`

## Testing
1. Configure two MCP servers that expose a tool with the same name
2. Start nanobot → should see warning in logs about the duplicate
3. Normal tool registration (no duplicates) should have no warning

## Acknowledgment
Fix identified and developed with assistance from Claude Opus 4.6