### PR TITLE
security: SSRF protection, media path check, spawn/cron limits

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -64,6 +64,8 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        max_concurrent_subagents: int | None = 5,
+        allow_private_ip: bool = False,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -76,6 +78,7 @@ class AgentLoop:
         self.context_window_tokens = context_window_tokens
         self.web_search_config = web_search_config or WebSearchConfig()
         self.web_proxy = web_proxy
+        self.allow_private_ip = allow_private_ip
         self.exec_config = exec_config or ExecToolConfig()
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
@@ -92,6 +95,7 @@ class AgentLoop:
             web_proxy=web_proxy,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            max_concurrent=max_concurrent_subagents,
         )
 
         self._running = False
@@ -126,8 +130,8 @@ class AgentLoop:
             path_append=self.exec_config.path_append,
         ))
         self.tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
-        self.tools.register(WebFetchTool(proxy=self.web_proxy))
-        self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
+        self.tools.register(WebFetchTool(proxy=self.web_proxy, allow_private_ip=self.allow_private_ip))
+        self.tools.register(MessageTool(send_callback=self.bus.publish_outbound, workspace=self.workspace))
         self.tools.register(SpawnTool(manager=self.subagents))
         if self.cron_service:
             self.tools.register(CronTool(self.cron_service))

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -33,6 +33,7 @@ class SubagentManager:
         web_proxy: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
+        max_concurrent: int | None = 5,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -44,6 +45,7 @@ class SubagentManager:
         self.web_proxy = web_proxy
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
+        self._max_concurrent = max_concurrent
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
 
@@ -56,6 +58,8 @@ class SubagentManager:
         session_key: str | None = None,
     ) -> str:
         """Spawn a subagent to execute a task in the background."""
+        if self._max_concurrent is not None and len(self._running_tasks) >= self._max_concurrent:
+            return f"Error: maximum number of concurrent subagents ({self._max_concurrent}) reached. Wait for running tasks to complete."
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
         origin = {"channel": origin_channel, "chat_id": origin_chat_id}

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -132,15 +132,18 @@ class CronTool(Tool):
         else:
             return "Error: either every_seconds, cron_expr, or at is required"
 
-        job = self._cron.add_job(
-            name=message[:30],
-            schedule=schedule,
-            message=message,
-            deliver=True,
-            channel=self._channel,
-            to=self._chat_id,
-            delete_after_run=delete_after,
-        )
+        try:
+            job = self._cron.add_job(
+                name=message[:30],
+                schedule=schedule,
+                message=message,
+                deliver=True,
+                channel=self._channel,
+                to=self._chat_id,
+                delete_after_run=delete_after,
+            )
+        except ValueError as e:
+            return f"Error: {e}"
         return f"Created job '{job.name}' (id: {job.id})"
 
     def _list_jobs(self) -> str:

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -1,5 +1,6 @@
 """Message tool for sending messages to users."""
 
+from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from nanobot.agent.tools.base import Tool
@@ -15,12 +16,14 @@ class MessageTool(Tool):
         default_channel: str = "",
         default_chat_id: str = "",
         default_message_id: str | None = None,
+        workspace: Path | None = None,
     ):
         self._send_callback = send_callback
         self._default_channel = default_channel
         self._default_chat_id = default_chat_id
         self._default_message_id = default_message_id
         self._sent_in_turn: bool = False
+        self._workspace = workspace.resolve() if workspace else None
 
     def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
         """Set the current message context."""
@@ -70,6 +73,25 @@ class MessageTool(Tool):
             "required": ["content"]
         }
 
+    def _filter_media(self, media: list[str]) -> list[str]:
+        """Filter media paths to only allow files within workspace or /tmp."""
+        if not media:
+            return []
+        allowed: list[str] = []
+        tmp_dir = Path("/tmp").resolve()
+        for path_str in media:
+            try:
+                p = Path(path_str).resolve()
+                in_workspace = self._workspace and p == self._workspace or (
+                    self._workspace and self._workspace in p.parents
+                )
+                in_tmp = p == tmp_dir or tmp_dir in p.parents
+                if in_workspace or in_tmp:
+                    allowed.append(path_str)
+            except (ValueError, OSError):
+                continue
+        return allowed
+
     async def execute(
         self,
         content: str,
@@ -88,6 +110,9 @@ class MessageTool(Tool):
 
         if not self._send_callback:
             return "Error: Message sending not configured"
+
+        if media:
+            media = self._filter_media(media)
 
         msg = OutboundMessage(
             channel=channel,

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import html
+import ipaddress
 import json
 import os
 import re
+import socket
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -21,6 +23,33 @@ if TYPE_CHECKING:
 # Shared constants
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36"
 MAX_REDIRECTS = 5  # Limit redirects to prevent DoS attacks
+
+# SSRF protection: block private/internal network ranges
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def _is_private_ip(hostname: str) -> bool:
+    """Check if hostname resolves to a private/loopback/internal IP address."""
+    try:
+        addrs = socket.getaddrinfo(hostname, None)
+        for _family, _, _, _, sockaddr in addrs:
+            ip = ipaddress.ip_address(sockaddr[0])
+            if any(ip in net for net in _BLOCKED_NETWORKS):
+                return True
+        return False
+    except (socket.gaierror, ValueError):
+        return True  # DNS failure → deny (fail-closed)
 
 
 def _strip_tags(text: str) -> str:
@@ -220,15 +249,21 @@ class WebFetchTool(Tool):
         "required": ["url"],
     }
 
-    def __init__(self, max_chars: int = 50000, proxy: str | None = None):
+    def __init__(self, max_chars: int = 50000, proxy: str | None = None, allow_private_ip: bool = False):
         self.max_chars = max_chars
         self.proxy = proxy
+        self.allow_private_ip = allow_private_ip
 
     async def execute(self, url: str, extractMode: str = "markdown", maxChars: int | None = None, **kwargs: Any) -> str:
         max_chars = maxChars or self.max_chars
         is_valid, error_msg = _validate_url(url)
         if not is_valid:
             return json.dumps({"error": f"URL validation failed: {error_msg}", "url": url}, ensure_ascii=False)
+
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        if not self.allow_private_ip and hostname and _is_private_ip(hostname):
+            return json.dumps({"error": f"Access to private/internal network address '{hostname}' is blocked for security reasons.", "url": url}, ensure_ascii=False)
 
         result = await self._fetch_jina(url, max_chars)
         if result is None:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -423,7 +423,7 @@ def gateway(
 
     # Create cron service first (callback set after agent creation)
     cron_store_path = get_cron_dir() / "jobs.json"
-    cron = CronService(cron_store_path)
+    cron = CronService(cron_store_path, max_jobs=config.tools.max_cron_jobs)
 
     # Create agent with cron service
     agent = AgentLoop(
@@ -441,6 +441,8 @@ def gateway(
         session_manager=session_manager,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        max_concurrent_subagents=config.tools.max_concurrent_subagents,
+        allow_private_ip=config.tools.web.allow_private_ip,
     )
 
     # Set cron callback (needs agent)
@@ -611,7 +613,7 @@ def agent(
 
     # Create cron service for tool usage (no callback needed for CLI unless running)
     cron_store_path = get_cron_dir() / "jobs.json"
-    cron = CronService(cron_store_path)
+    cron = CronService(cron_store_path, max_jobs=config.tools.max_cron_jobs)
 
     if logs:
         logger.enable("nanobot")
@@ -632,6 +634,8 @@ def agent(
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
+        max_concurrent_subagents=config.tools.max_concurrent_subagents,
+        allow_private_ip=config.tools.web.allow_private_ip,
     )
 
     # Show spinner when logs are off (no output to miss); skip when logs are on

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -120,6 +120,7 @@ class WebToolsConfig(Base):
     proxy: str | None = (
         None  # HTTP/SOCKS5 proxy URL, e.g. "http://127.0.0.1:7890" or "socks5://127.0.0.1:1080"
     )
+    allow_private_ip: bool = False  # If true, allow fetching private/internal network addresses
     search: WebSearchConfig = Field(default_factory=WebSearchConfig)
 
 
@@ -143,11 +144,26 @@ class MCPServerConfig(Base):
     enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
 
 class ToolsConfig(Base):
-    """Tools configuration."""
+    """Tool configuration.
+
+    Example (config.json)::
+
+        {
+          "tools": {
+            "web": { "allowPrivateIp": false },
+            "maxConcurrentSubagents": 5,
+            "maxCronJobs": 20
+          }
+        }
+
+    Set ``maxConcurrentSubagents`` or ``maxCronJobs`` to ``null`` for no limit.
+    """
 
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
+    max_concurrent_subagents: int | None = 5  # Maximum concurrent subagents; null = unlimited
+    max_cron_jobs: int | None = 20  # Maximum scheduled cron jobs; null = unlimited
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
 

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -66,10 +66,12 @@ class CronService:
     def __init__(
         self,
         store_path: Path,
-        on_job: Callable[[CronJob], Coroutine[Any, Any, str | None]] | None = None
+        on_job: Callable[[CronJob], Coroutine[Any, Any, str | None]] | None = None,
+        max_jobs: int | None = 20,
     ):
         self.store_path = store_path
         self.on_job = on_job
+        self._max_jobs = max_jobs
         self._store: CronStore | None = None
         self._last_mtime: float = 0.0
         self._timer_task: asyncio.Task | None = None
@@ -295,6 +297,8 @@ class CronService:
     ) -> CronJob:
         """Add a new job."""
         store = self._load_store()
+        if self._max_jobs is not None and len(store.jobs) >= self._max_jobs:
+            raise ValueError(f"Maximum number of cron jobs ({self._max_jobs}) reached. Remove existing jobs before adding new ones.")
         _validate_schedule_for_add(schedule)
         now = _now_ms()
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,225 @@
+"""Security hardening tests: SSRF protection, media path filter, spawn/cron limits."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import nanobot.agent.tools.web as web_mod
+from nanobot.agent.tools.message import MessageTool
+from nanobot.agent.tools.web import WebFetchTool, _is_private_ip
+
+
+# ---------------------------------------------------------------------------
+# SSRF protection (_is_private_ip / WebFetchTool)
+# ---------------------------------------------------------------------------
+
+def _make_addrinfo(ip: str):
+    """Build a minimal socket.getaddrinfo return value for a given IP string."""
+    family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+    return [(family, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+
+class TestSSRFProtection:
+
+    def test_ssrf_blocks_private_ipv4(self, monkeypatch):
+        """127.0.0.1 must be blocked."""
+        monkeypatch.setattr(web_mod.socket, "getaddrinfo", lambda h, p: _make_addrinfo("127.0.0.1"))
+        assert _is_private_ip("localhost") is True
+
+    def test_ssrf_blocks_rfc1918(self, monkeypatch):
+        """RFC-1918 private ranges (10.x, 172.16.x, 192.168.x) must be blocked."""
+        for ip in ("10.0.0.1", "10.255.255.255", "172.16.0.1", "172.31.255.255", "192.168.1.1"):
+            monkeypatch.setattr(web_mod.socket, "getaddrinfo", lambda h, p, _ip=ip: _make_addrinfo(_ip))
+            assert _is_private_ip("internal.host") is True, f"{ip} should be blocked"
+
+    def test_ssrf_blocks_link_local(self, monkeypatch):
+        """169.254.x (AWS instance metadata and link-local) must be blocked."""
+        monkeypatch.setattr(web_mod.socket, "getaddrinfo", lambda h, p: _make_addrinfo("169.254.169.254"))
+        assert _is_private_ip("metadata.internal") is True
+
+    def test_ssrf_allows_public(self, monkeypatch):
+        """A public IP must NOT be flagged as private."""
+        monkeypatch.setattr(web_mod.socket, "getaddrinfo", lambda h, p: _make_addrinfo("93.184.216.34"))
+        assert _is_private_ip("example.com") is False
+
+    def test_ssrf_dns_failure_denied(self, monkeypatch):
+        """DNS resolution failure must return True (fail-closed)."""
+        def _fail(host, port):
+            raise socket.gaierror("Name or service not known")
+
+        monkeypatch.setattr(web_mod.socket, "getaddrinfo", _fail)
+        assert _is_private_ip("nonexistent.invalid") is True
+
+    @pytest.mark.asyncio
+    async def test_ssrf_allow_private_ip_flag(self, monkeypatch):
+        """When allow_private_ip=True the SSRF check must be bypassed."""
+        # getaddrinfo would return a private IP, but the flag disables the check
+        monkeypatch.setattr(web_mod.socket, "getaddrinfo", lambda h, p: _make_addrinfo("127.0.0.1"))
+
+        tool = WebFetchTool(allow_private_ip=True)
+        assert tool.allow_private_ip is True
+
+        # Patch internal fetch methods to avoid real HTTP calls
+        async def _fake_jina(url, max_chars):
+            return '{"url":"http://127.0.0.1/","text":"ok"}'
+
+        monkeypatch.setattr(tool, "_fetch_jina", _fake_jina)
+
+        result = await tool.execute(url="http://127.0.0.1/")
+        # Should NOT contain the "blocked" error message
+        assert "blocked" not in result
+
+
+# ---------------------------------------------------------------------------
+# MessageTool media path filter
+# ---------------------------------------------------------------------------
+
+class TestMessageToolMediaFilter:
+
+    def test_media_filter_allows_workspace(self, tmp_path):
+        """Paths inside the workspace directory must pass through."""
+        tool = MessageTool(workspace=tmp_path)
+        inside = str(tmp_path / "image.png")
+        result = tool._filter_media([inside])
+        assert result == [inside]
+
+    def test_media_filter_allows_tmp(self, tmp_path):
+        """/tmp paths must pass through."""
+        tool = MessageTool(workspace=tmp_path)
+        # Use the resolved /tmp so the check works regardless of symlinks
+        tmp_file = str(Path("/tmp").resolve() / "voice.ogg")
+        result = tool._filter_media([tmp_file])
+        assert result == [tmp_file]
+
+    def test_media_filter_blocks_outside(self, tmp_path):
+        """Paths outside workspace and /tmp must be removed."""
+        tool = MessageTool(workspace=tmp_path)
+        outside = "/etc/passwd"
+        result = tool._filter_media([outside])
+        assert result == []
+
+    def test_media_filter_no_workspace(self):
+        """When workspace=None all paths outside /tmp are blocked."""
+        tool = MessageTool(workspace=None)
+        # /tmp is still allowed
+        tmp_file = str(Path("/tmp").resolve() / "ok.png")
+        assert tool._filter_media([tmp_file]) == [tmp_file]
+        # Arbitrary path is blocked
+        assert tool._filter_media(["/home/user/secret.jpg"]) == []
+
+
+# ---------------------------------------------------------------------------
+# SubagentManager spawn concurrency limit
+# ---------------------------------------------------------------------------
+
+class TestSpawnConcurrencyLimit:
+
+    def _make_manager(self, max_concurrent):
+        """Build a minimal SubagentManager without real provider/bus."""
+        from nanobot.agent.subagent import SubagentManager
+
+        manager = SubagentManager.__new__(SubagentManager)
+        manager._max_concurrent = max_concurrent
+        manager._running_tasks = {}
+        manager._session_tasks = {}
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_spawn_limit_blocks_when_full(self, monkeypatch):
+        """Reaching max_concurrent must return an error string immediately."""
+        manager = self._make_manager(max_concurrent=2)
+
+        # Pre-fill _running_tasks with fake done tasks so len == max_concurrent
+        fake_task = MagicMock(spec=asyncio.Task)
+        manager._running_tasks = {"a": fake_task, "b": fake_task}
+
+        # _run_subagent must never be called in this path
+        called = []
+
+        async def _noop(*args, **kwargs):
+            called.append(True)
+
+        monkeypatch.setattr(manager, "_run_subagent", _noop)
+
+        result = await manager.spawn(task="do something", session_key="ch:user")
+        assert "Error" in result or "maximum" in result.lower()
+        assert called == [], "_run_subagent should not have been called"
+
+    @pytest.mark.asyncio
+    async def test_spawn_no_limit_when_none(self, monkeypatch):
+        """max_concurrent=None must allow spawning even when many tasks are running."""
+        manager = self._make_manager(max_concurrent=None)
+
+        # Fill with many fake tasks
+        fake_task = MagicMock(spec=asyncio.Task)
+        manager._running_tasks = {str(i): fake_task for i in range(100)}
+
+        # Patch _run_subagent to be a coroutine that does nothing
+        async def _noop(task_id, task, label, origin):
+            pass
+
+        monkeypatch.setattr(manager, "_run_subagent", _noop)
+
+        result = await manager.spawn(task="unlimited task", session_key="ch:user")
+        # Should succeed (returns a start message, not an error)
+        assert "Error" not in result
+        assert "maximum" not in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# CronService max_jobs limit
+# ---------------------------------------------------------------------------
+
+class TestCronJobLimit:
+
+    def _make_cron(self, max_jobs, existing_jobs=0, tmp_path=None):
+        """Build a CronService with a pre-populated in-memory store."""
+        from nanobot.cron.service import CronService
+        from nanobot.cron.types import CronJob, CronJobState, CronPayload, CronSchedule, CronStore
+
+        store_path = (tmp_path / "cron.json") if tmp_path else Path("/tmp/cron_test.json")
+        svc = CronService(store_path=store_path, on_job=None, max_jobs=max_jobs)
+
+        # Build fake jobs
+        jobs = []
+        for i in range(existing_jobs):
+            jobs.append(CronJob(
+                id=f"job{i}",
+                name=f"job {i}",
+                enabled=True,
+                schedule=CronSchedule(kind="every", every_ms=60_000),
+                payload=CronPayload(kind="agent_turn", message="ping"),
+                state=CronJobState(),
+            ))
+        svc._store = CronStore(jobs=jobs)
+        return svc
+
+    def test_cron_limit_blocks_when_full(self, tmp_path):
+        """Adding a job when at max_jobs must raise ValueError."""
+        svc = self._make_cron(max_jobs=2, existing_jobs=2, tmp_path=tmp_path)
+        from nanobot.cron.types import CronSchedule
+
+        with pytest.raises(ValueError, match="[Mm]aximum"):
+            svc.add_job(
+                name="new job",
+                schedule=CronSchedule(kind="every", every_ms=5000),
+                message="hello",
+            )
+
+    def test_cron_no_limit_when_none(self, tmp_path):
+        """max_jobs=None must allow adding jobs beyond any count."""
+        svc = self._make_cron(max_jobs=None, existing_jobs=100, tmp_path=tmp_path)
+        from nanobot.cron.types import CronSchedule
+
+        # Should not raise
+        job = svc.add_job(
+            name="extra job",
+            schedule=CronSchedule(kind="every", every_ms=5000),
+            message="go",
+        )
+        assert job.id is not None


### PR DESCRIPTION
  ## Summary

  This PR adds four independent security improvements to nanobot:

  **1. SSRF protection for `WebFetchTool`**
  - Block requests to private/internal network addresses (loopback, RFC 1918,
  link-local/AWS metadata, IPv6 private ranges)
  - Uses `socket.getaddrinfo` to resolve all address families (IPv4, IPv6, mapped
  addresses)
  - Fail-closed: DNS resolution failures are treated as blocked
  - New config: `tools.web.allowPrivateIp` (default: `false`) to opt out when needed

  **2. `MessageTool` media attachment path check**
  - Restrict media file paths to workspace or `/tmp`
  - Prevents the agent from forwarding sensitive files through IM channels

  **3. Subagent concurrency limit**
  - New config: `tools.maxConcurrentSubagents` (default: 5, `null` = unlimited)

  **4. Cron job count limit**
  - New config: `tools.maxCronJobs` (default: 20, `null` = unlimited)

  ## Configuration

  ```json
  {
    "tools": {
      "web": { "allowPrivateIp": false },
      "maxConcurrentSubagents": 5,
      "maxCronJobs": 20
    }
  }
```

  Test plan

  - tests/test_security.py — 14 new test cases covering all four features