### PR TITLE
feat(telegram): Add Telegram link preview config with backward-compatible default

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ Connect nanobot to your favorite chat platform. Want to build your own? See the 
     "telegram": {
       "enabled": true,
       "token": "YOUR_BOT_TOKEN",
-      "allowFrom": ["YOUR_USER_ID"]
+      "allowFrom": ["YOUR_USER_ID"],
+      "linkPreview": true
     }
   }
 }

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -179,6 +179,7 @@ class TelegramConfig(Base):
     connection_pool_size: int = 32
     pool_timeout: float = 5.0
     streaming: bool = True
+    link_preview: bool = True
 
 
 class TelegramChannel(BaseChannel):
@@ -449,6 +450,12 @@ class TelegramChannel(BaseChannel):
                 )
                 await asyncio.sleep(delay)
 
+    def _link_preview_kwargs(self) -> dict[str, bool]:
+        """Map config to Telegram send/edit kwargs for link previews."""
+        if self.config.link_preview:
+            return {}
+        return {"disable_web_page_preview": True}
+
     async def _send_text(
         self,
         chat_id: int,
@@ -463,6 +470,7 @@ class TelegramChannel(BaseChannel):
                 self._app.bot.send_message,
                 chat_id=chat_id, text=html, parse_mode="HTML",
                 reply_parameters=reply_params,
+                **self._link_preview_kwargs(),
                 **(thread_kwargs or {}),
             )
         except Exception as e:
@@ -473,6 +481,7 @@ class TelegramChannel(BaseChannel):
                     chat_id=chat_id,
                     text=text,
                     reply_parameters=reply_params,
+                    **self._link_preview_kwargs(),
                     **(thread_kwargs or {}),
                 )
             except Exception as e2:
@@ -504,6 +513,7 @@ class TelegramChannel(BaseChannel):
                     self._app.bot.edit_message_text,
                     chat_id=int_chat_id, message_id=buf.message_id,
                     text=html, parse_mode="HTML",
+                    **self._link_preview_kwargs(),
                 )
             except Exception as e:
                 if self._is_not_modified_error(e):
@@ -516,6 +526,7 @@ class TelegramChannel(BaseChannel):
                         self._app.bot.edit_message_text,
                         chat_id=int_chat_id, message_id=buf.message_id,
                         text=buf.text,
+                        **self._link_preview_kwargs(),
                     )
                 except Exception as e2:
                     if self._is_not_modified_error(e2):
@@ -544,6 +555,7 @@ class TelegramChannel(BaseChannel):
                 sent = await self._call_with_retry(
                     self._app.bot.send_message,
                     chat_id=int_chat_id, text=buf.text,
+                    **self._link_preview_kwargs(),
                 )
                 buf.message_id = sent.message_id
                 buf.last_edit = now
@@ -556,6 +568,7 @@ class TelegramChannel(BaseChannel):
                     self._app.bot.edit_message_text,
                     chat_id=int_chat_id, message_id=buf.message_id,
                     text=buf.text,
+                    **self._link_preview_kwargs(),
                 )
                 buf.last_edit = now
             except Exception as e:

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -419,6 +419,10 @@ def test_telegram_group_policy_defaults_to_mention() -> None:
     assert TelegramConfig().group_policy == "mention"
 
 
+def test_telegram_link_preview_defaults_to_true() -> None:
+    assert TelegramConfig().link_preview is True
+
+
 def test_is_allowed_accepts_legacy_telegram_id_username_formats() -> None:
     channel = TelegramChannel(TelegramConfig(allow_from=["12345", "alice", "67890|bob"]), MessageBus())
 
@@ -450,6 +454,62 @@ async def test_send_progress_keeps_message_in_topic() -> None:
     )
 
     assert channel._app.bot.sent_messages[0]["message_thread_id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_send_tool_hint_renders_as_code_block() -> None:
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
+    channel = TelegramChannel(config, MessageBus())
+    channel._app = _FakeApp(lambda: None)
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content='read_file("a<b>&c.txt")',
+            metadata={"_progress": True, "_tool_hint": True},
+        )
+    )
+
+    assert channel._app.bot.sent_messages[0]["text"] == (
+        '<pre><code>read_file("a&lt;b&gt;&amp;c.txt")</code></pre>'
+    )
+    assert channel._app.bot.sent_messages[0]["parse_mode"] == "HTML"
+
+
+@pytest.mark.asyncio
+async def test_send_disables_link_preview_when_config_false() -> None:
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], link_preview=False)
+    channel = TelegramChannel(config, MessageBus())
+    channel._app = _FakeApp(lambda: None)
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="https://example.com",
+        )
+    )
+
+    assert channel._app.bot.sent_messages[0]["disable_web_page_preview"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_delta_disables_link_preview_when_config_false() -> None:
+    config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], link_preview=False)
+    channel = TelegramChannel(config, MessageBus())
+    channel._app = _FakeApp(lambda: None)
+    channel._app.bot.edit_message_text = AsyncMock()
+    channel._stream_bufs["123"] = _StreamBuf(
+        text="https://example.com",
+        message_id=7,
+        last_edit=0.0,
+        stream_id="s:0",
+    )
+
+    await channel.send_delta("123", "", {"_stream_end": True, "_stream_id": "s:0"})
+
+    assert channel._app.bot.edit_message_text.await_args.kwargs["disable_web_page_preview"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR adds a `linkPreview` option to the Telegram channel config.

## Changes

- add `channels.telegram.linkPreview` to `TelegramConfig`
- default `linkPreview` to `true` for backward compatibility
- disable Telegram web page previews by sending `disable_web_page_preview=True` when `linkPreview` is `false`
- apply the setting to both regular sends and streaming message updates
- document the new config option in the Telegram setup section of the README
- add tests for the default value and the disabled-preview send/edit behavior

## Why

Some Telegram users want to suppress automatic link previews to keep replies cleaner, especially when the bot sends URLs as plain text or during streaming updates.

## Testing

- added unit tests for:
  - default `linkPreview=True`
  - regular Telegram sends with previews disabled
  - streaming Telegram edits with previews disabled

## Notes

`linkPreview` defaults to `true`, so existing Telegram setups keep the current behavior unless the option is explicitly turned off.