### PR TITLE
fix(channels): respect RetryAfter delay from Telegram

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -435,7 +435,9 @@ class TelegramChannel(BaseChannel):
                 await self._send_text(chat_id, chunk, reply_params, thread_kwargs)
 
     async def _call_with_retry(self, fn, *args, **kwargs):
-        """Call an async Telegram API function with retry on pool/network timeout."""
+        """Call an async Telegram API function with retry on pool/network timeout and RetryAfter."""
+        from telegram.error import RetryAfter
+        
         for attempt in range(1, _SEND_MAX_RETRIES + 1):
             try:
                 return await fn(*args, **kwargs)
@@ -445,6 +447,15 @@ class TelegramChannel(BaseChannel):
                 delay = _SEND_RETRY_BASE_DELAY * (2 ** (attempt - 1))
                 logger.warning(
                     "Telegram timeout (attempt {}/{}), retrying in {:.1f}s",
+                    attempt, _SEND_MAX_RETRIES, delay,
+                )
+                await asyncio.sleep(delay)
+            except RetryAfter as e:
+                if attempt == _SEND_MAX_RETRIES:
+                    raise
+                delay = float(e.retry_after)
+                logger.warning(
+                    "Telegram Flood Control (attempt {}/{}), retrying in {:.1f}s",
                     attempt, _SEND_MAX_RETRIES, delay,
                 )
                 await asyncio.sleep(delay)


### PR DESCRIPTION
This PR fixes an issue where the `_send_with_retry` method in `ChannelManager` ignored the specific wait time requested by Telegram when a `RetryAfter` (Flood control exceeded) error occurred.

Previously, the manager used a fixed exponential backoff (1s, 2s, 4s), which was often shorter than the required wait time (e.g., 14 seconds), causing all retry attempts to be exhausted before the block was lifted.

This patch checks if the exception is a `RetryAfter` error and extracts the `retry_after` attribute, ensuring the delay is at least as long as the requested wait time.