### PR TITLE
fix(telegram): add group_mode config field to TelegramConfig

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -33,6 +33,7 @@ class TelegramConfig(Base):
         None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
     )
     reply_to_message: bool = False  # If true, bot replies quote the original message
+    group_mode: Literal["mention", "open"] = "open"  # "mention" = only respond when @mentioned in groups
 
 
 class FeishuConfig(Base):


### PR DESCRIPTION
## Problem

The Telegram channel has code to support \group_mode\ configuration (only respond when @mentioned in groups), but the  Pydantic model is missing this field. This causes the configuration to be silently ignored.

## Solution

Add the missing  field to  schema.

## Changes

- Added  to 

## Behavior

| group_mode | Description |
|------------|-------------|
| \mention\ | Only respond when @mentioned in groups |
| \open\ (default) | Respond to all messages |

## Testing

1. Set  to  in config
2. Start nanobot in a Telegram group
3. Send message without @bot → no response ✅
4. Send message with @bot → bot responds ✅

Fixes the issue where telegram group_mode config was ignored due to missing field in Pydantic model.