### PR TITLE
feat: optional Docker sandbox for shell exec tool

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -137,6 +137,7 @@ class AgentLoop:
                 timeout=self.exec_config.timeout,
                 restrict_to_workspace=self.restrict_to_workspace,
                 path_append=self.exec_config.path_append,
+                sandbox=self.exec_config.sandbox,
             ))
         self.tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
         self.tools.register(WebFetchTool(proxy=self.web_proxy))

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -1,8 +1,9 @@
-"""Shell execution tool."""
+"""Shell execution tool with optional Docker sandbox."""
 
 import asyncio
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 from typing import Any
@@ -13,7 +14,7 @@ from nanobot.agent.tools.base import Tool
 
 
 class ExecTool(Tool):
-    """Tool to execute shell commands."""
+    """Tool to execute shell commands, optionally inside a Docker sandbox."""
 
     def __init__(
         self,
@@ -23,7 +24,9 @@ class ExecTool(Tool):
         allow_patterns: list[str] | None = None,
         restrict_to_workspace: bool = False,
         path_append: str = "",
+        sandbox: "SandboxConfig | None" = None,
     ):
+        from nanobot.config.schema import SandboxConfig
         self.timeout = timeout
         self.working_dir = working_dir
         self.deny_patterns = deny_patterns or [
@@ -40,6 +43,13 @@ class ExecTool(Tool):
         self.allow_patterns = allow_patterns or []
         self.restrict_to_workspace = restrict_to_workspace
         self.path_append = path_append
+        self.sandbox = sandbox or SandboxConfig()
+
+        if self.sandbox.enabled and not self._docker_available():
+            logger.warning(
+                "Sandbox enabled but Docker is not available — "
+                "commands will run without sandbox"
+            )
 
     @property
     def name(self) -> str:
@@ -87,6 +97,12 @@ class ExecTool(Tool):
         if guard_error:
             return guard_error
 
+        if self.sandbox.enabled and self._docker_available():
+            return await self._run_sandboxed(command, cwd, timeout)
+        return await self._run_direct(command, cwd, timeout)
+
+    async def _run_direct(self, command: str, cwd: str, timeout: int | None = None) -> str:
+        """Run command directly on the host."""
         effective_timeout = min(timeout or self.timeout, self._MAX_TIMEOUT)
 
         env = os.environ.copy()
@@ -121,34 +137,89 @@ class ExecTool(Tool):
                             logger.debug("Process already reaped or not found: {}", e)
                 return f"Error: Command timed out after {effective_timeout} seconds"
 
-            output_parts = []
-
-            if stdout:
-                output_parts.append(stdout.decode("utf-8", errors="replace"))
-
-            if stderr:
-                stderr_text = stderr.decode("utf-8", errors="replace")
-                if stderr_text.strip():
-                    output_parts.append(f"STDERR:\n{stderr_text}")
-
-            output_parts.append(f"\nExit code: {process.returncode}")
-
-            result = "\n".join(output_parts) if output_parts else "(no output)"
-
-            # Head + tail truncation to preserve both start and end of output
-            max_len = self._MAX_OUTPUT
-            if len(result) > max_len:
-                half = max_len // 2
-                result = (
-                    result[:half]
-                    + f"\n\n... ({len(result) - max_len:,} chars truncated) ...\n\n"
-                    + result[-half:]
-                )
-
-            return result
+            return self._format_output(stdout, stderr, process.returncode)
 
         except Exception as e:
             return f"Error executing command: {str(e)}"
+
+    async def _run_sandboxed(self, command: str, cwd: str, timeout: int | None = None) -> str:
+        """Run command inside a Docker container."""
+        docker_cmd = self._build_docker_command(command, cwd)
+        effective_timeout = min(
+            timeout or self.sandbox.timeout or self.timeout,
+            self._MAX_TIMEOUT,
+        )
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *docker_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=effective_timeout
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                return f"Error: Sandboxed command timed out after {effective_timeout} seconds"
+
+            return self._format_output(stdout, stderr, process.returncode)
+
+        except Exception as e:
+            return f"Error executing sandboxed command: {str(e)}"
+
+    def _build_docker_command(self, command: str, cwd: str) -> list[str]:
+        """Build the docker run command list."""
+        args = [
+            "docker", "run", "--rm",
+            f"--memory={self.sandbox.memory_limit}",
+            f"--cpus={self.sandbox.cpu_limit}",
+            f"--network={self.sandbox.network}",
+        ]
+
+        if self.sandbox.mount_workspace and self.working_dir:
+            args.extend(["-v", f"{self.working_dir}:/workspace", "-w", "/workspace"])
+        else:
+            args.extend(["-w", "/workspace"])
+
+        args.extend([self.sandbox.image, "sh", "-c", command])
+        return args
+
+    @staticmethod
+    def _docker_available() -> bool:
+        """Check if Docker CLI is available on the system."""
+        return shutil.which("docker") is not None
+
+    @staticmethod
+    def _format_output(stdout: bytes, stderr: bytes, returncode: int) -> str:
+        """Format subprocess output into a result string."""
+        output_parts = []
+
+        if stdout:
+            output_parts.append(stdout.decode("utf-8", errors="replace"))
+
+        if stderr:
+            stderr_text = stderr.decode("utf-8", errors="replace")
+            if stderr_text.strip():
+                output_parts.append(f"STDERR:\n{stderr_text}")
+
+        output_parts.append(f"\nExit code: {returncode}")
+
+        result = "\n".join(output_parts) if output_parts else "(no output)"
+
+        # Head + tail truncation to preserve both start and end of output
+        max_len = 10_000
+        if len(result) > max_len:
+            half = max_len // 2
+            result = (
+                result[:half]
+                + f"\n\n... ({len(result) - max_len:,} chars truncated) ...\n\n"
+                + result[-half:]
+            )
+
+        return result
 
     def _guard_command(self, command: str, cwd: str) -> str | None:
         """Best-effort safety guard for potentially destructive commands."""

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -119,12 +119,24 @@ class WebToolsConfig(Base):
     search: WebSearchConfig = Field(default_factory=WebSearchConfig)
 
 
+class SandboxConfig(Base):
+    """Docker sandbox configuration for shell exec tool."""
+    enabled: bool = False
+    image: str = "python:3.12-slim"
+    memory_limit: str = "512m"
+    cpu_limit: float = 1.0
+    network: str = "none"  # "none", "bridge", or custom network name
+    timeout: int = 60
+    mount_workspace: bool = True
+
+
 class ExecToolConfig(Base):
     """Shell exec tool configuration."""
 
     enable: bool = True
     timeout: int = 60
     path_append: str = ""
+    sandbox: SandboxConfig = Field(default_factory=SandboxConfig)
 
 class MCPServerConfig(Base):
     """MCP server connection configuration (stdio or HTTP)."""

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,188 @@
+"""Tests for Docker sandbox execution in ExecTool."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from nanobot.config.schema import SandboxConfig
+from nanobot.agent.tools.shell import ExecTool
+
+
+# --- Unit tests for _docker_available ---
+
+def test_docker_available_when_present():
+    with patch("shutil.which", return_value="/usr/bin/docker"):
+        assert ExecTool._docker_available() is True
+
+
+def test_docker_not_available():
+    with patch("shutil.which", return_value=None):
+        assert ExecTool._docker_available() is False
+
+
+# --- Unit tests for _build_docker_command ---
+
+def test_build_docker_command_defaults():
+    sandbox = SandboxConfig(enabled=True)
+    tool = ExecTool(working_dir="/home/user/workspace", sandbox=sandbox)
+    cmd = tool._build_docker_command("echo hello", "/home/user/workspace")
+
+    assert cmd[0:3] == ["docker", "run", "--rm"]
+    assert "--memory=512m" in cmd
+    assert "--cpus=1.0" in cmd
+    assert "--network=none" in cmd
+    assert "-v" in cmd
+    assert "/home/user/workspace:/workspace" in cmd
+    assert cmd[-3:] == ["sh", "-c", "echo hello"]
+
+
+def test_build_docker_command_custom_image():
+    sandbox = SandboxConfig(enabled=True, image="node:20-slim")
+    tool = ExecTool(working_dir="/workspace", sandbox=sandbox)
+    cmd = tool._build_docker_command("node -e '1+1'", "/workspace")
+
+    assert "node:20-slim" in cmd
+
+
+def test_build_docker_command_no_workspace_mount():
+    sandbox = SandboxConfig(enabled=True, mount_workspace=False)
+    tool = ExecTool(working_dir="/workspace", sandbox=sandbox)
+    cmd = tool._build_docker_command("ls", "/workspace")
+
+    assert "-v" not in cmd
+    assert "-w" in cmd
+    assert "/workspace" in cmd
+
+
+def test_build_docker_command_no_working_dir():
+    """mount_workspace=True but no working_dir set — should skip volume mount."""
+    sandbox = SandboxConfig(enabled=True, mount_workspace=True)
+    tool = ExecTool(sandbox=sandbox)  # no working_dir
+    cmd = tool._build_docker_command("ls", "/tmp")
+
+    assert "-v" not in cmd
+
+
+def test_build_docker_command_custom_limits():
+    sandbox = SandboxConfig(
+        enabled=True,
+        memory_limit="1g",
+        cpu_limit=2.0,
+        network="bridge",
+    )
+    tool = ExecTool(working_dir="/ws", sandbox=sandbox)
+    cmd = tool._build_docker_command("python script.py", "/ws")
+
+    assert "--memory=1g" in cmd
+    assert "--cpus=2.0" in cmd
+    assert "--network=bridge" in cmd
+
+
+# --- Unit tests for _format_output ---
+
+def test_format_output_success():
+    result = ExecTool._format_output(b"hello world\n", b"", 0)
+    assert result == "hello world\n"
+
+
+def test_format_output_with_stderr():
+    result = ExecTool._format_output(b"out\n", b"warn: something\n", 0)
+    assert "out" in result
+    assert "STDERR:" in result
+    assert "warn: something" in result
+
+
+def test_format_output_nonzero_exit():
+    result = ExecTool._format_output(b"", b"error\n", 1)
+    assert "Exit code: 1" in result
+
+
+def test_format_output_empty():
+    result = ExecTool._format_output(b"", b"", 0)
+    assert result == "(no output)"
+
+
+def test_format_output_truncation():
+    long_output = b"x" * 20000
+    result = ExecTool._format_output(long_output, b"", 0)
+    assert "truncated" in result
+    assert len(result) < 20000
+
+
+# --- Unit tests for execute routing ---
+
+@pytest.mark.asyncio
+async def test_execute_routes_to_direct_when_sandbox_disabled():
+    sandbox = SandboxConfig(enabled=False)
+    tool = ExecTool(working_dir="/tmp", sandbox=sandbox)
+
+    with patch.object(tool, "_run_direct", new_callable=AsyncMock, return_value="direct") as mock_direct, \
+         patch.object(tool, "_run_sandboxed", new_callable=AsyncMock) as mock_sandboxed:
+        result = await tool.execute(command="echo hi")
+        mock_direct.assert_called_once()
+        mock_sandboxed.assert_not_called()
+        assert result == "direct"
+
+
+@pytest.mark.asyncio
+async def test_execute_routes_to_sandboxed_when_enabled_and_docker_available():
+    sandbox = SandboxConfig(enabled=True)
+    tool = ExecTool(working_dir="/tmp", sandbox=sandbox)
+
+    with patch.object(tool, "_run_sandboxed", new_callable=AsyncMock, return_value="sandboxed") as mock_sandboxed, \
+         patch.object(ExecTool, "_docker_available", return_value=True):
+        result = await tool.execute(command="echo hi")
+        mock_sandboxed.assert_called_once()
+        assert result == "sandboxed"
+
+
+@pytest.mark.asyncio
+async def test_execute_falls_back_to_direct_when_docker_unavailable():
+    sandbox = SandboxConfig(enabled=True)
+    tool = ExecTool(working_dir="/tmp", sandbox=sandbox)
+
+    with patch.object(tool, "_run_direct", new_callable=AsyncMock, return_value="direct") as mock_direct, \
+         patch.object(ExecTool, "_docker_available", return_value=False):
+        result = await tool.execute(command="echo hi")
+        mock_direct.assert_called_once()
+        assert result == "direct"
+
+
+# --- Guard still applies before sandbox ---
+
+@pytest.mark.asyncio
+async def test_guard_blocks_before_sandbox():
+    sandbox = SandboxConfig(enabled=True)
+    tool = ExecTool(working_dir="/tmp", sandbox=sandbox)
+
+    with patch.object(ExecTool, "_docker_available", return_value=True):
+        result = await tool.execute(command="rm -rf /")
+        assert "blocked by safety guard" in result
+
+
+# --- SandboxConfig defaults ---
+
+def test_sandbox_config_defaults():
+    cfg = SandboxConfig()
+    assert cfg.enabled is False
+    assert cfg.image == "python:3.12-slim"
+    assert cfg.memory_limit == "512m"
+    assert cfg.cpu_limit == 1.0
+    assert cfg.network == "none"
+    assert cfg.timeout == 60
+    assert cfg.mount_workspace is True
+
+
+def test_sandbox_config_in_exec_tool_config():
+    from nanobot.config.schema import ExecToolConfig
+    cfg = ExecToolConfig()
+    assert cfg.sandbox.enabled is False
+    assert cfg.sandbox.image == "python:3.12-slim"
+
+
+def test_sandbox_config_override():
+    from nanobot.config.schema import ExecToolConfig
+    cfg = ExecToolConfig(sandbox=SandboxConfig(enabled=True, image="ubuntu:24.04"))
+    assert cfg.sandbox.enabled is True
+    assert cfg.sandbox.image == "ubuntu:24.04"

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -83,7 +83,8 @@ def test_build_docker_command_custom_limits():
 
 def test_format_output_success():
     result = ExecTool._format_output(b"hello world\n", b"", 0)
-    assert result == "hello world\n"
+    assert "hello world" in result
+    assert "Exit code: 0" in result
 
 
 def test_format_output_with_stderr():
@@ -100,7 +101,7 @@ def test_format_output_nonzero_exit():
 
 def test_format_output_empty():
     result = ExecTool._format_output(b"", b"", 0)
-    assert result == "(no output)"
+    assert "Exit code: 0" in result
 
 
 def test_format_output_truncation():


### PR DESCRIPTION
## Summary
- Adds `SandboxConfig` to `ExecToolConfig` schema with configurable image, memory/CPU limits, network mode, and workspace mounting
- Extends `ExecTool` with `_run_sandboxed()` path that runs commands inside ephemeral Docker containers when sandbox is enabled
- Wires sandbox config from `AgentLoop` through to `ExecTool` registration
- Includes comprehensive test suite for sandbox execution, Docker command building, and fallback behavior

## Test plan
- [ ] Verify `ExecTool` runs commands directly when sandbox is disabled (default)
- [ ] Verify `ExecTool` routes to Docker when sandbox is enabled and Docker is available
- [ ] Verify graceful fallback when Docker is not installed
- [ ] Run `pytest tests/test_sandbox.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)