### PR TITLE
feat(agent): add configurable skill discovery mode

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -12,18 +12,22 @@ from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
 from nanobot.utils.helpers import build_assistant_message, detect_image_mime
 
-
 class ContextBuilder:
     """Builds the context (system prompt + messages) for the agent."""
 
     BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"]
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
 
-    def __init__(self, workspace: Path, timezone: str | None = None):
+    def __init__(
+        self,
+        workspace: Path,
+        timezone: str | None = None,
+        skill_discovery_threshold: int = 50,
+    ):
         self.workspace = workspace
         self.timezone = timezone
         self.memory = MemoryStore(workspace)
-        self.skills = SkillsLoader(workspace)
+        self.skills = SkillsLoader(workspace, discovery_threshold=skill_discovery_threshold)
 
     def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
@@ -43,7 +47,10 @@ class ContextBuilder:
             if always_content:
                 parts.append(f"# Active Skills\n\n{always_content}")
 
-        skills_summary = self.skills.build_skills_summary()
+        # Skills section: full summary or discovery mode
+        skills_summary = self.skills.build_skills_summary(
+            source="builtin" if self.skills.should_use_discovery_mode() else None
+        )
         if skills_summary:
             parts.append(f"""# Skills
 

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -22,12 +22,17 @@ class ContextBuilder:
         self,
         workspace: Path,
         timezone: str | None = None,
+        skill_discovery_enabled: bool = False,
         skill_discovery_threshold: int = 50,
     ):
         self.workspace = workspace
         self.timezone = timezone
         self.memory = MemoryStore(workspace)
-        self.skills = SkillsLoader(workspace, discovery_threshold=skill_discovery_threshold)
+        self.skills = SkillsLoader(
+            workspace,
+            discovery_enabled=skill_discovery_enabled,
+            discovery_threshold=skill_discovery_threshold,
+        )
 
     def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -47,10 +47,8 @@ class ContextBuilder:
             if always_content:
                 parts.append(f"# Active Skills\n\n{always_content}")
 
-        # Skills section: full summary or discovery mode
-        skills_summary = self.skills.build_skills_summary(
-            source="builtin" if self.skills.should_use_discovery_mode() else None
-        )
+        # Skills section: full summary or discovery mode (auto-selected)
+        skills_summary = self.skills.build_skills_summary()
         if skills_summary:
             parts.append(f"""# Skills
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -68,6 +68,7 @@ class AgentLoop:
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
         timezone: str | None = None,
+        skill_discovery_enabled: bool = False,
         skill_discovery_threshold: int = 50,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
@@ -90,6 +91,7 @@ class AgentLoop:
         self.context = ContextBuilder(
             workspace,
             timezone=timezone,
+            skill_discovery_enabled=skill_discovery_enabled,
             skill_discovery_threshold=skill_discovery_threshold,
         )
         self.sessions = session_manager or SessionManager(workspace)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -68,6 +68,7 @@ class AgentLoop:
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
         timezone: str | None = None,
+        skill_discovery_threshold: int = 50,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -86,7 +87,11 @@ class AgentLoop:
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
 
-        self.context = ContextBuilder(workspace, timezone=timezone)
+        self.context = ContextBuilder(
+            workspace,
+            timezone=timezone,
+            skill_discovery_threshold=skill_discovery_threshold,
+        )
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
         self.runner = AgentRunner(provider)

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -22,11 +22,13 @@ class SkillsLoader:
         self,
         workspace: Path,
         builtin_skills_dir: Path | None = None,
+        discovery_enabled: bool = False,
         discovery_threshold: int = 50,
     ):
         self.workspace = workspace
         self.workspace_skills = workspace / "skills"
         self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR
+        self._discovery_enabled = discovery_enabled
         self._discovery_threshold = discovery_threshold
         self._workspace_skill_count: int | None = None  # cache
 
@@ -245,8 +247,11 @@ class SkillsLoader:
         return self._workspace_skill_count
 
     def should_use_discovery_mode(self) -> bool:
-        """Check if should use discovery mode (too many workspace skills)."""
-        return self.get_workspace_skill_count() > self._discovery_threshold
+        """Check if should use discovery mode (enabled + threshold exceeded)."""
+        return (
+            self._discovery_enabled
+            and self.get_workspace_skill_count() > self._discovery_threshold
+        )
 
     def get_skill_metadata(self, name: str) -> dict | None:
         """

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -128,15 +128,20 @@ class SkillsLoader:
         """
         Build a summary of skills (name, description, path, availability).
 
+        When workspace skills exceed threshold, automatically filters to builtin only
+        (discovery mode) unless source is explicitly specified.
+
         Args:
-            source: Filter by source ("workspace" or "builtin"). None for all.
+            source: Filter by source ("workspace" or "builtin"). None for auto.
 
         Returns:
             XML-formatted skills summary.
         """
-        all_skills = self.list_skills(filter_unavailable=False)
+        # Auto-select source based on discovery mode
+        if source is None and self.should_use_discovery_mode():
+            source = "builtin"
 
-        # Filter by source if specified
+        all_skills = self.list_skills(filter_unavailable=False)
         if source:
             all_skills = [s for s in all_skills if s.get("source") == source]
 
@@ -159,7 +164,6 @@ class SkillsLoader:
             lines.append(f"    <description>{desc}</description>")
             lines.append(f"    <location>{path}</location>")
 
-            # Show missing requirements for unavailable skills
             if not available:
                 missing = self._get_missing_requirements(skill_meta)
                 if missing:

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -18,10 +18,17 @@ class SkillsLoader:
     specific tools or perform certain tasks.
     """
 
-    def __init__(self, workspace: Path, builtin_skills_dir: Path | None = None):
+    def __init__(
+        self,
+        workspace: Path,
+        builtin_skills_dir: Path | None = None,
+        discovery_threshold: int = 50,
+    ):
         self.workspace = workspace
         self.workspace_skills = workspace / "skills"
         self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR
+        self._discovery_threshold = discovery_threshold
+        self._workspace_skill_count: int | None = None  # cache
 
     def list_skills(self, filter_unavailable: bool = True) -> list[dict[str, str]]:
         """
@@ -94,21 +101,45 @@ class SkillsLoader:
             content = self.load_skill(name)
             if content:
                 content = self._strip_frontmatter(content)
+                # Replace {baseDir} with actual skill directory path
+                skill_dir = self._get_skill_dir(name)
+                if skill_dir:
+                    content = content.replace("{baseDir}", str(skill_dir))
                 parts.append(f"### Skill: {name}\n\n{content}")
 
         return "\n\n---\n\n".join(parts) if parts else ""
 
-    def build_skills_summary(self) -> str:
-        """
-        Build a summary of all skills (name, description, path, availability).
+    def _get_skill_dir(self, name: str) -> Path | None:
+        """Get the directory path for a skill."""
+        # Check workspace first
+        workspace_skill_dir = self.workspace_skills / name
+        if workspace_skill_dir.exists():
+            return workspace_skill_dir
 
-        This is used for progressive loading - the agent can read the full
-        skill content using read_file when needed.
+        # Check built-in
+        if self.builtin_skills:
+            builtin_skill_dir = self.builtin_skills / name
+            if builtin_skill_dir.exists():
+                return builtin_skill_dir
+
+        return None
+
+    def build_skills_summary(self, source: str | None = None) -> str:
+        """
+        Build a summary of skills (name, description, path, availability).
+
+        Args:
+            source: Filter by source ("workspace" or "builtin"). None for all.
 
         Returns:
             XML-formatted skills summary.
         """
         all_skills = self.list_skills(filter_unavailable=False)
+
+        # Filter by source if specified
+        if source:
+            all_skills = [s for s in all_skills if s.get("source") == source]
+
         if not all_skills:
             return ""
 
@@ -199,6 +230,19 @@ class SkillsLoader:
             if skill_meta.get("always") or meta.get("always"):
                 result.append(s["name"])
         return result
+
+    def get_workspace_skill_count(self) -> int:
+        """Get count of workspace skills (cached)."""
+        if self._workspace_skill_count is None:
+            self._workspace_skill_count = sum(
+                1 for s in self.list_skills(filter_unavailable=False)
+                if s.get("source") == "workspace"
+            )
+        return self._workspace_skill_count
+
+    def should_use_discovery_mode(self) -> bool:
+        """Check if should use discovery mode (too many workspace skills)."""
+        return self.get_workspace_skill_count() > self._discovery_threshold
 
     def get_skill_metadata(self, name: str) -> dict | None:
         """

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -550,6 +550,7 @@ def gateway(
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
         timezone=config.agents.defaults.timezone,
+        skill_discovery_threshold=config.agents.defaults.skill_discovery_threshold,
     )
 
     # Set cron callback (needs agent)
@@ -755,6 +756,7 @@ def agent(
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
         timezone=config.agents.defaults.timezone,
+        skill_discovery_threshold=config.agents.defaults.skill_discovery_threshold,
     )
 
     # Shared reference for progress callbacks

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -550,6 +550,7 @@ def gateway(
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
         timezone=config.agents.defaults.timezone,
+        skill_discovery_enabled=config.agents.defaults.skill_discovery_enabled,
         skill_discovery_threshold=config.agents.defaults.skill_discovery_threshold,
     )
 
@@ -756,6 +757,7 @@ def agent(
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
         timezone=config.agents.defaults.timezone,
+        skill_discovery_enabled=config.agents.defaults.skill_discovery_enabled,
         skill_discovery_threshold=config.agents.defaults.skill_discovery_threshold,
     )
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -42,6 +42,7 @@ class AgentDefaults(Base):
     max_tool_iterations: int = 40
     reasoning_effort: str | None = None  # low / medium / high - enables LLM thinking mode
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
+    skill_discovery_enabled: bool = False  # Enable skill discovery mode for large skill sets
     skill_discovery_threshold: int = 50  # Switch to discovery mode when workspace skills exceed this
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -42,6 +42,7 @@ class AgentDefaults(Base):
     max_tool_iterations: int = 40
     reasoning_effort: str | None = None  # low / medium / high - enables LLM thinking mode
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
+    skill_discovery_threshold: int = 50  # Switch to discovery mode when workspace skills exceed this
 
 
 class AgentsConfig(Base):

--- a/nanobot/skills/skill-discovery/SKILL.md
+++ b/nanobot/skills/skill-discovery/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: skill-discovery
+description: Find skills by keyword search.
+metadata: {"nanobot": {"emoji": "🔍"}}
+---
+
+# Skill Discovery
+
+Find skills when you don't know which one to use.
+
+## Search
+
+```bash
+python {baseDir}/scripts/search_skills.py -q "keyword" [-l N] [--json]
+```
+
+**Options:** `-l` limit results, `--json` machine output, `--no-rg` disable ripgrep.
+
+## Workflow
+
+1. Extract keywords from user request
+2. Search: `python {baseDir}/scripts/search_skills.py -q "keywords"`
+3. Read: `cat <path-from-results>`
+4. If no local match → use **clawhub** skill
+
+## Tips
+
+- Multiple keywords narrow results
+- Use both user language and English for better coverage

--- a/nanobot/skills/skill-discovery/scripts/search_skills.py
+++ b/nanobot/skills/skill-discovery/scripts/search_skills.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""
+Skill Discovery - Search local skills by keywords.
+
+A cross-platform skill search tool that works on macOS, Linux, and Windows.
+Supports multiple languages (English, Chinese, etc.) and output formats.
+
+Usage:
+    python search_skills.py -q "keyword" [options]
+
+Examples:
+    python search_skills.py -q "video"
+    python search_skills.py -q "send message" -l 5
+    python search_skills.py -q "image generation" --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional
+
+
+@dataclass
+class Skill:
+    """Represents a discovered skill."""
+
+    name: str
+    description: str
+    path: Path
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "path": str(self.path),
+        }
+
+
+class SkillFinder:
+    """
+    Find and search local skills.
+
+    Supports multiple search backends:
+    - ripgrep (rg): Fast, 10-100x quicker
+    - Python grep: Cross-platform fallback
+    """
+
+    # Builtin skills directory (relative to this script)
+    BUILTIN_SKILLS_DIR = Path(__file__).parent.parent.parent  # nanobot/skills/
+
+    def __init__(
+        self,
+        skills_dir: Optional[Path] = None,
+        prefer_rg: bool = True,
+    ):
+        """
+        Initialize the skill finder.
+
+        Args:
+            skills_dir: Workspace skills directory (auto-detect if None)
+            prefer_rg: Prefer ripgrep for searching (fallback to Python if unavailable)
+        """
+        self.workspace_skills_dir = skills_dir or self._detect_workspace_dir()
+        self.builtin_skills_dir = self.BUILTIN_SKILLS_DIR
+        self.prefer_rg = prefer_rg and self._has_ripgrep()
+
+    def _detect_workspace_dir(self) -> Optional[Path]:
+        """Auto-detect workspace skills directory."""
+        candidates = [
+            Path.home() / ".nanobot" / "workspace" / "skills",
+            Path.home() / ".nanobot" / "skills",
+        ]
+        for path in candidates:
+            if path.exists() and path.is_dir():
+                return path
+
+        # Check relative to current directory
+        local_skills = Path.cwd() / "skills"
+        if local_skills.exists():
+            return local_skills
+
+        return None
+
+    @property
+    def skills_dirs(self) -> list[Path]:
+        """Get all skills directories to search."""
+        dirs = []
+        if self.workspace_skills_dir:
+            dirs.append(self.workspace_skills_dir)
+        if self.builtin_skills_dir.exists():
+            dirs.append(self.builtin_skills_dir)
+        return dirs
+
+    @staticmethod
+    def _has_ripgrep() -> bool:
+        """Check if ripgrep is available."""
+        try:
+            subprocess.run(
+                ["rg", "--version"],
+                capture_output=True,
+                timeout=5,
+            )
+            return True
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+
+    def find_all_skills(self) -> Iterator[Path]:
+        """Find all SKILL.md files in all skills directories."""
+        for skills_dir in self.skills_dirs:
+            yield from skills_dir.rglob("SKILL.md")
+
+    @staticmethod
+    def parse_frontmatter(content: str) -> dict:
+        """
+        Parse YAML frontmatter from SKILL.md content.
+
+        Simple parser for flat key-value pairs. Handles:
+        - name: value
+        - name: "quoted value"
+        - name: 'quoted value'
+        """
+        metadata = {}
+
+        if not content.startswith("---"):
+            return metadata
+
+        # Find frontmatter boundaries
+        match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+        if not match:
+            return metadata
+
+        frontmatter = match.group(1)
+
+        for line in frontmatter.split("\n"):
+            # Skip empty lines and comments
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            if ":" not in line:
+                continue
+
+            key, value = line.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+
+            # Remove quotes
+            if (value.startswith('"') and value.endswith('"')) or \
+               (value.startswith("'") and value.endswith("'")):
+                value = value[1:-1]
+
+            metadata[key] = value
+
+        return metadata
+
+    def load_skill(self, skill_path: Path) -> Optional[Skill]:
+        """Load a skill from its SKILL.md file."""
+        try:
+            content = skill_path.read_text(encoding="utf-8")
+            metadata = self.parse_frontmatter(content)
+
+            name = metadata.get("name", skill_path.parent.name)
+            description = metadata.get("description", "")
+
+            return Skill(
+                name=name,
+                description=description,
+                path=skill_path,
+            )
+        except Exception:
+            return None
+
+    def _search_with_ripgrep(
+        self,
+        keywords: list[str],
+        case_insensitive: bool = True,
+    ) -> list[Path]:
+        """Search using ripgrep (fast)."""
+        if not self.skills_dirs:
+            return []
+
+        pattern = "|".join(re.escape(k) for k in keywords)
+        matches = []
+
+        for skills_dir in self.skills_dirs:
+            cmd = [
+                "rg",
+                "-i" if case_insensitive else "-s",
+                "-l",  # List matching files only
+                "--glob", "*/SKILL.md",
+                pattern,
+                str(skills_dir),
+            ]
+
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+
+                for line in result.stdout.strip().split("\n"):
+                    if line:
+                        matches.append(Path(line))
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                continue
+
+        return matches
+
+    def _search_with_python(
+        self,
+        keywords: list[str],
+        case_insensitive: bool = True,
+    ) -> list[Path]:
+        """Search using pure Python (cross-platform fallback)."""
+        if not self.skills_dirs:
+            return []
+
+        matches = []
+
+        for skill_path in self.find_all_skills():
+            skill = self.load_skill(skill_path)
+            if not skill:
+                continue
+
+            # Search in name and description
+            searchable = f"{skill.name} {skill.description}"
+
+            for keyword in keywords:
+                if case_insensitive:
+                    if keyword.lower() in searchable.lower():
+                        matches.append(skill_path)
+                        break
+                else:
+                    if keyword in searchable:
+                        matches.append(skill_path)
+                        break
+
+        return matches
+
+    def search(
+        self,
+        query: str,
+        case_insensitive: bool = True,
+        limit: int = 10,
+    ) -> list[Skill]:
+        """
+        Search skills by keywords.
+
+        Args:
+            query: Search query (space-separated keywords)
+            case_insensitive: Case-insensitive search
+            limit: Maximum number of results
+
+        Returns:
+            List of matching skills
+        """
+        # Extract keywords
+        keywords = [k for k in re.split(r"\s+", query.strip()) if k]
+        if not keywords:
+            return []
+
+        # Search
+        if self.prefer_rg:
+            paths = self._search_with_ripgrep(keywords, case_insensitive)
+            if not paths:
+                # Fallback to Python search
+                paths = self._search_with_python(keywords, case_insensitive)
+        else:
+            paths = self._search_with_python(keywords, case_insensitive)
+
+        # Load skills and limit results
+        skills = []
+        for path in paths[:limit]:
+            skill = self.load_skill(path)
+            if skill:
+                skills.append(skill)
+
+        return skills
+
+
+def format_output(
+    skills: list[Skill],
+    json_output: bool = False,
+    color: bool = True,
+) -> str:
+    """Format search results for output."""
+    if json_output:
+        return json.dumps(
+            {"results": [s.to_dict() for s in skills]},
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    if not skills:
+        msg = "No skills found. Try different keywords or search remote with clawhub."
+        return f"\033[33m{msg}\033[0m" if color else msg
+
+    # Color codes
+    cyan = "\033[36m" if color else ""
+    reset = "\033[0m" if color else ""
+
+    lines = []
+    for skill in skills:
+        lines.append(f"{cyan}{skill.name}{reset}: {skill.description}")
+        lines.append(f"  → {skill.path}")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        prog="search_skills.py",
+        description="Search local skills by keywords",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s -q "video"
+  %(prog)s -q "send message" -l 5
+  %(prog)s -q "image generation" --json
+  %(prog)s -q "github" -d ~/.nanobot/workspace/skills
+
+Tips:
+  - Use multiple keywords for narrower results
+  - Supports multiple languages (English, Chinese, etc.)
+  - Use --json for machine-readable output
+        """,
+    )
+
+    parser.add_argument(
+        "-q", "--query",
+        required=True,
+        help="Search keywords (space-separated for multiple)",
+    )
+    parser.add_argument(
+        "-d", "--dir",
+        type=Path,
+        help="Skills directory (default: auto-detect)",
+    )
+    parser.add_argument(
+        "-l", "--limit",
+        type=int,
+        default=10,
+        help="Maximum results (default: 10)",
+    )
+    parser.add_argument(
+        "-c", "--case",
+        choices=["auto", "sensitive", "insensitive"],
+        default="auto",
+        help="Case sensitivity (default: auto)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    parser.add_argument(
+        "--no-rg",
+        action="store_true",
+        help="Disable ripgrep, use Python search only",
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable colored output",
+    )
+
+    args = parser.parse_args()
+
+    # Determine case sensitivity
+    if args.case == "sensitive":
+        case_insensitive = False
+    elif args.case == "insensitive":
+        case_insensitive = True
+    else:
+        # auto: case-insensitive unless query is all uppercase
+        case_insensitive = not args.query.isupper()
+
+    # Create finder and search
+    finder = SkillFinder(
+        skills_dir=args.dir,
+        prefer_rg=not args.no_rg,
+    )
+
+    skills = finder.search(
+        query=args.query,
+        case_insensitive=case_insensitive,
+        limit=args.limit,
+    )
+
+    # Output
+    color = sys.stdout.isatty() and not args.no_color
+    print(format_output(skills, json_output=args.json, color=color))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add configurable skill discovery mode to handle large skill sets:

- `skillDiscoveryEnabled: bool` - explicit toggle (default: `false`)
- `skillDiscoveryThreshold: int` - threshold for auto-switch (default: `50`)

When enabled and workspace skills exceed threshold, only builtin skills (including `skill-discovery`) are listed. Agent searches custom skills on-demand.

## Config

```json
{
  "agents": {
    "defaults": {
      "skillDiscoveryEnabled": true,
      "skillDiscoveryThreshold": 50
    }
  }
}
```

## Behavior

| enabled | workspace skills | Context |
|---------|------------------|---------|
| false | any | All skills |
| true | ≤ threshold | All skills |
| true | > threshold | Builtin + search |

## Files Changed

- `config/schema.py` - +enabled, +threshold
- `agent/skills.py` - discovery logic
- `agent/context.py` - pass config
- `agent/loop.py` - wire config
- `cli/commands.py` - pass values
- `skills/skill-discovery/` - search skill