### PR TITLE
feat: implement custom VL provider

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -67,6 +67,8 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
+        vision_provider: LLMProvider | None = None,
+        vision_model: str | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -84,6 +86,8 @@ class AgentLoop:
         self.restrict_to_workspace = restrict_to_workspace
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
+        self.vision_provider = vision_provider or provider
+        self.vision_model = vision_model or self.model
 
         self.context = ContextBuilder(workspace)
         self.sessions = session_manager or SessionManager(workspace)
@@ -223,11 +227,12 @@ class AgentLoop:
             iteration += 1
 
             tool_defs = self.tools.get_definitions()
+            active_provider, active_model = self._select_provider_for_messages(messages)
 
-            response = await self.provider.chat_with_retry(
+            response = await active_provider.chat_with_retry(
                 messages=messages,
                 tools=tool_defs,
-                model=self.model,
+                model=active_model,
             )
             usage = response.usage or {}
             self._last_usage = {
@@ -283,8 +288,21 @@ class AgentLoop:
                 f"I reached the maximum number of tool call iterations ({self.max_iterations}) "
                 "without completing the task. You can try breaking the task into smaller steps."
             )
-
         return final_content, tools_used, messages
+
+    def _select_provider_for_messages(
+        self,
+        messages: list[dict[str, Any]],
+    ) -> tuple[LLMProvider, str]:
+        """Choose the vision provider/model when image content is present."""
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "image_url":
+                    return self.vision_provider, self.vision_model
+        return self.provider, self.model
 
     async def run(self) -> None:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -407,25 +407,30 @@ def _onboard_plugins(config_path: Path) -> None:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
-def _make_provider(config: Config):
+def _make_provider(
+    config: Config,
+    *,
+    model: str | None = None,
+    forced_provider: str | None = None,
+):
     """Create the appropriate LLM provider from config."""
     from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
     from nanobot.providers.base import GenerationSettings
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
 
-    model = config.agents.defaults.model
-    provider_name = config.get_provider_name(model)
-    p = config.get_provider(model)
+    model = model or config.agents.defaults.model
+    provider_name = config.get_provider_name(model, forced_provider=forced_provider)
+    p = config.get_provider(model, forced_provider=forced_provider)
 
     # OpenAI Codex (OAuth)
     if provider_name == "openai_codex" or model.startswith("openai-codex/"):
         provider = OpenAICodexProvider(default_model=model)
     # Custom: direct OpenAI-compatible endpoint, bypasses LiteLLM
-    elif provider_name == "custom":
+    elif provider_name in {"custom", "custom_vision"}:
         from nanobot.providers.custom_provider import CustomProvider
         provider = CustomProvider(
             api_key=p.api_key if p else "no-key",
-            api_base=config.get_api_base(model) or "http://localhost:8000/v1",
+            api_base=config.get_api_base(model, forced_provider=forced_provider) or "http://localhost:8000/v1",
             default_model=model,
             extra_headers=p.extra_headers if p else None,
         )
@@ -464,6 +469,20 @@ def _make_provider(config: Config):
         reasoning_effort=defaults.reasoning_effort,
     )
     return provider
+
+
+def _make_vision_provider(config: Config):
+    """Create the dedicated vision provider when configured, otherwise fall back to the default provider."""
+    vision_model = config.agents.defaults.vision_model
+    vision_provider = config.agents.defaults.vision_provider
+    if not vision_model and not vision_provider:
+        return _make_provider(config)
+
+    return _make_provider(
+        config,
+        model=config.get_vision_model(),
+        forced_provider=vision_provider,
+    )
 
 
 def _load_runtime_config(config: str | None = None, workspace: str | None = None) -> Config:
@@ -530,14 +549,15 @@ def gateway(
         import logging
         logging.basicConfig(level=logging.DEBUG)
 
-    config = _load_runtime_config(config, workspace)
-    port = port if port is not None else config.gateway.port
+    runtime_config = _load_runtime_config(config, workspace)
+    port = port if port is not None else runtime_config.gateway.port
 
     console.print(f"{__logo__} Starting nanobot gateway version {__version__} on port {port}...")
-    sync_workspace_templates(config.workspace_path)
+    sync_workspace_templates(runtime_config.workspace_path)
     bus = MessageBus()
-    provider = _make_provider(config)
-    session_manager = SessionManager(config.workspace_path)
+    provider = _make_provider(runtime_config)
+    vision_provider = _make_vision_provider(runtime_config)
+    session_manager = SessionManager(runtime_config.workspace_path)
 
     # Create cron service first (callback set after agent creation)
     cron_store_path = get_cron_dir() / "jobs.json"
@@ -547,18 +567,20 @@ def gateway(
     agent = AgentLoop(
         bus=bus,
         provider=provider,
-        workspace=config.workspace_path,
-        model=config.agents.defaults.model,
-        max_iterations=config.agents.defaults.max_tool_iterations,
-        context_window_tokens=config.agents.defaults.context_window_tokens,
-        web_search_config=config.tools.web.search,
-        web_proxy=config.tools.web.proxy or None,
-        exec_config=config.tools.exec,
+        vision_provider=vision_provider,
+        workspace=runtime_config.workspace_path,
+        model=runtime_config.agents.defaults.model,
+        vision_model=runtime_config.get_vision_model(),
+        max_iterations=runtime_config.agents.defaults.max_tool_iterations,
+        context_window_tokens=runtime_config.agents.defaults.context_window_tokens,
+        web_search_config=runtime_config.tools.web.search,
+        web_proxy=runtime_config.tools.web.proxy or None,
+        exec_config=runtime_config.tools.exec,
         cron_service=cron,
-        restrict_to_workspace=config.tools.restrict_to_workspace,
+        restrict_to_workspace=runtime_config.tools.restrict_to_workspace,
         session_manager=session_manager,
-        mcp_servers=config.tools.mcp_servers,
-        channels_config=config.channels,
+        mcp_servers=runtime_config.tools.mcp_servers,
+        channels_config=runtime_config.channels,
     )
 
     # Set cron callback (needs agent)
@@ -610,7 +632,7 @@ def gateway(
     cron.on_job = on_cron_job
 
     # Create channel manager
-    channels = ChannelManager(config, bus)
+    channels = ChannelManager(runtime_config, bus)
 
     def _pick_heartbeat_target() -> tuple[str, str]:
         """Pick a routable channel/chat target for heartbeat-triggered messages."""
@@ -653,9 +675,9 @@ def gateway(
             return  # No external channel available to deliver to
         await bus.publish_outbound(OutboundMessage(channel=channel, chat_id=chat_id, content=response))
 
-    hb_cfg = config.gateway.heartbeat
+    hb_cfg = runtime_config.gateway.heartbeat
     heartbeat = HeartbeatService(
-        workspace=config.workspace_path,
+        workspace=runtime_config.workspace_path,
         provider=provider,
         model=agent.model,
         on_execute=on_heartbeat_execute,
@@ -723,11 +745,12 @@ def agent(
     from nanobot.config.paths import get_cron_dir
     from nanobot.cron.service import CronService
 
-    config = _load_runtime_config(config, workspace)
-    sync_workspace_templates(config.workspace_path)
+    runtime_config = _load_runtime_config(config, workspace)
+    sync_workspace_templates(runtime_config.workspace_path)
 
     bus = MessageBus()
-    provider = _make_provider(config)
+    provider = _make_provider(runtime_config)
+    vision_provider = _make_vision_provider(runtime_config)
 
     # Create cron service for tool usage (no callback needed for CLI unless running)
     cron_store_path = get_cron_dir() / "jobs.json"
@@ -741,17 +764,19 @@ def agent(
     agent_loop = AgentLoop(
         bus=bus,
         provider=provider,
-        workspace=config.workspace_path,
-        model=config.agents.defaults.model,
-        max_iterations=config.agents.defaults.max_tool_iterations,
-        context_window_tokens=config.agents.defaults.context_window_tokens,
-        web_search_config=config.tools.web.search,
-        web_proxy=config.tools.web.proxy or None,
-        exec_config=config.tools.exec,
+        vision_provider=vision_provider,
+        workspace=runtime_config.workspace_path,
+        model=runtime_config.agents.defaults.model,
+        vision_model=runtime_config.get_vision_model(),
+        max_iterations=runtime_config.agents.defaults.max_tool_iterations,
+        context_window_tokens=runtime_config.agents.defaults.context_window_tokens,
+        web_search_config=runtime_config.tools.web.search,
+        web_proxy=runtime_config.tools.web.proxy or None,
+        exec_config=runtime_config.tools.exec,
         cron_service=cron,
-        restrict_to_workspace=config.tools.restrict_to_workspace,
-        mcp_servers=config.tools.mcp_servers,
-        channels_config=config.channels,
+        restrict_to_workspace=runtime_config.tools.restrict_to_workspace,
+        mcp_servers=runtime_config.tools.mcp_servers,
+        channels_config=runtime_config.channels,
     )
 
     # Shared reference for progress callbacks

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -34,6 +34,8 @@ class AgentDefaults(Base):
     provider: str = (
         "auto"  # Provider name (e.g. "anthropic", "openrouter") or "auto" for auto-detection
     )
+    vision_model: str | None = None
+    vision_provider: str | None = None
     max_tokens: int = 8192
     context_window_tokens: int = 65_536
     temperature: float = 0.1
@@ -59,6 +61,7 @@ class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
+    custom_vision: ProviderConfig = Field(default_factory=ProviderConfig)  # Dedicated OpenAI-compatible vision endpoint
     azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -158,12 +161,14 @@ class Config(BaseSettings):
         return Path(self.agents.defaults.workspace).expanduser()
 
     def _match_provider(
-        self, model: str | None = None
+        self,
+        model: str | None = None,
+        forced_provider: str | None = None,
     ) -> tuple["ProviderConfig | None", str | None]:
         """Match provider config and its registry name. Returns (config, spec_name)."""
         from nanobot.providers.registry import PROVIDERS
 
-        forced = self.agents.defaults.provider
+        forced = forced_provider or self.agents.defaults.provider
         if forced != "auto":
             p = getattr(self.providers, forced, None)
             return (p, forced) if p else (None, None)
@@ -219,26 +224,42 @@ class Config(BaseSettings):
                 return p, spec.name
         return None, None
 
-    def get_provider(self, model: str | None = None) -> ProviderConfig | None:
+    def get_provider(
+        self,
+        model: str | None = None,
+        forced_provider: str | None = None,
+    ) -> ProviderConfig | None:
         """Get matched provider config (api_key, api_base, extra_headers). Falls back to first available."""
-        p, _ = self._match_provider(model)
+        p, _ = self._match_provider(model, forced_provider=forced_provider)
         return p
 
-    def get_provider_name(self, model: str | None = None) -> str | None:
+    def get_provider_name(
+        self,
+        model: str | None = None,
+        forced_provider: str | None = None,
+    ) -> str | None:
         """Get the registry name of the matched provider (e.g. "deepseek", "openrouter")."""
-        _, name = self._match_provider(model)
+        _, name = self._match_provider(model, forced_provider=forced_provider)
         return name
 
-    def get_api_key(self, model: str | None = None) -> str | None:
+    def get_api_key(
+        self,
+        model: str | None = None,
+        forced_provider: str | None = None,
+    ) -> str | None:
         """Get API key for the given model. Falls back to first available key."""
-        p = self.get_provider(model)
+        p = self.get_provider(model, forced_provider=forced_provider)
         return p.api_key if p else None
 
-    def get_api_base(self, model: str | None = None) -> str | None:
+    def get_api_base(
+        self,
+        model: str | None = None,
+        forced_provider: str | None = None,
+    ) -> str | None:
         """Get API base URL for the given model. Applies default URLs for gateway/local providers."""
         from nanobot.providers.registry import find_by_name
 
-        p, name = self._match_provider(model)
+        p, name = self._match_provider(model, forced_provider=forced_provider)
         if p and p.api_base:
             return p.api_base
         # Only gateways get a default api_base here. Standard providers
@@ -249,5 +270,37 @@ class Config(BaseSettings):
             if spec and (spec.is_gateway or spec.is_local) and spec.default_api_base:
                 return spec.default_api_base
         return None
+
+    def get_vision_model(self) -> str:
+        """Get the configured vision model, falling back to the default text model."""
+        return self.agents.defaults.vision_model or self.agents.defaults.model
+
+    def get_vision_provider(self) -> ProviderConfig | None:
+        """Get the configured provider for the vision model."""
+        return self.get_provider(
+            self.get_vision_model(),
+            forced_provider=self.agents.defaults.vision_provider,
+        )
+
+    def get_vision_provider_name(self) -> str | None:
+        """Get the registry name of the configured vision provider."""
+        return self.get_provider_name(
+            self.get_vision_model(),
+            forced_provider=self.agents.defaults.vision_provider,
+        )
+
+    def get_vision_api_key(self) -> str | None:
+        """Get API key for the configured vision model/provider."""
+        return self.get_api_key(
+            self.get_vision_model(),
+            forced_provider=self.agents.defaults.vision_provider,
+        )
+
+    def get_vision_api_base(self) -> str | None:
+        """Get API base URL for the configured vision model/provider."""
+        return self.get_api_base(
+            self.get_vision_model(),
+            forced_provider=self.agents.defaults.vision_provider,
+        )
 
     model_config = ConfigDict(env_prefix="NANOBOT_", env_nested_delimiter="__")


### PR DESCRIPTION
## Summary
Adds dedicated vision routing so multimodal turns can use a separate provider/model from text turns.

## Changes

### `nanobot/config/schema.py`
- Add `agents.defaults.vision_model`
- Add `agents.defaults.vision_provider`
- Add `providers.custom_vision`
- Extend provider resolution helpers with optional `forced_provider`
- Add vision helper methods:
  - `get_vision_model()`
  - `get_vision_provider()`
  - `get_vision_provider_name()`
  - `get_vision_api_key()`
  - `get_vision_api_base()`

### `nanobot/cli/commands.py`
- Refactor `_make_provider(...)` to accept `model` and `forced_provider`
- Add `_make_vision_provider(...)`
- In `gateway` and `agent`, construct both default and vision providers
- Pass both provider/model contexts into `AgentLoop`

### `nanobot/agent/loop.py`
- Add optional `vision_provider` and `vision_model` to `AgentLoop`
- Add per-turn provider/model selection:
  - if any message content block has `type == "image_url"`, use vision provider/model
  - otherwise use default provider/model

## Behavior
- Text-only behavior remains unchanged.
- Multimodal turns are routed to the configured vision backend.

## Diff summary
- Commit: `90b78c4`
- Files: 3
- Stats: `146 insertions`, `50 deletions`
