### PR TITLE
Add FastAPI web UI with SSE and CLI command

### DIFF
--- a/TODO/web-interface.md
+++ b/TODO/web-interface.md
@@ -1,0 +1,110 @@
+# Web Interface Plan
+
+## Goal
+
+Add a web interface as **another interface layer**, alongside CLI. Same level, same capabilities.
+
+```
+CLI ──┐
+      ├──▶ AgentLoop (core, unchanged)
+Web ──┘
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Backend: FastAPI + SSE                                  │
+│  - /api/chat    → SSE streaming endpoint                 │
+│  - /api/sessions → CRUD for sessions                     │
+│  - /static      → serve frontend                         │
+└─────────────────────────────────────────────────────────┘
+                         │
+                         ▼ calls
+┌─────────────────────────────────────────────────────────┐
+│  AgentLoop.process_direct()  ← 100% reuse existing code │
+│  - All tools, memory, sessions, MCP available           │
+└─────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────┐
+│  Frontend: Single HTML file + vanilla JS                 │
+│  - Tailwind CSS (CDN)                                    │
+│  - Marked.js (CDN) for Markdown                          │
+│  - EventSource for SSE streaming                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Implementation Steps
+
+### 1. Backend (`nanobot/web/`)
+
+```
+nanobot/web/
+├── __init__.py
+├── server.py          # FastAPI app, ~100 lines
+└── static/
+    └── index.html     # Single page app, ~200 lines
+```
+
+**Key endpoints:**
+
+```python
+# POST /api/chat - Stream response via SSE
+async def chat(message: str, session_id: str = "web:default"):
+    async def stream():
+        async for chunk in agent.process_direct(
+            message,
+            session_key=session_id,
+            on_progress=lambda msg: yield f"event: progress\ndata: {msg}\n\n"
+        ):
+            yield f"data: {chunk}\n\n"
+    return StreamingResponse(stream(), media_type="text/event-stream")
+
+# GET  /api/sessions      - List sessions
+# GET  /api/sessions/{id}  - Get session history
+# DEL  /api/sessions/{id}  - Delete session
+```
+
+### 2. Frontend (`static/index.html`)
+
+- Input box + send button
+- Chat history container
+- SSE client for streaming
+- Markdown rendering
+- Session switcher
+
+### 3. CLI Integration
+
+Add new command:
+```bash
+nanobot web        # Start web server on :8000
+nanobot web -p 3000  # Custom port
+```
+
+## Tech Stack Rationale
+
+| Choice | Why |
+|--------|-----|
+| FastAPI | nanobot already uses asyncio, native fit |
+| SSE | Simpler than WebSocket, one-way streaming is all we need |
+| Vanilla JS | Zero build step, single file, easy to modify |
+| Tailwind CDN | No npm, quick styling |
+
+## Dependencies
+
+Add to `pyproject.toml`:
+```toml
+[project.optional-dependencies]
+web = ["fastapi", "uvicorn[standard]"]
+```
+
+## Estimated Effort
+
+- Backend: ~100 lines
+- Frontend: ~200 lines
+- Total: ~300 lines
+
+## Reference
+
+See `nanobot/cli/commands.py` for how CLI uses `AgentLoop.process_direct()`.
+Web will do the exact same thing.

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -581,6 +581,38 @@ def gateway(
 
 
 # ============================================================================
+# Web Interface
+# ============================================================================
+
+
+@app.command()
+def web(
+    port: int = typer.Option(8000, "--port", "-p", help="Port to listen on"),
+    host: str = typer.Option("127.0.0.1", "--host", help="Host to bind to"),
+    workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
+    config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
+):
+    """Start the nanobot web interface."""
+    try:
+        import uvicorn
+    except ImportError:
+        console.print("[red]uvicorn not installed.[/red] Run: pip install 'nanobot-ai[web]'")
+        raise typer.Exit(1)
+
+    try:
+        from fastapi import FastAPI  # noqa: F401
+    except ImportError:
+        console.print("[red]fastapi not installed.[/red] Run: pip install 'nanobot-ai[web]'")
+        raise typer.Exit(1)
+
+    from nanobot.web.server import create_app
+
+    console.print(f"{__logo__} Starting web interface at http://{host}:{port} ...")
+    app_instance = create_app(config, workspace)
+    uvicorn.run(app_instance, host=host, port=port)
+
+
+# ============================================================================
 # Agent Commands
 # ============================================================================
 

--- a/nanobot/web/__init__.py
+++ b/nanobot/web/__init__.py
@@ -1,0 +1,1 @@
+"""Web interface for nanobot."""

--- a/nanobot/web/server.py
+++ b/nanobot/web/server.py
@@ -1,0 +1,159 @@
+"""FastAPI web server for nanobot web interface."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+
+_STATIC_DIR = Path(__file__).parent / "static"
+
+
+class ChatRequest(BaseModel):
+    message: str
+    session_id: str = "web:default"
+
+
+def create_app(config_path: str | None = None, workspace: str | None = None) -> FastAPI:
+    """Create and configure the FastAPI application."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.cli.commands import _load_runtime_config, _make_provider
+    from nanobot.config.paths import get_cron_dir
+    from nanobot.cron.service import CronService
+    from nanobot.session.manager import SessionManager
+    from nanobot.utils.helpers import sync_workspace_templates
+
+    cfg = _load_runtime_config(config_path, workspace)
+    sync_workspace_templates(cfg.workspace_path)
+
+    bus = MessageBus()
+    provider = _make_provider(cfg)
+
+    cron_store_path = get_cron_dir() / "jobs.json"
+    cron = CronService(cron_store_path)
+
+    session_manager = SessionManager(cfg.workspace_path)
+
+    agent = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=cfg.workspace_path,
+        model=cfg.agents.defaults.model,
+        max_iterations=cfg.agents.defaults.max_tool_iterations,
+        context_window_tokens=cfg.agents.defaults.context_window_tokens,
+        web_search_config=cfg.tools.web.search,
+        web_proxy=cfg.tools.web.proxy or None,
+        exec_config=cfg.tools.exec,
+        cron_service=cron,
+        restrict_to_workspace=cfg.tools.restrict_to_workspace,
+        session_manager=session_manager,
+        mcp_servers=cfg.tools.mcp_servers,
+        channels_config=cfg.channels,
+    )
+
+    app = FastAPI(title="nanobot web", docs_url=None, redoc_url=None)
+
+    @app.on_event("startup")
+    async def _startup() -> None:
+        await agent._connect_mcp()
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        await agent.close_mcp()
+
+    # ------------------------------------------------------------------
+    # Chat endpoint — SSE streaming
+    # ------------------------------------------------------------------
+
+    @app.post("/api/chat")
+    async def chat(request: ChatRequest) -> StreamingResponse:
+        queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+
+        async def on_progress(content: str, *, tool_hint: bool = False) -> None:
+            await queue.put({"type": "progress", "content": content, "tool_hint": tool_hint})
+
+        async def _run_agent() -> None:
+            try:
+                response = await agent.process_direct(
+                    request.message,
+                    session_key=request.session_id,
+                    channel="web",
+                    chat_id="browser",
+                    on_progress=on_progress,
+                )
+                await queue.put({"type": "done", "content": response or ""})
+            except Exception as exc:  # noqa: BLE001
+                await queue.put({"type": "error", "content": str(exc)})
+            finally:
+                await queue.put(None)  # sentinel
+
+        async def stream() -> Any:
+            task = asyncio.create_task(_run_agent())
+            try:
+                while True:
+                    item = await queue.get()
+                    if item is None:
+                        break
+                    yield f"data: {json.dumps(item, ensure_ascii=False)}\n\n"
+            finally:
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+        return StreamingResponse(
+            stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Session endpoints
+    # ------------------------------------------------------------------
+
+    @app.get("/api/sessions")
+    async def list_sessions() -> list[dict[str, Any]]:
+        return session_manager.list_sessions()
+
+    @app.get("/api/sessions/{session_id:path}")
+    async def get_session(session_id: str) -> dict[str, Any]:
+        session = session_manager.get_or_create(session_id)
+        return {
+            "key": session.key,
+            "messages": session.get_history(max_messages=0),
+            "created_at": session.created_at.isoformat(),
+            "updated_at": session.updated_at.isoformat(),
+        }
+
+    @app.delete("/api/sessions/{session_id:path}")
+    async def delete_session(session_id: str) -> dict[str, str]:
+        path = session_manager._get_session_path(session_id)
+        if not path.exists():
+            raise HTTPException(status_code=404, detail="Session not found")
+        path.unlink()
+        session_manager.invalidate(session_id)
+        return {"status": "deleted"}
+
+    # ------------------------------------------------------------------
+    # Static files / SPA
+    # ------------------------------------------------------------------
+
+    app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
+
+    @app.get("/")
+    async def index() -> FileResponse:
+        return FileResponse(_STATIC_DIR / "index.html")
+
+    return app

--- a/nanobot/web/static/index.html
+++ b/nanobot/web/static/index.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>nanobot</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <style>
+    /* Custom scrollbar */
+    ::-webkit-scrollbar { width: 4px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: #374151; border-radius: 2px; }
+
+    /* Markdown content styles */
+    .md-content pre { background: #1e293b; padding: 1rem; border-radius: 0.5rem; overflow-x: auto; margin: 0.5rem 0; }
+    .md-content code { font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 0.85em; }
+    .md-content p:not(:last-child) { margin-bottom: 0.5rem; }
+    .md-content ul, .md-content ol { padding-left: 1.25rem; margin: 0.5rem 0; }
+    .md-content li { margin-bottom: 0.25rem; }
+    .md-content h1, .md-content h2, .md-content h3 { font-weight: 600; margin: 0.75rem 0 0.5rem; }
+    .md-content h1 { font-size: 1.25rem; }
+    .md-content h2 { font-size: 1.1rem; }
+    .md-content h3 { font-size: 1rem; }
+    .md-content blockquote { border-left: 3px solid #4b5563; padding-left: 0.75rem; color: #9ca3af; margin: 0.5rem 0; }
+    .md-content a { color: #60a5fa; text-decoration: underline; }
+    .md-content table { border-collapse: collapse; width: 100%; margin: 0.5rem 0; }
+    .md-content th, .md-content td { border: 1px solid #374151; padding: 0.4rem 0.75rem; }
+    .md-content th { background: #1f2937; }
+
+    /* Blinking cursor for streaming */
+    .streaming-cursor::after {
+      content: '▋';
+      animation: blink 1s step-end infinite;
+      color: #60a5fa;
+    }
+    @keyframes blink { 0%,100% { opacity: 1; } 50% { opacity: 0; } }
+
+    /* Session item hover */
+    .session-item:hover .session-delete { opacity: 1; }
+    .session-delete { opacity: 0; transition: opacity 0.15s; }
+  </style>
+</head>
+<body class="h-full bg-gray-950 text-gray-100 flex">
+
+  <!-- Sidebar -->
+  <aside class="w-64 flex-shrink-0 bg-gray-900 border-r border-gray-800 flex flex-col">
+    <div class="p-4 border-b border-gray-800 flex items-center justify-between">
+      <span class="font-semibold text-blue-400 tracking-wide">🐈 nanobot</span>
+      <button id="btn-new-session"
+        class="text-xs px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 transition-colors"
+        title="New session">+ New</button>
+    </div>
+
+    <div class="flex-1 overflow-y-auto p-2" id="session-list">
+      <!-- populated by JS -->
+    </div>
+  </aside>
+
+  <!-- Main chat area -->
+  <main class="flex-1 flex flex-col min-w-0">
+
+    <!-- Header -->
+    <header class="px-6 py-3 border-b border-gray-800 flex items-center gap-3">
+      <span id="header-session" class="text-sm text-gray-400 font-mono truncate">web:default</span>
+      <span class="ml-auto text-xs text-gray-600" id="status-indicator"></span>
+    </header>
+
+    <!-- Messages -->
+    <div class="flex-1 overflow-y-auto px-4 py-6 space-y-4" id="messages">
+      <div class="text-center text-gray-600 text-sm mt-16 select-none" id="empty-hint">
+        Send a message to start chatting
+      </div>
+    </div>
+
+    <!-- Input area -->
+    <div class="px-4 pb-4 pt-2 border-t border-gray-800">
+      <div class="flex gap-2 items-end max-w-4xl mx-auto">
+        <textarea
+          id="input"
+          rows="1"
+          placeholder="Message nanobot… (Enter to send, Shift+Enter for newline)"
+          class="flex-1 resize-none bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500 transition-colors max-h-48 overflow-y-auto"
+        ></textarea>
+        <button id="btn-send"
+          class="px-4 py-3 rounded-xl bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors text-sm font-medium flex-shrink-0"
+        >Send</button>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    // ──────────────────────────────────────────────────────────
+    // State
+    // ──────────────────────────────────────────────────────────
+    let currentSession = 'web:default';
+    let isStreaming = false;
+    let currentController = null;
+
+    const messagesEl = document.getElementById('messages');
+    const inputEl = document.getElementById('input');
+    const btnSend = document.getElementById('btn-send');
+    const sessionList = document.getElementById('session-list');
+    const headerSession = document.getElementById('header-session');
+    const statusIndicator = document.getElementById('status-indicator');
+    const emptyHint = document.getElementById('empty-hint');
+
+    marked.setOptions({ breaks: true, gfm: true });
+
+    // ──────────────────────────────────────────────────────────
+    // Sessions
+    // ──────────────────────────────────────────────────────────
+    async function loadSessions() {
+      try {
+        const res = await fetch('/api/sessions');
+        const sessions = await res.json();
+        renderSessionList(sessions);
+      } catch (_) {}
+    }
+
+    function renderSessionList(sessions) {
+      sessionList.innerHTML = '';
+
+      // Always include current session at top if not in list
+      const keys = sessions.map(s => s.key);
+      if (!keys.includes(currentSession)) {
+        sessions.unshift({ key: currentSession });
+      }
+
+      sessions.forEach(s => {
+        const div = document.createElement('div');
+        div.className = 'session-item flex items-center gap-1 rounded-lg px-3 py-2 cursor-pointer text-sm mb-1 ' +
+          (s.key === currentSession ? 'bg-gray-700 text-white' : 'text-gray-400 hover:bg-gray-800 hover:text-gray-200');
+        div.dataset.key = s.key;
+
+        const label = document.createElement('span');
+        label.className = 'flex-1 truncate';
+        label.textContent = s.key.replace(/^web:/, '');
+
+        const del = document.createElement('button');
+        del.className = 'session-delete text-gray-600 hover:text-red-400 transition-colors ml-1 flex-shrink-0';
+        del.innerHTML = '×';
+        del.title = 'Delete session';
+        del.addEventListener('click', async (e) => {
+          e.stopPropagation();
+          if (!confirm(`Delete session "${s.key}"?`)) return;
+          await fetch(`/api/sessions/${encodeURIComponent(s.key)}`, { method: 'DELETE' });
+          if (s.key === currentSession) {
+            switchSession('web:default');
+          }
+          loadSessions();
+        });
+
+        div.appendChild(label);
+        div.appendChild(del);
+        div.addEventListener('click', () => switchSession(s.key));
+        sessionList.appendChild(div);
+      });
+    }
+
+    function switchSession(key) {
+      currentSession = key;
+      headerSession.textContent = key;
+      messagesEl.innerHTML = '';
+      emptyHint && messagesEl.appendChild(emptyHint);
+      emptyHint.style.display = 'block';
+      loadSessions();
+      loadHistory();
+    }
+
+    async function loadHistory() {
+      try {
+        const res = await fetch(`/api/sessions/${encodeURIComponent(currentSession)}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        messagesEl.innerHTML = '';
+        const msgs = data.messages || [];
+        if (msgs.length === 0) {
+          messagesEl.appendChild(emptyHint);
+          emptyHint.style.display = 'block';
+          return;
+        }
+        emptyHint.style.display = 'none';
+        msgs.forEach(m => {
+          if (m.role === 'user') appendMessage('user', m.content);
+          else if (m.role === 'assistant' && m.content) appendMessage('assistant', m.content);
+        });
+        scrollToBottom();
+      } catch (_) {}
+    }
+
+    document.getElementById('btn-new-session').addEventListener('click', () => {
+      const id = prompt('Session name (will be prefixed with "web:"):', Date.now().toString());
+      if (!id) return;
+      const key = id.startsWith('web:') ? id : `web:${id}`;
+      switchSession(key);
+    });
+
+    // ──────────────────────────────────────────────────────────
+    // Messages
+    // ──────────────────────────────────────────────────────────
+    function appendMessage(role, content, { streaming = false } = {}) {
+      emptyHint.style.display = 'none';
+
+      const wrap = document.createElement('div');
+      wrap.className = 'flex ' + (role === 'user' ? 'justify-end' : 'justify-start') + ' max-w-4xl mx-auto w-full';
+
+      const bubble = document.createElement('div');
+      bubble.className = role === 'user'
+        ? 'bg-blue-600 text-white rounded-2xl rounded-tr-sm px-4 py-2.5 max-w-[75%] text-sm leading-relaxed'
+        : 'bg-gray-800 text-gray-100 rounded-2xl rounded-tl-sm px-4 py-2.5 max-w-[85%] text-sm leading-relaxed md-content';
+
+      if (role === 'user') {
+        bubble.textContent = content;
+      } else {
+        bubble.innerHTML = content ? marked.parse(content) : '';
+        if (streaming) bubble.classList.add('streaming-cursor');
+      }
+
+      wrap.appendChild(bubble);
+      messagesEl.appendChild(wrap);
+      scrollToBottom();
+      return bubble;
+    }
+
+    function appendProgressLine(text) {
+      const existing = document.getElementById('progress-line');
+      if (existing) { existing.remove(); }
+
+      const div = document.createElement('div');
+      div.id = 'progress-line';
+      div.className = 'flex justify-start max-w-4xl mx-auto w-full';
+      const inner = document.createElement('div');
+      inner.className = 'text-gray-500 text-xs italic px-1 py-0.5';
+      inner.textContent = '↳ ' + text;
+      div.appendChild(inner);
+      messagesEl.appendChild(div);
+      scrollToBottom();
+    }
+
+    function removeProgressLine() {
+      document.getElementById('progress-line')?.remove();
+    }
+
+    function scrollToBottom() {
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // Send
+    // ──────────────────────────────────────────────────────────
+    async function sendMessage() {
+      const text = inputEl.value.trim();
+      if (!text || isStreaming) return;
+
+      inputEl.value = '';
+      autoResize();
+      setStreaming(true);
+
+      appendMessage('user', text);
+
+      const assistantBubble = appendMessage('assistant', '', { streaming: true });
+
+      let responseText = '';
+
+      try {
+        const res = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: text, session_id: currentSession }),
+        });
+
+        if (!res.ok) {
+          const err = await res.text();
+          throw new Error(err);
+        }
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop(); // keep incomplete line
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            const raw = line.slice(6).trim();
+            if (!raw) continue;
+
+            let event;
+            try { event = JSON.parse(raw); } catch { continue; }
+
+            if (event.type === 'progress') {
+              appendProgressLine(event.content);
+            } else if (event.type === 'done') {
+              removeProgressLine();
+              responseText = event.content || '';
+              assistantBubble.classList.remove('streaming-cursor');
+              assistantBubble.innerHTML = responseText ? marked.parse(responseText) : '<em class="text-gray-500">No response</em>';
+              scrollToBottom();
+            } else if (event.type === 'error') {
+              removeProgressLine();
+              assistantBubble.classList.remove('streaming-cursor');
+              assistantBubble.innerHTML = `<span class="text-red-400">Error: ${event.content}</span>`;
+              scrollToBottom();
+            }
+          }
+        }
+      } catch (err) {
+        removeProgressLine();
+        assistantBubble.classList.remove('streaming-cursor');
+        assistantBubble.innerHTML = `<span class="text-red-400">Error: ${err.message}</span>`;
+        scrollToBottom();
+      } finally {
+        setStreaming(false);
+        loadSessions();
+      }
+    }
+
+    function setStreaming(val) {
+      isStreaming = val;
+      btnSend.disabled = val;
+      statusIndicator.textContent = val ? 'thinking…' : '';
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // Input auto-resize
+    // ──────────────────────────────────────────────────────────
+    function autoResize() {
+      inputEl.style.height = 'auto';
+      inputEl.style.height = Math.min(inputEl.scrollHeight, 192) + 'px';
+    }
+
+    inputEl.addEventListener('input', autoResize);
+    inputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+      }
+    });
+    btnSend.addEventListener('click', sendMessage);
+
+    // ──────────────────────────────────────────────────────────
+    // Init
+    // ──────────────────────────────────────────────────────────
+    loadSessions();
+    loadHistory();
+  </script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+web = [
+    "fastapi>=0.115.0,<1.0.0",
+    "uvicorn[standard]>=0.34.0,<1.0.0",
+]
 wecom = [
     "wecom-aibot-sdk-python>=0.1.5",
 ]


### PR DESCRIPTION
Introduce a web interface for nanobot: adds a FastAPI app (nanobot/web/server.py) that exposes an SSE streaming chat endpoint (/api/chat), session CRUD endpoints (/api/sessions), and serves a single-file SPA (nanobot/web/static/index.html). Adds a CLI command (nanobot cli: web) to launch the server and updates pyproject.toml with optional web dependencies. Also includes a TODO design doc (TODO/web-interface.md) and a minimal package init. The server reuses AgentLoop.process_direct to preserve existing agent behavior and streams progress/done/error events to the browser.