### PR TITLE
perf(tools): 缓存 Tool Definitions，避免循环内重复构建

### DIFF
--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -14,14 +14,17 @@ class ToolRegistry:
 
     def __init__(self):
         self._tools: dict[str, Tool] = {}
+        self._definitions_cache: list[dict[str, Any]] | None = None
 
     def register(self, tool: Tool) -> None:
         """Register a tool."""
         self._tools[tool.name] = tool
+        self._definitions_cache = None
 
     def unregister(self, name: str) -> None:
         """Unregister a tool by name."""
         self._tools.pop(name, None)
+        self._definitions_cache = None
 
     def get(self, name: str) -> Tool | None:
         """Get a tool by name."""
@@ -43,24 +46,26 @@ class ToolRegistry:
         return name if isinstance(name, str) else ""
 
     def get_definitions(self) -> list[dict[str, Any]]:
-        """Get tool definitions with stable ordering for cache-friendly prompts.
+        """Get tool definitions with stable ordering (cached until tools change).
 
         Built-in tools are sorted first as a stable prefix, then MCP tools are
-        sorted and appended.
+        sorted and appended. Result is cached and invalidated on register/unregister.
         """
-        definitions = [tool.to_schema() for tool in self._tools.values()]
-        builtins: list[dict[str, Any]] = []
-        mcp_tools: list[dict[str, Any]] = []
-        for schema in definitions:
-            name = self._schema_name(schema)
-            if name.startswith("mcp_"):
-                mcp_tools.append(schema)
-            else:
-                builtins.append(schema)
+        if self._definitions_cache is None:
+            definitions = [tool.to_schema() for tool in self._tools.values()]
+            builtins: list[dict[str, Any]] = []
+            mcp_tools: list[dict[str, Any]] = []
+            for schema in definitions:
+                name = self._schema_name(schema)
+                if name.startswith("mcp_"):
+                    mcp_tools.append(schema)
+                else:
+                    builtins.append(schema)
 
-        builtins.sort(key=self._schema_name)
-        mcp_tools.sort(key=self._schema_name)
-        return builtins + mcp_tools
+            builtins.sort(key=self._schema_name)
+            mcp_tools.sort(key=self._schema_name)
+            self._definitions_cache = builtins + mcp_tools
+        return self._definitions_cache
 
     def prepare_call(
         self,


### PR DESCRIPTION
## 概述

为 `ToolRegistry.get_definitions()` 添加缓存，避免在 agent loop 每次迭代中重复遍历工具集并调用 `to_schema()`。

## 问题

`get_definitions()` 在 `_run_agent_loop` 的每次迭代中被调用（第 197 行），每次都遍历所有已注册工具并调用 `to_schema()` 构建 JSON schema。但工具集在循环运行期间不会变化，这是不必要的重复计算。

## 改动

| 文件 | 变更 |
|---|---|
| `nanobot/agent/tools/registry.py` | 新增 `_definitions_cache` 字段；`register`/`unregister` 时清缓存；`get_definitions` 从缓存返回 |

**缓存策略：**
- `_definitions_cache` 初始为 `None`
- `get_definitions()` 首次调用时构建并缓存
- `register()` 或 `unregister()` 时将缓存置为 `None`（按需重建）

## 向后兼容性

- 外部行为完全不变
- 工具动态注册/注销后缓存自动失效
- 单次 agent loop 运行期间（工具集不变）只构建一次 schema 列表

Made with [Cursor](https://cursor.com)