### PR TITLE
feat: add read_image tool for local multimodal inspection

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -19,6 +19,7 @@ from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
+from nanobot.agent.tools.read_image import ReadImageTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.shell import ExecTool
@@ -117,7 +118,7 @@ class AgentLoop:
         allowed_dir = self.workspace if self.restrict_to_workspace else None
         extra_read = [BUILTIN_SKILLS_DIR] if allowed_dir else None
         self.tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir, extra_allowed_dirs=extra_read))
-        for cls in (WriteFileTool, EditFileTool, ListDirTool):
+        for cls in (WriteFileTool, EditFileTool, ListDirTool, ReadImageTool):
             self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
         self.tools.register(ExecTool(
             working_dir=str(self.workspace),
@@ -465,6 +466,15 @@ class AgentLoop:
                 continue  # skip empty assistant messages — they poison session context
             if role == "tool" and isinstance(content, str) and len(content) > self._TOOL_RESULT_MAX_CHARS:
                 entry["content"] = content[:self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
+            elif role == "tool" and isinstance(content, list):
+                # Strip base64 image data from multimodal tool results (e.g. read_image),
+                # keeping the text block with filename/size metadata.
+                stripped = [
+                    block for block in content
+                    if not (block.get("type") == "image_url"
+                            and block.get("image_url", {}).get("url", "").startswith("data:image/"))
+                ]
+                entry["content"] = stripped or "[image]"
             elif role == "user":
                 if isinstance(content, str) and content.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
                     # Strip the runtime-context prefix, keep only the user text.

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -459,6 +459,38 @@ class AgentLoop:
     def _save_turn(self, session: Session, messages: list[dict], skip: int) -> None:
         """Save new-turn messages into session, truncating large tool results."""
         from datetime import datetime
+
+        def _truncate_multimodal_blocks(blocks: list[dict]) -> list[dict] | str:
+            kept_blocks: list[dict] = []
+            total_chars = 0
+
+            for block in blocks:
+                if not isinstance(block, dict):
+                    continue
+                if (block.get("type") == "image_url"
+                        and isinstance(block.get("image_url"), dict)
+                        and block["image_url"].get("url", "").startswith("data:image/")):
+                    continue
+
+                if block.get("type") == "text" and isinstance(block.get("text"), str):
+                    remaining = self._TOOL_RESULT_MAX_CHARS - total_chars
+                    if remaining <= 0:
+                        break
+
+                    text = block["text"]
+                    if len(text) > remaining:
+                        kept_blocks.append({"type": "text", "text": text[:remaining] + "\n... (truncated)"})
+                        total_chars = self._TOOL_RESULT_MAX_CHARS
+                        break
+
+                    kept_blocks.append(block)
+                    total_chars += len(text)
+                    continue
+
+                kept_blocks.append(block)
+
+            return kept_blocks or "[image]"
+
         for m in messages[skip:]:
             entry = dict(m)
             role, content = entry.get("role"), entry.get("content")
@@ -467,14 +499,8 @@ class AgentLoop:
             if role == "tool" and isinstance(content, str) and len(content) > self._TOOL_RESULT_MAX_CHARS:
                 entry["content"] = content[:self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
             elif role == "tool" and isinstance(content, list):
-                # Strip base64 image data from multimodal tool results (e.g. read_image),
-                # keeping the text block with filename/size metadata.
-                stripped = [
-                    block for block in content
-                    if not (block.get("type") == "image_url"
-                            and block.get("image_url", {}).get("url", "").startswith("data:image/"))
-                ]
-                entry["content"] = stripped or "[image]"
+                # Strip inline image payloads and keep persisted multimodal tool output bounded.
+                entry["content"] = _truncate_multimodal_blocks(content)
             elif role == "user":
                 if isinstance(content, str) and content.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
                     # Strip the runtime-context prefix, keep only the user text.
@@ -486,10 +512,13 @@ class AgentLoop:
                 if isinstance(content, list):
                     filtered = []
                     for c in content:
+                        if not isinstance(c, dict):
+                            continue
                         if c.get("type") == "text" and isinstance(c.get("text"), str) and c["text"].startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
                             continue  # Strip runtime context from multimodal messages
                         if (c.get("type") == "image_url"
-                                and c.get("image_url", {}).get("url", "").startswith("data:image/")):
+                                and isinstance(c.get("image_url"), dict)
+                                and c["image_url"].get("url", "").startswith("data:image/")):
                             filtered.append({"type": "text", "text": "[image]"})
                         else:
                             filtered.append(c)

--- a/nanobot/agent/tools/read_image.py
+++ b/nanobot/agent/tools/read_image.py
@@ -1,7 +1,6 @@
 """Read image tool: lets the agent view an image file on disk."""
 
 import base64
-import mimetypes
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +12,12 @@ class ReadImageTool(Tool):
     """Read an image file and return it as a multimodal content block."""
 
     _MAX_BYTES = 20 * 1024 * 1024  # 20 MB
+    _SUPPORTED_MIME_TYPES = {
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+    }
 
     def __init__(self, workspace: Path | None = None, allowed_dir: Path | None = None):
         self._workspace = workspace
@@ -57,12 +62,21 @@ class ReadImageTool(Tool):
         if not resolved.is_file():
             return f"Error: file not found: {path_str}"
 
-        raw = resolved.read_bytes()
-        if len(raw) > self._MAX_BYTES:
-            return f"Error: image too large ({len(raw) / 1024 / 1024:.1f} MB, max 20 MB)"
+        try:
+            size_bytes = resolved.stat().st_size
+        except OSError as e:
+            return f"Error: could not access image file: {e}"
 
-        mime = detect_image_mime(raw) or mimetypes.guess_type(str(resolved))[0]
-        if not mime or not mime.startswith("image/"):
+        if size_bytes > self._MAX_BYTES:
+            return f"Error: image too large ({size_bytes / 1024 / 1024:.1f} MB, max 20 MB)"
+
+        try:
+            raw = resolved.read_bytes()
+        except OSError as e:
+            return f"Error: could not read image file: {e}"
+
+        mime = detect_image_mime(raw)
+        if mime not in self._SUPPORTED_MIME_TYPES:
             return f"Error: not a recognized image file ({resolved.suffix})"
 
         b64 = base64.b64encode(raw).decode()

--- a/nanobot/agent/tools/read_image.py
+++ b/nanobot/agent/tools/read_image.py
@@ -1,0 +1,72 @@
+"""Read image tool: lets the agent view an image file on disk."""
+
+import base64
+import mimetypes
+from pathlib import Path
+from typing import Any
+
+from nanobot.agent.tools.base import Tool
+from nanobot.utils.helpers import detect_image_mime
+
+
+class ReadImageTool(Tool):
+    """Read an image file and return it as a multimodal content block."""
+
+    _MAX_BYTES = 20 * 1024 * 1024  # 20 MB
+
+    def __init__(self, workspace: Path | None = None, allowed_dir: Path | None = None):
+        self._workspace = workspace
+        self._allowed_dir = allowed_dir
+
+    def _resolve(self, path: str) -> Path:
+        from nanobot.agent.tools.filesystem import _resolve_path
+        return _resolve_path(path, self._workspace, self._allowed_dir)
+
+    @property
+    def name(self) -> str:
+        return "read_image"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Read an image file and display it for visual analysis. "
+            "Supports JPEG, PNG, GIF, and WebP. Use this when you need to "
+            "see or describe an image on disk."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the image file (absolute or relative to workspace)",
+                },
+            },
+            "required": ["path"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str | list[dict[str, Any]]:
+        path_str = kwargs["path"]
+        try:
+            resolved = self._resolve(path_str)
+        except PermissionError as e:
+            return f"Error: {e}"
+
+        if not resolved.is_file():
+            return f"Error: file not found: {path_str}"
+
+        raw = resolved.read_bytes()
+        if len(raw) > self._MAX_BYTES:
+            return f"Error: image too large ({len(raw) / 1024 / 1024:.1f} MB, max 20 MB)"
+
+        mime = detect_image_mime(raw) or mimetypes.guess_type(str(resolved))[0]
+        if not mime or not mime.startswith("image/"):
+            return f"Error: not a recognized image file ({resolved.suffix})"
+
+        b64 = base64.b64encode(raw).decode()
+        return [
+            {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}},
+            {"type": "text", "text": f"[Image: {resolved.name}, {len(raw) / 1024:.0f} KB, {mime}]"},
+        ]

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -35,7 +35,7 @@ class ToolRegistry:
         """Get all tool definitions in OpenAI format."""
         return [tool.to_schema() for tool in self._tools.values()]
 
-    async def execute(self, name: str, params: dict[str, Any]) -> str:
+    async def execute(self, name: str, params: dict[str, Any]) -> str | list:
         """Execute a tool by name with given parameters."""
         _HINT = "\n\n[Analyze the error above and try a different approach.]"
 

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from nanobot.agent.tools.base import Tool
 
+ToolResult = str | list[dict[str, Any]]
+
 
 class ToolRegistry:
     """
@@ -35,7 +37,7 @@ class ToolRegistry:
         """Get all tool definitions in OpenAI format."""
         return [tool.to_schema() for tool in self._tools.values()]
 
-    async def execute(self, name: str, params: dict[str, Any]) -> str | list:
+    async def execute(self, name: str, params: dict[str, Any]) -> ToolResult:
         """Execute a tool by name with given parameters."""
         _HINT = "\n\n[Analyze the error above and try a different approach.]"
 

--- a/tests/test_read_image_tool.py
+++ b/tests/test_read_image_tool.py
@@ -1,0 +1,92 @@
+"""Tests for the read_image tool and related loop persistence behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.session.manager import Session
+
+
+PNG_1X1 = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR"
+    b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00"
+    b"\x1f\x15\xc4\x89"
+    b"\x00\x00\x00\rIDATx\x9cc\xf8\xcf\xc0\xf0\x1f\x00\x05\x00\x01\xff"
+    b"\x89\x99=\x1d"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+class TestReadImageTool:
+
+    @pytest.fixture()
+    def tool(self, tmp_path):
+        from nanobot.agent.tools.read_image import ReadImageTool
+
+        return ReadImageTool(workspace=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_read_image_returns_multimodal_blocks(self, tool, tmp_path):
+        image_path = tmp_path / "pixel.png"
+        image_path.write_bytes(PNG_1X1)
+
+        result = await tool.execute(path=str(image_path))
+
+        assert isinstance(result, list)
+        assert result[0]["type"] == "image_url"
+        assert result[0]["image_url"]["url"].startswith("data:image/png;base64,")
+        assert result[1] == {
+            "type": "text",
+            "text": "[Image: pixel.png, 0 KB, image/png]",
+        }
+
+    @pytest.mark.asyncio
+    async def test_read_image_rejects_non_image_file(self, tool, tmp_path):
+        text_path = tmp_path / "note.txt"
+        text_path.write_text("not an image", encoding="utf-8")
+
+        result = await tool.execute(path=str(text_path))
+
+        assert result == "Error: not a recognized image file (.txt)"
+
+
+@pytest.mark.asyncio
+async def test_save_turn_strips_base64_from_tool_image_results(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    with patch.object(AgentLoop, "_register_default_tools", lambda self: None), \
+         patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SubagentManager"):
+        loop = AgentLoop(bus=MessageBus(), provider=provider, workspace=tmp_path, model="test-model")
+
+    session = Session(key="cli:test")
+    loop._save_turn(
+        session,
+        [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "show image"},
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "name": "read_image",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                    {"type": "text", "text": "[Image: pixel.png, 1 KB, image/png]"},
+                ],
+            },
+        ],
+        skip=2,
+    )
+
+    assert len(session.messages) == 1
+    saved = session.messages[0]
+    assert saved["role"] == "tool"
+    assert saved["content"] == [{"type": "text", "text": "[Image: pixel.png, 1 KB, image/png]"}]
+    assert "timestamp" in saved

--- a/tests/test_read_image_tool.py
+++ b/tests/test_read_image_tool.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -52,6 +52,16 @@ class TestReadImageTool:
 
         assert result == "Error: not a recognized image file (.txt)"
 
+    @pytest.mark.asyncio
+    async def test_read_image_handles_read_failure(self, tool, tmp_path):
+        image_path = tmp_path / "pixel.png"
+        image_path.write_bytes(PNG_1X1)
+
+        with patch.object(type(image_path), "read_bytes", side_effect=OSError("boom")):
+            result = await tool.execute(path=str(image_path))
+
+        assert result == "Error: could not read image file: boom"
+
 
 @pytest.mark.asyncio
 async def test_save_turn_strips_base64_from_tool_image_results(tmp_path):
@@ -90,3 +100,43 @@ async def test_save_turn_strips_base64_from_tool_image_results(tmp_path):
     assert saved["role"] == "tool"
     assert saved["content"] == [{"type": "text", "text": "[Image: pixel.png, 1 KB, image/png]"}]
     assert "timestamp" in saved
+
+
+@pytest.mark.asyncio
+async def test_save_turn_skips_non_dict_tool_blocks_and_truncates_text(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    with patch.object(AgentLoop, "_register_default_tools", lambda self: None), \
+         patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SubagentManager"):
+        loop = AgentLoop(bus=MessageBus(), provider=provider, workspace=tmp_path, model="test-model")
+
+    long_text = "x" * (loop._TOOL_RESULT_MAX_CHARS + 100)
+    session = Session(key="cli:test")
+    loop._save_turn(
+        session,
+        [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "show image"},
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "name": "read_image",
+                "content": [
+                    "unexpected",
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                    {"type": "text", "text": long_text},
+                ],
+            },
+        ],
+        skip=2,
+    )
+
+    saved = session.messages[0]
+    assert isinstance(saved["content"], list)
+    assert saved["content"][0]["type"] == "text"
+    assert saved["content"][0]["text"].endswith("\n... (truncated)")


### PR DESCRIPTION
## Summary

This PR adds a `read_image` tool so nanobot can inspect image files from disk with multimodal-capable models.

Changes:
- add `nanobot.agent.tools.read_image.ReadImageTool`
- register the tool in the main agent loop
- allow tool execution to return multimodal content blocks
- avoid persisting raw base64 image payloads into session history

## Motivation

Nanobot already supports multimodal user inputs in several places. This tool extends that capability to local workspace images, which is useful for screenshots and image-based debugging tasks.

The history sanitization is included so image payloads do not bloat saved session context.

## Tool behavior

`read_image`:
- accepts a local file path
- validates file existence and image type
- enforces a size limit
- returns:
  - an `image_url` data URL block
  - a text metadata block with filename, size, and MIME type

## Tests

Added tests covering:
- successful multimodal output from `read_image`
- non-image rejection
- stripping base64 image payloads from persisted tool history
