### PR TITLE
fix(providers): add max_completion_tokens for openai o1 compatibility

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -230,6 +230,7 @@ class OpenAICompatProvider(LLMProvider):
             "model": model_name,
             "messages": self._sanitize_messages(self._sanitize_empty_content(messages)),
             "max_tokens": max(1, max_tokens),
+            "max_completion_tokens": max(1, max_tokens),
             "temperature": temperature,
         }
 


### PR DESCRIPTION
Fixes #2462

**What**
Adds `max_completion_tokens` alongside `max_tokens` in the `openai_compat_provider` payload.

**Why**
OpenAI deprecated `max_tokens` in favor of `max_completion_tokens` starting with the `o1` model series to separate the limit for final output tokens from the new "reasoning tokens". When using `o1` models via OpenAI-compatible endpoints, passing only `max_tokens` results in an `unsupported_parameter` error.

**How it works**
We now send both `max_tokens` and `max_completion_tokens` with the same value. This ensures compatibility with newer endpoints that require `max_completion_tokens` (like OpenAI's `o1` models or recent vLLM/Ollama versions) while maintaining backward compatibility with older local servers that might strictly validate the payload and reject unknown parameters.