### PR TITLE
feat(slack): add image/audio file support with Whisper transcription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ build/
 *.pyz
 *.pywz
 *.pyzz
+*.log
+.omc/
 .venv/
 venv/
 __pycache__/

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -37,14 +37,48 @@ class BaseChannel(ABC):
         self._running = False
 
     async def transcribe_audio(self, file_path: str | Path) -> str:
-        """Transcribe an audio file via Groq Whisper. Returns empty string on failure."""
-        if not self.transcription_api_key:
-            return ""
-        try:
-            from nanobot.providers.transcription import GroqTranscriptionProvider
+        """Transcribe an audio file via local Whisper CLI. Returns empty string on failure."""
+        import asyncio
+        import tempfile
 
-            provider = GroqTranscriptionProvider(api_key=self.transcription_api_key)
-            return await provider.transcribe(file_path)
+        path = Path(file_path)
+        if not path.exists():
+            logger.warning("{}: audio file not found: {}", self.name, file_path)
+            return ""
+
+        try:
+            # Create a temp directory for whisper output
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # Run whisper CLI - output to txt format
+                proc = await asyncio.create_subprocess_exec(
+                    "whisper",
+                    str(path),
+                    "--model",
+                    "medium",
+                    "--output_format",
+                    "txt",
+                    "--output_dir",
+                    tmpdir,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await proc.communicate()
+
+                if proc.returncode != 0:
+                    logger.warning("{}: whisper failed: {}", self.name, stderr.decode())
+                    return ""
+
+                # Read the generated .txt file (same basename as input)
+                txt_file = Path(tmpdir) / f"{path.stem}.txt"
+                if txt_file.exists():
+                    return txt_file.read_text(encoding="utf-8").strip()
+                return ""
+
+        except FileNotFoundError:
+            logger.warning(
+                "{}: whisper CLI not found. Install with: brew install openai-whisper", self.name
+            )
+            return ""
         except Exception as e:
             logger.warning("{}: audio transcription failed: {}", self.name, e)
             return ""
@@ -91,7 +125,9 @@ class BaseChannel(ABC):
         """
         pass
 
-    async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None) -> None:
+    async def send_delta(
+        self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None
+    ) -> None:
         """Deliver a streaming text chunk.
 
         Override in subclasses to enable streaming. Implementations should
@@ -107,7 +143,11 @@ class BaseChannel(ABC):
     def supports_streaming(self) -> bool:
         """True when config enables streaming AND this subclass implements send_delta."""
         cfg = self.config
-        streaming = cfg.get("streaming", False) if isinstance(cfg, dict) else getattr(cfg, "streaming", False)
+        streaming = (
+            cfg.get("streaming", False)
+            if isinstance(cfg, dict)
+            else getattr(cfg, "streaming", False)
+        )
         return bool(streaming) and type(self).send_delta is not BaseChannel.send_delta
 
     def is_allowed(self, sender_id: str) -> bool:
@@ -146,7 +186,8 @@ class BaseChannel(ABC):
             logger.warning(
                 "Access denied for sender {} on channel {}. "
                 "Add them to allowFrom list in config to grant access.",
-                sender_id, self.name,
+                sender_id,
+                self.name,
             )
             return
 

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -4,6 +4,7 @@ import asyncio
 import re
 from typing import Any
 
+import httpx
 from loguru import logger
 from pydantic import Field
 from slack_sdk.socket_mode.request import SocketModeRequest
@@ -341,6 +342,8 @@ class SlackChannel(BaseChannel):
         """
         Download file from Slack with retry logic and timeout protection.
 
+        Uses httpx with Authorization header to download private Slack files.
+
         Args:
             file_id: Slack file ID
             filename: Original filename
@@ -354,26 +357,37 @@ class SlackChannel(BaseChannel):
         media_dir.mkdir(parents=True, exist_ok=True)
         file_path = media_dir / f"{file_id}_{filename}"
 
+        # Prepare authorization header using bot token
+        headers = {"Authorization": f"Bearer {self.config.bot_token}"}
+
         for attempt in range(max_retries):
             try:
-                # Use asyncio.wait_for to add timeout (30s for download)
-                response = await asyncio.wait_for(
-                    self._web_client.request("GET", url_private),
-                    timeout=30.0,
-                )
-                response.raise_for_status()
+                # Use httpx to download with timeout
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(url_private, headers=headers)
+                    response.raise_for_status()
 
-                # Write file in chunks to avoid blocking
-                with open(file_path, "wb") as f:
-                    f.write(response.body)
+                    # Write file
+                    with open(file_path, "wb") as f:
+                        f.write(response.content)
 
-                logger.info("Downloaded Slack file: {} as {} (attempt {})", filename, file_path, attempt + 1)
-                return str(file_path)
+                    logger.info("Downloaded Slack file: {} as {} (attempt {})", filename, file_path, attempt + 1)
+                    return str(file_path)
 
             except asyncio.TimeoutError:
                 logger.warning("Download timeout for {} (attempt {})", filename, attempt + 1)
                 if attempt < max_retries - 1:
-                    await asyncio.sleep(1 * (attempt + 1))  # Exponential backoff
+                    await asyncio.sleep(1 * (attempt + 1))
+                    continue
+            except httpx.TimeoutException:
+                logger.warning("HTTP timeout for {} (attempt {})", filename, attempt + 1)
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(1 * (attempt + 1))
+                    continue
+            except httpx.HTTPStatusError as e:
+                logger.warning("HTTP error for {} (attempt {}): {}", filename, attempt + 1, e)
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(1 * (attempt + 1))
                     continue
             except Exception as e:
                 logger.warning("Download failed for {} (attempt {}): {}", filename, attempt + 1, e)

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -5,6 +5,7 @@ import re
 from typing import Any
 
 from loguru import logger
+from pydantic import Field
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.socket_mode.websockets import SocketModeClient
@@ -13,9 +14,8 @@ from slackify_markdown import slackify_markdown
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
-from pydantic import Field
-
 from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 
 
@@ -43,6 +43,7 @@ class SlackConfig(Base):
     group_policy: str = "mention"
     group_allow_from: list[str] = Field(default_factory=list)
     dm: SlackDMConfig = Field(default_factory=SlackDMConfig)
+    max_file_size: int = Field(default=26214400)  # 25MB default
 
 
 class SlackChannel(BaseChannel):
@@ -172,8 +173,9 @@ class SlackChannel(BaseChannel):
         sender_id = event.get("user")
         chat_id = event.get("channel")
 
-        # Ignore bot/system messages (any subtype = not a normal user message)
-        if event.get("subtype"):
+        # Ignore bot/system messages, but allow file_share for media support
+        subtype = event.get("subtype")
+        if subtype and subtype not in ("file_share",):
             return
         if self._bot_user_id and sender_id == self._bot_user_id:
             return
@@ -224,11 +226,29 @@ class SlackChannel(BaseChannel):
         # Thread-scoped session key for channel/group messages
         session_key = f"slack:{chat_id}:{thread_ts}" if thread_ts and channel_type != "im" else None
 
+        # Extract media from file_share events
+        media_paths: list[str] = []
+        content_parts: list[str] = []
+        if text:
+            content_parts.append(text)
+
+        if subtype == "file_share":
+            files = event.get("files") or []
+            for file_info in files:
+                media_path, content_addition = await self._process_slack_file(file_info)
+                if media_path:
+                    media_paths.append(media_path)
+                if content_addition:
+                    content_parts.append(content_addition)
+
+        final_content = "\n".join(content_parts) if content_parts else "[empty message]"
+
         try:
             await self._handle_message(
                 sender_id=sender_id,
                 chat_id=chat_id,
-                content=text,
+                content=final_content,
+                media=media_paths,
                 metadata={
                     "slack": {
                         "event": event,
@@ -262,6 +282,107 @@ class SlackChannel(BaseChannel):
                 )
             except Exception as e:
                 logger.debug("Slack done reaction failed: {}", e)
+
+    async def _process_slack_file(self, file_info: dict) -> tuple[str | None, str | None]:
+        """
+        Process a Slack file: download media and transcribe if audio.
+
+        Returns:
+            tuple: (media_path or None, content_addition or None)
+        """
+        if not self._web_client:
+            return None, None
+
+        file_id = file_info.get("id", "")
+        filetype = file_info.get("filetype", "")
+        filename = file_info.get("name", "slack_file")
+        size = file_info.get("size", 0)
+        url_private = file_info.get("url_private_download")
+
+        # Check file size limit
+        if size > self.config.max_file_size:
+            logger.warning("Slack file too large ({}MB), skipping: {}", size / 1024 / 1024, filename)
+            return None, f"[📎 {filename} - 文件过大]"
+
+        if not url_private:
+            return None, None
+
+        # Supported image types
+        image_types = {"png", "jpg", "jpeg", "gif", "webp", "bmp"}
+        # Supported audio types
+        audio_types = {"mp3", "m4a", "wav", "ogg", "flac", "aac", "webm"}
+
+        if filetype not in image_types and filetype not in audio_types:
+            logger.debug("Skipping unsupported file type: {}", filetype)
+            return None, f"[📎 {filename} - 不支持的格式]"
+
+        # Download with retry and timeout
+        media_path = await self._download_with_retry(file_id, filename, url_private)
+        if not media_path:
+            return None, f"[📎 {filename} - 下载失败]"
+
+        # Handle audio transcription
+        if filetype in audio_types:
+            transcription = await self.transcribe_audio(media_path)
+            if transcription:
+                logger.info("Transcribed audio {}: {}...", filename, transcription[:50])
+                return media_path, f"[🎤 音频转录: {transcription}]"
+            return media_path, f"[🎤 音频: {filename}]"
+
+        # Handle images
+        if filetype in image_types:
+            return media_path, f"[🖼️ 图片: {media_path}]"
+
+        return None, None
+
+    async def _download_with_retry(
+        self, file_id: str, filename: str, url_private: str, max_retries: int = 3
+    ) -> str | None:
+        """
+        Download file from Slack with retry logic and timeout protection.
+
+        Args:
+            file_id: Slack file ID
+            filename: Original filename
+            url_private: Private download URL
+            max_retries: Number of retry attempts
+
+        Returns:
+            Local file path or None on failure
+        """
+        media_dir = get_media_dir("slack")
+        media_dir.mkdir(parents=True, exist_ok=True)
+        file_path = media_dir / f"{file_id}_{filename}"
+
+        for attempt in range(max_retries):
+            try:
+                # Use asyncio.wait_for to add timeout (30s for download)
+                response = await asyncio.wait_for(
+                    self._web_client.request("GET", url_private),
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+
+                # Write file in chunks to avoid blocking
+                with open(file_path, "wb") as f:
+                    f.write(response.body)
+
+                logger.info("Downloaded Slack file: {} as {} (attempt {})", filename, file_path, attempt + 1)
+                return str(file_path)
+
+            except asyncio.TimeoutError:
+                logger.warning("Download timeout for {} (attempt {})", filename, attempt + 1)
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(1 * (attempt + 1))  # Exponential backoff
+                    continue
+            except Exception as e:
+                logger.warning("Download failed for {} (attempt {}): {}", filename, attempt + 1, e)
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(1 * (attempt + 1))
+                    continue
+
+        logger.error("Failed to download {} after {} attempts", filename, max_retries)
+        return None
 
     def _is_allowed(self, sender_id: str, chat_id: str, channel_type: str) -> bool:
         if channel_type == "im":

--- a/nanobot/skills/whisper/SKILL.md
+++ b/nanobot/skills/whisper/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: whisper
+description: Local speech-to-text with the Whisper CLI (no API key required).
+homepage: https://openai.com/research/whisper
+metadata: {"nanobot":{"emoji":"🎤","os":["darwin","linux"],"requires":{"bins":["whisper"]},"install":[{"id":"brew","kind":"brew","formula":"openai-whisper","bins":["whisper"],"label":"Install OpenAI Whisper (brew)"}]}}
+---
+
+# Whisper (CLI)
+
+Use `whisper` to transcribe audio locally.
+
+## Quick start
+
+- `whisper /path/audio.mp3 --model medium --output_format txt --output_dir .`
+- `whisper /path/audio.m4a --task translate --output_format srt`
+
+## Notes
+
+- Models download to `~/.cache/whisper` on first run.
+- `--model` defaults to `turbo` on this install.
+- Use smaller models for speed, larger for accuracy.
+
+## For nanobot transcription
+
+The base channel's `transcribe_audio` method uses this skill for local audio transcription.

--- a/scripts/manage_nanobot.sh
+++ b/scripts/manage_nanobot.sh
@@ -34,7 +34,7 @@ install() {
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>$(dirname $NANOBOT_BIN):/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>$(dirname $NANOBOT_BIN):/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     </dict>
 </dict>
 </plist>

--- a/scripts/manage_nanobot.sh
+++ b/scripts/manage_nanobot.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# --- 配置区域 ---
+SERVICE_NAME="com.nanobot.gateway"
+PLIST_PATH="$HOME/Library/LaunchAgents/${SERVICE_NAME}.plist"
+# 使用 which nanobot 找到的完整路径
+NANOBOT_BIN="$(pyenv root)/versions/$(pyenv version-name)/bin/nanobot"
+LOG_FILE="$HOME/Library/Logs/nanobot.log"
+ERROR_LOG="$HOME/Library/Logs/nanobot.err.log"
+# ----------------
+
+install() {
+    echo "正在创建 launchd 配置文件..."
+    cat <<EOF > "$PLIST_PATH"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${SERVICE_NAME}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${NANOBOT_BIN}</string>
+        <string>gateway</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>${LOG_FILE}</string>
+    <key>StandardErrorPath</key>
+    <string>${ERROR_LOG}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>$(dirname $NANOBOT_BIN):/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>
+EOF
+    echo "安装完成。配置文件位于: $PLIST_PATH"
+}
+
+start() {
+    echo "启动 Nanobot 服务..."
+    launchctl load "$PLIST_PATH"
+}
+
+stop() {
+    echo "停止 Nanobot 服务..."
+    launchctl unload "$PLIST_PATH"
+}
+
+restart() {
+    echo "正在重启 Nanobot 服务..."
+    stop
+    sleep 1
+    start
+    echo "重启操作已完成。"
+}
+
+uninstall() {
+    stop
+    echo "移除配置文件..."
+    rm -f "$PLIST_PATH"
+    echo "卸载完成。"
+}
+
+logs() {
+    echo "正在查看实时日志 (Ctrl+C 退出)..."
+    tail -f "$LOG_FILE" "$ERROR_LOG"
+}
+
+case "$1" in
+    install) install ;;
+    start) start ;;
+    stop) stop ;;
+    restart) restart ;;
+    uninstall) uninstall ;;
+    logs) logs ;;
+    *) echo "用法: $0 {install|start|stop|uninstall|logs}" ;;
+esac


### PR DESCRIPTION
## Summary
- 为 Slack 频道添加图片和音频文件接收功能
- 音频文件使用本地 Whisper CLI 自动转录成文字
- 下载的媒体文件路径会传递给 LLM，支持多模态对话

## Changes

### 新增功能
- **Slack 文件处理**：支持 `file_share` 事件，下载图片和音频
- **音频转录**：使用本地 Whisper (medium 模型) 转录音频
- **图片支持**：下载图片到本地，路径传递给 LLM
- **重试机制**：下载失败自动重试 3 次，指数退避
- **超时保护**：30 秒下载超时

### 支持格式
- 图片：png, jpg, jpeg, gif, webp, bmp
- 音频：mp3, m4a, wav, ogg, flac, aac, webm

### 配置项
- `max_file_size`: 最大文件大小限制（默认 25MB）

## 依赖
- 需要安装 Whisper CLI: `brew install openai-whisper`
- launchd PATH 已包含 `/opt/homebrew/bin`

## Files Changed
- `nanobot/channels/base.py`: Groq API → 本地 Whisper CLI
- `nanobot/channels/slack.py`: 文件下载和处理逻辑
- `nanobot/skills/whisper/SKILL.md`: Whisper 技能文档
- `scripts/manage_nanobot.sh`: macOS 服务管理脚本
- `.gitignore`: 添加日志忽略规则