### PR TITLE
refactor: rename tool progress text variable for clarity

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -244,9 +244,12 @@ class AgentLoop:
             async def before_execute_tools(self, context: AgentHookContext) -> None:
                 if on_progress:
                     if not on_stream:
-                        thought = loop_self._strip_think(context.response.content if context.response else None)
-                        if thought:
-                            await on_progress(thought)
+                        # Show only user-visible text before executing tools.
+                        display_text = loop_self._strip_think(
+                            context.response.content if context.response else None
+                        )
+                        if display_text:
+                            await on_progress(display_text)
                     tool_hint = loop_self._strip_think(loop_self._tool_hint(context.tool_calls))
                     await on_progress(tool_hint, tool_hint=True)
                 for tc in context.tool_calls:


### PR DESCRIPTION
## Summary
This renames a local variable in the tool-progress path from `thought` to `display_text` and adds a short comment to clarify the intent.

## Why
In `AgentLoop._run_agent_loop()`, this value is produced by `_strip_think(...)`, which removes internal `<think>...</think>` blocks and leaves the user-visible text that may be sent through `on_progress()` before tool execution.
The previous name `thought` was a bit misleading, because the code is not extracting thought content itself.

## Changes
- rename `thought` -> `display_text`
- add a short comment explaining that this path only surfaces user-visible text before executing tools

## Behavior
No functional behavior changes intended.