### PR TITLE
feat: per-MCP-server allowFrom access control

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -208,6 +208,7 @@ class AgentLoop:
         channel: str = "cli",
         chat_id: str = "direct",
         message_id: str | None = None,
+        sender_id: str | None = None,
     ) -> tuple[str | None, list[str], list[dict]]:
         """Run the agent iteration loop.
 
@@ -251,6 +252,18 @@ class AgentLoop:
             for tc in tool_calls:
                 args_str = json.dumps(tc.arguments, ensure_ascii=False)
                 logger.info("Tool call: {}({})", tc.name, args_str[:200])
+                # Check per-MCP-server allow_from restriction
+                tool_obj = self.tools.get(tc.name)
+                if (
+                    tool_obj is not None
+                    and hasattr(tool_obj, "allow_from")
+                    and tool_obj.allow_from
+                    and sender_id not in tool_obj.allow_from
+                ):
+                    logger.warning(
+                        "Tool call '{}' denied for sender '{}' (not in allow_from)",
+                        tc.name, sender_id,
+                    )
             self._set_tool_context(channel, chat_id, message_id)
 
         result = await self.runner.run(AgentRunSpec(

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -77,7 +77,7 @@ def _normalize_schema_for_openai(schema: Any) -> dict[str, Any]:
 class MCPToolWrapper(Tool):
     """Wraps a single MCP server tool as a nanobot Tool."""
 
-    def __init__(self, session, server_name: str, tool_def, tool_timeout: int = 30):
+    def __init__(self, session, server_name: str, tool_def, tool_timeout: int = 30, allow_from: list[str] | None = None):
         self._session = session
         self._original_name = tool_def.name
         self._name = f"mcp_{server_name}_{tool_def.name}"
@@ -85,6 +85,7 @@ class MCPToolWrapper(Tool):
         raw_schema = tool_def.inputSchema or {"type": "object", "properties": {}}
         self._parameters = _normalize_schema_for_openai(raw_schema)
         self._tool_timeout = tool_timeout
+        self.allow_from: list[str] = allow_from or []  # empty = no restriction
 
     @property
     def name(self) -> str:
@@ -221,7 +222,7 @@ async def connect_mcp_servers(
                         name,
                     )
                     continue
-                wrapper = MCPToolWrapper(session, name, tool_def, tool_timeout=cfg.tool_timeout)
+                wrapper = MCPToolWrapper(session, name, tool_def, tool_timeout=cfg.tool_timeout, allow_from=cfg.allow_from)
                 registry.register(wrapper)
                 logger.debug("MCP: registered tool '{}' from server '{}'", wrapper.name, name)
                 registered_count += 1

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -140,6 +140,7 @@ class MCPServerConfig(Base):
     headers: dict[str, str] = Field(default_factory=dict)  # HTTP/SSE: custom headers
     tool_timeout: int = 30  # seconds before a tool call is cancelled
     enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+    allow_from: list[str] = Field(default_factory=list)  # Restrict this server's tools to these sender IDs; [] = allow all
 
 class ToolsConfig(Base):
     """Tools configuration."""


### PR DESCRIPTION
## Description
In multi-user deployments, all users can invoke all MCP server tools by default. This adds an optional allowFrom list per MCP server so sensitive tools (databases, private APIs) can be restricted to specific users.

## Config
```json
"mcpServers": {
  "my-private-db": {
    "type": "stdio",
    "command": "...",
    "allowFrom": ["user123", "admin456"]
  }
}
```

Empty allowFrom (default) means no restriction.

## Changes
- `nanobot/config/schema.py`: add `allow_from` field to MCPServerConfig
- `nanobot/agent/tools/mcp.py`: pass `allow_from` to MCPToolWrapper; store as attribute
- `nanobot/agent/loop.py`: add `sender_id` param to `_run_agent_loop`; check `allow_from` before tool execution