### PR TITLE
fix(slack): process inbound file_share messages and forward attachments to the agent

### DIFF
--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -1,9 +1,11 @@
 """Slack channel implementation using Socket Mode."""
 
 import asyncio
+import mimetypes
 import re
 from typing import Any
 
+import httpx
 from loguru import logger
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
@@ -13,6 +15,7 @@ from slackify_markdown import slackify_markdown
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.config.paths import get_media_dir
 from pydantic import Field
 
 from nanobot.channels.base import BaseChannel
@@ -63,6 +66,7 @@ class SlackChannel(BaseChannel):
         self._web_client: AsyncWebClient | None = None
         self._socket_client: SocketModeClient | None = None
         self._bot_user_id: str | None = None
+        self._http: httpx.AsyncClient | None = None
 
     async def start(self) -> None:
         """Start the Slack Socket Mode client."""
@@ -76,6 +80,7 @@ class SlackChannel(BaseChannel):
         self._running = True
 
         self._web_client = AsyncWebClient(token=self.config.bot_token)
+        self._http = httpx.AsyncClient(timeout=30.0)
         self._socket_client = SocketModeClient(
             app_token=self.config.app_token,
             web_client=self._web_client,
@@ -106,6 +111,9 @@ class SlackChannel(BaseChannel):
             except Exception as e:
                 logger.warning("Slack socket close failed: {}", e)
             self._socket_client = None
+        if self._http:
+            await self._http.aclose()
+            self._http = None
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Slack."""
@@ -171,8 +179,10 @@ class SlackChannel(BaseChannel):
         sender_id = event.get("user")
         chat_id = event.get("channel")
 
-        # Ignore bot/system messages (any subtype = not a normal user message)
-        if event.get("subtype"):
+        subtype = event.get("subtype")
+
+        # Ignore bot/system messages except user-shared files.
+        if subtype and subtype != "file_share":
             return
         if self._bot_user_id and sender_id == self._bot_user_id:
             return
@@ -205,6 +215,13 @@ class SlackChannel(BaseChannel):
             return
 
         text = self._strip_bot_mention(text)
+        content_parts = [text] if text else []
+        media_paths: list[str] = []
+
+        if subtype == "file_share":
+            downloaded, tags = await self._download_inbound_files(event)
+            media_paths.extend(downloaded)
+            content_parts.extend(tags)
 
         thread_ts = event.get("thread_ts")
         if self.config.reply_in_thread and not thread_ts:
@@ -227,7 +244,8 @@ class SlackChannel(BaseChannel):
             await self._handle_message(
                 sender_id=sender_id,
                 chat_id=chat_id,
-                content=text,
+                content="\n".join(p for p in content_parts if p) or "[empty message]",
+                media=media_paths,
                 metadata={
                     "slack": {
                         "event": event,
@@ -239,6 +257,45 @@ class SlackChannel(BaseChannel):
             )
         except Exception:
             logger.exception("Error handling Slack message from {}", sender_id)
+
+    async def _download_inbound_files(self, event: dict[str, Any]) -> tuple[list[str], list[str]]:
+        """Download files from a Slack file_share event and return (paths, content_tags)."""
+        if not self._http:
+            return [], ["[attachment: download client unavailable]"]
+
+        media_dir = get_media_dir("slack")
+        media_dir.mkdir(parents=True, exist_ok=True)
+
+        media_paths: list[str] = []
+        content_tags: list[str] = []
+
+        for idx, f in enumerate(event.get("files") or []):
+            file_url = f.get("url_private_download") or f.get("url_private")
+            if not file_url:
+                continue
+
+            filename = (f.get("name") or f"slack_file_{idx}").replace("/", "_")
+            file_id = f.get("id") or f"f{idx}"
+            file_path = media_dir / f"{file_id}_{filename}"
+
+            try:
+                resp = await self._http.get(
+                    file_url,
+                    headers={"Authorization": f"Bearer {self.config.bot_token}"},
+                    follow_redirects=True,
+                )
+                resp.raise_for_status()
+                file_path.write_bytes(resp.content)
+                media_paths.append(str(file_path))
+
+                mime = (f.get("mimetype") or mimetypes.guess_type(filename)[0] or "").lower()
+                media_type = "image" if mime.startswith("image/") else "audio" if mime.startswith("audio/") else "file"
+                content_tags.append(f"[{media_type}: {file_path}]")
+            except Exception as e:
+                logger.warning("Failed to download Slack attachment {}: {}", filename, e)
+                content_tags.append(f"[attachment: {filename} - download failed]")
+
+        return media_paths, content_tags
 
     async def _update_react_emoji(self, chat_id: str, ts: str | None) -> None:
         """Remove the in-progress reaction and optionally add a done reaction."""


### PR DESCRIPTION
## Summary
This PR fixes Slack inbound media handling by processing `message` events with subtype `file_share` and forwarding downloaded attachments to the agent.

## Problem
Slack uploads (PDF/image/audio) were ignored because the Slack channel handler returned early for any event with `subtype`, and never passed inbound files to `_handle_message(..., media=...)`.

## Changes
- Accept `file_share` subtype instead of dropping all subtype events.
- Download inbound Slack files using bot-authenticated requests (`url_private_download` / `url_private`).
- Store downloaded files under NanoBot runtime media directory (`media/slack`).
- Pass downloaded paths to `_handle_message(..., media=...)`.
- Append attachment context tags to content (`[image: ...]`, `[audio: ...]`, `[file: ...]`).
- Keep existing outbound Slack file upload behavior unchanged.

## Notes
- This requires Slack bot scope `files:read` for downloading private files.
- `reactions:write` is still optional but recommended to avoid reaction warning logs.

## Validation
- Rebuilt and restarted gateway with patched code.
- Confirmed patched Slack handler is present in running container.
- Text flow remains unchanged; file uploads are now ingested instead of ignored.
