### PR TITLE
fix(heartbeat): prevent context explosion loop by truncating before run

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -623,6 +623,13 @@ def gateway(
         """Phase 2: execute heartbeat tasks through the full agent loop."""
         channel, chat_id = _pick_heartbeat_target()
 
+        # Pre-cleanup: ensure the heartbeat session is bounded before processing.
+        # This prevents an unrecoverable failure loop if a prior run failed to
+        # truncate due to a context-length crash or timeout.
+        session = agent.sessions.get_or_create("heartbeat")
+        session.retain_recent_legal_suffix(hb_cfg.keep_recent_messages)
+        agent.sessions.save(session)
+
         async def _silent(*_args, **_kwargs):
             pass
 
@@ -634,8 +641,7 @@ def gateway(
             on_progress=_silent,
         )
 
-        # Keep a small tail of heartbeat history so the loop stays bounded
-        # without losing all short-term context between runs.
+        # Post-cleanup: truncate again with the new turn's data.
         session = agent.sessions.get_or_create("heartbeat")
         session.retain_recent_legal_suffix(hb_cfg.keep_recent_messages)
         agent.sessions.save(session)


### PR DESCRIPTION
### Problem
Heartbeat sessions could get stuck in an unrecoverable failure loop if a prior run accumulated too much history and failed (e.g., due to context length limits or timeouts). Because truncation only happened *after* a successful run, the session would never be cleaned up if it kept failing.

### Solution
This PR adds a pre-execution truncation step for heartbeat sessions in the `gateway` command. This ensures that every heartbeat run starts with a clean, bounded context as defined by `keep_recent_messages`, regardless of the previous run's exit state.

### Changes
- Updated `on_heartbeat_execute` in `nanobot/cli/commands.py` to perform session truncation both before and after the agent loop.

### Impact
Fixes #2375. Improves reliability of long-running gateways and prevents 'ENORMOUS' token usage in recurring tasks.