### PR TITLE
fix(cli): support forced Codex OAuth re-login

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -909,6 +909,7 @@ def _register_login(name: str):
 @provider_app.command("login")
 def provider_login(
     provider: str = typer.Argument(..., help="OAuth provider (e.g. 'openai-codex', 'github-copilot')"),
+    force: bool = typer.Option(False, "--force", help="Discard cached OAuth credentials and sign in again."),
 ):
     """Authenticate with an OAuth provider."""
     from nanobot.providers.registry import PROVIDERS
@@ -926,13 +927,22 @@ def provider_login(
         raise typer.Exit(1)
 
     console.print(f"{__logo__} OAuth Login - {spec.label}\n")
-    handler()
+    handler(force=force)
 
 
 @_register_login("openai_codex")
-def _login_openai_codex() -> None:
+def _login_openai_codex(force: bool = False) -> None:
     try:
         from oauth_cli_kit import get_token, login_oauth_interactive
+        from oauth_cli_kit.storage import FileTokenStorage
+
+        storage = FileTokenStorage(token_filename="codex.json")
+        token_path = storage.get_token_path()
+
+        if force and token_path.exists():
+            token_path.unlink()
+            console.print(f"[yellow]Removed cached OAuth credentials[/yellow]  [dim]{token_path}[/dim]")
+
         token = None
         try:
             token = get_token()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -356,3 +356,44 @@ def test_gateway_uses_config_directory_for_cron_store(monkeypatch, tmp_path: Pat
 
     assert isinstance(result.exception, _StopGateway)
     assert seen["cron_store"] == config_file.parent / "cron" / "jobs.json"
+
+
+def test_provider_login_openai_codex_force_removes_cached_token(monkeypatch, tmp_path: Path) -> None:
+    token_path = tmp_path / "oauth-cli-kit" / "auth" / "codex.json"
+    token_path.parent.mkdir(parents=True)
+    token_path.write_text('{"access":"old","refresh":"old","expires":9999999999999,"account_id":"old"}')
+
+    class _Token:
+        access = "new-access"
+        account_id = "new-account"
+
+    class _Storage:
+        def __init__(self, token_filename: str = "oauth.json") -> None:
+            assert token_filename == "codex.json"
+
+        def get_token_path(self) -> Path:
+            return token_path
+
+    seen: dict[str, int] = {"get_token": 0, "login": 0}
+
+    def _get_token():
+        seen["get_token"] += 1
+        if seen["get_token"] == 1:
+            raise RuntimeError("missing token")
+        return _Token()
+
+    def _login_oauth_interactive(**_kwargs):
+        seen["login"] += 1
+        token_path.write_text('{"access":"new","refresh":"new","expires":9999999999999,"account_id":"new"}')
+        return _Token()
+
+    monkeypatch.setattr("oauth_cli_kit.storage.FileTokenStorage", _Storage)
+    monkeypatch.setattr("oauth_cli_kit.get_token", _get_token)
+    monkeypatch.setattr("oauth_cli_kit.login_oauth_interactive", _login_oauth_interactive)
+
+    result = runner.invoke(app, ["provider", "login", "openai-codex", "--force"])
+
+    assert result.exit_code == 0
+    assert "Removed cached OAuth credentials" in result.stdout
+    assert "Authenticated with OpenAI Codex" in result.stdout
+    assert seen["login"] == 1


### PR DESCRIPTION
## Summary

`nanobot provider login openai-codex` currently reuses any valid cached `oauth_cli_kit` token, even when that token belongs to the wrong OpenAI account or a stale business workspace.

In practice, the README guidance to switch out of the business workspace in the ChatGPT profile and run provider login again does not fix this case, because the existing cached token is still treated as valid and the login flow is skipped.

This can leave `nanobot agent` sending requests with stale credentials and surfacing errors like:

`HTTP 402: {"detail":{"code":"deactivated_workspace"}}`

## Changes

- add `--force` to `nanobot provider login`
- for `openai-codex`, remove the cached `oauth_cli_kit` token before login when `--force` is used
- add a CLI test covering the stale-token relogin flow

## Repro

1. Have a valid cached token in `~/.local/share/oauth-cli-kit/auth/codex.json` for an old or deactivated workspace
2. Switch to the desired non-business/personal workspace in ChatGPT
3. Run `nanobot provider login openai-codex`
4. Observe that the cached token is reused instead of re-authenticating
5. Run `nanobot agent -m "test"`
6. Observe Codex API failures from the stale account/workspace
7. Run `nanobot provider login openai-codex --force`
8. Re-authenticate with the correct account
9. Run `nanobot agent -m "test"` again

## Test

- `pytest -q tests/test_commands.py -k provider_login_openai_codex_force_removes_cached_token`
