### PR TITLE
fix: guard against empty message text in Telegram channel

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -441,7 +441,7 @@ class AgentLoop:
             initial_messages, on_progress=on_progress or _bus_progress,
         )
 
-        if final_content is None:
+        if not final_content or not final_content.strip():
             final_content = "I've completed processing but have no response to give."
 
         self._save_turn(session, all_msgs, 1 + len(history))

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -446,6 +446,8 @@ class TelegramChannel(BaseChannel):
         thread_kwargs: dict | None = None,
     ) -> None:
         """Send a plain text message with HTML fallback."""
+        if not text or not text.strip():
+            return
         try:
             html = _markdown_to_telegram_html(text)
             await self._call_with_retry(


### PR DESCRIPTION
## Summary
Fixes #100.

**Root cause:** `AgentLoop._process_message()` only checks `if final_content is None` but not empty/whitespace strings. When the LLM returns empty content after tool use, `TelegramChannel._send_text()` passes empty text to `send_message()`, which raises `BadRequest: Message text is empty`.

**Fix:** Two-layer defense:
1. In `loop.py`: Changed `if final_content is None` to `if not final_content or not final_content.strip()` to catch empty/whitespace strings.
2. In `telegram.py`: Added early return in `_send_text()` when text is empty or whitespace-only.

## Changes
- `nanobot/agent/loop.py`: Broadened empty content check to include empty strings and whitespace
- `nanobot/channels/telegram.py`: Added guard in `_send_text()` to skip empty messages

## Testing
- Verified fix prevents BadRequest for empty/whitespace content
- Default fallback message is used when content is empty
- No behavioral change for non-empty messages

Made with [Cursor](https://cursor.com)