### PR TITLE
feat(exec): add allowed_urls config for internal URL whitelist

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -137,6 +137,7 @@ class AgentLoop:
                 timeout=self.exec_config.timeout,
                 restrict_to_workspace=self.restrict_to_workspace,
                 path_append=self.exec_config.path_append,
+                allowed_urls=self.exec_config.allowed_urls,
             ))
         self.tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
         self.tools.register(WebFetchTool(proxy=self.web_proxy))

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -103,6 +103,7 @@ class SubagentManager:
                 timeout=self.exec_config.timeout,
                 restrict_to_workspace=self.restrict_to_workspace,
                 path_append=self.exec_config.path_append,
+                allowed_urls=self.exec_config.allowed_urls,
             ))
             tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
             tools.register(WebFetchTool(proxy=self.web_proxy))

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -23,6 +23,7 @@ class ExecTool(Tool):
         allow_patterns: list[str] | None = None,
         restrict_to_workspace: bool = False,
         path_append: str = "",
+        allowed_urls: list[str] | None = None,
     ):
         self.timeout = timeout
         self.working_dir = working_dir
@@ -40,6 +41,7 @@ class ExecTool(Tool):
         self.allow_patterns = allow_patterns or []
         self.restrict_to_workspace = restrict_to_workspace
         self.path_append = path_append
+        self.allowed_urls = allowed_urls or []
 
     @property
     def name(self) -> str:
@@ -164,7 +166,7 @@ class ExecTool(Tool):
                 return "Error: Command blocked by safety guard (not in allowlist)"
 
         from nanobot.security.network import contains_internal_url
-        if contains_internal_url(cmd):
+        if contains_internal_url(cmd, self.allowed_urls):
             return "Error: Command blocked by safety guard (internal/private URL detected)"
 
         if self.restrict_to_workspace:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -125,6 +125,7 @@ class ExecToolConfig(Base):
     enable: bool = True
     timeout: int = 60
     path_append: str = ""
+    allowed_urls: list[str] = Field(default_factory=list)
 
 class MCPServerConfig(Base):
     """MCP server connection configuration (stdio or HTTP)."""

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -94,10 +94,12 @@ def validate_resolved_url(url: str) -> tuple[bool, str]:
     return True, ""
 
 
-def contains_internal_url(command: str) -> bool:
+def contains_internal_url(command: str, allowed_urls: list[str] | None = None) -> bool:
     """Return True if the command string contains a URL targeting an internal/private address."""
     for m in _URL_RE.finditer(command):
         url = m.group(0)
+        if allowed_urls and any(url.startswith(prefix) for prefix in allowed_urls):
+            continue
         ok, _ = validate_url_target(url)
         if not ok:
             return True


### PR DESCRIPTION
## Summary

- Add `allowedUrls` (also accepts `allowed_urls`) field to `ExecToolConfig`
- URL prefix matching exempts specified URLs from the internal-network safety guard
- Supports granularity down to port and path level (e.g. `http://127.0.0.1:3000/api/`)
- Non-whitelisted internal URLs remain blocked as before
- All existing security tests pass (21 security + 39 tool validation)

Closes #2370

## Motivation

When an agent needs to call a local API (e.g. a local backend at `http://127.0.0.1:3000`), the exec tool's safety guard blocks the command with `"Error: Command blocked by safety guard (internal/private URL detected)"`. There is currently no way to whitelist trusted local endpoints.

## Configuration

```json
{
  "tools": {
    "exec": {
      "allowedUrls": [
        "http://127.0.0.1:3000/",
        "http://localhost:8080/api/"
      ]
    }
  }
}
```

## Design

Prefix-based matching (`url.startswith(prefix)`) was chosen over hostname matching because:
- It naturally distinguishes ports (`127.0.0.1:3000` vs `127.0.0.1:8080`)
- It allows path-level control (`/api/` only, not the entire host)
- It's simpler and more predictable (9 lines added, no new dependencies)

## Changed files

| File | Change |
|------|--------|
| `nanobot/config/schema.py` | Add `allowed_urls` field to `ExecToolConfig` |
| `nanobot/security/network.py` | Add `allowed_urls` param to `contains_internal_url()` |
| `nanobot/agent/tools/shell.py` | Wire `allowed_urls` through `ExecTool` |
| `nanobot/agent/loop.py` | Pass config to `ExecTool` instantiation |
| `nanobot/agent/subagent.py` | Same as above for subagents |

## Test plan

- [x] All 21 existing security tests pass
- [x] All 39 tool validation tests pass
- [x] Verified: whitelisted URL (`http://127.0.0.1:3000/...`) is allowed
- [x] Verified: non-whitelisted internal URL (`http://169.254.169.254/...`) still blocked
- [x] Verified: config loads correctly via `load_config()`