### PR TITLE
Add ordered multi-model provider fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,19 @@ Add or merge these **two parts** into your config (other options have defaults).
 }
 ```
 
+*Optional: add ordered multi-model fallback for transient provider/model failures:*
+```json
+{
+  "multi_model": {
+    "enabled": true,
+    "models": [
+      "anthropic/claude-opus-4-5",
+      "openrouter/openai/gpt-5-mini"
+    ]
+  }
+}
+```
+
 **3. Chat**
 
 ```bash

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -366,50 +366,85 @@ def _make_provider(config: Config):
     from nanobot.providers.base import GenerationSettings
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
     from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+    from nanobot.providers.multi_model_provider import ModelCandidate, MultiModelProvider
 
-    model = config.agents.defaults.model
-    provider_name = config.get_provider_name(model)
-    p = config.get_provider(model)
+    def _build_provider(model: str):
+        provider_name = config.get_provider_name(model)
+        p = config.get_provider(model)
 
-    # OpenAI Codex (OAuth)
-    if provider_name == "openai_codex" or model.startswith("openai-codex/"):
-        provider = OpenAICodexProvider(default_model=model)
-    # Custom: direct OpenAI-compatible endpoint, bypasses LiteLLM
-    elif provider_name == "custom":
-        from nanobot.providers.custom_provider import CustomProvider
-        provider = CustomProvider(
-            api_key=p.api_key if p else "no-key",
-            api_base=config.get_api_base(model) or "http://localhost:8000/v1",
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-        )
-    # Azure OpenAI: direct Azure OpenAI endpoint with deployment name
-    elif provider_name == "azure_openai":
-        if not p or not p.api_key or not p.api_base:
-            console.print("[red]Error: Azure OpenAI requires api_key and api_base.[/red]")
-            console.print("Set them in ~/.nanobot/config.json under providers.azure_openai section")
-            console.print("Use the model field to specify the deployment name.")
-            raise typer.Exit(1)
-        provider = AzureOpenAIProvider(
-            api_key=p.api_key,
-            api_base=p.api_base,
-            default_model=model,
-        )
-    else:
+        # OpenAI Codex (OAuth)
+        if provider_name == "openai_codex" or model.startswith("openai-codex/"):
+            return OpenAICodexProvider(default_model=model), provider_name or "openai_codex"
+
+        # Custom: direct OpenAI-compatible endpoint, bypasses LiteLLM
+        if provider_name == "custom":
+            from nanobot.providers.custom_provider import CustomProvider
+            return (
+                CustomProvider(
+                    api_key=p.api_key if p else "no-key",
+                    api_base=config.get_api_base(model) or "http://localhost:8000/v1",
+                    default_model=model,
+                    extra_headers=p.extra_headers if p else None,
+                ),
+                provider_name,
+            )
+
+        # Azure OpenAI: direct Azure OpenAI endpoint with deployment name
+        if provider_name == "azure_openai":
+            if not p or not p.api_key or not p.api_base:
+                console.print("[red]Error: Azure OpenAI requires api_key and api_base.[/red]")
+                console.print("Set them in ~/.nanobot/config.json under providers.azure_openai section")
+                console.print("Use the model field to specify the deployment name.")
+                raise typer.Exit(1)
+            return (
+                AzureOpenAIProvider(
+                    api_key=p.api_key,
+                    api_base=p.api_base,
+                    default_model=model,
+                ),
+                provider_name,
+            )
+
         from nanobot.providers.litellm_provider import LiteLLMProvider
         from nanobot.providers.registry import find_by_name
+
         spec = find_by_name(provider_name)
         if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and (spec.is_oauth or spec.is_local)):
             console.print("[red]Error: No API key configured.[/red]")
             console.print("Set one in ~/.nanobot/config.json under providers section")
             raise typer.Exit(1)
-        provider = LiteLLMProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-            provider_name=provider_name,
+        return (
+            LiteLLMProvider(
+                api_key=p.api_key if p else None,
+                api_base=config.get_api_base(model),
+                default_model=model,
+                extra_headers=p.extra_headers if p else None,
+                provider_name=provider_name,
+            ),
+            provider_name,
         )
+
+    default_model = config.multi_model.default_model or config.agents.defaults.model
+    configured_models = [model for model in config.multi_model.models if model]
+    if not configured_models:
+        configured_models = [default_model]
+    elif default_model not in configured_models:
+        configured_models.insert(0, default_model)
+
+    if config.multi_model.enabled and len(configured_models) > 1:
+        candidates = []
+        for candidate_model in configured_models:
+            built_provider, provider_name = _build_provider(candidate_model)
+            candidates.append(
+                ModelCandidate(
+                    model=candidate_model,
+                    provider_name=provider_name or "unknown",
+                    provider=built_provider,
+                )
+            )
+        provider = MultiModelProvider(candidates, default_model=default_model)
+    else:
+        provider, _ = _build_provider(default_model)
 
     defaults = config.agents.defaults
     provider.generation = GenerationSettings(

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -54,6 +54,14 @@ class AgentsConfig(Base):
     defaults: AgentDefaults = Field(default_factory=AgentDefaults)
 
 
+class MultiModelConfig(Base):
+    """Ordered model/provider fallback configuration."""
+
+    enabled: bool = False
+    default_model: str = ""
+    models: list[str] = Field(default_factory=list)
+
+
 class ProviderConfig(Base):
     """LLM provider configuration."""
 
@@ -154,6 +162,7 @@ class Config(BaseSettings):
     """Root configuration for nanobot."""
 
     agents: AgentsConfig = Field(default_factory=AgentsConfig)
+    multi_model: MultiModelConfig = Field(default_factory=MultiModelConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)

--- a/nanobot/providers/multi_model_provider.py
+++ b/nanobot/providers/multi_model_provider.py
@@ -1,0 +1,85 @@
+"""Sequential multi-model fallback provider."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+
+from nanobot.providers.base import LLMProvider, LLMResponse
+
+
+@dataclass
+class ModelCandidate:
+    """A concrete model/provider pair to try in fallback order."""
+
+    model: str
+    provider_name: str
+    provider: LLMProvider
+
+
+class MultiModelProvider(LLMProvider):
+    """Try configured model/provider candidates in order until one succeeds."""
+
+    def __init__(self, candidates: list[ModelCandidate], default_model: str):
+        super().__init__(api_key=None, api_base=None)
+        if not candidates:
+            raise ValueError("MultiModelProvider requires at least one candidate")
+        self._candidates = candidates
+        self._default_model = default_model
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+    ) -> LLMResponse:
+        requested_model = model or self._default_model
+        ordered = self._ordered_candidates(requested_model)
+        last_response: LLMResponse | None = None
+
+        for idx, candidate in enumerate(ordered):
+            if idx > 0:
+                logger.warning(
+                    "Primary model failed; falling back to {} via {}",
+                    candidate.model,
+                    candidate.provider_name,
+                )
+
+            response = await candidate.provider.chat(
+                messages=messages,
+                tools=tools,
+                model=candidate.model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                reasoning_effort=reasoning_effort,
+                tool_choice=tool_choice,
+            )
+            if response.finish_reason != "error":
+                return response
+            last_response = response
+
+        return last_response or LLMResponse(
+            content="Error calling LLM: no fallback models configured",
+            finish_reason="error",
+        )
+
+    def get_default_model(self) -> str:
+        """Return the configured primary model."""
+        return self._default_model
+
+    def _ordered_candidates(self, requested_model: str) -> list[ModelCandidate]:
+        if requested_model == self._default_model:
+            return self._candidates
+
+        exact = [candidate for candidate in self._candidates if candidate.model == requested_model]
+        if not exact:
+            return self._candidates
+
+        remainder = [candidate for candidate in self._candidates if candidate.model != requested_model]
+        return exact + remainder

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 from nanobot.cli.commands import _make_provider, app
 from nanobot.config.schema import Config
 from nanobot.providers.litellm_provider import LiteLLMProvider
+from nanobot.providers.multi_model_provider import MultiModelProvider
 from nanobot.providers.openai_codex_provider import _strip_model_prefix
 from nanobot.providers.registry import find_by_model
 
@@ -268,6 +269,40 @@ def test_make_provider_passes_extra_headers_to_custom_provider():
     assert kwargs["base_url"] == "https://example.com/v1"
     assert kwargs["default_headers"]["APP-Code"] == "demo-app"
     assert kwargs["default_headers"]["x-session-affinity"] == "sticky-session"
+
+
+def test_make_provider_builds_multi_model_fallback_chain():
+    from nanobot.cli.commands import _make_provider
+
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "model": "anthropic/claude-opus-4-5",
+                    "temperature": 0.2,
+                    "maxTokens": 2048,
+                }
+            },
+            "multi_model": {
+                "enabled": True,
+                "models": [
+                    "anthropic/claude-opus-4-5",
+                    "openrouter/openai/gpt-5-mini",
+                ],
+            },
+            "providers": {
+                "anthropic": {"apiKey": "anthropic-key"},
+                "openrouter": {"apiKey": "openrouter-key"},
+            },
+        }
+    )
+
+    provider = _make_provider(config)
+
+    assert isinstance(provider, MultiModelProvider)
+    assert provider.get_default_model() == "anthropic/claude-opus-4-5"
+    assert provider.generation.temperature == 0.2
+    assert provider.generation.max_tokens == 2048
 
 
 @pytest.fixture

--- a/tests/test_multi_model_provider.py
+++ b/tests/test_multi_model_provider.py
@@ -1,0 +1,72 @@
+import pytest
+
+from nanobot.providers.base import LLMProvider, LLMResponse
+from nanobot.providers.multi_model_provider import ModelCandidate, MultiModelProvider
+
+
+class ScriptedProvider(LLMProvider):
+    def __init__(self, responses, default_model: str):
+        super().__init__()
+        self._responses = list(responses)
+        self._default_model = default_model
+        self.calls: list[dict] = []
+
+    async def chat(self, *args, **kwargs) -> LLMResponse:
+        self.calls.append(kwargs)
+        return self._responses.pop(0)
+
+    def get_default_model(self) -> str:
+        return self._default_model
+
+
+@pytest.mark.asyncio
+async def test_multi_model_provider_falls_back_to_next_candidate() -> None:
+    primary = ScriptedProvider(
+        [LLMResponse(content="429 rate limit", finish_reason="error")],
+        default_model="anthropic/claude-opus-4-5",
+    )
+    secondary = ScriptedProvider(
+        [LLMResponse(content="ok")],
+        default_model="openrouter/openai/gpt-5-mini",
+    )
+    provider = MultiModelProvider(
+        [
+            ModelCandidate("anthropic/claude-opus-4-5", "anthropic", primary),
+            ModelCandidate("openrouter/openai/gpt-5-mini", "openrouter", secondary),
+        ],
+        default_model="anthropic/claude-opus-4-5",
+    )
+
+    response = await provider.chat(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.content == "ok"
+    assert primary.calls[0]["model"] == "anthropic/claude-opus-4-5"
+    assert secondary.calls[0]["model"] == "openrouter/openai/gpt-5-mini"
+
+
+@pytest.mark.asyncio
+async def test_multi_model_provider_prioritizes_requested_model_when_configured() -> None:
+    primary = ScriptedProvider(
+        [LLMResponse(content="ok from requested")],
+        default_model="openrouter/openai/gpt-5-mini",
+    )
+    secondary = ScriptedProvider(
+        [LLMResponse(content="should not be used")],
+        default_model="anthropic/claude-opus-4-5",
+    )
+    provider = MultiModelProvider(
+        [
+            ModelCandidate("anthropic/claude-opus-4-5", "anthropic", secondary),
+            ModelCandidate("openrouter/openai/gpt-5-mini", "openrouter", primary),
+        ],
+        default_model="anthropic/claude-opus-4-5",
+    )
+
+    response = await provider.chat(
+        messages=[{"role": "user", "content": "hello"}],
+        model="openrouter/openai/gpt-5-mini",
+    )
+
+    assert response.content == "ok from requested"
+    assert len(primary.calls) == 1
+    assert secondary.calls == []


### PR DESCRIPTION
## Summary
- add an opt-in `multi_model` config block for ordered fallback candidates
- introduce `MultiModelProvider` so nanobot can try multiple model/provider pairs in sequence
- wire `_make_provider()` to build the fallback chain and document the config

## Testing
- `/tmp/nanobot-official-20260316/.venv/bin/pytest /tmp/nanobot-official-20260316/tests/test_multi_model_provider.py /tmp/nanobot-official-20260316/tests/test_commands.py -q`
- `/tmp/nanobot-official-20260316/.venv/bin/python -m compileall /tmp/nanobot-official-20260316/nanobot`
