### PR TITLE
fix: When using custom_provider, a prompt "LiteLLM:WARNING" will still appear during conversation

### DIFF
--- a/nanobot/providers/__init__.py
+++ b/nanobot/providers/__init__.py
@@ -1,5 +1,30 @@
 """LLM provider abstraction module."""
 
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nanobot.providers.base import LLMProvider, LLMResponse
 
-__all__ = ["LLMProvider", "LLMResponse"]
+__all__ = ["LLMProvider", "LLMResponse", "LiteLLMProvider", "OpenAICodexProvider", "AzureOpenAIProvider"]
+
+_LAZY_IMPORTS = {
+    "LiteLLMProvider": ".litellm_provider",
+    "OpenAICodexProvider": ".openai_codex_provider",
+    "AzureOpenAIProvider": ".azure_openai_provider",
+}
+
+if TYPE_CHECKING:
+    from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+    from nanobot.providers.litellm_provider import LiteLLMProvider
+    from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+
+
+def __getattr__(name: str):
+    """Lazily expose provider implementations without importing all backends up front."""
+    module_name = _LAZY_IMPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(module_name, __name__)
+    return getattr(module, name)

--- a/tests/test_providers_init.py
+++ b/tests/test_providers_init.py
@@ -1,0 +1,37 @@
+"""Tests for lazy provider exports from nanobot.providers."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_importing_providers_package_is_lazy(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, "nanobot.providers", raising=False)
+    monkeypatch.delitem(sys.modules, "nanobot.providers.litellm_provider", raising=False)
+    monkeypatch.delitem(sys.modules, "nanobot.providers.openai_codex_provider", raising=False)
+    monkeypatch.delitem(sys.modules, "nanobot.providers.azure_openai_provider", raising=False)
+
+    providers = importlib.import_module("nanobot.providers")
+
+    assert "nanobot.providers.litellm_provider" not in sys.modules
+    assert "nanobot.providers.openai_codex_provider" not in sys.modules
+    assert "nanobot.providers.azure_openai_provider" not in sys.modules
+    assert providers.__all__ == [
+        "LLMProvider",
+        "LLMResponse",
+        "LiteLLMProvider",
+        "OpenAICodexProvider",
+        "AzureOpenAIProvider",
+    ]
+
+
+def test_explicit_provider_import_still_works(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, "nanobot.providers", raising=False)
+    monkeypatch.delitem(sys.modules, "nanobot.providers.litellm_provider", raising=False)
+
+    namespace: dict[str, object] = {}
+    exec("from nanobot.providers import LiteLLMProvider", namespace)
+
+    assert namespace["LiteLLMProvider"].__name__ == "LiteLLMProvider"
+    assert "nanobot.providers.litellm_provider" in sys.modules


### PR DESCRIPTION
#2145 

**环境**
provider：custom
litellm版本：`litellm==1.82.3`

**复现**
每次启动agent聊天都会有这个提示
```shell
(base) PS E:\Program\nanobot>  python -m nanobot agent -m "你好"
10:03:42 - LiteLLM:WARNING: get_model_cost_map.py:271 - LiteLLM: Failed to fetch remote model cost map from https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json: The read operation timed out. Falling back to local backup.
```
**原因**
nanobot/providers/__init__.py:4:1 里有这句：
`from nanobot.providers.litellm_provider import LiteLLMProvider`

**解决方法**
项目中没有使用顶级包导入的风格(from nanobot.providers import xxx)，优化下自动导入

