### PR TITLE
feat: add working_dir parameter to spawn tool for project-specific subagents

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -34,6 +34,7 @@ class SubagentManager:
         restrict_to_workspace: bool = False,
     ):
         from nanobot.config.schema import ExecToolConfig
+
         self.provider = provider
         self.workspace = workspace
         self.bus = bus
@@ -52,6 +53,7 @@ class SubagentManager:
         origin_channel: str = "cli",
         origin_chat_id: str = "direct",
         session_key: str | None = None,
+        working_dir: str | None = None,
     ) -> str:
         """Spawn a subagent to execute a task in the background."""
         task_id = str(uuid.uuid4())[:8]
@@ -59,7 +61,7 @@ class SubagentManager:
         origin = {"channel": origin_channel, "chat_id": origin_chat_id}
 
         bg_task = asyncio.create_task(
-            self._run_subagent(task_id, task, display_label, origin)
+            self._run_subagent(task_id, task, display_label, origin, working_dir)
         )
         self._running_tasks[task_id] = bg_task
         if session_key:
@@ -83,28 +85,40 @@ class SubagentManager:
         task: str,
         label: str,
         origin: dict[str, str],
+        working_dir: str | None = None,
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
 
         try:
+            # Resolve working directory
+            if working_dir:
+                work_path = Path(working_dir).expanduser().resolve()
+                if self.restrict_to_workspace and not work_path.is_relative_to(self.workspace):
+                    work_path = self.workspace
+            else:
+                work_path = self.workspace
+
             # Build subagent tools (no message tool, no spawn tool)
             tools = ToolRegistry()
-            allowed_dir = self.workspace if self.restrict_to_workspace else None
-            tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(WriteFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(EditFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ExecTool(
-                working_dir=str(self.workspace),
-                timeout=self.exec_config.timeout,
-                restrict_to_workspace=self.restrict_to_workspace,
-                path_append=self.exec_config.path_append,
-            ))
+            # Restrict file operations to work_path (not the broader workspace)
+            allowed_dir = work_path if self.restrict_to_workspace else None
+            tools.register(ReadFileTool(workspace=work_path, allowed_dir=allowed_dir))
+            tools.register(WriteFileTool(workspace=work_path, allowed_dir=allowed_dir))
+            tools.register(EditFileTool(workspace=work_path, allowed_dir=allowed_dir))
+            tools.register(ListDirTool(workspace=work_path, allowed_dir=allowed_dir))
+            tools.register(
+                ExecTool(
+                    working_dir=str(work_path),
+                    timeout=self.exec_config.timeout,
+                    restrict_to_workspace=self.restrict_to_workspace,
+                    path_append=self.exec_config.path_append,
+                )
+            )
             tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
             tools.register(WebFetchTool(proxy=self.web_proxy))
-            
-            system_prompt = self._build_subagent_prompt()
+
+            system_prompt = self._build_subagent_prompt(work_path)
             messages: list[dict[str, Any]] = [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": task},
@@ -125,28 +139,34 @@ class SubagentManager:
                 )
 
                 if response.has_tool_calls:
-                    tool_call_dicts = [
-                        tc.to_openai_tool_call()
-                        for tc in response.tool_calls
-                    ]
-                    messages.append(build_assistant_message(
-                        response.content or "",
-                        tool_calls=tool_call_dicts,
-                        reasoning_content=response.reasoning_content,
-                        thinking_blocks=response.thinking_blocks,
-                    ))
+                    tool_call_dicts = [tc.to_openai_tool_call() for tc in response.tool_calls]
+                    messages.append(
+                        build_assistant_message(
+                            response.content or "",
+                            tool_calls=tool_call_dicts,
+                            reasoning_content=response.reasoning_content,
+                            thinking_blocks=response.thinking_blocks,
+                        )
+                    )
 
                     # Execute tools
                     for tool_call in response.tool_calls:
                         args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
-                        logger.debug("Subagent [{}] executing: {} with arguments: {}", task_id, tool_call.name, args_str)
+                        logger.debug(
+                            "Subagent [{}] executing: {} with arguments: {}",
+                            task_id,
+                            tool_call.name,
+                            args_str,
+                        )
                         result = await tools.execute(tool_call.name, tool_call.arguments)
-                        messages.append({
-                            "role": "tool",
-                            "tool_call_id": tool_call.id,
-                            "name": tool_call.name,
-                            "content": result,
-                        })
+                        messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": tool_call.id,
+                                "name": tool_call.name,
+                                "content": result,
+                            }
+                        )
                 else:
                     final_result = response.content
                     break
@@ -192,15 +212,19 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
         )
 
         await self.bus.publish_inbound(msg)
-        logger.debug("Subagent [{}] announced result to {}:{}", task_id, origin['channel'], origin['chat_id'])
-    
-    def _build_subagent_prompt(self) -> str:
+        logger.debug(
+            "Subagent [{}] announced result to {}:{}", task_id, origin["channel"], origin["chat_id"]
+        )
+
+    def _build_subagent_prompt(self, work_path: Path | None = None) -> str:
         """Build a focused system prompt for the subagent."""
         from nanobot.agent.context import ContextBuilder
         from nanobot.agent.skills import SkillsLoader
 
+        work_path = work_path or self.workspace
         time_ctx = ContextBuilder._build_runtime_context(None, None)
-        parts = [f"""# Subagent
+        parts = [
+            f"""# Subagent
 
 {time_ctx}
 
@@ -208,18 +232,33 @@ You are a subagent spawned by the main agent to complete a specific task.
 Stay focused on the assigned task. Your final response will be reported back to the main agent.
 
 ## Workspace
-{self.workspace}"""]
+{work_path}"""
+        ]
 
-        skills_summary = SkillsLoader(self.workspace).build_skills_summary()
+        # Load AGENTS.md from working directory if it exists
+        agents_md = work_path / "AGENTS.md"
+        if agents_md.exists():
+            try:
+                agents_content = agents_md.read_text(encoding="utf-8")
+                parts.append(f"## Project Context\n\n{agents_content}")
+            except Exception:
+                pass
+
+        skills_summary = SkillsLoader(work_path).build_skills_summary()
         if skills_summary:
-            parts.append(f"## Skills\n\nRead SKILL.md with read_file to use a skill.\n\n{skills_summary}")
+            parts.append(
+                f"## Skills\n\nRead SKILL.md with read_file to use a skill.\n\n{skills_summary}"
+            )
 
         return "\n\n".join(parts)
 
     async def cancel_by_session(self, session_key: str) -> int:
         """Cancel all subagents for the given session. Returns count cancelled."""
-        tasks = [self._running_tasks[tid] for tid in self._session_tasks.get(session_key, [])
-                 if tid in self._running_tasks and not self._running_tasks[tid].done()]
+        tasks = [
+            self._running_tasks[tid]
+            for tid in self._session_tasks.get(session_key, [])
+            if tid in self._running_tasks and not self._running_tasks[tid].done()
+        ]
         for t in tasks:
             t.cancel()
         if tasks:

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -48,11 +48,17 @@ class SpawnTool(Tool):
                     "type": "string",
                     "description": "Optional short label for the task (for display)",
                 },
+                "working_dir": {
+                    "type": "string",
+                    "description": "Optional working directory for the subagent. File operations will be relative to this directory. It will also inherit the AGENTS.md and skills in that directory.",
+                },
             },
             "required": ["task"],
         }
 
-    async def execute(self, task: str, label: str | None = None, **kwargs: Any) -> str:
+    async def execute(
+        self, task: str, label: str | None = None, working_dir: str | None = None, **kwargs: Any
+    ) -> str:
         """Spawn a subagent to execute the given task."""
         return await self._manager.spawn(
             task=task,
@@ -60,4 +66,5 @@ class SpawnTool(Tool):
             origin_channel=self._origin_channel,
             origin_chat_id=self._origin_chat_id,
             session_key=self._session_key,
+            working_dir=working_dir,
         )


### PR DESCRIPTION
## Summary
Adds a `working_dir` parameter to the `spawn` tool, allowing subagents to operate in specific project directories and automatically inherit project conventions from `AGENTS.md` as well as the `SKILLS`.

## Problem
Previously, subagents always operated from the agent's workspace, making it difficult to:
- Run subagents in specific project directories
- Have subagents follow project-specific conventions (defined in `AGENTS.md`)
- Have subagents use `SKILLS` in the project directory
- Keep file operations isolated per project (sometimes they would put documentation and similar kindof files in the bot's base workdir, instead of the project itself)

## Solution
- Added optional `working_dir` parameter to `SpawnTool` JSON schema
- Pass `working_dir` through to `SubagentManager.spawn()`
- Resolve and validate working directory paths
- Set file tool base directories and exec working directory to specified path
- Automatically load `AGENTS.md` from `working_dir` into subagent system prompt

The new parameter is completely optional. In case it isn't included, it just functions normally. 

I have added to the AGENTS.md of my coding nanobot that every subagent spawned should include a workdir parameter. Seems like it works well for strictly structured projects that may have very specific workflow/architecture instructions in the AGENTS.md. Previously, subagents would missplace files somewhat often, and they never followed the more strict project conventions. 