### PR TITLE
feat(transcription): allow specifying language for Groq Whisper

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -23,6 +23,7 @@ class BaseChannel(ABC):
     name: str = "base"
     display_name: str = "Base"
     transcription_api_key: str = ""
+    transcription_language: str = ""
 
     def __init__(self, config: Any, bus: MessageBus):
         """
@@ -43,7 +44,10 @@ class BaseChannel(ABC):
         try:
             from nanobot.providers.transcription import GroqTranscriptionProvider
 
-            provider = GroqTranscriptionProvider(api_key=self.transcription_api_key)
+            provider = GroqTranscriptionProvider(
+                api_key=self.transcription_api_key,
+                language=self.transcription_language or None,
+            )
             return await provider.transcribe(file_path)
         except Exception as e:
             logger.warning("{}: audio transcription failed: {}", self.name, e)

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -35,6 +35,7 @@ class ChannelManager:
         from nanobot.channels.registry import discover_all
 
         groq_key = self.config.providers.groq.api_key
+        groq_lang = getattr(self.config.providers.groq, "transcription_language", "")
 
         for name, cls in discover_all().items():
             section = getattr(self.config.channels, name, None)
@@ -50,6 +51,7 @@ class ChannelManager:
             try:
                 channel = cls(section, self.bus)
                 channel.transcription_api_key = groq_key
+                channel.transcription_language = groq_lang
                 self.channels[name] = channel
                 logger.info("{} channel enabled", cls.display_name)
             except Exception as e:

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -14,9 +14,10 @@ class GroqTranscriptionProvider:
     Groq offers extremely fast transcription with a generous free tier.
     """
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, language: str | None = None):
         self.api_key = api_key or os.environ.get("GROQ_API_KEY")
         self.api_url = "https://api.groq.com/openai/v1/audio/transcriptions"
+        self.language = language
 
     async def transcribe(self, file_path: str | Path) -> str:
         """
@@ -44,6 +45,8 @@ class GroqTranscriptionProvider:
                         "file": (path.name, f),
                         "model": (None, "whisper-large-v3"),
                     }
+                    if self.language:
+                        files["language"] = (None, self.language)
                     headers = {
                         "Authorization": f"Bearer {self.api_key}",
                     }


### PR DESCRIPTION
## Summary

Adds a configurable `transcription_language` parameter so users can explicitly set the language for Groq Whisper transcription, improving accuracy when automatic detection is unreliable.

## Changes

- `transcription.py`: Accept optional `language` param and pass it to the Groq API
- `base.py`: Add `transcription_language` attribute to `BaseChannel`, forward it to the provider
- `manager.py`: Read `transcription_language` from groq provider config and assign it to channels

## Usage

Set `transcription_language` in the groq provider config (e.g. `"en"`, `"zh"`, `"ja"`). If not set, behavior is unchanged (automatic detection).

Closes #2421