### PR TITLE
feat: add explicit subagent model config and in-process runtime reload

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -164,7 +164,7 @@ class AgentLoop:
         self.tools = ToolRegistry()
         self._register_default_tools()
 
-        logger.info("Reloaded runtime config: main_model=%s subagent_model=%s", main_model, subagent_model)
+        logger.info("Reloaded runtime config: main_model={} subagent_model={}", main_model, subagent_model)
         return main_model, subagent_model
 
     def _register_default_tools(self) -> None:
@@ -437,7 +437,7 @@ class AgentLoop:
         cmd = raw.lower()
         first_token = raw.split(maxsplit=1)[0].lower() if raw else ""
         cmd_base = first_token.split("@", 1)[0]
-        if cmd == "/new":
+        if cmd_base == "/new":
             try:
                 if not await self.memory_consolidator.archive_unconsolidated(session):
                     return OutboundMessage(
@@ -458,7 +458,7 @@ class AgentLoop:
             self.sessions.invalidate(session.key)
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
                                   content="New session started.")
-        if cmd == "/help":
+        if cmd_base == "/help":
             lines = [
                 "🐈 nanobot commands:",
                 "/new — Start a new conversation",

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -26,7 +26,9 @@ from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.config.loader import load_config, save_config
 from nanobot.providers.base import LLMProvider
+from nanobot.providers.custom_provider import CustomProvider
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
@@ -47,6 +49,7 @@ class AgentLoop:
     """
 
     _TOOL_RESULT_MAX_CHARS = 16_000
+    _DEFAULT_SUBAGENT_MODEL = "claude-haiku-4-5-20251001"
 
     def __init__(
         self,
@@ -72,6 +75,7 @@ class AgentLoop:
         self.provider = provider
         self.workspace = workspace
         self.model = model or provider.get_default_model()
+        self.subagent_model = self._subagent_default_for_model(self.model)
         self.max_iterations = max_iterations
         self.context_window_tokens = context_window_tokens
         self.web_search_config = web_search_config or WebSearchConfig()
@@ -111,6 +115,23 @@ class AgentLoop:
             get_tool_definitions=self.tools.get_definitions,
         )
         self._register_default_tools()
+
+    def _switch_model(self, model_ref: str) -> None:
+        """Switch active model."""
+        self.model = model_ref
+        cfg = load_config()
+        self.provider = CustomProvider(
+            api_key=cfg.get_api_key() or "",
+            api_base=cfg.get_api_base(),
+            default_model=model_ref,
+        )
+        self.subagents.provider = self.provider
+        logger.info("Switched model to %s", model_ref)
+
+    @classmethod
+    def _subagent_default_for_model(cls, model: str) -> str:
+        """Return default subagent model (fast/cheap) for a given main model."""
+        return cls._DEFAULT_SUBAGENT_MODEL
 
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
@@ -378,7 +399,10 @@ class AgentLoop:
         session = self.sessions.get_or_create(key)
 
         # Slash commands
-        cmd = msg.content.strip().lower()
+        raw = msg.content.strip()
+        cmd = raw.lower()
+        first_token = raw.split(maxsplit=1)[0].lower() if raw else ""
+        cmd_base = first_token.split("@", 1)[0]
         if cmd == "/new":
             try:
                 if not await self.memory_consolidator.archive_unconsolidated(session):
@@ -404,12 +428,79 @@ class AgentLoop:
             lines = [
                 "🐈 nanobot commands:",
                 "/new — Start a new conversation",
+                "/model — Pick or set model (saved to config)",
+                "/reload — Reload nanobot gateway service",
                 "/stop — Stop the current task",
                 "/restart — Restart the bot",
                 "/help — Show available commands",
             ]
             return OutboundMessage(
                 channel=msg.channel, chat_id=msg.chat_id, content="\n".join(lines),
+            )
+        if cmd_base == "/reload":
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    "systemctl", "--user", "reload", "nanobot-gateway",
+                    stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                )
+                stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=20)
+            except FileNotFoundError:
+                return OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content="Reload failed: `systemctl` not found on this host.",
+                )
+            except asyncio.TimeoutError:
+                return OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content="Reload command timed out after 20s.",
+                )
+            except Exception as exc:
+                return OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content=f"Reload failed: {exc}",
+                )
+            stdout = stdout_b.decode(errors="ignore").strip()
+            stderr = stderr_b.decode(errors="ignore").strip()
+            if proc.returncode == 0:
+                detail = f"\n{stdout}" if stdout else ""
+                return OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content=f"Reloaded `nanobot-gateway` successfully.{detail}",
+                )
+            detail = stderr or stdout or "Unknown error"
+            return OutboundMessage(
+                channel=msg.channel, chat_id=msg.chat_id,
+                content=f"Reload failed (exit {proc.returncode}): {detail}",
+            )
+        if cmd_base == "/model":
+            parts = raw.split(maxsplit=1)
+            model_arg = parts[1].strip() if len(parts) > 1 else ""
+            if model_arg:
+                cfg = load_config()
+                subagent_model = self._subagent_default_for_model(model_arg)
+                cfg.agents.defaults.model = model_arg
+                self._switch_model(model_arg)
+                self.subagent_model = subagent_model
+                self.subagents.model = subagent_model
+                save_config(cfg)
+                return OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content=(
+                        f"Model saved and activated: {model_arg}\n"
+                        f"Subagent model: {subagent_model}"
+                    ),
+                )
+            all_models = sorted(mid for mid, _ in await self.provider.list_models())
+            content = f"Active: {self.model}"
+            return OutboundMessage(
+                channel=msg.channel, chat_id=msg.chat_id,
+                content=content,
+                metadata={
+                    "_model_list": all_models,
+                    "_model_action": "active",
+                    "_model_page": 0,
+                    "_current_model": self.model,
+                } if all_models else {},
             )
         await self.memory_consolidator.maybe_consolidate_by_tokens(session)
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -28,7 +28,7 @@ from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.config.loader import load_config, save_config
 from nanobot.providers.base import LLMProvider
-from nanobot.providers.custom_provider import CustomProvider
+from nanobot.runtime import make_provider, resolve_subagent_model
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
@@ -49,7 +49,6 @@ class AgentLoop:
     """
 
     _TOOL_RESULT_MAX_CHARS = 16_000
-    _DEFAULT_SUBAGENT_MODEL = "claude-haiku-4-5-20251001"
 
     def __init__(
         self,
@@ -57,6 +56,8 @@ class AgentLoop:
         provider: LLMProvider,
         workspace: Path,
         model: str | None = None,
+        subagent_provider: LLMProvider | None = None,
+        subagent_model: str | None = None,
         max_iterations: int = 40,
         context_window_tokens: int = 65_536,
         web_search_config: WebSearchConfig | None = None,
@@ -75,7 +76,7 @@ class AgentLoop:
         self.provider = provider
         self.workspace = workspace
         self.model = model or provider.get_default_model()
-        self.subagent_model = self._subagent_default_for_model(self.model)
+        self.subagent_model = subagent_model or self.model
         self.max_iterations = max_iterations
         self.context_window_tokens = context_window_tokens
         self.web_search_config = web_search_config or WebSearchConfig()
@@ -88,10 +89,10 @@ class AgentLoop:
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
         self.subagents = SubagentManager(
-            provider=provider,
+            provider=subagent_provider or provider,
             workspace=workspace,
             bus=bus,
-            model=self.model,
+            model=self.subagent_model,
             web_search_config=self.web_search_config,
             web_proxy=web_proxy,
             exec_config=self.exec_config,
@@ -116,22 +117,55 @@ class AgentLoop:
         )
         self._register_default_tools()
 
-    def _switch_model(self, model_ref: str) -> None:
-        """Switch active model."""
-        self.model = model_ref
-        cfg = load_config()
-        self.provider = CustomProvider(
-            api_key=cfg.get_api_key() or "",
-            api_base=cfg.get_api_base(),
-            default_model=model_ref,
-        )
-        self.subagents.provider = self.provider
-        logger.info("Switched model to %s", model_ref)
+    async def _reload_runtime_from_config(self, config: "Config | None" = None) -> tuple[str, str]:
+        """Reload provider, tools, MCP, and model state from config for future turns."""
+        from nanobot.config.schema import Config
 
-    @classmethod
-    def _subagent_default_for_model(cls, model: str) -> str:
-        """Return default subagent model (fast/cheap) for a given main model."""
-        return cls._DEFAULT_SUBAGENT_MODEL
+        cfg = config or load_config()
+        main_model = cfg.agents.defaults.model
+        subagent_model = resolve_subagent_model(cfg, main_model)
+        main_provider = make_provider(cfg, model=main_model)
+        subagent_provider = (
+            main_provider
+            if subagent_model == main_model
+            else make_provider(cfg, model=subagent_model)
+        )
+
+        if self._mcp_stack:
+            try:
+                await self._mcp_stack.aclose()
+            except Exception:
+                pass
+        self._mcp_stack = None
+        self._mcp_connected = False
+        self._mcp_connecting = False
+        self._mcp_servers = cfg.tools.mcp_servers
+
+        self.provider = main_provider
+        self.model = main_model
+        self.subagent_model = subagent_model
+        self.web_search_config = cfg.tools.web.search
+        self.web_proxy = cfg.tools.web.proxy or None
+        self.exec_config = cfg.tools.exec
+        self.restrict_to_workspace = cfg.tools.restrict_to_workspace
+        self.channels_config = cfg.channels
+
+        self.subagents.provider = subagent_provider
+        self.subagents.model = subagent_model
+        self.subagents.web_search_config = self.web_search_config
+        self.subagents.web_proxy = self.web_proxy
+        self.subagents.exec_config = self.exec_config
+        self.subagents.restrict_to_workspace = self.restrict_to_workspace
+
+        self.memory_consolidator.provider = main_provider
+        self.memory_consolidator.model = main_model
+        self.memory_consolidator.context_window_tokens = cfg.agents.defaults.context_window_tokens
+
+        self.tools = ToolRegistry()
+        self._register_default_tools()
+
+        logger.info("Reloaded runtime config: main_model=%s subagent_model=%s", main_model, subagent_model)
+        return main_model, subagent_model
 
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
@@ -428,8 +462,8 @@ class AgentLoop:
             lines = [
                 "🐈 nanobot commands:",
                 "/new — Start a new conversation",
-                "/model — Pick or set model (saved to config)",
-                "/reload — Reload nanobot gateway service",
+                "/model — Pick or set main/subagent model",
+                "/reload — Reload config/runtime in-process",
                 "/stop — Stop the current task",
                 "/restart — Restart the bot",
                 "/help — Show available commands",
@@ -439,59 +473,61 @@ class AgentLoop:
             )
         if cmd_base == "/reload":
             try:
-                proc = await asyncio.create_subprocess_exec(
-                    "systemctl", "--user", "reload", "nanobot-gateway",
-                    stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-                )
-                stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=20)
-            except FileNotFoundError:
-                return OutboundMessage(
-                    channel=msg.channel, chat_id=msg.chat_id,
-                    content="Reload failed: `systemctl` not found on this host.",
-                )
-            except asyncio.TimeoutError:
-                return OutboundMessage(
-                    channel=msg.channel, chat_id=msg.chat_id,
-                    content="Reload command timed out after 20s.",
-                )
+                main_model, subagent_model = await self._reload_runtime_from_config()
             except Exception as exc:
                 return OutboundMessage(
                     channel=msg.channel, chat_id=msg.chat_id,
                     content=f"Reload failed: {exc}",
                 )
-            stdout = stdout_b.decode(errors="ignore").strip()
-            stderr = stderr_b.decode(errors="ignore").strip()
-            if proc.returncode == 0:
-                detail = f"\n{stdout}" if stdout else ""
-                return OutboundMessage(
-                    channel=msg.channel, chat_id=msg.chat_id,
-                    content=f"Reloaded `nanobot-gateway` successfully.{detail}",
-                )
-            detail = stderr or stdout or "Unknown error"
             return OutboundMessage(
                 channel=msg.channel, chat_id=msg.chat_id,
-                content=f"Reload failed (exit {proc.returncode}): {detail}",
+                content=(
+                    "Reloaded config/runtime successfully.\n"
+                    f"Main model: {main_model}\n"
+                    f"Subagent model: {subagent_model}"
+                ),
             )
         if cmd_base == "/model":
-            parts = raw.split(maxsplit=1)
-            model_arg = parts[1].strip() if len(parts) > 1 else ""
-            if model_arg:
+            parts = raw.split(maxsplit=2)
+            if len(parts) > 2 and parts[1].lower() == "subagent":
+                subagent_arg = parts[2].strip()
                 cfg = load_config()
-                subagent_model = self._subagent_default_for_model(model_arg)
-                cfg.agents.defaults.model = model_arg
-                self._switch_model(model_arg)
-                self.subagent_model = subagent_model
-                self.subagents.model = subagent_model
+                if subagent_arg.lower() in {"clear", "default", "main"}:
+                    cfg.agents.defaults.subagent_model = None
+                else:
+                    cfg.agents.defaults.subagent_model = subagent_arg
                 save_config(cfg)
+                _, subagent_model = await self._reload_runtime_from_config(cfg)
                 return OutboundMessage(
                     channel=msg.channel, chat_id=msg.chat_id,
                     content=(
-                        f"Model saved and activated: {model_arg}\n"
+                        "Subagent model updated.\n"
+                        f"Main model: {self.model}\n"
+                        f"Subagent model: {subagent_model}"
+                    ),
+                )
+            model_arg = ""
+            if len(parts) > 2 and parts[1].lower() == "main":
+                model_arg = parts[2].strip()
+            elif len(parts) > 1 and parts[1].lower() != "subagent":
+                model_arg = raw.split(maxsplit=1)[1].strip()
+            if model_arg:
+                cfg = load_config()
+                cfg.agents.defaults.model = model_arg
+                save_config(cfg)
+                main_model, subagent_model = await self._reload_runtime_from_config(cfg)
+                return OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content=(
+                        "Model updated.\n"
+                        f"Main model: {main_model}\n"
                         f"Subagent model: {subagent_model}"
                     ),
                 )
             all_models = sorted(mid for mid, _ in await self.provider.list_models())
-            content = f"Active: {self.model}"
+            explicit_subagent = load_config().agents.defaults.subagent_model
+            subagent_display = explicit_subagent or f"{self.model} (follows main)"
+            content = f"Main: {self.model}\nSubagent: {subagent_display}"
             return OutboundMessage(
                 channel=msg.channel, chat_id=msg.chat_id,
                 content=content,

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -164,6 +164,7 @@ class ModelPickerState:
     action_prefix: str
     current_model: str
     page: int
+    token_to_model: dict[str, str]
 
     def total_pages(self, page_size: int) -> int:
         return max(1, (len(self.models) + page_size - 1) // page_size)
@@ -520,18 +521,26 @@ class TelegramChannel(BaseChannel):
                 return
             await self._update_model_picker(query, action_prefix, page)
             return
-        model_id = parts[1] if len(parts) == 2 else parts[2] if len(parts) >= 3 else payload
         chat_id = str(query.message.chat_id)
         sender_id = self._sender_id(query.from_user) if query.from_user else "unknown"
+        state = self._model_picker_state.get(chat_id)
+        if not state:
+            return
+        model_token = parts[1] if len(parts) == 2 else parts[2] if len(parts) >= 3 else payload
+        model_id = state.token_to_model.get(model_token)
+        if not model_id:
+            return
+        command = self._model_command_for_action(state.action_prefix, model_id)
+        label = "main model" if state.action_prefix == "set" else "subagent model"
 
         await self._handle_message(
             sender_id=sender_id,
             chat_id=chat_id,
-            content=f"/model {model_id}",
+            content=command,
         )
 
         try:
-            text = f"Model saved and active: <b>{model_id}</b>"
+            text = f"Requested {label}: <b>{model_id}</b>"
             await query.edit_message_text(text, parse_mode="HTML")
         except Exception:
             pass
@@ -551,6 +560,7 @@ class TelegramChannel(BaseChannel):
             action_prefix=action_prefix,
             current_model=current_model,
             page=page,
+            token_to_model={},
         )
         self._model_picker_state[chat_id] = state
         return self._render_model_keyboard(state)
@@ -571,12 +581,15 @@ class TelegramChannel(BaseChannel):
         state.clamp_page(MODEL_PICKER_PAGE_SIZE, state.page)
         total_pages = state.total_pages(MODEL_PICKER_PAGE_SIZE)
         page_models = state.page_models(MODEL_PICKER_PAGE_SIZE)
+        state.token_to_model = {}
 
         buttons: list[list[InlineKeyboardButton]] = []
-        for mid in page_models:
+        for idx, mid in enumerate(page_models):
             label = f"\u2713 {mid}" if mid == state.current_model else mid
+            token = str(idx)
+            state.token_to_model[token] = mid
             buttons.append([
-                InlineKeyboardButton(label, callback_data=f"model:{state.action_prefix}:{mid}")
+                InlineKeyboardButton(label, callback_data=f"model:{state.action_prefix}:{token}")
             ])
 
         nav_row: list[InlineKeyboardButton] = []
@@ -599,6 +612,13 @@ class TelegramChannel(BaseChannel):
             )
         buttons.append(nav_row)
         return InlineKeyboardMarkup(buttons)
+
+    @staticmethod
+    def _model_command_for_action(action_prefix: str, model_id: str) -> str:
+        """Map a picker action to the matching /model command."""
+        if action_prefix == "subagent":
+            return f"/model subagent {model_id}"
+        return f"/model {model_id}"
 
     @staticmethod
     def _sender_id(user) -> str:

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -202,8 +202,8 @@ class TelegramChannel(BaseChannel):
     BOT_COMMANDS = [
         BotCommand("start", "Start the bot"),
         BotCommand("new", "Start a new conversation"),
-        BotCommand("model", "Pick/set model (saved to config)"),
-        BotCommand("reload", "Reload nanobot gateway"),
+        BotCommand("model", "Pick/set main or subagent model"),
+        BotCommand("reload", "Reload config/runtime"),
         BotCommand("stop", "Stop the current task"),
         BotCommand("help", "Show available commands"),
         BotCommand("restart", "Restart the bot"),
@@ -480,8 +480,8 @@ class TelegramChannel(BaseChannel):
         await update.message.reply_text(
             "🐈 nanobot commands:\n"
             "/new — Start a new conversation\n"
-            "/model — Pick or set model\n"
-            "/reload — Reload nanobot gateway\n"
+            "/model — Pick or set main/subagent model\n"
+            "/reload — Reload config/runtime\n"
             "/stop — Stop the current task\n"
             "/restart — Restart the bot\n"
             "/help — Show available commands"

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import re
-import time
 import unicodedata
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from loguru import logger
 from pydantic import Field
-from telegram import BotCommand, ReplyParameters, Update
-from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
+from telegram import BotCommand, InlineKeyboardButton, InlineKeyboardMarkup, ReplyParameters, Update
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 from telegram.request import HTTPXRequest
 
 from nanobot.bus.events import OutboundMessage
@@ -23,6 +30,7 @@ from nanobot.utils.helpers import split_message
 
 TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
 TELEGRAM_REPLY_CONTEXT_MAX_LEN = TELEGRAM_MAX_MESSAGE_LEN  # Max length for reply context in user message
+MODEL_PICKER_PAGE_SIZE = 6
 
 
 def _strip_md(s: str) -> str:
@@ -150,6 +158,25 @@ def _markdown_to_telegram_html(text: str) -> str:
     return text
 
 
+@dataclass
+class ModelPickerState:
+    models: list[str]
+    action_prefix: str
+    current_model: str
+    page: int
+
+    def total_pages(self, page_size: int) -> int:
+        return max(1, (len(self.models) + page_size - 1) // page_size)
+
+    def clamp_page(self, page_size: int, requested: int) -> None:
+        total_pages = self.total_pages(page_size)
+        self.page = max(0, min(requested, total_pages - 1))
+
+    def page_models(self, page_size: int) -> list[str]:
+        start = self.page * page_size
+        return self.models[start : start + page_size]
+
+
 class TelegramConfig(Base):
     """Telegram channel configuration."""
 
@@ -175,6 +202,8 @@ class TelegramChannel(BaseChannel):
     BOT_COMMANDS = [
         BotCommand("start", "Start the bot"),
         BotCommand("new", "Start a new conversation"),
+        BotCommand("model", "Pick/set model (saved to config)"),
+        BotCommand("reload", "Reload nanobot gateway"),
         BotCommand("stop", "Stop the current task"),
         BotCommand("help", "Show available commands"),
         BotCommand("restart", "Restart the bot"),
@@ -197,6 +226,7 @@ class TelegramChannel(BaseChannel):
         self._message_threads: dict[tuple[str, int], int] = {}
         self._bot_user_id: int | None = None
         self._bot_username: str | None = None
+        self._model_picker_state: dict[str, ModelPickerState] = {}
 
     def is_allowed(self, sender_id: str) -> bool:
         """Preserve Telegram's legacy id|username allowlist matching."""
@@ -240,9 +270,12 @@ class TelegramChannel(BaseChannel):
         # Add command handlers
         self._app.add_handler(CommandHandler("start", self._on_start))
         self._app.add_handler(CommandHandler("new", self._forward_command))
+        self._app.add_handler(CommandHandler("model", self._on_model))
+        self._app.add_handler(CommandHandler("reload", self._forward_command))
         self._app.add_handler(CommandHandler("stop", self._forward_command))
         self._app.add_handler(CommandHandler("restart", self._forward_command))
         self._app.add_handler(CommandHandler("help", self._on_help))
+        self._app.add_handler(CallbackQueryHandler(self._on_model_callback, pattern=r"^model:"))
 
         # Add message handler for text, photos, voice, documents
         self._app.add_handler(
@@ -273,7 +306,7 @@ class TelegramChannel(BaseChannel):
 
         # Start polling (this runs until stopped)
         await self._app.updater.start_polling(
-            allowed_updates=["message"],
+            allowed_updates=["message", "callback_query"],
             drop_pending_updates=True  # Ignore old messages on startup
         )
 
@@ -371,22 +404,39 @@ class TelegramChannel(BaseChannel):
                     **thread_kwargs,
                 )
 
+        # Build inline keyboard if model list is present
+        reply_markup = None
+        metadata = msg.metadata or {}
+        model_list = metadata.get("_model_list")
+        model_action = metadata.get("_model_action", "active")
+        if model_list:
+            action_prefix = {
+                "active": "set",
+                "default": "default",
+                "subagent": "subagent",
+            }.get(model_action, "set")
+            page = int(metadata.get("_model_page") or 0)
+            current_model = metadata.get("_current_model", "")
+            reply_markup = self._build_model_keyboard(
+                chat_id=str(msg.chat_id),
+                model_list=model_list,
+                action_prefix=action_prefix,
+                page=page,
+                current_model=current_model,
+            )
+
         # Send text content
         if msg.content and msg.content != "[empty message]":
-            is_progress = msg.metadata.get("_progress", False)
-
             for chunk in split_message(msg.content, TELEGRAM_MAX_MESSAGE_LEN):
-                # Final response: simulate streaming via draft, then persist
-                if not is_progress:
-                    await self._send_with_streaming(chat_id, chunk, reply_params, thread_kwargs)
-                else:
-                    await self._send_text(chat_id, chunk, reply_params, thread_kwargs)
+                await self._send_text(chat_id, chunk, reply_params, reply_markup, thread_kwargs)
+                reply_markup = None
 
     async def _send_text(
         self,
         chat_id: int,
         text: str,
         reply_params=None,
+        reply_markup=None,
         thread_kwargs: dict | None = None,
     ) -> None:
         """Send a plain text message with HTML fallback."""
@@ -395,6 +445,7 @@ class TelegramChannel(BaseChannel):
             await self._app.bot.send_message(
                 chat_id=chat_id, text=html, parse_mode="HTML",
                 reply_parameters=reply_params,
+                reply_markup=reply_markup,
                 **(thread_kwargs or {}),
             )
         except Exception as e:
@@ -404,34 +455,11 @@ class TelegramChannel(BaseChannel):
                     chat_id=chat_id,
                     text=text,
                     reply_parameters=reply_params,
+                    reply_markup=reply_markup,
                     **(thread_kwargs or {}),
                 )
             except Exception as e2:
                 logger.error("Error sending Telegram message: {}", e2)
-
-    async def _send_with_streaming(
-        self,
-        chat_id: int,
-        text: str,
-        reply_params=None,
-        thread_kwargs: dict | None = None,
-    ) -> None:
-        """Simulate streaming via send_message_draft, then persist with send_message."""
-        draft_id = int(time.time() * 1000) % (2**31)
-        try:
-            step = max(len(text) // 8, 40)
-            for i in range(step, len(text), step):
-                await self._app.bot.send_message_draft(
-                    chat_id=chat_id, draft_id=draft_id, text=text[:i],
-                )
-                await asyncio.sleep(0.04)
-            await self._app.bot.send_message_draft(
-                chat_id=chat_id, draft_id=draft_id, text=text,
-            )
-            await asyncio.sleep(0.15)
-        except Exception:
-            pass
-        await self._send_text(chat_id, text, reply_params, thread_kwargs)
 
     async def _on_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /start command."""
@@ -452,10 +480,125 @@ class TelegramChannel(BaseChannel):
         await update.message.reply_text(
             "🐈 nanobot commands:\n"
             "/new — Start a new conversation\n"
+            "/model — Pick or set model\n"
+            "/reload — Reload nanobot gateway\n"
             "/stop — Stop the current task\n"
             "/restart — Restart the bot\n"
             "/help — Show available commands"
         )
+
+    async def _on_model(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /model command — forward to agent loop."""
+        if not update.message or not update.effective_user:
+            return
+        self._start_typing(str(update.message.chat_id))
+        await self._handle_message(
+            sender_id=self._sender_id(update.effective_user),
+            chat_id=str(update.message.chat_id),
+            content=update.message.text or "/model",
+        )
+
+    async def _on_model_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle model selection from inline keyboard."""
+        query = update.callback_query
+        if not query or not query.data:
+            return
+
+        await query.answer()
+        payload = query.data.removeprefix("model:")
+        parts = payload.split(":", 3)
+        action = parts[0] if parts else "set"
+        if action == "noop":
+            return
+        if action == "page":
+            if len(parts) < 3:
+                return
+            action_prefix = parts[1]
+            try:
+                page = int(parts[2])
+            except ValueError:
+                return
+            await self._update_model_picker(query, action_prefix, page)
+            return
+        model_id = parts[1] if len(parts) == 2 else parts[2] if len(parts) >= 3 else payload
+        chat_id = str(query.message.chat_id)
+        sender_id = self._sender_id(query.from_user) if query.from_user else "unknown"
+
+        await self._handle_message(
+            sender_id=sender_id,
+            chat_id=chat_id,
+            content=f"/model {model_id}",
+        )
+
+        try:
+            text = f"Model saved and active: <b>{model_id}</b>"
+            await query.edit_message_text(text, parse_mode="HTML")
+        except Exception:
+            pass
+
+    def _build_model_keyboard(
+        self,
+        *,
+        chat_id: str,
+        model_list: list,
+        action_prefix: str,
+        page: int,
+        current_model: str = "",
+    ) -> InlineKeyboardMarkup:
+        normalized: list[str] = [str(item) for item in model_list]
+        state = ModelPickerState(
+            models=normalized,
+            action_prefix=action_prefix,
+            current_model=current_model,
+            page=page,
+        )
+        self._model_picker_state[chat_id] = state
+        return self._render_model_keyboard(state)
+
+    async def _update_model_picker(self, query, action_prefix: str, page: int) -> None:
+        chat_id = str(query.message.chat_id)
+        state = self._model_picker_state.get(chat_id)
+        if not state or state.action_prefix != action_prefix:
+            return
+        state.clamp_page(MODEL_PICKER_PAGE_SIZE, page)
+        reply_markup = self._render_model_keyboard(state)
+        try:
+            await query.edit_message_reply_markup(reply_markup=reply_markup)
+        except Exception:
+            pass
+
+    def _render_model_keyboard(self, state: ModelPickerState) -> InlineKeyboardMarkup:
+        state.clamp_page(MODEL_PICKER_PAGE_SIZE, state.page)
+        total_pages = state.total_pages(MODEL_PICKER_PAGE_SIZE)
+        page_models = state.page_models(MODEL_PICKER_PAGE_SIZE)
+
+        buttons: list[list[InlineKeyboardButton]] = []
+        for mid in page_models:
+            label = f"\u2713 {mid}" if mid == state.current_model else mid
+            buttons.append([
+                InlineKeyboardButton(label, callback_data=f"model:{state.action_prefix}:{mid}")
+            ])
+
+        nav_row: list[InlineKeyboardButton] = []
+        if state.page > 0:
+            nav_row.append(
+                InlineKeyboardButton(
+                    "\u2190 Prev",
+                    callback_data=f"model:page:{state.action_prefix}:{state.page - 1}",
+                )
+            )
+        nav_row.append(
+            InlineKeyboardButton(f"{state.page + 1}/{total_pages}", callback_data="model:noop")
+        )
+        if state.page + 1 < total_pages:
+            nav_row.append(
+                InlineKeyboardButton(
+                    "Next \u2192",
+                    callback_data=f"model:page:{state.action_prefix}:{state.page + 1}",
+                )
+            )
+        buttons.append(nav_row)
+        return InlineKeyboardMarkup(buttons)
 
     @staticmethod
     def _sender_id(user) -> str:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -300,60 +300,22 @@ def _onboard_plugins(config_path: Path) -> None:
 
 def _make_provider(config: Config):
     """Create the appropriate LLM provider from config."""
-    from nanobot.providers.base import GenerationSettings
-    from nanobot.providers.openai_codex_provider import OpenAICodexProvider
-    from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+    from nanobot.runtime import make_provider
 
-    model = config.agents.defaults.model
-    provider_name = config.get_provider_name(model)
-    p = config.get_provider(model)
-
-    # OpenAI Codex (OAuth)
-    if provider_name == "openai_codex" or model.startswith("openai-codex/"):
-        provider = OpenAICodexProvider(default_model=model)
-    # Custom: direct OpenAI-compatible endpoint, bypasses LiteLLM
-    elif provider_name == "custom":
-        from nanobot.providers.custom_provider import CustomProvider
-        provider = CustomProvider(
-            api_key=p.api_key if p else "no-key",
-            api_base=config.get_api_base(model) or "http://localhost:8000/v1",
-            default_model=model,
-        )
-    # Azure OpenAI: direct Azure OpenAI endpoint with deployment name
-    elif provider_name == "azure_openai":
-        if not p or not p.api_key or not p.api_base:
-            console.print("[red]Error: Azure OpenAI requires api_key and api_base.[/red]")
+    try:
+        return make_provider(config)
+    except RuntimeError as exc:
+        msg = str(exc)
+        if "Azure OpenAI" in msg:
+            console.print(f"[red]Error: {msg}[/red]")
             console.print("Set them in ~/.nanobot/config.json under providers.azure_openai section")
             console.print("Use the model field to specify the deployment name.")
-            raise typer.Exit(1)
-        provider = AzureOpenAIProvider(
-            api_key=p.api_key,
-            api_base=p.api_base,
-            default_model=model,
-        )
-    else:
-        from nanobot.providers.litellm_provider import LiteLLMProvider
-        from nanobot.providers.registry import find_by_name
-        spec = find_by_name(provider_name)
-        if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and (spec.is_oauth or spec.is_local)):
+        elif "No API key configured" in msg:
             console.print("[red]Error: No API key configured.[/red]")
             console.print("Set one in ~/.nanobot/config.json under providers section")
-            raise typer.Exit(1)
-        provider = LiteLLMProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-            provider_name=provider_name,
-        )
-
-    defaults = config.agents.defaults
-    provider.generation = GenerationSettings(
-        temperature=defaults.temperature,
-        max_tokens=defaults.max_tokens,
-        reasoning_effort=defaults.reasoning_effort,
-    )
-    return provider
+        else:
+            console.print(f"[red]Error: {msg}[/red]")
+        raise typer.Exit(1) from exc
 
 
 def _load_runtime_config(config: str | None = None, workspace: str | None = None) -> Config:
@@ -418,7 +380,13 @@ def gateway(
     console.print(f"{__logo__} Starting nanobot gateway on port {port}...")
     sync_workspace_templates(config.workspace_path)
     bus = MessageBus()
+    from nanobot.runtime import make_provider, resolve_subagent_model
+
     provider = _make_provider(config)
+    subagent_model = resolve_subagent_model(config)
+    subagent_provider = provider if subagent_model == config.agents.defaults.model else make_provider(
+        config, model=subagent_model,
+    )
     session_manager = SessionManager(config.workspace_path)
 
     # Create cron service first (callback set after agent creation)
@@ -431,6 +399,8 @@ def gateway(
         provider=provider,
         workspace=config.workspace_path,
         model=config.agents.defaults.model,
+        subagent_provider=subagent_provider,
+        subagent_model=subagent_model,
         max_iterations=config.agents.defaults.max_tool_iterations,
         context_window_tokens=config.agents.defaults.context_window_tokens,
         web_search_config=config.tools.web.search,
@@ -607,7 +577,13 @@ def agent(
     sync_workspace_templates(config.workspace_path)
 
     bus = MessageBus()
+    from nanobot.runtime import make_provider, resolve_subagent_model
+
     provider = _make_provider(config)
+    subagent_model = resolve_subagent_model(config)
+    subagent_provider = provider if subagent_model == config.agents.defaults.model else make_provider(
+        config, model=subagent_model,
+    )
 
     # Create cron service for tool usage (no callback needed for CLI unless running)
     cron_store_path = get_cron_dir() / "jobs.json"
@@ -623,6 +599,8 @@ def agent(
         provider=provider,
         workspace=config.workspace_path,
         model=config.agents.defaults.model,
+        subagent_provider=subagent_provider,
+        subagent_model=subagent_model,
         max_iterations=config.agents.defaults.max_tool_iterations,
         context_window_tokens=config.agents.defaults.context_window_tokens,
         web_search_config=config.tools.web.search,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -32,6 +32,7 @@ class AgentDefaults(Base):
 
     workspace: str = "~/.nanobot/workspace"
     model: str = "anthropic/claude-opus-4-5"
+    subagent_model: str | None = None
     provider: str = (
         "auto"  # Provider name (e.g. "anthropic", "openrouter") or "auto" for auto-detection
     )

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -192,6 +192,10 @@ class LLMProvider(ABC):
         """
         pass
 
+    async def list_models(self) -> list[tuple[str, str]]:
+        """Return available models when the provider can enumerate them."""
+        return []
+
     @classmethod
     def _is_transient_error(cls, content: str | None) -> bool:
         err = (content or "").lower()

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -60,3 +60,10 @@ class CustomProvider(LLMProvider):
     def get_default_model(self) -> str:
         return self.default_model
 
+    async def list_models(self) -> list[tuple[str, str]]:
+        """List available models from the endpoint."""
+        try:
+            result = await self._client.models.list()
+            return [(m.id, m.id) for m in result.data]
+        except Exception:
+            return []

--- a/nanobot/runtime.py
+++ b/nanobot/runtime.py
@@ -1,0 +1,65 @@
+"""Shared runtime helpers for provider/model resolution."""
+
+from __future__ import annotations
+
+from nanobot.config.schema import Config
+from nanobot.providers.base import GenerationSettings, LLMProvider
+
+
+def resolve_subagent_model(config: Config, main_model: str | None = None) -> str:
+    """Resolve the effective subagent model from config."""
+    resolved_main = main_model or config.agents.defaults.model
+    return config.agents.defaults.subagent_model or resolved_main
+
+
+def make_provider(config: Config, model: str | None = None) -> LLMProvider:
+    """Create an LLM provider for the given model using normal config resolution."""
+    from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+    from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+
+    resolved_model = model or config.agents.defaults.model
+    provider_name = config.get_provider_name(resolved_model)
+    p = config.get_provider(resolved_model)
+
+    if provider_name == "openai_codex" or resolved_model.startswith("openai-codex/"):
+        provider: LLMProvider = OpenAICodexProvider(default_model=resolved_model)
+    elif provider_name == "custom":
+        from nanobot.providers.custom_provider import CustomProvider
+
+        provider = CustomProvider(
+            api_key=p.api_key if p else "no-key",
+            api_base=config.get_api_base(resolved_model) or "http://localhost:8000/v1",
+            default_model=resolved_model,
+        )
+    elif provider_name == "azure_openai":
+        if not p or not p.api_key or not p.api_base:
+            raise RuntimeError("Azure OpenAI requires api_key and api_base.")
+        provider = AzureOpenAIProvider(
+            api_key=p.api_key,
+            api_base=p.api_base,
+            default_model=resolved_model,
+        )
+    else:
+        from nanobot.providers.litellm_provider import LiteLLMProvider
+        from nanobot.providers.registry import find_by_name
+
+        spec = find_by_name(provider_name)
+        if not resolved_model.startswith("bedrock/") and not (p and p.api_key) and not (
+            spec and (spec.is_oauth or spec.is_local)
+        ):
+            raise RuntimeError("No API key configured.")
+        provider = LiteLLMProvider(
+            api_key=p.api_key if p else None,
+            api_base=config.get_api_base(resolved_model),
+            default_model=resolved_model,
+            extra_headers=p.extra_headers if p else None,
+            provider_name=provider_name,
+        )
+
+    defaults = config.agents.defaults
+    provider.generation = GenerationSettings(
+        temperature=defaults.temperature,
+        max_tokens=defaults.max_tokens,
+        reasoning_effort=defaults.reasoning_effort,
+    )
+    return provider

--- a/tests/test_model_command.py
+++ b/tests/test_model_command.py
@@ -1,4 +1,4 @@
-"""Tests for /model and /reload slash commands."""
+"""Tests for /model, /reload, and slash command aliases."""
 
 from __future__ import annotations
 
@@ -148,3 +148,30 @@ async def test_reload_reloads_runtime_in_process(tmp_path):
         "Main model: main-model\n"
         "Subagent model: sub-model"
     )
+
+
+@pytest.mark.asyncio
+async def test_help_command_accepts_telegram_command_suffix(tmp_path):
+    loop, _provider, _subagents = _make_loop(tmp_path)
+
+    response = await loop._process_message(
+        InboundMessage(channel="telegram", sender_id="u1", chat_id="123", content="/help@nanobot_test")
+    )
+
+    assert response is not None
+    assert "/model — Pick or set main/subagent model" in response.content
+
+
+@pytest.mark.asyncio
+async def test_new_command_accepts_telegram_command_suffix(tmp_path):
+    loop, _provider, _subagents = _make_loop(tmp_path)
+
+    response = await loop._process_message(
+        InboundMessage(channel="telegram", sender_id="u1", chat_id="123", content="/new@nanobot_test")
+    )
+
+    loop.memory_consolidator.archive_unconsolidated.assert_awaited_once()
+    loop.sessions.save.assert_called_once()
+    loop.sessions.invalidate.assert_called_once()
+    assert response is not None
+    assert response.content == "New session started."

--- a/tests/test_model_command.py
+++ b/tests/test_model_command.py
@@ -1,0 +1,150 @@
+"""Tests for /model and /reload slash commands."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.bus.events import InboundMessage
+from nanobot.config.schema import Config
+from nanobot.session.manager import Session
+
+
+def _make_loop(tmp_path, *, model: str = "main-model"):
+    """Create a minimal AgentLoop for command testing."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = model
+    provider.list_models = AsyncMock(return_value=[("z-model", "z-model"), ("a-model", "a-model")])
+
+    session = Session(key="telegram:123")
+
+    with patch.object(AgentLoop, "_register_default_tools", lambda self: None), \
+         patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SubagentManager") as mock_subagents:
+        subagents = MagicMock()
+        mock_subagents.return_value = subagents
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model=model)
+
+    loop.sessions = MagicMock()
+    loop.sessions.get_or_create.return_value = session
+    loop.memory_consolidator = MagicMock()
+    loop.memory_consolidator.archive_unconsolidated = AsyncMock(return_value=True)
+    loop.memory_consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=None)
+    return loop, provider, subagents
+
+
+@pytest.mark.asyncio
+async def test_loop_uses_explicit_subagent_model_when_provided(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "main-model"
+
+    with patch.object(AgentLoop, "_register_default_tools", lambda self: None), \
+         patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SubagentManager") as mock_subagents:
+        AgentLoop(
+            bus=MessageBus(),
+            provider=provider,
+            workspace=tmp_path,
+            model="main-model",
+            subagent_model="sub-model",
+        )
+
+    assert mock_subagents.call_args.kwargs["model"] == "sub-model"
+
+
+@pytest.mark.asyncio
+async def test_model_status_shows_main_and_following_subagent(tmp_path):
+    loop, _provider, _subagents = _make_loop(tmp_path)
+    config = Config()
+    config.agents.defaults.model = "main-model"
+    config.agents.defaults.subagent_model = None
+
+    with patch("nanobot.agent.loop.load_config", return_value=config):
+        response = await loop._process_message(
+            InboundMessage(channel="telegram", sender_id="u1", chat_id="123", content="/model")
+        )
+
+    assert response is not None
+    assert response.content == "Main: main-model\nSubagent: main-model (follows main)"
+    assert response.metadata["_model_list"] == ["a-model", "z-model"]
+    assert response.metadata["_current_model"] == "main-model"
+
+
+@pytest.mark.asyncio
+async def test_model_subagent_command_persists_explicit_subagent_model(tmp_path):
+    loop, _provider, _subagents = _make_loop(tmp_path)
+    config = Config()
+    config.agents.defaults.model = "main-model"
+
+    loop._reload_runtime_from_config = AsyncMock(return_value=("main-model", "sub-model"))
+
+    with patch("nanobot.agent.loop.load_config", return_value=config), \
+         patch("nanobot.agent.loop.save_config") as mock_save:
+        response = await loop._process_message(
+            InboundMessage(
+                channel="telegram",
+                sender_id="u1",
+                chat_id="123",
+                content="/model subagent sub-model",
+            )
+        )
+
+    assert config.agents.defaults.subagent_model == "sub-model"
+    mock_save.assert_called_once_with(config)
+    loop._reload_runtime_from_config.assert_awaited_once_with(config)
+    assert response is not None
+    assert "Subagent model updated." in response.content
+    assert "Subagent model: sub-model" in response.content
+
+
+@pytest.mark.asyncio
+async def test_model_subagent_clear_reverts_to_main_model(tmp_path):
+    loop, _provider, _subagents = _make_loop(tmp_path)
+    config = Config()
+    config.agents.defaults.model = "main-model"
+    config.agents.defaults.subagent_model = "old-sub-model"
+
+    loop._reload_runtime_from_config = AsyncMock(return_value=("main-model", "main-model"))
+
+    with patch("nanobot.agent.loop.load_config", return_value=config), \
+         patch("nanobot.agent.loop.save_config") as mock_save:
+        response = await loop._process_message(
+            InboundMessage(
+                channel="telegram",
+                sender_id="u1",
+                chat_id="123",
+                content="/model subagent clear",
+            )
+        )
+
+    assert config.agents.defaults.subagent_model is None
+    mock_save.assert_called_once_with(config)
+    loop._reload_runtime_from_config.assert_awaited_once_with(config)
+    assert response is not None
+    assert "Subagent model: main-model" in response.content
+
+
+@pytest.mark.asyncio
+async def test_reload_reloads_runtime_in_process(tmp_path):
+    loop, _provider, _subagents = _make_loop(tmp_path)
+    loop._reload_runtime_from_config = AsyncMock(return_value=("main-model", "sub-model"))
+
+    response = await loop._process_message(
+        InboundMessage(channel="telegram", sender_id="u1", chat_id="123", content="/reload")
+    )
+
+    loop._reload_runtime_from_config.assert_awaited_once_with()
+    assert response is not None
+    assert response.content == (
+        "Reloaded config/runtime successfully.\n"
+        "Main model: main-model\n"
+        "Subagent model: sub-model"
+    )

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -663,3 +663,50 @@ async def test_on_help_includes_restart_command() -> None:
     update.message.reply_text.assert_awaited_once()
     help_text = update.message.reply_text.await_args.args[0]
     assert "/restart" in help_text
+
+
+def test_build_model_keyboard_uses_compact_callback_tokens() -> None:
+    channel = TelegramChannel(TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]), MessageBus())
+
+    keyboard = channel._build_model_keyboard(
+        chat_id="123",
+        model_list=["very-long-provider/model-name-that-should-not-be-in-callback-data"],
+        action_prefix="set",
+        page=0,
+        current_model="",
+    )
+
+    callback_data = keyboard.inline_keyboard[0][0].callback_data
+    assert callback_data == "model:set:0"
+    assert len(callback_data) < 64
+
+
+@pytest.mark.asyncio
+async def test_model_callback_preserves_subagent_action() -> None:
+    channel = TelegramChannel(TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]), MessageBus())
+    channel._handle_message = AsyncMock()
+    channel._build_model_keyboard(
+        chat_id="123",
+        model_list=["provider/model-a"],
+        action_prefix="subagent",
+        page=0,
+        current_model="provider/model-a",
+    )
+
+    query = SimpleNamespace(
+        data="model:subagent:0",
+        message=SimpleNamespace(chat_id=123),
+        from_user=SimpleNamespace(id=12345, username="alice"),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+    )
+    update = SimpleNamespace(callback_query=query)
+
+    await channel._on_model_callback(update, None)
+
+    channel._handle_message.assert_awaited_once_with(
+        sender_id="12345|alice",
+        chat_id="123",
+        content="/model subagent provider/model-a",
+    )
+    query.edit_message_text.assert_awaited_once()


### PR DESCRIPTION
## Summary

This PR improves runtime model management by making subagent model selection explicit and by adding an application-level in-process reload path.

Changes:
- add `agents.defaults.subagent_model`
- make subagent model behavior explicit:
  - when `subagent_model` is set, subagents use it
  - when unset, subagents use the main model
- add `/model` support for viewing/updating main and subagent model selection
- implement `/reload` as in-process config/runtime reload
- share provider/model resolution through a common runtime helper
- add a default `list_models()` method on the provider base class

## Motivation

This keeps subagent model selection predictable and removes the need for deployment-specific reload behavior.

Instead of relying on external service-manager assumptions, `/reload` refreshes nanobot’s runtime state directly from config for future turns.

## Command behavior

- `/model`
  - shows current main model and subagent model
- `/model <model>`
  - updates the main model
- `/model main <model>`
  - updates the main model explicitly
- `/model subagent <model>`
  - sets an explicit subagent model
- `/model subagent clear`
  - clears the explicit subagent model so subagents follow the main model
- `/reload`
  - reloads config/runtime state in-process


## Screenshots
<img width="1052" height="563" alt="Screenshot 2026-03-16 at 5 01 38 PM" src="https://github.com/user-attachments/assets/f00a9c0d-8dbb-48a8-a5ee-d649db687a50" />

## Tests

Added tests covering:
- explicit subagent model wiring
- `/model` status output
- `/model subagent <model>`
- `/model subagent clear`
- `/reload` in-process runtime refresh
