### PR TITLE
fix: only use Jina Reader when JINA_API_KEY is explicitly set

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -264,12 +264,13 @@ class WebFetchTool(Tool):
         return result
 
     async def _fetch_jina(self, url: str, max_chars: int) -> str | None:
-        """Try fetching via Jina Reader API. Returns None on failure."""
+        """Try fetching via Jina Reader API. Returns None on failure or if no API key is set."""
+        jina_key = os.environ.get("JINA_API_KEY", "")
+        if not jina_key:
+            # Skip Jina to avoid sending URLs to third-party service without explicit opt-in
+            return None
         try:
-            headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
-            jina_key = os.environ.get("JINA_API_KEY", "")
-            if jina_key:
-                headers["Authorization"] = f"Bearer {jina_key}"
+            headers = {"Accept": "application/json", "User-Agent": USER_AGENT, "Authorization": f"Bearer {jina_key}"}
             async with httpx.AsyncClient(proxy=self.proxy, timeout=20.0) as client:
                 r = await client.get(f"https://r.jina.ai/{url}", headers=headers)
                 if r.status_code == 429:

--- a/tests/test_web_fetch_security.py
+++ b/tests/test_web_fetch_security.py
@@ -70,6 +70,16 @@ async def test_web_fetch_result_contains_untrusted_flag():
 
 
 @pytest.mark.asyncio
+async def test_fetch_jina_skipped_without_api_key(monkeypatch):
+    """When JINA_API_KEY is not set, _fetch_jina should return None immediately
+    to avoid sending URLs to third-party service without explicit opt-in."""
+    tool = WebFetchTool()
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+    result = await tool._fetch_jina("https://example.com", max_chars=1000)
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_web_fetch_blocks_private_redirect_before_returning_image(monkeypatch):
     tool = WebFetchTool()
 


### PR DESCRIPTION
## Summary
- fix privacy issue where `WebFetchTool` always sent URLs to Jina Reader API regardless of whether `JINA_API_KEY` was set
- now `_fetch_jina` returns `None` immediately if no API key is configured, avoiding third-party service calls without explicit opt-in
- fallback to local `readability-lxml` extraction remains unchanged

## Testing
- added `test_fetch_jina_skipped_without_api_key` to verify the new behavior
- existing SSRF and security tests continue to pass

Fixes #2341
