### PR TITLE
fix(agent): retry synthesis when LLM returns empty content after tool calls

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -191,6 +191,8 @@ class AgentLoop:
         iteration = 0
         final_content = None
         tools_used: list[str] = []
+        synthesis_retries = 0
+        _MAX_SYNTHESIS_RETRIES = 2
 
         while iteration < self.max_iterations:
             iteration += 1
@@ -239,15 +241,18 @@ class AgentLoop:
                     break
                 # When the model returns empty content after executing tool calls,
                 # it likely finished the task but forgot to synthesize a response.
-                # Continue the loop so it gets a chance to produce a summary instead
-                # of falling through to the "I've completed processing" fallback.
+                # Retry up to _MAX_SYNTHESIS_RETRIES times so it gets a chance to
+                # produce a summary instead of falling through to the
+                # "I've completed processing" fallback.
                 # Fixes: https://github.com/HKUDS/nanobot/issues/235
                 #        https://github.com/HKUDS/nanobot/issues/640
-                if clean is None and tools_used:
+                if clean is None and tools_used and synthesis_retries < _MAX_SYNTHESIS_RETRIES:
+                    synthesis_retries += 1
                     logger.warning(
                         "LLM returned empty content after tool calls — retrying synthesis "
-                        "(iteration {})",
-                        iteration,
+                        "(attempt {}/{})",
+                        synthesis_retries,
+                        _MAX_SYNTHESIS_RETRIES,
                     )
                     messages = self.context.add_assistant_message(
                         messages,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -9,7 +9,7 @@ import re
 import sys
 from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from loguru import logger
 
@@ -116,12 +116,14 @@ class AgentLoop:
         allowed_dir = self.workspace if self.restrict_to_workspace else None
         for cls in (ReadFileTool, WriteFileTool, EditFileTool, ListDirTool):
             self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
-        self.tools.register(ExecTool(
-            working_dir=str(self.workspace),
-            timeout=self.exec_config.timeout,
-            restrict_to_workspace=self.restrict_to_workspace,
-            path_append=self.exec_config.path_append,
-        ))
+        self.tools.register(
+            ExecTool(
+                working_dir=str(self.workspace),
+                timeout=self.exec_config.timeout,
+                restrict_to_workspace=self.restrict_to_workspace,
+                path_append=self.exec_config.path_append,
+            )
+        )
         self.tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
         self.tools.register(WebFetchTool(proxy=self.web_proxy))
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
@@ -135,6 +137,7 @@ class AgentLoop:
             return
         self._mcp_connecting = True
         from nanobot.agent.tools.mcp import connect_mcp_servers
+
         try:
             self._mcp_stack = AsyncExitStack()
             await self._mcp_stack.__aenter__()
@@ -168,12 +171,14 @@ class AgentLoop:
     @staticmethod
     def _tool_hint(tool_calls: list) -> str:
         """Format tool calls as concise hint, e.g. 'web_search("query")'."""
+
         def _fmt(tc):
             args = (tc.arguments[0] if isinstance(tc.arguments, list) else tc.arguments) or {}
             val = next(iter(args.values()), None) if isinstance(args, dict) else None
             if not isinstance(val, str):
                 return tc.name
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
+
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
     async def _run_agent_loop(
@@ -207,12 +212,11 @@ class AgentLoop:
                     tool_hint = self._strip_think(tool_hint)
                     await on_progress(tool_hint, tool_hint=True)
 
-                tool_call_dicts = [
-                    tc.to_openai_tool_call()
-                    for tc in response.tool_calls
-                ]
+                tool_call_dicts = [tc.to_openai_tool_call() for tc in response.tool_calls]
                 messages = self.context.add_assistant_message(
-                    messages, response.content, tool_call_dicts,
+                    messages,
+                    response.content,
+                    tool_call_dicts,
                     reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
                 )
@@ -233,8 +237,29 @@ class AgentLoop:
                     logger.error("LLM returned error: {}", (clean or "")[:200])
                     final_content = clean or "Sorry, I encountered an error calling the AI model."
                     break
+                # When the model returns empty content after executing tool calls,
+                # it likely finished the task but forgot to synthesize a response.
+                # Continue the loop so it gets a chance to produce a summary instead
+                # of falling through to the "I've completed processing" fallback.
+                # Fixes: https://github.com/HKUDS/nanobot/issues/235
+                #        https://github.com/HKUDS/nanobot/issues/640
+                if clean is None and tools_used:
+                    logger.warning(
+                        "LLM returned empty content after tool calls — retrying synthesis "
+                        "(iteration {})",
+                        iteration,
+                    )
+                    messages = self.context.add_assistant_message(
+                        messages,
+                        "",
+                        reasoning_content=response.reasoning_content,
+                        thinking_blocks=response.thinking_blocks,
+                    )
+                    continue
                 messages = self.context.add_assistant_message(
-                    messages, clean, reasoning_content=response.reasoning_content,
+                    messages,
+                    clean,
+                    reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
                 )
                 final_content = clean
@@ -272,7 +297,13 @@ class AgentLoop:
             else:
                 task = asyncio.create_task(self._dispatch(msg))
                 self._active_tasks.setdefault(msg.session_key, []).append(task)
-                task.add_done_callback(lambda t, k=msg.session_key: self._active_tasks.get(k, []) and self._active_tasks[k].remove(t) if t in self._active_tasks.get(k, []) else None)
+                task.add_done_callback(
+                    lambda t, k=msg.session_key: (
+                        self._active_tasks.get(k, []) and self._active_tasks[k].remove(t)
+                        if t in self._active_tasks.get(k, [])
+                        else None
+                    )
+                )
 
     async def _handle_stop(self, msg: InboundMessage) -> None:
         """Cancel all active tasks and subagents for the session."""
@@ -286,15 +317,23 @@ class AgentLoop:
         sub_cancelled = await self.subagents.cancel_by_session(msg.session_key)
         total = cancelled + sub_cancelled
         content = f"Stopped {total} task(s)." if total else "No active task to stop."
-        await self.bus.publish_outbound(OutboundMessage(
-            channel=msg.channel, chat_id=msg.chat_id, content=content,
-        ))
+        await self.bus.publish_outbound(
+            OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content=content,
+            )
+        )
 
     async def _handle_restart(self, msg: InboundMessage) -> None:
         """Restart the process in-place via os.execv."""
-        await self.bus.publish_outbound(OutboundMessage(
-            channel=msg.channel, chat_id=msg.chat_id, content="Restarting...",
-        ))
+        await self.bus.publish_outbound(
+            OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content="Restarting...",
+            )
+        )
 
         async def _do_restart():
             await asyncio.sleep(1)
@@ -312,19 +351,26 @@ class AgentLoop:
                 if response is not None:
                     await self.bus.publish_outbound(response)
                 elif msg.channel == "cli":
-                    await self.bus.publish_outbound(OutboundMessage(
-                        channel=msg.channel, chat_id=msg.chat_id,
-                        content="", metadata=msg.metadata or {},
-                    ))
+                    await self.bus.publish_outbound(
+                        OutboundMessage(
+                            channel=msg.channel,
+                            chat_id=msg.chat_id,
+                            content="",
+                            metadata=msg.metadata or {},
+                        )
+                    )
             except asyncio.CancelledError:
                 logger.info("Task cancelled for session {}", msg.session_key)
                 raise
             except Exception:
                 logger.exception("Error processing message for session {}", msg.session_key)
-                await self.bus.publish_outbound(OutboundMessage(
-                    channel=msg.channel, chat_id=msg.chat_id,
-                    content="Sorry, I encountered an error.",
-                ))
+                await self.bus.publish_outbound(
+                    OutboundMessage(
+                        channel=msg.channel,
+                        chat_id=msg.chat_id,
+                        content="Sorry, I encountered an error.",
+                    )
+                )
 
     async def close_mcp(self) -> None:
         """Close MCP connections."""
@@ -349,8 +395,9 @@ class AgentLoop:
         """Process a single inbound message and return the response."""
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
-            channel, chat_id = (msg.chat_id.split(":", 1) if ":" in msg.chat_id
-                                else ("cli", msg.chat_id))
+            channel, chat_id = (
+                msg.chat_id.split(":", 1) if ":" in msg.chat_id else ("cli", msg.chat_id)
+            )
             logger.info("Processing system message from {}", msg.sender_id)
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
@@ -359,14 +406,19 @@ class AgentLoop:
             history = session.get_history(max_messages=0)
             messages = self.context.build_messages(
                 history=history,
-                current_message=msg.content, channel=channel, chat_id=chat_id,
+                current_message=msg.content,
+                channel=channel,
+                chat_id=chat_id,
             )
             final_content, _, all_msgs = await self._run_agent_loop(messages)
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
-            return OutboundMessage(channel=channel, chat_id=chat_id,
-                                  content=final_content or "Background task completed.")
+            return OutboundMessage(
+                channel=channel,
+                chat_id=chat_id,
+                content=final_content or "Background task completed.",
+            )
 
         preview = msg.content[:80] + "..." if len(msg.content) > 80 else msg.content
         logger.info("Processing message from {}:{}: {}", msg.channel, msg.sender_id, preview)
@@ -395,8 +447,9 @@ class AgentLoop:
             session.clear()
             self.sessions.save(session)
             self.sessions.invalidate(session.key)
-            return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
-                                  content="New session started.")
+            return OutboundMessage(
+                channel=msg.channel, chat_id=msg.chat_id, content="New session started."
+            )
         if cmd == "/help":
             lines = [
                 "🐈 nanobot commands:",
@@ -406,7 +459,9 @@ class AgentLoop:
                 "/help — Show available commands",
             ]
             return OutboundMessage(
-                channel=msg.channel, chat_id=msg.chat_id, content="\n".join(lines),
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content="\n".join(lines),
             )
         await self.memory_consolidator.maybe_consolidate_by_tokens(session)
 
@@ -420,19 +475,26 @@ class AgentLoop:
             history=history,
             current_message=msg.content,
             media=msg.media if msg.media else None,
-            channel=msg.channel, chat_id=msg.chat_id,
+            channel=msg.channel,
+            chat_id=msg.chat_id,
         )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
             meta = dict(msg.metadata or {})
             meta["_progress"] = True
             meta["_tool_hint"] = tool_hint
-            await self.bus.publish_outbound(OutboundMessage(
-                channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
-            ))
+            await self.bus.publish_outbound(
+                OutboundMessage(
+                    channel=msg.channel,
+                    chat_id=msg.chat_id,
+                    content=content,
+                    metadata=meta,
+                )
+            )
 
         final_content, _, all_msgs = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
+            initial_messages,
+            on_progress=on_progress or _bus_progress,
         )
 
         if final_content is None:
@@ -448,22 +510,31 @@ class AgentLoop:
         preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
         logger.info("Response to {}:{}: {}", msg.channel, msg.sender_id, preview)
         return OutboundMessage(
-            channel=msg.channel, chat_id=msg.chat_id, content=final_content,
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content=final_content,
             metadata=msg.metadata or {},
         )
 
     def _save_turn(self, session: Session, messages: list[dict], skip: int) -> None:
         """Save new-turn messages into session, truncating large tool results."""
         from datetime import datetime
+
         for m in messages[skip:]:
             entry = dict(m)
             role, content = entry.get("role"), entry.get("content")
             if role == "assistant" and not content and not entry.get("tool_calls"):
                 continue  # skip empty assistant messages — they poison session context
-            if role == "tool" and isinstance(content, str) and len(content) > self._TOOL_RESULT_MAX_CHARS:
-                entry["content"] = content[:self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
+            if (
+                role == "tool"
+                and isinstance(content, str)
+                and len(content) > self._TOOL_RESULT_MAX_CHARS
+            ):
+                entry["content"] = content[: self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
             elif role == "user":
-                if isinstance(content, str) and content.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
+                if isinstance(content, str) and content.startswith(
+                    ContextBuilder._RUNTIME_CONTEXT_TAG
+                ):
                     # Strip the runtime-context prefix, keep only the user text.
                     parts = content.split("\n\n", 1)
                     if len(parts) > 1 and parts[1].strip():
@@ -473,10 +544,15 @@ class AgentLoop:
                 if isinstance(content, list):
                     filtered = []
                     for c in content:
-                        if c.get("type") == "text" and isinstance(c.get("text"), str) and c["text"].startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
+                        if (
+                            c.get("type") == "text"
+                            and isinstance(c.get("text"), str)
+                            and c["text"].startswith(ContextBuilder._RUNTIME_CONTEXT_TAG)
+                        ):
                             continue  # Strip runtime context from multimodal messages
-                        if (c.get("type") == "image_url"
-                                and c.get("image_url", {}).get("url", "").startswith("data:image/")):
+                        if c.get("type") == "image_url" and c.get("image_url", {}).get(
+                            "url", ""
+                        ).startswith("data:image/"):
                             filtered.append({"type": "text", "text": "[image]"})
                         else:
                             filtered.append(c)
@@ -498,5 +574,7 @@ class AgentLoop:
         """Process a message directly (for CLI or cron usage)."""
         await self._connect_mcp()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
-        response = await self._process_message(msg, session_key=session_key, on_progress=on_progress)
+        response = await self._process_message(
+            msg, session_key=session_key, on_progress=on_progress
+        )
         return response.content if response else ""

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -242,8 +242,10 @@ class AgentLoop:
                 # When the model returns empty content after executing tool calls,
                 # it likely finished the task but forgot to synthesize a response.
                 # Retry up to _MAX_SYNTHESIS_RETRIES times so it gets a chance to
-                # produce a summary instead of falling through to the
-                # "I've completed processing" fallback.
+                # Thinking models (e.g. Qwen3) sometimes emit only a <think> block
+                # which gets stripped to None. Append an explicit user nudge so the
+                # model knows it must produce a visible text response.
+                # Retry up to _MAX_SYNTHESIS_RETRIES times before giving up.
                 # Fixes: https://github.com/HKUDS/nanobot/issues/235
                 #        https://github.com/HKUDS/nanobot/issues/640
                 if clean is None and tools_used and synthesis_retries < _MAX_SYNTHESIS_RETRIES:
@@ -254,11 +256,11 @@ class AgentLoop:
                         synthesis_retries,
                         _MAX_SYNTHESIS_RETRIES,
                     )
-                    messages = self.context.add_assistant_message(
-                        messages,
-                        "",
-                        reasoning_content=response.reasoning_content,
-                        thinking_blocks=response.thinking_blocks,
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": "Please summarize the results in a clear response.",
+                        }
                     )
                     continue
                 messages = self.context.add_assistant_message(

--- a/tests/test_message_tool_suppress.py
+++ b/tests/test_message_tool_suppress.py
@@ -26,13 +26,16 @@ class TestMessageToolSuppressLogic:
     async def test_suppress_when_sent_to_same_target(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)
         tool_call = ToolCallRequest(
-            id="call1", name="message",
+            id="call1",
+            name="message",
             arguments={"content": "Hello", "channel": "feishu", "chat_id": "chat123"},
         )
-        calls = iter([
-            LLMResponse(content="", tool_calls=[tool_call]),
-            LLMResponse(content="Done", tool_calls=[]),
-        ])
+        calls = iter(
+            [
+                LLMResponse(content="", tool_calls=[tool_call]),
+                LLMResponse(content="Done", tool_calls=[]),
+            ]
+        )
         loop.provider.chat_with_retry = AsyncMock(side_effect=lambda *a, **kw: next(calls))
         loop.tools.get_definitions = MagicMock(return_value=[])
 
@@ -51,13 +54,20 @@ class TestMessageToolSuppressLogic:
     async def test_not_suppress_when_sent_to_different_target(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)
         tool_call = ToolCallRequest(
-            id="call1", name="message",
-            arguments={"content": "Email content", "channel": "email", "chat_id": "user@example.com"},
+            id="call1",
+            name="message",
+            arguments={
+                "content": "Email content",
+                "channel": "email",
+                "chat_id": "user@example.com",
+            },
         )
-        calls = iter([
-            LLMResponse(content="", tool_calls=[tool_call]),
-            LLMResponse(content="I've sent the email.", tool_calls=[]),
-        ])
+        calls = iter(
+            [
+                LLMResponse(content="", tool_calls=[tool_call]),
+                LLMResponse(content="I've sent the email.", tool_calls=[]),
+            ]
+        )
         loop.provider.chat_with_retry = AsyncMock(side_effect=lambda *a, **kw: next(calls))
         loop.tools.get_definitions = MagicMock(return_value=[])
 
@@ -66,7 +76,9 @@ class TestMessageToolSuppressLogic:
         if isinstance(mt, MessageTool):
             mt.set_send_callback(AsyncMock(side_effect=lambda m: sent.append(m)))
 
-        msg = InboundMessage(channel="feishu", sender_id="user1", chat_id="chat123", content="Send email")
+        msg = InboundMessage(
+            channel="feishu", sender_id="user1", chat_id="chat123", content="Send email"
+        )
         result = await loop._process_message(msg)
 
         assert len(sent) == 1
@@ -77,7 +89,9 @@ class TestMessageToolSuppressLogic:
     @pytest.mark.asyncio
     async def test_not_suppress_when_no_message_tool_used(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)
-        loop.provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="Hello!", tool_calls=[]))
+        loop.provider.chat_with_retry = AsyncMock(
+            return_value=LLMResponse(content="Hello!", tool_calls=[])
+        )
         loop.tools.get_definitions = MagicMock(return_value=[])
 
         msg = InboundMessage(channel="feishu", sender_id="user1", chat_id="chat123", content="Hi")
@@ -86,18 +100,78 @@ class TestMessageToolSuppressLogic:
         assert result is not None
         assert "Hello" in result.content
 
+    @pytest.mark.asyncio
+    async def test_retry_synthesis_when_empty_content_after_tool_calls(
+        self, tmp_path: Path
+    ) -> None:
+        """Retry when LLM returns empty content after tool calls (fixes #235, #640).
+
+        Sequence:
+          1. tool call response
+          2. empty content (no tool calls) — should trigger retry
+          3. actual content — should become final_content
+        """
+        loop = _make_loop(tmp_path)
+        tool_call = ToolCallRequest(id="call1", name="read_file", arguments={"path": "foo.txt"})
+        calls = iter(
+            [
+                LLMResponse(content="", tool_calls=[tool_call]),
+                LLMResponse(content=None, tool_calls=[]),  # empty after tool → retry
+                LLMResponse(content="Here is the result.", tool_calls=[]),
+            ]
+        )
+        loop.provider.chat_with_retry = AsyncMock(side_effect=lambda *a, **kw: next(calls))
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.tools.execute = AsyncMock(return_value="file contents")
+
+        final_content, tools_used, _ = await loop._run_agent_loop([])
+
+        assert final_content == "Here is the result."
+        assert tools_used == ["read_file"]
+
+    @pytest.mark.asyncio
+    async def test_retry_synthesis_capped_at_max_retries(self, tmp_path: Path) -> None:
+        """After _MAX_SYNTHESIS_RETRIES consecutive empty responses, stop retrying.
+
+        After the cap is hit the next empty response is treated as a normal (non-retry)
+        empty reply: final_content=None is set and the loop breaks.
+        """
+        loop = _make_loop(tmp_path)
+        tool_call = ToolCallRequest(id="call1", name="read_file", arguments={"path": "foo.txt"})
+        # 1 tool call + 2 retried empties (hitting the cap) + 1 final empty (breaks loop)
+        calls = iter(
+            [
+                LLMResponse(content="", tool_calls=[tool_call]),
+                LLMResponse(content=None, tool_calls=[]),  # retry 1
+                LLMResponse(content=None, tool_calls=[]),  # retry 2 (cap reached)
+                LLMResponse(content=None, tool_calls=[]),  # cap exceeded → normal branch → break
+            ]
+        )
+        loop.provider.chat_with_retry = AsyncMock(side_effect=lambda *a, **kw: next(calls))
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.tools.execute = AsyncMock(return_value="file contents")
+
+        final_content, tools_used, _ = await loop._run_agent_loop([])
+
+        # After 2 retries the loop exits with final_content=None (triggers fallback upstream)
+        assert final_content is None
+        # chat_with_retry called exactly 4 times: 1 tool call + 2 retries + 1 cap-exceeded break
+        assert loop.provider.chat_with_retry.call_count == 4
+
     async def test_progress_hides_internal_reasoning(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)
         tool_call = ToolCallRequest(id="call1", name="read_file", arguments={"path": "foo.txt"})
-        calls = iter([
-            LLMResponse(
-                content="Visible<think>hidden</think>",
-                tool_calls=[tool_call],
-                reasoning_content="secret reasoning",
-                thinking_blocks=[{"signature": "sig", "thought": "secret thought"}],
-            ),
-            LLMResponse(content="Done", tool_calls=[]),
-        ])
+        calls = iter(
+            [
+                LLMResponse(
+                    content="Visible<think>hidden</think>",
+                    tool_calls=[tool_call],
+                    reasoning_content="secret reasoning",
+                    thinking_blocks=[{"signature": "sig", "thought": "secret thought"}],
+                ),
+                LLMResponse(content="Done", tool_calls=[]),
+            ]
+        )
         loop.provider.chat_with_retry = AsyncMock(side_effect=lambda *a, **kw: next(calls))
         loop.tools.get_definitions = MagicMock(return_value=[])
         loop.tools.execute = AsyncMock(return_value="ok")
@@ -117,7 +191,6 @@ class TestMessageToolSuppressLogic:
 
 
 class TestMessageToolTurnTracking:
-
     def test_sent_in_turn_tracks_same_target(self) -> None:
         tool = MessageTool()
         tool.set_context("feishu", "chat1")


### PR DESCRIPTION
## Problem

When using local thinking models (e.g. Qwen3 via Ollama) that return only a
`<think>...</think>` block after executing tool calls, `_strip_think()` strips
the entire content to `None`, causing the agent loop to hit the fallback:

> "I've completed processing but have no response to give."

Fixes #235, fixes #640.

## Root Cause

In `_run_agent_loop`, after tool calls:

1. The model returns `content="<think>...</think>"` (thinking block only, no visible text)
2. `_strip_think()` removes the think block → `clean = None`
3. The `else` branch sets `final_content = None` and breaks
4. Back in `_process_message`: `final_content is None` → fallback fires

## Fix

When `clean is None` and `tools_used` is non-empty, instead of breaking with
`final_content = None`, append an explicit **user nudge** so the model knows it
must produce visible text, then `continue` the loop:

```python
if clean is None and tools_used and synthesis_retries < _MAX_SYNTHESIS_RETRIES:
    synthesis_retries += 1
    logger.warning(
        "LLM returned empty content after tool calls — retry {}/{}",
        synthesis_retries,
        _MAX_SYNTHESIS_RETRIES,
    )
    messages.append(
        {
            "role": "user",
            "content": "Please summarize the results in a clear response.",
        }
    )
    continue
```

Using a **user message** (rather than an empty assistant message) is critical for
thinking models: an empty assistant message is treated as "still thinking", while
a user message signals that the model must now produce a final answer.

## Testing

Reproduced with `qwen3.5-9b-32k` (Ollama, Qwen3 thinking model) + MCP tools.
After the fix, the model correctly synthesizes a response from the tool results
instead of returning the fallback message.

The fix is bounded by `_MAX_SYNTHESIS_RETRIES` (= 2) so there is no risk of
infinite loops.