### PR TITLE
agent: wait for outbound message delivery acknowledgement

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -1,5 +1,6 @@
 """Message tool for sending messages to users."""
 
+import asyncio
 from typing import Any, Awaitable, Callable
 
 from nanobot.agent.tools.base import Tool
@@ -97,10 +98,13 @@ class MessageTool(Tool):
             metadata={
                 "message_id": message_id,
             },
+            delivery_future=asyncio.get_running_loop().create_future(),
         )
 
         try:
             await self._send_callback(msg)
+            if msg.delivery_future is not None:
+                await msg.delivery_future
             if channel == self._default_channel and chat_id == self._default_chat_id:
                 self._sent_in_turn = True
             media_info = f" with {len(media)} attachments" if media else ""

--- a/nanobot/bus/events.py
+++ b/nanobot/bus/events.py
@@ -1,5 +1,7 @@
 """Event types for the message bus."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -34,5 +36,5 @@ class OutboundMessage:
     reply_to: str | None = None
     media: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
-
+    delivery_future: Any | None = field(default=None, repr=False, compare=False)
 

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from loguru import logger
 
+from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.config.schema import Config
@@ -123,23 +124,39 @@ class ChannelManager:
 
                 if msg.metadata.get("_progress"):
                     if msg.metadata.get("_tool_hint") and not self.config.channels.send_tool_hints:
+                        self._resolve_delivery(msg)
                         continue
                     if not msg.metadata.get("_tool_hint") and not self.config.channels.send_progress:
+                        self._resolve_delivery(msg)
                         continue
 
                 channel = self.channels.get(msg.channel)
                 if channel:
                     try:
                         await channel.send(msg)
+                        self._resolve_delivery(msg)
                     except Exception as e:
+                        self._resolve_delivery(msg, e)
                         logger.error("Error sending to {}: {}", msg.channel, e)
                 else:
+                    error = RuntimeError(f"Unknown channel: {msg.channel}")
+                    self._resolve_delivery(msg, error)
                     logger.warning("Unknown channel: {}", msg.channel)
 
             except asyncio.TimeoutError:
                 continue
             except asyncio.CancelledError:
                 break
+
+    @staticmethod
+    def _resolve_delivery(msg: OutboundMessage, error: Exception | None = None) -> None:
+        future = getattr(msg, "delivery_future", None)
+        if not future or future.done():
+            return
+        if error is None:
+            future.set_result(None)
+            return
+        future.set_exception(error)
 
     def get_channel(self, name: str) -> BaseChannel | None:
         """Get a channel by name."""

--- a/tests/test_message_delivery_ack.py
+++ b/tests/test_message_delivery_ack.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from nanobot.agent.tools.message import MessageTool
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.manager import ChannelManager
+
+
+@pytest.mark.asyncio
+async def test_message_tool_waits_for_delivery_ack() -> None:
+    delivered: list[OutboundMessage] = []
+
+    async def send_callback(msg: OutboundMessage) -> None:
+        delivered.append(msg)
+        assert msg.delivery_future is not None
+        msg.delivery_future.set_result(None)
+
+    tool = MessageTool(send_callback=send_callback, default_channel="feishu", default_chat_id="chat1")
+    result = await tool.execute(content="hello")
+
+    assert result == "Message sent to feishu:chat1"
+    assert len(delivered) == 1
+    assert tool._sent_in_turn is True
+
+
+@pytest.mark.asyncio
+async def test_message_tool_returns_dispatch_error() -> None:
+    async def send_callback(msg: OutboundMessage) -> None:
+        assert msg.delivery_future is not None
+        msg.delivery_future.set_exception(RuntimeError("boom"))
+
+    tool = MessageTool(send_callback=send_callback, default_channel="feishu", default_chat_id="chat1")
+    result = await tool.execute(content="hello")
+
+    assert result == "Error sending message: boom"
+    assert tool._sent_in_turn is False
+
+
+class _FakeChannel:
+    def __init__(self, error: Exception | None = None):
+        self.error = error
+        self.sent: list[OutboundMessage] = []
+
+    async def send(self, msg: OutboundMessage) -> None:
+        self.sent.append(msg)
+        if self.error is not None:
+            raise self.error
+
+
+def _make_manager(*, send_progress: bool = True, send_tool_hints: bool = False) -> ChannelManager:
+    manager = ChannelManager.__new__(ChannelManager)
+    manager.config = SimpleNamespace(
+        channels=SimpleNamespace(send_progress=send_progress, send_tool_hints=send_tool_hints)
+    )
+    manager.bus = MessageBus()
+    manager.channels = {}
+    manager._dispatch_task = None
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_delivery_future_on_success() -> None:
+    manager = _make_manager()
+    channel = _FakeChannel()
+    manager.channels["feishu"] = channel
+    msg = OutboundMessage(
+        channel="feishu",
+        chat_id="chat1",
+        content="hello",
+        delivery_future=asyncio.get_running_loop().create_future(),
+    )
+
+    await manager.bus.publish_outbound(msg)
+    task = asyncio.create_task(manager._dispatch_outbound())
+    await asyncio.wait_for(msg.delivery_future, timeout=1.0)
+    task.cancel()
+    await task
+
+    assert channel.sent == [msg]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_delivery_future_on_failure() -> None:
+    manager = _make_manager()
+    manager.channels["feishu"] = _FakeChannel(RuntimeError("send failed"))
+    msg = OutboundMessage(
+        channel="feishu",
+        chat_id="chat1",
+        content="hello",
+        delivery_future=asyncio.get_running_loop().create_future(),
+    )
+
+    await manager.bus.publish_outbound(msg)
+    task = asyncio.create_task(manager._dispatch_outbound())
+    with pytest.raises(RuntimeError, match="send failed"):
+        await asyncio.wait_for(msg.delivery_future, timeout=1.0)
+    task.cancel()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_delivery_future_for_unknown_channel() -> None:
+    manager = _make_manager()
+    msg = OutboundMessage(
+        channel="missing",
+        chat_id="chat1",
+        content="hello",
+        delivery_future=asyncio.get_running_loop().create_future(),
+    )
+
+    await manager.bus.publish_outbound(msg)
+    task = asyncio.create_task(manager._dispatch_outbound())
+    with pytest.raises(RuntimeError, match="Unknown channel: missing"):
+        await asyncio.wait_for(msg.delivery_future, timeout=1.0)
+    task.cancel()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_suppressed_progress_delivery_future() -> None:
+    manager = _make_manager(send_progress=False)
+    msg = OutboundMessage(
+        channel="feishu",
+        chat_id="chat1",
+        content="hello",
+        metadata={"_progress": True},
+        delivery_future=asyncio.get_running_loop().create_future(),
+    )
+
+    await manager.bus.publish_outbound(msg)
+    task = asyncio.create_task(manager._dispatch_outbound())
+    await asyncio.wait_for(msg.delivery_future, timeout=1.0)
+    task.cancel()
+    await task

--- a/tests/test_message_tool_suppress.py
+++ b/tests/test_message_tool_suppress.py
@@ -19,6 +19,12 @@ def _make_loop(tmp_path: Path) -> AgentLoop:
     return AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
 
 
+async def _ack_and_store(msg: OutboundMessage, sent: list[OutboundMessage]) -> None:
+    sent.append(msg)
+    if msg.delivery_future is not None and not msg.delivery_future.done():
+        msg.delivery_future.set_result(None)
+
+
 class TestMessageToolSuppressLogic:
     """Final reply suppressed only when message tool sends to the same target."""
 
@@ -39,7 +45,10 @@ class TestMessageToolSuppressLogic:
         sent: list[OutboundMessage] = []
         mt = loop.tools.get("message")
         if isinstance(mt, MessageTool):
-            mt.set_send_callback(AsyncMock(side_effect=lambda m: sent.append(m)))
+            async def _send(msg: OutboundMessage) -> None:
+                await _ack_and_store(msg, sent)
+
+            mt.set_send_callback(_send)
 
         msg = InboundMessage(channel="feishu", sender_id="user1", chat_id="chat123", content="Send")
         result = await loop._process_message(msg)
@@ -64,7 +73,10 @@ class TestMessageToolSuppressLogic:
         sent: list[OutboundMessage] = []
         mt = loop.tools.get("message")
         if isinstance(mt, MessageTool):
-            mt.set_send_callback(AsyncMock(side_effect=lambda m: sent.append(m)))
+            async def _send(msg: OutboundMessage) -> None:
+                await _ack_and_store(msg, sent)
+
+            mt.set_send_callback(_send)
 
         msg = InboundMessage(channel="feishu", sender_id="user1", chat_id="chat123", content="Send email")
         result = await loop._process_message(msg)


### PR DESCRIPTION
## Summary

This changes outbound `message` sends to wait for channel-dispatch acknowledgement instead of treating queue acceptance as success.

The patch:

- adds an optional `delivery_future` to `OutboundMessage`
- resolves that future in `ChannelManager` on success, failure, unknown channel, and suppressed progress/tool-hint sends
- updates `MessageTool` to wait for dispatch acknowledgement before returning success
- adds focused regression tests for the new dispatch contract

## Why

Before this change, the `message` tool could return success as soon as an outbound event was queued, even if the actual channel send failed afterwards.

This makes the tool result more truthful and gives the agent a cleaner contract for retries and follow-up behavior.

We have been running this behavior in production for more than a week across real outbound traffic.

## Testing

```bash
uv run --with pytest --with pytest-asyncio python -m pytest -q tests/test_message_tool.py tests/test_message_tool_suppress.py tests/test_message_delivery_ack.py
```

## Notes

- This does not try to guarantee downstream human receipt.
- It narrows the meaning of success to "channel send call completed successfully."

Closes #2221
