### PR TITLE
Add message filtering based on severity 

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -448,7 +448,7 @@ def gateway(
         """Execute a cron job through the agent."""
         from nanobot.agent.tools.cron import CronTool
         from nanobot.agent.tools.message import MessageTool
-        from nanobot.utils.evaluator import evaluate_response
+        from nanobot.utils.evaluator import evaluate_response, should_publish
 
         reminder_note = (
             "[Scheduled Task] Timer finished.\n\n"
@@ -476,10 +476,10 @@ def gateway(
             return response
 
         if job.payload.deliver and job.payload.to and response:
-            should_notify = await evaluate_response(
+            level = await evaluate_response(
                 response, job.payload.message, provider, agent.model,
             )
-            if should_notify:
+            if should_publish(level, config.gateway.cron.notification_level):
                 from nanobot.bus.events import OutboundMessage
                 await bus.publish_outbound(OutboundMessage(
                     channel=job.payload.channel or "cli",
@@ -541,6 +541,7 @@ def gateway(
         on_notify=on_heartbeat_notify,
         interval_s=hb_cfg.interval_s,
         enabled=hb_cfg.enabled,
+        notification_level=hb_cfg.notification_level,
     )
 
     if channels.enabled_channels:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -95,6 +95,13 @@ class HeartbeatConfig(Base):
 
     enabled: bool = True
     interval_s: int = 30 * 60  # 30 minutes
+    notification_level: Literal["all", "error", "silent"] = "all"
+
+
+class CronConfig(Base):
+    """Cron notification configuration."""
+
+    notification_level: Literal["all", "error", "silent"] = "all"
 
 
 class GatewayConfig(Base):
@@ -103,6 +110,7 @@ class GatewayConfig(Base):
     host: str = "0.0.0.0"
     port: int = 18790
     heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
+    cron: CronConfig = Field(default_factory=CronConfig)
 
 
 class WebSearchConfig(Base):

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
 from loguru import logger
+from nanobot.utils.evaluator import NotificationLevel
 
 if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
@@ -59,6 +60,7 @@ class HeartbeatService:
         on_notify: Callable[[str], Coroutine[Any, Any, None]] | None = None,
         interval_s: int = 30 * 60,
         enabled: bool = True,
+        notification_level: NotificationLevel = "all",
     ):
         self.workspace = workspace
         self.provider = provider
@@ -67,6 +69,7 @@ class HeartbeatService:
         self.on_notify = on_notify
         self.interval_s = interval_s
         self.enabled = enabled
+        self.notification_level = notification_level
         self._running = False
         self._task: asyncio.Task | None = None
 
@@ -139,7 +142,7 @@ class HeartbeatService:
 
     async def _tick(self) -> None:
         """Execute a single heartbeat tick."""
-        from nanobot.utils.evaluator import evaluate_response
+        from nanobot.utils.evaluator import evaluate_response, should_publish
 
         content = self._read_heartbeat_file()
         if not content:
@@ -160,14 +163,18 @@ class HeartbeatService:
                 response = await self.on_execute(tasks)
 
                 if response:
-                    should_notify = await evaluate_response(
+                    level = await evaluate_response(
                         response, tasks, self.provider, self.model,
                     )
-                    if should_notify and self.on_notify:
-                        logger.info("Heartbeat: completed, delivering response")
+                    if should_publish(level, self.notification_level) and self.on_notify:
+                        logger.info("Heartbeat: completed, delivering {} response", level)
                         await self.on_notify(response)
                     else:
-                        logger.info("Heartbeat: silenced by post-run evaluation")
+                        logger.info(
+                            "Heartbeat: suppressed level={} by policy={}",
+                            level,
+                            self.notification_level,
+                        )
         except Exception:
             logger.exception("Heartbeat execution failed")
 

--- a/nanobot/utils/evaluator.py
+++ b/nanobot/utils/evaluator.py
@@ -1,52 +1,49 @@
-"""Post-run evaluation for background tasks (heartbeat & cron).
-
-After the agent executes a background task, this module makes a lightweight
-LLM call to decide whether the result warrants notifying the user.
-"""
+"""Post-run evaluation for background tasks (heartbeat & cron)."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from loguru import logger
 
 if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
 
+EvaluationLevel = Literal["normal", "error"]
+NotificationLevel = Literal["all", "error", "silent"]
+
 _EVALUATE_TOOL = [
     {
         "type": "function",
         "function": {
-            "name": "evaluate_notification",
-            "description": "Decide whether the user should be notified about this background task result.",
+            "name": "evaluate_background_result",
+            "description": "Classify the result of a background task as normal or error.",
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "should_notify": {
-                        "type": "boolean",
-                        "description": "true = result contains actionable/important info the user should see; false = routine or empty, safe to suppress",
+                    "level": {
+                        "type": "string",
+                        "enum": ["normal", "error"],
+                        "description": "Return 'error' for failures, broken checks, blocked work, or anything requiring attention. Return 'normal' for routine, successful, or informational results.",
                     },
                     "reason": {
                         "type": "string",
-                        "description": "One-sentence reason for the decision",
+                        "description": "One-sentence reason for the classification",
                     },
                 },
-                "required": ["should_notify"],
+                "required": ["level"],
             },
         },
     }
 ]
 
 _SYSTEM_PROMPT = (
-    "You are a notification gate for a background agent. "
+    "You are a classifier for background agent results. "
     "You will be given the original task and the agent's response. "
-    "Call the evaluate_notification tool to decide whether the user "
-    "should be notified.\n\n"
-    "Notify when the response contains actionable information, errors, "
-    "completed deliverables, or anything the user explicitly asked to "
-    "be reminded about.\n\n"
-    "Suppress when the response is a routine status check with nothing "
-    "new, a confirmation that everything is normal, or essentially empty."
+    "You must call the evaluate_background_result tool and return exactly one level.\n\n"
+    "Return level='error' when the response reports a failure, problem, exception, blocked work, bad status, or anything that needs attention.\n"
+    "Return level='normal' when the response is successful, routine, informational, empty, or says everything is fine.\n\n"
+    "Do not decide whether to notify. Only classify the result as 'normal' or 'error'."
 )
 
 
@@ -55,12 +52,12 @@ async def evaluate_response(
     task_context: str,
     provider: LLMProvider,
     model: str,
-) -> bool:
-    """Decide whether a background-task result should be delivered to the user.
+) -> EvaluationLevel:
+    """Classify a background-task result as ``normal`` or ``error``.
 
     Uses a lightweight tool-call LLM request (same pattern as heartbeat
-    ``_decide()``).  Falls back to ``True`` (notify) on any failure so
-    that important messages are never silently dropped.
+    ``_decide()``). Falls back to ``error`` on any failure so important
+    messages are never silently downgraded.
     """
     try:
         llm_response = await provider.chat_with_retry(
@@ -78,15 +75,27 @@ async def evaluate_response(
         )
 
         if not llm_response.has_tool_calls:
-            logger.warning("evaluate_response: no tool call returned, defaulting to notify")
-            return True
+            logger.warning("evaluate_response: no tool call returned, defaulting to error")
+            return "error"
 
         args = llm_response.tool_calls[0].arguments
-        should_notify = args.get("should_notify", True)
+        level = args.get("level", "error")
         reason = args.get("reason", "")
-        logger.info("evaluate_response: should_notify={}, reason={}", should_notify, reason)
-        return bool(should_notify)
+        if level not in {"normal", "error"}:
+            logger.warning("evaluate_response: invalid level '{}', defaulting to error", level)
+            return "error"
+        logger.info("evaluate_response: level={}, reason={}", level, reason)
+        return level
 
     except Exception:
-        logger.exception("evaluate_response failed, defaulting to notify")
-        return True
+        logger.exception("evaluate_response failed, defaulting to error")
+        return "error"
+
+
+def should_publish(level: EvaluationLevel, policy: NotificationLevel) -> bool:
+    """Apply config policy to an evaluator result."""
+    if policy == "silent":
+        return False
+    if policy == "error":
+        return level == "error"
+    return True

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -456,6 +456,52 @@ def test_gateway_uses_config_directory_for_cron_store(monkeypatch, tmp_path: Pat
     assert seen["cron_store"] == config_file.parent / "cron" / "jobs.json"
 
 
+def test_gateway_passes_notification_level_to_heartbeat_service(monkeypatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "instance" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text("{}")
+
+    config = Config()
+    config.agents.defaults.workspace = str(tmp_path / "config-workspace")
+    config.gateway.heartbeat.notification_level = "error"
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr("nanobot.config.loader.set_config_path", lambda _path: None)
+    monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
+    monkeypatch.setattr("nanobot.config.paths.get_cron_dir", lambda: config_file.parent / "cron")
+    monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
+    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
+    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: object())
+    monkeypatch.setattr("nanobot.session.manager.SessionManager", lambda _workspace: object())
+
+    class _FakeCron:
+        def __init__(self, _store_path: Path) -> None:
+            pass
+
+        def status(self) -> dict[str, int]:
+            return {"jobs": 0}
+
+    class _FakeAgentLoop:
+        def __init__(self, *args, **kwargs) -> None:
+            self.model = "test-model"
+
+    class _StopHeartbeat:
+        def __init__(self, *args, **kwargs) -> None:
+            seen.update(kwargs)
+            raise _StopGateway("stop")
+
+    monkeypatch.setattr("nanobot.cron.service.CronService", _FakeCron)
+    monkeypatch.setattr("nanobot.agent.loop.AgentLoop", _FakeAgentLoop)
+    monkeypatch.setattr("nanobot.heartbeat.service.HeartbeatService", _StopHeartbeat)
+
+    result = runner.invoke(app, ["gateway", "--config", str(config_file)])
+
+    assert isinstance(result.exception, _StopGateway)
+    assert seen["notification_level"] == "error"
+    assert seen["interval_s"] == config.gateway.heartbeat.interval_s
+    assert seen["enabled"] == config.gateway.heartbeat.enabled
+
+
 def test_gateway_uses_configured_port_when_cli_flag_is_missing(monkeypatch, tmp_path: Path) -> None:
     config_file = tmp_path / "instance" / "config.json"
     config_file.parent.mkdir(parents=True)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nanobot.utils.evaluator import evaluate_response
+from nanobot.utils.evaluator import evaluate_response, should_publish
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 
 
@@ -18,31 +18,31 @@ class DummyProvider(LLMProvider):
         return "test-model"
 
 
-def _eval_tool_call(should_notify: bool, reason: str = "") -> LLMResponse:
+def _eval_tool_call(level: str, reason: str = "") -> LLMResponse:
     return LLMResponse(
         content="",
         tool_calls=[
             ToolCallRequest(
                 id="eval_1",
-                name="evaluate_notification",
-                arguments={"should_notify": should_notify, "reason": reason},
+                name="evaluate_background_result",
+                arguments={"level": level, "reason": reason},
             )
         ],
     )
 
 
 @pytest.mark.asyncio
-async def test_should_notify_true() -> None:
-    provider = DummyProvider([_eval_tool_call(True, "user asked to be reminded")])
+async def test_returns_normal_level() -> None:
+    provider = DummyProvider([_eval_tool_call("normal", "routine success")])
     result = await evaluate_response("Task completed with results", "check emails", provider, "m")
-    assert result is True
+    assert result == "normal"
 
 
 @pytest.mark.asyncio
-async def test_should_notify_false() -> None:
-    provider = DummyProvider([_eval_tool_call(False, "routine check, nothing new")])
+async def test_returns_error_level() -> None:
+    provider = DummyProvider([_eval_tool_call("error", "service is failing")])
     result = await evaluate_response("All clear, no updates", "check status", provider, "m")
-    assert result is False
+    assert result == "error"
 
 
 @pytest.mark.asyncio
@@ -53,11 +53,26 @@ async def test_fallback_on_error() -> None:
 
     provider = FailingProvider([])
     result = await evaluate_response("some response", "some task", provider, "m")
-    assert result is True
+    assert result == "error"
 
 
 @pytest.mark.asyncio
 async def test_no_tool_call_fallback() -> None:
     provider = DummyProvider([LLMResponse(content="I think you should notify", tool_calls=[])])
     result = await evaluate_response("some response", "some task", provider, "m")
-    assert result is True
+    assert result == "error"
+
+
+@pytest.mark.parametrize(
+    ("level", "policy", "expected"),
+    [
+        ("normal", "all", True),
+        ("error", "all", True),
+        ("normal", "error", False),
+        ("error", "error", True),
+        ("normal", "silent", False),
+        ("error", "silent", False),
+    ],
+)
+def test_should_publish(level: str, policy: str, expected: bool) -> None:
+    assert should_publish(level, policy) is expected

--- a/tests/test_heartbeat_service.py
+++ b/tests/test_heartbeat_service.py
@@ -125,7 +125,7 @@ async def test_trigger_now_returns_none_when_decision_is_skip(tmp_path) -> None:
 
 @pytest.mark.asyncio
 async def test_tick_notifies_when_evaluator_says_yes(tmp_path, monkeypatch) -> None:
-    """Phase 1 run -> Phase 2 execute -> Phase 3 evaluate=notify -> on_notify called."""
+    """Phase 1 run -> Phase 2 execute -> Phase 3 evaluate=error -> on_notify called."""
     (tmp_path / "HEARTBEAT.md").write_text("- [ ] check deployments", encoding="utf-8")
 
     provider = DummyProvider([
@@ -157,10 +157,11 @@ async def test_tick_notifies_when_evaluator_says_yes(tmp_path, monkeypatch) -> N
         model="openai/gpt-4o-mini",
         on_execute=_on_execute,
         on_notify=_on_notify,
+        notification_level="error",
     )
 
     async def _eval_notify(*a, **kw):
-        return True
+        return "error"
 
     monkeypatch.setattr("nanobot.utils.evaluator.evaluate_response", _eval_notify)
 
@@ -171,7 +172,7 @@ async def test_tick_notifies_when_evaluator_says_yes(tmp_path, monkeypatch) -> N
 
 @pytest.mark.asyncio
 async def test_tick_suppresses_when_evaluator_says_no(tmp_path, monkeypatch) -> None:
-    """Phase 1 run -> Phase 2 execute -> Phase 3 evaluate=silent -> on_notify NOT called."""
+    """Phase 1 run -> Phase 2 execute -> Phase 3 evaluate=normal -> on_notify NOT called."""
     (tmp_path / "HEARTBEAT.md").write_text("- [ ] check status", encoding="utf-8")
 
     provider = DummyProvider([
@@ -203,18 +204,17 @@ async def test_tick_suppresses_when_evaluator_says_no(tmp_path, monkeypatch) -> 
         model="openai/gpt-4o-mini",
         on_execute=_on_execute,
         on_notify=_on_notify,
+        notification_level="error",
     )
 
     async def _eval_silent(*a, **kw):
-        return False
+        return "normal"
 
     monkeypatch.setattr("nanobot.utils.evaluator.evaluate_response", _eval_silent)
 
     await service._tick()
     assert executed == ["check status"]
     assert notified == []
-
-
 @pytest.mark.asyncio
 async def test_decide_retries_transient_error_then_succeeds(tmp_path, monkeypatch) -> None:
     provider = DummyProvider([


### PR DESCRIPTION
# Background 

Currently both heartbeat and cron jobs send a status report to a channel. This can cause your main or general channel to be full of "Done doing xyz job" messages. 

# Methodology 

Currently `evaluate_response` only returns a boolean on whether to notify or not. We modify it instead return a severity and we filter it with configurable thresholds.

The filtering is implemented separately for heartbeat and cron job as there is no unified place for this. 

# Key Changes

`nanobot/utils/evaluator.py`: modify the evaluator tool to now return `normal` or `error`

`nanobot/heartbeat/service.py`: filtering for heartbeat

`nanobot/cli/commands.py`: filtering for cron job

`naanobot/config/schema.py`: new settings to configure notification thresholds. 

# Use of AI

I've coded this entirely using codex cli.

## Development history
Full development history and a small look on how I guided this creation can be found [here](https://github.com/rick2047/nanobot/pull/6). 
## Failed Attempts
I tried other designs which were abandoned.
- [Trying to solve on a gateway level](https://github.com/rick2047/nanobot/pull/2). Did not pan out, too fragmented
- [Another attempt at gateway level](https://github.com/rick2047/nanobot/pull/5)

# Open questions 
- Any documentation updates needed? 