### PR TITLE
fix: ensure user-scheduled reminders are always delivered

### DIFF
--- a/nanobot/utils/evaluator.py
+++ b/nanobot/utils/evaluator.py
@@ -42,11 +42,15 @@ _SYSTEM_PROMPT = (
     "You will be given the original task and the agent's response. "
     "Call the evaluate_notification tool to decide whether the user "
     "should be notified.\n\n"
-    "Notify when the response contains actionable information, errors, "
-    "completed deliverables, or anything the user explicitly asked to "
-    "be reminded about.\n\n"
-    "Suppress when the response is a routine status check with nothing "
-    "new, a confirmation that everything is normal, or essentially empty."
+    "ALWAYS notify when:\n"
+    "- The original task mentions 'remind' or 'reminder' (user-scheduled reminders MUST be delivered)\n"
+    "- The response contains actionable information or errors\n"
+    "- The response includes completed deliverables\n"
+    "- The response asks for user input or decisions\n\n"
+    "Suppress ONLY when:\n"
+    "- The response is a routine status check with nothing new\n"
+    "- The response confirms everything is normal with no changes\n"
+    "- The response is essentially empty or just an acknowledgment"
 )
 
 

--- a/tests/agent/test_evaluator.py
+++ b/tests/agent/test_evaluator.py
@@ -1,7 +1,7 @@
 import pytest
 
-from nanobot.utils.evaluator import evaluate_response
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.utils.evaluator import evaluate_response
 
 
 class DummyProvider(LLMProvider):
@@ -60,4 +60,30 @@ async def test_fallback_on_error() -> None:
 async def test_no_tool_call_fallback() -> None:
     provider = DummyProvider([LLMResponse(content="I think you should notify", tool_calls=[])])
     result = await evaluate_response("some response", "some task", provider, "m")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_reminder_should_always_notify() -> None:
+    """Test that user-scheduled reminders are always delivered."""
+    provider = DummyProvider([_eval_tool_call(True, "user reminder must be delivered")])
+    result = await evaluate_response(
+        "Time to take a bath 🛁",
+        "Remind me in 2 minutes to take a bath",
+        provider,
+        "m"
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_cron_reminder_with_context() -> None:
+    """Test that cron job reminders with context are delivered."""
+    provider = DummyProvider([_eval_tool_call(True, "scheduled reminder")])
+    result = await evaluate_response(
+        "Here's your daily reminder to check the server logs",
+        "[Scheduled Task] Timer finished. Task 'daily-check' has been triggered. Scheduled instruction: Remind me daily to check server logs",
+        provider,
+        "m"
+    )
     assert result is True


### PR DESCRIPTION
The evaluator was incorrectly suppressing user-scheduled cron reminders, classifying them as "routine acknowledgments". This caused reminders to fire successfully but never reach the user.

Changes:
- Updated _SYSTEM_PROMPT to explicitly prioritize reminder delivery
- Added "ALWAYS notify" section highlighting reminder keywords
- Made notification rules more explicit and structured
- Added test cases for reminder scenarios

Fixes #2369