### PR TITLE
feat(channels): add "restart" command

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import os
+import sys
 import weakref
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -392,6 +394,15 @@ class AgentLoop:
         if cmd == "/help":
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
                                   content="🐈 nanobot commands:\n/new — Start a new conversation\n/stop — Stop the current task\n/help — Show available commands")
+        if cmd == "/restart":
+            await self.bus.publish_outbound(OutboundMessage(
+                channel=msg.channel, chat_id=msg.chat_id, content="🔄 Restarting..."
+            ))
+            async def _r():
+                await asyncio.sleep(1)
+                os.execv(sys.executable, [sys.executable] + sys.argv)
+            asyncio.create_task(_r())
+            return None
 
         unconsolidated = len(session.messages) - session.last_consolidated
         if (unconsolidated >= self.memory_window and session.key not in self._consolidating):

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -162,6 +162,7 @@ class TelegramChannel(BaseChannel):
         BotCommand("new", "Start a new conversation"),
         BotCommand("stop", "Stop the current task"),
         BotCommand("help", "Show available commands"),
+        BotCommand("restart", "Restart the bot"),
     ]
 
     def __init__(
@@ -223,6 +224,7 @@ class TelegramChannel(BaseChannel):
         self._app.add_handler(CommandHandler("start", self._on_start))
         self._app.add_handler(CommandHandler("new", self._forward_command))
         self._app.add_handler(CommandHandler("stop", self._forward_command))
+        self._app.add_handler(CommandHandler("restart", self._forward_command))
         self._app.add_handler(CommandHandler("help", self._on_help))
 
         # Add message handler for text, photos, voice, documents


### PR DESCRIPTION
This PR adds the "/restart" command for all channels (except email), implemented in a concise way that follows existing styles and patterns.

**Why:**
Restarting the backend process allows for reloading configs and other elements that may have been changed by the user or by the bot itself. Doing it from the comfort of the message channel is a nice convenience..