### PR TITLE
fix(tools): strip <think> blocks from message tool content

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -84,6 +84,9 @@ class MessageTool(Tool):
         media: list[str] | None = None,
         **kwargs: Any
     ) -> str:
+        from nanobot.utils.helpers import strip_think
+        content = strip_think(content)
+        
         channel = channel or self._default_channel
         chat_id = chat_id or self._default_chat_id
         message_id = message_id or self._default_message_id


### PR DESCRIPTION
When using models with reasoning capabilities (like DeepSeek or Kimi), they sometimes embed their `<think>...</think>` blocks directly into the `content` argument of tool calls. 

While `AgentLoop` correctly strips these blocks from the final response and stream deltas, it doesn't strip them from the `message` tool arguments. This causes the raw thinking process to leak into the chat when the agent explicitly calls the `message` tool.

This PR adds `strip_think` to the `MessageTool.execute` method to ensure reasoning blocks are removed before sending the message to the user.