### PR TITLE
feat: stream LLM output to Telegram replies

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -45,6 +45,7 @@ class AgentLoop:
     """
 
     _TOOL_RESULT_MAX_CHARS = 500
+    _MAX_LLM_ERROR_RETRIES = 2
 
     def __init__(
         self,
@@ -177,19 +178,54 @@ class AgentLoop:
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
+    @staticmethod
+    def _is_retryable_llm_error(content: str | None) -> bool:
+        """Detect transient upstream/model gateway errors worth retrying."""
+        if not content:
+            return False
+        text = content.lower()
+        retryable_markers = (
+            "error code: 502",
+            "error code: 503",
+            "bad gateway",
+            "service unavailable",
+            "timeout",
+            "timed out",
+            "connection reset",
+            "temporarily unavailable",
+        )
+        return any(marker in text for marker in retryable_markers)
+
     async def _run_agent_loop(
         self,
         initial_messages: list[dict],
         on_progress: Callable[..., Awaitable[None]] | None = None,
+        stream_text_progress: bool = False,
     ) -> tuple[str | None, list[str], list[dict]]:
         """Run the agent iteration loop. Returns (final_content, tools_used, messages)."""
         messages = initial_messages
         iteration = 0
         final_content = None
         tools_used: list[str] = []
+        llm_error_retries = 0
+        streamed_text = ""
+        last_stream_preview = ""
+
+        async def _on_text_delta(delta: str) -> None:
+            nonlocal streamed_text, last_stream_preview
+            if not on_progress or not stream_text_progress or not delta:
+                return
+            streamed_text += delta
+            clean = self._strip_think(streamed_text)
+            if not clean or clean == last_stream_preview:
+                return
+            last_stream_preview = clean
+            await on_progress(clean, replace=True)
 
         while iteration < self.max_iterations:
             iteration += 1
+            streamed_text = ""
+            last_stream_preview = ""
 
             response = await self.provider.chat(
                 messages=messages,
@@ -198,13 +234,14 @@ class AgentLoop:
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
                 reasoning_effort=self.reasoning_effort,
+                on_text_delta=_on_text_delta if stream_text_progress else None,
             )
 
             if response.has_tool_calls:
                 if on_progress:
-                    thought = self._strip_think(response.content)
-                    if thought:
-                        await on_progress(thought)
+                    clean = self._strip_think(response.content)
+                    if clean and not response.streamed_output:
+                        await on_progress(clean)
                     await on_progress(self._tool_hint(response.tool_calls), tool_hint=True)
 
                 tool_call_dicts = [
@@ -238,7 +275,24 @@ class AgentLoop:
                 # poison the context and cause permanent 400 loops (#1303).
                 if response.finish_reason == "error":
                     logger.error("LLM returned error: {}", (clean or "")[:200])
-                    final_content = clean or "Sorry, I encountered an error calling the AI model."
+                    if (
+                        llm_error_retries < self._MAX_LLM_ERROR_RETRIES
+                        and self._is_retryable_llm_error(clean)
+                    ):
+                        llm_error_retries += 1
+                        delay = 0.8 * (2 ** (llm_error_retries - 1))
+                        logger.warning(
+                            "Retrying transient LLM failure {}/{} in {:.1f}s",
+                            llm_error_retries,
+                            self._MAX_LLM_ERROR_RETRIES,
+                            delay,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                    final_content = (
+                        "Upstream model is temporarily unavailable (502/timeout). "
+                        "Please retry in 10-30 seconds."
+                    )
                     break
                 messages = self.context.add_assistant_message(
                     messages, clean, reasoning_content=response.reasoning_content,
@@ -424,16 +478,25 @@ class AgentLoop:
             channel=msg.channel, chat_id=msg.chat_id,
         )
 
-        async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
+        async def _bus_progress(
+            content: str,
+            *,
+            tool_hint: bool = False,
+            replace: bool = False,
+        ) -> None:
             meta = dict(msg.metadata or {})
             meta["_progress"] = True
             meta["_tool_hint"] = tool_hint
+            if replace:
+                meta["_progress_mode"] = "replace"
             await self.bus.publish_outbound(OutboundMessage(
                 channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
             ))
 
         final_content, _, all_msgs = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
+            initial_messages,
+            on_progress=on_progress or _bus_progress,
+            stream_text_progress=(msg.channel == "telegram"),
         )
 
         if final_content is None:
@@ -500,7 +563,7 @@ class AgentLoop:
         session_key: str = "cli:direct",
         channel: str = "cli",
         chat_id: str = "direct",
-        on_progress: Callable[[str], Awaitable[None]] | None = None,
+        on_progress: Callable[..., Awaitable[None]] | None = None,
     ) -> str:
         """Process a message directly (for CLI or cron usage)."""
         await self._connect_mcp()

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -180,6 +180,10 @@ class TelegramChannel(BaseChannel):
         self._media_group_tasks: dict[str, asyncio.Task] = {}
         self._message_threads: dict[tuple[str, int], int] = {}
         self._draft_messages: dict[str, int] = {}
+        self._draft_last_text: dict[str, str] = {}
+        self._draft_pending_text: dict[str, str] = {}
+        self._draft_flush_tasks: dict[str, asyncio.Task] = {}
+        self._draft_edit_interval = 0.4
 
     def is_allowed(self, sender_id: str) -> bool:
         """Preserve Telegram's legacy id|username allowlist matching."""
@@ -272,6 +276,9 @@ class TelegramChannel(BaseChannel):
             task.cancel()
         self._media_group_tasks.clear()
         self._media_group_buffers.clear()
+        for task in self._draft_flush_tasks.values():
+            task.cancel()
+        self._draft_flush_tasks.clear()
 
         if self._app:
             logger.info("Stopping Telegram bot...")
@@ -280,6 +287,9 @@ class TelegramChannel(BaseChannel):
             await self._app.shutdown()
             self._app = None
         self._draft_messages.clear()
+        self._draft_last_text.clear()
+        self._draft_pending_text.clear()
+
     @staticmethod
     def _get_media_type(path: str) -> str:
         """Guess media type from file extension."""
@@ -358,6 +368,11 @@ class TelegramChannel(BaseChannel):
     async def _clear_draft_message(self, chat_key: str, chat_id: int) -> None:
         if not self._app:
             return
+        task = self._draft_flush_tasks.pop(chat_key, None)
+        if task:
+            task.cancel()
+        self._draft_pending_text.pop(chat_key, None)
+        self._draft_last_text.pop(chat_key, None)
         message_id = self._draft_messages.pop(chat_key, None)
         if message_id is None:
             return
@@ -365,6 +380,44 @@ class TelegramChannel(BaseChannel):
             await self._app.bot.delete_message(chat_id=chat_id, message_id=message_id)
         except Exception as e:
             logger.debug("Failed to delete Telegram draft message {}:{}: {}", chat_id, message_id, e)
+
+    def _queue_draft_update(self, chat_key: str, chat_id: int, text: str) -> None:
+        self._draft_pending_text[chat_key] = text
+        task = self._draft_flush_tasks.get(chat_key)
+        if task and not task.done():
+            return
+        self._draft_flush_tasks[chat_key] = asyncio.create_task(self._flush_draft_update(chat_key, chat_id))
+
+    async def _flush_draft_update(
+        self,
+        chat_key: str,
+        chat_id: int,
+        *,
+        immediate: bool = False,
+    ) -> bool:
+        task = asyncio.current_task()
+        try:
+            if not immediate:
+                await asyncio.sleep(self._draft_edit_interval)
+
+            message_id = self._draft_messages.get(chat_key)
+            text = self._draft_pending_text.get(chat_key)
+            if message_id is None or not text:
+                return False
+            if text == self._draft_last_text.get(chat_key):
+                self._draft_pending_text.pop(chat_key, None)
+                return True
+            if await self._edit_text_message(chat_id, message_id, text):
+                self._draft_last_text[chat_key] = text
+                self._draft_pending_text.pop(chat_key, None)
+                return True
+            await self._clear_draft_message(chat_key, chat_id)
+            return False
+        except asyncio.CancelledError:
+            raise
+        finally:
+            if self._draft_flush_tasks.get(chat_key) is task:
+                self._draft_flush_tasks.pop(chat_key, None)
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Telegram."""
@@ -415,10 +468,10 @@ class TelegramChannel(BaseChannel):
                 )
                 if sent_id is not None:
                     self._draft_messages[chat_key] = sent_id
+                    self._draft_last_text[chat_key] = msg.content
                 return
-            if await self._edit_text_message(chat_id, draft_id, msg.content):
-                return
-            await self._clear_draft_message(chat_key, chat_id)
+            self._queue_draft_update(chat_key, chat_id, msg.content)
+            return
 
         if not is_progress and chat_key in self._draft_messages:
             can_finalize_draft = (
@@ -428,10 +481,17 @@ class TelegramChannel(BaseChannel):
                 and len(msg.content) <= 4000
             )
             if can_finalize_draft:
-                draft_id = self._draft_messages.pop(chat_key)
-                if await self._edit_text_message(chat_id, draft_id, msg.content):
+                self._draft_pending_text[chat_key] = msg.content
+                task = self._draft_flush_tasks.pop(chat_key, None)
+                if task:
+                    task.cancel()
+                if await self._flush_draft_update(chat_key, chat_id, immediate=True):
+                    self._draft_messages.pop(chat_key, None)
+                    self._draft_last_text.pop(chat_key, None)
+                    self._draft_pending_text.pop(chat_key, None)
                     return
-                self._draft_messages[chat_key] = draft_id
+                if chat_key in self._draft_messages:
+                    self._draft_last_text[chat_key] = msg.content
             await self._clear_draft_message(chat_key, chat_id)
 
         # Send media files

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -179,6 +179,7 @@ class TelegramChannel(BaseChannel):
         self._media_group_buffers: dict[str, dict] = {}
         self._media_group_tasks: dict[str, asyncio.Task] = {}
         self._message_threads: dict[tuple[str, int], int] = {}
+        self._draft_messages: dict[str, int] = {}
 
     def is_allowed(self, sender_id: str) -> bool:
         """Preserve Telegram's legacy id|username allowlist matching."""
@@ -198,7 +199,6 @@ class TelegramChannel(BaseChannel):
             return False
 
         return sid in allow_list or username in allow_list
-
     async def start(self) -> None:
         """Start the Telegram bot with long polling."""
         if not self.config.token:
@@ -279,7 +279,7 @@ class TelegramChannel(BaseChannel):
             await self._app.stop()
             await self._app.shutdown()
             self._app = None
-
+        self._draft_messages.clear()
     @staticmethod
     def _get_media_type(path: str) -> str:
         """Guess media type from file extension."""
@@ -291,6 +291,80 @@ class TelegramChannel(BaseChannel):
         if ext in ("mp3", "m4a", "wav", "aac"):
             return "audio"
         return "document"
+
+    async def _send_text_message(
+        self,
+        chat_id: int,
+        text: str,
+        *,
+        reply_params: ReplyParameters | None = None,
+        thread_kwargs: dict | None = None,
+    ) -> int | None:
+        if not self._app:
+            return None
+        try:
+            html = _markdown_to_telegram_html(text)
+            sent = await self._app.bot.send_message(
+                chat_id=chat_id,
+                text=html,
+                parse_mode="HTML",
+                reply_parameters=reply_params,
+                **(thread_kwargs or {}),
+            )
+        except Exception as e:
+            logger.warning("HTML parse failed, falling back to plain text: {}", e)
+            try:
+                sent = await self._app.bot.send_message(
+                    chat_id=chat_id,
+                    text=text,
+                    reply_parameters=reply_params,
+                    **(thread_kwargs or {}),
+                )
+            except Exception as e2:
+                logger.error("Error sending Telegram message: {}", e2)
+                return None
+        return getattr(sent, "message_id", None)
+
+    async def _edit_text_message(
+        self,
+        chat_id: int,
+        message_id: int,
+        text: str,
+    ) -> bool:
+        if not self._app:
+            return False
+        try:
+            html = _markdown_to_telegram_html(text)
+            await self._app.bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=message_id,
+                text=html,
+                parse_mode="HTML",
+            )
+            return True
+        except Exception as e:
+            logger.warning("Telegram draft HTML edit failed, falling back to plain text: {}", e)
+            try:
+                await self._app.bot.edit_message_text(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    text=text,
+                )
+                return True
+            except Exception as e2:
+                logger.error("Error editing Telegram draft message: {}", e2)
+                return False
+
+    async def _clear_draft_message(self, chat_key: str, chat_id: int) -> None:
+        if not self._app:
+            return
+        message_id = self._draft_messages.pop(chat_key, None)
+        if message_id is None:
+            return
+        try:
+            await self._app.bot.delete_message(chat_id=chat_id, message_id=message_id)
+        except Exception as e:
+            logger.debug("Failed to delete Telegram draft message {}:{}: {}", chat_id, message_id, e)
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Telegram."""
@@ -314,6 +388,13 @@ class TelegramChannel(BaseChannel):
         thread_kwargs = {}
         if message_thread_id is not None:
             thread_kwargs["message_thread_id"] = message_thread_id
+        chat_key = msg.chat_id
+        is_progress = bool(msg.metadata.get("_progress"))
+        use_draft_stream = (
+            is_progress
+            and not msg.metadata.get("_tool_hint")
+            and msg.metadata.get("_progress_mode") == "replace"
+        )
 
         reply_params = None
         if self.config.reply_to_message:
@@ -322,6 +403,36 @@ class TelegramChannel(BaseChannel):
                     message_id=reply_to_message_id,
                     allow_sending_without_reply=True
                 )
+
+        if use_draft_stream and msg.content and len(msg.content) <= 4000:
+            draft_id = self._draft_messages.get(chat_key)
+            if draft_id is None:
+                sent_id = await self._send_text_message(
+                    chat_id,
+                    msg.content,
+                    reply_params=reply_params,
+                    thread_kwargs=thread_kwargs,
+                )
+                if sent_id is not None:
+                    self._draft_messages[chat_key] = sent_id
+                return
+            if await self._edit_text_message(chat_id, draft_id, msg.content):
+                return
+            await self._clear_draft_message(chat_key, chat_id)
+
+        if not is_progress and chat_key in self._draft_messages:
+            can_finalize_draft = (
+                not msg.media
+                and msg.content
+                and msg.content != "[empty message]"
+                and len(msg.content) <= 4000
+            )
+            if can_finalize_draft:
+                draft_id = self._draft_messages.pop(chat_key)
+                if await self._edit_text_message(chat_id, draft_id, msg.content):
+                    return
+                self._draft_messages[chat_key] = draft_id
+            await self._clear_draft_message(chat_key, chat_id)
 
         # Send media files
         for media_path in (msg.media or []):
@@ -352,65 +463,13 @@ class TelegramChannel(BaseChannel):
 
         # Send text content
         if msg.content and msg.content != "[empty message]":
-            is_progress = msg.metadata.get("_progress", False)
-
             for chunk in split_message(msg.content, TELEGRAM_MAX_MESSAGE_LEN):
-                # Final response: simulate streaming via draft, then persist
-                if not is_progress:
-                    await self._send_with_streaming(chat_id, chunk, reply_params, thread_kwargs)
-                else:
-                    await self._send_text(chat_id, chunk, reply_params, thread_kwargs)
-
-    async def _send_text(
-        self,
-        chat_id: int,
-        text: str,
-        reply_params=None,
-        thread_kwargs: dict | None = None,
-    ) -> None:
-        """Send a plain text message with HTML fallback."""
-        try:
-            html = _markdown_to_telegram_html(text)
-            await self._app.bot.send_message(
-                chat_id=chat_id, text=html, parse_mode="HTML",
-                reply_parameters=reply_params,
-                **(thread_kwargs or {}),
-            )
-        except Exception as e:
-            logger.warning("HTML parse failed, falling back to plain text: {}", e)
-            try:
-                await self._app.bot.send_message(
-                    chat_id=chat_id,
-                    text=text,
-                    reply_parameters=reply_params,
-                    **(thread_kwargs or {}),
+                await self._send_text_message(
+                    chat_id,
+                    chunk,
+                    reply_params=reply_params,
+                    thread_kwargs=thread_kwargs,
                 )
-            except Exception as e2:
-                logger.error("Error sending Telegram message: {}", e2)
-
-    async def _send_with_streaming(
-        self,
-        chat_id: int,
-        text: str,
-        reply_params=None,
-        thread_kwargs: dict | None = None,
-    ) -> None:
-        """Simulate streaming via send_message_draft, then persist with send_message."""
-        draft_id = int(time.time() * 1000) % (2**31)
-        try:
-            step = max(len(text) // 8, 40)
-            for i in range(step, len(text), step):
-                await self._app.bot.send_message_draft(
-                    chat_id=chat_id, draft_id=draft_id, text=text[:i],
-                )
-                await asyncio.sleep(0.04)
-            await self._app.bot.send_message_draft(
-                chat_id=chat_id, draft_id=draft_id, text=text,
-            )
-            await asyncio.sleep(0.15)
-        except Exception:
-            pass
-        await self._send_text(chat_id, text, reply_params, thread_kwargs)
 
     async def _on_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /start command."""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -534,7 +534,12 @@ def agent(
         # Animated spinner is safe to use with prompt_toolkit input handling
         return console.status("[dim]nanobot is thinking...[/dim]", spinner="dots")
 
-    async def _cli_progress(content: str, *, tool_hint: bool = False) -> None:
+    async def _cli_progress(
+        content: str,
+        *,
+        tool_hint: bool = False,
+        replace: bool = False,
+    ) -> None:
         ch = agent_loop.channels_config
         if ch and tool_hint and not ch.send_tool_hints:
             return

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -2,7 +2,10 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Awaitable, Callable
+
+
+TextDeltaHandler = Callable[[str], Awaitable[None]]
 
 
 @dataclass
@@ -22,6 +25,7 @@ class LLMResponse:
     usage: dict[str, int] = field(default_factory=dict)
     reasoning_content: str | None = None  # Kimi, DeepSeek-R1 etc.
     thinking_blocks: list[dict] | None = None  # Anthropic extended thinking
+    streamed_output: bool = False
     
     @property
     def has_tool_calls(self) -> bool:
@@ -110,6 +114,7 @@ class LLMProvider(ABC):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        on_text_delta: TextDeltaHandler | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request.

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -129,6 +129,11 @@ class CustomProvider(LLMProvider):
                 content += text_delta
                 await on_text_delta(text_delta)
                 streamed_output = True
+            else:
+                reasoning_delta = getattr(delta, "reasoning_content", None)
+                if reasoning_delta:
+                    await on_text_delta(reasoning_delta)
+                    streamed_output = True
 
             for tc in getattr(delta, "tool_calls", None) or []:
                 index = getattr(tc, "index", 0) or 0
@@ -195,6 +200,11 @@ class CustomProvider(LLMProvider):
                     content += text_delta
                     await on_text_delta(text_delta)
                     streamed_output = True
+                else:
+                    reasoning_delta = delta.get("reasoning_content")
+                    if reasoning_delta:
+                        await on_text_delta(reasoning_delta)
+                        streamed_output = True
 
                 for tc in delta.get("tool_calls") or []:
                     index = tc.get("index", 0) or 0

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any
 
+import httpx
 import json_repair
 from openai import AsyncOpenAI
 
@@ -25,9 +27,12 @@ class CustomProvider(LLMProvider):
 
     async def chat(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
                    model: str | None = None, max_tokens: int = 4096, temperature: float = 0.7,
-                   reasoning_effort: str | None = None) -> LLMResponse:
+                   reasoning_effort: str | None = None, on_text_delta=None) -> LLMResponse:
+        upstream_model = model or self.default_model
+        if isinstance(upstream_model, str) and upstream_model.startswith("custom/"):
+            upstream_model = upstream_model.split("/", 1)[1]
         kwargs: dict[str, Any] = {
-            "model": model or self.default_model,
+            "model": upstream_model,
             "messages": self._sanitize_empty_content(messages),
             "max_tokens": max(1, max_tokens),
             "temperature": temperature,
@@ -37,10 +42,197 @@ class CustomProvider(LLMProvider):
         if tools:
             kwargs.update(tools=tools, tool_choice="auto")
         try:
+            if on_text_delta:
+                return await self._stream_via_sdk(kwargs, on_text_delta)
             return self._parse(await self._client.chat.completions.create(**kwargs))
         except Exception as e:
+            fallback = await self._chat_via_http(kwargs, on_text_delta=on_text_delta)
+            if fallback is not None:
+                return fallback
             return LLMResponse(content=f"Error: {e}", finish_reason="error")
 
+    async def _stream_via_sdk(self, kwargs: dict[str, Any], on_text_delta) -> LLMResponse:
+        stream = await self._client.chat.completions.create(stream=True, **kwargs)
+        return await self._consume_openai_stream(stream, on_text_delta=on_text_delta)
+
+    async def _chat_via_http(self, kwargs: dict[str, Any], on_text_delta=None) -> LLMResponse | None:
+        """Fallback for OpenAI-compatible endpoints that reject the official SDK."""
+        try:
+            base = (self.api_base or "").rstrip("/")
+            if not base:
+                return None
+            url = f"{base}/chat/completions"
+            request_kwargs = dict(kwargs)
+            if on_text_delta:
+                request_kwargs["stream"] = True
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            }
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                if on_text_delta:
+                    async with client.stream("POST", url, headers=headers, json=request_kwargs) as resp:
+                        resp.raise_for_status()
+                        return await self._consume_http_stream(resp, on_text_delta=on_text_delta)
+                resp = await client.post(url, headers=headers, json=request_kwargs)
+                resp.raise_for_status()
+                data = resp.json()
+
+            choice = (data.get("choices") or [{}])[0]
+            message = choice.get("message") or {}
+            tool_calls = []
+            for tc in message.get("tool_calls") or []:
+                function = tc.get("function") or {}
+                arguments = function.get("arguments") or {}
+                if isinstance(arguments, str):
+                    arguments = json_repair.loads(arguments)
+                tool_calls.append(
+                    ToolCallRequest(
+                        id=tc.get("id", ""),
+                        name=function.get("name", ""),
+                        arguments=arguments,
+                    )
+                )
+
+            usage = data.get("usage") or {}
+            return LLMResponse(
+                content=message.get("content"),
+                tool_calls=tool_calls,
+                finish_reason=choice.get("finish_reason") or "stop",
+                usage={
+                    "prompt_tokens": usage.get("prompt_tokens", 0),
+                    "completion_tokens": usage.get("completion_tokens", 0),
+                    "total_tokens": usage.get("total_tokens", 0),
+                },
+                reasoning_content=message.get("reasoning_content"),
+            )
+        except Exception:
+            return None
+
+    async def _consume_openai_stream(self, stream: Any, on_text_delta) -> LLMResponse:
+        content = ""
+        finish_reason = "stop"
+        streamed_output = False
+        tool_call_buffers: dict[int, dict[str, Any]] = {}
+
+        async for chunk in stream:
+            choices = getattr(chunk, "choices", None) or []
+            if not choices:
+                continue
+            choice = choices[0]
+            delta = getattr(choice, "delta", None)
+            if delta is None:
+                continue
+
+            text_delta = getattr(delta, "content", None)
+            if text_delta:
+                content += text_delta
+                await on_text_delta(text_delta)
+                streamed_output = True
+
+            for tc in getattr(delta, "tool_calls", None) or []:
+                index = getattr(tc, "index", 0) or 0
+                buf = tool_call_buffers.setdefault(index, {"id": "", "name": "", "arguments": ""})
+                if getattr(tc, "id", None):
+                    buf["id"] = tc.id
+                fn = getattr(tc, "function", None)
+                if fn is not None:
+                    if getattr(fn, "name", None):
+                        buf["name"] = fn.name
+                    if getattr(fn, "arguments", None):
+                        buf["arguments"] += fn.arguments
+
+            if getattr(choice, "finish_reason", None):
+                finish_reason = choice.finish_reason or "stop"
+
+        tool_calls: list[ToolCallRequest] = []
+        for buf in tool_call_buffers.values():
+            raw_arguments = buf["arguments"] or "{}"
+            try:
+                arguments = json_repair.loads(raw_arguments)
+            except Exception:
+                arguments = {"raw": raw_arguments}
+            tool_calls.append(
+                ToolCallRequest(
+                    id=buf["id"] or "",
+                    name=buf["name"] or "",
+                    arguments=arguments,
+                )
+            )
+
+        return LLMResponse(
+            content=content,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            streamed_output=streamed_output,
+        )
+
+    async def _consume_http_stream(self, response: httpx.Response, on_text_delta) -> LLMResponse:
+        content = ""
+        finish_reason = "stop"
+        streamed_output = False
+        tool_call_buffers: dict[int, dict[str, Any]] = {}
+        buffer: list[str] = []
+
+        async for line in response.aiter_lines():
+            if line == "":
+                if not buffer:
+                    continue
+                data_lines = [part[5:].strip() for part in buffer if part.startswith("data:")]
+                buffer = []
+                payload = "\n".join(data_lines).strip()
+                if not payload or payload == "[DONE]":
+                    continue
+                try:
+                    event = json.loads(payload)
+                except Exception:
+                    continue
+
+                choice = (event.get("choices") or [{}])[0]
+                delta = choice.get("delta") or {}
+                text_delta = delta.get("content")
+                if text_delta:
+                    content += text_delta
+                    await on_text_delta(text_delta)
+                    streamed_output = True
+
+                for tc in delta.get("tool_calls") or []:
+                    index = tc.get("index", 0) or 0
+                    buf = tool_call_buffers.setdefault(index, {"id": "", "name": "", "arguments": ""})
+                    if tc.get("id"):
+                        buf["id"] = tc["id"]
+                    fn = tc.get("function") or {}
+                    if fn.get("name"):
+                        buf["name"] = fn["name"]
+                    if fn.get("arguments"):
+                        buf["arguments"] += fn["arguments"]
+
+                if choice.get("finish_reason"):
+                    finish_reason = choice["finish_reason"]
+                continue
+            buffer.append(line)
+
+        tool_calls: list[ToolCallRequest] = []
+        for buf in tool_call_buffers.values():
+            raw_arguments = buf["arguments"] or "{}"
+            try:
+                arguments = json_repair.loads(raw_arguments)
+            except Exception:
+                arguments = {"raw": raw_arguments}
+            tool_calls.append(
+                ToolCallRequest(
+                    id=buf["id"] or "",
+                    name=buf["name"] or "",
+                    arguments=arguments,
+                )
+            )
+
+        return LLMResponse(
+            content=content,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            streamed_output=streamed_output,
+        )
     def _parse(self, response: Any) -> LLMResponse:
         choice = response.choices[0]
         msg = choice.message
@@ -58,4 +250,3 @@ class CustomProvider(LLMProvider):
 
     def get_default_model(self) -> str:
         return self.default_model
-

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -257,10 +257,20 @@ class LiteLLMProvider(LLMProvider):
         # Pass api_base for custom endpoints
         if self.api_base:
             kwargs["api_base"] = self.api_base
-
-        # Pass extra headers (e.g. APP-Code for AiHubMix)
-        if self.extra_headers:
-            kwargs["extra_headers"] = self.extra_headers
+        
+        # Use provided extra headers or start empty
+        headers = dict(self.extra_headers) if self.extra_headers else {}
+        
+        # WORKAROUND: The Zhipu `coding/paas/v4` endpoint explicitly blocks requests with 'OpenAI' or 'Python'
+        # in the User-Agent, returning a fake Rate Limit Error. Spoof it as curl.
+        if "coding/paas/v4" in (self.api_base or ""):
+            headers["User-Agent"] = "curl/8.7.1"
+            
+        if headers:
+            # For OpenAI client specifically, we need to inject into `extra_headers`
+            kwargs["extra_headers"] = headers
+            # Also globally set litellm headers override just in case the backend client rebuilds
+            litellm.headers = headers
         
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
@@ -271,6 +281,31 @@ class LiteLLMProvider(LLMProvider):
             kwargs["tool_choice"] = "auto"
 
         try:
+            if on_text_delta:
+                stream_kwargs = dict(kwargs)
+                stream_kwargs["stream"] = True
+                response_stream = await acompletion(**stream_kwargs)
+                chunks: list[Any] = []
+                streamed_output = False
+
+                async for chunk in response_stream:
+                    chunks.append(chunk)
+                    try:
+                        delta = chunk.choices[0].delta
+                    except Exception:
+                        continue
+                    text_delta = getattr(delta, "content", None)
+                    if text_delta:
+                        await on_text_delta(text_delta)
+                        streamed_output = True
+
+                response = litellm.stream_chunk_builder(chunks=chunks, messages=kwargs["messages"])
+                if response is None:
+                    return LLMResponse(content="", streamed_output=streamed_output)
+                parsed = self._parse_response(response)
+                parsed.streamed_output = streamed_output
+                return parsed
+
             response = await acompletion(**kwargs)
             return self._parse_response(response)
         except Exception as e:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -214,6 +214,7 @@ class LiteLLMProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        on_text_delta=None,
     ) -> LLMResponse:
         """
         Send a chat completion request via LiteLLM.

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -32,6 +32,7 @@ class OpenAICodexProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        on_text_delta=None,
     ) -> LLMResponse:
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)
@@ -62,16 +63,21 @@ class OpenAICodexProvider(LLMProvider):
 
         try:
             try:
-                content, tool_calls, finish_reason = await _request_codex(url, headers, body, verify=True)
+                content, tool_calls, finish_reason, streamed_output = await _request_codex(
+                    url, headers, body, verify=True, on_text_delta=on_text_delta,
+                )
             except Exception as e:
                 if "CERTIFICATE_VERIFY_FAILED" not in str(e):
                     raise
                 logger.warning("SSL certificate verification failed for Codex API; retrying with verify=False")
-                content, tool_calls, finish_reason = await _request_codex(url, headers, body, verify=False)
+                content, tool_calls, finish_reason, streamed_output = await _request_codex(
+                    url, headers, body, verify=False, on_text_delta=on_text_delta,
+                )
             return LLMResponse(
                 content=content,
                 tool_calls=tool_calls,
                 finish_reason=finish_reason,
+                streamed_output=streamed_output,
             )
         except Exception as e:
             return LLMResponse(
@@ -106,13 +112,14 @@ async def _request_codex(
     headers: dict[str, str],
     body: dict[str, Any],
     verify: bool,
-) -> tuple[str, list[ToolCallRequest], str]:
+    on_text_delta=None,
+) -> tuple[str, list[ToolCallRequest], str, bool]:
     async with httpx.AsyncClient(timeout=60.0, verify=verify) as client:
         async with client.stream("POST", url, headers=headers, json=body) as response:
             if response.status_code != 200:
                 text = await response.aread()
                 raise RuntimeError(_friendly_error(response.status_code, text.decode("utf-8", "ignore")))
-            return await _consume_sse(response)
+            return await _consume_sse(response, on_text_delta=on_text_delta)
 
 
 def _convert_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -246,11 +253,15 @@ async def _iter_sse(response: httpx.Response) -> AsyncGenerator[dict[str, Any], 
         buffer.append(line)
 
 
-async def _consume_sse(response: httpx.Response) -> tuple[str, list[ToolCallRequest], str]:
+async def _consume_sse(
+    response: httpx.Response,
+    on_text_delta=None,
+) -> tuple[str, list[ToolCallRequest], str, bool]:
     content = ""
     tool_calls: list[ToolCallRequest] = []
     tool_call_buffers: dict[str, dict[str, Any]] = {}
     finish_reason = "stop"
+    streamed_output = False
 
     async for event in _iter_sse(response):
         event_type = event.get("type")
@@ -266,7 +277,11 @@ async def _consume_sse(response: httpx.Response) -> tuple[str, list[ToolCallRequ
                     "arguments": item.get("arguments") or "",
                 }
         elif event_type == "response.output_text.delta":
-            content += event.get("delta") or ""
+            delta = event.get("delta") or ""
+            content += delta
+            if delta and on_text_delta:
+                await on_text_delta(delta)
+                streamed_output = True
         elif event_type == "response.function_call_arguments.delta":
             call_id = event.get("call_id")
             if call_id and call_id in tool_call_buffers:
@@ -300,7 +315,7 @@ async def _consume_sse(response: httpx.Response) -> tuple[str, list[ToolCallRequ
         elif event_type in {"error", "response.failed"}:
             raise RuntimeError("Codex response failed")
 
-    return content, tool_calls, finish_reason
+    return content, tool_calls, finish_reason, streamed_output
 
 
 _FINISH_REASON_MAP = {"completed": "stop", "incomplete": "length", "failed": "error", "cancelled": "error"}

--- a/tests/test_streaming_output.py
+++ b/tests/test_streaming_output.py
@@ -10,6 +10,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.channels.telegram import TelegramChannel
 from nanobot.config.schema import TelegramConfig
 from nanobot.providers.base import LLMResponse
+from nanobot.providers.litellm_provider import LiteLLMProvider
 from nanobot.providers.openai_codex_provider import _consume_sse
 
 
@@ -105,6 +106,45 @@ async def test_agent_loop_emits_replace_progress_for_streamed_text() -> None:
 
     assert final_content == "Hello"
     assert progress_calls == [("Hel", True), ("Hello", True)]
+
+
+@pytest.mark.asyncio
+async def test_litellm_provider_streams_text_deltas() -> None:
+    provider = LiteLLMProvider(api_key="test", default_model="openai/gpt-4o-mini")
+    deltas: list[str] = []
+
+    async def _on_text_delta(delta: str) -> None:
+        deltas.append(delta)
+
+    async def _fake_acompletion(**kwargs):
+        if kwargs.get("stream"):
+            async def _gen():
+                yield SimpleNamespace(
+                    choices=[SimpleNamespace(delta=SimpleNamespace(content="Hel"))]
+                )
+                yield SimpleNamespace(
+                    choices=[SimpleNamespace(delta=SimpleNamespace(content="lo"))]
+                )
+            return _gen()
+        raise AssertionError("expected streaming path")
+
+    built_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Hello", tool_calls=None), finish_reason="stop")],
+        usage=None,
+    )
+
+    with (
+        patch("nanobot.providers.litellm_provider.acompletion", new=_fake_acompletion),
+        patch("nanobot.providers.litellm_provider.litellm.stream_chunk_builder", return_value=built_response),
+    ):
+        response = await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            on_text_delta=_on_text_delta,
+        )
+
+    assert deltas == ["Hel", "lo"]
+    assert response.content == "Hello"
+    assert response.streamed_output is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming_output.py
+++ b/tests/test_streaming_output.py
@@ -186,6 +186,46 @@ async def test_custom_provider_streams_text_deltas() -> None:
 
 
 @pytest.mark.asyncio
+async def test_custom_provider_streams_reasoning_deltas_before_content() -> None:
+    provider = CustomProvider(api_key="test", api_base="http://localhost:8000/v1", default_model="glm-5")
+    deltas: list[str] = []
+
+    async def _on_text_delta(delta: str) -> None:
+        deltas.append(delta)
+
+    async def _fake_stream_create(**kwargs):
+        assert kwargs["stream"] is True
+
+        async def _gen():
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content=None, reasoning_content="Thinking "), finish_reason=None)]
+            )
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content=None, reasoning_content="through it"), finish_reason=None)]
+            )
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content="OK", reasoning_content=None), finish_reason="stop")]
+            )
+
+        return _gen()
+
+    provider._client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=_fake_stream_create)
+        )
+    )
+
+    response = await provider.chat(
+        messages=[{"role": "user", "content": "hello"}],
+        on_text_delta=_on_text_delta,
+    )
+
+    assert deltas == ["Thinking ", "through it", "OK"]
+    assert response.content == "OK"
+    assert response.streamed_output is True
+
+
+@pytest.mark.asyncio
 async def test_telegram_reuses_draft_message_for_streaming_reply() -> None:
     channel = TelegramChannel(TelegramConfig(enabled=True, token="test"), MessageBus())
     bot = SimpleNamespace(

--- a/tests/test_streaming_output.py
+++ b/tests/test_streaming_output.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -228,6 +229,7 @@ async def test_custom_provider_streams_reasoning_deltas_before_content() -> None
 @pytest.mark.asyncio
 async def test_telegram_reuses_draft_message_for_streaming_reply() -> None:
     channel = TelegramChannel(TelegramConfig(enabled=True, token="test"), MessageBus())
+    channel._draft_edit_interval = 0.01
     bot = SimpleNamespace(
         send_message=AsyncMock(return_value=SimpleNamespace(message_id=42)),
         edit_message_text=AsyncMock(return_value=True),
@@ -264,5 +266,54 @@ async def test_telegram_reuses_draft_message_for_streaming_reply() -> None:
     )
 
     assert bot.send_message.await_count == 1
-    assert bot.edit_message_text.await_count == 2
+    assert bot.edit_message_text.await_count == 1
     assert bot.delete_message.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_telegram_coalesces_streaming_edits() -> None:
+    channel = TelegramChannel(TelegramConfig(enabled=True, token="test"), MessageBus())
+    channel._draft_edit_interval = 0.05
+    bot = SimpleNamespace(
+        send_message=AsyncMock(return_value=SimpleNamespace(message_id=42)),
+        edit_message_text=AsyncMock(return_value=True),
+        delete_message=AsyncMock(return_value=True),
+        send_photo=AsyncMock(),
+        send_voice=AsyncMock(),
+        send_audio=AsyncMock(),
+        send_document=AsyncMock(),
+    )
+    channel._app = SimpleNamespace(bot=bot)
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="Hel",
+            metadata={"_progress": True, "_progress_mode": "replace"},
+        )
+    )
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="Hell",
+            metadata={"_progress": True, "_progress_mode": "replace"},
+        )
+    )
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="Hello",
+            metadata={"_progress": True, "_progress_mode": "replace"},
+        )
+    )
+
+    assert bot.send_message.await_count == 1
+    assert bot.edit_message_text.await_count == 0
+
+    await asyncio.sleep(0.08)
+
+    assert bot.edit_message_text.await_count == 1
+    assert bot.edit_message_text.await_args_list[0].kwargs["text"] == "Hello"

--- a/tests/test_streaming_output.py
+++ b/tests/test_streaming_output.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.telegram import TelegramChannel
+from nanobot.config.schema import TelegramConfig
+from nanobot.providers.base import LLMResponse
+from nanobot.providers.openai_codex_provider import _consume_sse
+
+
+class _FakeSSELikeResponse:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+class _StreamingProvider:
+    def get_default_model(self) -> str:
+        return "openai-codex/gpt-5.1-codex"
+
+    async def chat(self, *args, **kwargs) -> LLMResponse:
+        on_text_delta = kwargs.get("on_text_delta")
+        if on_text_delta:
+            await on_text_delta("Hel")
+            await on_text_delta("lo")
+        return LLMResponse(content="Hello", streamed_output=True)
+
+
+def _make_agent_loop(provider):
+    from nanobot.agent.loop import AgentLoop
+
+    bus = MessageBus()
+    workspace = MagicMock()
+    workspace.__truediv__ = MagicMock(return_value=MagicMock())
+
+    with (
+        patch("nanobot.agent.loop.ContextBuilder") as mock_context_builder,
+        patch("nanobot.agent.loop.SessionManager"),
+        patch("nanobot.agent.loop.SubagentManager") as mock_sub_mgr,
+    ):
+        mock_sub_mgr.return_value.cancel_by_session = AsyncMock(return_value=0)
+        mock_context = mock_context_builder.return_value
+        mock_context.add_assistant_message.side_effect = (
+            lambda messages, content, *args, **kwargs: messages + [{"role": "assistant", "content": content}]
+        )
+        loop = AgentLoop(bus=bus, provider=provider, workspace=workspace)
+
+    loop.context_editor = SimpleNamespace(prepare=lambda messages: messages)
+    loop.tools.get_definitions = MagicMock(return_value=[])
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_codex_sse_forwards_text_deltas() -> None:
+    deltas: list[str] = []
+
+    async def _on_text_delta(delta: str) -> None:
+        deltas.append(delta)
+
+    response = _FakeSSELikeResponse(
+        [
+            'data: {"type":"response.output_text.delta","delta":"Hel"}',
+            "",
+            'data: {"type":"response.output_text.delta","delta":"lo"}',
+            "",
+            'data: {"type":"response.completed","response":{"status":"completed"}}',
+            "",
+        ]
+    )
+
+    content, tool_calls, finish_reason, streamed_output = await _consume_sse(
+        response,
+        on_text_delta=_on_text_delta,
+    )
+
+    assert content == "Hello"
+    assert tool_calls == []
+    assert finish_reason == "stop"
+    assert streamed_output is True
+    assert deltas == ["Hel", "lo"]
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_emits_replace_progress_for_streamed_text() -> None:
+    loop = _make_agent_loop(_StreamingProvider())
+    progress_calls: list[tuple[str, bool]] = []
+
+    async def _on_progress(content: str, *, replace: bool = False, tool_hint: bool = False) -> None:
+        assert tool_hint is False
+        progress_calls.append((content, replace))
+
+    final_content, _, _ = await loop._run_agent_loop(
+        [{"role": "user", "content": "hello"}],
+        on_progress=_on_progress,
+        stream_text_progress=True,
+    )
+
+    assert final_content == "Hello"
+    assert progress_calls == [("Hel", True), ("Hello", True)]
+
+
+@pytest.mark.asyncio
+async def test_telegram_reuses_draft_message_for_streaming_reply() -> None:
+    channel = TelegramChannel(TelegramConfig(enabled=True, token="test"), MessageBus())
+    bot = SimpleNamespace(
+        send_message=AsyncMock(return_value=SimpleNamespace(message_id=42)),
+        edit_message_text=AsyncMock(return_value=True),
+        delete_message=AsyncMock(return_value=True),
+        send_photo=AsyncMock(),
+        send_voice=AsyncMock(),
+        send_audio=AsyncMock(),
+        send_document=AsyncMock(),
+    )
+    channel._app = SimpleNamespace(bot=bot)
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="Hel",
+            metadata={"_progress": True, "_progress_mode": "replace"},
+        )
+    )
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="Hello",
+            metadata={"_progress": True, "_progress_mode": "replace"},
+        )
+    )
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="Hello world",
+        )
+    )
+
+    assert bot.send_message.await_count == 1
+    assert bot.edit_message_text.await_count == 2
+    assert bot.delete_message.await_count == 0

--- a/tests/test_streaming_output.py
+++ b/tests/test_streaming_output.py
@@ -10,6 +10,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.channels.telegram import TelegramChannel
 from nanobot.config.schema import TelegramConfig
 from nanobot.providers.base import LLMResponse
+from nanobot.providers.custom_provider import CustomProvider
 from nanobot.providers.litellm_provider import LiteLLMProvider
 from nanobot.providers.openai_codex_provider import _consume_sse
 
@@ -141,6 +142,43 @@ async def test_litellm_provider_streams_text_deltas() -> None:
             messages=[{"role": "user", "content": "hello"}],
             on_text_delta=_on_text_delta,
         )
+
+    assert deltas == ["Hel", "lo"]
+    assert response.content == "Hello"
+    assert response.streamed_output is True
+
+
+@pytest.mark.asyncio
+async def test_custom_provider_streams_text_deltas() -> None:
+    provider = CustomProvider(api_key="test", api_base="http://localhost:8000/v1", default_model="custom/test")
+    deltas: list[str] = []
+
+    async def _on_text_delta(delta: str) -> None:
+        deltas.append(delta)
+
+    async def _fake_stream_create(**kwargs):
+        assert kwargs["stream"] is True
+
+        async def _gen():
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content="Hel", tool_calls=None), finish_reason=None)]
+            )
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content="lo", tool_calls=None), finish_reason="stop")]
+            )
+
+        return _gen()
+
+    provider._client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=_fake_stream_create)
+        )
+    )
+
+    response = await provider.chat(
+        messages=[{"role": "user", "content": "hello"}],
+        on_text_delta=_on_text_delta,
+    )
 
     assert deltas == ["Hel", "lo"]
     assert response.content == "Hello"


### PR DESCRIPTION
## Summary
- add provider-level text-delta callbacks and stream them through the agent progress bus
- make Telegram reuse and edit a single draft message for replace-mode progress updates
- add custom-provider and GLM reasoning-delta support so OpenAI-compatible upstreams can stream before final content arrives

## Why
Telegram previously received only final complete bubbles for these provider paths. The branch wires streamed deltas end-to-end for:
- OpenAI Codex provider
- LiteLLM provider
- custom OpenAI-compatible provider

It also fixes the GLM-style stream shape where `reasoning_content` arrives before normal `content`, which otherwise made Telegram appear idle for most of the response.

## Key Files
- `nanobot/providers/base.py`
- `nanobot/providers/openai_codex_provider.py`
- `nanobot/providers/litellm_provider.py`
- `nanobot/providers/custom_provider.py`
- `nanobot/agent/loop.py`
- `nanobot/channels/telegram.py`
- `tests/test_streaming_output.py`

## Validation
```bash
uv run --with pytest --with pytest-asyncio pytest tests/test_streaming_output.py
uv run python -m compileall nanobot/providers/base.py nanobot/providers/litellm_provider.py nanobot/providers/openai_codex_provider.py nanobot/providers/custom_provider.py nanobot/agent/loop.py nanobot/cli/commands.py nanobot/channels/telegram.py tests/test_streaming_output.py
```

Results:
- `6 passed`
- `compileall` succeeded
