### PR TITLE
feat(memory_index): IndexService lifecycle, file watcher, and pre-retrieval injection

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -1,14 +1,19 @@
 """Context builder for assembling agent prompts."""
 
+from __future__ import annotations
+
 import base64
 import mimetypes
 import platform
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
 from nanobot.utils.helpers import build_assistant_message, current_time_str, detect_image_mime
+
+if TYPE_CHECKING:
+    from nanobot.memory_index.service import IndexService
 
 
 class ContextBuilder:
@@ -132,7 +137,7 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
 
         return "\n\n".join(parts) if parts else ""
 
-    def build_messages(
+    async def build_messages(
         self,
         history: list[dict[str, Any]],
         current_message: str,
@@ -141,6 +146,7 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
         channel: str | None = None,
         chat_id: str | None = None,
         current_role: str = "user",
+        index: IndexService | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
         runtime_ctx = self._build_runtime_context(channel, chat_id, self.timezone)
@@ -153,11 +159,21 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
         else:
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
 
-        return [
+        messages: list[dict[str, Any]] = [
             {"role": "system", "content": self.build_system_prompt(skill_names)},
             *history,
             {"role": current_role, "content": merged},
         ]
+
+        if index is not None and index._cfg.inject_top_k > 0:
+            results = await index.index.search(current_message, top_k=index._cfg.inject_top_k)
+            if results:
+                injection = "Relevant memory:\n\n" + "\n\n---\n\n".join(
+                    f"[{r.source} L{r.start_line}–{r.end_line}]\n{r.text}" for r in results
+                )
+                messages.insert(-1, {"role": "system", "content": injection})
+
+        return messages
 
     def _build_user_content(self, text: str, media: list[str] | None) -> str | list[dict[str, Any]]:
         """Build user message content with optional base64-encoded images."""

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -6,11 +6,9 @@ import platform
 from pathlib import Path
 from typing import Any
 
-from nanobot.utils.helpers import current_time_str
-
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
-from nanobot.utils.helpers import build_assistant_message, detect_image_mime
+from nanobot.utils.helpers import build_assistant_message, current_time_str, detect_image_mime
 
 
 class ContextBuilder:
@@ -19,9 +17,12 @@ class ContextBuilder:
     BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"]
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
 
-    def __init__(self, workspace: Path, timezone: str | None = None):
+    def __init__(
+        self, workspace: Path, timezone: str | None = None, memory_index_enabled: bool = False
+    ):
         self.workspace = workspace
         self.timezone = timezone
+        self.memory_index_enabled = memory_index_enabled
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
 
@@ -33,9 +34,16 @@ class ContextBuilder:
         if bootstrap:
             parts.append(bootstrap)
 
-        memory = self.memory.get_memory_context()
-        if memory:
-            parts.append(f"# Memory\n\n{memory}")
+        if self.memory_index_enabled:
+            parts.append(
+                "# Memory\n\n"
+                "Use the `memory_search` tool to recall facts, preferences, or past context "
+                "before answering questions that depend on prior sessions."
+            )
+        else:
+            memory = self.memory.get_memory_context()
+            if memory:
+                parts.append(f"# Memory\n\n{memory}")
 
         always_skills = self.skills.get_always_skills()
         if always_skills:
@@ -102,7 +110,9 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
 
     @staticmethod
     def _build_runtime_context(
-        channel: str | None, chat_id: str | None, timezone: str | None = None,
+        channel: str | None,
+        chat_id: str | None,
+        timezone: str | None = None,
     ) -> str:
         """Build untrusted runtime metadata block for injection before the user message."""
         lines = [f"Current Time: {current_time_str(timezone)}"]
@@ -165,36 +175,46 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
             if not mime or not mime.startswith("image/"):
                 continue
             b64 = base64.b64encode(raw).decode()
-            images.append({
-                "type": "image_url",
-                "image_url": {"url": f"data:{mime};base64,{b64}"},
-                "_meta": {"path": str(p)},
-            })
+            images.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{mime};base64,{b64}"},
+                    "_meta": {"path": str(p)},
+                }
+            )
 
         if not images:
             return text
         return images + [{"type": "text", "text": text}]
 
     def add_tool_result(
-        self, messages: list[dict[str, Any]],
-        tool_call_id: str, tool_name: str, result: Any,
+        self,
+        messages: list[dict[str, Any]],
+        tool_call_id: str,
+        tool_name: str,
+        result: Any,
     ) -> list[dict[str, Any]]:
         """Add a tool result to the message list."""
-        messages.append({"role": "tool", "tool_call_id": tool_call_id, "name": tool_name, "content": result})
+        messages.append(
+            {"role": "tool", "tool_call_id": tool_call_id, "name": tool_name, "content": result}
+        )
         return messages
 
     def add_assistant_message(
-        self, messages: list[dict[str, Any]],
+        self,
+        messages: list[dict[str, Any]],
         content: str | None,
         tool_calls: list[dict[str, Any]] | None = None,
         reasoning_content: str | None = None,
         thinking_blocks: list[dict] | None = None,
     ) -> list[dict[str, Any]]:
         """Add an assistant message to the message list."""
-        messages.append(build_assistant_message(
-            content,
-            tool_calls=tool_calls,
-            reasoning_content=reasoning_content,
-            thinking_blocks=thinking_blocks,
-        ))
+        messages.append(
+            build_assistant_message(
+                content,
+                tool_calls=tool_calls,
+                reasoning_content=reasoning_content,
+                thinking_blocks=thinking_blocks,
+            )
+        )
         return messages

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -165,8 +165,8 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
             {"role": current_role, "content": merged},
         ]
 
-        if index is not None and index._cfg.inject_top_k > 0:
-            results = await index.index.search(current_message, top_k=index._cfg.inject_top_k)
+        if index is not None and index.inject_top_k > 0:
+            results = await index.search(current_message, top_k=index.inject_top_k)
             if results:
                 injection = "Relevant memory:\n\n" + "\n\n---\n\n".join(
                     f"[{r.source} L{r.start_line}–{r.end_line}]\n{r.text}" for r in results

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import re
 import os
 import time
 from contextlib import AsyncExitStack, nullcontext
@@ -15,9 +14,9 @@ from loguru import logger
 
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.memory import MemoryConsolidator
+from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
-from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.registry import ToolRegistry
@@ -25,13 +24,18 @@ from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
-from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.bus.queue import MessageBus
+from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.providers.base import LLMProvider
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
-    from nanobot.config.schema import ChannelsConfig, ExecToolConfig, WebSearchConfig
+    from nanobot.config.schema import (
+        ChannelsConfig,
+        ExecToolConfig,
+        MemoryIndexConfig,
+        WebSearchConfig,
+    )
     from nanobot.cron.service import CronService
 
 
@@ -66,6 +70,7 @@ class AgentLoop:
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
         timezone: str | None = None,
+        memory_index_config: MemoryIndexConfig | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -84,7 +89,12 @@ class AgentLoop:
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
 
-        self.context = ContextBuilder(workspace, timezone=timezone)
+        self.memory_index_config = memory_index_config
+        self.context = ContextBuilder(
+            workspace,
+            timezone=timezone,
+            memory_index_enabled=bool(memory_index_config and memory_index_config.enabled),
+        )
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
         self.subagents = SubagentManager(
@@ -129,16 +139,22 @@ class AgentLoop:
         """Register the default set of tools."""
         allowed_dir = self.workspace if self.restrict_to_workspace else None
         extra_read = [BUILTIN_SKILLS_DIR] if allowed_dir else None
-        self.tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir, extra_allowed_dirs=extra_read))
+        self.tools.register(
+            ReadFileTool(
+                workspace=self.workspace, allowed_dir=allowed_dir, extra_allowed_dirs=extra_read
+            )
+        )
         for cls in (WriteFileTool, EditFileTool, ListDirTool):
             self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
         if self.exec_config.enable:
-            self.tools.register(ExecTool(
-                working_dir=str(self.workspace),
-                timeout=self.exec_config.timeout,
-                restrict_to_workspace=self.restrict_to_workspace,
-                path_append=self.exec_config.path_append,
-            ))
+            self.tools.register(
+                ExecTool(
+                    working_dir=str(self.workspace),
+                    timeout=self.exec_config.timeout,
+                    restrict_to_workspace=self.restrict_to_workspace,
+                    path_append=self.exec_config.path_append,
+                )
+            )
         self.tools.register(WebSearchTool(config=self.web_search_config, proxy=self.web_proxy))
         self.tools.register(WebFetchTool(proxy=self.web_proxy))
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
@@ -147,6 +163,13 @@ class AgentLoop:
             self.tools.register(
                 CronTool(self.cron_service, default_timezone=self.context.timezone or "UTC")
             )
+        if self.memory_index_config and self.memory_index_config.enabled:
+            from nanobot.agent.tools.memory_search import MemorySearchTool
+            from nanobot.memory_index import MemoryIndex
+
+            _index = MemoryIndex(self.workspace, self.memory_index_config)
+            self._schedule_background(_index.startup_index())
+            self.tools.register(MemorySearchTool(_index))
 
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""
@@ -154,6 +177,7 @@ class AgentLoop:
             return
         self._mcp_connecting = True
         from nanobot.agent.tools.mcp import connect_mcp_servers
+
         try:
             self._mcp_stack = AsyncExitStack()
             await self._mcp_stack.__aenter__()
@@ -183,17 +207,20 @@ class AgentLoop:
         if not text:
             return None
         from nanobot.utils.helpers import strip_think
+
         return strip_think(text) or None
 
     @staticmethod
     def _tool_hint(tool_calls: list) -> str:
         """Format tool calls as concise hint, e.g. 'web_search("query")'."""
+
         def _fmt(tc):
             args = (tc.arguments[0] if isinstance(tc.arguments, list) else tc.arguments) or {}
             val = next(iter(args.values()), None) if isinstance(args, dict) else None
             if not isinstance(val, str):
                 return tc.name
             return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
+
         return ", ".join(_fmt(tc) for tc in tool_calls)
 
     async def _run_agent_loop(
@@ -227,10 +254,11 @@ class AgentLoop:
         async def _filtered_stream(delta: str) -> None:
             nonlocal _stream_buf
             from nanobot.utils.helpers import strip_think
+
             prev_clean = strip_think(_stream_buf)
             _stream_buf += delta
             new_clean = strip_think(_stream_buf)
-            incremental = new_clean[len(prev_clean):]
+            incremental = new_clean[len(prev_clean) :]
             if incremental and _raw_stream:
                 await _raw_stream(incremental)
 
@@ -273,12 +301,11 @@ class AgentLoop:
                     tool_hint = self._strip_think(tool_hint)
                     await on_progress(tool_hint, tool_hint=True)
 
-                tool_call_dicts = [
-                    tc.to_openai_tool_call()
-                    for tc in response.tool_calls
-                ]
+                tool_call_dicts = [tc.to_openai_tool_call() for tc in response.tool_calls]
                 messages = self.context.add_assistant_message(
-                    messages, response.content, tool_call_dicts,
+                    messages,
+                    response.content,
+                    tool_call_dicts,
                     reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
                 )
@@ -296,10 +323,10 @@ class AgentLoop:
                 # independent calls in a single response on purpose.
                 # return_exceptions=True ensures all results are collected
                 # even if one tool is cancelled or raises BaseException.
-                results = await asyncio.gather(*(
-                    self.tools.execute(tc.name, tc.arguments)
-                    for tc in response.tool_calls
-                ), return_exceptions=True)
+                results = await asyncio.gather(
+                    *(self.tools.execute(tc.name, tc.arguments) for tc in response.tool_calls),
+                    return_exceptions=True,
+                )
 
                 for tool_call, result in zip(response.tool_calls, results):
                     if isinstance(result, BaseException):
@@ -318,7 +345,9 @@ class AgentLoop:
                     final_content = clean or "Sorry, I encountered an error calling the AI model."
                     break
                 messages = self.context.add_assistant_message(
-                    messages, clean, reasoning_content=response.reasoning_content,
+                    messages,
+                    clean,
+                    reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
                 )
                 final_content = clean
@@ -363,7 +392,13 @@ class AgentLoop:
                 continue
             task = asyncio.create_task(self._dispatch(msg))
             self._active_tasks.setdefault(msg.session_key, []).append(task)
-            task.add_done_callback(lambda t, k=msg.session_key: self._active_tasks.get(k, []) and self._active_tasks[k].remove(t) if t in self._active_tasks.get(k, []) else None)
+            task.add_done_callback(
+                lambda t, k=msg.session_key: (
+                    self._active_tasks.get(k, []) and self._active_tasks[k].remove(t)
+                    if t in self._active_tasks.get(k, [])
+                    else None
+                )
+            )
 
     async def _dispatch(self, msg: InboundMessage) -> None:
         """Process a message: per-session serial, cross-session concurrent."""
@@ -373,37 +408,55 @@ class AgentLoop:
             try:
                 on_stream = on_stream_end = None
                 if msg.metadata.get("_wants_stream"):
+
                     async def on_stream(delta: str) -> None:
-                        await self.bus.publish_outbound(OutboundMessage(
-                            channel=msg.channel, chat_id=msg.chat_id,
-                            content=delta, metadata={"_stream_delta": True},
-                        ))
+                        await self.bus.publish_outbound(
+                            OutboundMessage(
+                                channel=msg.channel,
+                                chat_id=msg.chat_id,
+                                content=delta,
+                                metadata={"_stream_delta": True},
+                            )
+                        )
 
                     async def on_stream_end(*, resuming: bool = False) -> None:
-                        await self.bus.publish_outbound(OutboundMessage(
-                            channel=msg.channel, chat_id=msg.chat_id,
-                            content="", metadata={"_stream_end": True, "_resuming": resuming},
-                        ))
+                        await self.bus.publish_outbound(
+                            OutboundMessage(
+                                channel=msg.channel,
+                                chat_id=msg.chat_id,
+                                content="",
+                                metadata={"_stream_end": True, "_resuming": resuming},
+                            )
+                        )
 
                 response = await self._process_message(
-                    msg, on_stream=on_stream, on_stream_end=on_stream_end,
+                    msg,
+                    on_stream=on_stream,
+                    on_stream_end=on_stream_end,
                 )
                 if response is not None:
                     await self.bus.publish_outbound(response)
                 elif msg.channel == "cli":
-                    await self.bus.publish_outbound(OutboundMessage(
-                        channel=msg.channel, chat_id=msg.chat_id,
-                        content="", metadata=msg.metadata or {},
-                    ))
+                    await self.bus.publish_outbound(
+                        OutboundMessage(
+                            channel=msg.channel,
+                            chat_id=msg.chat_id,
+                            content="",
+                            metadata=msg.metadata or {},
+                        )
+                    )
             except asyncio.CancelledError:
                 logger.info("Task cancelled for session {}", msg.session_key)
                 raise
             except Exception:
                 logger.exception("Error processing message for session {}", msg.session_key)
-                await self.bus.publish_outbound(OutboundMessage(
-                    channel=msg.channel, chat_id=msg.chat_id,
-                    content="Sorry, I encountered an error.",
-                ))
+                await self.bus.publish_outbound(
+                    OutboundMessage(
+                        channel=msg.channel,
+                        chat_id=msg.chat_id,
+                        content="Sorry, I encountered an error.",
+                    )
+                )
 
     async def close_mcp(self) -> None:
         """Drain pending background archives, then close MCP connections."""
@@ -439,8 +492,9 @@ class AgentLoop:
         """Process a single inbound message and return the response."""
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
-            channel, chat_id = (msg.chat_id.split(":", 1) if ":" in msg.chat_id
-                                else ("cli", msg.chat_id))
+            channel, chat_id = (
+                msg.chat_id.split(":", 1) if ":" in msg.chat_id else ("cli", msg.chat_id)
+            )
             logger.info("Processing system message from {}", msg.sender_id)
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
@@ -450,18 +504,25 @@ class AgentLoop:
             current_role = "assistant" if msg.sender_id == "subagent" else "user"
             messages = self.context.build_messages(
                 history=history,
-                current_message=msg.content, channel=channel, chat_id=chat_id,
+                current_message=msg.content,
+                channel=channel,
+                chat_id=chat_id,
                 current_role=current_role,
             )
             final_content, _, all_msgs = await self._run_agent_loop(
-                messages, channel=channel, chat_id=chat_id,
+                messages,
+                channel=channel,
+                chat_id=chat_id,
                 message_id=msg.metadata.get("message_id"),
             )
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
             self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
-            return OutboundMessage(channel=channel, chat_id=chat_id,
-                                  content=final_content or "Background task completed.")
+            return OutboundMessage(
+                channel=channel,
+                chat_id=chat_id,
+                content=final_content or "Background task completed.",
+            )
 
         preview = msg.content[:80] + "..." if len(msg.content) > 80 else msg.content
         logger.info("Processing message from {}:{}: {}", msg.channel, msg.sender_id, preview)
@@ -487,23 +548,30 @@ class AgentLoop:
             history=history,
             current_message=msg.content,
             media=msg.media if msg.media else None,
-            channel=msg.channel, chat_id=msg.chat_id,
+            channel=msg.channel,
+            chat_id=msg.chat_id,
         )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
             meta = dict(msg.metadata or {})
             meta["_progress"] = True
             meta["_tool_hint"] = tool_hint
-            await self.bus.publish_outbound(OutboundMessage(
-                channel=msg.channel, chat_id=msg.chat_id, content=content, metadata=meta,
-            ))
+            await self.bus.publish_outbound(
+                OutboundMessage(
+                    channel=msg.channel,
+                    chat_id=msg.chat_id,
+                    content=content,
+                    metadata=meta,
+                )
+            )
 
         final_content, _, all_msgs = await self._run_agent_loop(
             initial_messages,
             on_progress=on_progress or _bus_progress,
             on_stream=on_stream,
             on_stream_end=on_stream_end,
-            channel=msg.channel, chat_id=msg.chat_id,
+            channel=msg.channel,
+            chat_id=msg.chat_id,
             message_id=msg.metadata.get("message_id"),
         )
 
@@ -524,7 +592,9 @@ class AgentLoop:
         if on_stream is not None:
             meta["_streamed"] = True
         return OutboundMessage(
-            channel=msg.channel, chat_id=msg.chat_id, content=final_content,
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content=final_content,
             metadata=meta,
         )
 
@@ -556,17 +626,16 @@ class AgentLoop:
             ):
                 continue
 
-            if (
-                block.get("type") == "image_url"
-                and block.get("image_url", {}).get("url", "").startswith("data:image/")
-            ):
+            if block.get("type") == "image_url" and block.get("image_url", {}).get(
+                "url", ""
+            ).startswith("data:image/"):
                 filtered.append(self._image_placeholder(block))
                 continue
 
             if block.get("type") == "text" and isinstance(block.get("text"), str):
                 text = block["text"]
                 if truncate_text and len(text) > self._TOOL_RESULT_MAX_CHARS:
-                    text = text[:self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
+                    text = text[: self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
                 filtered.append({**block, "text": text})
                 continue
 
@@ -577,6 +646,7 @@ class AgentLoop:
     def _save_turn(self, session: Session, messages: list[dict], skip: int) -> None:
         """Save new-turn messages into session, truncating large tool results."""
         from datetime import datetime
+
         for m in messages[skip:]:
             entry = dict(m)
             role, content = entry.get("role"), entry.get("content")
@@ -584,14 +654,16 @@ class AgentLoop:
                 continue  # skip empty assistant messages — they poison session context
             if role == "tool":
                 if isinstance(content, str) and len(content) > self._TOOL_RESULT_MAX_CHARS:
-                    entry["content"] = content[:self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
+                    entry["content"] = content[: self._TOOL_RESULT_MAX_CHARS] + "\n... (truncated)"
                 elif isinstance(content, list):
                     filtered = self._sanitize_persisted_blocks(content, truncate_text=True)
                     if not filtered:
                         continue
                     entry["content"] = filtered
             elif role == "user":
-                if isinstance(content, str) and content.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
+                if isinstance(content, str) and content.startswith(
+                    ContextBuilder._RUNTIME_CONTEXT_TAG
+                ):
                     # Strip the runtime-context prefix, keep only the user text.
                     parts = content.split("\n\n", 1)
                     if len(parts) > 1 and parts[1].strip():
@@ -621,6 +693,9 @@ class AgentLoop:
         await self._connect_mcp()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
         return await self._process_message(
-            msg, session_key=session_key, on_progress=on_progress,
-            on_stream=on_stream, on_stream_end=on_stream_end,
+            msg,
+            session_key=session_key,
+            on_progress=on_progress,
+            on_stream=on_stream,
+            on_stream_end=on_stream_end,
         )

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
         WebSearchConfig,
     )
     from nanobot.cron.service import CronService
+    from nanobot.memory_index import MemoryIndex
 
 
 class AgentLoop:
@@ -109,6 +110,7 @@ class AgentLoop:
         )
 
         self._running = False
+        self._memory_index: MemoryIndex | None = None
         self._mcp_servers = mcp_servers or {}
         self._mcp_stack: AsyncExitStack | None = None
         self._mcp_connected = False
@@ -167,9 +169,9 @@ class AgentLoop:
             from nanobot.agent.tools.memory_search import MemorySearchTool
             from nanobot.memory_index import MemoryIndex
 
-            _index = MemoryIndex(self.workspace, self.memory_index_config)
-            self._schedule_background(_index.startup_index())
-            self.tools.register(MemorySearchTool(_index))
+            self._memory_index = MemoryIndex(self.workspace, self.memory_index_config)
+            self.tools.register(MemorySearchTool(self._memory_index))
+            # startup_index() is scheduled in run()/process_direct() once the event loop is running
 
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""
@@ -365,6 +367,9 @@ class AgentLoop:
     async def run(self) -> None:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
         self._running = True
+        if self._memory_index is not None:
+            self._schedule_background(self._memory_index.startup_index())
+            self._memory_index = None  # only schedule once
         await self._connect_mcp()
         logger.info("Agent loop started")
 
@@ -690,6 +695,9 @@ class AgentLoop:
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
     ) -> OutboundMessage | None:
         """Process a message directly and return the outbound payload."""
+        if self._memory_index is not None:
+            self._schedule_background(self._memory_index.startup_index())
+            self._memory_index = None  # only schedule once
         await self._connect_mcp()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
         return await self._process_message(

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
         WebSearchConfig,
     )
     from nanobot.cron.service import CronService
-    from nanobot.memory_index import MemoryIndex
+    from nanobot.memory_index.service import IndexService
 
 
 class AgentLoop:
@@ -110,7 +110,8 @@ class AgentLoop:
         )
 
         self._running = False
-        self._memory_index: MemoryIndex | None = None
+        self._index_service: IndexService | None = None
+        self._index_service_started: bool = False
         self._mcp_servers = mcp_servers or {}
         self._mcp_stack: AsyncExitStack | None = None
         self._mcp_connected = False
@@ -167,11 +168,11 @@ class AgentLoop:
             )
         if self.memory_index_config and self.memory_index_config.enabled:
             from nanobot.agent.tools.memory_search import MemorySearchTool
-            from nanobot.memory_index import MemoryIndex
+            from nanobot.memory_index.service import IndexService
 
-            self._memory_index = MemoryIndex(self.workspace, self.memory_index_config)
-            self.tools.register(MemorySearchTool(self._memory_index))
-            # startup_index() is scheduled in run()/process_direct() once the event loop is running
+            self._index_service = IndexService(self.workspace, self.memory_index_config)
+            self.tools.register(MemorySearchTool(self._index_service.index))
+            # start() is scheduled in run()/process_direct() once the event loop is running
 
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""
@@ -367,9 +368,12 @@ class AgentLoop:
     async def run(self) -> None:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
         self._running = True
-        if self._memory_index is not None:
-            self._schedule_background(self._memory_index.startup_index())
-            self._memory_index = None  # only schedule once
+        if self._index_service is not None and not self._index_service_started:
+            # Safe without a lock: asyncio is single-threaded; the flag is set
+            # synchronously before the first await, so concurrent coroutines
+            # see it immediately and skip the duplicate schedule.
+            self._index_service_started = True
+            self._schedule_background(self._index_service.start())
         await self._connect_mcp()
         logger.info("Agent loop started")
 
@@ -464,10 +468,12 @@ class AgentLoop:
                 )
 
     async def close_mcp(self) -> None:
-        """Drain pending background archives, then close MCP connections."""
+        """Drain pending background tasks, stop file watcher, then close MCP connections."""
         if self._background_tasks:
             await asyncio.gather(*self._background_tasks, return_exceptions=True)
             self._background_tasks.clear()
+        if self._index_service is not None:
+            await self._index_service.stop()
         if self._mcp_stack:
             try:
                 await self._mcp_stack.aclose()
@@ -507,12 +513,13 @@ class AgentLoop:
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
             history = session.get_history(max_messages=0)
             current_role = "assistant" if msg.sender_id == "subagent" else "user"
-            messages = self.context.build_messages(
+            messages = await self.context.build_messages(
                 history=history,
                 current_message=msg.content,
                 channel=channel,
                 chat_id=chat_id,
                 current_role=current_role,
+                index=self._index_service,
             )
             final_content, _, all_msgs = await self._run_agent_loop(
                 messages,
@@ -549,12 +556,13 @@ class AgentLoop:
                 message_tool.start_turn()
 
         history = session.get_history(max_messages=0)
-        initial_messages = self.context.build_messages(
+        initial_messages = await self.context.build_messages(
             history=history,
             current_message=msg.content,
             media=msg.media if msg.media else None,
             channel=msg.channel,
             chat_id=msg.chat_id,
+            index=self._index_service,
         )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
@@ -695,9 +703,10 @@ class AgentLoop:
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
     ) -> OutboundMessage | None:
         """Process a message directly and return the outbound payload."""
-        if self._memory_index is not None:
-            self._schedule_background(self._memory_index.startup_index())
-            self._memory_index = None  # only schedule once
+        if self._index_service is not None and not self._index_service_started:
+            # Same single-threaded asyncio safety as in run() — see comment there.
+            self._index_service_started = True
+            self._schedule_background(self._index_service.start())
         await self._connect_mcp()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
         return await self._process_message(

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -7,7 +7,7 @@ import json
 import weakref
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from loguru import logger
 
@@ -233,7 +233,7 @@ class MemoryConsolidator:
         model: str,
         sessions: SessionManager,
         context_window_tokens: int,
-        build_messages: Callable[..., list[dict[str, Any]]],
+        build_messages: Callable[..., Awaitable[list[dict[str, Any]]]],
         get_tool_definitions: Callable[[], list[dict[str, Any]]],
         max_completion_tokens: int = 4096,
     ):
@@ -277,11 +277,11 @@ class MemoryConsolidator:
 
         return last_boundary
 
-    def estimate_session_prompt_tokens(self, session: Session) -> tuple[int, str]:
+    async def estimate_session_prompt_tokens(self, session: Session) -> tuple[int, str]:
         """Estimate current prompt size for the normal session history view."""
         history = session.get_history(max_messages=0)
         channel, chat_id = (session.key.split(":", 1) if ":" in session.key else (None, None))
-        probe_messages = self._build_messages(
+        probe_messages = await self._build_messages(
             history=history,
             current_message="[token-probe]",
             channel=channel,
@@ -316,7 +316,7 @@ class MemoryConsolidator:
         async with lock:
             budget = self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
             target = budget // 2
-            estimated, source = self.estimate_session_prompt_tokens(session)
+            estimated, source = await self.estimate_session_prompt_tokens(session)
             if estimated <= 0:
                 return
             if estimated < budget:
@@ -361,6 +361,6 @@ class MemoryConsolidator:
                 session.last_consolidated = end_idx
                 self.sessions.save(session)
 
-                estimated, source = self.estimate_session_prompt_tokens(session)
+                estimated, source = await self.estimate_session_prompt_tokens(session)
                 if estimated <= 0:
                     return

--- a/nanobot/agent/tools/memory_search.py
+++ b/nanobot/agent/tools/memory_search.py
@@ -1,0 +1,56 @@
+"""MemorySearchTool — semantic search over indexed memory files."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from nanobot.agent.tools.base import Tool
+
+if TYPE_CHECKING:
+    from nanobot.memory_index.index import MemoryIndex
+
+
+class MemorySearchTool(Tool):
+    """Search long-term memory and conversation history semantically."""
+
+    def __init__(self, index: MemoryIndex) -> None:
+        self.index = index
+
+    @property
+    def name(self) -> str:
+        return "memory_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search long-term memory and conversation history semantically. "
+            "Use when recalling facts, preferences, or past context that may "
+            "not be in the current session."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Natural language search query",
+                },
+                "top_k": {
+                    "type": "integer",
+                    "description": "Number of results to return (default 5)",
+                    "minimum": 1,
+                    "maximum": 10,
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def execute(self, query: str, top_k: int = 5, **kwargs: Any) -> str:
+        results = await self.index.search(query, top_k=top_k)
+        if not results:
+            return "No relevant memory found."
+        return "\n\n---\n\n".join(
+            f"[{r.source} L{r.start_line}–{r.end_line}]\n{r.text}" for r in results
+        )

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -47,7 +47,7 @@ async def cmd_status(ctx: CommandContext) -> OutboundMessage:
     session = ctx.session or loop.sessions.get_or_create(ctx.key)
     ctx_est = 0
     try:
-        ctx_est, _ = loop.memory_consolidator.estimate_session_prompt_tokens(session)
+        ctx_est, _ = await loop.memory_consolidator.estimate_session_prompt_tokens(session)
     except Exception:
         pass
     if ctx_est <= 0:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -13,6 +13,7 @@ class Base(BaseModel):
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
+
 class ChannelsConfig(Base):
     """Configuration for chat channels.
 
@@ -25,7 +26,9 @@ class ChannelsConfig(Base):
 
     send_progress: bool = True  # stream agent's text progress to the channel
     send_tool_hints: bool = False  # stream tool-call hints (e.g. read_file("…"))
-    send_max_retries: int = Field(default=3, ge=0, le=10)  # Max delivery attempts (initial send included)
+    send_max_retries: int = Field(
+        default=3, ge=0, le=10
+    )  # Max delivery attempts (initial send included)
 
 
 class AgentDefaults(Base):
@@ -62,7 +65,9 @@ class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
-    azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
+    azure_openai: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -81,11 +86,21 @@ class ProvidersConfig(Base):
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)
-    volcengine_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine Coding Plan
-    byteplus: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus (VolcEngine international)
-    byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
-    openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
-    github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
+    volcengine_coding_plan: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # VolcEngine Coding Plan
+    byteplus: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # BytePlus (VolcEngine international)
+    byteplus_coding_plan: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # BytePlus Coding Plan
+    openai_codex: ProviderConfig = Field(
+        default_factory=ProviderConfig, exclude=True
+    )  # OpenAI Codex (OAuth)
+    github_copilot: ProviderConfig = Field(
+        default_factory=ProviderConfig, exclude=True
+    )  # Github Copilot (OAuth)
 
 
 class HeartbeatConfig(Base):
@@ -166,7 +181,10 @@ class MCPServerConfig(Base):
     url: str = ""  # HTTP/SSE: endpoint URL
     headers: dict[str, str] = Field(default_factory=dict)  # HTTP/SSE: custom headers
     tool_timeout: int = 30  # seconds before a tool call is cancelled
-    enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+    enabled_tools: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+
 
 class ToolsConfig(Base):
     """Tools configuration."""

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -169,6 +169,8 @@ class MemoryIndexConfig(Base):
     enabled: bool = False
     embedding: MemoryIndexEmbeddingConfig = Field(default_factory=MemoryIndexEmbeddingConfig)
     query: MemoryIndexQueryConfig = Field(default_factory=MemoryIndexQueryConfig)
+    inject_top_k: int = 3       # chunks auto-injected per turn; 0 = disabled
+    watch_files: bool = True    # enable watchdog file watcher
 
 
 class MCPServerConfig(Base):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -129,6 +129,33 @@ class ExecToolConfig(Base):
     timeout: int = 60
     path_append: str = ""
 
+
+class MemoryIndexEmbeddingConfig(Base):
+    """Embedding provider config for the memory index."""
+
+    provider: str = "ollama"
+    model: str = "nomic-embed-text"
+    base_url: str = "http://localhost:11434"
+    batch_size: int = 16
+    dim: int = 768  # must match model output dimension
+
+
+class MemoryIndexQueryConfig(Base):
+    """Search and ranking config for the memory index."""
+
+    top_k: int = 5
+    mmr_lambda: float = 0.5
+    temporal_decay_half_life_days: float = 90.0
+
+
+class MemoryIndexConfig(Base):
+    """Semantic memory index configuration. Off by default."""
+
+    enabled: bool = False
+    embedding: MemoryIndexEmbeddingConfig = Field(default_factory=MemoryIndexEmbeddingConfig)
+    query: MemoryIndexQueryConfig = Field(default_factory=MemoryIndexQueryConfig)
+
+
 class MCPServerConfig(Base):
     """MCP server connection configuration (stdio or HTTP)."""
 
@@ -158,6 +185,7 @@ class Config(BaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    memory_index: MemoryIndexConfig = Field(default_factory=MemoryIndexConfig)
 
     @property
     def workspace_path(self) -> Path:

--- a/nanobot/memory_index/__init__.py
+++ b/nanobot/memory_index/__init__.py
@@ -1,0 +1,5 @@
+"""Semantic memory index for nanobot."""
+
+from nanobot.memory_index.index import MemoryIndex
+
+__all__ = ["MemoryIndex"]

--- a/nanobot/memory_index/embeddings.py
+++ b/nanobot/memory_index/embeddings.py
@@ -36,7 +36,10 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
             json={"model": self.model, "prompt": text},
         )
         r.raise_for_status()
-        return r.json()["embedding"]
+        data = r.json()
+        if "embedding" not in data:
+            raise EmbeddingUnavailableError(f"Ollama response missing 'embedding' key: {data}")
+        return data["embedding"]
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         """Return one embedding per text. Uses in-memory cache to avoid re-embedding."""

--- a/nanobot/memory_index/embeddings.py
+++ b/nanobot/memory_index/embeddings.py
@@ -1,0 +1,63 @@
+"""Embedding providers for the memory index."""
+
+from __future__ import annotations
+
+import hashlib
+from abc import ABC, abstractmethod
+
+import httpx
+
+
+class EmbeddingUnavailableError(Exception):
+    """Raised when the embedding provider cannot be reached."""
+
+
+class EmbeddingProvider(ABC):
+    @abstractmethod
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]: ...
+
+
+class OllamaEmbeddingProvider(EmbeddingProvider):
+    """Embeds text via the Ollama /api/embeddings endpoint."""
+
+    def __init__(self, base_url: str, model: str, batch_size: int = 16) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.batch_size = batch_size
+        self._cache: dict[str, list[float]] = {}
+
+    def _cache_key(self, text: str) -> str:
+        return hashlib.sha256(f"{self.model}:{text}".encode()).hexdigest()
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Return one embedding per text. Uses in-memory cache to avoid re-embedding."""
+        results: list[list[float] | None] = [None] * len(texts)
+        uncached: list[tuple[int, str]] = []
+
+        for i, text in enumerate(texts):
+            key = self._cache_key(text)
+            if key in self._cache:
+                results[i] = self._cache[key]
+            else:
+                uncached.append((i, text))
+
+        if uncached:
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    for i, text in uncached:
+                        r = await client.post(
+                            f"{self.base_url}/api/embeddings",
+                            json={"model": self.model, "prompt": text},
+                        )
+                        r.raise_for_status()
+                        vec = r.json()["embedding"]
+                        self._cache[self._cache_key(text)] = vec
+                        results[i] = vec
+            except httpx.ConnectError as e:
+                raise EmbeddingUnavailableError(f"Ollama unreachable: {e}") from e
+            except httpx.TimeoutException as e:
+                raise EmbeddingUnavailableError(f"Ollama timed out: {e}") from e
+            except Exception as e:
+                raise EmbeddingUnavailableError(f"Embedding failed: {e}") from e
+
+        return [r for r in results if r is not None]

--- a/nanobot/memory_index/embeddings.py
+++ b/nanobot/memory_index/embeddings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from abc import ABC, abstractmethod
 
@@ -29,6 +30,14 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
     def _cache_key(self, text: str) -> str:
         return hashlib.sha256(f"{self.model}:{text}".encode()).hexdigest()
 
+    async def _embed_one(self, client: httpx.AsyncClient, text: str) -> list[float]:
+        r = await client.post(
+            f"{self.base_url}/api/embeddings",
+            json={"model": self.model, "prompt": text},
+        )
+        r.raise_for_status()
+        return r.json()["embedding"]
+
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         """Return one embedding per text. Uses in-memory cache to avoid re-embedding."""
         results: list[list[float] | None] = [None] * len(texts)
@@ -43,21 +52,22 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
 
         if uncached:
             try:
-                async with httpx.AsyncClient(timeout=30.0) as client:
-                    for i, text in uncached:
-                        r = await client.post(
-                            f"{self.base_url}/api/embeddings",
-                            json={"model": self.model, "prompt": text},
+                # process uncached in chunks of batch_size, concurrent within each chunk
+                for chunk_start in range(0, len(uncached), self.batch_size):
+                    chunk = uncached[chunk_start : chunk_start + self.batch_size]
+                    async with httpx.AsyncClient(timeout=30.0) as client:
+                        vecs = await asyncio.gather(
+                            *[self._embed_one(client, text) for _, text in chunk]
                         )
-                        r.raise_for_status()
-                        vec = r.json()["embedding"]
+                    for (i, text), vec in zip(chunk, vecs):
                         self._cache[self._cache_key(text)] = vec
                         results[i] = vec
-            except httpx.ConnectError as e:
+            except (httpx.ConnectError, httpx.TimeoutException) as e:
                 raise EmbeddingUnavailableError(f"Ollama unreachable: {e}") from e
-            except httpx.TimeoutException as e:
-                raise EmbeddingUnavailableError(f"Ollama timed out: {e}") from e
-            except Exception as e:
-                raise EmbeddingUnavailableError(f"Embedding failed: {e}") from e
+            except httpx.HTTPStatusError as e:
+                raise EmbeddingUnavailableError(
+                    f"Ollama HTTP error {e.response.status_code}: {e}"
+                ) from e
 
-        return [r for r in results if r is not None]
+        assert all(r is not None for r in results), "BUG: some embeddings were not set"
+        return results  # type: ignore[return-value]

--- a/nanobot/memory_index/index.py
+++ b/nanobot/memory_index/index.py
@@ -35,10 +35,9 @@ class MemoryIndex:
     def _check_vec_available(self) -> None:
         """Check once at init whether sqlite-vec can be loaded."""
         try:
-            import sqlite_vec  # noqa: F401
+            import sqlite_vec as sv
             conn = sqlite3.connect(":memory:")
             conn.enable_load_extension(True)
-            import sqlite_vec as sv
             sv.load(conn)
             conn.close()
             self._vec_available = True
@@ -67,6 +66,7 @@ class MemoryIndex:
         conn = self._open_conn()
         try:
             conn.executescript(schema_sql)
+            # executescript issues an implicit COMMIT; subsequent inserts start a new transaction
             if self._vec_available:
                 conn.execute(
                     f"CREATE VIRTUAL TABLE IF NOT EXISTS chunks_vec "

--- a/nanobot/memory_index/index.py
+++ b/nanobot/memory_index/index.py
@@ -36,6 +36,7 @@ class MemoryIndex:
         """Check once at init whether sqlite-vec can be loaded."""
         try:
             import sqlite_vec as sv
+
             conn = sqlite3.connect(":memory:")
             conn.enable_load_extension(True)
             sv.load(conn)
@@ -50,6 +51,7 @@ class MemoryIndex:
         conn.row_factory = sqlite3.Row
         if self._vec_available:
             import sqlite_vec
+
             conn.enable_load_extension(True)
             sqlite_vec.load(conn)
             conn.enable_load_extension(False)
@@ -72,9 +74,7 @@ class MemoryIndex:
                     f"CREATE VIRTUAL TABLE IF NOT EXISTS chunks_vec "
                     f"USING vec0(embedding FLOAT[{dim}])"
                 )
-            row = conn.execute(
-                "SELECT 1 FROM index_meta WHERE key='embedding_model'"
-            ).fetchone()
+            row = conn.execute("SELECT 1 FROM index_meta WHERE key='embedding_model'").fetchone()
             if not row:
                 conn.execute(
                     "INSERT INTO index_meta(key, value) VALUES (?, ?)",
@@ -112,15 +112,13 @@ class MemoryIndex:
 
     def _setup_provider(self) -> None:
         if self.config.embedding.provider == "ollama":
-            try:
-                from nanobot.memory_index.embeddings import OllamaEmbeddingProvider
-                self._provider = OllamaEmbeddingProvider(
-                    base_url=self.config.embedding.base_url,
-                    model=self.config.embedding.model,
-                    batch_size=self.config.embedding.batch_size,
-                )
-            except ImportError:
-                logger.debug("Embedding provider not yet available, skipping provider setup")
+            from nanobot.memory_index.embeddings import OllamaEmbeddingProvider
+
+            self._provider = OllamaEmbeddingProvider(
+                base_url=self.config.embedding.base_url,
+                model=self.config.embedding.model,
+                batch_size=self.config.embedding.batch_size,
+            )
 
     async def startup_index(self) -> None:
         """Re-index memory files at startup (skips unchanged files)."""
@@ -136,7 +134,10 @@ class MemoryIndex:
     async def _index_file(self, path: Path) -> None:
         """Index a single file if its content has changed."""
         from nanobot.memory_index.indexer import (
-            chunk_history_file, chunk_memory_file, file_hash, write_chunks,
+            chunk_history_file,
+            chunk_memory_file,
+            file_hash,
+            write_chunks,
         )
 
         current_hash = await asyncio.to_thread(file_hash, path)
@@ -144,9 +145,7 @@ class MemoryIndex:
 
         conn = self._open_conn()
         try:
-            row = conn.execute(
-                "SELECT hash FROM files WHERE path = ?", [str(path)]
-            ).fetchone()
+            row = conn.execute("SELECT hash FROM files WHERE path = ?", [str(path)]).fetchone()
         finally:
             conn.close()
 
@@ -161,6 +160,7 @@ class MemoryIndex:
         embeddings = None
         if self._vec_available and self._provider and chunks:
             from nanobot.memory_index.embeddings import EmbeddingUnavailableError
+
             try:
                 embeddings = await self._provider.embed_batch([c.text for c in chunks])
             except EmbeddingUnavailableError:

--- a/nanobot/memory_index/index.py
+++ b/nanobot/memory_index/index.py
@@ -1,0 +1,209 @@
+"""MemoryIndex — lifecycle and public search interface."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from nanobot.config.schema import MemoryIndexConfig
+    from nanobot.memory_index.search import SearchResult
+
+
+class MemoryIndex:
+    """Manages the SQLite memory index database."""
+
+    def __init__(self, workspace: Path, config: MemoryIndexConfig) -> None:
+        self.workspace = workspace
+        self.config = config
+        self.memory_dir = workspace / "memory"
+        self.db_path = self.memory_dir / ".index.db"
+        self._vec_available = False
+        self._provider = None
+        self._memory_dir_setup()
+        self._check_vec_available()
+        self._setup_db()
+        self._setup_provider()
+
+    def _memory_dir_setup(self) -> None:
+        self.memory_dir.mkdir(parents=True, exist_ok=True)
+
+    def _check_vec_available(self) -> None:
+        """Check once at init whether sqlite-vec can be loaded."""
+        try:
+            import sqlite_vec  # noqa: F401
+            conn = sqlite3.connect(":memory:")
+            conn.enable_load_extension(True)
+            import sqlite_vec as sv
+            sv.load(conn)
+            conn.close()
+            self._vec_available = True
+        except Exception as e:
+            logger.warning("sqlite-vec unavailable, BM25-only search active: {}", e)
+
+    def _open_conn(self) -> sqlite3.Connection:
+        """Open a connection with sqlite-vec loaded if available."""
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        if self._vec_available:
+            import sqlite_vec
+            conn.enable_load_extension(True)
+            sqlite_vec.load(conn)
+            conn.enable_load_extension(False)
+        return conn
+
+    def _setup_db(self) -> None:
+        schema_sql = (Path(__file__).parent / "schema.sql").read_text()
+        dim = self.config.embedding.dim
+
+        if self.db_path.exists() and self._has_model_mismatch():
+            logger.info("Embedding model changed, rebuilding memory index")
+            self.db_path.unlink()
+
+        conn = self._open_conn()
+        try:
+            conn.executescript(schema_sql)
+            if self._vec_available:
+                conn.execute(
+                    f"CREATE VIRTUAL TABLE IF NOT EXISTS chunks_vec "
+                    f"USING vec0(embedding FLOAT[{dim}])"
+                )
+            row = conn.execute(
+                "SELECT 1 FROM index_meta WHERE key='embedding_model'"
+            ).fetchone()
+            if not row:
+                conn.execute(
+                    "INSERT INTO index_meta(key, value) VALUES (?, ?)",
+                    ["embedding_model", self.config.embedding.model],
+                )
+                conn.execute(
+                    "INSERT INTO index_meta(key, value) VALUES (?, ?)",
+                    ["embedding_dim", str(dim)],
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _has_model_mismatch(self) -> bool:
+        try:
+            conn = sqlite3.connect(self.db_path)
+            try:
+                row = conn.execute(
+                    "SELECT value FROM index_meta WHERE key='embedding_model'"
+                ).fetchone()
+                if not row:
+                    return False
+                if row[0] != self.config.embedding.model:
+                    return True
+                row2 = conn.execute(
+                    "SELECT value FROM index_meta WHERE key='embedding_dim'"
+                ).fetchone()
+                if row2 and int(row2[0]) != self.config.embedding.dim:
+                    return True
+                return False
+            finally:
+                conn.close()
+        except Exception:
+            return False
+
+    def _setup_provider(self) -> None:
+        if self.config.embedding.provider == "ollama":
+            try:
+                from nanobot.memory_index.embeddings import OllamaEmbeddingProvider
+                self._provider = OllamaEmbeddingProvider(
+                    base_url=self.config.embedding.base_url,
+                    model=self.config.embedding.model,
+                    batch_size=self.config.embedding.batch_size,
+                )
+            except ImportError:
+                logger.debug("Embedding provider not yet available, skipping provider setup")
+
+    async def startup_index(self) -> None:
+        """Re-index memory files at startup (skips unchanged files)."""
+        memory_file = self.memory_dir / "MEMORY.md"
+        history_file = self.memory_dir / "HISTORY.md"
+        for path in [memory_file, history_file]:
+            if path.exists():
+                try:
+                    await self._index_file(path)
+                except Exception:
+                    logger.exception("Failed to index {}", path.name)
+
+    async def _index_file(self, path: Path) -> None:
+        """Index a single file if its content has changed."""
+        from nanobot.memory_index.indexer import (
+            chunk_history_file, chunk_memory_file, file_hash, write_chunks,
+        )
+
+        current_hash = await asyncio.to_thread(file_hash, path)
+        stat = path.stat()
+
+        conn = self._open_conn()
+        try:
+            row = conn.execute(
+                "SELECT hash FROM files WHERE path = ?", [str(path)]
+            ).fetchone()
+        finally:
+            conn.close()
+
+        if row and row["hash"] == current_hash:
+            return  # unchanged
+
+        if path.name == "MEMORY.md":
+            chunks = await asyncio.to_thread(chunk_memory_file, path)
+        else:
+            chunks = await asyncio.to_thread(chunk_history_file, path)
+
+        embeddings = None
+        if self._vec_available and self._provider and chunks:
+            from nanobot.memory_index.embeddings import EmbeddingUnavailableError
+            try:
+                embeddings = await self._provider.embed_batch([c.text for c in chunks])
+            except EmbeddingUnavailableError:
+                logger.warning(
+                    "Ollama unavailable while indexing {}, storing without embeddings",
+                    path.name,
+                )
+
+        await asyncio.to_thread(
+            write_chunks,
+            self.db_path,
+            path,
+            stat.st_mtime,
+            stat.st_size,
+            current_hash,
+            chunks,
+            embeddings,
+            self._vec_available,
+        )
+        logger.info("Indexed {} ({} chunks)", path.name, len(chunks))
+
+    async def search(self, query: str, top_k: int | None = None) -> list[SearchResult]:
+        """Hybrid BM25+vector search with temporal decay and MMR."""
+        from nanobot.memory_index.embeddings import EmbeddingUnavailableError
+        from nanobot.memory_index.search import sync_search
+
+        k = top_k or self.config.query.top_k
+        query_vec = None
+
+        if self._vec_available and self._provider:
+            try:
+                vecs = await self._provider.embed_batch([query])
+                query_vec = vecs[0]
+            except EmbeddingUnavailableError:
+                logger.debug("Ollama unavailable during search, using BM25-only")
+
+        return await asyncio.to_thread(
+            sync_search,
+            self.db_path,
+            query,
+            query_vec,
+            k,
+            self._vec_available,
+            self.config.query.mmr_lambda,
+            self.config.query.temporal_decay_half_life_days,
+        )

--- a/nanobot/memory_index/indexer.py
+++ b/nanobot/memory_index/indexer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import re
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 TOKEN_ESTIMATE_RATIO = 4  # characters per token (heuristic)
@@ -152,7 +152,10 @@ def _split_section(text: str, base_line: int, created_at: float) -> list[Chunk]:
             overlap_text = (
                 chunk_text[-(OVERLAP_TOKENS * TOKEN_ESTIMATE_RATIO) :] if chunk_text else ""
             )
-            line_offset += n_lines + 2
+            overlap_lines = overlap_text.count("\n") + 1 if overlap_text.strip() else 0
+            # Advance by the chunk's lines, then step back by overlap so next chunk's
+            # start_line reflects that it begins with repeated content from the previous chunk.
+            line_offset += n_lines + 2 - overlap_lines
             buf = [overlap_text, para] if overlap_text.strip() else [para]
             buf_tokens = len(overlap_text) // TOKEN_ESTIMATE_RATIO + para_tokens
         else:
@@ -176,4 +179,4 @@ def _split_section(text: str, base_line: int, created_at: float) -> list[Chunk]:
 
 
 def _parse_ts(ts_str: str) -> float:
-    return datetime.strptime(ts_str, "%Y-%m-%d %H:%M").timestamp()
+    return datetime.strptime(ts_str, "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc).timestamp()

--- a/nanobot/memory_index/indexer.py
+++ b/nanobot/memory_index/indexer.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-TOKEN_ESTIMATE_RATIO = 4   # characters per token (heuristic)
+TOKEN_ESTIMATE_RATIO = 4  # characters per token (heuristic)
 TARGET_TOKENS = 400
 OVERLAP_TOKENS = 50
 MIN_TOKENS = 50
@@ -125,7 +125,7 @@ def _split_section(text: str, base_line: int, created_at: float) -> list[Chunk]:
     # char check here so that genuine content ("Some fact.", 10 chars) is kept
     # while near-empty bodies ("hi", 2 chars) are dropped.
     lines = stripped.splitlines()
-    body_text = "\n".join(l for l in lines if not l.startswith("## ")).strip()
+    body_text = "\n".join(ln for ln in lines if not ln.startswith("## ")).strip()
     if len(body_text) < _MIN_BODY_CHARS:  # near-empty body → skip
         return []
 
@@ -148,11 +148,13 @@ def _split_section(text: str, base_line: int, created_at: float) -> list[Chunk]:
             n_lines = chunk_text.count("\n")
             if len(chunk_text) // TOKEN_ESTIMATE_RATIO >= MIN_TOKENS:
                 chunks.append(Chunk(chunk_text, line_offset, line_offset + n_lines, created_at))
-            # overlap: keep last paragraph for context continuity
-            overlap = buf[-1]
+            # overlap: use last OVERLAP_TOKENS worth of characters (~200 chars) for context
+            overlap_text = (
+                chunk_text[-(OVERLAP_TOKENS * TOKEN_ESTIMATE_RATIO) :] if chunk_text else ""
+            )
             line_offset += n_lines + 2
-            buf = [overlap, para]
-            buf_tokens = len(overlap) // TOKEN_ESTIMATE_RATIO + para_tokens
+            buf = [overlap_text, para] if overlap_text.strip() else [para]
+            buf_tokens = len(overlap_text) // TOKEN_ESTIMATE_RATIO + para_tokens
         else:
             buf.append(para)
             buf_tokens += para_tokens

--- a/nanobot/memory_index/indexer.py
+++ b/nanobot/memory_index/indexer.py
@@ -1,0 +1,177 @@
+"""File chunking and SQLite write pipeline for the memory index."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+TOKEN_ESTIMATE_RATIO = 4   # characters per token (heuristic)
+TARGET_TOKENS = 400
+OVERLAP_TOKENS = 50
+MIN_TOKENS = 50
+_MIN_BODY_CHARS = 8  # body shorter than this is considered empty and skipped
+
+_HISTORY_TS_RE = re.compile(r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2})\]")
+
+
+@dataclass
+class Chunk:
+    text: str
+    start_line: int
+    end_line: int
+    created_at: float  # unix timestamp
+
+
+def file_hash(path: Path) -> str:
+    """Return sha256 hex digest of a file's contents."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def chunk_memory_file(path: Path) -> list[Chunk]:
+    """Split MEMORY.md into chunks by ## section headers."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    mtime = path.stat().st_mtime
+
+    # Group lines into sections delimited by ## headers
+    sections: list[tuple[int, str]] = []
+    current_start = 0
+    current_lines: list[str] = []
+
+    for i, line in enumerate(lines):
+        if line.startswith("## ") and current_lines:
+            sections.append((current_start, "".join(current_lines)))
+            current_start = i
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+    if current_lines:
+        sections.append((current_start, "".join(current_lines)))
+
+    chunks: list[Chunk] = []
+    for start_line, section_text in sections:
+        chunks.extend(_split_section(section_text, start_line, mtime))
+    return chunks
+
+
+def chunk_history_file(path: Path) -> list[Chunk]:
+    """Split HISTORY.md into chunks by [YYYY-MM-DD HH:MM] entry boundaries."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+
+    # Parse entries
+    entries: list[tuple[int, float, list[str]]] = []
+    current_start = 0
+    current_ts: float | None = None
+    current_lines: list[str] = []
+
+    for i, line in enumerate(lines):
+        m = _HISTORY_TS_RE.match(line)
+        if m:
+            if current_lines and current_ts is not None:
+                entries.append((current_start, current_ts, current_lines[:]))
+            current_start = i
+            current_ts = _parse_ts(m.group(1))
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+    if current_lines and current_ts is not None:
+        entries.append((current_start, current_ts, current_lines[:]))
+
+    # Group entries into ~TARGET_TOKENS windows
+    chunks: list[Chunk] = []
+    buf_lines: list[str] = []
+    buf_start = 0
+    buf_ts: float | None = None
+    buf_tokens = 0
+
+    for start_line, ts, entry_lines in entries:
+        entry_tokens = len("".join(entry_lines)) // TOKEN_ESTIMATE_RATIO
+        if buf_lines and buf_tokens + entry_tokens > TARGET_TOKENS:
+            chunk_text = "".join(buf_lines).strip()
+            if chunk_text:
+                chunks.append(Chunk(chunk_text, buf_start, start_line - 1, buf_ts or ts))
+            buf_lines = entry_lines[:]
+            buf_start = start_line
+            buf_ts = ts
+            buf_tokens = entry_tokens
+        else:
+            if not buf_lines:
+                buf_start = start_line
+                buf_ts = ts
+            buf_lines.extend(entry_lines)
+            buf_tokens += entry_tokens
+
+    if buf_lines:
+        chunk_text = "".join(buf_lines).strip()
+        if chunk_text:
+            end_line = buf_start + len(buf_lines) - 1
+            chunks.append(Chunk(chunk_text, buf_start, end_line, buf_ts or 0.0))
+
+    return chunks
+
+
+def _split_section(text: str, base_line: int, created_at: float) -> list[Chunk]:
+    """Split one section into <=TARGET_TOKENS chunks with OVERLAP_TOKENS overlap."""
+    stripped = text.strip()
+    if not stripped:
+        return []
+
+    # Filter sections whose body (non-header lines) is trivially short.
+    # MIN_TOKENS is the threshold for chunk output, but we use a small absolute
+    # char check here so that genuine content ("Some fact.", 10 chars) is kept
+    # while near-empty bodies ("hi", 2 chars) are dropped.
+    lines = stripped.splitlines()
+    body_text = "\n".join(l for l in lines if not l.startswith("## ")).strip()
+    if len(body_text) < _MIN_BODY_CHARS:  # near-empty body → skip
+        return []
+
+    token_count = len(stripped) // TOKEN_ESTIMATE_RATIO
+
+    if token_count <= TARGET_TOKENS:
+        n_lines = stripped.count("\n")
+        return [Chunk(stripped, base_line, base_line + n_lines, created_at)]
+
+    paragraphs = re.split(r"\n\n+", stripped)
+    chunks: list[Chunk] = []
+    buf: list[str] = []
+    buf_tokens = 0
+    line_offset = base_line
+
+    for para in paragraphs:
+        para_tokens = len(para) // TOKEN_ESTIMATE_RATIO
+        if buf and buf_tokens + para_tokens > TARGET_TOKENS:
+            chunk_text = "\n\n".join(buf).strip()
+            n_lines = chunk_text.count("\n")
+            if len(chunk_text) // TOKEN_ESTIMATE_RATIO >= MIN_TOKENS:
+                chunks.append(Chunk(chunk_text, line_offset, line_offset + n_lines, created_at))
+            # overlap: keep last paragraph for context continuity
+            overlap = buf[-1]
+            line_offset += n_lines + 2
+            buf = [overlap, para]
+            buf_tokens = len(overlap) // TOKEN_ESTIMATE_RATIO + para_tokens
+        else:
+            buf.append(para)
+            buf_tokens += para_tokens
+
+    if buf:
+        chunk_text = "\n\n".join(buf).strip()
+        if chunk_text:
+            n_lines = chunk_text.count("\n")
+            tail_tokens = len(chunk_text) // TOKEN_ESTIMATE_RATIO
+            if chunks and tail_tokens < MIN_TOKENS:
+                # Merge short tail into last chunk
+                last = chunks[-1]
+                merged = last.text + "\n\n" + chunk_text
+                chunks[-1] = Chunk(merged, last.start_line, last.end_line + n_lines + 2, created_at)
+            else:
+                chunks.append(Chunk(chunk_text, line_offset, line_offset + n_lines, created_at))
+
+    return chunks
+
+
+def _parse_ts(ts_str: str) -> float:
+    return datetime.strptime(ts_str, "%Y-%m-%d %H:%M").timestamp()

--- a/nanobot/memory_index/indexer.py
+++ b/nanobot/memory_index/indexer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import re
+import sqlite3
+import struct
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -183,3 +185,90 @@ def _split_section(text: str, base_line: int, created_at: float) -> list[Chunk]:
 
 def _parse_ts(ts_str: str) -> float:
     return datetime.strptime(ts_str, "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc).timestamp()
+
+
+def write_chunks(
+    db_path: Path,
+    file_path: Path,
+    mtime: float,
+    size: int,
+    hash_: str,
+    chunks: list[Chunk],
+    embeddings: list[list[float]] | None,
+    vec_available: bool,
+) -> None:
+    """Write (or replace) chunks for one file in the SQLite index."""
+    conn = sqlite3.connect(db_path)
+    if vec_available:
+        try:
+            import sqlite_vec
+
+            conn.enable_load_extension(True)
+            sqlite_vec.load(conn)
+            conn.enable_load_extension(False)
+        except Exception:
+            vec_available = False
+
+    try:
+        # Remove existing records for this file (cascade removes chunks)
+        old_row = conn.execute("SELECT id FROM files WHERE path = ?", [str(file_path)]).fetchone()
+        if old_row:
+            old_ids = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT id FROM chunks WHERE file_id = ?", [old_row[0]]
+                ).fetchall()
+            ]
+            for cid in old_ids:
+                conn.execute("DELETE FROM chunks_fts WHERE rowid = ?", [cid])
+                if vec_available:
+                    try:
+                        conn.execute("DELETE FROM chunks_vec WHERE rowid = ?", [cid])
+                    except Exception:
+                        pass
+            conn.execute("DELETE FROM chunks WHERE file_id = ?", [old_row[0]])
+            conn.execute("DELETE FROM files WHERE id = ?", [old_row[0]])
+
+        # Insert new file record
+        cur = conn.execute(
+            "INSERT INTO files(path, mtime, size, hash) VALUES (?, ?, ?, ?)",
+            [str(file_path), mtime, size, hash_],
+        )
+        file_id = cur.lastrowid
+
+        for i, chunk in enumerate(chunks):
+            emb_bytes = None
+            if embeddings and i < len(embeddings):
+                vec = embeddings[i]
+                emb_bytes = struct.pack(f"{len(vec)}f", *vec)
+
+            cur = conn.execute(
+                "INSERT INTO chunks(file_id, text, start_line, end_line, created_at, embedding)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                [
+                    file_id,
+                    chunk.text,
+                    chunk.start_line,
+                    chunk.end_line,
+                    chunk.created_at,
+                    emb_bytes,
+                ],
+            )
+            chunk_id = cur.lastrowid
+
+            conn.execute(
+                "INSERT INTO chunks_fts(rowid, text) VALUES (?, ?)", [chunk_id, chunk.text]
+            )
+
+            if vec_available and emb_bytes:
+                try:
+                    conn.execute(
+                        "INSERT INTO chunks_vec(rowid, embedding) VALUES (?, ?)",
+                        [chunk_id, emb_bytes],
+                    )
+                except Exception:
+                    pass
+
+        conn.commit()
+    finally:
+        conn.close()

--- a/nanobot/memory_index/indexer.py
+++ b/nanobot/memory_index/indexer.py
@@ -152,6 +152,9 @@ def _split_section(text: str, base_line: int, created_at: float) -> list[Chunk]:
             overlap_text = (
                 chunk_text[-(OVERLAP_TOKENS * TOKEN_ESTIMATE_RATIO) :] if chunk_text else ""
             )
+            # Snap overlap to a line boundary so line counting is accurate
+            if overlap_text and "\n" in overlap_text:
+                overlap_text = overlap_text[overlap_text.index("\n") + 1 :]
             overlap_lines = overlap_text.count("\n") + 1 if overlap_text.strip() else 0
             # Advance by the chunk's lines, then step back by overlap so next chunk's
             # start_line reflects that it begins with repeated content from the previous chunk.

--- a/nanobot/memory_index/schema.sql
+++ b/nanobot/memory_index/schema.sql
@@ -1,0 +1,30 @@
+-- Static table DDL for nanobot memory index.
+-- chunks_vec is created separately in code (dimension is configurable).
+
+CREATE TABLE IF NOT EXISTS index_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS files (
+    id    INTEGER PRIMARY KEY,
+    path  TEXT UNIQUE NOT NULL,
+    mtime REAL NOT NULL,
+    size  INTEGER NOT NULL,
+    hash  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    id         INTEGER PRIMARY KEY,
+    file_id    INTEGER REFERENCES files(id) ON DELETE CASCADE,
+    text       TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line   INTEGER NOT NULL,
+    created_at REAL NOT NULL,
+    embedding  BLOB
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+    text,
+    tokenize='porter unicode61'
+);

--- a/nanobot/memory_index/search.py
+++ b/nanobot/memory_index/search.py
@@ -79,6 +79,10 @@ def apply_temporal_decay(
     }
 
 
+def _dot(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
 def mmr_rerank(
     scores: dict[int, float],
     chunk_vecs: dict[int, list[float]],
@@ -190,7 +194,3 @@ def sync_search(
         ]
     finally:
         conn.close()
-
-
-def _dot(a: list[float], b: list[float]) -> float:
-    return sum(x * y for x, y in zip(a, b))

--- a/nanobot/memory_index/search.py
+++ b/nanobot/memory_index/search.py
@@ -1,0 +1,196 @@
+"""Hybrid BM25+vector search with RRF fusion, temporal decay, and MMR."""
+
+from __future__ import annotations
+
+import math
+import sqlite3
+import struct
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+_RRF_K = 60
+
+
+@dataclass
+class SearchResult:
+    text: str
+    source: str
+    start_line: int
+    end_line: int
+    score: float
+
+
+def bm25_search(conn: sqlite3.Connection, query: str, k: int) -> list[int]:
+    """Return up to k chunk IDs ranked by BM25 (best first)."""
+    try:
+        rows = conn.execute(
+            "SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ? "
+            "ORDER BY bm25(chunks_fts) LIMIT ?",
+            [query, k],
+        ).fetchall()
+        return [r[0] for r in rows]
+    except sqlite3.OperationalError:
+        return []
+
+
+def vector_search(conn: sqlite3.Connection, query_vec: list[float], k: int) -> list[int]:
+    """Return up to k chunk IDs ranked by cosine distance (best first)."""
+    query_bytes = struct.pack(f"{len(query_vec)}f", *query_vec)
+    try:
+        rows = conn.execute(
+            "SELECT rowid FROM chunks_vec WHERE embedding MATCH ? ORDER BY distance LIMIT ?",
+            [query_bytes, k],
+        ).fetchall()
+        return [r[0] for r in rows]
+    except Exception:
+        return []
+
+
+def rrf_merge(bm25_ids: list[int], vec_ids: list[int]) -> dict[int, float]:
+    """Merge two ranked lists using Reciprocal Rank Fusion."""
+    scores: dict[int, float] = defaultdict(float)
+    for rank, doc_id in enumerate(bm25_ids):
+        scores[doc_id] += 1.0 / (_RRF_K + rank)
+    for rank, doc_id in enumerate(vec_ids):
+        scores[doc_id] += 1.0 / (_RRF_K + rank)
+    return dict(scores)
+
+
+def apply_temporal_decay(
+    scores: dict[int, float],
+    conn: sqlite3.Connection,
+    half_life_days: float,
+) -> dict[int, float]:
+    """Multiply each score by exp(-age_days / half_life_days)."""
+    if not scores or half_life_days <= 0:
+        return scores
+    now = time.time()
+    placeholders = ",".join("?" * len(scores))
+    rows = conn.execute(
+        f"SELECT id, created_at FROM chunks WHERE id IN ({placeholders})",
+        list(scores.keys()),
+    ).fetchall()
+    id_to_ts = {r[0]: r[1] for r in rows}
+    return {
+        doc_id: score * math.exp(-(now - id_to_ts.get(doc_id, now)) / 86400 / half_life_days)
+        for doc_id, score in scores.items()
+    }
+
+
+def mmr_rerank(
+    scores: dict[int, float],
+    chunk_vecs: dict[int, list[float]],
+    query_vec: list[float] | None,
+    top_k: int,
+    lambda_: float,
+) -> list[int]:
+    """Maximal Marginal Relevance: diversify top-k results."""
+    if not scores:
+        return []
+    if query_vec is None or not chunk_vecs:
+        return sorted(scores, key=scores.__getitem__, reverse=True)[:top_k]
+
+    candidates = list(scores.keys())
+    selected: list[int] = []
+
+    while len(selected) < top_k and candidates:
+        best_id, best_score = None, float("-inf")
+        for cid in candidates:
+            relevance = scores[cid]
+            max_sim = (
+                max(_dot(chunk_vecs[cid], chunk_vecs[s]) for s in selected if s in chunk_vecs)
+                if selected
+                else 0.0
+            )
+            mmr_score = lambda_ * relevance - (1 - lambda_) * max_sim
+            if mmr_score > best_score:
+                best_score, best_id = mmr_score, cid
+        if best_id is None:
+            break
+        selected.append(best_id)
+        candidates.remove(best_id)
+
+    return selected
+
+
+def sync_search(
+    db_path: Path,
+    query: str,
+    query_vec: list[float] | None,
+    top_k: int,
+    vec_available: bool,
+    mmr_lambda: float,
+    half_life_days: float,
+) -> list[SearchResult]:
+    """Full search pipeline: BM25 + vector → RRF → decay → MMR → results."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    if vec_available:
+        try:
+            import sqlite_vec
+
+            conn.enable_load_extension(True)
+            sqlite_vec.load(conn)
+            conn.enable_load_extension(False)
+        except Exception:
+            vec_available = False
+
+    try:
+        candidate_k = top_k * 4
+        bm25_ids = bm25_search(conn, query, candidate_k)
+        vec_ids = (
+            vector_search(conn, query_vec, candidate_k) if (vec_available and query_vec) else []
+        )
+
+        if not bm25_ids and not vec_ids:
+            return []
+
+        merged = rrf_merge(bm25_ids, vec_ids)
+        decayed = apply_temporal_decay(merged, conn, half_life_days)
+
+        # Retrieve stored embeddings for MMR (from chunks.embedding BLOB)
+        chunk_vecs: dict[int, list[float]] = {}
+        if vec_available and query_vec:
+            dim = len(query_vec)
+            placeholders = ",".join("?" * len(decayed))
+            rows = conn.execute(
+                f"SELECT id, embedding FROM chunks WHERE id IN ({placeholders}) AND embedding IS NOT NULL",
+                list(decayed.keys()),
+            ).fetchall()
+            for r in rows:
+                if r["embedding"]:
+                    chunk_vecs[r["id"]] = list(struct.unpack(f"{dim}f", r["embedding"]))
+
+        ordered = mmr_rerank(decayed, chunk_vecs, query_vec, top_k, mmr_lambda)
+
+        if not ordered:
+            return []
+
+        placeholders = ",".join("?" * len(ordered))
+        rows = conn.execute(
+            f"SELECT c.id, c.text, c.start_line, c.end_line, f.path "
+            f"FROM chunks c JOIN files f ON c.file_id = f.id "
+            f"WHERE c.id IN ({placeholders})",
+            ordered,
+        ).fetchall()
+        id_to_row = {r["id"]: r for r in rows}
+
+        return [
+            SearchResult(
+                text=id_to_row[doc_id]["text"],
+                source=Path(id_to_row[doc_id]["path"]).name,
+                start_line=id_to_row[doc_id]["start_line"],
+                end_line=id_to_row[doc_id]["end_line"],
+                score=decayed.get(doc_id, 0.0),
+            )
+            for doc_id in ordered
+            if doc_id in id_to_row
+        ]
+    finally:
+        conn.close()
+
+
+def _dot(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))

--- a/nanobot/memory_index/service.py
+++ b/nanobot/memory_index/service.py
@@ -1,0 +1,62 @@
+"""IndexService — lifecycle wrapper around MemoryIndex with optional file watcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from nanobot.config.schema import MemoryIndexConfig
+
+
+class IndexService:
+    """Lifecycle object that owns MemoryIndex and an optional watchdog file observer."""
+
+    def __init__(self, workspace: Path, cfg: MemoryIndexConfig) -> None:
+        from nanobot.memory_index.index import MemoryIndex
+
+        self.index = MemoryIndex(workspace, cfg)
+        self._cfg = cfg
+        self._observer = None
+
+    async def start(self) -> None:
+        """Index memory files at startup; optionally start the file watcher."""
+        await self.index.startup_index()
+        if self._cfg.watch_files:
+            self._start_watcher()
+
+    async def stop(self) -> None:
+        """Stop the file watcher if running."""
+        if self._observer is not None:
+            self._observer.stop()
+            self._observer.join()
+            self._observer = None
+
+    def _start_watcher(self) -> None:
+        """Start a watchdog observer that re-indexes on MEMORY.md / HISTORY.md changes."""
+        import asyncio
+
+        from watchdog.events import FileSystemEventHandler
+        from watchdog.observers import Observer
+
+        loop = asyncio.get_running_loop()
+        index = self.index
+        memory_dir = self.index.memory_dir
+
+        class _MemoryFileHandler(FileSystemEventHandler):
+            def on_modified(self, event) -> None:
+                if not event.is_directory:
+                    p = Path(event.src_path)
+                    if p.name in ("MEMORY.md", "HISTORY.md"):
+                        asyncio.run_coroutine_threadsafe(index._index_file(p), loop)
+
+            def on_created(self, event) -> None:
+                self.on_modified(event)
+
+        observer = Observer()
+        observer.schedule(_MemoryFileHandler(), str(memory_dir), recursive=False)
+        observer.start()
+        self._observer = observer
+        logger.info("Memory file watcher started for {}", memory_dir)

--- a/nanobot/memory_index/service.py
+++ b/nanobot/memory_index/service.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from nanobot.config.schema import MemoryIndexConfig
+    from nanobot.memory_index.search import SearchResult
 
 
 class IndexService:
@@ -33,6 +34,19 @@ class IndexService:
             self._observer.stop()
             self._observer.join()
             self._observer = None
+
+    @property
+    def inject_top_k(self) -> int:
+        """Number of memory chunks to inject per turn (0 = disabled)."""
+        return self._cfg.inject_top_k
+
+    async def search(self, query: str, top_k: int | None = None) -> list[SearchResult]:
+        """Public search entry-point; delegates to MemoryIndex.
+
+        Keeping search on the service boundary (rather than exposing index.search directly)
+        allows future additions — caching, reindex guards, metrics — in one place.
+        """
+        return await self.index.search(query, top_k=top_k)
 
     def _start_watcher(self) -> None:
         """Start a watchdog observer that re-indexes on MEMORY.md / HISTORY.md changes."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
     "pytest-asyncio>=1.3.0,<2.0.0",
     "pytest-cov>=6.0.0,<7.0.0",
     "ruff>=0.1.0",
+    "watchdog>=3.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ matrix = [
     "mistune>=3.0.0,<4.0.0",
     "nh3>=0.2.17,<1.0.0",
 ]
+memory = [
+    "sqlite-vec>=0.1.0",
+]
 langsmith = [
     "langsmith>=0.1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ matrix = [
 ]
 memory = [
     "sqlite-vec>=0.1.0",
+    "watchdog>=3.0.0",
 ]
 langsmith = [
     "langsmith>=0.1.0",

--- a/tests/agent/test_context_injection.py
+++ b/tests/agent/test_context_injection.py
@@ -15,8 +15,8 @@ async def test_build_messages_injects_results_when_index_provided(tmp_path):
     ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
 
     mock_service = MagicMock()
-    mock_service._cfg.inject_top_k = 3
-    mock_service.index.search = AsyncMock(return_value=[_make_result("User prefers dark mode.")])
+    mock_service.inject_top_k = 3
+    mock_service.search = AsyncMock(return_value=[_make_result("User prefers dark mode.")])
 
     messages = await ctx.build_messages(
         history=[],
@@ -35,8 +35,8 @@ async def test_injection_message_is_inserted_before_user_message(tmp_path):
     ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
 
     mock_service = MagicMock()
-    mock_service._cfg.inject_top_k = 3
-    mock_service.index.search = AsyncMock(return_value=[_make_result("Some fact.")])
+    mock_service.inject_top_k = 3
+    mock_service.search = AsyncMock(return_value=[_make_result("Some fact.")])
 
     messages = await ctx.build_messages(
         history=[],
@@ -65,8 +65,8 @@ async def test_injection_includes_source_and_line_range(tmp_path):
         score=0.8,
     )
     mock_service = MagicMock()
-    mock_service._cfg.inject_top_k = 3
-    mock_service.index.search = AsyncMock(return_value=[result])
+    mock_service.inject_top_k = 3
+    mock_service.search = AsyncMock(return_value=[result])
 
     messages = await ctx.build_messages(
         history=[],
@@ -100,8 +100,8 @@ async def test_no_injection_when_empty_results(tmp_path):
     ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
 
     mock_service = MagicMock()
-    mock_service._cfg.inject_top_k = 3
-    mock_service.index.search = AsyncMock(return_value=[])
+    mock_service.inject_top_k = 3
+    mock_service.search = AsyncMock(return_value=[])
 
     messages = await ctx.build_messages(
         history=[],
@@ -119,8 +119,8 @@ async def test_no_injection_when_inject_top_k_is_zero(tmp_path):
     ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
 
     mock_service = MagicMock()
-    mock_service._cfg.inject_top_k = 0
-    mock_service.index.search = AsyncMock(return_value=[_make_result("Should not appear.")])
+    mock_service.inject_top_k = 0
+    mock_service.search = AsyncMock(return_value=[_make_result("Should not appear.")])
 
     messages = await ctx.build_messages(
         history=[],
@@ -128,7 +128,7 @@ async def test_no_injection_when_inject_top_k_is_zero(tmp_path):
         index=mock_service,
     )
 
-    mock_service.index.search.assert_not_called()
+    mock_service.search.assert_not_called()
     injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
     assert len(injected) == 0
 

--- a/tests/agent/test_context_injection.py
+++ b/tests/agent/test_context_injection.py
@@ -1,0 +1,160 @@
+"""Tests for pre-retrieval injection in build_messages()."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from nanobot.memory_index.search import SearchResult
+
+
+def _make_result(text: str) -> SearchResult:
+    return SearchResult(text=text, source="MEMORY.md", start_line=1, end_line=2, score=0.9)
+
+
+async def test_build_messages_injects_results_when_index_provided(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 3
+    mock_service.index.search = AsyncMock(return_value=[_make_result("User prefers dark mode.")])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="What theme do I like?",
+        index=mock_service,
+    )
+
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert len(injected) == 1
+    assert "dark mode" in injected[0]["content"]
+
+
+async def test_injection_message_is_inserted_before_user_message(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 3
+    mock_service.index.search = AsyncMock(return_value=[_make_result("Some fact.")])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="hello",
+        index=mock_service,
+    )
+
+    # Injection must come before the last (user) message
+    injection_idx = next(
+        i for i, m in enumerate(messages)
+        if m["role"] == "system" and "Relevant memory" in m.get("content", "")
+    )
+    assert injection_idx == len(messages) - 2  # second-to-last
+
+
+async def test_injection_includes_source_and_line_range(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    result = SearchResult(
+        text="User likes coffee.",
+        source="MEMORY.md",
+        start_line=5,
+        end_line=7,
+        score=0.8,
+    )
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 3
+    mock_service.index.search = AsyncMock(return_value=[result])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="What do I drink?",
+        index=mock_service,
+    )
+
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert "[MEMORY.md L5–7]" in injected[0]["content"]
+    assert "User likes coffee." in injected[0]["content"]
+
+
+async def test_no_injection_when_index_is_none(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=False)
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="hello",
+        index=None,
+    )
+
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert len(injected) == 0
+
+
+async def test_no_injection_when_empty_results(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 3
+    mock_service.index.search = AsyncMock(return_value=[])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="anything",
+        index=mock_service,
+    )
+
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert len(injected) == 0
+
+
+async def test_no_injection_when_inject_top_k_is_zero(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 0
+    mock_service.index.search = AsyncMock(return_value=[_make_result("Should not appear.")])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="anything",
+        index=mock_service,
+    )
+
+    mock_service.index.search.assert_not_called()
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert len(injected) == 0
+
+
+async def test_estimate_session_prompt_tokens_is_async(tmp_path):
+    """MemoryConsolidator.estimate_session_prompt_tokens() must be awaitable."""
+    from nanobot.agent.memory import MemoryConsolidator
+
+    async def fake_build(**kwargs):
+        return [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+
+    consolidator = MemoryConsolidator(
+        workspace=tmp_path,
+        provider=MagicMock(),
+        model="test-model",
+        sessions=MagicMock(),
+        context_window_tokens=8192,
+        build_messages=fake_build,
+        get_tool_definitions=lambda: [],
+    )
+
+    mock_session = MagicMock()
+    mock_session.messages = [{"role": "user", "content": "hi"}]
+    mock_session.key = "cli:test"
+    mock_session.get_history.return_value = []
+
+    tokens, source = await consolidator.estimate_session_prompt_tokens(mock_session)
+    assert isinstance(tokens, int)
+    assert isinstance(source, str)

--- a/tests/agent/test_context_prompt_cache.py
+++ b/tests/agent/test_context_prompt_cache.py
@@ -47,12 +47,12 @@ def test_system_prompt_stays_stable_when_clock_changes(tmp_path, monkeypatch) ->
     assert prompt1 == prompt2
 
 
-def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
+async def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
     """Runtime metadata should be merged with the user message."""
     workspace = _make_workspace(tmp_path)
     builder = ContextBuilder(workspace)
 
-    messages = builder.build_messages(
+    messages = await builder.build_messages(
         history=[],
         current_message="Return exactly: OK",
         channel="cli",

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -102,7 +102,7 @@ async def test_consolidation_loops_until_target_met(tmp_path, monkeypatch) -> No
     loop.sessions.save(session)
 
     call_count = [0]
-    def mock_estimate(_session):
+    async def mock_estimate(_session):
         call_count[0] += 1
         if call_count[0] == 1:
             return (500, "test")
@@ -139,7 +139,7 @@ async def test_consolidation_continues_below_trigger_until_half_target(tmp_path,
 
     call_count = [0]
 
-    def mock_estimate(_session):
+    async def mock_estimate(_session):
         call_count[0] += 1
         if call_count[0] == 1:
             return (500, "test")
@@ -184,7 +184,7 @@ async def test_preflight_consolidation_before_llm_call(tmp_path, monkeypatch) ->
     monkeypatch.setattr(memory_module, "estimate_message_tokens", lambda _m: 500)
 
     call_count = [0]
-    def mock_estimate(_session):
+    async def mock_estimate(_session):
         call_count[0] += 1
         return (1000 if call_count[0] <= 1 else 80, "test")
     loop.memory_consolidator.estimate_session_prompt_tokens = mock_estimate  # type: ignore[method-assign]

--- a/tests/agent/test_memory_index_integration.py
+++ b/tests/agent/test_memory_index_integration.py
@@ -26,7 +26,7 @@ def test_context_builder_loads_memory_file_when_disabled(tmp_path):
 
 
 async def test_agent_loop_registers_tool_when_enabled(tmp_path):
-    # Must be async: AgentLoop.__init__ calls asyncio.create_task for startup_index
+    # startup_index() is deferred to run()/process_direct(); only tool registration is checked here.
     from nanobot.agent.loop import AgentLoop
     from nanobot.bus.queue import MessageBus
 

--- a/tests/agent/test_memory_index_integration.py
+++ b/tests/agent/test_memory_index_integration.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+
+from nanobot.config.schema import MemoryIndexConfig
+
+
+def test_context_builder_shows_pointer_note_when_enabled(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+    prompt = ctx.build_system_prompt()
+    assert "memory_search" in prompt
+    assert "tool" in prompt.lower()
+    # Full MEMORY.md content should NOT be inlined
+    assert "Long-term Memory" not in prompt
+
+
+def test_context_builder_loads_memory_file_when_disabled(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "MEMORY.md").write_text("## Facts\n\nUser loves coffee.\n")
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=False)
+    prompt = ctx.build_system_prompt()
+    assert "User loves coffee" in prompt
+
+
+async def test_agent_loop_registers_tool_when_enabled(tmp_path):
+    # Must be async: AgentLoop.__init__ calls asyncio.create_task for startup_index
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    cfg = MemoryIndexConfig()
+    cfg.enabled = True
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        memory_index_config=cfg,
+    )
+    assert loop.tools.get("memory_search") is not None
+
+
+def test_agent_loop_does_not_register_tool_when_disabled(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        memory_index_config=MemoryIndexConfig(),  # enabled=False
+    )
+    assert loop.tools.get("memory_search") is None

--- a/tests/agent/test_memory_index_integration.py
+++ b/tests/agent/test_memory_index_integration.py
@@ -1,7 +1,5 @@
 from unittest.mock import MagicMock
 
-from nanobot.config.schema import MemoryIndexConfig
-
 
 def test_context_builder_shows_pointer_note_when_enabled(tmp_path):
     from nanobot.agent.context import ContextBuilder
@@ -25,16 +23,19 @@ def test_context_builder_loads_memory_file_when_disabled(tmp_path):
     assert "User loves coffee" in prompt
 
 
-async def test_agent_loop_registers_tool_when_enabled(tmp_path):
-    # startup_index() is deferred to run()/process_direct(); only tool registration is checked here.
+async def test_agent_loop_creates_index_service_when_enabled(tmp_path):
+    """AgentLoop._index_service is an IndexService instance when memory_index is enabled."""
     from nanobot.agent.loop import AgentLoop
     from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import MemoryIndexConfig
+    from nanobot.memory_index.service import IndexService
 
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
 
     cfg = MemoryIndexConfig()
     cfg.enabled = True
+    cfg.watch_files = False
 
     loop = AgentLoop(
         bus=MessageBus(),
@@ -42,12 +43,15 @@ async def test_agent_loop_registers_tool_when_enabled(tmp_path):
         workspace=tmp_path,
         memory_index_config=cfg,
     )
+
+    assert isinstance(loop._index_service, IndexService)
     assert loop.tools.get("memory_search") is not None
 
 
 def test_agent_loop_does_not_register_tool_when_disabled(tmp_path):
     from nanobot.agent.loop import AgentLoop
     from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import MemoryIndexConfig
 
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
@@ -59,3 +63,97 @@ def test_agent_loop_does_not_register_tool_when_disabled(tmp_path):
         memory_index_config=MemoryIndexConfig(),  # enabled=False
     )
     assert loop.tools.get("memory_search") is None
+    assert loop._index_service is None
+
+
+async def test_agent_loop_start_schedules_index_service_start(tmp_path):
+    """run() schedules IndexService.start() as a background task exactly once."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import MemoryIndexConfig
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    cfg = MemoryIndexConfig()
+    cfg.enabled = True
+    cfg.watch_files = False
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        memory_index_config=cfg,
+    )
+    loop._running = False  # prevent run() from looping
+
+    start_calls = []
+
+    async def fake_start():
+        start_calls.append(1)
+
+    loop._index_service.start = fake_start
+
+    with patch.object(loop, "_connect_mcp", new_callable=AsyncMock):
+        try:
+            await asyncio.wait_for(loop.run(), timeout=0.5)
+        except asyncio.TimeoutError:
+            pass
+
+    # Drain background tasks so fake_start actually runs
+    if loop._background_tasks:
+        await asyncio.gather(*loop._background_tasks, return_exceptions=True)
+
+    assert len(start_calls) == 1
+
+
+async def test_agent_loop_start_schedules_only_once(tmp_path):
+    """Calling process_direct() twice does not schedule IndexService.start() twice."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import MemoryIndexConfig
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation.max_tokens = 4096
+    provider.chat_with_retry = AsyncMock(return_value=MagicMock(
+        has_tool_calls=False,
+        content="Hi",
+        finish_reason="stop",
+        tool_calls=[],
+        usage={},
+        reasoning_content=None,
+        thinking_blocks=None,
+    ))
+
+    cfg = MemoryIndexConfig()
+    cfg.enabled = True
+    cfg.watch_files = False
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        memory_index_config=cfg,
+    )
+
+    start_calls = []
+
+    async def fake_start():
+        start_calls.append(1)
+
+    loop._index_service.start = fake_start
+
+    await loop.process_direct("hello")
+    await loop.process_direct("world")
+
+    if loop._background_tasks:
+        await asyncio.gather(*loop._background_tasks, return_exceptions=True)
+
+    assert len(start_calls) == 1  # only once, not twice

--- a/tests/cli/test_restart_command.py
+++ b/tests/cli/test_restart_command.py
@@ -127,7 +127,7 @@ class TestRestartCommand:
         loop.sessions.get_or_create.return_value = session
         loop._start_time = time.time() - 125
         loop._last_usage = {"prompt_tokens": 0, "completion_tokens": 0}
-        loop.memory_consolidator.estimate_session_prompt_tokens = MagicMock(
+        loop.memory_consolidator.estimate_session_prompt_tokens = AsyncMock(
             return_value=(20500, "tiktoken")
         )
 
@@ -164,7 +164,7 @@ class TestRestartCommand:
         session.get_history.return_value = [{"role": "user"}]
         loop.sessions.get_or_create.return_value = session
         loop._last_usage = {"prompt_tokens": 1200, "completion_tokens": 34}
-        loop.memory_consolidator.estimate_session_prompt_tokens = MagicMock(
+        loop.memory_consolidator.estimate_session_prompt_tokens = AsyncMock(
             return_value=(0, "none")
         )
 

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -5,6 +5,7 @@ import pytest
 
 def test_memory_index_defaults():
     from nanobot.config.schema import MemoryIndexConfig
+
     cfg = MemoryIndexConfig()
     assert cfg.enabled is False
     assert cfg.embedding.provider == "ollama"
@@ -19,16 +20,31 @@ def test_memory_index_defaults():
 
 def test_memory_index_on_root_config():
     from nanobot.config.schema import Config
+
     cfg = Config()
     assert cfg.memory_index.enabled is False
 
 
 def test_memory_index_camel_case():
     from nanobot.config.schema import MemoryIndexConfig
-    cfg = MemoryIndexConfig.model_validate({
-        "enabled": True,
-        "embedding": {"model": "mxbai-embed-large", "dim": 1024},
-    })
+
+    # snake_case keys (populate_by_name=True)
+    cfg = MemoryIndexConfig.model_validate(
+        {
+            "enabled": True,
+            "embedding": {"model": "mxbai-embed-large", "dim": 1024},
+        }
+    )
     assert cfg.enabled is True
     assert cfg.embedding.model == "mxbai-embed-large"
     assert cfg.embedding.dim == 1024
+
+    # camelCase keys (alias_generator=to_camel)
+    cfg2 = MemoryIndexConfig.model_validate(
+        {
+            "enabled": True,
+            "embedding": {"batchSize": 32, "baseUrl": "http://localhost:22222"},
+        }
+    )
+    assert cfg2.embedding.batch_size == 32
+    assert cfg2.embedding.base_url == "http://localhost:22222"

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -1,0 +1,34 @@
+"""Tests for nanobot.config.schema."""
+
+import pytest
+
+
+def test_memory_index_defaults():
+    from nanobot.config.schema import MemoryIndexConfig
+    cfg = MemoryIndexConfig()
+    assert cfg.enabled is False
+    assert cfg.embedding.provider == "ollama"
+    assert cfg.embedding.model == "nomic-embed-text"
+    assert cfg.embedding.base_url == "http://localhost:11434"
+    assert cfg.embedding.batch_size == 16
+    assert cfg.embedding.dim == 768
+    assert cfg.query.top_k == 5
+    assert cfg.query.mmr_lambda == 0.5
+    assert cfg.query.temporal_decay_half_life_days == 90.0
+
+
+def test_memory_index_on_root_config():
+    from nanobot.config.schema import Config
+    cfg = Config()
+    assert cfg.memory_index.enabled is False
+
+
+def test_memory_index_camel_case():
+    from nanobot.config.schema import MemoryIndexConfig
+    cfg = MemoryIndexConfig.model_validate({
+        "enabled": True,
+        "embedding": {"model": "mxbai-embed-large", "dim": 1024},
+    })
+    assert cfg.enabled is True
+    assert cfg.embedding.model == "mxbai-embed-large"
+    assert cfg.embedding.dim == 1024

--- a/tests/test_memory_index/test_chunking.py
+++ b/tests/test_memory_index/test_chunking.py
@@ -1,0 +1,86 @@
+import time
+from pathlib import Path
+import pytest
+from nanobot.memory_index.indexer import (
+    MIN_TOKENS, TARGET_TOKENS, chunk_history_file, chunk_memory_file,
+)
+
+
+def test_chunk_memory_splits_on_headers(tmp_path):
+    f = tmp_path / "MEMORY.md"
+    f.write_text(
+        "## Section A\n\nContent about section A.\n\n"
+        "## Section B\n\nContent about section B.\n"
+    )
+    chunks = chunk_memory_file(f)
+    assert len(chunks) == 2
+    assert "Content about section A" in chunks[0].text
+    assert "Content about section B" in chunks[1].text
+
+
+def test_chunk_memory_skips_short_sections(tmp_path):
+    f = tmp_path / "MEMORY.md"
+    # 'hi' is way below MIN_TOKENS
+    long_content = "word " * 60  # ~75 tokens
+    f.write_text(f"## Tiny\n\nhi\n\n## Normal\n\n{long_content}\n")
+    chunks = chunk_memory_file(f)
+    # Tiny section (< MIN_TOKENS) should not produce a standalone chunk
+    for c in chunks:
+        assert len(c.text) // 4 >= MIN_TOKENS
+
+
+def test_chunk_memory_created_at_from_mtime(tmp_path):
+    f = tmp_path / "MEMORY.md"
+    f.write_text("## Facts\n\nSome fact.\n")
+    before = time.time()
+    chunks = chunk_memory_file(f)
+    after = time.time()
+    assert chunks
+    assert before - 1 <= chunks[0].created_at <= after + 1
+
+
+def test_chunk_memory_large_section_splits_on_paragraphs(tmp_path):
+    f = tmp_path / "MEMORY.md"
+    # Each paragraph is ~50 tokens; with TARGET_TOKENS=400 we need 9+ paras to split
+    para = "word " * 55 + "\n"  # ~55 tokens
+    content = "\n\n".join([para] * 10)
+    f.write_text(f"## Big Section\n\n{content}\n")
+    chunks = chunk_memory_file(f)
+    assert len(chunks) >= 2
+
+
+def test_chunk_history_splits_by_timestamp(tmp_path):
+    f = tmp_path / "HISTORY.md"
+    f.write_text(
+        "[2025-01-01 10:00] USER: hello world\n\n"
+        "[2025-01-02 11:00] USER: another entry\n\n"
+    )
+    chunks = chunk_history_file(f)
+    assert len(chunks) >= 1
+    # created_at must be parsed from the timestamp, not file mtime
+    assert chunks[0].created_at > 0
+    # Jan 1 2025 is around unix 1735689600
+    assert chunks[0].created_at > 1_700_000_000
+
+
+def test_chunk_history_groups_small_entries(tmp_path):
+    f = tmp_path / "HISTORY.md"
+    entries = "".join(
+        f"[2025-01-{i + 1:02d} 10:00] USER: short entry {i}\n\n" for i in range(5)
+    )
+    f.write_text(entries)
+    chunks = chunk_history_file(f)
+    # All 5 tiny entries should fit in a single window
+    assert len(chunks) == 1
+
+
+def test_chunk_history_splits_large_window(tmp_path):
+    f = tmp_path / "HISTORY.md"
+    # Each entry ~60 tokens; 8 entries = ~480 tokens > TARGET_TOKENS
+    big_entry = "word " * 60
+    entries = "".join(
+        f"[2025-01-{i + 1:02d} 10:00] USER: {big_entry}\n\n" for i in range(8)
+    )
+    f.write_text(entries)
+    chunks = chunk_history_file(f)
+    assert len(chunks) >= 2

--- a/tests/test_memory_index/test_chunking.py
+++ b/tests/test_memory_index/test_chunking.py
@@ -1,16 +1,16 @@
 import time
-from pathlib import Path
-import pytest
+
 from nanobot.memory_index.indexer import (
-    MIN_TOKENS, TARGET_TOKENS, chunk_history_file, chunk_memory_file,
+    MIN_TOKENS,
+    chunk_history_file,
+    chunk_memory_file,
 )
 
 
 def test_chunk_memory_splits_on_headers(tmp_path):
     f = tmp_path / "MEMORY.md"
     f.write_text(
-        "## Section A\n\nContent about section A.\n\n"
-        "## Section B\n\nContent about section B.\n"
+        "## Section A\n\nContent about section A.\n\n## Section B\n\nContent about section B.\n"
     )
     chunks = chunk_memory_file(f)
     assert len(chunks) == 2
@@ -52,8 +52,7 @@ def test_chunk_memory_large_section_splits_on_paragraphs(tmp_path):
 def test_chunk_history_splits_by_timestamp(tmp_path):
     f = tmp_path / "HISTORY.md"
     f.write_text(
-        "[2025-01-01 10:00] USER: hello world\n\n"
-        "[2025-01-02 11:00] USER: another entry\n\n"
+        "[2025-01-01 10:00] USER: hello world\n\n[2025-01-02 11:00] USER: another entry\n\n"
     )
     chunks = chunk_history_file(f)
     assert len(chunks) >= 1
@@ -65,9 +64,7 @@ def test_chunk_history_splits_by_timestamp(tmp_path):
 
 def test_chunk_history_groups_small_entries(tmp_path):
     f = tmp_path / "HISTORY.md"
-    entries = "".join(
-        f"[2025-01-{i + 1:02d} 10:00] USER: short entry {i}\n\n" for i in range(5)
-    )
+    entries = "".join(f"[2025-01-{i + 1:02d} 10:00] USER: short entry {i}\n\n" for i in range(5))
     f.write_text(entries)
     chunks = chunk_history_file(f)
     # All 5 tiny entries should fit in a single window
@@ -78,9 +75,46 @@ def test_chunk_history_splits_large_window(tmp_path):
     f = tmp_path / "HISTORY.md"
     # Each entry ~60 tokens; 8 entries = ~480 tokens > TARGET_TOKENS
     big_entry = "word " * 60
-    entries = "".join(
-        f"[2025-01-{i + 1:02d} 10:00] USER: {big_entry}\n\n" for i in range(8)
-    )
+    entries = "".join(f"[2025-01-{i + 1:02d} 10:00] USER: {big_entry}\n\n" for i in range(8))
     f.write_text(entries)
     chunks = chunk_history_file(f)
     assert len(chunks) >= 2
+
+
+def test_chunk_memory_merges_short_tail(tmp_path):
+    # Create a MEMORY.md with one section that splits into paragraphs,
+    # where the last paragraph is very short (< 50 tokens)
+    content = "# Long-term Memory\n\n## Big Section\n\n"
+    # Add a large first paragraph (> 400 tokens)
+    content += "A " * 250 + "\n\n"  # ~250 tokens first paragraph
+    # Add a short second paragraph (< 50 tokens)
+    content += "Short tail.\n"
+
+    p = tmp_path / "MEMORY.md"
+    p.write_text(content)
+    chunks = chunk_memory_file(p)
+
+    # Should not have a standalone chunk for "Short tail."
+    # The short tail should be merged into the last chunk
+    assert not any(c.text.strip() == "Short tail." for c in chunks)
+    # The last chunk should contain "Short tail."
+    assert "Short tail." in chunks[-1].text
+
+
+def test_chunk_memory_overlap_on_split(tmp_path):
+    # Create a single section with two large paragraphs that together exceed TARGET_TOKENS
+    content = "## Big Section\n\n"
+    content += "Alpha " * 250 + "\n\n"  # ~250 tokens first para
+    content += "Beta " * 250 + "\n"  # ~250 tokens second para
+    # Together ~500 tokens > TARGET_TOKENS=400, so the section will split
+
+    p = tmp_path / "MEMORY.md"
+    p.write_text(content)
+    chunks = chunk_memory_file(p)
+
+    # Should produce multiple chunks
+    assert len(chunks) >= 2
+    # The second chunk should contain overlap text from the end of the first chunk.
+    # Overlap is the last OVERLAP_TOKENS * TOKEN_ESTIMATE_RATIO = 200 chars of chunk[0].
+    overlap_text = chunks[0].text[-200:]
+    assert overlap_text.strip() in chunks[1].text

--- a/tests/test_memory_index/test_chunking.py
+++ b/tests/test_memory_index/test_chunking.py
@@ -1,4 +1,7 @@
 import time
+from datetime import datetime, timezone
+
+import pytest
 
 from nanobot.memory_index.indexer import (
     MIN_TOKENS,
@@ -58,8 +61,10 @@ def test_chunk_history_splits_by_timestamp(tmp_path):
     assert len(chunks) >= 1
     # created_at must be parsed from the timestamp, not file mtime
     assert chunks[0].created_at > 0
-    # Jan 1 2025 is around unix 1735689600
-    assert chunks[0].created_at > 1_700_000_000
+    # [2025-01-01 10:00] in UTC = 1735725600.0
+    assert chunks[0].created_at == pytest.approx(
+        datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc).timestamp()
+    )
 
 
 def test_chunk_history_groups_small_entries(tmp_path):

--- a/tests/test_memory_index/test_embeddings.py
+++ b/tests/test_memory_index/test_embeddings.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import httpx
 import pytest
 
@@ -57,6 +59,7 @@ async def test_embed_batch_caches_results(monkeypatch):
 
 
 async def test_embed_batch_respects_batch_size(monkeypatch):
+    """3 texts with batch_size=2 should make exactly 3 individual API calls (Ollama API is per-text)."""
     calls = []
 
     async def mock_post(self, url, **kw):
@@ -67,6 +70,27 @@ async def test_embed_batch_respects_batch_size(monkeypatch):
     provider = OllamaEmbeddingProvider(
         base_url="http://localhost:11434", model="nomic-embed-text", batch_size=2
     )
-    # 3 texts with batch_size=2 should make 3 individual calls (Ollama API is per-text)
     await provider.embed_batch(["a", "b", "c"])
     assert len(calls) == 3
+
+
+async def test_embed_batch_concurrent_within_batch(monkeypatch):
+    """batch_size=2 with 3 texts should fire 2 requests concurrently, then 1."""
+    concurrent_at_peak = 0
+    current_concurrent = 0
+
+    async def mock_post(self, url, **kw):
+        nonlocal concurrent_at_peak, current_concurrent
+        current_concurrent += 1
+        concurrent_at_peak = max(concurrent_at_peak, current_concurrent)
+        await asyncio.sleep(0)  # yield to let other coroutines start
+        current_concurrent -= 1
+        return _mock_response([0.1])
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    provider = OllamaEmbeddingProvider(
+        base_url="http://localhost:11434", model="nomic-embed-text", batch_size=2
+    )
+    result = await provider.embed_batch(["a", "b", "c"])
+    assert len(result) == 3
+    assert concurrent_at_peak == 2  # peak concurrency matches batch_size

--- a/tests/test_memory_index/test_embeddings.py
+++ b/tests/test_memory_index/test_embeddings.py
@@ -1,0 +1,72 @@
+import httpx
+import pytest
+
+from nanobot.memory_index.embeddings import (
+    EmbeddingUnavailableError,
+    OllamaEmbeddingProvider,
+)
+
+
+def _mock_response(embedding: list[float]) -> httpx.Response:
+    r = httpx.Response(200, json={"embedding": embedding})
+    r._request = httpx.Request("POST", "http://localhost:11434/api/embeddings")
+    return r
+
+
+async def test_embed_batch_returns_vectors(monkeypatch):
+    async def mock_post(self, url, **kw):
+        return _mock_response([0.1, 0.2, 0.3])
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    provider = OllamaEmbeddingProvider(
+        base_url="http://localhost:11434", model="nomic-embed-text", batch_size=16
+    )
+    result = await provider.embed_batch(["hello world", "foo bar"])
+    assert len(result) == 2
+    assert result[0] == pytest.approx([0.1, 0.2, 0.3])
+    assert result[1] == pytest.approx([0.1, 0.2, 0.3])
+
+
+async def test_embed_batch_raises_on_connection_error(monkeypatch):
+    async def mock_post(self, url, **kw):
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    provider = OllamaEmbeddingProvider(
+        base_url="http://localhost:11434", model="nomic-embed-text", batch_size=16
+    )
+    with pytest.raises(EmbeddingUnavailableError):
+        await provider.embed_batch(["hello"])
+
+
+async def test_embed_batch_caches_results(monkeypatch):
+    call_count = 0
+
+    async def mock_post(self, url, **kw):
+        nonlocal call_count
+        call_count += 1
+        return _mock_response([0.5, 0.5])
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    provider = OllamaEmbeddingProvider(
+        base_url="http://localhost:11434", model="nomic-embed-text", batch_size=16
+    )
+    await provider.embed_batch(["same text"])
+    await provider.embed_batch(["same text"])
+    assert call_count == 1  # second call hits cache
+
+
+async def test_embed_batch_respects_batch_size(monkeypatch):
+    calls = []
+
+    async def mock_post(self, url, **kw):
+        calls.append(kw.get("json", {}).get("prompt", ""))
+        return _mock_response([0.1])
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    provider = OllamaEmbeddingProvider(
+        base_url="http://localhost:11434", model="nomic-embed-text", batch_size=2
+    )
+    # 3 texts with batch_size=2 should make 3 individual calls (Ollama API is per-text)
+    await provider.embed_batch(["a", "b", "c"])
+    assert len(calls) == 3

--- a/tests/test_memory_index/test_indexer.py
+++ b/tests/test_memory_index/test_indexer.py
@@ -1,24 +1,31 @@
 import sqlite3
 from pathlib import Path
-import pytest
+
 from nanobot.config.schema import MemoryIndexConfig
 from nanobot.memory_index.index import MemoryIndex
+from nanobot.memory_index.indexer import Chunk, file_hash, write_chunks
 
 
 def test_index_creates_tables(tmp_path):
     idx = MemoryIndex(tmp_path, MemoryIndexConfig())
     conn = sqlite3.connect(idx.db_path)
-    tables = {r[0] for r in conn.execute(
-        "SELECT name FROM sqlite_master WHERE type IN ('table','shadow') AND name NOT LIKE 'sqlite_%'"
-    ).fetchall()}
+    tables = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type IN ('table','shadow') AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+    }
     conn.close()
     assert "files" in tables
     assert "chunks" in tables
     assert "index_meta" in tables
     # chunks_fts is a virtual table
-    vtables = {r[0] for r in sqlite3.connect(idx.db_path).execute(
-        "SELECT name FROM sqlite_master WHERE type='table'"
-    ).fetchall()}
+    vtables = {
+        r[0]
+        for r in sqlite3.connect(idx.db_path)
+        .execute("SELECT name FROM sqlite_master WHERE type='table'")
+        .fetchall()
+    }
     assert "chunks_fts" in vtables
 
 
@@ -49,7 +56,82 @@ def test_index_rebuilds_on_model_mismatch(tmp_path):
     idx_b = MemoryIndex(tmp_path, cfg_b)
     conn = sqlite3.connect(idx_b.db_path)
     file_count = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
-    stored_model = conn.execute("SELECT value FROM index_meta WHERE key='embedding_model'").fetchone()[0]
+    stored_model = conn.execute(
+        "SELECT value FROM index_meta WHERE key='embedding_model'"
+    ).fetchone()[0]
     conn.close()
     assert file_count == 0
     assert stored_model == "mxbai-embed-large"
+
+
+def _open(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_write_chunks_inserts_rows(tmp_path):
+    idx = MemoryIndex(tmp_path, MemoryIndexConfig())
+    f = tmp_path / "memory" / "MEMORY.md"
+    f.write_text("## Facts\n\nSome fact.\n")
+    chunks = [Chunk("Some fact.", 2, 2, 1_700_000_000.0)]
+    write_chunks(
+        idx.db_path, f, f.stat().st_mtime, f.stat().st_size, file_hash(f), chunks, None, False
+    )
+    conn = _open(idx.db_path)
+    assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM files").fetchone()[0] == 1
+    conn.close()
+
+
+def test_write_chunks_replaces_on_reindex(tmp_path):
+    idx = MemoryIndex(tmp_path, MemoryIndexConfig())
+    f = tmp_path / "memory" / "MEMORY.md"
+    f.write_text("## A\n\nOld content.\n")
+    old_chunk = [Chunk("Old content.", 2, 2, 1_700_000_000.0)]
+    write_chunks(
+        idx.db_path, f, f.stat().st_mtime, f.stat().st_size, "hash1", old_chunk, None, False
+    )
+
+    new_chunk = [Chunk("New content.", 2, 2, 1_700_000_000.0)]
+    write_chunks(
+        idx.db_path, f, f.stat().st_mtime, f.stat().st_size, "hash2", new_chunk, None, False
+    )
+
+    conn = _open(idx.db_path)
+    texts = [r[0] for r in conn.execute("SELECT text FROM chunks").fetchall()]
+    conn.close()
+    assert texts == ["New content."]  # old chunk gone
+
+
+def test_write_chunks_populates_fts(tmp_path):
+    idx = MemoryIndex(tmp_path, MemoryIndexConfig())
+    f = tmp_path / "memory" / "MEMORY.md"
+    f.write_text("## Facts\n\nThe sky is blue.\n")
+    chunks = [Chunk("The sky is blue.", 2, 2, 1_700_000_000.0)]
+    write_chunks(
+        idx.db_path, f, f.stat().st_mtime, f.stat().st_size, file_hash(f), chunks, None, False
+    )
+    conn = _open(idx.db_path)
+    result = conn.execute("SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH 'sky'").fetchall()
+    conn.close()
+    assert len(result) == 1
+
+
+async def test_startup_index_skips_unchanged_file(tmp_path):
+    cfg = MemoryIndexConfig()
+    idx = MemoryIndex(tmp_path, cfg)
+    f = tmp_path / "memory" / "MEMORY.md"
+    f.write_text("## Facts\n\nA fact.\n")
+
+    await idx.startup_index()
+    conn = _open(idx.db_path)
+    count_after_first = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    conn.close()
+
+    # Run again — should not duplicate
+    await idx.startup_index()
+    conn = _open(idx.db_path)
+    count_after_second = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    conn.close()
+    assert count_after_first == count_after_second

--- a/tests/test_memory_index/test_indexer.py
+++ b/tests/test_memory_index/test_indexer.py
@@ -103,6 +103,14 @@ def test_write_chunks_replaces_on_reindex(tmp_path):
     conn.close()
     assert texts == ["New content."]  # old chunk gone
 
+    conn = _open(idx.db_path)
+    # Old text should be gone from FTS
+    old_fts = conn.execute(
+        "SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH 'Old'",
+    ).fetchall()
+    conn.close()
+    assert old_fts == []  # FTS cleaned up on re-index
+
 
 def test_write_chunks_populates_fts(tmp_path):
     idx = MemoryIndex(tmp_path, MemoryIndexConfig())
@@ -122,7 +130,7 @@ async def test_startup_index_skips_unchanged_file(tmp_path):
     cfg = MemoryIndexConfig()
     idx = MemoryIndex(tmp_path, cfg)
     f = tmp_path / "memory" / "MEMORY.md"
-    f.write_text("## Facts\n\nA fact.\n")
+    f.write_text("## Facts\n\nSome fact.\n")
 
     await idx.startup_index()
     conn = _open(idx.db_path)
@@ -134,4 +142,5 @@ async def test_startup_index_skips_unchanged_file(tmp_path):
     conn = _open(idx.db_path)
     count_after_second = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
     conn.close()
+    assert count_after_first > 0  # first run actually indexed something
     assert count_after_first == count_after_second

--- a/tests/test_memory_index/test_indexer.py
+++ b/tests/test_memory_index/test_indexer.py
@@ -1,0 +1,55 @@
+import sqlite3
+from pathlib import Path
+import pytest
+from nanobot.config.schema import MemoryIndexConfig
+from nanobot.memory_index.index import MemoryIndex
+
+
+def test_index_creates_tables(tmp_path):
+    idx = MemoryIndex(tmp_path, MemoryIndexConfig())
+    conn = sqlite3.connect(idx.db_path)
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type IN ('table','shadow') AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()}
+    conn.close()
+    assert "files" in tables
+    assert "chunks" in tables
+    assert "index_meta" in tables
+    # chunks_fts is a virtual table
+    vtables = {r[0] for r in sqlite3.connect(idx.db_path).execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()}
+    assert "chunks_fts" in vtables
+
+
+def test_index_stores_model_metadata(tmp_path):
+    cfg = MemoryIndexConfig()
+    idx = MemoryIndex(tmp_path, cfg)
+    conn = sqlite3.connect(idx.db_path)
+    row = conn.execute("SELECT value FROM index_meta WHERE key='embedding_model'").fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] == cfg.embedding.model
+
+
+def test_index_rebuilds_on_model_mismatch(tmp_path):
+    # Create index with model A
+    cfg_a = MemoryIndexConfig()
+    idx_a = MemoryIndex(tmp_path, cfg_a)
+    # Write a dummy file record to verify it gets wiped
+    conn = sqlite3.connect(idx_a.db_path)
+    conn.execute("INSERT INTO files(path, mtime, size, hash) VALUES ('x', 0, 0, 'abc')")
+    conn.commit()
+    conn.close()
+
+    # Create index with different model — should wipe and rebuild
+    cfg_b = MemoryIndexConfig()
+    cfg_b.embedding.model = "mxbai-embed-large"
+    cfg_b.embedding.dim = 1024
+    idx_b = MemoryIndex(tmp_path, cfg_b)
+    conn = sqlite3.connect(idx_b.db_path)
+    file_count = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+    stored_model = conn.execute("SELECT value FROM index_meta WHERE key='embedding_model'").fetchone()[0]
+    conn.close()
+    assert file_count == 0
+    assert stored_model == "mxbai-embed-large"

--- a/tests/test_memory_index/test_search.py
+++ b/tests/test_memory_index/test_search.py
@@ -1,0 +1,156 @@
+import math
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from nanobot.config.schema import MemoryIndexConfig
+from nanobot.memory_index.index import MemoryIndex
+from nanobot.memory_index.indexer import Chunk, write_chunks
+from nanobot.memory_index.search import (
+    apply_temporal_decay,
+    bm25_search,
+    mmr_rerank,
+    rrf_merge,
+    sync_search,
+)
+
+
+def _make_db(tmp_path: Path, chunks_by_file: dict[str, list[Chunk]]) -> Path:
+    """Create a test index DB with given chunks (no embeddings)."""
+    cfg = MemoryIndexConfig()
+    idx = MemoryIndex(tmp_path, cfg)
+    for filename, chunks in chunks_by_file.items():
+        f = tmp_path / "memory" / filename
+        f.write_text("placeholder")
+        write_chunks(
+            idx.db_path, f, f.stat().st_mtime, f.stat().st_size, filename, chunks, None, False
+        )
+    return idx.db_path
+
+
+def _open(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_bm25_search_returns_matching_chunk(tmp_path):
+    db = _make_db(
+        tmp_path,
+        {
+            "MEMORY.md": [
+                Chunk("The capital of France is Paris.", 1, 1, time.time()),
+                Chunk("Python is a programming language.", 2, 2, time.time()),
+            ]
+        },
+    )
+    conn = _open(db)
+    ids = bm25_search(conn, "France Paris", 5)
+    conn.close()
+    assert len(ids) >= 1  # at least the France/Paris chunk matches
+
+
+def test_bm25_search_returns_empty_on_no_match(tmp_path):
+    db = _make_db(
+        tmp_path,
+        {
+            "MEMORY.md": [
+                Chunk("The sky is blue.", 1, 1, time.time()),
+            ]
+        },
+    )
+    conn = _open(db)
+    ids = bm25_search(conn, "xyzzy_nonexistent_token_zzz", 5)
+    conn.close()
+    assert ids == []
+
+
+def test_rrf_merge_boosts_shared_doc(tmp_path):
+    # doc 1 appears in both lists; doc 2 only in bm25; doc 3 only in vec
+    scores = rrf_merge([1, 2], [1, 3])
+    assert scores[1] > scores[2]  # doc 1 boosted by both
+    assert scores[1] > scores[3]
+
+
+def test_rrf_merge_single_list(tmp_path):
+    scores = rrf_merge([5, 6, 7], [])
+    assert 5 in scores
+    assert scores[5] > scores[6] > scores[7]
+
+
+def test_temporal_decay_penalizes_old_chunk(tmp_path):
+    now = time.time()
+    old_ts = now - 180 * 86400  # 180 days ago
+    db = _make_db(
+        tmp_path,
+        {
+            "MEMORY.md": [
+                Chunk("Recent fact.", 1, 1, now),
+                Chunk("Old fact.", 2, 2, old_ts),
+            ]
+        },
+    )
+    conn = _open(db)
+    ids = [r[0] for r in conn.execute("SELECT id FROM chunks ORDER BY id").fetchall()]
+    conn.close()
+    recent_id, old_id = ids[0], ids[1]
+    base_scores = {recent_id: 1.0, old_id: 1.0}
+    conn = _open(db)
+    decayed = apply_temporal_decay(base_scores, conn, half_life_days=90.0)
+    conn.close()
+    # 180-day-old chunk should score roughly exp(-2) ≈ 0.135 of original
+    assert decayed[old_id] < decayed[recent_id]
+    assert decayed[old_id] == pytest.approx(math.exp(-2.0), rel=0.05)
+
+
+def test_mmr_rerank_increases_diversity(tmp_path):
+    # Two near-identical vectors and one diverse vector
+    # MMR should prefer the diverse one in the top-2
+    vec_a = [1.0, 0.0, 0.0]
+    vec_b = [0.99, 0.14, 0.0]  # very similar to a
+    vec_c = [0.0, 1.0, 0.0]  # diverse
+
+    scores = {1: 0.9, 2: 0.8, 3: 0.5}  # doc 1 and 2 score higher, but similar
+    chunk_vecs = {1: vec_a, 2: vec_b, 3: vec_c}
+
+    result = mmr_rerank(scores, chunk_vecs, query_vec=[1.0, 0.0, 0.0], top_k=2, lambda_=0.5)
+    assert 1 in result  # highest relevance always selected first
+    assert 3 in result  # diverse doc preferred over near-duplicate doc 2
+    assert 2 not in result
+
+
+def test_mmr_rerank_falls_back_to_score_order_without_vecs(tmp_path):
+    scores = {1: 0.9, 2: 0.7, 3: 0.5}
+    result = mmr_rerank(scores, {}, query_vec=None, top_k=2, lambda_=0.5)
+    assert result == [1, 2]
+
+
+def test_sync_search_end_to_end(tmp_path):
+    db = _make_db(
+        tmp_path,
+        {
+            "MEMORY.md": [
+                Chunk("The user prefers dark mode interfaces.", 1, 1, time.time()),
+                Chunk("Python is a programming language.", 2, 2, time.time()),
+                Chunk("The user lives in New York.", 3, 3, time.time()),
+            ]
+        },
+    )
+    results = sync_search(db, "dark mode preference", None, 2, False, 0.5, 90.0)
+    assert len(results) <= 2
+    assert any("dark mode" in r.text for r in results)
+
+
+def test_sync_search_returns_empty_for_no_match(tmp_path):
+    db = _make_db(
+        tmp_path,
+        {
+            "MEMORY.md": [
+                Chunk("Unrelated content about cats.", 1, 1, time.time()),
+            ]
+        },
+    )
+    results = sync_search(db, "xyzzy_nonexistent", None, 5, False, 0.5, 90.0)
+    assert results == []

--- a/tests/test_memory_index/test_search.py
+++ b/tests/test_memory_index/test_search.py
@@ -67,14 +67,14 @@ def test_bm25_search_returns_empty_on_no_match(tmp_path):
     assert ids == []
 
 
-def test_rrf_merge_boosts_shared_doc(tmp_path):
+def test_rrf_merge_boosts_shared_doc():
     # doc 1 appears in both lists; doc 2 only in bm25; doc 3 only in vec
     scores = rrf_merge([1, 2], [1, 3])
     assert scores[1] > scores[2]  # doc 1 boosted by both
     assert scores[1] > scores[3]
 
 
-def test_rrf_merge_single_list(tmp_path):
+def test_rrf_merge_single_list():
     scores = rrf_merge([5, 6, 7], [])
     assert 5 in scores
     assert scores[5] > scores[6] > scores[7]

--- a/tests/test_memory_index/test_service.py
+++ b/tests/test_memory_index/test_service.py
@@ -1,0 +1,56 @@
+from nanobot.config.schema import MemoryIndexConfig
+
+
+def test_memory_index_config_defaults_include_injection_fields():
+    cfg = MemoryIndexConfig()
+    assert cfg.inject_top_k == 3
+    assert cfg.watch_files is True
+
+
+def test_memory_index_config_inject_top_k_can_be_zero():
+    cfg = MemoryIndexConfig(inject_top_k=0)
+    assert cfg.inject_top_k == 0
+
+
+def test_memory_index_config_watch_files_can_be_disabled():
+    cfg = MemoryIndexConfig(watch_files=False)
+    assert cfg.watch_files is False
+
+
+async def test_index_service_start_indexes_memory_file(tmp_path):
+    from nanobot.memory_index.service import IndexService
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "MEMORY.md").write_text("## Facts\n\nUser likes Python programming.\n")
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False  # disable watcher — not tested here
+    service = IndexService(tmp_path, cfg)
+    await service.start()
+
+    results = await service.index.search("Python programming", top_k=1)
+    assert len(results) >= 1
+    assert "Python" in results[0].text
+
+    await service.stop()
+
+
+async def test_index_service_stop_is_idempotent(tmp_path):
+    from nanobot.memory_index.service import IndexService
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False
+    service = IndexService(tmp_path, cfg)
+    await service.start()
+    await service.stop()
+    await service.stop()  # must not raise
+
+
+async def test_index_service_stop_without_start_is_safe(tmp_path):
+    from nanobot.memory_index.service import IndexService
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False
+    service = IndexService(tmp_path, cfg)
+    await service.stop()  # must not raise — observer is None

--- a/tests/test_memory_index/test_service.py
+++ b/tests/test_memory_index/test_service.py
@@ -54,3 +54,98 @@ async def test_index_service_stop_without_start_is_safe(tmp_path):
     cfg.watch_files = False
     service = IndexService(tmp_path, cfg)
     await service.stop()  # must not raise — observer is None
+
+
+async def test_start_watcher_creates_and_starts_observer(tmp_path):
+    """_start_watcher() schedules an Observer on the memory directory."""
+    from unittest.mock import MagicMock, patch
+
+    from nanobot.memory_index.service import IndexService
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False  # prevent auto-start in .start()
+    service = IndexService(tmp_path, cfg)
+
+    mock_observer = MagicMock()
+    with patch("watchdog.observers.Observer", return_value=mock_observer):
+        service._start_watcher()
+
+        mock_observer.schedule.assert_called_once()
+        # Second positional arg to schedule is the watched directory path
+        _handler, watched_dir, *_ = mock_observer.schedule.call_args[0]
+        assert watched_dir == str(tmp_path / "memory")
+        mock_observer.start.assert_called_once()
+        assert service._observer is mock_observer
+
+
+async def test_stop_stops_and_joins_observer(tmp_path):
+    """stop() calls observer.stop() and observer.join()."""
+    from unittest.mock import MagicMock
+
+    from nanobot.memory_index.service import IndexService
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False
+    service = IndexService(tmp_path, cfg)
+
+    mock_observer = MagicMock()
+    service._observer = mock_observer
+
+    await service.stop()
+
+    mock_observer.stop.assert_called_once()
+    mock_observer.join.assert_called_once()
+    assert service._observer is None
+
+
+async def test_watcher_only_triggers_for_memory_files(tmp_path):
+    """Handler on_modified only schedules re-index for MEMORY.md and HISTORY.md."""
+    from unittest.mock import MagicMock, patch
+
+    from watchdog.events import FileModifiedEvent
+
+    from nanobot.memory_index.service import IndexService
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False
+    service = IndexService(tmp_path, cfg)
+
+    scheduled = []
+
+    def fake_run_threadsafe(coro, loop):
+        # Close the coroutine to avoid ResourceWarning
+        coro.close()
+        scheduled.append(True)
+
+    captured_handler = None
+
+    def capture_schedule(handler, path, recursive=False):
+        nonlocal captured_handler
+        captured_handler = handler
+
+    mock_observer = MagicMock()
+    mock_observer.schedule.side_effect = capture_schedule
+
+    with patch("watchdog.observers.Observer", return_value=mock_observer), \
+         patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_threadsafe):
+        service._start_watcher()
+
+        assert captured_handler is not None
+
+        # Trigger on MEMORY.md — should schedule
+        captured_handler.on_modified(FileModifiedEvent(str(memory_dir / "MEMORY.md")))
+        assert len(scheduled) == 1
+
+        # Trigger on HISTORY.md — should schedule
+        captured_handler.on_modified(FileModifiedEvent(str(memory_dir / "HISTORY.md")))
+        assert len(scheduled) == 2
+
+        # Trigger on unrelated file — should NOT schedule
+        captured_handler.on_modified(FileModifiedEvent(str(memory_dir / "notes.txt")))
+        assert len(scheduled) == 2  # still 2

--- a/tests/test_memory_index/test_tool.py
+++ b/tests/test_memory_index/test_tool.py
@@ -1,0 +1,55 @@
+from unittest.mock import AsyncMock, MagicMock
+
+from nanobot.agent.tools.memory_search import MemorySearchTool
+from nanobot.memory_index.search import SearchResult
+
+
+def _make_tool(results: list[SearchResult]) -> MemorySearchTool:
+    index = MagicMock()
+    index.search = AsyncMock(return_value=results)
+    return MemorySearchTool(index)
+
+
+async def test_tool_formats_results():
+    results = [
+        SearchResult("The user prefers dark mode.", "MEMORY.md", 5, 5, 0.9),
+        SearchResult("The user lives in Berlin.", "MEMORY.md", 10, 10, 0.7),
+    ]
+    tool = _make_tool(results)
+    output = await tool.execute(query="preferences")
+    assert "MEMORY.md" in output
+    assert "dark mode" in output
+    assert "Berlin" in output
+    assert "---" in output  # separator between results
+
+
+async def test_tool_returns_no_results_message():
+    tool = _make_tool([])
+    output = await tool.execute(query="something obscure")
+    assert output == "No relevant memory found."
+
+
+async def test_tool_passes_top_k():
+    index = MagicMock()
+    index.search = AsyncMock(return_value=[])
+    tool = MemorySearchTool(index)
+    await tool.execute(query="test", top_k=3)
+    index.search.assert_called_once_with("test", top_k=3)
+
+
+async def test_tool_default_top_k():
+    index = MagicMock()
+    index.search = AsyncMock(return_value=[])
+    tool = MemorySearchTool(index)
+    await tool.execute(query="test")
+    index.search.assert_called_once_with("test", top_k=5)
+
+
+def test_tool_schema():
+    index = MagicMock()
+    tool = MemorySearchTool(index)
+    assert tool.name == "memory_search"
+    schema = tool.to_schema()
+    assert schema["function"]["name"] == "memory_search"
+    assert "query" in schema["function"]["parameters"]["properties"]
+    assert "query" in schema["function"]["parameters"]["required"]


### PR DESCRIPTION
## Summary

Builds on #2618. Closes #80. Relates to #135.

Adds an `IndexService` that wraps `MemoryIndex` with:
1. A `watchdog`-based file watcher that auto-reindexes `MEMORY.md`/`HISTORY.md` on change
2. **Pre-retrieval injection** — on every agent turn, the top-k most relevant memory chunks are automatically prepended to the context, even without an explicit `memory_search` call

**Disabled by default** — requires `memory_index.enabled = true`.

### What's included

- **`nanobot/memory_index/service.py`** — `IndexService`:
  - `start()` / `stop()` lifecycle (called from `AgentLoop.run()` and `close_mcp()`)
  - `watchdog` observer that debounces file-change events and re-indexes in the background
  - `search(query, top_k)` delegates to `MemoryIndex.search()`

- **`nanobot/config/schema.py`** — two new fields on `MemoryIndexConfig`:
  - `inject_top_k: int = 3` — chunks injected per turn (0 = disabled)
  - `watch_files: bool = True` — enable/disable the file watcher

- **`nanobot/agent/context.py`** — `build_messages()` made `async`; accepts an optional `index: IndexService` parameter; when provided and `inject_top_k > 0`, runs a retrieval query against the user's message and prepends results as a structured context block

- **`nanobot/agent/loop.py`** — `AgentLoop` stores `_index_service`; passes it to `build_messages()` on every turn; schedules `IndexService.start()` lazily on first use (safe for both `run()` and `process_direct()`)

- **`pyproject.toml`** — adds `watchdog` to the `[memory]` optional dependency group

### Pre-retrieval injection flow

```
user message
     │
     ▼
IndexService.search(message, top_k=inject_top_k)
     │
     ▼
[Memory context block prepended to messages]
     │
     ▼
LLM receives enriched context without needing to call memory_search explicitly
```

### Tests

14 new tests in `tests/test_memory_index/test_service.py` and `tests/agent/test_context_injection.py` covering watcher lifecycle, debounce behavior, and context injection with/without index.

> **Note:** This PR is stacked on #2618. If reviewing independently, apply #2618 first, or change the base branch to `feature/pr1-semantic-memory-index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)