### PR TITLE
fix(provider): auto-normalize tool arguments in ToolCallRequest

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -356,7 +356,7 @@ class AnthropicProvider(LLMProvider):
                 tool_calls.append(ToolCallRequest(
                     id=block.id,
                     name=block.name,
-                    arguments=block.input if isinstance(block.input, dict) else {},
+                    arguments=block.input,
                 ))
             elif block.type == "thinking":
                 thinking_blocks.append({

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -172,16 +172,11 @@ class AzureOpenAIProvider(LLMProvider):
             tool_calls = []
             if message.get("tool_calls"):
                 for tc in message["tool_calls"]:
-                    # Parse arguments from JSON string if needed
-                    args = tc["function"]["arguments"]
-                    if isinstance(args, str):
-                        args = json_repair.loads(args)
-
                     tool_calls.append(
                         ToolCallRequest(
                             id=tc["id"],
                             name=tc["function"]["name"],
-                            arguments=args,
+                            arguments=tc["function"]["arguments"],
                         )
                     )
 
@@ -293,7 +288,7 @@ class AzureOpenAIProvider(LLMProvider):
         tool_calls = [
             ToolCallRequest(
                 id=buf["id"], name=buf["name"],
-                arguments=json_repair.loads(buf["arguments"]) if buf["arguments"] else {},
+                arguments=buf["arguments"] or {},
             )
             for buf in tool_call_buffers.values()
         ]

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+import json_repair
 from loguru import logger
 
 
@@ -19,6 +20,31 @@ class ToolCallRequest:
     extra_content: dict[str, Any] | None = None
     provider_specific_fields: dict[str, Any] | None = None
     function_provider_specific_fields: dict[str, Any] | None = None
+
+    def __post_init__(self):
+        """Normalize tool arguments after initialization."""
+        def normalize(args: Any) -> dict:
+            # Parse JSON string
+            if isinstance(args, str):
+                try:
+                    args = json_repair.loads(args)
+                except Exception:
+                    logger.warning(f"Tool arguments is not valid JSON: {args[:100]}...")
+                    return {"raw": args}
+
+            # Extract from single-element list (recursive)
+            if isinstance(args, list) and args and isinstance(args[0], dict):
+                logger.warning(f"Provider returned tool arguments as list (length: {len(args)})")
+                return args[0]
+
+            # Wrap non-dict values
+            if isinstance(args, dict):
+                return args
+            logger.warning(f"Tool arguments is not a dict after normalization, got type: {type(args).__name__}")
+            return {"raw": args}
+        
+        if not isinstance(self.arguments, dict):
+            self.arguments = normalize(self.arguments)
 
     def to_openai_tool_call(self) -> dict[str, Any]:
         """Serialize to an OpenAI-style tool_call payload."""

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -287,15 +287,11 @@ async def _consume_sse(
                     continue
                 buf = tool_call_buffers.get(call_id) or {}
                 args_raw = buf.get("arguments") or item.get("arguments") or "{}"
-                try:
-                    args = json.loads(args_raw)
-                except Exception:
-                    args = {"raw": args_raw}
                 tool_calls.append(
                     ToolCallRequest(
                         id=f"{call_id}|{buf.get('id') or item.get('id') or 'fc_0'}",
                         name=buf.get("name") or item.get("name"),
-                        arguments=args,
+                        arguments=args_raw,
                     )
                 )
         elif event_type == "response.completed":

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -357,14 +357,11 @@ class OpenAICompatProvider(LLMProvider):
             for tc in raw_tool_calls:
                 tc_map = self._maybe_mapping(tc) or {}
                 fn = self._maybe_mapping(tc_map.get("function")) or {}
-                args = fn.get("arguments", {})
-                if isinstance(args, str):
-                    args = json_repair.loads(args)
                 ec, prov, fn_prov = _extract_tc_extras(tc)
                 parsed_tool_calls.append(ToolCallRequest(
                     id=_short_tool_id(),
                     name=str(fn.get("name") or ""),
-                    arguments=args if isinstance(args, dict) else {},
+                    arguments=fn.get("arguments", {}),
                     extra_content=ec,
                     provider_specific_fields=prov,
                     function_provider_specific_fields=fn_prov,
@@ -398,14 +395,11 @@ class OpenAICompatProvider(LLMProvider):
 
         tool_calls = []
         for tc in raw_tool_calls:
-            args = tc.function.arguments
-            if isinstance(args, str):
-                args = json_repair.loads(args)
             ec, prov, fn_prov = _extract_tc_extras(tc)
             tool_calls.append(ToolCallRequest(
                 id=_short_tool_id(),
                 name=tc.function.name,
-                arguments=args,
+                arguments=tc.function.arguments,
                 extra_content=ec,
                 provider_specific_fields=prov,
                 function_provider_specific_fields=fn_prov,
@@ -498,7 +492,7 @@ class OpenAICompatProvider(LLMProvider):
                 ToolCallRequest(
                     id=b["id"] or _short_tool_id(),
                     name=b["name"],
-                    arguments=json_repair.loads(b["arguments"]) if b["arguments"] else {},
+                    arguments=b["arguments"] or {},
                     extra_content=b.get("extra_content"),
                     provider_specific_fields=b.get("prov"),
                     function_provider_specific_fields=b.get("fn_prov"),


### PR DESCRIPTION
## fix(provider): auto-normalize tool arguments in ToolCallRequest

### Summary
Fix Issue #2373 

Added a `__post_init__` method to `ToolCallRequest` to automatically normalize tool arguments. Different LLM providers return tool arguments in inconsistent formats (JSON      
string, dict, single-element list, etc.). Now `ToolCallRequest` handles this uniformly when creating instances.

### Background
Some models like **MiniMax** (or under certain error conditions) return tool_calls arguments as array-formatted JSON strings instead of standard dictionary form, for example:  

```json
{
  "role": "assistant",
  "content": "...",
  "tool_calls": [
    {
      "id": "Qqrc1OHBX",
      "type": "function",
      "function": {
        "name": "write_file",
        "arguments": "[{\"path\": \"...\", ,\"content\": \"...\"}]"
      }
    }
  ],
}
```

### Solution

Automatically handled in ToolCallRequest.__post_init__:
1. JSON string → Parse using json_repair.loads() (more robust than json.loads)
2. Single-element list → Extract the first element
3. Non-dict value → Wrap as {"raw": args} for debugging

### Changes
| File| Changes|
|------|------|
| `providers/base.py` | Added ToolCallRequest.__post_init__ method |
| `anthropic_provider.py` | Simplified: directly pass raw block.input |
| `azure_openai_provider.py` | Simplified: directly pass raw arguments |
| `openai_compat_provider.py` | Simplified: directly pass raw arguments |
| `openai_codex_provider.py` | Simplified: directly pass raw arguments |

### Benefits

- ✅ Unified handling: all providers don't need to care about argument formats
- ✅ Cleaner code: removed redundant parsing logic from each provider
- ✅ More robust: json_repair can repair malformed JSON

### Test

Unit tests passed
