### PR TITLE
Multi agent handoff

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -115,8 +115,7 @@ You are nanobot, a helpful AI assistant.
 ## Runtime
 {runtime}
 
-## Workspace
-Your workspace is at: {workspace_path}
+## Your Personal Data
 - Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)
 - History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
 - Custom skills: {workspace_path}/skills/{{skill-name}}/SKILL.md

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -19,14 +19,21 @@ class ContextBuilder:
     BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"]
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
 
-    def __init__(self, workspace: Path):
+    def __init__(self, workspace: Path, team_members: list[dict[str, str]] | None = None,
+                 current_agent: str | None = None):
         self.workspace = workspace
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
+        self.team_members = team_members or []
+        self.current_agent = current_agent
 
     def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
         parts = [self._get_identity()]
+
+        team = self._build_team_context()
+        if team:
+            parts.append(team)
 
         bootstrap = self._load_bootstrap_files()
         if bootstrap:
@@ -52,6 +59,35 @@ Skills with available="false" need dependencies installed first - you can try in
 {skills_summary}""")
 
         return "\n\n---\n\n".join(parts)
+
+    def _build_team_context(self) -> str:
+        """Build team context with transfer guidance."""
+        if not self.team_members:
+            return ""
+        others = [
+            m for m in self.team_members
+            if m.get("name") and m.get("name") != self.current_agent
+        ]
+        if not others:
+            return ""
+        header = "## Team\n"
+        lines = []
+        if self.current_agent:
+            lines.append(f"You are the `{self.current_agent}` agent.")
+        lines.append(
+            "You can hand off this conversation to other top-level agents when they are better suited."
+        )
+        lines.append("Available teammates:")
+        for member in others:
+            name = member.get("name", "")
+            model = member.get("model", "")
+            suffix = f" (model: {model})" if model else ""
+            lines.append(f"- {name}{suffix}")
+        lines.append(
+            "To hand off, call the tool `transfer_to_<agent>` (e.g. `transfer_to_coder`). "
+            "Handoffs are invisible to the user; continue seamlessly after transferring."
+        )
+        return header + "\n".join(lines)
 
     def _get_identity(self) -> str:
         """Get the core identity section."""

--- a/nanobot/agent/handoff.py
+++ b/nanobot/agent/handoff.py
@@ -1,0 +1,98 @@
+"""Model handoff routing for top-level agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.events import InboundMessage, OutboundMessage
+
+
+@dataclass
+class HandoffOutcome:
+    response: "OutboundMessage | None"
+    sent: bool
+
+
+class HandoffRouter:
+    """Routes sessions between top-level agents and executes handoffs."""
+
+    def __init__(self, agents: dict[str, "AgentLoop"], default_name: str = "defaults"):
+        self.agents = agents
+        self.default_name = default_name
+        self.routes: dict[str, str] = {}
+
+    def list_team(self) -> list[dict[str, str]]:
+        return [
+            {"name": name, "model": agent.model}
+            for name, agent in sorted(self.agents.items())
+        ]
+
+    def list_agent_names(self, *, exclude: str | None = None) -> list[str]:
+        return [
+            name for name in sorted(self.agents.keys())
+            if name != exclude
+        ]
+
+    def route_for(self, session_key: str) -> str:
+        return self.routes.get(session_key, self.default_name)
+
+    def set_route(self, session_key: str, agent_name: str) -> None:
+        if agent_name in self.agents:
+            self.routes[session_key] = agent_name
+        else:
+            logger.warning("Unknown handoff target '{}'", agent_name)
+
+    async def dispatch(
+        self,
+        agent_name: str,
+        msg: "InboundMessage",
+        session_key: str | None = None,
+    ) -> "OutboundMessage | None":
+        agent = self.agents.get(agent_name)
+        if not agent:
+            return None
+        return await agent._process_message(msg, session_key=session_key or msg.session_key)
+
+    async def handoff(
+        self,
+        source_name: str,
+        target_name: str,
+        msg: "InboundMessage",
+        session_key: str,
+    ) -> HandoffOutcome:
+        target = self.agents.get(target_name)
+        if not target:
+            return HandoffOutcome(response=None, sent=False)
+
+        self.set_route(session_key, target_name)
+
+        source = self.agents.get(source_name)
+        if source:
+            self._sync_session(source, target, session_key)
+
+        logger.info("Handoff {} -> {}", source_name, target_name)
+
+        response = await target._process_message(msg, session_key=session_key)
+        return HandoffOutcome(response=response, sent=response is None)
+
+    def _sync_session(self, source: "AgentLoop", target: "AgentLoop", session_key: str) -> None:
+        """Seed target session with source history if target has none yet."""
+        source_session = source.sessions.get_or_create(session_key)
+        target_session = target.sessions.get_or_create(session_key)
+
+        if target_session.messages:
+            return
+        if not source_session.messages:
+            return
+
+        target_session.messages = list(source_session.messages)
+        target_session.last_consolidated = source_session.last_consolidated
+        target_session.metadata["handoff_synced_from"] = source.agent_name
+        target_session.metadata["handoff_synced_at"] = datetime.now().isoformat()
+        target.sessions.save(target_session)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -90,7 +90,6 @@ class AgentLoop:
             workspace, team_members=team_members, current_agent=agent_name
         )
         self.sessions = session_manager or SessionManager(workspace)
-        self.tools = ToolRegistry()
         self.subagents = SubagentManager(
             provider=provider,
             workspace=workspace,
@@ -114,6 +113,9 @@ class AgentLoop:
         )
         self.handoff: HandoffRouter | None = None
         self._handoff_tools: dict[str, str] = {}
+        self.tools = self._register_default_tools()
+        self.session_tools = {}
+
         self.memory_consolidator = MemoryConsolidator(
             workspace=workspace,
             provider=provider,
@@ -123,27 +125,34 @@ class AgentLoop:
             build_messages=self.context.build_messages,
             get_tool_definitions=self.tools.get_definitions,
         )
-        self._register_default_tools()
+
         if handoff:
             self.attach_handoff(handoff)
 
-    def _register_default_tools(self) -> None:
-        """Register the default set of tools."""
-        allowed_dir = self.workspace if self.restrict_to_workspace else None
+    def _register_filesystem_tools(self, working_dir) -> ToolRegistry:
+        """Register filesystem tools for a session-specific working directory."""
+        tools = ToolRegistry()
+        allowed_dir = working_dir if self.restrict_to_workspace else None
         for cls in (ReadFileTool, WriteFileTool, EditFileTool, ListDirTool):
-            self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
-        self.tools.register(ExecTool(
-            working_dir=str(self.workspace),
+            tools.register(cls(workspace=working_dir, allowed_dir=allowed_dir))
+        tools.register(ExecTool(
+            working_dir=str(working_dir),
             timeout=self.exec_config.timeout,
             restrict_to_workspace=self.restrict_to_workspace,
             path_append=self.exec_config.path_append,
         ))
-        self.tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
-        self.tools.register(WebFetchTool(proxy=self.web_proxy))
-        self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
-        self.tools.register(SpawnTool(manager=self.subagents))
+        return tools
+
+    def _register_default_tools(self) -> ToolRegistry:
+        """Register the default set of tools."""
+        tools = ToolRegistry()
+        tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
+        tools.register(WebFetchTool(proxy=self.web_proxy))
+        tools.register(MessageTool(send_callback=self.bus.publish_outbound))
+        tools.register(SpawnTool(manager=self.subagents))
         if self.cron_service:
-            self.tools.register(CronTool(self.cron_service))
+            tools.register(CronTool(self.cron_service))
+        return tools
 
     def attach_handoff(self, router: HandoffRouter) -> None:
         """Attach a handoff router and register transfer tools."""
@@ -210,6 +219,7 @@ class AgentLoop:
         self,
         initial_messages: list[dict],
         on_progress: Callable[..., Awaitable[None]] | None = None,
+        session_tools: ToolRegistry | None = None,
     ) -> tuple[str | None, list[str], list[dict], bool]:
         """Run the agent iteration loop."""
         messages = initial_messages
@@ -222,6 +232,8 @@ class AgentLoop:
             iteration += 1
 
             tool_defs = self.tools.get_definitions()
+            if session_tools is not None:
+                tool_defs.extend(session_tools.get_definitions())
 
             response = await self.provider.chat_with_retry(
                 messages=messages,
@@ -247,6 +259,7 @@ class AgentLoop:
                 )
 
                 for tool_call in response.tool_calls:
+                    tools = session_tools if (session_tools and session_tools.has(tool_call.name)) else self.tools
                     tools_used.append(tool_call.name)
                     if self.handoff and tool_call.name in self._handoff_tools:
                         target = self._handoff_tools[tool_call.name]
@@ -259,7 +272,7 @@ class AgentLoop:
                         return final_content, tools_used, messages, handoff_sent
                     args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
                     logger.info("Tool call: {}({})", tool_call.name, args_str[:200])
-                    result = await self.tools.execute(tool_call.name, tool_call.arguments)
+                    result = await tools.execute(tool_call.name, tool_call.arguments)
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
@@ -445,6 +458,9 @@ class AgentLoop:
 
         key = session_key or msg.session_key
         session = self.sessions.get_or_create(key)
+        self.session_tools.setdefault(key, self._register_filesystem_tools(self.workspace / key.replace(':', '_')))
+
+        session_tools = self.session_tools[key]
 
         # Slash commands
         cmd = msg.content.strip().lower()
@@ -510,6 +526,7 @@ class AgentLoop:
         try:
             final_content, _, all_msgs, handoff_sent = await self._run_agent_loop(
                 initial_messages, on_progress=on_progress or _bus_progress,
+                session_tools = session_tools,
             )
         finally:
             self._handoff_ctx.reset(token)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json
 import os
 import re
@@ -14,10 +15,12 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable
 from loguru import logger
 
 from nanobot.agent.context import ContextBuilder
+from nanobot.agent.handoff import HandoffRouter
 from nanobot.agent.memory import MemoryConsolidator
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
+from nanobot.agent.tools.handoff import TransferTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.shell import ExecTool
@@ -63,6 +66,9 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        agent_name: str = "defaults",
+        handoff: HandoffRouter | None = None,
+        team_members: list[dict[str, str]] | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -71,6 +77,7 @@ class AgentLoop:
         self.provider = provider
         self.workspace = workspace
         self.model = model or provider.get_default_model()
+        self.agent_name = agent_name
         self.max_iterations = max_iterations
         self.context_window_tokens = context_window_tokens
         self.web_search_config = web_search_config or WebSearchConfig()
@@ -79,7 +86,9 @@ class AgentLoop:
         self.cron_service = cron_service
         self.restrict_to_workspace = restrict_to_workspace
 
-        self.context = ContextBuilder(workspace)
+        self.context = ContextBuilder(
+            workspace, team_members=team_members, current_agent=agent_name
+        )
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
         self.subagents = SubagentManager(
@@ -100,6 +109,11 @@ class AgentLoop:
         self._mcp_connecting = False
         self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
         self._processing_lock = asyncio.Lock()
+        self._handoff_ctx: contextvars.ContextVar[tuple[InboundMessage, str] | None] = (
+            contextvars.ContextVar("handoff_ctx", default=None)
+        )
+        self.handoff: HandoffRouter | None = None
+        self._handoff_tools: dict[str, str] = {}
         self.memory_consolidator = MemoryConsolidator(
             workspace=workspace,
             provider=provider,
@@ -110,6 +124,8 @@ class AgentLoop:
             get_tool_definitions=self.tools.get_definitions,
         )
         self._register_default_tools()
+        if handoff:
+            self.attach_handoff(handoff)
 
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
@@ -128,6 +144,20 @@ class AgentLoop:
         self.tools.register(SpawnTool(manager=self.subagents))
         if self.cron_service:
             self.tools.register(CronTool(self.cron_service))
+
+    def attach_handoff(self, router: HandoffRouter) -> None:
+        """Attach a handoff router and register transfer tools."""
+        self.handoff = router
+        self._register_handoff_tools()
+
+    def _register_handoff_tools(self) -> None:
+        if not self.handoff:
+            return
+        for name in self.handoff.list_agent_names(exclude=self.agent_name):
+            tool = TransferTool(name)
+            self._handoff_tools[tool.name] = name
+            if not self.tools.has(tool.name):
+                self.tools.register(tool)
 
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""
@@ -180,12 +210,13 @@ class AgentLoop:
         self,
         initial_messages: list[dict],
         on_progress: Callable[..., Awaitable[None]] | None = None,
-    ) -> tuple[str | None, list[str], list[dict]]:
+    ) -> tuple[str | None, list[str], list[dict], bool]:
         """Run the agent iteration loop."""
         messages = initial_messages
         iteration = 0
         final_content = None
         tools_used: list[str] = []
+        handoff_sent = False
 
         while iteration < self.max_iterations:
             iteration += 1
@@ -217,6 +248,15 @@ class AgentLoop:
 
                 for tool_call in response.tool_calls:
                     tools_used.append(tool_call.name)
+                    if self.handoff and tool_call.name in self._handoff_tools:
+                        target = self._handoff_tools[tool_call.name]
+                        final_content, handoff_sent, tool_result = await self._handle_handoff(
+                            target
+                        )
+                        messages = self.context.add_tool_result(
+                            messages, tool_call.id, tool_call.name, tool_result
+                        )
+                        return final_content, tools_used, messages, handoff_sent
                     args_str = json.dumps(tool_call.arguments, ensure_ascii=False)
                     logger.info("Tool call: {}({})", tool_call.name, args_str[:200])
                     result = await self.tools.execute(tool_call.name, tool_call.arguments)
@@ -245,7 +285,39 @@ class AgentLoop:
                 "without completing the task. You can try breaking the task into smaller steps."
             )
 
-        return final_content, tools_used, messages
+        return final_content, tools_used, messages, handoff_sent
+
+    async def _handle_handoff(
+        self, target: str
+    ) -> tuple[str | None, bool, str]:
+        """Handle a handoff tool call and return (content, sent, tool_result)."""
+        if not self.handoff:
+            return (
+                "Sorry, handoff is not available.",
+                False,
+                "Handoff failed: router unavailable.",
+            )
+        ctx = self._handoff_ctx.get()
+        if not ctx:
+            return (
+                "Sorry, handoff is not available.",
+                False,
+                "Handoff failed: missing context.",
+            )
+        msg, session_key = ctx
+        outcome = await self.handoff.handoff(
+            self.agent_name, target, msg, session_key=session_key
+        )
+        tool_result = f"Handoff to {target}."
+        if outcome.sent:
+            return None, True, tool_result
+        if outcome.response:
+            return outcome.response.content, False, tool_result
+        return (
+            "Sorry, the handoff did not return a response.",
+            False,
+            tool_result,
+        )
 
     async def run(self) -> None:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
@@ -342,6 +414,11 @@ class AgentLoop:
         on_progress: Callable[[str], Awaitable[None]] | None = None,
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
+        key = session_key or msg.session_key
+        if self.handoff:
+            target_name = self.handoff.route_for(key)
+            if target_name != self.agent_name:
+                return await self.handoff.dispatch(target_name, msg, session_key=key)
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
             channel, chat_id = (msg.chat_id.split(":", 1) if ":" in msg.chat_id
@@ -356,7 +433,7 @@ class AgentLoop:
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
             )
-            final_content, _, all_msgs = await self._run_agent_loop(messages)
+            final_content, _, all_msgs, _ = await self._run_agent_loop(messages)
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
@@ -426,17 +503,26 @@ class AgentLoop:
                 channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
             ))
 
-        final_content, _, all_msgs = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
-        )
+        token = self._handoff_ctx.set((msg, key))
+        final_content = None
+        all_msgs: list[dict] = []
+        handoff_sent = False
+        try:
+            final_content, _, all_msgs, handoff_sent = await self._run_agent_loop(
+                initial_messages, on_progress=on_progress or _bus_progress,
+            )
+        finally:
+            self._handoff_ctx.reset(token)
 
-        if final_content is None:
+        if final_content is None and not handoff_sent:
             final_content = "I've completed processing but have no response to give."
 
         self._save_turn(session, all_msgs, 1 + len(history))
         self.sessions.save(session)
         await self.memory_consolidator.maybe_consolidate_by_tokens(session)
 
+        if handoff_sent:
+            return None
         if (mt := self.tools.get("message")) and isinstance(mt, MessageTool) and mt._sent_in_turn:
             return None
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -55,6 +55,7 @@ class AgentLoop:
         bus: MessageBus,
         provider: LLMProvider,
         workspace: Path,
+        initial_workspace: Path | None = None,
         model: str | None = None,
         max_iterations: int = 40,
         context_window_tokens: int = 65_536,
@@ -76,6 +77,7 @@ class AgentLoop:
         self.channels_config = channels_config
         self.provider = provider
         self.workspace = workspace
+        self.initial_workspace = initial_workspace
         self.model = model or provider.get_default_model()
         self.agent_name = agent_name
         self.max_iterations = max_iterations
@@ -458,7 +460,11 @@ class AgentLoop:
 
         key = session_key or msg.session_key
         session = self.sessions.get_or_create(key)
-        self.session_tools.setdefault(key, self._register_filesystem_tools(self.workspace / key.replace(':', '_')))
+        base_workspace = self.initial_workspace or self.workspace
+        self.session_tools.setdefault(
+            key,
+            self._register_filesystem_tools(base_workspace / key.replace(":", "_")),
+        )
 
         session_tools = self.session_tools[key]
 

--- a/nanobot/agent/tools/handoff.py
+++ b/nanobot/agent/tools/handoff.py
@@ -1,0 +1,35 @@
+"""Handoff tool for transferring control to another top-level agent."""
+
+from typing import Any
+
+from nanobot.agent.tools.base import Tool
+
+
+class TransferTool(Tool):
+    """Tool definition for model handoff."""
+
+    def __init__(self, target: str):
+        self._target = target
+
+    @property
+    def name(self) -> str:
+        return f"transfer_to_{self._target}"
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Hand off this conversation to the {self._target} agent. "
+            "Use when another agent is better suited. This is invisible to the user."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
+    async def execute(self, **_kwargs: Any) -> str:
+        # Actual handoff is handled by the agent loop; this is a schema stub.
+        return "Handoff requested."

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -330,6 +330,7 @@ def _build_agent_team(
 
     agents = config.agents.list_members()
     team = [{"name": name, "model": cfg.model} for name, cfg in agents.items()]
+    primary_workspace = Path(next(iter(agents.values())).workspace).expanduser() if agents else Path(config.agents.defaults.workspace).expanduser()
 
     loops: dict[str, AgentLoop] = {}
     is_primary = True
@@ -341,6 +342,7 @@ def _build_agent_team(
             bus=bus,
             provider=provider,
             workspace=workspace,
+            initial_workspace=primary_workspace,
             model=cfg.model,
             max_iterations=cfg.max_tool_iterations,
             context_window_tokens=cfg.context_window_tokens,

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -32,7 +32,7 @@ from rich.text import Text
 
 from nanobot import __logo__, __version__
 from nanobot.config.paths import get_workspace_path
-from nanobot.config.schema import Config
+from nanobot.config.schema import AgentDefaults, Config
 from nanobot.utils.helpers import sync_workspace_templates
 
 app = typer.Typer(
@@ -260,13 +260,13 @@ def onboard():
 
 
 
-def _make_provider(config: Config):
+def _make_provider(config: Config, model: str | None = None, defaults: AgentDefaults | None = None):
     """Create the appropriate LLM provider from config."""
     from nanobot.providers.base import GenerationSettings
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
     from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
 
-    model = config.agents.defaults.model
+    model = model or config.agents.defaults.model
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
 
@@ -309,13 +309,59 @@ def _make_provider(config: Config):
             provider_name=provider_name,
         )
 
-    defaults = config.agents.defaults
+    defaults = defaults or config.agents.defaults
     provider.generation = GenerationSettings(
         temperature=defaults.temperature,
         max_tokens=defaults.max_tokens,
         reasoning_effort=defaults.reasoning_effort,
     )
     return provider
+
+
+def _build_agent_team(
+    config: Config,
+    bus: "MessageBus",
+    cron: "CronService | None",
+    session_manager: "SessionManager | None" = None,
+) -> dict[str, "AgentLoop"]:
+    from nanobot.agent.handoff import HandoffRouter
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.session.manager import SessionManager
+
+    agents = config.agents.list_members()
+    team = [{"name": name, "model": cfg.model} for name, cfg in agents.items()]
+
+    loops: dict[str, AgentLoop] = {}
+    for name, cfg in agents.items():
+        workspace = Path(cfg.workspace).expanduser()
+        sync_workspace_templates(workspace)
+        provider = _make_provider(config, model=cfg.model, defaults=cfg)
+        loop = AgentLoop(
+            bus=bus,
+            provider=provider,
+            workspace=workspace,
+            model=cfg.model,
+            max_iterations=cfg.max_tool_iterations,
+            context_window_tokens=cfg.context_window_tokens,
+            web_search_config=config.tools.web.search,
+            web_proxy=config.tools.web.proxy or None,
+            exec_config=config.tools.exec,
+            cron_service=cron if name == "defaults" else None,
+            restrict_to_workspace=config.tools.restrict_to_workspace,
+            session_manager=session_manager if (name == "defaults" and session_manager) else SessionManager(workspace),
+            mcp_servers=config.tools.mcp_servers,
+            channels_config=config.channels,
+            agent_name=name,
+            team_members=team,
+        )
+        loops[name] = loop
+
+    if len(loops) > 1:
+        router = HandoffRouter(loops, default_name="defaults")
+        for loop in loops.values():
+            loop.attach_handoff(router)
+
+    return loops
 
 
 def _load_runtime_config(config: str | None = None, workspace: str | None = None) -> Config:
@@ -360,7 +406,6 @@ def gateway(
     config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
 ):
     """Start the nanobot gateway."""
-    from nanobot.agent.loop import AgentLoop
     from nanobot.bus.queue import MessageBus
     from nanobot.channels.manager import ChannelManager
     from nanobot.config.paths import get_cron_dir
@@ -380,30 +425,15 @@ def gateway(
     console.print(f"{__logo__} Starting nanobot gateway on port {port}...")
     sync_workspace_templates(config.workspace_path)
     bus = MessageBus()
-    provider = _make_provider(config)
     session_manager = SessionManager(config.workspace_path)
 
     # Create cron service first (callback set after agent creation)
     cron_store_path = get_cron_dir() / "jobs.json"
     cron = CronService(cron_store_path)
 
-    # Create agent with cron service
-    agent = AgentLoop(
-        bus=bus,
-        provider=provider,
-        workspace=config.workspace_path,
-        model=config.agents.defaults.model,
-        max_iterations=config.agents.defaults.max_tool_iterations,
-        context_window_tokens=config.agents.defaults.context_window_tokens,
-        web_search_config=config.tools.web.search,
-        web_proxy=config.tools.web.proxy or None,
-        exec_config=config.tools.exec,
-        cron_service=cron,
-        restrict_to_workspace=config.tools.restrict_to_workspace,
-        session_manager=session_manager,
-        mcp_servers=config.tools.mcp_servers,
-        channels_config=config.channels,
-    )
+    # Create agent team (default + optional handoff agents)
+    loops = _build_agent_team(config, bus=bus, cron=cron, session_manager=session_manager)
+    agent = loops["defaults"]
 
     # Set cron callback (needs agent)
     async def on_cron_job(job: CronJob) -> str | None:
@@ -492,7 +522,7 @@ def gateway(
     hb_cfg = config.gateway.heartbeat
     heartbeat = HeartbeatService(
         workspace=config.workspace_path,
-        provider=provider,
+        provider=agent.provider,
         model=agent.model,
         on_execute=on_heartbeat_execute,
         on_notify=on_heartbeat_notify,
@@ -550,42 +580,26 @@ def agent(
     """Interact with the agent directly."""
     from loguru import logger
 
-    from nanobot.agent.loop import AgentLoop
     from nanobot.bus.queue import MessageBus
     from nanobot.config.paths import get_cron_dir
     from nanobot.cron.service import CronService
 
     config = _load_runtime_config(config, workspace)
     _print_deprecated_memory_window_notice(config)
-    sync_workspace_templates(config.workspace_path)
-
-    bus = MessageBus()
-    provider = _make_provider(config)
 
     # Create cron service for tool usage (no callback needed for CLI unless running)
     cron_store_path = get_cron_dir() / "jobs.json"
     cron = CronService(cron_store_path)
+    bus = MessageBus()
+    loops = _build_agent_team(config, bus=bus, cron=cron, session_manager=None)
+    agent_loop = loops["defaults"]
 
     if logs:
         logger.enable("nanobot")
     else:
         logger.disable("nanobot")
 
-    agent_loop = AgentLoop(
-        bus=bus,
-        provider=provider,
-        workspace=config.workspace_path,
-        model=config.agents.defaults.model,
-        max_iterations=config.agents.defaults.max_tool_iterations,
-        context_window_tokens=config.agents.defaults.context_window_tokens,
-        web_search_config=config.tools.web.search,
-        web_proxy=config.tools.web.proxy or None,
-        exec_config=config.tools.exec,
-        cron_service=cron,
-        restrict_to_workspace=config.tools.restrict_to_workspace,
-        mcp_servers=config.tools.mcp_servers,
-        channels_config=config.channels,
-    )
+    # agent_loop created via _build_agent_team
 
     # Show spinner when logs are off (no output to miss); skip when logs are on
     def _thinking_ctx():

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -332,6 +332,7 @@ def _build_agent_team(
     team = [{"name": name, "model": cfg.model} for name, cfg in agents.items()]
 
     loops: dict[str, AgentLoop] = {}
+    is_primary = True
     for name, cfg in agents.items():
         workspace = Path(cfg.workspace).expanduser()
         sync_workspace_templates(workspace)
@@ -346,18 +347,20 @@ def _build_agent_team(
             web_search_config=config.tools.web.search,
             web_proxy=config.tools.web.proxy or None,
             exec_config=config.tools.exec,
-            cron_service=cron if name == "defaults" else None,
+            cron_service=cron if is_primary else None,
             restrict_to_workspace=config.tools.restrict_to_workspace,
-            session_manager=session_manager if (name == "defaults" and session_manager) else SessionManager(workspace),
+            session_manager=session_manager if (is_primary and session_manager) else SessionManager(workspace),
             mcp_servers=config.tools.mcp_servers,
             channels_config=config.channels,
             agent_name=name,
             team_members=team,
         )
         loops[name] = loop
+        is_primary = False
 
     if len(loops) > 1:
-        router = HandoffRouter(loops, default_name="defaults")
+        default_name = next(iter(loops.keys()))
+        router = HandoffRouter(loops, default_name=default_name)
         for loop in loops.values():
             loop.attach_handoff(router)
 
@@ -433,7 +436,7 @@ def gateway(
 
     # Create agent team (default + optional handoff agents)
     loops = _build_agent_team(config, bus=bus, cron=cron, session_manager=session_manager)
-    agent = loops["defaults"]
+    agent = next(iter(loops.values()))
 
     # Set cron callback (needs agent)
     async def on_cron_job(job: CronJob) -> str | None:
@@ -592,7 +595,7 @@ def agent(
     cron = CronService(cron_store_path)
     bus = MessageBus()
     loops = _build_agent_team(config, bus=bus, cron=cron, session_manager=None)
-    agent_loop = loops["defaults"]
+    agent_loop = next(iter(loops.values()))
 
     if logs:
         logger.enable("nanobot")

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
 
@@ -254,7 +254,27 @@ class AgentDefaults(Base):
 class AgentsConfig(Base):
     """Agent configuration."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="allow")
+
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
+    members: dict[str, AgentDefaults] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _collect_members(self):
+        extras = self.model_extra or {}
+        for name, value in extras.items():
+            if name in {"defaults", "members"}:
+                continue
+            self.members[name] = AgentDefaults.model_validate(value)
+        return self
+
+    def get_member(self, name: str) -> AgentDefaults | None:
+        if name in {"defaults"}:
+            return self.defaults
+        return self.members.get(name)
+
+    def list_members(self) -> dict[str, AgentDefaults]:
+        return {"defaults": self.defaults, **self.members}
 
 
 class ProviderConfig(Base):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -256,25 +256,37 @@ class AgentsConfig(Base):
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="allow")
 
-    defaults: AgentDefaults = Field(default_factory=AgentDefaults)
     members: dict[str, AgentDefaults] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _collect_members(self):
         extras = self.model_extra or {}
+        if "defaults" in extras:
+            self.members["defaults"] = AgentDefaults.model_validate(extras["defaults"])
         for name, value in extras.items():
-            if name in {"defaults", "members"}:
+            if name == "defaults":
                 continue
             self.members[name] = AgentDefaults.model_validate(value)
         return self
 
     def get_member(self, name: str) -> AgentDefaults | None:
-        if name in {"defaults"}:
-            return self.defaults
         return self.members.get(name)
 
     def list_members(self) -> dict[str, AgentDefaults]:
-        return {"defaults": self.defaults, **self.members}
+        return self.members
+
+    @property
+    def defaults(self) -> AgentDefaults:
+        if self.members:
+            return self.members[next(iter(self.members.keys()))]
+        return AgentDefaults()
+
+    @defaults.setter
+    def defaults(self, value: AgentDefaults) -> None:
+        if self.members:
+            first_key = next(iter(self.members.keys()))
+            self.members[first_key] = value
+            return
 
 
 class ProviderConfig(Base):

--- a/tests/test_agents_config.py
+++ b/tests/test_agents_config.py
@@ -1,0 +1,43 @@
+from nanobot.config.schema import Config
+
+
+def test_agents_config_collects_members() -> None:
+    data = {
+        "agents": {
+            "defaults": {
+                "workspace": "~/.nanobot/workspace",
+                "model": "gpt-5.2-codex",
+            },
+            "coder": {
+                "workspace": "~/.nanobot/coder",
+                "model": "gpt-5.4-codex",
+            },
+        }
+    }
+
+    config = Config.model_validate(data)
+
+    assert "coder" in config.agents.members
+    assert config.agents.get_member("coder").model == "gpt-5.4-codex"
+
+    members = config.agents.list_members()
+    assert "defaults" in members
+    assert "coder" in members
+
+
+def test_agents_config_defaults_fallbacks_to_first_member() -> None:
+    data = {
+        "agents": {
+            "coder": {
+                "workspace": "~/.nanobot/coder",
+                "model": "gpt-5.4-codex",
+            },
+            "tester": {
+                "workspace": "~/.nanobot/tester",
+                "model": "gpt-5.2-codex",
+            },
+        }
+    }
+
+    config = Config.model_validate(data)
+    assert config.agents.defaults.model == "gpt-5.4-codex"

--- a/tests/test_handoff_router.py
+++ b/tests/test_handoff_router.py
@@ -1,0 +1,40 @@
+import pytest
+
+from nanobot.agent.handoff import HandoffRouter
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.session.manager import SessionManager
+
+
+class DummyAgent:
+    def __init__(self, name: str, workspace, response: str):
+        self.agent_name = name
+        self.model = f"model-{name}"
+        self.sessions = SessionManager(workspace)
+        self._response = response
+
+    async def _process_message(self, msg: InboundMessage, session_key: str | None = None) -> OutboundMessage:
+        return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content=self._response)
+
+
+@pytest.mark.asyncio
+async def test_handoff_routes_and_syncs_session(tmp_path) -> None:
+    source = DummyAgent("default", tmp_path / "default", "from default")
+    target = DummyAgent("coder", tmp_path / "coder", "from coder")
+
+    router = HandoffRouter({"default": source, "coder": target}, default_name="default")
+
+    session_key = "cli:direct"
+    session = source.sessions.get_or_create(session_key)
+    session.add_message("user", "hello")
+    source.sessions.save(session)
+
+    msg = InboundMessage(channel="cli", sender_id="user", chat_id="direct", content="handoff please")
+    outcome = await router.handoff("default", "coder", msg, session_key=session_key)
+
+    assert router.route_for(session_key) == "coder"
+    assert outcome.response is not None
+    assert outcome.response.content == "from coder"
+
+    target_session = target.sessions.get_or_create(session_key)
+    assert target_session.messages
+    assert target_session.metadata["handoff_synced_from"] == "default"


### PR DESCRIPTION
Multi agent handoff implementation. Multiple agents configured.  Starting with the initial agent ("defaults" or first), each agent may call a tool to handoff the conversation to another agent.

# Summary
- Add multi-agent handoff with `transfer_to_<agent>` tools, per-agent models/workspaces, and routing.
- Per-session filesystem tool registration from #1345. For consistent filesystem view across handoff.
- Ensure handoff sessions share a base workspace (initial agent) for consistent relative paths.
- Tests for agents config parsing and handoff routing.

# Details
- New handoff router and transfer tool for top-level agent switching.
- Agent loop updated to support handoff routing, session tool registries, and per-session working dirs.
- Context now includes team instructions for handoff (only when other agents exist).
- Creates multiple agent loops, sets a primary agent for cron/session manager, and wires handoff.
- Config parsing treats `agents` entries as direct members and ensures `defaults` is first.