### PR TITLE
feat configure loguru and logging levels based on verbose flag

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -476,12 +476,8 @@ def gateway(
     from loguru import logger
 
     logger.remove()
-    if verbose:
-        logger.add(sys.stderr, level="DEBUG")
-        logging.getLogger().setLevel(logging.DEBUG)
-    else:
-        logger.add(sys.stderr, level="INFO")
-        logging.getLogger().setLevel(logging.INFO)
+    logger.add(sys.stderr, level="DEBUG" if verbose else "INFO")
+    logging.getLogger().setLevel(logging.DEBUG if verbose else logging.INFO)
 
     config = _load_runtime_config(config, workspace)
     _print_deprecated_memory_window_notice(config)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -471,9 +471,17 @@ def gateway(
     from nanobot.heartbeat.service import HeartbeatService
     from nanobot.session.manager import SessionManager
 
+    # Configure loguru and logging levels based on verbose flag
+    import logging
+    from loguru import logger
+
+    logger.remove()
     if verbose:
-        import logging
-        logging.basicConfig(level=logging.DEBUG)
+        logger.add(sys.stderr, level="DEBUG")
+        logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logger.add(sys.stderr, level="INFO")
+        logging.getLogger().setLevel(logging.INFO)
 
     config = _load_runtime_config(config, workspace)
     _print_deprecated_memory_window_notice(config)


### PR DESCRIPTION
## Summary

- Configure loguru log level to be controlled by `--verbose` / `-v` flag
- Default log level is `INFO` - no debug output without `-v`
- With `--verbose`, log level becomes `DEBUG`

## Motivation

Previously, loguru's default log level was `DEBUG`. This change ensures debug   logs are only shown when explicitly enabled via `-v`.

## Changes

- Modified `nanobot/cli/commands.py` to configure loguru based on `verbose` flag
- **Default** (no flag): `INFO` level
- **With `--verbose` / `-v`**: `DEBUG` level

## Test

- Run nanobot gateway without `-v` flag → verify only INFO+ level logs are shown
- Run nanobot gateway with `-v` flag → verify DEBUG level logs appear