### PR TITLE
docs: add subagent workspace assignment hint to spawn tool description

### DIFF
--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -33,7 +33,8 @@ class SpawnTool(Tool):
             "Spawn a subagent to handle a task in the background. "
             "Use this for complex or time-consuming tasks that can run independently. "
             "The subagent will complete the task and report back when done. "
-            "For deliverables or existing projects, inspect the workspace and assign/create a dedicated working directory for the subagent."
+            "For deliverables or existing projects, inspect the workspace first "
+            "and use a dedicated subdirectory when helpful."
         )
 
     @property


### PR DESCRIPTION
Current sub agents spawning tool can easily mess up the working space, looking like this.
<img width="244" height="468" alt="截屏2026-03-18 08 38 18" src="https://github.com/user-attachments/assets/600a642d-2b6d-4d83-9e23-3efa7e794df8" />
This PR implements a quick and clean solution, which is to add instructions in the spawning tool to inspect the structure of the workspace and assign directory for the task. 
After the fix, similar run results to workspace like this:
<img width="243" height="560" alt="截屏2026-03-19 14 12 57" src="https://github.com/user-attachments/assets/b9526130-61f3-4c1e-8044-22507dde986c" />