### PR TITLE
Unintended Discord behaviour with Threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ If you prefer to configure manually, add the following to `~/.nanobot/config.jso
 > - `"mention"` (default) — Only respond when @mentioned
 > - `"open"` — Respond to all messages
 > DMs always respond when the sender is in `allowFrom`.
-> - If you set group policy to open create new threads as private threads and then @ the bot into it. Otherwise bot the thread itself and the channel will spawn a bot session
+> - If you set group policy to open create new threads as private threads and then @ the bot into it. Otherwise the thread itself and the channel in which you spawned it will spawn a bot session.
 
 **5. Invite the bot**
 - OAuth2 → URL Generator


### PR DESCRIPTION
I noticed my bot always replied to me in the thread and in the channel i created the thread in when group policy was open.
It annoyed me quite a bit until i thought about it for a moment and figured out that creating the threads private fixes that.
I tried it, it works, and adding it as a comment to the discord setup guide might help others.
Voila, my first pr :)