### PR TITLE
fix(heartbeat): inject current datetime into Phase 1 prompt

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -3,10 +3,10 @@
 import base64
 import mimetypes
 import platform
-import time
-from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+from nanobot.utils.helpers import current_time_str
 
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
@@ -99,9 +99,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
     @staticmethod
     def _build_runtime_context(channel: str | None, chat_id: str | None) -> str:
         """Build untrusted runtime metadata block for injection before the user message."""
-        now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
-        tz = time.strftime("%Z") or "UTC"
-        lines = [f"Current Time: {now} ({tz})"]
+        lines = [f"Current Time: {current_time_str()}"]
         if channel and chat_id:
             lines += [f"Channel: {channel}", f"Chat ID: {chat_id}"]
         return ContextBuilder._RUNTIME_CONTEXT_TAG + "\n" + "\n".join(lines)

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
@@ -88,19 +87,13 @@ class HeartbeatService:
 
         Returns (action, tasks) where action is 'skip' or 'run'.
         """
-        now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+        from nanobot.utils.helpers import current_time_str
 
         response = await self.provider.chat_with_retry(
             messages=[
-                {"role": "system", "content": (
-                    "You are a heartbeat agent. Call the heartbeat tool to report your decision. "
-                    "The current date/time is provided so you can evaluate time-based conditions. "
-                    "Choose 'run' if there are active tasks to execute. "
-                    "Choose 'skip' if the file has no actionable tasks, if blocking conditions "
-                    "are not yet met, or if tasks are scheduled for a future time that has not arrived yet."
-                )},
+                {"role": "system", "content": "You are a heartbeat agent. Call the heartbeat tool to report your decision."},
                 {"role": "user", "content": (
-                    f"Current date/time: {now_str}\n\n"
+                    f"Current Time: {current_time_str()}\n\n"
                     "Review the following HEARTBEAT.md and decide whether there are active tasks.\n\n"
                     f"{content}"
                 )},

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,13 @@ def ensure_dir(path: Path) -> Path:
 def timestamp() -> str:
     """Current ISO timestamp."""
     return datetime.now().isoformat()
+
+
+def current_time_str() -> str:
+    """Human-readable current time with weekday and timezone, e.g. '2026-03-15 22:30 (Saturday) (CST)'."""
+    now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
+    tz = time.strftime("%Z") or "UTC"
+    return f"{now} ({tz})"
 
 
 _UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*]')

--- a/tests/test_heartbeat_service.py
+++ b/tests/test_heartbeat_service.py
@@ -253,8 +253,8 @@ async def test_decide_retries_transient_error_then_succeeds(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_decide_prompt_includes_current_datetime(tmp_path) -> None:
-    """Phase 1 prompt must contain the current date/time so the LLM can judge task urgency."""
+async def test_decide_prompt_includes_current_time(tmp_path) -> None:
+    """Phase 1 user prompt must contain current time so the LLM can judge task urgency."""
 
     captured_messages: list[dict] = []
 
@@ -283,14 +283,7 @@ async def test_decide_prompt_includes_current_datetime(tmp_path) -> None:
 
     await service._decide("- [ ] check servers at 10:00 UTC")
 
-    # System prompt should mention date/time awareness
-    system_msg = captured_messages[0]
-    assert system_msg["role"] == "system"
-    assert "date/time" in system_msg["content"].lower()
-
-    # User prompt should contain a UTC timestamp
     user_msg = captured_messages[1]
     assert user_msg["role"] == "user"
-    assert "Current date/time:" in user_msg["content"]
-    assert "UTC" in user_msg["content"]
+    assert "Current Time:" in user_msg["content"]
 


### PR DESCRIPTION
## Problem

Phase 1 `_decide()` sends HEARTBEAT.md content to the LLM but doesn't include the current date/time. The LLM cannot determine if scheduled tasks are actually due, so it defaults to `run` for anything with a task description — defeating Phase 1's pre-screening purpose.

Fixes #1929

## Changes

- Inject `Current date/time: YYYY-MM-DD HH:MM UTC` into the user prompt
- Update system prompt to instruct the LLM to use time information for scheduling decisions
- Add test `test_decide_prompt_includes_current_datetime` verifying the datetime injection

## Testing

```
uv run python -m pytest tests/test_heartbeat_service.py -v
# 8 passed
```