### PR TITLE
feat: enhance cron tool and skill with name parameter and playbook support

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -49,6 +49,7 @@ class CronTool(Tool):
                     "enum": ["add", "list", "remove"],
                     "description": "Action to perform",
                 },
+                "name": {"type": "string", "description": "Optional short name for the job"},
                 "message": {"type": "string", "description": "Reminder message (for add)"},
                 "every_seconds": {
                     "type": "integer",
@@ -74,6 +75,7 @@ class CronTool(Tool):
     async def execute(
         self,
         action: str,
+        name: str | None = None,
         message: str = "",
         every_seconds: int | None = None,
         cron_expr: str | None = None,
@@ -85,7 +87,7 @@ class CronTool(Tool):
         if action == "add":
             if self._in_cron_context.get():
                 return "Error: cannot schedule new jobs from within a cron job execution"
-            return self._add_job(message, every_seconds, cron_expr, tz, at)
+            return self._add_job(name, message, every_seconds, cron_expr, tz, at)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
@@ -94,6 +96,7 @@ class CronTool(Tool):
 
     def _add_job(
         self,
+        name: str | None,
         message: str,
         every_seconds: int | None,
         cron_expr: str | None,
@@ -134,7 +137,7 @@ class CronTool(Tool):
             return "Error: either every_seconds, cron_expr, or at is required"
 
         job = self._cron.add_job(
-            name=message[:30],
+            name=name or message[:30],
             schedule=schedule,
             message=message,
             deliver=True,

--- a/nanobot/skills/cron/SKILL.md
+++ b/nanobot/skills/cron/SKILL.md
@@ -1,57 +1,105 @@
 ---
 name: cron
-description: Schedule reminders and recurring tasks.
+description: Schedule automated recurring workflows, background monitors, and reminders. Use when the user wants to run tasks periodically (e.g., daily, hourly) or at a specific time in the future.
 ---
 
-# Cron
+# Cron Scheduler & Playbook Manager
 
-Use the `cron` tool to schedule reminders or recurring tasks.
+This skill helps you schedule background tasks. 
 
-## Three Modes
+Because scheduled tasks run entirely autonomously in the future without user supervision, **stability, state management, and clear instructions are critical**. To achieve this, we separate tasks into "Simple" (stateless, single-step) and "Complex" (multi-step, stateful, requiring custom logic). 
 
-1. **Reminder** - message is sent directly to user
-2. **Task** - message is a task description, agent executes and sends result
-3. **One-time** - runs once at a specific time, then auto-deletes
+For complex tasks, you will not just call a tool; you will design and write a **Playbook** inside the user's workspace that acts as a strict Standard Operating Procedure (SOP) for the future agent.
 
-## Examples
+## Assessing Task Complexity
 
-Fixed reminder:
-```
-cron(action="add", message="Time to take a break!", every_seconds=1200)
-```
+When a user asks to schedule a task, first assess its complexity:
 
-Dynamic task (agent executes each time):
-```
-cron(action="add", message="Check HKUDS/nanobot GitHub stars and report", every_seconds=600)
-```
+*   **Simple Task:** Needs no memory of the past, uses standard built-in tools (e.g., "Remind me to drink water every 2 hours", "Summarize the latest HackerNews frontpage every morning"). 
+*   **Complex Task:** Requires comparing data against previous runs (state), involves brittle web scraping, requires custom scripts, or needs to handle specific error conditions (e.g., "Check apple.com daily and tell me ONLY if there are new products compared to yesterday").
 
-One-time scheduled task (compute ISO datetime from current time):
-```
-cron(action="add", message="Remind me about the meeting", at="<ISO datetime>")
-```
+If the task is simple, go straight to **Scheduling**. If complex, you must first build a **Task Package**.
 
-Timezone-aware cron:
-```
-cron(action="add", message="Morning standup", cron_expr="0 9 * * 1-5", tz="America/Vancouver")
-```
+## The Anatomy of a Complex Task
 
-List/remove:
-```
-cron(action="list")
-cron(action="remove", job_id="abc123")
+All complex scheduled tasks MUST be stored in the user's workspace under the `.cron/tasks/` directory to keep the root directory clean. 
+
+Organize the task into a dedicated folder:
+
+```text
+<workspace_root>/.cron/tasks/<task_name>/
+├── playbook.md (required)      # The explicit instructions for the future agent
+├── state.json (optional)       # Where the agent should read/write state between runs
+├── scripts/ (optional)         # Custom Python/Bash scripts written by you to ensure stability
+└── output/ (optional)          # Where reports, diffs, or downloaded assets are saved
 ```
 
-## Time Expressions
+*Why this structure?* Future agents running in a cron job lack the context of this current conversation. By grouping the playbook, state, and scripts together, you give the future agent a fully self-contained environment to succeed.
 
-| User says | Parameters |
-|-----------|------------|
-| every 20 minutes | every_seconds: 1200 |
-| every hour | every_seconds: 3600 |
-| every day at 8am | cron_expr: "0 8 * * *" |
-| weekdays at 5pm | cron_expr: "0 17 * * 1-5" |
-| 9am Vancouver time daily | cron_expr: "0 9 * * *", tz: "America/Vancouver" |
-| at a specific time | at: ISO datetime string (compute from current time) |
+## Creating a Complex Task (The Workflow)
 
-## Timezone
+Do not just write a cron command and guess. Follow this sequence:
 
-Use `tz` with `cron_expr` to schedule in a specific IANA timezone. Without `tz`, the server's local timezone is used.
+### 1. Interview and Design
+If the user's request is vague, ask clarifying questions. What constitutes "a change"? Where should the output go? How should failures be handled?
+
+### 2. Write Helper Scripts (If necessary)
+If the task involves a fragile operation (like parsing a complex DOM or authenticating an API), **do not trust the future agent to figure it out on the fly.** Write a python or bash script, place it in `.cron/tasks/<task_name>/scripts/`, and test it now.
+
+### 3. Write the `playbook.md`
+Create the playbook. This is the most important step. Prefer imperative verbs and explain the *why*. Use the following structure:
+
+```markdown
+# [Task Name] Playbook
+
+## Context & Objective
+[Explain what this task does and why it runs. E.g., "This task runs daily to monitor for new product releases. We only want to alert the user if there is a DIFF from the previous day."]
+
+## State Management
+- **State File:** `.cron/tasks/<task_name>/state.json`
+[Explain exactly how to use the state file. E.g., "Read the list of product IDs from state.json. If it doesn't exist, assume it's the first run. After fetching new data, ALWAYS overwrite state.json with the newest product IDs."]
+
+## Execution Sequence
+1. **Fetch Data:** [e.g., "Run `python .cron/tasks/<task_name>/scripts/fetch.py` to get the latest JSON."]
+2. **Compare:** [e.g., "Compare the fetched data against state.json."]
+3. **Act:** [e.g., "If there are new items, format a markdown report and send it to the user. If NO changes are found, you MUST exit silently without messaging the user."]
+
+## Constraints & Error Handling
+- [e.g., "If the website returns 403, do not retry. Just exit silently."]
+- [e.g., "Only use built-in Python libraries like `urllib.request`, do not install `requests`."]
+```
+
+### 4. Schedule the Job
+
+Once the playbook is written (and scripts are tested), schedule it. 
+
+**Crucial: The `message` Parameter format**
+The `message` you pass to the `cron` tool MUST be human-readable so that when the user lists their cron jobs, they know what it is. It MUST contain both a **Summary** and the **Playbook Path**.
+
+**Format:**
+`[Task Summary] - Playbook: <path/to/playbook.md>`
+
+## Tool Usage: `cron`
+
+Use the `cron` tool to interact with the scheduling daemon.
+
+### Parameters
+*   `action`: "add", "list", or "remove"
+*   `name`: (Optional) A short, human-readable name for the job (e.g. "Apple Monitor"). Highly recommended for complex tasks.
+*   `message`: (For "add") The task description or Playbook pointer. **Do not put complex instructions here.**
+*   `every_seconds`: (Optional) Interval in seconds.
+*   `cron_expr`: (Optional) Standard cron expression (e.g., "0 0 * * *").
+*   `at`: (Optional) ISO datetime string for a one-time scheduled task.
+*   `tz`: (Optional) IANA timezone (e.g., "America/Vancouver").
+
+### Examples
+
+**Adding a Simple Task:**
+`cron(action="add", name="Tokyo Weather", message="Fetch weather for Tokyo and summarize", cron_expr="0 8 * * *")`
+
+**Adding a Complex Task:**
+`cron(action="add", name="Apple Product Monitor", message="Playbook: .cron/tasks/apple_monitor/playbook.md", cron_expr="0 0 * * *")`
+
+**Listing Tasks:**
+`cron(action="list")`
+*(When listing tasks, help the user understand the currently scheduled jobs by reading the summaries in the messages.)*


### PR DESCRIPTION
This PR brings two major improvements to the `cron` tool and its associated agent skill, improving the readability of scheduled jobs and establishing a reliable pattern for complex periodic workflows.

### 1. Addition of the `name` Parameter
Previously, the `cron` tool implicitly truncated the first 30 characters of the `message` to use as the job name. This led to fragmented and illegible job titles in `cron(action="list")`.
- We added an explicit, optional `name` parameter to the tool's schema.
- We maintained **100% backward compatibility** by safely falling back to `name or message[:30]` if the `name` parameter is omitted.

### 2. Introduction of the "Playbook" Paradigm for Complex Tasks
The `cron/SKILL.md` has been completely rewritten to elevate how the agent schedules complex, stateful tasks.
- **Problem**: Cramming multi-step logic, state management, and edge-case handling into a single `message` string resulted in hallucination and unreliable execution when the task was triggered in the future.
- **Solution**: The agent is now instructed to structure complex tasks into isolated, self-contained packages under a workspace-level `.cron/tasks/<task_name>/` directory.
- A **Playbook (`playbook.md`)** is generated beforehand, containing deterministic instructions and state file paths, so the triggered agent only needs to follow the playbook.
- The `message` now cleanly points to this playbook (e.g., `Apple Product Monitor - Playbook: .cron/tasks/apple_monitor/playbook.md`).

This drastically improves the stability of complex automated tasks running in the background.