### PR TITLE
fix(providers): stable prompt_cache_key for openai_codex provider

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -242,12 +242,14 @@ class AgentLoop:
                     tools=tool_defs,
                     model=self.model,
                     on_content_delta=_filtered_stream,
+                    prompt_cache_key=f"{channel}:{chat_id}",
                 )
             else:
                 response = await self.provider.chat_with_retry(
                     messages=messages,
                     tools=tool_defs,
                     model=self.model,
+                    prompt_cache_key=f"{channel}:{chat_id}",
                 )
 
             usage = response.usage or {}

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -401,6 +401,7 @@ class AnthropicProvider(LLMProvider):
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         kwargs = self._build_kwargs(
             messages, tools, model, max_tokens, temperature,
@@ -422,6 +423,7 @@ class AnthropicProvider(LLMProvider):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         kwargs = self._build_kwargs(
             messages, tools, model, max_tokens, temperature,

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -122,6 +122,7 @@ class AzureOpenAIProvider(LLMProvider):
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request to Azure OpenAI.
@@ -133,6 +134,7 @@ class AzureOpenAIProvider(LLMProvider):
             max_tokens: Maximum tokens in response (mapped to max_completion_tokens).
             temperature: Sampling temperature.
             reasoning_effort: Optional reasoning effort parameter.
+            prompt_cache_key: Optional stable key for prompt caching.
 
         Returns:
             LLMResponse with content and/or tool calls.
@@ -220,6 +222,7 @@ class AzureOpenAIProvider(LLMProvider):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         """Stream a chat completion via Azure OpenAI SSE."""
         deployment_name = model or self.default_model

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -171,6 +171,7 @@ class LLMProvider(ABC):
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         """
         Send a chat completion request.
@@ -182,8 +183,9 @@ class LLMProvider(ABC):
             max_tokens: Maximum tokens in response.
             temperature: Sampling temperature.
             tool_choice: Tool selection strategy ("auto", "required", or specific tool dict).
+            prompt_cache_key: Optional stable key for prompt caching (e.g. session identifier).
         
-        Returns:
+            Returns:
             LLMResponse with content and/or tool calls.
         """
         pass
@@ -234,6 +236,7 @@ class LLMProvider(ABC):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         """Stream a chat completion, calling *on_content_delta* for each text chunk.
 
@@ -246,6 +249,7 @@ class LLMProvider(ABC):
             messages=messages, tools=tools, model=model,
             max_tokens=max_tokens, temperature=temperature,
             reasoning_effort=reasoning_effort, tool_choice=tool_choice,
+            prompt_cache_key=prompt_cache_key,
         )
         if on_content_delta and response.content:
             await on_content_delta(response.content)
@@ -270,6 +274,7 @@ class LLMProvider(ABC):
         reasoning_effort: object = _SENTINEL,
         tool_choice: str | dict[str, Any] | None = None,
         on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         """Call chat_stream() with retry on transient provider failures."""
         if max_tokens is self._SENTINEL:
@@ -284,6 +289,7 @@ class LLMProvider(ABC):
             max_tokens=max_tokens, temperature=temperature,
             reasoning_effort=reasoning_effort, tool_choice=tool_choice,
             on_content_delta=on_content_delta,
+            prompt_cache_key=prompt_cache_key,
         )
 
         for attempt, delay in enumerate(self._CHAT_RETRY_DELAYS, start=1):
@@ -317,6 +323,7 @@ class LLMProvider(ABC):
         temperature: object = _SENTINEL,
         reasoning_effort: object = _SENTINEL,
         tool_choice: str | dict[str, Any] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         """Call chat() with retry on transient provider failures.
 
@@ -335,6 +342,7 @@ class LLMProvider(ABC):
             messages=messages, tools=tools, model=model,
             max_tokens=max_tokens, temperature=temperature,
             reasoning_effort=reasoning_effort, tool_choice=tool_choice,
+            prompt_cache_key=prompt_cache_key,
         )
 
         for attempt, delay in enumerate(self._CHAT_RETRY_DELAYS, start=1):

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -33,6 +33,7 @@ class OpenAICodexProvider(LLMProvider):
         reasoning_effort: str | None,
         tool_choice: str | dict[str, Any] | None,
         on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         """Shared request logic for both chat() and chat_stream()."""
         model = model or self.default_model
@@ -49,7 +50,7 @@ class OpenAICodexProvider(LLMProvider):
             "input": input_items,
             "text": {"verbosity": "medium"},
             "include": ["reasoning.encrypted_content"],
-            "prompt_cache_key": _prompt_cache_key(messages),
+            "prompt_cache_key": prompt_cache_key or _prompt_cache_key(messages),
             "tool_choice": tool_choice or "auto",
             "parallel_tool_calls": True,
         }
@@ -81,8 +82,12 @@ class OpenAICodexProvider(LLMProvider):
         model: str | None = None, max_tokens: int = 4096, temperature: float = 0.7,
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
-        return await self._call_codex(messages, tools, model, reasoning_effort, tool_choice)
+        return await self._call_codex(
+            messages, tools, model, reasoning_effort, tool_choice,
+            prompt_cache_key=prompt_cache_key,
+        )
 
     async def chat_stream(
         self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
@@ -90,8 +95,12 @@ class OpenAICodexProvider(LLMProvider):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
-        return await self._call_codex(messages, tools, model, reasoning_effort, tool_choice, on_content_delta)
+        return await self._call_codex(
+            messages, tools, model, reasoning_effort, tool_choice,
+            on_content_delta, prompt_cache_key=prompt_cache_key,
+        )
 
     def get_default_model(self) -> str:
         return self.default_model

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -445,6 +445,7 @@ class OpenAICompatProvider(LLMProvider):
         temperature: float = 0.7,
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         kwargs = self._build_kwargs(
             messages, tools, model, max_tokens, temperature,
@@ -465,6 +466,7 @@ class OpenAICompatProvider(LLMProvider):
         reasoning_effort: str | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        prompt_cache_key: str | None = None,
     ) -> LLMResponse:
         kwargs = self._build_kwargs(
             messages, tools, model, max_tokens, temperature,


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `openai_codex` provider used a per-turn hash of the entire `messages` list as the `prompt_cache_key`. Because the conversation grows every turn, this hash changed every time, defeating the purpose of prompt caching.

## Changes

- Updated `LLMProvider` base class to accept an optional `prompt_cache_key`.
- Updated all provider implementations (`Anthropic`, `Azure`, `OpenAICompat`, `OpenAICodex`) to support the new parameter.
- Modified `OpenAICodexProvider` to use the passed-in `prompt_cache_key` if available, falling back to the previous hash behavior only if none is provided.
- Updated `AgentLoop` to pass the session identifier (`channel:chat_id`) as the `prompt_cache_key`.

## Verification

Verified with a reproduction script that:
1. The cache key remains stable across multiple turns in the same session.
2. The `AgentLoop` correctly threads the session key through to the provider.

This aligns `nanobot` behavior with Codex CLI and significantly improves cache hit rates for multi-turn sessions using the Responses API.