### PR TITLE
fix(qq): restore plain text replies for legacy clients

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -114,16 +114,16 @@ class QQChannel(BaseChannel):
             if msg_type == "group":
                 await self._client.api.post_group_message(
                     group_openid=msg.chat_id,
-                    msg_type=2,
-                    markdown={"content": msg.content},
+                    msg_type=0,
+                    content=msg.content,
                     msg_id=msg_id,
                     msg_seq=self._msg_seq,
                 )
             else:
                 await self._client.api.post_c2c_message(
                     openid=msg.chat_id,
-                    msg_type=2,
-                    markdown={"content": msg.content},
+                    msg_type=0,
+                    content=msg.content,
                     msg_id=msg_id,
                     msg_seq=self._msg_seq,
                 )

--- a/tests/test_qq_channel.py
+++ b/tests/test_qq_channel.py
@@ -44,7 +44,7 @@ async def test_on_group_message_routes_to_group_chat_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_group_message_uses_group_api_with_msg_seq() -> None:
+async def test_send_group_message_uses_plain_text_group_api_with_msg_seq() -> None:
     channel = QQChannel(QQConfig(app_id="app", secret="secret", allow_from=["*"]), MessageBus())
     channel._client = _FakeClient()
     channel._chat_type_cache["group123"] = "group"
@@ -60,7 +60,37 @@ async def test_send_group_message_uses_group_api_with_msg_seq() -> None:
 
     assert len(channel._client.api.group_calls) == 1
     call = channel._client.api.group_calls[0]
-    assert call["group_openid"] == "group123"
-    assert call["msg_id"] == "msg1"
-    assert call["msg_seq"] == 2
+    assert call == {
+        "group_openid": "group123",
+        "msg_type": 0,
+        "content": "hello",
+        "msg_id": "msg1",
+        "msg_seq": 2,
+    }
     assert not channel._client.api.c2c_calls
+
+
+@pytest.mark.asyncio
+async def test_send_c2c_message_uses_plain_text_c2c_api_with_msg_seq() -> None:
+    channel = QQChannel(QQConfig(app_id="app", secret="secret", allow_from=["*"]), MessageBus())
+    channel._client = _FakeClient()
+
+    await channel.send(
+        OutboundMessage(
+            channel="qq",
+            chat_id="user123",
+            content="hello",
+            metadata={"message_id": "msg1"},
+        )
+    )
+
+    assert len(channel._client.api.c2c_calls) == 1
+    call = channel._client.api.c2c_calls[0]
+    assert call == {
+        "openid": "user123",
+        "msg_type": 0,
+        "content": "hello",
+        "msg_id": "msg1",
+        "msg_seq": 2,
+    }
+    assert not channel._client.api.group_calls


### PR DESCRIPTION
## Summary
- restore QQ outbound sends to plain text payloads (`msg_type=0` + `content`)
- keep the existing `msg_seq` behavior for both group and C2C sends
- add regression coverage for plain-text group and C2C QQ sends

## Why
Fixes #1936. The recent markdown payload switch broke interactions for older QQ clients, while plain-text sends were previously compatible.

## Validation
- `git diff --check`
- `PYTHONPATH=. pytest -q tests/test_qq_channel.py` *(fails in this environment: missing dependency `tiktoken` during test import)*
