### PR TITLE
chore[ci]: add code coverage reporting with pytest-cov and Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
 
-    - name: Run tests
-      run: python -m pytest tests/ -v
+    - name: Run tests with coverage
+      run: python -m pytest tests/ -v --cov=nanobot --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ langsmith = [
 dev = [
     "pytest>=9.0.0,<10.0.0",
     "pytest-asyncio>=1.3.0,<2.0.0",
+    "pytest-cov>=4.0.0,<5.0.0",
     "ruff>=0.1.0",
     "matrix-nio[e2e]>=0.25.2",
     "mistune>=3.0.0,<4.0.0",


### PR DESCRIPTION
Through this function, we can check the code coverage for new PR.

https://docs.codecov.com/docs/github-2-getting-a-codecov-account-and-uploading-coverage

<img width="926" height="572" alt="image" src="https://github.com/user-attachments/assets/7e40aefc-3709-4746-8175-c58b1bf4e644" />

