### PR TITLE
fix(exec): 修复 Windows 上 explorer.exe 返回 exit code 1 的误报问题

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +45,7 @@ class ExecTool(Tool):
 
     _MAX_TIMEOUT = 600
     _MAX_OUTPUT = 10_000
+    _WIN_GUI_COMMANDS = frozenset({"explorer", "explorer.exe"})
 
     @property
     def description(self) -> str:
@@ -122,7 +124,12 @@ class ExecTool(Tool):
                 if stderr_text.strip():
                     output_parts.append(f"STDERR:\n{stderr_text}")
 
-            output_parts.append(f"\nExit code: {process.returncode}")
+            if self._is_win_gui_command(command) and process.returncode == 1:
+                output_parts.append(
+                    "\nExit code: 0 (explorer.exe returns 1 on Windows even on success, normalized to 0)"
+                )
+            else:
+                output_parts.append(f"\nExit code: {process.returncode}")
 
             result = "\n".join(output_parts) if output_parts else "(no output)"
 
@@ -174,6 +181,18 @@ class ExecTool(Tool):
                     return "Error: Command blocked by safety guard (path outside working dir)"
 
         return None
+
+    @staticmethod
+    def _is_win_gui_command(command: str) -> bool:
+        """Detect Windows GUI commands that return non-zero exit codes on success."""
+        if sys.platform != "win32":
+            return False
+        try:
+            token = command.strip().split()[0].strip('"').strip("'")
+            name = Path(token).name.lower()
+            return name in ExecTool._WIN_GUI_COMMANDS
+        except (IndexError, ValueError):
+            return False
 
     @staticmethod
     def _extract_absolute_paths(command: str) -> list[str]:


### PR DESCRIPTION
## Summary

- 修复 Windows 上执行 `explorer <path>` 打开目录时，工具返回 `Exit code: 1` 导致 LLM 误判为执行失败的问题
- `explorer.exe` 在 Windows 上是 GUI Shell 进程，即使成功打开目录也会返回 exit code 1（已知行为），添加检测逻辑将其归一化为 0

## Changes

- 新增 `_WIN_GUI_COMMANDS` 白名单常量，包含 `explorer` / `explorer.exe`
- 新增 `_is_win_gui_command()` 静态方法，检测命令是否为 Windows GUI 命令（含平台守卫）
- 修改 exit code 输出逻辑：当检测到 Windows GUI 命令且 exit code 为 1 时，归一化为 0 并附带说明

## Test plan

- [ ] 在 Windows 上执行 `explorer C:\Users\<user>\Desktop`，确认返回 `Exit code: 0` 及说明文本
- [ ] 在 macOS/Linux 上执行任意命令，确认行为不受影响（`_is_win_gui_command` 直接返回 `False`）
- [ ] 执行非 explorer 命令失败时，确认 exit code 仍正常返回非零值

Made with [Cursor](https://cursor.com)