### PR TITLE
feat(channel): add iMessage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ Connect nanobot to your favorite chat platform. Want to build your own? See the 
 | **QQ** | App ID + App Secret |
 | **Wecom** | Bot ID + Bot Secret |
 | **iMessage** | macOS (local) or Photon server credentials (remote) |
-| **Wecom App** | Corp ID + Agent ID + Secret + Token + AES Key |
 | **Mochat** | Claw token (auto-setup available) |
 
 <details>
@@ -832,77 +831,6 @@ nanobot gateway
 </details>
 
 <details>
-<summary><b>Wecom App (企业微信应用)</b></summary>
-
-> Uses **webhook callback** mode — requires a publicly accessible server or port forwarding.
->
-> Different from WeCom (WebSocket mode). Choose based on your network environment.
-
-**1. Install the optional dependency**
-
-```bash
-pip install wecom-app-svr
-```
-
-**2. Create a WeCom AI Bot**
-
-Go to the WeCom admin console → My Apps → Create App → Enable **API** mode. Copy the following credentials:
-- **Corp ID** (from the admin console)
-- **Agent ID** (from the app)
-- **Secret** (from the app)
-- **Token** (you set this when configuring the webhook)
-- **AES Key** (you set this when configuring the webhook)
-
-**3. Configure the callback URL**
-
-In the WeCom app configuration:
-- Set callback URL to: `http://<your-server>:<port>/wecom_app`
-- Set the Token and AES Key to match your config
-
-**4. Configure**
-
-```json
-{
-  "channels": {
-    "wecom_app": {
-      "enabled": true,
-      "token": "your_token",
-      "corpId": "your_corp_id",
-      "secret": "your_secret",
-      "agentid": "your_agent_id",
-      "aesKey": "your_aes_key",
-      "host": "0.0.0.0",
-      "port": 18791,
-      "path": "/wecom_app",
-      "allowFrom": ["your_user_id"]
-    }
-  }
-}
-```
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `host` | `0.0.0.0` | Server bind address |
-| `port` | `18791` | Server listen port (must match WeCom callback URL) |
-| `path` | `/wecom_app` | Callback path |
-| `token` | - | Verification token from WeCom admin |
-| `aesKey` | - | AES key from WeCom admin |
-| `corpId` | - | Your WeCom Corp ID |
-| `agentid` | - | Your WeCom App Agent ID |
-| `secret` | - | Your WeCom App Secret |
-| `welcome_message` | - | Message sent when user enters the chat |
-
-**5. Run**
-
-```bash
-nanobot gateway
-```
-
-> **Note**: Wecom App requires the callback URL to be accessible from WeCom servers. If you're running locally, use port forwarding (e.g., ngrok, cloudflare tunnel) or deploy on a public server.
-
-</details>
-
-<details>
 <summary><b>iMessage</b></summary>
 
 Supports two modes via [Photon](https://photon.codes):
@@ -961,7 +889,7 @@ nanobot gateway
 > `proxy`: Optional HTTP proxy URL (e.g. `"http://127.0.0.1:7890"`).
 > `pollInterval`: Polling interval in seconds (default `2.0`).
 
-> **Note:** Remote mode routes through Photon's proxy server (`imessage-swagger.photon.codes`). Messages and attachments transit this endpoint, which is hosted and operated by Photon. See [Photon's privacy policy](https://photon.codes) for details.
+> **Note:** Remote mode routes messages through Photon's [advanced-imessage-http-proxy](https://github.com/photon-hq/advanced-imessage-http-proxy). Your messages and attachments transit Photon's infrastructure — the same provider that hosts your iMessage Kit server. If you need full on-device privacy, use local mode instead.
 
 **Feature comparison:**
 

--- a/nanobot/channels/imessage.py
+++ b/nanobot/channels/imessage.py
@@ -24,11 +24,10 @@ from nanobot.config.schema import Base
 from nanobot.utils.helpers import split_message
 
 _DEFAULT_DB_PATH = str(Path.home() / "Library" / "Messages" / "chat.db")
-_LOCAL_POLL_INTERVAL = 2.0
-_REMOTE_POLL_INTERVAL = 2.0
+_DEFAULT_POLL_INTERVAL = 2.0
 
 _AUDIO_EXTENSIONS = frozenset({".m4a", ".mp3", ".wav", ".aac", ".ogg", ".caf", ".opus"})
-_MAX_MESSAGE_LEN = 20000
+_MAX_MESSAGE_LEN = 6000
 
 
 def _split_paragraphs(text: str) -> list[str]:
@@ -54,7 +53,7 @@ class IMessageConfig(Base):
     server_url: str = ""
     api_key: str = ""
     proxy: str | None = None
-    poll_interval: float = _REMOTE_POLL_INTERVAL
+    poll_interval: float = _DEFAULT_POLL_INTERVAL
     database_path: str = _DEFAULT_DB_PATH
     allow_from: list[str] = Field(default_factory=list)
     group_policy: Literal["open", "ignore"] = "open"
@@ -104,7 +103,8 @@ def _resolve_proxy_url(server_url: str) -> str:
     """
     if _is_photon_kit_url(server_url):
         logger.info(
-            "Photon Kit URL detected — routing through proxy at {}",
+            "Photon Kit URL detected — routing through proxy at {} "
+            "(hosted by Photon, the same provider as your iMessage Kit server).",
             _PHOTON_PROXY_URL,
         )
         return _PHOTON_PROXY_URL
@@ -204,7 +204,7 @@ class IMessageChannel(BaseChannel):
                 await self._poll_local_db(db_path)
             except Exception as e:
                 logger.warning("iMessage local poll error: {}", e)
-            await asyncio.sleep(_LOCAL_POLL_INTERVAL)
+            await asyncio.sleep(max(0.5, self.config.poll_interval))
 
     def _get_max_rowid(self, db_path: str) -> int:
         try:
@@ -223,7 +223,20 @@ class IMessageChannel(BaseChannel):
             self._last_rowid = max(self._last_rowid, int(row["ROWID"]))
 
     def _fetch_new_messages(self, db_path: str) -> list[dict[str, Any]]:
-        with sqlite3.connect(db_path, uri=True) as conn:
+        for attempt in range(3):
+            try:
+                return self._query_new_messages(db_path)
+            except sqlite3.OperationalError as e:
+                if "locked" in str(e) and attempt < 2:
+                    import time
+
+                    time.sleep(0.5 * (attempt + 1))
+                    continue
+                raise
+        return []
+
+    def _query_new_messages(self, db_path: str) -> list[dict[str, Any]]:
+        with sqlite3.connect(db_path, uri=True, timeout=10) as conn:
             conn.row_factory = sqlite3.Row
             cur = conn.execute(
                 """
@@ -338,7 +351,13 @@ class IMessageChannel(BaseChannel):
 
     @staticmethod
     def _escape_applescript(s: str) -> str:
-        return s.replace("\\", "\\\\").replace('"', '\\"')
+        return (
+            s.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
 
     async def _applescript_send_text(self, recipient: str, text: str) -> None:
         escaped_recipient = self._escape_applescript(recipient)


### PR DESCRIPTION
## Summary

Add iMessage as a built-in channel for nanobot via [Photon](https://photon.codes).

- **Local mode** (macOS): reads `~/Library/Messages/chat.db` via `sqlite3`, sends via AppleScript, handles attachments and voice transcription
- **Remote mode**: connects to a Photon endpoint over pure HTTP with optional proxy support

### Features

- All Photon HTTP proxy endpoints implemented
- Tapback reactions, typing indicators, mark-as-read
- Paragraph splitting — each `\n\n` block sends as a separate iMessage bubble
- Startup seeds existing message IDs to skip old messages on restart
- Voice transcription via Groq Whisper (both modes)

### Checklist

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] Single focused commit
- [x] No new dependencies
- [x] Follows existing channel patterns
- [x] Tested end-to-end on both modes