### PR TITLE
feat: Provider endpoint rotation with cooldown failover 

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -255,6 +255,23 @@ def _make_provider(config: Config):
         console.print("Set one in ~/.nanobot/config.json under providers section")
         raise typer.Exit(1)
 
+    # --- Endpoint rotation pool ---
+    if p and p.endpoints:
+        from nanobot.providers.endpoint_pool import EndpointPool
+
+        sorted_eps = sorted(p.endpoints, key=lambda e: e.priority)
+        providers: list[LiteLLMProvider] = []
+        for ep in sorted_eps:
+            providers.append(LiteLLMProvider(
+                api_key=ep.api_key or p.api_key,
+                api_base=ep.api_base or config.get_api_base(model),
+                default_model=ep.model or model,
+                extra_headers=ep.extra_headers or (p.extra_headers if p else None),
+                provider_name=provider_name,
+            ))
+        cooldown = sorted_eps[0].cooldown_seconds if sorted_eps else 60.0
+        return EndpointPool(providers, cooldown_seconds=cooldown)
+
     return LiteLLMProvider(
         api_key=p.api_key if p else None,
         api_base=config.get_api_base(model),

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -240,12 +240,24 @@ class AgentsConfig(Base):
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
 
 
+class EndpointConfig(Base):
+    """Single endpoint override within a provider (for rotation pools)."""
+
+    api_key: str = ""
+    api_base: str | None = None
+    model: str | None = None  # Override default model for this endpoint
+    extra_headers: dict[str, str] | None = None
+    priority: int = 0  # Lower = higher priority
+    cooldown_seconds: float = 60.0
+
+
 class ProviderConfig(Base):
     """LLM provider configuration."""
 
     api_key: str = ""
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
+    endpoints: list[EndpointConfig] = Field(default_factory=list)  # Multiple endpoints for rotation
 
 
 class ProvidersConfig(Base):

--- a/nanobot/providers/__init__.py
+++ b/nanobot/providers/__init__.py
@@ -4,5 +4,6 @@ from nanobot.providers.base import LLMProvider, LLMResponse
 from nanobot.providers.litellm_provider import LiteLLMProvider
 from nanobot.providers.openai_codex_provider import OpenAICodexProvider
 from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+from nanobot.providers.endpoint_pool import EndpointPool
 
-__all__ = ["LLMProvider", "LLMResponse", "LiteLLMProvider", "OpenAICodexProvider", "AzureOpenAIProvider"]
+__all__ = ["LLMProvider", "LLMResponse", "LiteLLMProvider", "OpenAICodexProvider", "AzureOpenAIProvider", "EndpointPool"]

--- a/nanobot/providers/endpoint_pool.py
+++ b/nanobot/providers/endpoint_pool.py
@@ -1,0 +1,184 @@
+"""Endpoint rotation pool — wraps multiple LLMProvider instances with failover.
+
+Usage:
+    pool = EndpointPool([provider_a, provider_b])
+    resp = await pool.chat_with_retry(messages=...)
+
+When an endpoint fails with a transient error, the pool marks it on cooldown
+and tries the next one.  If all endpoints are on cooldown the least-recently-
+failed one is used as a last resort.
+
+This class implements the LLMProvider interface so callers (agent loop, etc.)
+need zero changes.
+
+Configuration
+=============
+
+Add an ``endpoints`` list to any provider in ``~/.nanobot/config.json``.
+Without ``endpoints`` the provider works exactly as before (single endpoint).
+
+Basic — multiple API keys for the same provider::
+
+    {
+      "providers": {
+        "openrouter": {
+          "apiKey": "sk-or-default",
+          "endpoints": [
+            { "apiKey": "sk-or-key-1", "priority": 0 },
+            { "apiKey": "sk-or-key-2", "priority": 1 }
+          ]
+        }
+      }
+    }
+
+Degradation — primary model falls back to a cheaper one::
+
+    {
+      "providers": {
+        "openrouter": {
+          "apiKey": "sk-or-xxx",
+          "endpoints": [
+            { "apiKey": "sk-or-key-1", "model": "anthropic/claude-sonnet-4-5", "priority": 0 },
+            { "apiKey": "sk-or-key-2", "model": "anthropic/claude-haiku-3.5",  "priority": 1, "cooldownSeconds": 120 }
+          ]
+        }
+      }
+    }
+
+Multiple base URLs (e.g. local GPU servers)::
+
+    {
+      "providers": {
+        "custom": {
+          "apiKey": "no-key",
+          "apiBase": "http://localhost:8000/v1",
+          "endpoints": [
+            { "apiBase": "http://gpu-server-1:8000/v1", "priority": 0 },
+            { "apiBase": "http://gpu-server-2:8000/v1", "priority": 1 }
+          ]
+        }
+      }
+    }
+
+Endpoint fields (all optional, inherit from the outer provider if omitted):
+
+=================  ======  ===========  ==========================================
+Field              Type    Default      Description
+=================  ======  ===========  ==========================================
+apiKey             str     outer value  API key for this endpoint
+apiBase            str     outer value  Base URL for this endpoint
+model              str     global model Model override for this endpoint
+extraHeaders       dict    outer value  Custom HTTP headers
+priority           int     0            Lower = tried first
+cooldownSeconds    float   60.0         Seconds to skip endpoint after failure
+=================  ======  ===========  ==========================================
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from loguru import logger
+
+from nanobot.providers.base import LLMProvider, LLMResponse
+
+
+class EndpointPool(LLMProvider):
+    """Round-robin pool of LLMProvider endpoints with cooldown-based failover."""
+
+    def __init__(
+        self,
+        endpoints: list[LLMProvider],
+        cooldown_seconds: float = 60.0,
+    ):
+        if not endpoints:
+            raise ValueError("EndpointPool requires at least one endpoint")
+        super().__init__()
+        self._endpoints = endpoints
+        self._cooldown_seconds = cooldown_seconds
+        # endpoint index → timestamp when cooldown expires
+        self._cooldowns: dict[int, float] = {}
+        # round-robin cursor
+        self._cursor = 0
+
+    # ------------------------------------------------------------------
+    # LLMProvider interface
+    # ------------------------------------------------------------------
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+    ) -> LLMResponse:
+        """Try endpoints in order, skipping those on cooldown."""
+        order = self._pick_order()
+        last_resp: LLMResponse | None = None
+
+        for idx in order:
+            provider = self._endpoints[idx]
+            try:
+                resp = await provider.chat(
+                    messages=messages,
+                    tools=tools,
+                    model=model,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    reasoning_effort=reasoning_effort,
+                )
+            except Exception as exc:
+                resp = LLMResponse(
+                    content=f"Error calling LLM: {exc}",
+                    finish_reason="error",
+                )
+
+            if resp.finish_reason != "error" or not self._is_transient_error(resp.content):
+                # Success or non-transient error — clear cooldown and return.
+                self._cooldowns.pop(idx, None)
+                self._cursor = (idx + 1) % len(self._endpoints)
+                return resp
+
+            # Transient failure — cooldown this endpoint and try next.
+            self._cooldowns[idx] = time.monotonic() + self._cooldown_seconds
+            logger.warning(
+                "Endpoint {} failed (transient), cooling down for {}s. Trying next.",
+                idx,
+                self._cooldown_seconds,
+            )
+            last_resp = resp
+
+        # All endpoints failed — return the last error.
+        return last_resp  # type: ignore[return-value]
+
+    def get_default_model(self) -> str:
+        return self._endpoints[0].get_default_model()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _pick_order(self) -> list[int]:
+        """Return endpoint indices: available ones first (round-robin), then cooldown ones (least-recently-failed first)."""
+        now = time.monotonic()
+        n = len(self._endpoints)
+
+        available: list[int] = []
+        on_cooldown: list[tuple[float, int]] = []  # (expiry, index)
+
+        for offset in range(n):
+            idx = (self._cursor + offset) % n
+            expiry = self._cooldowns.get(idx)
+            if expiry is None or now >= expiry:
+                available.append(idx)
+                # Expired cooldown — clean up.
+                self._cooldowns.pop(idx, None)
+            else:
+                on_cooldown.append((expiry, idx))
+
+        # Sort cooldown endpoints by expiry ascending (try the one closest to recovery first).
+        on_cooldown.sort()
+        return available + [idx for _, idx in on_cooldown]

--- a/tests/test_endpoint_pool.py
+++ b/tests/test_endpoint_pool.py
@@ -1,0 +1,289 @@
+"""Tests for EndpointPool — round-robin rotation with cooldown failover.
+
+Imports base.py and endpoint_pool.py directly (not through __init__.py)
+to avoid pulling in heavy dependencies like litellm.
+"""
+
+import importlib
+import time
+
+import pytest
+
+# Import the two modules we actually need, bypassing the package __init__.py
+# which eagerly imports providers that need litellm, oauth_cli_kit, etc.
+_base = importlib.import_module("nanobot.providers.base")
+_pool = importlib.import_module("nanobot.providers.endpoint_pool")
+
+LLMProvider = _base.LLMProvider
+LLMResponse = _base.LLMResponse
+EndpointPool = _pool.EndpointPool
+
+
+class ScriptedProvider(LLMProvider):
+    """Provider that returns pre-scripted responses in order."""
+
+    def __init__(self, responses, name=""):
+        super().__init__()
+        self._responses = list(responses)
+        self._name = name
+        self.calls = 0
+
+    async def chat(self, *args, **kwargs) -> LLMResponse:
+        self.calls += 1
+        response = self._responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    def get_default_model(self) -> str:
+        return f"test-model-{self._name}"
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_empty_endpoints_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        EndpointPool([])
+
+
+def test_single_endpoint_works():
+    pool = EndpointPool([ScriptedProvider([LLMResponse(content="ok")])])
+    assert pool.get_default_model() == "test-model-"
+
+
+# ---------------------------------------------------------------------------
+# Basic rotation — first endpoint succeeds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_on_first_endpoint():
+    ep0 = ScriptedProvider([LLMResponse(content="from-0")], name="0")
+    ep1 = ScriptedProvider([LLMResponse(content="from-1")], name="1")
+    pool = EndpointPool([ep0, ep1])
+
+    resp = await pool.chat(messages=[])
+    assert resp.content == "from-0"
+    assert ep0.calls == 1
+    assert ep1.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Failover — first endpoint fails, second succeeds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failover_to_second_endpoint():
+    ep0 = ScriptedProvider(
+        [LLMResponse(content="429 rate limit", finish_reason="error")], name="0"
+    )
+    ep1 = ScriptedProvider([LLMResponse(content="from-1")], name="1")
+    pool = EndpointPool([ep0, ep1], cooldown_seconds=60)
+
+    resp = await pool.chat(messages=[])
+    assert resp.content == "from-1"
+    assert ep0.calls == 1
+    assert ep1.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Failover — exception from provider is caught
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failover_on_exception():
+    # "connection refused" contains "connection" which is a transient error marker
+    ep0 = ScriptedProvider([ConnectionError("connection refused")], name="0")
+    ep1 = ScriptedProvider([LLMResponse(content="from-1")], name="1")
+    pool = EndpointPool([ep0, ep1], cooldown_seconds=60)
+
+    resp = await pool.chat(messages=[])
+    assert resp.content == "from-1"
+
+
+# ---------------------------------------------------------------------------
+# All endpoints fail — returns last error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_endpoints_fail_returns_last_error():
+    ep0 = ScriptedProvider(
+        [LLMResponse(content="429 rate limit", finish_reason="error")], name="0"
+    )
+    ep1 = ScriptedProvider(
+        [LLMResponse(content="503 server error", finish_reason="error")], name="1"
+    )
+    pool = EndpointPool([ep0, ep1])
+
+    resp = await pool.chat(messages=[])
+    assert resp.finish_reason == "error"
+    assert "503" in resp.content
+    assert ep0.calls == 1
+    assert ep1.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Non-transient error — no failover, returns immediately
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_transient_error_no_failover():
+    ep0 = ScriptedProvider(
+        [LLMResponse(content="401 unauthorized", finish_reason="error")], name="0"
+    )
+    ep1 = ScriptedProvider([LLMResponse(content="from-1")], name="1")
+    pool = EndpointPool([ep0, ep1])
+
+    resp = await pool.chat(messages=[])
+    assert resp.content == "401 unauthorized"
+    # Non-transient error — should NOT try ep1.
+    assert ep1.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Cooldown — failed endpoint is skipped on next call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cooldown_skips_failed_endpoint():
+    ep0 = ScriptedProvider(
+        [
+            LLMResponse(content="429 rate limit", finish_reason="error"),
+            LLMResponse(content="from-0-recovered"),
+        ],
+        name="0",
+    )
+    ep1 = ScriptedProvider(
+        [LLMResponse(content="from-1-a"), LLMResponse(content="from-1-b")],
+        name="1",
+    )
+    pool = EndpointPool([ep0, ep1], cooldown_seconds=9999)
+
+    # Call 1: ep0 fails → failover to ep1
+    resp1 = await pool.chat(messages=[])
+    assert resp1.content == "from-1-a"
+
+    # Call 2: ep0 is on cooldown (9999s) → goes to ep1 first
+    resp2 = await pool.chat(messages=[])
+    assert resp2.content == "from-1-b"
+    assert ep0.calls == 1  # ep0 was NOT retried
+
+
+# ---------------------------------------------------------------------------
+# Cooldown expiry — endpoint recovers after cooldown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cooldown_expires_endpoint_recovers(monkeypatch):
+    ep0 = ScriptedProvider(
+        [
+            LLMResponse(content="429 rate limit", finish_reason="error"),
+            LLMResponse(content="from-0-recovered"),
+        ],
+        name="0",
+    )
+    ep1 = ScriptedProvider(
+        [LLMResponse(content="from-1")],
+        name="1",
+    )
+    pool = EndpointPool([ep0, ep1], cooldown_seconds=1)
+
+    # Call 1: ep0 fails → failover to ep1
+    resp1 = await pool.chat(messages=[])
+    assert resp1.content == "from-1"
+
+    # Simulate cooldown expiry by patching time.monotonic
+    real_monotonic = time.monotonic
+    monkeypatch.setattr(
+        "nanobot.providers.endpoint_pool.time.monotonic",
+        lambda: real_monotonic() + 2,  # 2s later, cooldown (1s) is expired
+    )
+
+    # Call 2: ep0 cooldown expired → ep0 is available again
+    resp2 = await pool.chat(messages=[])
+    assert resp2.content == "from-0-recovered"
+
+
+# ---------------------------------------------------------------------------
+# Round-robin cursor advances
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_robin_cursor():
+    """After ep0 succeeds, next call starts from ep1 (round-robin)."""
+    ep0 = ScriptedProvider(
+        [LLMResponse(content="from-0"), LLMResponse(content="from-0-again")],
+        name="0",
+    )
+    ep1 = ScriptedProvider(
+        [LLMResponse(content="from-1"), LLMResponse(content="from-1-again")],
+        name="1",
+    )
+    pool = EndpointPool([ep0, ep1])
+
+    resp1 = await pool.chat(messages=[])
+    assert resp1.content == "from-0"  # starts at cursor=0
+
+    resp2 = await pool.chat(messages=[])
+    assert resp2.content == "from-1"  # cursor advanced to 1
+
+    resp3 = await pool.chat(messages=[])
+    assert resp3.content == "from-0-again"  # cursor wrapped to 0
+
+
+# ---------------------------------------------------------------------------
+# get_default_model returns first endpoint's model
+# ---------------------------------------------------------------------------
+
+
+def test_get_default_model():
+    ep0 = ScriptedProvider([], name="primary")
+    ep1 = ScriptedProvider([], name="backup")
+    pool = EndpointPool([ep0, ep1])
+    assert pool.get_default_model() == "test-model-primary"
+
+
+# ---------------------------------------------------------------------------
+# chat_with_retry works through the pool (inherited from LLMProvider)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_with_retry_works_with_pool(monkeypatch):
+    """EndpointPool inherits chat_with_retry from LLMProvider.
+    Retry logic should wrap the pool's chat() which already does failover."""
+    ep0 = ScriptedProvider(
+        [
+            # First chat_with_retry attempt: both endpoints fail
+            LLMResponse(content="429 rate limit", finish_reason="error"),
+            # Second chat_with_retry attempt (after retry): ep0 recovers
+            LLMResponse(content="from-0-ok"),
+        ],
+        name="0",
+    )
+    ep1 = ScriptedProvider(
+        [LLMResponse(content="503 server error", finish_reason="error")],
+        name="1",
+    )
+    pool = EndpointPool([ep0, ep1], cooldown_seconds=0)  # no cooldown for simplicity
+
+    delays: list[int] = []
+
+    async def _fake_sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", _fake_sleep)
+
+    resp = await pool.chat_with_retry(messages=[])
+    assert resp.content == "from-0-ok"
+    assert len(delays) == 1  # one retry delay from chat_with_retry


### PR DESCRIPTION
# feat: Provider endpoint rotation with cooldown failover

## Summary

- Add `EndpointPool` — a round-robin LLM provider pool with automatic failover and cooldown, implementing the `LLMProvider` interface transparently
- Add `endpoints` configuration field to `ProviderConfig` for multi-endpoint rotation
- Add 12 unit tests covering all rotation and failover scenarios

## Motivation

When relying on a single API key or endpoint, rate limits (429) or transient server errors (502/503) cause the bot to stall. This change allows configuring multiple endpoints per provider, enabling automatic failover without any changes to the agent loop or channel layer.

## Design

Uses the **decorator/proxy pattern** — `EndpointPool` wraps multiple `LLMProvider` instances and exposes the same interface. The agent loop calls `chat_with_retry()` as before, completely unaware of the pool underneath.

```
Agent Loop  ->  EndpointPool (LLMProvider)  ->  Provider A (primary)
                                            ->  Provider B (fallback)
                                            ->  Provider C (fallback)
```

**Key behaviors:**

- **Round-robin**: Successful calls advance the cursor, distributing load across endpoints
- **Transient failover**: 429 / 5xx / timeout errors trigger automatic switch to the next endpoint
- **Cooldown**: Failed endpoints are skipped for a configurable duration (default 60s), then automatically recover
- **Non-transient passthrough**: 401 / 400 errors return immediately without trying other endpoints
- **Last resort**: If all endpoints are on cooldown, the one closest to recovery is tried first

## Changes

| File | Change |
|------|--------|
| `providers/endpoint_pool.py` | **New** — `EndpointPool` class (~110 lines) with full configuration docs |
| `config/schema.py` | Add `EndpointConfig` class + `endpoints` field on `ProviderConfig` |
| `cli/commands.py` | Add pool creation branch in `_make_provider` (~12 lines) |
| `providers/__init__.py` | Add `EndpointPool` export |
| `tests/test_endpoint_pool.py` | **New** — 12 test cases |

## Backward Compatibility

Fully backward compatible. Without `endpoints` configured, behavior is identical to before.

## Configuration Example

### Basic — multiple API keys for the same provider

```json
{
  "providers": {
    "openrouter": {
      "apiKey": "sk-or-default",
      "endpoints": [
        { "apiKey": "sk-or-key-1", "priority": 0 },
        { "apiKey": "sk-or-key-2", "priority": 1 }
      ]
    }
  }
}
```

### Degradation — primary model falls back to a cheaper one

```json
{
  "providers": {
    "openrouter": {
      "apiKey": "sk-or-xxx",
      "endpoints": [
        { "apiKey": "sk-or-key-1", "model": "anthropic/claude-sonnet-4-5", "priority": 0 },
        { "apiKey": "sk-or-key-2", "model": "anthropic/claude-haiku-3.5", "priority": 1, "cooldownSeconds": 120 }
      ]
    }
  }
}
```

### Multiple base URLs (e.g. local GPU servers)

```json
{
  "providers": {
    "custom": {
      "apiKey": "no-key",
      "apiBase": "http://localhost:8000/v1",
      "endpoints": [
        { "apiBase": "http://gpu-server-1:8000/v1", "priority": 0 },
        { "apiBase": "http://gpu-server-2:8000/v1", "priority": 1 }
      ]
    }
  }
}
```

### Endpoint fields reference

All fields are optional. Omitted fields inherit from the outer provider config.

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `apiKey` | string | outer value | API key for this endpoint |
| `apiBase` | string | outer value | Base URL for this endpoint |
| `model` | string | global model | Model override for this endpoint |
| `extraHeaders` | object | outer value | Custom HTTP headers |
| `priority` | int | 0 | Lower value = tried first |
| `cooldownSeconds` | float | 60.0 | Seconds to skip endpoint after failure |