### PR TITLE
fix: include reasoning_content in subagent assistant messages

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -145,11 +145,16 @@ class SubagentManager:
                         }
                         for tc in response.tool_calls
                     ]
-                    messages.append({
+                    assistant_msg: dict[str, Any] = {
                         "role": "assistant",
                         "content": response.content or "",
                         "tool_calls": tool_call_dicts,
-                    })
+                    }
+                    if response.reasoning_content is not None:
+                        assistant_msg["reasoning_content"] = response.reasoning_content
+                    if response.thinking_blocks:
+                        assistant_msg["thinking_blocks"] = response.thinking_blocks
+                    messages.append(assistant_msg)
 
                     # Execute tools
                     for tool_call in response.tool_calls:


### PR DESCRIPTION
## Summary

- Includes `reasoning_content` and `thinking_blocks` in assistant messages built by the subagent loop
- Matches the pattern already used by the main agent loop via `context.add_assistant_message()`

## Problem

Deepseek Reasoner requires the `reasoning_content` field in assistant messages when thinking mode is active. The subagent loop was building assistant messages without this field:

```python
messages.append({
    "role": "assistant",
    "content": response.content or "",
    "tool_calls": tool_call_dicts,
    # Missing: reasoning_content, thinking_blocks
})
```

This caused `BadRequestError` when spawning subagents with Deepseek Reasoner:
```
Missing `reasoning_content` field in the assistant message at message index 2
```

The main agent loop (`AgentLoop._run_agent_loop`) already handles this correctly via `context.add_assistant_message()`, but the subagent builds messages directly.

## Fix

Include the fields conditionally (only when present):

```python
assistant_msg = {
    "role": "assistant",
    "content": response.content or "",
    "tool_calls": tool_call_dicts,
}
if response.reasoning_content is not None:
    assistant_msg["reasoning_content"] = response.reasoning_content
if response.thinking_blocks:
    assistant_msg["thinking_blocks"] = response.thinking_blocks
messages.append(assistant_msg)
```

## Test plan

- [ ] Spawn subagent with Deepseek Reasoner — no more `reasoning_content` error
- [ ] Spawn subagent with non-reasoning models (OpenAI, Anthropic) — still works
- [ ] Subagent tool calls complete and results are announced

Fixes #1834