### PR TITLE
feat: support dynamic custom providers via extras config

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -234,7 +234,10 @@ class AgentLoop:
                 # Don't persist error responses to session history — they can
                 # poison the context and cause permanent 400 loops (#1303).
                 if response.finish_reason == "error":
-                    logger.error("LLM returned error: {}", (clean or "")[:200])
+                    import re
+                    err_brief = re.sub(r"<[^>]+>", " ", clean or "").strip()
+                    err_brief = re.sub(r"\s+", " ", err_brief)[:200]
+                    logger.error("LLM returned error: {}", err_brief)
                     final_content = clean or "Sorry, I encountered an error calling the AI model."
                     break
                 messages = self.context.add_assistant_message(

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -354,8 +354,23 @@ def _make_provider(config: Config):
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
 
+    # Extras: dynamic custom providers
+    if provider_name and provider_name.startswith("extras:"):
+        if not p or not p.api_key:
+            console.print(f"[red]Error: No API key configured for extras provider '{provider_name}'.[/red]")
+            raise typer.Exit(1)
+        # Strip provider prefix: "scnet/MiniMax-M2.5" → "MiniMax-M2.5"
+        bare_model = model.split("/", 1)[1] if "/" in model else model
+        # Look up model declaration for context_window / max_tokens overrides
+        model_cfg = config.get_model_config(model)
+        from nanobot.providers.custom_provider import CustomProvider
+        provider = CustomProvider(
+            api_key=p.api_key,
+            api_base=p.api_base or "http://localhost:8000/v1",
+            default_model=bare_model,
+        )
     # OpenAI Codex (OAuth)
-    if provider_name == "openai_codex" or model.startswith("openai-codex/"):
+    elif provider_name == "openai_codex" or model.startswith("openai-codex/"):
         provider = OpenAICodexProvider(default_model=model)
     # Custom: direct OpenAI-compatible endpoint, bypasses LiteLLM
     elif provider_name == "custom":
@@ -394,11 +409,21 @@ def _make_provider(config: Config):
         )
 
     defaults = config.agents.defaults
+    # Apply model declaration overrides for max_tokens / context_window
+    model_cfg = config.get_model_config(model)
+    gen_max_tokens = model_cfg.max_tokens if model_cfg else defaults.max_tokens
     provider.generation = GenerationSettings(
         temperature=defaults.temperature,
-        max_tokens=defaults.max_tokens,
+        max_tokens=gen_max_tokens,
         reasoning_effort=defaults.reasoning_effort,
     )
+
+    # Apply model declaration overrides
+    if model_cfg:
+        provider.model_supports_image = model_cfg.supports_image
+        if model_cfg.context_window:
+            config.agents.defaults.context_window_tokens = model_cfg.context_window
+
     return provider
 
 
@@ -1026,6 +1051,20 @@ def status():
             else:
                 has_key = bool(p.api_key)
                 console.print(f"{spec.label}: {'[green]✓[/green]' if has_key else '[dim]not set[/dim]'}")
+
+        # Extras providers
+        for name, ep in config.providers.extras.items():
+            has_key = bool(ep.api_key)
+            api_type = ep.api or "openai"
+            model_count = len(ep.models)
+            label = f"{name} (extras, {api_type})"
+            status = f"[green]✓[/green] {model_count} model(s)" if has_key else "[dim]not set[/dim]"
+            console.print(f"{label}: {status}")
+            if has_key and ep.models:
+                for mc in ep.models:
+                    img = "[green]img[/green]" if mc.supports_image else "[dim]no-img[/dim]"
+                    think = "[green]think[/green]" if mc.supports_reasoning else ""
+                    console.print(f"  - {mc.id}  ctx={mc.context_window}  {img} {think}")
 
 
 # ============================================================================

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -359,16 +359,25 @@ def _make_provider(config: Config):
         if not p or not p.api_key:
             console.print(f"[red]Error: No API key configured for extras provider '{provider_name}'.[/red]")
             raise typer.Exit(1)
+        api_protocol = (p.api or "openai").lower()
         # Strip provider prefix: "scnet/MiniMax-M2.5" → "MiniMax-M2.5"
         bare_model = model.split("/", 1)[1] if "/" in model else model
         # Look up model declaration for context_window / max_tokens overrides
         model_cfg = config.get_model_config(model)
-        from nanobot.providers.custom_provider import CustomProvider
-        provider = CustomProvider(
-            api_key=p.api_key,
-            api_base=p.api_base or "http://localhost:8000/v1",
-            default_model=bare_model,
-        )
+        if api_protocol == "openai-responses":
+            from nanobot.providers.openai_responses_provider import OpenAIResponsesProvider
+            provider = OpenAIResponsesProvider(
+                api_key=p.api_key,
+                api_base=p.api_base or "https://api.openai.com/v1",
+                default_model=bare_model,
+            )
+        else:
+            from nanobot.providers.custom_provider import CustomProvider
+            provider = CustomProvider(
+                api_key=p.api_key,
+                api_base=p.api_base or "http://localhost:8000/v1",
+                default_model=bare_model,
+            )
     # OpenAI Codex (OAuth)
     elif provider_name == "openai_codex" or model.startswith("openai-codex/"):
         provider = OpenAICodexProvider(default_model=model)

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -55,12 +55,25 @@ class AgentsConfig(Base):
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
 
 
+class ModelConfig(Base):
+    """Model capability declaration for custom providers."""
+
+    id: str                          # Model ID, e.g. "MiniMax-M2.5"
+    name: str = ""                   # Display name, defaults to id
+    supports_image: bool = False     # Whether the model supports image input
+    supports_reasoning: bool = False # Whether the model supports reasoning/thinking
+    context_window: int = 200000     # Context window size in tokens
+    max_tokens: int = 8192           # Maximum output tokens
+
+
 class ProviderConfig(Base):
     """LLM provider configuration."""
 
     api_key: str = ""
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
+    api: str | None = None  # API protocol: "openai" (default), "anthropic"
+    models: list[ModelConfig] = Field(default_factory=list)  # Model capability declarations
 
 
 class ProvidersConfig(Base):
@@ -88,6 +101,7 @@ class ProvidersConfig(Base):
     byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig)  # Github Copilot (OAuth)
+    extras: dict[str, ProviderConfig] = Field(default_factory=dict)  # Custom providers (dynamic)
 
 
 class HeartbeatConfig(Base):
@@ -168,11 +182,17 @@ class Config(BaseSettings):
     def _match_provider(
         self, model: str | None = None
     ) -> tuple["ProviderConfig | None", str | None]:
-        """Match provider config and its registry name. Returns (config, spec_name)."""
+        """Match provider config and its registry name. Returns (config, spec_name).
+
+        For extras providers, spec_name is "extras:<key>" (e.g. "extras:scnet").
+        """
         from nanobot.providers.registry import PROVIDERS
 
         forced = self.agents.defaults.provider
         if forced != "auto":
+            # Check extras first
+            if forced in self.providers.extras:
+                return self.providers.extras[forced], f"extras:{forced}"
             p = getattr(self.providers, forced, None)
             return (p, forced) if p else (None, None)
 
@@ -180,6 +200,12 @@ class Config(BaseSettings):
         model_normalized = model_lower.replace("-", "_")
         model_prefix = model_lower.split("/", 1)[0] if "/" in model_lower else ""
         normalized_prefix = model_prefix.replace("-", "_")
+
+        # Extras: match by explicit provider prefix (e.g. "scnet/MiniMax-M2.5")
+        if model_prefix:
+            for key, p in self.providers.extras.items():
+                if key.lower().replace("-", "_") == normalized_prefix and p.api_key:
+                    return p, f"extras:{key}"
 
         def _kw_matches(kw: str) -> bool:
             kw = kw.lower()
@@ -225,6 +251,12 @@ class Config(BaseSettings):
             p = getattr(self.providers, spec.name, None)
             if p and p.api_key:
                 return p, spec.name
+
+        # Fallback: extras with a configured api_key
+        for key, p in self.providers.extras.items():
+            if p.api_key:
+                return p, f"extras:{key}"
+
         return None, None
 
     def get_provider(self, model: str | None = None) -> ProviderConfig | None:
@@ -249,6 +281,9 @@ class Config(BaseSettings):
         p, name = self._match_provider(model)
         if p and p.api_base:
             return p.api_base
+        # Extras providers always use their configured api_base (no default)
+        if name and name.startswith("extras:"):
+            return None
         # Only gateways get a default api_base here. Standard providers
         # (like Moonshot) set their base URL via env vars in _setup_env
         # to avoid polluting the global litellm.api_base.
@@ -256,6 +291,19 @@ class Config(BaseSettings):
             spec = find_by_name(name)
             if spec and (spec.is_gateway or spec.is_local) and spec.default_api_base:
                 return spec.default_api_base
+        return None
+
+    def get_model_config(self, model: str | None = None) -> "ModelConfig | None":
+        """Find model capability declaration from extras providers."""
+        p, name = self._match_provider(model)
+        if not p or not p.models:
+            return None
+        # Strip provider prefix to get bare model id
+        raw = model or self.agents.defaults.model
+        bare = raw.split("/", 1)[1] if "/" in raw else raw
+        for mc in p.models:
+            if mc.id == bare:
+                return mc
         return None
 
     model_config = ConfigDict(env_prefix="NANOBOT_", env_nested_delimiter="__")

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -104,6 +104,7 @@ class LLMProvider(ABC):
         self.api_key = api_key
         self.api_base = api_base
         self.generation: GenerationSettings = GenerationSettings()
+        self.model_supports_image: bool | None = None  # Set from ModelConfig declaration
 
     @staticmethod
     def _sanitize_empty_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -254,6 +255,13 @@ class LLMProvider(ABC):
         if reasoning_effort is self._SENTINEL:
             reasoning_effort = self.generation.reasoning_effort
 
+        # Proactively strip images if model declaration says images are unsupported
+        if self.model_supports_image is False:
+            stripped = self._strip_image_content(messages)
+            if stripped is not None:
+                logger.info("Model does not support images (declared), stripping images proactively")
+                messages = stripped
+
         kw: dict[str, Any] = dict(
             messages=messages, tools=tools, model=model,
             max_tokens=max_tokens, temperature=temperature,
@@ -274,10 +282,13 @@ class LLMProvider(ABC):
                         return await self._safe_chat(**{**kw, "messages": stripped})
                 return response
 
+            # Strip HTML tags for cleaner log output
+            import re
+            err_text = re.sub(r"<[^>]+>", " ", response.content or "").strip()
+            err_text = re.sub(r"\s+", " ", err_text)[:150]
             logger.warning(
                 "LLM transient error (attempt {}/{}), retrying in {}s: {}",
-                attempt, len(self._CHAT_RETRY_DELAYS), delay,
-                (response.content or "")[:120].lower(),
+                attempt, len(self._CHAT_RETRY_DELAYS), delay, err_text,
             )
             await asyncio.sleep(delay)
 

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -17,18 +17,24 @@ class CustomProvider(LLMProvider):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         # Keep affinity stable for this provider instance to improve backend cache locality.
+        import httpx
         self._client = AsyncOpenAI(
             api_key=api_key,
             base_url=api_base,
             default_headers={"x-session-affinity": uuid.uuid4().hex},
+            http_client=httpx.AsyncClient(proxy=None),  # Avoid proxy pollution from other channels
         )
 
     async def chat(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
                    model: str | None = None, max_tokens: int = 4096, temperature: float = 0.7,
                    reasoning_effort: str | None = None,
                    tool_choice: str | dict[str, Any] | None = None) -> LLMResponse:
+        resolved = model or self.default_model
+        # Strip provider prefix (e.g. "scnet/MiniMax-M2.5" → "MiniMax-M2.5")
+        if "/" in resolved:
+            resolved = resolved.split("/", 1)[1]
         kwargs: dict[str, Any] = {
-            "model": model or self.default_model,
+            "model": resolved,
             "messages": self._sanitize_empty_content(messages),
             "max_tokens": max(1, max_tokens),
             "temperature": temperature,

--- a/nanobot/providers/openai_responses_provider.py
+++ b/nanobot/providers/openai_responses_provider.py
@@ -1,0 +1,108 @@
+"""Generic OpenAI Responses API provider — uses httpx + SSE streaming."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.providers.openai_codex_provider import (
+    _consume_sse,
+    _convert_messages,
+    _convert_tools,
+    _friendly_error,
+)
+
+
+class OpenAIResponsesProvider(LLMProvider):
+    """Call any OpenAI-compatible Responses API endpoint with a standard API key."""
+
+    def __init__(
+        self,
+        api_key: str = "",
+        api_base: str = "https://api.openai.com/v1",
+        default_model: str = "gpt-4o",
+    ):
+        super().__init__(api_key, api_base)
+        self.default_model = default_model
+        self._base_url = api_base.rstrip("/")
+        self._http = httpx.AsyncClient(
+            timeout=httpx.Timeout(600.0, connect=10.0),
+            proxy=None,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+        logger.info(
+            "OpenAIResponsesProvider init: base_url={}, model={}",
+            self._base_url, default_model,
+        )
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+    ) -> LLMResponse:
+        model = model or self.default_model
+        if "/" in model:
+            model = model.split("/", 1)[1]
+
+        system_prompt, input_items = _convert_messages(messages)
+
+        body: dict[str, Any] = {
+            "model": model,
+            "stream": True,
+            "input": input_items,
+            "tool_choice": tool_choice or "auto",
+            "parallel_tool_calls": True,
+        }
+
+        if system_prompt:
+            body["instructions"] = system_prompt
+
+        if max_tokens:
+            body["max_output_tokens"] = max(1, max_tokens)
+
+        if temperature is not None:
+            body["temperature"] = temperature
+
+        if reasoning_effort:
+            body["reasoning"] = {"effort": reasoning_effort}
+
+        if tools:
+            body["tools"] = _convert_tools(tools)
+
+        url = f"{self._base_url}/responses"
+
+        try:
+            logger.debug("OpenAIResponsesProvider.chat: url={}, model={}", url, model)
+            async with self._http.stream("POST", url, json=body) as response:
+                if response.status_code != 200:
+                    text = (await response.aread()).decode("utf-8", "ignore")
+                    error_text = text[:300]
+                    logger.error("Responses API error {}: {}", response.status_code, error_text)
+                    return LLMResponse(
+                        content=f"Error: HTTP {response.status_code}: {error_text}",
+                        finish_reason="error",
+                    )
+                content, tool_calls, finish_reason = await _consume_sse(response)
+                return LLMResponse(
+                    content=content or None,
+                    tool_calls=tool_calls,
+                    finish_reason=finish_reason,
+                )
+        except Exception as e:
+            logger.error("OpenAIResponsesProvider.chat error: {}", e)
+            return LLMResponse(content=f"Error: {e}", finish_reason="error")
+
+    def get_default_model(self) -> str:
+        return self.default_model

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -454,6 +454,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         strip_model_prefix=False,
         model_overrides=(),
     ),
+
 )
 
 


### PR DESCRIPTION
## Summary
- Add `extras` dict in `ProvidersConfig` for dynamically adding LLM providers without code changes
- Each extras provider declares optional model capabilities (`supportsImage`, `contextWindow`, `maxTokens`)
- Add `ModelConfig` data class and extend `ProviderConfig` with `api`/`models` fields
- Route extras providers to `CustomProvider` (OpenAI-compatible) with model prefix stripping
- Proactively strip images when model declares no image support
- Strip HTML tags from transient error logs for cleaner output
- Add `proxy=None` to httpx clients to prevent proxy pollution from other channels

## Config example
```json
{
  "providers": {
    "extras": {
      "scnet": {
        "apiKey": "sk-xxx",
        "apiBase": "https://api.scnet.cn/api/llm/v1",
        "api": "openai",
        "models": [
          { "id": "MiniMax-M2.5", "supportsImage": false, "contextWindow": 100000, "maxTokens": 8192 }
        ]
      }
    }
  }
}
```

## Test plan
- [ ] `nanobot status` displays extras providers and their model declarations
- [ ] `scnet/MiniMax-M2.5` routes to CustomProvider with correct base URL
- [ ] Model capabilities (supportsImage=false) trigger proactive image stripping
- [ ] Existing built-in providers remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)