### PR TITLE
fix(cron): lock message recipient during cron job execution

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -21,6 +21,23 @@ class MessageTool(Tool):
         self._default_chat_id = default_chat_id
         self._default_message_id = default_message_id
         self._sent_in_turn: bool = False
+        self._locked_channel: str | None = None
+        self._locked_chat_id: str | None = None
+
+    def lock_recipient(self, channel: str, chat_id: str) -> None:
+        """Lock delivery to this channel:chat_id (e.g. for cron job execution).
+
+        While locked, any attempt to send to a different recipient is silently
+        redirected to the locked target. This is a code-level guarantee that
+        cannot be overridden by the agent's reasoning or memory.
+        """
+        self._locked_channel = channel
+        self._locked_chat_id = chat_id
+
+    def unlock_recipient(self) -> None:
+        """Remove the recipient lock after the cron job finishes."""
+        self._locked_channel = None
+        self._locked_chat_id = None
 
     def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
         """Set the current message context."""
@@ -87,6 +104,12 @@ class MessageTool(Tool):
         channel = channel or self._default_channel
         chat_id = chat_id or self._default_chat_id
         message_id = message_id or self._default_message_id
+
+        # If a recipient lock is active, force delivery to the locked target
+        # regardless of what the agent decided. Code-level guarantee.
+        if self._locked_channel and self._locked_chat_id:
+            channel = self._locked_channel
+            chat_id = self._locked_chat_id
 
         if not channel or not chat_id:
             return "Error: No target channel/chat specified"

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -559,26 +559,39 @@ def gateway(
         from nanobot.agent.tools.message import MessageTool
         from nanobot.utils.evaluator import evaluate_response
 
+        target_channel = job.payload.channel or "cli"
+        target_chat_id = job.payload.to or "direct"
+
         reminder_note = (
             "[Scheduled Task] Timer finished.\n\n"
             f"Task '{job.name}' has been triggered.\n"
-            f"Scheduled instruction: {job.payload.message}"
+            f"Scheduled instruction: {job.payload.message}\n\n"
+            f"Deliver the response to channel='{target_channel}' chat_id='{target_chat_id}'."
         )
 
         cron_tool = agent.tools.get("cron")
         cron_token = None
         if isinstance(cron_tool, CronTool):
             cron_token = cron_tool.set_cron_context(True)
+
+        # Lock the recipient so the agent cannot redirect the message
+        # to a different user (e.g. the system owner read from memory).
+        message_tool = agent.tools.get("message")
+        if isinstance(message_tool, MessageTool):
+            message_tool.lock_recipient(target_channel, target_chat_id)
+
         try:
             resp = await agent.process_direct(
                 reminder_note,
                 session_key=f"cron:{job.id}",
-                channel=job.payload.channel or "cli",
-                chat_id=job.payload.to or "direct",
+                channel=target_channel,
+                chat_id=target_chat_id,
             )
         finally:
             if isinstance(cron_tool, CronTool) and cron_token is not None:
                 cron_tool.reset_cron_context(cron_token)
+            if isinstance(message_tool, MessageTool):
+                message_tool.unlock_recipient()
 
         response = resp.content if resp else ""
 


### PR DESCRIPTION
## Problem
In multi-user deployments, when a cron job fires the agent reads MEMORY.md (which contains the system owner's data) and may send the reminder to the wrong user instead of the job creator.

Example: User B creates a reminder. When it fires, the agent reads MEMORY.md, sees the system owner's contact info, and sends the reminder to the system owner instead of User B.

## Solution
Add `lock_recipient(channel, chat_id)` / `unlock_recipient()` to `MessageTool`. While locked, any send attempt is forcibly redirected to the locked target regardless of what the agent decides. The lock is set before agent execution and released in a `finally` block.

This is a **code-level guarantee**, not a prompt-level one.

## Changes
- `nanobot/agent/tools/message.py`: add `lock_recipient()` / `unlock_recipient()`; apply lock in `execute()`
- `nanobot/cli/commands.py`: lock recipient before cron job execution; unlock in finally block; include target channel/chat_id in reminder note