### PR TITLE
fix(cron): clarify cron tool message describes executable task on tri…

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -49,7 +49,7 @@ class CronTool(Tool):
                     "enum": ["add", "list", "remove"],
                     "description": "Action to perform",
                 },
-                "message": {"type": "string", "description": "Reminder message (for add)"},
+                "message": {"type": "string", "description": "Task instruction or reminder text (for add). The agent will execute this as a full task when triggered — e.g. 'Check the weather and report' or 'Remind me to drink water'. You can write any actionable instruction here."},
                 "every_seconds": {
                     "type": "integer",
                     "description": "Interval in seconds (for recurring tasks)",


### PR DESCRIPTION

### Summary

The `message` parameter of the `cron` tool was described as "Reminder message (for add)", causing the LLM to treat it as a static text payload rather than a task instruction. This misled the agent into believing cron could only deliver fixed messages, not execute dynamic tasks.

### Error Behavior
<img width="1522" height="437" alt="image" src="https://github.com/user-attachments/assets/5cf95cd3-8363-44b4-9f4e-4d3f878d3546" />

When a user requested "tell me the weather in 3 minutes", the agent:

1. Created the job with a static placeholder message instead of an actionable instruction
2. Immediately told the user that cron "can only send fixed messages" and "cannot auto-execute weather queries" — contradicting the actual capability
3. Suggested the user request the weather manually after the timer fires

The task execution mechanism was fully functional; only the agent's understanding of the parameter was wrong.

### Change

`nanobot/agent/tools/cron.py` — one-line change to the `message` parameter description:

```
- "Reminder message (for add)"
+ "Task instruction or reminder text (for add). The agent will execute this as a full task when triggered — e.g. 'Check the weather and report' or 'Remind me to drink water'. You can write any actionable instruction here."
```

### After Fix 
<img width="1509" height="322" alt="image" src="https://github.com/user-attachments/assets/4dbe8b6a-e8ca-4836-89c2-b1433718b969" />

When a user requests "tell me the weather in 3 minutes", the agent now:

1. Sets `message` to a proper task instruction 
2. When triggered, correctly interprets the message as an executable task, calls the weather skill, and delivers the result to the user's channel