### PR TITLE
feat(heartbeat): skip LLM call when HEARTBEAT.md has no active tasks

### DIFF
--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -82,6 +82,22 @@ class HeartbeatService:
                 return None
         return None
 
+    def _has_active_tasks(self, content: str) -> bool:
+        """Check if HEARTBEAT.md has actual tasks (non-comment/non-empty content).
+
+        Returns True if there are any non-comment, non-whitespace lines that could
+        represent tasks. This avoids calling the LLM when the file is effectively empty.
+        """
+        lines = content.strip().split("\n")
+        for line in lines:
+            stripped = line.strip()
+            # Skip empty lines, comments, and markdown headers
+            if not stripped or stripped.startswith("#") or stripped.startswith("<!--"):
+                continue
+            # If we find any non-empty, non-comment line, assume it could be a task
+            return True
+        return False
+
     async def _decide(self, content: str) -> tuple[str, str]:
         """Phase 1: ask LLM to decide skip/run via virtual tool call.
 
@@ -147,6 +163,10 @@ class HeartbeatService:
         content = self._read_heartbeat_file()
         if not content:
             logger.debug("Heartbeat: HEARTBEAT.md missing or empty")
+            return
+
+        if not self._has_active_tasks(content):
+            logger.debug("Heartbeat: no active tasks, skipping LLM call")
             return
 
         logger.info("Heartbeat: checking for tasks...")

--- a/tests/agent/test_heartbeat_service.py
+++ b/tests/agent/test_heartbeat_service.py
@@ -253,6 +253,90 @@ async def test_decide_retries_transient_error_then_succeeds(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_has_active_tasks_returns_false_for_empty_content(tmp_path) -> None:
+    """Test that _has_active_tasks returns False for empty or comment-only content."""
+    provider = DummyProvider([])
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+    )
+
+    # Empty content
+    assert not service._has_active_tasks("")
+    assert not service._has_active_tasks("   \n\n   ")
+
+    # Only comments
+    assert not service._has_active_tasks("# Active Tasks")
+    assert not service._has_active_tasks("# Active Tasks\n## Section")
+    assert not service._has_active_tasks("<!-- comment -->")
+    assert not service._has_active_tasks("# Header\n\n<!-- comment -->\n## Another header")
+
+
+@pytest.mark.asyncio
+async def test_has_active_tasks_returns_true_for_content_with_tasks(tmp_path) -> None:
+    """Test that _has_active_tasks returns True when there's actual content."""
+    provider = DummyProvider([])
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+    )
+
+    # Task list
+    assert service._has_active_tasks("- [ ] do something")
+    assert service._has_active_tasks("# Active Tasks\n- [ ] check server")
+    assert service._has_active_tasks("## Tasks\n\nSome text here")
+    assert service._has_active_tasks("# Header\n\n- task item")
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_llm_call_when_no_active_tasks(tmp_path) -> None:
+    """Test that _tick skips LLM call when HEARTBEAT.md has no active tasks."""
+    (tmp_path / "HEARTBEAT.md").write_text("# Active Tasks\n\n<!-- No tasks -->", encoding="utf-8")
+
+    provider = DummyProvider([])
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+    )
+
+    await service._tick()
+    # Provider should not be called
+    assert provider.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_tick_calls_llm_when_active_tasks_present(tmp_path) -> None:
+    """Test that _tick calls LLM when HEARTBEAT.md has active tasks."""
+    (tmp_path / "HEARTBEAT.md").write_text("- [ ] check servers", encoding="utf-8")
+
+    provider = DummyProvider([
+        LLMResponse(
+            content="",
+            tool_calls=[
+                ToolCallRequest(
+                    id="hb_1",
+                    name="heartbeat",
+                    arguments={"action": "skip"},
+                )
+            ],
+        )
+    ])
+
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+    )
+
+    await service._tick()
+    # Provider should be called
+    assert provider.calls == 1
+
+
+@pytest.mark.asyncio
 async def test_decide_prompt_includes_current_time(tmp_path) -> None:
     """Phase 1 user prompt must contain current time so the LLM can judge task urgency."""
 


### PR DESCRIPTION
Avoid unnecessary LLM API calls when HEARTBEAT.md contains only comments, headers, or whitespace. This saves tokens and reduces costs for users who don't actively use heartbeat tasks.

Changes:
- Added _has_active_tasks() method to check for non-empty content
- Early return in _tick() when no tasks are present
- Comprehensive test coverage for empty/comment-only files
- All existing tests continue to pass

Implements #2406