### PR TITLE
feat: add silent heartbeat mode

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -606,6 +606,7 @@ def gateway(
         interval_s=hb_cfg.interval_s,
         enabled=hb_cfg.enabled,
     )
+    heartbeat.set_silent(hb_cfg.silent)
 
     if channels.enabled_channels:
         console.print(f"[green]✓[/green] Channels enabled: {', '.join(channels.enabled_channels)}")

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -94,6 +94,11 @@ class HeartbeatConfig(Base):
 
     enabled: bool = True
     interval_s: int = 30 * 60  # 30 minutes
+    # When true, the heartbeat will still run tasks but will not
+    # deliver results back to chat channels. This is intended for
+    # users who want heartbeat checks to run silently in the
+    # background without generating notifications.
+    silent: bool = False
 
 
 class GatewayConfig(Base):

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
@@ -67,8 +69,16 @@ class HeartbeatService:
         self.on_notify = on_notify
         self.interval_s = interval_s
         self.enabled = enabled
+        # Base silent mode flag from config. The final behavior can be
+        # overridden by the HEARTBEAT_SILENT environment variable or
+        # a special directive inside HEARTBEAT.md.
+        self.silent = False
         self._running = False
         self._task: asyncio.Task | None = None
+
+    def set_silent(self, silent: bool) -> None:
+        """Set base silent mode from configuration."""
+        self.silent = bool(silent)
 
     @property
     def heartbeat_file(self) -> Path:
@@ -81,6 +91,30 @@ class HeartbeatService:
             except Exception:
                 return None
         return None
+
+    def _effective_silent(self, content: str) -> bool:
+        """Compute effective silent mode.
+
+        Precedence (lowest → highest):
+        - HeartbeatService.silent (from config)
+        - HEARTBEAT_SILENT environment variable
+        - ``<!-- SILENT: true/false -->`` directive in HEARTBEAT.md
+        """
+        silent = self.silent
+
+        env = os.getenv("HEARTBEAT_SILENT")
+        if env is not None:
+            value = env.strip().lower()
+            if value in {"1", "true", "yes", "on"}:
+                silent = True
+            elif value in {"0", "false", "no", "off"}:
+                silent = False
+
+        match = re.search(r"<!--\s*SILENT:\s*(true|false)\s*-->", content, re.IGNORECASE)
+        if match:
+            silent = match.group(1).lower() == "true"
+
+        return silent
 
     async def _decide(self, content: str) -> tuple[str, str]:
         """Phase 1: ask LLM to decide skip/run via virtual tool call.
@@ -166,11 +200,12 @@ class HeartbeatService:
                     should_notify = await evaluate_response(
                         response, tasks, self.provider, self.model,
                     )
-                    if should_notify and self.on_notify:
+                    silent = self._effective_silent(content)
+                    if should_notify and self.on_notify and not silent:
                         logger.info("Heartbeat: completed, delivering response")
                         await self.on_notify(response)
                     else:
-                        logger.info("Heartbeat: silenced by post-run evaluation")
+                        logger.info("Heartbeat: silenced by post-run evaluation or config")
         except Exception:
             logger.exception("Heartbeat execution failed")
 

--- a/tests/test_heartbeat_service.py
+++ b/tests/test_heartbeat_service.py
@@ -216,6 +216,154 @@ async def test_tick_suppresses_when_evaluator_says_no(tmp_path, monkeypatch) -> 
 
 
 @pytest.mark.asyncio
+async def test_tick_respects_silent_config(tmp_path, monkeypatch) -> None:
+    """When silent is enabled via config, on_notify is not called."""
+    (tmp_path / "HEARTBEAT.md").write_text("- [ ] check status", encoding="utf-8")
+
+    provider = DummyProvider([
+        LLMResponse(
+            content="",
+            tool_calls=[
+                ToolCallRequest(
+                    id="hb_1",
+                    name="heartbeat",
+                    arguments={"action": "run", "tasks": "check status"},
+                )
+            ],
+        ),
+    ])
+
+    executed: list[str] = []
+    notified: list[str] = []
+
+    async def _on_execute(tasks: str) -> str:
+        executed.append(tasks)
+        return "everything is fine, no issues"
+
+    async def _on_notify(response: str) -> None:
+        notified.append(response)
+
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+        on_execute=_on_execute,
+        on_notify=_on_notify,
+    )
+    service.set_silent(True)
+
+    async def _eval_notify(*a, **kw):
+        return True
+
+    monkeypatch.setattr("nanobot.utils.evaluator.evaluate_response", _eval_notify)
+
+    await service._tick()
+    assert executed == ["check status"]
+    assert notified == []
+
+
+@pytest.mark.asyncio
+async def test_tick_respects_silent_env(tmp_path, monkeypatch) -> None:
+    """HEARTBEAT_SILENT=true suppresses notifications."""
+    import os
+
+    (tmp_path / "HEARTBEAT.md").write_text("- [ ] check status", encoding="utf-8")
+
+    provider = DummyProvider([
+        LLMResponse(
+            content="",
+            tool_calls=[
+                ToolCallRequest(
+                    id="hb_1",
+                    name="heartbeat",
+                    arguments={"action": "run", "tasks": "check status"},
+                )
+            ],
+        ),
+    ])
+
+    executed: list[str] = []
+    notified: list[str] = []
+
+    async def _on_execute(tasks: str) -> str:
+        executed.append(tasks)
+        return "everything is fine, no issues"
+
+    async def _on_notify(response: str) -> None:
+        notified.append(response)
+
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+        on_execute=_on_execute,
+        on_notify=_on_notify,
+    )
+
+    async def _eval_notify(*a, **kw):
+        return True
+
+    monkeypatch.setattr("nanobot.utils.evaluator.evaluate_response", _eval_notify)
+    monkeypatch.setenv("HEARTBEAT_SILENT", "true")
+
+    await service._tick()
+    assert executed == ["check status"]
+    assert notified == []
+
+
+@pytest.mark.asyncio
+async def test_tick_respects_silent_directive(tmp_path, monkeypatch) -> None:
+    """<!-- SILENT: true --> in HEARTBEAT.md suppresses notifications."""
+    content = """## Active Tasks
+
+<!-- SILENT: true -->
+
+- [ ] check status
+"""
+    (tmp_path / "HEARTBEAT.md").write_text(content, encoding="utf-8")
+
+    provider = DummyProvider([
+        LLMResponse(
+            content="",
+            tool_calls=[
+                ToolCallRequest(
+                    id="hb_1",
+                    name="heartbeat",
+                    arguments={"action": "run", "tasks": "check status"},
+                )
+            ],
+        ),
+    ])
+
+    executed: list[str] = []
+    notified: list[str] = []
+
+    async def _on_execute(tasks: str) -> str:
+        executed.append(tasks)
+        return "everything is fine, no issues"
+
+    async def _on_notify(response: str) -> None:
+        notified.append(response)
+
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+        on_execute=_on_execute,
+        on_notify=_on_notify,
+    )
+
+    async def _eval_notify(*a, **kw):
+        return True
+
+    monkeypatch.setattr("nanobot.utils.evaluator.evaluate_response", _eval_notify)
+
+    await service._tick()
+    assert executed == ["check status"]
+    assert notified == []
+
+
+@pytest.mark.asyncio
 async def test_decide_retries_transient_error_then_succeeds(tmp_path, monkeypatch) -> None:
     provider = DummyProvider([
         LLMResponse(content="429 rate limit", finish_reason="error"),


### PR DESCRIPTION
## Summary

- Add silent flag to gateway heartbeat config.
- Support HEARTBEAT_SILENT env and <!-- SILENT: true --> directive in HEARTBEAT.md to suppress heartbeat notifications while still running checks.
- Wire silent behavior into HeartbeatService and cover with unit tests.

## Test Plan

- pip install -e .
- pytest tests/test_heartbeat_service.py

Fixes #2126
