### PR TITLE
Enable web search provider and suport tavily.

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -63,6 +63,7 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        web_search_provider: str = "",
     ):
         from nanobot.config.schema import ExecToolConfig
         self.bus = bus
@@ -74,6 +75,7 @@ class AgentLoop:
         self.context_window_tokens = context_window_tokens
         self.brave_api_key = brave_api_key
         self.web_proxy = web_proxy
+        self.web_search_provider = web_search_provider
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
@@ -90,6 +92,7 @@ class AgentLoop:
             web_proxy=web_proxy,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            web_search_provider=web_search_provider,
         )
 
         self._running = False
@@ -121,7 +124,7 @@ class AgentLoop:
             restrict_to_workspace=self.restrict_to_workspace,
             path_append=self.exec_config.path_append,
         ))
-        self.tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
+        self.tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy, provider=self.web_search_provider))
         self.tools.register(WebFetchTool(proxy=self.web_proxy))
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
         self.tools.register(SpawnTool(manager=self.subagents))

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -32,6 +32,7 @@ class SubagentManager:
         web_proxy: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
+        web_search_provider: str = "",
     ):
         from nanobot.config.schema import ExecToolConfig
         self.provider = provider
@@ -40,6 +41,7 @@ class SubagentManager:
         self.model = model or provider.get_default_model()
         self.brave_api_key = brave_api_key
         self.web_proxy = web_proxy
+        self.web_search_provider = web_search_provider
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
@@ -101,7 +103,7 @@ class SubagentManager:
                 restrict_to_workspace=self.restrict_to_workspace,
                 path_append=self.exec_config.path_append,
             ))
-            tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy))
+            tools.register(WebSearchTool(api_key=self.brave_api_key, proxy=self.web_proxy, provider=self.web_search_provider))
             tools.register(WebFetchTool(proxy=self.web_proxy))
             
             system_prompt = self._build_subagent_prompt()

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -45,7 +45,7 @@ def _validate_url(url: str) -> tuple[bool, str]:
 
 
 class WebSearchTool(Tool):
-    """Search the web using Brave Search API."""
+    """Search the web using Brave Search API or Tavily API."""
 
     name = "web_search"
     description = "Search the web. Returns titles, URLs, and snippets."
@@ -58,17 +58,76 @@ class WebSearchTool(Tool):
         "required": ["query"]
     }
 
-    def __init__(self, api_key: str | None = None, max_results: int = 5, proxy: str | None = None):
+    def __init__(self, api_key: str | None = None, max_results: int = 5, proxy: str | None = None, provider: str = ""):
         self._init_api_key = api_key
+        self._provider = provider
         self.max_results = max_results
         self.proxy = proxy
 
     @property
     def api_key(self) -> str:
         """Resolve API key at call time so env/config changes are picked up."""
-        return self._init_api_key or os.environ.get("BRAVE_API_KEY", "")
+        return self._init_api_key or os.environ.get("BRAVE_API_KEY", "") or os.environ.get("TAVILY_API_KEY", "")
+
+    @property
+    def provider(self) -> str:
+        """Resolve provider at call time."""
+        return self._provider or os.environ.get("WEB_SEARCH_PROVIDER", "")
 
     async def execute(self, query: str, count: int | None = None, **kwargs: Any) -> str:
+        provider = self.provider.lower() if self.provider else ""
+
+        # Use configured provider or auto-detect based on API key format
+        if provider == "tavily" or (not provider and self.api_key.startswith("tvly-")):
+            return await self._tavily_search(query, count)
+        elif provider == "brave" or self.api_key:
+            return await self._brave_search(query, count)
+        else:
+            return (
+                "Error: No search API key configured. Set provider to 'tavily' or 'brave' "
+                "in config, and set the corresponding API key (TAVILY_API_KEY or BRAVE_API_KEY), "
+                "then restart."
+            )
+
+    async def _tavily_search(self, query: str, count: int | None = None) -> str:
+        """Search using Tavily API."""
+        try:
+            from tavily import TavilyClient
+
+            n = min(max(count or self.max_results, 1), 10)
+            logger.debug("WebSearch (Tavily): {}", "proxy enabled" if self.proxy else "direct connection")
+
+            client = TavilyClient(api_key=self.api_key)
+            response = client.search(
+                query=query,
+                max_results=n,
+                include_answer=True,
+                include_raw_content=False,
+                include_domains=None
+            )
+
+            results = response.get("results", [])
+            if not results:
+                return f"No results for: {query}"
+
+            lines = [f"Results for: {query}\n"]
+            for i, item in enumerate(results, 1):
+                title = item.get("title", "")
+                url = item.get("url", "")
+                content = item.get("content", "")[:200] if item.get("content") else ""
+                lines.append(f"{i}. {title}\n   {url}")
+                if content:
+                    lines.append(f"   {content}...")
+            return "\n".join(lines)
+        except ImportError:
+            logger.error("Tavily SDK not installed. Run: pip install tavily-python")
+            return "Error: Tavily SDK not installed. Run: pip install tavily-python"
+        except Exception as e:
+            logger.error("WebSearch (Tavily) error: {}", e)
+            return f"Error: {e}"
+
+    async def _brave_search(self, query: str, count: int | None = None) -> str:
+        """Search using Brave Search API."""
         if not self.api_key:
             return (
                 "Error: Brave Search API key not configured. Set it in "
@@ -78,7 +137,7 @@ class WebSearchTool(Tool):
 
         try:
             n = min(max(count or self.max_results, 1), 10)
-            logger.debug("WebSearch: {}", "proxy enabled" if self.proxy else "direct connection")
+            logger.debug("WebSearch (Brave): {}", "proxy enabled" if self.proxy else "direct connection")
             async with httpx.AsyncClient(proxy=self.proxy) as client:
                 r = await client.get(
                     "https://api.search.brave.com/res/v1/web/search",

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -356,6 +356,7 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        web_search_provider=config.tools.web.search.provider,
     )
 
     # Set cron callback (needs agent)
@@ -538,6 +539,7 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        web_search_provider=config.tools.web.search.provider,
     )
 
     # Show spinner when logs are off (no output to miss); skip when logs are on

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -307,7 +307,8 @@ class GatewayConfig(Base):
 class WebSearchConfig(Base):
     """Web search tool configuration."""
 
-    api_key: str = ""  # Brave Search API key
+    provider: str = ""  # Search provider: "brave" or "tavily" (auto-detected if empty)
+    api_key: str = ""  # API key for the selected provider
     max_results: int = 5
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+tavily = [
+    "tavily-python>=0.5.0",
+]
 wecom = [
     "wecom-aibot-sdk-python>=0.1.2",
 ]


### PR DESCRIPTION
Summary
- Add Tavily as an alternative web search provider
- Support configurable web search provider selection
- Auto-detect provider based on API key format
Changes
- nanobot/agent/tools/web.py: Add Tavily search implementation, refactor to support multiple providers
- nanobot/config/schema.py: Add provider field to WebSearchConfig
- nanobot/agent/loop.py & subagent.py: Pass web_search_provider to WebSearchTool
- nanobot/cli/commands.py: Pass provider config to agent
- pyproject.toml: Add tavily optional dependency
Usage
{
  "tools": {
    "web": {
      "search": {
        "provider": "tavily",
        "apiKey": "your_tavily_api_key"
      }
    }
  }
}
Or use environment variables:
- TAVILY_API_KEY + WEB_SEARCH_PROVIDER=tavily
- BRAVE_API_KEY (auto-detected)
Auto-detection: If API key starts with tvly-, automatically uses Tavily.