### PR TITLE
feat(web): add Gemini fallback for web search

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -25,23 +25,23 @@ MAX_REDIRECTS = 5  # Limit redirects to prevent DoS attacks
 
 def _strip_tags(text: str) -> str:
     """Remove HTML tags and decode entities."""
-    text = re.sub(r'<script[\s\S]*?</script>', '', text, flags=re.I)
-    text = re.sub(r'<style[\s\S]*?</style>', '', text, flags=re.I)
-    text = re.sub(r'<[^>]+>', '', text)
+    text = re.sub(r"<script[\s\S]*?</script>", "", text, flags=re.I)
+    text = re.sub(r"<style[\s\S]*?</style>", "", text, flags=re.I)
+    text = re.sub(r"<[^>]+>", "", text)
     return html.unescape(text).strip()
 
 
 def _normalize(text: str) -> str:
     """Normalize whitespace."""
-    text = re.sub(r'[ \t]+', ' ', text)
-    return re.sub(r'\n{3,}', '\n\n', text).strip()
+    text = re.sub(r"[ \t]+", " ", text)
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
 
 
 def _validate_url(url: str) -> tuple[bool, str]:
     """Validate URL: must be http(s) with valid domain."""
     try:
         p = urlparse(url)
-        if p.scheme not in ('http', 'https'):
+        if p.scheme not in ("http", "https"):
             return False, f"Only http/https allowed, got '{p.scheme or 'none'}'"
         if not p.netloc:
             return False, "Missing domain"
@@ -73,7 +73,12 @@ class WebSearchTool(Tool):
         "type": "object",
         "properties": {
             "query": {"type": "string", "description": "Search query"},
-            "count": {"type": "integer", "description": "Results (1-10)", "minimum": 1, "maximum": 10},
+            "count": {
+                "type": "integer",
+                "description": "Results (1-10)",
+                "minimum": 1,
+                "maximum": 10,
+            },
         },
         "required": ["query"],
     }
@@ -104,8 +109,8 @@ class WebSearchTool(Tool):
     async def _search_brave(self, query: str, n: int) -> str:
         api_key = self.config.api_key or os.environ.get("BRAVE_API_KEY", "")
         if not api_key:
-            logger.warning("BRAVE_API_KEY not set, falling back to DuckDuckGo")
-            return await self._search_duckduckgo(query, n)
+            logger.warning("BRAVE_API_KEY not set, trying fallback chain (Gemini → DuckDuckGo)")
+            return await self._fallback_chain(query, n)
         try:
             async with httpx.AsyncClient(proxy=self.proxy) as client:
                 r = await client.get(
@@ -116,7 +121,11 @@ class WebSearchTool(Tool):
                 )
                 r.raise_for_status()
             items = [
-                {"title": x.get("title", ""), "url": x.get("url", ""), "content": x.get("description", "")}
+                {
+                    "title": x.get("title", ""),
+                    "url": x.get("url", ""),
+                    "content": x.get("description", ""),
+                }
                 for x in r.json().get("web", {}).get("results", [])
             ]
             return _format_results(query, items, n)
@@ -126,8 +135,8 @@ class WebSearchTool(Tool):
     async def _search_tavily(self, query: str, n: int) -> str:
         api_key = self.config.api_key or os.environ.get("TAVILY_API_KEY", "")
         if not api_key:
-            logger.warning("TAVILY_API_KEY not set, falling back to DuckDuckGo")
-            return await self._search_duckduckgo(query, n)
+            logger.warning("TAVILY_API_KEY not set, trying fallback chain (Gemini → DuckDuckGo)")
+            return await self._fallback_chain(query, n)
         try:
             async with httpx.AsyncClient(proxy=self.proxy) as client:
                 r = await client.post(
@@ -144,8 +153,8 @@ class WebSearchTool(Tool):
     async def _search_searxng(self, query: str, n: int) -> str:
         base_url = (self.config.base_url or os.environ.get("SEARXNG_BASE_URL", "")).strip()
         if not base_url:
-            logger.warning("SEARXNG_BASE_URL not set, falling back to DuckDuckGo")
-            return await self._search_duckduckgo(query, n)
+            logger.warning("SEARXNG_BASE_URL not set, trying fallback chain (Gemini → DuckDuckGo)")
+            return await self._fallback_chain(query, n)
         endpoint = f"{base_url.rstrip('/')}/search"
         is_valid, error_msg = _validate_url(endpoint)
         if not is_valid:
@@ -166,8 +175,8 @@ class WebSearchTool(Tool):
     async def _search_jina(self, query: str, n: int) -> str:
         api_key = self.config.api_key or os.environ.get("JINA_API_KEY", "")
         if not api_key:
-            logger.warning("JINA_API_KEY not set, falling back to DuckDuckGo")
-            return await self._search_duckduckgo(query, n)
+            logger.warning("JINA_API_KEY not set, trying fallback chain (Gemini → DuckDuckGo)")
+            return await self._fallback_chain(query, n)
         try:
             headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
             async with httpx.AsyncClient(proxy=self.proxy) as client:
@@ -180,12 +189,64 @@ class WebSearchTool(Tool):
                 r.raise_for_status()
             data = r.json().get("data", [])[:n]
             items = [
-                {"title": d.get("title", ""), "url": d.get("url", ""), "content": d.get("content", "")[:500]}
+                {
+                    "title": d.get("title", ""),
+                    "url": d.get("url", ""),
+                    "content": d.get("content", "")[:500],
+                }
                 for d in data
             ]
             return _format_results(query, items, n)
         except Exception as e:
             return f"Error: {e}"
+
+    async def _search_gemini(self, query: str, n: int) -> str:
+        """Search using Gemini with Google Search grounding (fallback when no API key for primary provider)."""
+        api_key = self.config.gemini_api_key or os.environ.get("GEMINI_API_KEY", "")
+        if not api_key:
+            return ""  # No key configured, signal to try next fallback
+
+        try:
+            from litellm import acompletion
+
+            model = self.config.gemini_model
+            if not model.startswith("gemini/"):
+                model = f"gemini/{model}"
+
+            response = await acompletion(
+                model=model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"Search the web for: {query}. List the top {n} search results with titles, URLs, and brief summaries (1-2 sentences each). Format as a numbered list.",
+                    }
+                ],
+                tools=[{"google_search": {}}],
+                api_key=api_key,
+            )
+
+            content = response.choices[0].message.content or ""
+
+            # Try to extract grounding metadata for better formatting
+            choice = response.choices[0]
+            if hasattr(choice, "grounding_metadata") and choice.grounding_metadata:
+                gm = choice.grounding_metadata
+                queries = getattr(gm, "web_search_queries", [])
+                if queries:
+                    content = f"(Google Search queries: {', '.join(queries)})\n\n{content}"
+
+            return content if content.strip() else ""
+        except Exception as e:
+            logger.warning("Gemini search fallback failed: {}", e)
+            return ""  # Signal to try next fallback
+
+    async def _fallback_chain(self, query: str, n: int) -> str:
+        """Try Gemini fallback, then DuckDuckGo."""
+        if self.config.gemini_fallback:
+            result = await self._search_gemini(query, n)
+            if result:
+                return result
+        return await self._search_duckduckgo(query, n)
 
     async def _search_duckduckgo(self, query: str, n: int) -> str:
         try:
@@ -196,7 +257,11 @@ class WebSearchTool(Tool):
             if not raw:
                 return f"No results for: {query}"
             items = [
-                {"title": r.get("title", ""), "url": r.get("href", ""), "content": r.get("body", "")}
+                {
+                    "title": r.get("title", ""),
+                    "url": r.get("href", ""),
+                    "content": r.get("body", ""),
+                }
                 for r in raw
             ]
             return _format_results(query, items, n)
@@ -224,11 +289,15 @@ class WebFetchTool(Tool):
         self.max_chars = max_chars
         self.proxy = proxy
 
-    async def execute(self, url: str, extractMode: str = "markdown", maxChars: int | None = None, **kwargs: Any) -> str:
+    async def execute(
+        self, url: str, extractMode: str = "markdown", maxChars: int | None = None, **kwargs: Any
+    ) -> str:
         max_chars = maxChars or self.max_chars
         is_valid, error_msg = _validate_url(url)
         if not is_valid:
-            return json.dumps({"error": f"URL validation failed: {error_msg}", "url": url}, ensure_ascii=False)
+            return json.dumps(
+                {"error": f"URL validation failed: {error_msg}", "url": url}, ensure_ascii=False
+            )
 
         result = await self._fetch_jina(url, max_chars)
         if result is None:
@@ -261,10 +330,18 @@ class WebFetchTool(Tool):
             if truncated:
                 text = text[:max_chars]
 
-            return json.dumps({
-                "url": url, "finalUrl": data.get("url", url), "status": r.status_code,
-                "extractor": "jina", "truncated": truncated, "length": len(text), "text": text,
-            }, ensure_ascii=False)
+            return json.dumps(
+                {
+                    "url": url,
+                    "finalUrl": data.get("url", url),
+                    "status": r.status_code,
+                    "extractor": "jina",
+                    "truncated": truncated,
+                    "length": len(text),
+                    "text": text,
+                },
+                ensure_ascii=False,
+            )
         except Exception as e:
             logger.debug("Jina Reader failed for {}, falling back to readability: {}", url, e)
             return None
@@ -289,7 +366,11 @@ class WebFetchTool(Tool):
                 text, extractor = json.dumps(r.json(), indent=2, ensure_ascii=False), "json"
             elif "text/html" in ctype or r.text[:256].lower().startswith(("<!doctype", "<html")):
                 doc = Document(r.text)
-                content = self._to_markdown(doc.summary()) if extract_mode == "markdown" else _strip_tags(doc.summary())
+                content = (
+                    self._to_markdown(doc.summary())
+                    if extract_mode == "markdown"
+                    else _strip_tags(doc.summary())
+                )
                 text = f"# {doc.title()}\n\n{content}" if doc.title() else content
                 extractor = "readability"
             else:
@@ -299,10 +380,18 @@ class WebFetchTool(Tool):
             if truncated:
                 text = text[:max_chars]
 
-            return json.dumps({
-                "url": url, "finalUrl": str(r.url), "status": r.status_code,
-                "extractor": extractor, "truncated": truncated, "length": len(text), "text": text,
-            }, ensure_ascii=False)
+            return json.dumps(
+                {
+                    "url": url,
+                    "finalUrl": str(r.url),
+                    "status": r.status_code,
+                    "extractor": extractor,
+                    "truncated": truncated,
+                    "length": len(text),
+                    "text": text,
+                },
+                ensure_ascii=False,
+            )
         except httpx.ProxyError as e:
             logger.error("WebFetch proxy error for {}: {}", url, e)
             return json.dumps({"error": f"Proxy error: {e}", "url": url}, ensure_ascii=False)
@@ -312,11 +401,21 @@ class WebFetchTool(Tool):
 
     def _to_markdown(self, html_content: str) -> str:
         """Convert HTML to markdown."""
-        text = re.sub(r'<a\s+[^>]*href=["\']([^"\']+)["\'][^>]*>([\s\S]*?)</a>',
-                      lambda m: f'[{_strip_tags(m[2])}]({m[1]})', html_content, flags=re.I)
-        text = re.sub(r'<h([1-6])[^>]*>([\s\S]*?)</h\1>',
-                      lambda m: f'\n{"#" * int(m[1])} {_strip_tags(m[2])}\n', text, flags=re.I)
-        text = re.sub(r'<li[^>]*>([\s\S]*?)</li>', lambda m: f'\n- {_strip_tags(m[1])}', text, flags=re.I)
-        text = re.sub(r'</(p|div|section|article)>', '\n\n', text, flags=re.I)
-        text = re.sub(r'<(br|hr)\s*/?>', '\n', text, flags=re.I)
+        text = re.sub(
+            r'<a\s+[^>]*href=["\']([^"\']+)["\'][^>]*>([\s\S]*?)</a>',
+            lambda m: f"[{_strip_tags(m[2])}]({m[1]})",
+            html_content,
+            flags=re.I,
+        )
+        text = re.sub(
+            r"<h([1-6])[^>]*>([\s\S]*?)</h\1>",
+            lambda m: f"\n{'#' * int(m[1])} {_strip_tags(m[2])}\n",
+            text,
+            flags=re.I,
+        )
+        text = re.sub(
+            r"<li[^>]*>([\s\S]*?)</li>", lambda m: f"\n- {_strip_tags(m[1])}", text, flags=re.I
+        )
+        text = re.sub(r"</(p|div|section|article)>", "\n\n", text, flags=re.I)
+        text = re.sub(r"<(br|hr)\s*/?>", "\n", text, flags=re.I)
         return _normalize(_strip_tags(text))

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -46,7 +46,9 @@ class AgentDefaults(Base):
     @property
     def should_warn_deprecated_memory_window(self) -> bool:
         """Return True when old memoryWindow is present without contextWindowTokens."""
-        return self.memory_window is not None and "context_window_tokens" not in self.model_fields_set
+        return (
+            self.memory_window is not None and "context_window_tokens" not in self.model_fields_set
+        )
 
 
 class AgentsConfig(Base):
@@ -67,7 +69,9 @@ class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
-    azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
+    azure_openai: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -83,9 +87,15 @@ class ProvidersConfig(Base):
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)
-    volcengine_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine Coding Plan
-    byteplus: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus (VolcEngine international)
-    byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
+    volcengine_coding_plan: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # VolcEngine Coding Plan
+    byteplus: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # BytePlus (VolcEngine international)
+    byteplus_coding_plan: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # BytePlus Coding Plan
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig)  # Github Copilot (OAuth)
 
@@ -112,6 +122,9 @@ class WebSearchConfig(Base):
     api_key: str = ""
     base_url: str = ""  # SearXNG base URL
     max_results: int = 5
+    gemini_fallback: bool = True  # Use Gemini with Google Search grounding as fallback
+    gemini_api_key: str = ""  # Gemini API key (falls back to GEMINI_API_KEY env var)
+    gemini_model: str = "gemini-2.5-flash-lite"  # Gemini model for fallback search
 
 
 class WebToolsConfig(Base):
@@ -140,7 +153,10 @@ class MCPServerConfig(Base):
     url: str = ""  # HTTP/SSE: endpoint URL
     headers: dict[str, str] = Field(default_factory=dict)  # HTTP/SSE: custom headers
     tool_timeout: int = 30  # seconds before a tool call is cancelled
-    enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+    enabled_tools: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+
 
 class ToolsConfig(Base):
     """Tools configuration."""


### PR DESCRIPTION
- Add gemini_fallback, gemini_api_key, gemini_model to WebSearchConfig
- Add _search_gemini method using LiteLLM with Google Search grounding
- Add _fallback_chain method for provider -> Gemini -> DuckDuckGo
- Update all search providers to use fallback chain when API key missing

Fallback order: configured provider -> Gemini (if enabled) -> DuckDuckGo