### PR TITLE
feat: add provider and model chat commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,51 @@ nanobot agent
 
 That's it! You have a working AI assistant in 2 minutes.
 
+## /provider Command
+
+Inside chat channels and `nanobot agent`, `/provider` manages backend switching through:
+
+- `agents.defaults.provider`
+- `agents.defaults.model`
+
+Examples:
+
+```text
+/provider
+/provider openai
+/provider gemini
+```
+
+Behavior:
+
+- `/provider` shows the current config path, current provider/model, and the configured providers that are usable from the current config
+- `/provider <provider>` switches to that provider and sets the model to the first model discovered from that provider endpoint
+- If no models can be discovered from the target provider URL, the switch is rejected instead of saving a half-broken config
+- Saving a change updates `~/.nanobot/config.json` (or the active `--config` file) directly
+- Restart nanobot after changing `/provider`
+
+## /model Command
+
+Inside chat channels and `nanobot agent`, `/model` selects models for the current provider:
+
+Examples:
+
+```text
+/model
+/model gpt-4o
+/model claude-sonnet-4-5
+/model ollama llama3.2
+```
+
+Behavior:
+
+- `/model` shows the current config path, current provider/model, the active provider URL, and the model options discovered from that provider endpoint
+- `/model <model>` saves the selected model for the current provider only
+- `/model <provider> <model>` is accepted only when `<provider>` matches the current provider
+- Use `/provider` if you want to switch providers first
+- Saving a change updates `~/.nanobot/config.json` (or the active `--config` file) directly
+- Restart nanobot after changing `/model`
+
 ## 💬 Chat Apps
 
 Connect nanobot to your favorite chat platform. Want to build your own? See the [Channel Plugin Guide](.docs/CHANNEL_PLUGIN_GUIDE.md).

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -396,12 +396,30 @@ class AgentLoop:
             lines = [
                 "🐈 nanobot commands:",
                 "/new — Start a new conversation",
+                "/provider — Show or change the configured provider",
+                "/model — Show or change the configured model",
                 "/stop — Stop the current task",
                 "/restart — Restart the bot",
                 "/help — Show available commands",
             ]
             return OutboundMessage(
                 channel=msg.channel, chat_id=msg.chat_id, content="\n".join(lines),
+            )
+        if cmd == "/provider" or cmd.startswith("/provider "):
+            from nanobot.model_management import handle_provider_command
+
+            return OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content=handle_provider_command(msg.content),
+            )
+        if cmd == "/model" or cmd.startswith("/model "):
+            from nanobot.model_management import handle_model_command
+
+            return OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content=handle_model_command(msg.content),
             )
         await self.memory_consolidator.maybe_consolidate_by_tokens(session)
 

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -175,6 +175,8 @@ class TelegramChannel(BaseChannel):
     BOT_COMMANDS = [
         BotCommand("start", "Start the bot"),
         BotCommand("new", "Start a new conversation"),
+        BotCommand("provider", "Show or change the configured provider"),
+        BotCommand("model", "Show or change the configured model"),
         BotCommand("stop", "Stop the current task"),
         BotCommand("help", "Show available commands"),
         BotCommand("restart", "Restart the bot"),
@@ -452,6 +454,8 @@ class TelegramChannel(BaseChannel):
         await update.message.reply_text(
             "🐈 nanobot commands:\n"
             "/new — Start a new conversation\n"
+            "/provider — Show or change the configured provider\n"
+            "/model — Show or change the configured model\n"
             "/stop — Stop the current task\n"
             "/help — Show available commands"
         )

--- a/nanobot/model_management.py
+++ b/nanobot/model_management.py
@@ -1,0 +1,430 @@
+"""Config-backed `/provider` and `/model` command handling."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from nanobot.config.loader import get_config_path, load_config, save_config
+from nanobot.config.schema import Config
+from nanobot.providers.registry import PROVIDERS, ProviderSpec, find_by_name
+
+OPENAI_COMPATIBLE_PROVIDERS = frozenset(
+    {
+        "custom",
+        "openai",
+        "openrouter",
+        "deepseek",
+        "groq",
+        "minimax",
+        "aihubmix",
+        "siliconflow",
+        "volcengine",
+        "dashscope",
+        "moonshot",
+        "zhipu",
+        "vllm",
+        "byteplus",
+        "volcengine_coding_plan",
+        "byteplus_coding_plan",
+    }
+)
+
+HOSTED_PROVIDER_BASES = {
+    "openai": "https://api.openai.com/v1",
+    "anthropic": "https://api.anthropic.com/v1",
+    "deepseek": "https://api.deepseek.com/v1",
+    "groq": "https://api.groq.com/openai/v1",
+    "gemini": "https://generativelanguage.googleapis.com/v1beta",
+    "dashscope": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "zhipu": "https://open.bigmodel.cn/api/paas/v4",
+}
+
+DISCOVERY_TIMEOUT = 3.0
+MODEL_USAGE_TEXT = (
+    "Usage:\n"
+    "- /model\n"
+    "- /model <model>\n"
+    "- /model <current-provider> <model>"
+)
+PROVIDER_USAGE_TEXT = (
+    "Usage:\n"
+    "- /provider\n"
+    "- /provider <provider>"
+)
+
+
+@dataclass(frozen=True)
+class ModelSelection:
+    provider: ProviderSpec
+    config_model: str
+
+
+class CommandError(ValueError):
+    """Raised when `/provider` or `/model` parsing/validation fails."""
+
+
+def handle_provider_command(command_text: str) -> str:
+    """Switch the configured provider and default to its first discovered model."""
+    config_path = get_config_path()
+    config = load_config(config_path)
+
+    try:
+        command_parts = shlex.split(command_text)
+    except ValueError:
+        return f"Invalid command syntax.\n{PROVIDER_USAGE_TEXT}"
+
+    if len(command_parts) == 1:
+        return format_provider_status(config, config_path)
+    if len(command_parts) != 2:
+        return PROVIDER_USAGE_TEXT
+
+    try:
+        selection = _provider_selection(config, command_parts[1])
+    except CommandError as exc:
+        return str(exc)
+
+    _save_selection(config, config_path, selection)
+    return (
+        "Saved provider configuration.\n"
+        f"Config file: {config_path}\n"
+        f"Provider: {selection.provider.name}\n"
+        f"Model: {selection.config_model}\n"
+        "Restart nanobot to apply."
+    )
+
+
+def handle_model_command(command_text: str) -> str:
+    """Switch the configured model within the current provider."""
+    config_path = get_config_path()
+    config = load_config(config_path)
+
+    try:
+        command_parts = shlex.split(command_text)
+    except ValueError:
+        return f"Invalid command syntax.\n{MODEL_USAGE_TEXT}"
+
+    if len(command_parts) == 1:
+        return format_model_status(config, config_path)
+    if len(command_parts) not in {2, 3}:
+        return MODEL_USAGE_TEXT
+
+    try:
+        current_spec = _current_provider_spec(config)
+        selection = _selection_from_command(current_spec, command_parts)
+    except CommandError as exc:
+        return str(exc)
+
+    _save_selection(config, config_path, selection)
+    return (
+        "Saved model configuration.\n"
+        f"Config file: {config_path}\n"
+        f"Provider: {selection.provider.name}\n"
+        f"Model: {selection.config_model}\n"
+        "Restart nanobot to apply."
+    )
+
+
+def format_provider_status(config: Config, config_path: Path) -> str:
+    """Show current provider and switchable providers."""
+    try:
+        current_spec = _current_provider_spec(config)
+    except CommandError as exc:
+        return str(exc)
+
+    lines = [
+        "Provider Configuration",
+        f"Config file: {config_path}",
+        f"Current provider: {current_spec.name}",
+        f"Current model: {config.agents.defaults.model}",
+        "",
+        "Available providers:",
+    ]
+
+    available_specs = _available_provider_specs(config, current_spec)
+    if not available_specs:
+        lines.append("- No configured providers are available.")
+        return "\n".join(lines)
+
+    for spec in available_specs:
+        provider_url = _provider_api_base(config, spec) or "(not configured)"
+        lines.append(f"- /provider {spec.name} ({provider_url})")
+    return "\n".join(lines)
+
+
+def format_model_status(config: Config, config_path: Path) -> str:
+    """Show current provider and its discovered models."""
+    try:
+        current_spec = _current_provider_spec(config)
+    except CommandError as exc:
+        return str(exc)
+
+    current_model = config.agents.defaults.model
+    current_option_model = _option_model_for_provider(current_spec, current_model)
+    models = discover_models_for_provider(config, current_spec)
+    if current_option_model and current_option_model not in models:
+        models.insert(0, current_option_model)
+
+    lines = [
+        "Model Configuration",
+        f"Config file: {config_path}",
+        f"Current provider: {current_spec.name}",
+        f"Current model: {current_model}",
+        f"Provider URL: {_provider_api_base(config, current_spec) or '(not configured)'}",
+        "",
+        "Available models:",
+    ]
+
+    if not models:
+        lines.append("- No models discovered from the current provider URL.")
+        return "\n".join(lines)
+
+    for model in models:
+        lines.append(f"- /model {model}")
+    return "\n".join(lines)
+
+
+def discover_models_for_provider(config: Config, spec: ProviderSpec) -> list[str]:
+    """Discover models for one provider."""
+    provider_config = getattr(config.providers, spec.name, None)
+    if provider_config is None:
+        return []
+
+    try:
+        if spec.name == "ollama":
+            return _discover_ollama_models(_provider_api_base(config, spec))
+        if spec.name == "anthropic":
+            return _discover_anthropic_models(_provider_api_base(config, spec), provider_config.api_key)
+        if spec.name == "gemini":
+            return _discover_gemini_models(_provider_api_base(config, spec), provider_config.api_key)
+        if spec.name in OPENAI_COMPATIBLE_PROVIDERS:
+            return _discover_openai_compatible_models(
+                _provider_api_base(config, spec),
+                provider_config.api_key,
+                provider_config.extra_headers or {},
+            )
+    except Exception:
+        return []
+    return []
+
+
+def _provider_selection(config: Config, provider: str) -> ModelSelection:
+    spec = find_by_name(_normalize_provider_name(provider))
+    if spec is None:
+        raise CommandError(f"Unknown provider `{provider}`.")
+    if not _is_provider_available(config, spec):
+        raise CommandError(f"Provider `{spec.name}` is not configured for use.")
+
+    models = discover_models_for_provider(config, spec)
+    if not models:
+        raise CommandError(f"No models discovered for `{spec.name}`. Check its apiKey/apiBase and try again.")
+    return _build_selection(spec, models[0])
+
+
+def _selection_from_command(current_spec: ProviderSpec, command_parts: list[str]) -> ModelSelection:
+    if len(command_parts) == 2:
+        return _build_selection(current_spec, command_parts[1])
+
+    requested_provider = _normalize_provider_name(command_parts[1])
+    if requested_provider != current_spec.name:
+        raise CommandError(
+            f"Current provider is `{current_spec.name}`. `/model` only selects models from that provider URL."
+        )
+    return _build_selection(current_spec, command_parts[2])
+
+
+def _build_selection(spec: ProviderSpec, model: str) -> ModelSelection:
+    normalized_model = model.strip()
+    if not normalized_model:
+        raise CommandError("Model name is required.")
+
+    if "/" in normalized_model:
+        prefix, remainder = normalized_model.split("/", 1)
+        if _normalize_provider_name(prefix) != spec.name:
+            raise CommandError(
+                f"Current provider is `{spec.name}`. `/model` only selects models from that provider URL."
+            )
+        normalized_model = remainder
+
+    if spec.is_gateway or spec.is_local or spec.is_direct:
+        config_model = normalized_model
+    else:
+        config_model = f"{spec.name.replace('_', '-')}/{normalized_model}"
+    return ModelSelection(provider=spec, config_model=config_model)
+
+
+def _save_selection(config: Config, config_path: Path, selection: ModelSelection) -> None:
+    candidate = config.model_copy(deep=True)
+    candidate.agents.defaults.provider = selection.provider.name
+    candidate.agents.defaults.model = selection.config_model
+    save_config(candidate, config_path)
+
+
+def _current_provider_spec(config: Config) -> ProviderSpec:
+    provider_name = config.get_provider_name(config.agents.defaults.model) or config.agents.defaults.provider
+    spec = find_by_name(provider_name) if provider_name else None
+    if spec is None:
+        raise CommandError("Current model does not resolve to a known provider.")
+    return spec
+
+
+def _available_provider_specs(config: Config, current_spec: ProviderSpec) -> list[ProviderSpec]:
+    return [spec for spec in PROVIDERS if spec == current_spec or _is_provider_available(config, spec)]
+
+
+def _is_provider_available(config: Config, spec: ProviderSpec) -> bool:
+    current_spec = _current_provider_spec(config)
+    if current_spec.name == spec.name:
+        return True
+
+    provider_config = getattr(config.providers, spec.name, None)
+    if provider_config is None:
+        return False
+    if spec.name in {"custom", "azure_openai"}:
+        return bool(provider_config.api_key and provider_config.api_base)
+    if spec.is_oauth:
+        return _oauth_provider_available(spec)
+    if spec.is_local:
+        return bool(provider_config.api_base)
+    if spec.is_gateway:
+        return bool(provider_config.api_key)
+    return bool(provider_config.api_key)
+
+
+def _oauth_provider_available(spec: ProviderSpec) -> bool:
+    if spec.name == "openai_codex":
+        try:
+            from oauth_cli_kit import get_token
+
+            token = get_token()
+            return bool(token and getattr(token, "access", None))
+        except Exception:
+            return False
+    return False
+
+
+def _provider_api_base(config: Config, spec: ProviderSpec) -> str | None:
+    provider_config = getattr(config.providers, spec.name, None)
+    if provider_config and provider_config.api_base:
+        return provider_config.api_base.rstrip("/")
+    if spec.default_api_base:
+        return spec.default_api_base.rstrip("/")
+    default_base = HOSTED_PROVIDER_BASES.get(spec.name)
+    return default_base.rstrip("/") if default_base else None
+
+
+def _discover_openai_compatible_models(
+    api_base: str | None,
+    api_key: str | None,
+    extra_headers: dict[str, str],
+) -> list[str]:
+    if not api_base:
+        return []
+
+    headers = {"Accept": "application/json", **extra_headers}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    with httpx.Client(timeout=DISCOVERY_TIMEOUT, follow_redirects=True) as client:
+        response = client.get(f"{api_base.rstrip('/')}/models", headers=headers)
+        if response.status_code >= 400:
+            return []
+        payload = response.json()
+
+    items = payload.get("data") or payload.get("models") or []
+    return _unique_strings(item.get("id") or item.get("name") for item in items if isinstance(item, dict))
+
+
+def _discover_ollama_models(api_base: str | None) -> list[str]:
+    if not api_base:
+        return []
+
+    with httpx.Client(timeout=DISCOVERY_TIMEOUT, follow_redirects=True) as client:
+        response = client.get(f"{api_base.rstrip('/')}/api/tags")
+        if response.status_code >= 400:
+            return []
+        payload = response.json()
+
+    items = payload.get("models") or []
+    return _unique_strings(item.get("name") for item in items if isinstance(item, dict))
+
+
+def _discover_anthropic_models(api_base: str | None, api_key: str | None) -> list[str]:
+    if not api_base or not api_key:
+        return []
+
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "Accept": "application/json",
+    }
+
+    with httpx.Client(timeout=DISCOVERY_TIMEOUT, follow_redirects=True) as client:
+        response = client.get(f"{api_base.rstrip('/')}/models", headers=headers)
+        if response.status_code >= 400:
+            return []
+        payload = response.json()
+
+    items = payload.get("data") or payload.get("models") or []
+    return _unique_strings(item.get("id") or item.get("name") for item in items if isinstance(item, dict))
+
+
+def _discover_gemini_models(api_base: str | None, api_key: str | None) -> list[str]:
+    if not api_base or not api_key:
+        return []
+
+    with httpx.Client(timeout=DISCOVERY_TIMEOUT, follow_redirects=True) as client:
+        response = client.get(
+            f"{api_base.rstrip('/')}/models",
+            params={"key": api_key},
+            headers={"Accept": "application/json"},
+        )
+        if response.status_code >= 400:
+            return []
+        payload = response.json()
+
+    items = payload.get("models") or []
+    models: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        methods = item.get("supportedGenerationMethods") or []
+        if methods and not any(method in {"generateContent", "streamGenerateContent"} for method in methods):
+            continue
+        name = item.get("name") or ""
+        if name.startswith("models/"):
+            name = name.split("/", 1)[1]
+        if name:
+            models.append(name)
+    return _unique_strings(models)
+
+
+def _unique_strings(values) -> list[str]:
+    seen: set[str] = set()
+    output: list[str] = []
+    for value in values:
+        if not value or not isinstance(value, str):
+            continue
+        if value in seen:
+            continue
+        seen.add(value)
+        output.append(value)
+    return output
+
+
+def _option_model_for_provider(spec: ProviderSpec, model: str) -> str:
+    if spec.is_gateway or spec.is_local or spec.is_direct:
+        return model.split("/", 1)[1] if model.startswith(f"{spec.name}/") else model
+    if "/" not in model:
+        return model
+    prefix, remainder = model.split("/", 1)
+    if _normalize_provider_name(prefix) == spec.name:
+        return remainder
+    return model
+
+
+def _normalize_provider_name(provider: str) -> str:
+    return provider.strip().lower().replace("-", "_")

--- a/tests/test_model_command.py
+++ b/tests/test_model_command.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.config.loader import load_config, save_config
+from nanobot.config.schema import Config
+
+
+def _write_config(config_path: Path, config: Config) -> None:
+    save_config(config, config_path)
+
+
+def _make_loop(tmp_path: Path) -> AgentLoop:
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    return AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def get(self, *args, **kwargs) -> _FakeResponse:
+        return self._response
+
+
+def test_discover_openai_compatible_models_parses_model_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nanobot.model_management import _discover_openai_compatible_models
+
+    monkeypatch.setattr(
+        "nanobot.model_management.httpx.Client",
+        lambda **kwargs: _FakeClient(
+            _FakeResponse({"data": [{"id": "gpt-4o"}, {"id": "gpt-4.1"}, {"id": "gpt-4o"}]})
+        ),
+    )
+
+    models = _discover_openai_compatible_models("https://api.example.com/v1", "key", {})
+
+    assert models == ["gpt-4o", "gpt-4.1"]
+
+
+def test_handle_model_command_lists_only_current_provider_models(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from nanobot.model_management import handle_model_command
+
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "openai", "model": "openai/gpt-4o"}},
+            "providers": {
+                "openai": {"apiKey": "oa-key"},
+                "gemini": {"apiKey": "gm-key"},
+            },
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+
+    calls: list[str] = []
+
+    def _discover(_config, spec):
+        calls.append(spec.name)
+        return ["gpt-4.1", "gpt-4o-mini"] if spec.name == "openai" else ["gemini-2.5-pro"]
+
+    monkeypatch.setattr("nanobot.model_management.discover_models_for_provider", _discover)
+
+    result = handle_model_command("/model")
+
+    assert "Model Configuration" in result
+    assert "Current provider: openai" in result
+    assert "/model gpt-4.1" in result
+    assert "/model gpt-4o-mini" in result
+    assert "gemini-2.5-pro" not in result
+    assert calls == ["openai"]
+
+
+def test_handle_model_command_updates_model_with_single_argument(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from nanobot.model_management import handle_model_command
+
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "openai", "model": "openai/gpt-4o"}},
+            "providers": {"openai": {"apiKey": "oa-key"}},
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+
+    result = handle_model_command("/model gpt-4.1")
+    updated = load_config(config_path)
+
+    assert "Saved model configuration." in result
+    assert updated.agents.defaults.provider == "openai"
+    assert updated.agents.defaults.model == "openai/gpt-4.1"
+
+
+def test_handle_model_command_rejects_provider_switching(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from nanobot.model_management import handle_model_command
+
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "openai", "model": "openai/gpt-4o"}},
+            "providers": {
+                "openai": {"apiKey": "oa-key"},
+                "gemini": {"apiKey": "gm-key"},
+            },
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+
+    result = handle_model_command("/model gemini gemini-2.5-pro")
+    updated = load_config(config_path)
+
+    assert "Current provider is `openai`" in result
+    assert updated.agents.defaults.provider == "openai"
+    assert updated.agents.defaults.model == "openai/gpt-4o"
+
+
+def test_handle_model_command_handles_invalid_shell_quoting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from nanobot.model_management import handle_model_command
+
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "anthropic", "model": "anthropic/claude-sonnet-4-5"}},
+            "providers": {"anthropic": {"apiKey": "ant-key"}},
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+
+    result = handle_model_command('/model "')
+
+    assert "Invalid command syntax." in result
+
+
+def test_handle_provider_command_lists_available_providers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from nanobot.model_management import handle_provider_command
+
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "openai", "model": "openai/gpt-4o"}},
+            "providers": {
+                "openai": {"apiKey": "oa-key"},
+                "gemini": {"apiKey": "gm-key"},
+                "ollama": {"apiBase": "http://localhost:11434"},
+            },
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+
+    result = handle_provider_command("/provider")
+
+    assert "Provider Configuration" in result
+    assert "Current provider: openai" in result
+    assert "/provider openai" in result
+    assert "/provider gemini" in result
+    assert "/provider ollama" in result
+
+
+def test_handle_provider_command_switches_provider_and_sets_first_discovered_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from nanobot.model_management import handle_provider_command
+
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "openai", "model": "openai/gpt-4o"}},
+            "providers": {
+                "openai": {"apiKey": "oa-key"},
+                "gemini": {"apiKey": "gm-key"},
+            },
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+    monkeypatch.setattr(
+        "nanobot.model_management.discover_models_for_provider",
+        lambda _config, spec: ["gemini-2.5-pro", "gemini-2.0-flash"] if spec.name == "gemini" else ["gpt-4o"],
+    )
+
+    result = handle_provider_command("/provider gemini")
+    updated = load_config(config_path)
+
+    assert "Saved provider configuration." in result
+    assert updated.agents.defaults.provider == "gemini"
+    assert updated.agents.defaults.model == "gemini/gemini-2.5-pro"
+
+
+def test_handle_provider_command_rejects_provider_without_discovered_models(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from nanobot.model_management import handle_provider_command
+
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "openai", "model": "openai/gpt-4o"}},
+            "providers": {
+                "openai": {"apiKey": "oa-key"},
+                "gemini": {"apiKey": "gm-key"},
+            },
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+    monkeypatch.setattr(
+        "nanobot.model_management.discover_models_for_provider",
+        lambda _config, spec: [] if spec.name == "gemini" else ["gpt-4o"],
+    )
+
+    result = handle_provider_command("/provider gemini")
+    updated = load_config(config_path)
+
+    assert "No models discovered for `gemini`" in result
+    assert updated.agents.defaults.provider == "openai"
+    assert updated.agents.defaults.model == "openai/gpt-4o"
+
+
+def test_handle_provider_command_handles_invalid_shell_quoting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from nanobot.model_management import handle_provider_command
+
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "anthropic", "model": "anthropic/claude-sonnet-4-5"}},
+            "providers": {"anthropic": {"apiKey": "ant-key"}},
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+
+    result = handle_provider_command('/provider "')
+
+    assert "Invalid command syntax." in result
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_handles_model_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "anthropic", "model": "anthropic/claude-sonnet-4-5"}},
+            "providers": {"anthropic": {"apiKey": "ant-key"}},
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+    monkeypatch.setattr(
+        "nanobot.model_management.discover_models_for_provider",
+        lambda _config, spec: ["claude-sonnet-4-5"] if spec.name == "anthropic" else [],
+    )
+
+    loop = _make_loop(tmp_path)
+    response = await loop._process_message(
+        InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="/model")
+    )
+
+    assert response is not None
+    assert "Model Configuration" in response.content
+    assert "/model claude-sonnet-4-5" in response.content
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_handles_provider_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "openai", "model": "openai/gpt-4o"}},
+            "providers": {
+                "openai": {"apiKey": "oa-key"},
+                "gemini": {"apiKey": "gm-key"},
+            },
+        }
+    )
+    _write_config(config_path, config)
+    monkeypatch.setattr("nanobot.model_management.get_config_path", lambda: config_path)
+    monkeypatch.setattr(
+        "nanobot.model_management.discover_models_for_provider",
+        lambda _config, spec: ["gemini-2.5-pro"] if spec.name == "gemini" else ["gpt-4o"],
+    )
+
+    loop = _make_loop(tmp_path)
+    response = await loop._process_message(
+        InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="/provider gemini")
+    )
+
+    assert response is not None
+    assert "Saved provider configuration." in response.content

--- a/tests/test_telegram_model_command.py
+++ b/tests/test_telegram_model_command.py
@@ -1,0 +1,8 @@
+from nanobot.channels.telegram import TelegramChannel
+
+
+def test_telegram_bot_commands_include_provider_and_model() -> None:
+    command_names = [command.command for command in TelegramChannel.BOT_COMMANDS]
+
+    assert "provider" in command_names
+    assert "model" in command_names


### PR DESCRIPTION
## Summary

This PR adds two explicit chat commands for runtime config switching:

- `/provider` switches the active provider
- `/model` switches the active model under the current provider

The goal is to keep provider switching and model switching separate, so the command behavior is predictable.

## What It Implements

- adds `nanobot/model_management.py`
- adds `/provider` handling in the agent loop
- adds `/model` handling in the agent loop
- adds Telegram command menu entries for both commands
- documents the commands in `README.md`
- adds focused tests for command parsing, config writes, and Telegram command registration

## Behavior

### `/provider`
- `/provider` shows configured, usable providers
- `/provider <name>` switches to that provider
- after switching provider, nanobot discovers models from that provider endpoint and saves the first available model
- if no models are discovered, the switch is rejected

### `/model`
- `/model` shows models discovered from the current provider URL
- `/model <model>` saves a new model under the current provider
- `/model <provider> <model>` is only accepted when `<provider>` matches the current provider

## Flow

```mermaid
flowchart TD
    A["User sends command"] --> B{"Command type?"}

    B -->|"/provider"| C["Read config"]
    C --> D["List usable providers"]
    D --> E{"Target provider chosen?"}
    E -->|No| F["Show provider list"]
    E -->|Yes| G["Discover models from target provider URL"]
    G --> H{"Any models found?"}
    H -->|No| I["Reject switch"]
    H -->|Yes| J["Save provider + first model"]

    B -->|"/model"| K["Read config"]
    K --> L["Resolve current provider"]
    L --> M["Discover models from current provider URL"]
    M --> N{"Has model argument?"}
    N -->|No| O["Show model list"]
    N -->|Yes| P["Validate current-provider scope"]
    P --> Q["Save selected model"]
```

## Validation

```bash
pytest -q tests/test_model_command.py tests/test_telegram_model_command.py
```

Result: `12 passed`
