### PR TITLE
fix: nanobot onboard update config crash

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from nanobot.config.schema import Config
 
-
 # Global variable to store current config path (for multi-instance support)
 _current_config_path: Path | None = None
 
@@ -59,7 +58,7 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
     path = config_path or get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    data = config.model_dump(by_alias=True)
+    data = config.model_dump(mode="json", by_alias=True)
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
更新了某个版本后，执行 onboard，并选择 N，然后 nanobot crash 了，
并且配置文件也变得不可用了。
本 commit 修复了这个问题。

以下是问题记录
- onboard 挂掉
![img_v3_02vv_d7b6620f-1204-44bc-bfba-ef0c61a348dg](https://github.com/user-attachments/assets/36877bd5-867d-418d-9ede-8af3dc731ee2)
![img_v3_02vv_b4f7aaaf-d6fc-4ac3-acb3-a6267ef056bg](https://github.com/user-attachments/assets/4ea7b065-cf6a-4085-baba-3dc07dcc3998)

- 配置文件不可用导致gateway起不来
<img width="1314" height="349" alt="image" src="https://github.com/user-attachments/assets/07136e32-eec3-4ac5-ad83-d41acde65b06" />