### PR TITLE
feat(qq): add configurable instant acknowledgment message

### DIFF
--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -134,6 +134,7 @@ class QQConfig(Base):
     secret: str = ""
     allow_from: list[str] = Field(default_factory=list)
     msg_format: Literal["plain", "markdown"] = "plain"
+    ack_message: str = "⏳ Processing..."
 
     # Optional: directory to save inbound attachments. If empty, use nanobot get_media_dir("qq").
     media_dir: str = ""
@@ -483,6 +484,17 @@ class QQChannel(BaseChannel):
 
         if not content and not media_paths:
             return
+
+        if self.config.ack_message:
+            try:
+                await self._send_text_only(
+                    chat_id=chat_id,
+                    is_group=is_group,
+                    msg_id=data.id,
+                    content=self.config.ack_message,
+                )
+            except Exception:
+                logger.debug("QQ ack message failed for chat_id={}", chat_id)
 
         await self._handle_message(
             sender_id=user_id,

--- a/tests/channels/test_qq_ack_message.py
+++ b/tests/channels/test_qq_ack_message.py
@@ -1,0 +1,172 @@
+"""Tests for QQ channel ack_message feature.
+
+Covers the four verification points from the PR:
+1. C2C message: ack appears instantly
+2. Group message: ack appears instantly
+3. ack_message set to "": no ack sent
+4. Custom ack_message text: correct text delivered
+Each test also verifies that normal message processing is not blocked.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from nanobot.channels import qq
+
+    QQ_AVAILABLE = getattr(qq, "QQ_AVAILABLE", False)
+except ImportError:
+    QQ_AVAILABLE = False
+
+if not QQ_AVAILABLE:
+    pytest.skip("QQ dependencies not installed (qq-botpy)", allow_module_level=True)
+
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.qq import QQChannel, QQConfig
+
+
+class _FakeApi:
+    def __init__(self) -> None:
+        self.c2c_calls: list[dict] = []
+        self.group_calls: list[dict] = []
+
+    async def post_c2c_message(self, **kwargs) -> None:
+        self.c2c_calls.append(kwargs)
+
+    async def post_group_message(self, **kwargs) -> None:
+        self.group_calls.append(kwargs)
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.api = _FakeApi()
+
+
+@pytest.mark.asyncio
+async def test_ack_sent_on_c2c_message() -> None:
+    """Ack is sent immediately for C2C messages, then normal processing continues."""
+    channel = QQChannel(
+        QQConfig(
+            app_id="app",
+            secret="secret",
+            allow_from=["*"],
+            ack_message="⏳ Processing...",
+        ),
+        MessageBus(),
+    )
+    channel._client = _FakeClient()
+
+    data = SimpleNamespace(
+        id="msg1",
+        content="hello",
+        author=SimpleNamespace(user_openid="user1"),
+        attachments=[],
+    )
+    await channel._on_message(data, is_group=False)
+
+    assert len(channel._client.api.c2c_calls) >= 1
+    ack_call = channel._client.api.c2c_calls[0]
+    assert ack_call["content"] == "⏳ Processing..."
+    assert ack_call["openid"] == "user1"
+    assert ack_call["msg_id"] == "msg1"
+    assert ack_call["msg_type"] == 0
+
+    msg = await channel.bus.consume_inbound()
+    assert msg.content == "hello"
+    assert msg.sender_id == "user1"
+
+
+@pytest.mark.asyncio
+async def test_ack_sent_on_group_message() -> None:
+    """Ack is sent immediately for group messages, then normal processing continues."""
+    channel = QQChannel(
+        QQConfig(
+            app_id="app",
+            secret="secret",
+            allow_from=["*"],
+            ack_message="⏳ Processing...",
+        ),
+        MessageBus(),
+    )
+    channel._client = _FakeClient()
+
+    data = SimpleNamespace(
+        id="msg2",
+        content="hello group",
+        group_openid="group123",
+        author=SimpleNamespace(member_openid="user1"),
+        attachments=[],
+    )
+    await channel._on_message(data, is_group=True)
+
+    assert len(channel._client.api.group_calls) >= 1
+    ack_call = channel._client.api.group_calls[0]
+    assert ack_call["content"] == "⏳ Processing..."
+    assert ack_call["group_openid"] == "group123"
+    assert ack_call["msg_id"] == "msg2"
+    assert ack_call["msg_type"] == 0
+
+    msg = await channel.bus.consume_inbound()
+    assert msg.content == "hello group"
+    assert msg.chat_id == "group123"
+
+
+@pytest.mark.asyncio
+async def test_no_ack_when_ack_message_empty() -> None:
+    """Setting ack_message to empty string disables the ack entirely."""
+    channel = QQChannel(
+        QQConfig(
+            app_id="app",
+            secret="secret",
+            allow_from=["*"],
+            ack_message="",
+        ),
+        MessageBus(),
+    )
+    channel._client = _FakeClient()
+
+    data = SimpleNamespace(
+        id="msg3",
+        content="hello",
+        author=SimpleNamespace(user_openid="user1"),
+        attachments=[],
+    )
+    await channel._on_message(data, is_group=False)
+
+    assert len(channel._client.api.c2c_calls) == 0
+    assert len(channel._client.api.group_calls) == 0
+
+    msg = await channel.bus.consume_inbound()
+    assert msg.content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_custom_ack_message_text() -> None:
+    """Custom Chinese ack_message text is delivered correctly."""
+    custom = "正在处理中，请稍候..."
+    channel = QQChannel(
+        QQConfig(
+            app_id="app",
+            secret="secret",
+            allow_from=["*"],
+            ack_message=custom,
+        ),
+        MessageBus(),
+    )
+    channel._client = _FakeClient()
+
+    data = SimpleNamespace(
+        id="msg4",
+        content="test input",
+        author=SimpleNamespace(user_openid="user1"),
+        attachments=[],
+    )
+    await channel._on_message(data, is_group=False)
+
+    assert len(channel._client.api.c2c_calls) >= 1
+    ack_call = channel._client.api.c2c_calls[0]
+    assert ack_call["content"] == custom
+
+    msg = await channel.bus.consume_inbound()
+    assert msg.content == "test input"


### PR DESCRIPTION
## Summary

QQ's API does not support native typing indicators like Telegram (`send_chat_action`)
or Discord (periodic typing). When agent processing takes time — especially with
reasoning models where a single round can exceed 40–90 seconds — users experience
silence with no feedback at all, then a sudden response.

This adds a configurable `ackMessage` field to QQ channel config (default:
`"⏳ Processing..."`). When non-empty, an instant text reply is sent immediately
upon receiving a message, before the agent starts processing.
Set to `""` to disable.

## Relationship with `sendProgress` (PR #1000)

This PR is **complementary** to `sendProgress`, not a replacement.

`sendProgress` controls whether intermediate tool-call status messages (e.g.
"I'll check the weather for you") are forwarded to the user during agent
processing. However, it has two limitations that `ackMessage` addresses:

1. **It only fires when the agent makes tool calls.** Some models complete tasks
   in a single LLM pass with no tool calls, producing no progress messages at all.
2. **It cannot fill the initial gap.** Even when tool calls do occur, there is a
   significant delay between the user's message arriving and the first tool call
   being issued — this is the LLM's reasoning/thinking time, which can be 40–90+
   seconds with reasoning models.

`ackMessage` provides **deterministic instant feedback** regardless of model
behavior or whether tool calls occur.

![ackMessage vs sendProgress timeline](https://github.com/user-attachments/assets/58ce604d-3500-430e-be63-45c41748ef94)

## Changes

- Add `ack_message` config field to `QQConfig` (default: `"⏳ Processing..."`)
- Send ack message in `_on_message` before `_handle_message`, using the existing
  `_send_text_only` method (no duplicated API call code)
- Wrapped in `try/except` with `logger.debug` so ack failure is logged but never
  blocks normal message processing

## Impact

Provides immediate feedback to QQ users while the agent processes their request,
matching the UX parity that Telegram and Discord channels already have via native
typing indicators. This is especially valuable for reasoning models where the
initial processing delay is measured in minutes rather than seconds.

## Verified

- Tested with QQ C2C and Group messages: ack appears instantly
- Set `ackMessage` to `""`: no ack sent
- Set `ackMessage` to custom Chinese text: custom text appears correctly
- Normal agent responses continue working after ack
- Tested with reasoning model (Grok 4): ack fills a ~90s gap before first response

Screenshot below shows the ack arriving instantly, followed by a visible time gap
before the agent's actual response:

![QQ ack demo](https://github.com/user-attachments/assets/cbde49d5-6a4d-49fa-9926-4cd85ccefc52)

## Future Improvements

A potential enhancement would be a **delayed ack** mechanism: start a short timer
(e.g. 3 seconds) instead of sending immediately; if the agent responds before the
timer fires, cancel the ack to avoid unnecessary messages. This was intentionally
left out of this PR to keep the change minimal and reviewable. In practice, LLM
calls almost always exceed 3 seconds, so the ack would fire in the vast majority
of cases anyway.
