### PR TITLE
feat(cli): add slash command auto-completion

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -94,8 +94,12 @@ def _restore_terminal() -> None:
         pass
 
 
-def _init_prompt_session() -> None:
-    """Create the prompt_toolkit session with persistent file history."""
+def _init_prompt_session(router=None) -> None:
+    """Create the prompt_toolkit session with persistent file history.
+
+    Args:
+        router: Optional CommandRouter for slash command auto-completion.
+    """
     global _PROMPT_SESSION, _SAVED_TERM_ATTRS
 
     # Save terminal state so we can restore it on exit
@@ -110,11 +114,17 @@ def _init_prompt_session() -> None:
     history_file = get_cli_history_path()
     history_file.parent.mkdir(parents=True, exist_ok=True)
 
-    _PROMPT_SESSION = PromptSession(
-        history=FileHistory(str(history_file)),
-        enable_open_in_editor=False,
-        multiline=False,   # Enter submits (single line mode)
-    )
+    session_kwargs = {
+        "history": FileHistory(str(history_file)),
+        "enable_open_in_editor": False,
+        "multiline": False,   # Enter submits (single line mode)
+    }
+
+    _PROMPT_SESSION = PromptSession(**session_kwargs)
+
+    if router is not None:
+        from nanobot.cli.completion import attach_slash_completion
+        attach_slash_completion(_PROMPT_SESSION, router)
 
 
 def _make_console() -> Console:
@@ -791,7 +801,7 @@ def agent(
     else:
         # Interactive mode — route through bus like other channels
         from nanobot.bus.events import InboundMessage
-        _init_prompt_session()
+        _init_prompt_session(router=agent_loop.commands)
         console.print(f"{__logo__} Interactive mode (type [bold]exit[/bold] or [bold]Ctrl+C[/bold] to quit)\n")
 
         if ":" in session_id:

--- a/nanobot/cli/completion.py
+++ b/nanobot/cli/completion.py
@@ -25,9 +25,18 @@ class SlashCommandCompleter(Completer):
         """Return completions matching the current word being typed."""
         word = document.get_word_before_cursor()
 
-        # Only show completions when user has typed a slash
+        # Only show completions when word starts with slash
         if not word.startswith("/"):
             return []
+
+        # Only show completions when slash is truly at line start
+        # (no non-whitespace content before the first /)
+        stripped = document.text_before_cursor.rstrip()
+        if "/" in stripped:
+            before_slash = stripped[:stripped.index("/")]
+            if before_slash.strip() != "":
+                # There is content before / → not at line start
+                return []
 
         # Collect all registered commands
         commands: list[tuple[str, str]] = []

--- a/nanobot/cli/completion.py
+++ b/nanobot/cli/completion.py
@@ -1,0 +1,74 @@
+"""Slash command auto-completion for prompt_toolkit."""
+
+from __future__ import annotations
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.document import Document
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nanobot.command.router import CommandRouter
+
+
+class SlashCommandCompleter(Completer):
+    """Dynamic completer that provides slash command suggestions.
+
+    Suggests commands as the user types "/..." and shows the command
+    description from the handler's docstring.
+    """
+
+    def __init__(self, router: CommandRouter) -> None:
+        self._router = router
+
+    def get_completions(self, document: Document, _) -> list[Completion]:
+        """Return completions matching the current word being typed."""
+        word = document.get_word_before_cursor()
+
+        # Only show completions when user has typed a slash
+        if not word.startswith("/"):
+            return []
+
+        # Collect all registered commands
+        commands: list[tuple[str, str]] = []
+
+        # Priority commands (exact match)
+        for cmd in self._router._priority:
+            handler = self._router._priority[cmd]
+            doc = handler.__doc__ or ""
+            commands.append((cmd, doc.strip()))
+
+        # Exact commands
+        for cmd in self._router._exact:
+            if cmd not in self._router._priority:
+                handler = self._router._exact[cmd]
+                doc = handler.__doc__ or ""
+                commands.append((cmd, doc.strip()))
+
+        # Prefix commands
+        for pfx, handler in self._router._prefix:
+            doc = handler.__doc__ or ""
+            commands.append((pfx, doc.strip()))
+
+        # Filter and create completions
+        completions = []
+        lower_word = word.lower()
+        for cmd, description in commands:
+            if cmd.lower().startswith(lower_word):
+                # Provide the full command as completion
+                completions.append(
+                    Completion(
+                        text=cmd,
+                        start_position=-len(word),
+                        display=cmd,
+                        display_meta=description[:60] if description else "",
+                    )
+                )
+
+        return completions
+
+
+def attach_slash_completion(session: PromptSession, router: CommandRouter) -> None:
+    """Attach slash command completion to a PromptSession."""
+    completer = SlashCommandCompleter(router)
+    session.completer = completer


### PR DESCRIPTION
Summary

  Add slash command auto-completion in interactive CLI mode. When user types / in interactive mode, a dropdown menu shows available commands with descriptions; typing further filters the list progressively
  (e.g. /st shows /status and /stop).

  Problem

  Users had no way to discover available slash commands in interactive mode. They had to remember exact command names like /new, /stop, /status, /help, /restart and type them manually with no assistance.

  Changes

  - nanobot/cli/completion.py (new): SlashCommandCompleter class implementing prompt_toolkit.Completer interface; reads registered commands from CommandRouter and returns matching completions with handler
  docstrings as descriptions; attach_slash_completion() helper to bind the completer to a PromptSession
  - nanobot/cli/commands.py: _init_prompt_session() now accepts optional router parameter and attaches the slash completer when provided; call site passes agent_loop.commands

  Backward Compatibility

  - Interactive mode works exactly as before when router is not provided
  - Non-interactive (single message) mode is unaffected
  - Existing slash commands (/new, /stop, /restart, /status, /help) behave identically

  Test Plan

  - Type / in interactive mode → dropdown shows all commands with descriptions
  - Type /st → list filters to /status and /stop
  - Type /help and press Enter → /help command executes normally
  - Type /status and press Enter → /status command executes normally
  - Type hello (no slash) → no completion popup shown
  - Tab/Enter to select a completion → command is inserted and can be executed