### PR TITLE
fix: respect NANOBOT_HOME environment variable for multi-instance support

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -1,6 +1,7 @@
 """Configuration loading utilities."""
 
 import json
+import os
 from pathlib import Path
 
 from nanobot.config.schema import Config
@@ -8,6 +9,14 @@ from nanobot.config.schema import Config
 
 # Global variable to store current config path (for multi-instance support)
 _current_config_path: Path | None = None
+
+
+def get_nanobot_home() -> Path:
+    """Get the Nanobot home directory, respecting NANOBOT_HOME environment variable."""
+    env_home = os.environ.get("NANOBOT_HOME")
+    if env_home:
+        return Path(env_home).expanduser()
+    return Path.home() / ".nanobot"
 
 
 def set_config_path(path: Path) -> None:
@@ -20,7 +29,7 @@ def get_config_path() -> Path:
     """Get the configuration file path."""
     if _current_config_path:
         return _current_config_path
-    return Path.home() / ".nanobot" / "config.json"
+    return get_nanobot_home() / "config.json"
 
 
 def load_config(config_path: Path | None = None) -> Config:

--- a/nanobot/config/paths.py
+++ b/nanobot/config/paths.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from nanobot.config.loader import get_config_path
+from nanobot.config.loader import get_config_path, get_nanobot_home
 from nanobot.utils.helpers import ensure_dir
 
 
@@ -36,20 +36,20 @@ def get_logs_dir() -> Path:
 
 def get_workspace_path(workspace: str | None = None) -> Path:
     """Resolve and ensure the agent workspace path."""
-    path = Path(workspace).expanduser() if workspace else Path.home() / ".nanobot" / "workspace"
+    path = Path(workspace).expanduser() if workspace else get_nanobot_home() / "workspace"
     return ensure_dir(path)
 
 
 def get_cli_history_path() -> Path:
     """Return the shared CLI history file path."""
-    return Path.home() / ".nanobot" / "history" / "cli_history"
+    return get_nanobot_home() / "history" / "cli_history"
 
 
 def get_bridge_install_dir() -> Path:
     """Return the shared WhatsApp bridge installation directory."""
-    return Path.home() / ".nanobot" / "bridge"
+    return get_nanobot_home() / "bridge"
 
 
 def get_legacy_sessions_dir() -> Path:
     """Return the legacy global session directory used for migration fallback."""
-    return Path.home() / ".nanobot" / "sessions"
+    return get_nanobot_home() / "sessions"


### PR DESCRIPTION
Fixes #1739

## Problem
On Windows, the NANOBOT_HOME environment variable was being ignored, causing multiple instances to conflict when trying to run simultaneously.

Both instances would default to `C:\Users\<username>\.nanobot\`, resulting in:
- Same config.json being loaded
- Telegram bot token conflicts
- `telegram.error.Conflict` loop

## Solution
Added `get_nanobot_home()` function that:
1. Checks `NANOBOT_HOME` environment variable first
2. Falls back to default `~/.nanobot` if not set

Updated all path helpers to use this function:
- `get_config_path()`
- `get_workspace_path()`
- `get_cli_history_path()`
- `get_bridge_install_dir()`
- `get_legacy_sessions_dir()`

## Testing
- Env var respected when set
- Default behavior unchanged when not set
- Enables multi-instance on Windows

## Files Changed
- `nanobot/config/loader.py` - Added get_nanobot_home()
- `nanobot/config/paths.py` - Use get_nanobot_home() throughout
