### PR TITLE
fix: detect tilde paths in restrictToWorkspace shell guard

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -143,10 +143,10 @@ class ExecTool(Tool):
 
             for raw in self._extract_absolute_paths(cmd):
                 try:
-                    p = Path(raw.strip()).resolve()
+                    p = Path(raw.strip()).expanduser().resolve()
                 except Exception:
                     continue
-                if p.is_absolute() and cwd_path not in p.parents and p != cwd_path:
+                if not p.is_relative_to(cwd_path):
                     return "Error: Command blocked by safety guard (path outside working dir)"
 
         return None
@@ -155,4 +155,5 @@ class ExecTool(Tool):
     def _extract_absolute_paths(command: str) -> list[str]:
         win_paths = re.findall(r"[A-Za-z]:\\[^\s\"'|><;]+", command)   # Windows: C:\...
         posix_paths = re.findall(r"(?:^|[\s|>])(/[^\s\"'>]+)", command) # POSIX: /absolute only
-        return win_paths + posix_paths
+        tilde_paths = re.findall(r"(?:^|[\s|>])(~[^\s\"'>]*)", command) # Tilde: ~/...
+        return win_paths + posix_paths + tilde_paths


### PR DESCRIPTION
## Summary

- Adds `~` (tilde) path detection to `_extract_absolute_paths()` so paths like `~/.nanobot/config.json` are caught by the workspace restriction
- Uses `expanduser()` before `resolve()` to properly expand tilde to the actual home directory
- Switches from manual parent-chain check to `is_relative_to()` for more robust containment validation

## Problem

The `restrictToWorkspace` security feature only extracted paths starting with `/` (POSIX) or drive letters (Windows). Paths starting with `~` were completely invisible to the guard, allowing agents to read/write files outside the workspace:

```bash
# These bypassed the guard:
cat ~/.nanobot/config.json          # API keys
cat ~/../../etc/passwd              # System files
```

The regex in `_extract_absolute_paths()`:
```python
posix_paths = re.findall(r"(?:^|[\s|>])(/[^\s\"'>]+)", command)  # Only /absolute
```

## Fix

```python
tilde_paths = re.findall(r"(?:^|[\s|>])(~[^\s\"'>]*)", command)  # Now catches ~/...
```

And expand before checking:
```python
p = Path(raw.strip()).expanduser().resolve()
if not p.is_relative_to(cwd_path):
    return "Error: ..."
```

## Test plan

- [ ] `cat ~/.nanobot/config.json` is blocked when restrictToWorkspace=true
- [ ] `cat ~/file` is blocked
- [ ] `cat /etc/passwd` still blocked (existing behavior)
- [ ] Commands with workspace-relative paths still work
- [ ] Commands without paths still work

Fixes #1817