### PR TITLE
feat(discord): add configurable read receipt via 👀 reaction

### DIFF
--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -32,6 +32,7 @@ class DiscordConfig(Base):
     gateway_url: str = "wss://gateway.discord.gg/?v=10&encoding=json"
     intents: int = 37377
     group_policy: Literal["mention", "open"] = "mention"
+    read_receipt: bool = True  # React with 👀 when message is received, remove after reply
 
 
 class DiscordChannel(BaseChannel):
@@ -342,7 +343,7 @@ class DiscordChannel(BaseChannel):
         await self._start_typing(channel_id)
 
         message_id = str(payload.get("id", ""))
-        if message_id:
+        if message_id and self.config.read_receipt:
             await self._add_reaction(channel_id, message_id, "👀")
             self._pending_reactions[channel_id] = message_id
 


### PR DESCRIPTION
## What this does

React with 👀 the moment a message is received, then remove the reaction once the bot sends its reply.

This gives the user an immediate visual signal: **"your message was seen and is being processed"** — especially useful when the LLM takes a few seconds to respond.

## Demo flow

```
User sends message  →  bot reacts 👀
Bot finishes reply  →  👀 removed
```

## Config

Opt-out via `config.json` (default: `true`):

```json
"discord": {
  "read_receipt": false
}
```

## Implementation notes

- Uses Discord REST API: `PUT/DELETE /channels/{id}/messages/{id}/reactions/{emoji}/@me`
- `_pending_reactions: dict[str, str]` maps `channel_id → message_id` so `send()` knows which reaction to clean up
- Emoji is URL-encoded via `urllib.parse.quote` before being placed in the URL path
- No external dependencies added

## Limitations

- If the bot crashes between receiving and replying, the 👀 stays on the message (Discord has no way to clean up on reconnect without storing state to disk)
- One reaction slot per channel — concurrent messages in the same channel will only track the latest message_id

## Motivation

Small UX detail that makes the bot feel more alive and responsive, similar to how iMessage/WhatsApp show read receipts.