### PR TITLE
feat: add language parameter for Groq Whisper API

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -23,6 +23,7 @@ class BaseChannel(ABC):
     name: str = "base"
     display_name: str = "Base"
     transcription_api_key: str = ""
+    transcription_language: str | None = None
 
     def __init__(self, config: Any, bus: MessageBus):
         """
@@ -43,7 +44,10 @@ class BaseChannel(ABC):
         try:
             from nanobot.providers.transcription import GroqTranscriptionProvider
 
-            provider = GroqTranscriptionProvider(api_key=self.transcription_api_key)
+            provider = GroqTranscriptionProvider(
+                api_key=self.transcription_api_key,
+                language=self.transcription_language,
+            )
             return await provider.transcribe(file_path)
         except Exception as e:
             logger.warning("{}: audio transcription failed: {}", self.name, e)

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -50,6 +50,10 @@ class ChannelManager:
             try:
                 channel = cls(section, self.bus)
                 channel.transcription_api_key = groq_key
+                # Pass transcription language from Groq provider config if available
+                groq_config = getattr(self.config.providers, "groq", None)
+                if groq_config and hasattr(groq_config, "transcription_language"):
+                    channel.transcription_language = groq_config.transcription_language
                 self.channels[name] = channel
                 logger.info("{} channel enabled", cls.display_name)
             except Exception as e:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -54,6 +54,7 @@ class ProviderConfig(Base):
     api_key: str = ""
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
+    transcription_language: str | None = None  # Language code for Groq transcription (e.g., "en", "zh")
 
 
 class ProvidersConfig(Base):

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -14,9 +14,10 @@ class GroqTranscriptionProvider:
     Groq offers extremely fast transcription with a generous free tier.
     """
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, language: str | None = None):
         self.api_key = api_key or os.environ.get("GROQ_API_KEY")
         self.api_url = "https://api.groq.com/openai/v1/audio/transcriptions"
+        self.language = language  # ISO-639-1 code (e.g., "en", "zh", "ja")
 
     async def transcribe(self, file_path: str | Path) -> str:
         """
@@ -44,6 +45,10 @@ class GroqTranscriptionProvider:
                         "file": (path.name, f),
                         "model": (None, "whisper-large-v3"),
                     }
+                    # Add language parameter if specified
+                    if self.language:
+                        files["language"] = (None, self.language)
+
                     headers = {
                         "Authorization": f"Bearer {self.api_key}",
                     }

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+
+import pytest
+
+from nanobot.providers.transcription import GroqTranscriptionProvider
+
+
+@pytest.mark.asyncio
+async def test_transcription_without_language() -> None:
+    """Test transcription without language parameter."""
+    provider = GroqTranscriptionProvider(api_key="test-key")
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"text": "Hello world"}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_post = AsyncMock(return_value=mock_response)
+        mock_client.return_value.__aenter__.return_value.post = mock_post
+        with patch("builtins.open", mock_open(read_data=b"audio data")):
+            with patch.object(Path, "exists", return_value=True):
+                result = await provider.transcribe("test.mp3")
+
+    assert result == "Hello world"
+    assert provider.language is None
+
+
+@pytest.mark.asyncio
+async def test_transcription_with_language() -> None:
+    """Test transcription with language parameter."""
+    provider = GroqTranscriptionProvider(api_key="test-key", language="zh")
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"text": "你好世界"}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_post = AsyncMock(return_value=mock_response)
+        mock_client.return_value.__aenter__.return_value.post = mock_post
+        with patch("builtins.open", mock_open(read_data=b"audio data")):
+            with patch.object(Path, "exists", return_value=True):
+                result = await provider.transcribe("test.mp3")
+
+    assert result == "你好世界"
+    assert provider.language == "zh"
+
+    # Verify language was passed in the files parameter
+    call_kwargs = mock_post.call_args[1]
+    files = call_kwargs["files"]
+    assert "language" in files
+    assert files["language"] == (None, "zh")
+
+
+@pytest.mark.asyncio
+async def test_transcription_file_not_found() -> None:
+    """Test transcription with non-existent file."""
+    provider = GroqTranscriptionProvider(api_key="test-key")
+
+    with patch.object(Path, "exists", return_value=False):
+        result = await provider.transcribe("nonexistent.mp3")
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_transcription_api_error() -> None:
+    """Test transcription with API error."""
+    provider = GroqTranscriptionProvider(api_key="test-key")
+
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(side_effect=Exception("API error"))
+        with patch("builtins.open", mock_open(read_data=b"audio data")):
+            with patch.object(Path, "exists", return_value=True):
+                result = await provider.transcribe("test.mp3")
+
+    assert result == ""


### PR DESCRIPTION
Allow users to specify the transcription language for more accurate results. The language parameter follows ISO-639-1 format (e.g., "en", "zh", "ja").

Changes:
- Added `language` parameter to GroqTranscriptionProvider
- Added `transcription_language` field to ProviderConfig schema
- Updated BaseChannel to pass language to transcription provider
- ChannelManager now propagates language from Groq provider config
- Comprehensive test coverage for language parameter

Configuration example in config.json:
```json
{
  "providers": {
    "groq": {
      "apiKey": "your-key",
      "transcriptionLanguage": "zh"
    }
  }
}
```

Implements #2421