### PR TITLE
fix: When using custom_provider, a prompt "LiteLLM:WARNING" will still appear during conversation

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -7,8 +7,6 @@ import string
 from typing import Any
 
 import json_repair
-import litellm
-from litellm import acompletion
 from loguru import logger
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
@@ -42,6 +40,8 @@ class LiteLLMProvider(LLMProvider):
         provider_name: str | None = None,
     ):
         super().__init__(api_key, api_base)
+        import litellm
+        self.acompletion = litellm.acompletion
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
 
@@ -278,7 +278,7 @@ class LiteLLMProvider(LLMProvider):
             kwargs["tool_choice"] = tool_choice or "auto"
 
         try:
-            response = await acompletion(**kwargs)
+            response = await self.acompletion(**kwargs)
             return self._parse_response(response)
         except Exception as e:
             # Return error as content for graceful handling


### PR DESCRIPTION
#2145 

**环境**
litellm版本：`litellm==1.82.3`

**复现**
每次启动agent聊天都会有这个提示
```shell
(base) PS E:\Program\nanobot>  python -m nanobot agent -m "你好"
10:03:42 - LiteLLM:WARNING: get_model_cost_map.py:271 - LiteLLM: Failed to fetch remote model cost map from https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json: The read operation timed out. Falling back to local backup.
```
**原因**
nanobot/providers/__init__.py:4:1 里有这句：
`from nanobot.providers.litellm_provider import LiteLLMProvider`

**解决方法**
只在真实使用到LiteLLMProvider的时候，才导入对应的包

另外若的确使用LiteLLMProvider，可以设置下面的环境变量解决
`LITELLM_LOCAL_MODEL_COST_MAP=true`