### PR TITLE
feat: add exec output truncation config (issue #1871)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -7,7 +7,7 @@ import json
 import re
 from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from loguru import logger
 
@@ -118,6 +118,8 @@ class AgentLoop:
             timeout=self.exec_config.timeout,
             restrict_to_workspace=self.restrict_to_workspace,
             path_append=self.exec_config.path_append,
+            max_output=self.exec_config.max_output,
+            truncate_mode=self.exec_config.truncate_mode,
         ))
         self.tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
         self.tools.register(WebFetchTool(proxy=self.web_proxy))

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -20,6 +20,8 @@ class ExecTool(Tool):
         allow_patterns: list[str] | None = None,
         restrict_to_workspace: bool = False,
         path_append: str = "",
+        max_output: int = 10_000,
+        truncate_mode: str = "both",
     ):
         self.timeout = timeout
         self.working_dir = working_dir
@@ -37,6 +39,8 @@ class ExecTool(Tool):
         self.allow_patterns = allow_patterns or []
         self.restrict_to_workspace = restrict_to_workspace
         self.path_append = path_append
+        self.max_output = max_output
+        self.truncate_mode = truncate_mode
 
     @property
     def name(self) -> str:
@@ -126,15 +130,19 @@ class ExecTool(Tool):
 
             result = "\n".join(output_parts) if output_parts else "(no output)"
 
-            # Head + tail truncation to preserve both start and end of output
-            max_len = self._MAX_OUTPUT
+            # Truncate output based on configured mode
+            max_len = self.max_output
             if len(result) > max_len:
-                half = max_len // 2
-                result = (
-                    result[:half]
-                    + f"\n\n... ({len(result) - max_len:,} chars truncated) ...\n\n"
-                    + result[-half:]
-                )
+                if self.truncate_mode == "tail":
+                    # Keep only the tail portion
+                    result = result[-max_len:] + f"\n\n... ({len(result) - max_len:,} chars truncated)"
+                else:  # "both" - preserve start and end
+                    half = max_len // 2
+                    result = (
+                        result[:half]
+                        + f"\n\n... ({len(result) - max_len:,} chars truncated) ...\n\n"
+                        + result[-half:]
+                    )
 
             return result
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -324,6 +324,8 @@ class ExecToolConfig(Base):
 
     timeout: int = 60
     path_append: str = ""
+    max_output: int = 10_000
+    truncate_mode: str = "both"
 
 
 class MCPServerConfig(Base):

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -389,6 +389,42 @@ async def test_exec_head_tail_truncation() -> None:
     assert "Exit code:" in result
 
 
+async def test_exec_custom_max_output() -> None:
+    """Custom max_output should override the default."""
+    tool = ExecTool(max_output=100)
+    # Generate output that exceeds custom max_output
+    big = "X" * 200
+    result = await tool.execute(command=f"echo '{big}'")
+    assert "chars truncated" in result
+    # Should preserve head only (tail mode default)
+    assert result.startswith("X")
+    assert "X" * 50 in result  # ~100 chars
+
+
+async def test_exec_truncate_mode_tail() -> None:
+    """truncate_mode='tail' should only preserve the end of output."""
+    tool = ExecTool(max_output=100, truncate_mode="tail")
+    big = "A" * 50 + "\n" + "B" * 200
+    result = await tool.execute(command=f"echo '{big}'")
+    assert "chars truncated" in result
+    # Should start with truncated message, not As
+    assert not result.startswith("A")
+    # Should end with Bs (the tail)
+    assert "B" in result
+
+
+async def test_exec_truncate_mode_both() -> None:
+    """truncate_mode='both' should preserve both head and tail."""
+    tool = ExecTool(max_output=100, truncate_mode="both")
+    big = "A" * 100 + "\n" + "B" * 100
+    result = await tool.execute(command=f"echo '{big}'")
+    assert "chars truncated" in result
+    # Should start with As (head)
+    assert result.startswith("A")
+    # Should end with Bs (tail)
+    assert "B" in result
+
+
 async def test_exec_timeout_parameter() -> None:
     """LLM-supplied timeout should override the constructor default."""
     tool = ExecTool(timeout=60)


### PR DESCRIPTION
## Summary
- Add `max_output` config for exec tool (default 10000 characters)
- Add `truncate_mode` config ("both" or "tail")
- Resolve issue #1871

## Changes
Users can now configure exec output truncation via config:
- `max_output`: max characters in output (default: 10000)
- `truncate_mode`: "both" preserves start+end, "tail" keeps end only

## Test plan
- [x] Local tests pass (pytest)
- [x] Code lint passes (ruff)