### PR TITLE
fix(openrouter): preserve native aliases without breaking routed models

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -170,6 +170,11 @@ class LiteLLMProvider(LLMProvider):
         return frozenset()
 
     @staticmethod
+    def _is_openrouter_native_alias(model: str) -> bool:
+        """Return True for OpenRouter-native aliases like `openrouter/free`."""
+        return model.startswith("openrouter/") and model.count("/") == 1
+
+    @staticmethod
     def _normalize_tool_call_id(tool_call_id: Any) -> Any:
         """Normalize tool_call_id to a provider-safe 9-char alphanumeric form."""
         if not isinstance(tool_call_id, str):
@@ -248,6 +253,12 @@ class LiteLLMProvider(LLMProvider):
             "max_tokens": max_tokens,
             "temperature": temperature,
         }
+
+        # OpenRouter native IDs like `openrouter/free` collide with LiteLLM's
+        # routing prefix. Pass an explicit provider hint so LiteLLM preserves
+        # the original model ID instead of stripping its leading segment.
+        if self._gateway and self._gateway.name == "openrouter" and self._is_openrouter_native_alias(original_model):
+            kwargs["custom_llm_provider"] = "openrouter"
 
         # Apply model-specific overrides (e.g. kimi-k2.5 temperature)
         self._apply_model_overrides(model, kwargs)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -194,6 +194,30 @@ def test_litellm_provider_canonicalizes_github_copilot_hyphen_prefix():
     assert resolved == "github_copilot/gpt-5.3-codex"
 
 
+@pytest.mark.parametrize("model,expected", [
+    ("openrouter/free", "openrouter/free"),
+    ("moonshotai/kimi-k2.5:exacto", "openrouter/moonshotai/kimi-k2.5:exacto"),
+    ("anthropic/claude-3", "openrouter/anthropic/claude-3"),
+])
+def test_openrouter_gateway_resolves_models_without_double_prefixing(model, expected):
+    provider = LiteLLMProvider(
+        default_model=model,
+        provider_name="openrouter",
+        api_key="sk-or-test",
+    )
+    assert provider._resolve_model(model) == expected
+
+
+def test_non_openrouter_gateway_does_not_double_prefix_existing_routing_prefix():
+    provider = LiteLLMProvider(
+        default_model="openai/gpt-4o-mini",
+        provider_name="siliconflow",
+        api_key="sk-test",
+    )
+
+    assert provider._resolve_model("openai/gpt-4o-mini") == "openai/gpt-4o-mini"
+
+
 def test_openai_codex_strip_prefix_supports_hyphen_and_underscore():
     assert _strip_model_prefix("openai-codex/gpt-5.1-codex") == "gpt-5.1-codex"
     assert _strip_model_prefix("openai_codex/gpt-5.1-codex") == "gpt-5.1-codex"

--- a/tests/test_litellm_openrouter_provider.py
+++ b/tests/test_litellm_openrouter_provider.py
@@ -1,0 +1,51 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nanobot.providers.litellm_provider import LiteLLMProvider
+
+
+class _StopGateway(RuntimeError):
+    pass
+
+
+def _make_openrouter_provider(model: str) -> LiteLLMProvider:
+    return LiteLLMProvider(
+        default_model=model,
+        provider_name="openrouter",
+        api_key="sk-or-test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_native_model_uses_custom_llm_provider_hint():
+    provider = _make_openrouter_provider("openrouter/free")
+
+    with patch("nanobot.providers.litellm_provider.acompletion", new=AsyncMock(side_effect=_StopGateway)) as mock_acompletion:
+        response = await provider.chat([{"role": "user", "content": "hello"}], model="openrouter/free")
+
+    assert "Error calling LLM" in response.content
+    assert mock_acompletion.await_args.kwargs["model"] == "openrouter/free"
+    assert mock_acompletion.await_args.kwargs["custom_llm_provider"] == "openrouter"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "expected_model"),
+    [
+        ("openrouter/anthropic/claude-3", "openrouter/anthropic/claude-3"),
+        ("moonshotai/kimi-k2.5:exacto", "openrouter/moonshotai/kimi-k2.5:exacto"),
+    ],
+)
+async def test_openrouter_non_native_models_do_not_use_custom_llm_provider_hint(
+    model: str,
+    expected_model: str,
+):
+    provider = _make_openrouter_provider(model)
+
+    with patch("nanobot.providers.litellm_provider.acompletion", new=AsyncMock(side_effect=_StopGateway)) as mock_acompletion:
+        response = await provider.chat([{"role": "user", "content": "hello"}], model=model)
+
+    assert "Error calling LLM" in response.content
+    assert mock_acompletion.await_args.kwargs["model"] == expected_model
+    assert "custom_llm_provider" not in mock_acompletion.await_args.kwargs


### PR DESCRIPTION
## Summary

Fix #847 by preserving OpenRouter native aliases like `openrouter/free` in LiteLLM.

The fix is scoped so that routed models such as `moonshotai/kimi-k2.5:exacto`
continue to work normally, and explicit routed model strings like
`openrouter/anthropic/claude-3` keep their existing behavior.

## Tests

Added regression coverage for:
- `openrouter/free`
- `moonshotai/kimi-k2.5:exacto`
- `openrouter/anthropic/claude-3`