### PR TITLE
feat(subagent): inherit tools from parent agent instead of hardcoding

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -98,6 +98,7 @@ class AgentLoop:
             web_proxy=web_proxy,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            tools=self.tools,
         )
 
         self._running = False

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -8,14 +8,14 @@ from typing import Any
 
 from loguru import logger
 
-from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.registry import ToolRegistry
-from nanobot.agent.tools.shell import ExecTool
-from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.config.schema import ExecToolConfig
 from nanobot.providers.base import LLMProvider
+
+# Tools to exclude from subagent (communication/spawning tools)
+EXCLUDED_TOOLS = {"message", "spawn", "cron"}
 
 
 class SubagentManager:
@@ -34,6 +34,7 @@ class SubagentManager:
         web_proxy: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
+        tools: ToolRegistry | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.provider = provider
@@ -47,6 +48,7 @@ class SubagentManager:
         self.web_proxy = web_proxy
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
+        self.tools = tools
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
 
@@ -82,6 +84,37 @@ class SubagentManager:
         logger.info("Spawned subagent [{}]: {}", task_id, display_label)
         return f"Subagent [{display_label}] started (id: {task_id}). I'll notify you when it completes."
 
+    def _build_tools(self) -> ToolRegistry:
+        """Build subagent tools, inheriting from parent if available."""
+        if self.tools:
+            # Inherit tools from parent, excluding communication/spawning tools
+            registry = ToolRegistry()
+            for name, tool in self.tools.items():
+                if name not in EXCLUDED_TOOLS:
+                    registry.register(tool)
+            return registry
+        else:
+            # Fallback: build minimal tool set (backward compatibility)
+            from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
+            from nanobot.agent.tools.shell import ExecTool
+            from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
+
+            registry = ToolRegistry()
+            allowed_dir = self.workspace if self.restrict_to_workspace else None
+            registry.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
+            registry.register(WriteFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
+            registry.register(EditFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
+            registry.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir))
+            registry.register(ExecTool(
+                working_dir=str(self.workspace),
+                timeout=self.exec_config.timeout,
+                restrict_to_workspace=self.restrict_to_workspace,
+                path_append=self.exec_config.path_append,
+            ))
+            registry.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
+            registry.register(WebFetchTool(proxy=self.web_proxy))
+            return registry
+
     async def _run_subagent(
         self,
         task_id: str,
@@ -93,22 +126,7 @@ class SubagentManager:
         logger.info("Subagent [{}] starting task: {}", task_id, label)
 
         try:
-            # Build subagent tools (no message tool, no spawn tool)
-            tools = ToolRegistry()
-            allowed_dir = self.workspace if self.restrict_to_workspace else None
-            tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(WriteFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(EditFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ExecTool(
-                working_dir=str(self.workspace),
-                timeout=self.exec_config.timeout,
-                restrict_to_workspace=self.restrict_to_workspace,
-                path_append=self.exec_config.path_append,
-            ))
-            tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
-            tools.register(WebFetchTool(proxy=self.web_proxy))
-            
+            tools = self._build_tools()
             system_prompt = self._build_subagent_prompt()
             messages: list[dict[str, Any]] = [
                 {"role": "system", "content": system_prompt},

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -68,3 +68,7 @@ class ToolRegistry:
 
     def __contains__(self, name: str) -> bool:
         return name in self._tools
+
+    def items(self) -> list[tuple[str, Tool]]:
+        """Get list of (name, tool) pairs."""
+        return list(self._tools.items())


### PR DESCRIPTION
Subagent tools were hardcoded with a fixed set of tools (read_file, write_file, exec, web_search, etc.). This meant:

- New tools added to the main agent were not available to subagents
- MCP tools connected to the main agent could not be used by subagents
- Any tool changes required modifying both loop.py and subagent.py

Now, SubagentManager accepts a `tools` parameter referencing the parent agent's ToolRegistry. Subagents inherit all parent tools except:
- message (communication tool)
- spawn (prevents nested subagent spawning)
- cron (scheduled task tool)

Changes:
- SubagentManager.__init__: add `tools: ToolRegistry | None` parameter
- SubagentManager._build_tools(): inherit and filter parent tools
- ToolRegistry.items(): add public method to iterate over tools
- AgentLoop: pass `tools=self.tools` when creating SubagentManager