### PR TITLE
chore: bump wecom-aibot-sdk-python to >=0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 
 [project.optional-dependencies]
 wecom = [
-    "wecom-aibot-sdk-python>=0.1.2",
+    "wecom-aibot-sdk-python>=0.1.5",
 ]
 matrix = [
     "matrix-nio[e2e]>=0.25.2",


### PR DESCRIPTION
- Includes bug fixes for duplicate recv loops
- Handles disconnected_event properly
- Fixes heartbeat timeout