### PR TITLE
feat(feishu): add thread reply support for topic group messages

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -960,6 +960,9 @@ class FeishuChannel(BaseChannel):
                 and not msg.metadata.get("_progress", False)
             ):
                 reply_message_id = msg.metadata.get("message_id") or None
+            # For topic group messages, always reply to keep context in thread
+            elif msg.metadata.get("thread_id"):
+                reply_message_id = msg.metadata.get("root_id") or msg.metadata.get("message_id") or None
 
             first_send = True  # tracks whether the reply has already been used
 
@@ -1121,6 +1124,7 @@ class FeishuChannel(BaseChannel):
             # Extract reply context (parent/root message IDs)
             parent_id = getattr(message, "parent_id", None) or None
             root_id = getattr(message, "root_id", None) or None
+            thread_id = getattr(message, "thread_id", None) or None
 
             # Prepend quoted message text when the user replied to another message
             if parent_id and self._client:
@@ -1149,6 +1153,7 @@ class FeishuChannel(BaseChannel):
                     "msg_type": msg_type,
                     "parent_id": parent_id,
                     "root_id": root_id,
+                    "thread_id": thread_id,
                 }
             )
 


### PR DESCRIPTION
## Summary

Add thread reply support for Feishu topic group messages. When messages contain `thread_id`, the bot will reply using the root message ID to keep the conversation context in the thread.

## Changes

- Extract `thread_id` from incoming Feishu messages and include it in metadata
- Add logic to reply using root message ID when `thread_id` is present in outgoing messages
- Maintain thread context in topic group conversations

## Related Issues

Closes #2256

## Testing

- All existing Feishu tests pass (42/42)
- Tested with topic group message scenarios

---

Generated with AI