### PR TITLE
fix(utils): correct off-by-one in find_legal_message_start

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -115,7 +115,7 @@ def find_legal_message_start(messages: list[dict[str, Any]]) -> int:
             if tid and str(tid) not in declared:
                 start = i + 1
                 declared.clear()
-                for prev in messages[start : i + 1]:
+                for prev in messages[start:i]:
                     if prev.get("role") == "assistant":
                         for tc in prev.get("tool_calls") or []:
                             if isinstance(tc, dict) and tc.get("id"):


### PR DESCRIPTION
Fixes #2583.

Corrects an off-by-one error in `find_legal_message_start` (previously `_find_legal_start` in session/manager.py, now in `nanobot/utils/helpers.py`).

When an orphan tool result is found, the loop rebuilds the `declared` set by iterating `messages[start:i+1]`. This includes the orphan message itself — if it happens to have role "assistant" with tool_calls, those IDs get added to `declared`, defeating the orphan detection.

Fix: slice to `messages[start:i]` (exclusive upper bound).