### PR TITLE
Endpoint channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,66 @@ nanobot gateway
 
 </details>
 
+
+<details>
+<summary><b>Endpoint</b></summary>
+
+Provide a OpenAI /v1/responses interface, allowing connecting external channels.
+
+**1. Install dependencies
+
+```
+pip install flask[async]
+```
+
+**2. Configure**
+
+> - `host` is 127.0.0.1 by default. Set it to 0.0.0.0 to listen on all interfaces.
+> - `port` defaults to 8080. Set it to the port you want the server to listen on.
+
+```json
+{
+  "channels": {
+    "endpoint": {
+      "enabled": true,
+      "host": "0.0.0.0",
+      "port": 8080
+    }
+  }
+}
+```
+
+**3. Run**
+
+```bash
+nanobot gateway
+```
+
+**3. Test**
+
+```
+curl -X POST "http://localhost:8080/v1/responses" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "model": "agent-v1",
+       "messages": [
+         {
+           "role": "user",
+           "content": "Who are you?"
+         }
+       ],
+       "user": "test-user"
+     }'
+```
+
+**4. Example external channel **
+
+```
+python tests/test_endpoint_webchat_server.py
+```
+
+</details>
+
 ## 🌐 Agent Social Network
 
 🐈 nanobot is capable of linking to the agent social network (agent community). **Just send one message and your nanobot joins automatically!**

--- a/README.md
+++ b/README.md
@@ -781,6 +781,7 @@ pip install flask[async]
   "channels": {
     "endpoint": {
       "enabled": true,
+      "api_key": "xxx",
       "host": "0.0.0.0",
       "port": 8080
     }
@@ -799,22 +800,17 @@ nanobot gateway
 ```
 curl -X POST "http://localhost:8080/v1/responses" \
      -H "Content-Type: application/json" \
+     -H "Authorization: Bearer xxx"
      -d '{
-       "model": "agent-v1",
-       "messages": [
-         {
-           "role": "user",
-           "content": "Who are you?"
-         }
-       ],
-       "user": "test-user"
+       "model": "any",
+       "input": "who are you?"
      }'
 ```
 
 **4. Example external channel **
 
 ```
-python tests/test_endpoint_webchat_server.py
+NANOBOT_API_KEY=xxx python tests/test_endpoint_webchat_server.py
 ```
 
 </details>

--- a/nanobot/channels/endpoint.py
+++ b/nanobot/channels/endpoint.py
@@ -2,7 +2,7 @@ import uuid
 import time
 import threading
 import concurrent.futures
-from typing import Any
+from typing import Any, List, Dict, Optional
 
 from flask import Flask, request, jsonify
 from werkzeug.serving import make_server
@@ -24,8 +24,11 @@ class EndpointConfig(Base):
 
 class EndpointChannel(BaseChannel):
     """
-    HTTP endpoint channel implementing an OpenAI-compatible /v1/responses interface.
+    HTTP endpoint channel implementing an OpenAI /v1/responses interface.
     Simplified implementation using Flask's async support and thread-safe futures.
+
+    This channel translates Responses API style POST requests into bus messages
+    and waits for the corresponding outbound response to fulfill the HTTP request.
     """
 
     name: str = "endpoint"
@@ -57,23 +60,59 @@ class EndpointChannel(BaseChannel):
         @self.app.route("/v1/responses", methods=["POST"])
         async def create_response():
             """
-            OpenAI-like chat completion endpoint.
+            OpenAI Responses API endpoint.
+
+            Request Schema:
+            {
+                "model": "...",
+                "input": [
+                    {"type": "message", "role": "user", "content": [{"type": "text", "text": "..."}]}
+                ],
+                "instructions": "System instructions",
+                "previous_response_id": "resp_...",
+                "store": true,
+                "metadata": {...}
+            }
             """
             data = request.get_json()
-            if not data or "messages" not in data:
-                return jsonify({"error": "Invalid request"}), 400
+            if not data:
+                return jsonify({"error": "Missing request body"}), 400
 
-            user_messages = [m for m in data["messages"] if m.get("role") == "user"]
-            if not user_messages:
-                return jsonify({"error": "No user message found"}), 400
+            # Input is an array of items in Responses API
+            input_items = data.get("input", [])
+            instructions = data.get("instructions", "")
 
-            content = user_messages[-1].get("content", "")
+            content = ""
+            if isinstance(input_items, list):
+                # Extract text from the last user message item
+                for item in reversed(input_items):
+                    if item.get("type") == "message" and item.get("role") == "user":
+                        item_content = item.get("content")
+                        if isinstance(item_content, list):
+                            content = " ".join([c.get("text", "") for c in item_content if c.get("type") == "text"])
+                        elif isinstance(item_content, str):
+                            content = item_content
+                        break
+            elif isinstance(input_items, str):
+                # Handle simplified input string if provided
+                content = input_items
+
+            # Fallback to legacy 'messages' if 'input' is empty
+            if not content and "messages" in data:
+                for m in reversed(data["messages"]):
+                    if m.get("role") == "user":
+                        content = m.get("content", "")
+                        break
+
+            if not content:
+                return jsonify({"error": "Invalid request: 'input' or 'messages' with user content is required"}), 400
+
             sender_id = data.get("user", "default_user")
+            chat_id = data.get("previous_response_id", f"resp_{uuid.uuid4().hex}")
 
             if not self.is_allowed(sender_id):
                 return jsonify({"error": "Access denied"}), 403
 
-            chat_id = str(uuid.uuid4())
             future = concurrent.futures.Future()
             self._pending_responses[chat_id] = future
 
@@ -82,7 +121,13 @@ class EndpointChannel(BaseChannel):
                 await self._handle_message(
                     sender_id=sender_id,
                     chat_id=chat_id,
-                    content=content
+                    content=content,
+                    metadata={
+                        "http_request": True,
+                        "instructions": instructions,
+                        "store": data.get("store", True),
+                        "model": data.get("model")
+                    }
                 )
 
                 # Wait for the response message (blocking the request thread is safe
@@ -93,18 +138,30 @@ class EndpointChannel(BaseChannel):
                 except concurrent.futures.TimeoutError:
                     return jsonify({"error": "Response timeout"}), 504
 
+                # Construct Response object matching OpenAI spec
                 return jsonify({
-                    "id": f"chatcmpl-{chat_id}",
-                    "object": "chat.completion",
-                    "created": int(time.time()),
-                    "choices": [{
-                        "index": 0,
-                        "message": {
+                    "id": chat_id,
+                    "object": "response",
+                    "created_at": int(time.time()),
+                    "model": data.get("model", "agent-v1"),
+                    "status": "completed",
+                    "output": [
+                        {
+                            "id": f"msg_{uuid.uuid4().hex}",
+                            "type": "message",
+                            "status": "completed",
                             "role": "assistant",
-                            "content": outbound_msg.content
-                        },
-                        "finish_reason": "stop"
-                    }]
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": outbound_msg.content
+                                }
+                            ]
+                        }
+                    ],
+                    "usage": {
+                        "total_tokens": -1
+                    }
                 })
 
             finally:
@@ -137,3 +194,5 @@ class EndpointChannel(BaseChannel):
         if future and not future.done():
             future.set_result(msg)
             logger.debug(f"Resolved response for {msg.chat_id}")
+        else:
+            logger.warning(f"Received outbound message for unknown or expired chat_id: {msg.chat_id}")

--- a/nanobot/channels/endpoint.py
+++ b/nanobot/channels/endpoint.py
@@ -1,0 +1,139 @@
+import uuid
+import time
+import threading
+import concurrent.futures
+from typing import Any
+
+from flask import Flask, request, jsonify
+from werkzeug.serving import make_server
+from loguru import logger
+
+
+from pydantic import Field
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
+
+class EndpointConfig(Base):
+    enabled: bool = False
+    host: str = "0.0.0.0"
+    port: int = 8080
+    allow_from: list[str] = Field(default_factory=lambda: ["*"])
+
+class EndpointChannel(BaseChannel):
+    """
+    HTTP endpoint channel implementing an OpenAI-compatible /v1/responses interface.
+    Simplified implementation using Flask's async support and thread-safe futures.
+    """
+
+    name: str = "endpoint"
+
+    @classmethod
+    def default_config(cls) -> dict[str, Any]:
+        return EndpointConfig().model_dump(by_alias=True)
+
+    def __init__(self, config: Any, bus: MessageBus):
+        if isinstance(config, dict):
+            config = EndpointConfig.model_validate(config)
+        super().__init__(config, bus)
+        self.app = Flask(__name__)
+        self._server = None
+        self._server_thread = None
+        self._pending_responses: dict[str, concurrent.futures.Future] = {}
+        self._setup_routes()
+
+    def _setup_routes(self) -> None:
+        """Register Flask routes."""
+
+        @self.app.after_request
+        def add_cors_headers(response):
+            response.headers.add('Access-Control-Allow-Origin', '*')
+            response.headers.add('Access-Control-Allow-Headers', 'Content-Type,Authorization')
+            response.headers.add('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS')
+            return response
+
+        @self.app.route("/v1/responses", methods=["POST"])
+        async def create_response():
+            """
+            OpenAI-like chat completion endpoint.
+            """
+            data = request.get_json()
+            if not data or "messages" not in data:
+                return jsonify({"error": "Invalid request"}), 400
+
+            user_messages = [m for m in data["messages"] if m.get("role") == "user"]
+            if not user_messages:
+                return jsonify({"error": "No user message found"}), 400
+
+            content = user_messages[-1].get("content", "")
+            sender_id = data.get("user", "default_user")
+
+            if not self.is_allowed(sender_id):
+                return jsonify({"error": "Access denied"}), 403
+
+            chat_id = str(uuid.uuid4())
+            future = concurrent.futures.Future()
+            self._pending_responses[chat_id] = future
+
+            try:
+                # Directly forward to the message bus via base class
+                await self._handle_message(
+                    sender_id=sender_id,
+                    chat_id=chat_id,
+                    content=content
+                )
+
+                # Wait for the response message (blocking the request thread is safe
+                # here because werkzeug is running in threaded mode)
+                timeout = getattr(self.config, "request_timeout", 60.0)
+                try:
+                    outbound_msg = future.result(timeout=timeout)
+                except concurrent.futures.TimeoutError:
+                    return jsonify({"error": "Response timeout"}), 504
+
+                return jsonify({
+                    "id": f"chatcmpl-{chat_id}",
+                    "object": "chat.completion",
+                    "created": int(time.time()),
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": outbound_msg.content
+                        },
+                        "finish_reason": "stop"
+                    }]
+                })
+
+            finally:
+                self._pending_responses.pop(chat_id, None)
+
+    async def start(self) -> None:
+        """Start the Flask server in a background thread."""
+        host = getattr(self.config, "host", "0.0.0.0")
+        port = getattr(self.config, "port", 8080)
+
+        self._server = make_server(host, port, self.app, threaded=True)
+        self._server_thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._server_thread.start()
+
+        self._running = True
+        logger.info(f"Endpoint channel running on http://{host}:{port}")
+
+    async def stop(self) -> None:
+        """Stop the Flask server."""
+        if self._server:
+            self._server.shutdown()
+        if self._server_thread:
+            self._server_thread.join(timeout=2.0)
+        self._running = False
+        logger.info("Endpoint channel stopped")
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Fulfill the interface by resolving the pending future."""
+        future = self._pending_responses.get(msg.chat_id)
+        if future and not future.done():
+            future.set_result(msg)
+            logger.debug(f"Resolved response for {msg.chat_id}")

--- a/nanobot/channels/endpoint.py
+++ b/nanobot/channels/endpoint.py
@@ -1,10 +1,11 @@
 import uuid
 import time
 import threading
-import concurrent.futures
-from typing import Any, List, Dict, Optional
+import queue
+import json
+from typing import Any
 
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, Response, stream_with_context
 from werkzeug.serving import make_server
 from loguru import logger
 
@@ -24,6 +25,8 @@ class EndpointConfig(Base):
     host: str = "127.0.0.1"
     port: int = 8080
     allow_from: list[str] = Field(default_factory=lambda: ["*"])
+    streaming: bool = True
+    request_timeout: float = 60.0
 
 class EndpointChannel(BaseChannel):
     """
@@ -47,8 +50,52 @@ class EndpointChannel(BaseChannel):
         self.app = Flask(__name__)
         self._server = None
         self._server_thread = None
-        self._pending_responses: dict[str, concurrent.futures.Future] = {}
+        self._response_queues: dict[str, queue.SimpleQueue] = {}
+        self._responses_lock = threading.Lock()
         self._setup_routes()
+
+    def _register_queue(self, chat_id: str) -> queue.SimpleQueue:
+        q: queue.SimpleQueue = queue.SimpleQueue()
+        with self._responses_lock:
+            self._response_queues[chat_id] = q
+        return q
+
+    def _get_queue(self, chat_id: str) -> queue.SimpleQueue | None:
+        with self._responses_lock:
+            return self._response_queues.get(chat_id)
+
+    def _pop_queue(self, chat_id: str) -> None:
+        with self._responses_lock:
+            self._response_queues.pop(chat_id, None)
+
+    def _build_response_payload(self, chat_id: str, model: str, content: str, created_at: int) -> dict[str, Any]:
+        return {
+            "id": chat_id,
+            "object": "response",
+            "created_at": created_at,
+            "model": model,
+            "status": "completed",
+            "output": [
+                {
+                    "id": f"msg_{uuid.uuid4().hex}",
+                    "type": "message",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": content
+                        }
+                    ]
+                }
+            ],
+            "usage": {
+                "total_tokens": -1
+            }
+        }
+
+    def _sse_event(self, event: str, data: dict[str, Any]) -> str:
+        return f"event: {event}\ndata: {json.dumps(data)}\n\n"
 
     def _setup_routes(self) -> None:
         """Register Flask routes."""
@@ -133,8 +180,8 @@ class EndpointChannel(BaseChannel):
             if not self.is_allowed(sender_id):
                 return jsonify({"error": "Access denied"}), 403
 
-            future = concurrent.futures.Future()
-            self._pending_responses[chat_id] = future
+            stream = bool(data.get("stream", False))
+            q = self._register_queue(chat_id)
 
             try:
                 # Directly forward to the message bus via base class
@@ -146,46 +193,94 @@ class EndpointChannel(BaseChannel):
                         "http_request": True,
                         "instructions": instructions,
                         "store": data.get("store", True),
-                        "model": data.get("model")
+                        "model": data.get("model"),
+                        "stream": stream
                     }
                 )
 
-                # Wait for the response message (blocking the request thread is safe
-                # here because werkzeug is running in threaded mode)
-                timeout = getattr(self.config, "request_timeout", 60.0)
-                try:
-                    outbound_msg = future.result(timeout=timeout)
-                except concurrent.futures.TimeoutError:
-                    return jsonify({"error": "Response timeout"}), 504
+                timeout = float(getattr(self.config, "request_timeout", 60.0))
+                model = data.get("model", "agent-v1")
+                created_at = int(time.time())
 
-                # Construct Response object matching OpenAI spec
-                return jsonify({
-                    "id": chat_id,
-                    "object": "response",
-                    "created_at": int(time.time()),
-                    "model": data.get("model", "agent-v1"),
-                    "status": "completed",
-                    "output": [
-                        {
-                            "id": f"msg_{uuid.uuid4().hex}",
-                            "type": "message",
-                            "status": "completed",
-                            "role": "assistant",
-                            "content": [
+                if stream:
+                    def event_stream():
+                        buffer = ""
+                        try:
+                            yield self._sse_event(
+                                "response.created",
                                 {
-                                    "type": "text",
-                                    "text": outbound_msg.content
+                                    "id": chat_id,
+                                    "object": "response",
+                                    "created_at": created_at,
+                                    "model": model,
+                                    "status": "in_progress"
                                 }
-                            ]
-                        }
-                    ],
-                    "usage": {
-                        "total_tokens": -1
+                            )
+                            while True:
+                                try:
+                                    item = q.get(timeout=timeout)
+                                except queue.Empty:
+                                    yield self._sse_event("response.error", {"error": "Response timeout"})
+                                    break
+
+                                item_type = item.get("type")
+                                if item_type == "delta":
+                                    delta = item.get("delta", "")
+                                    buffer += delta
+                                    yield self._sse_event(
+                                        "response.output_text.delta",
+                                        {"delta": delta, "response_id": chat_id}
+                                    )
+                                elif item_type == "end":
+                                    meta = item.get("meta", {})
+                                    if meta.get("_resuming"):
+                                        continue
+                                    payload = self._build_response_payload(chat_id, model, buffer, created_at)
+                                    yield self._sse_event("response.completed", payload)
+                                    break
+                                elif item_type == "final":
+                                    outbound_msg = item.get("msg")
+                                    content_text = outbound_msg.content if outbound_msg else buffer
+                                    payload = self._build_response_payload(chat_id, model, content_text, created_at)
+                                    yield self._sse_event("response.completed", payload)
+                                    break
+                        finally:
+                            self._pop_queue(chat_id)
+
+                    headers = {
+                        "Cache-Control": "no-cache",
+                        "Connection": "keep-alive",
+                        "X-Accel-Buffering": "no"
                     }
-                })
+                    return Response(stream_with_context(event_stream()), mimetype="text/event-stream", headers=headers)
+
+                # Non-streaming: aggregate deltas or await final message
+                buffer = ""
+                while True:
+                    try:
+                        item = q.get(timeout=timeout)
+                    except queue.Empty:
+                        return jsonify({"error": "Response timeout"}), 504
+
+                    item_type = item.get("type")
+                    if item_type == "delta":
+                        buffer += item.get("delta", "")
+                        continue
+                    if item_type == "end":
+                        meta = item.get("meta", {})
+                        if meta.get("_resuming"):
+                            continue
+                        payload = self._build_response_payload(chat_id, model, buffer, created_at)
+                        return jsonify(payload)
+                    if item_type == "final":
+                        outbound_msg = item.get("msg")
+                        content_text = outbound_msg.content if outbound_msg else buffer
+                        payload = self._build_response_payload(chat_id, model, content_text, created_at)
+                        return jsonify(payload)
 
             finally:
-                self._pending_responses.pop(chat_id, None)
+                if not stream:
+                    self._pop_queue(chat_id)
 
     async def start(self) -> None:
         """Start the Flask server in a background thread."""
@@ -209,10 +304,26 @@ class EndpointChannel(BaseChannel):
         logger.info("Endpoint channel stopped")
 
     async def send(self, msg: OutboundMessage) -> None:
-        """Fulfill the interface by resolving the pending future."""
-        future = self._pending_responses.get(msg.chat_id)
-        if future and not future.done():
-            future.set_result(msg)
-            logger.debug(f"Resolved response for {msg.chat_id}")
+        """Fulfill the interface by delivering a final message to the queue."""
+        q = self._get_queue(msg.chat_id)
+        if q:
+            q.put_nowait({"type": "final", "msg": msg})
+            logger.debug(f"Enqueued final response for {msg.chat_id}")
         else:
             logger.warning(f"Received outbound message for unknown or expired chat_id: {msg.chat_id}")
+
+    async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None) -> None:
+        """Deliver a streaming chunk to the pending response queue."""
+        q = self._get_queue(chat_id)
+        if not q:
+            logger.warning(f"Received stream delta for unknown or expired chat_id: {chat_id}")
+            return
+
+        meta = metadata or {}
+        if meta.get("_stream_end"):
+            q.put_nowait({"type": "end", "meta": meta})
+            logger.debug(f"Enqueued stream end for {chat_id}")
+            return
+
+        q.put_nowait({"type": "delta", "delta": delta, "meta": meta})
+        logger.debug(f"Enqueued stream delta for {chat_id}")

--- a/nanobot/channels/endpoint.py
+++ b/nanobot/channels/endpoint.py
@@ -11,6 +11,8 @@ from loguru import logger
 
 from pydantic import Field
 
+from functools import wraps
+
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
@@ -18,7 +20,8 @@ from nanobot.config.schema import Base
 
 class EndpointConfig(Base):
     enabled: bool = False
-    host: str = "0.0.0.0"
+    api_key: str = ""
+    host: str = "127.0.0.1"
     port: int = 8080
     allow_from: list[str] = Field(default_factory=lambda: ["*"])
 
@@ -50,6 +53,22 @@ class EndpointChannel(BaseChannel):
     def _setup_routes(self) -> None:
         """Register Flask routes."""
 
+        def require_api_key(f):
+            @wraps(f)
+            async def decorated(*args, **kwargs):
+                if self.config.api_key != "":
+                    auth = request.headers.get("Authorization", "")
+                    # Expect format: "Bearer <key>"
+                    if not auth.startswith("Bearer "):
+                        return jsonify({"error": "missing_authorization"}), 401
+                    token = auth.split(" ", 1)[1].strip()
+                    if not token:
+                        return jsonify({"error": "invalid_token"}), 401
+                    if token != self.config.api_key:
+                        return jsonify({"error": "invalid_api_key"}), 403
+                return await f(*args, **kwargs)
+            return decorated
+
         @self.app.after_request
         def add_cors_headers(response):
             response.headers.add('Access-Control-Allow-Origin', '*')
@@ -58,6 +77,7 @@ class EndpointChannel(BaseChannel):
             return response
 
         @self.app.route("/v1/responses", methods=["POST"])
+        @require_api_key
         async def create_response():
             """
             OpenAI Responses API endpoint.

--- a/nanobot/channels/endpoint.py
+++ b/nanobot/channels/endpoint.py
@@ -19,6 +19,54 @@ from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.config.schema import Base
 
+import re
+import base64
+import mimetypes
+from pathlib import Path
+
+def save_data_url(data_url: str, out_dir: str = ".", filename: str = "image") -> str:
+    # match data:[<mediatype>][;base64],<data>
+    m = re.match(r"data:(?P<mime>[^;,\s]+)?(?:;base64)?,(?P<data>.+)$", data_url, re.I)
+    if not m:
+        raise ValueError("Input is not a valid data URL")
+
+    mime = m.group("mime") or "application/octet-stream"
+    b64data = m.group("data")
+
+    try:
+        decoded = base64.b64decode(b64data, validate=True)
+    except Exception:
+        # fallback: try without validation (tolerant)
+        decoded = base64.b64decode(b64data)
+
+    # guess extension from MIME type
+    ext = mimetypes.guess_extension(mime.split(";")[0].lower()) or ""
+    # common override for image/png vs .png etc.
+    if not ext and mime.startswith("image/"):
+        ext = "." + mime.split("/", 1)[1]
+
+    out_path = Path(out_dir) / (filename + ext)
+
+    out_path.write_bytes(decoded)
+    return str(out_path)
+
+def file_to_data_url(filename: str) -> str:
+    """
+    Read a file and return a data URL like: data:<mime>;base64,<base64-data>
+    """
+    p = Path(filename)
+    if not p.is_file():
+        raise FileNotFoundError(f"No such file: {filename}")
+
+    mime, _ = mimetypes.guess_type(p.name)
+    if not mime:
+        mime = "application/octet-stream"
+
+    data = p.read_bytes()
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{b64}"
+
+
 class EndpointConfig(Base):
     enabled: bool = False
     api_key: str = ""
@@ -68,8 +116,8 @@ class EndpointChannel(BaseChannel):
         with self._responses_lock:
             self._response_queues.pop(chat_id, None)
 
-    def _build_response_payload(self, chat_id: str, model: str, content: str, created_at: int) -> dict[str, Any]:
-        return {
+    def _build_response_payload(self, chat_id: str, model: str, content: str, created_at: int, urls: list[str] | None = None) -> dict[str, Any]:
+        payload = {
             "id": chat_id,
             "object": "response",
             "created_at": created_at,
@@ -93,6 +141,10 @@ class EndpointChannel(BaseChannel):
                 "total_tokens": -1
             }
         }
+        if urls:
+            content_list = payload["output"][0]["content"]
+            content_list.extend([{"type": "image_url", "image_url": {"url": url}} for url in urls])
+        return payload
 
     def _sse_event(self, event: str, data: dict[str, Any]) -> str:
         return f"event: {event}\ndata: {json.dumps(data)}\n\n"
@@ -150,6 +202,7 @@ class EndpointChannel(BaseChannel):
             instructions = data.get("instructions", "")
 
             content = ""
+            images = []
             if isinstance(input_items, list):
                 # Extract text from the last user message item
                 for item in reversed(input_items):
@@ -157,6 +210,18 @@ class EndpointChannel(BaseChannel):
                         item_content = item.get("content")
                         if isinstance(item_content, list):
                             content = " ".join([c.get("text", "") for c in item_content if c.get("type") == "text"])
+                            images = [
+                                c.get("image_url").get("url")
+                                for c in item_content
+                                if c.get("type") == "image_url"
+                                and "image_url" in c
+                                and "url" in c.get("image_url")
+                            ]
+                            images = [
+                                save_data_url(url, filename=f"image_{i}")
+                                for i, url in enumerate(images)
+                                if url and url.startswith("data:")
+                            ]
                         elif isinstance(item_content, str):
                             content = item_content
                         break
@@ -189,6 +254,7 @@ class EndpointChannel(BaseChannel):
                     sender_id=sender_id,
                     chat_id=chat_id,
                     content=content,
+                    media=images,
                     metadata={
                         "http_request": True,
                         "instructions": instructions,
@@ -241,7 +307,8 @@ class EndpointChannel(BaseChannel):
                                 elif item_type == "final":
                                     outbound_msg = item.get("msg")
                                     content_text = outbound_msg.content if outbound_msg else buffer
-                                    payload = self._build_response_payload(chat_id, model, content_text, created_at)
+                                    urls = [file_to_data_url(file) for file in outbound_msg.media] if outbound_msg and outbound_msg.media else None
+                                    payload = self._build_response_payload(chat_id, model, content_text, created_at, urls=urls)
                                     yield self._sse_event("response.completed", payload)
                                     break
                         finally:
@@ -275,7 +342,8 @@ class EndpointChannel(BaseChannel):
                     if item_type == "final":
                         outbound_msg = item.get("msg")
                         content_text = outbound_msg.content if outbound_msg else buffer
-                        payload = self._build_response_payload(chat_id, model, content_text, created_at)
+                        urls = [file_to_data_url(file) for file in outbound_msg.media] if outbound_msg and outbound_msg.media else None
+                        payload = self._build_response_payload(chat_id, model, content_text, created_at, urls=urls)
                         return jsonify(payload)
 
             finally:

--- a/tests/test_endpoint_streaming_webchat_server.py
+++ b/tests/test_endpoint_streaming_webchat_server.py
@@ -49,6 +49,7 @@ HTML_PAGE = """<!doctype html>
       <div id="messages"></div>
       <form id="send-form">
         <textarea id="prompt" placeholder="Type a message" required></textarea>
+        <input id="image-file" type="file" accept="image/*" />
         <button type="submit" id="send-btn">Send</button>
       </form>
     </section>
@@ -103,6 +104,13 @@ HTML_PAGE = """<!doctype html>
       localStorage.setItem('endpoint_sessions', JSON.stringify(sessions));
     };
 
+    const readFileAsDataUrl = (file) => new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error || new Error('Failed to read file'));
+      reader.readAsDataURL(file);
+    });
+
     const parseSse = (chunk, onEvent) => {
       const events = chunk.split('\\n\\n');
       for (const evt of events) {
@@ -136,11 +144,14 @@ HTML_PAGE = """<!doctype html>
       }
 
       const promptEl = document.getElementById('prompt');
+      const imageInput = document.getElementById('image-file');
+      const imageFile = imageInput.files && imageInput.files[0] ? imageInput.files[0] : null;
       const content = promptEl.value.trim();
-      if (!content) return;
+      if (!content && !imageFile) return;
 
       const sendBtn = document.getElementById('send-btn');
       promptEl.value = '';
+      imageInput.value = '';
       promptEl.disabled = true;
       sendBtn.disabled = true;
 
@@ -148,19 +159,27 @@ HTML_PAGE = """<!doctype html>
       const lastAssistantMsg = [...history].reverse().find(m => m.role === 'assistant' && m.id);
       const prevId = lastAssistantMsg ? lastAssistantMsg.id : undefined;
 
-      addMsgToUI('user', content);
-      history.push({ role: 'user', content });
+      const userLabel = imageFile ? (content ? content + " [image]" : "[image]") : content;
+      addMsgToUI('user', userLabel);
+      history.push({ role: 'user', content: userLabel });
       saveHistory(activeId, history);
 
       let streamEl = null;
       let streamText = '';
 
       try {
+        const imageDataUrl = imageFile ? await readFileAsDataUrl(imageFile) : null;
+        const contentParts = [];
+        if (content) contentParts.push({ type: "text", text: content });
+        if (imageDataUrl) contentParts.push({ type: "image_url", image_url: { url: imageDataUrl } });
+        const inputPayload = [
+          { type: "message", role: "user", content: contentParts }
+        ];
         const r = await fetch(endpointUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer """ + os.getenv('NANOBOT_API_KEY', '') + """' },
           body: JSON.stringify({
-            input: content,
+            input: inputPayload,
             user: "web-test-user",
             previous_response_id: prevId,
             stream: true

--- a/tests/test_endpoint_streaming_webchat_server.py
+++ b/tests/test_endpoint_streaming_webchat_server.py
@@ -267,9 +267,10 @@ class TestEndpointStreamingWebChat:
                     stream=True
                 )
 
-                def generate() -> Iterable[str]:
-                    for line in upstream.iter_lines(decode_unicode=True):
-                        yield f"{line}\n"
+                def generate():
+                    for chunk in upstream.iter_content(chunk_size=8192):
+                        if chunk:
+                            yield chunk
 
                 headers = {
                     "Cache-Control": "no-cache",

--- a/tests/test_endpoint_streaming_webchat_server.py
+++ b/tests/test_endpoint_streaming_webchat_server.py
@@ -1,0 +1,294 @@
+import threading
+import time
+import os
+from typing import Any, Iterable
+from flask import Flask, render_template_string, request, Response, jsonify
+import requests
+from werkzeug.serving import make_server
+from loguru import logger
+
+HTML_PAGE = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="color-scheme" content="light dark">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <title>endpoint webchat streaming test</title>
+  <style>
+    :root { --panel: #7f81861e; --line: #8f90a054; --accent: #0f766e; --accent-dim: #115e59; --danger: #b91c1c; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: ui-rounded, sans-serif; min-height: 100vh; }
+    .shell { display: grid; grid-template-columns: 340px 1fr; height: 100vh; background: var(--panel); }
+    .panel { overflow: hidden; display: flex; flex-direction: column; height: 100%; }
+    .chats { border-right: 1px solid var(--line); }
+    .panel h2 { margin: 0; padding: 16px; font-size: 14px; border-bottom: 1px solid var(--line); }
+    #chat-list { list-style: none; overflow-y: auto; flex: 1; padding: 0; margin: 0; }
+    #chat-list li { padding: 12px 16px; border-bottom: 1px solid #7f7f7f5f; cursor: pointer; transition: background .2s; }
+    #chat-list li:hover { background: #7f7f7f1a; }
+    #chat-list li.active { border-left: 3px solid var(--accent); background: #7f7f7f2a; }
+    form { display: flex; gap: 8px; padding: 12px; border-top: 1px solid var(--line); }
+    textarea { flex: 1; border-radius: 6px; border: 1px solid var(--line); padding: 8px; font: inherit; }
+    button { cursor: pointer; background: var(--accent); border: none; border-radius: 6px; padding: 8px 16px; color: white; font-weight: 600; }
+    button:hover { background: var(--accent-dim); }
+    #messages { padding: 20px; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; flex: 1; }
+    .msg { max-width: 80%; border-radius: 12px; padding: 10px 14px; border: 1px solid var(--line); line-height: 1.4; }
+    .user { align-self: flex-end; background: #94a1b933; border-bottom-right-radius: 4px; }
+    .assistant { align-self: flex-start; background: #7f7f7f1f; border-bottom-left-radius: 4px; }
+    .system { align-self: center; font-size: 12px; opacity: 0.7; font-style: italic; border: none; background: none; }
+    .error { color: #f87171; border-color: #f87171; }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <section class="panel chats">
+      <h2>Chats</h2>
+      <ul id="chat-list"></ul>
+      <form id="new-chat-form"><input id="chat-title" placeholder="Session Name" required style="flex:1; padding:8px; border-radius:6px; border:1px solid var(--line);" /><button type="submit">New</button></form>
+    </section>
+    <section class="panel chat">
+      <div id="messages"></div>
+      <form id="send-form">
+        <textarea id="prompt" placeholder="Type a message" required></textarea>
+        <button type="submit" id="send-btn">Send</button>
+      </form>
+    </section>
+  </main>
+
+  <script>
+    let activeId = null;
+    let sessions = JSON.parse(localStorage.getItem('endpoint_sessions') || '[]');
+    const endpointUrl = "/v1/responses/stream";
+
+    const addMsgToUI = (role, content, isError = false) => {
+      const el = document.createElement('div');
+      el.className = `msg ${role} ${isError ? 'error' : ''}`;
+      el.textContent = content;
+      document.getElementById('messages').appendChild(el);
+      document.getElementById('messages').scrollTop = document.getElementById('messages').scrollHeight;
+      return el;
+    };
+
+    const saveHistory = (id, history) => {
+      localStorage.setItem(`history_${id}`, JSON.stringify(history));
+    };
+
+    const getHistory = (id) => {
+      return JSON.parse(localStorage.getItem(`history_${id}`) || '[]');
+    };
+
+    const selectSession = (id) => {
+      activeId = id;
+      renderSessions();
+      const messagesContainer = document.getElementById('messages');
+      messagesContainer.innerHTML = '';
+
+      const history = getHistory(id);
+      if (history.length === 0) {
+        addMsgToUI('system', 'New session started.');
+      } else {
+        history.forEach(m => addMsgToUI(m.role, m.content));
+      }
+    };
+
+    const renderSessions = () => {
+      const list = document.getElementById('chat-list');
+      list.innerHTML = '';
+      sessions.forEach(s => {
+        const li = document.createElement('li');
+        li.textContent = s.title;
+        if (s.id === activeId) li.className = 'active';
+        li.onclick = () => selectSession(s.id);
+        list.appendChild(li);
+      });
+      localStorage.setItem('endpoint_sessions', JSON.stringify(sessions));
+    };
+
+    const parseSse = (chunk, onEvent) => {
+      const events = chunk.split('\\n\\n');
+      for (const evt of events) {
+        if (!evt.trim()) continue;
+        let eventName = '';
+        let dataLines = [];
+        evt.split('\\n').forEach(line => {
+          if (line.startsWith('event:')) eventName = line.slice(6).trim();
+          if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
+        });
+        const data = dataLines.join('\\n');
+        if (!data) continue;
+        onEvent(eventName, data);
+      }
+    };
+
+    document.getElementById('new-chat-form').onsubmit = (e) => {
+      e.preventDefault();
+      const title = document.getElementById('chat-title').value;
+      const id = 'sess_' + Date.now().toString(16);
+      sessions.unshift({ id, title });
+      document.getElementById('chat-title').value = '';
+      selectSession(id);
+    };
+
+    document.getElementById('send-form').onsubmit = async (e) => {
+      e.preventDefault();
+      if (!activeId) {
+        alert("Please select or create a session first.");
+        return;
+      }
+
+      const promptEl = document.getElementById('prompt');
+      const content = promptEl.value.trim();
+      if (!content) return;
+
+      const sendBtn = document.getElementById('send-btn');
+      promptEl.value = '';
+      promptEl.disabled = true;
+      sendBtn.disabled = true;
+
+      const history = getHistory(activeId);
+      const lastAssistantMsg = [...history].reverse().find(m => m.role === 'assistant' && m.id);
+      const prevId = lastAssistantMsg ? lastAssistantMsg.id : undefined;
+
+      addMsgToUI('user', content);
+      history.push({ role: 'user', content });
+      saveHistory(activeId, history);
+
+      let streamEl = null;
+      let streamText = '';
+
+      try {
+        const r = await fetch(endpointUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer """ + os.getenv('NANOBOT_API_KEY', '') + """' },
+          body: JSON.stringify({
+            input: content,
+            user: "web-test-user",
+            previous_response_id: prevId,
+            stream: true
+          })
+        });
+
+        const contentType = r.headers.get('content-type') || '';
+        if (!r.ok || !contentType.includes('text/event-stream')) {
+          const data = await r.json();
+          throw new Error(data.error || 'Server error');
+        }
+
+        streamEl = addMsgToUI('assistant', '');
+
+        const reader = r.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let finalResponseId = null;
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const parts = buffer.split('\\n\\n');
+          buffer = parts.pop();
+          parts.forEach(part => {
+            parseSse(part, (event, data) => {
+              if (data === '[DONE]') return;
+              let payload = null;
+              try { payload = JSON.parse(data); } catch (_) { payload = null; }
+
+              if (event === 'response.output_text.delta' && payload && payload.delta) {
+                streamText += payload.delta;
+                streamEl.textContent = streamText;
+              } else if (event === 'response.completed' && payload) {
+                finalResponseId = payload.id || finalResponseId;
+                if (payload.output && Array.isArray(payload.output)) {
+                  const msgItem = payload.output.find(item => item.type === 'message');
+                  if (msgItem && msgItem.content && Array.isArray(msgItem.content)) {
+                    const textPart = msgItem.content.find(c => c.type === 'text');
+                    if (textPart) streamText = textPart.text;
+                  }
+                }
+                streamEl.textContent = streamText;
+              } else if (event === 'response.error') {
+                throw new Error((payload && payload.error) || 'Server error');
+              }
+            });
+          });
+        }
+
+        if (streamText) {
+          history.push({ role: 'assistant', content: streamText, id: finalResponseId });
+          saveHistory(activeId, history);
+        } else {
+          addMsgToUI('system', 'No output received.', true);
+        }
+
+      } catch (err) {
+        addMsgToUI('system', 'Error: ' + err.message, true);
+      } finally {
+        promptEl.disabled = false;
+        sendBtn.disabled = false;
+        promptEl.focus();
+      }
+    };
+
+    if (sessions.length > 0) {
+      selectSession(sessions[0].id);
+    } else {
+      renderSessions();
+    }
+  </script>
+</body>
+</html>
+"""
+
+class TestEndpointStreamingWebChat:
+    def __init__(self, port=8082):
+        self.app = Flask(__name__)
+        self.port = port
+        self._setup_routes()
+        self.config = {}
+
+    def _setup_routes(self) -> None:
+        """Define routes for the test interface."""
+
+        @self.app.route('/')
+        def index():
+            return render_template_string(HTML_PAGE)
+
+        @self.app.route('/v1/responses/stream', methods=['POST'])
+        def proxy_stream():
+            """Proxy the streaming request to the actual EndpointChannel."""
+            endpoint_url = getattr(self.config, "endpoint_url", "http://localhost:8080/v1/responses")
+            payload = dict(request.json or {})
+            payload["stream"] = True
+            try:
+                upstream = requests.post(
+                    endpoint_url,
+                    headers={ 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + os.getenv('NANOBOT_API_KEY', '') },
+                    json=payload,
+                    timeout=getattr(self.config, "request_timeout", 65.0),
+                    stream=True
+                )
+
+                def generate() -> Iterable[str]:
+                    for line in upstream.iter_lines(decode_unicode=True):
+                        yield f"{line}\n"
+
+                headers = {
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no"
+                }
+                return Response(generate(), status=upstream.status_code, mimetype="text/event-stream", headers=headers)
+            except Exception as e:
+                logger.error(f"Responses streaming proxy error: {e}")
+                return jsonify({"error": str(e)}), 500
+
+    def start(self):
+        self._server = make_server("0.0.0.0", self.port, self.app)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+        logger.info(f"Streaming test UI running on http://0.0.0.0:{self.port}")
+
+if __name__ == "__main__":
+    ui = TestEndpointStreamingWebChat()
+    ui.start()
+    try:
+        while True: time.sleep(1)
+    except KeyboardInterrupt: pass

--- a/tests/test_endpoint_streaming_webchat_server.py
+++ b/tests/test_endpoint_streaming_webchat_server.py
@@ -57,7 +57,7 @@ HTML_PAGE = """<!doctype html>
   <script>
     let activeId = null;
     let sessions = JSON.parse(localStorage.getItem('endpoint_sessions') || '[]');
-    const endpointUrl = "/v1/responses/stream";
+    const endpointUrl = "/v1/responses";
 
     const addMsgToUI = (role, content, isError = false) => {
       const el = document.createElement('div');
@@ -252,7 +252,7 @@ class TestEndpointStreamingWebChat:
         def index():
             return render_template_string(HTML_PAGE)
 
-        @self.app.route('/v1/responses/stream', methods=['POST'])
+        @self.app.route('/v1/responses', methods=['POST'])
         def proxy_stream():
             """Proxy the streaming request to the actual EndpointChannel."""
             endpoint_url = getattr(self.config, "endpoint_url", "http://localhost:8080/v1/responses")

--- a/tests/test_endpoint_webchat_server.py
+++ b/tests/test_endpoint_webchat_server.py
@@ -12,7 +12,7 @@ HTML_PAGE = """<!doctype html>
   <meta charset="utf-8" />
   <meta name="color-scheme" content="light dark">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
-  <title>endpoint direct test</title>
+  <title>endpoint webchat test</title>
   <style>
     :root { --panel: #7f81861e; --line: #8f90a054; --accent: #6f5ff07f; --accent-dim: #4f46a07f; --danger: #9f12397f; }
     * { box-sizing: border-box; }
@@ -36,7 +36,7 @@ HTML_PAGE = """<!doctype html>
 <body>
   <main class="shell">
     <section class="panel chats">
-      <h2>Direct Endpoint Test</h2>
+      <h2>Endpoint webchat Test</h2>
       <ul id="chat-list"></ul>
       <form id="new-chat-form"><input id="chat-title" placeholder="Session Name" required /><button type="submit">Start</button></form>
     </section>
@@ -51,7 +51,7 @@ HTML_PAGE = """<!doctype html>
 
   <script>
     let activeId = null;
-    const endpointUrl = "/v1/responses"; // Direct URL
+    const endpointUrl = "/v1/responses";
 
     const addMsg = (role, content) => {
       const el = document.createElement('div');
@@ -68,7 +68,6 @@ HTML_PAGE = """<!doctype html>
       li.className = 'active';
       document.getElementById('chat-list').appendChild(li);
       document.getElementById('messages').innerHTML = '';
-      addMsg('system', 'Connected directly to ' + endpointUrl);
     };
 
     document.getElementById('send-form').onsubmit = async (e) => {
@@ -83,11 +82,20 @@ HTML_PAGE = """<!doctype html>
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             messages: [{role: 'user', content}],
-            user: "direct-test-user"
+            user: "test-user"
           })
         });
         const data = await r.json();
-        addMsg('assistant', data.choices[0].message.content);
+        let reply = '';
+        if (data.output && Array.isArray(data.output)) {
+          const msgItem = data.output.find(item => item.type === 'message');
+          if (msgItem && msgItem.content && Array.isArray(msgItem.content)) {
+            // Find the first text part in the content array
+            const textPart = msgItem.content.find(c => c.type === 'text');
+            if (textPart) reply = textPart.text;
+          }
+        }
+        addMsg('assistant', reply || 'Error: No output text');
       } catch (err) {
         addMsg('system', 'Connection failed: ' + err.message);
       }

--- a/tests/test_endpoint_webchat_server.py
+++ b/tests/test_endpoint_webchat_server.py
@@ -49,6 +49,7 @@ HTML_PAGE = """<!doctype html>
       <div id="messages"></div>
       <form id="send-form">
         <textarea id="prompt" placeholder="Type a message" required></textarea>
+        <input id="image-file" type="file" accept="image/*" />
         <button type="submit" id="send-btn">Send</button>
       </form>
     </section>
@@ -102,6 +103,13 @@ HTML_PAGE = """<!doctype html>
       localStorage.setItem('endpoint_sessions', JSON.stringify(sessions));
     };
 
+    const readFileAsDataUrl = (file) => new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error || new Error('Failed to read file'));
+      reader.readAsDataURL(file);
+    });
+
     document.getElementById('new-chat-form').onsubmit = (e) => {
       e.preventDefault();
       const title = document.getElementById('chat-title').value;
@@ -119,11 +127,14 @@ HTML_PAGE = """<!doctype html>
       }
 
       const promptEl = document.getElementById('prompt');
+      const imageInput = document.getElementById('image-file');
+      const imageFile = imageInput.files && imageInput.files[0] ? imageInput.files[0] : null;
       const content = promptEl.value.trim();
-      if (!content) return;
+      if (!content && !imageFile) return;
 
       const sendBtn = document.getElementById('send-btn');
       promptEl.value = '';
+      imageInput.value = '';
       promptEl.disabled = true;
       sendBtn.disabled = true;
 
@@ -133,16 +144,24 @@ HTML_PAGE = """<!doctype html>
       const lastAssistantMsg = [...history].reverse().find(m => m.role === 'assistant' && m.id);
       const prevId = lastAssistantMsg ? lastAssistantMsg.id : undefined;
 
-      addMsgToUI('user', content);
-      history.push({ role: 'user', content });
+      const userLabel = imageFile ? (content ? content + " [image]" : "[image]") : content;
+      addMsgToUI('user', userLabel);
+      history.push({ role: 'user', content: userLabel });
       saveHistory(activeId, history);
 
       try {
+        const imageDataUrl = imageFile ? await readFileAsDataUrl(imageFile) : null;
+        const contentParts = [];
+        if (content) contentParts.push({ type: "text", text: content });
+        if (imageDataUrl) contentParts.push({ type: "image_url", image_url: { url: imageDataUrl } });
+        const inputPayload = [
+          { type: "message", role: "user", content: contentParts }
+        ];
         const r = await fetch(endpointUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer """ + os.getenv('NANOBOT_API_KEY', '') + """' },
           body: JSON.stringify({
-            input: content,
+            input: inputPayload,
             user: "web-test-user",
             previous_response_id: prevId
           })

--- a/tests/test_endpoint_webchat_server.py
+++ b/tests/test_endpoint_webchat_server.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import os
 from typing import Any
 from flask import Flask, render_template_string, request, jsonify
 import requests
@@ -139,7 +140,7 @@ HTML_PAGE = """<!doctype html>
       try {
         const r = await fetch(endpointUrl, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer """ + os.getenv('NANOBOT_API_KEY', '') + """' },
           body: JSON.stringify({
             input: content,
             user: "web-test-user",
@@ -208,6 +209,7 @@ class TestEndpointWebChat:
             try:
                 response = requests.post(
                     endpoint_url,
+                    headers={ 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + os.getenv('NANOBOT_API_KEY', '') },
                     json=request.json,
                     timeout=getattr(self.config, "request_timeout", 65.0)
                 )

--- a/tests/test_endpoint_webchat_server.py
+++ b/tests/test_endpoint_webchat_server.py
@@ -1,0 +1,139 @@
+import threading
+import time
+from typing import Any
+from flask import Flask, render_template_string, request, jsonify
+import requests
+from werkzeug.serving import make_server
+from loguru import logger
+
+HTML_PAGE = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="color-scheme" content="light dark">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <title>endpoint direct test</title>
+  <style>
+    :root { --panel: #7f81861e; --line: #8f90a054; --accent: #6f5ff07f; --accent-dim: #4f46a07f; --danger: #9f12397f; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: ui-rounded, sans-serif; min-height: 100vh; }
+    .shell { display: grid; grid-template-columns: 340px 1fr; height: 100vh; background: var(--panel); }
+    .panel { overflow: hidden; display: flex; flex-direction: column; height: 100%; }
+    .chats { border-right: 1px solid var(--line); }
+    .panel h2 { margin: 0; padding: 16px; font-size: 14px; border-bottom: 1px solid var(--line); }
+    #chat-list { list-style: none; overflow-y: auto; flex: 1; padding: 0; }
+    #chat-list li { padding: 12px 16px; border-bottom: 1px solid #7f7f7f5f; cursor: pointer; }
+    #chat-list li.active { border-left: 3px solid var(--accent); }
+    form { display: flex; gap: 8px; padding: 12px; border-top: 1px solid var(--line); }
+    textarea { flex: 1; border-radius: 6px; border: 1px solid var(--line); padding: 8px; }
+    button { cursor: pointer; background: var(--accent); border: none; border-radius: 6px; padding: 8px 16px; }
+    #messages { padding: 20px; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; flex: 1; }
+    .msg { max-width: 80%; border-radius: 12px; padding: 10px; border: 1px solid var(--line); }
+    .user { align-self: flex-end; background: #94a1b933; }
+    .assistant { align-self: flex-start; background: #7f7f7f1f; }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <section class="panel chats">
+      <h2>Direct Endpoint Test</h2>
+      <ul id="chat-list"></ul>
+      <form id="new-chat-form"><input id="chat-title" placeholder="Session Name" required /><button type="submit">Start</button></form>
+    </section>
+    <section class="panel chat">
+      <div id="messages"></div>
+      <form id="send-form">
+        <textarea id="prompt" placeholder="Type a message" required></textarea>
+        <button type="submit" id="send-btn">Send</button>
+      </form>
+    </section>
+  </main>
+
+  <script>
+    let activeId = null;
+    const endpointUrl = "/v1/responses"; // Direct URL
+
+    const addMsg = (role, content) => {
+      const el = document.createElement('div');
+      el.className = `msg ${role}`;
+      el.textContent = content;
+      document.getElementById('messages').appendChild(el);
+    };
+
+    document.getElementById('new-chat-form').onsubmit = (e) => {
+      e.preventDefault();
+      activeId = Date.now().toString(16);
+      const li = document.createElement('li');
+      li.textContent = document.getElementById('chat-title').value;
+      li.className = 'active';
+      document.getElementById('chat-list').appendChild(li);
+      document.getElementById('messages').innerHTML = '';
+      addMsg('system', 'Connected directly to ' + endpointUrl);
+    };
+
+    document.getElementById('send-form').onsubmit = async (e) => {
+      e.preventDefault();
+      const content = document.getElementById('prompt').value;
+      addMsg('user', content);
+      document.getElementById('prompt').value = '';
+
+      try {
+        const r = await fetch(endpointUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            messages: [{role: 'user', content}],
+            user: "direct-test-user"
+          })
+        });
+        const data = await r.json();
+        addMsg('assistant', data.choices[0].message.content);
+      } catch (err) {
+        addMsg('system', 'Connection failed: ' + err.message);
+      }
+    };
+  </script>
+</body>
+</html>
+"""
+
+class TestEndpointWebChat:
+    def __init__(self, port=8081):
+        self.app = Flask(__name__)
+        self.port = port
+        self._setup_routes()
+        self.config = {}
+
+    def _setup_routes(self) -> None:
+        """Define routes for the test interface."""
+
+        @self.app.route('/')
+        def index():
+            return render_template_string(HTML_PAGE)
+
+        @self.app.route('/v1/responses', methods=['POST'])
+        def proxy():
+            """Proxy the request to the actual EndpointChannel."""
+            endpoint_url = getattr(self.config, "endpoint_url", "http://localhost:8080/v1/responses")
+            try:
+                response = requests.post(
+                    endpoint_url,
+                    json=request.json,
+                    timeout=getattr(self.config, "request_timeout", 65.0)
+                )
+                return jsonify(response.json()), response.status_code
+            except Exception as e:
+                logger.error(f"Responses proxy error: {e}")
+                return jsonify({"error": str(e)}), 500
+
+    def start(self):
+        self._server = make_server("0.0.0.0", self.port, self.app)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+        logger.info(f"Test UI running on http://0.0.0.0:{self.port}")
+
+if __name__ == "__main__":
+    ui = TestEndpointWebChat()
+    ui.start()
+    try:
+        while True: time.sleep(1)
+    except KeyboardInterrupt: pass

--- a/tests/test_endpoint_webchat_server.py
+++ b/tests/test_endpoint_webchat_server.py
@@ -21,24 +21,28 @@ HTML_PAGE = """<!doctype html>
     .panel { overflow: hidden; display: flex; flex-direction: column; height: 100%; }
     .chats { border-right: 1px solid var(--line); }
     .panel h2 { margin: 0; padding: 16px; font-size: 14px; border-bottom: 1px solid var(--line); }
-    #chat-list { list-style: none; overflow-y: auto; flex: 1; padding: 0; }
-    #chat-list li { padding: 12px 16px; border-bottom: 1px solid #7f7f7f5f; cursor: pointer; }
-    #chat-list li.active { border-left: 3px solid var(--accent); }
+    #chat-list { list-style: none; overflow-y: auto; flex: 1; padding: 0; margin: 0; }
+    #chat-list li { padding: 12px 16px; border-bottom: 1px solid #7f7f7f5f; cursor: pointer; transition: background .2s; }
+    #chat-list li:hover { background: #7f7f7f1a; }
+    #chat-list li.active { border-left: 3px solid var(--accent); background: #7f7f7f2a; }
     form { display: flex; gap: 8px; padding: 12px; border-top: 1px solid var(--line); }
-    textarea { flex: 1; border-radius: 6px; border: 1px solid var(--line); padding: 8px; }
-    button { cursor: pointer; background: var(--accent); border: none; border-radius: 6px; padding: 8px 16px; }
+    textarea { flex: 1; border-radius: 6px; border: 1px solid var(--line); padding: 8px; font: inherit; }
+    button { cursor: pointer; background: var(--accent); border: none; border-radius: 6px; padding: 8px 16px; color: white; font-weight: 600; }
+    button:hover { background: var(--accent-dim); }
     #messages { padding: 20px; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; flex: 1; }
-    .msg { max-width: 80%; border-radius: 12px; padding: 10px; border: 1px solid var(--line); }
-    .user { align-self: flex-end; background: #94a1b933; }
-    .assistant { align-self: flex-start; background: #7f7f7f1f; }
+    .msg { max-width: 80%; border-radius: 12px; padding: 10px 14px; border: 1px solid var(--line); line-height: 1.4; }
+    .user { align-self: flex-end; background: #94a1b933; border-bottom-right-radius: 4px; }
+    .assistant { align-self: flex-start; background: #7f7f7f1f; border-bottom-left-radius: 4px; }
+    .system { align-self: center; font-size: 12px; opacity: 0.7; font-style: italic; border: none; background: none; }
+    .error { color: #f87171; border-color: #f87171; }
   </style>
 </head>
 <body>
   <main class="shell">
     <section class="panel chats">
-      <h2>Endpoint webchat Test</h2>
+      <h2>Chats</h2>
       <ul id="chat-list"></ul>
-      <form id="new-chat-form"><input id="chat-title" placeholder="Session Name" required /><button type="submit">Start</button></form>
+      <form id="new-chat-form"><input id="chat-title" placeholder="Session Name" required style="flex:1; padding:8px; border-radius:6px; border:1px solid var(--line);" /><button type="submit">New</button></form>
     </section>
     <section class="panel chat">
       <div id="messages"></div>
@@ -51,55 +55,133 @@ HTML_PAGE = """<!doctype html>
 
   <script>
     let activeId = null;
+    let sessions = JSON.parse(localStorage.getItem('endpoint_sessions') || '[]');
     const endpointUrl = "/v1/responses";
 
-    const addMsg = (role, content) => {
+    const addMsgToUI = (role, content, isError = false) => {
       const el = document.createElement('div');
-      el.className = `msg ${role}`;
+      el.className = `msg ${role} ${isError ? 'error' : ''}`;
       el.textContent = content;
       document.getElementById('messages').appendChild(el);
+      document.getElementById('messages').scrollTop = document.getElementById('messages').scrollHeight;
+    };
+
+    const saveHistory = (id, history) => {
+      localStorage.setItem(`history_${id}`, JSON.stringify(history));
+    };
+
+    const getHistory = (id) => {
+      return JSON.parse(localStorage.getItem(`history_${id}`) || '[]');
+    };
+
+    const selectSession = (id) => {
+      activeId = id;
+      renderSessions();
+      const messagesContainer = document.getElementById('messages');
+      messagesContainer.innerHTML = '';
+
+      const history = getHistory(id);
+      if (history.length === 0) {
+        addMsgToUI('system', 'New session started.');
+      } else {
+        history.forEach(m => addMsgToUI(m.role, m.content));
+      }
+    };
+
+    const renderSessions = () => {
+      const list = document.getElementById('chat-list');
+      list.innerHTML = '';
+      sessions.forEach(s => {
+        const li = document.createElement('li');
+        li.textContent = s.title;
+        if (s.id === activeId) li.className = 'active';
+        li.onclick = () => selectSession(s.id);
+        list.appendChild(li);
+      });
+      localStorage.setItem('endpoint_sessions', JSON.stringify(sessions));
     };
 
     document.getElementById('new-chat-form').onsubmit = (e) => {
       e.preventDefault();
-      activeId = Date.now().toString(16);
-      const li = document.createElement('li');
-      li.textContent = document.getElementById('chat-title').value;
-      li.className = 'active';
-      document.getElementById('chat-list').appendChild(li);
-      document.getElementById('messages').innerHTML = '';
+      const title = document.getElementById('chat-title').value;
+      const id = 'sess_' + Date.now().toString(16);
+      sessions.unshift({ id, title });
+      document.getElementById('chat-title').value = '';
+      selectSession(id);
     };
 
     document.getElementById('send-form').onsubmit = async (e) => {
       e.preventDefault();
-      const content = document.getElementById('prompt').value;
-      addMsg('user', content);
-      document.getElementById('prompt').value = '';
+      if (!activeId) {
+        alert("Please select or create a session first.");
+        return;
+      }
+
+      const promptEl = document.getElementById('prompt');
+      const content = promptEl.value.trim();
+      if (!content) return;
+
+      const sendBtn = document.getElementById('send-btn');
+      promptEl.value = '';
+      promptEl.disabled = true;
+      sendBtn.disabled = true;
+
+      const history = getHistory(activeId);
+
+      // Find the last assistant response to get the previous_response_id
+      const lastAssistantMsg = [...history].reverse().find(m => m.role === 'assistant' && m.id);
+      const prevId = lastAssistantMsg ? lastAssistantMsg.id : undefined;
+
+      addMsgToUI('user', content);
+      history.push({ role: 'user', content });
+      saveHistory(activeId, history);
 
       try {
         const r = await fetch(endpointUrl, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            messages: [{role: 'user', content}],
-            user: "test-user"
+            input: content,
+            user: "web-test-user",
+            previous_response_id: prevId
           })
         });
         const data = await r.json();
+
+        if (!r.ok) throw new Error(data.error || 'Server error');
+
         let reply = '';
         if (data.output && Array.isArray(data.output)) {
           const msgItem = data.output.find(item => item.type === 'message');
           if (msgItem && msgItem.content && Array.isArray(msgItem.content)) {
-            // Find the first text part in the content array
             const textPart = msgItem.content.find(c => c.type === 'text');
             if (textPart) reply = textPart.text;
           }
         }
-        addMsg('assistant', reply || 'Error: No output text');
+
+        if (reply) {
+          addMsgToUI('assistant', reply);
+          history.push({ role: 'assistant', content: reply, id: data.id });
+          saveHistory(activeId, history);
+        } else {
+          addMsgToUI('system', 'No output received.', true);
+        }
+
       } catch (err) {
-        addMsg('system', 'Connection failed: ' + err.message);
+        addMsgToUI('system', 'Error: ' + err.message, true);
+      } finally {
+        promptEl.disabled = false;
+        sendBtn.disabled = false;
+        promptEl.focus();
       }
     };
+
+    // Initial load
+    if (sessions.length > 0) {
+      selectSession(sessions[0].id);
+    } else {
+      renderSessions();
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
# Add Endpoint Channel for OpenAI-Compatible API/Endpoint

This PR introduces a new `EndpointChannel` that allows external applications to interact with nanobot via an OpenAI-compatible `/v1/responses` interface.

## Change benefits
- Allows external channel providers such as custom web chats or custom messaging services.
- Exposes nanobot as an endpoint, potentially allowing chaining with other tools.
- Potentially allows separation of nanobot/channels entirely, which is about 50% of the current non-test nanobot python.

## Key Changes

- **EndpointChannel Implementation**: Added `nanobot/channels/endpoint.py`, providing a Flask[async] based HTTP server that:
  - Accepts POST requests at `/v1/responses`.
  - Maps incoming messages to the nanobot Channel.
  - Waits for and returns the agent's response in a format compatible with OpenAI's Responses API.
- **A standalone reference webchat UI**, `tests/test_endpoint_webchat_server.py`, that uses the Endpoint Channel.

## How to Use

1. Enable the channel in your configuration:
   ```json
   {
     "channels": {
       "endpoint": {
         "enabled": true,
         "port": 8080
       }
     }
   }
   ```
2. Start

```
nanobot gateway
```

3. Send a request:

```bash
 curl -X POST "http://localhost:8080/v1/responses" \
        -H "Content-Type: application/json" \
        -d '{"model": "any", "input": "who are you?"}'
```

4. Start the reference web chat UI:

```
python tests/test_endpoint_webchat_server.py
```

## Future/Followup changes
- Complete pytest tests for Endpoint Channel. (AI generation did not yield good tests so far).
- Implement /v1/responses streaming events.