### PR TITLE
fix: remove global litellm.api_base assignment

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -54,9 +54,6 @@ class LiteLLMProvider(LLMProvider):
         if api_key:
             self._setup_env(api_key, api_base, default_model)
 
-        if api_base:
-            litellm.api_base = api_base
-
         # Disable LiteLLM logging noise
         litellm.suppress_debug_info = True
         # Drop unsupported parameters for providers (e.g., gpt-5 rejects some params)


### PR DESCRIPTION
## Summary
- Removes the global `litellm.api_base = api_base` assignment in `LiteLLMProvider.__init__`
- This global state mutation caused issues when multiple provider instances with different API bases were used — the last one to initialize would overwrite the base URL for all providers

## Test plan
- [x] Existing tests pass (339/339)
- [ ] Verify multiple LiteLLM provider instances with different `api_base` values work correctly in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)