### PR TITLE
feat: remove reasoning text from context

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -475,6 +475,8 @@ class AgentLoop:
                     if not filtered:
                         continue
                     entry["content"] = filtered
+            entry.pop("reasoning_content", None)
+            entry.pop("thinking_blocks", None)
             entry.setdefault("timestamp", datetime.now().isoformat())
             session.messages.append(entry)
         session.updated_at = datetime.now()


### PR DESCRIPTION
Reasoning tokens, produced by thinking models, _can be_ discarded by engines, but still may contribute to overall token and context window usage.
Its generally recommended to discard them.

Proposed change automatically removes "reasoning_content" and "thinking_blocks" parts from context on each turn. 
Might save great amount of tokens usage and costs for user.

I found out about their presence in nanobot context while debugging llm requests on unrelated issue.