### PR TITLE
feat(whatsapp): auto-mention sender in group replies

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -102,12 +102,20 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
 
     @staticmethod
     def _build_runtime_context(
-        channel: str | None, chat_id: str | None, timezone: str | None = None,
+        channel: str | None,
+        chat_id: str | None,
+        sender_id: str | None = None,
+        sender_name: str | None = None,
+        timezone: str | None = None,
     ) -> str:
         """Build untrusted runtime metadata block for injection before the user message."""
         lines = [f"Current Time: {current_time_str(timezone)}"]
         if channel and chat_id:
             lines += [f"Channel: {channel}", f"Chat ID: {chat_id}"]
+        if sender_id:
+            lines.append(f"Sender ID: {sender_id}")
+        if sender_name:
+            lines.append(f"Sender Name: {sender_name}")
         return ContextBuilder._RUNTIME_CONTEXT_TAG + "\n" + "\n".join(lines)
 
     def _load_bootstrap_files(self) -> str:
@@ -130,10 +138,12 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
         media: list[str] | None = None,
         channel: str | None = None,
         chat_id: str | None = None,
+        sender_id: str | None = None,
+        sender_name: str | None = None,
         current_role: str = "user",
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
-        runtime_ctx = self._build_runtime_context(channel, chat_id, self.timezone)
+        runtime_ctx = self._build_runtime_context(channel, chat_id, sender_id, sender_name, self.timezone)
         user_content = self._build_user_content(current_message, media)
 
         # Merge runtime context and user content into a single user message

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -506,6 +506,8 @@ class AgentLoop:
             current_message=msg.content,
             media=msg.media if msg.media else None,
             channel=msg.channel, chat_id=msg.chat_id,
+            sender_id=msg.metadata.get("sender_id"),
+            sender_name=msg.metadata.get("sender_name"),
         )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
@@ -539,6 +541,8 @@ class AgentLoop:
         logger.info("Response to {}:{}: {}", msg.channel, msg.sender_id, preview)
 
         meta = dict(msg.metadata or {})
+        if msg.sender_id:
+            meta["sender_id"] = msg.sender_id
         if on_stream is not None:
             meta["_streamed"] = True
         return OutboundMessage(

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -142,7 +142,16 @@ class WhatsAppChannel(BaseChannel):
 
         if msg.content:
             try:
-                payload = {"type": "send", "to": chat_id, "text": msg.content}
+                content = msg.content
+                # Auto-mention the sender in group replies so the @mention is
+                # tappable.  The bridge's extractMentionJids() turns @<digits>
+                # into the correct JID (LID or phone).
+                meta = msg.metadata or {}
+                sender_id = meta.get("sender_id")
+                if meta.get("is_group") and sender_id and f"@{sender_id}" not in content:
+                    content = f"@{sender_id} {content}"
+
+                payload = {"type": "send", "to": chat_id, "text": content}
                 await self._ws.send(json.dumps(payload, ensure_ascii=False))
             except Exception as e:
                 logger.error("Error sending WhatsApp message: {}", e)
@@ -220,6 +229,8 @@ class WhatsAppChannel(BaseChannel):
                     media_tag = f"[{media_type}: {p}]"
                     content = f"{content}\n{media_tag}" if content else media_tag
 
+            push_name = data.get("pushName", "")
+
             await self._handle_message(
                 sender_id=sender_id,
                 chat_id=sender,  # Use full LID for replies
@@ -229,6 +240,8 @@ class WhatsAppChannel(BaseChannel):
                     "message_id": message_id,
                     "timestamp": data.get("timestamp"),
                     "is_group": data.get("isGroup", False),
+                    "sender_id": sender_id,
+                    "sender_name": push_name,
                 },
             )
 


### PR DESCRIPTION
## Summary
- WhatsApp channel passes `pushName` and `sender_id` through inbound metadata
- Agent context injects Sender ID / Sender Name into the LLM runtime context
- Agent loop forwards `sender_id` into outbound metadata
- WhatsApp `send()` auto-prepends `@sender_id` for group messages, making replies tappable

## Problem

In WhatsApp groups, when the bot replies to a user, the reply is plain text with no attribution. The user who asked the question doesn't get a notification or tappable @mention. This is especially problematic in active groups where replies can get lost.

## Dependencies

This PR works end-to-end with the bridge-side PRs:
- #2070 — `participant` field (sender JID for group messages)
- #2501 — LID-aware `detectBotMention` + `isReplyToBot`
- #2502 — Tappable outbound mentions (`extractMentionJids` + `sendMessage(mentions?)`)

The bridge converts `@<digits>` in the text into the correct WhatsApp JID (`@lid` for 14+ digit LIDs, `@s.whatsapp.net` for phone numbers) and populates the `mentions` array in the Baileys payload.

## Changes

### `nanobot/channels/whatsapp.py`
- Passes `pushName` (WhatsApp display name) and `sender_id` in inbound metadata
- `send()`: auto-prepends `@sender_id` to group reply content if not already present

### `nanobot/agent/context.py`
- `_build_runtime_context()` and `build_messages()` accept optional `sender_id` / `sender_name`
- Runtime context block includes `Sender ID` and `Sender Name` lines when available

### `nanobot/agent/loop.py`
- Passes `sender_id` / `sender_name` from inbound metadata to `build_messages()`
- Injects `sender_id` into outbound metadata so `send()` can use it

## Backward Compatibility

- All new parameters are optional with `None` defaults
- Channels that don't provide sender metadata (Telegram, Discord, etc.) are unaffected
- Auto-mention only triggers for group messages with a `sender_id` — DMs are untouched
- 592 existing tests pass

## Test plan
- [ ] Send message in WhatsApp group → bot reply starts with tappable @mention
- [ ] Send message where bot already mentions sender → no double @mention
- [ ] Send DM → no @mention prepended
- [ ] Telegram/Discord messages → unchanged behavior
- [ ] Verify LLM sees `Sender ID` and `Sender Name` in runtime context

Generated with [Claude Code](https://claude.com/claude-code)