### PR TITLE
fix(memory): persist auto consolidation progress

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -401,7 +401,8 @@ class AgentLoop:
             async def _consolidate_and_unlock():
                 try:
                     async with lock:
-                        await self._consolidate_memory(session)
+                        if await self._consolidate_memory(session):
+                            self.sessions.save(session)
                 finally:
                     self._consolidating.discard(session.key)
                     _task = asyncio.current_task()

--- a/tests/test_consolidate_offset.py
+++ b/tests/test_consolidate_offset.py
@@ -526,6 +526,54 @@ class TestConsolidationDeduplicationGuard:
         )
 
     @pytest.mark.asyncio
+    async def test_auto_consolidation_persists_last_consolidated(self, tmp_path: Path) -> None:
+        """Background consolidation should persist last_consolidated after finishing."""
+        from nanobot.agent.loop import AgentLoop
+        from nanobot.bus.events import InboundMessage
+        from nanobot.bus.queue import MessageBus
+        from nanobot.providers.base import LLMResponse
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        loop = AgentLoop(
+            bus=bus, provider=provider, workspace=tmp_path, model="test-model", memory_window=10
+        )
+
+        loop.provider.chat = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        session_key = "cli:test"
+        session = loop.sessions.get_or_create(session_key)
+        for i in range(15):
+            session.add_message("user", f"msg{i}")
+            session.add_message("assistant", f"resp{i}")
+        loop.sessions.save(session)
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+        expected_last_consolidated = len(session.messages) - 3
+
+        async def _fake_consolidate(sess, archive_all: bool = False) -> bool:
+            started.set()
+            await release.wait()
+            sess.last_consolidated = expected_last_consolidated
+            return True
+
+        loop._consolidate_memory = _fake_consolidate  # type: ignore[method-assign]
+
+        msg = InboundMessage(channel="cli", sender_id="user", chat_id="test", content="hello")
+        await loop._process_message(msg)
+        await started.wait()
+
+        release.set()
+        await asyncio.sleep(0.05)
+
+        loop.sessions.invalidate(session_key)
+        reloaded = loop.sessions.get_or_create(session_key)
+        assert reloaded.last_consolidated == expected_last_consolidated
+
+    @pytest.mark.asyncio
     async def test_new_command_guard_prevents_concurrent_consolidation(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_consolidate_offset.py
+++ b/tests/test_consolidate_offset.py
@@ -567,7 +567,9 @@ class TestConsolidationDeduplicationGuard:
         await started.wait()
 
         release.set()
-        await asyncio.sleep(0.05)
+        consolidation_tasks = getattr(loop, "_consolidation_tasks", None)
+        if consolidation_tasks:
+            await asyncio.gather(*consolidation_tasks)
 
         loop.sessions.invalidate(session_key)
         reloaded = loop.sessions.get_or_create(session_key)


### PR DESCRIPTION
## Summary
- persist `last_consolidated` after background auto-consolidation succeeds
- add a focused regression test to verify the updated offset survives a session reload
- prevent the same unconsolidated session tail from being reprocessed on every turn

## Test plan
- [x] `python3 -m py_compile nanobot/agent/loop.py tests/test_consolidate_offset.py`
- [ ] `python3 -m pytest -q tests/test_consolidate_offset.py -k persists_last_consolidated` (not runnable in this environment: `pytest` and project runtime deps are unavailable)

## Context
This fixes the behavior described in #1698, where automatic consolidation updates `last_consolidated` only in memory and never persists it back to the session file.

Made with [Cursor](https://cursor.com)