### PR TITLE
feat: add Vertex AI provider with Google Cloud ADC authentication

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -445,10 +445,20 @@ def _make_provider(config: Config):
         from nanobot.providers.litellm_provider import LiteLLMProvider
         from nanobot.providers.registry import find_by_name
         spec = find_by_name(provider_name)
-        if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and (spec.is_oauth or spec.is_local)):
+        if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and (spec.is_oauth or spec.is_local or spec.no_api_key_ok)):
             console.print("[red]Error: No API key configured.[/red]")
             console.print("Set one in ~/.nanobot/config.json under providers section")
             raise typer.Exit(1)
+
+        # Vertex AI: set project/location env vars for LiteLLM ADC auth
+        if provider_name == "vertex_ai" and p:
+            from nanobot.config.schema import VertexAIProviderConfig
+            if isinstance(p, VertexAIProviderConfig):
+                if p.project:
+                    os.environ.setdefault("VERTEXAI_PROJECT", p.project)
+                if p.location:
+                    os.environ.setdefault("VERTEXAI_LOCATION", p.location)
+
         provider = LiteLLMProvider(
             api_key=p.api_key if p else None,
             api_base=config.get_api_base(model),
@@ -1103,9 +1113,16 @@ def status():
             if spec.is_oauth:
                 console.print(f"{spec.label}: [green]✓ (OAuth)[/green]")
             elif spec.is_local:
-                # Local deployments show api_base instead of api_key
                 if p.api_base:
                     console.print(f"{spec.label}: [green]✓ {p.api_base}[/green]")
+                else:
+                    console.print(f"{spec.label}: [dim]not set[/dim]")
+            elif spec.no_api_key_ok:
+                from nanobot.config.schema import VertexAIProviderConfig
+                if isinstance(p, VertexAIProviderConfig) and p.project:
+                    console.print(f"{spec.label}: [green]✓ {p.project}/{p.location} (cloud auth)[/green]")
+                elif p.api_key:
+                    console.print(f"{spec.label}: [green]✓[/green]")
                 else:
                     console.print(f"{spec.label}: [dim]not set[/dim]")
             else:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -55,6 +55,13 @@ class ProviderConfig(Base):
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
 
 
+class VertexAIProviderConfig(ProviderConfig):
+    """Vertex AI provider — uses Google Cloud ADC instead of API keys."""
+
+    project: str = ""  # GCP project ID (e.g. "my-project-123")
+    location: str = "us-central1"  # GCP region
+
+
 class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
@@ -70,6 +77,7 @@ class ProvidersConfig(Base):
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     ollama: ProviderConfig = Field(default_factory=ProviderConfig)  # Ollama local models
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
+    vertex_ai: VertexAIProviderConfig = Field(default_factory=VertexAIProviderConfig)  # Google Cloud Vertex AI (ADC auth)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
@@ -181,14 +189,14 @@ class Config(BaseSettings):
         for spec in PROVIDERS:
             p = getattr(self.providers, spec.name, None)
             if p and model_prefix and normalized_prefix == spec.name:
-                if spec.is_oauth or spec.is_local or p.api_key:
+                if spec.is_oauth or spec.is_local or spec.no_api_key_ok or p.api_key:
                     return p, spec.name
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
             p = getattr(self.providers, spec.name, None)
             if p and any(_kw_matches(kw) for kw in spec.keywords):
-                if spec.is_oauth or spec.is_local or p.api_key:
+                if spec.is_oauth or spec.is_local or spec.no_api_key_ok or p.api_key:
                     return p, spec.name
 
         # Fallback: configured local providers can route models without

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -44,6 +44,7 @@ class LiteLLMProvider(LLMProvider):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
+        self._provider_name = provider_name
 
         # Detect gateway / local deployment.
         # provider_name (from config key) is the primary signal;
@@ -90,16 +91,20 @@ class LiteLLMProvider(LLMProvider):
 
     def _resolve_model(self, model: str) -> str:
         """Resolve model name by applying provider/gateway prefixes."""
+        from nanobot.providers.registry import find_by_name
+
         if self._gateway:
             prefix = self._gateway.litellm_prefix
             if self._gateway.strip_model_prefix:
                 model = model.split("/")[-1]
-            if prefix:
+            if prefix and not model.startswith(f"{prefix}/"):
                 model = f"{prefix}/{model}"
             return model
 
-        # Standard mode: auto-prefix for known providers
-        spec = find_by_model(model)
+        # Explicit provider_name takes priority over keyword matching.
+        # This ensures e.g. provider="vertex_ai" with model="gemini-2.5-pro"
+        # resolves to "vertex_ai/gemini-2.5-pro" instead of "gemini/gemini-2.5-pro".
+        spec = (find_by_name(self._provider_name) if self._provider_name else None) or find_by_model(model)
         if spec and spec.litellm_prefix:
             model = self._canonicalize_explicit_prefix(model, spec.name, spec.litellm_prefix)
             if not any(model.startswith(s) for s in spec.skip_prefixes):

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -98,7 +98,7 @@ class LiteLLMProvider(LLMProvider):
             prefix = self._gateway.litellm_prefix
             if self._gateway.strip_model_prefix:
                 model = model.split("/")[-1]
-            if prefix and not model.startswith(f"{prefix}/"):
+            if prefix:
                 model = f"{prefix}/{model}"
             return model
 

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -61,6 +61,9 @@ class ProviderSpec:
     # Provider supports cache_control on content blocks (e.g. Anthropic prompt caching)
     supports_prompt_caching: bool = False
 
+    # Provider works without an API key (e.g. uses cloud IAM / ADC auth)
+    no_api_key_ok: bool = False
+
     @property
     def label(self) -> str:
         return self.display_name or self.name.title()
@@ -325,6 +328,25 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="",
         strip_model_prefix=False,
         model_overrides=(),
+    ),
+    # Vertex AI: Google Cloud-hosted Gemini, uses ADC instead of API keys.
+    # Requires VERTEXAI_PROJECT and VERTEXAI_LOCATION env vars (set from config).
+    ProviderSpec(
+        name="vertex_ai",
+        keywords=("vertex", "vertex_ai"),
+        env_key="",
+        display_name="Vertex AI",
+        litellm_prefix="vertex_ai",  # gemini-2.5-pro → vertex_ai/gemini-2.5-pro
+        skip_prefixes=("vertex_ai/",),
+        env_extras=(),
+        is_gateway=False,
+        is_local=False,
+        detect_by_key_prefix="",
+        detect_by_base_keyword="",
+        default_api_base="",
+        strip_model_prefix=False,
+        model_overrides=(),
+        no_api_key_ok=True,
     ),
     # Zhipu: LiteLLM uses "zai/" prefix.
     # Also mirrors key to ZHIPUAI_API_KEY (some LiteLLM paths check that).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+vertex = [
+    "google-cloud-aiplatform>=1.38.0",
+]
 wecom = [
     "wecom-aibot-sdk-python>=0.1.5",
 ]


### PR DESCRIPTION
## Summary

- Adds a new `vertex_ai` provider that supports Google Cloud Application Default Credentials (ADC), allowing users to call Gemini models via Vertex AI without an API key
- Fixes model resolution to respect the explicit `provider` setting over keyword-based matching, preventing misrouting (e.g. `gemini-2.5-pro` with `provider: "vertex_ai"` was incorrectly resolved to the `gemini/` prefix instead of `vertex_ai/`)
- Adds `google-cloud-aiplatform` as an optional dependency (`pip install nanobot-ai[vertex]`)

## Motivation

Users on Google Cloud can authenticate via `gcloud auth application-default login` and use Gemini models through Vertex AI without managing API keys. This is especially useful for enterprise/GCP-native environments where IAM-based auth is preferred.

## Changes

- **`nanobot/providers/registry.py`** — Added `no_api_key_ok` flag to `ProviderSpec`; added `vertex_ai` provider entry
- **`nanobot/config/schema.py`** — Added `VertexAIProviderConfig` with `project`/`location` fields; allow `no_api_key_ok` providers through matching
- **`nanobot/cli/commands.py`** — Set `VERTEXAI_PROJECT`/`VERTEXAI_LOCATION` env vars from config; updated API key check and status display for cloud-auth providers
- **`nanobot/providers/litellm_provider.py`** — Store `provider_name` and use it in `_resolve_model` so explicit provider takes priority over keyword matching
- **`pyproject.toml`** — Added `vertex` optional dependency group

## Configuration

```json
{
  "providers": {
    "vertexAi": {
      "project": "my-gcp-project",
      "location": "us-central1"
    }
  },
  "agents": {
    "defaults": {
      "model": "gemini-2.5-pro",
      "provider": "vertex_ai"
    }
  }
}