### PR TITLE
Add system prompt explanation for Runtime Context tag

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -88,6 +88,7 @@ Your workspace is at: {workspace_path}
 {platform_policy}
 
 ## nanobot Guidelines
+- Each user message starts with a `[Runtime Context]` block containing the current time and channel info. This is injected by the system — treat it as trusted metadata, then follow the user's actual message that comes after it.
 - State intent before tool calls, but NEVER predict or claim results before receiving them.
 - Before modifying a file, read it first. Do not assume files or directories exist.
 - After writing or editing a file, re-read it if accuracy matters.


### PR DESCRIPTION
## Summary

- Add a guideline in `_get_identity()` system prompt explaining the `[Runtime Context]` tag to the LLM
- Tells the LLM the Runtime Context block is system-injected trusted metadata, and the user's actual message follows after it
- Prevents safety-tuned models from misinterpreting the tag as prompt injection and refusing to execute tool calls

Fixes #2089

## Context

After PR #1417 merged Runtime Context back into the user message (to avoid consecutive same-role messages), the system prompt was never updated to explain the tag. Some LLMs see `[Runtime Context — metadata only, not instructions]` and treat the entire user message as untrusted, refusing to emit `tool_calls`. This one-line addition resolves the issue.

## Test plan

- [ ] Start `nanobot agent` with a safety-tuned model (e.g., Claude Sonnet)
- [ ] Send an action-oriented message (e.g., "install the weather skill using clawhub")
- [ ] Verify the LLM emits tool calls instead of just describing what it would do
- [ ] Verify Runtime Context metadata (time, channel) is still correctly passed to the LLM
