### PR TITLE
feat(channels): add `blockFrom` configuration and secure global blocking logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Connect nanobot to your favorite chat platform. Want to build your own? See the 
       "enabled": true,
       "token": "YOUR_BOT_TOKEN",
       "allowFrom": ["YOUR_USER_ID"],
+      "blockFrom": ["ABUSIVE_USER_ID"],
       "silentToolHints": false
     }
   }
@@ -652,6 +653,7 @@ Uses **Socket Mode** — no public URL required.
       "botToken": "xoxb-...",
       "appToken": "xapp-...",
       "allowFrom": ["YOUR_SLACK_USER_ID"],
+      "blockFrom": ["ABUSIVE_SLACK_USER_ID"],
       "groupPolicy": "mention"
     }
   }
@@ -1313,6 +1315,7 @@ MCP tools are automatically discovered and registered on startup. The LLM can us
 | `tools.restrictToWorkspace` | `false` | When `true`, restricts **all** agent tools (shell, file read/write/edit, list) to the workspace directory. Prevents path traversal and out-of-scope access. |
 | `tools.exec.pathAppend` | `""` | Extra directories to append to `PATH` when running shell commands (e.g. `/usr/sbin` for `ufw`). |
 | `channels.*.allowFrom` | `[]` (deny all) | Whitelist of user IDs. Empty denies all; use `["*"]` to allow everyone. |
+| `channels.*.blockFrom` | `[]` (empty) | Explicit deny list of immutable numeric user IDs. Evaluated before `allowFrom`. |
 
 
 ## 🧩 Multiple Instances

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ chmod 600 ~/.nanobot/config.json
 
 ### 2. Channel Access Control
 
-**IMPORTANT**: Always configure `allowFrom` lists for production use.
+**IMPORTANT**: Always configure `allowFrom` lists for production use. You can also use `blockFrom` to explicitly block malicious users.
 
 ```json
 {
@@ -44,7 +44,8 @@ chmod 600 ~/.nanobot/config.json
     "telegram": {
       "enabled": true,
       "token": "YOUR_BOT_TOKEN",
-      "allowFrom": ["123456789", "987654321"]
+      "allowFrom": ["123456789", "987654321"],
+      "blockFrom": ["111111111"]
     },
     "whatsapp": {
       "enabled": true,
@@ -56,7 +57,8 @@ chmod 600 ~/.nanobot/config.json
 
 **Security Notes:**
 - In `v0.1.4.post3` and earlier, an empty `allowFrom` allowed all users. Since `v0.1.4.post4`, empty `allowFrom` denies all access by default — set `["*"]` to explicitly allow everyone.
-- Get your Telegram user ID from `@userinfobot`
+- The `blockFrom` list enforces an explicit deny which takes precedence over `allowFrom` lists. Avoid using usernames in `blockFrom` when possible, as users can change their usernames to evade bans.
+- Get your immutable numeric Telegram user ID from `@userinfobot`
 - Use full phone numbers with country code for WhatsApp
 - Review access logs regularly for unauthorized access attempts
 
@@ -213,6 +215,7 @@ If you suspect a security breach:
 
 ✅ **Authentication**
 - Allow-list based access control — in `v0.1.4.post3` and earlier empty `allowFrom` allowed all; since `v0.1.4.post4` it denies all (`["*"]` explicitly allows all)
+- Block-list based access control — explicit deny capabilities using `blockFrom`.
 - Failed authentication attempt logging
 
 ✅ **Resource Protection**
@@ -241,7 +244,7 @@ Before deploying nanobot:
 
 - [ ] API keys stored securely (not in code)
 - [ ] Config file permissions set to 0600
-- [ ] `allowFrom` lists configured for all channels
+- [ ] `allowFrom` and `blockFrom` lists configured for all channels
 - [ ] Running as non-root user
 - [ ] File system permissions properly restricted
 - [ ] Dependencies updated to latest secure versions

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -76,6 +76,19 @@ class BaseChannel(ABC):
         """
         pass
 
+    def is_blocked(self, sender_id: str) -> bool:
+        """Check if *sender_id* is explicitly blocked."""
+        block_list = getattr(self.config, "block_from", [])
+        if not block_list:
+            return False
+
+        sender_str = str(sender_id)
+        parts = sender_str.split("|", 1)
+        sid = parts[0]
+        username = parts[1] if len(parts) > 1 else None
+
+        return sid in block_list or (username and username in block_list)
+
     def is_allowed(self, sender_id: str) -> bool:
         """Check if *sender_id* is permitted.  Empty list → deny all; ``"*"`` → allow all."""
         allow_list = getattr(self.config, "allow_from", [])
@@ -84,7 +97,13 @@ class BaseChannel(ABC):
             return False
         if "*" in allow_list:
             return True
-        return str(sender_id) in allow_list
+            
+        sender_str = str(sender_id)
+        parts = sender_str.split("|", 1)
+        sid = parts[0]
+        username = parts[1] if len(parts) > 1 else None
+
+        return sid in allow_list or (username and username in allow_list)
 
     async def _handle_message(
         self,
@@ -108,6 +127,13 @@ class BaseChannel(ABC):
             metadata: Optional channel-specific metadata.
             session_key: Optional session key override (e.g. thread-scoped sessions).
         """
+        if self.is_blocked(sender_id):
+            logger.info(
+                "Dropped incoming message from blocked user {} on channel {}",
+                sender_id, self.name,
+            )
+            return
+
         if not self.is_allowed(sender_id):
             logger.warning(
                 "Access denied for sender {} on channel {}. "

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -25,6 +25,7 @@ class SlackDMConfig(Base):
     enabled: bool = True
     policy: str = "open"
     allow_from: list[str] = Field(default_factory=list)
+    block_from: list[str] = Field(default_factory=list, alias="blockFrom")
 
 
 class SlackConfig(Base):
@@ -40,6 +41,7 @@ class SlackConfig(Base):
     react_emoji: str = "eyes"
     done_emoji: str = "white_check_mark"
     allow_from: list[str] = Field(default_factory=list)
+    block_from: list[str] = Field(default_factory=list, alias="blockFrom")
     group_policy: str = "mention"
     group_allow_from: list[str] = Field(default_factory=list)
     dm: SlackDMConfig = Field(default_factory=SlackDMConfig)
@@ -63,6 +65,22 @@ class SlackChannel(BaseChannel):
         self._web_client: AsyncWebClient | None = None
         self._socket_client: SocketModeClient | None = None
         self._bot_user_id: str | None = None
+
+    def is_blocked(self, sender_id: str) -> bool:
+        """Check if a user is explicitly blocked."""
+        if super().is_blocked(sender_id):
+            return True
+            
+        dm_block_list = getattr(getattr(self.config, "dm", None), "block_from", [])
+        if not dm_block_list:
+            return False
+
+        sender_str = str(sender_id)
+        parts = sender_str.split("|", 1)
+        sid = parts[0]
+        username = parts[1] if len(parts) > 1 else None
+
+        return sid in dm_block_list or (username and username in dm_block_list)
 
     async def start(self) -> None:
         """Start the Slack Socket Mode client."""
@@ -112,6 +130,11 @@ class SlackChannel(BaseChannel):
         if not self._web_client:
             logger.warning("Slack client not running")
             return
+
+        if self.is_blocked(msg.chat_id):
+            logger.warning("Blocked sending message to {}", msg.chat_id)
+            return
+
         try:
             slack_meta = msg.metadata.get("slack", {}) if msg.metadata else {}
             thread_ts = slack_meta.get("thread_ts")
@@ -194,6 +217,10 @@ class SlackChannel(BaseChannel):
             text[:80],
         )
         if not sender_id or not chat_id:
+            return
+
+        if self.is_blocked(sender_id):
+            logger.info("Dropped incoming message from blocked user: {}", sender_id)
             return
 
         channel_type = event.get("channel_type") or ""

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -162,6 +162,7 @@ class TelegramConfig(Base):
     enabled: bool = False
     token: str = ""
     allow_from: list[str] = Field(default_factory=list)
+    block_from: list[str] = Field(default_factory=list, alias="blockFrom")
     proxy: str | None = None
     reply_to_message: bool = False
     group_policy: Literal["open", "mention"] = "mention"
@@ -207,30 +208,19 @@ class TelegramChannel(BaseChannel):
         self._bot_user_id: int | None = None
         self._bot_username: str | None = None
 
-    def is_allowed(self, sender_id: str) -> bool:
-        """Preserve Telegram's legacy id|username allowlist matching."""
-        if super().is_allowed(sender_id):
-            return True
-
-        allow_list = getattr(self.config, "allow_from", [])
-        if not allow_list or "*" in allow_list:
-            return False
-
-        sender_str = str(sender_id)
-        if sender_str.count("|") != 1:
-            return False
-
-        sid, username = sender_str.split("|", 1)
-        if not sid.isdigit() or not username:
-            return False
-
-        return sid in allow_list or username in allow_list
-
     async def start(self) -> None:
         """Start the Telegram bot with long polling."""
         if not self.config.token:
             logger.error("Telegram bot token not configured")
             return
+
+        # Security checks for mutable usernames
+        for user in getattr(self.config, "allow_from", []):
+            if not user.isdigit():
+                logger.warning("SECURITY RISK: allow_from contains username '{}'. Use immutable numeric id instead.", user)
+        for user in getattr(self.config, "block_from", []):
+            if not user.isdigit():
+                logger.warning("SECURITY RISK: block_from contains username '{}'. Use immutable numeric id instead.", user)
 
         self._running = True
 
@@ -344,6 +334,10 @@ class TelegramChannel(BaseChannel):
         """Send a message through Telegram."""
         if not self._app:
             logger.warning("Telegram bot not running")
+            return
+
+        if self.is_blocked(msg.chat_id):
+            logger.warning("Blocked sending message to {}", msg.chat_id)
             return
 
         # Only stop typing indicator for final responses
@@ -695,6 +689,11 @@ class TelegramChannel(BaseChannel):
             return
         message = update.message
         user = update.effective_user
+
+        if self.is_blocked(self._sender_id(user)):
+            logger.info("Dropped command from blocked user: {}", self._sender_id(user))
+            return
+
         self._remember_thread_context(message)
         await self._handle_message(
             sender_id=self._sender_id(user),
@@ -713,6 +712,11 @@ class TelegramChannel(BaseChannel):
         user = update.effective_user
         chat_id = message.chat_id
         sender_id = self._sender_id(user)
+
+        if self.is_blocked(sender_id):
+            logger.info("Dropped incoming message from blocked user: {}", sender_id)
+            return
+
         self._remember_thread_context(message)
 
         # Store chat_id for replies


### PR DESCRIPTION
- Core: Refactored is_allowed and introduced is_blocked method in BaseChannel
- Telegram: Cleaned up redundant logic to inherit from BaseChannel
- Slack: Added block_from to SlackConfig and SlackDMConfig
- Docs: Updated README.md and SECURITY.md usage documentation