### PR TITLE
qol: add version id to log output

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(gh pr diff:*)",
-      "Bash(git checkout:*)",
-      "Bash(git fetch:*)"
-    ]
-  }
-}


### PR DESCRIPTION
When the gateway starts up, it writes out some diagnostics.
To debug deployment issues, including the version id of nanobot here.