### PR TITLE
fix: make heartbeat runs ephemeral

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -515,6 +515,7 @@ class AgentLoop:
         on_progress: Callable[[str], Awaitable[None]] | None = None,
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
+        ephemeral_session: bool = False,
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
         # System messages: parse origin from chat_id ("channel:chat_id")
@@ -544,11 +545,17 @@ class AgentLoop:
         logger.info("Processing message from {}:{}: {}", msg.channel, msg.sender_id, preview)
 
         key = session_key or msg.session_key
-        session = self.sessions.get_or_create(key)
+        session: Session | None = None
+
+        if not ephemeral_session:
+            session = self.sessions.get_or_create(key)
 
         # Slash commands
         cmd = msg.content.strip().lower()
         if cmd == "/new":
+            if session is None:
+                return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
+                                      content="New session started.")
             snapshot = session.messages[session.last_consolidated:]
             session.clear()
             self.sessions.save(session)
@@ -560,6 +567,8 @@ class AgentLoop:
             return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id,
                                   content="New session started.")
         if cmd == "/status":
+            if session is None:
+                session = self.sessions.get_or_create(key)
             return self._status_response(msg, session)
         if cmd == "/help":
             lines = [
@@ -576,14 +585,16 @@ class AgentLoop:
                 content="\n".join(lines),
                 metadata={"render_as": "text"},
             )
-        await self.memory_consolidator.maybe_consolidate_by_tokens(session)
+
+        if session is not None:
+            await self.memory_consolidator.maybe_consolidate_by_tokens(session)
 
         self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()
 
-        history = session.get_history(max_messages=0)
+        history = session.get_history(max_messages=0) if session is not None else []
         initial_messages = self.context.build_messages(
             history=history,
             current_message=msg.content,
@@ -609,9 +620,10 @@ class AgentLoop:
         if final_content is None:
             final_content = "I've completed processing but have no response to give."
 
-        self._save_turn(session, all_msgs, 1 + len(history))
-        self.sessions.save(session)
-        self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
+        if session is not None:
+            self._save_turn(session, all_msgs, 1 + len(history))
+            self.sessions.save(session)
+            self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
 
         if (mt := self.tools.get("message")) and isinstance(mt, MessageTool) and mt._sent_in_turn:
             return None
@@ -715,11 +727,20 @@ class AgentLoop:
         on_progress: Callable[[str], Awaitable[None]] | None = None,
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
+        ephemeral_session: bool = False,
     ) -> OutboundMessage | None:
-        """Process a message directly and return the outbound payload."""
+        """Process a message directly and return the outbound payload.
+
+        When ``ephemeral_session`` is True, no session history is loaded or persisted.
+        """
         await self._connect_mcp()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
-        return await self._process_message(
-            msg, session_key=session_key, on_progress=on_progress,
-            on_stream=on_stream, on_stream_end=on_stream_end,
-        )
+        async with self._processing_lock:
+            return await self._process_message(
+                msg,
+                session_key=session_key,
+                on_progress=on_progress,
+                on_stream=on_stream,
+                on_stream_end=on_stream_end,
+                ephemeral_session=ephemeral_session,
+            )

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -620,6 +620,7 @@ def gateway(
             channel=channel,
             chat_id=chat_id,
             on_progress=_silent,
+            ephemeral_session=True,
         )
         
         # Clear the heartbeat session to prevent token overflow from accumulated tasks

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -69,6 +69,7 @@ class HeartbeatService:
         self.enabled = enabled
         self._running = False
         self._task: asyncio.Task | None = None
+        self._execute_lock = asyncio.Lock()
 
     @property
     def heartbeat_file(self) -> Path:
@@ -144,42 +145,44 @@ class HeartbeatService:
         """Execute a single heartbeat tick."""
         from nanobot.utils.evaluator import evaluate_response
 
-        content = self._read_heartbeat_file()
-        if not content:
-            logger.debug("Heartbeat: HEARTBEAT.md missing or empty")
-            return
-
-        logger.info("Heartbeat: checking for tasks...")
-
-        try:
-            action, tasks = await self._decide(content)
-
-            if action != "run":
-                logger.info("Heartbeat: OK (nothing to report)")
+        async with self._execute_lock:
+            content = self._read_heartbeat_file()
+            if not content:
+                logger.debug("Heartbeat: HEARTBEAT.md missing or empty")
                 return
 
-            logger.info("Heartbeat: tasks found, executing...")
-            if self.on_execute:
-                response = await self.on_execute(tasks)
+            logger.info("Heartbeat: checking for tasks...")
 
-                if response:
-                    should_notify = await evaluate_response(
-                        response, tasks, self.provider, self.model,
-                    )
-                    if should_notify and self.on_notify:
-                        logger.info("Heartbeat: completed, delivering response")
-                        await self.on_notify(response)
-                    else:
-                        logger.info("Heartbeat: silenced by post-run evaluation")
-        except Exception:
-            logger.exception("Heartbeat execution failed")
+            try:
+                action, tasks = await self._decide(content)
+
+                if action != "run":
+                    logger.info("Heartbeat: OK (nothing to report)")
+                    return
+
+                logger.info("Heartbeat: tasks found, executing...")
+                if self.on_execute:
+                    response = await self.on_execute(tasks)
+
+                    if response:
+                        should_notify = await evaluate_response(
+                            response, tasks, self.provider, self.model,
+                        )
+                        if should_notify and self.on_notify:
+                            logger.info("Heartbeat: completed, delivering response")
+                            await self.on_notify(response)
+                        else:
+                            logger.info("Heartbeat: silenced by post-run evaluation")
+            except Exception:
+                logger.exception("Heartbeat execution failed")
 
     async def trigger_now(self) -> str | None:
         """Manually trigger a heartbeat."""
-        content = self._read_heartbeat_file()
-        if not content:
-            return None
-        action, tasks = await self._decide(content)
-        if action != "run" or not self.on_execute:
-            return None
-        return await self.on_execute(tasks)
+        async with self._execute_lock:
+            content = self._read_heartbeat_file()
+            if not content:
+                return None
+            action, tasks = await self._decide(content)
+            if action != "run" or not self.on_execute:
+                return None
+            return await self.on_execute(tasks)

--- a/tests/test_heartbeat_service.py
+++ b/tests/test_heartbeat_service.py
@@ -287,3 +287,37 @@ async def test_decide_prompt_includes_current_time(tmp_path) -> None:
     assert user_msg["role"] == "user"
     assert "Current Time:" in user_msg["content"]
 
+
+@pytest.mark.asyncio
+async def test_tick_and_trigger_now_do_not_overlap_execution(tmp_path, monkeypatch) -> None:
+    (tmp_path / "HEARTBEAT.md").write_text("- [ ] do thing", encoding="utf-8")
+
+    active = 0
+    peak_active = 0
+    calls = 0
+
+    async def _on_execute(_tasks: str) -> str:
+        nonlocal active, peak_active, calls
+        calls += 1
+        active += 1
+        peak_active = max(peak_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return ""
+
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=DummyProvider([]),
+        model="openai/gpt-4o-mini",
+        on_execute=_on_execute,
+    )
+
+    async def _always_run(_content: str) -> tuple[str, str]:
+        return "run", "check open tasks"
+
+    monkeypatch.setattr(service, "_decide", _always_run)
+
+    await asyncio.gather(service._tick(), service.trigger_now())
+
+    assert calls == 2
+    assert peak_active == 1

--- a/tests/test_loop_consolidation_tokens.py
+++ b/tests/test_loop_consolidation_tokens.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -194,3 +195,37 @@ async def test_preflight_consolidation_before_llm_call(tmp_path, monkeypatch) ->
     assert "consolidate" in order
     assert "llm" in order
     assert order.index("consolidate") < order.index("llm")
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_direct_run_does_not_persist_session_or_consolidate(tmp_path) -> None:
+    loop = _make_loop(tmp_path, estimated_tokens=1000, context_window_tokens=200)
+    loop.memory_consolidator.maybe_consolidate_by_tokens = AsyncMock()  # type: ignore[method-assign]
+
+    await loop.process_direct("heartbeat run", session_key="heartbeat", ephemeral_session=True)
+
+    assert not loop.sessions._get_session_path("heartbeat").exists()
+    session = loop.sessions.get_or_create("heartbeat")
+    assert session.messages == []
+    loop.memory_consolidator.maybe_consolidate_by_tokens.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_direct_run_ignores_existing_session_history(tmp_path) -> None:
+    loop = _make_loop(tmp_path, estimated_tokens=100, context_window_tokens=200)
+    sentinel = "EPHEMERAL_SENTINEL_9aa0f4c4"
+
+    session = loop.sessions.get_or_create("heartbeat")
+    session.messages = [
+        {"role": "user", "content": sentinel, "timestamp": "2026-01-01T00:00:00"},
+        {"role": "assistant", "content": "old", "timestamp": "2026-01-01T00:00:01"},
+    ]
+    loop.sessions.save(session)
+
+    await loop.process_direct("new heartbeat tick", session_key="heartbeat", ephemeral_session=True)
+
+    sent_messages = loop.provider.chat_with_retry.await_args.kwargs["messages"]
+    assert sentinel not in json.dumps(sent_messages, ensure_ascii=False)
+
+    reloaded = loop.sessions.get_or_create("heartbeat")
+    assert [m["content"] for m in reloaded.messages] == [sentinel, "old"]


### PR DESCRIPTION
Fixes #2375

This PR keeps heartbeat stateless across runs without removing the temporary conversation state it needs during a single execution.

The current nightly fix clears the `heartbeat` session after `process_direct()` returns. That stops the token growth, but heartbeat still loads and persists a real session before clearing it. This change moves the behavior into `AgentLoop` instead: heartbeat direct runs now use an ephemeral session path that keeps per-run tool-call context in memory, but skips loading prior history, skips persisting the turn, and skips session consolidation.

I also serialize heartbeat execution so `_tick()` and `trigger_now()` cannot overlap, which avoids two heartbeat runs stepping on each other.

This keeps the intended architecture from the issue discussion: heartbeat remains a stateless background check, and any durable state should live in memory files or explicit task stores rather than `heartbeat.jsonl`.

Tests cover the new ephemeral direct-run behavior and the heartbeat execution lock.