### PR TITLE
fix(heartbeat): trim session history to prevent unbounded token growth 修剪心跳会话的历史以防止平方指数级的 token增长

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -612,14 +612,10 @@ def gateway(
             on_progress=_silent,
         )
 
-        # Trim heartbeat session to prevent unbounded token growth
-        # Keep only recent messages for minimal context while avoiding history explosion
+        # Use the existing consolidation mechanism to archive old heartbeat messages
+        # This prevents unbounded token growth while preserving context in MEMORY.md/HISTORY.md
         session = agent.sessions.get_or_create("heartbeat")
-        max_heartbeat_messages = 20
-        if len(session.messages) > max_heartbeat_messages:
-            session.messages = session.messages[-max_heartbeat_messages:]
-            session.last_consolidated = 0  # Reset consolidation marker
-            logger.debug("Heartbeat session trimmed to last {} messages to prevent token accumulation", max_heartbeat_messages)
+        await agent.memory_consolidator.maybe_consolidate_by_tokens(session)
 
         return resp.content if resp else ""
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -611,6 +611,16 @@ def gateway(
             chat_id=chat_id,
             on_progress=_silent,
         )
+
+        # Trim heartbeat session to prevent unbounded token growth
+        # Keep only recent messages for minimal context while avoiding history explosion
+        session = agent.sessions.get_or_create("heartbeat")
+        max_heartbeat_messages = 20
+        if len(session.messages) > max_heartbeat_messages:
+            session.messages = session.messages[-max_heartbeat_messages:]
+            session.last_consolidated = 0  # Reset consolidation marker
+            logger.debug("Heartbeat session trimmed to last {} messages to prevent token accumulation", max_heartbeat_messages)
+
         return resp.content if resp else ""
 
     async def on_heartbeat_notify(response: str) -> None:


### PR DESCRIPTION
Fixes #2375

                                                                                                                                                                                                             
  ## Summary                                                                                                                                                                                                  
  Fixes #2375                                                                                                                                                                                                 
                                                                                                                                                                                                              
  Replace the heartbeat session's unbounded token growth with intelligent consolidation using the existing `maybe_consolidate_by_tokens()` mechanism.                                                         
                                                                                                                                                                                                              
  ## Problem                                                                                                                                                                                                  
  The heartbeat service was accumulating session history indefinitely, causing token usage to grow from a few thousand to 560k+ tokens per execution because:                                                 
  - Heartbeat uses a fixed `session_key="heartbeat"` for all executions                                                                                                                                       
  - Each execution appends messages to the session                                                                                                                                                            
  - Without cleanup, the entire history is sent as context to the LLM                                                                                                                                         
  - Over time (e.g., checking email every 30min), this accumulates hundreds of turns                                                                                                                          
                                                                                                                                                                                                              
  ## Solution                                                                                                                                                                                                 
  Use the existing intelligent consolidation mechanism (`maybe_consolidate_by_tokens`) instead of naive truncation:                                                                                           
                                                                                                                                                                                                              
  **Benefits over simple truncation:**                                                                                                                                                                        
  - ✅ **Adaptive threshold**: Dynamically triggered when token usage exceeds 50% of context window (not arbitrary message count)                                                                             
  - ✅ **Preserves context**: Old messages are summarized and archived to MEMORY.md/HISTORY.md via LLM (not discarded)                                                                                        
  - ✅ **Intelligent boundaries**: Archives at user-turn boundaries for coherent conversation flow                                                                                                            
  - ✅ **Incremental processing**: Maintains `last_consolidated` marker to avoid reprocessing                                                                                                                 
  - ✅ **Consistent with codebase**: Uses same mechanism as all other sessions                                                                                                                                
                                                                                                                                                                                                              
  **Previous naive approach would have:**                                                                                                                                                                     
  - ❌ Hard-coded 20 message limit regardless of actual token size                                                                                                                                            
  - ❌ Discarded historical context completely                                                                                                                                                                
  - ❌ Reset consolidation markers, breaking incremental archival                                                                                                                                             
                                                                                                                                                                                                              
  ## Technical Details                                                                                                                                                                                        
  The `maybe_consolidate_by_tokens()` method:                                                                                                                                                                 
  1. Estimates current session token usage                                                                                                                                                                    
  2. Triggers archival when usage exceeds context_window / 2                                                                                                                                                  
  3. Selects safe message boundaries (user turns)                                                                                                                                                             
  4. Summarizes old messages via LLM                                                                                                                                                                          
  5. Writes summaries to persistent memory files                                                                                                                                                              
  6. Updates `last_consolidated` marker                                                                                                                                                                       
                                                                                                                                                                                                              
  ## Impact                                                                                                                                                                                                   
  - Heartbeat session management now consistent with other session types                                                                                                                                      
  - Historical context preserved in structured format                                                                                                                                                         
  - No breaking changes to existing functionality                                                                                                                                                             
  - Only affects the `heartbeat` session, other sessions unaffected                                                                                                                                           
                                                                                                                                                                                                              
摘要
修复 #2375

用智能的 maybe_consolidate_by_tokens() 机制替换心跳会话中无限制的令牌增长问题。

问题
心跳服务会无限累积会话历史，导致每次执行的令牌使用量从几千增长到 56 万以上，原因如下：
心跳服务对所有执行使用给固定的 session_key="heartbeat"
每次执行都会向会话追加消息
由于未进行清理，整个历史记录都会作为上下文发送给大语言模型
随着时间推移（例如每 30 分钟检查一次邮件），累积了数百轮对话
解决方案
使用现有的智能合并机制（maybe_consolidate_by_tokens）替代简单的截断方式：

相比简单截断的优势：

✅ 自适应阈值：当令牌使用量超过上下文窗口的 50% 时动态触发（而非任意设定的消息条数）
✅ 保留上下文：旧消息通过 LLM 总结并归档到 MEMORY.md / HISTORY.md（而非直接丢弃）
✅ 智能边界：在用户对话轮次边界进行归档，保证对话流的连贯性
✅ 增量处理：维护 last_consolidated 标记，避免重复处理
✅ 与代码库一致：使用与其他所有会话相同的机制

之前的简单截断方案会：

❌ 无论实际令牌大小如何，硬编码限制 20 条消息
❌ 完全丢弃历史上下文
❌ 重置合并标记，破坏增量归档

技术细节
maybe_consolidate_by_tokens() 方法：
估算当前会话的令牌使用量
当使用量超过上下文窗口的一半时触发归档
选择安全的消息边界（用户对话轮次）
通过 LLM 总结旧消息
将总结写入持久化记忆文件
更新 last_consolidated 标记

影响
心跳会话管理现在与其他会话类型保持一致
历史上下文以结构化格式保留
无破坏性变更影响现有功能
仅影响 heartbeat 会话，其他会话不受影响
