### PR TITLE
fix(exec): prevent interactive prompts from hanging (stdin + /dev/tty bypass)

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -96,6 +96,7 @@ class ExecTool(Tool):
                 stdin=asyncio.subprocess.DEVNULL,  # Prevent interactive prompts from hanging
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,  # Disconnect from /dev/tty (ssh and similar programs bypass stdin)
                 cwd=cwd,
                 env=env,
             )


### PR DESCRIPTION
## Summary

Fixes an issue where shell commands with interactive prompts (like `ssh`) would hang indefinitely. This PR includes two commits that work together to fully prevent interactive prompt hangs.

## Problem

Commands like `ssh` that prompt for user input (password, host key confirmation) would hang for 60 seconds because:
1. The agent cannot see or respond to interactive prompts
2. Programs can bypass stdin redirection by reading directly from `/dev/tty`

## Solution

### Commit 1: `stdin=DEVNULL`
Connects stdin to `/dev/null` so programs reading from standard input fail immediately instead of waiting for input.

### Commit 2: `start_new_session=True`
Creates a new session to disconnect the subprocess from the controlling terminal. This prevents programs like `ssh` from bypassing `stdin=DEVNULL` by opening `/dev/tty` directly.

Both are needed because:
- `stdin=DEVNULL` alone: Programs can still read from `/dev/tty`
- `start_new_session=True` alone: Programs without a controlling terminal may still try to read from stdin

## Changes

```python
process = await asyncio.create_subprocess_shell(
    command,
    stdin=asyncio.subprocess.DEVNULL,      # Prevent stdin prompts
    stdout=asyncio.subprocess.PIPE,
    stderr=asyncio.subprocess.PIPE,
    start_new_session=True,                # Disconnect from /dev/tty
    cwd=cwd,
    env=env,
)
```

## Result

- Interactive prompts fail immediately with clear error messages
- No more 60-second timeouts for commands like `ssh`