### PR TITLE
feat(api): add lean unix-socket json-rpc channel

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -151,6 +151,113 @@ class AgentLoop:
         finally:
             self._mcp_connecting = False
 
+    def _resolve_api_exposed_tools(self, allowed_tools: set[str] | None = None) -> set[str]:
+        """Expand API exposure entries into concrete tool names.
+
+        Supports:
+        - exact tool names, e.g. ``exec`` or ``mcp_home assistant_GetLiveContext``
+        - MCP server scopes, e.g. ``mcp:home assistant`` to expose every
+          ``mcp_home assistant_*`` tool from that server
+        """
+        specs = {
+            str(item).strip()
+            for item in (allowed_tools or set())
+            if str(item).strip()
+        }
+        if not specs:
+            return set()
+
+        resolved = {spec for spec in specs if not spec.startswith("mcp:")}
+        prefixes = []
+        for spec in specs:
+            if not spec.startswith("mcp:"):
+                continue
+            server_name = spec[4:].strip()
+            if not server_name:
+                continue
+            prefixes.append(f"mcp_{server_name}_")
+
+        if prefixes:
+            for tool_name in self.tools.tool_names:
+                if any(tool_name.startswith(prefix) for prefix in prefixes):
+                    resolved.add(tool_name)
+
+        return resolved
+
+    async def list_api_tools(self, allowed_tools: set[str] | None = None) -> list[dict[str, Any]]:
+        """Return tools explicitly exposed through the API channel."""
+        requested = {str(item).strip() for item in (allowed_tools or set()) if str(item).strip()}
+        if not requested:
+            return []
+        if any(spec.startswith("mcp_") or spec.startswith("mcp:") for spec in requested):
+            await self._connect_mcp()
+        allowed = self._resolve_api_exposed_tools(requested)
+        if not allowed:
+            return []
+
+        tools: list[dict[str, Any]] = []
+        for name in sorted(allowed):
+            tool = self.tools.get(name)
+            if tool is None:
+                continue
+            tools.append(
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                }
+            )
+        return tools
+
+    async def call_api_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        allowed_tools: set[str] | None = None,
+    ) -> dict[str, Any]:
+        """Execute one tool explicitly exposed through the API channel."""
+        tool_name = str(name or "").strip()
+        if not tool_name:
+            raise ValueError("tool name is required")
+        if not isinstance(arguments, dict):
+            raise ValueError("tool arguments must be an object")
+
+        requested = {str(item).strip() for item in (allowed_tools or set()) if str(item).strip()}
+        if any(spec.startswith("mcp_") or spec.startswith("mcp:") for spec in requested):
+            await self._connect_mcp()
+        allowed = self._resolve_api_exposed_tools(requested)
+        if allowed and tool_name not in allowed:
+            raise LookupError(f"tool not exposed: {tool_name}")
+        if tool_name.startswith("mcp_"):
+            await self._connect_mcp()
+
+        tool = self.tools.get(tool_name)
+        if tool is None:
+            raise LookupError(f"tool not found: {tool_name}")
+
+        errors = tool.validate_params(arguments)
+        if errors:
+            raise ValueError("; ".join(errors))
+
+        result = await tool.execute(**arguments)
+        content = result if isinstance(result, str) else str(result)
+
+        parsed: Any = None
+        is_json = False
+        if content:
+            try:
+                parsed = json.loads(content)
+                is_json = True
+            except json.JSONDecodeError:
+                parsed = None
+
+        return {
+            "tool_name": tool_name,
+            "content": content,
+            "parsed": parsed,
+            "is_json": is_json,
+        }
+
     def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
         """Update context for all tools that need routing info."""
         for name in ("message", "spawn", "cron"):

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -44,6 +44,7 @@ class ExecTool(Tool):
 
     _MAX_TIMEOUT = 600
     _MAX_OUTPUT = 10_000
+    _MAX_OUTPUT_HARD_LIMIT = 500_000
 
     @property
     def description(self) -> str:
@@ -71,13 +72,22 @@ class ExecTool(Tool):
                     "minimum": 1,
                     "maximum": 600,
                 },
+                "max_output_chars": {
+                    "type": "integer",
+                    "description": (
+                        "Maximum number of output characters to return before truncation "
+                        f"(default {self._MAX_OUTPUT}, max {self._MAX_OUTPUT_HARD_LIMIT})."
+                    ),
+                    "minimum": 1,
+                    "maximum": self._MAX_OUTPUT_HARD_LIMIT,
+                },
             },
             "required": ["command"],
         }
 
     async def execute(
         self, command: str, working_dir: str | None = None,
-        timeout: int | None = None, **kwargs: Any,
+        timeout: int | None = None, max_output_chars: int | None = None, **kwargs: Any,
     ) -> str:
         cwd = working_dir or self.working_dir or os.getcwd()
         guard_error = self._guard_command(command, cwd)
@@ -85,6 +95,9 @@ class ExecTool(Tool):
             return guard_error
 
         effective_timeout = min(timeout or self.timeout, self._MAX_TIMEOUT)
+        effective_max_output = self._MAX_OUTPUT
+        if isinstance(max_output_chars, int) and max_output_chars > 0:
+            effective_max_output = min(max_output_chars, self._MAX_OUTPUT_HARD_LIMIT)
 
         env = os.environ.copy()
         if self.path_append:
@@ -127,7 +140,7 @@ class ExecTool(Tool):
             result = "\n".join(output_parts) if output_parts else "(no output)"
 
             # Head + tail truncation to preserve both start and end of output
-            max_len = self._MAX_OUTPUT
+            max_len = effective_max_output
             if len(result) > max_len:
                 half = max_len // 2
                 result = (

--- a/nanobot/channels/api.py
+++ b/nanobot/channels/api.py
@@ -1,0 +1,369 @@
+"""Unix-socket JSON-RPC API channel for external clients."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from loguru import logger
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+
+_JSONRPC_VERSION = "2.0"
+_RPC_PARSE_ERROR = -32700
+_RPC_INVALID_REQUEST = -32600
+_RPC_METHOD_NOT_FOUND = -32601
+_RPC_INVALID_PARAMS = -32602
+_RPC_INTERNAL_ERROR = -32603
+_RPC_APPLICATION_ERROR = -32000
+
+
+class _RpcError(Exception):
+    """JSON-RPC application error."""
+
+    def __init__(self, code: int, message: str, data: Any | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+def _default_socket_path() -> str:
+    return str(Path.home() / ".nanobot" / "api.sock")
+
+
+def _encode(payload: dict[str, Any]) -> bytes:
+    return (json.dumps(payload, ensure_ascii=False) + "\n").encode()
+
+
+def _jsonrpc_notification(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "jsonrpc": _JSONRPC_VERSION,
+        "method": method,
+    }
+    if params is not None:
+        payload["params"] = params
+    return payload
+
+
+def _jsonrpc_success(request_id: Any, result: Any) -> dict[str, Any]:
+    return {
+        "jsonrpc": _JSONRPC_VERSION,
+        "id": request_id,
+        "result": result,
+    }
+
+
+def _jsonrpc_error(
+    request_id: Any,
+    code: int,
+    message: str,
+    data: Any | None = None,
+) -> dict[str, Any]:
+    error: dict[str, Any] = {
+        "code": code,
+        "message": message,
+    }
+    if data is not None:
+        error["data"] = data
+    return {
+        "jsonrpc": _JSONRPC_VERSION,
+        "id": request_id,
+        "error": error,
+    }
+
+
+class _ClientConnection:
+    """Represents one connected API client."""
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        channel: "ApiChannel",
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._channel = channel
+        self._send_lock = asyncio.Lock()
+        self.chat_id = "api"
+
+    async def send(self, payload: dict[str, Any]) -> None:
+        async with self._send_lock:
+            try:
+                self._writer.write(_encode(payload))
+                await self._writer.drain()
+            except (ConnectionResetError, BrokenPipeError, OSError):
+                pass
+
+    async def send_notification(self, method: str, params: dict[str, Any] | None = None) -> None:
+        await self.send(_jsonrpc_notification(method, params))
+
+    async def send_result(self, request_id: Any, result: Any) -> None:
+        await self.send(_jsonrpc_success(request_id, result))
+
+    async def send_error(
+        self,
+        request_id: Any,
+        code: int,
+        message: str,
+        data: Any | None = None,
+    ) -> None:
+        await self.send(_jsonrpc_error(request_id, code, message, data))
+
+    async def run(self) -> None:
+        peer = self._writer.get_extra_info("peername") or "unix"
+        logger.info("API channel: client connected ({})", peer)
+        try:
+            while True:
+                try:
+                    line = await self._reader.readline()
+                except (ConnectionResetError, OSError):
+                    break
+                if not line:
+                    break
+                await self._handle_line(line)
+        finally:
+            self._channel._remove_client(self)
+            with contextlib.suppress(Exception):
+                self._writer.close()
+                await self._writer.wait_closed()
+            logger.info("API channel: client disconnected ({})", peer)
+
+    async def _handle_line(self, line: bytes) -> None:
+        raw = line.decode(errors="replace").strip()
+        if not raw:
+            return
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            await self.send_error(None, _RPC_PARSE_ERROR, f"JSON parse error: {exc}")
+            return
+
+        if not isinstance(payload, dict):
+            await self.send_error(None, _RPC_INVALID_REQUEST, "request must be a JSON object")
+            return
+
+        request_id = payload.get("id")
+        has_response = "id" in payload
+        if payload.get("jsonrpc") != _JSONRPC_VERSION:
+            if has_response:
+                await self.send_error(request_id, _RPC_INVALID_REQUEST, "jsonrpc must be '2.0'")
+            return
+
+        method = payload.get("method")
+        if not isinstance(method, str) or not method.strip():
+            if has_response:
+                await self.send_error(request_id, _RPC_INVALID_REQUEST, "method must be a string")
+            return
+
+        params = payload.get("params", {})
+        if params is None:
+            params = {}
+        if not isinstance(params, dict):
+            if has_response:
+                await self.send_error(request_id, _RPC_INVALID_PARAMS, "params must be an object")
+            return
+
+        try:
+            result = await self._dispatch_method(method.strip(), params)
+        except _RpcError as exc:
+            if has_response:
+                await self.send_error(request_id, exc.code, exc.message, exc.data)
+            return
+        except Exception:
+            logger.exception("API channel request failed: {}", method)
+            if has_response:
+                await self.send_error(request_id, _RPC_INTERNAL_ERROR, "internal error")
+            return
+
+        if has_response:
+            await self.send_result(request_id, result if result is not None else {"status": "ok"})
+
+    async def _dispatch_method(self, method: str, params: dict[str, Any]) -> dict[str, Any] | None:
+        if method == "ping":
+            return {"pong": True}
+
+        if method == "message.send":
+            content = str(params.get("content", "")).strip()
+            if not content:
+                raise _RpcError(_RPC_INVALID_PARAMS, "content is required")
+            chat_id = str(params.get("chat_id", self.chat_id)).strip() or "api"
+            sender_id = str(params.get("sender_id", "user")).strip() or "user"
+            media = params.get("media", [])
+            metadata = params.get("metadata", {})
+            self.chat_id = chat_id
+            await self._channel.publish_message(
+                chat_id=chat_id,
+                sender_id=sender_id,
+                content=content,
+                media=media,
+                metadata=metadata,
+            )
+            return {"status": "accepted"}
+
+        if method == "command.execute":
+            command = str(params.get("command", "")).strip().lower()
+            chat_id = str(params.get("chat_id", self.chat_id)).strip() or "api"
+            sender_id = str(params.get("sender_id", "user")).strip() or "user"
+            self.chat_id = chat_id
+            if command != "reset":
+                raise _RpcError(_RPC_INVALID_PARAMS, f"unknown command: {command!r}")
+            await self._channel.publish_command(
+                chat_id=chat_id,
+                sender_id=sender_id,
+                command=command,
+            )
+            return {"status": "accepted"}
+
+        if method == "tool.list":
+            lister = self._channel._tool_lister
+            if lister is None:
+                return {"tools": []}
+            return {"tools": await lister()}
+
+        if method == "tool.call":
+            caller = self._channel._tool_caller
+            if caller is None:
+                raise _RpcError(_RPC_APPLICATION_ERROR, "tool runtime is unavailable")
+
+            tool_name = str(params.get("name", "")).strip()
+            if not tool_name:
+                raise _RpcError(_RPC_INVALID_PARAMS, "name is required")
+
+            arguments = params.get("arguments", {})
+            if arguments is None:
+                arguments = {}
+            if not isinstance(arguments, dict):
+                raise _RpcError(_RPC_INVALID_PARAMS, "arguments must be an object")
+
+            try:
+                return await caller(tool_name, arguments)
+            except LookupError as exc:
+                raise _RpcError(_RPC_INVALID_PARAMS, str(exc)) from exc
+            except ValueError as exc:
+                raise _RpcError(_RPC_INVALID_PARAMS, str(exc)) from exc
+            except RuntimeError as exc:
+                raise _RpcError(_RPC_APPLICATION_ERROR, str(exc)) from exc
+
+        raise _RpcError(_RPC_METHOD_NOT_FOUND, f"unknown method: {method!r}")
+
+
+class ApiChannel(BaseChannel):
+    """Unix-socket JSON-RPC channel for local external clients."""
+
+    name = "api"
+
+    def __init__(self, config: Any, bus: MessageBus) -> None:
+        super().__init__(config, bus)
+        raw_path = getattr(config, "socket_path", None) or _default_socket_path()
+        self._socket_path = str(Path(raw_path).expanduser())
+        self._clients: dict[int, _ClientConnection] = {}
+        self._server: asyncio.AbstractServer | None = None
+        self._tool_lister: Callable[[], Awaitable[list[dict[str, Any]]]] | None = None
+        self._tool_caller: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]] | None = None
+
+    def set_tool_runtime(
+        self,
+        *,
+        list_tools: Callable[[], Awaitable[list[dict[str, Any]]]],
+        call_tool: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]],
+    ) -> None:
+        self._tool_lister = list_tools
+        self._tool_caller = call_tool
+
+    async def start(self) -> None:
+        path = Path(self._socket_path)
+        path.unlink(missing_ok=True)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._server = await asyncio.start_unix_server(self._on_client_connected, path=str(path))
+        self._running = True
+        logger.info("API channel listening on {}", path)
+        async with self._server:
+            await self._server.serve_forever()
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._server:
+            self._server.close()
+            with contextlib.suppress(Exception):
+                await self._server.wait_closed()
+            self._server = None
+
+        for conn in list(self._clients.values()):
+            with contextlib.suppress(Exception):
+                conn._writer.close()
+                await conn._writer.wait_closed()
+        self._clients.clear()
+
+        with contextlib.suppress(FileNotFoundError):
+            Path(self._socket_path).unlink()
+
+    async def send(self, msg: OutboundMessage) -> None:
+        payload = {
+            "content": msg.content,
+            "chat_id": msg.chat_id,
+            "is_progress": bool(msg.metadata.get("_progress")),
+            "is_tool_hint": bool(msg.metadata.get("_tool_hint")),
+        }
+        targets = self._target_clients(msg.chat_id)
+        await asyncio.gather(
+            *(conn.send_notification("message", payload) for conn in targets),
+            return_exceptions=True,
+        )
+
+    async def publish_message(
+        self,
+        *,
+        chat_id: str,
+        sender_id: str,
+        content: str,
+        media: Any = None,
+        metadata: Any = None,
+    ) -> None:
+        if not self.is_allowed(sender_id):
+            raise _RpcError(_RPC_APPLICATION_ERROR, f"sender not allowed: {sender_id}")
+        inbound = InboundMessage(
+            channel=self.name,
+            sender_id=sender_id,
+            chat_id=chat_id,
+            content=content,
+            media=list(media) if isinstance(media, list) else [],
+            metadata=dict(metadata) if isinstance(metadata, dict) else {},
+        )
+        await self.bus.publish_inbound(inbound)
+
+    async def publish_command(self, *, chat_id: str, sender_id: str, command: str) -> None:
+        if not self.is_allowed(sender_id):
+            raise _RpcError(_RPC_APPLICATION_ERROR, f"sender not allowed: {sender_id}")
+        if command != "reset":
+            raise _RpcError(_RPC_INVALID_PARAMS, f"unknown command: {command!r}")
+        inbound = InboundMessage(
+            channel=self.name,
+            sender_id=sender_id,
+            chat_id=chat_id,
+            content="/new",
+        )
+        await self.bus.publish_inbound(inbound)
+
+    async def _on_client_connected(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        conn = _ClientConnection(reader, writer, self)
+        self._clients[id(conn)] = conn
+        await conn.run()
+
+    def _remove_client(self, conn: _ClientConnection) -> None:
+        self._clients.pop(id(conn), None)
+
+    def _target_clients(self, chat_id: str) -> list[_ClientConnection]:
+        matching = [conn for conn in self._clients.values() if conn.chat_id == chat_id]
+        return matching if matching else list(self._clients.values())

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -27,6 +27,7 @@ class ChannelManager:
         self.bus = bus
         self.channels: dict[str, BaseChannel] = {}
         self._dispatch_task: asyncio.Task | None = None
+        self._api_channel: "ApiChannel | None" = None
 
         self._init_channels()
 
@@ -54,6 +55,15 @@ class ChannelManager:
                 logger.info("{} channel enabled", cls.display_name)
             except Exception as e:
                 logger.warning("{} channel not available: {}", name, e)
+
+        # API channel
+        if self.config.channels.api.enabled:
+            from nanobot.channels.api import ApiChannel
+
+            api_channel = ApiChannel(self.config.channels.api, self.bus)
+            self.channels["api"] = api_channel
+            self._api_channel = api_channel
+            logger.info("API channel enabled ({})", api_channel._socket_path)
 
         self._validate_allow_from()
 
@@ -140,6 +150,10 @@ class ChannelManager:
                 continue
             except asyncio.CancelledError:
                 break
+
+    @property
+    def api_channel(self):
+        return self._api_channel
 
     def get_channel(self, name: str) -> BaseChannel | None:
         """Get a channel by name."""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -444,6 +444,15 @@ def gateway(
     )
 
     # Set cron callback (needs agent)
+    channels = ChannelManager(config, bus)
+
+    if channels.api_channel is not None:
+        exposed_tools = set(config.channels.api.exposed_tools)
+        channels.api_channel.set_tool_runtime(
+            list_tools=lambda: agent.list_api_tools(exposed_tools),
+            call_tool=lambda name, arguments: agent.call_api_tool(name, arguments, exposed_tools),
+        )
+
     async def on_cron_job(job: CronJob) -> str | None:
         """Execute a cron job through the agent."""
         from nanobot.agent.tools.cron import CronTool
@@ -488,9 +497,6 @@ def gateway(
                 ))
         return response
     cron.on_job = on_cron_job
-
-    # Create channel manager
-    channels = ChannelManager(config, bus)
 
     def _pick_heartbeat_target() -> tuple[str, str]:
         """Pick a routable channel/chat target for heartbeat-triggered messages."""

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -14,6 +14,15 @@ class Base(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
+class ApiChannelConfig(Base):
+    """Unix-socket API channel configuration."""
+
+    enabled: bool = False
+    socket_path: str = ""
+    allow_from: list[str] = Field(default_factory=lambda: ["*"])
+    exposed_tools: list[str] = Field(default_factory=list)
+
+
 class ChannelsConfig(Base):
     """Configuration for chat channels.
 
@@ -25,6 +34,7 @@ class ChannelsConfig(Base):
 
     send_progress: bool = True  # stream agent's text progress to the channel
     send_tool_hints: bool = False  # stream tool-call hints (e.g. read_file("…"))
+    api: ApiChannelConfig = Field(default_factory=ApiChannelConfig)
 
 
 class AgentDefaults(Base):

--- a/tests/test_api_channel.py
+++ b/tests/test_api_channel.py
@@ -1,0 +1,120 @@
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.api import ApiChannel, _ClientConnection
+from nanobot.config.schema import ApiChannelConfig
+
+
+class _DummyWriter:
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def get_extra_info(self, _name: str):
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+def _make_connection(channel: ApiChannel) -> _ClientConnection:
+    return _ClientConnection(reader=None, writer=_DummyWriter(), channel=channel)
+
+
+@pytest.mark.asyncio
+async def test_message_send_publishes_inbound_message() -> None:
+    bus = MessageBus()
+    channel = ApiChannel(ApiChannelConfig(enabled=True), bus)
+    conn = _make_connection(channel)
+
+    result = await conn._dispatch_method(
+        "message.send",
+        {"content": "hello", "chat_id": "web", "sender_id": "tester"},
+    )
+
+    inbound = await bus.consume_inbound()
+    assert result == {"status": "accepted"}
+    assert inbound.channel == "api"
+    assert inbound.chat_id == "web"
+    assert inbound.sender_id == "tester"
+    assert inbound.content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_command_execute_reset_publishes_new_session_command() -> None:
+    bus = MessageBus()
+    channel = ApiChannel(ApiChannelConfig(enabled=True), bus)
+    conn = _make_connection(channel)
+
+    result = await conn._dispatch_method(
+        "command.execute",
+        {"command": "reset", "chat_id": "web", "sender_id": "tester"},
+    )
+
+    inbound = await bus.consume_inbound()
+    assert result == {"status": "accepted"}
+    assert inbound.content == "/new"
+    assert inbound.chat_id == "web"
+    assert inbound.sender_id == "tester"
+
+
+@pytest.mark.asyncio
+async def test_tool_methods_use_registered_runtime() -> None:
+    bus = MessageBus()
+    channel = ApiChannel(ApiChannelConfig(enabled=True), bus)
+    conn = _make_connection(channel)
+
+    async def list_tools():
+        return [{"name": "sample", "description": "sample tool", "parameters": {}}]
+
+    async def call_tool(name: str, arguments: dict[str, object]):
+        return {
+            "tool_name": name,
+            "content": "{}",
+            "parsed": arguments,
+            "is_json": True,
+        }
+
+    channel.set_tool_runtime(list_tools=list_tools, call_tool=call_tool)
+
+    listed = await conn._dispatch_method("tool.list", {})
+    called = await conn._dispatch_method("tool.call", {"name": "sample", "arguments": {"x": 1}})
+
+    assert listed == {"tools": [{"name": "sample", "description": "sample tool", "parameters": {}}]}
+    assert called == {
+        "tool_name": "sample",
+        "content": "{}",
+        "parsed": {"x": 1},
+        "is_json": True,
+    }
+
+
+def test_resolve_api_exposed_tools_supports_mcp_server_scope() -> None:
+    loop = AgentLoop.__new__(AgentLoop)
+
+    class _Registry:
+        tool_names = [
+            "exec",
+            "mcp_home assistant_GetLiveContext",
+            "mcp_home assistant_HassTurnOn",
+            "mcp_foundry dnd_status",
+        ]
+
+    loop.tools = _Registry()
+
+    resolved = loop._resolve_api_exposed_tools({"exec", "mcp:home assistant"})
+
+    assert resolved == {
+        "exec",
+        "mcp_home assistant_GetLiveContext",
+        "mcp_home assistant_HassTurnOn",
+    }

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -382,13 +382,27 @@ async def test_exec_head_tail_truncation() -> None:
     # Generate output that exceeds _MAX_OUTPUT (10_000 chars)
     # Use python to generate output to avoid command line length limits
     result = await tool.execute(
-        command="python -c \"print('A' * 6000 + '\\n' + 'B' * 6000)\""
+        command="python3 -c \"print('A' * 6000 + '\\n' + 'B' * 6000)\""
     )
     assert "chars truncated" in result
     # Head portion should start with As
     assert result.startswith("A")
     # Tail portion should end with the exit code which comes after Bs
     assert "Exit code:" in result
+
+
+async def test_exec_respects_max_output_chars_override() -> None:
+    """Caller-supplied max_output_chars should override the default truncation limit."""
+    tool = ExecTool()
+    command = "python3 -c \"print('A' * 12000)\""
+
+    truncated = await tool.execute(command=command)
+    assert "chars truncated" in truncated
+
+    full = await tool.execute(command=command, max_output_chars=20000)
+    assert "chars truncated" not in full
+    assert "Exit code: 0" in full
+    assert "A" * 12000 in full
 
 
 async def test_exec_timeout_parameter() -> None:


### PR DESCRIPTION
This pull request introduces a new local JSON-RPC API channel for external clients, enabling programmatic access to the agent's messaging and tool interfaces via a Unix socket. The changes include the implementation of the API channel, configuration updates to support it, integration with the agent and channel manager, and comprehensive tests. The most important changes are grouped below.

**API Channel Implementation:**

* Added `ApiChannel` in `nanobot/channels/api.py`, providing a Unix-socket JSON-RPC server that allows external clients to send messages, execute commands, and interact with tools. The channel supports methods for sending messages, executing commands, listing tools, and calling tools, with robust error handling and JSON-RPC compliance.

**Agent Integration and Tool Exposure:**

* Added methods to `AgentLoop` (`_resolve_api_exposed_tools`, `list_api_tools`, `call_api_tool`) to support controlled tool exposure and invocation from the API channel, including support for server-scoped tool exposure (e.g., `mcp:home assistant`).
* Updated the CLI gateway command to initialize the API channel, wiring up agent tool listing and invocation according to the configured exposed tools. [[1]](diffhunk://#diff-39b2eb0f7fc50c39153fb55c8cd261769ecbb4f233ca8e8f9f5ea57dbcf70a57R447-R455) [[2]](diffhunk://#diff-39b2eb0f7fc50c39153fb55c8cd261769ecbb4f233ca8e8f9f5ea57dbcf70a57L492-L494)

**Channel Manager and Configuration:**

* Introduced `ApiChannelConfig` to the configuration schema, enabling/disabling the API channel, specifying socket path, allowed clients, and exposed tools. [[1]](diffhunk://#diff-efb49dd5c06433d760183227c9f24fde37bb8373891a9d8e4e62e200eb16501bR17-R25) [[2]](diffhunk://#diff-efb49dd5c06433d760183227c9f24fde37bb8373891a9d8e4e62e200eb16501bR37)
* Modified `ChannelManager` to support the new API channel, including initialization, property access, and logging. [[1]](diffhunk://#diff-ad0f1a75ef345ac5ec932d2599eb525f96c58e9c2b1d5278c2280b56d6841c97R30) [[2]](diffhunk://#diff-ad0f1a75ef345ac5ec932d2599eb525f96c58e9c2b1d5278c2280b56d6841c97R59-R67) [[3]](diffhunk://#diff-ad0f1a75ef345ac5ec932d2599eb525f96c58e9c2b1d5278c2280b56d6841c97R154-R157)

**Testing:**

* Added `tests/test_api_channel.py` with tests for message sending, command execution, tool listing, tool calling, and tool exposure resolution, ensuring the API channel and agent integration work as intended.