### PR TITLE
Fix TypeError for MCP tools with nullable JSON Schema params

### DIFF
--- a/nanobot/agent/tools/base.py
+++ b/nanobot/agent/tools/base.py
@@ -21,6 +21,20 @@ class Tool(ABC):
         "object": dict,
     }
 
+    @staticmethod
+    def _resolve_type(t: Any) -> str | None:
+        """Resolve JSON Schema type to a simple string.
+
+        JSON Schema allows ``"type": ["string", "null"]`` (union types).
+        We extract the first non-null type so validation/casting works.
+        """
+        if isinstance(t, list):
+            for item in t:
+                if item != "null":
+                    return item
+            return None
+        return t
+
     @property
     @abstractmethod
     def name(self) -> str:
@@ -78,7 +92,7 @@ class Tool(ABC):
 
     def _cast_value(self, val: Any, schema: dict[str, Any]) -> Any:
         """Cast a single value according to schema."""
-        target_type = schema.get("type")
+        target_type = self._resolve_type(schema.get("type"))
 
         if target_type == "boolean" and isinstance(val, bool):
             return val
@@ -131,7 +145,11 @@ class Tool(ABC):
         return self._validate(params, {**schema, "type": "object"}, "")
 
     def _validate(self, val: Any, schema: dict[str, Any], path: str) -> list[str]:
-        t, label = schema.get("type"), path or "parameter"
+        raw_type = schema.get("type")
+        nullable = isinstance(raw_type, list) and "null" in raw_type
+        t, label = self._resolve_type(raw_type), path or "parameter"
+        if nullable and val is None:
+            return []
         if t == "integer" and (not isinstance(val, int) or isinstance(val, bool)):
             return [f"{label} should be integer"]
         if t == "number" and (

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -406,3 +406,64 @@ async def test_exec_timeout_capped_at_max() -> None:
     # Should not raise — just clamp to 600
     result = await tool.execute(command="echo ok", timeout=9999)
     assert "Exit code: 0" in result
+
+
+# --- _resolve_type and nullable param tests ---
+
+
+def test_resolve_type_simple_string() -> None:
+    """Simple string type passes through unchanged."""
+    assert Tool._resolve_type("string") == "string"
+
+
+def test_resolve_type_union_with_null() -> None:
+    """Union type ['string', 'null'] resolves to 'string'."""
+    assert Tool._resolve_type(["string", "null"]) == "string"
+
+
+def test_resolve_type_only_null() -> None:
+    """Union type ['null'] resolves to None (no non-null type)."""
+    assert Tool._resolve_type(["null"]) is None
+
+
+def test_resolve_type_none_input() -> None:
+    """None input passes through as None."""
+    assert Tool._resolve_type(None) is None
+
+
+def test_validate_nullable_param_accepts_string() -> None:
+    """Nullable string param should accept a string value."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"name": {"type": ["string", "null"]}},
+        }
+    )
+    errors = tool.validate_params({"name": "hello"})
+    assert errors == []
+
+
+def test_validate_nullable_param_accepts_none() -> None:
+    """Nullable string param should accept None."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"name": {"type": ["string", "null"]}},
+        }
+    )
+    errors = tool.validate_params({"name": None})
+    assert errors == []
+
+
+def test_cast_nullable_param_no_crash() -> None:
+    """cast_params should not crash on nullable type (the original bug)."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"name": {"type": ["string", "null"]}},
+        }
+    )
+    result = tool.cast_params({"name": "hello"})
+    assert result["name"] == "hello"
+    result = tool.cast_params({"name": None})
+    assert result["name"] is None


### PR DESCRIPTION
## Summary

- MCP servers (e.g. Zapier) return JSON Schema union types like `"type": ["string", "null"]` for nullable parameters
- `validate_params()` and `cast_params()` expected only simple strings as `type`, causing `TypeError: unhashable type: 'list'` on every MCP tool call with nullable parameters
- Added `_resolve_type()` static method to extract the first non-null type from union types, and integrated it into `_cast_value()` and `_validate()`

## Details

**Problem:** Any MCP tool with nullable parameters (common in Zapier, and valid per JSON Schema spec) would crash with:
```
TypeError: unhashable type: 'list'
```
This happened because `_TYPE_MAP[t]` was called with `t = ["string", "null"]` (a list), which is not hashable.

**Fix:** `_resolve_type()` normalizes union types:
- `"string"` → `"string"` (passthrough)
- `["string", "null"]` → `"string"` (extract non-null type)
- `["null"]` → `None` (no non-null type)
- `None` → `None` (passthrough)

Additionally, `_validate()` now correctly accepts `None` values when the schema declares a nullable type (`"null"` in the type array).

## Test plan

- [x] `_resolve_type("string")` → `"string"`
- [x] `_resolve_type(["string", "null"])` → `"string"`
- [x] `_resolve_type(["null"])` → `None`
- [x] `_resolve_type(None)` → `None`
- [x] `validate_params` with `"type": ["string", "null"]` accepts string value
- [x] `validate_params` with `"type": ["string", "null"]` accepts `None`
- [x] `cast_params` with `"type": ["string", "null"]` — no crash
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)