### PR TITLE
docs: add WhatsApp community link

### DIFF
--- a/COMMUNICATION.md
+++ b/COMMUNICATION.md
@@ -1,4 +1,8 @@
-We provide QR codes for joining the HKUDS discussion groups on **WeChat** and **Feishu**.
+We provide community links for joining the HKUDS discussion groups on **WeChat**, **Feishu**, and **WhatsApp**.
+
+You can join the WhatsApp group here:
+
+- [WhatsApp Group Invite](https://chat.whatsapp.com/IP6m2vBdq96768ytPesn1f)
 
 You can join by scanning the QR codes below:
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     <a href="./COMMUNICATION.md"><img src="https://img.shields.io/badge/Feishu-Group-E9DBFC?style=flat&logo=feishu&logoColor=white" alt="Feishu"></a>
     <a href="./COMMUNICATION.md"><img src="https://img.shields.io/badge/WeChat-Group-C5EAB4?style=flat&logo=wechat&logoColor=white" alt="WeChat"></a>
     <a href="https://discord.gg/MnCvHqpUGB"><img src="https://img.shields.io/badge/Discord-Community-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord"></a>
+    <a href="https://chat.whatsapp.com/IP6m2vBdq96768ytPesn1f"><img src="https://img.shields.io/badge/WhatsApp-Group-25D366?style=flat&logo=whatsapp&logoColor=white" alt="WhatsApp"></a>
   </p>
 </div>
 


### PR DESCRIPTION
## Summary
- add a WhatsApp group badge to the README header alongside the existing community links
- document the WhatsApp invite link in COMMUNICATION.md

## Testing
- not run (documentation-only change)