### PR TITLE
fix(agent): count all message fields in token estimation

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -115,7 +115,11 @@ def estimate_prompt_tokens(
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None = None,
 ) -> int:
-    """Estimate prompt tokens with tiktoken."""
+    """Estimate prompt tokens with tiktoken.
+
+    Counts all fields that providers send to the LLM: content, tool_calls,
+    reasoning_content, tool_call_id, name, plus per-message framing overhead.
+    """
     try:
         enc = tiktoken.get_encoding("cl100k_base")
         parts: list[str] = []
@@ -129,9 +133,25 @@ def estimate_prompt_tokens(
                         txt = part.get("text", "")
                         if txt:
                             parts.append(txt)
+
+            tc = msg.get("tool_calls")
+            if tc:
+                parts.append(json.dumps(tc, ensure_ascii=False))
+
+            rc = msg.get("reasoning_content")
+            if isinstance(rc, str) and rc:
+                parts.append(rc)
+
+            for key in ("name", "tool_call_id"):
+                value = msg.get(key)
+                if isinstance(value, str) and value:
+                    parts.append(value)
+
         if tools:
             parts.append(json.dumps(tools, ensure_ascii=False))
-        return len(enc.encode("\n".join(parts)))
+
+        per_message_overhead = len(messages) * 4
+        return len(enc.encode("\n".join(parts))) + per_message_overhead
     except Exception:
         return 0
 
@@ -160,14 +180,18 @@ def estimate_message_tokens(message: dict[str, Any]) -> int:
     if message.get("tool_calls"):
         parts.append(json.dumps(message["tool_calls"], ensure_ascii=False))
 
+    rc = message.get("reasoning_content")
+    if isinstance(rc, str) and rc:
+        parts.append(rc)
+
     payload = "\n".join(parts)
     if not payload:
-        return 1
+        return 4
     try:
         enc = tiktoken.get_encoding("cl100k_base")
-        return max(1, len(enc.encode(payload)))
+        return max(4, len(enc.encode(payload)) + 4)
     except Exception:
-        return max(1, len(payload) // 4)
+        return max(4, len(payload) // 4 + 4)
 
 
 def estimate_prompt_tokens_chain(


### PR DESCRIPTION
## Summary

- **fix: `estimate_prompt_tokens()` severely undercounting tokens** — previously only counted the `content` text field, completely ignoring `tool_calls` JSON (which constitutes ~72% of actual payload for tool-heavy sessions), `reasoning_content`, `tool_call_id`, `name` fields, and per-message framing overhead. This caused the memory consolidator to never trigger, leading to unbounded context growth and eventual `context window exceeds limit` errors from the LLM provider.
- **fix: `estimate_message_tokens()` missing `reasoning_content`** — added reasoning_content counting and corrected per-message overhead from 1 to 4 tokens for more accurate boundary detection during consolidation.

### Impact

Verified against a real cron session (~2492 messages):

| Metric | Before | After |
|--------|--------|-------|
| Estimated tokens | 51,783 | 343,945 |
| Consolidation trigger | Never (thinks 51K < 65K limit) | Correctly triggers (343K > 65K) |
| Accuracy | ~14.6% of real payload | ~6.6x improvement |

### Root cause

Tool-heavy sessions (e.g. cron jobs executing parallel `curl` commands) accumulate massive `tool_calls` JSON payloads in assistant messages and full execution results in tool messages. The old estimator was blind to all of this, so `maybe_consolidate_by_tokens` never fired — sessions grew until the LLM provider rejected the request.

## Test plan

- [x] All 45 existing consolidation/session tests pass
- [x] Verified new estimate matches expected magnitude on real cron session data
- [x] Confirmed stable runtime with cron jobs after deployment