### PR TITLE
feat(whatsapp): add group_policy to control bot response behavior in groups

### DIFF
--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import mimetypes
 from collections import OrderedDict
-from typing import Any
+from typing import Any, Literal
 
 from loguru import logger
 
@@ -23,6 +23,7 @@ class WhatsAppConfig(Base):
     bridge_url: str = "ws://localhost:3001"
     bridge_token: str = ""
     allow_from: list[str] = Field(default_factory=list)
+    group_policy: Literal["open", "mention"] = "open"  # "open" responds to all, "mention" only when @mentioned
 
 
 class WhatsAppChannel(BaseChannel):
@@ -138,6 +139,13 @@ class WhatsAppChannel(BaseChannel):
                     self._processed_message_ids.popitem(last=False)
 
             # Extract just the phone number or lid as chat_id
+            is_group = data.get("isGroup", False)
+            was_mentioned = data.get("wasMentioned", False)
+
+            if is_group and getattr(self.config, "group_policy", "open") == "mention":
+                if not was_mentioned:
+                    return
+
             user_id = pn if pn else sender
             sender_id = user_id.split("@")[0] if "@" in user_id else user_id
             logger.info("Sender {}", sender)


### PR DESCRIPTION
## Summary

Add `group_policy` configuration option to `WhatsAppConfig`, allowing users to control whether the bot responds to all messages in group chats or only when explicitly mentioned.

## Problem

Fixes #2211

Currently, when the bot is added to a WhatsApp group, it responds to **every** message regardless of user intent. There is no way to configure the bot to only respond when @mentioned. This mirrors the issue previously solved for Telegram in #1389.

## Changes

### `nanobot/channels/whatsapp.py`
- Added `group_policy: Literal["open", "mention"] = "open"` to `WhatsAppConfig`
- Added group policy enforcement in `_handle_bridge_message()`
- When `group_policy` is `"mention"`, messages in group chats are skipped unless `wasMentioned` is true in the bridge payload.
- Private (DM) messages are unaffected and always processed.

*Note: This relies on the `wasMentioned` field from the bridge payload, which is being added in PR #2070.*

## Usage

```json
{
  "channels": {
    "whatsapp": {
      "enabled": true,
      "bridge_url": "ws://localhost:3001",
      "groupPolicy": "mention"
    }
  }
}
```

## Backward Compatibility

- Default value is `"open"` (existing behavior), so this is a non-breaking change.
- No changes to private/DM message handling.