### PR TITLE
fix: bump litellm version to 1.82.1 for Moonshot provider support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 
 dependencies = [
     "typer>=0.20.0,<1.0.0",
-    "litellm>=1.81.5,<2.0.0",
+    "litellm>=1.82.1,<2.0.0",
     "pydantic>=2.12.0,<3.0.0",
     "pydantic-settings>=2.12.0,<3.0.0",
     "websockets>=16.0,<17.0",


### PR DESCRIPTION
Now LiteLLM 1.82.1 has been published to PyPI. On my machine, just run
```shell
uv tool upgrade nanobot-ai
```

to upgrade all dependencies of `nanobot-ai`, uv will upgrade LiteLLM to 1.82.1, and then Kimi K2.5 (Moonshot provider) will be able to see image input.

This PR only bumps the `litellm` in `pyproject.toml` to 1.82.1 to fix issue #1628 . 9 (of 243) test cases fail, but it seems not related to LiteLLM.