### PR TITLE
feat: add Loop Guard to prevent infinite tool call loops

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -212,6 +212,9 @@ class AgentLoop:
         iteration = 0
         final_content = None
         tools_used: list[str] = []
+        
+        recent_tool_calls: list[str] = []
+        LOOP_GUARD_THRESHOLD = 4
 
         while iteration < self.max_iterations:
             iteration += 1
@@ -225,6 +228,21 @@ class AgentLoop:
             )
 
             if response.has_tool_calls:
+                # Loop Guard check
+                current_calls_sig = json.dumps([
+                    {"name": tc.name, "args": tc.arguments} 
+                    for tc in response.tool_calls
+                ], sort_keys=True)
+                
+                recent_tool_calls.append(current_calls_sig)
+                if len(recent_tool_calls) > LOOP_GUARD_THRESHOLD:
+                    recent_tool_calls.pop(0)
+                    
+                if len(recent_tool_calls) == LOOP_GUARD_THRESHOLD and len(set(recent_tool_calls)) == 1:
+                    logger.error("Loop Guard triggered: identical tool calls repeated {} times.", LOOP_GUARD_THRESHOLD)
+                    final_content = "I've stopped processing because I got stuck in a loop repeating the same actions. Please check my previous steps or rephrase your request."
+                    break
+
                 if on_progress:
                     thought = self._strip_think(response.content)
                     if thought:


### PR DESCRIPTION
## Description
This PR introduces a **Loop Guard** mechanism to prevent the agent from getting stuck in infinite tool call loops.

### The Problem
Currently, if the LLM gets stuck and repeatedly calls the same tool with the exact same arguments (e.g., failing to read a file, or repeatedly sending the same message), it will burn through the entire `max_iterations` limit (default 40), wasting tokens and potentially spamming external APIs or chat channels.

### The Solution
Added a simple tracking mechanism in `_run_agent_loop`:
- Tracks the last `LOOP_GUARD_THRESHOLD` (set to 4) tool calls.
- If the exact same tool calls (same names and arguments) are repeated 4 times in a row, the loop is forcefully broken.
- The agent returns a graceful error message explaining that it got stuck in a loop, rather than silently burning tokens or crashing.

This addresses issues like #1240 (message tool loop) and #425 (write_file loop).