### PR TITLE
fix(agent): save subagent results as assistant role instead of user

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -370,10 +370,16 @@ class AgentLoop:
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
             history = session.get_history(max_messages=0)
+            
+            # Build messages but override the role for system messages
             messages = self.context.build_messages(
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
             )
+            # The last message is the current_message, change its role to assistant
+            if messages and messages[-1]["role"] == "user":
+                messages[-1]["role"] = "assistant"
+                
             final_content, _, all_msgs = await self._run_agent_loop(messages)
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the result of a subagent (spawned via the `spawn` tool) is incorrectly saved into the session history as a `user` message instead of an `assistant` message.

When a subagent completes its task, it publishes an `InboundMessage` with `channel="system"`. In `loop.py`, `_process_message` handles this by calling `context.build_messages()`, which by default appends the `current_message` as a `user` role. This PR simply overrides the role of that final message to `assistant` before passing it to the agent loop. This prevents the LLM from getting confused about who actually performed the background task.

Fixes #2092

## Test plan

- [x] Spawn a subagent using the `spawn` tool.
- [x] Wait for it to complete and announce its result.
- [x] Verify in the `.jsonl` session history file that the subagent's result message is saved with `"role": "assistant"` instead of `"role": "user"`.