### PR TITLE
[紧急]修复we_chat在pyproject.toml配置的问题

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,13 +75,6 @@ build-backend = "hatchling.build"
 [tool.hatch.metadata]
 allow-direct-references = true
 
-[tool.hatch.build.targets.wheel]
-packages = ["nanobot"]
-
-[tool.hatch.build.targets.wheel.sources]
-"nanobot" = "nanobot"
-
-# Include non-Python files in skills and templates
 [tool.hatch.build]
 include = [
     "nanobot/**/*.py",
@@ -90,6 +83,15 @@ include = [
     "nanobot/skills/**/*.sh",
 ]
 
+[tool.hatch.build.targets.wheel]
+packages = ["nanobot"]
+
+[tool.hatch.build.targets.wheel.sources]
+"nanobot" = "nanobot"
+
+[tool.hatch.build.targets.wheel.force-include]
+"bridge" = "nanobot/bridge"
+
 [tool.hatch.build.targets.sdist]
 include = [
     "nanobot/",
@@ -97,9 +99,6 @@ include = [
     "README.md",
     "LICENSE",
 ]
-
-[tool.hatch.build.targets.wheel.force-include]
-"bridge" = "nanobot/bridge"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
pyproject.toml 里 allow-direct-references = true 已经设置了，但 TOML 中存在一个潜在问题：[tool.hatch.build] 定义在 [tool.hatch.build.targets.wheel] 之后，而最后还有 [tool.hatch.build.targets.wheel.force-include] 又回到了子表。这种乱序在某些 TOML 解析器中会导致配置读取异常。

修复方式是将 [tool.hatch.build] 父表移到所有子表之前，保持正确的层级顺序