### PR TITLE
feat(telegram): send tool hint message in telegram silently

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -431,8 +431,15 @@ class TelegramChannel(BaseChannel):
 
         # Send text content
         if msg.content and msg.content != "[empty message]":
+            disable_notification = bool(msg.metadata.get("_tool_hint"))
             for chunk in split_message(msg.content, TELEGRAM_MAX_MESSAGE_LEN):
-                await self._send_text(chat_id, chunk, reply_params, thread_kwargs)
+                await self._send_text(
+                    chat_id,
+                    chunk,
+                    reply_params,
+                    thread_kwargs,
+                    disable_notification=disable_notification,
+                )
 
     async def _call_with_retry(self, fn, *args, **kwargs):
         """Call an async Telegram API function with retry on pool/network timeout."""
@@ -455,6 +462,8 @@ class TelegramChannel(BaseChannel):
         text: str,
         reply_params=None,
         thread_kwargs: dict | None = None,
+        *,
+        disable_notification: bool = False,
     ) -> None:
         """Send a plain text message with HTML fallback."""
         try:
@@ -463,6 +472,7 @@ class TelegramChannel(BaseChannel):
                 self._app.bot.send_message,
                 chat_id=chat_id, text=html, parse_mode="HTML",
                 reply_parameters=reply_params,
+                disable_notification=disable_notification,
                 **(thread_kwargs or {}),
             )
         except Exception as e:
@@ -473,6 +483,7 @@ class TelegramChannel(BaseChannel):
                     chat_id=chat_id,
                     text=text,
                     reply_parameters=reply_params,
+                    disable_notification=disable_notification,
                     **(thread_kwargs or {}),
                 )
             except Exception as e2:

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -453,6 +453,45 @@ async def test_send_progress_keeps_message_in_topic() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_tool_hint_uses_silent_notification() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content='read_file("README.md")',
+            metadata={"_progress": True, "_tool_hint": True},
+        )
+    )
+
+    assert channel._app.bot.sent_messages[0]["disable_notification"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_regular_message_keeps_notification_default() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+
+    await channel.send(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="123",
+            content="hello",
+        )
+    )
+
+    assert channel._app.bot.sent_messages[0]["disable_notification"] is False
+
+
+@pytest.mark.asyncio
 async def test_send_reply_infers_topic_from_message_id_cache() -> None:
     config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"], reply_to_message=True)
     channel = TelegramChannel(config, MessageBus())


### PR DESCRIPTION
## Summary

This PR makes Telegram tool hint messages silent by setting `disable_notification=True` when the outbound message is marked with `_tool_hint`.

## Why

Telegram tool hints are progress-style messages that describe tool calls such as `read_file(...)` or `web_search(...)`. They are useful for transparency, but they should not trigger push notifications the same way as normal assistant replies.

## Changes

- Detect `_tool_hint` in Telegram outbound messages and derive a `disable_notification` flag.
- Pass `disable_notification` through both the HTML send path and the plain-text fallback path.
- Add regression tests to verify:
  - tool hint messages are sent silently
  - regular messages keep the default notification behavior

## Files

- [nanobot/channels/telegram.py](d:/code/nanobot/nanobot/channels/telegram.py#L434)
- [tests/channels/test_telegram_channel.py](d:/code/nanobot/tests/channels/test_telegram_channel.py#L456)
