### PR TITLE
fix:subagent result messages incorrectly recorded as user role

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -125,6 +125,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         media: list[str] | None = None,
         channel: str | None = None,
         chat_id: str | None = None,
+        current_role: str = "user",
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
         runtime_ctx = self._build_runtime_context(channel, chat_id)
@@ -140,7 +141,7 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         return [
             {"role": "system", "content": self.build_system_prompt(skill_names)},
             *history,
-            {"role": "user", "content": merged},
+            {"role": current_role, "content": merged},
         ]
 
     def _build_user_content(self, text: str, media: list[str] | None) -> str | list[dict[str, Any]]:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -370,9 +370,12 @@ class AgentLoop:
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
             history = session.get_history(max_messages=0)
+            # Subagent results should be assistant role, other system messages use user role
+            current_role = "assistant" if msg.sender_id == "subagent" else "user"
             messages = self.context.build_messages(
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
+                current_role=current_role,
             )
             final_content, _, all_msgs = await self._run_agent_loop(messages)
             self._save_turn(session, all_msgs, 1 + len(history))


### PR DESCRIPTION
fix issue https://github.com/HKUDS/nanobot/issues/2092

how to fix?

Add a current_role parameter to context.build_messages(), which
defaults to user.

When processing a message where:
channel == "system" and msg.sender_id == "subagent" 
current_role is set to assistant before building the message list.

This ensures that subagent result messages are correctly attributed to
the assistant role.