### PR TITLE
feat(runner): repair empty final responses before falling back

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -16,7 +16,12 @@ from loguru import logger
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.hook import AgentHook, AgentHookContext
 from nanobot.agent.memory import MemoryConsolidator
-from nanobot.agent.runner import AgentRunSpec, AgentRunner
+from nanobot.agent.runner import (
+    EMPTY_FINAL_RESPONSE_PLACEHOLDER,
+    EMPTY_FINAL_RESPONSE_REPROMPT,
+    AgentRunSpec,
+    AgentRunner,
+)
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
@@ -538,6 +543,10 @@ class AgentLoop:
         for m in messages[skip:]:
             entry = dict(m)
             role, content = entry.get("role"), entry.get("content")
+            if role == "assistant" and content == EMPTY_FINAL_RESPONSE_PLACEHOLDER:
+                continue
+            if role == "user" and content == EMPTY_FINAL_RESPONSE_REPROMPT:
+                continue
             if role == "assistant" and not content and not entry.get("tool_calls"):
                 continue  # skip empty assistant messages — they poison session context
             if role == "tool":

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -16,6 +16,31 @@ _DEFAULT_MAX_ITERATIONS_MESSAGE = (
     "without completing the task. You can try breaking the task into smaller steps."
 )
 _DEFAULT_ERROR_MESSAGE = "Sorry, I encountered an error calling the AI model."
+EMPTY_FINAL_RESPONSE_MAX_RETRIES = 1
+EMPTY_FINAL_RESPONSE_PLACEHOLDER = "[empty assistant response]"
+EMPTY_FINAL_RESPONSE_REPROMPT = (
+    "Your previous response contained no user-visible content. "
+    "Reply with a concise final answer for the user based on the work already completed. "
+    "Do not call tools, and do not output only hidden reasoning or an empty message."
+)
+
+
+def _append_empty_response_reprompt(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Append a repair prompt after an empty assistant reply."""
+    if (
+        messages
+        and messages[-1].get("role") == "assistant"
+        and messages[-1].get("content") is None
+        and not messages[-1].get("tool_calls")
+    ):
+        messages[-1] = {
+            **messages[-1],
+            "content": EMPTY_FINAL_RESPONSE_PLACEHOLDER,
+        }
+    elif messages and messages[-1].get("role") == "user":
+        messages.append(build_assistant_message(EMPTY_FINAL_RESPONSE_PLACEHOLDER))
+    messages.append({"role": "user", "content": EMPTY_FINAL_RESPONSE_REPROMPT})
+    return messages
 
 
 @dataclass(slots=True)
@@ -64,13 +89,15 @@ class AgentRunner:
         error: str | None = None
         stop_reason = "completed"
         tool_events: list[dict[str, str]] = []
+        empty_response_retries = 0
+        text_only_repair = False
 
         for iteration in range(spec.max_iterations):
             context = AgentHookContext(iteration=iteration, messages=messages)
             await hook.before_iteration(context)
             kwargs: dict[str, Any] = {
                 "messages": messages,
-                "tools": spec.tools.get_definitions(),
+                "tools": None if text_only_repair else spec.tools.get_definitions(),
                 "model": spec.model,
             }
             if spec.temperature is not None:
@@ -101,6 +128,7 @@ class AgentRunner:
             context.tool_calls = list(response.tool_calls)
 
             if response.has_tool_calls:
+                text_only_repair = False
                 if hook.wants_streaming():
                     await hook.on_stream_end(context, resuming=True)
 
@@ -154,6 +182,14 @@ class AgentRunner:
                 reasoning_content=response.reasoning_content,
                 thinking_blocks=response.thinking_blocks,
             ))
+            if clean is None and empty_response_retries < EMPTY_FINAL_RESPONSE_MAX_RETRIES:
+                empty_response_retries += 1
+                messages = _append_empty_response_reprompt(messages)
+                text_only_repair = True
+                context.final_content = None
+                await hook.after_iteration(context)
+                continue
+            text_only_repair = False
             final_content = clean
             context.final_content = final_content
             context.stop_reason = stop_reason

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1,5 +1,6 @@
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.loop import AgentLoop
+from nanobot.agent.runner import EMPTY_FINAL_RESPONSE_PLACEHOLDER, EMPTY_FINAL_RESPONSE_REPROMPT
 from nanobot.session.manager import Session
 
 
@@ -72,3 +73,20 @@ def test_save_turn_keeps_tool_results_under_16k() -> None:
     )
 
     assert session.messages[0]["content"] == content
+
+
+def test_save_turn_skips_empty_response_repair_artifacts() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:empty-repair")
+
+    loop._save_turn(
+        session,
+        [
+            {"role": "assistant", "content": EMPTY_FINAL_RESPONSE_PLACEHOLDER},
+            {"role": "user", "content": EMPTY_FINAL_RESPONSE_REPROMPT},
+            {"role": "assistant", "content": "final reply"},
+        ],
+        skip=0,
+    )
+
+    assert [msg["content"] for msg in session.messages] == ["final reply"]

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -259,6 +259,53 @@ async def test_runner_returns_structured_tool_error():
 
 
 @pytest.mark.asyncio
+async def test_runner_retries_empty_final_response_without_tools():
+    from nanobot.agent.runner import (
+        EMPTY_FINAL_RESPONSE_PLACEHOLDER,
+        EMPTY_FINAL_RESPONSE_REPROMPT,
+        AgentRunSpec,
+        AgentRunner,
+    )
+
+    provider = MagicMock()
+    calls: list[dict] = []
+
+    async def chat_with_retry(**kwargs):
+        calls.append({
+            **kwargs,
+            "messages": [dict(message) for message in kwargs["messages"]],
+        })
+        if len(calls) == 1:
+            return LLMResponse(content=None, tool_calls=[], usage={})
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = [{"type": "function", "function": {"name": "list_dir"}}]
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "do task"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=3,
+    ))
+
+    assert result.final_content == "done"
+    assert len(calls) == 2
+    assert calls[0]["tools"] == [{"type": "function", "function": {"name": "list_dir"}}]
+    assert calls[1]["tools"] is None
+    assert calls[1]["messages"][-2] == {
+        "role": "assistant",
+        "content": EMPTY_FINAL_RESPONSE_PLACEHOLDER,
+    }
+    assert calls[1]["messages"][-1] == {
+        "role": "user",
+        "content": EMPTY_FINAL_RESPONSE_REPROMPT,
+    }
+
+
+@pytest.mark.asyncio
 async def test_loop_max_iterations_message_stays_stable(tmp_path):
     loop = _make_loop(tmp_path)
     loop.provider.chat_with_retry = AsyncMock(return_value=LLMResponse(


### PR DESCRIPTION
## Summary

Fixes cases where the agent finishes tool work but returns no user-visible final answer, which currently falls back to:

`I've completed processing but have no response to give.`

This PR adds a single repair retry in the shared runner instead of immediately surfacing that fallback.

## What Changed

- add empty-final-response repair logic to `AgentRunner`
- when the model returns no tool calls and no visible content:
  - inject a placeholder assistant message
  - append a repair prompt
  - retry once in text-only mode
- disable tools during the repair retry to avoid re-entering the tool loop
- skip the injected repair artifacts when persisting session history
- add regression tests for:
  - retrying empty final responses
  - not persisting repair artifacts into session history

## Why

Today the shared execution path can receive a response like:

- `tool_calls=[]`
- `content=None`

In that case the runner stops and `AgentLoop` falls back to:

`I've completed processing but have no response to give.`

That is a poor user-facing outcome, and in many cases the model only needs one explicit nudge to produce a normal final answer.

Implementing the fix in `AgentRunner` keeps the behavior consistent across both main conversations and subagents.

## Scope

This is intentionally a small fix:

- no change to normal successful responses
- no change to normal tool execution flow
- only triggers when the response is non-error, non-tool, and empty
- retries at most once

## Testing

Completed:

- `py_compile nanobot/agent/runner.py`
- `py_compile nanobot/agent/loop.py`
- `py_compile tests/agent/test_runner.py`
- `py_compile tests/agent/test_loop_save_turn.py`

Also validated with a targeted inline script that confirmed:

- an empty final response triggers one repair retry
- the retry disables tools
- the repair prompt is injected as expected
- a normal final answer can be recovered