### PR TITLE
Fix Codex forced function tool_choice payload

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -49,7 +49,7 @@ class OpenAICodexProvider(LLMProvider):
             "text": {"verbosity": "medium"},
             "include": ["reasoning.encrypted_content"],
             "prompt_cache_key": _prompt_cache_key(messages),
-            "tool_choice": tool_choice or "auto",
+            "tool_choice": _normalize_tool_choice(tool_choice),
             "parallel_tool_calls": True,
         }
 
@@ -88,6 +88,29 @@ def _strip_model_prefix(model: str) -> str:
     if model.startswith("openai-codex/") or model.startswith("openai_codex/"):
         return model.split("/", 1)[1]
     return model
+
+
+def _normalize_tool_choice(tool_choice: str | dict[str, Any] | None) -> str | dict[str, Any]:
+    """Normalize OpenAI-style tool_choice objects for the Codex Responses API."""
+    if tool_choice is None:
+        return "auto"
+    if isinstance(tool_choice, str):
+        return tool_choice
+    if not isinstance(tool_choice, dict):
+        return "auto"
+
+    choice_type = tool_choice.get("type")
+    if choice_type == "function":
+        name = tool_choice.get("name")
+        if not name:
+            fn = tool_choice.get("function")
+            if isinstance(fn, dict):
+                name = fn.get("name")
+        if name:
+            return {"type": "function", "name": name}
+        return "auto"
+
+    return tool_choice
 
 
 def _build_headers(account_id: str, token: str) -> dict[str, str]:

--- a/tests/test_openai_codex_provider.py
+++ b/tests/test_openai_codex_provider.py
@@ -1,0 +1,61 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from nanobot.providers.openai_codex_provider import (
+    OpenAICodexProvider,
+    _normalize_tool_choice,
+)
+
+
+def test_normalize_tool_choice_flattens_openai_function_shape() -> None:
+    assert _normalize_tool_choice(
+        {"type": "function", "function": {"name": "save_memory"}}
+    ) == {"type": "function", "name": "save_memory"}
+
+
+def test_normalize_tool_choice_keeps_flat_function_shape() -> None:
+    assert _normalize_tool_choice({"type": "function", "name": "save_memory"}) == {
+        "type": "function",
+        "name": "save_memory",
+    }
+
+
+def test_codex_provider_sends_flattened_tool_choice() -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_request_codex(url, headers, body, verify):
+        captured["body"] = body
+        return "ok", [], "stop"
+
+    async def run() -> None:
+        provider = OpenAICodexProvider(default_model="openai-codex/gpt-5.4")
+        with (
+            patch(
+                "nanobot.providers.openai_codex_provider.get_codex_token",
+                return_value=SimpleNamespace(account_id="acct_123", access="token_123"),
+            ),
+            patch(
+                "nanobot.providers.openai_codex_provider._request_codex",
+                side_effect=fake_request_codex,
+            ),
+        ):
+            response = await provider.chat(
+                messages=[{"role": "user", "content": "hello"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "save_memory",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                tool_choice={"type": "function", "function": {"name": "save_memory"}},
+            )
+
+        assert response.finish_reason == "stop"
+
+    asyncio.run(run())
+
+    assert captured["body"]["tool_choice"] == {"type": "function", "name": "save_memory"}


### PR DESCRIPTION
## Summary
- normalize OpenAI-style forced function tool_choice objects before sending Codex Responses API requests
- keep existing string and flat tool_choice values unchanged
- add regression tests covering the nested OpenAI chat-completions shape used by memory consolidation

## Why
Codex requests could fail with `Unknown parameter: 'tool_choice.function'` when nanobot passed a nested tool_choice object like `{"type":"function","function":{"name":"save_memory"}}` directly to the Responses API. When that happened, the primary Codex model failed and nanobot unnecessarily fell back to the secondary provider.

## Testing
- `python -m pytest tests/test_openai_codex_provider.py tests/test_memory_consolidation_types.py -q`
- verified a real `openai-codex/gpt-5.4` tool call succeeds with forced `save_memory` tool choice after normalization
