### PR TITLE
feat(search): add Serper.dev as Google Search provider

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -106,6 +106,8 @@ class WebSearchTool(Tool):
             return await self._search_jina(query, n)
         elif provider == "brave":
             return await self._search_brave(query, n)
+        elif provider == "serper":
+            return await self._search_serper(query, n)
         else:
             return f"Error: unknown search provider '{provider}'"
 
@@ -262,6 +264,30 @@ class WebFetchTool(Tool):
         if result is None:
             result = await self._fetch_readability(url, extractMode, max_chars)
         return result
+
+    async def _search_serper(self, query: str, n: int) -> str:
+        api_key = self.config.api_key or os.environ.get("SERPER_API_KEY", "")
+        if not api_key:
+            logger.warning("SERPER_API_KEY not set, falling back to DuckDuckGo")
+            return await self._search_duckduckgo(query, n)
+        try:
+            async with httpx.AsyncClient(proxy=self.proxy) as client:
+                r = await client.post(
+                    "https://google.serper.dev/search",
+                    headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
+                    json={"q": query, "num": n},
+                    timeout=10.0,
+                )
+                r.raise_for_status()
+            data = r.json()
+            items = [
+                {"title": x.get("title", ""), "url": x.get("link", ""), "content": x.get("snippet", "")}
+                for x in data.get("organic", [])
+            ]
+            return _format_results(query, items, n)
+        except Exception as e:
+            logger.warning("Serper search failed: {}", e)
+            return f"Error: Serper search failed ({e})"
 
     async def _fetch_jina(self, url: str, max_chars: int) -> str | None:
         """Try fetching via Jina Reader API. Returns None on failure."""

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -107,10 +107,11 @@ class GatewayConfig(Base):
 class WebSearchConfig(Base):
     """Web search tool configuration."""
 
-    provider: str = "brave"  # brave, tavily, duckduckgo, searxng, jina
+    provider: str = "brave"  # brave, tavily, duckduckgo, searxng, jina, firecrawl, serper
     api_key: str = ""
     base_url: str = ""  # SearXNG base URL
     max_results: int = 5
+    firecrawl_api_key: str = ""  # Firecrawl key for web_fetch scraping (independent of search provider)
 
 
 class WebToolsConfig(Base):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -107,11 +107,10 @@ class GatewayConfig(Base):
 class WebSearchConfig(Base):
     """Web search tool configuration."""
 
-    provider: str = "brave"  # brave, tavily, duckduckgo, searxng, jina, firecrawl, serper
+    provider: str = "brave"  # brave, tavily, duckduckgo, searxng, jina, serper
     api_key: str = ""
     base_url: str = ""  # SearXNG base URL
     max_results: int = 5
-    firecrawl_api_key: str = ""  # Firecrawl key for web_fetch scraping (independent of search provider)
 
 
 class WebToolsConfig(Base):


### PR DESCRIPTION
Adds Serper.dev as a web search provider option. Serper provides real Google search results and is widely used in agent workflows.

Config: set provider to 'serper' and provide apiKey in web.search config.

Changes:
- nanobot/agent/tools/web.py: add _search_serper() method
- nanobot/config/schema.py: add serper to provider list; add firecrawl_api_key field

Falls back to DuckDuckGo if API key is not configured.