### PR TITLE
feat: support per-turn selected skill injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ nanobot agent
 
 That's it! You have a working AI assistant in 2 minutes.
 
+To preload specific skills for a turn, repeat `--skill`:
+
+```bash
+nanobot agent -m "Create a PR for this repo" --skill github --skill summarize
+```
+
 ## 💬 Chat Apps
 
 Connect nanobot to your favorite chat platform. Want to build your own? See the [Channel Plugin Guide](./docs/CHANNEL_PLUGIN_GUIDE.md).
@@ -1292,6 +1298,7 @@ nanobot gateway --config ~/.nanobot-telegram/config.json --workspace /tmp/nanobo
 | `nanobot agent -m "..."` | Chat with the agent |
 | `nanobot agent -w <workspace>` | Chat against a specific workspace |
 | `nanobot agent -w <workspace> -c <config>` | Chat against a specific workspace/config |
+| `nanobot agent -m "..." --skill github --skill tmux` | Chat with preloaded selected skills |
 | `nanobot agent` | Interactive chat mode |
 | `nanobot agent --no-markdown` | Show plain-text replies |
 | `nanobot agent --logs` | Show runtime logs during chat |

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -24,6 +24,18 @@ class ContextBuilder:
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
 
+    @staticmethod
+    def _merge_skill_names(
+        always_skills: list[str],
+        selected_skills: list[str] | None,
+    ) -> list[str]:
+        """Merge skill names while preserving first-seen order."""
+        merged: list[str] = []
+        for name in [*always_skills, *(selected_skills or [])]:
+            if name and name not in merged:
+                merged.append(name)
+        return merged
+
     def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
         parts = [self._get_identity()]
@@ -37,10 +49,11 @@ class ContextBuilder:
             parts.append(f"# Memory\n\n{memory}")
 
         always_skills = self.skills.get_always_skills()
-        if always_skills:
-            always_content = self.skills.load_skills_for_context(always_skills)
-            if always_content:
-                parts.append(f"# Active Skills\n\n{always_content}")
+        active_skills = self._merge_skill_names(always_skills, skill_names)
+        if active_skills:
+            active_content = self.skills.load_skills_for_context(active_skills)
+            if active_content:
+                parts.append(f"# Active Skills\n\n{active_content}")
 
         skills_summary = self.skills.build_skills_summary()
         if skills_summary:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -163,6 +163,23 @@ class AgentLoop:
                     tool.set_context(channel, chat_id, *([message_id] if name == "message" else []))
 
     @staticmethod
+    def _extract_skill_names(metadata: dict[str, Any] | None) -> list[str] | None:
+        """Read per-turn selected skills from message metadata."""
+        if not metadata:
+            return None
+        raw = metadata.get("skill_names")
+        if raw is None:
+            return None
+        if isinstance(raw, str):
+            names = [raw]
+        elif isinstance(raw, list):
+            names = [item for item in raw if isinstance(item, str)]
+        else:
+            return None
+        cleaned = [name.strip() for name in names if name.strip()]
+        return cleaned or None
+
+    @staticmethod
     def _strip_think(text: str | None) -> str | None:
         """Remove <think>…</think> blocks that some models embed in content."""
         if not text:
@@ -372,9 +389,13 @@ class AgentLoop:
             history = session.get_history(max_messages=0)
             # Subagent results should be assistant role, other system messages use user role
             current_role = "assistant" if msg.sender_id == "subagent" else "user"
+            skill_names = self._extract_skill_names(msg.metadata)
             messages = self.context.build_messages(
                 history=history,
-                current_message=msg.content, channel=channel, chat_id=chat_id,
+                current_message=msg.content,
+                skill_names=skill_names,
+                channel=channel,
+                chat_id=chat_id,
                 current_role=current_role,
             )
             final_content, _, all_msgs = await self._run_agent_loop(messages)
@@ -422,9 +443,11 @@ class AgentLoop:
                 message_tool.start_turn()
 
         history = session.get_history(max_messages=0)
+        skill_names = self._extract_skill_names(msg.metadata)
         initial_messages = self.context.build_messages(
             history=history,
             current_message=msg.content,
+            skill_names=skill_names,
             media=msg.media if msg.media else None,
             channel=msg.channel, chat_id=msg.chat_id,
         )
@@ -501,10 +524,17 @@ class AgentLoop:
         session_key: str = "cli:direct",
         channel: str = "cli",
         chat_id: str = "direct",
+        skill_names: list[str] | None = None,
         on_progress: Callable[[str], Awaitable[None]] | None = None,
     ) -> str:
         """Process a message directly (for CLI or cron usage)."""
         await self._connect_mcp()
-        msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
+        msg = InboundMessage(
+            channel=channel,
+            sender_id="user",
+            chat_id=chat_id,
+            content=content,
+            metadata={"skill_names": skill_names} if skill_names else {},
+        )
         response = await self._process_message(msg, session_key=session_key, on_progress=on_progress)
         return response.content if response else ""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -655,6 +655,11 @@ def agent(
     session_id: str = typer.Option("cli:direct", "--session", "-s", help="Session ID"),
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace directory"),
     config: str | None = typer.Option(None, "--config", "-c", help="Config file path"),
+    skill: list[str] | None = typer.Option(
+        None,
+        "--skill",
+        help="Preload one or more skills for this turn. Repeat the flag to pass multiple skills.",
+    ),
     markdown: bool = typer.Option(True, "--markdown/--no-markdown", help="Render assistant output as Markdown"),
     logs: bool = typer.Option(False, "--logs/--no-logs", help="Show nanobot runtime logs during chat"),
 ):
@@ -715,7 +720,12 @@ def agent(
             nonlocal _thinking
             _thinking = _ThinkingSpinner(enabled=not logs)
             with _thinking:
-                response = await agent_loop.process_direct(message, session_id, on_progress=_cli_progress)
+                response = await agent_loop.process_direct(
+                    message,
+                    session_id,
+                    skill_names=skill,
+                    on_progress=_cli_progress,
+                )
             _thinking = None
             _print_agent_response(response, render_markdown=markdown)
             await agent_loop.close_mcp()
@@ -804,6 +814,7 @@ def agent(
                             sender_id="user",
                             chat_id=cli_chat_id,
                             content=user_input,
+                            metadata={"skill_names": skill} if skill else {},
                         ))
 
                         nonlocal _thinking

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -569,3 +569,16 @@ def test_gateway_cli_port_overrides_configured_port(monkeypatch, tmp_path: Path)
 
     assert isinstance(result.exception, _StopGateway)
     assert "port 18792" in result.stdout
+
+
+def test_agent_message_mode_passes_selected_skills(mock_agent_runtime):
+    result = runner.invoke(
+        app,
+        ["agent", "-m", "hello", "--skill", "github", "--skill", "tmux"],
+    )
+
+    assert result.exit_code == 0
+    args = mock_agent_runtime["agent_loop"].process_direct.await_args
+    assert args.args == ("hello", "cli:direct")
+    assert args.kwargs["skill_names"] == ["github", "tmux"]
+    assert callable(args.kwargs["on_progress"])

--- a/tests/test_context_skills.py
+++ b/tests/test_context_skills.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from nanobot.agent.context import ContextBuilder
+from nanobot.agent.skills import SkillsLoader
+
+
+def _write_skill(workspace: Path, name: str, body: str, *, always: bool = False) -> None:
+    skill_dir = workspace / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    frontmatter = "---\n"
+    if always:
+        frontmatter += "always: true\n"
+    frontmatter += "---\n"
+    (skill_dir / "SKILL.md").write_text(f"{frontmatter}\n{body}\n", encoding="utf-8")
+
+
+def test_build_system_prompt_includes_selected_and_always_skills(tmp_path: Path):
+    _write_skill(tmp_path, "always-skill", "Always skill body", always=True)
+    _write_skill(tmp_path, "selected-skill", "Selected skill body")
+    _write_skill(tmp_path, "other-skill", "Other skill body")
+    empty_builtin_dir = tmp_path / "builtin"
+    empty_builtin_dir.mkdir()
+
+    builder = ContextBuilder(tmp_path)
+    builder.skills = SkillsLoader(tmp_path, builtin_skills_dir=empty_builtin_dir)
+
+    prompt = builder.build_system_prompt(
+        ["selected-skill", "always-skill", "selected-skill", "missing-skill"]
+    )
+
+    assert "# Active Skills" in prompt
+    assert "### Skill: always-skill" in prompt
+    assert "### Skill: selected-skill" in prompt
+    assert prompt.count("### Skill: always-skill") == 1
+    assert prompt.count("### Skill: selected-skill") == 1
+    assert "Always skill body" in prompt
+    assert "Selected skill body" in prompt
+    assert "Other skill body" not in prompt
+


### PR DESCRIPTION
## Summary
- wire per-turn selected skills through the current agent path
- expose repeated `--skill` in the CLI for direct and interactive agent turns
- add focused tests for selected-skill context injection and CLI forwarding

## Why
`ContextBuilder.build_system_prompt()` already accepts `skill_names`, but there was no end-to-end path to use it for a single turn.
This small PR adds only that path.

## Scope
- `nanobot/agent/context.py`
- `nanobot/agent/loop.py`
- `nanobot/cli/commands.py`
- `tests/test_commands.py`
- `tests/test_context_skills.py`
- `README.md`

## Validation
```bash
PYTHONPATH=. pytest tests/test_context_skills.py tests/test_commands.py -q
```

Passed locally (`32 passed`).
