### PR TITLE
fix(telegram): respect send_progress config to disable streaming and prevent duplicate messages

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -377,7 +377,7 @@ class TelegramChannel(BaseChannel):
 
             for chunk in split_message(msg.content, TELEGRAM_MAX_MESSAGE_LEN):
                 # Final response: simulate streaming via draft, then persist
-                if not is_progress:
+                if not is_progress and getattr(self.config, "send_progress", True):
                     await self._send_with_streaming(chat_id, chunk, reply_params, thread_kwargs)
                 else:
                     await self._send_text(chat_id, chunk, reply_params, thread_kwargs)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Telegram channel occasionally sends duplicate messages (one unformatted, one formatted) when `_send_with_streaming` fails to update the draft message in time.

The fix respects the global `send_progress` configuration (which defaults to `True`). If a user sets `"sendProgress": false` in their `channels` config, the Telegram channel will now completely bypass the `_send_with_streaming` draft simulation and send the final message directly via `_send_text`. This provides a reliable way to disable streaming and prevent duplicate messages.

Fixes #1692

## Test plan

- [x] Verify that with `"sendProgress": true` (default), the bot still simulates streaming via drafts.
- [x] Verify that with `"sendProgress": false`, the bot skips `_send_with_streaming` and sends the final message directly, preventing duplicates.