### PR TITLE
fix: add defensive checks for intermittent NoneType errors in agent loop and response parsing

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -192,12 +192,14 @@ class AgentLoop:
     def _tool_hint(tool_calls: list) -> str:
         """Format tool calls as concise hint, e.g. 'web_search("query")'."""
         def _fmt(tc):
-            args = (tc.arguments[0] if isinstance(tc.arguments, list) else tc.arguments) or {}
+            if tc is None:
+                return "unknown"
+            args = (tc.arguments[0] if isinstance(tc.arguments, list) and tc.arguments else tc.arguments) or {}
             val = next(iter(args.values()), None) if isinstance(args, dict) else None
             if not isinstance(val, str):
-                return tc.name
-            return f'{tc.name}("{val[:40]}…")' if len(val) > 40 else f'{tc.name}("{val}")'
-        return ", ".join(_fmt(tc) for tc in tool_calls)
+                return tc.name or "unknown"
+            return f'{tc.name or "unknown"}("{val[:40]}…")' if len(val) > 40 else f'{tc.name or "unknown"}("{val}")'
+        return ", ".join(_fmt(tc) for tc in tool_calls if tc)
 
     async def _run_agent_loop(
         self,
@@ -249,9 +251,11 @@ class AgentLoop:
                             await on_progress(thought)
                     tool_hint = loop_self._strip_think(loop_self._tool_hint(context.tool_calls))
                     await on_progress(tool_hint, tool_hint=True)
-                for tc in context.tool_calls:
+                for tc in (context.tool_calls or []):
+                    if not tc:
+                        continue
                     args_str = json.dumps(tc.arguments, ensure_ascii=False)
-                    logger.info("Tool call: {}({})", tc.name, args_str[:200])
+                    logger.info("Tool call: {}({})", tc.name or "unknown", args_str[:200])
                 loop_self._set_tool_context(channel, chat_id, message_id)
 
             def finalize_content(self, context: AgentHookContext, content: str | None) -> str | None:
@@ -421,7 +425,8 @@ class AgentLoop:
             return OutboundMessage(channel=channel, chat_id=chat_id,
                                   content=final_content or "Background task completed.")
 
-        preview = msg.content[:80] + "..." if len(msg.content) > 80 else msg.content
+        content = msg.content or ""
+        preview = content[:80] + "..." if len(content) > 80 else content
         logger.info("Processing message from {}:{}: {}", msg.channel, msg.sender_id, preview)
 
         key = session_key or msg.session_key
@@ -475,7 +480,8 @@ class AgentLoop:
         if (mt := self.tools.get("message")) and isinstance(mt, MessageTool) and mt._sent_in_turn:
             return None
 
-        preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
+        final_content_safe = final_content or ""
+        preview = final_content_safe[:120] + "..." if len(final_content_safe) > 120 else final_content_safe
         logger.info("Response to {}:{}: {}", msg.channel, msg.sender_id, preview)
 
         meta = dict(msg.metadata or {})

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -103,11 +103,12 @@ class MemoryStore:
     def _format_messages(messages: list[dict]) -> str:
         lines = []
         for message in messages:
-            if not message.get("content"):
+            if not message or not message.get("content"):
                 continue
-            tools = f" [tools: {', '.join(message['tools_used'])}]" if message.get("tools_used") else ""
+            tools_used = message.get("tools_used")
+            tools = f" [tools: {', '.join(tools_used)}]" if isinstance(tools_used, list) and tools_used else ""
             lines.append(
-                f"[{message.get('timestamp', '?')[:16]}] {message['role'].upper()}{tools}: {message['content']}"
+                f"[{message.get('timestamp', '?')[:16]}] {message.get('role', 'UNKNOWN').upper()}{tools}: {message['content']}"
             )
         return "\n".join(lines)
 

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -364,7 +364,7 @@ class OpenAICompatProvider(LLMProvider):
                 if isinstance(tool_calls, list) and tool_calls:
                     raw_tool_calls.extend(tool_calls)
                     if ch_map.get("finish_reason") in ("tool_calls", "stop"):
-                        finish_reason = str(ch_map["finish_reason"])
+                        finish_reason = str(ch_map.get("finish_reason") or "stop")
                 if not content:
                     content = self._extract_text_content(m.get("content"))
                 if not reasoning_content:
@@ -372,6 +372,8 @@ class OpenAICompatProvider(LLMProvider):
 
             parsed_tool_calls = []
             for tc in raw_tool_calls:
+                if tc is None:
+                    continue
                 tc_map = self._maybe_mapping(tc) or {}
                 fn = self._maybe_mapping(tc_map.get("function")) or {}
                 args = fn.get("arguments", {})
@@ -399,30 +401,39 @@ class OpenAICompatProvider(LLMProvider):
             return LLMResponse(content="Error: API returned empty choices.", finish_reason="error")
 
         choice = response.choices[0]
+        if choice is None:
+            return LLMResponse(content="Error: API returned null choice.", finish_reason="error")
         msg = choice.message
-        content = msg.content
+        content = msg.content if msg else None
         finish_reason = choice.finish_reason
 
         raw_tool_calls: list[Any] = []
         for ch in response.choices:
+            if ch is None:
+                continue
             m = ch.message
-            if hasattr(m, "tool_calls") and m.tool_calls:
+            if m and hasattr(m, "tool_calls") and m.tool_calls:
                 raw_tool_calls.extend(m.tool_calls)
                 if ch.finish_reason in ("tool_calls", "stop"):
                     finish_reason = ch.finish_reason
-            if not content and m.content:
+            if not content and m and m.content:
                 content = m.content
 
         tool_calls = []
         for tc in raw_tool_calls:
-            args = tc.function.arguments
+            if tc is None:
+                continue
+            fn = getattr(tc, "function", None)
+            if fn is None:
+                continue
+            args = getattr(fn, "arguments", {})
             if isinstance(args, str):
                 args = json_repair.loads(args)
             ec, prov, fn_prov = _extract_tc_extras(tc)
             tool_calls.append(ToolCallRequest(
                 id=_short_tool_id(),
-                name=tc.function.name,
-                arguments=args,
+                name=getattr(fn, "name", "") or "",
+                arguments=args if isinstance(args, dict) else {},
                 extra_content=ec,
                 provider_specific_fields=prov,
                 function_provider_specific_fields=fn_prov,
@@ -470,6 +481,8 @@ class OpenAICompatProvider(LLMProvider):
                 buf["fn_prov"] = fn_prov
 
         for chunk in chunks:
+            if chunk is None:
+                continue
             if isinstance(chunk, str):
                 content_parts.append(chunk)
                 continue
@@ -501,26 +514,30 @@ class OpenAICompatProvider(LLMProvider):
                 usage = cls._extract_usage(chunk) or usage
                 continue
             choice = chunk.choices[0]
+            if choice is None:
+                continue
             if choice.finish_reason:
                 finish_reason = choice.finish_reason
             delta = choice.delta
-            if delta and delta.content:
-                content_parts.append(delta.content)
-            for tc in (delta.tool_calls or []) if delta else []:
-                _accum_tc(tc, getattr(tc, "index", 0))
+            if delta:
+                if delta.content:
+                    content_parts.append(delta.content)
+                for tc in (delta.tool_calls or []):
+                    _accum_tc(tc, getattr(tc, "index", 0))
 
         return LLMResponse(
             content="".join(content_parts) or None,
             tool_calls=[
                 ToolCallRequest(
                     id=b["id"] or _short_tool_id(),
-                    name=b["name"],
+                    name=str(b.get("name") or "unknown"),
                     arguments=json_repair.loads(b["arguments"]) if b["arguments"] else {},
                     extra_content=b.get("extra_content"),
                     provider_specific_fields=b.get("prov"),
                     function_provider_specific_fields=b.get("fn_prov"),
                 )
                 for b in tc_bufs.values()
+                if b.get("name")
             ],
             finish_reason=finish_reason,
             usage=usage,

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -11,6 +11,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 import json_repair
+from loguru import logger
 from openai import AsyncOpenAI
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
@@ -373,6 +374,7 @@ class OpenAICompatProvider(LLMProvider):
             parsed_tool_calls = []
             for tc in raw_tool_calls:
                 if tc is None:
+                    logger.warning("Skipping null tool call in raw_tool_calls (mapping path)")
                     continue
                 tc_map = self._maybe_mapping(tc) or {}
                 fn = self._maybe_mapping(tc_map.get("function")) or {}
@@ -380,6 +382,11 @@ class OpenAICompatProvider(LLMProvider):
                 if isinstance(args, str):
                     args = json_repair.loads(args)
                 ec, prov, fn_prov = _extract_tc_extras(tc)
+
+                if not isinstance(args, dict):
+                    logger.warning("Tool arguments for '{}' are not a dict (mapping path): {}", 
+                                   fn.get("name", "unknown"), type(args))
+
                 parsed_tool_calls.append(ToolCallRequest(
                     id=_short_tool_id(),
                     name=str(fn.get("name") or ""),
@@ -402,6 +409,7 @@ class OpenAICompatProvider(LLMProvider):
 
         choice = response.choices[0]
         if choice is None:
+            logger.warning("API returned null choice (model: {})", getattr(response, "model", "unknown"))
             return LLMResponse(content="Error: API returned null choice.", finish_reason="error")
         msg = choice.message
         content = msg.content if msg else None
@@ -410,6 +418,7 @@ class OpenAICompatProvider(LLMProvider):
         raw_tool_calls: list[Any] = []
         for ch in response.choices:
             if ch is None:
+                logger.warning("Skipping null choice in choices (model: {})", getattr(response, "model", "unknown"))
                 continue
             m = ch.message
             if m and hasattr(m, "tool_calls") and m.tool_calls:
@@ -422,14 +431,21 @@ class OpenAICompatProvider(LLMProvider):
         tool_calls = []
         for tc in raw_tool_calls:
             if tc is None:
+                logger.warning("Skipping null tool call in raw_tool_calls (model: {})", getattr(response, "model", "unknown"))
                 continue
             fn = getattr(tc, "function", None)
             if fn is None:
+                logger.warning("Tool call missing 'function' object (model: {})", getattr(response, "model", "unknown"))
                 continue
             args = getattr(fn, "arguments", {})
             if isinstance(args, str):
                 args = json_repair.loads(args)
             ec, prov, fn_prov = _extract_tc_extras(tc)
+            
+            if not isinstance(args, dict):
+                logger.warning("Tool arguments for '{}' are not a dict (model: {}): {}", 
+                               getattr(fn, "name", "unknown"), getattr(response, "model", "unknown"), type(args))
+
             tool_calls.append(ToolCallRequest(
                 id=_short_tool_id(),
                 name=getattr(fn, "name", "") or "",
@@ -482,6 +498,7 @@ class OpenAICompatProvider(LLMProvider):
 
         for chunk in chunks:
             if chunk is None:
+                logger.warning("Skipping null chunk in chat stream")
                 continue
             if isinstance(chunk, str):
                 content_parts.append(chunk)
@@ -515,6 +532,7 @@ class OpenAICompatProvider(LLMProvider):
                 continue
             choice = chunk.choices[0]
             if choice is None:
+                logger.warning("Skipping null choice in chunk (model: {})", getattr(chunk, "model", "unknown"))
                 continue
             if choice.finish_reason:
                 finish_reason = choice.finish_reason
@@ -525,20 +543,31 @@ class OpenAICompatProvider(LLMProvider):
                 for tc in (delta.tool_calls or []):
                     _accum_tc(tc, getattr(tc, "index", 0))
 
+        tool_calls = []
+        for idx, b in tc_bufs.items():
+            name = b.get("name")
+            if not name:
+                logger.warning("Skipping tool call with empty name at index {}", idx)
+                continue
+            
+            args_raw = b.get("arguments", "")
+            args = json_repair.loads(args_raw) if args_raw else {}
+            if not isinstance(args, dict):
+                 logger.warning("Tool arguments for '{}' are not a dict in stream: {}", 
+                                name, type(args))
+
+            tool_calls.append(ToolCallRequest(
+                id=b["id"] or _short_tool_id(),
+                name=str(name),
+                arguments=args if isinstance(args, dict) else {},
+                extra_content=b.get("extra_content"),
+                provider_specific_fields=b.get("prov"),
+                function_provider_specific_fields=b.get("fn_prov"),
+            ))
+
         return LLMResponse(
             content="".join(content_parts) or None,
-            tool_calls=[
-                ToolCallRequest(
-                    id=b["id"] or _short_tool_id(),
-                    name=str(b.get("name") or "unknown"),
-                    arguments=json_repair.loads(b["arguments"]) if b["arguments"] else {},
-                    extra_content=b.get("extra_content"),
-                    provider_specific_fields=b.get("prov"),
-                    function_provider_specific_fields=b.get("fn_prov"),
-                )
-                for b in tc_bufs.values()
-                if b.get("name")
-            ],
+            tool_calls=tool_calls,
             finish_reason=finish_reason,
             usage=usage,
         )


### PR DESCRIPTION
This PR addresses issue #2613, where the agent loop intermittently crashes with a `NoneType' object is not subscriptable` error when processing multi-step tasks or during streaming.

The issue likely stems from malformed or incomplete tool call payloads returned by some LLM providers, or from unexpected `None` values in the response structure (especially during high-concurrency or streaming scenarios).

Key changes:
- Added defensive null checks and fallback values in `AgentLoop._tool_hint` and `_run_agent_loop` hook to handle potential `None` tool call objects.
- Hardened `OpenAICompatProvider._parse` and `_parse_chunks` to safely handle `null` choices, messages, or deltas in API responses.
- Improved `MemoryStore._format_messages` to handle cases where `tools_used` or `content` might be missing.
- Added safety checks for log message previews to avoid crashing on empty content.

These changes ensure the agent remains stable even when encountering inconsistent data from external LLM APIs, preventing total loop failures and allowing for more robust error handling.

Tests run:
- Verified that standard tool-use flows still pass with `pytest tests/agent/test_runner.py tests/providers/test_litellm_kwargs.py`.
- Manual inspection of the code paths to ensure `None` values are now caught before they cause subscripting errors.

Fixes #2613.