### PR TITLE
Prevent cron job self-duplication by injecting anti-recursion directive

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -269,8 +269,12 @@ class CronService:
 
         try:
             if self.on_job:
+                original = job.payload.message
                 job.payload.message = f"{job.payload.message}\n\n[SYSTEM DIRECTIVE: Fulfill the above request. Do NOT schedule, create, or suggest any new cron jobs or recurring tasks.]"
+
                 await self.on_job(job)
+                
+                job.payload.message = original
 
             job.state.last_status = "ok"
             job.state.last_error = None

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -269,6 +269,7 @@ class CronService:
 
         try:
             if self.on_job:
+                job.payload.message = f"{job.payload.message}\n\n[SYSTEM DIRECTIVE: Fulfill the above request. Do NOT schedule, create, or suggest any new cron jobs or recurring tasks.]"
                 await self.on_job(job)
 
             job.state.last_status = "ok"


### PR DESCRIPTION
break recursion loop by telling agent not to create new crons when run from cron