### PR TITLE
Check if the content is empty?

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -137,7 +137,8 @@ class LiteLLMProvider(LLMProvider):
                     new_content = [{"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}]
                 else:
                     new_content = list(content)
-                    new_content[-1] = {**new_content[-1], "cache_control": {"type": "ephemeral"}}
+                    if new_content:
+                        new_content[-1] = {**new_content[-1], "cache_control": {"type": "ephemeral"}}
                 new_messages.append({**msg, "content": new_content})
             else:
                 new_messages.append(msg)


### PR DESCRIPTION
_apply_cache_control 方法中处理 system 消息 content 非字符串的逻辑：
else:
    new_content = list(content)
    new_content[-1] = {**new_content[-1], "cache_control": {"type": "ephemeral"}}
 system 消息的 content 是空列表（[]），new_content[-1] 会直接抛出 IndexError: list index out of range 异常，导致整个 LLM 请求崩溃。