### PR TITLE
fix: add lxml[html_clean] as explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "oauth-cli-kit>=0.1.3,<1.0.0",
     "loguru>=0.7.3,<1.0.0",
     "readability-lxml>=0.8.4,<1.0.0",
+    "lxml[html_clean]>=5.0,<6.0.0",
     "rich>=14.0.0,<15.0.0",
     "croniter>=6.0.0,<7.0.0",
     "dingtalk-stream>=0.24.0,<1.0.0",


### PR DESCRIPTION
lxml 5.x has moved lxml.html.clean to a separate package lxml_html_clean. Without declaring it explicitly, the dependency is missing and imports fail at runtime. This was discovered while running the test suite (pytest).