### PR TITLE
feat(providers): support service_tier and text_verbosity extra params

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -200,6 +200,8 @@ class AgentLoop:
                 messages=messages,
                 tools=tool_defs,
                 model=self.model,
+                service_tier=self.provider.config.agents.defaults.service_tier if hasattr(self.provider, "config") else None,
+                text_verbosity=self.provider.config.agents.defaults.text_verbosity if hasattr(self.provider, "config") else None,
             )
 
             if response.has_tool_calls:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -42,6 +42,8 @@ class AgentDefaults(Base):
     # Deprecated compatibility field: accepted from old configs but ignored at runtime.
     memory_window: int | None = Field(default=None, exclude=True)
     reasoning_effort: str | None = None  # low / medium / high — enables LLM thinking mode
+    service_tier: str | None = None  # auto / standard_only (for Anthropic)
+    text_verbosity: str | None = None  # low / medium / high (for OpenAI)
 
     @property
     def should_warn_deprecated_memory_window(self) -> bool:

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -175,6 +175,8 @@ class LLMProvider(ABC):
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
+        service_tier: str | None = None,
+        text_verbosity: str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request.
@@ -240,6 +242,8 @@ class LLMProvider(ABC):
         temperature: object = _SENTINEL,
         reasoning_effort: object = _SENTINEL,
         tool_choice: str | dict[str, Any] | None = None,
+        service_tier: str | None = None,
+        text_verbosity: str | None = None,
     ) -> LLMResponse:
         """Call chat() with retry on transient provider failures.
 
@@ -258,6 +262,7 @@ class LLMProvider(ABC):
             messages=messages, tools=tools, model=model,
             max_tokens=max_tokens, temperature=temperature,
             reasoning_effort=reasoning_effort, tool_choice=tool_choice,
+            service_tier=service_tier, text_verbosity=text_verbosity,
         )
 
         for attempt, delay in enumerate(self._CHAT_RETRY_DELAYS, start=1):

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -216,6 +216,8 @@ class LiteLLMProvider(LLMProvider):
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
+        service_tier: str | None = None,
+        text_verbosity: str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request via LiteLLM.
@@ -272,6 +274,12 @@ class LiteLLMProvider(LLMProvider):
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
             kwargs["drop_params"] = True
+            
+        if service_tier:
+            kwargs["service_tier"] = service_tier
+            
+        if text_verbosity:
+            kwargs["text_verbosity"] = text_verbosity
         
         if tools:
             kwargs["tools"] = tools


### PR DESCRIPTION
## Summary

This PR introduces support for two advanced provider-specific parameters recently added to the upstream `openclaw` project:

1. **`service_tier`** (Anthropic): Allows users to explicitly request `"auto"` or `"standard_only"` routing. This is especially useful for users with pre-funded Anthropic accounts who want to utilize the faster `auto` tier (similar to `openclaw`'s fast mode).
2. **`text_verbosity`** (OpenAI): Allows users to control the verbosity of O1/O3 models (`"low"`, `"medium"`, `"high"`), enabling the "think more, say less" pattern.

*References to upstream `openclaw` implementations:*
- Anthropic `service_tier`: openclaw/openclaw#45453
- OpenAI `text.verbosity`: openclaw/openclaw#47106

## Design & Implementation

- Added `service_tier` and `text_verbosity` to `AgentDefaults` in `schema.py`.
- Updated the `LLMProvider` base class and `LiteLLMProvider` to accept these parameters in `chat()` and `chat_with_retry()`.
- In `LiteLLMProvider`, these parameters are passed directly into `litellm.acompletion(**kwargs)`. LiteLLM natively supports passing these extra parameters to the respective provider APIs.
- In `AgentLoop`, the parameters are extracted from the config and passed to the provider during the chat loop.

This implementation is lightweight, fully backward compatible, and leverages LiteLLM's existing parameter passthrough capabilities.