### PR TITLE
fix: filter image_url from session history for non-vision models

### DIFF
--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -60,6 +60,15 @@ class Session:
             for k in ("tool_calls", "tool_call_id", "name"):
                 if k in m:
                     entry[k] = m[k]
+            # Filter image_url from multimodal content for models that don't support vision
+            if isinstance(entry.get("content"), list):
+                filtered = []
+                for c in entry["content"]:
+                    if c.get("type") == "image_url":
+                        filtered.append({"type": "text", "text": "[image]"})
+                    else:
+                        filtered.append(c)
+                entry["content"] = filtered
             out.append(entry)
         return out
 


### PR DESCRIPTION
## Problem

When loading session history, `image_url` content blocks were not being filtered in `get_history()`. This caused errors when using models that don't support vision capabilities (e.g., Baidu Qianfan, DeepSeek, etc.).

Error example:
```
Error code: 400 - {'error': {'code': 'invalid_argument', 'message': 'Invalid content type. image_url is only supported by certain models'}}
```

## Solution

Add filtering logic in `Session.get_history()` to replace `image_url` blocks with `[image]` placeholder text, consistent with the existing filtering done in `_save_turn()`.

## Changes

- Modified `nanobot/session/manager.py`: Added image_url filtering in `get_history()` method

## Testing

- All existing tests pass
- The change is backward compatible