### PR TITLE
fix(providers): handle empty choices in custom provider response

### DIFF
--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -54,6 +54,11 @@ class CustomProvider(LLMProvider):
             return LLMResponse(content=f"Error: {e}", finish_reason="error")
 
     def _parse(self, response: Any) -> LLMResponse:
+        if not response.choices:
+            return LLMResponse(
+                content="Error: API returned empty choices. This may indicate a temporary service issue or an invalid model response.",
+                finish_reason="error"
+            )
         choice = response.choices[0]
         msg = choice.message
         tool_calls = [

--- a/tests/test_custom_provider.py
+++ b/tests/test_custom_provider.py
@@ -1,0 +1,13 @@
+from types import SimpleNamespace
+
+from nanobot.providers.custom_provider import CustomProvider
+
+
+def test_custom_provider_parse_handles_empty_choices() -> None:
+    provider = CustomProvider()
+    response = SimpleNamespace(choices=[])
+
+    result = provider._parse(response)
+
+    assert result.finish_reason == "error"
+    assert "empty choices" in result.content


### PR DESCRIPTION
Return API Error，not "'NoneType' object is not subscriptable"

Close #2138