### PR TITLE
feat: Implement multi-backend subagent routing, delegation, and loop stability fixes

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -360,6 +360,10 @@ class AgentLoop:
         session_key: str | None = None,
         on_progress: Callable[[str], Awaitable[None]] | None = None,
     ) -> OutboundMessage | None:
+
+        # Safely handle metadata to prevent AttributeError
+        metadata = msg.metadata or {}
+
         """Process a single inbound message and return the response."""
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
@@ -369,14 +373,16 @@ class AgentLoop:
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
-            self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
+            self._set_tool_context(channel, chat_id, metadata.get("message_id"))
             history = session.get_history(max_messages=0)
             messages = self.context.build_messages(
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
             )
+            # Calculate memory offset dynamically
+            skip_count = len(messages) - 1
             final_content, _, all_msgs = await self._run_agent_loop(messages)
-            self._save_turn(session, all_msgs, 1 + len(history))
+            self._save_turn(session, all_msgs, skip_count)  # Use skip_count instead of 1 + len(history)
             self.sessions.save(session)
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
             return OutboundMessage(channel=channel, chat_id=chat_id,
@@ -424,7 +430,7 @@ class AgentLoop:
             )
         await self.memory_consolidator.maybe_consolidate_by_tokens(session)
 
-        self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
+        self._set_tool_context(msg.channel, msg.chat_id, metadata.get("message_id"))
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()
@@ -436,6 +442,9 @@ class AgentLoop:
             media=msg.media if msg.media else None,
             channel=msg.channel, chat_id=msg.chat_id,
         )
+
+        # Calculate memory offset dynamically
+        skip_count = len(initial_messages) - 1
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
             meta = dict(msg.metadata or {})
@@ -452,7 +461,7 @@ class AgentLoop:
         if final_content is None:
             final_content = "I've completed processing but have no response to give."
 
-        self._save_turn(session, all_msgs, 1 + len(history))
+        self._save_turn(session, all_msgs, skip_count)  # Use skip_count instead of 1 + len(history)
         self.sessions.save(session)
         await self.memory_consolidator.maybe_consolidate_by_tokens(session)
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
 class AgentLoop:
     """
     The agent loop is the core processing engine.
-
     It:
     1. Receives messages from the bus
     2. Builds context with history, memory, skills
@@ -63,6 +62,8 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        subagent_configs: dict | None = None,
+        provider_factory: Callable[[str, str], LLMProvider] | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -78,10 +79,28 @@ class AgentLoop:
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
+        self.subagent_configs = subagent_configs or {}
+        self.provider_factory = provider_factory
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
+
+        # Resolve Consolidator Delegate
+        cons_config = next((c for c in self.subagent_configs.values() if "consolidator" in c.delegate), None)
+        cons_model = cons_config.model if cons_config else self.model
+        cons_provider = self.provider_factory(cons_config.model, cons_config.provider) if (cons_config and self.provider_factory) else provider
+
+        self.memory_consolidator = MemoryConsolidator(
+            workspace=workspace,
+            provider=cons_provider,
+            model=cons_model,
+            sessions=self.sessions,
+            context_window_tokens=context_window_tokens,
+            build_messages=self.context.build_messages,
+            get_tool_definitions=self.tools.get_definitions,
+        )
+
         self.subagents = SubagentManager(
             provider=provider,
             workspace=workspace,
@@ -91,6 +110,9 @@ class AgentLoop:
             web_proxy=web_proxy,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            subagent_configs=self.subagent_configs,
+            provider_factory=self.provider_factory,
+            parent_tools=self.tools,
         )
 
         self._running = False
@@ -100,15 +122,7 @@ class AgentLoop:
         self._mcp_connecting = False
         self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
         self._processing_lock = asyncio.Lock()
-        self.memory_consolidator = MemoryConsolidator(
-            workspace=workspace,
-            provider=provider,
-            model=self.model,
-            sessions=self.sessions,
-            context_window_tokens=context_window_tokens,
-            build_messages=self.context.build_messages,
-            get_tool_definitions=self.tools.get_definitions,
-        )
+
         self._register_default_tools()
 
     def _register_default_tools(self) -> None:

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from loguru import logger
 
@@ -17,6 +17,9 @@ from nanobot.bus.queue import MessageBus
 from nanobot.config.schema import ExecToolConfig
 from nanobot.providers.base import LLMProvider
 from nanobot.utils.helpers import build_assistant_message
+
+if TYPE_CHECKING:
+    from nanobot.config.schema import ExecToolConfig, WebSearchConfig, SubagentConfig
 
 
 class SubagentManager:
@@ -32,17 +35,21 @@ class SubagentManager:
         web_proxy: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
+        subagent_configs: dict[str, "SubagentConfig"] | None = None,
+        provider_factory: Callable[[str, str], LLMProvider] | None = None,
+        parent_tools: ToolRegistry | None = None,
     ):
-        from nanobot.config.schema import ExecToolConfig, WebSearchConfig
-
         self.provider = provider
         self.workspace = workspace
         self.bus = bus
         self.model = model or provider.get_default_model()
-        self.web_search_config = web_search_config or WebSearchConfig()
+        self.web_search_config = web_search_config
         self.web_proxy = web_proxy
-        self.exec_config = exec_config or ExecToolConfig()
+        self.exec_config = exec_config
         self.restrict_to_workspace = restrict_to_workspace
+        self.subagent_configs = subagent_configs or {}
+        self.provider_factory = provider_factory
+        self.parent_tools = parent_tools
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
 
@@ -50,6 +57,7 @@ class SubagentManager:
         self,
         task: str,
         label: str | None = None,
+        subagent_id: str | None = None,
         origin_channel: str = "cli",
         origin_chat_id: str = "direct",
         session_key: str | None = None,
@@ -59,8 +67,24 @@ class SubagentManager:
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
         origin = {"channel": origin_channel, "chat_id": origin_chat_id}
 
+        config = self.subagent_configs.get(subagent_id) if subagent_id else None
+
+        agent_model = config.model if config else self.model
+        agent_temp = (config.temperature if config and config.temperature is not None else 0.1)
+        agent_max_tokens = (config.max_tokens if config and config.max_tokens is not None else 8192)
+        agent_reasoning = config.reasoning_effort if config else None
+        max_iterations = (config.max_iterations if config and config.max_iterations is not None else 15)
+
+        provider = self.provider
+        if config and self.provider_factory:
+            provider = self.provider_factory(config.model, config.provider)
+
         bg_task = asyncio.create_task(
-            self._run_subagent(task_id, task, display_label, origin)
+            self._run_subagent(
+                task_id, task, display_label, origin,
+                provider, agent_model, agent_temp, agent_max_tokens,
+                agent_reasoning, max_iterations, config
+            )
         )
         self._running_tasks[task_id] = bg_task
         if session_key:
@@ -75,8 +99,8 @@ class SubagentManager:
 
         bg_task.add_done_callback(_cleanup)
 
-        logger.info("Spawned subagent [{}]: {}", task_id, display_label)
-        return f"Subagent [{display_label}] started (id: {task_id}). I'll notify you when it completes."
+        logger.info("Spawned subagent [{}]: {} (Model: {})", task_id, display_label, agent_model)
+        return f"Subagent [{display_label}] started (id: {task_id}, model: {agent_model}). I'll notify you when it completes."
 
     async def _run_subagent(
         self,
@@ -84,6 +108,13 @@ class SubagentManager:
         task: str,
         label: str,
         origin: dict[str, str],
+        provider: LLMProvider,
+        model: str,
+        temperature: float,
+        max_tokens: int,
+        reasoning_effort: str | None,
+        max_iterations: int,
+        config: "SubagentConfig | None",
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
@@ -96,15 +127,25 @@ class SubagentManager:
             tools.register(WriteFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
             tools.register(EditFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
             tools.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ExecTool(
-                working_dir=str(self.workspace),
-                timeout=self.exec_config.timeout,
-                restrict_to_workspace=self.restrict_to_workspace,
-                path_append=self.exec_config.path_append,
-            ))
-            tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
+            if self.exec_config:
+                tools.register(ExecTool(
+                    working_dir=str(self.workspace),
+                    timeout=self.exec_config.timeout,
+                    restrict_to_workspace=self.restrict_to_workspace,
+                    path_append=self.exec_config.path_append,
+                ))
+            if self.web_search_config:
+                tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
             tools.register(WebFetchTool(proxy=self.web_proxy))
-            
+
+            # Mount allowed MCP tools
+            if config and config.allowed_mcp_servers and self.parent_tools:
+                for server_name in config.allowed_mcp_servers:
+                    prefix = f"mcp_{server_name}_"
+                    for tool_name, tool in self.parent_tools._tools.items():
+                        if tool_name.startswith(prefix) or tool_name == server_name:
+                            tools.register(tool)
+
             system_prompt = self._build_subagent_prompt()
             messages: list[dict[str, Any]] = [
                 {"role": "system", "content": system_prompt},
@@ -112,17 +153,19 @@ class SubagentManager:
             ]
 
             # Run agent loop (limited iterations)
-            max_iterations = 15
             iteration = 0
             final_result: str | None = None
 
             while iteration < max_iterations:
                 iteration += 1
 
-                response = await self.provider.chat_with_retry(
+                response = await provider.chat_with_retry(
                     messages=messages,
                     tools=tools.get_definitions(),
-                    model=self.model,
+                    model=model,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    reasoning_effort=reasoning_effort,
                 )
 
                 if response.has_tool_calls:
@@ -194,7 +237,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
 
         await self.bus.publish_inbound(msg)
         logger.debug("Subagent [{}] announced result to {}:{}", task_id, origin['channel'], origin['chat_id'])
-    
+
     def _build_subagent_prompt(self) -> str:
         """Build a focused system prompt for the subagent."""
         from nanobot.agent.context import ContextBuilder

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -233,6 +233,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
             sender_id="subagent",
             chat_id=f"{origin['channel']}:{origin['chat_id']}",
             content=announce_content,
+            metadata={},
         )
 
         await self.bus.publish_inbound(msg)

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -29,34 +29,55 @@ class SpawnTool(Tool):
 
     @property
     def description(self) -> str:
-        return (
+        base = (
             "Spawn a subagent to handle a task in the background. "
             "Use this for complex or time-consuming tasks that can run independently. "
             "The subagent will complete the task and report back when done."
         )
+        if self._manager.subagent_configs:
+            info_lines = ["\n\nAvailable subagents:"]
+            for k, v in self._manager.subagent_configs.items():
+                details = [f"Model: {v.model}"]
+                if v.latency:
+                    details.append(f"Latency: {v.latency}")
+                if v.cost:
+                    details.append(f"Cost: {v.cost}")
+                info_lines.append(f"- {k}: {v.description} ({', '.join(details)})")
+            return base + "\n".join(info_lines)
+        return base
 
     @property
     def parameters(self) -> dict[str, Any]:
+        props = {
+            "task": {
+                "type": "string",
+                "description": "The task for the subagent to complete",
+            },
+            "label": {
+                "type": "string",
+                "description": "Optional short label for the task (for display)",
+            },
+        }
+
+        if self._manager.subagent_configs:
+            props["subagent_id"] = {
+                "type": "string",
+                "description": "Optional ID of a specific subagent to use.",
+                "enum": list(self._manager.subagent_configs.keys()),
+            }
+
         return {
             "type": "object",
-            "properties": {
-                "task": {
-                    "type": "string",
-                    "description": "The task for the subagent to complete",
-                },
-                "label": {
-                    "type": "string",
-                    "description": "Optional short label for the task (for display)",
-                },
-            },
+            "properties": props,
             "required": ["task"],
         }
 
-    async def execute(self, task: str, label: str | None = None, **kwargs: Any) -> str:
+    async def execute(self, task: str, label: str | None = None, subagent_id: str | None = None, **kwargs: Any) -> str:
         """Spawn a subagent to execute the given task."""
         return await self._manager.spawn(
             task=task,
             label=label,
+            subagent_id=subagent_id,
             origin_channel=self._origin_channel,
             origin_chat_id=self._origin_chat_id,
             session_key=self._session_key,

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -420,7 +420,7 @@ def gateway(
     bus = MessageBus()
 
     provider = _make_provider(config)
-    provider_factory = lambda m, p_override="auto": _make_provider(config, m, p_override)
+    provider_factory = lambda m, p_override=None: _make_provider(config, m, p_override)
     session_manager = SessionManager(config.workspace_path)
 
     # Create cron service first (callback set after agent creation)
@@ -630,7 +630,7 @@ def agent(
 
     bus = MessageBus()
     provider = _make_provider(config)
-    provider_factory = lambda m, p_override="auto": _make_provider(config, m, p_override)
+    provider_factory = lambda m, p_override=None: _make_provider(config, m, p_override)
 
     # Create cron service for tool usage (no callback needed for CLI unless running)
     cron_store_path = get_cron_dir() / "jobs.json"

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -298,15 +298,15 @@ def _onboard_plugins(config_path: Path) -> None:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
-def _make_provider(config: Config):
+def _make_provider(config: Config, model: str | None = None, provider_override: str | None = None):
     """Create the appropriate LLM provider from config."""
     from nanobot.providers.base import GenerationSettings
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
     from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
 
-    model = config.agents.defaults.model
-    provider_name = config.get_provider_name(model)
-    p = config.get_provider(model)
+    model = model or config.agents.defaults.model
+    provider_name = config.get_provider_name(model, provider_override)
+    p = config.get_provider(model, provider_override)
 
     # OpenAI Codex (OAuth)
     if provider_name == "openai_codex" or model.startswith("openai-codex/"):
@@ -316,7 +316,7 @@ def _make_provider(config: Config):
         from nanobot.providers.custom_provider import CustomProvider
         provider = CustomProvider(
             api_key=p.api_key if p else "no-key",
-            api_base=config.get_api_base(model) or "http://localhost:8000/v1",
+            api_base=config.get_api_base(model, provider_override) or "http://localhost:8000/v1",
             default_model=model,
         )
     # Azure OpenAI: direct Azure OpenAI endpoint with deployment name
@@ -341,7 +341,7 @@ def _make_provider(config: Config):
             raise typer.Exit(1)
         provider = LiteLLMProvider(
             api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
+            api_base=config.get_api_base(model, provider_override),
             default_model=model,
             extra_headers=p.extra_headers if p else None,
             provider_name=provider_name,
@@ -418,12 +418,25 @@ def gateway(
     console.print(f"{__logo__} Starting nanobot gateway on port {port}...")
     sync_workspace_templates(config.workspace_path)
     bus = MessageBus()
+
     provider = _make_provider(config)
+    provider_factory = lambda m, p_override="auto": _make_provider(config, m, p_override)
     session_manager = SessionManager(config.workspace_path)
 
     # Create cron service first (callback set after agent creation)
     cron_store_path = get_cron_dir() / "jobs.json"
     cron = CronService(cron_store_path)
+
+    # Extract Gateway Delegates
+    eval_config = next((c for c in config.agents.subagents.values() if "evaluator" in c.delegate), None)
+    eval_provider = provider_factory(eval_config.model, eval_config.provider) if eval_config else provider
+    eval_model = eval_config.model if eval_config else config.agents.defaults.model
+    eval_temp = eval_config.temperature if eval_config and eval_config.temperature is not None else 0.0
+
+    hb_config = next((c for c in config.agents.subagents.values() if "heartbeat_decider" in c.delegate), None)
+    hb_provider = provider_factory(hb_config.model, hb_config.provider) if hb_config else provider
+    hb_model = hb_config.model if hb_config else config.agents.defaults.model
+    hb_temp = hb_config.temperature if hb_config and hb_config.temperature is not None else 0.0
 
     # Create agent with cron service
     agent = AgentLoop(
@@ -441,6 +454,8 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_configs=config.agents.subagents,
+        provider_factory=provider_factory,
     )
 
     # Set cron callback (needs agent)
@@ -477,7 +492,10 @@ def gateway(
 
         if job.payload.deliver and job.payload.to and response:
             should_notify = await evaluate_response(
-                response, job.payload.message, provider, agent.model,
+                response, job.payload.message, eval_provider, eval_model,
+                temperature=eval_temp,
+                reasoning_effort=eval_config.reasoning_effort if eval_config else None,
+                max_tokens=eval_config.max_tokens if eval_config and eval_config.max_tokens is not None else 256
             )
             if should_notify:
                 from nanobot.bus.events import OutboundMessage
@@ -541,6 +559,12 @@ def gateway(
         on_notify=on_heartbeat_notify,
         interval_s=hb_cfg.interval_s,
         enabled=hb_cfg.enabled,
+        decider_provider=hb_provider,
+        decider_model=hb_model,
+        decider_temperature=hb_temp,
+        evaluator_provider=eval_provider,
+        evaluator_model=eval_model,
+        evaluator_config=eval_config,
     )
 
     if channels.enabled_channels:
@@ -578,8 +602,6 @@ def gateway(
     asyncio.run(run())
 
 
-
-
 # ============================================================================
 # Agent Commands
 # ============================================================================
@@ -608,6 +630,7 @@ def agent(
 
     bus = MessageBus()
     provider = _make_provider(config)
+    provider_factory = lambda m, p_override="auto": _make_provider(config, m, p_override)
 
     # Create cron service for tool usage (no callback needed for CLI unless running)
     cron_store_path = get_cron_dir() / "jobs.json"
@@ -632,6 +655,8 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        subagent_configs=config.agents.subagents,
+        provider_factory=provider_factory,
     )
 
     # Show spinner when logs are off (no output to miss); skip when logs are on

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -50,7 +50,7 @@ class SubagentConfig(Base):
     """Configuration for a specific subagent."""
 
     model: str
-    provider: str = "auto"
+    provider: str | None = None
     description: str = "A specialized subagent."
     latency: str | None = None
     cost: str | None = None

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -32,9 +32,7 @@ class AgentDefaults(Base):
 
     workspace: str = "~/.nanobot/workspace"
     model: str = "anthropic/claude-opus-4-5"
-    provider: str = (
-        "auto"  # Provider name (e.g. "anthropic", "openrouter") or "auto" for auto-detection
-    )
+    provider: str = "auto"  # Provider name (e.g. "anthropic", "openrouter") or "auto" for auto-detection
     max_tokens: int = 8192
     context_window_tokens: int = 65_536
     temperature: float = 0.1
@@ -45,14 +43,30 @@ class AgentDefaults(Base):
 
     @property
     def should_warn_deprecated_memory_window(self) -> bool:
-        """Return True when old memoryWindow is present without contextWindowTokens."""
         return self.memory_window is not None and "context_window_tokens" not in self.model_fields_set
+        """Return True when old memoryWindow is present without contextWindowTokens."""
+
+class SubagentConfig(Base):
+    """Configuration for a specific subagent."""
+
+    model: str
+    provider: str = "auto"
+    description: str = "A specialized subagent."
+    latency: str | None = None
+    cost: str | None = None
+    temperature: float | None = None
+    max_tokens: int | None = None
+    reasoning_effort: str | None = None
+    max_iterations: int | None = None
+    allowed_mcp_servers: list[str] | None = None
+    delegate: list[str] = Field(default_factory=list)
 
 
 class AgentsConfig(Base):
     """Agent configuration."""
 
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
+    subagents: dict[str, SubagentConfig] = Field(default_factory=dict)
 
 
 class ProviderConfig(Base):
@@ -117,9 +131,7 @@ class WebSearchConfig(Base):
 class WebToolsConfig(Base):
     """Web tools configuration."""
 
-    proxy: str | None = (
-        None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
-    )
+    proxy: str | None = None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
     search: WebSearchConfig = Field(default_factory=WebSearchConfig)
 
 
@@ -141,6 +153,7 @@ class MCPServerConfig(Base):
     headers: dict[str, str] = Field(default_factory=dict)  # HTTP/SSE: custom headers
     tool_timeout: int = 30  # seconds before a tool call is cancelled
     enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+
 
 class ToolsConfig(Base):
     """Tools configuration."""
@@ -166,12 +179,12 @@ class Config(BaseSettings):
         return Path(self.agents.defaults.workspace).expanduser()
 
     def _match_provider(
-        self, model: str | None = None
+        self, model: str | None = None, provider_override: str | None = None
     ) -> tuple["ProviderConfig | None", str | None]:
         """Match provider config and its registry name. Returns (config, spec_name)."""
         from nanobot.providers.registry import PROVIDERS
 
-        forced = self.agents.defaults.provider
+        forced = provider_override if provider_override is not None else self.agents.defaults.provider
         if forced != "auto":
             p = getattr(self.providers, forced, None)
             return (p, forced) if p else (None, None)
@@ -227,26 +240,26 @@ class Config(BaseSettings):
                 return p, spec.name
         return None, None
 
-    def get_provider(self, model: str | None = None) -> ProviderConfig | None:
+    def get_provider(self, model: str | None = None, provider_override: str | None = None) -> ProviderConfig | None:
         """Get matched provider config (api_key, api_base, extra_headers). Falls back to first available."""
-        p, _ = self._match_provider(model)
+        p, _ = self._match_provider(model, provider_override)
         return p
 
-    def get_provider_name(self, model: str | None = None) -> str | None:
+    def get_provider_name(self, model: str | None = None, provider_override: str | None = None) -> str | None:
         """Get the registry name of the matched provider (e.g. "deepseek", "openrouter")."""
-        _, name = self._match_provider(model)
+        _, name = self._match_provider(model, provider_override)
         return name
 
-    def get_api_key(self, model: str | None = None) -> str | None:
+    def get_api_key(self, model: str | None = None, provider_override: str | None = None) -> str | None:
         """Get API key for the given model. Falls back to first available key."""
-        p = self.get_provider(model)
+        p = self.get_provider(model, provider_override)
         return p.api_key if p else None
 
-    def get_api_base(self, model: str | None = None) -> str | None:
+    def get_api_base(self, model: str | None = None, provider_override: str | None = None) -> str | None:
         """Get API base URL for the given model. Applies default URLs for gateway/local providers."""
         from nanobot.providers.registry import find_by_name
 
-        p, name = self._match_provider(model)
+        p, name = self._match_provider(model, provider_override)
         if p and p.api_base:
             return p.api_base
         # Only gateways get a default api_base here. Standard providers

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -40,11 +40,9 @@ _HEARTBEAT_TOOL = [
 class HeartbeatService:
     """
     Periodic heartbeat service that wakes the agent to check for tasks.
-
     Phase 1 (decision): reads HEARTBEAT.md and asks the LLM — via a virtual
     tool call — whether there are active tasks.  This avoids free-text parsing
     and the unreliable HEARTBEAT_OK token.
-
     Phase 2 (execution): only triggered when Phase 1 returns ``run``.  The
     ``on_execute`` callback runs the task through the full agent loop and
     returns the result to deliver.
@@ -59,6 +57,12 @@ class HeartbeatService:
         on_notify: Callable[[str], Coroutine[Any, Any, None]] | None = None,
         interval_s: int = 30 * 60,
         enabled: bool = True,
+        decider_provider: LLMProvider | None = None,
+        decider_model: str | None = None,
+        decider_temperature: float = 0.0,
+        evaluator_provider: LLMProvider | None = None,
+        evaluator_model: str | None = None,
+        evaluator_config: Any | None = None,
     ):
         self.workspace = workspace
         self.provider = provider
@@ -67,6 +71,15 @@ class HeartbeatService:
         self.on_notify = on_notify
         self.interval_s = interval_s
         self.enabled = enabled
+
+        self.decider_provider = decider_provider or provider
+        self.decider_model = decider_model or model
+        self.decider_temperature = decider_temperature
+
+        self.evaluator_provider = evaluator_provider or provider
+        self.evaluator_model = evaluator_model or model
+        self.evaluator_config = evaluator_config
+
         self._running = False
         self._task: asyncio.Task | None = None
 
@@ -84,10 +97,9 @@ class HeartbeatService:
 
     async def _decide(self, content: str) -> tuple[str, str]:
         """Phase 1: ask LLM to decide skip/run via virtual tool call.
-
         Returns (action, tasks) where action is 'skip' or 'run'.
         """
-        response = await self.provider.chat_with_retry(
+        response = await self.decider_provider.chat_with_retry(
             messages=[
                 {"role": "system", "content": "You are a heartbeat agent. Call the heartbeat tool to report your decision."},
                 {"role": "user", "content": (
@@ -96,7 +108,8 @@ class HeartbeatService:
                 )},
             ],
             tools=_HEARTBEAT_TOOL,
-            model=self.model,
+            model=self.decider_model,
+            temperature=self.decider_temperature,
         )
 
         if not response.has_tool_calls:
@@ -160,8 +173,13 @@ class HeartbeatService:
                 response = await self.on_execute(tasks)
 
                 if response:
+                    eval_temp = self.evaluator_config.temperature if self.evaluator_config and self.evaluator_config.temperature is not None else 0.0
+                    eval_reasoning = self.evaluator_config.reasoning_effort if self.evaluator_config else None
+                    eval_max = self.evaluator_config.max_tokens if self.evaluator_config and self.evaluator_config.max_tokens is not None else 256
+
                     should_notify = await evaluate_response(
-                        response, tasks, self.provider, self.model,
+                        response, tasks, self.evaluator_provider, self.evaluator_model,
+                        temperature=eval_temp, reasoning_effort=eval_reasoning, max_tokens=eval_max
                     )
                     if should_notify and self.on_notify:
                         logger.info("Heartbeat: completed, delivering response")

--- a/nanobot/utils/evaluator.py
+++ b/nanobot/utils/evaluator.py
@@ -1,5 +1,4 @@
 """Post-run evaluation for background tasks (heartbeat & cron).
-
 After the agent executes a background task, this module makes a lightweight
 LLM call to decide whether the result warrants notifying the user.
 """
@@ -55,9 +54,11 @@ async def evaluate_response(
     task_context: str,
     provider: LLMProvider,
     model: str,
+    temperature: float = 0.0,
+    max_tokens: int = 256,
+    reasoning_effort: str | None = None,
 ) -> bool:
     """Decide whether a background-task result should be delivered to the user.
-
     Uses a lightweight tool-call LLM request (same pattern as heartbeat
     ``_decide()``).  Falls back to ``True`` (notify) on any failure so
     that important messages are never silently dropped.
@@ -73,8 +74,9 @@ async def evaluate_response(
             ],
             tools=_EVALUATE_TOOL,
             model=model,
-            max_tokens=256,
-            temperature=0.0,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
         )
 
         if not llm_response.has_tool_calls:

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -1,0 +1,95 @@
+"""Tests for subagent execution and model delegation."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.subagent import SubagentManager
+from nanobot.config.schema import SubagentConfig
+from nanobot.providers.base import LLMProvider
+
+
+@pytest.fixture
+def mock_provider():
+    provider = MagicMock(spec=LLMProvider)
+    provider.get_default_model.return_value = "main/model"
+    mock_response = MagicMock()
+    mock_response.has_tool_calls = False
+    mock_response.content = "Task finished by main provider"
+    mock_response.finish_reason = "stop"
+    provider.chat_with_retry = AsyncMock(return_value=mock_response)
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_subagent_spawn_with_delegated_model(tmp_path: Path, mock_provider: LLMProvider):
+    sub_config = SubagentConfig(
+        model="claude-3-haiku",
+        provider="anthropic",
+        description="Fast coder",
+        temperature=0.2,
+        max_tokens=2048
+    )
+
+    mock_factory_provider = MagicMock(spec=LLMProvider)
+    mock_response = MagicMock()
+    mock_response.has_tool_calls = False
+    mock_response.content = "Done via haiku"
+    mock_factory_provider.chat_with_retry = AsyncMock(return_value=mock_response)
+
+    def provider_factory(model_str, provider_override):
+        if model_str == "claude-3-haiku" and provider_override == "anthropic":
+            return mock_factory_provider
+        return mock_provider
+
+    bus = MagicMock()
+
+    manager = SubagentManager(
+        provider=mock_provider,
+        workspace=tmp_path,
+        bus=bus,
+        subagent_configs={"coder": sub_config},
+        provider_factory=provider_factory
+    )
+
+    # Spawn specific subagent
+    await manager.spawn("Write a script", subagent_id="coder")
+
+    # Wait to allow background loop iteration
+    await asyncio.sleep(0.1)
+
+    # Ensure delegated factory was queried with correct subagent parameters
+    mock_factory_provider.chat_with_retry.assert_called_once()
+    kwargs = mock_factory_provider.chat_with_retry.call_args.kwargs
+    assert kwargs["model"] == "claude-3-haiku"
+    assert kwargs["temperature"] == 0.2
+    assert kwargs["max_tokens"] == 2048
+
+    # The main provider should not have been called
+    mock_provider.chat_with_retry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subagent_fallback(tmp_path: Path, mock_provider: LLMProvider):
+    bus = MagicMock()
+
+    # Initialize without subagent configs
+    manager = SubagentManager(
+        provider=mock_provider,
+        workspace=tmp_path,
+        bus=bus,
+        subagent_configs={},
+        provider_factory=None
+    )
+
+    # Spawn default background agent
+    await manager.spawn("Test fallback")
+    await asyncio.sleep(0.1)
+
+    # Validate main provider was used with default parameters
+    mock_provider.chat_with_retry.assert_called_once()
+    kwargs = mock_provider.chat_with_retry.call_args.kwargs
+    assert kwargs["model"] == "main/model"
+    assert kwargs["temperature"] == 0.1


### PR DESCRIPTION
## Overview

This PR introduces the ability for subagents to utilize different LLM backends (models, providers, temperatures, token limits) independently from the main agent. It also introduces a delegate system, allowing specific background tasks (like memory consolidation, heartbeat decisions, and evaluation) to be routed to specialized, cost-effective, or specialized subagents.

Alongside these features, this PR includes bug fixes: agent loop amnesia & metadata crash, memory indexing drift.


## Key Features & Modifications

**1. Subagent Configuration & Backend Routing**

- nanobot/config/schema.py: Added SubagentConfig to the main configuration schema. Subagents can now be defined with specific overrides: model, provider, temperature, max_tokens, reasoning_effort, max_iterations, and allowed_mcp_servers.

- nanobot/cli/commands.py: Refactored _make_provider into a flexible factory function that accepts model and provider_override strings, allowing the CLI gateway to instantiate disparate providers dynamically.

- nanobot/agent/subagent.py: SubagentManager now consumes provider_factory to spin up background tasks using the exact constraints defined in SubagentConfig. Unspecified parameters safely fall back to the main agent's configuration.

- nanobot/agent/tools/spawn.py: Enhanced the SpawnTool description to dynamically advertise available subagents (including optional metadata like latency and cost) to the main agent, allowing it to deliberately choose specialized subagents via subagent_id.

**2. Service Delegation**

- Added the delegate array to SubagentConfig, allowing background pipelines to utilize subagent backends:

  - heartbeat_decider: Routes phase 1 heartbeat task assessments.

  - evaluator: Routes post-run notification evaluation logic (nanobot/utils/evaluator.py).

  - consolidator: Routes MemoryConsolidator execution (nanobot/agent/loop.py).


## Bug Fixes & Hardening

**1. Agent Loop Amnesia & Metadata Crash:**

- Fixed a silent task crash where subagent result announcements pushed to the bus with metadata=None caused an AttributeError during message_id retrieval in loop.py.

- Fix: Enforced metadata={} fallback on subagent broadcasts and safe extraction (metadata = msg.metadata or {}) in _process_message.

**2. Memory Indexing Drift:**

- Fixed an issue where dynamic system prompts (like injected memories or MCP tool descriptions) skewed the hardcoded 1 + len(history) memory offset, causing the agent to drop or duplicate context.

- Fix: Updated _process_message to calculate memory offsets dynamically (skip_count = len(initial_messages) - 1) immediately before LLM generation for both system and user messages.


## Testing

- Added tests/test_subagent.py to verify that SubagentManager correctly queries the delegated provider factory with the right parameters and handles fallbacks accurately.

- Conducted local end-to-end testing with llama.cpp custom provider to ensure subagent tool usage and memory consolidation complete successfully without JSON schema errors or dropped context.


## Example config.json configuration

```json
{
  "agents": {
    "defaults": {
      "model": "your-main-model",
      "provider": "custom"
    },
    "subagents": {
      "coder": {
        "model": "anthropic/claude-3-haiku",
        "provider": "anthropic",
        "description": "A fast, cheap model perfect for writing isolated scripts.",
        "latency": "low",
        "cost": "$0.25/1M",
        "temperature": 0.1,
        "maxTokens": 4096,
        "maxIterations": 10,
        "allowedMcpServers": ["github", "local_fs"]
      },
      "evaluator_agent": {
        "model": "openai/gpt-4o-mini",
        "provider": "openai",
        "description": "Background router for system tasks.",
        "temperature": 0.0,
        "maxTokens": 256,
        "delegate": ["evaluator", "heartbeat_decider"]
      },
      "memory_manager": {
        "model": "anthropic/claude-3-haiku",
        "provider": "anthropic",
        "delegate": ["consolidator"]
      }
    }
  }
}
```

###  Schema Field Breakdown

Under agents.subagents, you can define any number of subagents using a unique key (e.g., "coder").

- model (string, required): The specific model ID to use for this subagent (e.g., "gpt-4o", "llama-3").

- provider (string, optional): The provider name (e.g., "openai", "anthropic", "custom", "auto"). If omitted, it automatically inherits the main agent's provider.

- description (string, optional): A short description of what this subagent is good at. The main agent reads this to decide which subagent to spawn.

- latency (string, optional): Information for the main agent to know how fast this subagent is (e.g., "low", "high").

- cost (string, optional): Information for the main agent to know how expensive this subagent is.

- temperature (float, optional): The temperature setting. Defaults to 0.1 if omitted.

- maxTokens (integer, optional): Maximum output tokens. Defaults to 8192.

- reasoningEffort (string, optional): For reasoning models (like o1 or o3), controls the reasoning budget (e.g., "low", "medium", "high").

- maxIterations (integer, optional): The maximum number of tool-call loops this subagent can perform before timing out. Defaults to 15.

- allowedMcpServers (array of strings, optional): A whitelist of MCP server names this subagent is allowed to use. If omitted, it has no MCP access.

- delegate (array of strings, optional): Assigns this subagent to handle core background system tasks. Available delegates:

  - "evaluator": Handles post-task evaluations (deciding if a user needs to be notified of a cron job or heartbeat result).

  - "heartbeat_decider": Reviews the HEARTBEAT.md file every 30 minutes to see if the agent needs to wake up.

  - "consolidator": Handles the heavy summarization tasks to compress long conversational memory.