### PR TITLE
fix: prevent consecutive assistant messages in conversation hi…

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -6,11 +6,9 @@ import platform
 from pathlib import Path
 from typing import Any
 
-from nanobot.utils.helpers import current_time_str
-
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
-from nanobot.utils.helpers import build_assistant_message, detect_image_mime
+from nanobot.utils.helpers import build_assistant_message, current_time_str, detect_image_mime
 
 
 class ContextBuilder:
@@ -140,11 +138,25 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
         else:
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
 
-        return [
+        messages = [
             {"role": "system", "content": self.build_system_prompt(skill_names)},
             *history,
-            {"role": current_role, "content": merged},
         ]
+
+        # Prevent consecutive same-role messages that some LLM APIs reject
+        if messages and messages[-1].get("role") == current_role:
+            # If last message has same role, merge content or force to user role
+            last_msg = messages[-1]
+            if isinstance(last_msg.get("content"), str) and isinstance(merged, str):
+                # Merge string content
+                messages[-1] = {"role": current_role, "content": f"{last_msg['content']}\n\n{merged}"}
+            else:
+                # For complex content or tool calls, force current message to user role
+                messages.append({"role": "user", "content": merged})
+        else:
+            messages.append({"role": current_role, "content": merged})
+
+        return messages
 
     def _build_user_content(self, text: str, media: list[str] | None) -> str | list[dict[str, Any]]:
         """Build user message content with optional base64-encoded images."""

--- a/tests/agent/test_consecutive_messages.py
+++ b/tests/agent/test_consecutive_messages.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+
+import pytest
+
+from nanobot.agent.context import ContextBuilder
+
+
+@pytest.fixture
+def context_builder(tmp_path: Path) -> ContextBuilder:
+    """Create a context builder with temporary workspace."""
+    return ContextBuilder(workspace=tmp_path)
+
+
+def test_build_messages_prevents_consecutive_assistant_roles(context_builder):
+    """Test that consecutive assistant messages are prevented."""
+    history = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+
+    # Subagent result comes in with role="assistant"
+    messages = context_builder.build_messages(
+        history=history,
+        current_message="Subagent completed the task",
+        current_role="assistant",
+    )
+
+    # Should merge or convert to user role to avoid consecutive assistant messages
+    roles = [m["role"] for m in messages if m["role"] != "system"]
+
+    # Check that there are no consecutive assistant messages
+    for i in range(len(roles) - 1):
+        assert not (roles[i] == "assistant" and roles[i + 1] == "assistant"), \
+            f"Found consecutive assistant messages at positions {i} and {i+1}"
+
+
+def test_build_messages_merges_consecutive_assistant_content(context_builder):
+    """Test that consecutive assistant messages with string content are merged."""
+    history = [
+        {"role": "user", "content": "Do task"},
+        {"role": "assistant", "content": "Working on it..."},
+    ]
+
+    messages = context_builder.build_messages(
+        history=history,
+        current_message="Task completed",
+        current_role="assistant",
+    )
+
+    # Find the last assistant message
+    assistant_msgs = [m for m in messages if m["role"] == "assistant"]
+    assert len(assistant_msgs) == 1, "Should merge into single assistant message"
+
+    # Content should be merged
+    assert "Working on it..." in assistant_msgs[0]["content"]
+    assert "Task completed" in assistant_msgs[0]["content"]
+
+
+def test_build_messages_allows_alternating_roles(context_builder):
+    """Test that alternating roles are preserved."""
+    history = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi!"},
+    ]
+
+    messages = context_builder.build_messages(
+        history=history,
+        current_message="How are you?",
+        current_role="user",
+    )
+
+    roles = [m["role"] for m in messages if m["role"] != "system"]
+    assert roles == ["user", "assistant", "user"]
+
+
+def test_build_messages_handles_tool_calls_in_history(context_builder):
+    """Test that messages with tool calls don't cause issues."""
+    history = [
+        {"role": "user", "content": "Read a file"},
+        {
+            "role": "assistant",
+            "content": "Let me read that",
+            "tool_calls": [{"id": "1", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}]
+        },
+        {"role": "tool", "tool_call_id": "1", "name": "read_file", "content": "file content"},
+    ]
+
+    messages = context_builder.build_messages(
+        history=history,
+        current_message="Subagent result",
+        current_role="assistant",
+    )
+
+    # Tool message is not assistant, so new assistant message is OK
+    roles = [m["role"] for m in messages if m["role"] != "system"]
+    assert roles[-2] == "tool"
+    assert roles[-1] in ["assistant", "user"]  # Either role is acceptable after tool


### PR DESCRIPTION
…story

Some LLM APIs (e.g., vLLM-based providers) reject requests with consecutive assistant messages. This occurred when subagent results (role=assistant) were appended to history that already ended with an assistant message.

Solution:
- Check if last history message has same role as current message
- If roles match and both are strings, merge the content
- If roles match but content is complex, force current to user role
- This prevents API errors while preserving conversation context

Changes:
- Enhanced build_messages() to detect and handle consecutive roles
- Added comprehensive test suite for various message patterns
- All existing tests continue to pass

Fixes #2376