### PR TITLE
fix(config): apply env overrides when loading files

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -1,7 +1,9 @@
 """Configuration loading utilities."""
 
 import json
+import os
 from pathlib import Path
+from typing import Any
 
 from nanobot.config.schema import Config
 
@@ -40,6 +42,9 @@ def load_config(config_path: Path | None = None) -> Config:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
             data = _migrate_config(data)
+            env_overrides = _load_env_overrides()
+            if env_overrides:
+                data = _deep_merge(data, env_overrides)
             return Config.model_validate(data)
         except (json.JSONDecodeError, ValueError) as e:
             print(f"Warning: Failed to load config from {path}: {e}")
@@ -73,3 +78,45 @@ def _migrate_config(data: dict) -> dict:
     if "restrictToWorkspace" in exec_cfg and "restrictToWorkspace" not in tools:
         tools["restrictToWorkspace"] = exec_cfg.pop("restrictToWorkspace")
     return data
+
+
+def _load_env_overrides() -> dict[str, Any]:
+    """Collect NANOBOT_* environment overrides into a nested config dict."""
+    prefix = "NANOBOT_"
+    overrides: dict[str, Any] = {}
+
+    for key, raw_value in os.environ.items():
+        if not key.startswith(prefix):
+            continue
+
+        path = [part.lower() for part in key[len(prefix):].split("__") if part]
+        if not path:
+            continue
+
+        current = overrides
+        for part in path[:-1]:
+            current = current.setdefault(part, {})
+        current[path[-1]] = _parse_env_value(raw_value)
+
+    return overrides
+
+
+def _parse_env_value(value: str) -> Any:
+    """Parse JSON-like environment values while keeping plain strings intact."""
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def _deep_merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge env overrides onto config file data."""
+    merged = dict(base)
+
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+
+    return merged

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -3,7 +3,9 @@
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args, get_origin
+
+from pydantic import BaseModel
 
 from nanobot.config.schema import Config
 
@@ -41,7 +43,10 @@ def load_config(config_path: Path | None = None) -> Config:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
+            if not isinstance(data, dict):
+                raise ValueError("Config file must contain a JSON object at the top level")
             data = _migrate_config(data)
+            data = _normalize_model_data(Config, data)
             env_overrides = _load_env_overrides()
             if env_overrides:
                 data = _deep_merge(data, env_overrides)
@@ -99,6 +104,68 @@ def _load_env_overrides() -> dict[str, Any]:
         current[path[-1]] = _parse_env_value(raw_value)
 
     return overrides
+
+
+def _normalize_model_data(model: type[BaseModel], data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize config dict keys to Pydantic field names before merging overrides."""
+    normalized: dict[str, Any] = {}
+
+    field_lookup = {}
+    for field_name, field in model.model_fields.items():
+        field_lookup[field_name] = (field_name, field.annotation)
+        if field.alias:
+            field_lookup[field.alias] = (field_name, field.annotation)
+
+    for raw_key, value in data.items():
+        field_info = field_lookup.get(raw_key)
+        if field_info is None:
+            normalized[raw_key] = _normalize_untyped_value(value)
+            continue
+
+        field_name, annotation = field_info
+        normalized[field_name] = _normalize_value(annotation, value)
+
+    return normalized
+
+
+def _normalize_value(annotation: Any, value: Any) -> Any:
+    """Normalize nested config values using their annotated model types."""
+    model = _extract_model_type(annotation)
+    if model and isinstance(value, dict):
+        return _normalize_model_data(model, value)
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    if origin is dict and len(args) == 2 and isinstance(value, dict):
+        return {key: _normalize_value(args[1], item) for key, item in value.items()}
+
+    if origin is list and len(args) == 1 and isinstance(value, list):
+        return [_normalize_value(args[0], item) for item in value]
+
+    return value
+
+
+def _extract_model_type(annotation: Any) -> type[BaseModel] | None:
+    """Return the nested Pydantic model type from an annotation, if present."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+
+    for arg in get_args(annotation):
+        model = _extract_model_type(arg)
+        if model is not None:
+            return model
+
+    return None
+
+
+def _normalize_untyped_value(value: Any) -> Any:
+    """Recursively copy unknown nested structures without changing their keys."""
+    if isinstance(value, dict):
+        return {key: _normalize_untyped_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_untyped_value(item) for item in value]
+    return value
 
 
 def _parse_env_value(value: str) -> Any:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,46 @@
+import json
+
+from nanobot.config.loader import load_config
+
+
+def test_load_config_applies_env_overrides_on_top_of_file(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "deepseek": {
+                        "apiKey": "",
+                        "apiBase": "https://file.example",
+                    }
+                },
+                "agents": {
+                    "defaults": {
+                        "model": "file-model",
+                        "workspace": "~/file-workspace",
+                    }
+                },
+            }
+        )
+    )
+
+    monkeypatch.setenv("NANOBOT_PROVIDERS__DEEPSEEK__API_KEY", "env-secret")
+    monkeypatch.setenv("NANOBOT_AGENTS__DEFAULTS__WORKSPACE", "~/env-workspace")
+
+    config = load_config(config_path)
+
+    assert config.providers.deepseek.api_key == "env-secret"
+    assert config.providers.deepseek.api_base == "https://file.example"
+    assert config.agents.defaults.workspace == "~/env-workspace"
+    assert config.agents.defaults.model == "file-model"
+
+
+def test_load_config_parses_scalar_env_values(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"gateway": {"port": 18790}}))
+
+    monkeypatch.setenv("NANOBOT_GATEWAY__PORT", "18791")
+
+    config = load_config(config_path)
+
+    assert config.gateway.port == 18791

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,9 +1,17 @@
 import json
+import os
 
 from nanobot.config.loader import load_config
 
 
+def _clear_nanobot_env(monkeypatch) -> None:
+    for key in list(os.environ):
+        if key.startswith("NANOBOT_"):
+            monkeypatch.delenv(key, raising=False)
+
+
 def test_load_config_applies_env_overrides_on_top_of_file(monkeypatch, tmp_path) -> None:
+    _clear_nanobot_env(monkeypatch)
     config_path = tmp_path / "config.json"
     config_path.write_text(
         json.dumps(
@@ -36,6 +44,7 @@ def test_load_config_applies_env_overrides_on_top_of_file(monkeypatch, tmp_path)
 
 
 def test_load_config_parses_scalar_env_values(monkeypatch, tmp_path) -> None:
+    _clear_nanobot_env(monkeypatch)
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({"gateway": {"port": 18790}}))
 
@@ -43,4 +52,20 @@ def test_load_config_parses_scalar_env_values(monkeypatch, tmp_path) -> None:
 
     config = load_config(config_path)
 
+    assert config.gateway.port == 18791
+
+
+def test_load_config_falls_back_to_env_defaults_for_non_object_json(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    _clear_nanobot_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(["not", "an", "object"]))
+
+    monkeypatch.setenv("NANOBOT_GATEWAY__PORT", "18791")
+
+    config = load_config(config_path)
+    captured = capsys.readouterr()
+
+    assert "Failed to load config" in captured.out
     assert config.gateway.port == 18791


### PR DESCRIPTION
## Summary
- merge `NANOBOT_*` environment variables on top of `config.json` before validation
- preserve config file values for fields that are not overridden by the environment
- add focused tests covering nested string overrides and scalar coercion for config-backed loads

## Test plan
- [x] `python3 -m py_compile nanobot/config/loader.py tests/test_config_loader.py`
- [ ] `python3 -m pytest -q tests/test_config_loader.py` (not runnable in this environment because project test dependencies are unavailable)

## Context
Fixes #1791.

Made with [Cursor](https://cursor.com)