### PR TITLE
Reconcile upstream changes with custom features

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -61,6 +61,10 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        cf_crawl_config: Any | None = None,
+        memory_max_chars: int | None = None,
+        memory_max_tokens: int | None = None,
+        memory_compaction_enabled: bool | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -97,6 +101,13 @@ class AgentLoop:
         self._mcp_connecting = False
         self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
         self._processing_lock = asyncio.Lock()
+
+        # Use custom memory settings if provided (stored for potential future use)
+        self.memory_max_chars = memory_max_chars or 8000
+        self.memory_max_tokens = memory_max_tokens or 2000
+        self.memory_compaction_enabled = memory_compaction_enabled if memory_compaction_enabled is not None else True
+        self.cf_crawl_config = cf_crawl_config
+
         self.memory_consolidator = MemoryConsolidator(
             workspace=workspace,
             provider=provider,
@@ -106,7 +117,13 @@ class AgentLoop:
             build_messages=self.context.build_messages,
             get_tool_definitions=self.tools.get_definitions,
         )
+
         self._register_default_tools()
+
+        # Register CfCrawlTool if config provided
+        if cf_crawl_config:
+            from nanobot.agent.tools.cf_crawl import CfCrawlTool
+            self.tools.register(CfCrawlTool(config=cf_crawl_config))
 
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""

--- a/nanobot/agent/tools/cf_crawl.py
+++ b/nanobot/agent/tools/cf_crawl.py
@@ -1,0 +1,187 @@
+import asyncio
+from datetime import datetime
+
+import httpx
+from loguru import logger
+
+from nanobot.agent.tools.base import Tool
+from nanobot.config.schema import CfCrawlConfig
+
+
+class CfCrawlTool(Tool):
+    """Cloudflare Browser Rendering / Crawl API tool."""
+
+    name = "cf_crawl"
+    description = "Crawl web pages using Cloudflare Browser Rendering API"
+    parameters = {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "Starting URL to crawl",
+            },
+            "max_pages": {
+                "type": "integer",
+                "description": "Maximum pages to crawl (default: 20)",
+                "default": 20,
+            },
+            "output_format": {
+                "type": "string",
+                "description": "Output format for crawled content",
+                "enum": ["markdown", "html", "json"],
+                "default": "markdown",
+            },
+            "modified_since": {
+                "type": "string",
+                "description": "ISO 8601 timestamp to filter pages modified after this time",
+            },
+            "static_mode": {
+                "type": "boolean",
+                "description": "Use static mode (no JavaScript execution)",
+                "default": False,
+            },
+        },
+        "required": ["url"],
+    }
+
+    def __init__(self, config: CfCrawlConfig | None = None):
+        super().__init__()
+        self.config = config
+
+    async def execute(self, **kwargs) -> str:
+        """Execute the cf_crawl tool."""
+        url = kwargs.get("url")
+        if not url:
+            return "Error: 'url' parameter is required"
+
+        max_pages = kwargs.get("max_pages", 20)
+        output_format = kwargs.get("output_format", "markdown")
+        modified_since = kwargs.get("modified_since")
+        static_mode = kwargs.get("static_mode", False)
+
+        # Validate configuration
+        if not self.config:
+            return "Error: cf_crawl tool is not configured. Please set api_token and account_id."
+
+        if not self.config.api_token:
+            return "Error: Cloudflare API token is not configured."
+
+        if not self.config.account_id:
+            return "Error: Cloudflare account ID is not configured."
+
+        headers = {
+            "Authorization": f"Bearer {self.config.api_token}",
+            "Content-Type": "application/json",
+        }
+
+        # Build crawl configuration
+        crawl_config = {
+            "start_url": url,
+            "max_pages": max_pages,
+            "output_format": output_format,
+            "static_mode": static_mode,
+        }
+
+        if modified_since:
+            # Validate ISO 8601 format
+            try:
+                datetime.fromisoformat(modified_since.replace("Z", "+00:00"))
+            except ValueError:
+                return "Error: 'modified_since' must be a valid ISO 8601 timestamp"
+
+            crawl_config["modified_since"] = modified_since
+
+        # Initiate crawl job
+        endpoint = f"{self.config.base_url}/accounts/{self.config.account_id}/browser-rendering/crawl"
+
+        try:
+            logger.debug(f"Initiating crawl job for {url}")
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    endpoint,
+                    headers=headers,
+                    json=crawl_config,
+                    timeout=30,
+                )
+
+                if response.status_code != 200:
+                    return f"Error: Failed to initiate crawl job. Status: {response.status_code}, Response: {response.text}"
+
+                job_data = response.json()
+                job_id = job_data.get("result", {}).get("id")
+
+                if not job_id:
+                    return "Error: No job ID returned from crawl initiation"
+
+                logger.debug(f"Crawl job started: {job_id}")
+
+        except httpx.TimeoutException:
+            return "Error: Timeout while initiating crawl job"
+        except httpx.RequestError as e:
+            return f"Error: Network error while initiating crawl job: {str(e)}"
+
+        # Poll for job completion
+        poll_endpoint = f"{self.config.base_url}/accounts/{self.config.account_id}/browser-rendering/crawl/{job_id}"
+        start_time = asyncio.get_event_loop().time()
+        poll_interval = 3  # seconds
+        timeout = 120  # seconds
+
+        async with httpx.AsyncClient() as client:
+            while asyncio.get_event_loop().time() - start_time < timeout:
+                try:
+                    response = await client.get(poll_endpoint, headers=headers, timeout=10)
+
+                    if response.status_code != 200:
+                        return f"Error: Failed to poll job status. Status: {response.status_code}, Response: {response.text}"
+
+                    job_data = response.json()
+                    result = job_data.get("result", {})
+                    status = result.get("status")
+
+                    if status == "complete":
+                        logger.debug(f"Crawl job completed: {job_id}")
+                        return self._format_response(result)
+
+                    elif status == "failed":
+                        error_message = result.get("error", "Unknown error")
+                        return f"Error: Crawl job failed: {error_message}"
+
+                    elif status in ["queued", "running"]:
+                        await asyncio.sleep(poll_interval)
+                        logger.debug(f"Crawl job still {status}, polling again...")
+                        continue
+
+                    else:
+                        return f"Error: Unexpected job status: {status}"
+
+                except httpx.TimeoutException:
+                    logger.debug("Poll request timed out, retrying...")
+                    await asyncio.sleep(poll_interval)
+                except httpx.RequestError as e:
+                    logger.debug(f"Poll request failed: {str(e)}")
+                    await asyncio.sleep(poll_interval)
+
+        return "Error: Crawl job timed out (120s limit exceeded)"
+
+    def _format_response(self, result: dict) -> str:
+        """Format crawl result as structured text."""
+        crawled_pages = result.get("crawled_pages", [])
+
+        if not crawled_pages:
+            return "No pages were crawled."
+
+        output_parts = []
+
+        for page in crawled_pages:
+            url = page.get("url", "Unknown URL")
+            content = page.get("content", "")
+            output_parts.append(f"## {url}\n{content}\n")
+
+        response = "\n".join(output_parts)
+
+        # Truncate to 50000 chars if needed
+        if len(response) > 50000:
+            response = response[:50000]
+            response += "\n\n[Content truncated due to size limit]"
+
+        return response

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -168,12 +168,26 @@ def main(
 
 
 @app.command()
-def onboard():
+def onboard(
+    config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
+):
     """Initialize nanobot configuration and workspace."""
-    from nanobot.config.loader import get_config_path, load_config, save_config
+    from nanobot.config.loader import get_config_path, load_config, save_config, set_config_path
     from nanobot.config.schema import Config
 
-    config_path = get_config_path()
+    config_path = None
+    if config:
+        config_path = Path(config).expanduser().resolve()
+        if not config_path.exists():
+            console.print(f"[red]Error: Config file not found: {config_path}[/red]")
+            raise typer.Exit(1)
+        set_config_path(config_path)
+        console.print(f"[dim]Using config: {config_path}[/dim]")
+
+    if config_path:
+        config_path = config_path
+    else:
+        config_path = get_config_path()
 
     if config_path.exists():
         console.print(f"[yellow]Config already exists at {config_path}[/yellow]")
@@ -184,7 +198,7 @@ def onboard():
             save_config(config)
             console.print(f"[green]✓[/green] Config reset to defaults at {config_path}")
         else:
-            config = load_config()
+            config = load_config(config_path)
             save_config(config)
             console.print(f"[green]✓[/green] Config refreshed at {config_path} (existing values preserved)")
     else:
@@ -215,9 +229,9 @@ def onboard():
 
 def _make_provider(config: Config):
     """Create the appropriate LLM provider from config."""
+    from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
     from nanobot.providers.base import GenerationSettings
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
-    from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
 
     model = config.agents.defaults.model
     provider_name = config.get_provider_name(model)
@@ -348,6 +362,10 @@ def gateway(
         model=config.agents.defaults.model,
         max_iterations=config.agents.defaults.max_tool_iterations,
         context_window_tokens=config.agents.defaults.context_window_tokens,
+        cf_crawl_config=config.tools.cf_crawl,
+        memory_max_chars=config.agents.defaults.memory_max_chars,
+        memory_max_tokens=config.agents.defaults.memory_max_tokens,
+        memory_compaction_enabled=config.agents.defaults.memory_compaction_enabled,
         brave_api_key=config.tools.web.search.api_key or None,
         web_proxy=config.tools.web.proxy or None,
         exec_config=config.tools.exec,
@@ -531,6 +549,10 @@ def agent(
         model=config.agents.defaults.model,
         max_iterations=config.agents.defaults.max_tool_iterations,
         context_window_tokens=config.agents.defaults.context_window_tokens,
+        cf_crawl_config=config.tools.cf_crawl,
+        memory_max_chars=config.agents.defaults.memory_max_chars,
+        memory_max_tokens=config.agents.defaults.memory_max_tokens,
+        memory_compaction_enabled=config.agents.defaults.memory_compaction_enabled,
         brave_api_key=config.tools.web.search.api_key or None,
         web_proxy=config.tools.web.proxy or None,
         exec_config=config.tools.exec,

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from nanobot.config.schema import Config
 
-
 # Global variable to store current config path (for multi-instance support)
 _current_config_path: Path | None = None
 
@@ -21,6 +20,17 @@ def get_config_path() -> Path:
     if _current_config_path:
         return _current_config_path
     return Path.home() / ".nanobot" / "config.json"
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge override into base, with override values taking precedence."""
+    result = base.copy()
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
 
 
 def load_config(config_path: Path | None = None) -> Config:
@@ -39,6 +49,20 @@ def load_config(config_path: Path | None = None) -> Config:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
+
+            extends_path = data.pop("extends", None)
+            if extends_path:
+                base_path = Path(extends_path).expanduser()
+                if not base_path.is_absolute():
+                    base_path = path.parent / base_path
+                try:
+                    with open(base_path, encoding="utf-8") as f:
+                        base_data = json.load(f)
+                    data = _deep_merge(base_data, data)
+                except (FileNotFoundError, json.JSONDecodeError) as e:
+                    print(f"Warning: Base config {base_path} not found or invalid: {e}")
+                    print("Proceeding with child config only.")
+
             data = _migrate_config(data)
             return Config.model_validate(data)
         except (json.JSONDecodeError, ValueError) as e:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -243,6 +243,9 @@ class AgentDefaults(Base):
     # Deprecated compatibility field: accepted from old configs but ignored at runtime.
     memory_window: int | None = Field(default=None, exclude=True)
     reasoning_effort: str | None = None  # low / medium / high — enables LLM thinking mode
+    memory_max_chars: int = 8000
+    memory_max_tokens: int = 2000
+    memory_compaction_enabled: bool = True
 
     @property
     def should_warn_deprecated_memory_window(self) -> bool:
@@ -310,6 +313,14 @@ class WebSearchConfig(Base):
     max_results: int = 5
 
 
+class CfCrawlConfig(Base):
+    """Cloudflare Browser Rendering / Crawl API configuration."""
+
+    api_token: str = ""  # Cloudflare API token
+    account_id: str = ""  # Cloudflare account ID
+    base_url: str = "https://api.cloudflare.com/client/v4"
+
+
 class WebToolsConfig(Base):
     """Web tools configuration."""
 
@@ -343,6 +354,7 @@ class ToolsConfig(Base):
 
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
+    cf_crawl: CfCrawlConfig = Field(default_factory=CfCrawlConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
@@ -355,6 +367,7 @@ class Config(BaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    extends: str | None = Field(default=None, exclude=True)
 
     @property
     def workspace_path(self) -> Path:

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -27,7 +27,6 @@ def _short_tool_id() -> str:
 class LiteLLMProvider(LLMProvider):
     """
     LLM provider using LiteLLM for multi-provider support.
-    
     Supports OpenRouter, Anthropic, OpenAI, Gemini, MiniMax, and many other providers through
     a unified interface.  Provider-specific logic is driven by the registry
     (see providers/registry.py) — no if-elif chains needed here.
@@ -40,10 +39,12 @@ class LiteLLMProvider(LLMProvider):
         default_model: str = "anthropic/claude-opus-4-5",
         extra_headers: dict[str, str] | None = None,
         provider_name: str | None = None,
+        suppress_tools_param: bool = False,
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
+        self.suppress_tools_param = suppress_tools_param
 
         # Detect gateway / local deployment.
         # provider_name (from config key) is the primary signal;
@@ -260,12 +261,12 @@ class LiteLLMProvider(LLMProvider):
         # Pass extra headers (e.g. APP-Code for AiHubMix)
         if self.extra_headers:
             kwargs["extra_headers"] = self.extra_headers
-        
+
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
             kwargs["drop_params"] = True
-        
-        if tools:
+
+        if tools and not self.suppress_tools_param:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
 
@@ -330,6 +331,10 @@ class LiteLLMProvider(LLMProvider):
                 "total_tokens": response.usage.total_tokens,
             }
 
+        # Extract tool calls from text content (for Qwen models that output XML/JSON)
+        if tool_calls is None and content:
+            tool_calls, content = LiteLLMProvider._extract_text_tool_calls(content)
+
         reasoning_content = getattr(message, "reasoning_content", None) or None
         thinking_blocks = getattr(message, "thinking_blocks", None) or None
 
@@ -341,6 +346,68 @@ class LiteLLMProvider(LLMProvider):
             reasoning_content=reasoning_content,
             thinking_blocks=thinking_blocks,
         )
+
+    @staticmethod
+    def _extract_text_tool_calls(content: str) -> tuple[list[ToolCallRequest], str | None]:
+        """Parse tool calls embedded as JSON or XML in text content.
+
+        Returns (tool_calls, remaining_content). If the entire content is a
+        tool-call envelope the remaining content is set to None so the agent
+        loop doesn't forward raw JSON/XML to the user.
+        """
+        import re
+
+        # Try XML format: <tool_call><function=name><parameter=key>value</parameter>...</function></tool_call>
+        # Model may omit closing </function> tag, so match up to </tool_call> or end of string.
+        xml_match = re.search(r"<tool_call>", content)
+        if xml_match:
+            calls = []
+            xml_body = content[xml_match.start():]
+            for fn_match in re.finditer(
+                r"<function=(\w+)>(.*?)(?:</function>|</tool_call>|\Z)",
+                xml_body,
+                re.DOTALL,
+            ):
+                name = fn_match.group(1)
+                body = fn_match.group(2)
+                arguments = {}
+                for param in re.finditer(r"<parameter=(\w+)>(.*?)</parameter>", body, re.DOTALL):
+                    arguments[param.group(1)] = param.group(2).strip()
+                if arguments:
+                    calls.append(ToolCallRequest(id=_short_tool_id(), name=name, arguments=arguments))
+            if calls:
+                logger.info("_parse_response: extracted {} XML-embedded tool call(s): {}",
+                            len(calls), [c.name for c in calls])
+                preamble = content[:xml_match.start()].strip() or None
+                return calls, preamble
+
+        # Fall back to JSON format
+        match = re.search(r"[{\[]", content)
+        if not match:
+            return [], content
+        json_start = match.start()
+        candidate = content[json_start:].strip()
+        try:
+            parsed = json_repair.loads(candidate)
+        except Exception:
+            return [], content
+        candidates = parsed if isinstance(parsed, list) else [parsed]
+        calls = []
+        for obj in candidates:
+            if (isinstance(obj, dict)
+                    and isinstance(obj.get("name"), str)
+                    and isinstance(obj.get("arguments"), dict)):
+                calls.append(ToolCallRequest(
+                    id=_short_tool_id(),
+                    name=obj["name"],
+                    arguments=obj["arguments"],
+                ))
+        if calls:
+            preamble = content[:json_start].strip() or None
+            logger.info("_parse_response: extracted {} JSON-embedded tool call(s): {}",
+                        len(calls), [c.name for c in calls])
+            return calls, preamble
+        return [], content
 
     def get_default_model(self) -> str:
         """Get the default model."""


### PR DESCRIPTION
- Restore suppress_tools_param and _extract_text_tool_calls for Qwen models
- Add CfCrawlConfig, memory settings, and extends field to schema
- Pass custom params through to AgentLoop and CfCrawlTool
- Add --config option to onboard command
- Recreate CfCrawlTool from git history
- Fix boolean bug in memory_compaction_enabled
- Remove bare pass error suppression in CfCrawlTool registration
- Convert _extract_text_tool_calls to staticmethod

Qwen3.5 35B A3B