### PR TITLE
fix(memory): reserve completion headroom before token consolidation

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -115,6 +115,7 @@ class AgentLoop:
             context_window_tokens=context_window_tokens,
             build_messages=self.context.build_messages,
             get_tool_definitions=self.tools.get_definitions,
+            max_completion_tokens=provider.generation.max_tokens,
         )
         self._register_default_tools()
 

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -224,6 +224,8 @@ class MemoryConsolidator:
 
     _MAX_CONSOLIDATION_ROUNDS = 5
 
+    _SAFETY_BUFFER = 1024  # extra headroom for tokenizer estimation drift
+
     def __init__(
         self,
         workspace: Path,
@@ -233,12 +235,14 @@ class MemoryConsolidator:
         context_window_tokens: int,
         build_messages: Callable[..., list[dict[str, Any]]],
         get_tool_definitions: Callable[[], list[dict[str, Any]]],
+        max_completion_tokens: int = 4096,
     ):
         self.store = MemoryStore(workspace)
         self.provider = provider
         self.model = model
         self.sessions = sessions
         self.context_window_tokens = context_window_tokens
+        self.max_completion_tokens = max_completion_tokens
         self._build_messages = build_messages
         self._get_tool_definitions = get_tool_definitions
         self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
@@ -300,17 +304,22 @@ class MemoryConsolidator:
         return True
 
     async def maybe_consolidate_by_tokens(self, session: Session) -> None:
-        """Loop: archive old messages until prompt fits within half the context window."""
+        """Loop: archive old messages until prompt fits within safe budget.
+
+        The budget reserves space for completion tokens and a safety buffer
+        so the LLM request never exceeds the context window.
+        """
         if not session.messages or self.context_window_tokens <= 0:
             return
 
         lock = self.get_lock(session.key)
         async with lock:
-            target = self.context_window_tokens // 2
+            budget = self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
+            target = budget // 2
             estimated, source = self.estimate_session_prompt_tokens(session)
             if estimated <= 0:
                 return
-            if estimated < self.context_window_tokens:
+            if estimated < budget:
                 logger.debug(
                     "Token consolidation idle {}: {}/{} via {}",
                     session.key,

--- a/tests/test_loop_consolidation_tokens.py
+++ b/tests/test_loop_consolidation_tokens.py
@@ -9,8 +9,10 @@ from nanobot.providers.base import LLMResponse
 
 
 def _make_loop(tmp_path, *, estimated_tokens: int, context_window_tokens: int) -> AgentLoop:
+    from nanobot.providers.base import GenerationSettings
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings(max_tokens=0)
     provider.estimate_prompt_tokens.return_value = (estimated_tokens, "test-counter")
     _response = LLMResponse(content="ok", tool_calls=[])
     provider.chat_with_retry = AsyncMock(return_value=_response)
@@ -24,6 +26,7 @@ def _make_loop(tmp_path, *, estimated_tokens: int, context_window_tokens: int) -
         context_window_tokens=context_window_tokens,
     )
     loop.tools.get_definitions = MagicMock(return_value=[])
+    loop.memory_consolidator._SAFETY_BUFFER = 0
     return loop
 
 


### PR DESCRIPTION
## Summary

This PR fixes a context budgeting bug in token-based memory consolidation.

Previously, consolidation only triggered when the estimated prompt size approached the full `context_window_tokens` limit. That meant we were not reserving space for response generation (`max_tokens`) or for token estimation drift. In practice, this could still cause `ContextWindowExceededError` even though preflight consolidation had already run.

This PR updates the consolidation threshold to reserve:
- completion headroom from `provider.generation.max_tokens`
- an additional safety buffer for tokenizer estimation drift

As a result, consolidation now starts earlier and keeps the final request safely below the model's real context limit.

## Changes

- pass provider-level completion budget into `MemoryConsolidator`
- compute a safe prompt budget as:

  `context_window_tokens - max_completion_tokens - safety_buffer`

- use that safe budget as the trigger threshold for consolidation
- continue consolidating toward half of the safe budget once triggered
- update token-consolidation tests to explicitly control completion headroom and safety buffer in mocks

## Why this matters

For large-context models, checking only the prompt size is not enough.

A request must satisfy:

`prompt_tokens + completion_tokens <= context_window_tokens`

Before this fix, we effectively checked only:

`prompt_tokens < context_window_tokens`

That allowed requests to cross the real provider limit once completion tokens were added.

## Example

For a model with:

- `context_window_tokens = 131072`
- `max_tokens = 8192`
- `safety_buffer = 1024`

the old behavior could wait until the prompt was near `131072` before consolidating.

After this change, consolidation starts once prompt usage approaches:

`131072 - 8192 - 1024 = 121856`

This leaves enough room for generation and reduces the chance of provider-side overflow errors.

## Test Plan

- added/updated token consolidation tests
- verified full test suite passes

```bash
python -m pytest -q
```

Result:

- `561 passed`

## Notes

This PR only addresses the first issue: reserving completion headroom during preflight consolidation.

It does **not** yet add per-iteration or mid-loop context budget checks while tool calls are accumulating within a single agent run. That can be addressed separately if we want an additional layer of protection for long tool-heavy turns.