### PR TITLE
fix(agent): make session messages persistence more frequent.

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -185,6 +185,7 @@ class AgentLoop:
         self,
         initial_messages: list[dict],
         on_progress: Callable[..., Awaitable[None]] | None = None,
+        on_iteration_complete: Callable[[list[dict]], Awaitable[None]] | None = None,
     ) -> tuple[str | None, list[str], list[dict]]:
         """Run the agent iteration loop."""
         messages = initial_messages
@@ -230,6 +231,8 @@ class AgentLoop:
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
+                if on_iteration_complete:
+                    await on_iteration_complete(messages)
             else:
                 clean = self._strip_think(response.content)
                 # Don't persist error responses to session history — they can
@@ -242,6 +245,8 @@ class AgentLoop:
                     messages, clean, reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
                 )
+                if on_iteration_complete:
+                    await on_iteration_complete(messages)
                 final_content = clean
                 break
 
@@ -253,6 +258,14 @@ class AgentLoop:
             )
 
         return final_content, tools_used, messages
+
+    def _flush_new_messages(self, session: Session, messages: list[dict], skip: int) -> int:
+        """Persist any new source messages since the previous flush cursor."""
+        if skip >= len(messages):
+            return len(messages)
+        self._save_turn(session, messages, skip)
+        self.sessions.save(session)
+        return len(messages)
 
     async def run(self) -> None:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
@@ -384,9 +397,16 @@ class AgentLoop:
                 current_message=msg.content, channel=channel, chat_id=chat_id,
                 current_role=current_role,
             )
-            final_content, _, all_msgs = await self._run_agent_loop(messages)
-            self._save_turn(session, all_msgs, 1 + len(history))
-            self.sessions.save(session)
+            persisted_count = self._flush_new_messages(session, messages, 1 + len(history))
+
+            async def _persist_progress(all_msgs: list[dict]) -> None:
+                nonlocal persisted_count
+                persisted_count = self._flush_new_messages(session, all_msgs, persisted_count)
+
+            final_content, _, _ = await self._run_agent_loop(
+                messages,
+                on_iteration_complete=_persist_progress,
+            )
             self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
             return OutboundMessage(channel=channel, chat_id=chat_id,
                                   content=final_content or "Background task completed.")
@@ -435,6 +455,7 @@ class AgentLoop:
             media=msg.media if msg.media else None,
             channel=msg.channel, chat_id=msg.chat_id,
         )
+        persisted_count = self._flush_new_messages(session, initial_messages, 1 + len(history))
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
             meta = dict(msg.metadata or {})
@@ -444,15 +465,18 @@ class AgentLoop:
                 channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
             ))
 
-        final_content, _, all_msgs = await self._run_agent_loop(
-            initial_messages, on_progress=on_progress or _bus_progress,
+        async def _persist_progress(all_msgs: list[dict]) -> None:
+            nonlocal persisted_count
+            persisted_count = self._flush_new_messages(session, all_msgs, persisted_count)
+
+        final_content, _, _ = await self._run_agent_loop(
+            initial_messages,
+            on_progress=on_progress or _bus_progress,
+            on_iteration_complete=_persist_progress,
         )
 
         if final_content is None:
             final_content = "I've completed processing but have no response to give."
-
-        self._save_turn(session, all_msgs, 1 + len(history))
-        self.sessions.save(session)
         self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
 
         if (mt := self.tools.get("message")) and isinstance(mt, MessageTool) and mt._sent_in_turn:

--- a/tests/test_loop_incremental_persistence.py
+++ b/tests/test_loop_incremental_persistence.py
@@ -1,0 +1,149 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.tools.base import Tool
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse, ToolCallRequest
+from nanobot.session.manager import SessionManager
+
+
+class DemoTool(Tool):
+    @property
+    def name(self) -> str:
+        return "demo_tool"
+
+    @property
+    def description(self) -> str:
+        return "Demo tool for loop persistence tests."
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        }
+
+    async def execute(self, **kwargs):
+        return f"tool:{kwargs['value']}"
+
+
+def _make_loop(tmp_path) -> AgentLoop:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.chat_with_retry = AsyncMock()
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+    )
+    loop.memory_consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    loop._schedule_background = lambda coro: coro.close()  # type: ignore[method-assign]
+    loop.tools.register(DemoTool())
+    return loop
+
+
+def test_persists_completed_tool_loop_before_next_llm_call(tmp_path) -> None:
+    loop = _make_loop(tmp_path)
+    session_key = "cli:test"
+    tool_response = LLMResponse(
+        content="thinking",
+        tool_calls=[ToolCallRequest(id="call_1", name="demo_tool", arguments={"value": "first"})],
+    )
+    final_response = LLMResponse(content="done", tool_calls=[])
+    call_count = 0
+
+    async def fake_chat_with_retry(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return tool_response
+        persisted = SessionManager(tmp_path).get_or_create(session_key)
+        assert [message["role"] for message in persisted.messages] == ["user", "assistant", "tool"]
+        assert persisted.messages[1]["tool_calls"][0]["function"]["name"] == "demo_tool"
+        assert persisted.messages[2]["content"] == "tool:first"
+        return final_response
+
+    loop.provider.chat_with_retry = fake_chat_with_retry
+
+    result = asyncio.run(loop.process_direct("hello", session_key=session_key))
+
+    assert result == "done"
+    persisted = SessionManager(tmp_path).get_or_create(session_key)
+    assert [message["role"] for message in persisted.messages] == ["user", "assistant", "tool", "assistant"]
+    assert persisted.messages[-1]["content"] == "done"
+
+
+def test_crash_keeps_previously_completed_tool_loop(tmp_path) -> None:
+    loop = _make_loop(tmp_path)
+    session_key = "cli:test"
+    loop.provider.chat_with_retry = AsyncMock(side_effect=[
+        LLMResponse(
+            content="thinking",
+            tool_calls=[ToolCallRequest(id="call_1", name="demo_tool", arguments={"value": "first"})],
+        ),
+        RuntimeError("boom"),
+    ])
+
+    try:
+        asyncio.run(loop.process_direct("hello", session_key=session_key))
+    except RuntimeError as exc:
+        assert str(exc) == "boom"
+    else:
+        raise AssertionError("expected RuntimeError")
+
+    persisted = SessionManager(tmp_path).get_or_create(session_key)
+    assert [message["role"] for message in persisted.messages] == ["user", "assistant", "tool"]
+    assert persisted.get_history(max_messages=0) == [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": "thinking",
+            "tool_calls": persisted.messages[1]["tool_calls"],
+        },
+        {
+            "role": "tool",
+            "content": "tool:first",
+            "tool_call_id": "call_1",
+            "name": "demo_tool",
+        },
+    ]
+
+
+def test_final_response_persists_once_without_duplicates(tmp_path) -> None:
+    loop = _make_loop(tmp_path)
+    session_key = "cli:test"
+    loop.provider.chat_with_retry = AsyncMock(side_effect=[
+        LLMResponse(
+            content="thinking",
+            tool_calls=[ToolCallRequest(id="call_1", name="demo_tool", arguments={"value": "first"})],
+        ),
+        LLMResponse(content="done", tool_calls=[]),
+    ])
+
+    result = asyncio.run(loop.process_direct("hello", session_key=session_key))
+
+    assert result == "done"
+    persisted = SessionManager(tmp_path).get_or_create(session_key)
+    assert [message["role"] for message in persisted.messages] == ["user", "assistant", "tool", "assistant"]
+    assert [message.get("content") for message in persisted.messages] == [
+        "hello",
+        "thinking",
+        "tool:first",
+        "done",
+    ]
+
+
+def test_no_tool_response_persists_once(tmp_path) -> None:
+    loop = _make_loop(tmp_path)
+    session_key = "cli:test"
+    loop.provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="done", tool_calls=[]))
+
+    result = asyncio.run(loop.process_direct("hello", session_key=session_key))
+
+    assert result == "done"
+    persisted = SessionManager(tmp_path).get_or_create(session_key)
+    assert [message["role"] for message in persisted.messages] == ["user", "assistant"]
+    assert [message.get("content") for message in persisted.messages] == ["hello", "done"]


### PR DESCRIPTION
Currently, session jsonl files are only persisted when LLM stops (i.e. no tool calls). However, sometimes the agent fails midway, losing all its progress.

This PR fixes it by persisting to jsonl file each *iteration*: LLM responds with some tool calls, run all the tools and persist one LLM message with multiple tool results together. This approach strictly follows the message format without dangling tool calls while persisting just enough progress.