### PR TITLE
Feat(WeiXin): WeXin multimodal capabilities and align with version 2.1.1

### DIFF
--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -385,6 +385,7 @@ class WeixinChannel(BaseChannel):
                         )
                         return False
                     qrcode_id, scan_url = await self._fetch_qr_code()
+                    current_poll_base_url = self.config.base_url
                     self._print_qr_code(scan_url)
                     continue
                 # status == "wait" — keep polling

--- a/tests/channels/test_weixin_channel.py
+++ b/tests/channels/test_weixin_channel.py
@@ -520,6 +520,41 @@ async def test_qr_login_redirect_without_host_keeps_current_polling_base_url() -
 
 
 @pytest.mark.asyncio
+async def test_qr_login_resets_redirect_base_url_after_qr_refresh() -> None:
+    channel, _bus = _make_channel()
+    channel._running = True
+    channel._save_state = lambda: None
+    channel._print_qr_code = lambda url: None
+    channel._fetch_qr_code = AsyncMock(side_effect=[("qr-1", "url-1"), ("qr-2", "url-2")])
+
+    channel._api_get_with_base = AsyncMock(
+        side_effect=[
+            {"status": "scaned_but_redirect", "redirect_host": "idc.redirect.test"},
+            {"status": "expired"},
+            {
+                "status": "confirmed",
+                "bot_token": "token-5",
+                "ilink_bot_id": "bot-5",
+                "baseurl": "https://example.test",
+                "ilink_user_id": "wx-user",
+            },
+        ]
+    )
+
+    ok = await channel._qr_login()
+
+    assert ok is True
+    assert channel._token == "token-5"
+    assert channel._api_get_with_base.await_count == 3
+    first_call = channel._api_get_with_base.await_args_list[0]
+    second_call = channel._api_get_with_base.await_args_list[1]
+    third_call = channel._api_get_with_base.await_args_list[2]
+    assert first_call.kwargs["base_url"] == "https://ilinkai.weixin.qq.com"
+    assert second_call.kwargs["base_url"] == "https://idc.redirect.test"
+    assert third_call.kwargs["base_url"] == "https://ilinkai.weixin.qq.com"
+
+
+@pytest.mark.asyncio
 async def test_process_message_skips_bot_messages() -> None:
     channel, bus = _make_channel()
 


### PR DESCRIPTION
## Background
The official Weixin plugin supports a broader ilinkai protocol surface than Nanobot previously implemented.

Beyond basic long-poll receive/send, it also carries complete protocol headers, supports CDN upload/download URL dual forms (upload_full_url / full_url), handles QR polling redirection and transient gateway/network failures, falls back to referenced media when quoted messages contain downloadable attachments, exposes typing via getConfig + sendTyping, and supports richer outbound media behavior including voice sends and typing keepalive.

Nanobot’s Weixin channel previously lacked or only partially implemented these behaviors: request headers were not fully aligned with the reference plugin; outbound upload only handled upload_param; inbound media download only handled constructed CDN URLs; QR login polling did not follow redirect hosts and was less tolerant of transient poll failures; quoted/referenced media was not downloaded as a fallback; typing only had no support at first, then only a minimal start/cancel flow; getConfig cache behavior was simpler than the reference strategy; and outbound voice media was not sent using the Weixin voice message type.

## Goal
Align Nanobot’s Weixin channel more closely with the ilinkai/reference plugin by:
- completing protocol header behavior
- supporting upload_full_url and full_url
- handling QR redirect and transient QR poll failures
- adding referenced media fallback download
- implementing getConfig + sendTyping with keepalive and stronger cache behavior
- adding outbound voice message support

## Scope
All changes are limited to `nanobot/channels/weixin.py` and corresponding test files.

## Acceptance Criteria
- weixin.py reads reference package metadata and sends aligned protocol headers, including iLink-App-Id, iLink-App-ClientVersion, AuthorizationType, X-WECHAT-UIN, optional SKRouteTag, and aligned BASE_INFO.channel_version; add/update header and version tests
- Outbound media upload supports both upload_full_url and upload_param, preferring upload_full_url when present and failing only when both are absent; add tests for both branches
- Inbound media download supports both media.full_url and encrypt_query_param, preferring full_url when present and falling back otherwise; keep non-image AES handling protocol-aligned and add full-file regression coverage
- QR login polling follows scaned_but_redirect / redirect_host semantics, preserves existing confirmed/expired behavior, and treats transient timeout/transport/HTTP 5xx poll failures as retryable where justified by the reference implementation; add redirect and transient-failure tests
- Inbound message processing falls back to quoted/referenced media (ref_msg.message_item) only when no top-level downloadable media candidate exists; preserve existing quoted-text behavior and add fallback tests
- Typing support is implemented through ilinkai getconfig and sendtyping: acquire/cache typing_ticket, start typing before send, keep typing alive during long sends, and cancel typing in finally; add tests for ticket fetch, cache behavior, keepalive lifecycle, and cancel semantics
- getConfig caching is upgraded from a fixed TTL to a more reference-aligned strategy with refresh scheduling, retry backoff, and safe stale-ticket reuse where appropriate; add cache-path tests
- Outbound voice media is sent using the Weixin voice message path (media_type=4, voice_item, type=3) when given supported audio input, instead of being downgraded to a generic file attachment; add voice-send tests
- Run the entire tests/channels/test_weixin_channel.py file for verification after each feature group to ensure the Weixin model remains regression-safe