### PR TITLE
feat(telegram): Render Telegram tool hints as code blocks

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -28,6 +28,16 @@ TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
 TELEGRAM_REPLY_CONTEXT_MAX_LEN = TELEGRAM_MAX_MESSAGE_LEN  # Max length for reply context in user message
 
 
+def _escape_telegram_html(text: str) -> str:
+    """Escape text for Telegram HTML parse mode."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _tool_hint_to_telegram_html(text: str) -> str:
+    """Render tool hints as a Telegram code block."""
+    return f"<pre><code>{_escape_telegram_html(text)}</code></pre>" if text else ""
+
+
 def _strip_md(s: str) -> str:
     """Strip markdown inline formatting from text."""
     s = re.sub(r'\*\*(.+?)\*\*', r'\1', s)
@@ -120,7 +130,7 @@ def _markdown_to_telegram_html(text: str) -> str:
     text = re.sub(r'^>\s*(.*)$', r'\1', text, flags=re.MULTILINE)
 
     # 5. Escape HTML special characters
-    text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    text = _escape_telegram_html(text)
 
     # 6. Links [text](url) - must be before bold/italic to handle nested cases
     text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', text)
@@ -141,13 +151,13 @@ def _markdown_to_telegram_html(text: str) -> str:
     # 11. Restore inline code with HTML tags
     for i, code in enumerate(inline_codes):
         # Escape HTML in code content
-        escaped = code.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        escaped = _escape_telegram_html(code)
         text = text.replace(f"\x00IC{i}\x00", f"<code>{escaped}</code>")
 
     # 12. Restore code blocks with HTML tags
     for i, code in enumerate(code_blocks):
         # Escape HTML in code content
-        escaped = code.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        escaped = _escape_telegram_html(code)
         text = text.replace(f"\x00CB{i}\x00", f"<pre><code>{escaped}</code></pre>")
 
     return text
@@ -431,8 +441,15 @@ class TelegramChannel(BaseChannel):
 
         # Send text content
         if msg.content and msg.content != "[empty message]":
+            render_as_code = bool(msg.metadata.get("_tool_hint"))
             for chunk in split_message(msg.content, TELEGRAM_MAX_MESSAGE_LEN):
-                await self._send_text(chat_id, chunk, reply_params, thread_kwargs)
+                await self._send_text(
+                    chat_id,
+                    chunk,
+                    reply_params,
+                    thread_kwargs,
+                    render_as_code=render_as_code,
+                )
 
     async def _call_with_retry(self, fn, *args, **kwargs):
         """Call an async Telegram API function with retry on pool/network timeout."""
@@ -455,10 +472,11 @@ class TelegramChannel(BaseChannel):
         text: str,
         reply_params=None,
         thread_kwargs: dict | None = None,
+        render_as_code: bool = False,
     ) -> None:
         """Send a plain text message with HTML fallback."""
         try:
-            html = _markdown_to_telegram_html(text)
+            html = _tool_hint_to_telegram_html(text) if render_as_code else _markdown_to_telegram_html(text)
             await self._call_with_retry(
                 self._app.bot.send_message,
                 chat_id=chat_id, text=html, parse_mode="HTML",

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -453,6 +453,27 @@ async def test_send_progress_keeps_message_in_topic() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_tool_hint_renders_as_code_block() -> None:
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    channel = TelegramChannel(config, MessageBus())
+    channel._app = _FakeApp(lambda: None)
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content='read_file("a<b>&c.txt")',
+            metadata={"_progress": True, "_tool_hint": True},
+        )
+    )
+
+    assert channel._app.bot.sent_messages[0]["text"] == (
+        '<pre><code>read_file("a&lt;b&gt;&amp;c.txt")</code></pre>'
+    )
+    assert channel._app.bot.sent_messages[0]["parse_mode"] == "HTML"
+
+
+@pytest.mark.asyncio
 async def test_send_reply_infers_topic_from_message_id_cache() -> None:
     config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], reply_to_message=True)
     channel = TelegramChannel(config, MessageBus())


### PR DESCRIPTION
## Summary

This PR updates the Telegram channel to render `_tool_hint` messages as code blocks instead of regular text.

## Changes

- render Telegram tool hints with `<pre><code>...</code></pre>`
- escape HTML-sensitive characters in tool hints to avoid Telegram HTML parse errors
- reuse a shared Telegram HTML escaping helper in the existing markdown/code rendering flow
- add a regression test covering tool hint code-block rendering and HTML escaping

## Why

Tool hints are easier to scan when they are visually separated from normal assistant text. Rendering them as code blocks also prevents formatting issues when tool arguments contain characters like `<`, `>`, or `&`.

## Testing

- added a regression test for Telegram tool hint rendering
- manually verified the send path with a minimal local script