### PR TITLE
feat(geoclaw): add geospatial workflow agent MVP

### DIFF
--- a/COMMUNICATION.md
+++ b/COMMUNICATION.md
@@ -1,5 +1,7 @@
 We provide QR codes for joining the HKUDS discussion groups on **WeChat** and **Feishu**.
 
+This repository includes both the upstream `nanobot` runtime and the `GeoClaw` geospatial extension layer, so these channels are also the right place to discuss GeoClaw-related implementation questions for this fork.
+
 You can join by scanning the QR codes below:
 
 <img src="https://github.com/HKUDS/.github/blob/main/profile/QR.png" alt="WeChat QR Code" width="400"/>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,15 @@
-# Contributing to nanobot
+# Contributing to GeoClaw
 
 Thank you for being here.
 
-nanobot is built with a simple belief: good tools should feel calm, clear, and humane.
+This repository now contains two layers:
+
+- `geoclaw/`: the primary product layer, focused on reproducible geospatial workflows
+- `nanobot/`: the inherited lightweight agent runtime that GeoClaw extends
+
+When contributing, please keep the separation clear: geospatial workflow behavior, tools, schemas, renderers, and skills should live under `geoclaw/`, while generic runtime improvements should remain in `nanobot/`.
+
+GeoClaw is built with a simple belief: geospatial tooling should feel calm, clear, reproducible, and safe to run locally.
 We care deeply about useful features, but we also believe in achieving more with less:
 solutions should be powerful without becoming heavy, and ambitious without becoming
 needlessly complicated.
@@ -33,6 +40,7 @@ We use a two-branch model to balance stability and exploration:
 - New features or functionality
 - Refactoring that may affect existing behavior
 - Changes to APIs or configuration
+- New GeoClaw workflow capabilities or geospatial tools
 
 **Target `main` if your PR includes:**
 
@@ -71,25 +79,27 @@ Keep setup boring and reliable. The goal is to get you into the code quickly:
 
 ```bash
 # Clone the repository
-git clone https://github.com/HKUDS/nanobot.git
-cd nanobot
+cd geoclaw
 
 # Install with dev dependencies
 pip install -e ".[dev]"
+
+# Install GeoClaw's geospatial stack too (recommended for this fork)
+pip install -e ".[geo]"
 
 # Run tests
 pytest
 
 # Lint code
-ruff check nanobot/
+ruff check nanobot/ geoclaw/ tests/
 
 # Format code
-ruff format nanobot/
+ruff format nanobot/ geoclaw/ tests/
 ```
 
 ## Code Style
 
-We care about more than passing lint. We want nanobot to stay small, calm, and readable.
+We care about more than passing lint. We want GeoClaw to stay small, calm, and readable.
 
 When contributing, please aim for code that feels:
 
@@ -113,10 +123,10 @@ In practice:
 
 If you have questions, ideas, or half-formed insights, you are warmly welcome here.
 
-Please feel free to open an [issue](https://github.com/HKUDS/nanobot/issues), join the community, or simply reach out:
+Please feel free to open an issue, join the community, or simply reach out:
 
 - [Discord](https://discord.gg/MnCvHqpUGB)
 - [Feishu/WeChat](./COMMUNICATION.md)
 - Email: Xubin Ren (@Re-bin) — <xubinrencs@gmail.com>
 
-Thank you for spending your time and care on nanobot. We would love for more people to participate in this community, and we genuinely welcome contributions of all sizes.
+Thank you for spending your time and care on GeoClaw. At the same time, please remember that part of this repository is an inherited nanobot runtime, so some contributions may naturally touch both layers.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
-  <img src="nanobot_logo.png" alt="nanobot" width="500">
-  <h1>nanobot: Ultra-Lightweight Personal AI Assistant</h1>
+  <img src="nanobot_logo.png" alt="GeoClaw" width="500">
+  <h1>GeoClaw: Lightweight Geospatial Workflow Agent</h1>
   <p>
-    <a href="https://pypi.org/project/nanobot-ai/"><img src="https://img.shields.io/pypi/v/nanobot-ai" alt="PyPI"></a>
-    <a href="https://pepy.tech/project/nanobot-ai"><img src="https://static.pepy.tech/badge/nanobot-ai" alt="Downloads"></a>
+    <img src="https://img.shields.io/badge/focus-geospatial_workflows-1f7a8c" alt="Geospatial Workflows">
+    <img src="https://img.shields.io/badge/runtime-nanobot_based-4c6ef5" alt="nanobot based">
     <img src="https://img.shields.io/badge/python-≥3.11-blue" alt="Python">
     <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
     <a href="./COMMUNICATION.md"><img src="https://img.shields.io/badge/Feishu-Group-E9DBFC?style=flat&logo=feishu&logoColor=white" alt="Feishu"></a>
@@ -12,13 +12,49 @@
   </p>
 </div>
 
-🐈 **nanobot** is an **ultra-lightweight** personal AI assistant inspired by [OpenClaw](https://github.com/openclaw/openclaw).
+🌍 **GeoClaw** is a lightweight geospatial workflow agent for turning natural-language requests into reproducible spatial analysis runs.
 
-⚡️ Delivers core agent functionality with **99% fewer lines of code** than OpenClaw.
+It is designed for typed tools, local-first execution, deterministic outputs, and workspace-isolated artifacts instead of free-form GIS command generation.
 
-📏 Real-time line count: run `bash core_agent_lines.sh` to verify anytime.
+GeoClaw focuses on operational geospatial workflows such as AOI validation, OSM extraction, raster summarization, STAC search, routing, and H3 aggregation.
 
-## 📢 News
+## What GeoClaw Is
+
+GeoClaw is not:
+
+- a desktop GIS replacement
+- a generic chatbot with ad-hoc shell access
+- a map UI product first
+
+GeoClaw is:
+
+- AOI sanity checking
+- vector summaries
+- OSM extraction and place profiling
+- raster clipping, statistics, and previews
+- STAC search, ranking, and best-scene selection
+- H3 aggregation and neighborhood summaries
+- routing, isochrones, and accessibility coverage
+- DuckDB Spatial and GDAL-style dataset operations
+
+## Current Status
+
+Current implementation status in this repository:
+
+- `32` registered GeoClaw tools
+- `6` packaged workflow skills
+- deterministic outputs under `runs/<run_id>/`
+- `32 passed` GeoClaw tests in the current local suite
+
+## Built on nanobot
+
+GeoClaw is implemented by extending nanobot rather than replacing it.
+
+It keeps nanobot's runtime strengths, including channels, sessions, memory, MCP compatibility, multi-instance configuration, and workspace sandboxing, then layers a geospatial tool-and-skill system on top.
+
+## Runtime Base Notes
+
+The notes below come from the upstream nanobot runtime that GeoClaw builds on.
 
 - **2026-03-16** 🚀 Released **v0.1.4.post5** — a refinement-focused release with stronger reliability and channel support, and a more dependable day-to-day experience. Please see [release notes](https://github.com/HKUDS/nanobot/releases/tag/v0.1.4.post5) for details.
 - **2026-03-15** 🧩 DingTalk rich media, smarter built-in skills, and cleaner model compatibility.
@@ -70,9 +106,19 @@
 
 </details>
 
-> 🐈 nanobot is for educational, research, and technical exchange purposes only. It is unrelated to crypto and does not involve any official token or coin.
+> GeoClaw is for educational, research, and technical exchange purposes only. It is unrelated to crypto and does not involve any official token or coin.
 
-## Key Features of nanobot:
+## Why GeoClaw
+
+🌍 **Geospatial-First**: The core workflows are about places, geometry, rasters, networks, and spatial aggregation.
+
+🧰 **Typed Tools**: GeoClaw prefers explicit Python-backed tool interfaces over letting the model invent arbitrary GIS shell commands.
+
+📁 **Reproducible Runs**: Each workflow writes machine-readable outputs and artifacts into a workspace-scoped run directory.
+
+🏠 **Local-First**: The stack is designed for self-hosted or local execution with a moderate Python dependency footprint.
+
+## Inherited Runtime Qualities
 
 🪶 **Ultra-Lightweight**: A super lightweight implementation of OpenClaw — 99% smaller, significantly faster.
 
@@ -85,15 +131,19 @@
 ## 🏗️ Architecture
 
 <p align="center">
-  <img src="nanobot_arch.png" alt="nanobot architecture" width="800">
+  <img src="nanobot_arch.png" alt="GeoClaw architecture base" width="800">
 </p>
 
 ## Table of Contents
 
-- [News](#-news)
-- [Key Features](#key-features-of-nanobot)
+- [What GeoClaw Is](#what-geoclaw-is)
+- [Current Status](#current-status)
+- [Built on nanobot](#built-on-nanobot)
+- [Runtime Base Notes](#runtime-base-notes)
+- [Why GeoClaw](#why-geoclaw)
+- [Inherited Runtime Qualities](#inherited-runtime-qualities)
 - [Architecture](#️-architecture)
-- [Features](#-features)
+- [Runtime Features](#-runtime-features)
 - [Install](#-install)
 - [Quick Start](#-quick-start)
 - [Chat Apps](#-chat-apps)
@@ -107,7 +157,7 @@
 - [Contribute & Roadmap](#-contribute--roadmap)
 - [Star History](#-star-history)
 
-## ✨ Features
+## ✨ Runtime Features
 
 <table align="center">
   <tr align="center">
@@ -130,15 +180,27 @@
   </tr>
 </table>
 
+The section above reflects the broader nanobot runtime capabilities that GeoClaw inherits. GeoClaw itself narrows that general-purpose agent base into a reproducible geospatial workflow agent.
+
 ## 📦 Install
 
-**Install from source** (latest features, recommended for development)
+**Install from source** (recommended for local development)
 
 ```bash
-git clone https://github.com/HKUDS/nanobot.git
-cd nanobot
+# clone your GeoClaw repository
+cd geoclaw
 pip install -e .
 ```
+
+**Install with GeoClaw geospatial extras**
+
+```bash
+# clone your GeoClaw repository
+cd geoclaw
+pip install -e ".[geo]"
+```
+
+This installs the Python geospatial stack used by GeoClaw, including `geopandas`, `shapely`, `pyproj`, `rasterio`, `rioxarray`, `duckdb`, `quackosm`, `osmnx`, `pystac-client`, and `h3`.
 
 **Install with [uv](https://github.com/astral-sh/uv)** (stable, fast)
 
@@ -178,20 +240,22 @@ nanobot channels login
 ## 🚀 Quick Start
 
 > [!TIP]
-> Set your API key in `~/.nanobot/config.json`.
+> GeoClaw currently reuses nanobot's runtime config layout, so the default config path is still `~/.nanobot/config.json`.
 > Get API keys: [OpenRouter](https://openrouter.ai/keys) (Global)
 >
 > For other LLM providers, please see the [Providers](#providers) section.
 >
 > For web search capability setup, please see [Web Search](#web-search).
 
-**1. Initialize**
+### GeoClaw First Run
+
+**1. Initialize runtime config**
 
 ```bash
 nanobot onboard
 ```
 
-**2. Configure** (`~/.nanobot/config.json`)
+**2. Configure provider/model** (`~/.nanobot/config.json`)
 
 Add or merge these **two parts** into your config (other options have defaults).
 
@@ -218,13 +282,30 @@ Add or merge these **two parts** into your config (other options have defaults).
 }
 ```
 
-**3. Chat**
+**3. Run GeoClaw**
+
+```bash
+geoclaw sync-skills
+geoclaw agent -m "检查这个 AOI，并给我推荐后续地理分析流程"
+```
+
+Example requests:
+
+```bash
+geoclaw agent -m "用这个 bbox 做 AOI sanity check: 116.3,39.9,116.5,40.0"
+geoclaw agent -m "分析这个区域的 OSM place profile"
+geoclaw agent -m "从这里步行 15 分钟的可达范围是什么？"
+geoclaw agent -m "搜索 2024 年夏季这个 AOI 的低云量 STAC 场景"
+geoclaw agent -m "把这些点按 H3 resolution 8 做覆盖聚合"
+```
+
+### Underlying Runtime CLI
+
+If you want the generic runtime CLI instead of the geospatial workflow layer:
 
 ```bash
 nanobot agent
 ```
-
-That's it! You have a working AI assistant in 2 minutes.
 
 ## 💬 Chat Apps
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,10 @@
 # Security Policy
 
+This repository is centered on **GeoClaw**, a geospatial workflow layer built by extending nanobot. The guidance below applies to both GeoClaw workflows and the inherited nanobot runtime beneath them.
+
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in nanobot, please report it by:
+If you discover a security vulnerability in GeoClaw or in the bundled nanobot runtime, please report it by:
 
 1. **DO NOT** open a public GitHub issue
 2. Create a private security advisory on GitHub or contact the repository maintainers (xubinrencs@gmail.com)
@@ -67,7 +69,7 @@ The `exec` tool can execute shell commands. While dangerous command patterns are
 - ✅ Review all tool usage in agent logs
 - ✅ Understand what commands the agent is running
 - ✅ Use a dedicated user account with limited privileges
-- ✅ Never run nanobot as root
+- ✅ Never run GeoClaw or nanobot as root
 - ❌ Don't disable security checks
 - ❌ Don't run on systems with sensitive data without careful review
 
@@ -82,10 +84,16 @@ The `exec` tool can execute shell commands. While dangerous command patterns are
 
 File operations have path traversal protection, but:
 
-- ✅ Run nanobot with a dedicated user account
+- ✅ Run GeoClaw with a dedicated user account
 - ✅ Use filesystem permissions to protect sensitive directories
 - ✅ Regularly audit file operations in logs
 - ❌ Don't give unrestricted access to sensitive files
+
+For GeoClaw specifically:
+- ✅ Keep all generated artifacts inside the workspace `runs/` directory
+- ✅ Validate user-supplied AOI files before downstream processing
+- ✅ Prefer typed tools over arbitrary shell-based GIS commands
+- ❌ Don't allow unrestricted filesystem browsing for local geospatial data
 
 ### 5. Network Security
 
@@ -93,6 +101,11 @@ File operations have path traversal protection, but:
 - All external API calls use HTTPS by default
 - Timeouts are configured to prevent hanging requests
 - Consider using a firewall to restrict outbound connections if needed
+
+**GeoClaw external sources:**
+- STAC catalogs and OSM-derived downloads should be treated as external dependencies
+- Review and constrain outbound access when running GeoClaw in sensitive environments
+- Prefer local or self-hosted data sources when possible
 
 **WhatsApp Bridge:**
 - The bridge binds to `127.0.0.1:3001` (localhost only, not accessible from external network)
@@ -187,6 +200,7 @@ For production use:
 - **LLM providers see your prompts** - review their privacy policies
 - **Chat history is stored locally** - protect the `~/.nanobot` directory
 - **API keys are in plain text** - use OS keyring for production
+- **GeoClaw artifacts may contain sensitive location data** - protect `runs/`, exported GeoJSON, raster clips, and route outputs
 
 ### 10. Incident Response
 
@@ -237,7 +251,7 @@ If you suspect a security breach:
 
 ## Security Checklist
 
-Before deploying nanobot:
+Before deploying GeoClaw:
 
 - [ ] API keys stored securely (not in code)
 - [ ] Config file permissions set to 0600

--- a/docs/CHANNEL_PLUGIN_GUIDE.md
+++ b/docs/CHANNEL_PLUGIN_GUIDE.md
@@ -2,6 +2,8 @@
 
 Build a custom nanobot channel in three steps: subclass, package, install.
 
+GeoClaw reuses the same channel architecture because it runs on top of nanobot's runtime. If you expose GeoClaw through a custom chat or webhook integration, this guide still applies unchanged.
+
 ## How It Works
 
 nanobot discovers channel plugins via Python [entry points](https://packaging.python.org/en/latest/specifications/entry-points/). When `nanobot gateway` starts, it scans:

--- a/geoclaw/__init__.py
+++ b/geoclaw/__init__.py
@@ -1,0 +1,6 @@
+"""
+GeoClaw - A geospatial workflow agent built on nanobot.
+"""
+
+__version__ = "0.1.0"
+__logo__ = "🌍"

--- a/geoclaw/adapters/__init__.py
+++ b/geoclaw/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""GeoClaw adapters for workspace and CRS management."""

--- a/geoclaw/adapters/crs.py
+++ b/geoclaw/adapters/crs.py
@@ -1,0 +1,57 @@
+"""CRS inference and validation utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def suggest_utm_crs(lon: float, lat: float) -> str:
+    """Return the EPSG code for the UTM zone covering (*lon*, *lat*)."""
+    zone_number = int((lon + 180) / 6) + 1
+    if lat >= 0:
+        return f"EPSG:{32600 + zone_number}"
+    return f"EPSG:{32700 + zone_number}"
+
+
+def suggest_projected_crs(west: float, south: float, east: float, north: float) -> str:
+    """Suggest a projected CRS for a bounding box.
+
+    Uses the centroid to pick a UTM zone.  For very large extents that span
+    many UTM zones a Web Mercator fallback is returned.
+    """
+    lon_span = abs(east - west)
+    if lon_span > 12:
+        return "EPSG:3857"
+    center_lon = (west + east) / 2
+    center_lat = (south + north) / 2
+    return suggest_utm_crs(center_lon, center_lat)
+
+
+def validate_epsg(code: str) -> bool:
+    """Check whether *code* looks like a valid EPSG string."""
+    if not code.upper().startswith("EPSG:"):
+        return False
+    try:
+        int(code.split(":")[1])
+        return True
+    except (IndexError, ValueError):
+        return False
+
+
+def describe_crs(crs_input: Any) -> dict[str, Any]:
+    """Return a dict describing the CRS in human-readable terms.
+
+    Accepts pyproj.CRS, a string like 'EPSG:4326', or a WKT string.
+    """
+    try:
+        from pyproj import CRS
+        crs = CRS(crs_input)
+        return {
+            "name": crs.name,
+            "authority": crs.to_authority() if crs.to_authority() else None,
+            "is_geographic": crs.is_geographic,
+            "is_projected": crs.is_projected,
+            "units": str(crs.axis_info[0].unit_name) if crs.axis_info else "unknown",
+        }
+    except Exception as exc:
+        return {"error": str(exc)}

--- a/geoclaw/adapters/workspace.py
+++ b/geoclaw/adapters/workspace.py
@@ -1,0 +1,70 @@
+"""Workspace sandbox management — all artifacts stay under workspace root."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class WorkspaceManager:
+    """Enforces workspace isolation for GeoClaw file operations."""
+
+    def __init__(self, workspace: Path):
+        self._root = workspace.expanduser().resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    @property
+    def runs_dir(self) -> Path:
+        d = self._root / "runs"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    @property
+    def skills_dir(self) -> Path:
+        d = self._root / "skills"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def resolve_path(self, user_path: str) -> Path:
+        """Resolve a user-supplied path, enforcing sandbox boundaries.
+
+        Relative paths are resolved against the workspace root.
+        Absolute paths are allowed only if they fall under the workspace.
+        """
+        p = Path(user_path).expanduser()
+        if not p.is_absolute():
+            p = self._root / p
+        resolved = p.resolve()
+        if not self._is_under(resolved, self._root):
+            raise PermissionError(
+                f"Path '{user_path}' resolves to '{resolved}' which is outside "
+                f"workspace '{self._root}'"
+            )
+        return resolved
+
+    def resolve_input_path(self, user_path: str) -> Path:
+        """Resolve an input file path — allows reading from anywhere that exists."""
+        p = Path(user_path).expanduser()
+        if not p.is_absolute():
+            p = self._root / p
+        resolved = p.resolve()
+        if not resolved.exists():
+            raise FileNotFoundError(f"Input path does not exist: {resolved}")
+        return resolved
+
+    def new_run_dir(self, run_id: str) -> Path:
+        """Create and return a run directory."""
+        d = self.runs_dir / run_id
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    @staticmethod
+    def _is_under(path: Path, directory: Path) -> bool:
+        try:
+            path.relative_to(directory)
+            return True
+        except ValueError:
+            return False

--- a/geoclaw/cli.py
+++ b/geoclaw/cli.py
@@ -1,0 +1,94 @@
+"""GeoClaw CLI entrypoints."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from geoclaw import __logo__, __version__
+from geoclaw.runtime import GeoClawLoop, sync_geoclaw_skills
+
+app = typer.Typer(
+    name="geoclaw",
+    help=f"{__logo__} GeoClaw - geospatial workflow agent built on nanobot",
+    no_args_is_help=True,
+)
+console = Console()
+
+
+@app.callback()
+def main() -> None:
+    """GeoClaw commands."""
+
+
+@app.command()
+def sync_skills(
+    workspace: str | None = typer.Option(
+        None, "--workspace", "-w", help="Workspace directory to sync packaged skills into"
+    ),
+):
+    """Copy packaged GeoClaw skills into the target workspace."""
+    from nanobot.config.paths import get_workspace_path
+
+    workspace_path = get_workspace_path(workspace)
+    sync_geoclaw_skills(workspace_path)
+    console.print(f"[green]Synced GeoClaw skills to[/green] {workspace_path / 'skills'}")
+
+
+@app.command()
+def agent(
+    message: str = typer.Option(..., "--message", "-m", help="Message to send to GeoClaw"),
+    session_id: str = typer.Option("cli:direct", "--session", "-s", help="Session ID"),
+    workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
+    config: str | None = typer.Option(None, "--config", "-c", help="Config file path"),
+    markdown: bool = typer.Option(True, "--markdown/--no-markdown", help="Render markdown output"),
+):
+    """Run a single GeoClaw request through nanobot runtime + geospatial tools."""
+    from rich.markdown import Markdown
+
+    from nanobot.bus.queue import MessageBus
+    from nanobot.cli.commands import _load_runtime_config, _make_provider
+    from nanobot.config.paths import get_cron_dir
+    from nanobot.cron.service import CronService
+
+    loaded = _load_runtime_config(config, workspace)
+    sync_geoclaw_skills(loaded.workspace_path)
+
+    bus = MessageBus()
+    provider = _make_provider(loaded)
+    cron = CronService(get_cron_dir() / "jobs.json")
+    loop = GeoClawLoop(
+        bus=bus,
+        provider=provider,
+        workspace=loaded.workspace_path,
+        model=loaded.agents.defaults.model,
+        max_iterations=loaded.agents.defaults.max_tool_iterations,
+        context_window_tokens=loaded.agents.defaults.context_window_tokens,
+        web_search_config=loaded.tools.web.search,
+        web_proxy=loaded.tools.web.proxy or None,
+        exec_config=loaded.tools.exec,
+        cron_service=cron,
+        restrict_to_workspace=loaded.tools.restrict_to_workspace,
+        mcp_servers=loaded.tools.mcp_servers,
+        channels_config=loaded.channels,
+    )
+
+    async def _run_once() -> str:
+        try:
+            return await loop.process_direct(message, session_key=session_id)
+        finally:
+            await loop.close_mcp()
+
+    console.print(f"[cyan]{__logo__} GeoClaw v{__version__}[/cyan]")
+    response = asyncio.run(_run_once())
+    if markdown:
+        console.print(Markdown(response))
+    else:
+        console.print(response)
+
+
+if __name__ == "__main__":
+    app()

--- a/geoclaw/config.py
+++ b/geoclaw/config.py
@@ -1,0 +1,22 @@
+"""GeoClaw-specific configuration extensions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+
+class GeoClawConfig(BaseModel):
+    """Configuration knobs specific to geoclaw tools."""
+
+    workspace: str = "~/.nanobot/workspace"
+    max_aoi_area_sq_km: float = 50_000.0
+    max_raster_pixels: int = 100_000_000
+    default_h3_resolution: int = 8
+    osm_timeout_seconds: int = 120
+    stac_timeout_seconds: int = 60
+
+    @property
+    def workspace_path(self) -> Path:
+        return Path(self.workspace).expanduser()

--- a/geoclaw/prompts/__init__.py
+++ b/geoclaw/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""GeoClaw prompt templates."""

--- a/geoclaw/prompts/system.py
+++ b/geoclaw/prompts/system.py
@@ -1,0 +1,29 @@
+"""GeoClaw system prompt fragments injected into the nanobot context."""
+
+GEOCLAW_IDENTITY = """# GeoClaw 🌍
+
+You are GeoClaw, a geospatial workflow agent built on nanobot.
+You turn natural-language requests into reproducible geospatial workflows.
+
+## Capabilities
+- AOI intake and sanity checking (CRS, validity, extent, area)
+- Vector operations (read, summarise, join, buffer, reproject)
+- Raster / EO summarisation (clip, zonal stats, preview)
+- OSM extraction and place intelligence
+- Routing / isochrone / accessibility analysis
+- STAC search and preview
+- Hex-based spatial aggregation (H3)
+
+## Workflow Rules
+1. Always validate the AOI first using `geo_inspect_aoi` before deeper analysis.
+2. Use `geo_validate_geometry` to ensure geometry is valid.
+3. Use `geo_suggest_crs` to recommend a suitable projected CRS.
+4. After completing a workflow, call `geo_render_workflow` to produce summary.md + result.json.
+5. Keep all artifacts inside the workspace `runs/` directory.
+6. Report machine-readable results alongside human-readable summaries.
+7. When uncertain about CRS, always ask — never silently assume.
+8. For large areas (>50,000 km²), warn the user about processing time.
+
+## Tool Naming Convention
+All geospatial tools are prefixed with `geo_`.
+"""

--- a/geoclaw/prompts/templates.py
+++ b/geoclaw/prompts/templates.py
@@ -1,0 +1,40 @@
+"""Prompt templates for skill explanations."""
+
+AOI_SUMMARY_TEMPLATE = """## AOI Sanity Check Results
+
+**CRS**: {crs}
+**Geometry Valid**: {is_valid}
+**Feature Count**: {feature_count}
+**Extent**: {extent}
+**Estimated Area**: {area_estimate}
+**Recommended Projected CRS**: {suggested_crs}
+
+### Downstream Suggestions
+{suggestions}
+"""
+
+OSM_PROFILE_TEMPLATE = """## OSM Place Profile
+
+**Area**: {area_name}
+**Total Features Extracted**: {total_features}
+
+### Category Breakdown
+{category_table}
+
+### Summary
+{narrative}
+"""
+
+RASTER_SUMMARY_TEMPLATE = """## Raster Exposure Summary
+
+**Source**: {source}
+**Clipped Extent**: {extent}
+**Resolution**: {resolution}
+**Band Count**: {band_count}
+
+### Statistics
+{stats_table}
+
+### Method Notes
+{method_notes}
+"""

--- a/geoclaw/renderers/__init__.py
+++ b/geoclaw/renderers/__init__.py
@@ -1,0 +1,1 @@
+"""GeoClaw output renderers."""

--- a/geoclaw/renderers/preview.py
+++ b/geoclaw/renderers/preview.py
@@ -1,0 +1,3 @@
+"""Preview image generation — stub for Phase 2."""
+
+# TODO: Implement PNG preview generation for vector and raster data

--- a/geoclaw/renderers/workflow.py
+++ b/geoclaw/renderers/workflow.py
@@ -1,0 +1,136 @@
+"""Render workflow results to summary.md, result.json, and provenance.json."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from geoclaw.schemas.common import ToolResult
+
+
+class WorkflowRenderer:
+    """Produces the standard output files for a completed GeoClaw workflow."""
+
+    def render(
+        self,
+        results: list[ToolResult],
+        run_id: str,
+        title: str,
+        output_dir: Path,
+    ) -> Path:
+        """Write summary.md, result.json, and provenance.json to *output_dir*."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        md = self._build_markdown(results, run_id, title)
+        (output_dir / "summary.md").write_text(md, encoding="utf-8")
+
+        payload = {
+            "run_id": run_id,
+            "title": title,
+            "timestamp": datetime.now().isoformat(),
+            "results": [r.model_dump(mode="json") for r in results],
+        }
+        (output_dir / "result.json").write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
+
+        provenance = [
+            r.provenance.model_dump(mode="json")
+            for r in results
+            if r.provenance is not None
+        ]
+        if provenance:
+            (output_dir / "provenance.json").write_text(
+                json.dumps(provenance, indent=2, ensure_ascii=False, default=str),
+                encoding="utf-8",
+            )
+
+        return output_dir
+
+    def render_from_dicts(
+        self,
+        result_dicts: list[dict[str, Any]],
+        run_id: str,
+        title: str,
+        output_dir: Path,
+    ) -> Path:
+        """Convenience variant that accepts raw dicts instead of ToolResult objects."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        md_parts = [f"# {title}", f"**Run ID**: `{run_id}`", f"**Generated**: {datetime.now().isoformat()}", ""]
+        for i, rd in enumerate(result_dicts, 1):
+            tool = rd.get("tool_name", "unknown")
+            success = rd.get("success", False)
+            status = "OK" if success else "FAILED"
+            summary = rd.get("summary", "")
+            md_parts.append(f"## Step {i}: {tool} [{status}]")
+            if summary:
+                md_parts.append(summary)
+            if rd.get("errors"):
+                md_parts.append("**Errors**: " + "; ".join(rd["errors"]))
+            if rd.get("warnings"):
+                md_parts.append("**Warnings**: " + "; ".join(rd["warnings"]))
+            if rd.get("artifacts"):
+                md_parts.append("**Artifacts**:")
+                for a in rd["artifacts"]:
+                    path = a.get("path", "")
+                    fmt = a.get("format", "")
+                    md_parts.append(f"  - `{path}` ({fmt})")
+            md_parts.append("")
+
+        (output_dir / "summary.md").write_text("\n".join(md_parts), encoding="utf-8")
+
+        payload = {
+            "run_id": run_id,
+            "title": title,
+            "timestamp": datetime.now().isoformat(),
+            "results": result_dicts,
+        }
+        (output_dir / "result.json").write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
+
+        provenance = [rd.get("provenance") for rd in result_dicts if rd.get("provenance")]
+        if provenance:
+            (output_dir / "provenance.json").write_text(
+                json.dumps(provenance, indent=2, ensure_ascii=False, default=str),
+                encoding="utf-8",
+            )
+
+        return output_dir
+
+    # ------------------------------------------------------------------
+
+    def _build_markdown(
+        self, results: list[ToolResult], run_id: str, title: str
+    ) -> str:
+        parts = [
+            f"# {title}",
+            f"**Run ID**: `{run_id}`",
+            f"**Generated**: {datetime.now().isoformat()}",
+            "",
+        ]
+        for i, r in enumerate(results, 1):
+            status = "OK" if r.success else "FAILED"
+            parts.append(f"## Step {i}: {r.tool_name} [{status}]")
+            if r.summary:
+                parts.append(r.summary)
+            if r.errors:
+                parts.append("**Errors**: " + "; ".join(r.errors))
+            if r.warnings:
+                parts.append("**Warnings**: " + "; ".join(r.warnings))
+            if r.artifacts:
+                parts.append("**Artifacts**:")
+                for a in r.artifacts:
+                    parts.append(f"  - `{a.path}` ({a.format})")
+            if r.data:
+                parts.append("**Data**:")
+                parts.append("```json")
+                parts.append(json.dumps(r.data, indent=2, ensure_ascii=False, default=str))
+                parts.append("```")
+            parts.append("")
+        return "\n".join(parts)

--- a/geoclaw/runtime.py
+++ b/geoclaw/runtime.py
@@ -1,0 +1,53 @@
+"""GeoClaw runtime built on top of the nanobot agent loop."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from nanobot.agent.context import ContextBuilder
+from nanobot.agent.loop import AgentLoop
+
+from geoclaw.prompts.system import GEOCLAW_IDENTITY
+from geoclaw.tools import register_all_geo_tools
+
+
+class GeoClawContextBuilder(ContextBuilder):
+    """Context builder that brands the agent as GeoClaw."""
+
+    def _get_identity(self) -> str:
+        base = super()._get_identity()
+        return base + "\n\n---\n\n" + GEOCLAW_IDENTITY
+
+
+def sync_geoclaw_skills(workspace: Path) -> None:
+    """Copy packaged GeoClaw skills into the workspace skill directory."""
+    source_dir = Path(__file__).parent / "skills"
+    target_dir = workspace / "skills"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    for skill_dir in source_dir.iterdir():
+        if not skill_dir.is_dir():
+            continue
+        src = skill_dir / "SKILL.md"
+        if not src.exists():
+            continue
+        dest_dir = target_dir / skill_dir.name
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest_dir / "SKILL.md")
+
+
+class GeoClawLoop(AgentLoop):
+    """AgentLoop with GeoClaw tools and prompt customisation."""
+
+    def __init__(self, *args, **kwargs):
+        workspace = kwargs.get("workspace") or (args[2] if len(args) > 2 else None)
+        super().__init__(*args, **kwargs)
+        self.context = GeoClawContextBuilder(self.workspace)
+        self.memory_consolidator._build_messages = self.context.build_messages
+        sync_geoclaw_skills(self.workspace)
+
+    def _register_default_tools(self) -> None:
+        super()._register_default_tools()
+        for tool in register_all_geo_tools(self.workspace):
+            self.tools.register(tool)

--- a/geoclaw/schemas/__init__.py
+++ b/geoclaw/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""GeoClaw data schemas."""

--- a/geoclaw/schemas/common.py
+++ b/geoclaw/schemas/common.py
@@ -1,0 +1,84 @@
+"""Common schemas shared across all GeoClaw tools."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ArtifactMeta(BaseModel):
+    """Metadata for a single output artifact."""
+
+    path: str
+    format: str = Field(description="File format: geojson, geoparquet, tif, png, csv, etc.")
+    size_bytes: int = 0
+    description: str = ""
+
+
+class ProvenanceMeta(BaseModel):
+    """Reproducibility metadata for a tool invocation."""
+
+    tool_name: str
+    tool_version: str = "0.1.0"
+    timestamp: datetime = Field(default_factory=datetime.now)
+    input_hash: str = ""
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    duration_seconds: float = 0.0
+    crs_used: str | None = None
+
+
+class ToolResult(BaseModel):
+    """Standard result envelope returned by every GeoClaw tool."""
+
+    success: bool
+    tool_name: str
+    summary: str = ""
+    data: dict[str, Any] = Field(default_factory=dict)
+    artifacts: list[ArtifactMeta] = Field(default_factory=list)
+    provenance: ProvenanceMeta | None = None
+    errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    def to_llm_string(self) -> str:
+        """Serialize to a concise string suitable for LLM consumption."""
+        parts = [f"[{self.tool_name}] {'OK' if self.success else 'FAILED'}"]
+        if self.summary:
+            parts.append(self.summary)
+        if self.errors:
+            parts.append("Errors: " + "; ".join(self.errors))
+        if self.warnings:
+            parts.append("Warnings: " + "; ".join(self.warnings))
+        if self.artifacts:
+            arts = ", ".join(f"{a.path} ({a.format})" for a in self.artifacts)
+            parts.append(f"Artifacts: {arts}")
+        if self.data:
+            import json
+            parts.append("Data: " + json.dumps(self.data, ensure_ascii=False, default=str))
+        return "\n".join(parts)
+
+
+class BBox(BaseModel):
+    """Bounding box in (west, south, east, north) order."""
+
+    west: float
+    south: float
+    east: float
+    north: float
+    crs: str = "EPSG:4326"
+
+    def as_tuple(self) -> tuple[float, float, float, float]:
+        return (self.west, self.south, self.east, self.north)
+
+    def area_degrees(self) -> float:
+        return abs(self.east - self.west) * abs(self.north - self.south)
+
+
+class AOIInput(BaseModel):
+    """Flexible AOI specification — exactly one field should be set."""
+
+    bbox: BBox | None = None
+    geojson: dict | None = None
+    file_path: str | None = None
+    place_name: str | None = None

--- a/geoclaw/skills/accessibility_analysis/SKILL.md
+++ b/geoclaw/skills/accessibility_analysis/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: accessibility_analysis
+description: Compute routes, isochrones, and service-area coverage
+metadata: {"nanobot":{"always":false,"emoji":"🚗"}}
+---
+
+# Accessibility Analysis
+
+Use this skill when the user wants route distance, travel-time reach, service areas, or reachable destination counts from one or more origins.
+
+## Current Implementation
+- Backed by real tools: `geo_build_network`, `geo_compute_route`, `geo_compute_isochrone`, `geo_compute_service_coverage`, `geo_render_workflow`
+- Uses OSM-derived network construction through the GeoClaw tool layer rather than arbitrary shell commands
+- Produces route, isochrone, or coverage artifacts under `runs/<run_id>/`
+
+## When To Trigger
+- The user asks for a route between places.
+- The user asks how far someone can go within a time threshold.
+- The user asks how many POIs, services, or destinations are reachable.
+- The user asks which places remain uncovered.
+
+## Accepted Inputs
+- AOI as bbox, place name, inline GeoJSON, or local file path
+- origin and destination point objects with `lon` / `lat`
+- one or more origins for service coverage
+- destination points as GeoJSON for coverage analysis
+- mode: `walk`, `bike`, `drive`, or `all`
+- time threshold in minutes or distance threshold in meters
+
+## Preferred Tool Sequence
+1. Call `geo_inspect_aoi` if the AOI is not already normalized.
+2. Call `geo_build_network` with the AOI and requested mode.
+3. If the user wants a single route, call `geo_compute_route`.
+4. If the user wants a reachable area, call `geo_compute_isochrone`.
+5. If the user wants counts of reachable destinations, call `geo_compute_service_coverage`.
+6. Call `geo_render_workflow` to save outputs and provenance.
+
+## Tool Sequence Preference
+- Prefer `walk` for pedestrian accessibility, `drive` for travel-time routing, and `bike` only when explicitly requested.
+- Prefer time thresholds when the user frames accessibility in minutes.
+- Prefer service coverage over route-only output when the user asks about reachable opportunities, not just path geometry.
+
+## Fallback Logic
+- If the network build fails for a very large AOI, ask the user to reduce the AOI.
+- If routing fails because origin and destination are disconnected, explain that no network path exists.
+- If destination coverage fails because inputs are not points, ask for point destinations.
+- If both time and distance thresholds are missing, ask the user which one they want to use.
+
+## Expected Outputs
+- Route geometry and travel distance / time.
+- Isochrone or service-area geometry.
+- Reachable destination counts and uncovered totals.
+- Saved outputs suitable for later spatial aggregation or reporting.
+
+## Explanation Template
+Explain the result in this order:
+1. Which AOI and travel mode were used.
+2. What network analysis was run.
+3. The key accessibility metric: route time, reachable area, or reachable destination count.
+4. Any important caveats such as disconnected streets or coarse AOI boundaries.
+5. Suggested next step, such as OSM place profiling for destinations or H3 aggregation of uncovered points.

--- a/geoclaw/skills/aoi_sanity_check/SKILL.md
+++ b/geoclaw/skills/aoi_sanity_check/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: aoi_sanity_check
+description: Validate and inspect an Area of Interest before downstream geospatial analysis
+metadata: {"nanobot":{"always":false,"emoji":"🗺️"}}
+---
+
+# AOI Sanity Check
+
+Use this skill when the user supplies a geographic area and wants to understand:
+- whether the geometry is valid
+- what CRS it uses
+- how large the area is
+- what downstream workflows make sense
+
+## Current Implementation
+- Backed by real tools: `geo_inspect_aoi`, `geo_validate_geometry`, `geo_suggest_crs`, `geo_render_workflow`
+- Produces reproducible outputs under `runs/<run_id>/`
+- Use this as the default entrypoint before OSM, raster, STAC, network, or H3 workflows
+
+## Accepted Inputs
+- bounding box
+- place name
+- inline GeoJSON geometry / Feature / FeatureCollection
+- local file path to GeoJSON / Shapefile / GeoPackage
+
+## Preferred Tool Sequence
+1. Call `geo_inspect_aoi` with the most concrete AOI representation available.
+2. If a geometry or file is involved, call `geo_validate_geometry`.
+3. Call `geo_suggest_crs` with the AOI bounds.
+4. Call `geo_render_workflow` to create `summary.md` and `result.json` under the same `run_id`.
+
+## Fallback Logic
+- If `place_name` geocoding fails, ask for a bbox or local file path.
+- If the file cannot be read, report the exact path / format error and ask for GeoJSON, GPKG, or SHP.
+- If the geometry is invalid, explain why and offer `auto_fix=true` with `geo_validate_geometry`.
+- If the AOI is extremely large, warn that OSM, routing, and raster analysis may be slow.
+
+## Expected Outputs
+- CRS description
+- geometry validity
+- extent / bounding box
+- feature count
+- area estimate
+- recommended projected CRS
+- downstream suggestions such as:
+  - `osm_place_profile` for place intelligence
+  - `raster_exposure_summary` for raster or EO summaries
+  - `stac_search_preview` for imagery discovery
+  - `hex_service_coverage` for aggregation
+
+## Explanation Template
+Explain the result in this order:
+1. What input was interpreted as the AOI
+2. Whether the geometry is valid
+3. Which CRS was detected and which projected CRS is recommended
+4. Approximate area and why it matters for later workflows
+5. The most suitable next workflow(s)

--- a/geoclaw/skills/hex_service_coverage/SKILL.md
+++ b/geoclaw/skills/hex_service_coverage/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: hex_service_coverage
+description: Aggregate spatial data into H3 hexagons for coverage analysis
+metadata: {"nanobot":{"always":false,"emoji":"⬡"}}
+---
+
+# Hex Service Coverage
+
+Use this skill when the user wants spatial aggregation, hotspot identification, service intensity mapping, or scale-sensitive hex summaries.
+
+## Current Implementation
+- Backed by real tools: `geo_point_to_h3`, `geo_polygon_to_h3`, `geo_aggregate_by_h3`, `geo_neighborhood_summary`, `geo_render_workflow`
+- Supports both point-to-cell assignment and polygon polyfill workflows
+- Produces aggregation layers and summary outputs under `runs/<run_id>/`
+
+## When To Trigger
+- The user asks where coverage is strong or weak.
+- The user wants point or polygon data aggregated into H3 cells.
+- The user wants a scale-sensitive summary instead of raw feature maps.
+
+## Accepted Inputs
+- point dataset as GeoJSON or file path
+- polygon dataset when polyfill is appropriate
+- H3 resolution
+- optional metric property and aggregation method
+
+## Preferred Tool Sequence
+1. If the request includes an AOI, call `geo_inspect_aoi` first.
+2. For point data, call `geo_point_to_h3`.
+3. For polygon data, call `geo_polygon_to_h3`.
+4. Call `geo_aggregate_by_h3` with the requested resolution and metric.
+5. Optionally call `geo_neighborhood_summary` for a hotspot cell if the user asks about local context.
+6. Call `geo_render_workflow` to save the workflow outputs.
+
+## Tool Sequence Preference
+- Prefer `count` aggregation when the user does not specify a metric.
+- Use `sum` or `mean` only when a numeric property is explicitly available.
+- Explain the trade-off between coarse and fine H3 resolution.
+
+## Fallback Logic
+- If the input contains no supported geometry type, ask the user for point or polygon features.
+- If polygon-to-H3 produces too many cells, recommend a coarser resolution.
+- If no metric field is available, fall back to feature counts.
+- If the user wants service accessibility rather than density, suggest `accessibility_analysis` instead.
+
+## Expected Outputs
+- H3 aggregation output layer.
+- Coverage distribution statistics.
+- Hot/cold or dense/sparse cell interpretation.
+- A short note on how the chosen resolution affects interpretation.
+
+## Explanation Template
+Explain the result in this order:
+1. What dataset and H3 resolution were used.
+2. How many cells were produced.
+3. What the distribution looks like.
+4. Which cells appear dense or sparse.
+5. Whether a finer or coarser resolution would be better for the next iteration.

--- a/geoclaw/skills/osm_place_profile/SKILL.md
+++ b/geoclaw/skills/osm_place_profile/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: osm_place_profile
+description: Extract and summarise OpenStreetMap features for an AOI
+metadata: {"nanobot":{"always":false,"emoji":"🏙️"}}
+---
+
+# OSM Place Profile
+
+Use this skill when the user wants place intelligence from OpenStreetMap for a neighborhood, campus, district, city block, or explicit AOI.
+
+## Current Implementation
+- Backed by real tools: `geo_inspect_aoi`, `geo_validate_geometry`, `geo_extract_osm`, `geo_build_place_profile`, `geo_render_workflow`
+- Saves extracted features and workflow outputs inside `runs/<run_id>/artifacts`
+- Best suited for local-scale AOIs where OSM completeness is expected to be reasonable
+
+## When To Trigger
+- The user asks what is in an area.
+- The user asks for amenities, shops, leisure, tourism, buildings, or other OSM-tagged context.
+- The user wants a saved OSM extract plus a concise narrative profile.
+
+## Accepted Inputs
+- bbox
+- place name
+- inline GeoJSON
+- local vector file path
+- optional `tags_filter` to constrain extraction
+
+## Preferred Tool Sequence
+1. Call `geo_inspect_aoi` to normalize the AOI and get the `run_id`.
+2. If the AOI came from geometry or file input, call `geo_validate_geometry`.
+3. Call `geo_extract_osm` with the AOI and either the supplied `tags_filter` or the default thematic tags.
+4. Call `geo_build_place_profile` on the saved OSM output or returned GeoJSON.
+5. Call `geo_render_workflow` with the shared `run_id` to write `summary.md` and `result.json`.
+
+## Tool Sequence Preference
+- Prefer broad discovery tags first: `amenity`, `shop`, `leisure`, `tourism`, `building`.
+- Use a user-provided `tags_filter` only when the request is clearly thematic.
+- If the AOI is large, warn before extraction and recommend narrowing the area.
+
+## Fallback Logic
+- If AOI resolution fails, ask for a bbox or local file.
+- If OSM extraction returns zero features, explain that either the area is sparsely mapped or the tag filter is too restrictive.
+- If extraction fails for a large AOI, ask the user to reduce the search area or narrow tags.
+- If GeoParquet export fails, still continue with GeoJSON output and explain the degraded export.
+
+## Expected Outputs
+- Extracted OSM features saved as GeoJSON and, if possible, GeoParquet.
+- Category counts by major OSM tag family.
+- Place profile narrative summarizing the dominant land uses or amenities.
+- Reproducible workflow artifacts under `runs/<run_id>/artifacts`.
+
+## Explanation Template
+Explain the result in this order:
+1. What AOI was used.
+2. How many OSM features were extracted.
+3. Which categories dominated the extract.
+4. What the area seems to be based on mapped features.
+5. Which downstream workflow is most useful next, such as routing, raster summary, or H3 aggregation.

--- a/geoclaw/skills/raster_exposure_summary/SKILL.md
+++ b/geoclaw/skills/raster_exposure_summary/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: raster_exposure_summary
+description: Clip a raster to an AOI and produce zonal statistics
+metadata: {"nanobot":{"always":false,"emoji":"🛰️"}}
+---
+
+# Raster Exposure Summary
+
+Use this skill when the user wants to quantify raster values inside an AOI, inspect a clipped raster, or generate a quick EO preview.
+
+## Current Implementation
+- Backed by real tools: `geo_read_raster`, `geo_clip_raster`, `geo_raster_summary`, `geo_export_raster_preview`, `geo_render_workflow`
+- Supports local rasters and raster assets handed off from a prior STAC workflow
+- Writes clipped rasters, preview PNGs, and structured summaries under `runs/<run_id>/`
+
+## When To Trigger
+- The user provides a raster file and asks for summary statistics.
+- The user wants exposure, intensity, elevation, hazard, land-cover, or EO pixel summaries for an AOI.
+- The user wants a clipped raster and preview image saved for later use.
+
+## Accepted Inputs
+- AOI as bbox, place name, inline GeoJSON, or vector file
+- local raster path
+- optionally a raster selected from a previous STAC workflow
+- optional band number
+
+## Preferred Tool Sequence
+1. Call `geo_inspect_aoi` to normalize the AOI and obtain bounds.
+2. If geometry-based AOI is used, call `geo_validate_geometry`.
+3. Call `geo_read_raster` to inspect raster CRS, dimensions, and metadata.
+4. Call `geo_clip_raster` with the AOI and the source raster.
+5. Call `geo_raster_summary` on the clipped raster.
+6. Call `geo_export_raster_preview` to produce a PNG preview.
+7. Call `geo_render_workflow` to save `summary.md` and `result.json`.
+
+## Tool Sequence Preference
+- Prefer clipping before summarizing so the reported statistics are AOI-specific.
+- Prefer the first band unless the user explicitly specifies another band.
+- If the raster is large, warn that clipping may take longer and keep the analysis focused on the AOI.
+
+## Fallback Logic
+- If AOI and raster CRS differ, explain that reprojection may be needed before precise zonal work.
+- If clipping fails, fall back to reporting source raster metadata and ask the user to verify the AOI overlap.
+- If preview generation fails, continue with clipped raster and statistics.
+- If the raster band has no valid pixels, explain that the AOI may fall outside data coverage or into nodata.
+
+## Expected Outputs
+- Source raster metadata.
+- Clipped raster saved to `artifacts/`.
+- Basic statistics such as min, max, mean, std, and valid pixel count.
+- PNG preview image.
+- Method notes about clipping and band selection.
+
+## Explanation Template
+Explain the result in this order:
+1. Which raster and AOI were used.
+2. What clip was produced.
+3. What the core pixel statistics mean.
+4. Any nodata or CRS caveats.
+5. Whether the output is suitable for downstream reporting or further STAC/raster workflows.

--- a/geoclaw/skills/stac_search_preview/SKILL.md
+++ b/geoclaw/skills/stac_search_preview/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: stac_search_preview
+description: Search STAC catalogs for imagery and rank candidate scenes
+metadata: {"nanobot":{"always":false,"emoji":"🔍"}}
+---
+
+# STAC Search & Preview
+
+Use this skill when the user wants to discover imagery for an AOI, compare candidate scenes, or pick a best scene before download or raster analysis.
+
+## Current Implementation
+- Backed by real tools: `geo_search_stac`, `geo_rank_stac_assets`, `geo_preview_stac_assets`, `geo_select_best_scene`, `geo_render_workflow`
+- Keeps outputs compact by ranking scenes and surfacing only the most relevant preview metadata
+- Designed to hand off selected scenes into later raster workflows without losing provenance
+
+## When To Trigger
+- The user asks for satellite scenes over an AOI and time range.
+- The user mentions cloud cover, scene ranking, quicklooks, previews, or best imagery selection.
+- The user needs a shortlist before running raster analysis.
+
+## Accepted Inputs
+- `catalog_url`
+- AOI as bbox
+- time interval via `datetime`
+- optional `collections`
+- optional `query` filters
+- optional asset preference list
+
+## Preferred Tool Sequence
+1. Call `geo_inspect_aoi` if the AOI is not already normalized.
+2. Call `geo_search_stac` with catalog URL, bbox, datetime, collections, and query filters.
+3. Call `geo_rank_stac_assets` with the returned items and user asset preferences.
+4. Call `geo_preview_stac_assets` to surface quicklook or thumbnail references.
+5. Call `geo_select_best_scene` using the ranked items.
+6. Call `geo_render_workflow` to write `summary.md` and `result.json`.
+
+## Tool Sequence Preference
+- Prefer user-specified collections if provided.
+- Prefer low cloud cover plus availability of `visual`, `thumbnail`, or explicitly requested assets.
+- Keep the ranked list short and relevant; do not overwhelm the user with raw STAC payloads.
+
+## Fallback Logic
+- If no scenes are found, suggest widening the date range, relaxing filters, or checking a different collection.
+- If cloud metadata is missing, rank by asset availability and recency instead.
+- If preview assets are unavailable, continue with the ranked list and explain the missing quicklooks.
+- If multiple scenes are tied, explain the tie and return the top few candidates.
+
+## Expected Outputs
+- Ranked candidate scenes.
+- Preview references where available.
+- A selected best scene with reasoning.
+- Enough metadata to hand off to raster workflows.
+
+## Explanation Template
+Explain the result in this order:
+1. Which catalog, AOI, and date range were searched.
+2. How many scenes matched.
+3. Why the top scene ranked highest.
+4. Which preview assets are available.
+5. Whether the selected scene is ready for raster clipping and summary.

--- a/geoclaw/tools/__init__.py
+++ b/geoclaw/tools/__init__.py
@@ -1,0 +1,91 @@
+"""GeoClaw geospatial tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from geoclaw.tools.aoi import (
+    InspectAOITool,
+    RenderWorkflowTool,
+    SuggestCRSTool,
+    ValidateGeometryTool,
+)
+from geoclaw.tools.duckdb_ops import (
+    AggregateFeaturesTool,
+    RunSpatialSQLTool,
+    SummarizeByGeometryTool,
+)
+from geoclaw.tools.gdal_ops import (
+    ClipDatasetTool,
+    ConvertFormatTool,
+    InspectDatasetTool,
+    ReprojectDatasetTool,
+    TranslateToCOGTool,
+)
+from geoclaw.tools.hex import (
+    AggregateByH3Tool,
+    NeighborhoodSummaryTool,
+    PointToH3Tool,
+    PolygonToH3Tool,
+)
+from geoclaw.tools.network import (
+    BuildNetworkTool,
+    ComputeIsochroneTool,
+    ComputeRouteTool,
+    ComputeServiceCoverageTool,
+)
+from geoclaw.tools.osm import BuildPlaceProfileTool, ExtractOSMByGeometryTool
+from geoclaw.tools.raster import (
+    ClipRasterTool,
+    ExportRasterPreviewTool,
+    RasterSummaryTool,
+    ReadRasterTool,
+)
+from geoclaw.tools.stac import (
+    PreviewSTACAssetsTool,
+    RankSTACAssetsTool,
+    SearchSTACTool,
+    SelectBestSceneTool,
+)
+from geoclaw.tools.vector import ReadVectorTool, SummarizeVectorTool
+
+
+def register_all_geo_tools(workspace: Path) -> list:
+    """Instantiate the GeoClaw tool set for a workspace."""
+    return [
+        InspectAOITool(workspace),
+        ValidateGeometryTool(workspace),
+        SuggestCRSTool(workspace),
+        RenderWorkflowTool(workspace),
+        InspectDatasetTool(workspace),
+        ReprojectDatasetTool(workspace),
+        ClipDatasetTool(workspace),
+        ConvertFormatTool(workspace),
+        TranslateToCOGTool(workspace),
+        RunSpatialSQLTool(workspace),
+        AggregateFeaturesTool(workspace),
+        SummarizeByGeometryTool(workspace),
+        ReadVectorTool(workspace),
+        SummarizeVectorTool(workspace),
+        BuildNetworkTool(workspace),
+        ComputeRouteTool(workspace),
+        ComputeIsochroneTool(workspace),
+        ComputeServiceCoverageTool(workspace),
+        ExtractOSMByGeometryTool(workspace),
+        BuildPlaceProfileTool(workspace),
+        ReadRasterTool(workspace),
+        ClipRasterTool(workspace),
+        RasterSummaryTool(workspace),
+        ExportRasterPreviewTool(workspace),
+        SearchSTACTool(workspace),
+        RankSTACAssetsTool(workspace),
+        PreviewSTACAssetsTool(workspace),
+        SelectBestSceneTool(workspace),
+        PointToH3Tool(workspace),
+        PolygonToH3Tool(workspace),
+        AggregateByH3Tool(workspace),
+        NeighborhoodSummaryTool(workspace),
+    ]
+
+
+__all__ = ["register_all_geo_tools"]

--- a/geoclaw/tools/aoi.py
+++ b/geoclaw/tools/aoi.py
@@ -1,0 +1,374 @@
+"""AOI inspection, validation, and CRS suggestion tools."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from nanobot.agent.tools.base import Tool
+
+from geoclaw.adapters.crs import describe_crs, suggest_projected_crs, validate_epsg
+from geoclaw.schemas.common import ArtifactMeta, ToolResult
+from geoclaw.tools.base import GeoTool
+from geoclaw.tools.common import bbox_from_geojson, estimate_area_sq_km, parse_bbox
+
+
+# ---------------------------------------------------------------------------
+# geo_inspect_aoi
+# ---------------------------------------------------------------------------
+
+class InspectAOITool(GeoTool):
+    """Load an AOI from bbox / GeoJSON / file / place name and return key properties."""
+
+    @property
+    def name(self) -> str:
+        return "geo_inspect_aoi"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Inspect an Area of Interest. Accepts a bbox, inline GeoJSON, "
+            "a file path (GeoJSON/GPKG/SHP), or a place name. Returns CRS, "
+            "extent, feature count, area estimate, and geometry type."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "bbox": {
+                    "type": "object",
+                    "description": "Bounding box {west, south, east, north} or [w,s,e,n]",
+                },
+                "geojson": {
+                    "type": "object",
+                    "description": "Inline GeoJSON geometry, Feature, or FeatureCollection",
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to a vector file (GeoJSON, GPKG, SHP)",
+                },
+                "place_name": {
+                    "type": "string",
+                    "description": "Place name to geocode (e.g. 'Beijing')",
+                },
+                "run_id": {
+                    "type": "string",
+                    "description": "Optional run ID for artifact storage",
+                },
+            },
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        params = {k: v for k, v in kwargs.items() if k != "run_id"}
+        try:
+            result = self._inspect(params, run_id)
+            prov = self._make_provenance(params, time.monotonic() - t0)
+            result.provenance = prov
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+    def _inspect(self, params: dict, run_id: str) -> ToolResult:
+        import geopandas as gpd
+        from shapely.geometry import box, mapping, shape
+
+        bbox_raw = params.get("bbox")
+        geojson_raw = params.get("geojson")
+        file_path = params.get("file_path")
+        place_name = params.get("place_name")
+
+        gdf: gpd.GeoDataFrame | None = None
+        source = "unknown"
+
+        if file_path:
+            p = Path(file_path).expanduser()
+            if not p.exists():
+                return self._fail(f"File not found: {file_path}")
+            gdf = gpd.read_file(str(p))
+            source = f"file:{p.name}"
+
+        elif geojson_raw:
+            geom_type = geojson_raw.get("type", "")
+            if geom_type == "FeatureCollection":
+                gdf = gpd.GeoDataFrame.from_features(geojson_raw["features"], crs="EPSG:4326")
+            elif geom_type == "Feature":
+                gdf = gpd.GeoDataFrame.from_features([geojson_raw], crs="EPSG:4326")
+            else:
+                s = shape(geojson_raw)
+                gdf = gpd.GeoDataFrame(geometry=[s], crs="EPSG:4326")
+            source = "inline_geojson"
+
+        elif bbox_raw:
+            bb = parse_bbox(bbox_raw)
+            s = box(bb.west, bb.south, bb.east, bb.north)
+            gdf = gpd.GeoDataFrame(geometry=[s], crs="EPSG:4326")
+            source = "bbox"
+
+        elif place_name:
+            try:
+                import osmnx as ox
+                gdf = ox.geocode_to_gdf(place_name)
+                source = f"geocode:{place_name}"
+            except Exception as exc:
+                return self._fail(f"Geocoding '{place_name}' failed: {exc}")
+
+        else:
+            return self._fail("No AOI provided. Supply bbox, geojson, file_path, or place_name.")
+
+        if gdf is None or gdf.empty:
+            return self._fail("Resulting GeoDataFrame is empty.")
+
+        crs_str = str(gdf.crs) if gdf.crs else "unknown"
+        bounds = gdf.total_bounds  # [minx, miny, maxx, maxy]
+        bb = parse_bbox(list(bounds))
+        area_km2 = estimate_area_sq_km(bb)
+        geom_types = list(gdf.geometry.geom_type.unique())
+        feature_count = len(gdf)
+
+        # Save as GeoJSON artifact
+        artifacts: list[ArtifactMeta] = []
+        try:
+            geojson_str = gdf.to_json(ensure_ascii=False)
+            art = self._save_artifact(run_id, "aoi.geojson", geojson_str, "geojson", "Inspected AOI")
+            artifacts.append(art)
+        except Exception:
+            pass
+
+        data = {
+            "source": source,
+            "crs": crs_str,
+            "feature_count": feature_count,
+            "geometry_types": geom_types,
+            "bounds": {"west": bounds[0], "south": bounds[1], "east": bounds[2], "north": bounds[3]},
+            "area_estimate_sq_km": round(area_km2, 2),
+            "run_id": run_id,
+        }
+        summary = (
+            f"AOI from {source}: {feature_count} feature(s), "
+            f"CRS={crs_str}, ~{area_km2:.1f} km², "
+            f"geometry type(s): {', '.join(geom_types)}"
+        )
+        warnings: list[str] = []
+        if area_km2 > 50_000:
+            warnings.append(f"Large AOI ({area_km2:.0f} km²) — downstream operations may be slow.")
+
+        return self._ok(summary, data=data, artifacts=artifacts, warnings=warnings)
+
+
+# ---------------------------------------------------------------------------
+# geo_validate_geometry
+# ---------------------------------------------------------------------------
+
+class ValidateGeometryTool(GeoTool):
+    """Check geometry validity and report issues."""
+
+    @property
+    def name(self) -> str:
+        return "geo_validate_geometry"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Validate geometries in a GeoJSON or file. Reports invalid geometries "
+            "and optionally auto-fixes them with buffer(0)."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "geojson": {
+                    "type": "object",
+                    "description": "Inline GeoJSON to validate",
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to a vector file to validate",
+                },
+                "auto_fix": {
+                    "type": "boolean",
+                    "description": "Attempt to fix invalid geometries with buffer(0)",
+                },
+            },
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        try:
+            result = self._validate(kwargs)
+            prov = self._make_provenance(kwargs, time.monotonic() - t0)
+            result.provenance = prov
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+    def _validate(self, params: dict) -> ToolResult:
+        import geopandas as gpd
+        from shapely.geometry import shape
+
+        geojson_raw = params.get("geojson")
+        file_path = params.get("file_path")
+        auto_fix = params.get("auto_fix", False)
+
+        if file_path:
+            gdf = gpd.read_file(str(Path(file_path).expanduser()))
+        elif geojson_raw:
+            geom_type = geojson_raw.get("type", "")
+            if geom_type == "FeatureCollection":
+                gdf = gpd.GeoDataFrame.from_features(geojson_raw["features"], crs="EPSG:4326")
+            elif geom_type == "Feature":
+                gdf = gpd.GeoDataFrame.from_features([geojson_raw], crs="EPSG:4326")
+            else:
+                s = shape(geojson_raw)
+                gdf = gpd.GeoDataFrame(geometry=[s], crs="EPSG:4326")
+        else:
+            return self._fail("Provide geojson or file_path to validate.")
+
+        total = len(gdf)
+        invalid_mask = ~gdf.geometry.is_valid
+        invalid_count = int(invalid_mask.sum())
+        reasons: list[str] = []
+
+        from shapely.validation import explain_validity
+        for idx in gdf.index[invalid_mask]:
+            r = explain_validity(gdf.geometry[idx])
+            reasons.append(f"Feature {idx}: {r}")
+
+        fixed = False
+        if auto_fix and invalid_count > 0:
+            gdf.geometry = gdf.geometry.buffer(0)
+            remaining = int((~gdf.geometry.is_valid).sum())
+            fixed = True
+        else:
+            remaining = invalid_count
+
+        data = {
+            "total_features": total,
+            "invalid_count": invalid_count,
+            "invalid_reasons": reasons[:20],
+            "auto_fixed": fixed,
+            "remaining_invalid": remaining,
+        }
+        if invalid_count == 0:
+            summary = f"All {total} geometries are valid."
+        elif fixed and remaining == 0:
+            summary = f"{invalid_count}/{total} invalid geometries fixed with buffer(0)."
+        else:
+            summary = f"{invalid_count}/{total} geometries are invalid."
+
+        return self._ok(summary, data=data)
+
+
+# ---------------------------------------------------------------------------
+# geo_suggest_crs
+# ---------------------------------------------------------------------------
+
+class SuggestCRSTool(GeoTool):
+    """Suggest a projected CRS for a given extent."""
+
+    @property
+    def name(self) -> str:
+        return "geo_suggest_crs"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Suggest a suitable projected CRS (e.g. UTM zone) for an extent. "
+            "Takes a bounding box in EPSG:4326 and returns a recommended EPSG code."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "west": {"type": "number", "description": "Western longitude"},
+                "south": {"type": "number", "description": "Southern latitude"},
+                "east": {"type": "number", "description": "Eastern longitude"},
+                "north": {"type": "number", "description": "Northern latitude"},
+            },
+            "required": ["west", "south", "east", "north"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        try:
+            w, s, e, n = kwargs["west"], kwargs["south"], kwargs["east"], kwargs["north"]
+            suggested = suggest_projected_crs(w, s, e, n)
+            info = describe_crs(suggested)
+            data = {
+                "suggested_crs": suggested,
+                "crs_info": info,
+                "input_bounds": {"west": w, "south": s, "east": e, "north": n},
+            }
+            summary = f"Recommended projected CRS: {suggested} ({info.get('name', '')})"
+            prov = self._make_provenance(kwargs, time.monotonic() - t0, crs_used=suggested)
+            return self._ok(summary, data=data, provenance=prov).to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+# ---------------------------------------------------------------------------
+# geo_render_workflow
+# ---------------------------------------------------------------------------
+
+class RenderWorkflowTool(GeoTool):
+    """Render workflow results to summary.md + result.json in a run directory."""
+
+    @property
+    def name(self) -> str:
+        return "geo_render_workflow"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Render a completed workflow's results to summary.md and result.json. "
+            "Provide the run_id and a list of result JSON strings."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "run_id": {
+                    "type": "string",
+                    "description": "The run ID to render results for",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Workflow title for the summary",
+                },
+                "results_json": {
+                    "type": "string",
+                    "description": "JSON array of ToolResult dicts to render",
+                },
+            },
+            "required": ["run_id", "title"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        try:
+            run_id = kwargs["run_id"]
+            title = kwargs.get("title", "GeoClaw Workflow")
+            results_raw = kwargs.get("results_json", "[]")
+            results = json.loads(results_raw) if isinstance(results_raw, str) else results_raw
+
+            from geoclaw.renderers.workflow import WorkflowRenderer
+            renderer = WorkflowRenderer()
+            output_dir = self._runs_dir() / run_id
+            renderer.render_from_dicts(results, run_id, title, output_dir)
+
+            return self._ok(
+                f"Workflow rendered to {output_dir}",
+                data={"run_dir": str(output_dir)},
+            ).to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()

--- a/geoclaw/tools/base.py
+++ b/geoclaw/tools/base.py
@@ -1,0 +1,137 @@
+"""GeoTool — base class for all GeoClaw geospatial tools."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from nanobot.agent.tools.base import Tool
+
+from geoclaw.schemas.common import ArtifactMeta, ProvenanceMeta, ToolResult
+
+
+class GeoTool(Tool):
+    """Abstract base for GeoClaw tools.
+
+    Extends the nanobot Tool ABC with:
+    - workspace-scoped artifact management
+    - automatic provenance tracking
+    - standardised ToolResult serialisation
+    """
+
+    def __init__(self, workspace: Path):
+        self._workspace = workspace
+
+    # ------------------------------------------------------------------
+    # Workspace helpers
+    # ------------------------------------------------------------------
+
+    def _runs_dir(self) -> Path:
+        d = self._workspace / "runs"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _new_run_id(self) -> str:
+        return datetime.now().strftime("%Y%m%d_%H%M%S") + "_" + uuid.uuid4().hex[:8]
+
+    def _artifact_dir(self, run_id: str) -> Path:
+        d = self._runs_dir() / run_id / "artifacts"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _save_artifact(
+        self,
+        run_id: str,
+        filename: str,
+        content: str | bytes,
+        fmt: str,
+        description: str = "",
+    ) -> ArtifactMeta:
+        """Write *content* to the run's artifact directory and return metadata."""
+        art_dir = self._artifact_dir(run_id)
+        path = art_dir / filename
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content, encoding="utf-8")
+        return ArtifactMeta(
+            path=str(path),
+            format=fmt,
+            size_bytes=path.stat().st_size,
+            description=description,
+        )
+
+    # ------------------------------------------------------------------
+    # Provenance helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _hash_params(params: dict[str, Any]) -> str:
+        serialised = json.dumps(params, sort_keys=True, default=str)
+        return hashlib.sha256(serialised.encode()).hexdigest()
+
+    def _make_provenance(
+        self,
+        params: dict[str, Any],
+        duration: float,
+        crs_used: str | None = None,
+    ) -> ProvenanceMeta:
+        return ProvenanceMeta(
+            tool_name=self.name,
+            tool_version="0.1.0",
+            timestamp=datetime.now(),
+            input_hash=self._hash_params(params),
+            parameters=params,
+            duration_seconds=round(duration, 3),
+            crs_used=crs_used,
+        )
+
+    # ------------------------------------------------------------------
+    # Result helpers
+    # ------------------------------------------------------------------
+
+    def _ok(
+        self,
+        summary: str,
+        data: dict[str, Any] | None = None,
+        artifacts: list[ArtifactMeta] | None = None,
+        provenance: ProvenanceMeta | None = None,
+        warnings: list[str] | None = None,
+    ) -> ToolResult:
+        return ToolResult(
+            success=True,
+            tool_name=self.name,
+            summary=summary,
+            data=data or {},
+            artifacts=artifacts or [],
+            provenance=provenance,
+            warnings=warnings or [],
+        )
+
+    def _fail(self, error: str, warnings: list[str] | None = None) -> ToolResult:
+        return ToolResult(
+            success=False,
+            tool_name=self.name,
+            summary=f"Error: {error}",
+            errors=[error],
+            warnings=warnings or [],
+        )
+
+    # ------------------------------------------------------------------
+    # Execution wrapper
+    # ------------------------------------------------------------------
+
+    async def _run_with_provenance(
+        self, params: dict[str, Any], coro
+    ) -> tuple[Any, float, ProvenanceMeta]:
+        """Await *coro*, measure wall time, and build provenance."""
+        t0 = time.monotonic()
+        result = await coro
+        duration = time.monotonic() - t0
+        prov = self._make_provenance(params, duration)
+        return result, duration, prov

--- a/geoclaw/tools/common.py
+++ b/geoclaw/tools/common.py
@@ -1,0 +1,68 @@
+"""Shared helpers used across GeoClaw tool modules."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from geoclaw.adapters.workspace import WorkspaceManager
+from geoclaw.schemas.common import BBox
+
+
+def parse_bbox(raw: Any) -> BBox:
+    """Coerce various bbox representations into a BBox.
+
+    Accepts:
+      - a dict with west/south/east/north keys
+      - a list/tuple of [west, south, east, north]
+      - a JSON string of either form
+    """
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if isinstance(raw, BBox):
+        return raw
+    if isinstance(raw, (list, tuple)) and len(raw) == 4:
+        return BBox(west=raw[0], south=raw[1], east=raw[2], north=raw[3])
+    if isinstance(raw, dict):
+        return BBox(**raw)
+    raise ValueError(f"Cannot parse bbox from {type(raw).__name__}: {raw!r}")
+
+
+def bbox_from_geojson(geojson: dict) -> BBox:
+    """Compute the bounding box of a GeoJSON geometry or feature."""
+    from shapely.geometry import shape
+    geom = _extract_geometry(geojson)
+    s = shape(geom)
+    minx, miny, maxx, maxy = s.bounds
+    return BBox(west=minx, south=miny, east=maxx, north=maxy)
+
+
+def _extract_geometry(geojson: dict) -> dict:
+    """Pull the geometry dict from a GeoJSON object (Feature, FeatureCollection, or bare)."""
+    t = geojson.get("type", "")
+    if t == "Feature":
+        return geojson["geometry"]
+    if t == "FeatureCollection":
+        return geojson["features"][0]["geometry"]
+    return geojson
+
+
+def estimate_area_sq_km(bbox: BBox) -> float:
+    """Rough area estimate for a geographic bbox in square kilometres.
+
+    Uses a simple cos(mid-latitude) scaling.  Not suitable for precise work.
+    """
+    import math
+    mid_lat = (bbox.south + bbox.north) / 2
+    lat_km = 111.32
+    lon_km = 111.32 * math.cos(math.radians(mid_lat))
+    width = abs(bbox.east - bbox.west) * lon_km
+    height = abs(bbox.north - bbox.south) * lat_km
+    return width * height
+
+
+def safe_read_geojson(path: Path) -> dict:
+    """Read a GeoJSON file and return the parsed dict."""
+    text = path.read_text(encoding="utf-8")
+    return json.loads(text)

--- a/geoclaw/tools/duckdb_ops.py
+++ b/geoclaw/tools/duckdb_ops.py
@@ -1,0 +1,196 @@
+"""DuckDB Spatial tools."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from geoclaw.tools.base import GeoTool
+
+
+def _connect_spatial():
+    import duckdb
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial")
+    con.execute("LOAD spatial")
+    return con
+
+
+def _duckdb_path_literal(path: str) -> str:
+    return str(Path(path).expanduser()).replace("\\", "/")
+
+
+class RunSpatialSQLTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_duckdb_run_spatial_sql"
+
+    @property
+    def description(self) -> str:
+        return "Run spatial SQL in DuckDB with the spatial extension loaded."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "sql": {"type": "string"},
+                "limit": {"type": "integer"},
+            },
+            "required": ["sql"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        try:
+            con = _connect_spatial()
+            sql = kwargs["sql"]
+            if kwargs.get("limit"):
+                sql = f"SELECT * FROM ({sql}) t LIMIT {int(kwargs['limit'])}"
+            rows = con.execute(sql).fetchall()
+            columns = [c[0] for c in con.description] if con.description else []
+            result = self._ok(
+                summary=f"Executed DuckDB spatial SQL and returned {len(rows)} row(s).",
+                data={"columns": columns, "rows": rows},
+                provenance=self._make_provenance(
+                    {"sql": kwargs["sql"], "limit": kwargs.get("limit")},
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class AggregateFeaturesTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_duckdb_aggregate_features"
+
+    @property
+    def description(self) -> str:
+        return "Aggregate features from a vector dataset by group field using DuckDB."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "group_by": {"type": "string"},
+                "metric_field": {"type": "string"},
+                "agg_method": {"type": "string", "enum": ["count", "sum", "avg", "min", "max"]},
+            },
+            "required": ["file_path", "group_by"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        try:
+            con = _connect_spatial()
+            file_path = _duckdb_path_literal(kwargs["file_path"])
+            group_by = kwargs["group_by"]
+            metric_field = kwargs.get("metric_field")
+            method = kwargs.get("agg_method", "count")
+
+            source = f"ST_Read('{file_path}')"
+            if method == "count" or not metric_field:
+                expr = "COUNT(*) AS value"
+            else:
+                expr = f"{method.upper()}({metric_field}) AS value"
+
+            sql = f"""
+                SELECT {group_by} AS group_key, {expr}
+                FROM {source}
+                GROUP BY {group_by}
+                ORDER BY value DESC
+            """
+            rows = con.execute(sql).fetchall()
+            result = self._ok(
+                summary=f"Aggregated {len(rows)} grouped result(s) with DuckDB.",
+                data={
+                    "group_by": group_by,
+                    "metric_field": metric_field,
+                    "agg_method": method,
+                    "rows": rows,
+                },
+                provenance=self._make_provenance(
+                    {
+                        "file_path": kwargs["file_path"],
+                        "group_by": group_by,
+                        "metric_field": metric_field,
+                        "agg_method": method,
+                    },
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class SummarizeByGeometryTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_duckdb_summarize_by_geometry"
+
+    @property
+    def description(self) -> str:
+        return "Summarize features intersecting a geometry using DuckDB spatial predicates."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "geojson": {"type": "object"},
+                "metric_field": {"type": "string"},
+                "agg_method": {"type": "string", "enum": ["count", "sum", "avg", "min", "max"]},
+            },
+            "required": ["file_path", "geojson"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import json as _json
+        from shapely.geometry import shape
+
+        t0 = time.monotonic()
+        try:
+            con = _connect_spatial()
+            file_path = _duckdb_path_literal(kwargs["file_path"])
+            geom_wkt = shape(kwargs["geojson"]).wkt
+            metric_field = kwargs.get("metric_field")
+            method = kwargs.get("agg_method", "count")
+            expr = "COUNT(*) AS value" if method == "count" or not metric_field else f"{method.upper()}({metric_field}) AS value"
+            sql = f"""
+                SELECT
+                    COUNT(*) AS matched_features,
+                    {expr}
+                FROM ST_Read('{file_path}')
+                WHERE ST_Intersects(geom, ST_GeomFromText('{geom_wkt}'))
+            """
+            row = con.execute(sql).fetchone()
+            result = self._ok(
+                summary=f"Summarized features intersecting the supplied geometry.",
+                data={
+                    "matched_features": row[0] if row else 0,
+                    "value": row[1] if row and len(row) > 1 else None,
+                    "agg_method": method,
+                    "metric_field": metric_field,
+                },
+                provenance=self._make_provenance(
+                    {
+                        "file_path": kwargs["file_path"],
+                        "metric_field": metric_field,
+                        "agg_method": method,
+                    },
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()

--- a/geoclaw/tools/gdal_ops.py
+++ b/geoclaw/tools/gdal_ops.py
@@ -1,0 +1,343 @@
+"""GDAL-style dataset operations with safe Python-first implementations."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from geoclaw.tools.base import GeoTool
+
+
+def _is_raster(path: Path) -> bool:
+    return path.suffix.lower() in {".tif", ".tiff", ".img", ".vrt"}
+
+
+class InspectDatasetTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_gdal_inspect_dataset"
+
+    @property
+    def description(self) -> str:
+        return "Inspect raster or vector dataset metadata in a GDAL-style envelope."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+        import rasterio
+
+        t0 = time.monotonic()
+        try:
+            path = Path(kwargs["path"]).expanduser()
+            if _is_raster(path):
+                with rasterio.open(path) as src:
+                    data = {
+                        "dataset_type": "raster",
+                        "crs": str(src.crs) if src.crs else None,
+                        "bounds": list(src.bounds),
+                        "width": src.width,
+                        "height": src.height,
+                        "band_count": src.count,
+                        "dtypes": list(src.dtypes),
+                        "driver": src.driver,
+                    }
+            else:
+                gdf = gpd.read_file(path)
+                data = {
+                    "dataset_type": "vector",
+                    "crs": str(gdf.crs) if gdf.crs else None,
+                    "bounds": gdf.total_bounds.tolist() if not gdf.empty else [None] * 4,
+                    "feature_count": len(gdf),
+                    "columns": list(gdf.columns),
+                    "geometry_types": list(gdf.geometry.geom_type.unique()) if not gdf.empty else [],
+                }
+            result = self._ok(
+                summary=f"Inspected dataset {path.name}.",
+                data=data,
+                provenance=self._make_provenance({"path": str(path)}, time.monotonic() - t0),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class ReprojectDatasetTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_gdal_reproject_dataset"
+
+    @property
+    def description(self) -> str:
+        return "Reproject raster or vector dataset to a target CRS and save the result."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "target_crs": {"type": "string"},
+                "run_id": {"type": "string"},
+            },
+            "required": ["path", "target_crs"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+        import rasterio
+        from rasterio.warp import Resampling, calculate_default_transform, reproject
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        try:
+            path = Path(kwargs["path"]).expanduser()
+            target_crs = kwargs["target_crs"]
+            if _is_raster(path):
+                with rasterio.open(path) as src:
+                    transform, width, height = calculate_default_transform(
+                        src.crs, target_crs, src.width, src.height, *src.bounds
+                    )
+                    meta = src.meta.copy()
+                    meta.update({"crs": target_crs, "transform": transform, "width": width, "height": height})
+                    out_path = self._artifact_dir(run_id) / f"{path.stem}_reprojected.tif"
+                    with rasterio.open(out_path, "w", **meta) as dst:
+                        for i in range(1, src.count + 1):
+                            reproject(
+                                source=rasterio.band(src, i),
+                                destination=rasterio.band(dst, i),
+                                src_transform=src.transform,
+                                src_crs=src.crs,
+                                dst_transform=transform,
+                                dst_crs=target_crs,
+                                resampling=Resampling.nearest,
+                            )
+            else:
+                gdf = gpd.read_file(path).to_crs(target_crs)
+                out_path = self._artifact_dir(run_id) / f"{path.stem}_reprojected.geojson"
+                gdf.to_file(out_path, driver="GeoJSON")
+
+            result = self._ok(
+                summary=f"Reprojected {path.name} to {target_crs}.",
+                data={"output_path": str(out_path), "target_crs": target_crs, "run_id": run_id},
+                artifacts=[
+                    self._save_artifact(
+                        run_id,
+                        "reproject_manifest.json",
+                        json.dumps({"output_path": str(out_path)}, ensure_ascii=False),
+                        "json",
+                        "Reproject manifest",
+                    )
+                ],
+                provenance=self._make_provenance(
+                    {"path": str(path), "target_crs": target_crs},
+                    time.monotonic() - t0,
+                    crs_used=target_crs,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class ClipDatasetTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_gdal_clip_dataset"
+
+    @property
+    def description(self) -> str:
+        return "Clip raster or vector dataset by bbox or GeoJSON and save the result."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "bbox": {"type": "object"},
+                "geojson": {"type": "object"},
+                "run_id": {"type": "string"},
+            },
+            "required": ["path"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+        from shapely.geometry import box, shape
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        try:
+            path = Path(kwargs["path"]).expanduser()
+            if kwargs.get("geojson") is not None:
+                clip_geom = shape(kwargs["geojson"])
+            elif kwargs.get("bbox") is not None:
+                from geoclaw.tools.common import parse_bbox
+
+                bb = parse_bbox(kwargs["bbox"])
+                clip_geom = box(bb.west, bb.south, bb.east, bb.north)
+            else:
+                return self._fail("Provide bbox or geojson.").to_llm_string()
+
+            if _is_raster(path):
+                from geoclaw.tools.raster import ClipRasterTool
+
+                return await ClipRasterTool(self._workspace).execute(
+                    raster_path=str(path),
+                    bbox=kwargs.get("bbox"),
+                    geojson=kwargs.get("geojson"),
+                    run_id=run_id,
+                )
+            else:
+                gdf = gpd.read_file(path)
+                clipped = gdf.clip(clip_geom)
+                out_path = self._artifact_dir(run_id) / f"{path.stem}_clipped.geojson"
+                clipped.to_file(out_path, driver="GeoJSON")
+                result = self._ok(
+                    summary=f"Clipped vector dataset to {len(clipped)} feature(s).",
+                    data={"output_path": str(out_path), "feature_count": len(clipped), "run_id": run_id},
+                    artifacts=[
+                        self._save_artifact(
+                            run_id,
+                            "clip_dataset_manifest.json",
+                            json.dumps({"output_path": str(out_path)}, ensure_ascii=False),
+                            "json",
+                            "Dataset clip manifest",
+                        )
+                    ],
+                    provenance=self._make_provenance(
+                        {"path": str(path), "has_bbox": kwargs.get("bbox") is not None},
+                        time.monotonic() - t0,
+                    ),
+                )
+                return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class ConvertFormatTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_gdal_convert_format"
+
+    @property
+    def description(self) -> str:
+        return "Convert raster or vector dataset to another common format."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "target_format": {"type": "string"},
+                "run_id": {"type": "string"},
+            },
+            "required": ["path", "target_format"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+        import rasterio
+        from rasterio.shutil import copy as rio_copy
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        try:
+            path = Path(kwargs["path"]).expanduser()
+            target_format = kwargs["target_format"].lower()
+            if _is_raster(path):
+                ext_map = {"gtiff": ".tif", "tiff": ".tif", "cog": ".tif"}
+                out_path = self._artifact_dir(run_id) / f"{path.stem}_converted{ext_map.get(target_format, '.tif')}"
+                driver = "COG" if target_format == "cog" else "GTiff"
+                rio_copy(str(path), str(out_path), driver=driver)
+            else:
+                gdf = gpd.read_file(path)
+                if target_format in {"geojson", "json"}:
+                    out_path = self._artifact_dir(run_id) / f"{path.stem}_converted.geojson"
+                    gdf.to_file(out_path, driver="GeoJSON")
+                elif target_format in {"parquet", "geoparquet"}:
+                    out_path = self._artifact_dir(run_id) / f"{path.stem}_converted.parquet"
+                    gdf.to_parquet(out_path)
+                else:
+                    return self._fail(f"Unsupported vector target format: {target_format}").to_llm_string()
+
+            result = self._ok(
+                summary=f"Converted {path.name} to {target_format}.",
+                data={"output_path": str(out_path), "target_format": target_format, "run_id": run_id},
+                artifacts=[
+                    self._save_artifact(
+                        run_id,
+                        "convert_manifest.json",
+                        json.dumps({"output_path": str(out_path)}, ensure_ascii=False),
+                        "json",
+                        "Format conversion manifest",
+                    )
+                ],
+                provenance=self._make_provenance(
+                    {"path": str(path), "target_format": target_format},
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class TranslateToCOGTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_gdal_translate_to_cog"
+
+    @property
+    def description(self) -> str:
+        return "Translate a raster dataset to a Cloud Optimized GeoTIFF (COG) when supported."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "run_id": {"type": "string"},
+            },
+            "required": ["path"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        from rasterio.shutil import copy as rio_copy
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        try:
+            path = Path(kwargs["path"]).expanduser()
+            if not _is_raster(path):
+                return self._fail("translate_to_cog only supports raster datasets.").to_llm_string()
+            out_path = self._artifact_dir(run_id) / f"{path.stem}.cog.tif"
+            rio_copy(str(path), str(out_path), driver="COG")
+            result = self._ok(
+                summary=f"Translated {path.name} to COG.",
+                data={"output_path": str(out_path), "run_id": run_id},
+                artifacts=[
+                    self._save_artifact(
+                        run_id,
+                        "cog_manifest.json",
+                        json.dumps({"output_path": str(out_path)}, ensure_ascii=False),
+                        "json",
+                        "COG translation manifest",
+                    )
+                ],
+                provenance=self._make_provenance({"path": str(path)}, time.monotonic() - t0),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()

--- a/geoclaw/tools/hex.py
+++ b/geoclaw/tools/hex.py
@@ -1,0 +1,292 @@
+"""H3 hex aggregation tools."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import h3
+
+from geoclaw.tools.base import GeoTool
+
+
+def _load_geodataframe(file_path: str | None = None, geojson: dict | None = None):
+    import geopandas as gpd
+    from shapely.geometry import shape
+
+    if file_path:
+        gdf = gpd.read_file(str(Path(file_path).expanduser()))
+    elif geojson is not None:
+        geo_type = geojson.get("type", "")
+        if geo_type == "FeatureCollection":
+            gdf = gpd.GeoDataFrame.from_features(geojson["features"], crs="EPSG:4326")
+        elif geo_type == "Feature":
+            gdf = gpd.GeoDataFrame.from_features([geojson], crs="EPSG:4326")
+        else:
+            gdf = gpd.GeoDataFrame(geometry=[shape(geojson)], crs="EPSG:4326")
+    else:
+        raise ValueError("Provide file_path or geojson.")
+    if gdf.crs and str(gdf.crs).upper() != "EPSG:4326":
+        gdf = gdf.to_crs("EPSG:4326")
+    return gdf
+
+
+class PointToH3Tool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_point_to_h3"
+
+    @property
+    def description(self) -> str:
+        return "Assign point features to H3 cells at the requested resolution."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "geojson": {"type": "object"},
+                "resolution": {"type": "integer"},
+                "run_id": {"type": "string"},
+            },
+            "required": ["resolution"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        try:
+            gdf = _load_geodataframe(kwargs.get("file_path"), kwargs.get("geojson"))
+            points = gdf[gdf.geometry.geom_type.isin(["Point", "MultiPoint"])].copy()
+            if points.empty:
+                return self._fail("No point geometries found in input.").to_llm_string()
+
+            resolution = kwargs["resolution"]
+            points["h3_cell"] = points.geometry.apply(lambda geom: h3.latlng_to_cell(geom.y, geom.x, resolution))
+            out_path = self._artifact_dir(run_id) / "points_h3.geojson"
+            points.to_file(out_path, driver="GeoJSON")
+            result = self._ok(
+                summary=f"Assigned {len(points)} point(s) to H3 resolution {resolution}.",
+                data={
+                    "resolution": resolution,
+                    "feature_count": len(points),
+                    "unique_cells": int(points["h3_cell"].nunique()),
+                    "run_id": run_id,
+                },
+                artifacts=[
+                    self._save_artifact(
+                        run_id,
+                        "points_h3_manifest.json",
+                        json.dumps({"path": str(out_path)}, ensure_ascii=False),
+                        "json",
+                        "H3 point manifest",
+                    ),
+                ],
+                provenance=self._make_provenance(
+                    {"resolution": resolution, "feature_count": len(points)},
+                    time.monotonic() - t0,
+                    crs_used="EPSG:4326",
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class PolygonToH3Tool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_polygon_to_h3"
+
+    @property
+    def description(self) -> str:
+        return "Polyfill polygon features into H3 cells at the requested resolution."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "geojson": {"type": "object"},
+                "resolution": {"type": "integer"},
+            },
+            "required": ["resolution"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        from shapely.geometry import mapping
+
+        t0 = time.monotonic()
+        try:
+            gdf = _load_geodataframe(kwargs.get("file_path"), kwargs.get("geojson"))
+            polys = gdf[gdf.geometry.geom_type.isin(["Polygon", "MultiPolygon"])].copy()
+            if polys.empty:
+                return self._fail("No polygon geometries found in input.").to_llm_string()
+            resolution = kwargs["resolution"]
+            cell_counts = []
+            for geom in polys.geometry:
+                cells = h3.geo_to_cells(mapping(geom), resolution)
+                cell_counts.append(len(cells))
+            result = self._ok(
+                summary=f"Polyfilled {len(polys)} polygon(s) to H3 resolution {resolution}.",
+                data={
+                    "resolution": resolution,
+                    "feature_count": len(polys),
+                    "cell_counts": cell_counts,
+                    "total_cells": int(sum(cell_counts)),
+                },
+                provenance=self._make_provenance(
+                    {"resolution": resolution, "feature_count": len(polys)},
+                    time.monotonic() - t0,
+                    crs_used="EPSG:4326",
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class AggregateByH3Tool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_aggregate_by_h3"
+
+    @property
+    def description(self) -> str:
+        return "Aggregate point features by H3 cell using count, sum, or mean."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "geojson": {"type": "object"},
+                "resolution": {"type": "integer"},
+                "metric_property": {"type": "string"},
+                "agg_method": {"type": "string", "enum": ["count", "sum", "mean"]},
+                "run_id": {"type": "string"},
+            },
+            "required": ["resolution"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+        import pandas as pd
+        from shapely.geometry import Polygon
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        try:
+            gdf = _load_geodataframe(kwargs.get("file_path"), kwargs.get("geojson"))
+            points = gdf[gdf.geometry.geom_type == "Point"].copy()
+            if points.empty:
+                return self._fail("Aggregation currently supports Point features only.").to_llm_string()
+
+            resolution = kwargs["resolution"]
+            points["h3_cell"] = points.geometry.apply(lambda geom: h3.latlng_to_cell(geom.y, geom.x, resolution))
+
+            metric = kwargs.get("metric_property")
+            method = kwargs.get("agg_method", "count")
+            if method == "count" or not metric:
+                agg = points.groupby("h3_cell").size().reset_index(name="value")
+            elif method == "sum":
+                agg = points.groupby("h3_cell")[metric].sum().reset_index(name="value")
+            else:
+                agg = points.groupby("h3_cell")[metric].mean().reset_index(name="value")
+
+            agg["geometry"] = agg["h3_cell"].apply(
+                lambda cell: Polygon([(lng, lat) for lat, lng in h3.cell_to_boundary(cell)])
+            )
+            hex_gdf = gpd.GeoDataFrame(agg, geometry="geometry", crs="EPSG:4326")
+            out_path = self._artifact_dir(run_id) / "hex_aggregation.geojson"
+            hex_gdf.to_file(out_path, driver="GeoJSON")
+
+            values = hex_gdf["value"]
+            data = {
+                "resolution": resolution,
+                "hex_count": len(hex_gdf),
+                "distribution": {
+                    "min": float(values.min()) if len(values) else None,
+                    "max": float(values.max()) if len(values) else None,
+                    "mean": float(values.mean()) if len(values) else None,
+                },
+                "metric_property": metric,
+                "agg_method": method,
+                "run_id": run_id,
+            }
+            result = self._ok(
+                summary=f"Aggregated {len(points)} point(s) into {len(hex_gdf)} H3 cell(s).",
+                data=data,
+                artifacts=[
+                    self._save_artifact(
+                        run_id,
+                        "hex_aggregation_manifest.json",
+                        json.dumps({"path": str(out_path)}, ensure_ascii=False),
+                        "json",
+                        "Hex aggregation manifest",
+                    )
+                ],
+                provenance=self._make_provenance(
+                    {
+                        "resolution": resolution,
+                        "metric_property": metric,
+                        "agg_method": method,
+                    },
+                    time.monotonic() - t0,
+                    crs_used="EPSG:4326",
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class NeighborhoodSummaryTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_neighborhood_summary"
+
+    @property
+    def description(self) -> str:
+        return "Summarize the H3 neighborhood around a cell using grid distance k."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "h3_cell": {"type": "string"},
+                "k": {"type": "integer"},
+            },
+            "required": ["h3_cell"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        try:
+            h3_cell = kwargs["h3_cell"]
+            k = kwargs.get("k", 1)
+            neighbors = list(h3.grid_disk(h3_cell, k))
+            center = h3.cell_to_latlng(h3_cell)
+            result = self._ok(
+                summary=f"H3 neighborhood contains {len(neighbors)} cell(s) for k={k}.",
+                data={
+                    "h3_cell": h3_cell,
+                    "k": k,
+                    "neighbor_count": len(neighbors),
+                    "center_latlng": center,
+                    "neighbors": neighbors,
+                },
+                provenance=self._make_provenance(
+                    {"h3_cell": h3_cell, "k": k},
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()

--- a/geoclaw/tools/network.py
+++ b/geoclaw/tools/network.py
@@ -1,0 +1,456 @@
+"""Network, routing, isochrone, and coverage tools."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+
+from geoclaw.tools.base import GeoTool
+from geoclaw.tools.osm import _load_geometry_from_input
+
+
+def _mode_speed_kph(mode: str) -> float:
+    speeds = {
+        "walk": 5.0,
+        "bike": 15.0,
+        "drive": 35.0,
+        "all": 20.0,
+    }
+    return speeds.get(mode, 5.0)
+
+
+def _network_type(mode: str) -> str:
+    mapping = {"walk": "walk", "bike": "bike", "drive": "drive", "all": "all"}
+    return mapping.get(mode, "walk")
+
+
+def _point_feature_to_tuple(point: dict[str, Any]) -> tuple[float, float]:
+    if "lon" in point and "lat" in point:
+        return float(point["lon"]), float(point["lat"])
+    if "x" in point and "y" in point:
+        return float(point["x"]), float(point["y"])
+    raise ValueError(f"Point must contain lon/lat or x/y, got: {point}")
+
+
+def _build_graph_for_aoi(
+    *,
+    mode: str,
+    bbox: dict | None = None,
+    geojson: dict | None = None,
+    file_path: str | None = None,
+    place_name: str | None = None,
+):
+    import osmnx as ox
+
+    geometry = _load_geometry_from_input(
+        bbox=bbox,
+        geojson=geojson,
+        file_path=file_path,
+        place_name=place_name,
+    )
+    graph = ox.graph_from_polygon(geometry, network_type=_network_type(mode), simplify=True)
+    speed_kph = _mode_speed_kph(mode)
+    speed_mps = speed_kph * 1000 / 3600
+    for _, _, _, data in graph.edges(keys=True, data=True):
+        length = float(data.get("length", 0.0))
+        data["travel_time"] = length / speed_mps if speed_mps > 0 else length
+    return graph
+
+
+def _nearest_node(graph, lon: float, lat: float) -> Any:
+    import osmnx as ox
+
+    return ox.distance.nearest_nodes(graph, lon, lat)
+
+
+def _route_linestring(graph, path_nodes: list[Any]):
+    from shapely.geometry import LineString
+
+    coords = [(graph.nodes[node]["x"], graph.nodes[node]["y"]) for node in path_nodes]
+    if len(coords) < 2:
+        raise ValueError("Route path needs at least 2 nodes.")
+    return LineString(coords)
+
+
+def _nodes_to_polygon(graph, nodes: list[Any]):
+    import geopandas as gpd
+
+    pts = gpd.GeoDataFrame(
+        geometry=gpd.points_from_xy(
+            [graph.nodes[n]["x"] for n in nodes],
+            [graph.nodes[n]["y"] for n in nodes],
+        ),
+        crs="EPSG:4326",
+    )
+    projected = pts.to_crs("EPSG:3857")
+    poly = projected.buffer(60).union_all().convex_hull
+    return gpd.GeoSeries([poly], crs="EPSG:3857").to_crs("EPSG:4326").iloc[0]
+
+
+class BuildNetworkTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_build_network"
+
+    @property
+    def description(self) -> str:
+        return "Build an OSMnx street network for an AOI and save it as GraphML."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "bbox": {"type": "object"},
+                "geojson": {"type": "object"},
+                "file_path": {"type": "string"},
+                "place_name": {"type": "string"},
+                "mode": {"type": "string", "enum": ["walk", "bike", "drive", "all"]},
+                "run_id": {"type": "string"},
+            },
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import osmnx as ox
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        mode = kwargs.get("mode", "walk")
+        params = {k: v for k, v in kwargs.items() if k != "run_id"}
+        try:
+            graph = _build_graph_for_aoi(
+                mode=mode,
+                bbox=kwargs.get("bbox"),
+                geojson=kwargs.get("geojson"),
+                file_path=kwargs.get("file_path"),
+                place_name=kwargs.get("place_name"),
+            )
+            graph_path = self._artifact_dir(run_id) / "network.graphml"
+            ox.save_graphml(graph, graph_path)
+            result = self._ok(
+                summary=(
+                    f"Built {mode} network with {graph.number_of_nodes()} node(s) and "
+                    f"{graph.number_of_edges()} edge(s)."
+                ),
+                data={
+                    "run_id": run_id,
+                    "mode": mode,
+                    "node_count": graph.number_of_nodes(),
+                    "edge_count": graph.number_of_edges(),
+                    "graphml_path": str(graph_path),
+                },
+                artifacts=[
+                    self._save_artifact(
+                        run_id,
+                        "network_manifest.json",
+                        json.dumps({"graphml_path": str(graph_path)}, ensure_ascii=False),
+                        "json",
+                        "Network manifest",
+                    )
+                ],
+                provenance=self._make_provenance(params, time.monotonic() - t0),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class ComputeRouteTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_compute_route"
+
+    @property
+    def description(self) -> str:
+        return "Compute shortest route between origin and destination on an OSMnx network."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "bbox": {"type": "object"},
+                "geojson": {"type": "object"},
+                "file_path": {"type": "string"},
+                "place_name": {"type": "string"},
+                "mode": {"type": "string", "enum": ["walk", "bike", "drive", "all"]},
+                "origin": {"type": "object"},
+                "destination": {"type": "object"},
+                "run_id": {"type": "string"},
+            },
+            "required": ["origin", "destination"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        mode = kwargs.get("mode", "walk")
+        try:
+            graph = _build_graph_for_aoi(
+                mode=mode,
+                bbox=kwargs.get("bbox"),
+                geojson=kwargs.get("geojson"),
+                file_path=kwargs.get("file_path"),
+                place_name=kwargs.get("place_name"),
+            )
+            origin_lon, origin_lat = _point_feature_to_tuple(kwargs["origin"])
+            dest_lon, dest_lat = _point_feature_to_tuple(kwargs["destination"])
+            origin_node = _nearest_node(graph, origin_lon, origin_lat)
+            dest_node = _nearest_node(graph, dest_lon, dest_lat)
+            path = nx.shortest_path(graph, origin_node, dest_node, weight="length")
+            length_m = float(nx.shortest_path_length(graph, origin_node, dest_node, weight="length"))
+            travel_s = float(nx.shortest_path_length(graph, origin_node, dest_node, weight="travel_time"))
+            line = _route_linestring(graph, path)
+            gdf = gpd.GeoDataFrame(
+                [{"length_m": length_m, "travel_time_s": travel_s}],
+                geometry=[line],
+                crs="EPSG:4326",
+            )
+            out_path = self._artifact_dir(run_id) / "route.geojson"
+            gdf.to_file(out_path, driver="GeoJSON")
+            result = self._ok(
+                summary=f"Computed route of {length_m:.0f} m in ~{travel_s/60:.1f} min.",
+                data={
+                    "run_id": run_id,
+                    "mode": mode,
+                    "path_node_count": len(path),
+                    "length_m": round(length_m, 2),
+                    "travel_time_s": round(travel_s, 2),
+                    "origin_node": origin_node,
+                    "destination_node": dest_node,
+                },
+                artifacts=[
+                    self._save_artifact(
+                        run_id,
+                        "route_manifest.json",
+                        json.dumps({"route_path": str(out_path)}, ensure_ascii=False),
+                        "json",
+                        "Route manifest",
+                    )
+                ],
+                provenance=self._make_provenance(
+                    {
+                        "mode": mode,
+                        "origin": kwargs["origin"],
+                        "destination": kwargs["destination"],
+                    },
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class ComputeIsochroneTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_compute_isochrone"
+
+    @property
+    def description(self) -> str:
+        return "Compute an isochrone / service area around an origin point."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "bbox": {"type": "object"},
+                "geojson": {"type": "object"},
+                "file_path": {"type": "string"},
+                "place_name": {"type": "string"},
+                "mode": {"type": "string", "enum": ["walk", "bike", "drive", "all"]},
+                "origin": {"type": "object"},
+                "time_threshold_minutes": {"type": "number"},
+                "distance_threshold_meters": {"type": "number"},
+                "run_id": {"type": "string"},
+            },
+            "required": ["origin"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        mode = kwargs.get("mode", "walk")
+        try:
+            graph = _build_graph_for_aoi(
+                mode=mode,
+                bbox=kwargs.get("bbox"),
+                geojson=kwargs.get("geojson"),
+                file_path=kwargs.get("file_path"),
+                place_name=kwargs.get("place_name"),
+            )
+            origin_lon, origin_lat = _point_feature_to_tuple(kwargs["origin"])
+            origin_node = _nearest_node(graph, origin_lon, origin_lat)
+            if kwargs.get("time_threshold_minutes") is not None:
+                threshold = float(kwargs["time_threshold_minutes"]) * 60
+                weight = "travel_time"
+            elif kwargs.get("distance_threshold_meters") is not None:
+                threshold = float(kwargs["distance_threshold_meters"])
+                weight = "length"
+            else:
+                return self._fail("Provide time_threshold_minutes or distance_threshold_meters.").to_llm_string()
+
+            lengths = nx.single_source_dijkstra_path_length(graph, origin_node, cutoff=threshold, weight=weight)
+            reachable_nodes = list(lengths.keys())
+            polygon = _nodes_to_polygon(graph, reachable_nodes)
+            gdf = gpd.GeoDataFrame(
+                [{"node_count": len(reachable_nodes), "threshold": threshold, "weight": weight}],
+                geometry=[polygon],
+                crs="EPSG:4326",
+            )
+            out_path = self._artifact_dir(run_id) / "isochrone.geojson"
+            gdf.to_file(out_path, driver="GeoJSON")
+            result = self._ok(
+                summary=f"Isochrone reaches {len(reachable_nodes)} node(s) for threshold {threshold:.0f} {weight}.",
+                data={
+                    "run_id": run_id,
+                    "mode": mode,
+                    "origin_node": origin_node,
+                    "reachable_node_count": len(reachable_nodes),
+                    "threshold": threshold,
+                    "weight": weight,
+                },
+                artifacts=[
+                    self._save_artifact(
+                        run_id,
+                        "isochrone_manifest.json",
+                        json.dumps({"isochrone_path": str(out_path)}, ensure_ascii=False),
+                        "json",
+                        "Isochrone manifest",
+                    )
+                ],
+                provenance=self._make_provenance(
+                    {
+                        "mode": mode,
+                        "origin": kwargs["origin"],
+                        "time_threshold_minutes": kwargs.get("time_threshold_minutes"),
+                        "distance_threshold_meters": kwargs.get("distance_threshold_meters"),
+                    },
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class ComputeServiceCoverageTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_compute_service_coverage"
+
+    @property
+    def description(self) -> str:
+        return "Count reachable destination points from one or more origins within a threshold."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "bbox": {"type": "object"},
+                "geojson": {"type": "object"},
+                "file_path": {"type": "string"},
+                "place_name": {"type": "string"},
+                "mode": {"type": "string", "enum": ["walk", "bike", "drive", "all"]},
+                "origins": {"type": "array", "items": {"type": "object"}},
+                "destinations_geojson": {"type": "object"},
+                "time_threshold_minutes": {"type": "number"},
+                "distance_threshold_meters": {"type": "number"},
+            },
+            "required": ["origins", "destinations_geojson"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+        from shapely.geometry import shape
+
+        t0 = time.monotonic()
+        mode = kwargs.get("mode", "walk")
+        try:
+            graph = _build_graph_for_aoi(
+                mode=mode,
+                bbox=kwargs.get("bbox"),
+                geojson=kwargs.get("geojson"),
+                file_path=kwargs.get("file_path"),
+                place_name=kwargs.get("place_name"),
+            )
+            if kwargs.get("time_threshold_minutes") is not None:
+                threshold = float(kwargs["time_threshold_minutes"]) * 60
+                weight = "travel_time"
+            elif kwargs.get("distance_threshold_meters") is not None:
+                threshold = float(kwargs["distance_threshold_meters"])
+                weight = "length"
+            else:
+                return self._fail("Provide time_threshold_minutes or distance_threshold_meters.").to_llm_string()
+
+            origins = [_point_feature_to_tuple(item) for item in kwargs["origins"]]
+            destinations_gj = kwargs["destinations_geojson"]
+            if destinations_gj.get("type") == "FeatureCollection":
+                dest_gdf = gpd.GeoDataFrame.from_features(destinations_gj["features"], crs="EPSG:4326")
+            elif destinations_gj.get("type") == "Feature":
+                dest_gdf = gpd.GeoDataFrame.from_features([destinations_gj], crs="EPSG:4326")
+            else:
+                dest_gdf = gpd.GeoDataFrame(geometry=[shape(destinations_gj)], crs="EPSG:4326")
+            dest_points = dest_gdf[dest_gdf.geometry.geom_type == "Point"].copy()
+            if dest_points.empty:
+                return self._fail("destinations_geojson must contain Point features.").to_llm_string()
+
+            origin_nodes = [_nearest_node(graph, lon, lat) for lon, lat in origins]
+            dest_points["dest_node"] = dest_points.geometry.apply(lambda geom: _nearest_node(graph, geom.x, geom.y))
+
+            reachable_mask = []
+            min_costs = []
+            for dest_node in dest_points["dest_node"]:
+                costs = []
+                for origin_node in origin_nodes:
+                    try:
+                        cost = nx.shortest_path_length(graph, origin_node, dest_node, weight=weight)
+                        costs.append(float(cost))
+                    except nx.NetworkXNoPath:
+                        continue
+                min_cost = min(costs) if costs else math.inf
+                min_costs.append(min_cost)
+                reachable_mask.append(min_cost <= threshold)
+
+            dest_points["min_cost"] = min_costs
+            dest_points["reachable"] = reachable_mask
+            reachable_count = int(dest_points["reachable"].sum())
+            total = len(dest_points)
+
+            result = self._ok(
+                summary=f"Reachable destinations: {reachable_count}/{total} within threshold {threshold:.0f}.",
+                data={
+                    "mode": mode,
+                    "weight": weight,
+                    "threshold": threshold,
+                    "origin_count": len(origins),
+                    "destination_count": total,
+                    "reachable_count": reachable_count,
+                    "uncovered_count": total - reachable_count,
+                },
+                provenance=self._make_provenance(
+                    {
+                        "mode": mode,
+                        "origin_count": len(origins),
+                        "destination_count": total,
+                        "threshold": threshold,
+                        "weight": weight,
+                    },
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()

--- a/geoclaw/tools/osm.py
+++ b/geoclaw/tools/osm.py
@@ -1,0 +1,249 @@
+"""OSM extraction and place profile tools."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from geoclaw.tools.base import GeoTool
+from geoclaw.tools.common import parse_bbox
+
+
+def _load_geometry_from_input(
+    *,
+    bbox: dict | list | None = None,
+    geojson: dict | None = None,
+    file_path: str | None = None,
+    place_name: str | None = None,
+):
+    import geopandas as gpd
+    from shapely.geometry import box, shape
+
+    if geojson is not None:
+        geo_type = geojson.get("type", "")
+        if geo_type == "FeatureCollection":
+            gdf = gpd.GeoDataFrame.from_features(geojson["features"], crs="EPSG:4326")
+        elif geo_type == "Feature":
+            gdf = gpd.GeoDataFrame.from_features([geojson], crs="EPSG:4326")
+        else:
+            gdf = gpd.GeoDataFrame(geometry=[shape(geojson)], crs="EPSG:4326")
+        return gdf.union_all()
+
+    if bbox is not None:
+        bb = parse_bbox(bbox)
+        return box(bb.west, bb.south, bb.east, bb.north)
+
+    if file_path:
+        gdf = gpd.read_file(str(Path(file_path).expanduser()))
+        if gdf.crs and str(gdf.crs).upper() != "EPSG:4326":
+            gdf = gdf.to_crs("EPSG:4326")
+        return gdf.union_all()
+
+    if place_name:
+        import osmnx as ox
+
+        gdf = ox.geocode_to_gdf(place_name)
+        if gdf.crs and str(gdf.crs).upper() != "EPSG:4326":
+            gdf = gdf.to_crs("EPSG:4326")
+        return gdf.union_all()
+
+    raise ValueError("Provide bbox, geojson, file_path, or place_name.")
+
+
+class ExtractOSMByGeometryTool(GeoTool):
+    """Extract OpenStreetMap features for an AOI using QuackOSM."""
+
+    @property
+    def name(self) -> str:
+        return "geo_extract_osm"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Extract OpenStreetMap features for an AOI using QuackOSM. Accepts "
+            "bbox, GeoJSON, file path, or place name plus optional tags_filter."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "bbox": {"type": "object"},
+                "geojson": {"type": "object"},
+                "file_path": {"type": "string"},
+                "place_name": {"type": "string"},
+                "tags_filter": {
+                    "type": "object",
+                    "description": "QuackOSM tag filter mapping, e.g. {'amenity': True}",
+                },
+                "run_id": {"type": "string"},
+            },
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        from quackosm import convert_geometry_to_geodataframe
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        params = {k: v for k, v in kwargs.items() if k != "run_id"}
+        try:
+            geometry = _load_geometry_from_input(
+                bbox=kwargs.get("bbox"),
+                geojson=kwargs.get("geojson"),
+                file_path=kwargs.get("file_path"),
+                place_name=kwargs.get("place_name"),
+            )
+            tags_filter = kwargs.get("tags_filter") or {
+                "amenity": True,
+                "shop": True,
+                "leisure": True,
+                "tourism": True,
+                "building": True,
+            }
+            work_dir = self._artifact_dir(run_id)
+            gdf = convert_geometry_to_geodataframe(
+                geometry_filter=geometry,
+                tags_filter=tags_filter,
+                working_directory=work_dir,
+                allow_uncovered_geometry=True,
+                verbosity_mode="silent",
+            )
+            if gdf.crs and str(gdf.crs).upper() != "EPSG:4326":
+                gdf = gdf.to_crs("EPSG:4326")
+
+            category_counts: dict[str, int] = {}
+            for col in ("amenity", "shop", "leisure", "tourism", "building", "highway"):
+                if col in gdf.columns:
+                    values = gdf[col].dropna().astype(str)
+                    if not values.empty:
+                        category_counts[col] = int(values.shape[0])
+
+            artifacts = []
+            geojson_artifact = self._save_artifact(
+                run_id,
+                "osm_extract.geojson",
+                gdf.to_json(),
+                "geojson",
+                "OSM extract",
+            )
+            artifacts.append(geojson_artifact)
+            try:
+                parquet_path = self._artifact_dir(run_id) / "osm_extract.parquet"
+                gdf.to_parquet(parquet_path)
+                artifacts.append(
+                    type(geojson_artifact)(
+                        path=str(parquet_path),
+                        format="geoparquet",
+                        size_bytes=parquet_path.stat().st_size,
+                        description="OSM extract (GeoParquet)",
+                    )
+                )
+            except Exception:
+                pass
+
+            result = self._ok(
+                summary=f"Extracted {len(gdf)} OSM feature(s) for the AOI.",
+                data={
+                    "run_id": run_id,
+                    "feature_count": len(gdf),
+                    "columns": list(gdf.columns),
+                    "category_counts": category_counts,
+                    "tags_filter": tags_filter,
+                },
+                artifacts=artifacts,
+                provenance=self._make_provenance(params, time.monotonic() - t0, crs_used="EPSG:4326"),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class BuildPlaceProfileTool(GeoTool):
+    """Build a narrative place profile from extracted OSM features."""
+
+    @property
+    def name(self) -> str:
+        return "geo_build_place_profile"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Build a place profile from an OSM extraction GeoJSON or file. Returns "
+            "category counts, summary stats, and a short narrative."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string"},
+                "geojson": {"type": "object"},
+            },
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+        from shapely.geometry import shape
+
+        t0 = time.monotonic()
+        try:
+            if kwargs.get("file_path"):
+                gdf = gpd.read_file(str(Path(kwargs["file_path"]).expanduser()))
+            elif kwargs.get("geojson"):
+                geojson = kwargs["geojson"]
+                geo_type = geojson.get("type", "")
+                if geo_type == "FeatureCollection":
+                    gdf = gpd.GeoDataFrame.from_features(geojson["features"], crs="EPSG:4326")
+                elif geo_type == "Feature":
+                    gdf = gpd.GeoDataFrame.from_features([geojson], crs="EPSG:4326")
+                else:
+                    gdf = gpd.GeoDataFrame(geometry=[shape(geojson)], crs="EPSG:4326")
+            else:
+                return self._fail("Provide file_path or geojson.").to_llm_string()
+
+            category_values: dict[str, dict[str, int]] = {}
+            for col in ("amenity", "shop", "leisure", "tourism", "building", "highway"):
+                if col in gdf.columns:
+                    series = gdf[col].dropna().astype(str)
+                    if not series.empty:
+                        category_values[col] = series.value_counts().head(10).astype(int).to_dict()
+
+            geom_mix = (
+                gdf.geometry.geom_type.value_counts().astype(int).to_dict()
+                if not gdf.empty
+                else {}
+            )
+            top_sections = []
+            for key, vals in category_values.items():
+                if vals:
+                    preview = ", ".join(f"{k} ({v})" for k, v in list(vals.items())[:3])
+                    top_sections.append(f"{key}: {preview}")
+            narrative = (
+                f"The AOI contains {len(gdf)} mapped OSM features. "
+                + ("Top mapped categories are " + "; ".join(top_sections) + "." if top_sections else "Few thematic tags were present.")
+            )
+
+            result = self._ok(
+                summary=f"Built place profile for {len(gdf)} OSM feature(s).",
+                data={
+                    "feature_count": len(gdf),
+                    "geometry_mix": geom_mix,
+                    "category_values": category_values,
+                    "narrative": narrative,
+                },
+                provenance=self._make_provenance(
+                    {
+                        "file_path": kwargs.get("file_path"),
+                        "has_geojson": kwargs.get("geojson") is not None,
+                    },
+                    time.monotonic() - t0,
+                    crs_used=str(gdf.crs) if gdf.crs else None,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()

--- a/geoclaw/tools/raster.py
+++ b/geoclaw/tools/raster.py
@@ -1,0 +1,273 @@
+"""Raster tools for clipping, summary, and preview export."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from geoclaw.tools.base import GeoTool
+from geoclaw.tools.common import parse_bbox
+
+
+def _geometry_mapping_from_input(*, bbox=None, geojson=None):
+    from shapely.geometry import box, mapping, shape
+
+    if geojson is not None:
+        return mapping(shape(geojson))
+    if bbox is not None:
+        bb = parse_bbox(bbox)
+        return mapping(box(bb.west, bb.south, bb.east, bb.north))
+    raise ValueError("Provide bbox or geojson.")
+
+
+class ReadRasterTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_read_raster"
+
+    @property
+    def description(self) -> str:
+        return "Read raster metadata including CRS, bounds, shape, band count, dtype, and nodata."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "raster_path": {"type": "string"},
+            },
+            "required": ["raster_path"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import rasterio
+
+        t0 = time.monotonic()
+        try:
+            raster_path = Path(kwargs["raster_path"]).expanduser()
+            with rasterio.open(raster_path) as src:
+                result = self._ok(
+                    summary=f"Raster {raster_path.name}: {src.count} band(s), {src.width}x{src.height}.",
+                    data={
+                        "raster_path": str(raster_path),
+                        "crs": str(src.crs) if src.crs else None,
+                        "bounds": list(src.bounds),
+                        "width": src.width,
+                        "height": src.height,
+                        "band_count": src.count,
+                        "dtypes": list(src.dtypes),
+                        "nodata": src.nodata,
+                        "transform": list(src.transform)[:6],
+                    },
+                    provenance=self._make_provenance(
+                        {"raster_path": str(raster_path)},
+                        time.monotonic() - t0,
+                        crs_used=str(src.crs) if src.crs else None,
+                    ),
+                )
+                return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class ClipRasterTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_clip_raster"
+
+    @property
+    def description(self) -> str:
+        return "Clip a raster by bbox or GeoJSON AOI and save the clipped raster to artifacts."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "raster_path": {"type": "string"},
+                "bbox": {"type": "object"},
+                "geojson": {"type": "object"},
+                "run_id": {"type": "string"},
+            },
+            "required": ["raster_path"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import rasterio
+        from rasterio.mask import mask
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        try:
+            raster_path = Path(kwargs["raster_path"]).expanduser()
+            geom = _geometry_mapping_from_input(bbox=kwargs.get("bbox"), geojson=kwargs.get("geojson"))
+            with rasterio.open(raster_path) as src:
+                out_image, out_transform = mask(src, [geom], crop=True)
+                out_meta = src.meta.copy()
+                out_meta.update(
+                    {
+                        "height": out_image.shape[1],
+                        "width": out_image.shape[2],
+                        "transform": out_transform,
+                    }
+                )
+                out_path = self._artifact_dir(run_id) / "clipped.tif"
+                with rasterio.open(out_path, "w", **out_meta) as dst:
+                    dst.write(out_image)
+
+            artifact = self._save_artifact(
+                run_id,
+                "clip_manifest.json",
+                json.dumps({"clipped_raster": str(out_path)}, ensure_ascii=False),
+                "json",
+                "Clip manifest",
+            )
+            result = self._ok(
+                summary=f"Clipped raster saved to {out_path}.",
+                data={"run_id": run_id, "clipped_raster_path": str(out_path)},
+                artifacts=[
+                    artifact,
+                    type(artifact)(
+                        path=str(out_path),
+                        format="tif",
+                        size_bytes=out_path.stat().st_size,
+                        description="Clipped raster",
+                    ),
+                ],
+                provenance=self._make_provenance(
+                    {
+                        "raster_path": str(raster_path),
+                        "has_bbox": kwargs.get("bbox") is not None,
+                        "has_geojson": kwargs.get("geojson") is not None,
+                    },
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class RasterSummaryTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_raster_summary"
+
+    @property
+    def description(self) -> str:
+        return "Compute basic raster statistics such as min, max, mean, std, and valid pixel count."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "raster_path": {"type": "string"},
+                "band": {"type": "integer"},
+            },
+            "required": ["raster_path"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import rasterio
+
+        t0 = time.monotonic()
+        try:
+            raster_path = Path(kwargs["raster_path"]).expanduser()
+            band = kwargs.get("band", 1)
+            with rasterio.open(raster_path) as src:
+                arr = src.read(band, masked=True)
+                valid = arr.compressed()
+                stats = {
+                    "band": band,
+                    "min": float(valid.min()) if valid.size else None,
+                    "max": float(valid.max()) if valid.size else None,
+                    "mean": float(valid.mean()) if valid.size else None,
+                    "std": float(valid.std()) if valid.size else None,
+                    "valid_pixel_count": int(valid.size),
+                    "nodata": src.nodata,
+                }
+                result = self._ok(
+                    summary=f"Raster summary for {raster_path.name}, band {band}.",
+                    data=stats,
+                    provenance=self._make_provenance(
+                        {"raster_path": str(raster_path), "band": band},
+                        time.monotonic() - t0,
+                        crs_used=str(src.crs) if src.crs else None,
+                    ),
+                )
+                return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class ExportRasterPreviewTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_export_raster_preview"
+
+    @property
+    def description(self) -> str:
+        return "Export a PNG preview for a raster band, optionally with percentile stretch."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "raster_path": {"type": "string"},
+                "band": {"type": "integer"},
+                "run_id": {"type": "string"},
+            },
+            "required": ["raster_path"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import matplotlib.pyplot as plt
+        import rasterio
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        try:
+            raster_path = Path(kwargs["raster_path"]).expanduser()
+            band = kwargs.get("band", 1)
+            with rasterio.open(raster_path) as src:
+                arr = src.read(band, masked=True).astype("float32")
+                valid = arr.compressed()
+                if valid.size == 0:
+                    return self._fail("Raster band has no valid pixels.").to_llm_string()
+                lo, hi = np.percentile(valid, [2, 98])
+                stretched = np.clip((arr.filled(lo) - lo) / max(hi - lo, 1e-9), 0, 1)
+                preview_path = self._artifact_dir(run_id) / "preview.png"
+                plt.imsave(preview_path, stretched, cmap="viridis")
+
+            result = self._ok(
+                summary=f"Raster preview saved to {preview_path}.",
+                data={"preview_path": str(preview_path), "run_id": run_id, "band": band},
+                artifacts=[
+                    self._save_artifact(
+                        run_id,
+                        "preview_manifest.json",
+                        json.dumps({"preview_path": str(preview_path)}, ensure_ascii=False),
+                        "json",
+                        "Preview manifest",
+                    ),
+                    type(self._save_artifact(run_id, "preview.meta", "generated", "txt", "Preview metadata"))(
+                        path=str(preview_path),
+                        format="png",
+                        size_bytes=preview_path.stat().st_size,
+                        description="Raster preview",
+                    ),
+                ],
+                provenance=self._make_provenance(
+                    {"raster_path": str(raster_path), "band": band},
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()

--- a/geoclaw/tools/stac.py
+++ b/geoclaw/tools/stac.py
@@ -1,0 +1,231 @@
+"""STAC search, ranking, and scene selection tools."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from geoclaw.tools.base import GeoTool
+from geoclaw.tools.common import parse_bbox
+
+
+def _normalise_search_results(items) -> list[dict[str, Any]]:
+    normalised = []
+    for item in items:
+        item_dict = item.to_dict() if hasattr(item, "to_dict") else item
+        props = item_dict.get("properties", {})
+        assets = item_dict.get("assets", {})
+        normalised.append(
+            {
+                "id": item_dict.get("id"),
+                "collection": item_dict.get("collection"),
+                "datetime": props.get("datetime"),
+                "cloud_cover": props.get("eo:cloud_cover", props.get("cloud_cover")),
+                "assets": {
+                    key: {"href": value.get("href"), "type": value.get("type")}
+                    for key, value in assets.items()
+                },
+                "bbox": item_dict.get("bbox"),
+                "properties": props,
+            }
+        )
+    return normalised
+
+
+class SearchSTACTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_search_stac"
+
+    @property
+    def description(self) -> str:
+        return "Search a STAC API by AOI, time range, collections, and optional query filters."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "catalog_url": {"type": "string"},
+                "bbox": {"type": "object"},
+                "datetime": {"type": "string"},
+                "collections": {"type": "array", "items": {"type": "string"}},
+                "limit": {"type": "integer"},
+                "query": {"type": "object"},
+            },
+            "required": ["catalog_url"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        from pystac_client import Client
+
+        t0 = time.monotonic()
+        try:
+            catalog = Client.open(kwargs["catalog_url"])
+            search_kwargs: dict[str, Any] = {"limit": kwargs.get("limit", 10)}
+            if kwargs.get("bbox"):
+                search_kwargs["bbox"] = list(parse_bbox(kwargs["bbox"]).as_tuple())
+            if kwargs.get("datetime"):
+                search_kwargs["datetime"] = kwargs["datetime"]
+            if kwargs.get("collections"):
+                search_kwargs["collections"] = kwargs["collections"]
+            if kwargs.get("query"):
+                search_kwargs["query"] = kwargs["query"]
+
+            items = list(catalog.search(**search_kwargs).items())
+            results = _normalise_search_results(items)
+            result = self._ok(
+                summary=f"Found {len(results)} STAC item(s).",
+                data={"catalog_url": kwargs["catalog_url"], "items": results},
+                provenance=self._make_provenance(search_kwargs, time.monotonic() - t0),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class RankSTACAssetsTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_rank_stac_assets"
+
+    @property
+    def description(self) -> str:
+        return "Rank STAC search results by cloud cover and preferred asset keys."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "items_json": {"type": "string"},
+                "asset_preferences": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["items_json"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        try:
+            items = json.loads(kwargs["items_json"])
+            prefs = kwargs.get("asset_preferences") or ["visual", "rendered_preview", "thumbnail", "B04", "image"]
+
+            ranked = []
+            for item in items:
+                assets = item.get("assets", {})
+                asset_bonus = 0
+                matched_assets = []
+                for pref in prefs:
+                    if pref in assets:
+                        asset_bonus += 10
+                        matched_assets.append(pref)
+                cloud = item.get("cloud_cover")
+                cloud_penalty = float(cloud) if cloud is not None else 50.0
+                score = asset_bonus - cloud_penalty
+                ranked.append(
+                    {
+                        **item,
+                        "score": score,
+                        "matched_assets": matched_assets,
+                    }
+                )
+
+            ranked.sort(key=lambda x: x["score"], reverse=True)
+            result = self._ok(
+                summary=f"Ranked {len(ranked)} STAC item(s).",
+                data={"ranked_items": ranked},
+                provenance=self._make_provenance(
+                    {"asset_preferences": prefs, "item_count": len(items)},
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class PreviewSTACAssetsTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_preview_stac_assets"
+
+    @property
+    def description(self) -> str:
+        return "Extract preview/thumbnail asset references from STAC items."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "items_json": {"type": "string"},
+            },
+            "required": ["items_json"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        try:
+            items = json.loads(kwargs["items_json"])
+            previews = []
+            for item in items:
+                assets = item.get("assets", {})
+                preview = None
+                for key in ("thumbnail", "rendered_preview", "visual", "overview", "image"):
+                    if key in assets:
+                        preview = {"asset_key": key, "href": assets[key].get("href")}
+                        break
+                previews.append({"id": item.get("id"), "preview": preview})
+            result = self._ok(
+                summary=f"Collected preview references for {len(previews)} item(s).",
+                data={"previews": previews},
+                provenance=self._make_provenance({"item_count": len(items)}, time.monotonic() - t0),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class SelectBestSceneTool(GeoTool):
+    @property
+    def name(self) -> str:
+        return "geo_select_best_scene"
+
+    @property
+    def description(self) -> str:
+        return "Select the best STAC scene from ranked results and explain the decision."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "ranked_items_json": {"type": "string"},
+            },
+            "required": ["ranked_items_json"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        t0 = time.monotonic()
+        try:
+            ranked_items = json.loads(kwargs["ranked_items_json"])
+            if not ranked_items:
+                return self._fail("No ranked items provided.").to_llm_string()
+            best = ranked_items[0]
+            reasoning = (
+                f"Selected {best.get('id')} because it has the highest score "
+                f"({best.get('score')}) with cloud_cover={best.get('cloud_cover')} "
+                f"and preferred assets {best.get('matched_assets', [])}."
+            )
+            result = self._ok(
+                summary=f"Selected best STAC scene: {best.get('id')}.",
+                data={"best_scene": best, "reasoning": reasoning},
+                provenance=self._make_provenance(
+                    {"item_count": len(ranked_items)},
+                    time.monotonic() - t0,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()

--- a/geoclaw/tools/vector.py
+++ b/geoclaw/tools/vector.py
@@ -1,0 +1,170 @@
+"""Basic vector tools for the GeoClaw MVP."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from geoclaw.schemas.common import ArtifactMeta
+from geoclaw.tools.base import GeoTool
+
+
+class ReadVectorTool(GeoTool):
+    """Read a vector dataset and save a normalized GeoJSON artifact."""
+
+    @property
+    def name(self) -> str:
+        return "geo_read_vector"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Read a vector dataset from a local file path and return feature count, "
+            "CRS, geometry types, bounds, and a normalized GeoJSON artifact."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to a vector dataset supported by GeoPandas/Fiona",
+                },
+                "run_id": {
+                    "type": "string",
+                    "description": "Optional run ID for artifact storage",
+                },
+            },
+            "required": ["file_path"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+
+        t0 = time.monotonic()
+        run_id = kwargs.get("run_id") or self._new_run_id()
+        file_path = Path(kwargs["file_path"]).expanduser()
+        try:
+            gdf = gpd.read_file(str(file_path))
+            bounds = gdf.total_bounds.tolist() if not gdf.empty else [None, None, None, None]
+            artifacts: list[ArtifactMeta] = []
+            try:
+                artifact = self._save_artifact(
+                    run_id,
+                    f"{file_path.stem}.geojson",
+                    gdf.to_json(),
+                    "geojson",
+                    "Normalized vector dataset",
+                )
+                artifacts.append(artifact)
+            except Exception:
+                pass
+
+            result = self._ok(
+                summary=(
+                    f"Loaded {len(gdf)} feature(s) from {file_path.name} "
+                    f"with CRS {gdf.crs or 'unknown'}."
+                ),
+                data={
+                    "file_path": str(file_path),
+                    "feature_count": len(gdf),
+                    "columns": list(gdf.columns),
+                    "geometry_types": list(gdf.geometry.geom_type.unique()) if not gdf.empty else [],
+                    "crs": str(gdf.crs) if gdf.crs else None,
+                    "bounds": bounds,
+                    "run_id": run_id,
+                },
+                artifacts=artifacts,
+                provenance=self._make_provenance(
+                    {"file_path": str(file_path)},
+                    time.monotonic() - t0,
+                    crs_used=str(gdf.crs) if gdf.crs else None,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()
+
+
+class SummarizeVectorTool(GeoTool):
+    """Summarize geometry and attribute properties of a vector dataset."""
+
+    @property
+    def name(self) -> str:
+        return "geo_summarize_vector"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Summarize a vector dataset from file_path or inline GeoJSON. Returns feature "
+            "count, bounds, geometry mix, CRS, columns, null counts, and approximate area."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string", "description": "Path to a vector dataset"},
+                "geojson": {"type": "object", "description": "Inline GeoJSON"},
+            },
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        import geopandas as gpd
+        from shapely.geometry import shape
+
+        t0 = time.monotonic()
+        try:
+            if kwargs.get("file_path"):
+                gdf = gpd.read_file(str(Path(kwargs["file_path"]).expanduser()))
+            elif kwargs.get("geojson"):
+                geojson = kwargs["geojson"]
+                geo_type = geojson.get("type", "")
+                if geo_type == "FeatureCollection":
+                    gdf = gpd.GeoDataFrame.from_features(geojson["features"], crs="EPSG:4326")
+                elif geo_type == "Feature":
+                    gdf = gpd.GeoDataFrame.from_features([geojson], crs="EPSG:4326")
+                else:
+                    gdf = gpd.GeoDataFrame(geometry=[shape(geojson)], crs="EPSG:4326")
+            else:
+                return self._fail("Provide file_path or geojson.").to_llm_string()
+
+            bounds = gdf.total_bounds.tolist() if not gdf.empty else [None, None, None, None]
+            area_estimate = None
+            if not gdf.empty and str(gdf.crs).upper() == "EPSG:4326":
+                from geoclaw.tools.common import estimate_area_sq_km, parse_bbox
+
+                area_estimate = round(estimate_area_sq_km(parse_bbox(bounds)), 2)
+
+            null_counts = {
+                col: int(gdf[col].isna().sum())
+                for col in gdf.columns
+                if col != gdf.geometry.name
+            }
+            result = self._ok(
+                summary=f"Vector summary: {len(gdf)} feature(s), CRS={gdf.crs or 'unknown'}.",
+                data={
+                    "feature_count": len(gdf),
+                    "columns": list(gdf.columns),
+                    "geometry_types": list(gdf.geometry.geom_type.unique()) if not gdf.empty else [],
+                    "crs": str(gdf.crs) if gdf.crs else None,
+                    "bounds": bounds,
+                    "null_counts": null_counts,
+                    "area_estimate_sq_km": area_estimate,
+                },
+                provenance=self._make_provenance(
+                    {
+                        "file_path": kwargs.get("file_path"),
+                        "has_geojson": kwargs.get("geojson") is not None,
+                    },
+                    time.monotonic() - t0,
+                    crs_used=str(gdf.crs) if gdf.crs else None,
+                ),
+            )
+            return result.to_llm_string()
+        except Exception as exc:
+            return self._fail(str(exc)).to_llm_string()

--- a/nanobot/skills/README.md
+++ b/nanobot/skills/README.md
@@ -1,6 +1,8 @@
-# nanobot Skills
+# nanobot Runtime Skills
 
-This directory contains built-in skills that extend nanobot's capabilities.
+This directory contains built-in runtime skills inherited from nanobot.
+
+In this repository, GeoClaw is the primary product layer. Its packaged geospatial workflow skills live under `geoclaw/skills/`, are synced by `geoclaw sync-skills`, and are intentionally kept separate from these generic runtime skills.
 
 ## Skill Format
 
@@ -23,3 +25,16 @@ The skill format and metadata structure follow OpenClaw's conventions to maintai
 | `tmux` | Remote-control tmux sessions |
 | `clawhub` | Search and install skills from ClawHub registry |
 | `skill-creator` | Create new skills |
+
+## GeoClaw Packaged Skills
+
+GeoClaw currently ships these domain workflows:
+
+| Skill | Purpose |
+|-------|---------|
+| `aoi_sanity_check` | Validate AOI geometry, extent, area, and suggested CRS |
+| `osm_place_profile` | Extract and summarize OSM features for an area |
+| `accessibility_analysis` | Build networks, routes, isochrones, and service coverage |
+| `raster_exposure_summary` | Clip raster data, compute statistics, and render previews |
+| `stac_search_preview` | Search STAC catalogs, rank scenes, and preview assets |
+| `hex_service_coverage` | Aggregate points or polygons into H3-based summaries |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,19 @@ matrix = [
 langsmith = [
     "langsmith>=0.1.0",
 ]
+geo = [
+    "geopandas>=1.0.0",
+    "shapely>=2.0.0",
+    "pyproj>=3.6.0",
+    "rasterio>=1.3.0",
+    "rioxarray>=0.15.0",
+    "duckdb>=1.0.0",
+    "quackosm>=0.10.0",
+    "osmnx>=2.0.0",
+    "pystac-client>=0.8.0",
+    "h3>=4.0.0",
+    "matplotlib>=3.8.0",
+]
 dev = [
     "pytest>=9.0.0,<10.0.0",
     "pytest-asyncio>=1.3.0,<2.0.0",
@@ -72,6 +85,7 @@ dev = [
 
 [project.scripts]
 nanobot = "nanobot.cli.commands:app"
+geoclaw = "geoclaw.cli:app"
 
 [build-system]
 requires = ["hatchling"]
@@ -86,13 +100,16 @@ include = [
     "nanobot/templates/**/*.md",
     "nanobot/skills/**/*.md",
     "nanobot/skills/**/*.sh",
+    "geoclaw/**/*.py",
+    "geoclaw/skills/**/*.md",
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["nanobot"]
+packages = ["nanobot", "geoclaw"]
 
 [tool.hatch.build.targets.wheel.sources]
 "nanobot" = "nanobot"
+"geoclaw" = "geoclaw"
 
 [tool.hatch.build.targets.wheel.force-include]
 "bridge" = "nanobot/bridge"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def sample_geojson_path() -> Path:
+    return Path(__file__).parent / "fixtures" / "sample.geojson"
+
+
+@pytest.fixture()
+def sample_geojson_dict(sample_geojson_path: Path) -> dict:
+    return json.loads(sample_geojson_path.read_text(encoding="utf-8"))

--- a/tests/fixtures/sample.geojson
+++ b/tests/fixtures/sample.geojson
@@ -1,0 +1,23 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "sample_aoi"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [116.3, 39.9],
+            [116.5, 39.9],
+            [116.5, 40.0],
+            [116.3, 40.0],
+            [116.3, 39.9]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from geoclaw.schemas.common import AOIInput, ArtifactMeta, BBox, ProvenanceMeta, ToolResult
+
+
+def test_bbox_tuple_and_area():
+    bbox = BBox(west=116.3, south=39.9, east=116.5, north=40.0)
+    assert bbox.as_tuple() == (116.3, 39.9, 116.5, 40.0)
+    assert bbox.area_degrees() > 0
+
+
+def test_tool_result_llm_string_contains_key_sections():
+    result = ToolResult(
+        success=True,
+        tool_name="geo_inspect_aoi",
+        summary="AOI looks good",
+        data={"feature_count": 1},
+        artifacts=[
+            ArtifactMeta(
+                path="runs/demo/artifacts/aoi.geojson",
+                format="geojson",
+                size_bytes=123,
+                description="AOI output",
+            )
+        ],
+        provenance=ProvenanceMeta(tool_name="geo_inspect_aoi"),
+    )
+    text = result.to_llm_string()
+    assert "[geo_inspect_aoi] OK" in text
+    assert "AOI looks good" in text
+    assert "Artifacts:" in text
+    assert "feature_count" in text
+
+
+def test_aoi_input_accepts_bbox():
+    aoi = AOIInput(bbox=BBox(west=0, south=0, east=1, north=1))
+    assert aoi.bbox is not None
+    assert aoi.file_path is None

--- a/tests/test_skills_smoke.py
+++ b/tests/test_skills_smoke.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import geopandas as gpd
+import networkx as nx
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_origin
+from shapely.geometry import Point
+
+from geoclaw.tools.aoi import InspectAOITool, RenderWorkflowTool, SuggestCRSTool, ValidateGeometryTool
+from geoclaw.tools.hex import AggregateByH3Tool, PointToH3Tool
+from geoclaw.tools.network import BuildNetworkTool, ComputeRouteTool
+from geoclaw.tools.osm import BuildPlaceProfileTool, ExtractOSMByGeometryTool
+from geoclaw.tools.raster import ClipRasterTool, ExportRasterPreviewTool, RasterSummaryTool, ReadRasterTool
+from geoclaw.tools.stac import PreviewSTACAssetsTool, RankSTACAssetsTool, SearchSTACTool, SelectBestSceneTool
+
+
+def _summary_result(tool_name: str, output: str) -> dict:
+    return {
+        "tool_name": tool_name,
+        "success": "[FAILED]" not in output,
+        "summary": output,
+        "errors": [],
+        "warnings": [],
+        "artifacts": [],
+    }
+
+
+def _fake_graph():
+    graph = nx.MultiDiGraph()
+    graph.add_node(1, x=116.30, y=39.90)
+    graph.add_node(2, x=116.31, y=39.91)
+    graph.add_node(3, x=116.32, y=39.92)
+    graph.add_edge(1, 2, key=0, length=1000.0, travel_time=600.0)
+    graph.add_edge(2, 3, key=0, length=1000.0, travel_time=600.0)
+    graph.add_edge(2, 1, key=0, length=1000.0, travel_time=600.0)
+    graph.add_edge(3, 2, key=0, length=1000.0, travel_time=600.0)
+    return graph
+
+
+def _fake_nearest_node(graph, lon: float, lat: float):
+    return min(
+        graph.nodes,
+        key=lambda n: (graph.nodes[n]["x"] - lon) ** 2 + (graph.nodes[n]["y"] - lat) ** 2,
+    )
+
+
+class _FakeItem:
+    def __init__(self, item_id: str, cloud_cover: float, assets: dict):
+        self._item_id = item_id
+        self._cloud_cover = cloud_cover
+        self._assets = assets
+
+    def to_dict(self):
+        return {
+            "id": self._item_id,
+            "collection": "sentinel-2-l2a",
+            "bbox": [116.3, 39.9, 116.5, 40.0],
+            "properties": {"datetime": "2024-06-01T00:00:00Z", "eo:cloud_cover": self._cloud_cover},
+            "assets": self._assets,
+        }
+
+
+class _FakeSearch:
+    def items(self):
+        return [
+            _FakeItem("scene-low-cloud", 3, {"visual": {"href": "https://example.com/low.png", "type": "image/png"}}),
+            _FakeItem("scene-high-cloud", 60, {"thumbnail": {"href": "https://example.com/high.png", "type": "image/png"}}),
+        ]
+
+
+class _FakeClient:
+    def search(self, **kwargs):
+        return _FakeSearch()
+
+
+@pytest.fixture()
+def smoke_raster_path(tmp_path):
+    path = tmp_path / "smoke.tif"
+    data = np.arange(100, dtype="float32").reshape((10, 10))
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=10,
+        width=10,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=from_origin(116.3, 40.0, 0.01, 0.01),
+        nodata=-9999,
+    ) as dst:
+        dst.write(data, 1)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_aoi_sanity_check_smoke(tmp_path, sample_geojson_dict):
+    run_id = "skill_aoi"
+    inspect_tool = InspectAOITool(tmp_path)
+    validate_tool = ValidateGeometryTool(tmp_path)
+    suggest_tool = SuggestCRSTool(tmp_path)
+    render_tool = RenderWorkflowTool(tmp_path)
+
+    inspect_output = await inspect_tool.execute(geojson=sample_geojson_dict, run_id=run_id)
+    validate_output = await validate_tool.execute(geojson=sample_geojson_dict)
+    suggest_output = await suggest_tool.execute(west=116.3, south=39.9, east=116.5, north=40.0)
+    render_output = await render_tool.execute(
+        run_id=run_id,
+        title="AOI Sanity Check",
+        results_json=json.dumps(
+            [
+                _summary_result("geo_inspect_aoi", inspect_output),
+                _summary_result("geo_validate_geometry", validate_output),
+                _summary_result("geo_suggest_crs", suggest_output),
+            ]
+        ),
+    )
+
+    assert "[geo_render_workflow] OK" in render_output
+    assert (tmp_path / "runs" / run_id / "summary.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_osm_place_profile_smoke(tmp_path, monkeypatch):
+    def fake_convert_geometry_to_geodataframe(**kwargs):
+        return gpd.GeoDataFrame(
+            {"amenity": ["school", "cafe"], "shop": [None, "supermarket"]},
+            geometry=[Point(116.31, 39.91), Point(116.32, 39.92)],
+            crs="EPSG:4326",
+        )
+
+    monkeypatch.setattr("quackosm.convert_geometry_to_geodataframe", fake_convert_geometry_to_geodataframe)
+
+    run_id = "skill_osm"
+    extract_tool = ExtractOSMByGeometryTool(tmp_path)
+    profile_tool = BuildPlaceProfileTool(tmp_path)
+    render_tool = RenderWorkflowTool(tmp_path)
+
+    extract_output = await extract_tool.execute(
+        bbox={"west": 116.3, "south": 39.9, "east": 116.4, "north": 40.0},
+        run_id=run_id,
+    )
+    profile_output = await profile_tool.execute(
+        file_path=str(tmp_path / "runs" / run_id / "artifacts" / "osm_extract.geojson")
+    )
+    render_output = await render_tool.execute(
+        run_id=run_id,
+        title="OSM Place Profile",
+        results_json=json.dumps(
+            [
+                _summary_result("geo_extract_osm", extract_output),
+                _summary_result("geo_build_place_profile", profile_output),
+            ]
+        ),
+    )
+    assert "[geo_render_workflow] OK" in render_output
+
+
+@pytest.mark.asyncio
+async def test_accessibility_analysis_smoke(tmp_path, monkeypatch):
+    graph = _fake_graph()
+    monkeypatch.setattr("geoclaw.tools.network._build_graph_for_aoi", lambda **kwargs: graph)
+    monkeypatch.setattr("geoclaw.tools.network._nearest_node", _fake_nearest_node)
+    monkeypatch.setattr("osmnx.save_graphml", lambda g, path: Path(path).write_text("graphml", encoding="utf-8"))
+
+    run_id = "skill_access"
+    build_tool = BuildNetworkTool(tmp_path)
+    route_tool = ComputeRouteTool(tmp_path)
+    render_tool = RenderWorkflowTool(tmp_path)
+
+    build_output = await build_tool.execute(
+        bbox={"west": 116.3, "south": 39.9, "east": 116.35, "north": 39.95},
+        mode="walk",
+        run_id=run_id,
+    )
+    route_output = await route_tool.execute(
+        bbox={"west": 116.3, "south": 39.9, "east": 116.35, "north": 39.95},
+        origin={"lon": 116.3001, "lat": 39.9001},
+        destination={"lon": 116.319, "lat": 39.919},
+        mode="walk",
+        run_id=run_id,
+    )
+    render_output = await render_tool.execute(
+        run_id=run_id,
+        title="Accessibility Analysis",
+        results_json=json.dumps(
+            [
+                _summary_result("geo_build_network", build_output),
+                _summary_result("geo_compute_route", route_output),
+            ]
+        ),
+    )
+    assert "[geo_render_workflow] OK" in render_output
+
+
+@pytest.mark.asyncio
+async def test_raster_exposure_summary_smoke(tmp_path, smoke_raster_path):
+    run_id = "skill_raster"
+    read_tool = ReadRasterTool(tmp_path)
+    clip_tool = ClipRasterTool(tmp_path)
+    summary_tool = RasterSummaryTool(tmp_path)
+    preview_tool = ExportRasterPreviewTool(tmp_path)
+    render_tool = RenderWorkflowTool(tmp_path)
+
+    read_output = await read_tool.execute(raster_path=str(smoke_raster_path))
+    clip_output = await clip_tool.execute(
+        raster_path=str(smoke_raster_path),
+        bbox={"west": 116.32, "south": 39.93, "east": 116.36, "north": 39.98},
+        run_id=run_id,
+    )
+    clipped_path = str(tmp_path / "runs" / run_id / "artifacts" / "clipped.tif")
+    summary_output = await summary_tool.execute(raster_path=clipped_path, band=1)
+    preview_output = await preview_tool.execute(raster_path=clipped_path, band=1, run_id=run_id)
+    render_output = await render_tool.execute(
+        run_id=run_id,
+        title="Raster Exposure Summary",
+        results_json=json.dumps(
+            [
+                _summary_result("geo_read_raster", read_output),
+                _summary_result("geo_clip_raster", clip_output),
+                _summary_result("geo_raster_summary", summary_output),
+                _summary_result("geo_export_raster_preview", preview_output),
+            ]
+        ),
+    )
+    assert "[geo_render_workflow] OK" in render_output
+
+
+@pytest.mark.asyncio
+async def test_stac_search_preview_smoke(tmp_path, monkeypatch):
+    monkeypatch.setattr("pystac_client.Client.open", lambda url: _FakeClient())
+
+    run_id = "skill_stac"
+    search_tool = SearchSTACTool(tmp_path)
+    rank_tool = RankSTACAssetsTool(tmp_path)
+    preview_tool = PreviewSTACAssetsTool(tmp_path)
+    select_tool = SelectBestSceneTool(tmp_path)
+    render_tool = RenderWorkflowTool(tmp_path)
+
+    items = [
+        {
+            "id": "scene-low-cloud",
+            "collection": "sentinel-2-l2a",
+            "datetime": "2024-06-01T00:00:00Z",
+            "cloud_cover": 3,
+            "assets": {"visual": {"href": "https://example.com/low.png", "type": "image/png"}},
+            "bbox": [116.3, 39.9, 116.5, 40.0],
+            "properties": {},
+        },
+        {
+            "id": "scene-high-cloud",
+            "collection": "sentinel-2-l2a",
+            "datetime": "2024-06-02T00:00:00Z",
+            "cloud_cover": 60,
+            "assets": {"thumbnail": {"href": "https://example.com/high.png", "type": "image/png"}},
+            "bbox": [116.3, 39.9, 116.5, 40.0],
+            "properties": {},
+        },
+    ]
+    ranked = [
+        {**items[0], "score": 7, "matched_assets": ["visual"]},
+        {**items[1], "score": -50, "matched_assets": ["thumbnail"]},
+    ]
+
+    search_output = await search_tool.execute(
+        catalog_url="https://example.com/stac",
+        bbox={"west": 116.3, "south": 39.9, "east": 116.5, "north": 40.0},
+        limit=2,
+    )
+    rank_output = await rank_tool.execute(items_json=json.dumps(items), asset_preferences=["visual", "thumbnail"])
+    preview_output = await preview_tool.execute(items_json=json.dumps(items))
+    select_output = await select_tool.execute(ranked_items_json=json.dumps(ranked))
+    render_output = await render_tool.execute(
+        run_id=run_id,
+        title="STAC Search Preview",
+        results_json=json.dumps(
+            [
+                _summary_result("geo_search_stac", search_output),
+                _summary_result("geo_rank_stac_assets", rank_output),
+                _summary_result("geo_preview_stac_assets", preview_output),
+                _summary_result("geo_select_best_scene", select_output),
+            ]
+        ),
+    )
+    assert "[geo_render_workflow] OK" in render_output
+
+
+@pytest.mark.asyncio
+async def test_hex_service_coverage_smoke(tmp_path):
+    points = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"weight": 1},
+                "geometry": {"type": "Point", "coordinates": [116.31, 39.91]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"weight": 2},
+                "geometry": {"type": "Point", "coordinates": [116.311, 39.911]},
+            },
+        ],
+    }
+    run_id = "skill_hex"
+    point_tool = PointToH3Tool(tmp_path)
+    agg_tool = AggregateByH3Tool(tmp_path)
+    render_tool = RenderWorkflowTool(tmp_path)
+
+    point_output = await point_tool.execute(geojson=points, resolution=8, run_id=run_id)
+    agg_output = await agg_tool.execute(
+        geojson=points,
+        resolution=8,
+        metric_property="weight",
+        agg_method="sum",
+        run_id=run_id,
+    )
+    render_output = await render_tool.execute(
+        run_id=run_id,
+        title="Hex Service Coverage",
+        results_json=json.dumps(
+            [
+                _summary_result("geo_point_to_h3", point_output),
+                _summary_result("geo_aggregate_by_h3", agg_output),
+            ]
+        ),
+    )
+    assert "[geo_render_workflow] OK" in render_output

--- a/tests/test_tools_aoi.py
+++ b/tests/test_tools_aoi.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from geoclaw.tools.aoi import InspectAOITool, SuggestCRSTool, ValidateGeometryTool
+
+geopandas = pytest.importorskip("geopandas")
+
+
+@pytest.mark.asyncio
+async def test_inspect_aoi_from_geojson_creates_run_artifact(tmp_path, sample_geojson_dict):
+    tool = InspectAOITool(tmp_path)
+    output = await tool.execute(geojson=sample_geojson_dict, run_id="demo_run")
+
+    assert "[geo_inspect_aoi] OK" in output
+    assert "feature_count" in output
+    assert (tmp_path / "runs" / "demo_run" / "artifacts" / "aoi.geojson").exists()
+
+
+@pytest.mark.asyncio
+async def test_validate_geometry_reports_valid_geometry(tmp_path, sample_geojson_dict):
+    tool = ValidateGeometryTool(tmp_path)
+    output = await tool.execute(geojson=sample_geojson_dict)
+
+    assert "[geo_validate_geometry] OK" in output
+    assert "valid" in output.lower()
+
+
+@pytest.mark.asyncio
+async def test_suggest_crs_returns_epsg(tmp_path):
+    tool = SuggestCRSTool(tmp_path)
+    output = await tool.execute(west=116.3, south=39.9, east=116.5, north=40.0)
+
+    assert "[geo_suggest_crs] OK" in output
+    assert "EPSG:" in output
+
+
+@pytest.mark.asyncio
+async def test_inspect_aoi_from_file_path(tmp_path, sample_geojson_path):
+    tool = InspectAOITool(tmp_path)
+    output = await tool.execute(file_path=str(sample_geojson_path), run_id="file_run")
+
+    assert "[geo_inspect_aoi] OK" in output
+    artifact_path = tmp_path / "runs" / "file_run" / "artifacts" / "aoi.geojson"
+    assert artifact_path.exists()
+    loaded = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert loaded["type"] == "FeatureCollection"

--- a/tests/test_tools_duckdb.py
+++ b/tests/test_tools_duckdb.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from geoclaw.tools.duckdb_ops import AggregateFeaturesTool, RunSpatialSQLTool, SummarizeByGeometryTool
+
+
+@pytest.mark.asyncio
+async def test_run_spatial_sql(tmp_path):
+    tool = RunSpatialSQLTool(tmp_path)
+    output = await tool.execute(sql="SELECT ST_AsText(ST_Point(1, 2)) AS wkt")
+    assert "[geo_duckdb_run_spatial_sql] OK" in output
+    assert "POINT (1 2)" in output
+
+
+@pytest.mark.asyncio
+async def test_aggregate_features_and_summarize_by_geometry(tmp_path):
+    data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"category": "a", "value": 1},
+                "geometry": {"type": "Point", "coordinates": [116.31, 39.91]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"category": "a", "value": 2},
+                "geometry": {"type": "Point", "coordinates": [116.32, 39.92]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"category": "b", "value": 4},
+                "geometry": {"type": "Point", "coordinates": [116.45, 40.05]},
+            },
+        ],
+    }
+    src = tmp_path / "duck.geojson"
+    src.write_text(json.dumps(data), encoding="utf-8")
+
+    agg_tool = AggregateFeaturesTool(tmp_path)
+    agg_output = await agg_tool.execute(
+        file_path=str(src),
+        group_by="category",
+        metric_field="value",
+        agg_method="sum",
+    )
+    assert "[geo_duckdb_aggregate_features] OK" in agg_output
+    assert "group_by" in agg_output
+
+    summarize_tool = SummarizeByGeometryTool(tmp_path)
+    summarize_output = await summarize_tool.execute(
+        file_path=str(src),
+        geojson={
+            "type": "Polygon",
+            "coordinates": [[[116.3, 39.9], [116.35, 39.9], [116.35, 39.95], [116.3, 39.95], [116.3, 39.9]]],
+        },
+        metric_field="value",
+        agg_method="sum",
+    )
+    assert "[geo_duckdb_summarize_by_geometry] OK" in summarize_output
+    assert "matched_features" in summarize_output

--- a/tests/test_tools_gdal.py
+++ b/tests/test_tools_gdal.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_origin
+
+from geoclaw.tools.gdal_ops import (
+    ClipDatasetTool,
+    ConvertFormatTool,
+    InspectDatasetTool,
+    ReprojectDatasetTool,
+    TranslateToCOGTool,
+)
+
+
+@pytest.fixture()
+def gdal_sample_raster(tmp_path):
+    path = tmp_path / "gdal_sample.tif"
+    data = np.arange(25, dtype="float32").reshape((5, 5))
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=5,
+        width=5,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=from_origin(116.3, 40.0, 0.01, 0.01),
+        nodata=-9999,
+    ) as dst:
+        dst.write(data, 1)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_inspect_and_reproject_vector(tmp_path, sample_geojson_path):
+    inspect_tool = InspectDatasetTool(tmp_path)
+    inspect_output = await inspect_tool.execute(path=str(sample_geojson_path))
+    assert "[geo_gdal_inspect_dataset] OK" in inspect_output
+
+    reproject_tool = ReprojectDatasetTool(tmp_path)
+    reproject_output = await reproject_tool.execute(
+        path=str(sample_geojson_path),
+        target_crs="EPSG:3857",
+        run_id="gdal_vec",
+    )
+    assert "[geo_gdal_reproject_dataset] OK" in reproject_output
+
+
+@pytest.mark.asyncio
+async def test_clip_and_convert_vector(tmp_path, sample_geojson_path):
+    clip_tool = ClipDatasetTool(tmp_path)
+    clip_output = await clip_tool.execute(
+        path=str(sample_geojson_path),
+        bbox={"west": 116.31, "south": 39.91, "east": 116.49, "north": 39.99},
+        run_id="gdal_clip",
+    )
+    assert "[geo_gdal_clip_dataset] OK" in clip_output
+
+    convert_tool = ConvertFormatTool(tmp_path)
+    convert_output = await convert_tool.execute(
+        path=str(sample_geojson_path),
+        target_format="geoparquet",
+        run_id="gdal_convert",
+    )
+    assert "[geo_gdal_convert_format] OK" in convert_output
+
+
+@pytest.mark.asyncio
+async def test_inspect_raster_and_translate_to_cog(tmp_path, gdal_sample_raster, monkeypatch):
+    inspect_tool = InspectDatasetTool(tmp_path)
+    inspect_output = await inspect_tool.execute(path=str(gdal_sample_raster))
+    assert "[geo_gdal_inspect_dataset] OK" in inspect_output
+
+    def fake_copy(src, dst, driver="GTiff", **kwargs):
+        from shutil import copyfile
+
+        copyfile(src, dst)
+
+    monkeypatch.setattr("rasterio.shutil.copy", fake_copy)
+    cog_tool = TranslateToCOGTool(tmp_path)
+    cog_output = await cog_tool.execute(path=str(gdal_sample_raster), run_id="cog_run")
+    assert "[geo_gdal_translate_to_cog] OK" in cog_output

--- a/tests/test_tools_hex.py
+++ b/tests/test_tools_hex.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from geoclaw.tools.hex import AggregateByH3Tool, NeighborhoodSummaryTool, PointToH3Tool
+
+
+POINT_FEATURES = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"weight": 1},
+            "geometry": {"type": "Point", "coordinates": [116.31, 39.91]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"weight": 2},
+            "geometry": {"type": "Point", "coordinates": [116.311, 39.911]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"weight": 3},
+            "geometry": {"type": "Point", "coordinates": [116.35, 39.95]},
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_point_to_h3_and_aggregate(tmp_path):
+    point_tool = PointToH3Tool(tmp_path)
+    agg_tool = AggregateByH3Tool(tmp_path)
+
+    point_output = await point_tool.execute(geojson=POINT_FEATURES, resolution=8, run_id="hex_run")
+    agg_output = await agg_tool.execute(
+        geojson=POINT_FEATURES,
+        resolution=8,
+        metric_property="weight",
+        agg_method="sum",
+        run_id="hex_agg_run",
+    )
+
+    assert "[geo_point_to_h3] OK" in point_output
+    assert "[geo_aggregate_by_h3] OK" in agg_output
+
+
+@pytest.mark.asyncio
+async def test_neighborhood_summary(tmp_path):
+    tool = NeighborhoodSummaryTool(tmp_path)
+    output = await tool.execute(h3_cell="8828308281fffff", k=1)
+    assert "[geo_neighborhood_summary] OK" in output
+    assert "neighbor_count" in output

--- a/tests/test_tools_network.py
+++ b/tests/test_tools_network.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from geoclaw.tools.network import (
+    BuildNetworkTool,
+    ComputeIsochroneTool,
+    ComputeRouteTool,
+    ComputeServiceCoverageTool,
+)
+
+
+def _fake_graph():
+    graph = nx.MultiDiGraph()
+    graph.add_node(1, x=116.30, y=39.90)
+    graph.add_node(2, x=116.31, y=39.91)
+    graph.add_node(3, x=116.32, y=39.92)
+    graph.add_node(4, x=116.34, y=39.94)
+    graph.add_edge(1, 2, key=0, length=1000.0, travel_time=600.0)
+    graph.add_edge(2, 3, key=0, length=1000.0, travel_time=600.0)
+    graph.add_edge(3, 4, key=0, length=1200.0, travel_time=720.0)
+    graph.add_edge(2, 1, key=0, length=1000.0, travel_time=600.0)
+    graph.add_edge(3, 2, key=0, length=1000.0, travel_time=600.0)
+    graph.add_edge(4, 3, key=0, length=1200.0, travel_time=720.0)
+    return graph
+
+
+def _fake_nearest_node(graph, lon: float, lat: float):
+    nodes = list(graph.nodes(data=True))
+    node_id, _ = min(
+        nodes,
+        key=lambda item: (item[1]["x"] - lon) ** 2 + (item[1]["y"] - lat) ** 2,
+    )
+    return node_id
+
+
+@pytest.mark.asyncio
+async def test_build_network(monkeypatch, tmp_path):
+    graph = _fake_graph()
+    monkeypatch.setattr("geoclaw.tools.network._build_graph_for_aoi", lambda **kwargs: graph)
+
+    def fake_save_graphml(graph_obj, path):
+        Path(path).write_text("graphml", encoding="utf-8")
+
+    monkeypatch.setattr("osmnx.save_graphml", fake_save_graphml)
+
+    tool = BuildNetworkTool(tmp_path)
+    output = await tool.execute(
+        bbox={"west": 116.3, "south": 39.9, "east": 116.35, "north": 39.95},
+        mode="walk",
+        run_id="network_run",
+    )
+
+    assert "[geo_build_network] OK" in output
+    assert (tmp_path / "runs" / "network_run" / "artifacts" / "network.graphml").exists()
+
+
+@pytest.mark.asyncio
+async def test_compute_route(monkeypatch, tmp_path):
+    graph = _fake_graph()
+    monkeypatch.setattr("geoclaw.tools.network._build_graph_for_aoi", lambda **kwargs: graph)
+    monkeypatch.setattr("geoclaw.tools.network._nearest_node", _fake_nearest_node)
+
+    tool = ComputeRouteTool(tmp_path)
+    output = await tool.execute(
+        bbox={"west": 116.3, "south": 39.9, "east": 116.35, "north": 39.95},
+        origin={"lon": 116.3001, "lat": 39.9001},
+        destination={"lon": 116.339, "lat": 39.939},
+        mode="walk",
+        run_id="route_run",
+    )
+
+    assert "[geo_compute_route] OK" in output
+    assert "length_m" in output
+
+
+@pytest.mark.asyncio
+async def test_compute_isochrone(monkeypatch, tmp_path):
+    graph = _fake_graph()
+    monkeypatch.setattr("geoclaw.tools.network._build_graph_for_aoi", lambda **kwargs: graph)
+    monkeypatch.setattr("geoclaw.tools.network._nearest_node", _fake_nearest_node)
+
+    tool = ComputeIsochroneTool(tmp_path)
+    output = await tool.execute(
+        bbox={"west": 116.3, "south": 39.9, "east": 116.35, "north": 39.95},
+        origin={"lon": 116.3001, "lat": 39.9001},
+        time_threshold_minutes=20,
+        mode="walk",
+        run_id="iso_run",
+    )
+
+    assert "[geo_compute_isochrone] OK" in output
+    assert "reachable_node_count" in output
+
+
+@pytest.mark.asyncio
+async def test_compute_service_coverage(monkeypatch, tmp_path):
+    graph = _fake_graph()
+    monkeypatch.setattr("geoclaw.tools.network._build_graph_for_aoi", lambda **kwargs: graph)
+    monkeypatch.setattr("geoclaw.tools.network._nearest_node", _fake_nearest_node)
+
+    destinations = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": "near"},
+                "geometry": {"type": "Point", "coordinates": [116.31, 39.91]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"name": "far"},
+                "geometry": {"type": "Point", "coordinates": [116.34, 39.94]},
+            },
+        ],
+    }
+
+    tool = ComputeServiceCoverageTool(tmp_path)
+    output = await tool.execute(
+        bbox={"west": 116.3, "south": 39.9, "east": 116.35, "north": 39.95},
+        origins=[{"lon": 116.3001, "lat": 39.9001}],
+        destinations_geojson=destinations,
+        time_threshold_minutes=25,
+        mode="walk",
+    )
+
+    assert "[geo_compute_service_coverage] OK" in output
+    assert "reachable_count" in output

--- a/tests/test_tools_osm.py
+++ b/tests/test_tools_osm.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from geoclaw.tools.osm import BuildPlaceProfileTool, ExtractOSMByGeometryTool
+
+
+@pytest.mark.asyncio
+async def test_extract_osm_with_monkeypatched_quackosm(tmp_path, monkeypatch):
+    def fake_convert_geometry_to_geodataframe(**kwargs):
+        return gpd.GeoDataFrame(
+            {
+                "amenity": ["school", "cafe"],
+                "shop": [None, "supermarket"],
+            },
+            geometry=[Point(116.31, 39.91), Point(116.32, 39.92)],
+            crs="EPSG:4326",
+        )
+
+    monkeypatch.setattr(
+        "quackosm.convert_geometry_to_geodataframe",
+        fake_convert_geometry_to_geodataframe,
+    )
+
+    tool = ExtractOSMByGeometryTool(tmp_path)
+    output = await tool.execute(
+        bbox={"west": 116.3, "south": 39.9, "east": 116.4, "north": 40.0},
+        run_id="osm_run",
+    )
+
+    assert "[geo_extract_osm] OK" in output
+    assert "feature_count" in output
+    assert (tmp_path / "runs" / "osm_run" / "artifacts" / "osm_extract.geojson").exists()
+
+
+@pytest.mark.asyncio
+async def test_build_place_profile_from_geojson(tmp_path):
+    gdf = gpd.GeoDataFrame(
+        {
+            "amenity": ["school", "school", "cafe"],
+            "shop": [None, None, "supermarket"],
+        },
+        geometry=[Point(116.31, 39.91), Point(116.32, 39.92), Point(116.33, 39.93)],
+        crs="EPSG:4326",
+    )
+    geojson = json.loads(gdf.to_json())
+
+    tool = BuildPlaceProfileTool(tmp_path)
+    output = await tool.execute(geojson=geojson)
+
+    assert "[geo_build_place_profile] OK" in output
+    assert "narrative" in output

--- a/tests/test_tools_raster.py
+++ b/tests/test_tools_raster.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_origin
+
+from geoclaw.tools.raster import ClipRasterTool, ExportRasterPreviewTool, RasterSummaryTool, ReadRasterTool
+
+
+@pytest.fixture()
+def sample_raster_path(tmp_path):
+    path = tmp_path / "sample.tif"
+    data = np.arange(100, dtype="float32").reshape((10, 10))
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=10,
+        width=10,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=from_origin(116.3, 40.0, 0.01, 0.01),
+        nodata=-9999,
+    ) as dst:
+        dst.write(data, 1)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_read_raster(sample_raster_path, tmp_path):
+    tool = ReadRasterTool(tmp_path)
+    output = await tool.execute(raster_path=str(sample_raster_path))
+    assert "[geo_read_raster] OK" in output
+    assert "band_count" in output
+
+
+@pytest.mark.asyncio
+async def test_clip_raster(sample_raster_path, tmp_path):
+    tool = ClipRasterTool(tmp_path)
+    output = await tool.execute(
+        raster_path=str(sample_raster_path),
+        bbox={"west": 116.32, "south": 39.93, "east": 116.36, "north": 39.98},
+        run_id="raster_run",
+    )
+    assert "[geo_clip_raster] OK" in output
+    assert (tmp_path / "runs" / "raster_run" / "artifacts" / "clipped.tif").exists()
+
+
+@pytest.mark.asyncio
+async def test_raster_summary_and_preview(sample_raster_path, tmp_path):
+    summary_tool = RasterSummaryTool(tmp_path)
+    preview_tool = ExportRasterPreviewTool(tmp_path)
+
+    summary_output = await summary_tool.execute(raster_path=str(sample_raster_path), band=1)
+    preview_output = await preview_tool.execute(
+        raster_path=str(sample_raster_path),
+        band=1,
+        run_id="preview_run",
+    )
+
+    assert "[geo_raster_summary] OK" in summary_output
+    assert "mean" in summary_output
+    assert "[geo_export_raster_preview] OK" in preview_output
+    assert (tmp_path / "runs" / "preview_run" / "artifacts" / "preview.png").exists()

--- a/tests/test_tools_stac.py
+++ b/tests/test_tools_stac.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from geoclaw.tools.stac import (
+    PreviewSTACAssetsTool,
+    RankSTACAssetsTool,
+    SearchSTACTool,
+    SelectBestSceneTool,
+)
+
+
+class _FakeItem:
+    def __init__(self, item_id: str, cloud_cover: float, assets: dict):
+        self._item_id = item_id
+        self._cloud_cover = cloud_cover
+        self._assets = assets
+
+    def to_dict(self):
+        return {
+            "id": self._item_id,
+            "collection": "sentinel-2-l2a",
+            "bbox": [116.3, 39.9, 116.5, 40.0],
+            "properties": {
+                "datetime": "2024-06-01T00:00:00Z",
+                "eo:cloud_cover": self._cloud_cover,
+            },
+            "assets": self._assets,
+        }
+
+
+class _FakeSearch:
+    def items(self):
+        return [
+            _FakeItem("scene-low-cloud", 3, {"visual": {"href": "https://example.com/low.png", "type": "image/png"}}),
+            _FakeItem("scene-high-cloud", 60, {"thumbnail": {"href": "https://example.com/high.png", "type": "image/png"}}),
+        ]
+
+
+class _FakeClient:
+    def search(self, **kwargs):
+        return _FakeSearch()
+
+
+@pytest.mark.asyncio
+async def test_search_rank_preview_and_select_stac(monkeypatch, tmp_path):
+    monkeypatch.setattr("pystac_client.Client.open", lambda url: _FakeClient())
+
+    search_tool = SearchSTACTool(tmp_path)
+    rank_tool = RankSTACAssetsTool(tmp_path)
+    preview_tool = PreviewSTACAssetsTool(tmp_path)
+    select_tool = SelectBestSceneTool(tmp_path)
+
+    search_output = await search_tool.execute(
+        catalog_url="https://example.com/stac",
+        bbox={"west": 116.3, "south": 39.9, "east": 116.5, "north": 40.0},
+        limit=2,
+    )
+    assert "[geo_search_stac] OK" in search_output
+
+    items = [
+        {
+            "id": "scene-low-cloud",
+            "collection": "sentinel-2-l2a",
+            "datetime": "2024-06-01T00:00:00Z",
+            "cloud_cover": 3,
+            "assets": {"visual": {"href": "https://example.com/low.png", "type": "image/png"}},
+            "bbox": [116.3, 39.9, 116.5, 40.0],
+            "properties": {},
+        },
+        {
+            "id": "scene-high-cloud",
+            "collection": "sentinel-2-l2a",
+            "datetime": "2024-06-02T00:00:00Z",
+            "cloud_cover": 60,
+            "assets": {"thumbnail": {"href": "https://example.com/high.png", "type": "image/png"}},
+            "bbox": [116.3, 39.9, 116.5, 40.0],
+            "properties": {},
+        },
+    ]
+    rank_output = await rank_tool.execute(items_json=json.dumps(items), asset_preferences=["visual", "thumbnail"])
+    preview_output = await preview_tool.execute(items_json=json.dumps(items))
+    ranked = [
+        {**items[0], "score": 7, "matched_assets": ["visual"]},
+        {**items[1], "score": -50, "matched_assets": ["thumbnail"]},
+    ]
+    select_output = await select_tool.execute(ranked_items_json=json.dumps(ranked))
+
+    assert "[geo_rank_stac_assets] OK" in rank_output
+    assert "[geo_preview_stac_assets] OK" in preview_output
+    assert "[geo_select_best_scene] OK" in select_output
+    assert "scene-low-cloud" in select_output

--- a/tests/test_tools_vector.py
+++ b/tests/test_tools_vector.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from geoclaw.tools.vector import ReadVectorTool, SummarizeVectorTool
+
+pytest.importorskip("geopandas")
+
+
+@pytest.mark.asyncio
+async def test_read_vector_returns_summary_and_artifact(tmp_path, sample_geojson_path):
+    tool = ReadVectorTool(tmp_path)
+    output = await tool.execute(file_path=str(sample_geojson_path), run_id="vector_run")
+
+    assert "[geo_read_vector] OK" in output
+    assert "feature_count" in output
+    assert (tmp_path / "runs" / "vector_run" / "artifacts" / "sample.geojson").exists()
+
+
+@pytest.mark.asyncio
+async def test_summarize_vector_with_geojson(tmp_path, sample_geojson_dict):
+    tool = SummarizeVectorTool(tmp_path)
+    output = await tool.execute(geojson=sample_geojson_dict)
+
+    assert "[geo_summarize_vector] OK" in output
+    assert "feature_count" in output
+    assert "EPSG:4326" in output


### PR DESCRIPTION
Add GeoClaw's typed geospatial tools, workflow skills, and smoke tests so spatial requests can run as reproducible local workflows. Refresh the docs to present GeoClaw as the primary product while keeping nanobot as the runtime base.

Made-with: Cursor