### PR TITLE
chore: add GitHub Actions workflow to publish Docker image to GHCR

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,48 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically builds and publishes the Docker image to GitHub Container Registry (ghcr.io) on every push to main.

**What it does:**
- Builds the Docker image from the root Dockerfile
- Pushes to `ghcr.io/hkuds/nanobot:latest` (and branch/version tags)
- Only pushes on main branch pushes (not on PRs)

**Why:**
Currently there is no published Docker image for nanobot. Users must clone the repo and run `docker build` locally. This workflow enables users to pull a pre-built image directly:
```
docker pull ghcr.io/hkuds/nanobot:latest
```

Tested successfully on our fork — build passes and image is published.