### PR TITLE
fix: Use shared session for cron and heartbeat to enable interactive conversations

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -527,7 +527,7 @@ def gateway(
         try:
             response = await agent.process_direct(
                 reminder_note,
-                session_key=f"cron:{job.id}",
+                session_key=f"{job.payload.channel}:{job.payload.to}",
                 channel=job.payload.channel or "cli",
                 chat_id=job.payload.to or "direct",
             )
@@ -582,7 +582,7 @@ def gateway(
 
         return await agent.process_direct(
             tasks,
-            session_key="heartbeat",
+            session_key=f"{channel}:{chat_id}",
             channel=channel,
             chat_id=chat_id,
             on_progress=_silent,


### PR DESCRIPTION
## Summary

Cron jobs and heartbeat currently use isolated sessions (`cron:{jobid}` and `heartbeat`), which prevents interactive conversations. When a cron job sends a message asking the user to choose between options A/B/C, the user's reply goes to a different session and is never seen by subsequent cron runs.

## Changes

- **Cron callback**: Changed `session_key=f"cron:{job.id}"` to `session_key=f"{job.payload.channel}:{job.payload.to}"`
- **Heartbeat**: Changed `session_key="heartbeat"` to `session_key=f"{channel}:{chat_id}"`

## Problem Solved

Before: Each cron/heartbeat run started with a blank context, unable to see previous replies.

After: Cron/heartbeat use the target channel's session (e.g., `telegram:8009753988`), enabling continuous conversations where the agent can see and respond to user replies.

## Example Use Case

```
# Cron job runs at 9 AM
Cron: "Good morning! I've analyzed the data. Should I: A) Send report, B) Wait for more data, C) Schedule meeting?"

# User replies
User: "A"

# Next cron run can now see the reply
Cron: "Great, sending the report now..."
```

## Testing

1. Create a cron job that asks a question
2. Reply to the cron message in Telegram
3. Next cron run should be able to see your reply

## Checklist

- [x] Code follows existing patterns
- [x] Minimal changes (2 lines)
- [ ] Tests pass (needs verification by maintainers)
- [ ] No breaking changes (backward compatible - existing jobs will just use shared session)
