### PR TITLE
fix(telegram): support sending media via URL

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -354,13 +354,22 @@ class TelegramChannel(BaseChannel):
                     "audio": self._app.bot.send_audio,
                 }.get(media_type, self._app.bot.send_document)
                 param = "photo" if media_type == "photo" else media_type if media_type in ("voice", "audio") else "document"
-                with open(media_path, 'rb') as f:
+                
+                if media_path.startswith(("http://", "https://")):
                     await sender(
                         chat_id=chat_id,
-                        **{param: f},
+                        **{param: media_path},
                         reply_parameters=reply_params,
                         **thread_kwargs,
                     )
+                else:
+                    with open(media_path, 'rb') as f:
+                        await sender(
+                            chat_id=chat_id,
+                            **{param: f},
+                            reply_parameters=reply_params,
+                            **thread_kwargs,
+                        )
             except Exception as e:
                 filename = media_path.rsplit("/", 1)[-1]
                 logger.error("Failed to send media {}: {}", media_path, e)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Telegram channel fails to send media if the `media_path` is a URL (e.g., returned by an MCP tool or an image generation API). 

Previously, the code blindly attempted to `open(media_path, 'rb')`, which resulted in `[Errno 2] No such file or directory` for URLs. This PR adds a simple check: if the path starts with `http://` or `https://`, it passes the URL directly to the Telegram API (which natively supports downloading and sending media from URLs). Otherwise, it falls back to the existing local file behavior.

Fixes #1792

## Test plan

- [x] Verify that local files still send correctly.
- [x] Verify that passing a valid image URL in the `media` array of the `message` tool successfully sends the image to the Telegram chat without crashing.