### PR TITLE
fix(agent): handle asyncio.CancelledError in message loop

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -265,9 +265,9 @@ class AgentLoop:
             except asyncio.TimeoutError:
                 continue
             except asyncio.CancelledError:
-                # anyio/MCP cancel scopes surface as CancelledError (a BaseException subclass).
-                # Re-raise only if the loop itself is being shut down; otherwise keep running.
-                if not self._running:
+                # Preserve real task cancellation so shutdown can complete cleanly.
+                # Only ignore non-task CancelledError signals that may leak from integrations.
+                if not self._running or asyncio.current_task().cancelling():
                     raise
                 continue
             except Exception as e:

--- a/tests/test_restart_command.py
+++ b/tests/test_restart_command.py
@@ -66,6 +66,18 @@ class TestRestartCommand:
             mock_handle.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_run_propagates_external_cancellation(self):
+        """External task cancellation should not be swallowed by the inbound wait loop."""
+        loop, _bus = _make_loop()
+
+        run_task = asyncio.create_task(loop.run())
+        await asyncio.sleep(0.1)
+        run_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(run_task, timeout=1.0)
+
+    @pytest.mark.asyncio
     async def test_help_includes_restart(self):
         loop, bus = _make_loop()
         msg = InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="/help")


### PR DESCRIPTION
- Catch asyncio.CancelledError separately from generic exceptions
- Re-raise CancelledError only when loop is shutting down (_running is False)
- Continue processing messages if CancelledError occurs during normal operation
- Prevents anyio/MCP cancel scopes from prematurely terminating the agent loop