### PR TITLE
Improve Groq provider model detection (Llama3/Mixtral/Gemma)

### DIFF
--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -287,7 +287,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
     # Needs "groq/" prefix for LiteLLM routing. Placed last — it rarely wins fallback.
     ProviderSpec(
         name="groq",
-        keywords=("groq",),
+        keywords=("groq", "llama3", "mixtral", "gemma"),
         env_key="GROQ_API_KEY",
         display_name="Groq",
         litellm_prefix="groq",              # llama3-8b-8192 → groq/llama3-8b-8192


### PR DESCRIPTION
Added `llama3`, `mixtral`, `gemma` keywords to `nanobot/providers/registry.py` to allow direct model names (e.g. `llama3-70b`) to route to Groq if API key is present, without needing `groq/` prefix.

---
*Automated PR created by OpenClaw daily-pr routine (Backlog queue).*