### PR TITLE
fix: clear heartbeat session to prevent token overflow

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -621,6 +621,12 @@ def gateway(
             chat_id=chat_id,
             on_progress=_silent,
         )
+        
+        # Clear the heartbeat session to prevent token overflow from accumulated tasks
+        session = agent.sessions.get_or_create("heartbeat")
+        session.clear()
+        agent.sessions.save(session)
+        
         return resp.content if resp else ""
 
     async def on_heartbeat_notify(response: str) -> None:


### PR DESCRIPTION
Fixes #2375

This PR addresses the issue where the `heartbeat` session accumulates tasks over time, leading to massive token consumption (up to 560k tokens) and eventual context overflow.

Since the heartbeat is a stateless background task that doesn't need to remember its past executions, this PR simply clears the `heartbeat` session immediately after `process_direct` completes. This ensures the session remains clean and token usage stays minimal.

This approach is similar to how `ironclaw` handles routine notifications (nearai/ironclaw#1524), by preventing background tasks from polluting the long-term context.