### PR TITLE
perf(loop): 并行化工具执行，提升多工具场景响应速度

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -250,12 +250,16 @@ class AgentLoop:
 
                 # Execute all tool calls concurrently — the LLM batches
                 # independent calls in a single response on purpose.
+                # return_exceptions=True ensures all results are collected
+                # even if one tool is cancelled or raises BaseException.
                 results = await asyncio.gather(*(
                     self.tools.execute(tc.name, tc.arguments)
                     for tc in response.tool_calls
-                ))
+                ), return_exceptions=True)
 
                 for tool_call, result in zip(response.tool_calls, results):
+                    if isinstance(result, BaseException):
+                        result = f"Error: {type(result).__name__}: {result}"
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )


### PR DESCRIPTION
## 概述

将 `_run_agent_loop` 中串行执行的 tool calls 改为 `asyncio.gather` 并行执行。

Related: #1378

## 问题

当前 LLM 在单次响应中返回 N 个 tool calls 时，代码以串行 for 循环逐个 await 执行，总耗时 = sum(每个工具时间)。

然而 LLM 将多个 tool calls 放在同一响应中，正是因为它们是独立的、可以并行执行的。

## 改动

| 文件 | 变更 |
|---|---|
| `nanobot/agent/loop.py` | tool calls 执行从串行 `for` 循环改为 `asyncio.gather` 并行 |

**改动前：**
```python
for tool_call in response.tool_calls:
    result = await self.tools.execute(tool_call.name, tool_call.arguments)
    messages = self.context.add_tool_result(messages, tool_call.id, tool_call.name, result)
```

**改动后：**
```python
results = await asyncio.gather(*(
    self.tools.execute(tc.name, tc.arguments)
    for tc in response.tool_calls
))
for tool_call, result in zip(response.tool_calls, results):
    messages = self.context.add_tool_result(messages, tool_call.id, tool_call.name, result)
```

## 预期效果

- N 个工具并行执行，总耗时从 **sum(time_i)** 降至 **max(time_i)**
- 典型场景：LLM 同时调用 `web_search` + `read_file` + `list_dir`，原先串行 3-5s，并行后 ~1-2s
- 工具结果仍按原始顺序添加到 messages，保持 OpenAI 消息格式正确

## 向后兼容性

- 单工具调用时行为与原先完全一致（`asyncio.gather` 退化为单个 await）
- 工具执行顺序不变（logging 和 results 都保持原顺序）