### PR TITLE
feat(telegram): support HTTP(S) URLs for media in TelegramChannel

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -19,6 +19,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
+from nanobot.security.network import validate_url_target
 from nanobot.utils.helpers import split_message
 
 TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
@@ -313,6 +314,10 @@ class TelegramChannel(BaseChannel):
             return "audio"
         return "document"
 
+    @staticmethod
+    def _is_remote_media_url(path: str) -> bool:
+        return path.startswith(("http://", "https://"))
+
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Telegram."""
         if not self._app:
@@ -356,7 +361,10 @@ class TelegramChannel(BaseChannel):
                 param = "photo" if media_type == "photo" else media_type if media_type in ("voice", "audio") else "document"
 
                 # Telegram Bot API accepts HTTP(S) URLs directly for media params.
-                if media_path.startswith(("http://", "https://")):
+                if self._is_remote_media_url(media_path):
+                    ok, error = validate_url_target(media_path)
+                    if not ok:
+                        raise ValueError(f"unsafe media URL: {error}")
                     await sender(
                         chat_id=chat_id,
                         **{param: media_path},

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -30,6 +30,7 @@ class _FakeUpdater:
 class _FakeBot:
     def __init__(self) -> None:
         self.sent_messages: list[dict] = []
+        self.sent_media: list[dict] = []
         self.get_me_calls = 0
 
     async def get_me(self):
@@ -41,6 +42,18 @@ class _FakeBot:
 
     async def send_message(self, **kwargs) -> None:
         self.sent_messages.append(kwargs)
+
+    async def send_photo(self, **kwargs) -> None:
+        self.sent_media.append({"kind": "photo", **kwargs})
+
+    async def send_voice(self, **kwargs) -> None:
+        self.sent_media.append({"kind": "voice", **kwargs})
+
+    async def send_audio(self, **kwargs) -> None:
+        self.sent_media.append({"kind": "audio", **kwargs})
+
+    async def send_document(self, **kwargs) -> None:
+        self.sent_media.append({"kind": "document", **kwargs})
 
     async def send_chat_action(self, **kwargs) -> None:
         pass
@@ -229,6 +242,65 @@ async def test_send_reply_infers_topic_from_message_id_cache() -> None:
 
     assert channel._app.bot.sent_messages[0]["message_thread_id"] == 42
     assert channel._app.bot.sent_messages[0]["reply_parameters"].message_id == 10
+
+
+@pytest.mark.asyncio
+async def test_send_remote_media_url_after_security_validation(monkeypatch) -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+    monkeypatch.setattr("nanobot.channels.telegram.validate_url_target", lambda url: (True, ""))
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="",
+            media=["https://example.com/cat.jpg"],
+        )
+    )
+
+    assert channel._app.bot.sent_media == [
+        {
+            "kind": "photo",
+            "chat_id": 123,
+            "photo": "https://example.com/cat.jpg",
+            "reply_parameters": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_blocks_unsafe_remote_media_url(monkeypatch) -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+    monkeypatch.setattr(
+        "nanobot.channels.telegram.validate_url_target",
+        lambda url: (False, "Blocked: example.com resolves to private/internal address 127.0.0.1"),
+    )
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="",
+            media=["http://example.com/internal.jpg"],
+        )
+    )
+
+    assert channel._app.bot.sent_media == []
+    assert channel._app.bot.sent_messages == [
+        {
+            "chat_id": 123,
+            "text": "[Failed to send: internal.jpg]",
+            "reply_parameters": None,
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Please see #1792. 

Managed to fix it. 

Core problem was ignoring the fact that media can be a URL, Telegram Bot api downloads it automatically. 

See Telegram bot API, particularly the [sendMedia](https://core.telegram.org/method/messages.sendMedia)  method and the core type [InputMedia](https://core.telegram.org/type/InputMedia). 


## Screenshot

<img width="1010" height="513" alt="image" src="https://github.com/user-attachments/assets/ce510a5f-3622-4d18-8668-ee5ecf75447c" />

Fix #1792 