### PR TITLE
fix(skill-creator): Fix grammar in SKILL.md: 'another the agent'

### DIFF
--- a/nanobot/skills/skill-creator/SKILL.md
+++ b/nanobot/skills/skill-creator/SKILL.md
@@ -295,7 +295,7 @@ After initialization, customize the SKILL.md and add resources as needed. If you
 
 ### Step 4: Edit the Skill
 
-When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of the agent to use. Include information that would be beneficial and non-obvious to the agent. Consider what procedural knowledge, domain-specific details, or reusable assets would help another the agent instance execute these tasks more effectively.
+When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of the agent to use. Include information that would be beneficial and non-obvious to the agent. Consider what procedural knowledge, domain-specific details, or reusable assets would help another agent instance execute these tasks more effectively.
 
 #### Learn Proven Design Patterns
 


### PR DESCRIPTION
Fix a grammar typo in `skill-creator/SKILL.md`: "another the agent" → "another agent".