### PR TITLE
fix: count image tokens in prompt estimation

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -97,6 +97,22 @@ def build_assistant_message(
     return msg
 
 
+def _estimate_image_tokens(part: dict) -> int:
+    """Estimate token cost of an image_url content part.
+
+    For data: URLs, estimate from base64 payload size.
+    For external URLs, return a conservative fallback of 765 tokens.
+    """
+    url = (part.get("image_url") or {}).get("url", "")
+    if url.startswith("data:"):
+        # Extract base64 payload after the comma
+        _, _, b64_payload = url.partition(",")
+        if b64_payload:
+            raw_bytes = len(b64_payload) * 3 // 4
+            return max(765, raw_bytes // 6)
+    return 765
+
+
 def estimate_prompt_tokens(
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None = None,
@@ -105,6 +121,7 @@ def estimate_prompt_tokens(
     try:
         enc = tiktoken.get_encoding("cl100k_base")
         parts: list[str] = []
+        image_tokens = 0
         for msg in messages:
             content = msg.get("content")
             if isinstance(content, str):
@@ -115,9 +132,11 @@ def estimate_prompt_tokens(
                         txt = part.get("text", "")
                         if txt:
                             parts.append(txt)
+                    elif isinstance(part, dict) and part.get("type") == "image_url":
+                        image_tokens += _estimate_image_tokens(part)
         if tools:
             parts.append(json.dumps(tools, ensure_ascii=False))
-        return len(enc.encode("\n".join(parts)))
+        return len(enc.encode("\n".join(parts))) + image_tokens
     except Exception:
         return 0
 
@@ -126,6 +145,7 @@ def estimate_message_tokens(message: dict[str, Any]) -> int:
     """Estimate prompt tokens contributed by one persisted message."""
     content = message.get("content")
     parts: list[str] = []
+    image_tokens = 0
     if isinstance(content, str):
         parts.append(content)
     elif isinstance(content, list):
@@ -134,6 +154,8 @@ def estimate_message_tokens(message: dict[str, Any]) -> int:
                 text = part.get("text", "")
                 if text:
                     parts.append(text)
+            elif isinstance(part, dict) and part.get("type") == "image_url":
+                image_tokens += _estimate_image_tokens(part)
             else:
                 parts.append(json.dumps(part, ensure_ascii=False))
     elif content is not None:
@@ -147,13 +169,13 @@ def estimate_message_tokens(message: dict[str, Any]) -> int:
         parts.append(json.dumps(message["tool_calls"], ensure_ascii=False))
 
     payload = "\n".join(parts)
-    if not payload:
+    if not payload and image_tokens == 0:
         return 1
     try:
         enc = tiktoken.get_encoding("cl100k_base")
-        return max(1, len(enc.encode(payload)))
+        return max(1, len(enc.encode(payload)) + image_tokens)
     except Exception:
-        return max(1, len(payload) // 4)
+        return max(1, len(payload) // 4 + image_tokens)
 
 
 def estimate_prompt_tokens_chain(

--- a/tests/test_image_token_estimation.py
+++ b/tests/test_image_token_estimation.py
@@ -1,0 +1,78 @@
+"""Tests for image token estimation in helpers."""
+
+import base64
+
+from nanobot.utils.helpers import (
+    _estimate_image_tokens,
+    estimate_message_tokens,
+    estimate_prompt_tokens,
+)
+
+
+class TestEstimateImageTokens:
+    def test_data_url_proportional_to_size(self):
+        """base64 data URL → tokens proportional to raw byte count."""
+        raw = b"\x00" * 6000  # 6000 raw bytes
+        b64 = base64.b64encode(raw).decode()
+        part = {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}}
+        tokens = _estimate_image_tokens(part)
+        # raw_bytes=6000, 6000//6=1000, max(765,1000)=1000
+        assert tokens == 1000
+
+    def test_data_url_small_image_uses_floor(self):
+        """Small images get at least 765 tokens."""
+        raw = b"\x00" * 100
+        b64 = base64.b64encode(raw).decode()
+        part = {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}}
+        tokens = _estimate_image_tokens(part)
+        assert tokens == 765
+
+    def test_external_url_returns_fallback(self):
+        """External (non-data:) URL → 765 fallback."""
+        part = {"type": "image_url", "image_url": {"url": "https://example.com/photo.jpg"}}
+        tokens = _estimate_image_tokens(part)
+        assert tokens == 765
+
+    def test_missing_url_returns_fallback(self):
+        """Malformed part with no url → 765 fallback."""
+        part = {"type": "image_url", "image_url": {}}
+        tokens = _estimate_image_tokens(part)
+        assert tokens == 765
+
+
+class TestEstimatePromptTokensWithImages:
+    def test_image_messages_count_more_than_text_only(self):
+        """Messages with image_url parts must estimate higher than text-only."""
+        raw = b"\x00" * 6000
+        b64 = base64.b64encode(raw).decode()
+
+        text_msg = [{"role": "user", "content": [{"type": "text", "text": "describe"}]}]
+        image_msg = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
+                ],
+            }
+        ]
+        text_tokens = estimate_prompt_tokens(text_msg)
+        image_tokens = estimate_prompt_tokens(image_msg)
+        assert image_tokens > text_tokens
+
+
+class TestEstimateMessageTokensWithImage:
+    def test_single_message_with_image(self):
+        """estimate_message_tokens must account for image_url parts."""
+        raw = b"\x00" * 6000
+        b64 = base64.b64encode(raw).decode()
+        msg = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
+            ],
+        }
+        tokens = estimate_message_tokens(msg)
+        # Must be at least 1000 (the image alone)
+        assert tokens >= 1000


### PR DESCRIPTION
## Summary
- Add `_estimate_image_tokens()` helper that estimates token cost from base64 payload size (`raw_bytes // 6`, floor 765) or returns a 765-token fallback for external URLs
- Update `estimate_prompt_tokens()` and `estimate_message_tokens()` to count `image_url` content parts that were previously ignored entirely
- Add 6 tests covering data URLs, external URLs, malformed parts, and integration with both estimation functions

## Problem
`estimate_prompt_tokens()` only counted `type: "text"` content parts via tiktoken. `image_url` parts (base64-encoded images) were completely skipped, causing token estimation to be wildly inaccurate for image-heavy sessions. In Telegram sessions with images, tiktoken estimated ~57K tokens while the actual prompt exceeded 1M tokens — so memory consolidation (threshold 65K) never triggered.

## Test plan
- [x] `test_data_url_proportional_to_size` — 6000 raw bytes → 1000 tokens
- [x] `test_data_url_small_image_uses_floor` — small image → 765 minimum
- [x] `test_external_url_returns_fallback` — non-data URL → 765 fallback
- [x] `test_missing_url_returns_fallback` — malformed part → 765 fallback
- [x] `test_image_messages_count_more_than_text_only` — image msg estimates higher than text-only
- [x] `test_single_message_with_image` — single message with image ≥ 1000 tokens
- [x] `uv run ruff check` passes
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)