### PR TITLE
fix(agent): message tool incorrectly replies to original chat when targeting different chat_id

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -86,12 +86,14 @@ class MessageTool(Tool):
     ) -> str:
         channel = channel or self._default_channel
         chat_id = chat_id or self._default_chat_id
-        # Only use default message_id if chat_id matches the default context.
-        # If targeting a different chat, don't reply to the original message.
-        if chat_id == self._default_chat_id:
+        # Only inherit default message_id when targeting the same channel+chat.
+        # Cross-chat sends must not carry the original message_id, because
+        # some channels (e.g. Feishu) use it to determine the target
+        # conversation via their Reply API, which would route the message
+        # to the wrong chat entirely.
+        if channel == self._default_channel and chat_id == self._default_chat_id:
             message_id = message_id or self._default_message_id
         else:
-            # Targeting a different chat - don't use default message_id
             message_id = None
 
         if not channel or not chat_id:


### PR DESCRIPTION
## Bug Description

When the `message` tool is used to send a message to a different `chat_id` than the current conversation, it was incorrectly including the default `message_id` from the original context. This caused channels (like Feishu) to send the message as a **reply** to the original chat instead of creating a **new message** in the target chat.

## Example

User is chatting in chat A, and asks bot to send a message to chat B:
- chat_id: `oc_chatB`
- channel: `feishu`
- content: "Hello group B!"

**Before fix:** Message is sent as a reply to chat A (wrong!)  
**After fix:** Message is properly sent as a new message to chat B

## Root Cause

In `message.py`, the code always uses the default `message_id`:
```python
message_id = message_id or self._default_message_id
```

This causes Feishu (and potentially other channels) to use the Reply API instead of the Create Message API when sending to a different chat.

## Changes

- Only use default `message_id` when `chat_id` matches the default context
- When targeting a different chat, set `message_id` to `None` to avoid unintended reply behavior

## Testing

- Tested with Feishu channel: cross-chat messages now properly delivered to target group
- Backward compatible: messages to same chat still work as before