### PR TITLE
fix(cron): suppress progress messages during cron job execution

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -506,12 +506,17 @@ def gateway(
         cron_token = None
         if isinstance(cron_tool, CronTool):
             cron_token = cron_tool.set_cron_context(True)
+
+        async def _noop_progress(content: str, **kwargs) -> None:
+            pass  # Suppress progress messages for cron jobs
+
         try:
             response = await agent.process_direct(
                 reminder_note,
                 session_key=f"cron:{job.id}",
                 channel=job.payload.channel or "cli",
                 chat_id=job.payload.to or "direct",
+                on_progress=_noop_progress,
             )
         finally:
             if isinstance(cron_tool, CronTool) and cron_token is not None:

--- a/tests/test_cron_progress.py
+++ b/tests/test_cron_progress.py
@@ -1,0 +1,69 @@
+"""Test that cron jobs suppress progress messages when on_progress is provided."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.queue import MessageBus
+
+
+@pytest.fixture
+def agent_with_bus(tmp_path):
+    """Create an AgentLoop with a mock bus to track outbound messages."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "SOUL.md").write_text("test")
+    (workspace / "USER.md").write_text("test")
+    (workspace / "AGENTS.md").write_text("test")
+
+    bus = MagicMock(spec=MessageBus)
+    bus.publish_outbound = AsyncMock()
+
+    provider = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = "done"
+    mock_response.has_tool_calls = False
+    mock_response.tool_calls = []
+    mock_response.reasoning_content = None
+    provider.chat_with_retry = AsyncMock(return_value=mock_response)
+
+    agent = AgentLoop(
+        provider=provider,
+        model="test/model",
+        workspace=workspace,
+        bus=bus,
+    )
+    return agent, bus
+
+
+@pytest.mark.asyncio
+async def test_process_direct_with_on_progress_does_not_publish_to_bus(agent_with_bus):
+    """When on_progress is provided, the bus should NOT receive progress messages.
+
+    This is the scenario for cron jobs: passing a no-op callback prevents
+    intermediate agent thoughts from being sent to the user's channel.
+    """
+    agent, bus = agent_with_bus
+
+    progress_calls = []
+
+    async def capture_progress(content: str, **kwargs) -> None:
+        progress_calls.append(content)
+
+    # Patch session save to avoid JSON serialization of mock objects
+    with patch.object(agent.sessions, "save"):
+        await agent.process_direct(
+            "test message",
+            session_key="cron:test",
+            channel="telegram",
+            chat_id="12345",
+            on_progress=capture_progress,
+        )
+
+    # The bus should NOT have received any progress messages
+    for call in bus.publish_outbound.call_args_list:
+        msg = call.args[0]
+        assert not msg.metadata.get("_progress", False), (
+            "Bus received a progress message despite on_progress callback being provided"
+        )


### PR DESCRIPTION
## Summary

- Cron jobs no longer send intermediate "thinking" progress messages to the user's channel
- Only the final result (via `message()` tool or `deliver` path) is sent
- One-line fix: pass a no-op `on_progress` callback to `process_direct()` in `on_cron_job`

## Problem

When `sendProgress` is enabled in config, cron job execution leaks progress messages to the user's channel. The flow:

1. Cron fires, calls `agent.process_direct()` without an `on_progress` callback
2. `_process_message()` falls back to `_bus_progress`, which publishes intermediate thoughts to the message bus
3. The Telegram channel receives and sends these as real messages
4. The agent then sends the actual result via the `message()` tool

The user sees two messages: the agent's internal reasoning, then the real output. This only affects scheduled tasks — direct chat progress is intentional and useful.

## Fix

```python
async def _noop_progress(content: str, **kwargs) -> None:
    pass  # Suppress progress messages for cron jobs

response = await agent.process_direct(
    reminder_note,
    session_key=f"cron:{job.id}",
    channel=job.payload.channel or "cli",
    chat_id=job.payload.to or "direct",
    on_progress=_noop_progress,
)
```

Note: the heartbeat service already does this correctly (line 574: `on_progress=_silent`).

## Test plan

- [ ] Trigger a cron job with `sendProgress: true` — verify only one message arrives (the result), not two
- [ ] Verify direct chat still shows progress messages normally
- [ ] Verify heartbeat behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)