### PR TITLE
fix(providers): enable streaming for custom provider

### DIFF
--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -32,29 +32,80 @@ class CustomProvider(LLMProvider):
             "messages": self._sanitize_empty_content(messages),
             "max_tokens": max(1, max_tokens),
             "temperature": temperature,
+            "stream": True,
         }
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
         if tools:
             kwargs.update(tools=tools, tool_choice=tool_choice or "auto")
         try:
-            return self._parse(await self._client.chat.completions.create(**kwargs))
+            stream = await self._client.chat.completions.create(**kwargs)
+            return await self._parse_stream(stream)
         except Exception as e:
             return LLMResponse(content=f"Error: {e}", finish_reason="error")
 
-    def _parse(self, response: Any) -> LLMResponse:
-        choice = response.choices[0]
-        msg = choice.message
-        tool_calls = [
-            ToolCallRequest(id=tc.id, name=tc.function.name,
-                            arguments=json_repair.loads(tc.function.arguments) if isinstance(tc.function.arguments, str) else tc.function.arguments)
-            for tc in (msg.tool_calls or [])
-        ]
-        u = response.usage
+    async def _parse_stream(self, stream: Any) -> LLMResponse:
+        """Collect streaming chunks and assemble into LLMResponse."""
+        content_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        tool_calls_map: dict[int, dict[str, Any]] = {}  # index -> {id, name, arguments}
+        finish_reason = "stop"
+        usage: dict[str, int] = {}
+
+        async for chunk in stream:
+            if not chunk.choices:
+                # Handle usage info in final chunk (some APIs send it separately)
+                if hasattr(chunk, "usage") and chunk.usage:
+                    u = chunk.usage
+                    usage = {"prompt_tokens": u.prompt_tokens, "completion_tokens": u.completion_tokens, "total_tokens": u.total_tokens}
+                continue
+
+            choice = chunk.choices[0]
+            delta = choice.delta
+
+            # Collect content
+            if delta.content:
+                content_parts.append(delta.content)
+
+            # Collect reasoning content if present
+            if hasattr(delta, "reasoning_content") and delta.reasoning_content:
+                reasoning_parts.append(delta.reasoning_content)
+
+            # Collect tool calls
+            if delta.tool_calls:
+                for tc in delta.tool_calls:
+                    idx = tc.index
+                    if idx not in tool_calls_map:
+                        tool_calls_map[idx] = {"id": "", "name": "", "arguments": ""}
+                    if tc.id:
+                        tool_calls_map[idx]["id"] = tc.id
+                    if tc.function:
+                        if tc.function.name:
+                            tool_calls_map[idx]["name"] = tc.function.name
+                        if tc.function.arguments:
+                            tool_calls_map[idx]["arguments"] += tc.function.arguments
+
+            # Capture finish reason
+            if choice.finish_reason:
+                finish_reason = choice.finish_reason
+
+        # Build tool_calls list
+        tool_calls = []
+        for idx in sorted(tool_calls_map.keys()):
+            tc_data = tool_calls_map[idx]
+            args = tc_data["arguments"]
+            tool_calls.append(ToolCallRequest(
+                id=tc_data["id"],
+                name=tc_data["name"],
+                arguments=json_repair.loads(args) if isinstance(args, str) and args else {}
+            ))
+
         return LLMResponse(
-            content=msg.content, tool_calls=tool_calls, finish_reason=choice.finish_reason or "stop",
-            usage={"prompt_tokens": u.prompt_tokens, "completion_tokens": u.completion_tokens, "total_tokens": u.total_tokens} if u else {},
-            reasoning_content=getattr(msg, "reasoning_content", None) or None,
+            content="".join(content_parts) or None,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            usage=usage,
+            reasoning_content="".join(reasoning_parts) or None,
         )
 
     def get_default_model(self) -> str:


### PR DESCRIPTION
## Summary

- Enable `stream=True` by default for the custom provider
- Add `_parse_stream` method to properly collect and assemble streaming chunks
- Fixes compatibility with OpenAI-compatible APIs that require streaming (e.g., NewAPI/OneAPI)

## Problem

Some OpenAI-compatible API gateways (like NewAPI/OneAPI) return error 400 with message "Stream must be set to true" when streaming is not enabled.

## Solution

Modified `custom_provider.py` to:
1. Always use `stream=True` in API requests
2. Properly handle streaming response chunks
3. Collect content, tool calls, reasoning content, and usage info from stream