### PR TITLE
feat(cron): Playbook-Driven Cron Architecture (Delayed Skill Execution)

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -49,7 +49,11 @@ class CronTool(Tool):
                     "enum": ["add", "list", "remove"],
                     "description": "Action to perform",
                 },
-                "message": {"type": "string", "description": "Reminder message (for add)"},
+                "message": {"type": "string", "description": "Reminder message (for add). Should be a brief title if playbook_path is provided."},
+                "playbook_path": {
+                    "type": "string",
+                    "description": "Optional path to a markdown playbook (e.g. 'cron_jobs/my_task/playbook.md') for complex, multi-step cron jobs.",
+                },
                 "every_seconds": {
                     "type": "integer",
                     "description": "Interval in seconds (for recurring tasks)",
@@ -75,6 +79,7 @@ class CronTool(Tool):
         self,
         action: str,
         message: str = "",
+        playbook_path: str | None = None,
         every_seconds: int | None = None,
         cron_expr: str | None = None,
         tz: str | None = None,
@@ -85,7 +90,7 @@ class CronTool(Tool):
         if action == "add":
             if self._in_cron_context.get():
                 return "Error: cannot schedule new jobs from within a cron job execution"
-            return self._add_job(message, every_seconds, cron_expr, tz, at)
+            return self._add_job(message, playbook_path, every_seconds, cron_expr, tz, at)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
@@ -95,13 +100,14 @@ class CronTool(Tool):
     def _add_job(
         self,
         message: str,
+        playbook_path: str | None,
         every_seconds: int | None,
         cron_expr: str | None,
         tz: str | None,
         at: str | None,
     ) -> str:
-        if not message:
-            return "Error: message is required for add"
+        if not message and not playbook_path:
+            return "Error: message or playbook_path is required for add"
         if not self._channel or not self._chat_id:
             return "Error: no session context (channel/chat_id)"
         if tz and not cron_expr:
@@ -133,10 +139,13 @@ class CronTool(Tool):
         else:
             return "Error: either every_seconds, cron_expr, or at is required"
 
+        job_name = message[:30] if message else playbook_path.split('/')[-1][:30]
+
         job = self._cron.add_job(
-            name=message[:30],
+            name=job_name,
             schedule=schedule,
-            message=message,
+            message=message or "",
+            playbook_path=playbook_path,
             deliver=True,
             channel=self._channel,
             to=self._chat_id,

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -568,11 +568,29 @@ def gateway(
         from nanobot.agent.tools.message import MessageTool
         from nanobot.utils.evaluator import evaluate_response
 
-        reminder_note = (
-            "[Scheduled Task] Timer finished.\n\n"
-            f"Task '{job.name}' has been triggered.\n"
-            f"Scheduled instruction: {job.payload.message}"
-        )
+        if job.payload.playbook_path:
+            playbook_full_path = config.workspace_path / job.payload.playbook_path
+            if playbook_full_path.exists():
+                playbook_content = playbook_full_path.read_text(encoding="utf-8")
+                reminder_note = (
+                    f"[Scheduled Task Playbook] Timer finished.\n\n"
+                    f"Task '{job.name}' has been triggered.\n"
+                    f"Please execute the following playbook strictly:\n\n"
+                    f"{playbook_content}"
+                )
+            else:
+                reminder_note = (
+                    f"[Scheduled Task Error] Timer finished, but playbook not found.\n\n"
+                    f"Task '{job.name}' has been triggered.\n"
+                    f"Playbook path: {job.payload.playbook_path}\n"
+                    f"Error: Playbook file does not exist. Please investigate."
+                )
+        else:
+            reminder_note = (
+                "[Scheduled Task] Timer finished.\n\n"
+                f"Task '{job.name}' has been triggered.\n"
+                f"Scheduled instruction: {job.payload.message}"
+            )
 
         cron_tool = agent.tools.get("cron")
         cron_token = None

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -106,6 +106,7 @@ class CronService:
                         payload=CronPayload(
                             kind=j["payload"].get("kind", "agent_turn"),
                             message=j["payload"].get("message", ""),
+                            playbook_path=j["payload"].get("playbookPath"),
                             deliver=j["payload"].get("deliver", False),
                             channel=j["payload"].get("channel"),
                             to=j["payload"].get("to"),
@@ -162,6 +163,7 @@ class CronService:
                     "payload": {
                         "kind": j.payload.kind,
                         "message": j.payload.message,
+                        "playbookPath": j.payload.playbook_path,
                         "deliver": j.payload.deliver,
                         "channel": j.payload.channel,
                         "to": j.payload.to,
@@ -316,6 +318,7 @@ class CronService:
         name: str,
         schedule: CronSchedule,
         message: str,
+        playbook_path: str | None = None,
         deliver: bool = False,
         channel: str | None = None,
         to: str | None = None,
@@ -334,6 +337,7 @@ class CronService:
             payload=CronPayload(
                 kind="agent_turn",
                 message=message,
+                playbook_path=playbook_path,
                 deliver=deliver,
                 channel=channel,
                 to=to,

--- a/nanobot/cron/types.py
+++ b/nanobot/cron/types.py
@@ -23,6 +23,8 @@ class CronPayload:
     """What to do when the job runs."""
     kind: Literal["system_event", "agent_turn"] = "agent_turn"
     message: str = ""
+    # Path to a playbook (markdown) file relative to workspace, for complex tasks
+    playbook_path: str | None = None
     # Deliver response to channel
     deliver: bool = False
     channel: str | None = None  # e.g. "whatsapp"

--- a/nanobot/skills/README.md
+++ b/nanobot/skills/README.md
@@ -23,3 +23,4 @@ The skill format and metadata structure follow OpenClaw's conventions to maintai
 | `tmux` | Remote-control tmux sessions |
 | `clawhub` | Search and install skills from ClawHub registry |
 | `skill-creator` | Create new skills |
+| `cron-architect` | Construct robust, reliable, and stateful scheduled tasks |

--- a/nanobot/skills/cron-architect/SKILL.md
+++ b/nanobot/skills/cron-architect/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cron-architect
+description: Guides the agent on how to construct robust, reliable, and stateful scheduled tasks (cron jobs) using a playbook-driven architecture.
+---
+
+# Cron Architect
+
+This skill teaches you how to create robust scheduled tasks (cron jobs) for users. 
+
+**DO NOT** just create a simple cron job with a plain text message if the task is complex (e.g., checking a website, tracking states, alerting on failures). Simple string messages cause the agent to lose context and fail when the job triggers.
+
+Instead, you must use a **Playbook-Driven Architecture**.
+
+## The Architecture
+The core concept is that a cron job should execute a concrete, context-rich **Playbook**.
+1. **Sandbox Directory**: Every complex task gets its own folder in `workspace/cron_jobs/<task_name>/`.
+2. **Execution Scripts**: You must write Python scripts to handle the heavy lifting (crawling, data processing, file locking).
+3. **State Management**: Your scripts should track their state in a local `state.json` file inside the sandbox directory.
+4. **Playbook Markdown**: A `<task_name>_playbook.md` file that acts as the primary prompt/context for the agent when the job triggers.
+5. **Registration**: The cron job is created by pointing to this playbook file.
+
+## Step-by-Step Execution
+
+When a user asks you to create a complex scheduled task (e.g., "Check Apple website for updates every day"):
+
+### 1. Clarification (If needed)
+Ask the user for specifics if the task is ambiguous:
+- "What exact URL should I monitor?"
+- "What constitutes an 'update'?"
+- "Do you want me to alert you only on changes, or also if the check fails?"
+
+### 2. Scaffold the Sandbox
+Create a dedicated directory for the task:
+```bash
+mkdir -p workspace/cron_jobs/apple_checker
+```
+
+### 3. Write the Script (e.g., `check.py`)
+Write a Python script that performs the actual check. 
+**Crucial Requirements for Scripts:**
+- **Concurrency**: Use Python file locks (e.g., `fcntl.flock` on Unix) to prevent overlapping runs.
+- **State**: Read and write to `state.json` to know if an alert should be sent (e.g., only alert if the hash of the website changed).
+- **Error Handling**: Use `try...except` blocks. Track consecutive errors in `state.json`. Only print an error to standard output if `consecutive_errors >= 3`.
+- **Output**: The script should print a clear, concise result to standard output ONLY if an action needs to be taken by the agent (e.g., "NEW PRODUCT FOUND: ..."). If no action is needed, the script should print nothing or "NO_CHANGES".
+
+### 4. Write the Playbook
+Create `workspace/cron_jobs/<task_name>/playbook.md`. This is the context injected into the agent when the cron job fires.
+
+Example `playbook.md`:
+```markdown
+# Scheduled Task: Apple Website Monitor
+
+**Goal**: Check if Apple released new products.
+
+**Instructions**:
+1. Run `python workspace/cron_jobs/apple_checker/check.py`.
+2. If the output says "NO_CHANGES", do not send any message to the user. Stop here.
+3. If the output contains product details, summarize them beautifully and send them to the user.
+4. If the output contains an error (e.g., failed 3 times), alert the user that the monitor is broken.
+```
+
+### 5. Register the Cron Job
+Finally, register the job using the `cron` tool, providing the `playbook_path`:
+
+```json
+{
+  "action": "add",
+  "playbook_path": "cron_jobs/apple_checker/playbook.md",
+  "cron_expr": "0 0 * * *"
+}
+```
+*(Note: Do not pass a `message` if you pass a `playbook_path`. You may pass an empty string or a very brief title.)*
+
+## Key Principles
+- **Silent Rot vs Alert Fatigue**: The script should handle transient errors silently. Only alert the user if the script fails repeatedly.
+- **File Locks**: Always lock a `.lock` file in the sandbox to prevent concurrent execution.
+- **Stateless Agent, Stateful Script**: The agent wakes up with no memory of past runs. All state must live in `state.json`.


### PR DESCRIPTION
This PR addresses the "blind awakening" problem in Agentic cron jobs by refactoring the scheduling mechanism into a **Playbook-Driven** architecture.

### Motivation
Previously, cron jobs relied on simple string messages (e.g., "Check Apple website"), which caused the agent to lose context upon triggering, making it incapable of handling complex tasks with state or retries.

### Solution
This PR introduces the principle of **"Minimalist Core, Smart Skills"**:

1. **Core Upgrade**: Added an optional `playbook_path` to `CronPayload`. When triggered, the core reads this markdown file and injects it as a high-weight system prompt (Zero-Turn Context), giving the Agent immediate procedural awareness without multi-turn dialogue.
2. **Built-in Skill (`cron-architect`)**: Added a new system skill that instructs the Agent on how to scaffold robust jobs. It guides the Agent to create a sandbox `workspace/cron_jobs/`, write python scripts with file locks (to prevent concurrent overlaps), implement state memory (via `state.json` to prevent alert fatigue), and generate the `.md` playbook for the engine to execute.
3. **100% Backward Compatible**: Existing cron jobs with just a `message` will continue to function exactly as before.

This transforms the cron system from a simple "mechanical alarm clock" into a robust framework for "deferred smart skill execution".