### PR TITLE
feat(channel): add NapCatQQ with group chat and images support

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,65 @@ Now send a message to the bot from QQ — it should respond!
 </details>
 
 <details>
+<summary><b>NapCat (QQ via NapCatQQ)</b></summary>
+
+Uses **NapCatQQ OneBot 11 forward WebSocket**. This is separate from the built-in `qq` channel, so you can use NapCat without affecting existing QQ support.
+
+**1. Set up NapCatQQ**
+- Deploy NapCatQQ and log in your QQ account
+- Enable the **forward WebSocket** server in NapCat
+- Note the WebSocket address and token if auth is enabled
+- Default NapCat setups often expose WebUI on `6099` and WebSocket on `3001`, but the WebSocket port is configurable
+
+**2. Configure**
+
+> - `url`: NapCat forward WebSocket URL. Default is `ws://127.0.0.1:3001/`, but use your actual configured host/port/path.
+> - `accessToken`: Optional. If you enabled token auth in NapCat, set it here.
+> - `allowFrom`: Add QQ user IDs. Use `["*"]` to allow all users.
+> - `groupPolicy`: `"mention"` (default — respond only when @mentioned in groups), `"open"` (respond to all allowed group messages). Private chats always respond.
+> - v1 behavior: nanobot receives text and image messages from NapCat, and sends plain-text replies back.
+
+```json
+{
+  "channels": {
+    "napcat": {
+      "enabled": true,
+      "url": "ws://127.0.0.1:3001/",
+      "accessToken": "",
+      "allowFrom": ["*"],
+      "groupPolicy": "mention"
+    }
+  }
+}
+```
+
+Example with a custom port and token:
+
+```json
+{
+  "channels": {
+    "napcat": {
+      "enabled": true,
+      "url": "ws://127.0.0.1:6098/",
+      "accessToken": "YOUR_NAPCAT_TOKEN",
+      "allowFrom": ["123456789"],
+      "groupPolicy": "mention"
+    }
+  }
+}
+```
+
+**3. Run**
+
+```bash
+nanobot gateway
+```
+
+Now message the logged-in QQ account through NapCat. Private chats will respond directly, and group chats will follow `groupPolicy`.
+
+</details>
+
+<details>
 <summary><b>DingTalk (钉钉)</b></summary>
 
 Uses **Stream Mode** — no public IP required.

--- a/README.md
+++ b/README.md
@@ -588,23 +588,22 @@ Now send a message to the bot from QQ — it should respond!
 </details>
 
 <details>
-<summary><b>NapCat (QQ via NapCatQQ)</b></summary>
+<summary><b>NapCat (QQ via NapCatQQ 支持群聊)</b></summary>
 
-Uses **NapCatQQ OneBot 11 forward WebSocket**. This is separate from the built-in `qq` channel, so you can use NapCat without affecting existing QQ support.
+Uses **[NapCatQQ](https://github.com/NapNeko/NapCatQQ) OneBot 11 forward WebSocket**.
 
 **1. Set up NapCatQQ**
-- Deploy NapCatQQ and log in your QQ account
-- Enable the **forward WebSocket** server in NapCat
-- Note the WebSocket address and token if auth is enabled
-- Default NapCat setups often expose WebUI on `6099` and WebSocket on `3001`, but the WebSocket port is configurable
+
+- Deploy NapCatQQ and log in your QQ bot (alt) account. Recommendation: follow the [official docker tutorial](https://github.com/NapNeko/NapCat-Docker).
+- In the webui, follow "网络配置" -> "新建" -> "Websocket 服务器" to create a forward websocket server.
+- Copy the forward websocket server's token.
 
 **2. Configure**
 
-> - `url`: NapCat forward WebSocket URL. Default is `ws://127.0.0.1:3001/`, but use your actual configured host/port/path.
-> - `accessToken`: Optional. If you enabled token auth in NapCat, set it here.
+> - `url`: NapCat forward WebSocket URL. Default is `ws://127.0.0.1:3001/`.
+> - `accessToken`: Set this to the forward websocket server's token.
 > - `allowFrom`: Add QQ user IDs. Use `["*"]` to allow all users.
 > - `groupPolicy`: `"mention"` (default — respond only when @mentioned in groups), `"open"` (respond to all allowed group messages). Private chats always respond.
-> - v1 behavior: nanobot receives text and image messages from NapCat, and sends plain-text replies back.
 
 ```json
 {
@@ -620,29 +619,13 @@ Uses **NapCatQQ OneBot 11 forward WebSocket**. This is separate from the built-i
 }
 ```
 
-Example with a custom port and token:
-
-```json
-{
-  "channels": {
-    "napcat": {
-      "enabled": true,
-      "url": "ws://127.0.0.1:6098/",
-      "accessToken": "YOUR_NAPCAT_TOKEN",
-      "allowFrom": ["123456789"],
-      "groupPolicy": "mention"
-    }
-  }
-}
-```
-
 **3. Run**
 
 ```bash
 nanobot gateway
 ```
 
-Now message the logged-in QQ account through NapCat. Private chats will respond directly, and group chats will follow `groupPolicy`.
+Now message the logged-in QQ account through NapCat.
 
 </details>
 

--- a/nanobot/channels/napcat.py
+++ b/nanobot/channels/napcat.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import mimetypes
 from collections import OrderedDict
 from itertools import count
+from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import urlparse
 
+import httpx
 from loguru import logger
 from pydantic import Field
 import websockets
@@ -15,6 +19,7 @@ import websockets
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 
 
@@ -171,13 +176,19 @@ class NapCatChannel(BaseChannel):
 
         segments = event.get("message")
         text = self._segments_to_text(segments)
-        media = self._segments_to_media(segments)
+        media = await self._download_image_segments(segments, message_id)
+        logger.info(
+            "NapCat inbound {} message {} from {} to {}: text_len={}, images={}",
+            message_type, message_id or "<no-id>", user_id, chat_id, len(text), len(media),
+        )
 
         if message_type == "group" and self.config.group_policy == "mention":
             if not self._contains_self_mention(segments):
+                logger.info("NapCat skipped group message {}: no @mention", message_id or "<no-id>")
                 return
 
         if not text and not media:
+            logger.info("NapCat skipped message {}: no text or usable media", message_id or "<no-id>")
             return
 
         await self._handle_message(
@@ -232,3 +243,35 @@ class NapCatChannel(BaseChannel):
             if url:
                 media.append(url)
         return media
+
+    async def _download_image_segments(self, segments: Any, message_id: str) -> list[str]:
+        """Download inbound image segments to local files so multimodal models can read them."""
+        urls = self._segments_to_media(segments)
+        if not urls:
+            return []
+
+        local_paths: list[str] = []
+        for index, url in enumerate(urls, start=1):
+            try:
+                path = await self._download_image(url, message_id or "msg", index)
+            except Exception as e:
+                logger.warning("NapCat failed to download image {} for {}: {}", index, message_id or "<no-id>", e)
+                continue
+            logger.info("NapCat downloaded image {} for {} -> {}", index, message_id or "<no-id>", path)
+            local_paths.append(path)
+        return local_paths
+
+    async def _download_image(self, url: str, message_id: str, index: int) -> str:
+        """Download one image URL to the NapCat media directory."""
+        media_dir = get_media_dir("napcat")
+        parsed = urlparse(url)
+        suffix = Path(parsed.path).suffix
+        if not suffix:
+            suffix = mimetypes.guess_extension("image/jpeg") or ".jpg"
+        file_path = media_dir / f"{message_id}_{index}{suffix}"
+
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            file_path.write_bytes(response.content)
+        return str(file_path)

--- a/nanobot/channels/napcat.py
+++ b/nanobot/channels/napcat.py
@@ -1,0 +1,234 @@
+"""NapCat channel implementation using OneBot 11 forward WebSocket."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import OrderedDict
+from itertools import count
+from typing import Any, Literal
+
+from loguru import logger
+from pydantic import Field
+import websockets
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
+
+
+class NapCatConfig(Base):
+    """NapCat OneBot WebSocket channel configuration."""
+
+    enabled: bool = False
+    url: str = "ws://127.0.0.1:3001/"
+    access_token: str = ""
+    allow_from: list[str] = Field(default_factory=list)
+    group_policy: Literal["open", "mention"] = "mention"
+    reconnect_delay_s: float = 5.0
+
+
+class NapCatChannel(BaseChannel):
+    """NapCat channel using OneBot 11 over forward WebSocket."""
+
+    name = "napcat"
+    display_name = "NapCat"
+
+    @classmethod
+    def default_config(cls) -> dict[str, Any]:
+        return NapCatConfig().model_dump(by_alias=True)
+
+    def __init__(self, config: Any, bus: MessageBus):
+        if isinstance(config, dict):
+            config = NapCatConfig.model_validate(config)
+        super().__init__(config, bus)
+        self.config: NapCatConfig = config
+        self._ws: Any = None
+        self._self_id: str | None = None
+        self._chat_type_cache: dict[str, str] = {}
+        self._processed_ids: OrderedDict[str, None] = OrderedDict()
+        self._echo_counter = count(1)
+        self._send_lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        """Start the NapCat forward WebSocket client."""
+        self._running = True
+        while self._running:
+            try:
+                await self._run_connection()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning("NapCat websocket error: {}", e)
+            finally:
+                self._ws = None
+
+            if self._running:
+                logger.info("Reconnecting NapCat in {}s...", self.config.reconnect_delay_s)
+                await asyncio.sleep(self.config.reconnect_delay_s)
+
+    async def stop(self) -> None:
+        """Stop the NapCat channel."""
+        self._running = False
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+
+    async def send(self, msg: OutboundMessage) -> None:
+        """Send a plain-text message via OneBot action requests."""
+        if not self._ws:
+            logger.warning("NapCat websocket not connected")
+            return
+
+        is_group = bool(
+            msg.metadata.get("is_group")
+            if msg.metadata
+            else self._chat_type_cache.get(msg.chat_id) == "group"
+        )
+        action = "send_group_msg" if is_group else "send_private_msg"
+        target_key = "group_id" if is_group else "user_id"
+        payload = {
+            "action": action,
+            "params": {target_key: msg.chat_id, "message": msg.content},
+            "echo": f"nanobot:{next(self._echo_counter)}",
+        }
+
+        async with self._send_lock:
+            await self._ws.send(json.dumps(payload, ensure_ascii=False))
+
+    async def _run_connection(self) -> None:
+        """Open the websocket and process inbound events until disconnect."""
+        headers = self._connect_headers()
+        async with websockets.connect(self.config.url, additional_headers=headers or None) as ws:
+            self._ws = ws
+            logger.info("NapCat websocket connected to {}", self.config.url)
+            async for raw in ws:
+                await self._handle_ws_message(raw)
+
+    def _connect_headers(self) -> dict[str, str]:
+        """Build websocket auth headers."""
+        if not self.config.access_token:
+            return {}
+        return {"Authorization": f"Bearer {self.config.access_token}"}
+
+    async def _handle_ws_message(self, raw: str) -> None:
+        """Handle a raw websocket frame from NapCat."""
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Invalid NapCat JSON: {}", raw[:200])
+            return
+
+        if not isinstance(data, dict):
+            return
+
+        if "self_id" in data and data["self_id"] is not None:
+            self._self_id = str(data["self_id"])
+
+        if "echo" in data and "status" in data:
+            if data.get("status") != "ok":
+                logger.warning(
+                    "NapCat action {} failed: status={} retcode={} message={}",
+                    data.get("echo"), data.get("status"), data.get("retcode"), data.get("message"),
+                )
+            return
+
+        if data.get("post_type") != "message":
+            return
+
+        await self._handle_event(data)
+
+    async def _handle_event(self, event: dict[str, Any]) -> None:
+        """Handle an inbound OneBot message event."""
+        message_id = str(event.get("message_id") or "")
+        if message_id:
+            if message_id in self._processed_ids:
+                return
+            self._processed_ids[message_id] = None
+            while len(self._processed_ids) > 1000:
+                self._processed_ids.popitem(last=False)
+
+        user_id = str(event.get("user_id") or "")
+        if not user_id:
+            return
+
+        if self._self_id and user_id == self._self_id:
+            return
+
+        message_type = str(event.get("message_type") or "")
+        if message_type == "group":
+            chat_id = str(event.get("group_id") or "")
+            self._chat_type_cache[chat_id] = "group"
+        elif message_type == "private":
+            chat_id = user_id
+            self._chat_type_cache[chat_id] = "private"
+        else:
+            return
+
+        segments = event.get("message")
+        text = self._segments_to_text(segments)
+        media = self._segments_to_media(segments)
+
+        if message_type == "group" and self.config.group_policy == "mention":
+            if not self._contains_self_mention(segments):
+                return
+
+        if not text and not media:
+            return
+
+        await self._handle_message(
+            sender_id=user_id,
+            chat_id=chat_id,
+            content=text,
+            media=media,
+            metadata={"message_id": message_id, "is_group": message_type == "group"},
+        )
+
+    def _contains_self_mention(self, segments: Any) -> bool:
+        """Check whether the message explicitly @mentions this bot."""
+        if not isinstance(segments, list) or not self._self_id:
+            return False
+        for segment in segments:
+            if not isinstance(segment, dict) or segment.get("type") != "at":
+                continue
+            qq = str((segment.get("data") or {}).get("qq") or "")
+            if qq == self._self_id:
+                return True
+        return False
+
+    @staticmethod
+    def _segments_to_text(segments: Any) -> str:
+        """Extract visible text from OneBot segments."""
+        if isinstance(segments, str):
+            return segments.strip()
+        if not isinstance(segments, list):
+            return ""
+
+        parts: list[str] = []
+        for segment in segments:
+            if not isinstance(segment, dict):
+                continue
+            data = segment.get("data") or {}
+            if segment.get("type") == "text":
+                text = str(data.get("text") or "")
+                if text:
+                    parts.append(text)
+        return "".join(parts).strip()
+
+    @staticmethod
+    def _segments_to_media(segments: Any) -> list[str]:
+        """Extract image URLs from OneBot message segments."""
+        if not isinstance(segments, list):
+            return []
+        media: list[str] = []
+        for segment in segments:
+            if not isinstance(segment, dict) or segment.get("type") != "image":
+                continue
+            url = str((segment.get("data") or {}).get("url") or "").strip()
+            if url:
+                media.append(url)
+        return media

--- a/tests/test_napcat_channel.py
+++ b/tests/test_napcat_channel.py
@@ -1,0 +1,240 @@
+import asyncio
+import json
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.napcat import NapCatChannel, NapCatConfig
+from nanobot.channels.registry import discover_all
+
+
+class _FakeWebSocket:
+    def __init__(self, incoming: list[str] | None = None) -> None:
+        self.incoming = list(incoming or [])
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(payload)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.incoming:
+            return self.incoming.pop(0)
+        raise StopAsyncIteration
+
+
+class _FakeConnect:
+    def __init__(self, ws: _FakeWebSocket, capture: dict) -> None:
+        self.ws = ws
+        self.capture = capture
+
+    async def __aenter__(self):
+        return self.ws
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _make_channel(**kwargs) -> NapCatChannel:
+    return NapCatChannel(NapCatConfig(allow_from=["*"], **kwargs), MessageBus())
+
+
+def test_napcat_is_discoverable_and_has_defaults() -> None:
+    channels = discover_all()
+    assert "napcat" in channels
+    assert channels["napcat"].default_config()["url"] == "ws://127.0.0.1:3001/"
+
+
+def test_inbound_private_message_routes_to_bus() -> None:
+    async def run() -> None:
+        channel = _make_channel()
+        await channel._handle_ws_message(json.dumps({
+            "post_type": "message",
+            "self_id": 10001,
+            "message_type": "private",
+            "message_id": 123,
+            "user_id": 20002,
+            "message": [{"type": "text", "data": {"text": "hello"}}],
+        }))
+        msg = await channel.bus.consume_inbound()
+        assert msg.sender_id == "20002"
+        assert msg.chat_id == "20002"
+        assert msg.content == "hello"
+        assert msg.metadata["message_id"] == "123"
+
+    asyncio.run(run())
+
+
+def test_inbound_group_message_open_policy_routes() -> None:
+    async def run() -> None:
+        channel = _make_channel(group_policy="open")
+        await channel._handle_ws_message(json.dumps({
+            "post_type": "message",
+            "self_id": 10001,
+            "message_type": "group",
+            "message_id": 123,
+            "user_id": 20002,
+            "group_id": 30003,
+            "message": [{"type": "text", "data": {"text": "hello group"}}],
+        }))
+        msg = await channel.bus.consume_inbound()
+        assert msg.sender_id == "20002"
+        assert msg.chat_id == "30003"
+        assert msg.content == "hello group"
+        assert msg.metadata["is_group"] is True
+
+    asyncio.run(run())
+
+
+def test_inbound_group_message_mention_policy_ignores_non_mentions() -> None:
+    async def run() -> None:
+        channel = _make_channel(group_policy="mention")
+        await channel._handle_ws_message(json.dumps({
+            "post_type": "message",
+            "self_id": 10001,
+            "message_type": "group",
+            "message_id": 123,
+            "user_id": 20002,
+            "group_id": 30003,
+            "message": [{"type": "text", "data": {"text": "hello group"}}],
+        }))
+        assert channel.bus.inbound_size == 0
+
+    asyncio.run(run())
+
+
+def test_inbound_group_message_mention_policy_accepts_at_self() -> None:
+    async def run() -> None:
+        channel = _make_channel(group_policy="mention")
+        await channel._handle_ws_message(json.dumps({
+            "post_type": "message",
+            "self_id": 10001,
+            "message_type": "group",
+            "message_id": 123,
+            "user_id": 20002,
+            "group_id": 30003,
+            "message": [
+                {"type": "at", "data": {"qq": "10001"}},
+                {"type": "text", "data": {"text": "hello bot"}},
+            ],
+        }))
+        msg = await channel.bus.consume_inbound()
+        assert msg.chat_id == "30003"
+        assert msg.content == "hello bot"
+
+    asyncio.run(run())
+
+
+def test_image_receive_populates_media_and_preserves_text() -> None:
+    async def run() -> None:
+        channel = _make_channel()
+        await channel._handle_ws_message(json.dumps({
+            "post_type": "message",
+            "self_id": 10001,
+            "message_type": "private",
+            "message_id": 123,
+            "user_id": 20002,
+            "message": [
+                {"type": "text", "data": {"text": "look"}},
+                {"type": "image", "data": {"url": "https://example.com/a.png"}},
+            ],
+        }))
+        msg = await channel.bus.consume_inbound()
+        assert msg.content == "look"
+        assert msg.media == ["https://example.com/a.png"]
+
+    asyncio.run(run())
+
+
+def test_outbound_private_message_sends_send_private_msg() -> None:
+    async def run() -> None:
+        channel = _make_channel()
+        channel._ws = _FakeWebSocket()
+        await channel.send(OutboundMessage(channel="napcat", chat_id="20002", content="hello"))
+        payload = json.loads(channel._ws.sent[0])
+        assert payload["action"] == "send_private_msg"
+        assert payload["params"] == {"user_id": "20002", "message": "hello"}
+        assert payload["echo"].startswith("nanobot:")
+
+    asyncio.run(run())
+
+
+def test_outbound_group_message_sends_send_group_msg() -> None:
+    async def run() -> None:
+        channel = _make_channel()
+        channel._ws = _FakeWebSocket()
+        await channel.send(OutboundMessage(
+            channel="napcat",
+            chat_id="30003",
+            content="hello group",
+            metadata={"is_group": True},
+        ))
+        payload = json.loads(channel._ws.sent[0])
+        assert payload["action"] == "send_group_msg"
+        assert payload["params"] == {"group_id": "30003", "message": "hello group"}
+
+    asyncio.run(run())
+
+
+def test_access_token_is_added_to_websocket_headers(monkeypatch) -> None:
+    async def run() -> None:
+        capture = {}
+        ws = _FakeWebSocket()
+        channel = _make_channel(access_token="secret")
+
+        def fake_connect(url, additional_headers=None):
+            capture["url"] = url
+            capture["headers"] = additional_headers
+            return _FakeConnect(ws, capture)
+
+        monkeypatch.setattr("nanobot.channels.napcat.websockets.connect", fake_connect)
+        await channel._run_connection()
+        assert capture["url"] == "ws://127.0.0.1:3001/"
+        assert capture["headers"] == {"Authorization": "Bearer secret"}
+
+    asyncio.run(run())
+
+
+def test_reconnect_path_sleeps_after_connection_error(monkeypatch) -> None:
+    async def run() -> None:
+        channel = _make_channel(reconnect_delay_s=0.25)
+        calls = {"count": 0}
+        sleeps: list[float] = []
+
+        async def fake_run_connection():
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RuntimeError("boom")
+            channel._running = False
+
+        async def fake_sleep(delay: float):
+            sleeps.append(delay)
+
+        monkeypatch.setattr(channel, "_run_connection", fake_run_connection)
+        monkeypatch.setattr("nanobot.channels.napcat.asyncio.sleep", fake_sleep)
+        await channel.start()
+        assert sleeps == [0.25]
+        assert calls["count"] == 2
+
+    asyncio.run(run())
+
+
+def test_self_sent_message_is_ignored() -> None:
+    async def run() -> None:
+        channel = _make_channel()
+        await channel._handle_ws_message(json.dumps({
+            "post_type": "message",
+            "self_id": 10001,
+            "message_type": "private",
+            "message_id": 123,
+            "user_id": 10001,
+            "message": [{"type": "text", "data": {"text": "loop"}}],
+        }))
+        assert channel.bus.inbound_size == 0
+
+    asyncio.run(run())

--- a/tests/test_napcat_channel.py
+++ b/tests/test_napcat_channel.py
@@ -130,9 +130,15 @@ def test_inbound_group_message_mention_policy_accepts_at_self() -> None:
     asyncio.run(run())
 
 
-def test_image_receive_populates_media_and_preserves_text() -> None:
+def test_image_receive_populates_local_media_and_preserves_text(monkeypatch) -> None:
     async def run() -> None:
         channel = _make_channel()
+        async def fake_download(url: str, message_id: str, index: int) -> str:
+            assert url == "https://example.com/a.png"
+            assert message_id == "123"
+            assert index == 1
+            return "/tmp/napcat_123_1.png"
+        monkeypatch.setattr(channel, "_download_image", fake_download)
         await channel._handle_ws_message(json.dumps({
             "post_type": "message",
             "self_id": 10001,
@@ -146,7 +152,7 @@ def test_image_receive_populates_media_and_preserves_text() -> None:
         }))
         msg = await channel.bus.consume_inbound()
         assert msg.content == "look"
-        assert msg.media == ["https://example.com/a.png"]
+        assert msg.media == ["/tmp/napcat_123_1.png"]
 
     asyncio.run(run())
 


### PR DESCRIPTION
The QQ Open Platform has a limit of 20 group members and does not support group chat here in nanobot.

This PR adds NapCatQQ channel, which turns your QQ (alt) account into a bot, supporting both texts and images. It doesn't interfere with the existing QQ channel. Tested on my machine and QQ alt account.