### PR TITLE
feat(channels): add base64 media upload for QQ and WeCom

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -1,6 +1,8 @@
 """QQ channel implementation using botpy SDK."""
 
 import asyncio
+import base64
+import os
 from collections import deque
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -118,6 +120,57 @@ class QQChannel(BaseChannel):
                 pass
         logger.info("QQ bot stopped")
 
+    async def _upload_file_base64(
+        self, file_path: str, chat_id: str, is_group: bool, file_type: int = 4,
+    ) -> "dict | None":
+        """Upload a local file to QQ using base64 — no public URL required.
+
+        Args:
+            file_path: Local path to the file.
+            chat_id: Target user/group openid.
+            is_group: Whether the target is a group.
+            file_type: QQ file_type (1=image, 2=video, 3=audio, 4=file).
+
+        Returns:
+            Media info dict from QQ API, or None on failure.
+        """
+        try:
+            with open(file_path, "rb") as f:
+                raw = f.read()
+            b64 = base64.b64encode(raw).decode()
+            payload = {"file_type": file_type, "file_data": b64, "srv_send_msg": False}
+            if is_group:
+                resp = await self._client.api.post_group_file(
+                    group_openid=chat_id, **payload,
+                )
+            else:
+                resp = await self._client.api.post_c2c_file(
+                    openid=chat_id, **payload,
+                )
+            if resp and hasattr(resp, "file_info"):
+                return {"file_info": resp.file_info}
+            if isinstance(resp, dict):
+                return resp
+            return None
+        except Exception as e:
+            logger.error("QQ base64 upload failed for {}: {}", file_path, e)
+            return None
+
+    async def _upload_local_file(
+        self, file_path: str, chat_id: str, is_group: bool,
+    ) -> "dict | None":
+        """Detect file type and upload a local file via base64."""
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext in (".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"):
+            file_type = 1
+        elif ext in (".mp4", ".avi", ".mov", ".mkv"):
+            file_type = 2
+        elif ext in (".mp3", ".m4a", ".wav", ".ogg", ".silk"):
+            file_type = 3
+        else:
+            file_type = 4
+        return await self._upload_file_base64(file_path, chat_id, is_group, file_type)
+
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through QQ."""
         if not self._client:
@@ -126,6 +179,35 @@ class QQChannel(BaseChannel):
 
         try:
             msg_id = msg.metadata.get("message_id")
+            chat_type = self._chat_type_cache.get(msg.chat_id, "c2c")
+            is_group = chat_type == "group"
+            content = msg.content or ""
+
+            # Send media files via base64 upload
+            for file_path in msg.media or []:
+                if not os.path.isfile(file_path):
+                    logger.warning("QQ media file not found: {}", file_path)
+                    continue
+                media_obj = await self._upload_local_file(file_path, msg.chat_id, is_group)
+                if media_obj is not None:
+                    self._msg_seq += 1
+                    media_payload: dict[str, Any] = {
+                        "msg_type": 7, "msg_id": msg_id,
+                        "msg_seq": self._msg_seq, "media": media_obj,
+                    }
+                    if is_group:
+                        await self._client.api.post_group_message(
+                            group_openid=msg.chat_id, **media_payload)
+                    else:
+                        await self._client.api.post_c2c_message(
+                            openid=msg.chat_id, **media_payload)
+                else:
+                    content += f"\n[file upload failed: {os.path.basename(file_path)}]"
+
+            # Send text content
+            if not content.strip():
+                return
+
             self._msg_seq += 1
             use_markdown = self.config.msg_format == "markdown"
             payload: dict[str, Any] = {
@@ -134,21 +216,16 @@ class QQChannel(BaseChannel):
                 "msg_seq": self._msg_seq,
             }
             if use_markdown:
-                payload["markdown"] = {"content": msg.content}
+                payload["markdown"] = {"content": content}
             else:
-                payload["content"] = msg.content
+                payload["content"] = content
 
-            chat_type = self._chat_type_cache.get(msg.chat_id, "c2c")
-            if chat_type == "group":
+            if is_group:
                 await self._client.api.post_group_message(
-                    group_openid=msg.chat_id,
-                    **payload,
-                )
+                    group_openid=msg.chat_id, **payload)
             else:
                 await self._client.api.post_c2c_message(
-                    openid=msg.chat_id,
-                    **payload,
-                )
+                    openid=msg.chat_id, **payload)
         except Exception as e:
             logger.error("Error sending QQ message: {}", e)
 

--- a/nanobot/channels/wecom.py
+++ b/nanobot/channels/wecom.py
@@ -1,7 +1,10 @@
 """WeCom (Enterprise WeChat) channel implementation using wecom_aibot_sdk."""
 
 import asyncio
+import base64
+import hashlib
 import importlib.util
+import mimetypes
 import os
 from collections import OrderedDict
 from typing import Any
@@ -336,6 +339,73 @@ class WecomChannel(BaseChannel):
             logger.error("Error downloading media: {}", e)
             return None
 
+    async def _upload_media_ws(
+        self, client: Any, file_path: str,
+    ) -> "tuple[str, str] | tuple[None, None]":
+        """Upload a local file to WeCom via WebSocket 3-step protocol (base64).
+
+        Steps: upload_init → base64 chunks → upload_finish.
+        Returns (media_id, media_type) on success, (None, None) on failure.
+        """
+        try:
+            raw = open(file_path, "rb").read()
+            fname = os.path.basename(file_path)
+            md5 = hashlib.md5(raw).hexdigest()
+            mime = mimetypes.guess_type(fname)[0] or "application/octet-stream"
+            if mime.startswith("image/"):
+                media_type = "image"
+            elif mime.startswith("video/"):
+                media_type = "video"
+            elif mime.startswith("audio/"):
+                media_type = "voice"
+            else:
+                media_type = "file"
+
+            CHUNK = 512 * 1024  # 512 KB chunks
+            total = len(raw)
+            chunks = (total + CHUNK - 1) // CHUNK
+
+            # Step 1: init
+            init_resp = await client.upload_file(
+                "upload_init",
+                {"filename": fname, "filetype": media_type, "filesize": total,
+                 "md5": md5, "chunk_count": chunks},
+            )
+            upload_id = (
+                init_resp.get("upload_id", "")
+                if isinstance(init_resp, dict) else getattr(init_resp, "upload_id", "")
+            )
+            if not upload_id:
+                logger.error("WeCom upload_init failed: {}", init_resp)
+                return None, None
+
+            # Step 2: send chunks
+            for i in range(chunks):
+                chunk_data = raw[i * CHUNK : (i + 1) * CHUNK]
+                b64 = base64.b64encode(chunk_data).decode()
+                await client.upload_file(
+                    "upload_part",
+                    {"upload_id": upload_id, "chunk_id": i + 1,
+                     "chunk_data": b64, "chunk_size": len(chunk_data)},
+                )
+
+            # Step 3: finish
+            fin_resp = await client.upload_file(
+                "upload_finish", {"upload_id": upload_id},
+            )
+            media_id = (
+                fin_resp.get("media_id", "")
+                if isinstance(fin_resp, dict) else getattr(fin_resp, "media_id", "")
+            )
+            if media_id:
+                logger.debug("WeCom uploaded {} → media_id={}", fname, media_id[:20])
+                return media_id, media_type
+            logger.error("WeCom upload_finish failed: {}", fin_resp)
+            return None, None
+        except Exception as e:
+            logger.error("WeCom file upload error for {}: {}", file_path, e)
+            return None, None
+
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through WeCom."""
         if not self._client:
@@ -343,14 +413,30 @@ class WecomChannel(BaseChannel):
             return
 
         try:
-            content = msg.content.strip()
-            if not content:
-                return
+            content = (msg.content or "").strip()
 
             # Get the stored frame for this chat
             frame = self._chat_frames.get(msg.chat_id)
             if not frame:
                 logger.warning("No frame found for chat {}, cannot reply", msg.chat_id)
+                return
+
+            # Send media files via WebSocket upload
+            for file_path in msg.media or []:
+                if not os.path.isfile(file_path):
+                    logger.warning("WeCom media file not found: {}", file_path)
+                    continue
+                media_id, media_type = await self._upload_media_ws(self._client, file_path)
+                if media_id:
+                    await self._client.reply(frame, {
+                        "msgtype": media_type,
+                        media_type: {"media_id": media_id},
+                    })
+                    logger.debug("WeCom sent {} → {}", media_type, msg.chat_id)
+                else:
+                    content += f"\n[file upload failed: {os.path.basename(file_path)}]"
+
+            if not content:
                 return
 
             # Use streaming reply for better UX


### PR DESCRIPTION
## Summary

Add base64 media upload support for QQ and WeCom channels, removing the dependency on public URLs/IPs for file delivery.

**2 files changed, 176 insertions(+), 13 deletions(-)**

## QQ channel (`nanobot/channels/qq.py`)
- Add `_upload_file_base64()` for file upload via QQ v2 `file_data` API
- Add `_upload_local_file()` with auto file-type detection (image/video/audio/file)
- Enhance `send()` to deliver media files alongside text messages

## WeCom channel (`nanobot/channels/wecom.py`)
- Add `_upload_media_ws()` using WebSocket 3-step upload protocol (`upload_init` → base64 chunks → `upload_finish`)
- Enhance `send()` to upload and deliver media files before text

## Key design decisions
- **No public URL required**: Both channels upload files as base64 through their respective APIs/WebSocket, so no inbound HTTP endpoint is needed
- **Minimal footprint**: Only touches the two channel files, no new dependencies
- **Auto file-type detection**: Uses `mimetypes` + extension mapping to determine QQ file_type (1=image, 2=video, 3=audio, 4=file)

## Testing
- Verified QQ: text, image (base64 upload → file_uuid → send), file (base64 upload → send) — all successful
- Verified WeCom: markdown files uploaded via WebSocket media protocol → media_id → sent successfully
- Production logs confirm: PDF reports, markdown documents all delivered via base64 upload
