### PR TITLE
fix: preserve tool_choice across provider implementations

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -40,6 +40,42 @@ _SAVE_MEMORY_TOOL = [
         },
     }
 ]
+
+
+def _get_provider_name(provider: Any) -> str | None:
+    """Best-effort extraction of provider name for memory tool-choice strategy."""
+    provider_name = getattr(provider, "provider_name", None)
+    if isinstance(provider_name, str) and provider_name:
+        return provider_name.lower()
+
+    gateway = getattr(provider, "_gateway", None)
+    gateway_name = getattr(gateway, "name", None)
+    if isinstance(gateway_name, str) and gateway_name:
+        return gateway_name.lower()
+
+    return None
+
+
+def _build_memory_tool_choice(provider: Any) -> dict[str, Any] | str | None:
+    """Return a provider-compatible tool_choice for memory consolidation.
+
+    Some providers behind gateways such as OpenRouter reject explicit OpenAI-style
+    function forcing:
+        {"type": "function", "function": {"name": "save_memory"}}
+
+    To avoid provider-specific request failures, only use forced function tool
+    choice for known-compatible providers, and fall back to a safer strategy for
+    OpenRouter and unknown providers.
+    """
+    provider_name = _get_provider_name(provider)
+
+    if provider_name == "openai":
+        return {"type": "function", "function": {"name": "save_memory"}}
+
+    if provider_name == "openrouter":
+        return "auto"
+
+    return "auto"
 
 
 class MemoryStore:
@@ -111,12 +147,14 @@ class MemoryStore:
 {chr(10).join(lines)}"""
 
         try:
+            tool_choice = _build_memory_tool_choice(provider)
             response = await provider.chat(
                 messages=[
                     {"role": "system", "content": "You are a memory consolidation agent. Call the save_memory tool with your consolidation of the conversation."},
                     {"role": "user", "content": prompt},
                 ],
                 tools=_SAVE_MEMORY_TOOL,
+                tool_choice=tool_choice,
                 model=model,
             )
 

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -88,6 +88,7 @@ class AzureOpenAIProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: dict[str, Any] | str | None = None,
     ) -> dict[str, Any]:
         """Prepare the request payload with Azure OpenAI 2024-10-21 compliance."""
         payload: dict[str, Any] = {
@@ -106,7 +107,7 @@ class AzureOpenAIProvider(LLMProvider):
 
         if tools:
             payload["tools"] = tools
-            payload["tool_choice"] = "auto"
+            payload["tool_choice"] = tool_choice if tool_choice is not None else "auto"
 
         return payload
 
@@ -118,6 +119,7 @@ class AzureOpenAIProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: dict[str, Any] | str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request to Azure OpenAI.
@@ -137,7 +139,7 @@ class AzureOpenAIProvider(LLMProvider):
         url = self._build_chat_url(deployment_name)
         headers = self._build_headers()
         payload = self._prepare_request_payload(
-            deployment_name, messages, tools, max_tokens, temperature, reasoning_effort
+            deployment_name, messages, tools, max_tokens, temperature, reasoning_effort, tool_choice
         )
 
         try:

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -110,6 +110,7 @@ class LLMProvider(ABC):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: dict[str, Any] | str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request.

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -25,7 +25,7 @@ class CustomProvider(LLMProvider):
 
     async def chat(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
                    model: str | None = None, max_tokens: int = 4096, temperature: float = 0.7,
-                   reasoning_effort: str | None = None) -> LLMResponse:
+                   reasoning_effort: str | None = None, tool_choice: dict[str, Any] | str | None = None) -> LLMResponse:
         kwargs: dict[str, Any] = {
             "model": model or self.default_model,
             "messages": self._sanitize_empty_content(messages),
@@ -35,7 +35,7 @@ class CustomProvider(LLMProvider):
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
         if tools:
-            kwargs.update(tools=tools, tool_choice="auto")
+            kwargs.update(tools=tools, tool_choice=tool_choice if tool_choice is not None else "auto")
         try:
             return self._parse(await self._client.chat.completions.create(**kwargs))
         except Exception as e:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -214,6 +214,7 @@ class LiteLLMProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: dict[str, Any] | str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request via LiteLLM.
@@ -267,7 +268,7 @@ class LiteLLMProvider(LLMProvider):
         
         if tools:
             kwargs["tools"] = tools
-            kwargs["tool_choice"] = "auto"
+            kwargs["tool_choice"] = tool_choice if tool_choice is not None else "auto"
 
         try:
             response = await acompletion(**kwargs)

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -32,6 +32,7 @@ class OpenAICodexProvider(LLMProvider):
         max_tokens: int = 4096,
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
+        tool_choice: dict[str, Any] | str | None = None,
     ) -> LLMResponse:
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)
@@ -48,7 +49,7 @@ class OpenAICodexProvider(LLMProvider):
             "text": {"verbosity": "medium"},
             "include": ["reasoning.encrypted_content"],
             "prompt_cache_key": _prompt_cache_key(messages),
-            "tool_choice": "auto",
+            "tool_choice": _normalize_codex_tool_choice(tool_choice),
             "parallel_tool_calls": True,
         }
 
@@ -224,6 +225,19 @@ def _split_tool_call_id(tool_call_id: Any) -> tuple[str, str | None]:
 def _prompt_cache_key(messages: list[dict[str, Any]]) -> str:
     raw = json.dumps(messages, ensure_ascii=True, sort_keys=True)
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _normalize_codex_tool_choice(tool_choice: dict[str, Any] | str | None) -> str:
+    """Normalize generic tool_choice values to the Codex Responses API shape.
+
+    The Responses API clearly supports string values such as "auto". We avoid
+    passing chat-completions-specific dict forms like
+    {"type": "function", "function": {"name": "save_memory"}} until their
+    compatibility is explicitly confirmed for Codex.
+    """
+    if isinstance(tool_choice, str) and tool_choice:
+        return tool_choice
+    return "auto"
 
 
 async def _iter_sse(response: httpx.Response) -> AsyncGenerator[dict[str, Any], None]:

--- a/tests/test_azure_openai_provider.py
+++ b/tests/test_azure_openai_provider.py
@@ -101,6 +101,12 @@ def test_prepare_request_payload():
     payload_with_tools = provider._prepare_request_payload("gpt-4o", messages, tools=tools)
     assert payload_with_tools["tools"] == tools
     assert payload_with_tools["tool_choice"] == "auto"
+
+    forced_choice = {"type": "function", "function": {"name": "save_memory"}}
+    payload_with_forced_tool_choice = provider._prepare_request_payload(
+        "gpt-4o", messages, tools=tools, tool_choice=forced_choice
+    )
+    assert payload_with_forced_tool_choice["tool_choice"] == forced_choice
     
     # Test with reasoning_effort
     payload_with_reasoning = provider._prepare_request_payload(

--- a/tests/test_litellm_tool_choice.py
+++ b/tests/test_litellm_tool_choice.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nanobot.providers.litellm_provider import LiteLLMProvider
+
+
+@pytest.mark.asyncio
+async def test_litellm_provider_uses_default_tool_choice_auto_when_tools_present() -> None:
+    provider = LiteLLMProvider(provider_name="openai", default_model="gpt-4o-mini")
+
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="ok", tool_calls=None, reasoning_content=None, thinking_blocks=None),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+    with patch("nanobot.providers.litellm_provider.acompletion", AsyncMock(return_value=fake_response)) as mock_completion:
+        result = await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[{"type": "function", "function": {"name": "save_memory", "parameters": {}}}],
+        )
+
+    assert result.content == "ok"
+    assert mock_completion.await_args.kwargs["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_litellm_provider_passes_through_explicit_tool_choice() -> None:
+    provider = LiteLLMProvider(provider_name="openai", default_model="gpt-4o-mini")
+
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="ok", tool_calls=None, reasoning_content=None, thinking_blocks=None),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+    forced_choice = {"type": "function", "function": {"name": "save_memory"}}
+
+    with patch("nanobot.providers.litellm_provider.acompletion", AsyncMock(return_value=fake_response)) as mock_completion:
+        await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[{"type": "function", "function": {"name": "save_memory", "parameters": {}}}],
+            tool_choice=forced_choice,
+        )
+
+    assert mock_completion.await_args.kwargs["tool_choice"] == forced_choice

--- a/tests/test_memory_consolidation_types.py
+++ b/tests/test_memory_consolidation_types.py
@@ -11,8 +11,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from nanobot.agent.memory import MemoryStore
+from nanobot.agent.memory import MemoryStore, _build_memory_tool_choice
 from nanobot.providers.base import LLMResponse, ToolCallRequest
+from nanobot.providers.litellm_provider import LiteLLMProvider
 
 
 def _make_session(message_count: int = 30, memory_window: int = 50):
@@ -220,3 +221,26 @@ class TestMemoryConsolidationTypeHandling:
         result = await store.consolidate(session, provider, "test-model", memory_window=50)
 
         assert result is False
+
+
+def test_memory_tool_choice_for_openai_provider() -> None:
+    provider = LiteLLMProvider(provider_name="openai")
+
+    assert _build_memory_tool_choice(provider) == {
+        "type": "function",
+        "function": {"name": "save_memory"},
+    }
+
+
+def test_memory_tool_choice_for_openrouter_provider() -> None:
+    provider = LiteLLMProvider(provider_name="openrouter")
+
+    assert _build_memory_tool_choice(provider) == "auto"
+
+
+def test_memory_tool_choice_for_unknown_provider_is_conservative() -> None:
+    provider = MagicMock()
+    provider.provider_name = None
+    provider._gateway = None
+
+    assert _build_memory_tool_choice(provider) == "auto"

--- a/tests/test_provider_tool_choice.py
+++ b/tests/test_provider_tool_choice.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nanobot.providers.custom_provider import CustomProvider
+from nanobot.providers.openai_codex_provider import _normalize_codex_tool_choice
+
+
+@pytest.mark.asyncio
+async def test_custom_provider_uses_default_tool_choice_auto_when_tools_present() -> None:
+    provider = CustomProvider(api_key="test-key", api_base="http://localhost:8000/v1", default_model="test-model")
+
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="ok", tool_calls=None),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+    with patch.object(provider._client.chat.completions, "create", AsyncMock(return_value=fake_response)) as mock_create:
+        result = await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[{"type": "function", "function": {"name": "save_memory", "parameters": {}}}],
+        )
+
+    assert result.content == "ok"
+    assert mock_create.await_args.kwargs["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_custom_provider_passes_through_explicit_tool_choice() -> None:
+    provider = CustomProvider(api_key="test-key", api_base="http://localhost:8000/v1", default_model="test-model")
+
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="ok", tool_calls=None),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+    forced_choice = {"type": "function", "function": {"name": "save_memory"}}
+
+    with patch.object(provider._client.chat.completions, "create", AsyncMock(return_value=fake_response)) as mock_create:
+        await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[{"type": "function", "function": {"name": "save_memory", "parameters": {}}}],
+            tool_choice=forced_choice,
+        )
+
+    assert mock_create.await_args.kwargs["tool_choice"] == forced_choice
+
+
+def test_codex_tool_choice_keeps_supported_string_values() -> None:
+    assert _normalize_codex_tool_choice("auto") == "auto"
+    assert _normalize_codex_tool_choice("required") == "required"
+
+
+def test_codex_tool_choice_downgrades_dict_form_to_auto() -> None:
+    assert _normalize_codex_tool_choice(
+        {"type": "function", "function": {"name": "save_memory"}}
+    ) == "auto"


### PR DESCRIPTION
## Summary
Follow-up fix for #1733 to preserve explicit `tool_choice` values across provider implementations and document provider-specific behavior with tests.

## What changed
- preserve explicit `tool_choice` in `LiteLLMProvider`
- preserve explicit `tool_choice` in `CustomProvider`
- preserve explicit `tool_choice` in `AzureOpenAIProvider`
- keep Codex-specific normalization behavior and add focused tests for it
- make memory consolidation pass provider-aware `tool_choice`
- add provider-level test coverage for LiteLLM, Custom, Azure, and Codex behavior

## Details
- `LiteLLMProvider`, `CustomProvider`, and `AzureOpenAIProvider` now use the caller-provided `tool_choice` when present, and only default to `"auto"` when tools are supplied without an explicit choice.
- `OpenAICodexProvider` still normalizes unsupported dict-style forced tool choice to `"auto"`; this is now covered by provider-focused tests.
- `MemoryStore` continues to build provider-aware tool choice and passes it through to `provider.chat(...)`.

## Tests
Added/updated tests:
- `tests/test_litellm_tool_choice.py`
- `tests/test_provider_tool_choice.py`
- `tests/test_azure_openai_provider.py`
- `tests/test_memory_consolidation_types.py`

I also re-checked the repository for other hardcoded `tool_choice="auto"` paths and did not find additional missed pass-through cases beyond the providers updated here.

## Notes
Test execution could not be completed in this environment because `pytest` is not installed. Syntax compilation succeeds with:

```bash
python3 -m compileall tests/test_litellm_tool_choice.py tests/test_provider_tool_choice.py tests/test_azure_openai_provider.py tests/test_memory_consolidation_types.py
```

Closes #1733
