### PR TITLE
fix: add hatch metadata allow-direct-references for wecom dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,6 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.hatch.metadata]
+allow-direct-references = true


### PR DESCRIPTION
## Summary

Add `[tool.hatch.metadata]` with `allow-direct-references = true` to fix build errors when installing from source using `uv` or `pip`.

## Problem

Installing nanobot from source with modern Python tooling (uv, pip) fails with:
```
ValueError: Dependency #1 of option `wecom` of field `project.optional-dependencies` cannot be a direct reference unless field `tool.hatch.metadata.allow-direct-references` is set to `true`
```

## Solution

Add the required hatch metadata configuration:
```toml
[tool.hatch.metadata]
allow-direct-references = true
```

This follows [Hatch documentation](https://hatch.pypa.io/latest/config/metadata/#allow-direct-references) and PEP 621 best practices.

Fixes #1883