### PR TITLE
fix(agent): add empty reasoning_content for kimi thinking mode

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -126,6 +126,8 @@ def build_assistant_message(
         msg["tool_calls"] = tool_calls
     if reasoning_content is not None:
         msg["reasoning_content"] = reasoning_content
+    elif thinking_blocks is not None:
+        msg["reasoning_content"] = ""
     if thinking_blocks:
         msg["thinking_blocks"] = thinking_blocks
     return msg


### PR DESCRIPTION
Fixes #2579.

Adds an empty `reasoning_content` field to assistant messages when thinking mode is enabled but no reasoning content is provided. This prevents Kimi K2.5 from throwing an `invalid_request_error` after multiple tool calls.