### PR TITLE
refactor(heartbeat): publish to bus instead of direct process_direct

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -313,7 +313,20 @@ class AgentLoop:
             try:
                 response = await self._process_message(msg)
                 if response is not None:
-                    await self.bus.publish_outbound(response)
+                    # Heartbeat messages: apply post-run evaluation
+                    if msg.metadata.get("_source") == "heartbeat":
+                        from nanobot.utils.evaluator import evaluate_response
+                        task_context = msg.metadata.get("_task_context", msg.content)
+                        should_notify = await evaluate_response(
+                            response.content, task_context, self.provider, self.model,
+                        )
+                        if should_notify:
+                            logger.info("Heartbeat: completed, delivering response")
+                            await self.bus.publish_outbound(response)
+                        else:
+                            logger.info("Heartbeat: silenced by post-run evaluation")
+                    else:
+                        await self.bus.publish_outbound(response)
                 elif msg.channel == "cli":
                     await self.bus.publish_outbound(OutboundMessage(
                         channel=msg.channel, chat_id=msg.chat_id,

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -509,36 +509,13 @@ def gateway(
         return "cli", "direct"
 
     # Create heartbeat service
-    async def on_heartbeat_execute(tasks: str) -> str:
-        """Phase 2: execute heartbeat tasks through the full agent loop."""
-        channel, chat_id = _pick_heartbeat_target()
-
-        async def _silent(*_args, **_kwargs):
-            pass
-
-        return await agent.process_direct(
-            tasks,
-            session_key="heartbeat",
-            channel=channel,
-            chat_id=chat_id,
-            on_progress=_silent,
-        )
-
-    async def on_heartbeat_notify(response: str) -> None:
-        """Deliver a heartbeat response to the user's channel."""
-        from nanobot.bus.events import OutboundMessage
-        channel, chat_id = _pick_heartbeat_target()
-        if channel == "cli":
-            return  # No external channel available to deliver to
-        await bus.publish_outbound(OutboundMessage(channel=channel, chat_id=chat_id, content=response))
-
     hb_cfg = config.gateway.heartbeat
     heartbeat = HeartbeatService(
         workspace=config.workspace_path,
         provider=provider,
         model=agent.model,
-        on_execute=on_heartbeat_execute,
-        on_notify=on_heartbeat_notify,
+        bus=bus,
+        pick_target=_pick_heartbeat_target,
         interval_s=hb_cfg.interval_s,
         enabled=hb_cfg.enabled,
     )

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Coroutine
+from typing import TYPE_CHECKING, Callable
 
 from loguru import logger
+
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
 
 if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
@@ -42,12 +45,11 @@ class HeartbeatService:
     Periodic heartbeat service that wakes the agent to check for tasks.
 
     Phase 1 (decision): reads HEARTBEAT.md and asks the LLM — via a virtual
-    tool call — whether there are active tasks.  This avoids free-text parsing
-    and the unreliable HEARTBEAT_OK token.
+    tool call — whether there are active tasks.
 
-    Phase 2 (execution): only triggered when Phase 1 returns ``run``.  The
-    ``on_execute`` callback runs the task through the full agent loop and
-    returns the result to deliver.
+    Phase 2 (execution): publishes an InboundMessage to the bus with
+    ``_source: "heartbeat"`` metadata. The agent processes it and applies
+    post-run evaluation to decide whether to notify the user.
     """
 
     def __init__(
@@ -55,16 +57,16 @@ class HeartbeatService:
         workspace: Path,
         provider: LLMProvider,
         model: str,
-        on_execute: Callable[[str], Coroutine[Any, Any, str]] | None = None,
-        on_notify: Callable[[str], Coroutine[Any, Any, None]] | None = None,
+        bus: MessageBus,
+        pick_target: Callable[[], tuple[str, str]] | None = None,
         interval_s: int = 30 * 60,
         enabled: bool = True,
     ):
         self.workspace = workspace
         self.provider = provider
         self.model = model
-        self.on_execute = on_execute
-        self.on_notify = on_notify
+        self.bus = bus
+        self.pick_target = pick_target or (lambda: ("cli", "heartbeat"))
         self.interval_s = interval_s
         self.enabled = enabled
         self._running = False
@@ -139,8 +141,6 @@ class HeartbeatService:
 
     async def _tick(self) -> None:
         """Execute a single heartbeat tick."""
-        from nanobot.utils.evaluator import evaluate_response
-
         content = self._read_heartbeat_file()
         if not content:
             logger.debug("Heartbeat: HEARTBEAT.md missing or empty")
@@ -155,28 +155,34 @@ class HeartbeatService:
                 logger.info("Heartbeat: OK (nothing to report)")
                 return
 
-            logger.info("Heartbeat: tasks found, executing...")
-            if self.on_execute:
-                response = await self.on_execute(tasks)
+            channel, chat_id = self.pick_target()
+            logger.info("Heartbeat: tasks found, publishing to bus ({}:{})...", channel, chat_id)
+            msg = InboundMessage(
+                channel=channel,
+                sender_id="heartbeat",
+                chat_id=chat_id,
+                content=tasks,
+                metadata={"_source": "heartbeat", "_task_context": tasks},
+            )
+            await self.bus.publish_inbound(msg)
 
-                if response:
-                    should_notify = await evaluate_response(
-                        response, tasks, self.provider, self.model,
-                    )
-                    if should_notify and self.on_notify:
-                        logger.info("Heartbeat: completed, delivering response")
-                        await self.on_notify(response)
-                    else:
-                        logger.info("Heartbeat: silenced by post-run evaluation")
         except Exception:
             logger.exception("Heartbeat execution failed")
 
-    async def trigger_now(self) -> str | None:
+    async def trigger_now(self) -> None:
         """Manually trigger a heartbeat."""
         content = self._read_heartbeat_file()
         if not content:
-            return None
+            return
         action, tasks = await self._decide(content)
-        if action != "run" or not self.on_execute:
-            return None
-        return await self.on_execute(tasks)
+        if action != "run":
+            return
+        channel, chat_id = self.pick_target()
+        msg = InboundMessage(
+            channel=channel,
+            sender_id="heartbeat",
+            chat_id=chat_id,
+            content=tasks,
+            metadata={"_source": "heartbeat", "_task_context": tasks},
+        )
+        await self.bus.publish_inbound(msg)

--- a/tests/test_heartbeat_service.py
+++ b/tests/test_heartbeat_service.py
@@ -1,7 +1,10 @@
 import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
 from nanobot.heartbeat.service import HeartbeatService
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 
@@ -25,11 +28,13 @@ class DummyProvider(LLMProvider):
 @pytest.mark.asyncio
 async def test_start_is_idempotent(tmp_path) -> None:
     provider = DummyProvider([])
+    bus = MessageBus()
 
     service = HeartbeatService(
         workspace=tmp_path,
         provider=provider,
         model="openai/gpt-4o-mini",
+        bus=bus,
         interval_s=9999,
         enabled=True,
     )
@@ -47,10 +52,12 @@ async def test_start_is_idempotent(tmp_path) -> None:
 @pytest.mark.asyncio
 async def test_decide_returns_skip_when_no_tool_call(tmp_path) -> None:
     provider = DummyProvider([LLMResponse(content="no tool call", tool_calls=[])])
+    bus = MessageBus()
     service = HeartbeatService(
         workspace=tmp_path,
         provider=provider,
         model="openai/gpt-4o-mini",
+        bus=bus,
     )
 
     action, tasks = await service._decide("heartbeat content")
@@ -59,7 +66,8 @@ async def test_decide_returns_skip_when_no_tool_call(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_trigger_now_executes_when_decision_is_run(tmp_path) -> None:
+async def test_tick_publishes_to_bus_when_decision_is_run(tmp_path) -> None:
+    """Phase 1 run -> Phase 2 publish to bus with _source=heartbeat metadata."""
     (tmp_path / "HEARTBEAT.md").write_text("- [ ] do thing", encoding="utf-8")
 
     provider = DummyProvider([
@@ -75,26 +83,37 @@ async def test_trigger_now_executes_when_decision_is_run(tmp_path) -> None:
         )
     ])
 
-    called_with: list[str] = []
+    bus = MessageBus()
+    pick_target_calls: list[tuple[str, str]] = []
 
-    async def _on_execute(tasks: str) -> str:
-        called_with.append(tasks)
-        return "done"
+    def _pick_target() -> tuple[str, str]:
+        result = ("telegram", "chat-123")
+        pick_target_calls.append(result)
+        return result
 
     service = HeartbeatService(
         workspace=tmp_path,
         provider=provider,
         model="openai/gpt-4o-mini",
-        on_execute=_on_execute,
+        bus=bus,
+        pick_target=_pick_target,
     )
 
-    result = await service.trigger_now()
-    assert result == "done"
-    assert called_with == ["check open tasks"]
+    await service._tick()
+
+    # Verify message was published to bus
+    msg = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
+    assert msg.content == "check open tasks"
+    assert msg.channel == "telegram"
+    assert msg.chat_id == "chat-123"
+    assert msg.metadata.get("_source") == "heartbeat"
+    assert msg.metadata.get("_task_context") == "check open tasks"
+    assert pick_target_calls == [("telegram", "chat-123")]
 
 
 @pytest.mark.asyncio
-async def test_trigger_now_returns_none_when_decision_is_skip(tmp_path) -> None:
+async def test_tick_does_not_publish_when_decision_is_skip(tmp_path) -> None:
+    """Phase 1 skip -> no message published to bus."""
     (tmp_path / "HEARTBEAT.md").write_text("- [ ] do thing", encoding="utf-8")
 
     provider = DummyProvider([
@@ -110,23 +129,23 @@ async def test_trigger_now_returns_none_when_decision_is_skip(tmp_path) -> None:
         )
     ])
 
-    async def _on_execute(tasks: str) -> str:
-        return tasks
-
+    bus = MessageBus()
     service = HeartbeatService(
         workspace=tmp_path,
         provider=provider,
         model="openai/gpt-4o-mini",
-        on_execute=_on_execute,
+        bus=bus,
     )
 
-    assert await service.trigger_now() is None
+    await service._tick()
+
+    # Verify no message was published
+    assert bus.inbound_size == 0
 
 
 @pytest.mark.asyncio
-async def test_tick_notifies_when_evaluator_says_yes(tmp_path, monkeypatch) -> None:
-    """Phase 1 run -> Phase 2 execute -> Phase 3 evaluate=notify -> on_notify called."""
-    (tmp_path / "HEARTBEAT.md").write_text("- [ ] check deployments", encoding="utf-8")
+async def test_trigger_now_publishes_to_bus(tmp_path) -> None:
+    (tmp_path / "HEARTBEAT.md").write_text("- [ ] do thing", encoding="utf-8")
 
     provider = DummyProvider([
         LLMResponse(
@@ -135,44 +154,32 @@ async def test_tick_notifies_when_evaluator_says_yes(tmp_path, monkeypatch) -> N
                 ToolCallRequest(
                     id="hb_1",
                     name="heartbeat",
-                    arguments={"action": "run", "tasks": "check deployments"},
+                    arguments={"action": "run", "tasks": "check open tasks"},
                 )
             ],
-        ),
+        )
     ])
 
-    executed: list[str] = []
-    notified: list[str] = []
-
-    async def _on_execute(tasks: str) -> str:
-        executed.append(tasks)
-        return "deployment failed on staging"
-
-    async def _on_notify(response: str) -> None:
-        notified.append(response)
-
+    bus = MessageBus()
     service = HeartbeatService(
         workspace=tmp_path,
         provider=provider,
         model="openai/gpt-4o-mini",
-        on_execute=_on_execute,
-        on_notify=_on_notify,
+        bus=bus,
+        pick_target=lambda: ("cli", "heartbeat"),
     )
 
-    async def _eval_notify(*a, **kw):
-        return True
+    await service.trigger_now()
 
-    monkeypatch.setattr("nanobot.utils.evaluator.evaluate_response", _eval_notify)
-
-    await service._tick()
-    assert executed == ["check deployments"]
-    assert notified == ["deployment failed on staging"]
+    # Verify message was published to bus
+    msg = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
+    assert msg.content == "check open tasks"
+    assert msg.metadata.get("_source") == "heartbeat"
 
 
 @pytest.mark.asyncio
-async def test_tick_suppresses_when_evaluator_says_no(tmp_path, monkeypatch) -> None:
-    """Phase 1 run -> Phase 2 execute -> Phase 3 evaluate=silent -> on_notify NOT called."""
-    (tmp_path / "HEARTBEAT.md").write_text("- [ ] check status", encoding="utf-8")
+async def test_trigger_now_does_nothing_when_decision_is_skip(tmp_path) -> None:
+    (tmp_path / "HEARTBEAT.md").write_text("- [ ] do thing", encoding="utf-8")
 
     provider = DummyProvider([
         LLMResponse(
@@ -181,38 +188,40 @@ async def test_tick_suppresses_when_evaluator_says_no(tmp_path, monkeypatch) -> 
                 ToolCallRequest(
                     id="hb_1",
                     name="heartbeat",
-                    arguments={"action": "run", "tasks": "check status"},
+                    arguments={"action": "skip"},
                 )
             ],
-        ),
+        )
     ])
 
-    executed: list[str] = []
-    notified: list[str] = []
-
-    async def _on_execute(tasks: str) -> str:
-        executed.append(tasks)
-        return "everything is fine, no issues"
-
-    async def _on_notify(response: str) -> None:
-        notified.append(response)
-
+    bus = MessageBus()
     service = HeartbeatService(
         workspace=tmp_path,
         provider=provider,
         model="openai/gpt-4o-mini",
-        on_execute=_on_execute,
-        on_notify=_on_notify,
+        bus=bus,
     )
 
-    async def _eval_silent(*a, **kw):
-        return False
+    await service.trigger_now()
 
-    monkeypatch.setattr("nanobot.utils.evaluator.evaluate_response", _eval_silent)
+    # Verify no message was published
+    assert bus.inbound_size == 0
 
-    await service._tick()
-    assert executed == ["check status"]
-    assert notified == []
+
+@pytest.mark.asyncio
+async def test_pick_target_default(tmp_path) -> None:
+    """Default pick_target returns ('cli', 'heartbeat')."""
+    provider = DummyProvider([])
+    bus = MessageBus()
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+        bus=bus,
+        # no pick_target provided
+    )
+
+    assert service.pick_target() == ("cli", "heartbeat")
 
 
 @pytest.mark.asyncio
@@ -238,10 +247,12 @@ async def test_decide_retries_transient_error_then_succeeds(tmp_path, monkeypatc
 
     monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
 
+    bus = MessageBus()
     service = HeartbeatService(
         workspace=tmp_path,
         provider=provider,
         model="openai/gpt-4o-mini",
+        bus=bus,
     )
 
     action, tasks = await service._decide("heartbeat content")


### PR DESCRIPTION
- Remove on_execute/on_notify callbacks from HeartbeatService
- HeartbeatService now publishes InboundMessage to bus with _source="heartbeat" metadata
- AgentLoop._dispatch handles evaluator logic for heartbeat messages
- Simplifies gateway initialization in commands.py
- Update tests to verify bus-based message flow

This unifies heartbeat with the standard message flow through the bus, making the architecture more consistent (only cron needs process_direct due to before/after context semantics).