### PR TITLE
feat: allow direct references in hatch metadata for wecom dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ nanobot = "nanobot.cli.commands:app"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["nanobot"]
 


### PR DESCRIPTION
## Summary

This PR adds `allow-direct-references = true` to Hatch metadata, which is required when using direct URL/Git dependencies in `project.optional-dependencies` (like the `wecom` extra).

Without this, installation fails with:
```
ValueError: Dependency #1 of option `wecom` ... cannot be a direct reference unless field `tool.hatch.metadata.allow-direct-references` is set to `true`
```

## Changes

- Added `[tool.hatch.metadata]` section in `pyproject.toml`
- Set `allow-direct-references = true`

## Test

Verified locally with:

```bash
uv venv --python 3.14
uv pip install -e .
nanobot --help  # succeeds
```

Fixes build error reported in issue #1883.