### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -79,6 +79,7 @@ class ProvidersConfig(Base):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
+    novita: ProviderConfig = Field(default_factory=ProviderConfig)  # Novita AI API gateway
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -400,7 +400,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         model_overrides=(),
     ),
     # Novita AI: OpenAI-compatible API gateway.
-    # Default model: deepseek/deepseek-v3.2; also supports zai-org/glm-5, minimax/minimax-m2.5.
+    # Default model: moonshotai/kimi-k2.5; also supports deepseek/deepseek-v3.2, zai-org/glm-5, minimax/minimax-m2.5.
     ProviderSpec(
         name="novita",
         keywords=("novita",),

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -399,6 +399,24 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         strip_model_prefix=False,
         model_overrides=(),
     ),
+    # Novita AI: OpenAI-compatible API gateway.
+    # Default model: deepseek/deepseek-v3.2; also supports zai-org/glm-5, minimax/minimax-m2.5.
+    ProviderSpec(
+        name="novita",
+        keywords=("novita",),
+        env_key="NOVITA_API_KEY",
+        display_name="Novita AI",
+        litellm_prefix="openai",  # deepseek/deepseek-v3.2 → openai/deepseek/deepseek-v3.2
+        skip_prefixes=(),
+        env_extras=(),
+        is_gateway=True,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="novita",
+        default_api_base="https://api.novita.ai/openai",
+        strip_model_prefix=False,
+        model_overrides=(),
+    ),
     # === Local deployment (matched by config key, NOT by api_base) =========
     # vLLM / any OpenAI-compatible local server.
     # Detected when config key is "vllm" (provider_name="vllm").

--- a/tests/test_novita_provider.py
+++ b/tests/test_novita_provider.py
@@ -1,0 +1,114 @@
+"""Tests for the Novita AI provider integration.
+
+Validates that:
+- The ProviderSpec is registered correctly with expected metadata.
+- Model names are prefixed correctly for LiteLLM routing via OpenAI-compatible API.
+- Auto-detection by api_base keyword works.
+- Default model (deepseek/deepseek-v3.2) and multi-model IDs route correctly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nanobot.providers.litellm_provider import LiteLLMProvider
+from nanobot.providers.registry import find_by_name, find_gateway
+
+
+def _fake_response(content: str = "ok") -> SimpleNamespace:
+    """Build a minimal acompletion-shaped response object."""
+    message = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning_content=None,
+        thinking_blocks=None,
+    )
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def test_novita_spec_exists() -> None:
+    """Novita AI must be registered in the provider registry."""
+    spec = find_by_name("novita")
+    assert spec is not None
+    assert spec.display_name == "Novita AI"
+    assert spec.env_key == "NOVITA_API_KEY"
+    assert spec.is_gateway is True
+    assert spec.default_api_base == "https://api.novita.ai/openai"
+    assert spec.litellm_prefix == "openai"
+
+
+def test_novita_detected_by_base_keyword() -> None:
+    """Novita should be auto-detected when api_base contains 'novita'."""
+    spec = find_gateway(api_base="https://api.novita.ai/openai")
+    assert spec is not None
+    assert spec.name == "novita"
+
+
+@pytest.mark.asyncio
+async def test_novita_prefixes_default_model() -> None:
+    """Default model deepseek/deepseek-v3.2 should get openai/ prefix for LiteLLM."""
+    mock_acompletion = AsyncMock(return_value=_fake_response())
+
+    with patch("nanobot.providers.litellm_provider.acompletion", mock_acompletion):
+        provider = LiteLLMProvider(
+            api_key="novita-test-key",
+            api_base="https://api.novita.ai/openai",
+            default_model="deepseek/deepseek-v3.2",
+            provider_name="novita",
+        )
+        await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            model="deepseek/deepseek-v3.2",
+        )
+
+    call_kwargs = mock_acompletion.call_args.kwargs
+    assert call_kwargs["model"] == "openai/deepseek/deepseek-v3.2", (
+        "Novita models need openai/ prefix for LiteLLM OpenAI-compatible routing"
+    )
+
+
+@pytest.mark.asyncio
+async def test_novita_prefixes_glm_model() -> None:
+    """Multi-model: zai-org/glm-5 should also get openai/ prefix."""
+    mock_acompletion = AsyncMock(return_value=_fake_response())
+
+    with patch("nanobot.providers.litellm_provider.acompletion", mock_acompletion):
+        provider = LiteLLMProvider(
+            api_key="novita-test-key",
+            api_base="https://api.novita.ai/openai",
+            default_model="zai-org/glm-5",
+            provider_name="novita",
+        )
+        await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            model="zai-org/glm-5",
+        )
+
+    call_kwargs = mock_acompletion.call_args.kwargs
+    assert call_kwargs["model"] == "openai/zai-org/glm-5"
+
+
+@pytest.mark.asyncio
+async def test_novita_prefixes_minimax_model() -> None:
+    """Multi-model: minimax/minimax-m2.5 should also get openai/ prefix."""
+    mock_acompletion = AsyncMock(return_value=_fake_response())
+
+    with patch("nanobot.providers.litellm_provider.acompletion", mock_acompletion):
+        provider = LiteLLMProvider(
+            api_key="novita-test-key",
+            api_base="https://api.novita.ai/openai",
+            default_model="minimax/minimax-m2.5",
+            provider_name="novita",
+        )
+        await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            model="minimax/minimax-m2.5",
+        )
+
+    call_kwargs = mock_acompletion.call_args.kwargs
+    assert call_kwargs["model"] == "openai/minimax/minimax-m2.5"

--- a/tests/test_novita_provider.py
+++ b/tests/test_novita_provider.py
@@ -4,7 +4,7 @@ Validates that:
 - The ProviderSpec is registered correctly with expected metadata.
 - Model names are prefixed correctly for LiteLLM routing via OpenAI-compatible API.
 - Auto-detection by api_base keyword works.
-- Default model (deepseek/deepseek-v3.2) and multi-model IDs route correctly.
+- Default model (moonshotai/kimi-k2.5) and multi-model IDs route correctly.
 """
 
 from __future__ import annotations
@@ -51,23 +51,23 @@ def test_novita_detected_by_base_keyword() -> None:
 
 @pytest.mark.asyncio
 async def test_novita_prefixes_default_model() -> None:
-    """Default model deepseek/deepseek-v3.2 should get openai/ prefix for LiteLLM."""
+    """Default model moonshotai/kimi-k2.5 should get openai/ prefix for LiteLLM."""
     mock_acompletion = AsyncMock(return_value=_fake_response())
 
     with patch("nanobot.providers.litellm_provider.acompletion", mock_acompletion):
         provider = LiteLLMProvider(
             api_key="novita-test-key",
             api_base="https://api.novita.ai/openai",
-            default_model="deepseek/deepseek-v3.2",
+            default_model="moonshotai/kimi-k2.5",
             provider_name="novita",
         )
         await provider.chat(
             messages=[{"role": "user", "content": "hello"}],
-            model="deepseek/deepseek-v3.2",
+            model="moonshotai/kimi-k2.5",
         )
 
     call_kwargs = mock_acompletion.call_args.kwargs
-    assert call_kwargs["model"] == "openai/deepseek/deepseek-v3.2", (
+    assert call_kwargs["model"] == "openai/moonshotai/kimi-k2.5", (
         "Novita models need openai/ prefix for LiteLLM OpenAI-compatible routing"
     )
 


### PR DESCRIPTION
## Summary
- Register Novita AI as an OpenAI-compatible gateway provider (`is_gateway=True`)
- Endpoint: `https://api.novita.ai/openai`, env var: `NOVITA_API_KEY`
- Default model: `deepseek/deepseek-v3.2`; also supports `zai-org/glm-5` and `minimax/minimax-m2.5`
- Auto-detection by `novita` keyword in `api_base` URL

## Changes
- `nanobot/providers/registry.py` — added `ProviderSpec` for Novita AI
- `nanobot/config/schema.py` — added `novita` field to `ProvidersConfig`
- `tests/test_novita_provider.py` — 5 tests covering spec registration, auto-detection, and model prefixing

## Test plan
- [x] `test_novita_spec_exists` — registry metadata is correct
- [x] `test_novita_detected_by_base_keyword` — auto-detection by api_base
- [x] `test_novita_prefixes_default_model` — deepseek/deepseek-v3.2 gets `openai/` prefix
- [x] `test_novita_prefixes_glm_model` — zai-org/glm-5 routing
- [x] `test_novita_prefixes_minimax_model` — minimax/minimax-m2.5 routing
