### PR TITLE
fix: exclude hidden files when syncing workspace templates

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -88,7 +88,7 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
         added.append(str(dest.relative_to(workspace)))
 
     for item in tpl.iterdir():
-        if item.name.endswith(".md"):
+        if item.name.endswith(".md") and not item.name.startswith("."):
             _write(item, workspace / item.name)
     _write(tpl / "memory" / "MEMORY.md", workspace / "memory" / "MEMORY.md")
     _write(None, workspace / "memory" / "HISTORY.md")


### PR DESCRIPTION
fix:

 ```python
   # nanobot/utils/helpers.py 第 91 行
   # before
   if item.name.endswith(".md"):

   # after
   if item.name.endswith(".md") and not item.name.startswith("."):
 ```

Skip files starting with '.' (e.g., macOS extended attributes like ._AGENTS.md) to prevent UnicodeDecodeError during template synchronization.