### PR TITLE
feat(command): add `/skill` slash command for user-activated skill injection

### DIFF
--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import sys
 
 from nanobot import __version__
 from nanobot.bus.events import OutboundMessage
 from nanobot.command.router import CommandContext, CommandRouter
 from nanobot.utils.helpers import build_status_content
+
+# Pattern to match $skill-name tokens (word chars + hyphens)
+_SKILL_REF = re.compile(r"\$([A-Za-z][A-Za-z0-9_-]*)")
 
 
 async def cmd_stop(ctx: CommandContext) -> OutboundMessage:
@@ -95,7 +99,7 @@ async def cmd_skill_list(ctx: CommandContext) -> OutboundMessage:
             chat_id=ctx.msg.chat_id,
             content="No skills found.",
         )
-    lines = ["Available skills:"]
+    lines = ["Available skills (use $<name> to activate):"]
     for s in skills:
         desc = loader._get_skill_description(s["name"])
         available = loader._check_requirements(loader._get_skill_meta(s["name"]))
@@ -109,26 +113,41 @@ async def cmd_skill_list(ctx: CommandContext) -> OutboundMessage:
     )
 
 
-async def cmd_skill_activate(ctx: CommandContext) -> OutboundMessage | None:
-    """Activate a skill by injecting its content into the user message."""
+async def intercept_skill_refs(ctx: CommandContext) -> OutboundMessage | None:
+    """Scan message for $skill-name references and inject matching skills."""
+    refs = _SKILL_REF.findall(ctx.msg.content)
+    if not refs:
+        return None
     loader = ctx.loop.context.skills
-    parts = ctx.args.strip().split(None, 1)
-    name = parts[0] if parts else ""
-    message = parts[1] if len(parts) > 1 else ""
-
-    if not name:
-        return await cmd_skill_list(ctx)
-
-    content = loader.load_skill(name)
-    if content is None:
-        return OutboundMessage(
-            channel=ctx.msg.channel,
-            chat_id=ctx.msg.chat_id,
-            content=f"Skill '{name}' not found. Use /skills to see available skills.",
-        )
-
-    stripped = loader._strip_frontmatter(content)
-    injected = f'<activated-skill name="{name}">\n{stripped}\n</activated-skill>'
+    skill_names = {s["name"] for s in loader.list_skills(filter_unavailable=True)}
+    matched = []
+    for name in dict.fromkeys(refs):  # deduplicate, preserve order
+        if name in skill_names:
+            matched.append(name)
+    if not matched:
+        return None
+    # Strip matched $refs from the message
+    message = ctx.msg.content
+    for name in matched:
+        message = re.sub(rf"\${re.escape(name)}\b", "", message)
+    message = message.strip()
+    # Build injected content
+    skill_blocks = []
+    for name in matched:
+        content = loader.load_skill(name)
+        if content:
+            stripped = loader._strip_frontmatter(content)
+            skill_blocks.append(f'<skill-content name="{name}">\n{stripped}\n</skill-content>')
+    if not skill_blocks:
+        return None
+    names = ", ".join(f"'{n}'" for n in matched)
+    injected = (
+        f"<system-reminder>\n"
+        f"The user activated skill(s) {names} via $-reference. "
+        f"The following skill content was auto-appended by the system.\n"
+        + "\n".join(skill_blocks)
+        + "\n</system-reminder>"
+    )
     ctx.msg.content = f"{injected}\n\n{message}" if message else injected
     return None  # fall through to LLM
 
@@ -141,8 +160,8 @@ async def cmd_help(ctx: CommandContext) -> OutboundMessage:
         "/stop — Stop the current task",
         "/restart — Restart the bot",
         "/status — Show bot status",
-        "/skill <name> [message] — Activate a skill for this message",
         "/skills — List available skills",
+        "$<name> — Activate a skill inline (e.g. $weather what's the forecast)",
         "/help — Show available commands",
     ]
     return OutboundMessage(
@@ -161,6 +180,5 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.exact("/new", cmd_new)
     router.exact("/status", cmd_status)
     router.exact("/help", cmd_help)
-    router.exact("/skill", cmd_skill_list)
     router.exact("/skills", cmd_skill_list)
-    router.prefix("/skill ", cmd_skill_activate)
+    router.intercept(intercept_skill_refs)

--- a/tests/cli/test_skill_command.py
+++ b/tests/cli/test_skill_command.py
@@ -1,4 +1,4 @@
-"""Tests for /skill and /skills slash commands."""
+"""Tests for /skills listing and $skill inline activation."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nanobot.bus.events import InboundMessage
-from nanobot.command.builtin import cmd_skill_activate, cmd_skill_list
+from nanobot.command.builtin import cmd_skill_list, intercept_skill_refs
 from nanobot.command.router import CommandContext
 
 
@@ -31,14 +31,12 @@ def _make_loop():
     return loop, bus
 
 
-def _make_ctx(content: str, args: str = "", loop=None):
+def _make_ctx(content: str, loop=None):
     """Build a CommandContext for testing."""
     if loop is None:
         loop, _ = _make_loop()
     msg = InboundMessage(channel="cli", sender_id="user", chat_id="direct", content=content)
-    return CommandContext(
-        msg=msg, session=None, key=msg.session_key, raw=content, args=args, loop=loop
-    )
+    return CommandContext(msg=msg, session=None, key=msg.session_key, raw=content, loop=loop)
 
 
 def _mock_skills_loader(skills=None, skill_content=None):
@@ -49,44 +47,47 @@ def _mock_skills_loader(skills=None, skill_content=None):
     loader._get_skill_description.side_effect = lambda name: f"{name} description"
     loader._get_skill_meta.return_value = {}
     loader._check_requirements.return_value = True
-    loader._strip_frontmatter.side_effect = lambda c: c.replace("---\nname: test\n---\n", "")
+    loader._strip_frontmatter.side_effect = lambda c: c
     return loader
+
+
+WEATHER_SKILLS = [
+    {"name": "weather", "path": "/skills/weather/SKILL.md", "source": "builtin"},
+]
+MULTI_SKILLS = [
+    {"name": "weather", "path": "/skills/weather/SKILL.md", "source": "builtin"},
+    {"name": "github", "path": "/skills/github/SKILL.md", "source": "builtin"},
+]
 
 
 class TestSkillList:
     @pytest.mark.asyncio
     async def test_lists_available_skills(self):
         loop, _ = _make_loop()
-        loader = _mock_skills_loader(
-            skills=[
-                {"name": "weather", "path": "/skills/weather/SKILL.md", "source": "builtin"},
-                {"name": "github", "path": "/skills/github/SKILL.md", "source": "builtin"},
-            ]
-        )
+        loader = _mock_skills_loader(skills=MULTI_SKILLS)
         loop.context = MagicMock()
         loop.context.skills = loader
 
-        ctx = _make_ctx("/skill", loop=loop)
+        ctx = _make_ctx("/skills", loop=loop)
         result = await cmd_skill_list(ctx)
 
         assert result is not None
         assert "weather" in result.content
         assert "github" in result.content
         assert "✓" in result.content
+        assert "$" in result.content  # hints about $ usage
 
     @pytest.mark.asyncio
     async def test_shows_unavailable_mark(self):
         loop, _ = _make_loop()
         loader = _mock_skills_loader(
-            skills=[
-                {"name": "tmux", "path": "/skills/tmux/SKILL.md", "source": "builtin"},
-            ]
+            skills=[{"name": "tmux", "path": "/skills/tmux/SKILL.md", "source": "builtin"}]
         )
         loader._check_requirements.return_value = False
         loop.context = MagicMock()
         loop.context.skills = loader
 
-        ctx = _make_ctx("/skill", loop=loop)
+        ctx = _make_ctx("/skills", loop=loop)
         result = await cmd_skill_list(ctx)
 
         assert "✗" in result.content
@@ -99,81 +100,128 @@ class TestSkillList:
         loop.context = MagicMock()
         loop.context.skills = loader
 
-        ctx = _make_ctx("/skill", loop=loop)
+        ctx = _make_ctx("/skills", loop=loop)
         result = await cmd_skill_list(ctx)
 
         assert "No skills found" in result.content
 
 
-class TestSkillActivate:
+class TestSkillInterceptor:
     @pytest.mark.asyncio
-    async def test_injects_skill_content_with_message(self):
+    async def test_injects_single_skill(self):
         loop, _ = _make_loop()
         loader = _mock_skills_loader(
-            skill_content={"weather": "Use the weather API to get forecasts."}
+            skills=WEATHER_SKILLS,
+            skill_content={"weather": "Use the weather API."},
         )
         loop.context = MagicMock()
         loop.context.skills = loader
 
-        ctx = _make_ctx(
-            "/skill weather what is the forecast", args="weather what is the forecast", loop=loop
-        )
-        result = await cmd_skill_activate(ctx)
+        ctx = _make_ctx("$weather what is the forecast", loop=loop)
+        result = await intercept_skill_refs(ctx)
 
         assert result is None  # falls through to LLM
-        assert '<activated-skill name="weather">' in ctx.msg.content
-        assert "Use the weather API" in ctx.msg.content
+        assert '<skill-content name="weather">' in ctx.msg.content
+        assert "Use the weather API." in ctx.msg.content
         assert "what is the forecast" in ctx.msg.content
-        assert ctx.msg.content.endswith("what is the forecast")
 
     @pytest.mark.asyncio
-    async def test_injects_skill_content_without_message(self):
+    async def test_injects_multiple_skills(self):
         loop, _ = _make_loop()
         loader = _mock_skills_loader(
-            skill_content={"weather": "Use the weather API to get forecasts."}
+            skills=MULTI_SKILLS,
+            skill_content={
+                "weather": "Weather skill content.",
+                "github": "GitHub skill content.",
+            },
         )
         loop.context = MagicMock()
         loop.context.skills = loader
 
-        ctx = _make_ctx("/skill weather", args="weather", loop=loop)
-        result = await cmd_skill_activate(ctx)
+        ctx = _make_ctx("$weather $github do something", loop=loop)
+        result = await intercept_skill_refs(ctx)
 
         assert result is None
-        assert '<activated-skill name="weather">' in ctx.msg.content
-        assert "</activated-skill>" in ctx.msg.content
-        # No trailing message
-        assert ctx.msg.content.endswith("</activated-skill>")
+        assert '<skill-content name="weather">' in ctx.msg.content
+        assert '<skill-content name="github">' in ctx.msg.content
+        assert "do something" in ctx.msg.content
+        # Both skills wrapped in a single system-reminder
+        assert ctx.msg.content.count("<system-reminder>") == 1
 
     @pytest.mark.asyncio
-    async def test_skill_not_found(self):
-        loop, _ = _make_loop()
-        loader = _mock_skills_loader(skill_content={})
-        loop.context = MagicMock()
-        loop.context.skills = loader
-
-        ctx = _make_ctx("/skill nonexistent", args="nonexistent", loop=loop)
-        result = await cmd_skill_activate(ctx)
-
-        assert result is not None
-        assert "not found" in result.content
-        assert "/skills" in result.content
-
-    @pytest.mark.asyncio
-    async def test_empty_name_falls_back_to_list(self):
+    async def test_skill_ref_anywhere_in_message(self):
         loop, _ = _make_loop()
         loader = _mock_skills_loader(
-            skills=[
-                {"name": "weather", "path": "/skills/weather/SKILL.md", "source": "builtin"},
-            ]
+            skills=WEATHER_SKILLS,
+            skill_content={"weather": "Weather skill content."},
         )
         loop.context = MagicMock()
         loop.context.skills = loader
 
-        ctx = _make_ctx("/skill ", args="", loop=loop)
-        result = await cmd_skill_activate(ctx)
+        ctx = _make_ctx("tell me $weather the forecast for NYC", loop=loop)
+        result = await intercept_skill_refs(ctx)
 
-        assert result is not None
-        assert "weather" in result.content
+        assert result is None
+        assert '<skill-content name="weather">' in ctx.msg.content
+        assert (
+            "tell me  the forecast for NYC" in ctx.msg.content
+            or "tell me the forecast for NYC" in ctx.msg.content
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_match_passes_through(self):
+        loop, _ = _make_loop()
+        loader = _mock_skills_loader(skills=WEATHER_SKILLS)
+        loop.context = MagicMock()
+        loop.context.skills = loader
+
+        ctx = _make_ctx("just a normal message", loop=loop)
+        result = await intercept_skill_refs(ctx)
+
+        assert result is None
+        assert ctx.msg.content == "just a normal message"
+
+    @pytest.mark.asyncio
+    async def test_unknown_ref_ignored(self):
+        loop, _ = _make_loop()
+        loader = _mock_skills_loader(skills=WEATHER_SKILLS)
+        loop.context = MagicMock()
+        loop.context.skills = loader
+
+        ctx = _make_ctx("$nonexistent do something", loop=loop)
+        result = await intercept_skill_refs(ctx)
+
+        assert result is None
+        assert ctx.msg.content == "$nonexistent do something"
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_refs(self):
+        loop, _ = _make_loop()
+        loader = _mock_skills_loader(
+            skills=WEATHER_SKILLS,
+            skill_content={"weather": "Weather skill content."},
+        )
+        loop.context = MagicMock()
+        loop.context.skills = loader
+
+        ctx = _make_ctx("$weather $weather forecast", loop=loop)
+        result = await intercept_skill_refs(ctx)
+
+        assert result is None
+        assert ctx.msg.content.count('<skill-content name="weather">') == 1
+
+    @pytest.mark.asyncio
+    async def test_dollar_amount_not_matched(self):
+        loop, _ = _make_loop()
+        loader = _mock_skills_loader(skills=WEATHER_SKILLS)
+        loop.context = MagicMock()
+        loop.context.skills = loader
+
+        ctx = _make_ctx("I have $100 in my account", loop=loop)
+        result = await intercept_skill_refs(ctx)
+
+        assert result is None
+        assert ctx.msg.content == "I have $100 in my account"
 
 
 class TestHelpIncludesSkill:
@@ -184,5 +232,5 @@ class TestHelpIncludesSkill:
         response = await loop._process_message(msg)
 
         assert response is not None
-        assert "/skill" in response.content
         assert "/skills" in response.content
+        assert "$" in response.content


### PR DESCRIPTION
### Summary

- Add `/skill <name> [message]` to activate a skill by injecting its content into the user message
- Add `/skill` and `/skills` to list available skills with availability status
- Update `/help` to include the new commands

### How it works

The `/skill <name>` prefix handler loads the skill's SKILL.md, strips frontmatter, wraps the content in `<activated-skill>` XML tags, and injects it into `msg.content`. It then returns `None` to fall through to the existing LLM path — no changes to the system prompt or agent loop needed.

```
<activated-skill name="weather">
{SKILL.md content, frontmatter stripped}
</activated-skill>

{user's message, if any}
```

`/skill` or `/skills` with no skill name returns a listing of all skills with availability marks.

### Changes

- `nanobot/command/builtin.py` — add `cmd_skill_list`, `cmd_skill_activate`, register routes, update help
- `tests/cli/test_skill_command.py` — 8 tests covering list, activate, not-found, empty args, help text

### Test plan

- [x] `/skills` lists available skills with availability marks
- [x] `/skill weather <msg>` injects skill content + message into user prompt
- [x] `/skill weather` (no message) injects skill content only
- [x] `/skill nonexistent` returns error with hint to use `/skills`
- [x] `/skill ` (empty name) falls back to listing
- [x] `/help` includes `/skill` and `/skills`
- [x] All existing command tests pass (no regressions)
