### PR TITLE
feat: add Railway.app deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ WORKDIR /app
 # Install Python dependencies first (cached layer)
 COPY pyproject.toml README.md LICENSE ./
 RUN mkdir -p nanobot bridge && touch nanobot/__init__.py && \
-    uv pip install --system --no-cache . && \
+    uv pip install --system --no-cache ".[api]" && \
     rm -rf nanobot bridge
 
 # Copy the full source and install
 COPY nanobot/ nanobot/
 COPY bridge/ bridge/
-RUN uv pip install --system --no-cache .
+RUN uv pip install --system --no-cache ".[api]"
 
 # Build the WhatsApp bridge
 RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ RUN mkdir -p /root/.nanobot
 EXPOSE 18790
 
 ENTRYPOINT ["nanobot"]
-CMD ["status"]
+CMD ["gateway"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,4 @@ RUN mkdir -p /root/.nanobot
 # Gateway default port
 EXPOSE 18790
 
-ENTRYPOINT ["nanobot"]
-CMD ["gateway"]
+CMD ["nanobot", "gateway"]

--- a/railway.toml
+++ b/railway.toml
@@ -2,7 +2,7 @@
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "nanobot gateway --port $PORT"
+startCommand = "/bin/sh -c 'exec nanobot gateway --port $PORT'"
 healthcheckPath = "/api/v1/health"
 healthcheckTimeout = 120
 restartPolicyType = "ON_FAILURE"

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "nanobot gateway --port $PORT"
+healthcheckPath = "/api/v1/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ dockerfilePath = "Dockerfile"
 [deploy]
 startCommand = "nanobot gateway --port $PORT"
 healthcheckPath = "/api/v1/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 120
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
- Adds `railway.toml` with build/deploy configuration, health check, and restart policy
- Fixes Dockerfile to default CMD to `gateway` instead of `status`, use `CMD` over `ENTRYPOINT` for Railway compatibility, and install fastapi/uvicorn extras
- Wraps start command in shell for `$PORT` environment variable expansion

## Test plan
- [ ] Verify `railway.toml` is picked up by Railway dashboard
- [ ] Verify Docker image builds and starts the gateway on configured port
- [ ] Verify health check endpoint responds within timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)