### PR TITLE
fix: pass agent config to memory consolidation LLM calls

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -481,6 +481,8 @@ class AgentLoop:
         return await MemoryStore(self.workspace).consolidate(
             session, self.provider, self.model,
             archive_all=archive_all, memory_window=self.memory_window,
+            temperature=self.temperature, max_tokens=self.max_tokens,
+            reasoning_effort=self.reasoning_effort,
         )
 
     async def process_direct(

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -74,6 +74,9 @@ class MemoryStore:
         *,
         archive_all: bool = False,
         memory_window: int = 50,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        reasoning_effort: str | None = None,
     ) -> bool:
         """Consolidate old messages into MEMORY.md + HISTORY.md via LLM tool call.
 
@@ -111,6 +114,13 @@ class MemoryStore:
 {chr(10).join(lines)}"""
 
         try:
+            kwargs: dict = {}
+            if temperature is not None:
+                kwargs["temperature"] = temperature
+            if max_tokens is not None:
+                kwargs["max_tokens"] = max_tokens
+            if reasoning_effort is not None:
+                kwargs["reasoning_effort"] = reasoning_effort
             response = await provider.chat(
                 messages=[
                     {"role": "system", "content": "You are a memory consolidation agent. Call the save_memory tool with your consolidation of the conversation."},
@@ -118,6 +128,7 @@ class MemoryStore:
                 ],
                 tools=_SAVE_MEMORY_TOOL,
                 model=model,
+                **kwargs,
             )
 
             if not response.has_tool_calls:


### PR DESCRIPTION
## Summary

- Forwards `temperature`, `max_tokens`, and `reasoning_effort` from `AgentLoop` to `MemoryStore.consolidate()`
- Passes these parameters through to `provider.chat()` during consolidation

## Problem

Memory consolidation calls `provider.chat()` without any generation parameters:

```python
response = await provider.chat(
    messages=[...],
    tools=_SAVE_MEMORY_TOOL,
    model=model,
    # No temperature, max_tokens, or reasoning_effort!
)
```

This falls back to LiteLLM defaults (temperature=0.7, max_tokens=4096), ignoring the user's agent configuration:

```json
{
  "agents": {
    "defaults": {
      "temperature": 0.05,
      "maxTokens": 8192
    }
  }
}
```

With only 4096 tokens, reasoning-heavy models consume the entire budget during thinking and never emit the `save_memory` tool call, causing consolidation to silently fail.

## Fix

Thread the agent's configured parameters through to the consolidation call:

```python
# loop.py
await MemoryStore(self.workspace).consolidate(
    session, self.provider, self.model,
    temperature=self.temperature, max_tokens=self.max_tokens,
    reasoning_effort=self.reasoning_effort,
)
```

## Test plan

- [ ] Verify consolidation uses configured temperature (proxy log or debug)
- [ ] Verify consolidation uses configured max_tokens
- [ ] Verify `save_memory` tool call is emitted with sufficient token budget
- [ ] Verify backward compatibility (no params = LiteLLM defaults)

Fixes #1823