### PR TITLE
fix(heartbeat): include current time in decision prompt

### DIFF
--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import time
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
@@ -87,10 +89,15 @@ class HeartbeatService:
 
         Returns (action, tasks) where action is 'skip' or 'run'.
         """
+        # Include current time so LLM can evaluate time-based tasks
+        now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
+        tz = time.strftime("%Z") or "UTC"
+
         response = await self.provider.chat(
             messages=[
                 {"role": "system", "content": "You are a heartbeat agent. Call the heartbeat tool to report your decision."},
                 {"role": "user", "content": (
+                    f"Current Time: {now} ({tz})\n\n"
                     "Review the following HEARTBEAT.md and decide whether there are active tasks.\n\n"
                     f"{content}"
                 )},


### PR DESCRIPTION
## Problem
The `HeartbeatService._decide()` method was missing the current time when asking the LLM to evaluate tasks in `HEARTBEAT.md`. This meant time-based tasks like "check weather at 9am every morning" could not be properly evaluated since the LLM had no context of the current time.

## Solution
Added the current datetime and timezone to the prompt, matching the behavior of `ContextBuilder._build_runtime_context()` used in normal message processing.

## Changes
- Import `datetime` and `time` modules
- Include `Current Time: {now} ({tz})` in the LLM prompt

## Test
The LLM can now properly evaluate time-based tasks in HEARTBEAT.md.