### PR TITLE
feat(bridge): tappable outbound @mentions with LID-aware JID construction

### DIFF
--- a/bridge/src/server.ts
+++ b/bridge/src/server.ts
@@ -10,6 +10,7 @@ interface SendCommand {
   type: 'send';
   to: string;
   text: string;
+  mentions?: string[];
 }
 
 interface SendMediaCommand {
@@ -107,7 +108,7 @@ export class BridgeServer {
     if (!this.wa) return;
 
     if (cmd.type === 'send') {
-      await this.wa.sendMessage(cmd.to, cmd.text);
+      await this.wa.sendMessage(cmd.to, cmd.text, cmd.mentions);
     } else if (cmd.type === 'send_media') {
       await this.wa.sendMedia(cmd.to, cmd.filePath, cmd.mimetype, cmd.caption, cmd.fileName);
     }

--- a/bridge/src/whatsapp.ts
+++ b/bridge/src/whatsapp.ts
@@ -250,12 +250,40 @@ export class WhatsAppClient {
     return null;
   }
 
-  async sendMessage(to: string, text: string): Promise<void> {
+  /**
+   * Extract mention JIDs from text containing @<digits> patterns.
+   *
+   * WhatsApp requires an explicit `mentions` array in the message payload
+   * for @mentions to be tappable. This method parses @-prefixed digit
+   * sequences and constructs the appropriate JID:
+   * - 14+ digits → LID domain (@lid)
+   * - Fewer digits → phone domain (@s.whatsapp.net)
+   *
+   * WhatsApp LIDs are typically 14-digit identifiers, whereas phone-number
+   * JIDs are typically 10–13 digits (country code + number).
+   */
+  static extractMentionJids(text: string): string[] {
+    const jids: string[] = [];
+    const pattern = /@(\d+)/g;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      const digits = match[1];
+      const domain = digits.length >= 14 ? 'lid' : 's.whatsapp.net';
+      jids.push(`${digits}@${domain}`);
+    }
+    return jids;
+  }
+
+  async sendMessage(to: string, text: string, mentions?: string[]): Promise<void> {
     if (!this.sock) {
       throw new Error('Not connected');
     }
 
-    await this.sock.sendMessage(to, { text });
+    const effectiveMentions = mentions ?? WhatsAppClient.extractMentionJids(text);
+    await this.sock.sendMessage(to, {
+      text,
+      ...(effectiveMentions.length ? { mentions: effectiveMentions } : {}),
+    });
   }
 
   async sendMedia(


### PR DESCRIPTION
## Summary
- Add `extractMentionJids()` to parse `@<digits>` patterns from outbound text and construct JIDs with the correct domain
- `sendMessage()` now accepts an optional `mentions` array; auto-extracts from text when not provided
- Bridge server passes through the `mentions` field from upstream callers

## Problem

WhatsApp requires an explicit `mentions` array in the message payload for @mentions to render as tappable profile links. Without this, `@12345` in the bot's reply is just plain text — not a clickable mention.

In LID-migrated groups, user identifiers are 14+ digit LIDs (`270454929518611@lid`) rather than phone-based JIDs (`1234567890@s.whatsapp.net`). The JID construction must use the correct domain based on digit length.

## Changes

### `bridge/src/whatsapp.ts`
- `extractMentionJids(text)`: static method that parses `@<digits>` patterns → JIDs (`@lid` for 14+ digits, `@s.whatsapp.net` for phone numbers)
- `sendMessage(to, text, mentions?)`: optional `mentions` param; falls back to auto-extraction via `extractMentionJids()`

### `bridge/src/server.ts`
- `SendCommand.mentions?: string[]`: optional field on the send command
- Passes `cmd.mentions` through to `sendMessage()`

## Backward Compatibility

- `sendMessage(to, text)` still works — mentions are auto-extracted from text
- If the caller provides explicit mentions, those take precedence (no auto-extraction)
- No changes to inbound message handling

## Test plan
- [ ] Send message with `@1234567890` in text → tappable mention (phone JID)
- [ ] Send message with `@27045492951861` in text → tappable mention (LID)
- [ ] Send message with explicit mentions array → uses provided JIDs
- [ ] Send message with no @patterns → no mentions array in payload
- [ ] Existing send_media path unaffected

Generated with [Claude Code](https://claude.com/claude-code)