### PR TITLE
feat: support custom API key and base URL for OpenAI Codex provider

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -407,7 +407,11 @@ def _make_provider(config: Config):
     # --- instantiation by backend ---
     if backend == "openai_codex":
         from nanobot.providers.openai_codex_provider import OpenAICodexProvider
-        provider = OpenAICodexProvider(default_model=model)
+        provider = OpenAICodexProvider(
+            default_model=model,
+            api_key=p.api_key if p and p.api_key else None,
+            api_base=p.api_base if p and p.api_base else None,
+        )
     elif backend == "azure_openai":
         from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
         provider = AzureOpenAIProvider(
@@ -438,6 +442,7 @@ def _make_provider(config: Config):
         temperature=defaults.temperature,
         max_tokens=defaults.max_tokens,
         reasoning_effort=defaults.reasoning_effort,
+        service_tier=defaults.service_tier,
     )
     return provider
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -40,6 +40,7 @@ class AgentDefaults(Base):
     temperature: float = 0.1
     max_tool_iterations: int = 40
     reasoning_effort: str | None = None  # low / medium / high - enables LLM thinking mode
+    service_tier: str | None = None  # OpenAI service tier: "auto", "default", "fast"
 
 
 class AgentsConfig(Base):

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -68,6 +68,7 @@ class GenerationSettings:
     temperature: float = 0.7
     max_tokens: int = 4096
     reasoning_effort: str | None = None
+    service_tier: str | None = None
 
 
 class LLMProvider(ABC):

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -19,11 +19,23 @@ DEFAULT_ORIGINATOR = "nanobot"
 
 
 class OpenAICodexProvider(LLMProvider):
-    """Use Codex OAuth to call the Responses API."""
+    """Use Codex OAuth to call the Responses API.
 
-    def __init__(self, default_model: str = "openai-codex/gpt-5.1-codex"):
-        super().__init__(api_key=None, api_base=None)
+    Supports two modes:
+    1. Default OAuth mode: uses OpenAI Codex OAuth token with chatgpt.com.
+    2. Custom API mode: uses api_key + api_base to connect to any
+       Responses-API-compatible endpoint (e.g. gmncode.cn).
+    """
+
+    def __init__(
+        self,
+        default_model: str = "openai-codex/gpt-5.1-codex",
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ):
+        super().__init__(api_key=api_key, api_base=api_base)
         self.default_model = default_model
+        self._custom_url = f"{api_base.rstrip('/')}/v1/responses" if api_base else None
 
     async def _call_codex(
         self,
@@ -38,8 +50,13 @@ class OpenAICodexProvider(LLMProvider):
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)
 
-        token = await asyncio.to_thread(get_codex_token)
-        headers = _build_headers(token.account_id, token.access)
+        if self.api_key:
+            headers = _build_apikey_headers(self.api_key)
+            url = self._custom_url or DEFAULT_CODEX_URL
+        else:
+            token = await asyncio.to_thread(get_codex_token)
+            headers = _build_headers(token.account_id, token.access)
+            url = self._custom_url or DEFAULT_CODEX_URL
 
         body: dict[str, Any] = {
             "model": _strip_model_prefix(model),
@@ -61,7 +78,7 @@ class OpenAICodexProvider(LLMProvider):
         try:
             try:
                 content, tool_calls, finish_reason = await _request_codex(
-                    DEFAULT_CODEX_URL, headers, body, verify=True,
+                    url, headers, body, verify=True,
                     on_content_delta=on_content_delta,
                 )
             except Exception as e:
@@ -69,7 +86,7 @@ class OpenAICodexProvider(LLMProvider):
                     raise
                 logger.warning("SSL verification failed for Codex API; retrying with verify=False")
                 content, tool_calls, finish_reason = await _request_codex(
-                    DEFAULT_CODEX_URL, headers, body, verify=False,
+                    url, headers, body, verify=False,
                     on_content_delta=on_content_delta,
                 )
             return LLMResponse(content=content, tool_calls=tool_calls, finish_reason=finish_reason)
@@ -109,6 +126,16 @@ def _build_headers(account_id: str, token: str) -> dict[str, str]:
         "chatgpt-account-id": account_id,
         "OpenAI-Beta": "responses=experimental",
         "originator": DEFAULT_ORIGINATOR,
+        "User-Agent": "nanobot (python)",
+        "accept": "text/event-stream",
+        "content-type": "application/json",
+    }
+
+
+def _build_apikey_headers(api_key: str) -> dict[str, str]:
+    """Build headers for API-key-based Responses API endpoints (e.g. gmncode.cn)."""
+    return {
+        "Authorization": f"Bearer {api_key}",
         "User-Agent": "nanobot (python)",
         "accept": "text/event-stream",
         "content-type": "application/json",

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -45,6 +45,7 @@ class OpenAICodexProvider(LLMProvider):
         reasoning_effort: str | None,
         tool_choice: str | dict[str, Any] | None,
         on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        service_tier: str | None = None,
     ) -> LLMResponse:
         """Shared request logic for both chat() and chat_stream()."""
         model = model or self.default_model
@@ -72,6 +73,8 @@ class OpenAICodexProvider(LLMProvider):
         }
         if reasoning_effort:
             body["reasoning"] = {"effort": reasoning_effort}
+        if service_tier:
+            body["service_tier"] = service_tier
         if tools:
             body["tools"] = _convert_tools(tools)
 
@@ -99,7 +102,8 @@ class OpenAICodexProvider(LLMProvider):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
     ) -> LLMResponse:
-        return await self._call_codex(messages, tools, model, reasoning_effort, tool_choice)
+        return await self._call_codex(messages, tools, model, reasoning_effort, tool_choice,
+                                      service_tier=self.generation.service_tier)
 
     async def chat_stream(
         self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
@@ -108,7 +112,8 @@ class OpenAICodexProvider(LLMProvider):
         tool_choice: str | dict[str, Any] | None = None,
         on_content_delta: Callable[[str], Awaitable[None]] | None = None,
     ) -> LLMResponse:
-        return await self._call_codex(messages, tools, model, reasoning_effort, tool_choice, on_content_delta)
+        return await self._call_codex(messages, tools, model, reasoning_effort, tool_choice, on_content_delta,
+                                      service_tier=self.generation.service_tier)
 
     def get_default_model(self) -> str:
         return self.default_model


### PR DESCRIPTION
## Summary

Allow OpenAICodexProvider to use a custom API key and base URL instead of OAuth, enabling compatibility with any Responses-API-compatible endpoint.

## Changes

- openai_codex_provider.py: Add api_key and api_base parameters; use Bearer token auth when api_key is provided; route requests to custom URL when api_base is set.
- commands.py: Pass api_key / api_base from config to OpenAICodexProvider; fix find_by_name crash when provider_name is None.

## Configuration

When apiKey is set, OAuth is bypassed. When apiBase is set, requests go to {apiBase}/v1/responses.