### PR TITLE
fix: format issue in feishu table

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -474,7 +474,7 @@ class FeishuChannel(BaseChannel):
             return [c.strip() for c in _line.strip("|").split("|")]
         headers = [cls._strip_md_formatting(h) for h in split(lines[0])]
         rows = [[cls._strip_md_formatting(c) for c in split(_line)] for _line in lines[2:]]
-        columns = [{"tag": "column", "name": f"c{i}", "display_name": h, "width": "auto"}
+        columns = [{"tag": "column", "name": f"c{i}", "display_name": h, "width": "auto", "data_type": "lark_md"}
                    for i, h in enumerate(headers)]
         return {
             "tag": "table",


### PR DESCRIPTION
When reply with interactive card, the feishu table fail to render markdown format properly and resulting in abnormal display:

<img width="595" height="107" alt="image" src="https://github.com/user-attachments/assets/18150560-b995-4af3-a924-db946b2113cf" />

We need to set the rows datatype to `lark_md` to make the content of the table well formatted.


