### PR TITLE
fix(agent): isolate message tool turn state for concurrent sessions

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -173,12 +173,18 @@ class AgentLoop:
         finally:
             self._mcp_connecting = False
 
-    def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
+    def _set_tool_context(
+        self, channel: str, chat_id: str, message_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Update context for all tools that need routing info."""
         for name in ("message", "spawn", "cron"):
             if tool := self.tools.get(name):
                 if hasattr(tool, "set_context"):
-                    tool.set_context(channel, chat_id, *([message_id] if name == "message" else []))
+                    if name == "message":
+                        tool.set_context(channel, chat_id, message_id, metadata)
+                    else:
+                        tool.set_context(channel, chat_id)
 
     @staticmethod
     def _strip_think(text: str | None) -> str | None:
@@ -209,6 +215,7 @@ class AgentLoop:
         channel: str = "cli",
         chat_id: str = "direct",
         message_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> tuple[str | None, list[str], list[dict]]:
         """Run the agent iteration loop.
 
@@ -252,7 +259,7 @@ class AgentLoop:
                 for tc in context.tool_calls:
                     args_str = json.dumps(tc.arguments, ensure_ascii=False)
                     logger.info("Tool call: {}({})", tc.name, args_str[:200])
-                loop_self._set_tool_context(channel, chat_id, message_id)
+                loop_self._set_tool_context(channel, chat_id, message_id, metadata)
 
             def finalize_content(self, context: AgentHookContext, content: str | None) -> str | None:
                 return loop_self._strip_think(content)
@@ -403,7 +410,7 @@ class AgentLoop:
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
-            self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
+            self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"), msg.metadata)
             if message_tool := self.tools.get("message"):
                 if isinstance(message_tool, MessageTool):
                     message_tool.start_turn()
@@ -417,6 +424,7 @@ class AgentLoop:
             final_content, _, all_msgs = await self._run_agent_loop(
                 messages, channel=channel, chat_id=chat_id,
                 message_id=msg.metadata.get("message_id"),
+                metadata=msg.metadata,
             )
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
@@ -438,7 +446,7 @@ class AgentLoop:
 
         await self.memory_consolidator.maybe_consolidate_by_tokens(session)
 
-        self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
+        self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"), msg.metadata)
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()
@@ -466,6 +474,7 @@ class AgentLoop:
             on_stream_end=on_stream_end,
             channel=msg.channel, chat_id=msg.chat_id,
             message_id=msg.metadata.get("message_id"),
+            metadata=msg.metadata,
         )
 
         if final_content is None:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -404,6 +404,9 @@ class AgentLoop:
             session = self.sessions.get_or_create(key)
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
+            if message_tool := self.tools.get("message"):
+                if isinstance(message_tool, MessageTool):
+                    message_tool.start_turn()
             history = session.get_history(max_messages=0)
             current_role = "assistant" if msg.sender_id == "subagent" else "user"
             messages = self.context.build_messages(
@@ -472,8 +475,11 @@ class AgentLoop:
         self.sessions.save(session)
         self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
 
-        if (mt := self.tools.get("message")) and isinstance(mt, MessageTool) and mt._sent_in_turn:
-            return None
+        if mt := self.tools.get("message"):
+            if isinstance(mt, MessageTool):
+                sent_targets = set(mt.get_turn_sends())
+                if (msg.channel, msg.chat_id) in sent_targets:
+                    return None
 
         preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
         logger.info("Response to {}:{}: {}", msg.channel, msg.sender_id, preview)

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -13,6 +13,7 @@ class _MessageTurnState:
     channel: str
     chat_id: str
     message_id: str | None
+    metadata: dict[str, Any] = field(default_factory=dict)
     sent_targets: set[tuple[str, str]] = field(default_factory=set)
 
 
@@ -46,12 +47,16 @@ class MessageTool(Tool):
             self._turn_state.set(state)
         return state
 
-    def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
+    def set_context(
+        self, channel: str, chat_id: str, message_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Set the current message context."""
         state = self._get_turn_state()
         state.channel = channel
         state.chat_id = chat_id
         state.message_id = message_id
+        state.metadata = dict(metadata or {})
 
     def set_send_callback(self, callback: Callable[[OutboundMessage], Awaitable[None]]) -> None:
         """Set the callback for sending messages."""
@@ -124,14 +129,16 @@ class MessageTool(Tool):
         if not self._send_callback:
             return "Error: Message sending not configured"
 
+        metadata = dict(state.metadata)
+        if message_id is not None:
+            metadata["message_id"] = message_id
+
         msg = OutboundMessage(
             channel=channel,
             chat_id=chat_id,
             content=content,
             media=media or [],
-            metadata={
-                "message_id": message_id,
-            },
+            metadata=metadata,
         )
 
         try:

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -1,9 +1,19 @@
 """Message tool for sending messages to users."""
 
+from contextvars import ContextVar
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable
 
 from nanobot.agent.tools.base import Tool
 from nanobot.bus.events import OutboundMessage
+
+
+@dataclass(slots=True)
+class _MessageTurnState:
+    channel: str
+    chat_id: str
+    message_id: str | None
+    sent_targets: set[tuple[str, str]] = field(default_factory=set)
 
 
 class MessageTool(Tool):
@@ -20,13 +30,28 @@ class MessageTool(Tool):
         self._default_channel = default_channel
         self._default_chat_id = default_chat_id
         self._default_message_id = default_message_id
-        self._sent_in_turn: bool = False
+        self._turn_state: ContextVar[_MessageTurnState | None] = ContextVar(
+            "message_turn_state",
+            default=None,
+        )
+
+    def _get_turn_state(self) -> _MessageTurnState:
+        state = self._turn_state.get()
+        if state is None:
+            state = _MessageTurnState(
+                channel=self._default_channel,
+                chat_id=self._default_chat_id,
+                message_id=self._default_message_id,
+            )
+            self._turn_state.set(state)
+        return state
 
     def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
         """Set the current message context."""
-        self._default_channel = channel
-        self._default_chat_id = chat_id
-        self._default_message_id = message_id
+        state = self._get_turn_state()
+        state.channel = channel
+        state.chat_id = chat_id
+        state.message_id = message_id
 
     def set_send_callback(self, callback: Callable[[OutboundMessage], Awaitable[None]]) -> None:
         """Set the callback for sending messages."""
@@ -34,7 +59,11 @@ class MessageTool(Tool):
 
     def start_turn(self) -> None:
         """Reset per-turn send tracking."""
-        self._sent_in_turn = False
+        self._get_turn_state().sent_targets.clear()
+
+    def get_turn_sends(self) -> list[tuple[str, str]]:
+        """Return outbound targets used in the current turn."""
+        return list(self._get_turn_state().sent_targets)
 
     @property
     def name(self) -> str:
@@ -84,9 +113,10 @@ class MessageTool(Tool):
         media: list[str] | None = None,
         **kwargs: Any
     ) -> str:
-        channel = channel or self._default_channel
-        chat_id = chat_id or self._default_chat_id
-        message_id = message_id or self._default_message_id
+        state = self._get_turn_state()
+        channel = channel or state.channel
+        chat_id = chat_id or state.chat_id
+        message_id = message_id or state.message_id
 
         if not channel or not chat_id:
             return "Error: No target channel/chat specified"
@@ -106,8 +136,7 @@ class MessageTool(Tool):
 
         try:
             await self._send_callback(msg)
-            if channel == self._default_channel and chat_id == self._default_chat_id:
-                self._sent_in_turn = True
+            state.sent_targets.add((channel, chat_id))
             media_info = f" with {len(media)} attachments" if media else ""
             return f"Message sent to {channel}:{chat_id}{media_info}"
         except Exception as e:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -583,8 +583,10 @@ def gateway(
         response = resp.content if resp else ""
 
         message_tool = agent.tools.get("message")
-        if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
-            return response
+        if isinstance(message_tool, MessageTool):
+            sent_targets = set(message_tool.get_turn_sends())
+            if (job.payload.channel or "cli", job.payload.to or "direct") in sent_targets:
+                return response
 
         if job.payload.deliver and job.payload.to and response:
             should_notify = await evaluate_response(

--- a/tests/tools/test_message_tool.py
+++ b/tests/tools/test_message_tool.py
@@ -1,6 +1,8 @@
 import pytest
+from unittest.mock import AsyncMock
 
 from nanobot.agent.tools.message import MessageTool
+from nanobot.bus.events import OutboundMessage
 
 
 @pytest.mark.asyncio
@@ -8,3 +10,29 @@ async def test_message_tool_returns_error_when_no_target_context() -> None:
     tool = MessageTool()
     result = await tool.execute(content="test")
     assert result == "Error: No target channel/chat specified"
+
+
+@pytest.mark.asyncio
+async def test_message_tool_preserves_context_metadata() -> None:
+    sent: list[OutboundMessage] = []
+    tool = MessageTool(send_callback=AsyncMock(side_effect=lambda msg: sent.append(msg)))
+
+    tool.set_context("telegram", "123", "10", {"message_id": 10, "message_thread_id": 42})
+
+    result = await tool.execute(content="hello")
+
+    assert result == "Message sent to telegram:123"
+    assert sent[0].metadata == {"message_id": "10", "message_thread_id": 42}
+
+
+@pytest.mark.asyncio
+async def test_message_tool_keeps_context_metadata_when_overriding_message_id() -> None:
+    sent: list[OutboundMessage] = []
+    tool = MessageTool(send_callback=AsyncMock(side_effect=lambda msg: sent.append(msg)))
+
+    tool.set_context("telegram", "123", "10", {"message_id": 10, "message_thread_id": 42})
+
+    result = await tool.execute(content="hello", message_id="11")
+
+    assert result == "Message sent to telegram:123"
+    assert sent[0].metadata == {"message_id": "11", "message_thread_id": 42}

--- a/tests/tools/test_message_tool_suppress.py
+++ b/tests/tools/test_message_tool_suppress.py
@@ -49,6 +49,35 @@ class TestMessageToolSuppressLogic:
         assert result is None  # suppressed
 
     @pytest.mark.asyncio
+    async def test_suppress_keeps_inbound_topic_metadata(self, tmp_path: Path) -> None:
+        loop = _make_loop(tmp_path)
+        tool_call = ToolCallRequest(id="call1", name="message", arguments={"content": "Hello"})
+        calls = iter([
+            LLMResponse(content="", tool_calls=[tool_call]),
+            LLMResponse(content="Done", tool_calls=[]),
+        ])
+        loop.provider.chat_with_retry = AsyncMock(side_effect=lambda *a, **kw: next(calls))
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        sent: list[OutboundMessage] = []
+        mt = loop.tools.get("message")
+        if isinstance(mt, MessageTool):
+            mt.set_send_callback(AsyncMock(side_effect=lambda m: sent.append(m)))
+
+        msg = InboundMessage(
+            channel="telegram",
+            sender_id="user1",
+            chat_id="123",
+            content="Send",
+            metadata={"message_id": 10, "message_thread_id": 42},
+        )
+        result = await loop._process_message(msg)
+
+        assert result is None  # suppressed
+        assert len(sent) == 1
+        assert sent[0].metadata == {"message_id": 10, "message_thread_id": 42}
+
+    @pytest.mark.asyncio
     async def test_not_suppress_when_sent_to_different_target(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)
         tool_call = ToolCallRequest(
@@ -127,7 +156,7 @@ class TestMessageToolTurnTracking:
         second_ready = asyncio.Event()
 
         async def first_turn() -> str:
-            tool.set_context("feishu", "chat1", "msg1")
+            tool.set_context("feishu", "chat1", "msg1", {"message_id": "msg1", "message_thread_id": "thread1"})
             tool.start_turn()
             allow_first_send.set()
             await second_ready.wait()
@@ -135,7 +164,7 @@ class TestMessageToolTurnTracking:
 
         async def second_turn() -> None:
             await allow_first_send.wait()
-            tool.set_context("telegram", "chat2", "msg2")
+            tool.set_context("telegram", "chat2", "msg2", {"message_id": "msg2", "message_thread_id": "thread2"})
             tool.start_turn()
             second_ready.set()
 
@@ -146,6 +175,51 @@ class TestMessageToolTurnTracking:
         assert sent[0].channel == "feishu"
         assert sent[0].chat_id == "chat1"
         assert sent[0].metadata["message_id"] == "msg1"
+        assert sent[0].metadata["message_thread_id"] == "thread1"
+
+    @pytest.mark.asyncio
+    async def test_metadata_isolated_across_concurrent_tasks(self) -> None:
+        sent: list[OutboundMessage] = []
+        first_ready = asyncio.Event()
+        allow_both_send = asyncio.Event()
+
+        async def send_callback(msg: OutboundMessage) -> None:
+            sent.append(msg)
+
+        tool = MessageTool(send_callback=AsyncMock(side_effect=send_callback))
+
+        async def first_turn() -> str:
+            tool.set_context("telegram", "chat1", "msg1", {"message_id": "msg1", "message_thread_id": 101})
+            tool.start_turn()
+            first_ready.set()
+            await allow_both_send.wait()
+            return await tool.execute("hello")
+
+        async def second_turn() -> str:
+            await first_ready.wait()
+            tool.set_context("telegram", "chat2", "msg2", {"message_id": "msg2", "message_thread_id": 202})
+            tool.start_turn()
+            allow_both_send.set()
+            return await tool.execute("hi")
+
+        result1, result2 = await asyncio.gather(first_turn(), second_turn())
+
+        assert result1 == "Message sent to telegram:chat1"
+        assert result2 == "Message sent to telegram:chat2"
+        assert len(sent) == 2
+        sent_by_chat = {msg.chat_id: msg for msg in sent}
+        assert sent_by_chat["chat1"] == OutboundMessage(
+            channel="telegram",
+            chat_id="chat1",
+            content="hello",
+            metadata={"message_id": "msg1", "message_thread_id": 101},
+        )
+        assert sent_by_chat["chat2"] == OutboundMessage(
+            channel="telegram",
+            chat_id="chat2",
+            content="hi",
+            metadata={"message_id": "msg2", "message_thread_id": 202},
+        )
 
     @pytest.mark.asyncio
     async def test_sent_targets_isolated_across_concurrent_tasks(self) -> None:

--- a/tests/tools/test_message_tool_suppress.py
+++ b/tests/tools/test_message_tool_suppress.py
@@ -1,5 +1,6 @@
 """Test message tool suppress logic for final replies."""
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -118,15 +119,77 @@ class TestMessageToolSuppressLogic:
 
 class TestMessageToolTurnTracking:
 
-    def test_sent_in_turn_tracks_same_target(self) -> None:
+    @pytest.mark.asyncio
+    async def test_default_context_isolated_across_concurrent_tasks(self) -> None:
+        sent: list[OutboundMessage] = []
+        tool = MessageTool(send_callback=AsyncMock(side_effect=lambda msg: sent.append(msg)))
+        allow_first_send = asyncio.Event()
+        second_ready = asyncio.Event()
+
+        async def first_turn() -> str:
+            tool.set_context("feishu", "chat1", "msg1")
+            tool.start_turn()
+            allow_first_send.set()
+            await second_ready.wait()
+            return await tool.execute("hello")
+
+        async def second_turn() -> None:
+            await allow_first_send.wait()
+            tool.set_context("telegram", "chat2", "msg2")
+            tool.start_turn()
+            second_ready.set()
+
+        result, _ = await asyncio.gather(first_turn(), second_turn())
+
+        assert result == "Message sent to feishu:chat1"
+        assert len(sent) == 1
+        assert sent[0].channel == "feishu"
+        assert sent[0].chat_id == "chat1"
+        assert sent[0].metadata["message_id"] == "msg1"
+
+    @pytest.mark.asyncio
+    async def test_sent_targets_isolated_across_concurrent_tasks(self) -> None:
+        sent: list[OutboundMessage] = []
+        send_started = asyncio.Event()
+        allow_send_finish = asyncio.Event()
+        second_ready = asyncio.Event()
+
+        async def send_callback(msg: OutboundMessage) -> None:
+            sent.append(msg)
+            send_started.set()
+            await allow_send_finish.wait()
+
+        tool = MessageTool(send_callback=AsyncMock(side_effect=send_callback))
+
+        async def first_turn() -> list[tuple[str, str]]:
+            tool.set_context("feishu", "chat1")
+            tool.start_turn()
+            await tool.execute("hello", channel="feishu", chat_id="chat1")
+            return tool.get_turn_sends()
+
+        async def second_turn() -> None:
+            await send_started.wait()
+            tool.set_context("feishu", "chat2")
+            tool.start_turn()
+            second_ready.set()
+
+        first_task = asyncio.create_task(first_turn())
+        second_task = asyncio.create_task(second_turn())
+        await second_ready.wait()
+        allow_send_finish.set()
+        sent_targets = await first_task
+        await second_task
+
+        assert len(sent) == 1
+        assert sent[0].chat_id == "chat1"
+        assert sent_targets == [("feishu", "chat1")]
+
+    @pytest.mark.asyncio
+    async def test_start_turn_resets_sent_targets(self) -> None:
         tool = MessageTool()
         tool.set_context("feishu", "chat1")
-        assert not tool._sent_in_turn
-        tool._sent_in_turn = True
-        assert tool._sent_in_turn
-
-    def test_start_turn_resets(self) -> None:
-        tool = MessageTool()
-        tool._sent_in_turn = True
+        tool.set_send_callback(AsyncMock())
+        await tool.execute("hello")
+        assert tool.get_turn_sends() == [("feishu", "chat1")]
         tool.start_turn()
-        assert not tool._sent_in_turn
+        assert tool.get_turn_sends() == []


### PR DESCRIPTION
## Summary
Fixes #2549.
- isolate `MessageTool` routing and per-turn suppression state so concurrent sessions cannot clobber each other
- restore target-aware final reply suppression so auto-replies are skipped only when the same turn already sent to the inbound target
- add regression tests for same-target vs cross-target behavior and concurrent turn-state isolation

## Root Cause
`MessageTool` stored default routing context and suppression state on a shared singleton instance. After per-session concurrent dispatch was introduced, overlapping turns could overwrite each other's state, causing incorrect suppression or routing.

## Verification
- `uv run python -m pytest tests/tools/test_message_tool.py tests/tools/test_message_tool_suppress.py`
- `uv run python -m compileall nanobot tests`