### PR TITLE
fix: restore ollama provider compatibility

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -265,20 +265,36 @@ def _make_provider(config: Config):
     from nanobot.providers.base import GenerationSettings
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
     from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+    from nanobot.providers.registry import find_by_name
 
     model = config.agents.defaults.model
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
+    spec = find_by_name(provider_name) if provider_name else None
+
+    if config.agents.defaults.provider != "auto" and spec is None:
+        console.print(f"[red]Error: Unknown provider: {config.agents.defaults.provider}[/red]")
+        console.print("Check ~/.nanobot/config.json under agents.defaults.provider")
+        raise typer.Exit(1)
 
     # OpenAI Codex (OAuth)
     if provider_name == "openai_codex" or model.startswith("openai-codex/"):
         provider = OpenAICodexProvider(default_model=model)
-    # Custom: direct OpenAI-compatible endpoint, bypasses LiteLLM
-    elif provider_name == "custom":
+    # Custom/Ollama: direct OpenAI-compatible endpoint, bypasses LiteLLM
+    elif provider_name in {"custom", "ollama"}:
         from nanobot.providers.custom_provider import CustomProvider
+
+        api_base = config.get_api_base(model)
+        if provider_name == "ollama":
+            api_base = (api_base or "http://localhost:11434").rstrip("/")
+            if not api_base.endswith("/v1"):
+                api_base = f"{api_base}/v1"
+        else:
+            api_base = api_base or "http://localhost:8000/v1"
+
         provider = CustomProvider(
-            api_key=p.api_key if p else "no-key",
-            api_base=config.get_api_base(model) or "http://localhost:8000/v1",
+            api_key=p.api_key if p and p.api_key else "no-key",
+            api_base=api_base,
             default_model=model,
         )
     # Azure OpenAI: direct Azure OpenAI endpoint with deployment name
@@ -295,8 +311,6 @@ def _make_provider(config: Config):
         )
     else:
         from nanobot.providers.litellm_provider import LiteLLMProvider
-        from nanobot.providers.registry import find_by_name
-        spec = find_by_name(provider_name)
         if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and (spec.is_oauth or spec.is_local)):
             console.print("[red]Error: No API key configured.[/red]")
             console.print("Set one in ~/.nanobot/config.json under providers section")

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -269,6 +269,7 @@ class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
+    ollama: ProviderConfig = Field(default_factory=ProviderConfig)  # Ollama local server
     azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -79,6 +79,24 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         litellm_prefix="",
         is_direct=True,
     ),
+    # === Ollama (local OpenAI-compatible endpoint) =========================
+    ProviderSpec(
+        name="ollama",
+        keywords=("ollama",),
+        env_key="OPENAI_API_KEY",
+        display_name="Ollama",
+        litellm_prefix="openai",
+        skip_prefixes=(),
+        env_extras=(),
+        is_gateway=False,
+        is_local=True,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="11434",
+        default_api_base="http://localhost:11434",
+        strip_model_prefix=False,
+        model_overrides=(),
+        is_direct=True,
+    ),
 
     # === Azure OpenAI (direct API calls with API version 2024-10-21) =====
     ProviderSpec(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,10 +4,12 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from click.exceptions import Exit
 from typer.testing import CliRunner
 
-from nanobot.cli.commands import app
+from nanobot.cli.commands import _make_provider, app
 from nanobot.config.schema import Config
+from nanobot.providers.custom_provider import CustomProvider
 from nanobot.providers.litellm_provider import LiteLLMProvider
 from nanobot.providers.openai_codex_provider import _strip_model_prefix
 from nanobot.providers.registry import find_by_model
@@ -177,6 +179,48 @@ def test_config_falls_back_to_vllm_when_ollama_not_configured():
 
     assert config.get_provider_name() == "vllm"
     assert config.get_api_base() == "http://localhost:8000"
+
+
+def test_make_provider_uses_custom_provider_for_ollama_and_adds_v1_suffix():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "ollama", "model": "llama3.2"}},
+            "providers": {"ollama": {"apiBase": "http://localhost:11434"}},
+        }
+    )
+
+    provider = _make_provider(config)
+
+    assert isinstance(provider, CustomProvider)
+    assert provider.api_base == "http://localhost:11434/v1"
+    assert provider.api_key == "no-key"
+    assert provider.get_default_model() == "llama3.2"
+
+
+def test_make_provider_keeps_ollama_v1_suffix_when_already_present():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "ollama", "model": "llama3.2"}},
+            "providers": {"ollama": {"apiBase": "http://localhost:11434/v1", "apiKey": "ignored"}},
+        }
+    )
+
+    provider = _make_provider(config)
+
+    assert isinstance(provider, CustomProvider)
+    assert provider.api_base == "http://localhost:11434/v1"
+    assert provider.api_key == "ignored"
+
+
+def test_make_provider_rejects_unknown_explicit_provider():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "does_not_exist", "model": "llama3.2"}},
+        }
+    )
+
+    with pytest.raises(Exit):
+        _make_provider(config)
 
 
 def test_find_by_model_prefers_explicit_prefix_over_generic_codex_keyword():


### PR DESCRIPTION

Reported in [#1947](https://github.com/HKUDS/nanobot/issues/1947): "Connecting nanobot to an ollama-qwen instance, error on ApiKey".
```markdown
## Summary

Fixes support for configuring local Ollama instances via:

```json
{
  "providers": {
    "ollama": {
      "apiBase": "http://localhost:11434"
    }
  },
  "agents": {
    "defaults": {
      "provider": "ollama",
      "model": "llama3.2"
    }
  }
}
```

This addresses [#1947](https://github.com/HKUDS/nanobot/issues/1947), where `provider: "ollama"` resulted in:

```text
Error: No API key configured.
```

even for local Ollama usage.

## What Changed

- add `ollama` to `ProvidersConfig`
- register `ollama` in the provider registry as a local direct provider
- route `ollama` through the direct OpenAI-compatible provider path
- normalize Ollama `apiBase` to `/v1` at runtime when needed
- return a clear `Unknown provider: ...` error for invalid explicit providers instead of a misleading API key error

## Why

The config shape documented for Ollama was not fully implemented in runtime provider resolution.

As a result:
- `providers.ollama` was not recognized by the schema
- `provider: "ollama"` could not resolve to a valid provider
- the CLI fell through to the generic API key error path

This PR restores the expected Ollama config behavior while reusing the existing direct OpenAI-compatible provider implementation.

## Testing

Passed:

```bash
python -m pytest tests/test_commands.py tests/test_config_migration.py tests/test_config_paths.py -q
```

Result:

```text
37 passed in 1.32s
```

Added coverage for:
- explicit `ollama` provider resolution
- Ollama default/custom `apiBase`
- automatic `/v1` normalization
- unknown explicit provider error handling

