### PR TITLE
feat(TUI): add TUI to interacte with nanobot in terminal

### DIFF
--- a/nanobot/channels/tui.py
+++ b/nanobot/channels/tui.py
@@ -38,6 +38,8 @@ _BRAILLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇"
 _COMMANDS: dict[str, str] = {
     "/help": "Show this help message",
     "/new": "Start a new conversation (clears session history)",
+    "/sessions": "List active TUI conversations",
+    "/switch <session>": "Switch to an existing conversation",
     "/clear": "Clear the terminal screen",
     "/stop": "Exit TUI mode",
 }
@@ -70,6 +72,54 @@ class TuiChannel(BaseChannel):
         self._session: PromptSession = PromptSession(
             history=InMemoryHistory(),
         )
+        self._sessions: dict[str, dict[str, Any]] = {}
+        self._session_order: list[str] = []
+        self._ensure_session(self._chat_id)
+
+    def _ensure_session(self, chat_id: str) -> dict[str, Any]:
+        """Create in-memory state for *chat_id* if missing and return it."""
+        if chat_id not in self._sessions:
+            self._sessions[chat_id] = {
+                "status": "idle",
+                "last_user_message": "",
+                "last_agent_preview": "",
+                "tool_events": [],
+            }
+            self._session_order.append(chat_id)
+        return self._sessions[chat_id]
+
+    def _update_session_status(self, chat_id: str, status: str) -> None:
+        self._ensure_session(chat_id)["status"] = status
+
+    def _record_user_message(self, chat_id: str, content: str) -> None:
+        self._ensure_session(chat_id)["last_user_message"] = content.strip()
+        self._update_session_status(chat_id, "queued")
+
+    def _record_agent_message(self, chat_id: str, content: str) -> None:
+        self._ensure_session(chat_id)["last_agent_preview"] = content.strip()
+        self._update_session_status(chat_id, "done")
+
+    def _record_tool_event(self, chat_id: str, content: str) -> None:
+        session = self._ensure_session(chat_id)
+        events = session["tool_events"]
+        events.append(content.strip())
+        del events[:-8]
+        self._update_session_status(chat_id, "tool")
+
+    def _session_summary(self, chat_id: str) -> str:
+        session = self._ensure_session(chat_id)
+        return session["last_agent_preview"] or session["last_user_message"] or "(empty)"
+
+    def _render_overview(self, chat_id: str, console: Console, *, include_tools: bool) -> None:
+        session = self._ensure_session(chat_id)
+        console.print(
+            f"[dim]Session:[/dim] [cyan]{chat_id}[/cyan]  "
+            f"[dim]Status:[/dim] [green]{session['status']}[/green]"
+        )
+        if include_tools and session["tool_events"]:
+            console.print("[dim]Activity:[/dim]")
+            for event in session["tool_events"][-3:]:
+                console.print(f"  [dim]- {event}[/dim]")
 
     async def _animate_loading(self) -> None:
         """Print a Braille spinner directly to the real terminal until cancelled."""
@@ -107,7 +157,9 @@ class TuiChannel(BaseChannel):
 
     async def _dispatch_command(self, text: str) -> bool:
         """Handle a slash command. Returns True if the TUI should exit."""
-        cmd = text.strip().split()[0].lower()
+        parts = text.strip().split(maxsplit=1)
+        cmd = parts[0].lower()
+        arg = parts[1].strip() if len(parts) > 1 else ""
 
         if cmd in {"/stop", "/exit", "/quit"}:
             return True
@@ -127,6 +179,7 @@ class TuiChannel(BaseChannel):
         elif cmd == "/new":
             self._session_counter += 1
             self._chat_id = f"tui-{self._session_counter}"
+            self._ensure_session(self._chat_id)
             n = self._session_counter
 
             def _print_new() -> None:
@@ -141,13 +194,61 @@ class TuiChannel(BaseChannel):
 
             await run_in_terminal(_print_new)
 
+        elif cmd == "/sessions":
+
+            def _print_sessions() -> None:
+                t = Table(show_header=True, header_style="bold cyan", border_style="dim")
+                t.add_column("Current", style="cyan", no_wrap=True)
+                t.add_column("Session", style="cyan", no_wrap=True)
+                t.add_column("Status", style="green", no_wrap=True)
+                t.add_column("Summary")
+                for chat_id in self._session_order:
+                    session = self._ensure_session(chat_id)
+                    t.add_row(
+                        "*" if chat_id == self._chat_id else "",
+                        chat_id,
+                        session["status"],
+                        self._session_summary(chat_id),
+                    )
+                print_formatted_text(ANSI(_to_ansi(lambda c: c.print(t))), end="")
+
+            await run_in_terminal(_print_sessions)
+
+        elif cmd == "/switch":
+
+            def _print_switch(message: str) -> None:
+                print_formatted_text(
+                    ANSI(_to_ansi(lambda c: c.print(message))),
+                    end="",
+                )
+
+            if not arg:
+                await run_in_terminal(lambda: _print_switch("[yellow]Usage:[/yellow] /switch <session>"))
+            elif arg not in self._sessions:
+                await run_in_terminal(
+                    lambda: _print_switch(
+                        f"[yellow]Unknown session:[/yellow] {arg}  "
+                        "Type [cyan]/sessions[/cyan] to list active sessions."
+                    )
+                )
+            else:
+                self._chat_id = arg
+                await run_in_terminal(
+                    lambda: _print_switch(f"[dim]Switched to session [cyan]{arg}[/cyan].[/dim]")
+                )
+
         elif cmd == "/clear":
 
             def _do_clear() -> None:
                 out = sys.__stdout__
                 out.write("\033[2J\033[H")
                 out.flush()
-                rule = _to_ansi(lambda c: c.rule("[bold cyan]nanobot TUI[/bold cyan]"))
+                rule = _to_ansi(
+                    lambda c: (
+                        c.rule("[bold cyan]nanobot TUI[/bold cyan]"),
+                        self._render_overview(self._chat_id, c, include_tools=True),
+                    )
+                )
                 out.write(rule)
                 out.flush()
 
@@ -200,6 +301,7 @@ class TuiChannel(BaseChannel):
                             break
                         continue
 
+                    self._record_user_message(self._chat_id, text)
                     self._response_done.clear()
                     await self._handle_message(
                         sender_id=self.config.user_id,
@@ -226,7 +328,16 @@ class TuiChannel(BaseChannel):
         """Display a message in the TUI."""
         is_progress = msg.metadata.get("_progress", False)
         is_tool_hint = msg.metadata.get("_tool_hint", False)
+        chat_id = msg.chat_id or self._chat_id
         content = msg.content or ""
+        session = self._ensure_session(chat_id)
+
+        if is_progress and is_tool_hint:
+            self._record_tool_event(chat_id, content)
+        elif is_progress:
+            self._update_session_status(chat_id, "thinking")
+        else:
+            self._record_agent_message(chat_id, content)
 
         if not is_progress:
             await self._stop_loading()
@@ -234,12 +345,23 @@ class TuiChannel(BaseChannel):
 
         def _render() -> None:
             if is_progress and is_tool_hint:
-                ansi = _to_ansi(lambda c: c.print(f"  [dim]> {content}[/dim]"))
+                ansi = _to_ansi(
+                    lambda c: (
+                        self._render_overview(chat_id, c, include_tools=False),
+                        c.print(f"  [dim]Tool: {content}[/dim]"),
+                    )
+                )
             elif is_progress:
-                ansi = _to_ansi(lambda c: c.print(f"  [dim]{content}[/dim]"))
+                ansi = _to_ansi(
+                    lambda c: (
+                        self._render_overview(chat_id, c, include_tools=False),
+                        c.print(f"  [dim]Status: {content}[/dim]"),
+                    )
+                )
             else:
                 ansi = _to_ansi(
                     lambda c: (
+                        self._render_overview(chat_id, c, include_tools=True),
                         c.print("[bold cyan]nanobot:[/bold cyan]"),
                         c.print(Markdown(content)),
                     )

--- a/nanobot/channels/tui.py
+++ b/nanobot/channels/tui.py
@@ -1,0 +1,252 @@
+"""TUI (Terminal User Interface) channel using prompt_toolkit and rich."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+
+from loguru import logger
+from prompt_toolkit import PromptSession, print_formatted_text
+from prompt_toolkit.application import run_in_terminal
+from prompt_toolkit.formatted_text import ANSI, HTML
+from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.patch_stdout import patch_stdout
+from pydantic import Field
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.table import Table
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
+
+_EXIT_WORDS = {"exit", "quit", ":q"}
+
+
+def _to_ansi(render_fn) -> str:
+    """Capture a Rich renderable as an ANSI string for prompt_toolkit output."""
+    c = Console(force_terminal=True, color_system="standard")
+    with c.capture() as capture:
+        render_fn(c)
+    return capture.get()
+
+
+_BRAILLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+_COMMANDS: dict[str, str] = {
+    "/help": "Show this help message",
+    "/new": "Start a new conversation (clears session history)",
+    "/clear": "Clear the terminal screen",
+    "/stop": "Exit TUI mode",
+}
+
+
+class TuiConfig(Base):
+    """TUI channel configuration."""
+
+    enabled: bool = False
+    allow_from: list[str] = Field(default_factory=lambda: ["local_user"])
+    user_id: str = "local_user"
+
+
+class TuiChannel(BaseChannel):
+    """Terminal User Interface channel using prompt_toolkit and rich."""
+
+    name = "tui"
+    display_name = "TUI"
+
+    def __init__(self, config: Any, bus: MessageBus):
+        if isinstance(config, dict):
+            config = TuiConfig.model_validate(config)
+        super().__init__(config, bus)
+        self.config: TuiConfig = config
+        self._chat_id: str = "tui"
+        self._session_counter: int = 0
+        self._loading_task: asyncio.Task[None] | None = None
+        self._response_done: asyncio.Event = asyncio.Event()
+        self._response_done.set()
+        self._session: PromptSession = PromptSession(
+            history=InMemoryHistory(),
+        )
+
+    async def _animate_loading(self) -> None:
+        """Print a Braille spinner directly to the real terminal until cancelled."""
+        out = sys.__stdout__
+        idx = 0
+        try:
+            while True:
+                frame = _BRAILLE_FRAMES[idx % len(_BRAILLE_FRAMES)]
+                out.write(f"\r\033[2K  {frame} thinking...")
+                out.flush()
+                idx += 1
+                await asyncio.sleep(0.12)
+        except asyncio.CancelledError:
+            out.write("\r\033[2K")
+            out.flush()
+
+    def _start_loading(self) -> None:
+        """Kick off the loading spinner as a background task."""
+        if self._loading_task is None or self._loading_task.done():
+            self._loading_task = asyncio.get_running_loop().create_task(self._animate_loading())
+
+    async def _stop_loading(self) -> None:
+        """Cancel the loading spinner and clear the line."""
+        if self._loading_task is not None and not self._loading_task.done():
+            self._loading_task.cancel()
+            try:
+                await self._loading_task
+            except asyncio.CancelledError:
+                pass
+            self._loading_task = None
+
+    @classmethod
+    def default_config(cls) -> dict[str, Any]:
+        return TuiConfig().model_dump(by_alias=True)
+
+    async def _dispatch_command(self, text: str) -> bool:
+        """Handle a slash command. Returns True if the TUI should exit."""
+        cmd = text.strip().split()[0].lower()
+
+        if cmd in {"/stop", "/exit", "/quit"}:
+            return True
+
+        if cmd == "/help":
+
+            def _print_help() -> None:
+                t = Table(show_header=True, header_style="bold cyan", border_style="dim")
+                t.add_column("Command", style="cyan", no_wrap=True)
+                t.add_column("Description")
+                for name, desc in _COMMANDS.items():
+                    t.add_row(name, desc)
+                print_formatted_text(ANSI(_to_ansi(lambda c: c.print(t))), end="")
+
+            await run_in_terminal(_print_help)
+
+        elif cmd == "/new":
+            self._session_counter += 1
+            self._chat_id = f"tui-{self._session_counter}"
+            n = self._session_counter
+
+            def _print_new() -> None:
+                print_formatted_text(
+                    ANSI(
+                        _to_ansi(
+                            lambda c: c.print(f"[dim]New session started (session {n}).[/dim]")
+                        )
+                    ),
+                    end="",
+                )
+
+            await run_in_terminal(_print_new)
+
+        elif cmd == "/clear":
+
+            def _do_clear() -> None:
+                out = sys.__stdout__
+                out.write("\033[2J\033[H")
+                out.flush()
+                rule = _to_ansi(lambda c: c.rule("[bold cyan]nanobot TUI[/bold cyan]"))
+                out.write(rule)
+                out.flush()
+
+            await run_in_terminal(_do_clear)
+
+        else:
+
+            def _print_unknown() -> None:
+                print_formatted_text(
+                    ANSI(
+                        _to_ansi(
+                            lambda c: c.print(
+                                f"[yellow]Unknown command: {cmd}[/yellow]  "
+                                "Type [cyan]/help[/cyan] for available commands."
+                            )
+                        )
+                    ),
+                    end="",
+                )
+
+            await run_in_terminal(_print_unknown)
+
+        return False
+
+    async def start(self) -> None:
+        """Start the TUI input loop."""
+        self._running = True
+
+        console = Console()
+        console.rule("[bold cyan]nanobot TUI[/bold cyan]")
+        console.print(
+            "[dim]Type your message and press Enter. "
+            "Type [cyan]/help[/cyan] for commands, [cyan]/stop[/cyan] or Ctrl+D to quit.[/dim]\n"
+        )
+
+        with patch_stdout():
+            while self._running:
+                try:
+                    text = await self._session.prompt_async(HTML("<b fg='ansiblue'>You:</b> "))
+                    text = text.strip()
+                    if not text:
+                        continue
+
+                    if text.lower() in _EXIT_WORDS:
+                        break
+
+                    if text.startswith("/"):
+                        should_exit = await self._dispatch_command(text)
+                        if should_exit:
+                            break
+                        continue
+
+                    self._response_done.clear()
+                    await self._handle_message(
+                        sender_id=self.config.user_id,
+                        chat_id=self._chat_id,
+                        content=text,
+                    )
+                    self._start_loading()
+                    await self._response_done.wait()
+                except KeyboardInterrupt:
+                    continue
+                except EOFError:
+                    break
+
+        self._running = False
+        console.print("\n[dim]Goodbye![/dim]")
+
+    async def stop(self) -> None:
+        """Stop the TUI channel."""
+        self._running = False
+        await self._stop_loading()
+        self._response_done.set()
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Display a message in the TUI."""
+        is_progress = msg.metadata.get("_progress", False)
+        is_tool_hint = msg.metadata.get("_tool_hint", False)
+        content = msg.content or ""
+
+        if not is_progress:
+            await self._stop_loading()
+            self._response_done.set()
+
+        def _render() -> None:
+            if is_progress and is_tool_hint:
+                ansi = _to_ansi(lambda c: c.print(f"  [dim]> {content}[/dim]"))
+            elif is_progress:
+                ansi = _to_ansi(lambda c: c.print(f"  [dim]{content}[/dim]"))
+            else:
+                ansi = _to_ansi(
+                    lambda c: (
+                        c.print("[bold cyan]nanobot:[/bold cyan]"),
+                        c.print(Markdown(content)),
+                    )
+                )
+            print_formatted_text(ANSI(ansi), end="")
+
+        try:
+            await run_in_terminal(_render)
+        except Exception as e:
+            logger.warning("TUI render error: {}", e)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -20,12 +20,11 @@ if sys.platform == "win32":
             pass
 
 import typer
-from prompt_toolkit import print_formatted_text
-from prompt_toolkit import PromptSession
+from prompt_toolkit import PromptSession, print_formatted_text
+from prompt_toolkit.application import run_in_terminal
 from prompt_toolkit.formatted_text import ANSI, HTML
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.patch_stdout import patch_stdout
-from prompt_toolkit.application import run_in_terminal
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.table import Table
@@ -216,7 +215,7 @@ def main(
 
 
 @app.command()
-def onboard():
+def onboard(interactive: bool = typer.Option(True, "--interactive/--no-interactive", help="Use interactive wizard")):
     """Initialize nanobot configuration and workspace."""
     from nanobot.config.loader import get_config_path, load_config, save_config
     from nanobot.config.schema import Config
@@ -224,22 +223,39 @@ def onboard():
     config_path = get_config_path()
 
     if config_path.exists():
-        console.print(f"[yellow]Config already exists at {config_path}[/yellow]")
-        console.print("  [bold]y[/bold] = overwrite with defaults (existing values will be lost)")
-        console.print("  [bold]N[/bold] = refresh config, keeping existing values and adding new fields")
-        if typer.confirm("Overwrite?"):
-            config = Config()
-            save_config(config)
-            console.print(f"[green]✓[/green] Config reset to defaults at {config_path}")
-        else:
+        if interactive:
             config = load_config()
-            save_config(config)
-            console.print(f"[green]✓[/green] Config refreshed at {config_path} (existing values preserved)")
+        else:
+            console.print(f"[yellow]Config already exists at {config_path}[/yellow]")
+            console.print("  [bold]y[/bold] = overwrite with defaults (existing values will be lost)")
+            console.print("  [bold]N[/bold] = refresh config, keeping existing values and adding new fields")
+            if typer.confirm("Overwrite?"):
+                config = Config()
+                save_config(config)
+                console.print(f"[green]✓[/green] Config reset to defaults at {config_path}")
+            else:
+                config = load_config()
+                save_config(config)
+                console.print(f"[green]✓[/green] Config refreshed at {config_path} (existing values preserved)")
     else:
-        save_config(Config())
+        config = Config()
+        save_config(config)
         console.print(f"[green]✓[/green] Created config at {config_path}")
 
-    console.print("[dim]Config template now uses `maxTokens` + `contextWindowTokens`; `memoryWindow` is no longer a runtime setting.[/dim]")
+    # Run interactive wizard if enabled
+    if interactive:
+        from nanobot.cli.onboard_wizard import run_onboard
+
+        try:
+            config = run_onboard()
+            save_config(config)
+            console.print(f"[green]✓[/green] Config saved at {config_path}")
+        except Exception as e:
+            console.print(f"[red]✗[/red] Error during configuration: {e}")
+            console.print("[yellow]Please run 'nanobot onboard' again to complete setup.[/yellow]")
+            raise typer.Exit(1)
+    else:
+        console.print("[dim]Config template now uses `maxTokens` + `contextWindowTokens`; `memoryWindow` is no longer a runtime setting.[/dim]")
 
     _onboard_plugins(config_path)
 
@@ -254,9 +270,8 @@ def onboard():
 
     console.print(f"\n{__logo__} nanobot is ready!")
     console.print("\nNext steps:")
-    console.print("  1. Add your API key to [cyan]~/.nanobot/config.json[/cyan]")
-    console.print("     Get one at: https://openrouter.ai/keys")
-    console.print("  2. Chat: [cyan]nanobot agent -m \"Hello!\"[/cyan]")
+    console.print("  1. Chat: [cyan]nanobot agent -m \"Hello!\"[/cyan]")
+    console.print("  2. Start gateway: [cyan]nanobot gateway[/cyan]")
     console.print("\n[dim]Want Telegram/WhatsApp? See: https://github.com/HKUDS/nanobot#-chat-apps[/dim]")
 
 
@@ -300,9 +315,9 @@ def _onboard_plugins(config_path: Path) -> None:
 
 def _make_provider(config: Config):
     """Create the appropriate LLM provider from config."""
+    from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
     from nanobot.providers.base import GenerationSettings
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
-    from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
 
     model = config.agents.defaults.model
     provider_name = config.get_provider_name(model)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -215,47 +215,31 @@ def main(
 
 
 @app.command()
-def onboard(interactive: bool = typer.Option(True, "--interactive/--no-interactive", help="Use interactive wizard")):
-    """Initialize nanobot configuration and workspace."""
+def onboard():
+    """Initialize nanobot configuration and workspace with interactive wizard."""
     from nanobot.config.loader import get_config_path, load_config, save_config
     from nanobot.config.schema import Config
 
     config_path = get_config_path()
 
     if config_path.exists():
-        if interactive:
-            config = load_config()
-        else:
-            console.print(f"[yellow]Config already exists at {config_path}[/yellow]")
-            console.print("  [bold]y[/bold] = overwrite with defaults (existing values will be lost)")
-            console.print("  [bold]N[/bold] = refresh config, keeping existing values and adding new fields")
-            if typer.confirm("Overwrite?"):
-                config = Config()
-                save_config(config)
-                console.print(f"[green]✓[/green] Config reset to defaults at {config_path}")
-            else:
-                config = load_config()
-                save_config(config)
-                console.print(f"[green]✓[/green] Config refreshed at {config_path} (existing values preserved)")
+        config = load_config()
     else:
         config = Config()
         save_config(config)
         console.print(f"[green]✓[/green] Created config at {config_path}")
 
-    # Run interactive wizard if enabled
-    if interactive:
-        from nanobot.cli.onboard_wizard import run_onboard
+    # Run interactive wizard
+    from nanobot.cli.onboard_wizard import run_onboard
 
-        try:
-            config = run_onboard()
-            save_config(config)
-            console.print(f"[green]✓[/green] Config saved at {config_path}")
-        except Exception as e:
-            console.print(f"[red]✗[/red] Error during configuration: {e}")
-            console.print("[yellow]Please run 'nanobot onboard' again to complete setup.[/yellow]")
-            raise typer.Exit(1)
-    else:
-        console.print("[dim]Config template now uses `maxTokens` + `contextWindowTokens`; `memoryWindow` is no longer a runtime setting.[/dim]")
+    try:
+        config = run_onboard()
+        save_config(config)
+        console.print(f"[green]✓[/green] Config saved at {config_path}")
+    except Exception as e:
+        console.print(f"[red]✗[/red] Error during configuration: {e}")
+        console.print("[yellow]Please run 'nanobot onboard' again to complete setup.[/yellow]")
+        raise typer.Exit(1)
 
     _onboard_plugins(config_path)
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -626,6 +626,103 @@ def gateway(
 
 
 # ============================================================================
+# TUI Command
+# ============================================================================
+
+
+@app.command()
+def tui(
+    workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
+    config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
+    logs: bool = typer.Option(False, "--logs/--no-logs", help="Show nanobot runtime logs"),
+):
+    """Start nanobot in interactive TUI mode."""
+    from loguru import logger
+
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.channels.tui import TuiChannel, TuiConfig
+    from nanobot.config.paths import get_cron_dir
+    from nanobot.cron.service import CronService
+    from nanobot.session.manager import SessionManager
+
+    if logs:
+        logger.enable("nanobot")
+    else:
+        logger.disable("nanobot")
+
+    cfg = _load_runtime_config(config, workspace)
+    _print_deprecated_memory_window_notice(cfg)
+    sync_workspace_templates(cfg.workspace_path)
+
+    bus = MessageBus()
+    provider = _make_provider(cfg)
+    session_manager = SessionManager(cfg.workspace_path)
+
+    cron_store_path = get_cron_dir() / "jobs.json"
+    cron = CronService(cron_store_path)
+
+    agent_loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=cfg.workspace_path,
+        model=cfg.agents.defaults.model,
+        max_iterations=cfg.agents.defaults.max_tool_iterations,
+        context_window_tokens=cfg.agents.defaults.context_window_tokens,
+        web_search_config=cfg.tools.web.search,
+        web_proxy=cfg.tools.web.proxy or None,
+        exec_config=cfg.tools.exec,
+        cron_service=cron,
+        restrict_to_workspace=cfg.tools.restrict_to_workspace,
+        session_manager=session_manager,
+        mcp_servers=cfg.tools.mcp_servers,
+        channels_config=cfg.channels,
+    )
+
+    tui_cfg = TuiConfig(enabled=True, allow_from=["*"])
+    channel = TuiChannel(tui_cfg, bus)
+
+    async def dispatch_outbound() -> None:
+        while True:
+            try:
+                msg = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+                if msg.metadata.get("_progress"):
+                    if msg.metadata.get("_tool_hint") and not cfg.channels.send_tool_hints:
+                        continue
+                    if not msg.metadata.get("_tool_hint") and not cfg.channels.send_progress:
+                        continue
+                try:
+                    await channel.send(msg)
+                except Exception as e:
+                    logger.error("TUI send error: {}", e)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+    async def run() -> None:
+        await cron.start()
+        agent_task = asyncio.create_task(agent_loop.run())
+        dispatch_task = asyncio.create_task(dispatch_outbound())
+        try:
+            await channel.start()
+        except KeyboardInterrupt:
+            pass
+        except Exception as e:
+            logger.error("TUI error: {}", e)
+        finally:
+            agent_loop.stop()
+            agent_task.cancel()
+            dispatch_task.cancel()
+            await asyncio.gather(agent_task, dispatch_task, return_exceptions=True)
+            cron.stop()
+            await agent_loop.close_mcp()
+
+    asyncio.run(run())
+
+
+
+# ============================================================================
 # Agent Commands
 # ============================================================================
 

--- a/nanobot/cli/model_info.py
+++ b/nanobot/cli/model_info.py
@@ -1,0 +1,226 @@
+"""Model information helpers for the onboard wizard.
+
+Provides model context window lookup and autocomplete suggestions using litellm.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+import litellm
+
+
+@lru_cache(maxsize=1)
+def _get_model_cost_map() -> dict[str, Any]:
+    """Get litellm's model cost map (cached)."""
+    return getattr(litellm, "model_cost", {})
+
+
+@lru_cache(maxsize=1)
+def get_all_models() -> list[str]:
+    """Get all known model names from litellm.
+    """
+    models = set()
+
+    # From model_cost (has pricing info)
+    cost_map = _get_model_cost_map()
+    for k in cost_map.keys():
+        if k != "sample_spec":
+            models.add(k)
+
+    # From models_by_provider (more complete provider coverage)
+    for provider_models in getattr(litellm, "models_by_provider", {}).values():
+        if isinstance(provider_models, (set, list)):
+            models.update(provider_models)
+
+    return sorted(models)
+
+
+def _normalize_model_name(model: str) -> str:
+    """Normalize model name for comparison."""
+    return model.lower().replace("-", "_").replace(".", "")
+
+
+def find_model_info(model_name: str) -> dict[str, Any] | None:
+    """Find model info with fuzzy matching.
+
+    Args:
+        model_name: Model name in any common format
+
+    Returns:
+        Model info dict or None if not found
+    """
+    cost_map = _get_model_cost_map()
+    if not cost_map:
+        return None
+
+    # Direct match
+    if model_name in cost_map:
+        return cost_map[model_name]
+
+    # Extract base name (without provider prefix)
+    base_name = model_name.split("/")[-1] if "/" in model_name else model_name
+    base_normalized = _normalize_model_name(base_name)
+
+    candidates = []
+
+    for key, info in cost_map.items():
+        if key == "sample_spec":
+            continue
+
+        key_base = key.split("/")[-1] if "/" in key else key
+        key_base_normalized = _normalize_model_name(key_base)
+
+        # Score the match
+        score = 0
+
+        # Exact base name match (highest priority)
+        if base_normalized == key_base_normalized:
+            score = 100
+        # Base name contains model
+        elif base_normalized in key_base_normalized:
+            score = 80
+        # Model contains base name
+        elif key_base_normalized in base_normalized:
+            score = 70
+        # Partial match
+        elif base_normalized[:10] in key_base_normalized:
+            score = 50
+
+        if score > 0:
+            # Prefer models with max_input_tokens
+            if info.get("max_input_tokens"):
+                score += 10
+            candidates.append((score, key, info))
+
+    if not candidates:
+        return None
+
+    # Return the best match
+    candidates.sort(key=lambda x: (-x[0], x[1]))
+    return candidates[0][2]
+
+
+def get_model_context_limit(model: str, provider: str = "auto") -> int | None:
+    """Get the maximum input context tokens for a model.
+
+    Args:
+        model: Model name (e.g., "claude-3.5-sonnet", "gpt-4o")
+        provider: Provider name for informational purposes (not yet used for filtering)
+
+    Returns:
+        Maximum input tokens, or None if unknown
+
+    Note:
+        The provider parameter is currently informational only. Future versions may
+        use it to prefer provider-specific model variants in the lookup.
+    """
+    # First try fuzzy search in model_cost (has more accurate max_input_tokens)
+    info = find_model_info(model)
+    if info:
+        # Prefer max_input_tokens (this is what we want for context window)
+        max_input = info.get("max_input_tokens")
+        if max_input and isinstance(max_input, int):
+            return max_input
+
+    # Fall back to litellm's get_max_tokens (returns max_output_tokens typically)
+    try:
+        result = litellm.get_max_tokens(model)
+        if result and result > 0:
+            return result
+    except (KeyError, ValueError, AttributeError):
+        # Model not found in litellm's database or invalid response
+        pass
+
+    # Last resort: use max_tokens from model_cost
+    if info:
+        max_tokens = info.get("max_tokens")
+        if max_tokens and isinstance(max_tokens, int):
+            return max_tokens
+
+    return None
+
+
+@lru_cache(maxsize=1)
+def _get_provider_keywords() -> dict[str, list[str]]:
+    """Build provider keywords mapping from nanobot's provider registry.
+
+    Returns:
+        Dict mapping provider name to list of keywords for model filtering.
+    """
+    try:
+        from nanobot.providers.registry import PROVIDERS
+
+        mapping = {}
+        for spec in PROVIDERS:
+            if spec.keywords:
+                mapping[spec.name] = list(spec.keywords)
+        return mapping
+    except ImportError:
+        return {}
+
+
+def get_model_suggestions(partial: str, provider: str = "auto", limit: int = 20) -> list[str]:
+    """Get autocomplete suggestions for model names.
+
+    Args:
+        partial: Partial model name typed by user
+        provider: Provider name for filtering (e.g., "openrouter", "minimax")
+        limit: Maximum number of suggestions to return
+
+    Returns:
+        List of matching model names
+    """
+    all_models = get_all_models()
+    if not all_models:
+        return []
+
+    partial_lower = partial.lower()
+    partial_normalized = _normalize_model_name(partial)
+
+    # Get provider keywords from registry
+    provider_keywords = _get_provider_keywords()
+
+    # Filter by provider if specified
+    allowed_keywords = None
+    if provider and provider != "auto":
+        allowed_keywords = provider_keywords.get(provider.lower())
+
+    matches = []
+
+    for model in all_models:
+        model_lower = model.lower()
+
+        # Apply provider filter
+        if allowed_keywords:
+            if not any(kw in model_lower for kw in allowed_keywords):
+                continue
+
+        # Match against partial input
+        if not partial:
+            matches.append(model)
+            continue
+
+        if partial_lower in model_lower:
+            # Score by position of match (earlier = better)
+            pos = model_lower.find(partial_lower)
+            score = 100 - pos
+            matches.append((score, model))
+        elif partial_normalized in _normalize_model_name(model):
+            score = 50
+            matches.append((score, model))
+
+    # Sort by score if we have scored matches
+    if matches and isinstance(matches[0], tuple):
+        matches.sort(key=lambda x: (-x[0], x[1]))
+        matches = [m[1] for m in matches]
+    else:
+        matches.sort()
+
+    return matches[:limit]
+
+
+def format_token_count(tokens: int) -> str:
+    """Format token count for display (e.g., 200000 -> '200,000')."""
+    return f"{tokens:,}"

--- a/nanobot/cli/onboard_wizard.py
+++ b/nanobot/cli/onboard_wizard.py
@@ -11,6 +11,11 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from nanobot.cli.model_info import (
+    format_token_count,
+    get_model_context_limit,
+    get_model_suggestions,
+)
 from nanobot.config.loader import get_config_path, load_config
 from nanobot.config.schema import Config
 
@@ -224,6 +229,109 @@ def _input_with_existing(
 # --- Pydantic Model Configuration ---
 
 
+def _get_current_provider(model: BaseModel) -> str:
+    """Get the current provider setting from a model (if available)."""
+    if hasattr(model, "provider"):
+        return getattr(model, "provider", "auto") or "auto"
+    return "auto"
+
+
+def _input_model_with_autocomplete(
+    display_name: str, current: Any, provider: str
+) -> str | None:
+    """Get model input with autocomplete suggestions.
+
+    """
+    from prompt_toolkit.completion import Completer, Completion
+
+    default = str(current) if current else ""
+
+    class DynamicModelCompleter(Completer):
+        """Completer that dynamically fetches model suggestions."""
+
+        def __init__(self, provider_name: str):
+            self.provider = provider_name
+
+        def get_completions(self, document, complete_event):
+            text = document.text_before_cursor
+            suggestions = get_model_suggestions(text, provider=self.provider, limit=50)
+            for model in suggestions:
+                # Skip if model doesn't contain the typed text
+                if text.lower() not in model.lower():
+                    continue
+                yield Completion(
+                    model,
+                    start_position=-len(text),
+                    display=model,
+                )
+
+    value = questionary.autocomplete(
+        f"{display_name}:",
+        choices=[""],  # Placeholder, actual completions from completer
+        completer=DynamicModelCompleter(provider),
+        default=default,
+        qmark="→",
+    ).ask()
+
+    return value if value else None
+
+
+def _input_context_window_with_recommendation(
+    display_name: str, current: Any, model_obj: BaseModel
+) -> int | None:
+    """Get context window input with option to fetch recommended value."""
+    current_val = current if current else ""
+
+    choices = ["Enter new value"]
+    if current_val:
+        choices.append("Keep existing value")
+    choices.append("🔍 Get recommended value")
+
+    choice = questionary.select(
+        display_name,
+        choices=choices,
+        default="Enter new value",
+    ).ask()
+
+    if choice is None:
+        return None
+
+    if choice == "Keep existing value":
+        return None
+
+    if choice == "🔍 Get recommended value":
+        # Get the model name from the model object
+        model_name = getattr(model_obj, "model", None)
+        if not model_name:
+            console.print("[yellow]⚠ Please configure the model field first[/yellow]")
+            return None
+
+        provider = _get_current_provider(model_obj)
+        context_limit = get_model_context_limit(model_name, provider)
+
+        if context_limit:
+            console.print(f"[green]✓ Recommended context window: {format_token_count(context_limit)} tokens[/green]")
+            return context_limit
+        else:
+            console.print("[yellow]⚠ Could not fetch model info, please enter manually[/yellow]")
+            # Fall through to manual input
+
+    # Manual input
+    value = questionary.text(
+        f"{display_name}:",
+        default=str(current_val) if current_val else "",
+    ).ask()
+
+    if value is None or value == "":
+        return None
+
+    try:
+        return int(value)
+    except ValueError:
+        console.print("[yellow]⚠ Invalid number format, value not saved[/yellow]")
+        return None
+
+
 def _configure_pydantic_model(
     model: BaseModel,
     display_name: str,
@@ -289,6 +397,23 @@ def _configure_pydantic_model(
                 _configure_pydantic_model(nested_model, field_display)
             continue
 
+        # Special handling for model field (autocomplete)
+        if field_name == "model":
+            provider = _get_current_provider(model)
+            new_value = _input_model_with_autocomplete(field_display, current_value, provider)
+            if new_value is not None and new_value != current_value:
+                setattr(model, field_name, new_value)
+                # Auto-fill context_window_tokens if it's at default value
+                _try_auto_fill_context_window(model, new_value)
+            continue
+
+        # Special handling for context_window_tokens field
+        if field_name == "context_window_tokens":
+            new_value = _input_context_window_with_recommendation(field_display, current_value, model)
+            if new_value is not None:
+                setattr(model, field_name, new_value)
+            continue
+
         if field_type == "bool":
             new_value = _input_bool(field_display, current_value)
             if new_value is not None:
@@ -297,6 +422,39 @@ def _configure_pydantic_model(
             new_value = _input_with_existing(field_display, current_value, field_type)
             if new_value is not None:
                 setattr(model, field_name, new_value)
+
+
+def _try_auto_fill_context_window(model: BaseModel, new_model_name: str) -> None:
+    """Try to auto-fill context_window_tokens if it's at default value.
+
+    Note:
+        This function imports AgentDefaults from nanobot.config.schema to get
+        the default context_window_tokens value. If the schema changes, this
+        coupling needs to be updated accordingly.
+    """
+    # Check if context_window_tokens field exists
+    if not hasattr(model, "context_window_tokens"):
+        return
+
+    current_context = getattr(model, "context_window_tokens", None)
+
+    # Check if current value is the default (65536)
+    # We only auto-fill if the user hasn't changed it from default
+    from nanobot.config.schema import AgentDefaults
+
+    default_context = AgentDefaults.model_fields["context_window_tokens"].default
+
+    if current_context != default_context:
+        return  # User has customized it, don't override
+
+    provider = _get_current_provider(model)
+    context_limit = get_model_context_limit(new_model_name, provider)
+
+    if context_limit:
+        setattr(model, "context_window_tokens", context_limit)
+        console.print(f"[green]✓ Auto-filled context window: {format_token_count(context_limit)} tokens[/green]")
+    else:
+        console.print("[dim]ℹ Could not auto-fill context window (model not in database)[/dim]")
 
 
 # --- Provider Configuration ---

--- a/nanobot/cli/onboard_wizard.py
+++ b/nanobot/cli/onboard_wizard.py
@@ -956,6 +956,7 @@ def run_onboard() -> Config:
                 choices=[
                     "🔌 Configure LLM Provider",
                     "💬 Configure Chat Channel",
+                    "⚙️ Configure Channel Common",
                     "🤖 Configure Agent Settings",
                     "🌐 Configure Gateway",
                     "🔧 Configure Tools",
@@ -969,6 +970,8 @@ def run_onboard() -> Config:
                 _configure_providers(config)
             elif answer == "💬 Configure Chat Channel":
                 _configure_channels(config)
+            elif answer == "⚙️ Configure Channel Common":
+                _configure_general_settings(config, "Channel Common")
             elif answer == "🤖 Configure Agent Settings":
                 _configure_agents(config)
             elif answer == "🌐 Configure Gateway":

--- a/nanobot/cli/onboard_wizard.py
+++ b/nanobot/cli/onboard_wizard.py
@@ -1,0 +1,697 @@
+"""Interactive onboarding questionnaire for nanobot."""
+
+import json
+import types
+from typing import Any, Callable, get_args, get_origin
+
+import questionary
+from loguru import logger
+from pydantic import BaseModel
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from nanobot.config.loader import get_config_path, load_config
+from nanobot.config.schema import Config
+
+console = Console()
+
+# --- Type Introspection ---
+
+
+def _get_field_type_info(field_info) -> tuple[str, Any]:
+    """Extract field type info from Pydantic field.
+
+    Returns: (type_name, inner_type)
+    - type_name: "str", "int", "float", "bool", "list", "dict", "model"
+    - inner_type: for list, the item type; for model, the model class
+    """
+    annotation = field_info.annotation
+    if annotation is None:
+        return "str", None
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    # Handle Optional[T] / T | None
+    if origin is types.UnionType:
+        non_none_args = [a for a in args if a is not type(None)]
+        if len(non_none_args) == 1:
+            annotation = non_none_args[0]
+            origin = get_origin(annotation)
+            args = get_args(annotation)
+
+    # Check for list
+    if origin is list or (hasattr(origin, "__name__") and origin.__name__ == "List"):
+        if args:
+            return "list", args[0]
+        return "list", str
+
+    # Check for dict
+    if origin is dict or (hasattr(origin, "__name__") and origin.__name__ == "Dict"):
+        return "dict", None
+
+    # Check for bool
+    if annotation is bool or (hasattr(annotation, "__name__") and annotation.__name__ == "bool"):
+        return "bool", None
+
+    # Check for int
+    if annotation is int or (hasattr(annotation, "__name__") and annotation.__name__ == "int"):
+        return "int", None
+
+    # Check for float
+    if annotation is float or (hasattr(annotation, "__name__") and annotation.__name__ == "float"):
+        return "float", None
+
+    # Check if it's a nested BaseModel
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return "model", annotation
+
+    return "str", None
+
+
+def _get_field_display_name(field_key: str, field_info) -> str:
+    """Get display name for a field."""
+    if field_info and field_info.description:
+        return field_info.description
+    name = field_key
+    suffix_map = {
+        "_s": " (seconds)",
+        "_ms": " (ms)",
+        "_url": " URL",
+        "_path": " Path",
+        "_id": " ID",
+        "_key": " Key",
+        "_token": " Token",
+    }
+    for suffix, replacement in suffix_map.items():
+        if name.endswith(suffix):
+            name = name[: -len(suffix)] + replacement
+            break
+    return name.replace("_", " ").title()
+
+
+# --- Value Formatting ---
+
+
+def _format_value(value: Any, rich: bool = True) -> str:
+    """Format a value for display."""
+    if value is None or value == "" or value == {} or value == []:
+        return "[dim]not set[/dim]" if rich else "[not set]"
+    if isinstance(value, list):
+        return ", ".join(str(v) for v in value)
+    if isinstance(value, dict):
+        return json.dumps(value)
+    return str(value)
+
+
+def _format_value_for_input(value: Any, field_type: str) -> str:
+    """Format a value for use as input default."""
+    if value is None or value == "":
+        return ""
+    if field_type == "list" and isinstance(value, list):
+        return ",".join(str(v) for v in value)
+    if field_type == "dict" and isinstance(value, dict):
+        return json.dumps(value)
+    return str(value)
+
+
+# --- Rich UI Components ---
+
+
+def _show_config_panel(display_name: str, model: BaseModel, fields: list) -> None:
+    """Display current configuration as a rich table."""
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Field", style="cyan")
+    table.add_column("Value")
+
+    for field_name, field_info in fields:
+        value = getattr(model, field_name, None)
+        display = _get_field_display_name(field_name, field_info)
+        formatted = _format_value(value, rich=True)
+        table.add_row(display, formatted)
+
+    console.print(Panel(table, title=f"[bold]{display_name}[/bold]", border_style="blue"))
+
+
+def _show_main_menu_header() -> None:
+    """Display the main menu header."""
+    from nanobot import __logo__, __version__
+
+    console.print()
+    # Use Align.CENTER for the single line of text
+    from rich.align import Align
+
+    console.print(
+        Align.center(f"{__logo__} [bold cyan]nanobot[{__version__}][/bold cyan]")
+    )
+    console.print()
+
+
+def _show_section_header(title: str, subtitle: str = "") -> None:
+    """Display a section header."""
+    console.print()
+    if subtitle:
+        console.print(
+            Panel(f"[dim]{subtitle}[/dim]", title=f"[bold]{title}[/bold]", border_style="blue")
+        )
+    else:
+        console.print(Panel("", title=f"[bold]{title}[/bold]", border_style="blue"))
+
+
+# --- Input Handlers ---
+
+
+def _input_bool(display_name: str, current: bool | None) -> bool | None:
+    """Get boolean input via confirm dialog."""
+    return questionary.confirm(
+        display_name,
+        default=bool(current) if current is not None else False,
+    ).ask()
+
+
+def _input_text(display_name: str, current: Any, field_type: str) -> Any:
+    """Get text input and parse based on field type."""
+    default = _format_value_for_input(current, field_type)
+
+    value = questionary.text(f"{display_name}:", default=default).ask()
+
+    if value is None or value == "":
+        return None
+
+    if field_type == "int":
+        try:
+            return int(value)
+        except ValueError:
+            console.print("[yellow]⚠ Invalid number format, value not saved[/yellow]")
+            return None
+    elif field_type == "float":
+        try:
+            return float(value)
+        except ValueError:
+            console.print("[yellow]⚠ Invalid number format, value not saved[/yellow]")
+            return None
+    elif field_type == "list":
+        return [v.strip() for v in value.split(",") if v.strip()]
+    elif field_type == "dict":
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            console.print("[yellow]⚠ Invalid JSON format, value not saved[/yellow]")
+            return None
+
+    return value
+
+
+def _input_with_existing(
+    display_name: str, current: Any, field_type: str
+) -> Any:
+    """Handle input with 'keep existing' option for non-empty values."""
+    has_existing = current is not None and current != "" and current != {} and current != []
+
+    if has_existing and not isinstance(current, list):
+        choice = questionary.select(
+            display_name,
+            choices=["Enter new value", "Keep existing value"],
+            default="Keep existing value",
+        ).ask()
+        if choice == "Keep existing value" or choice is None:
+            return None
+
+    return _input_text(display_name, current, field_type)
+
+
+# --- Pydantic Model Configuration ---
+
+
+def _configure_pydantic_model(
+    model: BaseModel,
+    display_name: str,
+    *,
+    skip_fields: set[str] | None = None,
+    finalize_hook: Callable | None = None,
+) -> None:
+    """Configure a Pydantic model interactively."""
+    skip_fields = skip_fields or set()
+
+    fields = []
+    for field_name, field_info in type(model).model_fields.items():
+        if field_name in skip_fields:
+            continue
+        fields.append((field_name, field_info))
+
+    if not fields:
+        console.print(f"[dim]{display_name}: No configurable fields[/dim]")
+        return
+
+    def get_choices() -> list[str]:
+        choices = []
+        for field_name, field_info in fields:
+            value = getattr(model, field_name, None)
+            display = _get_field_display_name(field_name, field_info)
+            formatted = _format_value(value, rich=False)
+            choices.append(f"{display}: {formatted}")
+        return choices + ["✓ Done"]
+
+    while True:
+        _show_config_panel(display_name, model, fields)
+        choices = get_choices()
+
+        answer = questionary.select(
+            "Select field to configure:",
+            choices=choices,
+            qmark="→",
+        ).ask()
+
+        if answer == "✓ Done" or answer is None:
+            if finalize_hook:
+                finalize_hook(model)
+            break
+
+        field_idx = next((i for i, c in enumerate(choices) if c == answer), -1)
+        if field_idx < 0 or field_idx >= len(fields):
+            break
+
+        field_name, field_info = fields[field_idx]
+        current_value = getattr(model, field_name, None)
+        field_type, _ = _get_field_type_info(field_info)
+        field_display = _get_field_display_name(field_name, field_info)
+
+        if field_type == "model":
+            nested_model = current_value
+            if nested_model is None:
+                _, nested_cls = _get_field_type_info(field_info)
+                if nested_cls:
+                    nested_model = nested_cls()
+                    setattr(model, field_name, nested_model)
+
+            if nested_model and isinstance(nested_model, BaseModel):
+                _configure_pydantic_model(nested_model, field_display)
+            continue
+
+        if field_type == "bool":
+            new_value = _input_bool(field_display, current_value)
+            if new_value is not None:
+                setattr(model, field_name, new_value)
+        else:
+            new_value = _input_with_existing(field_display, current_value, field_type)
+            if new_value is not None:
+                setattr(model, field_name, new_value)
+
+
+# --- Provider Configuration ---
+
+
+_PROVIDER_INFO: dict[str, tuple[str, bool, bool, str]] | None = None
+
+
+def _get_provider_info() -> dict[str, tuple[str, bool, bool, str]]:
+    """Get provider info from registry (cached)."""
+    global _PROVIDER_INFO
+    if _PROVIDER_INFO is None:
+        from nanobot.providers.registry import PROVIDERS
+
+        _PROVIDER_INFO = {}
+        for spec in PROVIDERS:
+            _PROVIDER_INFO[spec.name] = (
+                spec.display_name or spec.name,
+                spec.is_gateway,
+                spec.is_local,
+                spec.default_api_base,
+            )
+    return _PROVIDER_INFO
+
+
+def _get_provider_names() -> dict[str, str]:
+    """Get provider display names."""
+    info = _get_provider_info()
+    return {name: data[0] for name, data in info.items() if name}
+
+
+def _configure_provider(config: Config, provider_name: str) -> None:
+    """Configure a single LLM provider."""
+    provider_config = getattr(config.providers, provider_name, None)
+    if provider_config is None:
+        console.print(f"[red]Unknown provider: {provider_name}[/red]")
+        return
+
+    display_name = _get_provider_names().get(provider_name, provider_name)
+    info = _get_provider_info()
+    default_api_base = info.get(provider_name, (None, None, None, None))[3]
+
+    if default_api_base and not provider_config.api_base:
+        provider_config.api_base = default_api_base
+
+    _configure_pydantic_model(
+        provider_config,
+        display_name,
+    )
+
+
+def _configure_providers(config: Config) -> None:
+    """Configure LLM providers."""
+    _show_section_header("LLM Providers", "Select a provider to configure API key and endpoint")
+
+    def get_provider_choices() -> list[str]:
+        """Build provider choices with config status indicators."""
+        choices = []
+        for name, display in _get_provider_names().items():
+            provider = getattr(config.providers, name, None)
+            if provider and provider.api_key:
+                choices.append(f"{display} ✓")
+            else:
+                choices.append(display)
+        return choices + ["← Back"]
+
+    while True:
+        try:
+            choices = get_provider_choices()
+            answer = questionary.select(
+                "Select provider:",
+                choices=choices,
+                qmark="→",
+            ).ask()
+
+            if answer is None or answer == "← Back":
+                break
+
+            # Extract provider name from choice (remove " ✓" suffix if present)
+            provider_name = answer.replace(" ✓", "")
+            # Find the actual provider key from display names
+            for name, display in _get_provider_names().items():
+                if display == provider_name:
+                    _configure_provider(config, name)
+                    break
+
+        except KeyboardInterrupt:
+            console.print("\n[dim]Returning to main menu...[/dim]")
+            break
+
+
+# --- Channel Configuration ---
+
+
+def _get_channel_info() -> dict[str, tuple[str, type[BaseModel]]]:
+    """Get channel info (display name + config class) from channel modules."""
+    import importlib
+
+    from nanobot.channels.registry import discover_all
+
+    result = {}
+    for name, channel_cls in discover_all().items():
+        try:
+            mod = importlib.import_module(f"nanobot.channels.{name}")
+            config_cls = None
+            display_name = name.capitalize()
+            for attr_name in dir(mod):
+                attr = getattr(mod, attr_name)
+                if isinstance(attr, type) and issubclass(attr, BaseModel) and attr is not BaseModel:
+                    if "Config" in attr_name:
+                        config_cls = attr
+                        if hasattr(channel_cls, "display_name"):
+                            display_name = channel_cls.display_name
+                        break
+
+            if config_cls:
+                result[name] = (display_name, config_cls)
+        except Exception:
+            logger.warning(f"Failed to load channel module: {name}")
+    return result
+
+
+_CHANNEL_INFO: dict[str, tuple[str, type[BaseModel]]] | None = None
+
+
+def _get_channel_names() -> dict[str, str]:
+    """Get channel display names."""
+    global _CHANNEL_INFO
+    if _CHANNEL_INFO is None:
+        _CHANNEL_INFO = _get_channel_info()
+    return {name: info[0] for name, info in _CHANNEL_INFO.items() if name}
+
+
+def _get_channel_config_class(channel: str) -> type[BaseModel] | None:
+    """Get channel config class."""
+    global _CHANNEL_INFO
+    if _CHANNEL_INFO is None:
+        _CHANNEL_INFO = _get_channel_info()
+    return _CHANNEL_INFO.get(channel, (None, None))[1]
+
+
+def _configure_channel(config: Config, channel_name: str) -> None:
+    """Configure a single channel."""
+    channel_dict = getattr(config.channels, channel_name, None)
+    if channel_dict is None:
+        channel_dict = {}
+        setattr(config.channels, channel_name, channel_dict)
+
+    display_name = _get_channel_names().get(channel_name, channel_name)
+    config_cls = _get_channel_config_class(channel_name)
+
+    if config_cls is None:
+        console.print(f"[red]No configuration class found for {display_name}[/red]")
+        return
+
+    model = config_cls.model_validate(channel_dict) if channel_dict else config_cls()
+
+    def finalize(model: BaseModel):
+        new_dict = model.model_dump(by_alias=True, exclude_none=True)
+        setattr(config.channels, channel_name, new_dict)
+
+    _configure_pydantic_model(
+        model,
+        display_name,
+        finalize_hook=finalize,
+    )
+
+
+def _configure_channels(config: Config) -> None:
+    """Configure chat channels."""
+    _show_section_header("Chat Channels", "Select a channel to configure connection settings")
+
+    channel_names = list(_get_channel_names().keys())
+    choices = channel_names + ["← Back"]
+
+    while True:
+        try:
+            answer = questionary.select(
+                "Select channel:",
+                choices=choices,
+                qmark="→",
+            ).ask()
+
+            if answer is None or answer == "← Back":
+                break
+
+            _configure_channel(config, answer)
+        except KeyboardInterrupt:
+            console.print("\n[dim]Returning to main menu...[/dim]")
+            break
+
+
+# --- General Settings ---
+
+
+def _configure_general_settings(config: Config, section: str) -> None:
+    """Configure a general settings section."""
+    section_map = {
+        "Agent Settings": (config.agents.defaults, "Agent Defaults"),
+        "Gateway": (config.gateway, "Gateway Settings"),
+        "Tools": (config.tools, "Tools Settings"),
+        "Channel Common": (config.channels, "Channel Common Settings"),
+    }
+
+    if section not in section_map:
+        return
+
+    model, display_name = section_map[section]
+
+    if section == "Tools":
+        _configure_pydantic_model(
+            model,
+            display_name,
+            skip_fields={"mcp_servers"},
+        )
+    else:
+        _configure_pydantic_model(model, display_name)
+
+
+def _configure_agents(config: Config) -> None:
+    """Configure agent settings."""
+    _show_section_header("Agent Settings", "Configure default model, temperature, and behavior")
+    _configure_general_settings(config, "Agent Settings")
+
+
+def _configure_gateway(config: Config) -> None:
+    """Configure gateway settings."""
+    _show_section_header("Gateway", "Configure server host, port, and heartbeat")
+    _configure_general_settings(config, "Gateway")
+
+
+def _configure_tools(config: Config) -> None:
+    """Configure tools settings."""
+    _show_section_header("Tools", "Configure web search, shell exec, and other tools")
+    _configure_general_settings(config, "Tools")
+
+
+# --- Summary ---
+
+
+def _summarize_model(obj: BaseModel, indent: int = 2) -> list[tuple[str, str]]:
+    """Recursively summarize a Pydantic model. Returns list of (field, value) tuples."""
+    items = []
+
+    for field_name, field_info in type(obj).model_fields.items():
+        value = getattr(obj, field_name, None)
+        field_type, _ = _get_field_type_info(field_info)
+
+        if value is None or value == "" or value == {} or value == []:
+            continue
+
+        display = _get_field_display_name(field_name, field_info)
+
+        if field_type == "model" and isinstance(value, BaseModel):
+            nested_items = _summarize_model(value, indent)
+            for nested_field, nested_value in nested_items:
+                items.append((f"{display}.{nested_field}", nested_value))
+            continue
+
+        formatted = _format_value(value, rich=False)
+        if formatted != "[not set]":
+            items.append((display, formatted))
+
+    return items
+
+
+def _show_summary(config: Config) -> None:
+    """Display configuration summary using rich."""
+    console.print()
+
+    # Providers table
+    provider_table = Table(show_header=False, box=None, padding=(0, 2))
+    provider_table.add_column("Provider", style="cyan")
+    provider_table.add_column("Status")
+
+    for name, display in _get_provider_names().items():
+        provider = getattr(config.providers, name, None)
+        if provider and provider.api_key:
+            provider_table.add_row(display, "[green]✓ configured[/green]")
+        else:
+            provider_table.add_row(display, "[dim]not configured[/dim]")
+
+    console.print(Panel(provider_table, title="[bold]LLM Providers[/bold]", border_style="blue"))
+
+    # Channels table
+    channel_table = Table(show_header=False, box=None, padding=(0, 2))
+    channel_table.add_column("Channel", style="cyan")
+    channel_table.add_column("Status")
+
+    for name, display in _get_channel_names().items():
+        channel = getattr(config.channels, name, None)
+        if channel:
+            enabled = (
+                channel.get("enabled", False)
+                if isinstance(channel, dict)
+                else getattr(channel, "enabled", False)
+            )
+            if enabled:
+                channel_table.add_row(display, "[green]✓ enabled[/green]")
+            else:
+                channel_table.add_row(display, "[dim]disabled[/dim]")
+        else:
+            channel_table.add_row(display, "[dim]not configured[/dim]")
+
+    console.print(Panel(channel_table, title="[bold]Chat Channels[/bold]", border_style="blue"))
+
+    # Agent Settings
+    agent_items = _summarize_model(config.agents.defaults)
+    if agent_items:
+        agent_table = Table(show_header=False, box=None, padding=(0, 2))
+        agent_table.add_column("Setting", style="cyan")
+        agent_table.add_column("Value")
+        for field, value in agent_items:
+            agent_table.add_row(field, value)
+        console.print(Panel(agent_table, title="[bold]Agent Settings[/bold]", border_style="blue"))
+
+    # Gateway
+    gateway_items = _summarize_model(config.gateway)
+    if gateway_items:
+        gw_table = Table(show_header=False, box=None, padding=(0, 2))
+        gw_table.add_column("Setting", style="cyan")
+        gw_table.add_column("Value")
+        for field, value in gateway_items:
+            gw_table.add_row(field, value)
+        console.print(Panel(gw_table, title="[bold]Gateway[/bold]", border_style="blue"))
+
+    # Tools
+    tools_items = _summarize_model(config.tools)
+    if tools_items:
+        tools_table = Table(show_header=False, box=None, padding=(0, 2))
+        tools_table.add_column("Setting", style="cyan")
+        tools_table.add_column("Value")
+        for field, value in tools_items:
+            tools_table.add_row(field, value)
+        console.print(Panel(tools_table, title="[bold]Tools[/bold]", border_style="blue"))
+
+    # Channel Common
+    channel_common_items = _summarize_model(config.channels)
+    if channel_common_items:
+        cc_table = Table(show_header=False, box=None, padding=(0, 2))
+        cc_table.add_column("Setting", style="cyan")
+        cc_table.add_column("Value")
+        for field, value in channel_common_items:
+            cc_table.add_row(field, value)
+        console.print(Panel(cc_table, title="[bold]Channel Common[/bold]", border_style="blue"))
+
+
+# --- Main Entry Point ---
+
+
+def run_onboard() -> Config:
+    """Run the interactive onboarding questionnaire."""
+    config_path = get_config_path()
+
+    if config_path.exists():
+        config = load_config()
+    else:
+        config = Config()
+
+    while True:
+        try:
+            _show_main_menu_header()
+
+            answer = questionary.select(
+                "What would you like to configure?",
+                choices=[
+                    "🔌 Configure LLM Provider",
+                    "💬 Configure Chat Channel",
+                    "🤖 Configure Agent Settings",
+                    "🌐 Configure Gateway",
+                    "🔧 Configure Tools",
+                    "📋 View Configuration Summary",
+                    "💾 Save and Exit",
+                ],
+                qmark="→",
+            ).ask()
+
+            if answer == "🔌 Configure LLM Provider":
+                _configure_providers(config)
+            elif answer == "💬 Configure Chat Channel":
+                _configure_channels(config)
+            elif answer == "🤖 Configure Agent Settings":
+                _configure_agents(config)
+            elif answer == "🌐 Configure Gateway":
+                _configure_gateway(config)
+            elif answer == "🔧 Configure Tools":
+                _configure_tools(config)
+            elif answer == "📋 View Configuration Summary":
+                _show_summary(config)
+            elif answer == "💾 Save and Exit":
+                break
+        except KeyboardInterrupt:
+            console.print(
+                "\n\n[yellow]Operation cancelled. Use 'Save and Exit' to save changes.[/yellow]"
+            )
+            break
+
+    return config

--- a/nanobot/cli/onboard_wizard.py
+++ b/nanobot/cli/onboard_wizard.py
@@ -21,6 +21,127 @@ from nanobot.config.schema import Config
 
 console = Console()
 
+# --- Field Hints for Select Fields ---
+# Maps field names to (choices, hint_text)
+# To add a new select field with hints, add an entry:
+#   "field_name": (["choice1", "choice2", ...], "hint text for the field")
+_SELECT_FIELD_HINTS: dict[str, tuple[list[str], str]] = {
+    "reasoning_effort": (
+        ["low", "medium", "high"],
+        "low / medium / high — enables LLM thinking mode",
+    ),
+}
+
+# --- Key Bindings for Navigation ---
+
+_BACK_PRESSED = object()  # Sentinel value for back navigation
+
+
+def _select_with_back(
+    prompt: str, choices: list[str], default: str | None = None
+) -> str | None | object:
+    """Select with Escape/Left arrow support for going back.
+
+    Args:
+        prompt: The prompt text to display.
+        choices: List of choices to select from. Must not be empty.
+        default: The default choice to pre-select. If not in choices, first item is used.
+
+    Returns:
+        _BACK_PRESSED sentinel if user pressed Escape or Left arrow
+        The selected choice string if user confirmed
+        None if user cancelled (Ctrl+C)
+    """
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.keys import Keys
+    from prompt_toolkit.layout import Layout
+    from prompt_toolkit.layout.containers import HSplit, Window
+    from prompt_toolkit.layout.controls import FormattedTextControl
+    from prompt_toolkit.styles import Style
+
+    # Validate choices
+    if not choices:
+        logger.warning("Empty choices list provided to _select_with_back")
+        return None
+
+    # Find default index
+    selected_index = 0
+    if default and default in choices:
+        selected_index = choices.index(default)
+
+    # State holder for the result
+    state: dict[str, str | None | object] = {"result": None}
+
+    # Build menu items (uses closure over selected_index)
+    def get_menu_text():
+        items = []
+        for i, choice in enumerate(choices):
+            if i == selected_index:
+                items.append(("class:selected", f"→ {choice}\n"))
+            else:
+                items.append(("", f"  {choice}\n"))
+        return items
+
+    # Create layout
+    menu_control = FormattedTextControl(get_menu_text)
+    menu_window = Window(content=menu_control, height=len(choices))
+
+    prompt_control = FormattedTextControl(lambda: [("class:question", f"→ {prompt}")])
+    prompt_window = Window(content=prompt_control, height=1)
+
+    layout = Layout(HSplit([prompt_window, menu_window]))
+
+    # Key bindings
+    bindings = KeyBindings()
+
+    @bindings.add(Keys.Up)
+    def _up(event):
+        nonlocal selected_index
+        selected_index = (selected_index - 1) % len(choices)
+        event.app.invalidate()
+
+    @bindings.add(Keys.Down)
+    def _down(event):
+        nonlocal selected_index
+        selected_index = (selected_index + 1) % len(choices)
+        event.app.invalidate()
+
+    @bindings.add(Keys.Enter)
+    def _enter(event):
+        state["result"] = choices[selected_index]
+        event.app.exit()
+
+    @bindings.add("escape")
+    def _escape(event):
+        state["result"] = _BACK_PRESSED
+        event.app.exit()
+
+    @bindings.add(Keys.Left)
+    def _left(event):
+        state["result"] = _BACK_PRESSED
+        event.app.exit()
+
+    @bindings.add(Keys.ControlC)
+    def _ctrl_c(event):
+        state["result"] = None
+        event.app.exit()
+
+    # Style
+    style = Style.from_dict({
+        "selected": "fg:green bold",
+        "question": "fg:cyan",
+    })
+
+    app = Application(layout=layout, key_bindings=bindings, style=style)
+    try:
+        app.run()
+    except Exception:
+        logger.exception("Error in select prompt")
+        return None
+
+    return state["result"]
+
 # --- Type Introspection ---
 
 
@@ -365,11 +486,13 @@ def _configure_pydantic_model(
         _show_config_panel(display_name, model, fields)
         choices = get_choices()
 
-        answer = questionary.select(
-            "Select field to configure:",
-            choices=choices,
-            qmark="→",
-        ).ask()
+        answer = _select_with_back("Select field to configure:", choices)
+
+        if answer is _BACK_PRESSED:
+            # User pressed Escape or Left arrow - go back
+            if finalize_hook:
+                finalize_hook(model)
+            break
 
         if answer == "✓ Done" or answer is None:
             if finalize_hook:
@@ -411,6 +534,20 @@ def _configure_pydantic_model(
         if field_name == "context_window_tokens":
             new_value = _input_context_window_with_recommendation(field_display, current_value, model)
             if new_value is not None:
+                setattr(model, field_name, new_value)
+            continue
+
+        # Special handling for select fields with hints (e.g., reasoning_effort)
+        if field_name in _SELECT_FIELD_HINTS:
+            choices_list, hint = _SELECT_FIELD_HINTS[field_name]
+            select_choices = choices_list + ["(clear/unset)"]
+            console.print(f"[dim]  Hint: {hint}[/dim]")
+            new_value = _select_with_back(field_display, select_choices, default=current_value or select_choices[0])
+            if new_value is _BACK_PRESSED:
+                continue
+            if new_value == "(clear/unset)":
+                setattr(model, field_name, None)
+            elif new_value is not None:
                 setattr(model, field_name, new_value)
             continue
 
@@ -524,15 +661,13 @@ def _configure_providers(config: Config) -> None:
     while True:
         try:
             choices = get_provider_choices()
-            answer = questionary.select(
-                "Select provider:",
-                choices=choices,
-                qmark="→",
-            ).ask()
+            answer = _select_with_back("Select provider:", choices)
 
-            if answer is None or answer == "← Back":
+            if answer is _BACK_PRESSED or answer is None or answer == "← Back":
                 break
 
+            # Type guard: answer is now guaranteed to be a string
+            assert isinstance(answer, str)
             # Extract provider name from choice (remove " ✓" suffix if present)
             provider_name = answer.replace(" ✓", "")
             # Find the actual provider key from display names
@@ -632,15 +767,13 @@ def _configure_channels(config: Config) -> None:
 
     while True:
         try:
-            answer = questionary.select(
-                "Select channel:",
-                choices=choices,
-                qmark="→",
-            ).ask()
+            answer = _select_with_back("Select channel:", choices)
 
-            if answer is None or answer == "← Back":
+            if answer is _BACK_PRESSED or answer is None or answer == "← Back":
                 break
 
+            # Type guard: answer is now guaranteed to be a string
+            assert isinstance(answer, str)
             _configure_channel(config, answer)
         except KeyboardInterrupt:
             console.print("\n[dim]Returning to main menu...[/dim]")

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -3,6 +3,9 @@
 import json
 from pathlib import Path
 
+import pydantic
+from loguru import logger
+
 from nanobot.config.schema import Config
 
 
@@ -41,9 +44,9 @@ def load_config(config_path: Path | None = None) -> Config:
                 data = json.load(f)
             data = _migrate_config(data)
             return Config.model_validate(data)
-        except (json.JSONDecodeError, ValueError) as e:
-            print(f"Warning: Failed to load config from {path}: {e}")
-            print("Using default configuration.")
+        except (json.JSONDecodeError, ValueError, pydantic.ValidationError) as e:
+            logger.warning(f"Failed to load config from {path}: {e}")
+            logger.warning("Using default configuration.")
 
     return Config()
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -80,6 +80,7 @@ class ProvidersConfig(Base):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
+    mistral: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -399,6 +399,23 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         strip_model_prefix=False,
         model_overrides=(),
     ),
+    # Mistral AI: OpenAI-compatible API at api.mistral.ai/v1.
+    ProviderSpec(
+        name="mistral",
+        keywords=("mistral",),
+        env_key="MISTRAL_API_KEY",
+        display_name="Mistral",
+        litellm_prefix="mistral",  # mistral-large-latest → mistral/mistral-large-latest
+        skip_prefixes=("mistral/",),  # avoid double-prefix
+        env_extras=(),
+        is_gateway=False,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="",
+        default_api_base="https://api.mistral.ai/v1",
+        strip_model_prefix=False,
+        model_overrides=(),
+    ),
     # === Local deployment (matched by config key, NOT by api_base) =========
     # vLLM / any OpenAI-compatible local server.
     # Detected when config key is "vllm" (provider_name="vllm").

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "qq-botpy>=1.2.0,<2.0.0",
     "python-socks[asyncio]>=2.8.0,<3.0.0",
     "prompt-toolkit>=3.0.50,<4.0.0",
+    "questionary>=2.0.0,<3.0.0",
     "mcp>=1.26.0,<2.0.0",
     "json-repair>=0.57.0,<1.0.0",
     "chardet>=3.0.2,<6.0.0",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,4 @@
 import re
-import shutil
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,12 +11,6 @@ from nanobot.providers.litellm_provider import LiteLLMProvider
 from nanobot.providers.openai_codex_provider import _strip_model_prefix
 from nanobot.providers.registry import find_by_model
 
-
-def _strip_ansi(text):
-    """Remove ANSI escape codes from text."""
-    ansi_escape = re.compile(r'\x1b\[[0-9;]*m')
-    return ansi_escape.sub('', text)
-
 runner = CliRunner()
 
 
@@ -25,86 +18,10 @@ class _StopGateway(RuntimeError):
     pass
 
 
-@pytest.fixture
-def mock_paths():
-    """Mock config/workspace paths for test isolation."""
-    with patch("nanobot.config.loader.get_config_path") as mock_cp, \
-         patch("nanobot.config.loader.save_config") as mock_sc, \
-         patch("nanobot.config.loader.load_config") as mock_lc, \
-         patch("nanobot.cli.commands.get_workspace_path") as mock_ws:
-
-        base_dir = Path("./test_onboard_data")
-        if base_dir.exists():
-            shutil.rmtree(base_dir)
-        base_dir.mkdir()
-
-        config_file = base_dir / "config.json"
-        workspace_dir = base_dir / "workspace"
-
-        mock_cp.return_value = config_file
-        mock_ws.return_value = workspace_dir
-        mock_sc.side_effect = lambda config: config_file.write_text("{}")
-
-        yield config_file, workspace_dir
-
-        if base_dir.exists():
-            shutil.rmtree(base_dir)
-
-
-def test_onboard_fresh_install(mock_paths):
-    """No existing config — should create from scratch."""
-    config_file, workspace_dir = mock_paths
-
-    result = runner.invoke(app, ["onboard"])
-
-    assert result.exit_code == 0
-    assert "Created config" in result.stdout
-    assert "Created workspace" in result.stdout
-    assert "nanobot is ready" in result.stdout
-    assert config_file.exists()
-    assert (workspace_dir / "AGENTS.md").exists()
-    assert (workspace_dir / "memory" / "MEMORY.md").exists()
-
-
-def test_onboard_existing_config_refresh(mock_paths):
-    """Config exists, user declines overwrite — should refresh (load-merge-save)."""
-    config_file, workspace_dir = mock_paths
-    config_file.write_text('{"existing": true}')
-
-    result = runner.invoke(app, ["onboard"], input="n\n")
-
-    assert result.exit_code == 0
-    assert "Config already exists" in result.stdout
-    assert "existing values preserved" in result.stdout
-    assert workspace_dir.exists()
-    assert (workspace_dir / "AGENTS.md").exists()
-
-
-def test_onboard_existing_config_overwrite(mock_paths):
-    """Config exists, user confirms overwrite — should reset to defaults."""
-    config_file, workspace_dir = mock_paths
-    config_file.write_text('{"existing": true}')
-
-    result = runner.invoke(app, ["onboard"], input="y\n")
-
-    assert result.exit_code == 0
-    assert "Config already exists" in result.stdout
-    assert "Config reset to defaults" in result.stdout
-    assert workspace_dir.exists()
-
-
-def test_onboard_existing_workspace_safe_create(mock_paths):
-    """Workspace exists — should not recreate, but still add missing templates."""
-    config_file, workspace_dir = mock_paths
-    workspace_dir.mkdir(parents=True)
-    config_file.write_text("{}")
-
-    result = runner.invoke(app, ["onboard"], input="n\n")
-
-    assert result.exit_code == 0
-    assert "Created workspace" not in result.stdout
-    assert "Created AGENTS.md" in result.stdout
-    assert (workspace_dir / "AGENTS.md").exists()
+def _strip_ansi(text):
+    """Remove ANSI escape codes from text."""
+    ansi_escape = re.compile(r'\x1b\[[0-9;]*m')
+    return ansi_escape.sub('', text)
 
 
 def test_config_matches_github_copilot_codex_with_hyphen_prefix():

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -1,12 +1,6 @@
 import json
-from types import SimpleNamespace
 
-from typer.testing import CliRunner
-
-from nanobot.cli.commands import app
 from nanobot.config.loader import load_config, save_config
-
-runner = CliRunner()
 
 
 def test_load_config_keeps_max_tokens_and_warns_on_legacy_memory_window(tmp_path) -> None:
@@ -56,77 +50,3 @@ def test_save_config_writes_context_window_tokens_but_not_memory_window(tmp_path
     assert defaults["maxTokens"] == 2222
     assert defaults["contextWindowTokens"] == 65_536
     assert "memoryWindow" not in defaults
-
-
-def test_onboard_refresh_rewrites_legacy_config_template(tmp_path, monkeypatch) -> None:
-    config_path = tmp_path / "config.json"
-    workspace = tmp_path / "workspace"
-    config_path.write_text(
-        json.dumps(
-            {
-                "agents": {
-                    "defaults": {
-                        "maxTokens": 3333,
-                        "memoryWindow": 50,
-                    }
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    monkeypatch.setattr("nanobot.config.loader.get_config_path", lambda: config_path)
-    monkeypatch.setattr("nanobot.cli.commands.get_workspace_path", lambda: workspace)
-
-    result = runner.invoke(app, ["onboard"], input="n\n")
-
-    assert result.exit_code == 0
-    assert "contextWindowTokens" in result.stdout
-    saved = json.loads(config_path.read_text(encoding="utf-8"))
-    defaults = saved["agents"]["defaults"]
-    assert defaults["maxTokens"] == 3333
-    assert defaults["contextWindowTokens"] == 65_536
-    assert "memoryWindow" not in defaults
-
-
-def test_onboard_refresh_backfills_missing_channel_fields(tmp_path, monkeypatch) -> None:
-    config_path = tmp_path / "config.json"
-    workspace = tmp_path / "workspace"
-    config_path.write_text(
-        json.dumps(
-            {
-                "channels": {
-                    "qq": {
-                        "enabled": False,
-                        "appId": "",
-                        "secret": "",
-                        "allowFrom": [],
-                    }
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    monkeypatch.setattr("nanobot.config.loader.get_config_path", lambda: config_path)
-    monkeypatch.setattr("nanobot.cli.commands.get_workspace_path", lambda: workspace)
-    monkeypatch.setattr(
-        "nanobot.channels.registry.discover_all",
-        lambda: {
-            "qq": SimpleNamespace(
-                default_config=lambda: {
-                    "enabled": False,
-                    "appId": "",
-                    "secret": "",
-                    "allowFrom": [],
-                    "msgFormat": "plain",
-                }
-            )
-        },
-    )
-
-    result = runner.invoke(app, ["onboard"], input="n\n")
-
-    assert result.exit_code == 0
-    saved = json.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["channels"]["qq"]["msgFormat"] == "plain"

--- a/tests/test_mistral_provider.py
+++ b/tests/test_mistral_provider.py
@@ -1,0 +1,22 @@
+"""Tests for the Mistral provider registration."""
+
+from nanobot.config.schema import ProvidersConfig
+from nanobot.providers.registry import PROVIDERS
+
+
+def test_mistral_config_field_exists():
+    """ProvidersConfig should have a mistral field."""
+    config = ProvidersConfig()
+    assert hasattr(config, "mistral")
+
+
+def test_mistral_provider_in_registry():
+    """Mistral should be registered in the provider registry."""
+    specs = {s.name: s for s in PROVIDERS}
+    assert "mistral" in specs
+
+    mistral = specs["mistral"]
+    assert mistral.env_key == "MISTRAL_API_KEY"
+    assert mistral.litellm_prefix == "mistral"
+    assert mistral.default_api_base == "https://api.mistral.ai/v1"
+    assert "mistral/" in mistral.skip_prefixes

--- a/tests/test_onboard_logic.py
+++ b/tests/test_onboard_logic.py
@@ -1,0 +1,373 @@
+"""Unit tests for onboard core logic functions.
+
+These tests focus on the business logic behind the onboard wizard,
+without testing the interactive UI components.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, Field
+
+# Import functions to test
+from nanobot.cli.commands import _merge_missing_defaults
+from nanobot.cli.onboard_wizard import (
+    _format_value,
+    _get_field_display_name,
+    _get_field_type_info,
+)
+from nanobot.utils.helpers import sync_workspace_templates
+
+
+class TestMergeMissingDefaults:
+    """Tests for _merge_missing_defaults recursive config merging."""
+
+    def test_adds_missing_top_level_keys(self):
+        existing = {"a": 1}
+        defaults = {"a": 1, "b": 2, "c": 3}
+
+        result = _merge_missing_defaults(existing, defaults)
+
+        assert result == {"a": 1, "b": 2, "c": 3}
+
+    def test_preserves_existing_values(self):
+        existing = {"a": "custom_value"}
+        defaults = {"a": "default_value"}
+
+        result = _merge_missing_defaults(existing, defaults)
+
+        assert result == {"a": "custom_value"}
+
+    def test_merges_nested_dicts_recursively(self):
+        existing = {
+            "level1": {
+                "level2": {
+                    "existing": "kept",
+                }
+            }
+        }
+        defaults = {
+            "level1": {
+                "level2": {
+                    "existing": "replaced",
+                    "added": "new",
+                },
+                "level2b": "also_new",
+            }
+        }
+
+        result = _merge_missing_defaults(existing, defaults)
+
+        assert result == {
+            "level1": {
+                "level2": {
+                    "existing": "kept",
+                    "added": "new",
+                },
+                "level2b": "also_new",
+            }
+        }
+
+    def test_returns_existing_if_not_dict(self):
+        assert _merge_missing_defaults("string", {"a": 1}) == "string"
+        assert _merge_missing_defaults([1, 2, 3], {"a": 1}) == [1, 2, 3]
+        assert _merge_missing_defaults(None, {"a": 1}) is None
+        assert _merge_missing_defaults(42, {"a": 1}) == 42
+
+    def test_returns_existing_if_defaults_not_dict(self):
+        assert _merge_missing_defaults({"a": 1}, "string") == {"a": 1}
+        assert _merge_missing_defaults({"a": 1}, None) == {"a": 1}
+
+    def test_handles_empty_dicts(self):
+        assert _merge_missing_defaults({}, {"a": 1}) == {"a": 1}
+        assert _merge_missing_defaults({"a": 1}, {}) == {"a": 1}
+        assert _merge_missing_defaults({}, {}) == {}
+
+    def test_backfills_channel_config(self):
+        """Real-world scenario: backfill missing channel fields."""
+        existing_channel = {
+            "enabled": False,
+            "appId": "",
+            "secret": "",
+        }
+        default_channel = {
+            "enabled": False,
+            "appId": "",
+            "secret": "",
+            "msgFormat": "plain",
+            "allowFrom": [],
+        }
+
+        result = _merge_missing_defaults(existing_channel, default_channel)
+
+        assert result["msgFormat"] == "plain"
+        assert result["allowFrom"] == []
+
+
+class TestGetFieldTypeInfo:
+    """Tests for _get_field_type_info type extraction."""
+
+    def test_extracts_str_type(self):
+        class Model(BaseModel):
+            field: str
+
+        type_name, inner = _get_field_type_info(Model.model_fields["field"])
+        assert type_name == "str"
+        assert inner is None
+
+    def test_extracts_int_type(self):
+        class Model(BaseModel):
+            count: int
+
+        type_name, inner = _get_field_type_info(Model.model_fields["count"])
+        assert type_name == "int"
+        assert inner is None
+
+    def test_extracts_bool_type(self):
+        class Model(BaseModel):
+            enabled: bool
+
+        type_name, inner = _get_field_type_info(Model.model_fields["enabled"])
+        assert type_name == "bool"
+        assert inner is None
+
+    def test_extracts_float_type(self):
+        class Model(BaseModel):
+            ratio: float
+
+        type_name, inner = _get_field_type_info(Model.model_fields["ratio"])
+        assert type_name == "float"
+        assert inner is None
+
+    def test_extracts_list_type_with_item_type(self):
+        class Model(BaseModel):
+            items: list[str]
+
+        type_name, inner = _get_field_type_info(Model.model_fields["items"])
+        assert type_name == "list"
+        assert inner is str
+
+    def test_extracts_list_type_without_item_type(self):
+        # Plain list without type param falls back to str
+        class Model(BaseModel):
+            items: list  # type: ignore
+
+        # Plain list annotation doesn't match list check, returns str
+        type_name, inner = _get_field_type_info(Model.model_fields["items"])
+        assert type_name == "str"  # Falls back to str for untyped list
+        assert inner is None
+
+    def test_extracts_dict_type(self):
+        # Plain dict without type param falls back to str
+        class Model(BaseModel):
+            data: dict  # type: ignore
+
+        # Plain dict annotation doesn't match dict check, returns str
+        type_name, inner = _get_field_type_info(Model.model_fields["data"])
+        assert type_name == "str"  # Falls back to str for untyped dict
+        assert inner is None
+
+    def test_extracts_optional_type(self):
+        class Model(BaseModel):
+            optional: str | None = None
+
+        type_name, inner = _get_field_type_info(Model.model_fields["optional"])
+        # Should unwrap Optional and get str
+        assert type_name == "str"
+        assert inner is None
+
+    def test_extracts_nested_model_type(self):
+        class Inner(BaseModel):
+            x: int
+
+        class Outer(BaseModel):
+            nested: Inner
+
+        type_name, inner = _get_field_type_info(Outer.model_fields["nested"])
+        assert type_name == "model"
+        assert inner is Inner
+
+    def test_handles_none_annotation(self):
+        """Field with None annotation defaults to str."""
+        class Model(BaseModel):
+            field: Any = None
+
+        # Create a mock field_info with None annotation
+        field_info = SimpleNamespace(annotation=None)
+        type_name, inner = _get_field_type_info(field_info)
+        assert type_name == "str"
+        assert inner is None
+
+
+class TestGetFieldDisplayName:
+    """Tests for _get_field_display_name human-readable name generation."""
+
+    def test_uses_description_if_present(self):
+        class Model(BaseModel):
+            api_key: str = Field(description="API Key for authentication")
+
+        name = _get_field_display_name("api_key", Model.model_fields["api_key"])
+        assert name == "API Key for authentication"
+
+    def test_converts_snake_case_to_title(self):
+        field_info = SimpleNamespace(description=None)
+        name = _get_field_display_name("user_name", field_info)
+        assert name == "User Name"
+
+    def test_adds_url_suffix(self):
+        field_info = SimpleNamespace(description=None)
+        name = _get_field_display_name("api_url", field_info)
+        # Title case: "Api Url"
+        assert "Url" in name and "Api" in name
+
+    def test_adds_path_suffix(self):
+        field_info = SimpleNamespace(description=None)
+        name = _get_field_display_name("file_path", field_info)
+        assert "Path" in name and "File" in name
+
+    def test_adds_id_suffix(self):
+        field_info = SimpleNamespace(description=None)
+        name = _get_field_display_name("user_id", field_info)
+        # Title case: "User Id"
+        assert "Id" in name and "User" in name
+
+    def test_adds_key_suffix(self):
+        field_info = SimpleNamespace(description=None)
+        name = _get_field_display_name("api_key", field_info)
+        assert "Key" in name and "Api" in name
+
+    def test_adds_token_suffix(self):
+        field_info = SimpleNamespace(description=None)
+        name = _get_field_display_name("auth_token", field_info)
+        assert "Token" in name and "Auth" in name
+
+    def test_adds_seconds_suffix(self):
+        field_info = SimpleNamespace(description=None)
+        name = _get_field_display_name("timeout_s", field_info)
+        # Contains "(Seconds)" with title case
+        assert "(Seconds)" in name or "(seconds)" in name
+
+    def test_adds_ms_suffix(self):
+        field_info = SimpleNamespace(description=None)
+        name = _get_field_display_name("delay_ms", field_info)
+        # Contains "(Ms)" or "(ms)"
+        assert "(Ms)" in name or "(ms)" in name
+
+
+class TestFormatValue:
+    """Tests for _format_value display formatting."""
+
+    def test_formats_none_as_not_set(self):
+        assert "not set" in _format_value(None)
+
+    def test_formats_empty_string_as_not_set(self):
+        assert "not set" in _format_value("")
+
+    def test_formats_empty_dict_as_not_set(self):
+        assert "not set" in _format_value({})
+
+    def test_formats_empty_list_as_not_set(self):
+        assert "not set" in _format_value([])
+
+    def test_formats_string_value(self):
+        result = _format_value("hello")
+        assert "hello" in result
+
+    def test_formats_list_value(self):
+        result = _format_value(["a", "b"])
+        assert "a" in result or "b" in result
+
+    def test_formats_dict_value(self):
+        result = _format_value({"key": "value"})
+        assert "key" in result or "value" in result
+
+    def test_formats_int_value(self):
+        result = _format_value(42)
+        assert "42" in result
+
+    def test_formats_bool_true(self):
+        result = _format_value(True)
+        assert "true" in result.lower() or "✓" in result
+
+    def test_formats_bool_false(self):
+        result = _format_value(False)
+        assert "false" in result.lower() or "✗" in result
+
+
+class TestSyncWorkspaceTemplates:
+    """Tests for sync_workspace_templates file synchronization."""
+
+    def test_creates_missing_files(self, tmp_path):
+        """Should create template files that don't exist."""
+        workspace = tmp_path / "workspace"
+
+        added = sync_workspace_templates(workspace, silent=True)
+
+        # Check that some files were created
+        assert isinstance(added, list)
+        # The actual files depend on the templates directory
+
+    def test_does_not_overwrite_existing_files(self, tmp_path):
+        """Should not overwrite files that already exist."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir(parents=True)
+        (workspace / "AGENTS.md").write_text("existing content")
+
+        sync_workspace_templates(workspace, silent=True)
+
+        # Existing file should not be changed
+        content = (workspace / "AGENTS.md").read_text()
+        assert content == "existing content"
+
+    def test_creates_memory_directory(self, tmp_path):
+        """Should create memory directory structure."""
+        workspace = tmp_path / "workspace"
+
+        sync_workspace_templates(workspace, silent=True)
+
+        assert (workspace / "memory").exists() or (workspace / "skills").exists()
+
+    def test_returns_list_of_added_files(self, tmp_path):
+        """Should return list of relative paths for added files."""
+        workspace = tmp_path / "workspace"
+
+        added = sync_workspace_templates(workspace, silent=True)
+
+        assert isinstance(added, list)
+        # All paths should be relative to workspace
+        for path in added:
+            assert not Path(path).is_absolute()
+
+
+class TestProviderChannelInfo:
+    """Tests for provider and channel info retrieval."""
+
+    def test_get_provider_names_returns_dict(self):
+        from nanobot.cli.onboard_wizard import _get_provider_names
+
+        names = _get_provider_names()
+        assert isinstance(names, dict)
+        assert len(names) > 0
+        # Should include common providers
+        assert "openai" in names or "anthropic" in names
+
+    def test_get_channel_names_returns_dict(self):
+        from nanobot.cli.onboard_wizard import _get_channel_names
+
+        names = _get_channel_names()
+        assert isinstance(names, dict)
+        # Should include at least some channels
+        assert len(names) >= 0
+
+    def test_get_provider_info_returns_valid_structure(self):
+        from nanobot.cli.onboard_wizard import _get_provider_info
+
+        info = _get_provider_info()
+        assert isinstance(info, dict)
+        # Each value should be a tuple with expected structure
+        for provider_name, value in info.items():
+            assert isinstance(value, tuple)
+            assert len(value) == 4  # (display_name, needs_api_key, needs_api_base, env_var)

--- a/tests/test_tui_replay.py
+++ b/tests/test_tui_replay.py
@@ -1,0 +1,625 @@
+"""Tests for the TUI channel (nanobot/channels/tui.py)."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from a string."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.tui import TuiChannel, TuiConfig, _to_ansi
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_channel(allow_from: list[str] | None = None) -> TuiChannel:
+    cfg = TuiConfig(enabled=True, allow_from=allow_from or ["*"])
+    return TuiChannel(cfg, MessageBus())
+
+
+def _outbound(content: str, **meta) -> OutboundMessage:
+    return OutboundMessage(channel="tui", chat_id="tui", content=content, metadata=meta)
+
+
+def _patch_start_env():
+    """Shared context managers that suppress all terminal I/O in start() tests."""
+    return (
+        patch("nanobot.channels.tui.Console"),
+        patch("nanobot.channels.tui.patch_stdout"),
+        patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def test_tui_config_defaults():
+    cfg = TuiConfig()
+    assert cfg.enabled is False
+    assert cfg.allow_from == ["local_user"]
+    assert cfg.user_id == "local_user"
+
+
+def test_tui_config_from_camel_dict():
+    cfg = TuiConfig.model_validate({"enabled": True, "allowFrom": ["*"], "userId": "admin"})
+    assert cfg.enabled is True
+    assert cfg.allow_from == ["*"]
+    assert cfg.user_id == "admin"
+
+
+def test_default_config_keys():
+    d = TuiChannel.default_config()
+    assert isinstance(d, dict)
+    assert d["enabled"] is False
+    assert "allowFrom" in d
+    assert "userId" in d
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+def test_init_from_dict():
+    ch = TuiChannel({"enabled": True, "allowFrom": ["*"]}, MessageBus())
+    assert ch.config.enabled is True
+    assert ch.config.allow_from == ["*"]
+    assert ch._chat_id == "tui"
+    assert ch._session_counter == 0
+    assert ch._loading_task is None
+    assert ch._response_done.is_set()
+
+
+def test_init_from_config_object():
+    cfg = TuiConfig(enabled=True, allow_from=["user1"])
+    ch = TuiChannel(cfg, MessageBus())
+    assert ch.config is cfg
+
+
+def test_channel_name_and_display():
+    assert TuiChannel.name == "tui"
+    assert TuiChannel.display_name == "TUI"
+
+
+# ---------------------------------------------------------------------------
+# stop()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_stop_sets_running_false():
+    ch = _make_channel()
+    ch._running = True
+    await ch.stop()
+    assert ch._running is False
+
+
+@pytest.mark.asyncio
+async def test_stop_sets_response_done():
+    ch = _make_channel()
+    ch._response_done.clear()
+    await ch.stop()
+    assert ch._response_done.is_set()
+
+
+# ---------------------------------------------------------------------------
+# _to_ansi
+# ---------------------------------------------------------------------------
+
+def test_to_ansi_returns_string():
+    result = _to_ansi(lambda c: c.print("hello"))
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_to_ansi_contains_rendered_content():
+    result = _to_ansi(lambda c: c.print("hello world"))
+    assert "hello world" in result
+
+
+def test_to_ansi_contains_escape_codes():
+    """force_terminal=True should produce ANSI escape sequences."""
+    result = _to_ansi(lambda c: c.print("[bold]bold text[/bold]"))
+    assert "\x1b[" in result
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_command — return value
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dispatch_stop_returns_true():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        assert await ch._dispatch_command("/stop") is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_exit_returns_true():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        assert await ch._dispatch_command("/exit") is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_quit_returns_true():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        assert await ch._dispatch_command("/quit") is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_help_returns_false():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        assert await ch._dispatch_command("/help") is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_clear_returns_false():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        assert await ch._dispatch_command("/clear") is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_returns_false():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        assert await ch._dispatch_command("/foobar") is False
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_command — /new side-effects
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dispatch_new_increments_session_counter():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch._dispatch_command("/new")
+    assert ch._session_counter == 1
+    assert ch._chat_id == "tui-1"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_new_increments_each_call():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch._dispatch_command("/new")
+        await ch._dispatch_command("/new")
+        await ch._dispatch_command("/new")
+    assert ch._session_counter == 3
+    assert ch._chat_id == "tui-3"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_new_chat_id_format():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch._dispatch_command("/new")
+    assert ch._chat_id == f"tui-{ch._session_counter}"
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_command — run_in_terminal is called for rendering commands
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dispatch_help_calls_run_in_terminal():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
+        await ch._dispatch_command("/help")
+    mock_rit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_new_calls_run_in_terminal():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
+        await ch._dispatch_command("/new")
+    mock_rit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_clear_calls_run_in_terminal():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
+        await ch._dispatch_command("/clear")
+    mock_rit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_calls_run_in_terminal():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
+        await ch._dispatch_command("/unknown")
+    mock_rit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# send()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_final_response_calls_run_in_terminal():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
+        await ch.send(_outbound("Hello from agent"))
+    mock_rit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_progress_tool_hint_calls_run_in_terminal():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
+        await ch.send(_outbound("read_file(...)", _progress=True, _tool_hint=True))
+    mock_rit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_progress_non_tool_calls_run_in_terminal():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
+        await ch.send(_outbound("Thinking...", _progress=True))
+    mock_rit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_renders_correct_ansi_for_final_response():
+    """Final response callback should produce a Panel with Markdown content."""
+    ch = _make_channel()
+    captured_callbacks: list = []
+
+    async def capture_rit(fn):
+        captured_callbacks.append(fn)
+
+    with patch("nanobot.channels.tui.run_in_terminal", side_effect=capture_rit), \
+         patch("nanobot.channels.tui.print_formatted_text") as mock_pft:
+        await ch.send(_outbound("**bold** response"))
+        assert len(captured_callbacks) == 1
+        captured_callbacks[0]()  # invoke the render callback
+
+    mock_pft.assert_called_once()
+    ansi_arg = mock_pft.call_args[0][0]
+    assert hasattr(ansi_arg, "value")  # prompt_toolkit ANSI object
+    assert "bold" in ansi_arg.value or "\x1b[" in ansi_arg.value
+
+
+@pytest.mark.asyncio
+async def test_send_renders_correct_ansi_for_progress_tool_hint():
+    """Tool-hint callback should print with '>' prefix."""
+    ch = _make_channel()
+    captured_callbacks: list = []
+
+    async def capture_rit(fn):
+        captured_callbacks.append(fn)
+
+    with patch("nanobot.channels.tui.run_in_terminal", side_effect=capture_rit), \
+         patch("nanobot.channels.tui.print_formatted_text") as mock_pft:
+        await ch.send(_outbound("read_file(foo.txt)", _progress=True, _tool_hint=True))
+        captured_callbacks[0]()
+
+    ansi_str = mock_pft.call_args[0][0].value
+    plain = _strip_ansi(ansi_str)
+    assert "read_file(foo.txt)" in plain
+    assert ">" in plain
+
+
+@pytest.mark.asyncio
+async def test_send_empty_content_does_not_raise():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch.send(_outbound(""))
+
+
+@pytest.mark.asyncio
+async def test_send_swallows_run_in_terminal_error():
+    """A render failure must not propagate to the caller."""
+    ch = _make_channel()
+
+    async def boom(fn):
+        raise RuntimeError("terminal gone")
+
+    with patch("nanobot.channels.tui.run_in_terminal", side_effect=boom):
+        await ch.send(_outbound("hello"))  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# start() — input loop control flow
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_start_exit_word_terminates():
+    ch = _make_channel()
+    ch._session = MagicMock(prompt_async=AsyncMock(return_value="exit"))
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit:
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert ch._running is False
+
+
+@pytest.mark.asyncio
+async def test_start_quit_word_terminates():
+    ch = _make_channel()
+    ch._session = MagicMock(prompt_async=AsyncMock(return_value="quit"))
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit:
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert ch._running is False
+
+
+@pytest.mark.asyncio
+async def test_start_colon_q_terminates():
+    ch = _make_channel()
+    ch._session = MagicMock(prompt_async=AsyncMock(return_value=":q"))
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit:
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert ch._running is False
+
+
+@pytest.mark.asyncio
+async def test_start_eof_terminates():
+    ch = _make_channel()
+    ch._session = MagicMock(prompt_async=AsyncMock(side_effect=EOFError))
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit:
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert ch._running is False
+
+
+@pytest.mark.asyncio
+async def test_start_stop_command_terminates():
+    ch = _make_channel()
+    ch._session = MagicMock(prompt_async=AsyncMock(return_value="/stop"))
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit:
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert ch._running is False
+
+
+@pytest.mark.asyncio
+async def test_start_keyboard_interrupt_continues_loop():
+    """Ctrl+C should not exit; the next input still works."""
+    ch = _make_channel()
+    ch._session = MagicMock(
+        prompt_async=AsyncMock(side_effect=[KeyboardInterrupt, "exit"])
+    )
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit:
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert ch._running is False
+
+
+@pytest.mark.asyncio
+async def test_start_regular_message_calls_handle_message():
+    ch = _make_channel()
+    ch._session = MagicMock(
+        prompt_async=AsyncMock(side_effect=["hello agent", "exit"])
+    )
+
+    received: list[str] = []
+
+    async def fake_handle(sender_id, chat_id, content, **kwargs):
+        received.append(content)
+        ch._response_done.set()
+
+    ch._handle_message = fake_handle
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit, \
+         patch.object(ch, "_start_loading"):
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert received == ["hello agent"]
+
+
+@pytest.mark.asyncio
+async def test_start_uses_current_chat_id():
+    ch = _make_channel()
+    ch._chat_id = "tui-5"
+    ch._session = MagicMock(
+        prompt_async=AsyncMock(side_effect=["hi", "exit"])
+    )
+
+    received_chat_ids: list[str] = []
+
+    async def fake_handle(sender_id, chat_id, content, **kwargs):
+        received_chat_ids.append(chat_id)
+        ch._response_done.set()
+
+    ch._handle_message = fake_handle
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit, \
+         patch.object(ch, "_start_loading"):
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert received_chat_ids == ["tui-5"]
+
+
+@pytest.mark.asyncio
+async def test_start_empty_input_skipped():
+    ch = _make_channel()
+    ch._session = MagicMock(
+        prompt_async=AsyncMock(side_effect=["  ", "", "exit"])
+    )
+
+    received: list[str] = []
+
+    async def fake_handle(sender_id, chat_id, content, **kwargs):
+        received.append(content)
+
+    ch._handle_message = fake_handle
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit:
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_start_slash_command_not_forwarded_to_handle_message():
+    """/help should not be sent as a message to the agent."""
+    ch = _make_channel()
+    ch._session = MagicMock(
+        prompt_async=AsyncMock(side_effect=["/help", "exit"])
+    )
+
+    received: list[str] = []
+
+    async def fake_handle(sender_id, chat_id, content, **kwargs):
+        received.append(content)
+
+    ch._handle_message = fake_handle
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit:
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_start_new_command_changes_chat_id_for_subsequent_messages():
+    """/new should switch the session; the next message uses the new chat_id."""
+    ch = _make_channel()
+    ch._session = MagicMock(
+        prompt_async=AsyncMock(side_effect=["/new", "hello", "exit"])
+    )
+
+    received_chat_ids: list[str] = []
+
+    async def fake_handle(sender_id, chat_id, content, **kwargs):
+        received_chat_ids.append(chat_id)
+        ch._response_done.set()
+
+    ch._handle_message = fake_handle
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit, \
+         patch.object(ch, "_start_loading"):
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert len(received_chat_ids) == 1
+    assert received_chat_ids[0] == "tui-1"
+
+
+# ---------------------------------------------------------------------------
+# Loading indicator (_start_loading / _stop_loading / _response_done)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_start_loading_creates_task():
+    ch = _make_channel()
+    with patch.object(ch, "_animate_loading", new_callable=AsyncMock):
+        ch._start_loading()
+        assert ch._loading_task is not None
+        ch._loading_task.cancel()
+        try:
+            await ch._loading_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_stop_loading_cancels_task():
+    ch = _make_channel()
+    ch._loading_task = asyncio.get_event_loop().create_task(asyncio.sleep(10))
+    await ch._stop_loading()
+    assert ch._loading_task is None
+
+
+@pytest.mark.asyncio
+async def test_stop_loading_noop_when_no_task():
+    ch = _make_channel()
+    await ch._stop_loading()
+    assert ch._loading_task is None
+
+
+@pytest.mark.asyncio
+async def test_send_final_response_sets_response_done():
+    ch = _make_channel()
+    ch._response_done.clear()
+
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch.send(_outbound("Hello from agent"))
+
+    assert ch._response_done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_send_progress_does_not_set_response_done():
+    ch = _make_channel()
+    ch._response_done.clear()
+
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch.send(_outbound("working...", _progress=True))
+
+    assert not ch._response_done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_send_tool_hint_does_not_set_response_done():
+    ch = _make_channel()
+    ch._response_done.clear()
+
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch.send(_outbound("read_file(x)", _progress=True, _tool_hint=True))
+
+    assert not ch._response_done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_start_calls_start_loading_after_message():
+    """_start_loading should be called after user sends a message."""
+    ch = _make_channel()
+
+    loading_called = False
+
+    async def fake_handle(sender_id, chat_id, content, **kwargs):
+        ch._response_done.set()
+
+    ch._handle_message = fake_handle
+
+    original_start_loading = ch._start_loading
+
+    def tracking_start_loading():
+        nonlocal loading_called
+        loading_called = True
+        ch._response_done.set()
+
+    ch._start_loading = tracking_start_loading
+
+    ch._session = MagicMock(
+        prompt_async=AsyncMock(side_effect=["hello", "exit"])
+    )
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit:
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert loading_called is True

--- a/tests/test_tui_replay.py
+++ b/tests/test_tui_replay.py
@@ -78,6 +78,8 @@ def test_init_from_dict():
     assert ch._session_counter == 0
     assert ch._loading_task is None
     assert ch._response_done.is_set()
+    assert ch._session_order == ["tui"]
+    assert "tui" in ch._sessions
 
 
 def test_init_from_config_object():
@@ -172,6 +174,20 @@ async def test_dispatch_clear_returns_false():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_sessions_returns_false():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        assert await ch._dispatch_command("/sessions") is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_switch_returns_false():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        assert await ch._dispatch_command("/switch tui") is False
+
+
+@pytest.mark.asyncio
 async def test_dispatch_unknown_returns_false():
     ch = _make_channel()
     with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
@@ -210,6 +226,33 @@ async def test_dispatch_new_chat_id_format():
     assert ch._chat_id == f"tui-{ch._session_counter}"
 
 
+@pytest.mark.asyncio
+async def test_dispatch_new_registers_session():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch._dispatch_command("/new")
+    assert "tui-1" in ch._sessions
+    assert ch._session_order == ["tui", "tui-1"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_switch_changes_chat_id():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch._dispatch_command("/new")
+        await ch._dispatch_command("/switch tui")
+    assert ch._chat_id == "tui"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_switch_unknown_keeps_current_chat_id():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch._dispatch_command("/new")
+        await ch._dispatch_command("/switch missing")
+    assert ch._chat_id == "tui-1"
+
+
 # ---------------------------------------------------------------------------
 # _dispatch_command — run_in_terminal is called for rendering commands
 # ---------------------------------------------------------------------------
@@ -235,6 +278,22 @@ async def test_dispatch_clear_calls_run_in_terminal():
     ch = _make_channel()
     with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
         await ch._dispatch_command("/clear")
+    mock_rit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sessions_calls_run_in_terminal():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
+        await ch._dispatch_command("/sessions")
+    mock_rit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_switch_calls_run_in_terminal():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock) as mock_rit:
+        await ch._dispatch_command("/switch tui")
     mock_rit.assert_called_once()
 
 
@@ -276,7 +335,7 @@ async def test_send_progress_non_tool_calls_run_in_terminal():
 
 @pytest.mark.asyncio
 async def test_send_renders_correct_ansi_for_final_response():
-    """Final response callback should produce a Panel with Markdown content."""
+    """Final response callback should include session context and Markdown content."""
     ch = _make_channel()
     captured_callbacks: list = []
 
@@ -293,11 +352,15 @@ async def test_send_renders_correct_ansi_for_final_response():
     ansi_arg = mock_pft.call_args[0][0]
     assert hasattr(ansi_arg, "value")  # prompt_toolkit ANSI object
     assert "bold" in ansi_arg.value or "\x1b[" in ansi_arg.value
+    plain = _strip_ansi(ansi_arg.value)
+    assert "Session:" in plain
+    assert "Status:" in plain
+    assert "nanobot:" in plain
 
 
 @pytest.mark.asyncio
 async def test_send_renders_correct_ansi_for_progress_tool_hint():
-    """Tool-hint callback should print with '>' prefix."""
+    """Tool-hint callback should include session info and Tool label."""
     ch = _make_channel()
     captured_callbacks: list = []
 
@@ -312,7 +375,34 @@ async def test_send_renders_correct_ansi_for_progress_tool_hint():
     ansi_str = mock_pft.call_args[0][0].value
     plain = _strip_ansi(ansi_str)
     assert "read_file(foo.txt)" in plain
-    assert ">" in plain
+    assert "Tool:" in plain
+    assert "Session:" in plain
+
+
+@pytest.mark.asyncio
+async def test_send_progress_updates_session_status():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch.send(_outbound("Thinking...", _progress=True))
+    assert ch._sessions["tui"]["status"] == "thinking"
+
+
+@pytest.mark.asyncio
+async def test_send_tool_hint_records_tool_event():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch.send(_outbound("read_file(foo.txt)", _progress=True, _tool_hint=True))
+    assert ch._sessions["tui"]["status"] == "tool"
+    assert ch._sessions["tui"]["tool_events"] == ["read_file(foo.txt)"]
+
+
+@pytest.mark.asyncio
+async def test_send_final_response_updates_session_preview():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch.send(_outbound("Hello from agent"))
+    assert ch._sessions["tui"]["status"] == "done"
+    assert ch._sessions["tui"]["last_agent_preview"] == "Hello from agent"
 
 
 @pytest.mark.asyncio
@@ -434,6 +524,8 @@ async def test_start_regular_message_calls_handle_message():
         await asyncio.wait_for(ch.start(), timeout=2.0)
 
     assert received == ["hello agent"]
+    assert ch._sessions["tui"]["last_user_message"] == "hello agent"
+    assert ch._sessions["tui"]["status"] == "queued"
 
 
 @pytest.mark.asyncio
@@ -526,6 +618,29 @@ async def test_start_new_command_changes_chat_id_for_subsequent_messages():
 
     assert len(received_chat_ids) == 1
     assert received_chat_ids[0] == "tui-1"
+
+
+@pytest.mark.asyncio
+async def test_start_switch_command_changes_chat_id_for_subsequent_messages():
+    ch = _make_channel()
+    ch._session = MagicMock(
+        prompt_async=AsyncMock(side_effect=["/new", "/switch tui", "hello", "exit"])
+    )
+
+    received_chat_ids: list[str] = []
+
+    async def fake_handle(sender_id, chat_id, content, **kwargs):
+        received_chat_ids.append(chat_id)
+        ch._response_done.set()
+
+    ch._handle_message = fake_handle
+
+    p_console, p_stdout, p_rit = _patch_start_env()
+    with p_console, p_stdout, p_rit, \
+         patch.object(ch, "_start_loading"):
+        await asyncio.wait_for(ch.start(), timeout=2.0)
+
+    assert received_chat_ids == ["tui"]
 
 
 # ---------------------------------------------------------------------------
@@ -623,3 +738,13 @@ async def test_start_calls_start_loading_after_message():
         await asyncio.wait_for(ch.start(), timeout=2.0)
 
     assert loading_called is True
+
+
+@pytest.mark.asyncio
+async def test_clear_does_not_remove_session_registry():
+    ch = _make_channel()
+    with patch("nanobot.channels.tui.run_in_terminal", new_callable=AsyncMock):
+        await ch._dispatch_command("/new")
+        await ch._dispatch_command("/clear")
+    assert ch._session_order == ["tui", "tui-1"]
+    assert ch._chat_id == "tui-1"


### PR DESCRIPTION
This project is awesome,I replace openclaw with nanobot and resource consumption is very small. Nanobot interacte locally with tui I think this is useful.
- add `tui.py` in `channel` directionary
- use `nanobot tui` to enter tui mode
- add tools call process when agent is thinking 
- add `\new` 、`\stop`、`\help`、`\clear`、`\switch <session>`、`\sessions` command in tui mode
- add `test_tui_replay.py` test file

config.json in `channel`
```
    "tui": { "enabled": true,
      "allowFrom": [
        "local_user"
      ],
      "userId": "local_user"
    }
```