### PR TITLE
fix(whatsapp-bridge): download audio messages for transcription

### DIFF
--- a/bridge/src/whatsapp.ts
+++ b/bridge/src/whatsapp.ts
@@ -165,6 +165,11 @@ export class WhatsAppClient {
           fallbackContent = '[Video]';
           const path = await this.downloadMedia(msg, unwrapped.videoMessage.mimetype ?? undefined);
           if (path) mediaPaths.push(path);
+        } else if (unwrapped.audioMessage) {
+          fallbackContent = '[Voice Message]';
+          const mime = unwrapped.audioMessage.mimetype ?? 'audio/ogg; codecs=opus';
+          const path = await this.downloadMedia(msg, mime);
+          if (path) mediaPaths.push(path);
         }
 
         const finalContent = content || (mediaPaths.length === 0 ? fallbackContent : '') || '';


### PR DESCRIPTION
## Problem
Voice messages arrive as references, not downloaded files. The agent receives `[Voice Message]` with no audio content to transcribe.

## Solution
Detect `audioMessage` type in the bridge and download the buffer to a temp `.ogg` file, passing the local path in the `media` field so the Python channel can transcribe it.

## Changes
- `bridge/src/whatsapp.ts`: download audio buffer to temp file for voice messages

## Related
This is a prerequisite for PR #2529 (voice transcription via OpenAI/Groq Whisper).