### PR TITLE
perf(cli): optimize streaming UI responsiveness by throttling markdown renders

### DIFF
--- a/nanobot/cli/stream.py
+++ b/nanobot/cli/stream.py
@@ -102,7 +102,7 @@ class StreamRenderer:
             self._live = Live(self._render(), console=c, auto_refresh=False)
             self._live.start()
         now = time.monotonic()
-        if "\n" in delta or (now - self._t) > 0.05:
+        if "\n" in delta or (now - self._t) > 0.1:
             self._live.update(self._render())
             self._live.refresh()
             self._t = now


### PR DESCRIPTION
#### **Summary**
This PR optimizes the real-time streaming display in the CLI. It addresses an issue where the interface would become unresponsive or fail to stream incrementally when the LLM provided long Markdown responses.

#### **The Problem**
In the previous implementation, `StreamRenderer` attempted to refresh the `rich.live` display every 0.05 seconds. Because `rich.markdown.Markdown` re-parses the entire text buffer from scratch on every update, the computational cost grew exponentially as the response length increased. This blocked the asynchronous event loop, causing the CLI to "freeze" until the LLM finished generating.

#### **The Solution**
* **Adjusted Throttle:** Increased the minimum refresh interval from `0.05s` to `0.1s`.
* **Efficiency:** This 50ms difference significantly reduces the number of full-buffer re-parses, allowing the CPU to keep up with high-token-rate streams while maintaining a "real-time" feel.
* **Stability:** Confirmed that this fix resolves the UI lag while maintaining the high-quality Markdown formatting.

#### **Testing**
- Tested with `nanobot agent` (Markdown enabled).
- Verified that text now flows smoothly word-by-word instead of appearing in large chunks at the end.
- Verified that `--no-markdown` remains unaffected and performant.