### PR TITLE
fix(cli): add Matrix to channels status display

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -694,6 +694,15 @@ def channels_status():
         dc.gateway_url
     )
 
+    # Matrix
+    mx = config.channels.matrix
+    mx_config = mx.homeserver if mx.homeserver else "[dim]not configured[/dim]"
+    table.add_row(
+        "Matrix",
+        "✓" if mx.enabled else "✗",
+        mx_config
+    )
+
     # Feishu
     fs = config.channels.feishu
     fs_config = f"app_id: {fs.app_id[:10]}..." if fs.app_id else "[dim]not configured[/dim]"

--- a/tests/test_channels_status.py
+++ b/tests/test_channels_status.py
@@ -1,0 +1,44 @@
+"""Test channels status command."""
+from unittest.mock import patch
+
+from nanobot.cli.commands import channels_status
+
+
+def test_channels_status_includes_matrix():
+    """Test that channels status command includes Matrix channel."""
+    with patch("nanobot.config.loader.load_config") as mock_load_config, \
+         patch("nanobot.cli.commands.console") as mock_console:
+
+        # Mock config with default values
+        from nanobot.config.schema import Config
+        mock_config = Config()
+        mock_load_config.return_value = mock_config
+
+        # Call the command
+        channels_status()
+
+        # Verify console.print was called
+        assert mock_console.print.called
+
+        # Get the table that was printed
+        table = mock_console.print.call_args[0][0]
+
+        # Convert table to string to check content
+        from io import StringIO
+        from rich.console import Console
+
+        string_io = StringIO()
+        temp_console = Console(file=string_io, force_terminal=True)
+        temp_console.print(table)
+        output = string_io.getvalue()
+
+        # Verify Matrix is in the output
+        assert "Matrix" in output, "Matrix should be included in channels status output"
+
+        # Verify all expected channels are present
+        expected_channels = [
+            "WhatsApp", "Discord", "Matrix", "Feishu", "Mochat",
+            "Telegram", "Slack", "DingTalk", "QQ", "Email"
+        ]
+        for channel in expected_channels:
+            assert channel in output, f"{channel} should be in channels status output"


### PR DESCRIPTION
## Summary

- **Bug**: Matrix channel is missing from `nanobot channels status` output
- **Root cause**: `nanobot/cli/commands.py:channels_status()` function does not include Matrix in the table display
- **Fix**: Added Matrix channel row to the status table output

Fixes #1887

## Problem

The `nanobot channels status` command displays all configured channels, but Matrix was missing from the list even though it's defined in the config schema.

**Before fix:**
```
$ nanobot channels status
Channel Status
┏━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Channel  ┃ Enabled ┃ Configuration                                ┃
┡━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ WhatsApp │ ✗       │ ws://localhost:3001                          │
│ Discord  │ ✗       │ wss://gateway.discord.gg/?v=10&encoding=json │
│ Feishu   │ ✗       │ not configured                               │
│ Mochat   │ ✗       │ https://mochat.io                            │
│ Telegram │ ✗       │ not configured                               │
│ Slack    │ ✗       │ not configured                               │
│ DingTalk │ ✗       │ not configured                               │
│ QQ       │ ✗       │ not configured                               │
│ Email    │ ✗       │ not configured                               │
└──────────┴─────────┴──────────────────────────────────────────────┘
```

Matrix is defined in `nanobot/config/schema.py:219` but was not displayed.

## Changes

- `nanobot/cli/commands.py` — Added Matrix channel display between Discord and Feishu
- `tests/test_channels_status.py` — Added regression test to verify Matrix is included in output

**After fix:**
```
$ nanobot channels status
Channel Status
┏━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Channel  ┃ Enabled ┃ Configuration                                ┃
┡━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ WhatsApp │ ✗       │ ws://localhost:3001                          │
│ Discord  │ ✗       │ wss://gateway.discord.gg/?v=10&encoding=json │
│ Matrix   │ ✗       │ https://matrix.org                           │
│ Feishu   │ ✗       │ not configured                               │
│ Mochat   │ ✗       │ https://mochat.io                            │
│ Telegram │ ✗       │ not configured                               │
│ Slack    │ ✗       │ not configured                               │
│ DingTalk │ ✗       │ not configured                               │
│ QQ       │ ✗       │ not configured                               │
│ Email    │ ✗       │ not configured                               │
└──────────┴─────────┴──────────────────────────────────────────────┘
```

## Test plan

- [x] New test: `test_channels_status_includes_matrix` verifies Matrix is in output
- [x] Verified in real environment: `python -m nanobot channels status` shows Matrix
- [x] E2E tested with multiple config scenarios:
  - Matrix enabled with custom homeserver → displays ✓ + custom URL
  - Matrix disabled with default homeserver → displays ✗ + https://matrix.org
  - Matrix enabled with empty homeserver → displays ✓ + "not configured"
  - Matrix enabled with matrix.org → displays ✓ + https://matrix.org
- [x] 189 existing tests pass

## Effect on User Experience

**Before:** Users with Matrix channel configured cannot see its status in `nanobot channels status` output, causing confusion about whether Matrix is supported.

**After:** Matrix channel is properly displayed in the status table, showing its enabled state and homeserver configuration.