### PR TITLE
fix: strip bot mentions from user discord messages

### DIFF
--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -2,13 +2,14 @@
 
 import asyncio
 import json
+import re
 from pathlib import Path
 from typing import Any, Literal
 
 import httpx
-from pydantic import Field
 import websockets
 from loguru import logger
+from pydantic import Field
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -303,9 +304,12 @@ class DiscordChannel(BaseChannel):
             return
 
         # Check group channel policy (DMs always respond if is_allowed passes)
-        if guild_id is not None:
-            if not self._should_respond_in_group(payload, content):
-                return
+        if guild_id is not None and not self._should_respond_in_group(payload, content):
+            return
+
+        # Strip bot mentions
+        if content and self._bot_user_id:
+            content = re.sub(rf"<@!?{re.escape(self._bot_user_id)}>\s*", "", content).strip()
 
         content_parts = [content] if content else []
         media_paths: list[str] = []

--- a/tests/test_discord_channel.py
+++ b/tests/test_discord_channel.py
@@ -1,0 +1,91 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.discord import DiscordChannel
+from nanobot.channels.discord import DiscordConfig
+
+
+def _make_channel(*, group_policy: str = "mention") -> DiscordChannel:
+    bus = MessageBus()
+    channel = DiscordChannel(
+        DiscordConfig(
+            enabled=True,
+            token="test-token",
+            allow_from=["*"],
+            group_policy=group_policy,
+        ),
+        bus,
+    )
+    channel._bot_user_id = "999"
+    channel._start_typing = AsyncMock()
+    return channel
+
+
+def _make_payload(content: str, guild_id: str) -> dict:
+    return {
+        "id": "456",
+        "author": {"id": "111", "bot": False},
+        "channel_id": "222",
+        "content": content,
+        "attachments": [],
+        "guild_id": guild_id,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "expected_content"),
+    [
+        ("<@999> /new", "/new"),
+        ("<@!999> /help", "/help"),
+        ("/help <@!999>", "/help"),
+        ("<@!999> hello world", "hello world")
+    ],
+)
+async def test_handle_message_create_with_mention_policy(
+    content: str,
+    expected_content: str,
+) -> None:
+    channel = _make_channel(group_policy="mention")
+
+    await channel._handle_message_create(_make_payload(content=content, guild_id="123"))
+
+    msg = await channel.bus.consume_inbound()
+    assert msg.sender_id == "111"
+    assert msg.chat_id == "222"
+    assert msg.content == expected_content
+    assert msg.media == []
+    assert msg.metadata == {
+        "message_id": "456",
+        "guild_id": "123",
+        "reply_to": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_guild_message_without_mention_is_ignored_in_mention_mode() -> None:
+    channel = _make_channel(group_policy="mention")
+
+    await channel._handle_message_create(_make_payload(content="/new", guild_id="123"))
+
+    channel._start_typing.assert_not_awaited()
+    assert channel.bus.inbound_size == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "expected_content"),
+    [
+        ("/new", "/new"),
+        ("hello world", "hello world")
+    ],
+)
+async def test_handle_message_create_with_open_policy(content, expected_content) -> None:
+    channel = _make_channel(group_policy="open")
+
+    await channel._handle_message_create(_make_payload(content=content, guild_id="123"))
+
+    msg = await channel.bus.consume_inbound()
+    assert msg.content == expected_content


### PR DESCRIPTION
## Summary
Strip the bot user id mentions from Discord user messages before sending it off to the agent loop. 

- This fixes a case where the user wants to use slash commands such as `/new` or `/restart`, but the bot id being passed in with the message content fails the loop condition check.
- Also stops the bot user id from unnecessarily consumed as a token.
- Added some basic unit tests covering the changes as the discord channel was missing them.

side note: this implementation was present in the slack class, but missing in the discord class.
