### PR TITLE
fix(tool): prevent absurd agent behavior (even hang) when Brave API key is not configured.

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -123,7 +123,8 @@ class AgentLoop:
             restrict_to_workspace=self.restrict_to_workspace,
             path_append=self.exec_config.path_append,
         ))
-        self.tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
+        if self.brave_api_key and self.brave_api_key != "disabled":
+            self.tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
         self.tools.register(WebFetchTool(proxy=self.web_proxy))
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
         self.tools.register(SpawnTool(manager=self.subagents))


### PR DESCRIPTION
## Problem

1. The web_search tool cannot be disabled. If a web query is contextually relevant, the agent will attempt to use it regardless of configuration status.

2. If the Brave API key is missing or misconfigured, the tool returns the following detailed error message:
"Error: Brave Search API key not configured. Set it in ~/.nanobot/config.json under tools.web.search.apiKey (or export BRAVE_API_KEY), then restart the gateway."

3. Upon reading this error, some agents attempt to follow the instructions. With some specific foundation model backends, the agent tries to use other tools to inspect/modify config.json or even attempt to restart the gateway.

4. Occasionally, this results in a loop: Try web search -> Fail -> Attempt to fix config/restart -> Try web search again. This iteration significantly increases latency, and in rare cases, this causes the agent to hang indefinitely.

## Fix

Modify loop.py to prevent registering web_search tool when no API key configured or configured as "disabled".