### PR TITLE
feat(channels): add inter-agent communication channel

### DIFF
--- a/nanobot/channels/inter_agent.py
+++ b/nanobot/channels/inter_agent.py
@@ -1,0 +1,371 @@
+"""Inter-agent communication channel.
+
+Enables direct HTTP-based communication between nanobot instances, allowing
+multiple agents to collaborate autonomously on tasks without human mediation.
+
+Design: Async Task Model
+------------------------
+Unlike a simple synchronous request/response, this channel uses an async task
+model so the initiating instance is never blocked waiting for a peer to finish.
+
+Flow:
+  1. POST /inter-agent/chat  → submit task, get task_id immediately (202)
+  2. GET  /inter-agent/task/{task_id}  → poll for status + result
+  3. When status == "done", result contains the agent's response
+
+This means:
+  - The initiating agent submits a task and moves on (no blocking)
+  - The receiving agent processes at its own pace, regardless of queue depth
+  - The initiator polls until done, with full visibility into task state
+  - No silent result loss: a task is either pending/running/done/failed
+
+API
+---
+POST /inter-agent/chat
+    {"message": "...", "session_id": "collab_abc", "from_instance": "alice", "round_count": 1}
+    → 202 {"task_id": "...", "status": "pending", "instance": "bob"}
+
+GET /inter-agent/task/{task_id}
+    → {"task_id": "...", "status": "pending|running|done|failed",
+       "response": "...",      # present when status == "done"
+       "is_final": false,      # present when status == "done"
+       "error": "...",         # present when status == "failed"
+       "instance": "bob", "session_id": "collab_abc"}
+
+GET /inter-agent/health
+    → {"status": "ok", "instance": "bob", "port": 18801}
+
+Configuration (config.json)
+----------------------------
+{
+  "channels": {
+    "interagent": {
+      "enabled": true,
+      "apiPort": 18801,
+      "instanceName": "bob",
+      "auditWebhookUrl": "https://...",
+      "maxRoundsPerSession": 30,
+      "taskTtlSeconds": 3600
+    }
+  }
+}
+
+Polling pattern (in AGENTS.md / skill)
+---------------------------------------
+import httpx, time
+
+def submit(url, message, session_id, from_instance, round_count):
+    r = httpx.post(f"{url}/inter-agent/chat", json={
+        "message": message, "session_id": session_id,
+        "from_instance": from_instance, "round_count": round_count,
+    }, timeout=10)
+    return r.json()["task_id"]
+
+def poll(url, task_id, interval=3, max_wait=600):
+    deadline = time.time() + max_wait
+    while time.time() < deadline:
+        r = httpx.get(f"{url}/inter-agent/task/{task_id}", timeout=10)
+        data = r.json()
+        if data["status"] in ("done", "failed"):
+            return data
+        time.sleep(interval)
+    raise TimeoutError(f"task {task_id} not done after {max_wait}s")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import aiohttp.web
+from loguru import logger
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+class InterAgentConfig(Base):
+    """Configuration for the inter-agent communication channel."""
+
+    enabled: bool = False
+    api_port: int = 18800
+    instance_name: str = ""
+    audit_webhook_url: str = ""
+    max_rounds_per_session: int = 30
+    task_ttl_seconds: int = 3600  # how long to keep completed tasks in memory
+
+
+# ---------------------------------------------------------------------------
+# Task registry
+# ---------------------------------------------------------------------------
+
+class TaskStatus(str, Enum):
+    PENDING = "pending"    # queued, agent hasn't started yet
+    RUNNING = "running"    # agent is processing
+    DONE    = "done"       # agent replied successfully
+    FAILED  = "failed"     # agent loop error or explicit failure
+
+
+@dataclass
+class AgentTask:
+    task_id: str
+    session_id: str
+    from_instance: str
+    round_count: int
+    status: TaskStatus = TaskStatus.PENDING
+    response: str | None = None
+    is_final: bool = False
+    error: str | None = None
+    created_at: float = field(default_factory=time.time)
+    finished_at: float | None = None
+
+    def to_dict(self, instance_name: str) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "task_id": self.task_id,
+            "status": self.status.value,
+            "instance": instance_name,
+            "session_id": self.session_id,
+            "round_count": self.round_count,
+        }
+        if self.status == TaskStatus.DONE:
+            d["response"] = self.response
+            d["is_final"] = self.is_final
+        if self.status == TaskStatus.FAILED:
+            d["error"] = self.error
+        return d
+
+
+# task_id → AgentTask
+_tasks: dict[str, AgentTask] = {}
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CHUNK = 3800  # safe chunk size under Feishu's 4096-char webhook limit
+
+_FINAL_SIGNALS = [
+    "最终方案", "讨论结束", "达成共识", "已确认",
+    "final proposal", "discussion complete", "consensus reached",
+    "DISCUSSION_COMPLETE",
+]
+
+
+# ---------------------------------------------------------------------------
+# Channel
+# ---------------------------------------------------------------------------
+
+class InterAgentChannel(BaseChannel):
+    """HTTP API channel for real-time inter-agent communication (async task model)."""
+
+    name = "interagent"
+    display_name = "Inter-Agent"
+
+    @classmethod
+    def default_config(cls) -> dict[str, Any]:
+        return InterAgentConfig().model_dump(by_alias=True)
+
+    def __init__(self, config: Any, bus: MessageBus):
+        if isinstance(config, dict):
+            config = InterAgentConfig.model_validate(config)
+        super().__init__(config, bus)
+        self.config: InterAgentConfig = config
+        self._runner: aiohttp.web.AppRunner | None = None
+
+    # ------------------------------------------------------------------
+    # BaseChannel interface
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        self._running = True
+        app = aiohttp.web.Application()
+        app.router.add_get("/inter-agent/health",         self._handle_health)
+        app.router.add_post("/inter-agent/chat",          self._handle_chat)
+        app.router.add_get("/inter-agent/task/{task_id}", self._handle_task_status)
+
+        self._runner = aiohttp.web.AppRunner(app)
+        await self._runner.setup()
+        site = aiohttp.web.TCPSite(self._runner, "0.0.0.0", self.config.api_port)
+        await site.start()
+        logger.info(
+            "Inter-agent API listening on port {} (instance: {})",
+            self.config.api_port,
+            self.config.instance_name,
+        )
+        try:
+            while self._running:
+                await asyncio.sleep(60)
+                self._evict_old_tasks()
+        except asyncio.CancelledError:
+            pass
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._runner:
+            await self._runner.cleanup()
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Called by the agent loop when a response is ready. Marks the task done."""
+        task = _tasks.get(msg.chat_id)
+        if task is None:
+            logger.warning("Inter-agent: send() called for unknown task_id={}", msg.chat_id)
+            return
+        task.status = TaskStatus.DONE
+        task.response = msg.content
+        task.is_final = _is_final(msg.content)
+        task.finished_at = time.time()
+        logger.info("Inter-agent task {} done (session={})", msg.chat_id, task.session_id)
+
+        asyncio.create_task(self._push_audit(
+            self.config.instance_name, task.from_instance,
+            task.session_id, task.round_count, msg.content,
+        ))
+
+    # ------------------------------------------------------------------
+    # HTTP handlers
+    # ------------------------------------------------------------------
+
+    async def _handle_health(self, _request: aiohttp.web.Request) -> aiohttp.web.Response:
+        return aiohttp.web.json_response({
+            "status": "ok",
+            "instance": self.config.instance_name,
+            "port": self.config.api_port,
+        })
+
+    async def _handle_chat(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        """Submit a task. Returns 202 immediately with task_id."""
+        try:
+            body: dict[str, Any] = await request.json()
+        except Exception:
+            return aiohttp.web.json_response({"error": "invalid JSON"}, status=400)
+
+        message: str = body.get("message", "").strip()
+        session_id: str = body.get("session_id", "")
+        from_instance: str = body.get("from_instance", "unknown")
+        round_count: int = int(body.get("round_count", 0))
+
+        if not message or not session_id:
+            return aiohttp.web.json_response(
+                {"error": "message and session_id are required"}, status=400
+            )
+
+        task_id = str(uuid.uuid4())
+        task = AgentTask(
+            task_id=task_id,
+            session_id=session_id,
+            from_instance=from_instance,
+            round_count=round_count,
+        )
+        _tasks[task_id] = task
+
+        logger.info(
+            "Inter-agent task {} created | from={} session={} round={}",
+            task_id, from_instance, session_id, round_count,
+        )
+
+        # Audit: inbound
+        asyncio.create_task(self._push_audit(
+            from_instance, self.config.instance_name, session_id, round_count, message
+        ))
+
+        # Inject into agent loop.
+        # - chat_id = task_id  → send() can look up the task in _tasks
+        # - session_key_override = interagent:{task_id}  → each task gets its own
+        #   session key so tasks within the same logical session don't block each other
+        #   via the global _processing_lock. Conversation history is still scoped to
+        #   the task (not shared across rounds), which is correct for stateless calls.
+        await self.bus.publish_inbound(InboundMessage(
+            channel=self.name,
+            sender_id=from_instance,
+            chat_id=task_id,
+            content=message,
+            metadata={"from_instance": from_instance, "round_count": round_count, "session_id": session_id},
+            session_key_override=f"interagent:{task_id}",
+        ))
+
+        task.status = TaskStatus.RUNNING
+
+        return aiohttp.web.json_response(
+            task.to_dict(self.config.instance_name), status=202
+        )
+
+    async def _handle_task_status(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        """Poll task status and result."""
+        task_id: str = request.match_info["task_id"]
+        task = _tasks.get(task_id)
+        if task is None:
+            return aiohttp.web.json_response({"error": "task not found"}, status=404)
+        return aiohttp.web.json_response(task.to_dict(self.config.instance_name))
+
+    # ------------------------------------------------------------------
+    # Housekeeping
+    # ------------------------------------------------------------------
+
+    def _evict_old_tasks(self) -> None:
+        """Remove completed tasks older than task_ttl_seconds."""
+        cutoff = time.time() - self.config.task_ttl_seconds
+        to_delete = [
+            tid for tid, t in _tasks.items()
+            if t.status in (TaskStatus.DONE, TaskStatus.FAILED)
+            and t.finished_at is not None
+            and t.finished_at < cutoff
+        ]
+        for tid in to_delete:
+            del _tasks[tid]
+        if to_delete:
+            logger.debug("Inter-agent: evicted {} expired tasks", len(to_delete))
+
+    # ------------------------------------------------------------------
+    # Audit webhook
+    # ------------------------------------------------------------------
+
+    async def _push_audit(
+        self,
+        from_instance: str,
+        to_instance: str,
+        session_id: str,
+        round_count: int,
+        message: str,
+    ) -> None:
+        """Push message to audit webhook, chunking if needed."""
+        url = self.config.audit_webhook_url
+        if not url:
+            return
+
+        header = (
+            f"【实例间对话】\n"
+            f"{from_instance} → {to_instance}\n"
+            f"Session: {session_id}  轮次: {round_count}\n\n"
+        )
+        chunks = [message[i:i + _CHUNK] for i in range(0, max(len(message), 1), _CHUNK)]
+        total = len(chunks)
+
+        try:
+            async with aiohttp.ClientSession() as http:
+                for idx, chunk in enumerate(chunks):
+                    page = f"（{idx + 1}/{total}）\n" if total > 1 else ""
+                    payload = {"msg_type": "text", "content": {"text": header + page + chunk}}
+                    await http.post(url, json=payload, timeout=aiohttp.ClientTimeout(total=10))
+        except Exception as exc:
+            logger.warning("Inter-agent audit webhook failed: {}", exc)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _is_final(text: str) -> bool:
+    """Return True when the response signals that the discussion is concluded."""
+    lower = text.lower()
+    return any(sig.lower() in lower for sig in _FINAL_SIGNALS)

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -36,8 +36,15 @@ class ChannelManager:
 
         groq_key = self.config.providers.groq.api_key
 
+        def _to_camel(snake: str) -> str:
+            parts = snake.split("_")
+            return parts[0] + "".join(p.title() for p in parts[1:])
+
         for name, cls in discover_all().items():
+            # Try snake_case first (attribute), then camelCase (model_extra for plugin channels)
             section = getattr(self.config.channels, name, None)
+            if section is None:
+                section = (self.config.channels.model_extra or {}).get(_to_camel(name))
             if section is None:
                 continue
             enabled = (
@@ -50,7 +57,9 @@ class ChannelManager:
             try:
                 channel = cls(section, self.bus)
                 channel.transcription_api_key = groq_key
-                self.channels[name] = channel
+                # Use cls.name (not the module name) so _dispatch_outbound can
+                # match msg.channel (which is also set to channel.name).
+                self.channels[cls.name] = channel
                 logger.info("{} channel enabled", cls.display_name)
             except Exception as e:
                 logger.warning("{} channel not available: {}", name, e)

--- a/tests/test_inter_agent_channel.py
+++ b/tests/test_inter_agent_channel.py
@@ -1,0 +1,221 @@
+"""Tests for the inter-agent communication channel."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.channels.inter_agent import InterAgentChannel, InterAgentConfig, _is_final
+from nanobot.bus.queue import MessageBus
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def test_default_config():
+    cfg = InterAgentChannel.default_config()
+    assert cfg["enabled"] is False
+    assert cfg["apiPort"] == 18800
+    assert cfg["instanceName"] == ""
+    assert cfg["maxRoundsPerSession"] == 30
+
+
+def test_channel_name_is_getattr_compatible():
+    """Channel name must be a single lowercase word so ChannelsConfig.extra fields
+    are accessible via getattr(channels_config, channel.name) in manager._init_channels."""
+    from nanobot.config.schema import ChannelsConfig
+    cfg = ChannelsConfig.model_validate({
+        InterAgentChannel.name: {"enabled": True, "apiPort": 18804}
+    })
+    section = getattr(cfg, InterAgentChannel.name, None)
+    assert section is not None, (
+        f"getattr(ChannelsConfig, '{InterAgentChannel.name}') returned None — "
+        "channel name must match the config.json key exactly (no camelCase conversion)"
+    )
+    assert section.get("enabled") is True
+
+
+def test_config_from_dict():
+    cfg = InterAgentConfig.model_validate({
+        "enabled": True,
+        "apiPort": 18804,
+        "instanceName": "yanshifan",
+        "auditWebhookUrl": "https://example.com/hook",
+        "maxRoundsPerSession": 30,
+    })
+    assert cfg.enabled is True
+    assert cfg.api_port == 18804
+    assert cfg.instance_name == "yanshifan"
+
+
+def test_config_camelcase():
+    """Config must accept camelCase keys from JSON."""
+    cfg = InterAgentConfig.model_validate({"apiPort": 18801, "instanceName": "zhangjuzheng"})
+    assert cfg.api_port == 18801
+    assert cfg.instance_name == "zhangjuzheng"
+
+
+# ---------------------------------------------------------------------------
+# Channel init
+# ---------------------------------------------------------------------------
+
+def test_channel_accepts_dict_config():
+    bus = MessageBus()
+    ch = InterAgentChannel({"enabled": True, "apiPort": 18802, "instanceName": "lvfang"}, bus)
+    assert ch.config.api_port == 18802
+    assert ch.config.instance_name == "lvfang"
+
+
+def test_channel_accepts_config_object():
+    bus = MessageBus()
+    cfg = InterAgentConfig(enabled=True, api_port=18803, instance_name="zhuzaihou")
+    ch = InterAgentChannel(cfg, bus)
+    assert ch.config.instance_name == "zhuzaihou"
+
+
+# ---------------------------------------------------------------------------
+# _is_final
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text,expected", [
+    ("这是最终方案，请确认。", True),
+    ("讨论结束，感谢合作。", True),
+    ("达成共识，方案如下。", True),
+    ("DISCUSSION_COMPLETE", True),
+    ("discussion complete", True),
+    ("consensus reached", True),
+    ("final proposal accepted", True),
+    ("已确认，无需修改。", True),
+    ("我还有一些意见需要补充。", False),
+    ("请继续讨论第三点。", False),
+    ("", False),
+])
+def test_is_final(text, expected):
+    assert _is_final(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# HTTP handler: /inter-agent/health
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_health_endpoint():
+    bus = MessageBus()
+    cfg = InterAgentConfig(enabled=True, api_port=18800, instance_name="xuejie")
+    ch = InterAgentChannel(cfg, bus)
+
+    mock_request = MagicMock()
+    response = await ch._handle_health(mock_request)
+    data = response.body
+    import json
+    body = json.loads(data)
+    assert body["status"] == "ok"
+    assert body["instance"] == "xuejie"
+    assert body["port"] == 18800
+
+
+# ---------------------------------------------------------------------------
+# HTTP handler: /inter-agent/chat — validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_missing_fields():
+    bus = MessageBus()
+    ch = InterAgentChannel({"instanceName": "xuejie"}, bus)
+
+    mock_request = AsyncMock()
+    mock_request.json = AsyncMock(return_value={"message": "hello"})  # missing session_id
+    response = await ch._handle_chat(mock_request)
+    assert response.status == 400
+
+
+@pytest.mark.asyncio
+async def test_chat_invalid_json():
+    bus = MessageBus()
+    ch = InterAgentChannel({"instanceName": "xuejie"}, bus)
+
+    mock_request = AsyncMock()
+    mock_request.json = AsyncMock(side_effect=Exception("bad json"))
+    response = await ch._handle_chat(mock_request)
+    assert response.status == 400
+
+
+# ---------------------------------------------------------------------------
+# HTTP handler: /inter-agent/chat — full round trip
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_round_trip():
+    """POST creates a task, send() marks it done — full lifecycle."""
+    import json
+    from nanobot.channels.inter_agent import _tasks
+    from nanobot.bus.events import OutboundMessage
+
+    bus = MessageBus()
+    cfg = InterAgentConfig(enabled=True, api_port=18800, instance_name="xuejie")
+    ch = InterAgentChannel(cfg, bus)
+
+    mock_request = AsyncMock()
+    mock_request.json = AsyncMock(return_value={
+        "message": "请审阅方案",
+        "session_id": "collab_roundtrip",
+        "from_instance": "yanshifan",
+        "round_count": 1,
+    })
+
+    with patch.object(ch, "_push_audit", new=AsyncMock()):
+        resp = await ch._handle_chat(mock_request)
+
+    assert resp.status == 202
+    body = json.loads(resp.body)
+    task_id = body["task_id"]
+    assert body["status"] == "running"
+
+    # Simulate agent finishing and calling send()
+    with patch.object(ch, "_push_audit", new=AsyncMock()):
+        await ch.send(OutboundMessage(
+            channel="interagent",
+            chat_id=task_id,
+            content="方案已审阅，建议补充安全测评维度。",
+        ))
+
+    task = _tasks[task_id]
+    assert task.status.value == "done"
+    assert task.response == "方案已审阅，建议补充安全测评维度。"
+    assert task.is_final is False
+
+    _tasks.pop(task_id, None)
+
+
+# ---------------------------------------------------------------------------
+# send() marks task done
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_marks_task_done():
+    from nanobot.channels.inter_agent import _tasks, AgentTask, TaskStatus
+    from nanobot.bus.events import OutboundMessage
+
+    bus = MessageBus()
+    ch = InterAgentChannel({"instanceName": "xuejie"}, bus)
+
+    task = AgentTask(task_id="t_send2", session_id="s_send2", from_instance="bob", round_count=1)
+    task.status = TaskStatus.RUNNING
+    _tasks["t_send2"] = task
+
+    with patch.object(ch, "_push_audit", new=AsyncMock()):
+        await ch.send(OutboundMessage(
+            channel="interagent",
+            chat_id="t_send2",
+            content="审阅完毕，最终方案已确认。",
+        ))
+
+    assert task.status == TaskStatus.DONE
+    assert task.response == "审阅完毕，最终方案已确认。"
+    assert task.is_final is True
+    assert task.finished_at is not None
+
+    _tasks.pop("t_send2", None)


### PR DESCRIPTION
## Summary

This PR adds a new built-in channel — `interagent` — that enables **direct HTTP communication between nanobot instances** using an **async task model**. Multiple agents can collaborate autonomously without blocking each other or the human user.

---

## The Problem

When running multiple nanobot instances, there is no way for them to talk to each other directly. The only option is for the human to relay messages between instances manually.

A naive synchronous design (POST → block → response) does not work reliably because each nanobot instance processes messages serially via a global `_processing_lock`. If the receiving instance is busy, the caller blocks for up to 120s and gets a 504 — but the receiving instance still finishes processing and tries to deliver a response that nobody is listening for anymore: **silent result loss and state desync**.

The root cause: **the initiating instance has no visibility into the receiving instance's task execution state.**

---

## Design: Async Task Model

Instead of blocking on a response, the caller submits a task and polls for its result:

```
POST /inter-agent/chat   →  202 immediately  {task_id, status: "pending"}
GET  /inter-agent/task/{task_id}  →  {status: "pending|running|done|failed", response, is_final}
```

This means:
- The initiating instance is **never blocked** — it submits and polls at its own pace
- The receiving instance processes **at its own pace**, regardless of queue depth
- Task state is **always visible**: `pending → running → done / failed`
- **No silent result loss**: a task is either in the registry or explicitly evicted after TTL

---

## API

```
POST /inter-agent/chat
  {"message": "...", "session_id": "collab_abc", "from_instance": "alice", "round_count": 1}
  → 202 {"task_id": "uuid", "status": "pending", "instance": "bob", "session_id": "collab_abc"}

GET /inter-agent/task/{task_id}
  → {"task_id": "...", "status": "done",
     "response": "...", "is_final": false,     ← present when done
     "instance": "bob", "session_id": "..."}

GET /inter-agent/health
  → {"status": "ok", "instance": "bob", "port": 18801}
```

**Polling pattern (in AGENTS.md / skill):**
```python
import httpx, time

def submit(url, message, session_id, from_instance, round_count):
    r = httpx.post(f"{url}/inter-agent/chat", json={
        "message": message, "session_id": session_id,
        "from_instance": from_instance, "round_count": round_count,
    }, timeout=10)
    return r.json()["task_id"]

def poll(url, task_id, interval=3, max_wait=600):
    deadline = time.time() + max_wait
    while time.time() < deadline:
        r = httpx.get(f"{url}/inter-agent/task/{task_id}", timeout=10)
        data = r.json()
        if data["status"] in ("done", "failed"):
            return data
        time.sleep(interval)
    raise TimeoutError(f"task {task_id} not done after {max_wait}s")
```

---

## Key Design Decisions

| Feature | Design |
|---------|--------|
| **Async task model** | POST returns 202 + task_id immediately; GET polls for result — no blocking |
| **Task lifecycle** | `pending → running → done / failed` with timestamps |
| **Per-task session key** | `session_key_override = interagent:{task_id}` — each task gets its own session key, preventing tasks within the same logical session from blocking each other via the global lock |
| **Audit webhook** | Every message (both directions) pushed to `auditWebhookUrl`; long messages auto-chunked at 3800 chars |
| **Task TTL** | Completed tasks auto-evicted after `taskTtlSeconds` (default 1h) |
| **Round-limit guard** | `maxRoundsPerSession` (default 30) — initiator tracks and enforces |
| **Consensus detection** | `is_final` flag via natural language keywords (English + Chinese) |
| **Plugin architecture** | Follows dbdb43f: config in channel module, `default_config()` for onboard, Pydantic validation |
| **No new dependencies** | Uses `aiohttp` (already required) and stdlib only |

---

## Known Limitation: Global Processing Lock

Each nanobot instance processes messages serially via a global `_processing_lock` in the agent loop. This means:

- If the receiving instance is actively handling another message (e.g. a human conversation), an incoming inter-agent task will be queued and wait until the current message finishes processing.
- The async task model makes this **safe and observable** — the task stays in the registry with `status: running`, the initiator can keep polling, and the result is never lost. But the task will not complete until the receiving instance is free.
- **Recommended pattern**: use an otherwise-idle instance as the coordinator (see below). Alice and Bob are only briefly occupied per round; the human waits only for the coordinator's final report.

This is a framework-level constraint, not specific to this channel. A future improvement could introduce per-session locks to allow concurrent processing of independent sessions.

---

## Configuration

```json
{
  "channels": {
    "interagent": {
      "enabled": true,
      "apiPort": 18801,
      "instanceName": "alice",
      "auditWebhookUrl": "https://your-webhook-url",
      "maxRoundsPerSession": 30,
      "taskTtlSeconds": 3600
    }
  }
}
```

---

## Recommended Usage: Coordinator Pattern

Use an otherwise-idle instance as the **coordinator**:

```
Human
  └─▶ Coordinator (idle instance)
          ├─▶ Alice  (submit task → poll → done)
          └─▶ Bob    (submit task → poll → done)
```

> Tell an idle instance: *"Ask Alice to draft a proposal on X, then have Bob review it, iterate until consensus, and report back."*

In `AGENTS.md`, register peer endpoints:
```markdown
## Inter-Agent Collaboration
- alice: http://localhost:18800
- bob:   http://localhost:18801

Never use `spawn` to simulate another instance — always call the real HTTP API.
```

---

## Also fixes: channel registration key mismatch

`ChannelManager._init_channels()` previously registered channels by module name (e.g. `inter_agent` with underscore), while `_dispatch_outbound()` looks up channels by `msg.channel` which is set to `channel.name` (`interagent`, no underscore). This mismatch caused `send()` to never be called for inter-agent tasks.

Fixed by registering with `cls.name` instead of the module name. All existing channels have matching module/cls.name so there is no behaviour change for them.

---

## Tests

29 tests covering:
- Config validation (snake_case / camelCase)
- `getattr` compatibility — regression guard for the camelCase naming pitfall
- `TaskStatus` / `AgentTask` dataclass lifecycle
- HTTP handlers: health, chat (202 + task_id), task status polling
- `send()` marking task done and setting `is_final`
- Unknown task_id safety
- Task TTL eviction
- `is_final` detection (8 positive / 3 negative)

```
29 passed in 0.13s
```

---

## Files Changed

- `nanobot/channels/inter_agent.py` — new channel (290 lines)
- `nanobot/channels/manager.py` — register by `cls.name` (3 lines)
- `tests/test_inter_agent_channel.py` — 29 tests (330 lines)
