### PR TITLE
feat(timezone): read user timezone from USER.md for consistent time context

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -6,7 +6,7 @@ import platform
 from pathlib import Path
 from typing import Any
 
-from nanobot.utils.helpers import current_time_str
+from nanobot.utils.helpers import current_time_str, parse_user_timezone
 
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
@@ -98,9 +98,9 @@ Your workspace is at: {workspace_path}
 Reply directly with text for conversations. Only use the 'message' tool to send to a specific chat channel."""
 
     @staticmethod
-    def _build_runtime_context(channel: str | None, chat_id: str | None) -> str:
+    def _build_runtime_context(channel: str | None, chat_id: str | None, tz_name: str | None = None) -> str:
         """Build untrusted runtime metadata block for injection before the user message."""
-        lines = [f"Current Time: {current_time_str()}"]
+        lines = [f"Current Time: {current_time_str(tz_name)}"]
         if channel and chat_id:
             lines += [f"Channel: {channel}", f"Chat ID: {chat_id}"]
         return ContextBuilder._RUNTIME_CONTEXT_TAG + "\n" + "\n".join(lines)
@@ -127,7 +127,8 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         chat_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
-        runtime_ctx = self._build_runtime_context(channel, chat_id)
+        user_tz = parse_user_timezone(self.workspace)
+        runtime_ctx = self._build_runtime_context(channel, chat_id, tz_name=user_tz)
         user_content = self._build_user_content(current_message, media)
 
         # Merge runtime context and user content into a single user message

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -6,7 +6,7 @@ import platform
 from pathlib import Path
 from typing import Any
 
-from nanobot.utils.helpers import current_time_str, parse_user_timezone
+from nanobot.utils.helpers import current_time_str
 
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
@@ -19,8 +19,9 @@ class ContextBuilder:
     BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"]
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
 
-    def __init__(self, workspace: Path):
+    def __init__(self, workspace: Path, timezone: str | None = None):
         self.workspace = workspace
+        self.timezone = timezone
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
 
@@ -127,8 +128,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         chat_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
-        user_tz = parse_user_timezone(self.workspace)
-        runtime_ctx = self._build_runtime_context(channel, chat_id, tz_name=user_tz)
+        runtime_ctx = self._build_runtime_context(channel, chat_id, tz_name=self.timezone)
         user_content = self._build_user_content(current_message, media)
 
         # Merge runtime context and user content into a single user message

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -64,6 +64,7 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        timezone: str | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -80,7 +81,7 @@ class AgentLoop:
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
 
-        self.context = ContextBuilder(workspace)
+        self.context = ContextBuilder(workspace, timezone=timezone)
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
         self.subagents = SubagentManager(
@@ -92,6 +93,7 @@ class AgentLoop:
             web_proxy=web_proxy,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            timezone=timezone,
         )
 
         self._running = False

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -33,6 +33,7 @@ class SubagentManager:
         web_proxy: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
+        timezone: str | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -44,6 +45,7 @@ class SubagentManager:
         self.web_proxy = web_proxy
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
+        self.timezone = timezone
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
 
@@ -202,7 +204,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
         from nanobot.agent.context import ContextBuilder
         from nanobot.agent.skills import SkillsLoader
 
-        time_ctx = ContextBuilder._build_runtime_context(None, None)
+        time_ctx = ContextBuilder._build_runtime_context(None, None, tz_name=self.timezone)
         parts = [f"""# Subagent
 
 {time_ctx}

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -431,6 +431,22 @@ def _print_deprecated_memory_window_notice(config: Config) -> None:
         )
 
 
+def _resolve_timezone(config: Config) -> str | None:
+    """Resolve timezone: config.json first, USER.md fallback with deprecation warning."""
+    tz = config.agents.defaults.timezone
+    if tz is not None:
+        return tz
+    from loguru import logger
+    from nanobot.utils.helpers import parse_user_timezone
+    tz = parse_user_timezone(config.workspace_path)
+    if tz:
+        logger.warning(
+            "Timezone in USER.md is deprecated. Move to config.json: "
+            '"agents": {{ "defaults": {{ "timezone": "{}" }} }}', tz
+        )
+    return tz
+
+
 # ============================================================================
 # Gateway / Server
 # ============================================================================
@@ -472,6 +488,7 @@ def gateway(
     cron = CronService(cron_store_path)
 
     # Create agent with cron service
+    tz = _resolve_timezone(config)
     agent = AgentLoop(
         bus=bus,
         provider=provider,
@@ -487,6 +504,7 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        timezone=tz,
     )
 
     # Set cron callback (needs agent)
@@ -587,6 +605,7 @@ def gateway(
         on_notify=on_heartbeat_notify,
         interval_s=hb_cfg.interval_s,
         enabled=hb_cfg.enabled,
+        timezone=tz,
     )
 
     if channels.enabled_channels:
@@ -678,6 +697,7 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        timezone=_resolve_timezone(config),
     )
 
     # Shared reference for progress callbacks

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -42,6 +42,7 @@ class AgentDefaults(Base):
     # Deprecated compatibility field: accepted from old configs but ignored at runtime.
     memory_window: int | None = Field(default=None, exclude=True)
     reasoning_effort: str | None = None  # low / medium / high — enables LLM thinking mode
+    timezone: str | None = None  # IANA timezone (e.g. "Asia/Shanghai"), None = system time
 
     @property
     def should_warn_deprecated_memory_window(self) -> bool:

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -37,6 +37,9 @@ _HEARTBEAT_TOOL = [
 ]
 
 
+_UNSET = object()
+
+
 class HeartbeatService:
     """
     Periodic heartbeat service that wakes the agent to check for tasks.
@@ -69,6 +72,7 @@ class HeartbeatService:
         self.enabled = enabled
         self._running = False
         self._task: asyncio.Task | None = None
+        self._user_tz: str | None | type = _UNSET
 
     @property
     def heartbeat_file(self) -> Path:
@@ -87,13 +91,16 @@ class HeartbeatService:
 
         Returns (action, tasks) where action is 'skip' or 'run'.
         """
-        from nanobot.utils.helpers import current_time_str
+        from nanobot.utils.helpers import current_time_str, parse_user_timezone
+
+        if self._user_tz is _UNSET:
+            self._user_tz = parse_user_timezone(self.workspace)
 
         response = await self.provider.chat_with_retry(
             messages=[
                 {"role": "system", "content": "You are a heartbeat agent. Call the heartbeat tool to report your decision."},
                 {"role": "user", "content": (
-                    f"Current Time: {current_time_str()}\n\n"
+                    f"Current Time: {current_time_str(self._user_tz)}\n\n"
                     "Review the following HEARTBEAT.md and decide whether there are active tasks.\n\n"
                     f"{content}"
                 )},

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -37,8 +37,6 @@ _HEARTBEAT_TOOL = [
 ]
 
 
-_UNSET = object()
-
 
 class HeartbeatService:
     """
@@ -62,6 +60,7 @@ class HeartbeatService:
         on_notify: Callable[[str], Coroutine[Any, Any, None]] | None = None,
         interval_s: int = 30 * 60,
         enabled: bool = True,
+        timezone: str | None = None,
     ):
         self.workspace = workspace
         self.provider = provider
@@ -72,7 +71,7 @@ class HeartbeatService:
         self.enabled = enabled
         self._running = False
         self._task: asyncio.Task | None = None
-        self._user_tz: str | None | type = _UNSET
+        self._user_tz = timezone
 
     @property
     def heartbeat_file(self) -> Path:
@@ -91,10 +90,7 @@ class HeartbeatService:
 
         Returns (action, tasks) where action is 'skip' or 'run'.
         """
-        from nanobot.utils.helpers import current_time_str, parse_user_timezone
-
-        if self._user_tz is _UNSET:
-            self._user_tz = parse_user_timezone(self.workspace)
+        from nanobot.utils.helpers import current_time_str
 
         response = await self.provider.chat_with_retry(
             messages=[

--- a/nanobot/templates/USER.md
+++ b/nanobot/templates/USER.md
@@ -5,7 +5,7 @@ Information about the user to help personalize interactions.
 ## Basic Information
 
 - **Name**: (your name)
-- **Timezone**: (your timezone, e.g., UTC+8)
+- **Timezone**: (your timezone, e.g., Asia/Shanghai)
 - **Language**: (preferred language)
 
 ## Preferences

--- a/nanobot/templates/USER.md
+++ b/nanobot/templates/USER.md
@@ -5,7 +5,6 @@ Information about the user to help personalize interactions.
 ## Basic Information
 
 - **Name**: (your name)
-- **Timezone**: (your timezone, e.g., Asia/Shanghai)
 - **Language**: (preferred language)
 
 ## Preferences

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -34,11 +34,44 @@ def timestamp() -> str:
     return datetime.now().isoformat()
 
 
-def current_time_str() -> str:
+def current_time_str(tz_name: str | None = None) -> str:
     """Human-readable current time with weekday and timezone, e.g. '2026-03-15 22:30 (Saturday) (CST)'."""
+    if tz_name:
+        try:
+            from zoneinfo import ZoneInfo
+
+            now = datetime.now(ZoneInfo(tz_name)).strftime("%Y-%m-%d %H:%M (%A)")
+            return f"{now} ({tz_name})"
+        except (KeyError, Exception):
+            pass  # invalid tz → fallback to system timezone
     now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
     tz = time.strftime("%Z") or "UTC"
     return f"{now} ({tz})"
+
+
+def parse_user_timezone(workspace: Path) -> str | None:
+    """Parse IANA timezone from USER.md Timezone field, return None if not configured."""
+    user_md = workspace / "USER.md"
+    if not user_md.exists():
+        return None
+    try:
+        text = user_md.read_text(encoding="utf-8")
+    except Exception:
+        return None
+    for line in text.splitlines():
+        m = re.match(r'\s*[-*]\s*\*\*Timezone\*\*\s*:\s*(.+)', line)
+        if m:
+            val = m.group(1).strip()
+            if not val or val.startswith("("):
+                return None
+            try:
+                from zoneinfo import ZoneInfo
+
+                ZoneInfo(val)
+                return val
+            except (KeyError, Exception):
+                return None
+    return None
 
 
 _UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*]')

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,159 @@
+"""Tests for timezone consolidation — parse_user_timezone and current_time_str(tz_name)."""
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nanobot.utils.helpers import current_time_str, parse_user_timezone
+
+
+# --- current_time_str tests ---
+
+
+def test_current_time_str_no_arg_preserves_behavior() -> None:
+    """Calling with no argument should return a string with weekday and timezone abbreviation."""
+    result = current_time_str()
+    # Should match pattern: YYYY-MM-DD HH:MM (Weekday) (TZ)
+    assert re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} \(\w+\) \(.+\)", result)
+
+
+def test_current_time_str_valid_iana() -> None:
+    """Valid IANA timezone should appear in the output."""
+    result = current_time_str("Asia/Tokyo")
+    assert "(Asia/Tokyo)" in result
+    assert re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} \(\w+\) \(Asia/Tokyo\)", result)
+
+
+def test_current_time_str_invalid_fallback() -> None:
+    """Invalid timezone should fallback to system timezone without crashing."""
+    result = current_time_str("Invalid/Zone")
+    # Should NOT contain "Invalid/Zone", should contain a system tz
+    assert "Invalid/Zone" not in result
+    assert re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} \(\w+\) \(.+\)", result)
+
+
+# --- parse_user_timezone tests ---
+
+
+def test_parse_valid_iana(tmp_path: Path) -> None:
+    """USER.md with valid IANA timezone should return the timezone string."""
+    (tmp_path / "USER.md").write_text(
+        "# User Profile\n- **Timezone**: Asia/Shanghai\n", encoding="utf-8"
+    )
+    assert parse_user_timezone(tmp_path) == "Asia/Shanghai"
+
+
+def test_parse_placeholder_returns_none(tmp_path: Path) -> None:
+    """USER.md with default placeholder should return None."""
+    (tmp_path / "USER.md").write_text(
+        "# User Profile\n- **Timezone**: (your timezone, e.g., Asia/Shanghai)\n",
+        encoding="utf-8",
+    )
+    assert parse_user_timezone(tmp_path) is None
+
+
+def test_parse_missing_file(tmp_path: Path) -> None:
+    """Missing USER.md should return None."""
+    assert parse_user_timezone(tmp_path) is None
+
+
+def test_parse_invalid_tz_returns_none(tmp_path: Path) -> None:
+    """USER.md with invalid timezone (e.g. UTC+8) should return None after ZoneInfo validation."""
+    (tmp_path / "USER.md").write_text(
+        "# User Profile\n- **Timezone**: UTC+8\n", encoding="utf-8"
+    )
+    assert parse_user_timezone(tmp_path) is None
+
+
+def test_parse_empty_timezone_returns_none(tmp_path: Path) -> None:
+    """USER.md with empty timezone field should return None."""
+    (tmp_path / "USER.md").write_text(
+        "# User Profile\n- **Timezone**: \n", encoding="utf-8"
+    )
+    assert parse_user_timezone(tmp_path) is None
+
+
+def test_parse_indented_bullet(tmp_path: Path) -> None:
+    """Indented markdown bullet should still be parsed."""
+    (tmp_path / "USER.md").write_text(
+        "# User Profile\n    - **Timezone**: Asia/Shanghai\n", encoding="utf-8"
+    )
+    assert parse_user_timezone(tmp_path) == "Asia/Shanghai"
+
+
+def test_parse_asterisk_bullet(tmp_path: Path) -> None:
+    """Asterisk bullet should also be parsed."""
+    (tmp_path / "USER.md").write_text(
+        "# User Profile\n* **Timezone**: Europe/London\n", encoding="utf-8"
+    )
+    assert parse_user_timezone(tmp_path) == "Europe/London"
+
+
+# --- Integration tests ---
+
+
+def test_runtime_context_uses_user_tz(tmp_path: Path) -> None:
+    """ContextBuilder._build_runtime_context should use user timezone when provided."""
+    from nanobot.agent.context import ContextBuilder
+
+    result = ContextBuilder._build_runtime_context(
+        channel="cli", chat_id="test", tz_name="Asia/Tokyo"
+    )
+    assert "(Asia/Tokyo)" in result
+    assert "Current Time:" in result
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_uses_cached_tz(tmp_path: Path) -> None:
+    """HeartbeatService should parse timezone once and reuse on subsequent calls."""
+    from nanobot.heartbeat.service import HeartbeatService
+    from nanobot.providers.base import LLMProvider, LLMResponse
+
+    # Write USER.md with valid timezone
+    (tmp_path / "USER.md").write_text(
+        "# User Profile\n- **Timezone**: America/New_York\n", encoding="utf-8"
+    )
+    (tmp_path / "HEARTBEAT.md").write_text("check tasks", encoding="utf-8")
+
+    class FakeProvider(LLMProvider):
+        def __init__(self):
+            super().__init__()
+            self.captured_messages: list[dict] = []
+
+        def get_default_model(self) -> str:
+            return "test"
+
+        async def chat(self, *, messages=None, **kwargs) -> LLMResponse:
+            if messages:
+                self.captured_messages.extend(messages)
+            return LLMResponse(
+                content=None,
+                tool_calls=[
+                    type("TC", (), {
+                        "id": "1",
+                        "name": "heartbeat",
+                        "arguments": {"action": "skip"},
+                    })()
+                ],
+            )
+
+    provider = FakeProvider()
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="test",
+        enabled=False,
+    )
+
+    # First call: should parse timezone
+    await service._decide("test heartbeat content")
+    assert service._user_tz == "America/New_York"
+    assert any("(America/New_York)" in str(m.get("content", "")) for m in provider.captured_messages)
+
+    # Second call: should reuse cached timezone (no re-parsing)
+    provider.captured_messages.clear()
+    await service._decide("test heartbeat content 2")
+    assert service._user_tz == "America/New_York"
+    assert any("(America/New_York)" in str(m.get("content", "")) for m in provider.captured_messages)

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,8 +1,8 @@
-"""Tests for timezone consolidation — parse_user_timezone and current_time_str(tz_name)."""
+"""Tests for timezone configuration — config.json + USER.md deprecation fallback."""
 
 import re
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -15,7 +15,6 @@ from nanobot.utils.helpers import current_time_str, parse_user_timezone
 def test_current_time_str_no_arg_preserves_behavior() -> None:
     """Calling with no argument should return a string with weekday and timezone abbreviation."""
     result = current_time_str()
-    # Should match pattern: YYYY-MM-DD HH:MM (Weekday) (TZ)
     assert re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} \(\w+\) \(.+\)", result)
 
 
@@ -29,12 +28,11 @@ def test_current_time_str_valid_iana() -> None:
 def test_current_time_str_invalid_fallback() -> None:
     """Invalid timezone should fallback to system timezone without crashing."""
     result = current_time_str("Invalid/Zone")
-    # Should NOT contain "Invalid/Zone", should contain a system tz
     assert "Invalid/Zone" not in result
     assert re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} \(\w+\) \(.+\)", result)
 
 
-# --- parse_user_timezone tests ---
+# --- parse_user_timezone tests (kept for deprecation fallback) ---
 
 
 def test_parse_valid_iana(tmp_path: Path) -> None:
@@ -75,14 +73,6 @@ def test_parse_empty_timezone_returns_none(tmp_path: Path) -> None:
     assert parse_user_timezone(tmp_path) is None
 
 
-def test_parse_indented_bullet(tmp_path: Path) -> None:
-    """Indented markdown bullet should still be parsed."""
-    (tmp_path / "USER.md").write_text(
-        "# User Profile\n    - **Timezone**: Asia/Shanghai\n", encoding="utf-8"
-    )
-    assert parse_user_timezone(tmp_path) == "Asia/Shanghai"
-
-
 def test_parse_asterisk_bullet(tmp_path: Path) -> None:
     """Asterisk bullet should also be parsed."""
     (tmp_path / "USER.md").write_text(
@@ -91,11 +81,11 @@ def test_parse_asterisk_bullet(tmp_path: Path) -> None:
     assert parse_user_timezone(tmp_path) == "Europe/London"
 
 
-# --- Integration tests ---
+# --- Config-based integration tests ---
 
 
-def test_runtime_context_uses_user_tz(tmp_path: Path) -> None:
-    """ContextBuilder._build_runtime_context should use user timezone when provided."""
+def test_runtime_context_uses_config_timezone() -> None:
+    """ContextBuilder._build_runtime_context should use config timezone."""
     from nanobot.agent.context import ContextBuilder
 
     result = ContextBuilder._build_runtime_context(
@@ -105,16 +95,142 @@ def test_runtime_context_uses_user_tz(tmp_path: Path) -> None:
     assert "Current Time:" in result
 
 
-@pytest.mark.asyncio
-async def test_heartbeat_uses_cached_tz(tmp_path: Path) -> None:
-    """HeartbeatService should parse timezone once and reuse on subsequent calls."""
-    from nanobot.heartbeat.service import HeartbeatService
-    from nanobot.providers.base import LLMProvider, LLMResponse
+def test_runtime_context_no_timezone_uses_system() -> None:
+    """ContextBuilder._build_runtime_context with tz_name=None uses system time."""
+    from nanobot.agent.context import ContextBuilder
 
-    # Write USER.md with valid timezone
+    result = ContextBuilder._build_runtime_context(channel="cli", chat_id="test", tz_name=None)
+    assert "Current Time:" in result
+    # Should NOT contain any IANA timezone path
+    assert "/" not in result.split("Current Time:")[1].split("\n")[0] or "Asia/" not in result
+
+
+def test_context_builder_passes_timezone(tmp_path: Path) -> None:
+    """ContextBuilder stores timezone and passes it to _build_runtime_context."""
+    from nanobot.agent.context import ContextBuilder
+
+    # Create minimal workspace
+    (tmp_path / "memory").mkdir()
+    (tmp_path / "memory" / "MEMORY.md").write_text("", encoding="utf-8")
+
+    ctx = ContextBuilder(tmp_path, timezone="Asia/Shanghai")
+    assert ctx.timezone == "Asia/Shanghai"
+
+
+def test_config_schema_timezone_field() -> None:
+    """Config schema accepts timezone field without crashing."""
+    from nanobot.config.schema import Config
+
+    config = Config.model_validate({
+        "agents": {"defaults": {"timezone": "America/New_York"}}
+    })
+    assert config.agents.defaults.timezone == "America/New_York"
+
+
+def test_config_schema_timezone_none_default() -> None:
+    """Config without timezone defaults to None."""
+    from nanobot.config.schema import Config
+
+    config = Config()
+    assert config.agents.defaults.timezone is None
+
+
+def test_config_invalid_timezone_loads_gracefully() -> None:
+    """Invalid timezone in config should NOT crash config loading — no strict validator."""
+    from nanobot.config.schema import Config
+
+    # This MUST succeed (no validator = no crash). The invalid tz is handled at usage time.
+    config = Config.model_validate({
+        "agents": {"defaults": {"timezone": "Invalid/Zone"}}
+    })
+    assert config.agents.defaults.timezone == "Invalid/Zone"
+    # current_time_str gracefully falls back
+    result = current_time_str(config.agents.defaults.timezone)
+    assert "Invalid/Zone" not in result
+
+
+# --- Deprecation fallback tests ---
+
+
+def test_resolve_timezone_prefers_config(tmp_path: Path) -> None:
+    """_resolve_timezone should prefer config.json timezone over USER.md."""
+    from nanobot.cli.commands import _resolve_timezone
+    from nanobot.config.schema import Config
+
+    # USER.md has timezone but config also has one
+    (tmp_path / "USER.md").write_text(
+        "# User Profile\n- **Timezone**: Europe/London\n", encoding="utf-8"
+    )
+    config = Config.model_validate({
+        "agents": {"defaults": {"workspace": str(tmp_path), "timezone": "Asia/Tokyo"}}
+    })
+    assert _resolve_timezone(config) == "Asia/Tokyo"
+
+
+def test_resolve_timezone_fallback_to_user_md(tmp_path: Path) -> None:
+    """_resolve_timezone should fallback to USER.md when config.timezone is None."""
+    from nanobot.cli.commands import _resolve_timezone
+    from nanobot.config.schema import Config
+
     (tmp_path / "USER.md").write_text(
         "# User Profile\n- **Timezone**: America/New_York\n", encoding="utf-8"
     )
+    config = Config.model_validate({
+        "agents": {"defaults": {"workspace": str(tmp_path)}}
+    })
+    with patch("loguru.logger.warning") as mock_warn:
+        result = _resolve_timezone(config)
+        assert result == "America/New_York"
+        mock_warn.assert_called_once()
+        assert "deprecated" in str(mock_warn.call_args).lower()
+
+
+def test_resolve_timezone_no_tz_anywhere(tmp_path: Path) -> None:
+    """_resolve_timezone returns None when neither config nor USER.md has timezone."""
+    from nanobot.cli.commands import _resolve_timezone
+    from nanobot.config.schema import Config
+
+    config = Config.model_validate({
+        "agents": {"defaults": {"workspace": str(tmp_path)}}
+    })
+    assert _resolve_timezone(config) is None
+
+
+# --- Subagent timezone wiring test ---
+
+
+def test_subagent_manager_passes_timezone(tmp_path: Path) -> None:
+    """SubagentManager should pass timezone to _build_runtime_context."""
+    from unittest.mock import MagicMock
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test"
+    bus = MessageBus()
+
+    mgr = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=bus,
+        timezone="Europe/Berlin",
+    )
+    assert mgr.timezone == "Europe/Berlin"
+
+    # _build_subagent_prompt should contain the timezone
+    prompt = mgr._build_subagent_prompt()
+    assert "(Europe/Berlin)" in prompt
+
+
+# --- Heartbeat timezone wiring test ---
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_uses_constructor_timezone(tmp_path: Path) -> None:
+    """HeartbeatService should use timezone from constructor, not USER.md."""
+    from nanobot.heartbeat.service import HeartbeatService
+    from nanobot.providers.base import LLMProvider, LLMResponse
+
     (tmp_path / "HEARTBEAT.md").write_text("check tasks", encoding="utf-8")
 
     class FakeProvider(LLMProvider):
@@ -145,15 +261,9 @@ async def test_heartbeat_uses_cached_tz(tmp_path: Path) -> None:
         provider=provider,
         model="test",
         enabled=False,
+        timezone="America/New_York",
     )
 
-    # First call: should parse timezone
     await service._decide("test heartbeat content")
-    assert service._user_tz == "America/New_York"
-    assert any("(America/New_York)" in str(m.get("content", "")) for m in provider.captured_messages)
-
-    # Second call: should reuse cached timezone (no re-parsing)
-    provider.captured_messages.clear()
-    await service._decide("test heartbeat content 2")
     assert service._user_tz == "America/New_York"
     assert any("(America/New_York)" in str(m.get("content", "")) for m in provider.captured_messages)


### PR DESCRIPTION
## Problem

Closes #793.

`USER.md` already has a `Timezone` field in its template, but the codebase never reads it. `current_time_str()` only uses the system timezone (`time.strftime("%Z")`), which means LLM prompts always reflect the server's timezone rather than the user's actual location.

This was also raised by @rick2047 in [PR #2038 discussion](https://github.com/HKUDS/nanobot/pull/2038) — the agent should use user-configured timezone for time-aware decisions.

## Changes

- **`helpers.py`**: `current_time_str(tz_name)` now accepts an optional IANA timezone string. Falls back to system timezone for invalid/missing values. Added `parse_user_timezone(workspace)` to read and validate timezone from `USER.md` using `ZoneInfo`.
- **`context.py`**: `_build_runtime_context` passes user timezone through (kept as `@staticmethod`). `build_messages` calls `parse_user_timezone` per request.
- **`heartbeat/service.py`**: Caches parsed timezone with an `_UNSET` sentinel — parses once on first heartbeat tick, avoids disk I/O on subsequent ticks.
- **`USER.md` template**: Updated example from `UTC+8` to `Asia/Shanghai` (proper IANA format).

## Backward Compatibility

- `current_time_str()` with no arguments behaves identically to before.
- Missing `USER.md`, blank timezone, placeholder text, or invalid timezone all resolve to existing system timezone behavior.
- No existing tests broken.

## Tests

12 new tests in `tests/test_timezone.py`:
- `current_time_str`: no-arg preserves behavior, valid IANA, invalid fallback
- `parse_user_timezone`: valid IANA, placeholder, missing file, invalid tz, empty, indented bullet, asterisk bullet
- Integration: runtime context uses user tz, heartbeat caches tz