### PR TITLE
Added support for sending arbitrary additional arguments to backend LLMs

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -231,6 +231,7 @@ def _make_provider(config: Config):
             api_key=p.api_key if p else "no-key",
             api_base=config.get_api_base(model) or "http://localhost:8000/v1",
             default_model=model,
+            llm_arguments=p.llm_arguments if p else None,
         )
 
     # Azure OpenAI: direct Azure OpenAI endpoint with deployment name
@@ -245,6 +246,7 @@ def _make_provider(config: Config):
             api_key=p.api_key,
             api_base=p.api_base,
             default_model=model,
+            llm_arguments=p.llm_arguments if p else None,
         )
 
     from nanobot.providers.litellm_provider import LiteLLMProvider
@@ -260,6 +262,7 @@ def _make_provider(config: Config):
         api_base=config.get_api_base(model),
         default_model=model,
         extra_headers=p.extra_headers if p else None,
+        llm_arguments=p.llm_arguments if p else None,
         provider_name=provider_name,
     )
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -1,7 +1,7 @@
 """Configuration schema using Pydantic."""
 
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Any
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
@@ -245,6 +245,7 @@ class ProviderConfig(Base):
     api_key: str = ""
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
+    llm_arguments: dict[str, Any] | None = None  # Additional arguments for the LLM request body
 
 
 class ProvidersConfig(Base):

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -31,8 +31,9 @@ class AzureOpenAIProvider(LLMProvider):
         api_key: str = "",
         api_base: str = "",
         default_model: str = "gpt-5.2-chat",
+        llm_arguments: dict[str, Any] | None = None,
     ):
-        super().__init__(api_key, api_base)
+        super().__init__(api_key, api_base, llm_arguments)
         self.default_model = default_model
         self.api_version = "2024-10-21"
         
@@ -107,6 +108,9 @@ class AzureOpenAIProvider(LLMProvider):
         if tools:
             payload["tools"] = tools
             payload["tool_choice"] = "auto"
+            
+        if self.llm_arguments:
+            payload.update(self.llm_arguments)
 
         return payload
 

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -37,9 +37,10 @@ class LLMProvider(ABC):
     while maintaining a consistent interface.
     """
 
-    def __init__(self, api_key: str | None = None, api_base: str | None = None):
+    def __init__(self, api_key: str | None = None, api_base: str | None = None, llm_arguments: dict[str, Any] | None = None):
         self.api_key = api_key
         self.api_base = api_base
+        self.llm_arguments = llm_arguments or {}
 
     @staticmethod
     def _sanitize_empty_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -13,8 +13,8 @@ from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 
 class CustomProvider(LLMProvider):
 
-    def __init__(self, api_key: str = "no-key", api_base: str = "http://localhost:8000/v1", default_model: str = "default"):
-        super().__init__(api_key, api_base)
+    def __init__(self, api_key: str = "no-key", api_base: str = "http://localhost:8000/v1", default_model: str = "default", llm_arguments: dict[str, Any] | None = None):
+        super().__init__(api_key, api_base, llm_arguments)
         self.default_model = default_model
         # Keep affinity stable for this provider instance to improve backend cache locality.
         self._client = AsyncOpenAI(
@@ -36,6 +36,12 @@ class CustomProvider(LLMProvider):
             kwargs["reasoning_effort"] = reasoning_effort
         if tools:
             kwargs.update(tools=tools, tool_choice="auto")
+            
+        if self.llm_arguments:
+            filtered_args = {k: v for k, v in self.llm_arguments.items() if k not in kwargs}
+            kwargs.update(filtered_args)
+            if "extra_body" not in kwargs:
+                kwargs["extra_body"] = self.llm_arguments
         try:
             return self._parse(await self._client.chat.completions.create(**kwargs))
         except Exception as e:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -39,9 +39,10 @@ class LiteLLMProvider(LLMProvider):
         api_base: str | None = None,
         default_model: str = "anthropic/claude-opus-4-5",
         extra_headers: dict[str, str] | None = None,
+        llm_arguments: dict[str, Any] | None = None,
         provider_name: str | None = None,
     ):
-        super().__init__(api_key, api_base)
+        super().__init__(api_key, api_base, llm_arguments)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
 
@@ -260,6 +261,14 @@ class LiteLLMProvider(LLMProvider):
         # Pass extra headers (e.g. APP-Code for AiHubMix)
         if self.extra_headers:
             kwargs["extra_headers"] = self.extra_headers
+            
+        if self.llm_arguments:
+            # LiteLLM allows using extra_body to pass custom fields into the request body
+            # We also update kwargs as some fields might be native litellm arguments (e.g., stream)
+            filtered_args = {k: v for k, v in self.llm_arguments.items() if k not in kwargs}
+            kwargs.update(filtered_args)
+            if "extra_body" not in kwargs:
+                kwargs["extra_body"] = self.llm_arguments
         
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort


### PR DESCRIPTION
## Description
This PR is to provide the ability to add custom arguments to requests made by nanobot to backend LLMs. For example, for ollama, to get better tool calling capabilities, it's advised to disable streaming using the `"stream": false` argument. However, there is currently no option for achieving this in the nanobot's configuration. 

The proposed approach is universal and makes it possible to add `llmArguments` to the provider definition, which will then be added to all requests made to that provider. 

## Usage
Add `llmArguments` in the `providers.provider` section:
```
"providers": {
    "llmProvider": {
        "apiKey": "XXX",
        "apiBase": "XXX",
        "llmArguments": { 
            "think": false, 
            "stream": false 
        }
    }
},

```

## Changes Made
1. Config Schema (`nanobot/config/schema.py`): Added `llm_arguments: dict[str, Any] | None = None` to the 
ProviderConfig class. The `pydantic` configuration parses keys as either `llm_arguments` or `llmArguments` interchangeably.
2. Provider Base (`nanobot/providers/base.py`): Added `llm_arguments` to the base `LLMProvider.__init__` signature and state.
3. LiteLLM integration (`nanobot/providers/litellm_provider.py`): Passed `llm_arguments` down to `acompletion()`.
> NOTE
> For maximum compatibility with LiteLLM (especially when `drop_params=True` is set), `llm_arguments` are merged natively into `kwargs` and also added inside `extra_body` as a robust fallback.
4. Direct Provider Support (`nanobot/providers/custom_provider.py` & `nanobot/providers/azure_openai_provider.py`): Added support to the `CustomProvider` (injects to `extra_body`) and `AzureOpenAIProvider` (injects directly into the HTTP payload dictionary).
5. Config Loader (`nanobot/cli/commands.py`): In `_make_provider`, made sure to extract `p.llm_arguments` and deliver it to the respective provider's initialization method.

