### PR TITLE
fix(config): honour NANOBOT_* env vars when config.json exists

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -1,6 +1,7 @@
 """Configuration loading utilities."""
 
 import json
+import re
 from pathlib import Path
 
 from nanobot.config.schema import Config
@@ -40,7 +41,12 @@ def load_config(config_path: Path | None = None) -> Config:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
             data = _migrate_config(data)
-            return Config.model_validate(data)
+            # Normalise camelCase keys to snake_case so that init-kwargs and
+            # env_settings both use the same key format.  Without this,
+            # {"apiKey": "file-val"} and the env var producing {"api_key": "env-val"}
+            # end up as two separate keys in the deep-merged dict; Pydantic then
+            # resolves the alias (camelCase) over the field name, making env vars lose.
+            return Config(**_normalize_keys(data))
         except (json.JSONDecodeError, ValueError) as e:
             print(f"Warning: Failed to load config from {path}: {e}")
             print("Using default configuration.")
@@ -65,6 +71,27 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
+def _camel_to_snake(name: str) -> str:
+    """Convert a single camelCase (or PascalCase) identifier to snake_case."""
+    # Insert underscore between a lowercase/digit and an uppercase letter
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name).lower()
+
+
+def _normalize_keys(data: dict) -> dict:
+    """Recursively convert all dict keys from camelCase to snake_case.
+
+    Config JSON files use camelCase aliases (e.g. ``apiKey``), while
+    pydantic-settings' env var source uses snake_case field names
+    (e.g. ``api_key`` from ``NANOBOT_PROVIDERS__ANTHROPIC__API_KEY``).
+    Normalising both to snake_case lets pydantic-settings merge the two
+    sources correctly so that environment variables can override file values.
+    """
+    result = {}
+    for k, v in data.items():
+        result[_camel_to_snake(k)] = _normalize_keys(v) if isinstance(v, dict) else v
+    return result
+
+
 def _migrate_config(data: dict) -> dict:
     """Migrate old config formats to current."""
     # Move tools.exec.restrictToWorkspace → tools.restrictToWorkspace
@@ -73,3 +100,4 @@ def _migrate_config(data: dict) -> dict:
     if "restrictToWorkspace" in exec_cfg and "restrictToWorkspace" not in tools:
         tools["restrictToWorkspace"] = exec_cfg.pop("restrictToWorkspace")
     return data
+

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
 
 
 class Base(BaseModel):
@@ -259,3 +259,16 @@ class Config(BaseSettings):
         return None
 
     model_config = ConfigDict(env_prefix="NANOBOT_", env_nested_delimiter="__")
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # env vars take precedence over file data (init kwargs) so that
+        # NANOBOT_* environment variables always override config.json values.
+        return env_settings, init_settings

--- a/tests/test_config_env_override.py
+++ b/tests/test_config_env_override.py
@@ -1,0 +1,107 @@
+"""Tests that NANOBOT_* environment variables override config.json values.
+
+Regression tests for https://github.com/HKUDS/nanobot/issues/1791 - when a
+config.json file exists, pydantic-settings env var sources were bypassed because
+Config.model_validate() skips BaseSettings.__init__.  The fix switches to
+Config(**data) so env vars are read and settings_customise_sources puts
+env_settings first (highest priority).
+"""
+
+import json
+
+from nanobot.config.loader import load_config
+
+
+def test_env_var_overrides_model_in_config_file(tmp_path, monkeypatch) -> None:
+    """NANOBOT_AGENTS__DEFAULTS__MODEL overrides agents.defaults.model from file."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"agents": {"defaults": {"model": "anthropic/claude-opus-4-5"}}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("NANOBOT_AGENTS__DEFAULTS__MODEL", "openai/gpt-4o")
+
+    config = load_config(config_path)
+
+    assert config.agents.defaults.model == "openai/gpt-4o"
+
+
+def test_file_value_used_when_no_env_var_set(tmp_path, monkeypatch) -> None:
+    """When no env var is set, the config.json value is used unchanged."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"agents": {"defaults": {"model": "deepseek/deepseek-chat"}}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("NANOBOT_AGENTS__DEFAULTS__MODEL", raising=False)
+
+    config = load_config(config_path)
+
+    assert config.agents.defaults.model == "deepseek/deepseek-chat"
+
+
+def test_env_var_overrides_provider_api_key_in_config_file(tmp_path, monkeypatch) -> None:
+    """NANOBOT_PROVIDERS__ANTHROPIC__API_KEY overrides providers.anthropic.api_key from file."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"providers": {"anthropic": {"apiKey": "key-from-file"}}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("NANOBOT_PROVIDERS__ANTHROPIC__API_KEY", "key-from-env")
+
+    config = load_config(config_path)
+
+    assert config.providers.anthropic.api_key == "key-from-env"
+
+
+def test_file_api_key_used_when_no_env_var(tmp_path, monkeypatch) -> None:
+    """When no env var is set, api_key from config.json is preserved."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"providers": {"anthropic": {"apiKey": "sk-ant-file-key"}}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("NANOBOT_PROVIDERS__ANTHROPIC__API_KEY", raising=False)
+
+    config = load_config(config_path)
+
+    assert config.providers.anthropic.api_key == "sk-ant-file-key"
+
+
+def test_env_var_works_without_config_file(tmp_path, monkeypatch) -> None:
+    """NANOBOT_* env vars are honoured even when no config.json exists."""
+    config_path = tmp_path / "nonexistent.json"
+
+    monkeypatch.setenv("NANOBOT_AGENTS__DEFAULTS__MODEL", "groq/llama-3.3-70b-versatile")
+
+    config = load_config(config_path)
+
+    assert config.agents.defaults.model == "groq/llama-3.3-70b-versatile"
+
+
+def test_multiple_env_vars_override_multiple_file_values(tmp_path, monkeypatch) -> None:
+    """Multiple env vars can override multiple fields from a single config.json."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "agents": {"defaults": {"model": "anthropic/claude-opus-4-5", "maxTokens": 4096}},
+                "providers": {"openai": {"apiKey": "file-openai-key"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("NANOBOT_AGENTS__DEFAULTS__MODEL", "openai/gpt-4o-mini")
+    monkeypatch.setenv("NANOBOT_PROVIDERS__OPENAI__API_KEY", "env-openai-key")
+
+    config = load_config(config_path)
+
+    assert config.agents.defaults.model == "openai/gpt-4o-mini"
+    assert config.providers.openai.api_key == "env-openai-key"
+    # File-only value (maxTokens) is still read from the file
+    assert config.agents.defaults.max_tokens == 4096


### PR DESCRIPTION
## Problem

`NANOBOT_*` environment variables are silently ignored whenever `~/.nanobot/config.json` exists. This breaks common workflows such as Docker deployments, CI/CD pipelines, and **direnv** setups that rely on env vars to inject API keys without modifying the config file.

Fixes #1791.

## Root cause

`load_config()` takes two code paths:
- **No file:** `Config()` → calls `BaseSettings.__init__()` → reads env vars ✅
- **File exists:** `Config.model_validate(data)` → goes through Pydantic's Rust validator directly, bypassing `BaseSettings.__init__()` → **no env vars read** ❌

Even switching to `Config(**data)` alone is not enough. Config JSON uses camelCase aliases (e.g. `apiKey`), while pydantic-settings constructs snake_case keys from env vars (e.g. `api_key` from `NANOBOT_PROVIDERS__ANTHROPIC__API_KEY`). When pydantic-settings deep-merges the two sources these are different dict keys; Pydantic then resolves the camelCase alias over the field name — making the file value silently win even when `env_settings` has higher priority.

## Fix

Two cooperating changes:

**1. `nanobot/config/schema.py` — flip settings source priority**

```python
@classmethod
def settings_customise_sources(cls, settings_cls, init_settings, env_settings, ...):
    # env vars > file data (init kwargs) > defaults
    return env_settings, init_settings
```

**2. `nanobot/config/loader.py` — normalise JSON keys before passing as init kwargs**

```python
return Config(**_normalize_keys(data))   # was: Config.model_validate(data)
```

`_normalize_keys()` recursively converts camelCase dict keys to snake_case so that both the env var source and the file source use the same key names. This ensures pydantic-settings' priority ordering takes effect correctly.

## Tests

`tests/test_config_env_override.py` (6 new tests):
- `NANOBOT_AGENTS__DEFAULTS__MODEL` overrides `agents.defaults.model` from file
- `NANOBOT_PROVIDERS__ANTHROPIC__API_KEY` overrides `providers.anthropic.api_key` from file
- File values are preserved when no matching env var is set
- Multiple env vars can simultaneously override multiple fields
- Env vars work when no config file exists (preserves existing behaviour)

All existing `test_config_migration.py` and `test_config_paths.py` tests continue to pass.