### PR TITLE
fix: add fallback parser for text-based XML tool calls

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -25,7 +25,7 @@ from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
-from nanobot.providers.base import LLMProvider
+from nanobot.providers.base import LLMProvider, ToolCallRequest, short_tool_id
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
@@ -165,6 +165,36 @@ class AgentLoop:
             return None
         return re.sub(r"<think>[\s\S]*?</think>", "", text).strip() or None
 
+    # Regex for models that emit tool calls as XML text instead of structured API.
+    # Format: <tool_call><function=NAME><parameter=KEY>VALUE</parameter>...</function></tool_call>
+    _XML_TOOL_CALL_RE = re.compile(
+        r"<tool_call>\s*<function=(\w+)>([\s\S]*?)</function>\s*</tool_call>"
+    )
+    _XML_PARAM_RE = re.compile(r"<parameter=(\w+)>([\s\S]*?)</parameter>")
+
+    @classmethod
+    def _parse_text_tool_calls(cls, text: str) -> list[ToolCallRequest]:
+        """Parse XML-formatted tool calls from LLM text content.
+
+        Some models (especially open-source / domestic models accessed via
+        compatible APIs) don't use the structured function-calling API and
+        instead output tool calls as XML text.  This method extracts them
+        so the agent loop can execute them normally.
+        """
+        results: list[ToolCallRequest] = []
+        for m in cls._XML_TOOL_CALL_RE.finditer(text):
+            func_name = m.group(1)
+            body = m.group(2)
+            arguments: dict[str, Any] = {}
+            for pm in cls._XML_PARAM_RE.finditer(body):
+                arguments[pm.group(1)] = pm.group(2)
+            results.append(ToolCallRequest(
+                id=short_tool_id(),
+                name=func_name,
+                arguments=arguments,
+            ))
+        return results
+
     @staticmethod
     def _tool_hint(tool_calls: list) -> str:
         """Format tool calls as concise hint, e.g. 'web_search("query")'."""
@@ -197,6 +227,22 @@ class AgentLoop:
                 tools=tool_defs,
                 model=self.model,
             )
+
+            # Fallback: some models emit tool calls as XML text instead of
+            # using the structured function-calling API.  Parse them here so
+            # the rest of the loop can handle them normally.
+            if (
+                not response.has_tool_calls
+                and response.content
+                and "<tool_call>" in response.content
+            ):
+                parsed = self._parse_text_tool_calls(response.content)
+                if parsed:
+                    logger.info("Parsed {} text-format tool call(s) from response", len(parsed))
+                    response.tool_calls = parsed
+                    response.content = (
+                        self._XML_TOOL_CALL_RE.sub("", response.content).strip() or None
+                    )
 
             if response.has_tool_calls:
                 if on_progress:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -25,8 +25,9 @@ from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
-from nanobot.providers.base import LLMProvider, ToolCallRequest, short_tool_id
+from nanobot.providers.base import LLMProvider, ToolCallRequest
 from nanobot.session.manager import Session, SessionManager
+from nanobot.utils.helpers import parse_text_tool_calls, strip_text_tool_calls
 
 if TYPE_CHECKING:
     from nanobot.config.schema import ChannelsConfig, ExecToolConfig, WebSearchConfig
@@ -165,36 +166,6 @@ class AgentLoop:
             return None
         return re.sub(r"<think>[\s\S]*?</think>", "", text).strip() or None
 
-    # Regex for models that emit tool calls as XML text instead of structured API.
-    # Format: <tool_call><function=NAME><parameter=KEY>VALUE</parameter>...</function></tool_call>
-    _XML_TOOL_CALL_RE = re.compile(
-        r"<tool_call>\s*<function=(\w+)>([\s\S]*?)</function>\s*</tool_call>"
-    )
-    _XML_PARAM_RE = re.compile(r"<parameter=(\w+)>([\s\S]*?)</parameter>")
-
-    @classmethod
-    def _parse_text_tool_calls(cls, text: str) -> list[ToolCallRequest]:
-        """Parse XML-formatted tool calls from LLM text content.
-
-        Some models (especially open-source / domestic models accessed via
-        compatible APIs) don't use the structured function-calling API and
-        instead output tool calls as XML text.  This method extracts them
-        so the agent loop can execute them normally.
-        """
-        results: list[ToolCallRequest] = []
-        for m in cls._XML_TOOL_CALL_RE.finditer(text):
-            func_name = m.group(1)
-            body = m.group(2)
-            arguments: dict[str, Any] = {}
-            for pm in cls._XML_PARAM_RE.finditer(body):
-                arguments[pm.group(1)] = pm.group(2)
-            results.append(ToolCallRequest(
-                id=short_tool_id(),
-                name=func_name,
-                arguments=arguments,
-            ))
-        return results
-
     @staticmethod
     def _tool_hint(tool_calls: list) -> str:
         """Format tool calls as concise hint, e.g. 'web_search("query")'."""
@@ -236,13 +207,11 @@ class AgentLoop:
                 and response.content
                 and "<tool_call>" in response.content
             ):
-                parsed = self._parse_text_tool_calls(response.content)
+                parsed = parse_text_tool_calls(response.content)
                 if parsed:
                     logger.info("Parsed {} text-format tool call(s) from response", len(parsed))
                     response.tool_calls = parsed
-                    response.content = (
-                        self._XML_TOOL_CALL_RE.sub("", response.content).strip() or None
-                    )
+                    response.content = strip_text_tool_calls(response.content)
 
             if response.has_tool_calls:
                 if on_progress:

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -2,11 +2,20 @@
 
 import asyncio
 import json
+import secrets
+import string
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
 from loguru import logger
+
+_ALNUM = string.ascii_letters + string.digits
+
+
+def short_tool_id() -> str:
+    """Generate a 9-char alphanumeric ID compatible with all providers."""
+    return "".join(secrets.choice(_ALNUM) for _ in range(9))
 
 
 @dataclass

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -2,8 +2,6 @@
 
 import hashlib
 import os
-import secrets
-import string
 from typing import Any
 
 import json_repair
@@ -11,17 +9,12 @@ import litellm
 from litellm import acompletion
 from loguru import logger
 
-from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest, short_tool_id
 from nanobot.providers.registry import find_by_model, find_gateway
 
 # Standard chat-completion message keys.
 _ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content"})
 _ANTHROPIC_EXTRA_KEYS = frozenset({"thinking_blocks"})
-_ALNUM = string.ascii_letters + string.digits
-
-def _short_tool_id() -> str:
-    """Generate a 9-char alphanumeric ID compatible with all providers (incl. Mistral)."""
-    return "".join(secrets.choice(_ALNUM) for _ in range(9))
 
 
 class LiteLLMProvider(LLMProvider):
@@ -321,7 +314,7 @@ class LiteLLMProvider(LLMProvider):
             )
 
             tool_calls.append(ToolCallRequest(
-                id=_short_tool_id(),
+                id=short_tool_id(),
                 name=tc.function.name,
                 arguments=args,
                 provider_specific_fields=provider_specific_fields,

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -1,5 +1,7 @@
 """Utility functions for nanobot."""
 
+from __future__ import annotations
+
 import json
 import re
 from datetime import datetime
@@ -168,6 +170,45 @@ def estimate_prompt_tokens_chain(
     if estimated > 0:
         return int(estimated), "tiktoken"
     return 0, "none"
+
+
+# ---------------------------------------------------------------------------
+# Text-format XML tool-call parser
+# ---------------------------------------------------------------------------
+# Some models (especially open-source / domestic models accessed via
+# compatible APIs) don't use the structured function-calling API and instead
+# output tool calls as XML text:
+#   <tool_call><function=NAME><parameter=KEY>VALUE</parameter>...</function></tool_call>
+# These helpers extract them so the agent loop can execute them normally.
+
+_XML_TOOL_CALL_RE = re.compile(
+    r"<tool_call>\s*<function=(\w+)>([\s\S]*?)</function>\s*</tool_call>"
+)
+_XML_PARAM_RE = re.compile(r"<parameter=(\w+)>([\s\S]*?)</parameter>")
+
+
+def parse_text_tool_calls(text: str) -> list[ToolCallRequest]:
+    """Parse XML-formatted tool calls from LLM text content."""
+    from nanobot.providers.base import ToolCallRequest, short_tool_id
+
+    results: list[ToolCallRequest] = []
+    for m in _XML_TOOL_CALL_RE.finditer(text):
+        func_name = m.group(1)
+        body = m.group(2)
+        arguments: dict[str, Any] = {}
+        for pm in _XML_PARAM_RE.finditer(body):
+            arguments[pm.group(1)] = pm.group(2)
+        results.append(ToolCallRequest(
+            id=short_tool_id(),
+            name=func_name,
+            arguments=arguments,
+        ))
+    return results
+
+
+def strip_text_tool_calls(text: str) -> str | None:
+    """Remove XML tool-call blocks from text, return cleaned content or None."""
+    return _XML_TOOL_CALL_RE.sub("", text).strip() or None
 
 
 def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]:


### PR DESCRIPTION
## Summary

Some LLM models (especially open-source / domestic models via compatible APIs) don't use the structured function-calling API. Instead they output tool calls as XML text in `response.content`:

```xml
<tool_call>
<function=exec>
<parameter=command>summarize "https://..." --youtube auto</parameter>
<parameter=timeout>300</parameter>
</function>
</tool_call>
```

The agent loop treats this as a final text response and sends the raw XML directly to the user — the conversation stops and the tool is never executed.

## Changes

- **`nanobot/providers/base.py`**: Extract `short_tool_id()` as a shared utility (previously private in `litellm_provider.py`)
- **`nanobot/providers/litellm_provider.py`**: Import `short_tool_id` from `base` instead of local definition
- **`nanobot/agent/loop.py`**:
  - Add `_parse_text_tool_calls()` — regex-based parser for `<tool_call>` XML format
  - Add fallback logic in `_run_agent_loop` before the `has_tool_calls` check: if structured tool calls are empty but content contains `<tool_call>`, parse and convert them to `ToolCallRequest` objects

## How it works

After receiving the LLM response and before checking `has_tool_calls`, the fallback detects `<tool_call>` in `response.content`, parses it into `ToolCallRequest` objects, strips the XML from content, and lets the existing tool execution branch handle the rest. Type casting (e.g. string `"300"` → int) is handled by the existing `Tool.cast_params()` in the tool registry.

## Test plan

- [x] Regex parser tested against multiple XML formats (compact, multiline, multiple tool calls, no false positives)
- [x] Deployed and verified on Feishu channel — tool calls now execute correctly instead of echoing raw XML