### PR TITLE
feat(security):support `{env:VAR}` syntax for environment variable references

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -1,13 +1,11 @@
 """Configuration loading utilities."""
 
-import copy
 import json
 from pathlib import Path
 from typing import Any
 
 from nanobot.config.schema import Config
-from nanobot.config.secret_resolver import resolve_config, _REF_PATTERN
-
+from nanobot.config.secret_resolver import has_env_ref, resolve_config, resolve_env_vars
 
 # Global variable to store current config path (for multi-instance support)
 _current_config_path: Path | None = None
@@ -45,10 +43,10 @@ def load_config(config_path: Path | None = None) -> Config:
             raw_data = _migrate_config(raw_data)
 
             # Record original values of fields containing {env:VAR} references
-            env_refs: dict[str, Any] = {}
+            env_refs: dict[str, dict[str, str]] = {}
             _collect_env_refs(raw_data, "", env_refs)
 
-            resolved_data = resolve_config(copy.deepcopy(raw_data))  # Resolve {env:VAR} references
+            resolved_data = resolve_config(raw_data)
             config = Config.model_validate(resolved_data)
             config._env_refs = env_refs  # Preserve original {env:VAR} values for save_config
             return config
@@ -70,8 +68,7 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
     path = config_path or get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Use raw unresolved data if available to preserve {env:VAR} placeholders
-    # Use model_dump as base, but restore {env:VAR} references from original values
+    # Preserve original {env:VAR} placeholders only for values unchanged since load.
     data = config.model_dump(by_alias=True)
     if config._env_refs:
         _restore_env_refs(data, config._env_refs)
@@ -90,8 +87,8 @@ def _migrate_config(data: dict) -> dict:
     return data
 
 
-def _collect_env_refs(obj: Any, path: str, refs: dict[str, Any]) -> None:
-    """Collect field paths and original values for fields containing {env:VAR}."""
+def _collect_env_refs(obj: Any, path: str, refs: dict[str, dict[str, str]]) -> None:
+    """Collect field paths with original and resolved values for {env:VAR} strings."""
     if isinstance(obj, dict):
         for key, value in obj.items():
             child_path = f"{path}.{key}" if path else key
@@ -99,24 +96,97 @@ def _collect_env_refs(obj: Any, path: str, refs: dict[str, Any]) -> None:
     elif isinstance(obj, list):
         for idx, item in enumerate(obj):
             _collect_env_refs(item, f"{path}[{idx}]", refs)
-    elif isinstance(obj, str) and _REF_PATTERN.search(obj):
-        refs[path] = obj
+    elif isinstance(obj, str) and has_env_ref(obj):
+        refs[path] = {
+            "original": obj,
+            "resolved": resolve_env_vars(obj),
+        }
 
 
-def _restore_env_refs(data: dict, refs: dict[str, Any]) -> None:
-    """Restore original {env:VAR} values into data dict."""
-    for path, original_value in refs.items():
-        _set_by_path(data, path, original_value)
+def _restore_env_refs(data: dict, refs: dict[str, dict[str, str]]) -> None:
+    """Restore original {env:VAR} values into unchanged fields."""
+    for path, record in refs.items():
+        found, current_value = _get_by_path(data, path)
+        if not found:
+            continue
+        if current_value == record["resolved"]:
+            _set_by_path(data, path, record["original"])
 
 
-def _set_by_path(data: dict, path: str, value: Any) -> None:
-    """Set a value in nested dict by dot-notation path like 'providers.zhipu.apiKey'."""
-    parts = path.split(".")
+def _parse_path(path: str) -> list[str | int]:
+    """Parse dotted/list path like providers.openai.apiKey or args[0]."""
+    tokens: list[str | int] = []
+    buf = ""
+    i = 0
+    while i < len(path):
+        ch = path[i]
+        if ch == ".":
+            if buf:
+                tokens.append(buf)
+                buf = ""
+            i += 1
+            continue
+        if ch == "[":
+            if buf:
+                tokens.append(buf)
+                buf = ""
+            close = path.find("]", i + 1)
+            if close == -1:
+                return []
+            idx = path[i + 1 : close]
+            if not idx.isdigit():
+                return []
+            tokens.append(int(idx))
+            i = close + 1
+            continue
+        buf += ch
+        i += 1
+    if buf:
+        tokens.append(buf)
+    return tokens
+
+
+def _get_by_path(data: Any, path: str) -> tuple[bool, Any]:
+    """Get value from nested dict/list path."""
+    tokens = _parse_path(path)
+    if not tokens:
+        return False, None
+
     current = data
-    for part in parts[:-1]:
-        if part not in current:
-            return
-        current = current[part]
-    last_key = parts[-1]
-    if isinstance(current, dict) and last_key in current:
-        current[last_key] = value
+    for token in tokens:
+        if isinstance(token, int):
+            if not isinstance(current, list) or token >= len(current):
+                return False, None
+            current = current[token]
+        else:
+            if not isinstance(current, dict) or token not in current:
+                return False, None
+            current = current[token]
+    return True, current
+
+
+def _set_by_path(data: Any, path: str, value: Any) -> None:
+    """Set value in nested dict/list path."""
+    tokens = _parse_path(path)
+    if not tokens:
+        return
+
+    current = data
+    for token in tokens[:-1]:
+        if isinstance(token, int):
+            if not isinstance(current, list) or token >= len(current):
+                return
+            current = current[token]
+        else:
+            if not isinstance(current, dict) or token not in current:
+                return
+            current = current[token]
+
+    last = tokens[-1]
+    if isinstance(last, int):
+        if isinstance(current, list) and last < len(current):
+            current[last] = value
+        return
+
+    if isinstance(current, dict) and last in current:
+        current[last] = value

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from nanobot.config.schema import Config
+from nanobot.config.secret_resolver import resolve_config
 
 
 # Global variable to store current config path (for multi-instance support)
@@ -40,6 +41,7 @@ def load_config(config_path: Path | None = None) -> Config:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
             data = _migrate_config(data)
+            data = resolve_config(data)  # Resolve {env:VAR} references
             return Config.model_validate(data)
         except (json.JSONDecodeError, ValueError) as e:
             print(f"Warning: Failed to load config from {path}: {e}")

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -1,10 +1,12 @@
 """Configuration loading utilities."""
 
+import copy
 import json
 from pathlib import Path
+from typing import Any
 
 from nanobot.config.schema import Config
-from nanobot.config.secret_resolver import resolve_config
+from nanobot.config.secret_resolver import resolve_config, _REF_PATTERN
 
 
 # Global variable to store current config path (for multi-instance support)
@@ -39,10 +41,17 @@ def load_config(config_path: Path | None = None) -> Config:
     if path.exists():
         try:
             with open(path, encoding="utf-8") as f:
-                data = json.load(f)
-            data = _migrate_config(data)
-            data = resolve_config(data)  # Resolve {env:VAR} references
-            return Config.model_validate(data)
+                raw_data = json.load(f)
+            raw_data = _migrate_config(raw_data)
+
+            # Record original values of fields containing {env:VAR} references
+            env_refs: dict[str, Any] = {}
+            _collect_env_refs(raw_data, "", env_refs)
+
+            resolved_data = resolve_config(copy.deepcopy(raw_data))  # Resolve {env:VAR} references
+            config = Config.model_validate(resolved_data)
+            config._env_refs = env_refs  # Preserve original {env:VAR} values for save_config
+            return config
         except (json.JSONDecodeError, ValueError) as e:
             print(f"Warning: Failed to load config from {path}: {e}")
             print("Using default configuration.")
@@ -61,7 +70,11 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
     path = config_path or get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    # Use raw unresolved data if available to preserve {env:VAR} placeholders
+    # Use model_dump as base, but restore {env:VAR} references from original values
     data = config.model_dump(by_alias=True)
+    if config._env_refs:
+        _restore_env_refs(data, config._env_refs)
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
@@ -75,3 +88,35 @@ def _migrate_config(data: dict) -> dict:
     if "restrictToWorkspace" in exec_cfg and "restrictToWorkspace" not in tools:
         tools["restrictToWorkspace"] = exec_cfg.pop("restrictToWorkspace")
     return data
+
+
+def _collect_env_refs(obj: Any, path: str, refs: dict[str, Any]) -> None:
+    """Collect field paths and original values for fields containing {env:VAR}."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            child_path = f"{path}.{key}" if path else key
+            _collect_env_refs(value, child_path, refs)
+    elif isinstance(obj, list):
+        for idx, item in enumerate(obj):
+            _collect_env_refs(item, f"{path}[{idx}]", refs)
+    elif isinstance(obj, str) and _REF_PATTERN.search(obj):
+        refs[path] = obj
+
+
+def _restore_env_refs(data: dict, refs: dict[str, Any]) -> None:
+    """Restore original {env:VAR} values into data dict."""
+    for path, original_value in refs.items():
+        _set_by_path(data, path, original_value)
+
+
+def _set_by_path(data: dict, path: str, value: Any) -> None:
+    """Set a value in nested dict by dot-notation path like 'providers.zhipu.apiKey'."""
+    parts = path.split(".")
+    current = data
+    for part in parts[:-1]:
+        if part not in current:
+            return
+        current = current[part]
+    last_key = parts[-1]
+    if isinstance(current, dict) and last_key in current:
+        current[last_key] = value

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -159,6 +159,9 @@ class Config(BaseSettings):
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
 
+    # Reserved field to store original {env:VAR} values for save_config
+    _env_refs: dict | None = None
+
     @property
     def workspace_path(self) -> Path:
         """Get expanded workspace path."""

--- a/nanobot/config/secret_resolver.py
+++ b/nanobot/config/secret_resolver.py
@@ -5,6 +5,7 @@ Supports {env:VARIABLE_NAME} syntax to reference environment variables.
 
 import os
 import re
+from typing import Any
 
 # Pattern matches {env:VAR_NAME} where VAR_NAME follows env var naming conventions
 _REF_PATTERN = re.compile(r"\{env:([A-Z_][A-Z0-9_]*)\}")
@@ -18,19 +19,22 @@ def resolve_env_vars(value: str) -> str:
 
     Returns:
         String with all {env:VAR} references replaced by their values.
-        Unresolved references are left unchanged.
+        Missing env vars resolve to empty string.
     """
+
     def replacer(match: re.Match[str]) -> str:
         var_name = match.group(1)
-        env_value = os.environ.get(var_name)
-        if env_value is None:
-            return match.group(0)  # Keep original if env var doesn't exist
-        return env_value
+        return os.environ.get(var_name, "")
 
     return _REF_PATTERN.sub(replacer, value)
 
 
-def resolve_config(obj):
+def has_env_ref(value: str) -> bool:
+    """Return True if string contains at least one {env:VAR} reference."""
+    return bool(_REF_PATTERN.search(value))
+
+
+def resolve_config(obj: Any) -> Any:
     """Recursively resolve {env:VAR} references in a configuration object.
 
     Args:

--- a/nanobot/config/secret_resolver.py
+++ b/nanobot/config/secret_resolver.py
@@ -19,12 +19,15 @@ def resolve_env_vars(value: str) -> str:
 
     Returns:
         String with all {env:VAR} references replaced by their values.
-        Missing env vars resolve to empty string.
+        Missing env vars are left unchanged.
     """
 
     def replacer(match: re.Match[str]) -> str:
         var_name = match.group(1)
-        return os.environ.get(var_name, "")
+        env_value = os.environ.get(var_name)
+        if env_value is None:
+            return match.group(0)
+        return env_value
 
     return _REF_PATTERN.sub(replacer, value)
 

--- a/nanobot/config/secret_resolver.py
+++ b/nanobot/config/secret_resolver.py
@@ -1,0 +1,48 @@
+"""Secret reference resolver for configuration.
+
+Supports {env:VARIABLE_NAME} syntax to reference environment variables.
+"""
+
+import os
+import re
+
+# Pattern matches {env:VAR_NAME} where VAR_NAME follows env var naming conventions
+_REF_PATTERN = re.compile(r"\{env:([A-Z_][A-Z0-9_]*)\}")
+
+
+def resolve_env_vars(value: str) -> str:
+    """Resolve {env:VAR} references in a string.
+
+    Args:
+        value: String that may contain {env:VAR} references.
+
+    Returns:
+        String with all {env:VAR} references replaced by their values.
+        Unresolved references are left unchanged.
+    """
+    def replacer(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        env_value = os.environ.get(var_name)
+        if env_value is None:
+            return match.group(0)  # Keep original if env var doesn't exist
+        return env_value
+
+    return _REF_PATTERN.sub(replacer, value)
+
+
+def resolve_config(obj):
+    """Recursively resolve {env:VAR} references in a configuration object.
+
+    Args:
+        obj: Configuration value (str, dict, list, or other).
+
+    Returns:
+        Configuration with all {env:VAR} references resolved.
+    """
+    if isinstance(obj, str):
+        return resolve_env_vars(obj)
+    if isinstance(obj, dict):
+        return {k: resolve_config(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [resolve_config(item) for item in obj]
+    return obj

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -76,7 +76,9 @@ def test_onboard_refresh_rewrites_legacy_config_template(tmp_path, monkeypatch) 
     )
 
     monkeypatch.setattr("nanobot.config.loader.get_config_path", lambda: config_path)
-    monkeypatch.setattr("nanobot.cli.commands.get_workspace_path", lambda _workspace=None: workspace)
+    monkeypatch.setattr(
+        "nanobot.cli.commands.get_workspace_path", lambda _workspace=None: workspace
+    )
 
     result = runner.invoke(app, ["onboard"], input="n\n")
 
@@ -109,7 +111,9 @@ def test_onboard_refresh_backfills_missing_channel_fields(tmp_path, monkeypatch)
     )
 
     monkeypatch.setattr("nanobot.config.loader.get_config_path", lambda: config_path)
-    monkeypatch.setattr("nanobot.cli.commands.get_workspace_path", lambda _workspace=None: workspace)
+    monkeypatch.setattr(
+        "nanobot.cli.commands.get_workspace_path", lambda _workspace=None: workspace
+    )
     monkeypatch.setattr(
         "nanobot.channels.registry.discover_all",
         lambda: {
@@ -130,3 +134,107 @@ def test_onboard_refresh_backfills_missing_channel_fields(tmp_path, monkeypatch)
     assert result.exit_code == 0
     saved = json.loads(config_path.read_text(encoding="utf-8"))
     assert saved["channels"]["qq"]["msgFormat"] == "plain"
+
+
+def test_env_ref_round_trip_preserves_placeholder_after_save(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "openai": {
+                        "apiKey": "{env:OPENAI_API_KEY}",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-runtime")
+
+    config = load_config(config_path)
+    assert config.providers.openai.api_key == "sk-runtime"
+
+    save_config(config, config_path)
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["providers"]["openai"]["apiKey"] == "{env:OPENAI_API_KEY}"
+
+
+def test_env_ref_in_list_round_trip_preserves_placeholder(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "tools": {
+                    "mcpServers": {
+                        "demo": {
+                            "command": "npx",
+                            "args": [
+                                "-y",
+                                "run-tool",
+                                "--token",
+                                "{env:MCP_TOKEN}",
+                            ],
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MCP_TOKEN", "runtime-token")
+
+    config = load_config(config_path)
+    assert config.tools.mcp_servers["demo"].args[3] == "runtime-token"
+
+    save_config(config, config_path)
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["tools"]["mcpServers"]["demo"]["args"][3] == "{env:MCP_TOKEN}"
+
+
+def test_save_keeps_intentional_in_memory_override_of_env_ref(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "openai": {
+                        "apiKey": "{env:OPENAI_API_KEY}",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+
+    config = load_config(config_path)
+    config.providers.openai.api_key = "sk-manual-override"
+
+    save_config(config, config_path)
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["providers"]["openai"]["apiKey"] == "sk-manual-override"
+
+
+def test_missing_env_ref_resolves_empty_at_runtime_but_persists_placeholder(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "openai": {
+                        "apiKey": "{env:MISSING_OPENAI_KEY}",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+    assert config.providers.openai.api_key == ""
+    assert config.get_provider_name("openai/gpt-4.1") is None
+
+    save_config(config, config_path)
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["providers"]["openai"]["apiKey"] == "{env:MISSING_OPENAI_KEY}"

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -216,7 +216,7 @@ def test_save_keeps_intentional_in_memory_override_of_env_ref(tmp_path, monkeypa
     assert saved["providers"]["openai"]["apiKey"] == "sk-manual-override"
 
 
-def test_missing_env_ref_resolves_empty_at_runtime_but_persists_placeholder(tmp_path) -> None:
+def test_missing_env_ref_stays_unresolved_and_persists_placeholder(tmp_path) -> None:
     config_path = tmp_path / "config.json"
     config_path.write_text(
         json.dumps(
@@ -232,8 +232,7 @@ def test_missing_env_ref_resolves_empty_at_runtime_but_persists_placeholder(tmp_
     )
 
     config = load_config(config_path)
-    assert config.providers.openai.api_key == ""
-    assert config.get_provider_name("openai/gpt-4.1") is None
+    assert config.providers.openai.api_key == "{env:MISSING_OPENAI_KEY}"
 
     save_config(config, config_path)
     saved = json.loads(config_path.read_text(encoding="utf-8"))

--- a/tests/test_secret_resolver.py
+++ b/tests/test_secret_resolver.py
@@ -21,8 +21,8 @@ class TestResolveEnvVars:
         monkeypatch.setenv("HOST", "example.com")
         assert resolve_env_vars("{env:USER}@{env:HOST}") == "alice@example.com"
 
-    def test_unresolved_var_becomes_empty(self) -> None:
-        assert resolve_env_vars("{env:NONEXISTENT_VAR_XYZ}") == ""
+    def test_unresolved_var_kept_unchanged(self) -> None:
+        assert resolve_env_vars("{env:NONEXISTENT_VAR_XYZ}") == "{env:NONEXISTENT_VAR_XYZ}"
 
     def test_empty_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EMPTY_VAR", "")

--- a/tests/test_secret_resolver.py
+++ b/tests/test_secret_resolver.py
@@ -1,7 +1,5 @@
 """Tests for secret_resolver module."""
 
-import os
-
 import pytest
 
 from nanobot.config.secret_resolver import resolve_config, resolve_env_vars
@@ -23,9 +21,8 @@ class TestResolveEnvVars:
         monkeypatch.setenv("HOST", "example.com")
         assert resolve_env_vars("{env:USER}@{env:HOST}") == "alice@example.com"
 
-    def test_unresolved_var_kept_unchanged(self) -> None:
-        # Environment variable that doesn't exist should remain as-is
-        assert resolve_env_vars("{env:NONEXISTENT_VAR_XYZ}") == "{env:NONEXISTENT_VAR_XYZ}"
+    def test_unresolved_var_becomes_empty(self) -> None:
+        assert resolve_env_vars("{env:NONEXISTENT_VAR_XYZ}") == ""
 
     def test_empty_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EMPTY_VAR", "")

--- a/tests/test_secret_resolver.py
+++ b/tests/test_secret_resolver.py
@@ -1,0 +1,99 @@
+"""Tests for secret_resolver module."""
+
+import os
+
+import pytest
+
+from nanobot.config.secret_resolver import resolve_config, resolve_env_vars
+
+
+class TestResolveEnvVars:
+    """Tests for resolve_env_vars function."""
+
+    def test_simple_replacement(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_VAR", "secret_value")
+        assert resolve_env_vars("{env:TEST_VAR}") == "secret_value"
+
+    def test_replacement_with_prefix_suffix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("API_KEY", "abc123")
+        assert resolve_env_vars("prefix-{env:API_KEY}-suffix") == "prefix-abc123-suffix"
+
+    def test_multiple_replacements(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("USER", "alice")
+        monkeypatch.setenv("HOST", "example.com")
+        assert resolve_env_vars("{env:USER}@{env:HOST}") == "alice@example.com"
+
+    def test_unresolved_var_kept_unchanged(self) -> None:
+        # Environment variable that doesn't exist should remain as-is
+        assert resolve_env_vars("{env:NONEXISTENT_VAR_XYZ}") == "{env:NONEXISTENT_VAR_XYZ}"
+
+    def test_empty_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("EMPTY_VAR", "")
+        assert resolve_env_vars("{env:EMPTY_VAR}") == ""
+
+    def test_no_env_refs_returns_unchanged(self) -> None:
+        assert resolve_env_vars("plain string") == "plain string"
+        assert resolve_env_vars("") == ""
+
+    def test_invalid_var_name_format_ignored(self) -> None:
+        # Lowercase should not match (env var names must be uppercase)
+        assert resolve_env_vars("{env:lowercase}") == "{env:lowercase}"
+        # Starting with number should not match
+        assert resolve_env_vars("{env:123VAR}") == "{env:123VAR}"
+
+
+class TestResolveConfig:
+    """Tests for resolve_config function."""
+
+    def test_resolve_dict_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SECRET_KEY", "my_secret")
+        config = {"api_key": "{env:SECRET_KEY}", "name": "test"}
+        resolved = resolve_config(config)
+        assert resolved["api_key"] == "my_secret"
+        assert resolved["name"] == "test"
+
+    def test_resolve_nested_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOT_TOKEN", "token123")
+        config = {"telegram": {"token": "{env:BOT_TOKEN}", "enabled": True}}
+        resolved = resolve_config(config)
+        assert resolved["telegram"]["token"] == "token123"
+        assert resolved["telegram"]["enabled"] is True
+
+    def test_resolve_list_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KEY1", "val1")
+        monkeypatch.setenv("KEY2", "val2")
+        config = ["{env:KEY1}", "static", "{env:KEY2}"]
+        resolved = resolve_config(config)
+        assert resolved == ["val1", "static", "val2"]
+
+    def test_resolve_nested_list_in_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("API_KEY", "key123")
+        config = {"allowed_keys": ["{env:API_KEY}", "default_key"]}
+        resolved = resolve_config(config)
+        assert resolved["allowed_keys"] == ["key123", "default_key"]
+
+    def test_non_string_types_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NUM", "42")
+        config = {"count": 42, "ratio": 3.14, "enabled": True, "name": None}
+        resolved = resolve_config(config)
+        assert resolved["count"] == 42
+        assert resolved["ratio"] == 3.14
+        assert resolved["enabled"] is True
+        assert resolved["name"] is None
+
+    def test_empty_structures(self) -> None:
+        assert resolve_config({}) == {}
+        assert resolve_config([]) == []
+
+    def test_real_world_provider_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ZHIPU_API_KEY", "zhipu_secret")
+        monkeypatch.setenv("OPENAI_API_KEY", "openai_secret")
+        config = {
+            "providers": {
+                "zhipu": {"apiKey": "{env:ZHIPU_API_KEY}", "apiBase": "https://api.zhipu.cn"},
+                "openai": {"apiKey": "{env:OPENAI_API_KEY}", "apiBase": None},
+            }
+        }
+        resolved = resolve_config(config)
+        assert resolved["providers"]["zhipu"]["apiKey"] == "zhipu_secret"
+        assert resolved["providers"]["openai"]["apiKey"] == "openai_secret"


### PR DESCRIPTION
## Summary

Adds support for referencing environment variables in `config.json` using `{env:VAR_NAME}` syntax. This allows sensitive values like API keys to be stored in environment variables instead of plain text in the config file.

## Usage

```json
{
  "providers": {
    "zhipu": {
      "apiKey": "{env:ZHIPU_API_KEY}",
      "apiBase": "https://open.bigmodel.cn/api/coding/paas/v4"
    },
    "openai": {
      "apiKey": "{env:OPENAI_API_KEY}"
    }
  }
}
```

Set the environment variable before running:

```bash
export ZHIPU_API_KEY="your-secret-key"
uv run nanobot agent
```

## Behavior

- `{env:VAR_NAME}` is replaced with the value of `VAR_NAME` environment variable
- If the environment variable is not set, the placeholder is kept unchanged
- Works with nested configs, lists, and mixed content
- Resolution happens once at config load time

## Changes

| File | Change |
|------|--------|
| `nanobot/config/secret_resolver.py` | New module with `resolve_env_vars()` and `resolve_config()` |
| `nanobot/config/loader.py` | Call `resolve_config()` after loading JSON |
| `tests/test_secret_resolver.py` | 14 test cases |

## Test Plan

- [x] Unit tests for `resolve_env_vars()` function
- [x] Unit tests for `resolve_config()` recursive resolution
- [x] Tests for edge cases (missing vars, empty values, invalid formats)
- [x] Manual test with `nanobot agent` using `{env:ZHIPU_API_KEY}`
