### PR TITLE
feat(telegram): add react_emoji config for incoming messages

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -10,7 +10,7 @@ from typing import Any, Literal
 
 from loguru import logger
 from pydantic import Field
-from telegram import BotCommand, ReplyParameters, Update
+from telegram import BotCommand, ReactionTypeEmoji, ReplyParameters, Update
 from telegram.error import TimedOut
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 from telegram.request import HTTPXRequest
@@ -164,6 +164,7 @@ class TelegramConfig(Base):
     allow_from: list[str] = Field(default_factory=list)
     proxy: str | None = None
     reply_to_message: bool = False
+    react_emoji: str = "👀"
     group_policy: Literal["open", "mention"] = "mention"
     connection_pool_size: int = 32
     pool_timeout: float = 5.0
@@ -770,6 +771,7 @@ class TelegramChannel(BaseChannel):
                     "session_key": session_key,
                 }
                 self._start_typing(str_chat_id)
+                await self._add_reaction(str_chat_id, message.message_id, self.config.react_emoji)
             buf = self._media_group_buffers[key]
             if content and content != "[empty message]":
                 buf["contents"].append(content)
@@ -780,6 +782,7 @@ class TelegramChannel(BaseChannel):
 
         # Start typing indicator before processing
         self._start_typing(str_chat_id)
+        await self._add_reaction(str_chat_id, message.message_id, self.config.react_emoji)
 
         # Forward to the message bus
         await self._handle_message(
@@ -818,6 +821,19 @@ class TelegramChannel(BaseChannel):
         task = self._typing_tasks.pop(chat_id, None)
         if task and not task.done():
             task.cancel()
+
+    async def _add_reaction(self, chat_id: str, message_id: int, emoji: str) -> None:
+        """Add emoji reaction to a message (best-effort, non-blocking)."""
+        if not self._app or not emoji:
+            return
+        try:
+            await self._app.bot.set_message_reaction(
+                chat_id=int(chat_id),
+                message_id=message_id,
+                reaction=[ReactionTypeEmoji(emoji=emoji)],
+            )
+        except Exception as e:
+            logger.debug("Telegram reaction failed: {}", e)
 
     async def _typing_loop(self, chat_id: str) -> None:
         """Repeatedly send 'typing' action until cancelled."""


### PR DESCRIPTION
## Summary

This PR adds a `react_emoji` setting to the Telegram channel config. When configured, the bot will automatically react to incoming messages to acknowledge receipt before processing.

This aligns with the established configuration pattern in `nanobot` (e.g., PR #2054 and #1593). 

- `react_emoji: str = "👀"` (default)
- To disable the feature, users can simply set `react_emoji: ""` in their `config.json`.

## Test plan

- [x] Verify setting `react_emoji: "✍"` in `config.json` enables the reaction with the specified emoji.
- [x] Verify setting `react_emoji: ""` disables the reaction.
- [x] Verify reactions work correctly for both single messages and media groups.