### PR TITLE
fix(custom_provider): show raw API error instead of JSONDecodeError

### DIFF
--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -51,12 +51,12 @@ class CustomProvider(LLMProvider):
         try:
             return self._parse(await self._client.chat.completions.create(**kwargs))
         except Exception as e:
-            # Extract raw response body from non-JSON API errors.
-            # JSONDecodeError.doc contains the original text (e.g. "unsupported model: xxx");
-            # OpenAI APIError may carry it in response.text.
+            # JSONDecodeError.doc / APIError.response.text may carry the raw body
+            # (e.g. "unsupported model: xxx") which is far more useful than the
+            # generic "Expecting value …" message.  Truncate to avoid huge HTML pages.
             body = getattr(e, "doc", None) or getattr(getattr(e, "response", None), "text", None)
             if body and body.strip():
-                return LLMResponse(content=f"Error: {body.strip()}", finish_reason="error")
+                return LLMResponse(content=f"Error: {body.strip()[:500]}", finish_reason="error")
             return LLMResponse(content=f"Error: {e}", finish_reason="error")
 
     def _parse(self, response: Any) -> LLMResponse:


### PR DESCRIPTION
## Summary
- When an OpenAI-compatible API returns a non-JSON response (e.g. plain text `unsupported model: xxx` with HTTP 200), the OpenAI SDK raises a `JSONDecodeError` with the unhelpful message `Expecting value: line 1 column 1 (char 0)`
- This fix extracts the original response body from `JSONDecodeError.doc` (or `APIError.response.text`) so users see the actual error from the API

## Before
```
Error: Expecting value: line 1 column 1 (char 0)
```

## After
```
Error: unsupported model: MiniMax/MiniMax-M2.7
```

## Test plan
- [x] Configured a model that is not supported by the API gateway, verified the raw error message is shown
- [x] Verified normal model calls still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## result
fix this 
<img width="430" height="79" alt="image" src="https://github.com/user-attachments/assets/d29873a2-cdea-4723-9b7e-b503d8ce7472" />
 to 
<img width="429" height="86" alt="image" src="https://github.com/user-attachments/assets/cfc1026f-07dd-4ea8-b1ee-dddd6b8ad6d9" />
