### PR TITLE
fix: add openssh-client and use HTTPS for GitHub in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 # Install Node.js 20 for the WhatsApp bridge
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates gnupg git && \
+    apt-get install -y --no-install-recommends curl ca-certificates gnupg git openssh-client && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
@@ -26,6 +26,8 @@ COPY bridge/ bridge/
 RUN uv pip install --system --no-cache .
 
 # Build the WhatsApp bridge
+RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+
 WORKDIR /app/bridge
 RUN npm install && npm run build
 WORKDIR /app


### PR DESCRIPTION
- Add openssh-client to apt dependencies for git operations
- Configure git to use HTTPS instead of SSH for github.com to avoid SSH key requirements during Docker build