### PR TITLE
fix(skills): parse YAML boolean values in skill frontmatter

### DIFF
--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -222,7 +222,13 @@ class SkillsLoader:
                 for line in match.group(1).split("\n"):
                     if ":" in line:
                         key, value = line.split(":", 1)
-                        metadata[key.strip()] = value.strip().strip('"\'')
+                        val = value.strip().strip('"\'')
+                        # Convert YAML boolean strings to Python bools
+                        if val.lower() in ("true", "yes"):
+                            val = True
+                        elif val.lower() in ("false", "no"):
+                            val = False
+                        metadata[key.strip()] = val
                 return metadata
 
         return None


### PR DESCRIPTION
## Summary

The simple YAML parser in `get_skill_metadata()` stores all frontmatter values as Python strings. This causes YAML booleans like `always: false` to be parsed as the string `"false"`, which is truthy in Python. As a result, skills explicitly marked `always: false` are incorrectly loaded as always-on via `get_always_skills()`.

## Root Cause

In `agent/skills.py` line 225:
```python
metadata[key.strip()] = value.strip().strip('"\'')
```
All values become strings — `"true"`, `"false"`, etc. Then in `get_always_skills()` line 199:
```python
if skill_meta.get("always") or meta.get("always"):
```
`"false"` is truthy, so the skill is included.

## Fix

Convert recognized YAML boolean strings (`true`/`yes`/`false`/`no`, case-insensitive) to Python `bool` values after stripping, so that truthiness checks work correctly.

## Test

```python
# Before fix:
>>> bool("false")
True  # ← wrong, "false" is truthy

# After fix: value is parsed as Python False
>>> bool(False)
False  # ← correct
```