### PR TITLE
fix(memory): write long-term memory atomically

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -56,7 +58,23 @@ class MemoryStore:
         return ""
 
     def write_long_term(self, content: str) -> None:
-        self.memory_file.write_text(content, encoding="utf-8")
+        fd, tmp_path = tempfile.mkstemp(
+            dir=self.memory_file.parent,
+            prefix=f"{self.memory_file.name}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, self.memory_file)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def append_history(self, entry: str) -> None:
         with open(self.history_file, "a", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
This PR makes `MemoryStore.write_long_term()` use atomic file replacement instead of direct `write_text()`.

Session persistence was already hardened in **#1731** by switching `SessionManager.save()` to a temp-file + `os.replace()` flow. Long-term memory persistence (`MEMORY.md`) still used direct file overwrite, which left memory writes less durable and less consistent than session writes.

This change aligns long-term memory persistence with the same atomic-write pattern already used for session state.

## Why
`MemoryStore.write_long_term()` currently writes `MEMORY.md` directly:

```python
self.memory_file.write_text(content, encoding="utf-8")
```

Compared with atomic replace, this has weaker persistence guarantees:
- interruption during write can leave incomplete contents
- session state and memory state use inconsistent durability strategies
- successful consolidation still depends on a non-atomic final persistence step

This PR updates long-term memory persistence to:
- write to a temp file in the same directory
- flush and fsync
- atomically replace the target with `os.replace()`

## Relation to previous PRs
This PR is related to:

- **#1731**: that PR made `SessionManager.save()` atomic. This PR applies the same persistence-hardening approach to long-term memory storage, so session and memory state follow consistent durability semantics.
- **#1733**: that PR improves consolidation reliability by forcing the `save_memory` tool call. This PR complements it by making the final `MEMORY.md` write more robust once consolidation succeeds.

In short:
- **#1733** improves whether consolidation output is produced
- **#1731** improves how session state is persisted
- **this PR** improves how long-term memory is persisted

## Changes
- update `MemoryStore.write_long_term()` to use temp file + atomic replace
- ensure temp file is created in the same directory as `MEMORY.md`
- flush and fsync before replacement
- clean up temp file on failure

## Testing
I created a local virtual environment, installed `pytest`, and ran:

```bash
python -m pytest -q tests/test_memory_consolidation_types.py
```

Result:
- 7 passed
- 1 failed

The failing test is:
- `TestMemoryConsolidationTypeHandling::test_dict_arguments_serialized_to_json`

This failure appears unrelated to this PR. It is caused by consolidation payload normalization for non-string `history_entry` values (`str(dict)` instead of JSON serialization), while this PR only changes the write path for `MEMORY.md` to use atomic replace.

## Notes
This PR intentionally keeps scope small and only hardens `MEMORY.md` persistence. It does not change:
- memory consolidation logic
- `HISTORY.md` append semantics
- memory schema or validation
