### PR TITLE
feat(agent/tools): optimize read_file with streaming I/O and bounded output

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -101,44 +101,112 @@ class ReadFileTool(_FsTool):
             if not fp.is_file():
                 return f"Error: Not a file: {path}"
 
-            raw = fp.read_bytes()
-            if not raw:
+            # fast empty check
+            try:
+                if fp.stat().st_size == 0:
+                    return f"(Empty file: {path})"
+            except OSError:
+                pass
+
+            # Detect MIME from magic bytes without loading the whole file.
+            # We intentionally read only 12 bytes here because `detect_image_mime()` currently
+            # checks at most these ranges:
+            # - PNG:   data[:8]
+            # - JPEG:  data[:3]
+            # - GIF:   data[:6]
+            # - WEBP:  data[:4] and data[8:12]  -> requires 12 bytes total
+            # If `detect_image_mime()` starts supporting formats that require a longer header,
+            # update this read size accordingly.
+            try:
+                with fp.open("rb") as f:
+                    head = f.read(12)
+            except OSError as e:
+                return f"Error reading file: {e}"
+
+            if not head:
                 return f"(Empty file: {path})"
 
-            mime = detect_image_mime(raw) or mimetypes.guess_type(path)[0]
+            mime = detect_image_mime(head) or mimetypes.guess_type(path)[0]
             if mime and mime.startswith("image/"):
+                raw = fp.read_bytes()
                 return build_image_content_blocks(raw, mime, str(fp), f"(Image file: {path})")
 
-            try:
-                text_content = raw.decode("utf-8")
-            except UnicodeDecodeError:
-                return f"Error: Cannot read binary file {path} (MIME: {mime or 'unknown'}). Only UTF-8 text and images are supported."
-
-            all_lines = text_content.splitlines()
-            total = len(all_lines)
-
+            # normalize params
             if offset < 1:
                 offset = 1
+            per_page = limit or self._DEFAULT_LIMIT
+
+            selected: list[str] = []
+            selected_chars = 0
+            max_chars = self._MAX_CHARS
+            exceeded_budget = False
+
+            total = 0
+
+            try:
+                with fp.open("r", encoding="utf-8", errors="replace", newline=None) as f:
+                    for lineno, line in enumerate(f, start=1):
+                        total = lineno
+
+                        if lineno < offset:
+                            continue
+
+                        if len(selected) >= per_page or exceeded_budget:
+                            # still scan to compute total
+                            continue
+
+                        text = line.rstrip("\n").rstrip("\r")
+                        numbered = f"{lineno}| {text}"
+
+                        # account for newline join
+                        projected = selected_chars + len(numbered)
+                        if selected:
+                            projected += 1  # '\n'
+
+                        if projected > max_chars:
+                            if not selected:
+                                # ensure at least one line returned
+                                prefix = f"{lineno}| "
+                                available = max_chars - len(prefix)
+
+                                if available <= 0:
+                                    truncated = ""
+                                else:
+                                    if len(text) > available:
+                                        keep = max(0, available - 1)
+                                        truncated = text[:keep] + "…"
+                                    else:
+                                        truncated = text
+
+                                numbered = prefix + truncated
+                                selected.append(numbered)
+                                selected_chars = len(numbered)
+                            exceeded_budget = True
+                            continue
+
+                        selected.append(numbered)
+                        selected_chars = projected
+
+            except OSError as e:
+                return f"Error reading file: {e}"
+
+            if total == 0:
+                return f"(Empty file: {path})"
+
             if offset > total:
                 return f"Error: offset {offset} is beyond end of file ({total} lines)"
 
-            start = offset - 1
-            end = min(start + (limit or self._DEFAULT_LIMIT), total)
-            numbered = [f"{start + i + 1}| {line}" for i, line in enumerate(all_lines[start:end])]
-            result = "\n".join(numbered)
+            if not selected:
+                return f"(No content within budget: {path})"
 
-            if len(result) > self._MAX_CHARS:
-                trimmed, chars = [], 0
-                for line in numbered:
-                    chars += len(line) + 1
-                    if chars > self._MAX_CHARS:
-                        break
-                    trimmed.append(line)
-                end = start + len(trimmed)
-                result = "\n".join(trimmed)
+            result = "\n".join(selected)
+            end = int(selected[-1].split("|", 1)[0])
 
             if end < total:
-                result += f"\n\n(Showing lines {offset}-{end} of {total}. Use offset={end + 1} to continue.)"
+                result += (
+                    f"\n\n(Showing lines {offset}-{end} of {total}. "
+                    f"Use offset={end + 1} to continue.)"
+                )
             else:
                 result += f"\n\n(End of file — {total} lines total)"
             return result

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -187,6 +187,8 @@ class ReadFileTool(_FsTool):
                         selected.append(numbered)
                         selected_chars = projected
 
+            except UnicodeDecodeError as e:
+                return f"Error: Cannot read binary file {path} (MIME: {mime or 'unknown'}). Only UTF-8 text and images are supported."
             except OSError as e:
                 return f"Error reading file: {e}"
 
@@ -197,7 +199,7 @@ class ReadFileTool(_FsTool):
                 return f"Error: offset {offset} is beyond end of file ({total} lines)"
 
             if not selected:
-                return f"(No content within budget: {path})"
+                return f"(No content within budget. file:{path} has {total} lines. Try smaller offset or larger budget.)"
 
             result = "\n".join(selected)
             end = int(selected[-1].split("|", 1)[0])

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -144,7 +144,7 @@ class ReadFileTool(_FsTool):
             total = 0
 
             try:
-                with fp.open("r", encoding="utf-8", errors="replace", newline=None) as f:
+                with fp.open("r", encoding="utf-8", newline=None) as f:
                     for lineno, line in enumerate(f, start=1):
                         total = lineno
 

--- a/tests/test_filesystem_tools.py
+++ b/tests/test_filesystem_tools.py
@@ -87,6 +87,21 @@ class TestReadFileTool:
         assert len(result) <= ReadFileTool._MAX_CHARS + 500  # small margin for footer
         assert "Use offset=" in result
 
+    @pytest.mark.asyncio
+    async def test_text_file_does_not_read_all_bytes(self, tool, tmp_path, monkeypatch):
+        """Guard against OOM: text reads should stream instead of Path.read_bytes()."""
+        f = tmp_path / "huge.txt"
+        f.write_text("\n".join(f"line {i}" for i in range(1, 1000)), encoding="utf-8")
+
+        def _boom(self):  # noqa: ANN001
+            raise AssertionError("read_bytes() should not be called for text files")
+
+        monkeypatch.setattr(type(f), "read_bytes", _boom, raising=True)
+        result = await tool.execute(path=str(f), offset=10, limit=5)
+
+        for i in range(10, 15):
+            assert f"{i}| line {i}" in result
+
 
 # ---------------------------------------------------------------------------
 # _find_match  (unit tests for the helper)

--- a/tests/test_filesystem_tools.py
+++ b/tests/test_filesystem_tools.py
@@ -93,7 +93,7 @@ class TestReadFileTool:
         f = tmp_path / "huge.txt"
         f.write_text("\n".join(f"line {i}" for i in range(1, 1000)), encoding="utf-8")
 
-        def _boom(self):  # noqa: ANN001
+        def _boom(self):
             raise AssertionError("read_bytes() should not be called for text files")
 
         monkeypatch.setattr(type(f), "read_bytes", _boom, raising=True)

--- a/tests/test_filesystem_tools.py
+++ b/tests/test_filesystem_tools.py
@@ -102,6 +102,14 @@ class TestReadFileTool:
         for i in range(10, 15):
             assert f"{i}| line {i}" in result
 
+    @pytest.mark.asyncio
+    async def test_non_utf8_text_returns_clear_error(self, tool, tmp_path):
+        f = tmp_path / "gbk.txt"
+        f.write_bytes("你好\n".encode("gbk"))
+        result = await tool.execute(path=str(f))
+        assert "Error" in result
+        assert "UTF-8" in result
+
 
 # ---------------------------------------------------------------------------
 # _find_match  (unit tests for the helper)


### PR DESCRIPTION
## Background

The current `read_file` implementation reads the entire file into memory, decodes it, splits into lines, and then slices the result. This approach has a few issues:

- Memory usage is O(file_size), which is unsafe for large files may trigger OOM
- Even small reads (e.g. first 100 lines) still process the whole file

---

## Changes

This PR rewrites `read_file` to use a streaming approach:

- Read the file line-by-line instead of loading everything into memory
- Apply `offset` / `limit` during iteration
- Enforce `_MAX_CHARS` while building the output (bounded output)
- Ensure at least one line is returned with safe truncation if needed

---

## Result

- Memory usage reduced to O(limit)
- Output size is always controlled and well-formed
- Behavior and output format remain unchanged (including total line count)