### PR TITLE
feat: per-request system prompt and env for multi-tenant embedding

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -128,6 +128,7 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
         channel: str | None = None,
         chat_id: str | None = None,
         current_role: str = "user",
+        extra_system_prompt: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
         runtime_ctx = self._build_runtime_context(channel, chat_id)
@@ -140,8 +141,12 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
         else:
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
 
+        system_prompt = self.build_system_prompt(skill_names)
+        if extra_system_prompt:
+            system_prompt += f"\n\n{extra_system_prompt}"
+
         return [
-            {"role": "system", "content": self.build_system_prompt(skill_names)},
+            {"role": "system", "content": system_prompt},
             *history,
             {"role": current_role, "content": merged},
         ]

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -432,6 +432,8 @@ class AgentLoop:
         on_progress: Callable[[str], Awaitable[None]] | None = None,
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
+        extra_system_prompt: str | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
         # System messages: parse origin from chat_id ("channel:chat_id")
@@ -485,6 +487,7 @@ class AgentLoop:
             current_message=msg.content,
             media=msg.media if msg.media else None,
             channel=msg.channel, chat_id=msg.chat_id,
+            extra_system_prompt=extra_system_prompt,
         )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
@@ -502,6 +505,7 @@ class AgentLoop:
             on_stream_end=on_stream_end,
             channel=msg.channel, chat_id=msg.chat_id,
             message_id=msg.metadata.get("message_id"),
+            extra_env=extra_env,
         )
 
         if final_content is None:
@@ -613,11 +617,18 @@ class AgentLoop:
         on_progress: Callable[[str], Awaitable[None]] | None = None,
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
+        extra_system_prompt: str | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> OutboundMessage | None:
         """Process a message directly and return the outbound payload."""
         await self._connect_mcp()
+        if extra_env:
+            env_keys = ", ".join(extra_env.keys())
+            logger.debug(f"process_direct: extra_env keys: {env_keys}")
+
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
         return await self._process_message(
             msg, session_key=session_key, on_progress=on_progress,
             on_stream=on_stream, on_stream_end=on_stream_end,
+            extra_system_prompt=extra_system_prompt, extra_env=extra_env,
         )

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -199,6 +199,7 @@ class AgentLoop:
         on_progress: Callable[..., Awaitable[None]] | None = None,
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
+        extra_env: dict[str, str] | None = None,
         *,
         channel: str = "cli",
         chat_id: str = "direct",
@@ -294,7 +295,7 @@ class AgentLoop:
                 # return_exceptions=True ensures all results are collected
                 # even if one tool is cancelled or raises BaseException.
                 results = await asyncio.gather(*(
-                    self.tools.execute(tc.name, tc.arguments)
+                    self.tools.execute(tc.name, tc.arguments, env=extra_env)
                     for tc in response.tool_calls
                 ), return_exceptions=True)
 

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -35,7 +35,12 @@ class ToolRegistry:
         """Get all tool definitions in OpenAI format."""
         return [tool.to_schema() for tool in self._tools.values()]
 
-    async def execute(self, name: str, params: dict[str, Any]) -> Any:
+    async def execute(
+        self,
+        name: str,
+        params: dict[str, Any],
+        env: dict[str, str] | None = None,
+    ) -> Any:
         """Execute a tool by name with given parameters."""
         _HINT = "\n\n[Analyze the error above and try a different approach.]"
 
@@ -51,7 +56,10 @@ class ToolRegistry:
             errors = tool.validate_params(params)
             if errors:
                 return f"Error: Invalid parameters for tool '{name}': " + "; ".join(errors) + _HINT
-            result = await tool.execute(**params)
+            kwargs = dict(params)
+            if env is not None:
+                kwargs["env"] = env
+            result = await tool.execute(**kwargs)
             if isinstance(result, str) and result.startswith("Error"):
                 return result + _HINT
             return result

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -80,7 +80,8 @@ class ExecTool(Tool):
 
     async def execute(
         self, command: str, working_dir: str | None = None,
-        timeout: int | None = None, **kwargs: Any,
+        timeout: int | None = None, env: dict[str, str] | None = None,
+        **kwargs: Any,
     ) -> str:
         cwd = working_dir or self.working_dir or os.getcwd()
         guard_error = self._guard_command(command, cwd)
@@ -89,9 +90,11 @@ class ExecTool(Tool):
 
         effective_timeout = min(timeout or self.timeout, self._MAX_TIMEOUT)
 
-        env = os.environ.copy()
+        run_env = os.environ.copy()
         if self.path_append:
-            env["PATH"] = env.get("PATH", "") + os.pathsep + self.path_append
+            run_env["PATH"] = run_env.get("PATH", "") + os.pathsep + self.path_append
+        if env:
+            run_env.update(env)
 
         try:
             process = await asyncio.create_subprocess_shell(
@@ -99,7 +102,7 @@ class ExecTool(Tool):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
-                env=env,
+                env=run_env,
             )
 
             try:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,191 @@
+"""Tests for multi-tenant embedding parameters (extra_system_prompt, extra_env)."""
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
+
+import pytest
+
+from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.registry import ToolRegistry
+
+
+# --- extra_system_prompt in ContextBuilder ---
+
+def test_extra_system_prompt_appended():
+    """extra_system_prompt text appears at end of system prompt."""
+    from nanobot.agent.context import ContextBuilder
+    workspace = Path("/tmp/test-workspace-embedding")
+    workspace.mkdir(parents=True, exist_ok=True)
+    ctx = ContextBuilder(workspace)
+
+    messages = ctx.build_messages(
+        history=[],
+        current_message="hello",
+        extra_system_prompt="You are Orbis, a CRM assistant for Ruby.",
+    )
+
+    system_content = messages[0]["content"]
+    assert "You are Orbis, a CRM assistant for Ruby." in system_content
+    # It should appear after the base nanobot prompt
+    assert system_content.index("nanobot") < system_content.index("Orbis")
+
+
+def test_no_extra_prompt_unchanged():
+    """System prompt unchanged when extra_system_prompt is None."""
+    from nanobot.agent.context import ContextBuilder
+    workspace = Path("/tmp/test-workspace-embedding")
+    workspace.mkdir(parents=True, exist_ok=True)
+    ctx = ContextBuilder(workspace)
+
+    messages_without = ctx.build_messages(history=[], current_message="hello")
+    messages_with_none = ctx.build_messages(
+        history=[], current_message="hello", extra_system_prompt=None
+    )
+
+    assert messages_without[0]["content"] == messages_with_none[0]["content"]
+
+
+def test_extra_prompt_empty_string_unchanged():
+    """Empty string extra_system_prompt doesn't alter prompt."""
+    from nanobot.agent.context import ContextBuilder
+    workspace = Path("/tmp/test-workspace-embedding")
+    workspace.mkdir(parents=True, exist_ok=True)
+    ctx = ContextBuilder(workspace)
+
+    messages_without = ctx.build_messages(history=[], current_message="hello")
+    messages_with_empty = ctx.build_messages(
+        history=[], current_message="hello", extra_system_prompt=""
+    )
+
+    assert messages_without[0]["content"] == messages_with_empty[0]["content"]
+
+
+# --- env threading through ToolRegistry ---
+
+class EchoEnvTool(Tool):
+    """Test tool that returns env vars it received."""
+
+    @property
+    def name(self) -> str:
+        return "echo_env"
+
+    @property
+    def description(self) -> str:
+        return "Returns env it received"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"key": {"type": "string"}},
+            "required": ["key"],
+        }
+
+    async def execute(self, key: str, env: dict[str, str] | None = None, **kwargs) -> str:
+        if env and key in env:
+            return env[key]
+        return "(not found)"
+
+
+@pytest.mark.asyncio
+async def test_registry_passes_env_to_tool():
+    """ToolRegistry.execute() passes env kwarg to tool."""
+    reg = ToolRegistry()
+    reg.register(EchoEnvTool())
+
+    result = await reg.execute(
+        "echo_env",
+        {"key": "MY_TOKEN"},
+        env={"MY_TOKEN": "secret123", "PATH": "/usr/bin"},
+    )
+    assert result == "secret123"
+
+
+@pytest.mark.asyncio
+async def test_registry_no_env_passes_none():
+    """ToolRegistry.execute() without env does not inject env kwarg."""
+    reg = ToolRegistry()
+    reg.register(EchoEnvTool())
+
+    result = await reg.execute("echo_env", {"key": "MY_TOKEN"})
+    assert result == "(not found)"
+
+
+# --- ExecTool env passthrough ---
+
+@pytest.mark.asyncio
+async def test_exec_tool_passes_env_to_subprocess():
+    """ExecTool passes env dict to subprocess."""
+    from nanobot.agent.tools.shell import ExecTool
+
+    tool = ExecTool(working_dir="/tmp", timeout=10)
+
+    # Mock subprocess to capture the env kwarg
+    mock_process = MagicMock()
+    mock_process.communicate = AsyncMock(return_value=(b"hello\n", b""))
+    mock_process.returncode = 0
+    mock_process.kill = MagicMock()
+
+    with patch("asyncio.create_subprocess_shell", new_callable=AsyncMock, return_value=mock_process) as mock_create:
+        await tool.execute(command="echo $FOO", env={"FOO": "bar", "PATH": "/usr/bin"})
+
+        # Verify env was passed to create_subprocess_shell
+        call_kwargs = mock_create.call_args
+        assert call_kwargs.kwargs.get("env") == {"FOO": "bar", "PATH": "/usr/bin"}
+
+
+@pytest.mark.asyncio
+async def test_exec_tool_no_env_inherits_parent():
+    """ExecTool without env inherits parent process environment."""
+    from nanobot.agent.tools.shell import ExecTool
+
+    tool = ExecTool(working_dir="/tmp", timeout=10)
+
+    mock_process = MagicMock()
+    mock_process.communicate = AsyncMock(return_value=(b"ok\n", b""))
+    mock_process.returncode = 0
+    mock_process.kill = MagicMock()
+
+    with patch("asyncio.create_subprocess_shell", new_callable=AsyncMock, return_value=mock_process) as mock_create:
+        await tool.execute(command="echo hi")
+
+        # env should be None (inherits parent)
+        call_kwargs = mock_create.call_args
+        assert call_kwargs.kwargs.get("env") is None
+
+
+# --- os.environ not mutated ---
+
+def test_extra_env_does_not_mutate_os_environ():
+    """Merging extra_env must not modify os.environ."""
+    original_env = dict(os.environ)
+
+    # Simulate what _run_agent_loop does
+    extra_env = {"INJECTED_VAR_12345": "should_not_persist"}
+    merged = {**os.environ, **extra_env}
+
+    # os.environ should be unchanged
+    assert "INJECTED_VAR_12345" not in os.environ
+    assert os.environ == original_env
+
+    # But merged should contain it
+    assert merged["INJECTED_VAR_12345"] == "should_not_persist"
+
+
+# --- process_direct signature ---
+
+def test_process_direct_accepts_new_params():
+    """process_direct() accepts extra_system_prompt and extra_env params."""
+    import inspect
+    from nanobot.agent.loop import AgentLoop
+
+    sig = inspect.signature(AgentLoop.process_direct)
+    params = list(sig.parameters.keys())
+    assert "extra_system_prompt" in params
+    assert "extra_env" in params
+
+    # Check defaults are None
+    assert sig.parameters["extra_system_prompt"].default is None
+    assert sig.parameters["extra_env"].default is None

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -131,9 +131,12 @@ async def test_exec_tool_passes_env_to_subprocess():
     with patch("asyncio.create_subprocess_shell", new_callable=AsyncMock, return_value=mock_process) as mock_create:
         await tool.execute(command="echo $FOO", env={"FOO": "bar", "PATH": "/usr/bin"})
 
-        # Verify env was passed to create_subprocess_shell
+        # Verify extra env was merged into subprocess env
         call_kwargs = mock_create.call_args
-        assert call_kwargs.kwargs.get("env") == {"FOO": "bar", "PATH": "/usr/bin"}
+        passed_env = call_kwargs.kwargs.get("env")
+        assert passed_env is not None
+        assert passed_env["FOO"] == "bar"
+        assert passed_env["PATH"] == "/usr/bin"
 
 
 @pytest.mark.asyncio
@@ -151,9 +154,12 @@ async def test_exec_tool_no_env_inherits_parent():
     with patch("asyncio.create_subprocess_shell", new_callable=AsyncMock, return_value=mock_process) as mock_create:
         await tool.execute(command="echo hi")
 
-        # env should be None (inherits parent)
+        # env should be a copy of os.environ (no extra keys injected)
         call_kwargs = mock_create.call_args
-        assert call_kwargs.kwargs.get("env") is None
+        passed_env = call_kwargs.kwargs.get("env")
+        assert passed_env is not None
+        # Should contain parent env vars
+        assert "PATH" in passed_env
 
 
 # --- os.environ not mutated ---


### PR DESCRIPTION
## Summary
- Adds `extra_system_prompt` and `extra_env` parameters to `process_direct()` and `_process_message()` for multi-tenant use cases
- Threads `env` dict through `ToolRegistry.execute()` → `ExecTool.execute()` so per-request environment variables reach shell commands
- Enables HTTP API callers to inject tenant-specific credentials and system prompt extensions without mutating global state

## Test plan
- [ ] Verify `extra_system_prompt` appears in built messages
- [ ] Verify `extra_env` is passed through to tool execution
- [ ] Verify concurrent requests don't leak env between tenants
- [ ] Run `pytest tests/test_embedding.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)