### PR TITLE
fix(channel): coalesce queued stream deltas to reduce API calls

### DIFF
--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -180,7 +180,8 @@ class ChannelManager:
         final_metadata = dict(first_msg.metadata or {})
         non_matching: list[OutboundMessage] = []
 
-        # Drain all pending _stream_delta messages for the same (channel, chat_id)
+        # Only merge consecutive deltas. As soon as we hit any other message,
+        # stop and hand that boundary back to the dispatcher via `pending`.
         while True:
             try:
                 next_msg = self.bus.outbound.get_nowait()
@@ -201,8 +202,9 @@ class ChannelManager:
                     # Stream ended - stop coalescing this stream
                     break
             else:
-                # Keep for later processing
+                # First non-matching message defines the coalescing boundary.
                 non_matching.append(next_msg)
+                break
 
         merged = OutboundMessage(
             channel=first_msg.channel,

--- a/tests/channels/test_channel_manager_delta_coalescing.py
+++ b/tests/channels/test_channel_manager_delta_coalescing.py
@@ -170,6 +170,42 @@ class TestDeltaCoalescing:
         assert len(pending) == 0
 
     @pytest.mark.asyncio
+    async def test_coalescing_stops_at_first_non_matching_boundary(self, manager, bus):
+        """Only consecutive deltas should be merged; later deltas stay queued."""
+        await bus.publish_outbound(OutboundMessage(
+            channel="mock",
+            chat_id="chat1",
+            content="Hello",
+            metadata={"_stream_delta": True, "_stream_id": "seg-1"},
+        ))
+        await bus.publish_outbound(OutboundMessage(
+            channel="mock",
+            chat_id="chat1",
+            content="",
+            metadata={"_stream_end": True, "_stream_id": "seg-1"},
+        ))
+        await bus.publish_outbound(OutboundMessage(
+            channel="mock",
+            chat_id="chat1",
+            content="world",
+            metadata={"_stream_delta": True, "_stream_id": "seg-2"},
+        ))
+
+        first_msg = await bus.consume_outbound()
+        merged, pending = manager._coalesce_stream_deltas(first_msg)
+
+        assert merged.content == "Hello"
+        assert merged.metadata.get("_stream_end") is None
+        assert len(pending) == 1
+        assert pending[0].metadata.get("_stream_end") is True
+        assert pending[0].metadata.get("_stream_id") == "seg-1"
+
+        # The next stream segment must remain in queue order for later dispatch.
+        remaining = await bus.consume_outbound()
+        assert remaining.content == "world"
+        assert remaining.metadata.get("_stream_id") == "seg-2"
+
+    @pytest.mark.asyncio
     async def test_non_delta_message_preserved(self, manager, bus):
         """Non-delta messages should be preserved in pending list."""
         await bus.publish_outbound(OutboundMessage(


### PR DESCRIPTION
When LLM generates faster than channel can process, asyncio.Queue accumulates multiple _stream_delta messages. Each delta triggers a separate API call (~700ms each), causing visible delay after LLM finishes.

Solution: In _dispatch_outbound, drain all queued deltas for the same (channel, chat_id) before sending, combining them into a single API call. Non-matching messages are preserved in a pending buffer for subsequent processing.

This reduces N API calls to 1 when queue has N accumulated deltas.

Manual tested on Feishu


## Why this fix?

The model has already generated all the content, but it is still being sent slowly through the channel.

```log
2026-03-26 10:13:36.199 | DEBUG    | nanobot.channels.feishu:send_delta:1043 - send_delta called withchat_id=ou_3b6935d3ea70b277894359325042b7c4, delta='我觉得', metadata={'_stream_delta':True}
2026-03-26 10:13:37.947 | DEBUG    | nanobot.channels.feishu:_send_message_sync:949 -Feishu interactive message sent to ou_3b6935d3ea70b277894359325042b7c4:om_x100b537d2bda5d10b347bd0f9590b6b
2026-03-26 10:13:38.685 | DEBUG    | nanobot.channels.feishu:send_delta:1043 -send_delta called with chat_id=ou_3b6935d3ea70b277894359325042b7c4, delta='这个故事',
2026-03-26 10:13:39.456 | DEBUG    | nanobot.channels.feishu:send_delta:1043 -send_delta called with chat_id=ou_3b6935d3ea70b277894359325042b7c4, delta='很',metadata={'_stream_delta': True}
2026-03-26 10:13:40.146 | DEBUG    | nanobot.channels.feishu:send_delta:1043 -send_delta called with chat_id=ou_3b6935d3ea70b277894359325042b7c4, delta='温暖',metadata={'_stream_delta': True}
2026-03-26 10:13:40.507 | DEBUG    | nanobot.agent.loop:_run_agent_loop:292 - LLMresponse received (iteration 1): tool_calls=[], finish_reason=stop
2026-03-26 10:13:40.509 | INFO     | nanobot.agent.loop:_process_message:565 - Responseto feishu:ou_3b6935d3ea70b277894359325042b7c4: 我觉得这个故事很温暖！✨

几个我喜欢的地方：
- **意象美好** — 月光拼成字，画面感很强
- **情感真挚** — 小孩和月亮之间的对话，单纯又动人
- **寓意温柔** — "有些距离并不会让心变远"，是个很治愈的结尾

不过如果...
2026-03-26 10:13:40.562 | DEBUG    | nanobot.agent.memory:maybe_consolidate_by_tokens:323 - Token consolidation idle feishu:ou_3b6935d3ea70b277894359325042b7c4: 4403/200000 via tiktoken
2026-03-26 10:13:40.875 | DEBUG    | nanobot.channels.feishu:send_delta:1043 -send_delta called with chat_id=ou_3b6935d3ea70b277894359325042b7c4, delta='！', metadata={'_stream_delta': True}
2026-03-26 10:13:41.575 | DEBUG    | nanobot.channels.feishu:send_delta:1043 -send_delta called with chat_id=ou_3b6935d3ea70b277894359325042b7c4, delta='✨', metadata={'_stream_delta': True}
2026-03-26 10:13:42.281 | DEBUG    | nanobot.channels.feishu:send_delta:1043 -send_delta called with chat_id=ou_3b6935d3ea70b277894359325042b7c4, delta='几个', metadata={'_stream_delta': True}
```