### PR TITLE
fix: add 'ratelimit' to transient error markers

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -82,6 +82,7 @@ class LLMProvider(ABC):
     _TRANSIENT_ERROR_MARKERS = (
         "429",
         "rate limit",
+        "ratelimit",
         "500",
         "502",
         "503",


### PR DESCRIPTION
When OpenAI models experience high demand, they return:
  RateLimitError: OpenAIException - The current model is experiencing high demand

The error message contains 'RateLimitError' but not 'rate limit' (no space), causing it to not be recognized as a transient error and triggering an immediate failure instead of automatic retry.