### PR TITLE
Separate core memory from episodic memory recall

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -71,7 +71,6 @@ Skills with available="false" need dependencies installed first - you can try in
 - You are running on a POSIX system. Prefer UTF-8 and standard shell tools.
 - Use file tools when they are simpler or more reliable than shell commands.
 """
-
         return f"""# nanobot 🐈
 
 You are nanobot, a helpful AI assistant.
@@ -81,8 +80,9 @@ You are nanobot, a helpful AI assistant.
 
 ## Workspace
 Your workspace is at: {workspace_path}
-- Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)
-- History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
+- Core long-term memory: {workspace_path}/memory/MEMORY.md (always-injected durable facts and preferences)
+- Daily memory notes: {workspace_path}/memory/YYYY-MM-DD.md (episodic recall; use memory_search / memory_get)
+- History log: {workspace_path}/memory/HISTORY.md (legacy append-only log; not auto-injected)
 - Custom skills: {workspace_path}/skills/{{skill-name}}/SKILL.md
 
 {platform_policy}

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -8,7 +8,7 @@ import re
 import weakref
 from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from loguru import logger
 
@@ -17,6 +17,7 @@ from nanobot.agent.memory import MemoryStore
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
+from nanobot.agent.tools.memory import MemoryGetTool, MemorySearchTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.shell import ExecTool
@@ -125,6 +126,8 @@ class AgentLoop:
         ))
         self.tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
         self.tools.register(WebFetchTool(proxy=self.web_proxy))
+        self.tools.register(MemorySearchTool(workspace=self.workspace))
+        self.tools.register(MemoryGetTool(workspace=self.workspace))
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
         self.tools.register(SpawnTool(manager=self.subagents))
         if self.cron_service:

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import sqlite3
+from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -24,18 +26,20 @@ _SAVE_MEMORY_TOOL = [
             "parameters": {
                 "type": "object",
                 "properties": {
+                    "daily_note": {
+                        "type": "string",
+                        "description": "A dated episodic note for archival memory. Start with [YYYY-MM-DD HH:MM] when possible.",
+                    },
                     "history_entry": {
                         "type": "string",
-                        "description": "A paragraph (2-5 sentences) summarizing key events/decisions/topics. "
-                        "Start with [YYYY-MM-DD HH:MM]. Include detail useful for grep search.",
+                        "description": "Deprecated alias for daily_note. A dated episodic note.",
                     },
                     "memory_update": {
                         "type": "string",
-                        "description": "Full updated long-term memory as markdown. Include all existing "
-                        "facts plus new ones. Return unchanged if nothing new.",
+                        "description": "Full updated core long-term memory as markdown. Keep stable facts and preferences here; do not dump daily episodic notes into it.",
                     },
                 },
-                "required": ["history_entry", "memory_update"],
+                "required": ["memory_update"],
             },
         },
     }
@@ -43,28 +47,184 @@ _SAVE_MEMORY_TOOL = [
 
 
 class MemoryStore:
-    """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
+    """OpenClaw-style memory: compact core memory + dated notes + searchable recall."""
 
     def __init__(self, workspace: Path):
         self.memory_dir = ensure_dir(workspace / "memory")
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.history_file = self.memory_dir / "HISTORY.md"
+        self.pinned_file = self.memory_dir / "PINNED.md"
+        self.index_file = self.memory_dir / ".memory_index.sqlite3"
+
+    @staticmethod
+    def _read_file(path: Path) -> str:
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+        return ""
+
+    @staticmethod
+    def _coerce_text(value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        return json.dumps(value, ensure_ascii=False)
+
+    @staticmethod
+    def _extract_note_day(note: str) -> str:
+        if note.startswith("[") and len(note) >= 11:
+            candidate = note[1:11]
+            try:
+                datetime.strptime(candidate, "%Y-%m-%d")
+                return candidate
+            except ValueError:
+                pass
+        return datetime.now().strftime("%Y-%m-%d")
+
+    def _daily_note_path(self, day: str) -> Path:
+        return self.memory_dir / f"{day}.md"
+
+    def _doc_paths(self) -> list[Path]:
+        docs: list[Path] = []
+        if self.memory_file.exists():
+            docs.append(self.memory_file)
+        for path in sorted(self.memory_dir.glob("*.md")):
+            if path.name in {self.memory_file.name, self.history_file.name, self.pinned_file.name}:
+                continue
+            docs.append(path)
+        return docs
+
+    def _resolve_memory_path(self, path: str) -> Path:
+        target = Path(path).expanduser()
+        if not target.is_absolute():
+            if target.parts and target.parts[0] == "memory":
+                target = self.memory_dir / Path(*target.parts[1:])
+            else:
+                target = self.memory_dir / target
+        resolved = target.resolve()
+        try:
+            resolved.relative_to(self.memory_dir.resolve())
+        except ValueError as exc:
+            raise PermissionError(f"Path {path} is outside memory directory") from exc
+        return resolved
+
+    def _memory_relpath(self, path: Path) -> str:
+        return f"memory/{path.relative_to(self.memory_dir).as_posix()}"
+
+    def _index_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.index_file)
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS memory_docs (
+                path TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        return conn
+
+    @staticmethod
+    def _snippet(content: str, query: str, width: int = 160) -> str:
+        lower_content = content.lower()
+        lower_query = query.lower()
+        idx = lower_content.find(lower_query)
+        if idx < 0:
+            idx = 0
+        start = max(0, idx - 40)
+        end = min(len(content), start + width)
+        snippet = " ".join(content[start:end].split())
+        if start > 0:
+            snippet = "..." + snippet
+        if end < len(content):
+            snippet = snippet + "..."
+        return snippet
+
+    def rebuild_index(self) -> None:
+        conn = self._index_connection()
+        try:
+            conn.execute("DELETE FROM memory_docs")
+            for path in self._doc_paths():
+                conn.execute(
+                    "INSERT INTO memory_docs(path, content, updated_at) VALUES (?, ?, ?)",
+                    (
+                        self._memory_relpath(path),
+                        path.read_text(encoding="utf-8"),
+                        path.stat().st_mtime,
+                    ),
+                )
+            conn.commit()
+        finally:
+            conn.close()
 
     def read_long_term(self) -> str:
-        if self.memory_file.exists():
-            return self.memory_file.read_text(encoding="utf-8")
-        return ""
+        return self._read_file(self.memory_file)
+
+    def read_pinned(self) -> str:
+        return self._read_file(self.pinned_file)
 
     def write_long_term(self, content: str) -> None:
         self.memory_file.write_text(content, encoding="utf-8")
+        self.rebuild_index()
+
+    def write_daily_note(self, day: str, content: str) -> Path:
+        path = self._daily_note_path(day)
+        path.write_text(content.rstrip() + "\n", encoding="utf-8")
+        self.rebuild_index()
+        return path
+
+    def append_daily_note(self, note: str) -> Path:
+        path = self._daily_note_path(self._extract_note_day(note))
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(note.rstrip() + "\n\n")
+        self.rebuild_index()
+        return path
 
     def append_history(self, entry: str) -> None:
         with open(self.history_file, "a", encoding="utf-8") as f:
             f.write(entry.rstrip() + "\n\n")
 
+    def search(self, query: str, limit: int = 5) -> list[dict[str, str]]:
+        query = query.strip()
+        if not query:
+            return []
+        self.rebuild_index()
+        conn = self._index_connection()
+        try:
+            rows = conn.execute(
+                """
+                SELECT path, content
+                FROM memory_docs
+                WHERE lower(content) LIKE lower(?)
+                ORDER BY updated_at DESC, path ASC
+                LIMIT ?
+                """,
+                (f"%{query}%", limit),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        return [
+            {
+                "path": path,
+                "title": Path(path).name,
+                "snippet": self._snippet(content, query),
+            }
+            for path, content in rows
+        ]
+
+    def get_document(self, path: str) -> str:
+        target = self._resolve_memory_path(path)
+        if not target.exists():
+            raise FileNotFoundError(f"Memory document not found: {path}")
+        if not target.is_file():
+            raise FileNotFoundError(f"Memory document is not a file: {path}")
+        return target.read_text(encoding="utf-8")
+
     def get_memory_context(self) -> str:
         long_term = self.read_long_term()
         return f"## Long-term Memory\n{long_term}" if long_term else ""
+
+    def get_pinned_context(self) -> str:
+        return self.read_pinned().strip()
 
     async def consolidate(
         self,
@@ -75,10 +235,7 @@ class MemoryStore:
         archive_all: bool = False,
         memory_window: int = 50,
     ) -> bool:
-        """Consolidate old messages into MEMORY.md + HISTORY.md via LLM tool call.
-
-        Returns True on success (including no-op), False on failure.
-        """
+        """Consolidate old messages into MEMORY.md + dated daily notes via LLM tool call."""
         if archive_all:
             old_messages = session.messages
             keep_count = 0
@@ -104,16 +261,22 @@ class MemoryStore:
         current_memory = self.read_long_term()
         prompt = f"""Process this conversation and call the save_memory tool with your consolidation.
 
-## Current Long-term Memory
+## Current Core Memory
 {current_memory or "(empty)"}
 
 ## Conversation to Process
-{chr(10).join(lines)}"""
+{chr(10).join(lines)}
+
+Update memory_update with compact durable facts only.
+Put episodic progress and dated archival notes into daily_note."""
 
         try:
             response = await provider.chat(
                 messages=[
-                    {"role": "system", "content": "You are a memory consolidation agent. Call the save_memory tool with your consolidation of the conversation."},
+                    {
+                        "role": "system",
+                        "content": "You are a memory consolidation agent. Call save_memory with a compact core memory update and a dated daily note.",
+                    },
                     {"role": "user", "content": prompt},
                 ],
                 tools=_SAVE_MEMORY_TOOL,
@@ -125,7 +288,6 @@ class MemoryStore:
                 return False
 
             args = response.tool_calls[0].arguments
-            # Some providers return arguments as a JSON string instead of dict
             if isinstance(args, str):
                 args = json.loads(args)
             # Some providers return arguments as a list (handle edge case)
@@ -139,18 +301,24 @@ class MemoryStore:
                 logger.warning("Memory consolidation: unexpected arguments type {}", type(args).__name__)
                 return False
 
-            if entry := args.get("history_entry"):
-                if not isinstance(entry, str):
-                    entry = json.dumps(entry, ensure_ascii=False)
-                self.append_history(entry)
-            if update := args.get("memory_update"):
-                if not isinstance(update, str):
-                    update = json.dumps(update, ensure_ascii=False)
-                if update != current_memory:
-                    self.write_long_term(update)
+            note = args.get("daily_note") or args.get("history_entry")
+            if note:
+                note_text = self._coerce_text(note)
+                self.append_daily_note(note_text)
+                self.append_history(note_text)
+
+            update = args.get("memory_update")
+            if update is not None:
+                update_text = self._coerce_text(update)
+                if update_text != current_memory:
+                    self.write_long_term(update_text)
 
             session.last_consolidated = 0 if archive_all else len(session.messages) - keep_count
-            logger.info("Memory consolidation done: {} messages, last_consolidated={}", len(session.messages), session.last_consolidated)
+            logger.info(
+                "Memory consolidation done: {} messages, last_consolidated={}",
+                len(session.messages),
+                session.last_consolidated,
+            )
             return True
         except Exception:
             logger.exception("Memory consolidation failed")

--- a/nanobot/agent/tools/memory.py
+++ b/nanobot/agent/tools/memory.py
@@ -1,0 +1,88 @@
+"""Memory recall tools."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.agent.tools.base import Tool
+
+
+class MemorySearchTool(Tool):
+    """Search compact and archival memory documents."""
+
+    def __init__(self, workspace: Path):
+        self._store = MemoryStore(workspace)
+
+    @property
+    def name(self) -> str:
+        return "memory_search"
+
+    @property
+    def description(self) -> str:
+        return "Search long-term memory and dated memory notes. Use this instead of relying on archive memory being auto-injected."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Natural-language search query for memory recall.",
+                    "minLength": 1,
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return.",
+                    "minimum": 1,
+                    "maximum": 20,
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def execute(self, query: str, limit: int = 5, **kwargs: Any) -> str:
+        results = self._store.search(query, limit=limit)
+        if not results:
+            return "No matching memory found."
+        return json.dumps(results, ensure_ascii=False, indent=2)
+
+
+class MemoryGetTool(Tool):
+    """Read a specific memory document."""
+
+    def __init__(self, workspace: Path):
+        self._store = MemoryStore(workspace)
+
+    @property
+    def name(self) -> str:
+        return "memory_get"
+
+    @property
+    def description(self) -> str:
+        return "Read a specific file inside the workspace memory directory, such as memory/2026-03-09.md."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Memory document path, usually relative to the workspace like memory/2026-03-09.md.",
+                    "minLength": 1,
+                }
+            },
+            "required": ["path"],
+        }
+
+    async def execute(self, path: str, **kwargs: Any) -> str:
+        try:
+            return self._store.get_document(path)
+        except PermissionError as exc:
+            return f"Error: {exc}"
+        except FileNotFoundError as exc:
+            return f"Error: {exc}"

--- a/tests/test_memory_policy.py
+++ b/tests/test_memory_policy.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nanobot.agent.context import ContextBuilder
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.memory import MemoryStore
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse, ToolCallRequest
+
+
+def _make_session(message_count: int = 30):
+    class _Session:
+        def __init__(self) -> None:
+            self.messages = [
+                {"role": "user", "content": f"msg{i}", "timestamp": "2026-03-09T12:34:56"}
+                for i in range(message_count)
+            ]
+            self.last_consolidated = 0
+
+    return _Session()
+
+
+@pytest.mark.asyncio
+async def test_consolidation_writes_daily_note_and_core_memory(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    provider = AsyncMock()
+    provider.chat = AsyncMock(
+        return_value=LLMResponse(
+            content=None,
+            tool_calls=[
+                ToolCallRequest(
+                    id="call_1",
+                    name="save_memory",
+                    arguments={
+                        "history_entry": "[2026-03-09 12:34] Investigated memory policy and chose daily notes.",
+                        "memory_update": "# Memory\n- Prefer daily note archival for episodic memory.\n",
+                    },
+                )
+            ],
+        )
+    )
+
+    result = await store.consolidate(_make_session(message_count=60), provider, "test-model", memory_window=50)
+
+    assert result is True
+    assert store.memory_file.read_text(encoding="utf-8").startswith("# Memory")
+    daily_note = store.memory_dir / "2026-03-09.md"
+    assert daily_note.exists()
+    assert "Investigated memory policy" in daily_note.read_text(encoding="utf-8")
+
+
+def test_context_builder_injects_only_core_memory_not_daily_notes(tmp_path: Path) -> None:
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir(parents=True)
+    (memory_dir / "MEMORY.md").write_text("# Memory\n- User prefers concise updates.\n", encoding="utf-8")
+    (memory_dir / "2026-03-09.md").write_text("[2026-03-09 12:00] Temporary daily note.\n", encoding="utf-8")
+
+    prompt = ContextBuilder(tmp_path).build_system_prompt()
+
+    assert "User prefers concise updates" in prompt
+    assert "Temporary daily note" not in prompt
+
+
+def test_memory_search_and_get_cover_daily_and_core_memory(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    store.write_long_term("# Memory\n- User prefers concise updates.\n")
+    store.write_daily_note("2026-03-09", "[2026-03-09 12:00] Investigated memory policy for OpenClaw parity.")
+
+    search_results = store.search("OpenClaw parity", limit=5)
+
+    assert len(search_results) == 1
+    assert search_results[0]["path"] == "memory/2026-03-09.md"
+    assert "OpenClaw parity" in search_results[0]["snippet"]
+
+    document = store.get_document("memory/2026-03-09.md")
+    assert "Investigated memory policy" in document
+
+
+def test_memory_get_rejects_paths_outside_memory_dir(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    outside_file = tmp_path / "outside.md"
+    outside_file.write_text("nope", encoding="utf-8")
+
+    with pytest.raises(PermissionError):
+        store.get_document(str(outside_file))
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_registers_memory_recall_tools(tmp_path: Path) -> None:
+    provider = AsyncMock()
+    provider.get_default_model.return_value = "test-model"
+    loop = AgentLoop(bus=MessageBus(), provider=provider, workspace=tmp_path, model="test-model")
+
+    assert loop.tools.has("memory_search")
+    assert loop.tools.has("memory_get")
+
+    store = MemoryStore(tmp_path)
+    store.write_daily_note("2026-03-09", "[2026-03-09 12:00] Investigated memory policy for OpenClaw parity.")
+
+    search_result = await loop.tools.execute("memory_search", {"query": "OpenClaw parity"})
+    get_result = await loop.tools.execute("memory_get", {"path": "memory/2026-03-09.md"})
+
+    assert "2026-03-09.md" in search_result
+    assert "Investigated memory policy" in get_result


### PR DESCRIPTION
## Summary
- keep `MEMORY.md` as the compact always-injected core memory
- archive episodic memory into dated files under `memory/YYYY-MM-DD.md`
- add explicit `memory_search` and `memory_get` tools so archival memory is recalled on demand
- maintain a local sqlite-backed index to support searchable memory recall
- route consolidation output so durable facts stay in core memory while dated episodes go into daily notes

## Validation
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_memory_policy.py tests/test_memory_consolidation_types.py tests/test_commands.py tests/test_tool_validation.py tests/test_consolidate_offset.py tests/test_task_cancel.py -q`
- `uv run --with ruff python -m ruff check nanobot/agent/memory.py nanobot/agent/context.py nanobot/agent/loop.py nanobot/agent/tools/memory.py tests/test_memory_policy.py`
