### PR TITLE
feat(mcp): handle ImageContent in MCP tool responses

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -1,6 +1,9 @@
 """MCP client: connects to MCP servers and wraps their tools as native nanobot tools."""
 
 import asyncio
+import base64
+import os
+import tempfile
 from contextlib import AsyncExitStack
 from typing import Any
 
@@ -130,6 +133,13 @@ class MCPToolWrapper(Tool):
         for block in result.content:
             if isinstance(block, types.TextContent):
                 parts.append(block.text)
+            elif isinstance(block, types.ImageContent):
+                ext = (block.mimeType or "image/png").split("/")[-1]
+                fd, path = tempfile.mkstemp(suffix=f".{ext}", prefix="mcp_img_")
+                os.write(fd, base64.b64decode(block.data))
+                os.close(fd)
+                parts.append(path)
+                logger.debug("MCP tool '{}': saved image to {}", self._name, path)
             else:
                 parts.append(str(block))
         return "\n".join(parts) or "(no output)"


### PR DESCRIPTION
## Summary

- MCP tools can return `ImageContent` blocks (e.g., charts/graphs generated via FastMCP's `Image` helper), but `MCPToolWrapper.execute()` currently falls through to `str(block)`, producing a raw Pydantic model string with base64 data — unusable and token-wasteful.
- This change detects `ImageContent` blocks, decodes the base64 data, saves to a temp file, and returns the file path as text.
- The LLM can then pass the file path to the built-in `message` tool's `media` parameter to send images to channels (e.g., Telegram `send_photo`).

## Changes

- `nanobot/agent/tools/mcp.py`: Added `ImageContent` handling in the `execute()` result processing loop (+10 lines)

## How it works

```
MCP tool returns ImageContent(data=base64, mimeType="image/png")
  → MCPToolWrapper decodes base64, saves to /tmp/mcp_img_xxx.png
  → Returns file path as text to LLM
  → LLM calls message(content="Here's your chart", media=["/tmp/mcp_img_xxx.png"])
  → Channel sends photo to user
```

## Test plan

- [ ] MCP tool returning `ImageContent` via FastMCP's `Image(path=...)` helper
- [ ] Verify temp file is created with correct image data
- [ ] Verify LLM receives file path and can pass it to `message` tool
- [ ] Verify Telegram channel sends photo via `send_photo`
- [ ] Verify `TextContent` handling is unchanged
- [ ] Verify mixed content (text + image) returns both parts

🤖 Generated with [Claude Code](https://claude.com/claude-code)