### PR TITLE
fix: catch BaseException in MCP connection to handle CancelledError

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -139,7 +139,7 @@ class AgentLoop:
             await self._mcp_stack.__aenter__()
             await connect_mcp_servers(self._mcp_servers, self.tools, self._mcp_stack)
             self._mcp_connected = True
-        except Exception as e:
+        except BaseException as e:
             logger.error("Failed to connect MCP servers (will retry next message): {}", e)
             if self._mcp_stack:
                 try:


### PR DESCRIPTION
Fixes #1951

The issue is that CancelledError inherits from BaseException, not Exception, so it wasn't being caught by the retry logic. This caused nanobot to crash when MCP server wasn't ready on startup.

One-line fix: change `except Exception` to `except BaseException`