### PR TITLE
fix(security): set 0o600 permissions on config and session files

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -357,7 +357,9 @@ def _onboard_plugins(config_path: Path) -> None:
         else:
             channels[name] = _merge_missing_defaults(channels[name], cls.default_config())
 
-    with open(config_path, "w", encoding="utf-8") as f:
+    import os
+    fd = os.open(str(config_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -1,6 +1,7 @@
 """Configuration loading utilities."""
 
 import json
+import os
 from pathlib import Path
 
 from nanobot.config.schema import Config
@@ -61,7 +62,8 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
 
     data = config.model_dump(by_alias=True)
 
-    with open(path, "w", encoding="utf-8") as f:
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -1,6 +1,7 @@
 """Session management for conversation history."""
 
 import json
+import os
 import shutil
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -193,7 +194,8 @@ class SessionManager:
         """Save a session to disk."""
         path = self._get_session_path(session.key)
 
-        with open(path, "w", encoding="utf-8") as f:
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             metadata_line = {
                 "_type": "metadata",
                 "key": session.key,


### PR DESCRIPTION
## Summary

Config files (containing API keys) and session files (containing conversation history) are created with default umask permissions (`0o644` / `rw-r--r--`), allowing other local users on shared systems to read sensitive data.

This PR replaces `open(path, "w")` with `os.open(path, O_WRONLY|O_CREAT|O_TRUNC, 0o600)` to ensure only the file owner can read/write these files.

## Vulnerability Details

- **CWE-732**: Incorrect Permission Assignment for Critical Resource
- **CVSS 3.1**: 5.5 (Medium) — `AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`
- **Attack scenario**: On shared servers (university HPC, multi-tenant hosts), any local user can `cat ~/.nanobot/config.json` to steal API keys, or read session files to access conversation history containing sensitive data.

## Changes

| File | Function | Fix |
|------|----------|-----|
| `nanobot/config/loader.py` | `save_config()` | `os.open()` with `0o600` |
| `nanobot/session/manager.py` | `SessionManager.save()` | `os.open()` with `0o600` |
| `nanobot/cli/commands.py` | `_onboard_plugins()` | `os.open()` with `0o600` |

## Verification

```python
import os, stat, tempfile
from pathlib import Path

os.umask(0o022)  # default umask

from nanobot.config.loader import save_config
from nanobot.config.schema import Config

with tempfile.TemporaryDirectory() as tmpdir:
    path = Path(tmpdir) / "config.json"
    save_config(Config(), path)
    mode = stat.S_IMODE(path.stat().st_mode)
    assert mode == 0o600  # ✅ owner-only
```

## Test plan

- [x] `save_config()` creates files with `0o600`
- [x] `SessionManager.save()` creates files with `0o600`
- [x] Existing tests pass (no regressions)