### PR TITLE
docs: correct BaiLian dashscope apiBase endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ Config file: `~/.nanobot/config.json`
 > - **VolcEngine / BytePlus Coding Plan**: Use dedicated providers `volcengineCodingPlan` or `byteplusCodingPlan` instead of the pay-per-use `volcengine` / `byteplus` providers.
 > - **Zhipu Coding Plan**: If you're on Zhipu's coding plan, set `"apiBase": "https://open.bigmodel.cn/api/coding/paas/v4"` in your zhipu provider config.
 > - **MiniMax (Mainland China)**: If your API key is from MiniMax's mainland China platform (minimaxi.com), set `"apiBase": "https://api.minimaxi.com/v1"` in your minimax provider config.
-> - **Alibaba Cloud Coding Plan**: If you're on the Alibaba Cloud Coding Plan (BaiLian), set `"apiBase": "https://coding.dashscope.aliyuncs.com/v1"` in your dashscope provider config.
+> - **Alibaba Cloud Coding Plan**: If you're on the Alibaba Cloud Coding Plan (BaiLian), set `"apiBase": "https://dashscope.aliyuncs.com/compatible-mode/v1"` in your dashscope provider config.
 
 | Provider | Purpose | Get API Key |
 |----------|---------|-------------|


### PR DESCRIPTION
## Summary
- Correct the BaiLian dashscope apiBase example to use Alibaba Cloud OpenAI-compatible endpoint
- Change from coding.dashscope.aliyuncs.com/v1 to dashscope.aliyuncs.com/compatible-mode/v1
- Keep the change docs-only and scoped to the provider configuration tip

## Validation
- git diff --check

Closes #1949