### PR TITLE
fix(azure): normalize long tool call ids

### DIFF
--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from typing import Any
 from urllib.parse import urljoin
@@ -91,7 +92,7 @@ class AzureOpenAIProvider(LLMProvider):
     ) -> dict[str, Any]:
         """Prepare the request payload with Azure OpenAI 2024-10-21 compliance."""
         payload: dict[str, Any] = {
-            "messages": self._sanitize_request_messages(
+            "messages": self._sanitize_messages(
                 self._sanitize_empty_content(messages),
                 _AZURE_MSG_KEYS,
             ),
@@ -109,6 +110,47 @@ class AzureOpenAIProvider(LLMProvider):
             payload["tool_choice"] = "auto"
 
         return payload
+
+    @staticmethod
+    def _normalize_tool_call_id(tool_call_id: Any) -> Any:
+        """Normalize tool call ids to Azure-safe ASCII strings with <=40 chars."""
+        if not isinstance(tool_call_id, str):
+            return tool_call_id
+        if len(tool_call_id) <= 40 and tool_call_id.isascii():
+            return tool_call_id
+        return hashlib.sha1(tool_call_id.encode()).hexdigest()
+
+    @classmethod
+    def _sanitize_messages(
+        cls,
+        messages: list[dict[str, Any]],
+        allowed_keys: frozenset[str],
+    ) -> list[dict[str, Any]]:
+        """Strip unsupported keys and keep tool call ids in sync for Azure."""
+        sanitized = cls._sanitize_request_messages(messages, allowed_keys)
+        id_map: dict[str, str] = {}
+
+        def map_id(value: Any) -> Any:
+            if not isinstance(value, str):
+                return value
+            return id_map.setdefault(value, cls._normalize_tool_call_id(value))
+
+        for clean in sanitized:
+            if isinstance(clean.get("tool_calls"), list):
+                normalized_tool_calls = []
+                for tc in clean["tool_calls"]:
+                    if not isinstance(tc, dict):
+                        normalized_tool_calls.append(tc)
+                        continue
+                    tc_clean = dict(tc)
+                    tc_clean["id"] = map_id(tc_clean.get("id"))
+                    normalized_tool_calls.append(tc_clean)
+                clean["tool_calls"] = normalized_tool_calls
+
+            if "tool_call_id" in clean and clean["tool_call_id"]:
+                clean["tool_call_id"] = map_id(clean["tool_call_id"])
+
+        return sanitized
 
     async def chat(
         self,

--- a/tests/test_azure_openai_provider.py
+++ b/tests/test_azure_openai_provider.py
@@ -150,6 +150,40 @@ def test_prepare_request_payload_sanitizes_messages():
     ]
 
 
+def test_prepare_request_payload_normalizes_long_tool_call_ids():
+    """Test Azure payload shortens long tool call ids and keeps references aligned."""
+    provider = AzureOpenAIProvider(
+        api_key="test-key",
+        api_base="https://test-resource.openai.azure.com",
+        default_model="gpt-4o",
+    )
+
+    long_id = "call_" + ("x" * 78)
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{
+                "id": long_id,
+                "type": "function",
+                "function": {"name": "x", "arguments": "{}"},
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": long_id,
+            "name": "x",
+            "content": "ok",
+        },
+    ]
+
+    payload = provider._prepare_request_payload("gpt-5.4", messages)
+    normalized_id = payload["messages"][0]["tool_calls"][0]["id"]
+
+    assert normalized_id != long_id
+    assert len(normalized_id) == 40
+    assert payload["messages"][1]["tool_call_id"] == normalized_id
+
+
 @pytest.mark.asyncio
 async def test_chat_success():
     """Test successful chat request using model as deployment name."""


### PR DESCRIPTION
Keep Azure OpenAI tool call ids within the provider's length limit and preserve the mapping between assistant tool calls and tool responses.

## Summary
- normalize Azure OpenAI `tool_calls[].id` values before sending requests
- keep assistant `tool_calls[].id` and tool `tool_call_id` mappings in sync after normalization
- add regression coverage for long tool call ids that exceed Azure's length limit

## Why
Azure OpenAI rejects chat requests when a tool call id exceeds its maximum allowed length. This can happen in longer tool-using sessions where provider-generated ids are carried back into follow-up requests. LiteLLM already normalizes tool call ids for strict providers, but the direct `AzureOpenAIProvider` path was missing the same compatibility layer.

## Test plan
- [x] `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_azure_openai_provider.py`