### PR TITLE
feat: parse feishu code block content in post message

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -191,6 +191,10 @@ def _extract_post_content(content_json: dict) -> tuple[str, list[str]]:
                     texts.append(el.get("text", ""))
                 elif tag == "at":
                     texts.append(f"@{el.get('user_name', 'user')}")
+                elif tag == "code_block":
+                    lang = el.get("language", "")
+                    code_text = el.get("text", "")
+                    texts.append(f"\n```{lang}\n{code_text}\n```\n")
                 elif tag == "img" and (key := el.get("image_key")):
                     images.append(key)
         return (" ".join(texts).strip() or None), images
@@ -1039,7 +1043,7 @@ class FeishuChannel(BaseChannel):
             event = data.event
             message = event.message
             sender = event.sender
-
+            
             # Deduplication check
             message_id = message.message_id
             if message_id in self._processed_message_ids:


### PR DESCRIPTION
### 添加飞书富文本解析时的code block解析。
- **修改前**：agent 无法收到代码块中的消息
<img width="2038" height="430" alt="image" src="https://github.com/user-attachments/assets/4797b24c-a166-4bae-be93-a17e73be982f" />

- **修改后**：agent 可以收到代码块中的消息
<img width="1268" height="1700" alt="image" src="https://github.com/user-attachments/assets/f6016cd4-fcbe-46cc-a839-7263e9f542db" />
