### PR TITLE
fix: Delay in starting new chat due to archival (particularly in local llm setups)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -99,6 +99,8 @@ class AgentLoop:
         self._mcp_connected = False
         self._mcp_connecting = False
         self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
+        self._archiving_tasks: dict[str, asyncio.Task] = {}  # session_key -> background archival task
+        self._archiving_sessions: dict[str, Session] = {}  # session_key -> session to archive
         self._processing_lock = asyncio.Lock()
         self.memory_consolidator = MemoryConsolidator(
             workspace=workspace,
@@ -377,24 +379,23 @@ class AgentLoop:
         # Slash commands
         cmd = msg.content.strip().lower()
         if cmd == "/new":
-            try:
-                if not await self.memory_consolidator.archive_unconsolidated(session):
-                    return OutboundMessage(
-                        channel=msg.channel,
-                        chat_id=msg.chat_id,
-                        content="Memory archival failed, session not cleared. Please try again.",
-                    )
-            except Exception:
-                logger.exception("/new archival failed for {}", session.key)
-                return OutboundMessage(
-                    channel=msg.channel,
-                    chat_id=msg.chat_id,
-                    content="Memory archival failed, session not cleared. Please try again.",
-                )
+            existing_task = self._archiving_tasks.get(key)
+            if existing_task:
+                try:
+                    await existing_task
+                except Exception:
+                    logger.exception("/new: waiting on previous archival failed for {}", key)
 
-            session.clear()
-            self.sessions.save(session)
-            self.sessions.invalidate(session.key)
+            old_session = self.sessions.get_or_create(key)
+
+            if old_session.messages:
+                self._archiving_sessions[key] = old_session
+                task = asyncio.create_task(self._archive_old_session(key))
+                self._archiving_tasks[key] = task
+
+            new_session = Session(key=key)
+            self.sessions._cache[key] = new_session
+
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
                                   content="New session started.")
         if cmd == "/help":
@@ -500,3 +501,20 @@ class AgentLoop:
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
         response = await self._process_message(msg, session_key=session_key, on_progress=on_progress)
         return response.content if response else ""
+
+    async def _archive_old_session(self, key: str) -> None:
+        """Archive old session in background after /new command."""
+        old_session = self._archiving_sessions.pop(key, None)
+        if old_session is None:
+            return
+
+        task = self._archiving_tasks.pop(key, None)
+
+        try:
+            if not await self.memory_consolidator.archive_unconsolidated(old_session):
+                logger.warning("/new archival returned false for {}", key)
+        except Exception:
+            logger.exception("/new archival failed for {}", key)
+        finally:
+            if key in self._archiving_tasks:
+                self._archiving_tasks.pop(key, None)

--- a/tests/test_consolidate_offset.py
+++ b/tests/test_consolidate_offset.py
@@ -505,7 +505,7 @@ class TestNewCommandArchival:
         return loop
 
     @pytest.mark.asyncio
-    async def test_new_does_not_clear_session_when_archive_fails(self, tmp_path: Path) -> None:
+    async def test_new_clears_session_immediately_even_if_archive_fails(self, tmp_path: Path) -> None:
         from nanobot.bus.events import InboundMessage
 
         loop = self._make_loop(tmp_path)
@@ -514,7 +514,6 @@ class TestNewCommandArchival:
             session.add_message("user", f"msg{i}")
             session.add_message("assistant", f"resp{i}")
         loop.sessions.save(session)
-        before_count = len(session.messages)
 
         async def _failing_consolidate(_messages) -> bool:
             return False
@@ -525,8 +524,12 @@ class TestNewCommandArchival:
         response = await loop._process_message(new_msg)
 
         assert response is not None
-        assert "failed" in response.content.lower()
-        assert len(loop.sessions.get_or_create("cli:test").messages) == before_count
+        assert "new session started" in response.content.lower()
+        assert loop.sessions.get_or_create("cli:test").messages == []
+
+        task = loop._archiving_tasks.get("cli:test")
+        assert task is not None
+        await task
 
     @pytest.mark.asyncio
     async def test_new_archives_only_unconsolidated_messages(self, tmp_path: Path) -> None:
@@ -554,6 +557,10 @@ class TestNewCommandArchival:
 
         assert response is not None
         assert "new session started" in response.content.lower()
+
+        task = loop._archiving_tasks.get("cli:test")
+        assert task is not None
+        await task
         assert archived_count == 3
 
     @pytest.mark.asyncio
@@ -578,3 +585,109 @@ class TestNewCommandArchival:
         assert response is not None
         assert "new session started" in response.content.lower()
         assert loop.sessions.get_or_create("cli:test").messages == []
+
+    @pytest.mark.asyncio
+    async def test_new_returns_immediately_before_archival_completes(self, tmp_path: Path) -> None:
+        from nanobot.bus.events import InboundMessage
+
+        loop = self._make_loop(tmp_path)
+        session = loop.sessions.get_or_create("cli:test")
+        for i in range(3):
+            session.add_message("user", f"msg{i}")
+            session.add_message("assistant", f"resp{i}")
+        loop.sessions.save(session)
+
+        archival_started = False
+
+        async def _slow_consolidate(messages) -> bool:
+            nonlocal archival_started
+            archival_started = True
+            await asyncio.sleep(1.0)
+            return True
+
+        loop.memory_consolidator.consolidate_messages = _slow_consolidate  # type: ignore[method-assign]
+
+        new_msg = InboundMessage(channel="cli", sender_id="user", chat_id="test", content="/new")
+        response = await loop._process_message(new_msg)
+
+        assert response is not None
+        assert "new session started" in response.content.lower()
+        assert loop.sessions.get_or_create("cli:test").messages == []
+        assert not archival_started
+
+    @pytest.mark.asyncio
+    async def test_new_runs_background_archival_after_response(self, tmp_path: Path) -> None:
+        from nanobot.bus.events import InboundMessage
+
+        loop = self._make_loop(tmp_path)
+        session = loop.sessions.get_or_create("cli:test")
+        for i in range(3):
+            session.add_message("user", f"msg{i}")
+            session.add_message("assistant", f"resp{i}")
+        loop.sessions.save(session)
+
+        archival_started = False
+
+        async def _slow_consolidate(messages) -> bool:
+            nonlocal archival_started
+            archival_started = True
+            await asyncio.sleep(0.1)
+            return True
+
+        loop.memory_consolidator.consolidate_messages = _slow_consolidate  # type: ignore[method-assign]
+
+        new_msg = InboundMessage(channel="cli", sender_id="user", chat_id="test", content="/new")
+        response = await loop._process_message(new_msg)
+
+        assert response is not None
+        assert "new session started" in response.content.lower()
+
+        task = loop._archiving_tasks.get("cli:test")
+        assert task is not None
+        await task
+        assert archival_started
+
+    @pytest.mark.asyncio
+    async def test_new_waits_for_previous_archival(self, tmp_path: Path) -> None:
+        from nanobot.bus.events import InboundMessage
+
+        loop = self._make_loop(tmp_path)
+        session = loop.sessions.get_or_create("cli:test")
+        for i in range(3):
+            session.add_message("user", f"msg{i}")
+            session.add_message("assistant", f"resp{i}")
+        loop.sessions.save(session)
+
+        consolidation_count = 0
+
+        async def _slow_consolidate(messages) -> bool:
+            nonlocal consolidation_count
+            consolidation_count += 1
+            await asyncio.sleep(0.1)
+            return True
+
+        loop.memory_consolidator.consolidate_messages = _slow_consolidate  # type: ignore[method-assign]
+
+        new_msg = InboundMessage(channel="cli", sender_id="user", chat_id="test", content="/new")
+        response1 = await loop._process_message(new_msg)
+
+        assert response1 is not None
+        assert "new session started" in response1.content.lower()
+        assert loop.sessions.get_or_create("cli:test").messages == []
+
+        task1 = loop._archiving_tasks.get("cli:test")
+
+        new_msg2 = InboundMessage(channel="cli", sender_id="user", chat_id="test", content="/new")
+        response2 = await loop._process_message(new_msg2)
+
+        assert response2 is not None
+        assert "new session started" in response2.content.lower()
+
+        if task1:
+            await task1
+
+        task2 = loop._archiving_tasks.get("cli:test")
+        if task2:
+            await task2
+
+        assert consolidation_count == 1


### PR DESCRIPTION
# Problem

The `/new` command was slow because it ran session archival synchronously before responding to the user. This caused a delay even when there was little or no session history to archive.

# Solution

Run session archival in the background after creating a new session, so the response is returned immediately.

# Changes

- Modified `/new` handler in `nanobot/agent/loop.py` to:
  - Create a new empty session immediately
  - Return "New session started." response right away
  - Archive the old session in the background using `asyncio.create_task()`
  - Wait for any existing archival task before starting a new one (to avoid overlapping archival)

- Added new tests in `tests/test_consolidate_offset.py`:
  - `test_new_returns_immediately_before_archival_completes` - verifies response is immediate
  - `test_new_runs_background_archival_after_response` - verifies archival runs after response
  - `test_new_waits_for_previous_archival` - verifies multiple /new commands wait for previous archival

# Known Limitation

If the user sends `/new` and immediately asks about facts from the previous chat (before archival completes), the LLM may not have access to the newly saved MEMORY.md/HISTORY.md. The user would need to wait briefly or re-prompt after archival finishes. This is unlikely in practice but worth noting.
