### PR TITLE
fix(whatsapp-bridge): close existing clients on new connection to prevent duplicate messages

### DIFF
--- a/bridge/src/server.ts
+++ b/bridge/src/server.ts
@@ -79,6 +79,15 @@ export class BridgeServer {
   }
 
   private setupClient(ws: WebSocket): void {
+    // Close any existing clients before accepting the new one.
+    // This prevents duplicate message delivery when nanobot reconnects.
+    if (this.clients.size > 0) {
+      console.log(`⚠️  New client connected — closing ${this.clients.size} existing client(s)`);
+      for (const existing of this.clients) {
+        existing.close();
+      }
+      this.clients.clear();
+    }
     this.clients.add(ws);
 
     ws.on('message', async (data) => {


### PR DESCRIPTION
## Problem
When nanobot reconnects to the bridge (e.g. after a restart), the old WebSocket connection may still be open. The bridge broadcasts to all connected clients, so each message is delivered once per stale connection — causing the agent to process the same message multiple times.

## Solution
When a new client connects, close all existing clients before adding the new one. This ensures only one active client at a time without changing the broadcast pattern.

## Changes
- bridge/src/server.ts: close existing clients in setupClient() before accepting new connection