### PR TITLE
feat(memory): Graphiti temporal knowledge graph backend (MemoryBackend plugin API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ botpy.log
 nano.*.save
 .DS_Store
 uv.lock
+CLAUDE.md
+superpowers/

--- a/docs/superpowers/plans/2026-03-28-pr2-pre-retrieval-injection.md
+++ b/docs/superpowers/plans/2026-03-28-pr2-pre-retrieval-injection.md
@@ -1,0 +1,1063 @@
+# PR 2: Pre-Retrieval Injection + File Watcher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-inject top-k memory chunks into every agent turn's context, and keep the index live when MEMORY.md or HISTORY.md changes on disk.
+
+**Architecture:** A new `IndexService` lifecycle object wraps `MemoryIndex` + a `watchdog` file observer. `ContextBuilder.build_messages()` becomes `async` and accepts an optional `IndexService`; when present it queries the index with the user's message and prepends a `system` injection message. `AgentLoop` constructs `IndexService` instead of bare `MemoryIndex` and passes it through to `build_messages()`.
+
+**Tech Stack:** Python 3.11+, asyncio, `watchdog>=3.0.0` (new optional dep under `[memory]`), existing `sqlite-vec` + BM25 search pipeline from PR 1.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `nanobot/config/schema.py` | Add `inject_top_k: int = 3`, `watch_files: bool = True` to `MemoryIndexConfig` |
+| `pyproject.toml` | Add `watchdog>=3.0.0` to `[memory]` extras |
+| `nanobot/memory_index/service.py` | **New** — `IndexService` lifecycle: `start()`, `stop()`, `_start_watcher()` |
+| `nanobot/agent/context.py` | `build_messages()` → `async def`; add `index: IndexService | None = None` param; inject results before last message |
+| `nanobot/agent/memory.py` | `estimate_session_prompt_tokens()` → `async def`; `await self._build_messages(...)` at two call sites; update type annotation |
+| `nanobot/agent/loop.py` | Store `_index_service` + `_index_service_started` flag; schedule `start()` in `run()`/`process_direct()`; `await build_messages()` at both call sites; stop watcher in `close_mcp()` |
+| `tests/test_memory_index/test_service.py` | **New** — `IndexService` lifecycle + watcher tests |
+| `tests/agent/test_context_injection.py` | **New** — injection happy/null/empty-results paths |
+| `tests/agent/test_memory_index_integration.py` | Update existing tests to use `IndexService` |
+
+---
+
+## Task 1: Config Additions + watchdog Dependency
+
+**Files:**
+- Modify: `nanobot/config/schema.py:166-171`
+- Modify: `pyproject.toml:67-69`
+- Create: `tests/test_memory_index/test_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_memory_index/test_service.py`:
+```python
+from nanobot.config.schema import MemoryIndexConfig
+
+
+def test_memory_index_config_defaults_include_injection_fields():
+    cfg = MemoryIndexConfig()
+    assert cfg.inject_top_k == 3
+    assert cfg.watch_files is True
+
+
+def test_memory_index_config_inject_top_k_can_be_zero():
+    cfg = MemoryIndexConfig(inject_top_k=0)
+    assert cfg.inject_top_k == 0
+
+
+def test_memory_index_config_watch_files_can_be_disabled():
+    cfg = MemoryIndexConfig(watch_files=False)
+    assert cfg.watch_files is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_memory_index/test_service.py -v
+```
+Expected: `FAILED` — `MemoryIndexConfig` has no attribute `inject_top_k`.
+
+- [ ] **Step 3: Add fields to `MemoryIndexConfig` in `nanobot/config/schema.py`**
+
+```python
+class MemoryIndexConfig(Base):
+    """Semantic memory index configuration. Off by default."""
+
+    enabled: bool = False
+    embedding: MemoryIndexEmbeddingConfig = Field(default_factory=MemoryIndexEmbeddingConfig)
+    query: MemoryIndexQueryConfig = Field(default_factory=MemoryIndexQueryConfig)
+    inject_top_k: int = 3       # chunks auto-injected per turn; 0 = disabled
+    watch_files: bool = True    # enable watchdog file watcher
+```
+
+- [ ] **Step 4: Add watchdog to `[memory]` extras in `pyproject.toml`**
+
+```toml
+memory = [
+    "sqlite-vec>=0.1.0",
+    "watchdog>=3.0.0",
+]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest tests/test_memory_index/test_service.py -v
+```
+Expected: `3 passed`.
+
+- [ ] **Step 6: Install the new dep**
+
+```bash
+pip install "watchdog>=3.0.0"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add nanobot/config/schema.py pyproject.toml tests/test_memory_index/test_service.py
+git commit -m "feat(memory_index): add inject_top_k and watch_files config fields; add watchdog dep"
+```
+
+---
+
+## Task 2: IndexService — Lifecycle (start / stop)
+
+**Files:**
+- Create: `nanobot/memory_index/service.py`
+- Modify: `tests/test_memory_index/test_service.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_memory_index/test_service.py`:
+```python
+async def test_index_service_start_indexes_memory_file(tmp_path):
+    from nanobot.memory_index.service import IndexService
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "MEMORY.md").write_text("## Facts\n\nUser likes Python programming.\n")
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False  # disable watcher — not tested here
+    service = IndexService(tmp_path, cfg)
+    await service.start()
+
+    results = await service.index.search("Python programming", top_k=1)
+    assert len(results) >= 1
+    assert "Python" in results[0].text
+
+    await service.stop()
+
+
+async def test_index_service_stop_is_idempotent(tmp_path):
+    from nanobot.memory_index.service import IndexService
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False
+    service = IndexService(tmp_path, cfg)
+    await service.start()
+    await service.stop()
+    await service.stop()  # must not raise
+
+
+async def test_index_service_stop_without_start_is_safe(tmp_path):
+    from nanobot.memory_index.service import IndexService
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False
+    service = IndexService(tmp_path, cfg)
+    await service.stop()  # must not raise — observer is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_memory_index/test_service.py -v
+```
+Expected: `FAILED` — `ImportError: cannot import name 'IndexService'`.
+
+- [ ] **Step 3: Create `nanobot/memory_index/service.py`**
+
+```python
+"""IndexService — lifecycle wrapper around MemoryIndex with optional file watcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from nanobot.config.schema import MemoryIndexConfig
+    from nanobot.memory_index.search import SearchResult
+
+
+class IndexService:
+    """Lifecycle object that owns MemoryIndex and an optional watchdog file observer."""
+
+    def __init__(self, workspace: Path, cfg: MemoryIndexConfig) -> None:
+        from nanobot.memory_index.index import MemoryIndex
+
+        self.index = MemoryIndex(workspace, cfg)
+        self._cfg = cfg
+        self._observer = None
+
+    async def start(self) -> None:
+        """Index memory files at startup; optionally start the file watcher."""
+        await self.index.startup_index()
+        if self._cfg.watch_files:
+            self._start_watcher()
+
+    async def stop(self) -> None:
+        """Stop the file watcher if running."""
+        if self._observer is not None:
+            self._observer.stop()
+            self._observer.join()
+            self._observer = None
+
+    def _start_watcher(self) -> None:
+        """Start a watchdog observer that re-indexes on MEMORY.md / HISTORY.md changes."""
+        import asyncio
+
+        from watchdog.events import FileSystemEventHandler
+        from watchdog.observers import Observer
+
+        loop = asyncio.get_event_loop()
+        index = self.index
+        memory_dir = self.index.memory_dir
+
+        class _MemoryFileHandler(FileSystemEventHandler):
+            def on_modified(self, event) -> None:
+                if not event.is_directory:
+                    p = Path(event.src_path)
+                    if p.name in ("MEMORY.md", "HISTORY.md"):
+                        asyncio.run_coroutine_threadsafe(index._index_file(p), loop)
+
+            def on_created(self, event) -> None:
+                self.on_modified(event)
+
+        observer = Observer()
+        observer.schedule(_MemoryFileHandler(), str(memory_dir), recursive=False)
+        observer.start()
+        self._observer = observer
+        logger.info("Memory file watcher started for {}", memory_dir)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/test_memory_index/test_service.py::test_index_service_start_indexes_memory_file tests/test_memory_index/test_service.py::test_index_service_stop_is_idempotent tests/test_memory_index/test_service.py::test_index_service_stop_without_start_is_safe -v
+```
+Expected: `3 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nanobot/memory_index/service.py tests/test_memory_index/test_service.py
+git commit -m "feat(memory_index): add IndexService lifecycle (start/stop)"
+```
+
+---
+
+## Task 3: IndexService — File Watcher
+
+**Files:**
+- Modify: `tests/test_memory_index/test_service.py`
+
+The `_start_watcher()` implementation already exists from Task 2. This task adds tests for it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_memory_index/test_service.py`:
+```python
+def test_start_watcher_creates_and_starts_observer(tmp_path):
+    """_start_watcher() schedules an Observer on the memory directory."""
+    from unittest.mock import MagicMock, patch
+
+    from nanobot.memory_index.service import IndexService
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False  # prevent auto-start in .start()
+    service = IndexService(tmp_path, cfg)
+
+    mock_observer = MagicMock()
+    with patch("nanobot.memory_index.service.Observer", return_value=mock_observer):
+        service._start_watcher()
+
+    mock_observer.schedule.assert_called_once()
+    # Second positional arg to schedule is the watched directory path
+    _handler, watched_dir, *_ = mock_observer.schedule.call_args[0]
+    assert watched_dir == str(tmp_path / "memory")
+    mock_observer.start.assert_called_once()
+    assert service._observer is mock_observer
+
+
+def test_stop_stops_and_joins_observer(tmp_path):
+    """stop() calls observer.stop() and observer.join()."""
+    import asyncio
+    from unittest.mock import MagicMock, patch
+
+    from nanobot.memory_index.service import IndexService
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False
+    service = IndexService(tmp_path, cfg)
+
+    mock_observer = MagicMock()
+    service._observer = mock_observer
+
+    asyncio.get_event_loop().run_until_complete(service.stop())
+
+    mock_observer.stop.assert_called_once()
+    mock_observer.join.assert_called_once()
+    assert service._observer is None
+
+
+def test_watcher_only_triggers_for_memory_files(tmp_path):
+    """Handler on_modified only schedules re-index for MEMORY.md and HISTORY.md."""
+    import asyncio
+    from unittest.mock import MagicMock, patch
+
+    from nanobot.memory_index.service import IndexService
+    from watchdog.events import FileModifiedEvent
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+
+    cfg = MemoryIndexConfig()
+    cfg.watch_files = False
+    service = IndexService(tmp_path, cfg)
+
+    scheduled = []
+
+    def fake_run_threadsafe(coro, loop):
+        # Close the coroutine to avoid ResourceWarning
+        coro.close()
+        scheduled.append(True)
+
+    captured_handler = None
+
+    def capture_schedule(handler, path, recursive=False):
+        nonlocal captured_handler
+        captured_handler = handler
+
+    mock_observer = MagicMock()
+    mock_observer.schedule.side_effect = capture_schedule
+
+    with patch("nanobot.memory_index.service.Observer", return_value=mock_observer), \
+         patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_threadsafe):
+        service._start_watcher()
+
+    assert captured_handler is not None
+
+    # Trigger on MEMORY.md — should schedule
+    captured_handler.on_modified(FileModifiedEvent(str(memory_dir / "MEMORY.md")))
+    assert len(scheduled) == 1
+
+    # Trigger on HISTORY.md — should schedule
+    captured_handler.on_modified(FileModifiedEvent(str(memory_dir / "HISTORY.md")))
+    assert len(scheduled) == 2
+
+    # Trigger on unrelated file — should NOT schedule
+    captured_handler.on_modified(FileModifiedEvent(str(memory_dir / "notes.txt")))
+    assert len(scheduled) == 2  # still 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_memory_index/test_service.py::test_start_watcher_creates_and_starts_observer tests/test_memory_index/test_service.py::test_stop_stops_and_joins_observer tests/test_memory_index/test_service.py::test_watcher_only_triggers_for_memory_files -v
+```
+Expected: `FAILED` — `ImportError` or attribute errors because `nanobot.memory_index.service.Observer` isn't patchable at the right path.
+
+If the import patch path is wrong, adjust it: `watchdog.observers.Observer`. Check that `service.py` imports `Observer` inside `_start_watcher` so the patch path must match the call site. Since `_start_watcher` does `from watchdog.observers import Observer`, the correct patch path is `nanobot.memory_index.service.Observer`.
+
+- [ ] **Step 3: Run the full test_service.py to verify all tests pass**
+
+```bash
+pytest tests/test_memory_index/test_service.py -v
+```
+Expected: `9 passed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_memory_index/test_service.py
+git commit -m "test(memory_index): add IndexService watcher tests"
+```
+
+---
+
+## Task 4: `build_messages()` → async + Pre-Retrieval Injection
+
+**Files:**
+- Modify: `nanobot/agent/context.py`
+- Modify: `nanobot/agent/memory.py`
+- Create: `tests/agent/test_context_injection.py`
+
+**What changes:**
+- `build_messages()` becomes `async def` and gains an `index: IndexService | None = None` parameter.
+- When `index` is provided and `index._cfg.inject_top_k > 0`, the method awaits `index.index.search(current_message, top_k=...)` and inserts the results as a `system` message just before the last (user) message.
+- `MemoryConsolidator.estimate_session_prompt_tokens()` becomes `async` because it calls `build_messages`. Its two callers inside `maybe_consolidate_by_tokens()` get `await`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/agent/test_context_injection.py`:
+```python
+"""Tests for pre-retrieval injection in build_messages()."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.memory_index.search import SearchResult
+
+
+def _make_result(text: str) -> SearchResult:
+    return SearchResult(text=text, source="MEMORY.md", start_line=1, end_line=2, score=0.9)
+
+
+async def test_build_messages_injects_results_when_index_provided(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 3
+    mock_service.index.search = AsyncMock(return_value=[_make_result("User prefers dark mode.")])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="What theme do I like?",
+        index=mock_service,
+    )
+
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert len(injected) == 1
+    assert "dark mode" in injected[0]["content"]
+
+
+async def test_injection_message_is_inserted_before_user_message(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 3
+    mock_service.index.search = AsyncMock(return_value=[_make_result("Some fact.")])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="hello",
+        index=mock_service,
+    )
+
+    # Injection must come before the last (user) message
+    roles = [m["role"] for m in messages]
+    injection_idx = next(
+        i for i, m in enumerate(messages)
+        if m["role"] == "system" and "Relevant memory" in m.get("content", "")
+    )
+    assert injection_idx == len(messages) - 2  # second-to-last
+
+
+async def test_injection_includes_source_and_line_range(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    result = SearchResult(
+        text="User likes coffee.",
+        source="MEMORY.md",
+        start_line=5,
+        end_line=7,
+        score=0.8,
+    )
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 3
+    mock_service.index.search = AsyncMock(return_value=[result])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="What do I drink?",
+        index=mock_service,
+    )
+
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert "[MEMORY.md L5–7]" in injected[0]["content"]
+    assert "User likes coffee." in injected[0]["content"]
+
+
+async def test_no_injection_when_index_is_none(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=False)
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="hello",
+        index=None,
+    )
+
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert len(injected) == 0
+
+
+async def test_no_injection_when_empty_results(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 3
+    mock_service.index.search = AsyncMock(return_value=[])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="anything",
+        index=mock_service,
+    )
+
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert len(injected) == 0
+
+
+async def test_no_injection_when_inject_top_k_is_zero(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+
+    mock_service = MagicMock()
+    mock_service._cfg.inject_top_k = 0
+    mock_service.index.search = AsyncMock(return_value=[_make_result("Should not appear.")])
+
+    messages = await ctx.build_messages(
+        history=[],
+        current_message="anything",
+        index=mock_service,
+    )
+
+    mock_service.index.search.assert_not_called()
+    injected = [m for m in messages if m["role"] == "system" and "Relevant memory" in m.get("content", "")]
+    assert len(injected) == 0
+
+
+async def test_estimate_session_prompt_tokens_is_async(tmp_path):
+    """MemoryConsolidator.estimate_session_prompt_tokens() must be awaitable."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from nanobot.agent.memory import MemoryConsolidator
+
+    async def fake_build(**kwargs):
+        return [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+
+    consolidator = MemoryConsolidator(
+        workspace=tmp_path,
+        provider=MagicMock(),
+        model="test-model",
+        sessions=MagicMock(),
+        context_window_tokens=8192,
+        build_messages=fake_build,
+        get_tool_definitions=lambda: [],
+    )
+
+    mock_session = MagicMock()
+    mock_session.messages = [{"role": "user", "content": "hi"}]
+    mock_session.key = "cli:test"
+    mock_session.get_history.return_value = []
+
+    tokens, source = await consolidator.estimate_session_prompt_tokens(mock_session)
+    assert isinstance(tokens, int)
+    assert isinstance(source, str)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/agent/test_context_injection.py -v
+```
+Expected: `FAILED` — `build_messages()` is not a coroutine / `index` param does not exist.
+
+- [ ] **Step 3: Make `build_messages()` async in `nanobot/agent/context.py`**
+
+Add `from __future__ import annotations` and a `TYPE_CHECKING` guard at the top of the file:
+
+```python
+"""Context builder for assembling agent prompts."""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+import platform
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.agent.skills import SkillsLoader
+from nanobot.utils.helpers import build_assistant_message, current_time_str, detect_image_mime
+
+if TYPE_CHECKING:
+    from nanobot.memory_index.service import IndexService
+```
+
+Change the `build_messages` signature and body (replace the existing method starting at line 135):
+
+```python
+    async def build_messages(
+        self,
+        history: list[dict[str, Any]],
+        current_message: str,
+        skill_names: list[str] | None = None,
+        media: list[str] | None = None,
+        channel: str | None = None,
+        chat_id: str | None = None,
+        current_role: str = "user",
+        index: IndexService | None = None,
+    ) -> list[dict[str, Any]]:
+        """Build the complete message list for an LLM call."""
+        runtime_ctx = self._build_runtime_context(channel, chat_id, self.timezone)
+        user_content = self._build_user_content(current_message, media)
+
+        # Merge runtime context and user content into a single user message
+        # to avoid consecutive same-role messages that some providers reject.
+        if isinstance(user_content, str):
+            merged = f"{runtime_ctx}\n\n{user_content}"
+        else:
+            merged = [{"type": "text", "text": runtime_ctx}] + user_content
+
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": self.build_system_prompt(skill_names)},
+            *history,
+            {"role": current_role, "content": merged},
+        ]
+
+        if index is not None and index._cfg.inject_top_k > 0:
+            results = await index.index.search(current_message, top_k=index._cfg.inject_top_k)
+            if results:
+                injection = "Relevant memory:\n\n" + "\n\n---\n\n".join(
+                    f"[{r.source} L{r.start_line}–{r.end_line}]\n{r.text}" for r in results
+                )
+                messages.insert(-1, {"role": "system", "content": injection})
+
+        return messages
+```
+
+- [ ] **Step 4: Make `estimate_session_prompt_tokens()` async in `nanobot/agent/memory.py`**
+
+Add `Awaitable` to the import at the top of `memory.py`:
+```python
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+```
+
+Update the type annotation for `build_messages` in `MemoryConsolidator.__init__`:
+```python
+        build_messages: Callable[..., Awaitable[list[dict[str, Any]]]],
+```
+
+Change `estimate_session_prompt_tokens` from `def` to `async def` and add `await`:
+```python
+    async def estimate_session_prompt_tokens(self, session: Session) -> tuple[int, str]:
+        """Estimate current prompt size for the normal session history view."""
+        history = session.get_history(max_messages=0)
+        channel, chat_id = (session.key.split(":", 1) if ":" in session.key else (None, None))
+        probe_messages = await self._build_messages(
+            history=history,
+            current_message="[token-probe]",
+            channel=channel,
+            chat_id=chat_id,
+        )
+        return estimate_prompt_tokens_chain(
+            self.provider,
+            self.model,
+            probe_messages,
+            self._get_tool_definitions(),
+        )
+```
+
+Update both callers inside `maybe_consolidate_by_tokens()` (currently lines 319 and 364) to use `await`:
+```python
+            estimated, source = await self.estimate_session_prompt_tokens(session)
+```
+(There are two occurrences — both need `await`.)
+
+- [ ] **Step 5: Run the injection tests**
+
+```bash
+pytest tests/agent/test_context_injection.py -v
+```
+Expected: `7 passed`.
+
+- [ ] **Step 6: Run full test suite to check for regressions**
+
+```bash
+pytest --tb=short -q
+```
+Expected: all existing tests still pass. Pay attention to any test that calls `build_messages()` synchronously — they now need `await`.
+
+If any test in `tests/agent/` calls `ctx.build_messages(...)` without `await`, fix those tests by making them async and adding `await`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add nanobot/agent/context.py nanobot/agent/memory.py tests/agent/test_context_injection.py
+git commit -m "feat(agent): make build_messages async; add pre-retrieval injection via IndexService"
+```
+
+---
+
+## Task 5: `loop.py` Wiring — IndexService + Await build_messages
+
+**Files:**
+- Modify: `nanobot/agent/loop.py`
+- Modify: `tests/agent/test_memory_index_integration.py`
+
+**What changes:**
+- Replace `self._memory_index: MemoryIndex | None` with `self._index_service: IndexService | None` and add `self._index_service_started: bool = False`.
+- `_register_default_tools()` creates `IndexService` and stores it in `self._index_service`; passes `service.index` to `MemorySearchTool`.
+- `run()` and `process_direct()` schedule `self._index_service.start()` as a background task (guarded by `_index_service_started`).
+- Both `build_messages()` call sites in `_process_message()` become `await ctx.build_messages(..., index=self._index_service)`.
+- `close_mcp()` calls `await self._index_service.stop()` to clean up the watcher thread.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the full contents of `tests/agent/test_memory_index_integration.py` with:
+```python
+from unittest.mock import MagicMock
+
+
+def test_context_builder_shows_pointer_note_when_enabled(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=True)
+    prompt = ctx.build_system_prompt()
+    assert "memory_search" in prompt
+    assert "tool" in prompt.lower()
+    # Full MEMORY.md content should NOT be inlined
+    assert "Long-term Memory" not in prompt
+
+
+def test_context_builder_loads_memory_file_when_disabled(tmp_path):
+    from nanobot.agent.context import ContextBuilder
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "MEMORY.md").write_text("## Facts\n\nUser loves coffee.\n")
+    ctx = ContextBuilder(tmp_path, memory_index_enabled=False)
+    prompt = ctx.build_system_prompt()
+    assert "User loves coffee" in prompt
+
+
+async def test_agent_loop_creates_index_service_when_enabled(tmp_path):
+    """AgentLoop._index_service is an IndexService instance when memory_index is enabled."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import MemoryIndexConfig
+    from nanobot.memory_index.service import IndexService
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    cfg = MemoryIndexConfig()
+    cfg.enabled = True
+    cfg.watch_files = False
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        memory_index_config=cfg,
+    )
+
+    assert isinstance(loop._index_service, IndexService)
+    assert loop.tools.get("memory_search") is not None
+
+
+def test_agent_loop_does_not_register_tool_when_disabled(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import MemoryIndexConfig
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        memory_index_config=MemoryIndexConfig(),  # enabled=False
+    )
+    assert loop.tools.get("memory_search") is None
+    assert loop._index_service is None
+
+
+async def test_agent_loop_start_schedules_index_service_start(tmp_path):
+    """run() schedules IndexService.start() as a background task exactly once."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import MemoryIndexConfig
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    cfg = MemoryIndexConfig()
+    cfg.enabled = True
+    cfg.watch_files = False
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        memory_index_config=cfg,
+    )
+    loop._running = False  # prevent run() from looping
+
+    start_calls = []
+
+    async def fake_start():
+        start_calls.append(1)
+
+    loop._index_service.start = fake_start
+
+    with patch.object(loop, "_connect_mcp", new_callable=AsyncMock):
+        # run() exits immediately because _running=False and queue is empty
+        try:
+            await asyncio.wait_for(loop.run(), timeout=0.5)
+        except asyncio.TimeoutError:
+            pass
+
+    # Drain background tasks so fake_start actually runs
+    if loop._background_tasks:
+        await asyncio.gather(*loop._background_tasks, return_exceptions=True)
+
+    assert len(start_calls) == 1
+
+
+async def test_agent_loop_start_schedules_only_once(tmp_path):
+    """Calling process_direct() twice does not schedule IndexService.start() twice."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import MemoryIndexConfig
+
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.chat_with_retry = AsyncMock(return_value=MagicMock(
+        has_tool_calls=False,
+        content="Hi",
+        finish_reason="stop",
+        tool_calls=[],
+        usage={},
+        reasoning_content=None,
+        thinking_blocks=None,
+    ))
+
+    cfg = MemoryIndexConfig()
+    cfg.enabled = True
+    cfg.watch_files = False
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        memory_index_config=cfg,
+    )
+
+    start_calls = []
+
+    async def fake_start():
+        start_calls.append(1)
+
+    loop._index_service.start = fake_start
+
+    await loop.process_direct("hello")
+    await loop.process_direct("world")
+
+    if loop._background_tasks:
+        await asyncio.gather(*loop._background_tasks, return_exceptions=True)
+
+    assert len(start_calls) == 1  # only once, not twice
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/agent/test_memory_index_integration.py -v
+```
+Expected: `FAILED` — `AgentLoop` has no `_index_service` attribute (still uses `_memory_index`).
+
+- [ ] **Step 3: Update `nanobot/agent/loop.py`**
+
+**3a.** Update the `TYPE_CHECKING` block (replace `from nanobot.memory_index import MemoryIndex` with `IndexService`):
+```python
+if TYPE_CHECKING:
+    from nanobot.config.schema import (
+        ChannelsConfig,
+        ExecToolConfig,
+        MemoryIndexConfig,
+        WebSearchConfig,
+    )
+    from nanobot.cron.service import CronService
+    from nanobot.memory_index.service import IndexService
+```
+
+**3b.** In `__init__`, replace `self._memory_index: MemoryIndex | None = None` with two new attributes. Find this line:
+```python
+        self._running = False
+        self._memory_index: MemoryIndex | None = None
+        self._mcp_servers = mcp_servers or {}
+```
+Replace with:
+```python
+        self._running = False
+        self._index_service: IndexService | None = None
+        self._index_service_started: bool = False
+        self._mcp_servers = mcp_servers or {}
+```
+
+**3c.** In `_register_default_tools()`, replace the `memory_index_config` block:
+```python
+        if self.memory_index_config and self.memory_index_config.enabled:
+            from nanobot.agent.tools.memory_search import MemorySearchTool
+            from nanobot.memory_index.service import IndexService
+
+            self._index_service = IndexService(self.workspace, self.memory_index_config)
+            self.tools.register(MemorySearchTool(self._index_service.index))
+            # start() is scheduled in run()/process_direct() once the event loop is running
+```
+
+**3d.** In `run()`, replace the `_memory_index` startup block:
+```python
+        if self._index_service is not None and not self._index_service_started:
+            self._index_service_started = True
+            self._schedule_background(self._index_service.start())
+```
+
+**3e.** In `process_direct()`, replace the `_memory_index` startup block:
+```python
+        if self._index_service is not None and not self._index_service_started:
+            self._index_service_started = True
+            self._schedule_background(self._index_service.start())
+```
+
+**3f.** In `_process_message()`, find the **system message path** call site (around line 510):
+```python
+            messages = self.context.build_messages(
+                history=history,
+                current_message=msg.content,
+                channel=channel,
+                chat_id=chat_id,
+                current_role=current_role,
+            )
+```
+Replace with:
+```python
+            messages = await self.context.build_messages(
+                history=history,
+                current_message=msg.content,
+                channel=channel,
+                chat_id=chat_id,
+                current_role=current_role,
+                index=self._index_service,
+            )
+```
+
+**3g.** Find the **regular message path** call site (around line 552):
+```python
+        initial_messages = self.context.build_messages(
+            history=history,
+            current_message=msg.content,
+            media=msg.media if msg.media else None,
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+        )
+```
+Replace with:
+```python
+        initial_messages = await self.context.build_messages(
+            history=history,
+            current_message=msg.content,
+            media=msg.media if msg.media else None,
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            index=self._index_service,
+        )
+```
+
+**3h.** In `close_mcp()`, add watcher cleanup before the MCP stack cleanup:
+```python
+    async def close_mcp(self) -> None:
+        """Drain pending background tasks, stop file watcher, then close MCP connections."""
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+            self._background_tasks.clear()
+        if self._index_service is not None:
+            await self._index_service.stop()
+        if self._mcp_stack:
+            try:
+                await self._mcp_stack.aclose()
+            except (RuntimeError, BaseExceptionGroup):
+                pass
+            self._mcp_stack = None
+```
+
+- [ ] **Step 4: Run the integration tests**
+
+```bash
+pytest tests/agent/test_memory_index_integration.py -v
+```
+Expected: `6 passed`.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+pytest --tb=short -q
+```
+Expected: all tests pass, 0 regressions. If any test calls `context.build_messages(...)` synchronously, update it to be async and add `await`.
+
+- [ ] **Step 6: Lint**
+
+```bash
+ruff check nanobot/
+```
+Expected: no errors. Fix any `F401` (unused import) if the old `MemoryIndex` import lingers.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add nanobot/agent/loop.py tests/agent/test_memory_index_integration.py
+git commit -m "feat(agent): wire IndexService into AgentLoop; pre-retrieval injection on every turn"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+
+| Spec requirement | Covered by |
+|---|---|
+| Auto-inject top-k chunks every agent turn | Task 4 (`build_messages` injection) + Task 5 (both call sites) |
+| Live updates on MEMORY.md / HISTORY.md change | Task 3 (file watcher), Task 2 (`_start_watcher()`) |
+| `IndexService` lifecycle object | Task 2 |
+| `inject_top_k: int = 3` config field | Task 1 |
+| `watch_files: bool = True` config field | Task 1 |
+| `watchdog>=3.0.0` added to `[memory]` extras | Task 1 |
+| `build_messages()` → `async def` | Task 4 |
+| `_process_message` awaits `build_messages()` | Task 5 |
+| Explicit `memory_search` tool still registered | Task 5 (`MemorySearchTool(self._index_service.index)`) |
+
+**Testing checklist:**
+
+- [x] `IndexService.start()` / `stop()` lifecycle
+- [x] File change event triggers re-index (watchdog mock)
+- [x] `build_messages()` injects results when index has matches
+- [x] `build_messages()` is unchanged when `index=None` or `inject_top_k=0`
+- [x] No injection when index returns empty results
+- [x] `_process_message` correctly awaits `build_messages()`
+- [x] `IndexService.start()` scheduled only once (double-scheduling guard)
+- [x] `MemoryConsolidator.estimate_session_prompt_tokens()` is async
+
+**Type consistency check:**
+
+- `IndexService._cfg` is `MemoryIndexConfig` — used as `index._cfg.inject_top_k` ✓
+- `IndexService.index` is `MemoryIndex` — used as `index.index.search(...)` ✓
+- `MemorySearchTool(self._index_service.index)` — matches existing `MemorySearchTool(MemoryIndex)` constructor ✓
+- `build_messages(..., index: IndexService | None = None)` — all call sites pass a keyword arg or omit it ✓

--- a/docs/superpowers/plans/2026-03-29-graphiti-memory-core.md
+++ b/docs/superpowers/plans/2026-03-29-graphiti-memory-core.md
@@ -1,0 +1,1158 @@
+# Graphiti Memory Lobe — Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `MemoryBackend` abstraction to nanobot core so the Graphiti memory plugin (Plan 2) can slot in and replace the flat-file memory system.
+
+**Architecture:** `MemoryBackend` ABC lives in `nanobot/agent/memory.py`; `MemoryStore` implements it as the default (zero behavior change). `ContextBuilder.build_messages()` becomes async and injects retrieved context when a backend is active. `AgentLoop` discovers backends via the `nanobot.memory` entry-point group and dispatches per-turn consolidation when `backend.consolidates_per_turn` is True.
+
+**Tech Stack:** Python 3.11+, `asyncio`, `importlib.metadata` (stdlib entry-point discovery). No new dependencies.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `nanobot/config/schema.py` | Add `MemoryConfig(Base)` + `Config.memory` field |
+| `nanobot/agent/memory.py` | Add `MemoryBackend` ABC; `MemoryStore` subclasses it; `MemoryConsolidator` gets `skip_llm` param + async `estimate_session_prompt_tokens` |
+| `nanobot/agent/context.py` | `build_messages()` → async + `session_key` param + memory injection; `_get_identity()` backend-aware |
+| `nanobot/agent/loop.py` | `memory_backend` param, tool registration, `await build_messages`, per-turn consolidation dispatch, deferred `backend.start()` |
+| `nanobot/cli/commands.py` | Add `load_memory_backend(config)` call at both `AgentLoop` creation sites |
+| `tests/agent/test_memory_backend.py` | **New** — `MemoryBackend` ABC contract, `MemoryStore` implementation |
+| `tests/agent/test_context_memory_inject.py` | **New** — async `build_messages` with and without memory injection |
+| `tests/agent/test_loop_memory_backend.py` | **New** — backend discovery fallback, `consolidates_per_turn` dispatch, tool registration |
+
+---
+
+## Task 1: `MemoryConfig` in `nanobot/config/schema.py`
+
+**Files:**
+- Modify: `nanobot/config/schema.py` (around line 152, before the `Config` class)
+
+**Context:** `Config(BaseSettings)` currently has `agents`, `channels`, `providers`, `gateway`, `tools` fields. Add `memory` field. `MemoryConfig` needs `backend: str = "default"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/agent/test_memory_backend.py` (config section only for now):
+```python
+def test_memory_config_defaults():
+    from nanobot.config.schema import MemoryConfig
+
+    cfg = MemoryConfig()
+    assert cfg.backend == "default"
+
+
+def test_memory_config_backend_can_be_set():
+    from nanobot.config.schema import MemoryConfig
+
+    cfg = MemoryConfig(backend="graphiti")
+    assert cfg.backend == "graphiti"
+
+
+def test_config_has_memory_field():
+    from nanobot.config.schema import Config
+
+    cfg = Config()
+    assert cfg.memory.backend == "default"
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+pytest tests/agent/test_memory_backend.py -v -k "memory_config or config_has_memory"
+```
+Expected: `FAILED` — `cannot import name 'MemoryConfig'`
+
+- [ ] **Step 3: Add `MemoryConfig` and `Config.memory` field**
+
+In `nanobot/config/schema.py`, insert before the `Config` class (after `ToolsConfig`):
+```python
+class MemoryConfig(Base):
+    """Memory backend configuration."""
+
+    backend: str = "default"
+```
+
+Then add to `Config`:
+```python
+class Config(BaseSettings):
+    """Root configuration for nanobot."""
+
+    agents: AgentsConfig = Field(default_factory=AgentsConfig)
+    channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
+    providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
+    gateway: GatewayConfig = Field(default_factory=GatewayConfig)
+    tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    memory: MemoryConfig = Field(default_factory=MemoryConfig)
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+pytest tests/agent/test_memory_backend.py -v -k "memory_config or config_has_memory"
+```
+
+- [ ] **Step 5: Run full suite — no regressions**
+
+```bash
+pytest --tb=short -q
+```
+Expected: 647 passed (644 + 3 new), 1 skipped.
+
+- [ ] **Commit**
+
+```
+feat(config): add MemoryConfig with backend field
+```
+
+---
+
+## Task 2: `MemoryBackend` ABC + `MemoryStore` implementation
+
+**Files:**
+- Modify: `nanobot/agent/memory.py`
+- Modify: `tests/agent/test_memory_backend.py` (add to existing file)
+
+**Context:** `MemoryStore` currently starts at line 75 with no base class. We add `MemoryBackend` ABC before it, then make `MemoryStore` subclass it. `MemoryBackend.consolidate()` and `retrieve()` are abstract. The default `consolidates_per_turn` is `False`; `get_tools()` returns `[]`; `start()`/`stop()` are no-ops.
+
+For `MemoryStore`:
+- `consolidates_per_turn = False`
+- `get_tools()` → `[]`
+- `start(provider)` → no-op (file-based, no async init needed)
+- `stop()` → no-op
+- `consolidate(messages, session_key)` → no-op (MemoryConsolidator handles consolidation for the MemoryStore path; this method is only called by AgentLoop for per-turn backends)
+- `retrieve(query, session_key, top_k=5)` → returns `self.get_memory_context()` (ignores query, returns full MEMORY.md — preserves current behavior as the default)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/agent/test_memory_backend.py`:
+```python
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def test_memory_backend_abc_cannot_be_instantiated_directly():
+    from nanobot.agent.memory import MemoryBackend
+
+    with pytest.raises(TypeError):
+        MemoryBackend()
+
+
+def test_memory_store_is_memory_backend(tmp_path):
+    from nanobot.agent.memory import MemoryBackend, MemoryStore
+
+    store = MemoryStore(tmp_path)
+    assert isinstance(store, MemoryBackend)
+
+
+def test_memory_store_consolidates_per_turn_is_false(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    assert store.consolidates_per_turn is False
+
+
+def test_memory_store_get_tools_returns_empty_list(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    assert store.get_tools() == []
+
+
+async def test_memory_store_retrieve_returns_memory_context(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "MEMORY.md").write_text("I like coffee")
+
+    result = await store.retrieve("anything", "telegram:123")
+    assert "I like coffee" in result
+
+
+async def test_memory_store_retrieve_returns_empty_string_when_no_file(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    result = await store.retrieve("anything", "telegram:123")
+    assert result == ""
+
+
+async def test_memory_store_consolidate_is_noop(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    # Should not raise and should not create any files
+    await store.consolidate([{"role": "user", "content": "hello"}], "telegram:123")
+    assert not (tmp_path / "memory" / "MEMORY.md").exists()
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+pytest tests/agent/test_memory_backend.py -v -k "backend_abc or is_memory_backend or consolidates_per_turn or get_tools or store_retrieve or store_consolidate"
+```
+Expected: `FAILED` — `cannot import name 'MemoryBackend'`
+
+- [ ] **Step 3: Add `MemoryBackend` ABC to `nanobot/agent/memory.py`**
+
+Add these imports at the top of the file (after existing imports):
+```python
+from abc import ABC, abstractmethod
+```
+
+Insert the `MemoryBackend` class before the `MemoryStore` class (around line 75):
+```python
+class MemoryBackend(ABC):
+    """Abstract base class for nanobot memory backends.
+
+    Backends are discovered via the ``nanobot.memory`` entry-point group.
+    The default backend is ``MemoryStore`` (flat-file MEMORY.md).
+    """
+
+    @property
+    def consolidates_per_turn(self) -> bool:
+        """True if this backend captures facts after every turn.
+
+        When True, AgentLoop fires ``consolidate()`` as a background task
+        after each turn, and MemoryConsolidator skips its LLM archival step.
+        When False (default), MemoryConsolidator governs consolidation under
+        token-pressure.
+        """
+        return False
+
+    def get_tools(self) -> list:
+        """Return extra Tool instances to register in AgentLoop. Default: none."""
+        return []
+
+    async def start(self, provider: Any) -> None:
+        """Lifecycle: called once at agent startup (after the event loop is running)."""
+
+    async def stop(self) -> None:
+        """Lifecycle: called on graceful shutdown."""
+
+    @abstractmethod
+    async def consolidate(self, messages: list[dict], session_key: str) -> None:
+        """Post-turn: extract and store facts from the completed turn's messages."""
+
+    @abstractmethod
+    async def retrieve(self, query: str, session_key: str, top_k: int = 5) -> str:
+        """Pre-turn: return a formatted context block of relevant memories, or '' if none."""
+```
+
+- [ ] **Step 4: Make `MemoryStore` subclass `MemoryBackend`**
+
+Change the `MemoryStore` class definition and add the four required methods. The existing methods (`read_long_term`, `write_long_term`, etc.) are unchanged.
+
+Change:
+```python
+class MemoryStore:
+    """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
+```
+To:
+```python
+class MemoryStore(MemoryBackend):
+    """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
+```
+
+Add these four methods at the end of the `MemoryStore` class (after the existing `_raw_archive` method):
+```python
+    # --- MemoryBackend interface ---
+
+    async def consolidate(self, messages: list[dict], session_key: str) -> None:
+        """No-op: MemoryConsolidator handles consolidation for the MemoryStore path."""
+
+    async def retrieve(self, query: str, session_key: str, top_k: int = 5) -> str:
+        """Return full MEMORY.md content (query-independent, preserves current behaviour)."""
+        return self.get_memory_context()
+```
+
+- [ ] **Step 5: Run — verify PASSED**
+
+```bash
+pytest tests/agent/test_memory_backend.py -v
+```
+
+- [ ] **Step 6: Run full suite — no regressions**
+
+```bash
+pytest --tb=short -q
+```
+Expected: 654 passed (644 + 10 new), 1 skipped.
+
+- [ ] **Commit**
+
+```
+feat(agent): add MemoryBackend ABC; MemoryStore implements it
+```
+
+---
+
+## Task 3: Async `build_messages` with memory injection
+
+**Files:**
+- Modify: `nanobot/agent/context.py`
+- Create: `tests/agent/test_context_memory_inject.py`
+
+**Context:** `ContextBuilder.__init__` currently creates `self.memory = MemoryStore(workspace)`. After this task it accepts `memory_backend: MemoryBackend | None = None` instead. `build_messages()` becomes async and, when a backend and session_key are provided, injects a system-role block of retrieved context before the conversation history. `build_system_prompt()` removes its MEMORY.md injection call (injection moves to `build_messages()`). `_get_identity()` is backend-aware: shows MEMORY.md workspace tip when no backend, shows tool surface description when a per-turn backend is active.
+
+The memory injection block format (inserted as a `{"role": "system", "content": ...}` entry before history):
+```
+[Memory — {n} relevant facts]
+• fact one (2026-01-10)
+• fact two (2026-01-09)
+```
+
+When `retrieve()` returns `""` (empty), no block is inserted.
+
+`build_messages()` signature after change:
+```python
+async def build_messages(
+    self,
+    history: list[dict[str, Any]],
+    current_message: str,
+    skill_names: list[str] | None = None,
+    media: list[str] | None = None,
+    channel: str | None = None,
+    chat_id: str | None = None,
+    current_role: str = "user",
+    session_key: str | None = None,   # NEW — if set with memory_backend, triggers retrieval
+) -> list[dict[str, Any]]:
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/agent/test_context_memory_inject.py`:
+```python
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+from nanobot.agent.context import ContextBuilder
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    return ws
+
+
+async def test_build_messages_returns_list(tmp_path):
+    ws = _make_workspace(tmp_path)
+    ctx = ContextBuilder(ws)
+    result = await ctx.build_messages(history=[], current_message="hi")
+    assert isinstance(result, list)
+    assert result[-1]["role"] == "user"
+
+
+async def test_build_messages_no_backend_no_injection(tmp_path):
+    ws = _make_workspace(tmp_path)
+    ctx = ContextBuilder(ws)
+    result = await ctx.build_messages(
+        history=[], current_message="hi", session_key="telegram:123"
+    )
+    # Without a backend there is no memory block
+    roles = [m["role"] for m in result]
+    assert roles.count("system") == 1  # only the main system prompt
+
+
+async def test_build_messages_with_backend_injects_memory_block(tmp_path):
+    ws = _make_workspace(tmp_path)
+    mock_backend = MagicMock()
+    mock_backend.retrieve = AsyncMock(return_value="[Memory — 1 relevant facts]\n• you like tea (2026-01-01)")
+    ctx = ContextBuilder(ws, memory_backend=mock_backend)
+
+    result = await ctx.build_messages(
+        history=[], current_message="hi", session_key="telegram:123"
+    )
+
+    memory_blocks = [m for m in result if m.get("role") == "system" and "Memory" in (m.get("content") or "")]
+    assert len(memory_blocks) == 1
+    mock_backend.retrieve.assert_awaited_once_with("hi", "telegram:123", 5)
+
+
+async def test_build_messages_empty_retrieve_skips_injection(tmp_path):
+    ws = _make_workspace(tmp_path)
+    mock_backend = MagicMock()
+    mock_backend.retrieve = AsyncMock(return_value="")
+    ctx = ContextBuilder(ws, memory_backend=mock_backend)
+
+    result = await ctx.build_messages(
+        history=[], current_message="hi", session_key="telegram:123"
+    )
+
+    roles = [m["role"] for m in result]
+    assert roles.count("system") == 1
+
+
+async def test_build_messages_no_session_key_skips_retrieval(tmp_path):
+    ws = _make_workspace(tmp_path)
+    mock_backend = MagicMock()
+    mock_backend.retrieve = AsyncMock(return_value="some memory")
+    ctx = ContextBuilder(ws, memory_backend=mock_backend)
+
+    await ctx.build_messages(history=[], current_message="probe", session_key=None)
+
+    mock_backend.retrieve.assert_not_awaited()
+
+
+async def test_memory_block_inserted_before_history(tmp_path):
+    ws = _make_workspace(tmp_path)
+    mock_backend = MagicMock()
+    mock_backend.retrieve = AsyncMock(return_value="[Memory — 1 relevant facts]\n• you like tea")
+    ctx = ContextBuilder(ws, memory_backend=mock_backend)
+    history = [{"role": "user", "content": "old message"}, {"role": "assistant", "content": "old reply"}]
+
+    result = await ctx.build_messages(
+        history=history, current_message="new message", session_key="telegram:123"
+    )
+
+    # Order: system_prompt, memory_block, history..., current_user_message
+    system_indices = [i for i, m in enumerate(result) if m["role"] == "system"]
+    first_history_idx = next(i for i, m in enumerate(result) if m.get("content") == "old message")
+    assert system_indices[-1] < first_history_idx
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+pytest tests/agent/test_context_memory_inject.py -v
+```
+Expected: `FAILED` — `build_messages() was never awaited` (it's currently sync)
+
+- [ ] **Step 3: Update `ContextBuilder`**
+
+In `nanobot/agent/context.py`:
+
+**a) Update `__init__`** — accept `memory_backend`, drop direct `MemoryStore` construction:
+```python
+from nanobot.agent.memory import MemoryStore
+
+class ContextBuilder:
+    """Builds the context (system prompt + messages) for the agent."""
+
+    BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"]
+    _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
+
+    def __init__(
+        self,
+        workspace: Path,
+        timezone: str | None = None,
+        memory_backend=None,  # MemoryBackend | None
+    ):
+        self.workspace = workspace
+        self.timezone = timezone
+        self.memory_backend = memory_backend
+        # Keep self.memory for MemoryConsolidator probe calls that still need MemoryStore
+        self.memory = MemoryStore(workspace)
+        self.skills = SkillsLoader(workspace)
+```
+
+**b) Update `build_system_prompt()`** — remove the MEMORY.md injection block entirely. Replace the memory section with nothing (or conditionally based on backend). Delete these lines:
+```python
+        memory = self.memory.get_memory_context()
+        if memory:
+            parts.append(f"# Memory\n\n{memory}")
+```
+
+**c) Update `_get_identity()`** — replace the workspace memory tip lines:
+
+Old (lines ~85-87):
+```
+- Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)
+- History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
+```
+
+Replace with a conditional block. After the `workspace_path` line construction, add:
+```python
+        if self.memory_backend is not None and self.memory_backend.consolidates_per_turn:
+            memory_tip = "- Memory: Relevant facts from past conversations are automatically surfaced each turn.\n  Use memory_search for targeted recall, memory_forget to correct errors, memory_list to audit stored facts."
+        else:
+            memory_tip = f"- Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)\n- History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM]."
+```
+And use `{memory_tip}` in the f-string instead of the two hardcoded lines.
+
+**d) Make `build_messages()` async** — add `session_key` param, inject memory block:
+```python
+    async def build_messages(
+        self,
+        history: list[dict[str, Any]],
+        current_message: str,
+        skill_names: list[str] | None = None,
+        media: list[str] | None = None,
+        channel: str | None = None,
+        chat_id: str | None = None,
+        current_role: str = "user",
+        session_key: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Build the complete message list for an LLM call."""
+        runtime_ctx = self._build_runtime_context(channel, chat_id, self.timezone)
+        user_content = self._build_user_content(current_message, media)
+
+        if isinstance(user_content, str):
+            merged = f"{runtime_ctx}\n\n{user_content}"
+        else:
+            merged = [{"type": "text", "text": runtime_ctx}] + user_content
+
+        memory_block: list[dict[str, Any]] = []
+        if self.memory_backend is not None and session_key is not None:
+            retrieved = await self.memory_backend.retrieve(current_message, session_key, 5)
+            if retrieved:
+                memory_block = [{"role": "system", "content": retrieved}]
+
+        return [
+            {"role": "system", "content": self.build_system_prompt(skill_names)},
+            *memory_block,
+            *history,
+            {"role": current_role, "content": merged},
+        ]
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+pytest tests/agent/test_context_memory_inject.py -v
+```
+
+- [ ] **Step 5: Fix any broken existing tests**
+
+Some existing tests call `self.context.build_messages(...)` without `await`. Run:
+```bash
+pytest tests/ --tb=short -q 2>&1 | grep FAILED
+```
+For each failure caused by `build_messages` being async, add `await` to the call site in the test. The test file `tests/agent/test_context_prompt_cache.py` may need updating if it calls `build_messages` directly.
+
+- [ ] **Step 6: Run full suite — no regressions**
+
+```bash
+pytest --tb=short -q
+```
+Expected: 660 passed (644 + 16 new), 1 skipped.
+
+- [ ] **Commit**
+
+```
+feat(agent): make build_messages async; inject memory backend context block
+```
+
+---
+
+## Task 4: `MemoryConsolidator` — `skip_llm` gating + async estimate
+
+**Files:**
+- Modify: `nanobot/agent/memory.py`
+- Modify: `tests/agent/test_memory_backend.py` (add consolidator tests)
+
+**Context:** Two changes to `MemoryConsolidator`:
+
+1. `maybe_consolidate_by_tokens(session, skip_llm=False)` — when `skip_llm=True`, the loop drops old messages without calling `consolidate_messages()`. This is used when a per-turn backend (Graphiti) is active, since it already captured facts.
+
+2. `estimate_session_prompt_tokens(session)` becomes `async` because `self._build_messages(...)` is now a coroutine (it's `ContextBuilder.build_messages` which is now async). The `_build_messages` type hint is updated accordingly.
+
+The `_build_messages` probe call does NOT pass `session_key`, so it defaults to `None` — no memory retrieval happens during token estimation.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/agent/test_memory_backend.py`:
+```python
+async def test_consolidator_skip_llm_drops_messages_without_llm_call(tmp_path):
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from nanobot.agent.memory import MemoryConsolidator, MemoryStore
+    from nanobot.agent.context import ContextBuilder
+    from nanobot.session.manager import SessionManager
+    from nanobot.providers.base import GenerationSettings
+
+    provider = MagicMock()
+    provider.generation = GenerationSettings(max_tokens=0)
+    provider.estimate_prompt_tokens = MagicMock(return_value=(50, "test"))
+
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    ctx = ContextBuilder(ws)
+    sessions = SessionManager(ws)
+
+    consolidator = MemoryConsolidator(
+        workspace=ws,
+        provider=provider,
+        model="test-model",
+        sessions=sessions,
+        context_window_tokens=200,
+        build_messages=ctx.build_messages,
+        get_tool_definitions=MagicMock(return_value=[]),
+    )
+    consolidator.consolidate_messages = AsyncMock(return_value=True)
+    consolidator._SAFETY_BUFFER = 0
+
+    session = sessions.get_or_create("telegram:123")
+    session.messages = [
+        {"role": "user", "content": "u1", "timestamp": "2026-01-01T00:00:00"},
+        {"role": "assistant", "content": "a1", "timestamp": "2026-01-01T00:00:01"},
+        {"role": "user", "content": "u2", "timestamp": "2026-01-01T00:00:02"},
+        {"role": "assistant", "content": "a2", "timestamp": "2026-01-01T00:00:03"},
+    ]
+
+    await consolidator.maybe_consolidate_by_tokens(session, skip_llm=True)
+
+    # LLM consolidation must NOT have been called
+    consolidator.consolidate_messages.assert_not_awaited()
+    # But session must have been pruned (last_consolidated advanced)
+    assert session.last_consolidated > 0
+
+
+async def test_consolidator_skip_llm_false_still_calls_llm(tmp_path):
+    from unittest.mock import AsyncMock, MagicMock
+    from nanobot.agent.memory import MemoryConsolidator
+    from nanobot.agent.context import ContextBuilder
+    from nanobot.session.manager import SessionManager
+    from nanobot.providers.base import GenerationSettings
+
+    provider = MagicMock()
+    provider.generation = GenerationSettings(max_tokens=0)
+    provider.estimate_prompt_tokens = MagicMock(return_value=(1000, "test"))
+
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    ctx = ContextBuilder(ws)
+    sessions = SessionManager(ws)
+
+    consolidator = MemoryConsolidator(
+        workspace=ws,
+        provider=provider,
+        model="test-model",
+        sessions=sessions,
+        context_window_tokens=200,
+        build_messages=ctx.build_messages,
+        get_tool_definitions=MagicMock(return_value=[]),
+    )
+    consolidator.consolidate_messages = AsyncMock(return_value=True)
+    consolidator._SAFETY_BUFFER = 0
+
+    session = sessions.get_or_create("telegram:123")
+    session.messages = [
+        {"role": "user", "content": "u1", "timestamp": "2026-01-01T00:00:00"},
+        {"role": "assistant", "content": "a1", "timestamp": "2026-01-01T00:00:01"},
+        {"role": "user", "content": "u2", "timestamp": "2026-01-01T00:00:02"},
+        {"role": "assistant", "content": "a2", "timestamp": "2026-01-01T00:00:03"},
+    ]
+
+    await consolidator.maybe_consolidate_by_tokens(session, skip_llm=False)
+
+    consolidator.consolidate_messages.assert_awaited()
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+pytest tests/agent/test_memory_backend.py -v -k "skip_llm"
+```
+Expected: `FAILED` — `maybe_consolidate_by_tokens() got unexpected keyword argument 'skip_llm'`
+
+- [ ] **Step 3: Update `MemoryConsolidator` in `nanobot/agent/memory.py`**
+
+**a) Update `_build_messages` type hint** in `MemoryConsolidator.__init__`:
+```python
+from typing import Awaitable
+
+# Change line 236:
+build_messages: Callable[..., Awaitable[list[dict[str, Any]]]],
+```
+
+**b) Make `estimate_session_prompt_tokens` async**:
+```python
+    async def estimate_session_prompt_tokens(self, session: Session) -> tuple[int, str]:
+        """Estimate current prompt size for the normal session history view."""
+        history = session.get_history(max_messages=0)
+        channel, chat_id = (session.key.split(":", 1) if ":" in session.key else (None, None))
+        probe_messages = await self._build_messages(
+            history=history,
+            current_message="[token-probe]",
+            channel=channel,
+            chat_id=chat_id,
+            # session_key intentionally omitted → no memory retrieval during probe
+        )
+        return estimate_prompt_tokens_chain(
+            self.provider,
+            self.model,
+            probe_messages,
+            self._get_tool_definitions(),
+        )
+```
+
+**c) Add `skip_llm` parameter to `maybe_consolidate_by_tokens`** and `await` the now-async estimate:
+```python
+    async def maybe_consolidate_by_tokens(
+        self, session: Session, skip_llm: bool = False
+    ) -> None:
+        """Loop: archive old messages until prompt fits within safe budget."""
+        if not session.messages or self.context_window_tokens <= 0:
+            return
+
+        lock = self.get_lock(session.key)
+        async with lock:
+            budget = self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
+            target = budget // 2
+            estimated, source = await self.estimate_session_prompt_tokens(session)  # now awaited
+            if estimated <= 0:
+                return
+            if estimated < budget:
+                logger.debug(
+                    "Token consolidation idle {}: {}/{} via {}",
+                    session.key,
+                    estimated,
+                    self.context_window_tokens,
+                    source,
+                )
+                return
+
+            for round_num in range(self._MAX_CONSOLIDATION_ROUNDS):
+                if estimated <= target:
+                    return
+
+                boundary = self.pick_consolidation_boundary(session, max(1, estimated - target))
+                if boundary is None:
+                    logger.debug(
+                        "Token consolidation: no safe boundary for {} (round {})",
+                        session.key,
+                        round_num,
+                    )
+                    return
+
+                end_idx = boundary[0]
+                chunk = session.messages[session.last_consolidated:end_idx]
+                if not chunk:
+                    return
+
+                logger.info(
+                    "Token consolidation round {} for {}: {}/{} via {}, chunk={} msgs",
+                    round_num,
+                    session.key,
+                    estimated,
+                    self.context_window_tokens,
+                    source,
+                    len(chunk),
+                )
+
+                if not skip_llm:
+                    if not await self.consolidate_messages(chunk):
+                        return
+
+                session.last_consolidated = end_idx
+                self.sessions.save(session)
+
+                estimated, source = await self.estimate_session_prompt_tokens(session)  # now awaited
+                if estimated <= 0:
+                    return
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+pytest tests/agent/test_memory_backend.py -v -k "skip_llm"
+```
+
+- [ ] **Step 5: Fix any broken existing consolidation tests**
+
+The existing consolidation tests in `tests/agent/test_loop_consolidation_tokens.py` pass `build_messages=self.context.build_messages`. Since `build_messages` is now async, and `estimate_session_prompt_tokens` now `await`s it, this should work. Run:
+```bash
+pytest tests/agent/test_loop_consolidation_tokens.py -v
+```
+If any test fails due to `MagicMock` not being awaitable, replace `MagicMock` with `AsyncMock` for `build_messages` in those tests, or update the `_make_loop` helper to pass `ctx.build_messages` directly.
+
+- [ ] **Step 6: Run full suite — no regressions**
+
+```bash
+pytest --tb=short -q
+```
+Expected: 662 passed (644 + 18 new), 1 skipped.
+
+- [ ] **Commit**
+
+```
+feat(agent): gate MemoryConsolidator LLM call via skip_llm; async estimate_session_prompt_tokens
+```
+
+---
+
+## Task 5: `AgentLoop` wiring
+
+**Files:**
+- Modify: `nanobot/agent/loop.py`
+- Create: `tests/agent/test_loop_memory_backend.py`
+
+**Context:** `AgentLoop.__init__` gets a new optional `memory_backend: MemoryBackend | None = None` parameter. When None, it defaults to `MemoryStore(workspace)`. It passes the backend to `ContextBuilder`, registers `backend.get_tools()`, and stores a reference.
+
+`run()` and `process_direct()` both call `await self.memory_backend.start(self.provider)` before processing (deferred init — same pattern used in the QMD branch for `startup_index()`). A `_backend_started` flag prevents double-start.
+
+`_process_message()` changes:
+1. `self.context.build_messages(...)` becomes `await self.context.build_messages(..., session_key=key)`
+2. Post-turn: when `backend.consolidates_per_turn`, fire `backend.consolidate(turn_messages, key)` as background task
+3. `maybe_consolidate_by_tokens(session)` → `maybe_consolidate_by_tokens(session, skip_llm=self.memory_backend.consolidates_per_turn)`
+
+The `turn_messages` to consolidate are the new messages added in this turn: `all_msgs[1 + len(history):]` (everything after the initial system prompt + history).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/agent/test_loop_memory_backend.py`:
+```python
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.memory import MemoryBackend, MemoryStore
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse, GenerationSettings
+
+
+def _make_loop(tmp_path, memory_backend=None):
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings(max_tokens=0)
+    provider.estimate_prompt_tokens.return_value = (50, "test")
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+    provider.chat_stream_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+
+    return AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        memory_backend=memory_backend,
+    )
+
+
+def test_agent_loop_defaults_to_memory_store_backend(tmp_path):
+    loop = _make_loop(tmp_path)
+    assert isinstance(loop.memory_backend, MemoryStore)
+
+
+def test_agent_loop_accepts_custom_backend(tmp_path):
+    class FakeBackend(MemoryBackend):
+        async def consolidate(self, messages, session_key): pass
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    backend = FakeBackend()
+    loop = _make_loop(tmp_path, memory_backend=backend)
+    assert loop.memory_backend is backend
+
+
+def test_agent_loop_registers_backend_tools(tmp_path):
+    from nanobot.agent.tools.base import Tool
+
+    class FakeTool(Tool):
+        @property
+        def name(self): return "fake_tool"
+        @property
+        def description(self): return "fake"
+        @property
+        def parameters(self): return {"type": "object", "properties": {}}
+        async def execute(self, **kwargs): return "ok"
+
+    class FakeBackend(MemoryBackend):
+        def get_tools(self): return [FakeTool()]
+        async def consolidate(self, messages, session_key): pass
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    loop = _make_loop(tmp_path, memory_backend=FakeBackend())
+    assert loop.tools.get("fake_tool") is not None
+
+
+async def test_agent_loop_calls_backend_start_before_first_message(tmp_path):
+    class FakeBackend(MemoryBackend):
+        started = False
+        async def start(self, provider): self.started = True
+        async def consolidate(self, messages, session_key): pass
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    backend = FakeBackend()
+    loop = _make_loop(tmp_path, memory_backend=backend)
+    await loop.process_direct("hello", session_key="cli:test")
+    assert backend.started is True
+
+
+async def test_per_turn_backend_consolidate_called_after_message(tmp_path):
+    class FakeBackend(MemoryBackend):
+        consolidate_calls = []
+        @property
+        def consolidates_per_turn(self): return True
+        async def start(self, provider): pass
+        async def consolidate(self, messages, session_key):
+            self.consolidate_calls.append(session_key)
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    backend = FakeBackend()
+    loop = _make_loop(tmp_path, memory_backend=backend)
+    await loop.process_direct("hello", session_key="telegram:123")
+    # Allow background task to complete
+    import asyncio
+    await asyncio.sleep(0)
+    assert "telegram:123" in backend.consolidate_calls
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+pytest tests/agent/test_loop_memory_backend.py -v
+```
+Expected: `FAILED` — `AgentLoop.__init__() got unexpected keyword argument 'memory_backend'`
+
+- [ ] **Step 3: Update `nanobot/agent/loop.py`**
+
+**a) Add import** at the top (with TYPE_CHECKING):
+```python
+if TYPE_CHECKING:
+    from nanobot.config.schema import ChannelsConfig, ExecToolConfig, WebSearchConfig
+    from nanobot.cron.service import CronService
+    from nanobot.agent.memory import MemoryBackend
+```
+
+**b) Add `memory_backend` parameter to `__init__`**:
+```python
+    def __init__(
+        self,
+        bus: MessageBus,
+        provider: LLMProvider,
+        workspace: Path,
+        model: str | None = None,
+        max_iterations: int = 40,
+        context_window_tokens: int = 65_536,
+        web_search_config: WebSearchConfig | None = None,
+        web_proxy: str | None = None,
+        exec_config: ExecToolConfig | None = None,
+        cron_service: CronService | None = None,
+        restrict_to_workspace: bool = False,
+        session_manager: SessionManager | None = None,
+        mcp_servers: dict | None = None,
+        channels_config: ChannelsConfig | None = None,
+        timezone: str | None = None,
+        memory_backend: MemoryBackend | None = None,  # NEW
+    ):
+```
+
+**c) Set `self.memory_backend`** early in `__init__` (after `self.workspace = workspace`):
+```python
+        from nanobot.agent.memory import MemoryStore
+        self.memory_backend = memory_backend if memory_backend is not None else MemoryStore(workspace)
+        self._backend_started = False
+```
+
+**d) Pass `memory_backend` to `ContextBuilder`**:
+```python
+        self.context = ContextBuilder(workspace, timezone=timezone, memory_backend=self.memory_backend)
+```
+
+**e) Register backend tools** in `_register_default_tools()`, after the existing tool registrations:
+```python
+        for tool in self.memory_backend.get_tools():
+            self.tools.register(tool)
+```
+
+**f) Add deferred `_start_backend()` method**:
+```python
+    async def _start_backend(self) -> None:
+        """Start the memory backend once (deferred to avoid event-loop issues at __init__)."""
+        if not self._backend_started:
+            await self.memory_backend.start(self.provider)
+            self._backend_started = True
+```
+
+**g) Call `_start_backend()` in `run()`**, after `await self._connect_mcp()`:
+```python
+    async def run(self) -> None:
+        self._running = True
+        await self._connect_mcp()
+        await self._start_backend()   # NEW
+        logger.info("Agent loop started")
+        ...
+```
+
+**h) Call `_start_backend()` in `process_direct()`**, after `await self._connect_mcp()`:
+```python
+    async def process_direct(self, content, ...):
+        await self._connect_mcp()
+        await self._start_backend()   # NEW
+        msg = InboundMessage(...)
+        return await self._process_message(...)
+```
+
+**i) Update both `build_messages` call sites** in `_process_message()` to be `await`ed and pass `session_key`:
+
+Replace (line ~409):
+```python
+            messages = self.context.build_messages(
+                history=history,
+                current_message=msg.content, channel=channel, chat_id=chat_id,
+                current_role=current_role,
+            )
+```
+With:
+```python
+            messages = await self.context.build_messages(
+                history=history,
+                current_message=msg.content, channel=channel, chat_id=chat_id,
+                current_role=current_role,
+                session_key=key,
+            )
+```
+
+Replace (line ~444):
+```python
+        initial_messages = self.context.build_messages(
+            history=history,
+            current_message=msg.content,
+            media=msg.media if msg.media else None,
+            channel=msg.channel, chat_id=msg.chat_id,
+        )
+```
+With:
+```python
+        initial_messages = await self.context.build_messages(
+            history=history,
+            current_message=msg.content,
+            media=msg.media if msg.media else None,
+            channel=msg.channel, chat_id=msg.chat_id,
+            session_key=key,
+        )
+```
+
+**j) Fire per-turn consolidation and update `maybe_consolidate_by_tokens` call**:
+
+After `self._save_turn(session, all_msgs, 1 + len(history))`, add per-turn consolidation dispatch. Replace (line ~473):
+```python
+        self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
+```
+With:
+```python
+        if self.memory_backend.consolidates_per_turn:
+            turn_messages = all_msgs[1 + len(history):]
+            self._schedule_background(
+                self.memory_backend.consolidate(turn_messages, key)
+            )
+        self._schedule_background(
+            self.memory_consolidator.maybe_consolidate_by_tokens(
+                session, skip_llm=self.memory_backend.consolidates_per_turn
+            )
+        )
+```
+
+Do the same for the system-message path (line ~420):
+```python
+        self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
+```
+→
+```python
+        if self.memory_backend.consolidates_per_turn:
+            turn_messages = all_msgs[1 + len(history):]
+            self._schedule_background(
+                self.memory_backend.consolidate(turn_messages, key)
+            )
+        self._schedule_background(
+            self.memory_consolidator.maybe_consolidate_by_tokens(
+                session, skip_llm=self.memory_backend.consolidates_per_turn
+            )
+        )
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+pytest tests/agent/test_loop_memory_backend.py -v
+```
+
+- [ ] **Step 5: Run full suite — no regressions**
+
+```bash
+pytest --tb=short -q
+```
+Expected: 667 passed (644 + 23 new), 1 skipped.
+
+- [ ] **Commit**
+
+```
+feat(agent): wire MemoryBackend into AgentLoop; per-turn consolidation dispatch
+```
+
+---
+
+## Task 6: CLI wiring — `load_memory_backend` utility
+
+**Files:**
+- Modify: `nanobot/agent/loop.py` (add `load_memory_backend` function)
+- Modify: `nanobot/cli/commands.py` (two AgentLoop creation sites)
+
+**Context:** A standalone function `load_memory_backend(config)` discovers installed `nanobot.memory` entry-points and returns the appropriate backend. It reads `config.memory.backend` to select which entry-point to load. If `"default"` or no matching entry-point, returns `MemoryStore(config.workspace_path)`.
+
+- [ ] **Step 1: Add `load_memory_backend` to `nanobot/agent/loop.py`**
+
+Add after the imports, before the `AgentLoop` class:
+```python
+def load_memory_backend(config: Any) -> "MemoryBackend":
+    """Discover and instantiate the configured memory backend from installed entry-points.
+
+    Falls back to the built-in MemoryStore when:
+    - ``config.memory.backend`` is ``"default"``
+    - No matching entry-point is registered
+    """
+    from importlib.metadata import entry_points
+    from nanobot.agent.memory import MemoryStore
+
+    backend_name = getattr(getattr(config, "memory", None), "backend", "default")
+    if backend_name == "default":
+        return MemoryStore(config.workspace_path)
+
+    for ep in entry_points(group="nanobot.memory"):
+        if ep.name == backend_name:
+            backend_cls = ep.load()
+            return backend_cls(config)
+
+    logger.warning(
+        "Memory backend '{}' not found in nanobot.memory entry-points; "
+        "falling back to default MemoryStore",
+        backend_name,
+    )
+    return MemoryStore(config.workspace_path)
+```
+
+- [ ] **Step 2: Update both `AgentLoop` creation sites in `nanobot/cli/commands.py`**
+
+Import at the top of the affected function (or at the file level if already imported):
+```python
+from nanobot.agent.loop import AgentLoop, load_memory_backend
+```
+
+For both `AgentLoop(...)` calls (lines ~537 and ~743), add `memory_backend=load_memory_backend(config)`:
+
+```python
+    agent = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=config.workspace_path,
+        ...
+        memory_backend=load_memory_backend(config),   # NEW
+    )
+```
+
+- [ ] **Step 3: Run full suite — no regressions**
+
+```bash
+pytest --tb=short -q
+```
+Expected: still 667 passed, 1 skipped (no new tests in this task).
+
+- [ ] **Commit**
+
+```
+feat(agent): add load_memory_backend entry-point discovery; wire into CLI
+```
+
+---
+
+## Self-Review Checklist (done inline above)
+
+- **Spec coverage:** ✓ MemoryBackend ABC (Task 2), MemoryStore impl (Task 2), async build_messages (Task 3), memory injection (Task 3), identity update (Task 3), consolidates_per_turn gating (Task 4), AgentLoop wiring (Task 5), entry-point discovery (Task 6), config field (Task 1)
+- **No placeholders:** All steps contain complete code
+- **Type consistency:** `MemoryBackend` used consistently; `skip_llm: bool` matches call sites; `session_key: str | None = None` matches all call sites
+- **Call site coverage:** All three `build_messages` call sites updated (loop.py:409, loop.py:444, memory.py:284 probe via async chain)

--- a/docs/superpowers/plans/2026-03-29-graphiti-memory-plugin.md
+++ b/docs/superpowers/plans/2026-03-29-graphiti-memory-plugin.md
@@ -1,0 +1,1336 @@
+# Graphiti Memory Plugin — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `nanobot-graphiti`, a separate installable plugin that wires a Graphiti temporal knowledge graph into nanobot as a `MemoryBackend`, replacing flat-file memory with per-turn entity extraction and query-scoped retrieval.
+
+**Architecture:** A standalone Python package at `plugins/nanobot-graphiti/`. Registers `GraphitiMemoryBackend` under the `nanobot.memory` entry-point group. `start(provider)` builds the Graphiti client from nanobot's `LLMProvider`. `consolidate()` calls `graphiti.add_episode()` after every turn (background task). `retrieve()` calls `graphiti.search()` and injects a `[Memory — N facts]` block before each user message. Three tools (`memory_search`, `memory_forget`, `memory_list`) are registered into `AgentLoop`'s tool registry via `get_tools()`.
+
+**Tech Stack:** `graphiti-core>=0.3`, `kuzu>=0.9` (default embedded graph DB), `openai>=2.0` (already a nanobot dep, reused for Graphiti's LLM/embedder adapter), Python 3.11+, pytest, `pytest-asyncio`.
+
+**Prerequisite:** Plan 1 (`2026-03-29-graphiti-memory-core.md`) must be executed first. This plan assumes `MemoryBackend` ABC, `MemoryConfig`, and `load_memory_backend()` are all in place.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `nanobot/config/schema.py` | Amend `MemoryConfig` — add `model_config = ConfigDict(extra="allow")` |
+| `plugins/nanobot-graphiti/pyproject.toml` | **New** — package metadata, entry-point, dependencies |
+| `plugins/nanobot-graphiti/nanobot_graphiti/__init__.py` | **New** — public export of `GraphitiMemoryBackend` |
+| `plugins/nanobot-graphiti/nanobot_graphiti/config.py` | **New** — `GraphitiConfig` pydantic model |
+| `plugins/nanobot-graphiti/nanobot_graphiti/backend.py` | **New** — `GraphitiMemoryBackend` (start, consolidate, retrieve, get_tools) |
+| `plugins/nanobot-graphiti/nanobot_graphiti/tools.py` | **New** — `MemorySearchTool`, `MemoryForgetTool`, `MemoryListTool` |
+| `plugins/nanobot-graphiti/tests/__init__.py` | **New** — empty |
+| `plugins/nanobot-graphiti/tests/conftest.py` | **New** — shared fixtures (mock Graphiti client, sample session key) |
+| `plugins/nanobot-graphiti/tests/test_backend.py` | **New** — backend contract, consolidate, retrieve, session scoping |
+| `plugins/nanobot-graphiti/tests/test_tools.py` | **New** — tool parameter validation, correct Graphiti method dispatch |
+
+---
+
+## Task 1: Amend `MemoryConfig` + Package Scaffold
+
+**Files:**
+- Modify: `nanobot/config/schema.py` (add `extra="allow"` to `MemoryConfig`)
+- Create: `plugins/nanobot-graphiti/pyproject.toml`
+- Create: `plugins/nanobot-graphiti/nanobot_graphiti/__init__.py`
+- Create: `plugins/nanobot-graphiti/tests/__init__.py`
+
+**Context:** `MemoryConfig` was added in Plan 1. It needs `extra="allow"` so that `memory.graphiti:` in `config.yaml` is accessible as `config.memory.model_extra["graphiti"]` — the same pattern `ChannelsConfig` uses. The package lives in `plugins/nanobot-graphiti/` (not inside the `nanobot/` package tree) to keep it installable independently.
+
+- [ ] **Step 1: Write the failing test for `MemoryConfig` extra fields**
+
+Add to `tests/agent/test_memory_backend.py` (the file created in Plan 1):
+```python
+def test_memory_config_accepts_extra_graphiti_section():
+    from nanobot.config.schema import MemoryConfig
+
+    cfg = MemoryConfig(**{"backend": "graphiti", "graphiti": {"graph_db": "kuzu", "top_k": 10}})
+    assert cfg.model_extra["graphiti"] == {"graph_db": "kuzu", "top_k": 10}
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+pytest tests/agent/test_memory_backend.py::test_memory_config_accepts_extra_graphiti_section -v
+```
+Expected: `FAILED` — extra fields are silently ignored (no `model_extra` key).
+
+- [ ] **Step 3: Add `extra="allow"` to `MemoryConfig` in `nanobot/config/schema.py`**
+
+Find `class MemoryConfig(Base):` (added in Plan 1) and add the config override:
+```python
+class MemoryConfig(Base):
+    """Memory backend configuration."""
+
+    model_config = ConfigDict(extra="allow")
+
+    backend: str = "default"
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+pytest tests/agent/test_memory_backend.py::test_memory_config_accepts_extra_graphiti_section -v
+```
+
+- [ ] **Step 5: Create the plugin package skeleton**
+
+```bash
+mkdir -p plugins/nanobot-graphiti/nanobot_graphiti
+mkdir -p plugins/nanobot-graphiti/tests
+touch plugins/nanobot-graphiti/tests/__init__.py
+touch plugins/nanobot-graphiti/nanobot_graphiti/__init__.py
+```
+
+- [ ] **Step 6: Write `plugins/nanobot-graphiti/pyproject.toml`**
+
+```toml
+[project]
+name = "nanobot-graphiti"
+version = "0.1.0"
+description = "Graphiti temporal memory backend for nanobot"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+dependencies = [
+    "nanobot-ai>=0.1.4",
+    "graphiti-core>=0.3",
+    "kuzu>=0.9",
+]
+
+[project.entry-points."nanobot.memory"]
+graphiti = "nanobot_graphiti:GraphitiMemoryBackend"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nanobot_graphiti"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+```
+
+- [ ] **Step 7: Write minimal `plugins/nanobot-graphiti/nanobot_graphiti/__init__.py`**
+
+```python
+"""nanobot-graphiti — Graphiti temporal memory backend for nanobot."""
+
+from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+__all__ = ["GraphitiMemoryBackend"]
+```
+
+- [ ] **Step 8: Install the plugin in editable mode (from repo root)**
+
+```bash
+pip install -e plugins/nanobot-graphiti/
+```
+
+- [ ] **Step 9: Run full nanobot suite — no regressions**
+
+```bash
+pytest --tb=short -q
+```
+Expected: same count as after Plan 1 (no regressions from the `extra="allow"` change).
+
+- [ ] **Commit**
+
+```
+feat(config): allow extra fields in MemoryConfig for plugin config sections
+```
+
+---
+
+## Task 2: `GraphitiConfig` Pydantic Model
+
+**Files:**
+- Create: `plugins/nanobot-graphiti/nanobot_graphiti/config.py`
+- Create: `plugins/nanobot-graphiti/tests/test_backend.py` (config section only for now)
+
+**Context:** `GraphitiConfig` is a standalone Pydantic `BaseModel` (not subclassing nanobot's `Base` — no camelCase alias needed in a plugin). It reads the plugin's section of nanobot's config. `_from_nanobot_config(config)` is a classmethod factory that reads `config.memory.model_extra.get("graphiti", {})` and validates it into a `GraphitiConfig` instance.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `plugins/nanobot-graphiti/tests/test_backend.py`:
+```python
+"""Tests for GraphitiMemoryBackend and GraphitiConfig."""
+
+import pytest
+
+
+# ── Config ──────────────────────────────────────────────────────────────────
+
+def test_graphiti_config_defaults():
+    from nanobot_graphiti.config import GraphitiConfig
+
+    cfg = GraphitiConfig()
+    assert cfg.graph_db == "kuzu"
+    assert cfg.kuzu_path == "~/.nanobot/workspace/memory/graph"
+    assert cfg.top_k == 5
+    assert cfg.scope == "user"
+    assert cfg.embedding_model == "text-embedding-3-small"
+
+
+def test_graphiti_config_accepts_neo4j():
+    from nanobot_graphiti.config import GraphitiConfig
+
+    cfg = GraphitiConfig(graph_db="neo4j", neo4j_uri="bolt://myhost:7687", neo4j_password="secret")
+    assert cfg.graph_db == "neo4j"
+    assert cfg.neo4j_uri == "bolt://myhost:7687"
+
+
+def test_graphiti_config_from_nanobot_config_kuzu():
+    """_from_nanobot_config() parses memory.model_extra["graphiti"] section."""
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.config import GraphitiConfig
+
+    nanobot_config = MagicMock()
+    nanobot_config.memory.model_extra = {"graphiti": {"graph_db": "kuzu", "top_k": 10}}
+
+    cfg = GraphitiConfig._from_nanobot_config(nanobot_config)
+    assert cfg.graph_db == "kuzu"
+    assert cfg.top_k == 10
+
+
+def test_graphiti_config_from_nanobot_config_missing_section():
+    """_from_nanobot_config() falls back to defaults when section absent."""
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.config import GraphitiConfig
+
+    nanobot_config = MagicMock()
+    nanobot_config.memory.model_extra = {}
+
+    cfg = GraphitiConfig._from_nanobot_config(nanobot_config)
+    assert cfg.graph_db == "kuzu"
+    assert cfg.top_k == 5
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "config" 2>&1 | head -20
+```
+Expected: `FAILED` — `cannot import name 'GraphitiConfig'`
+
+- [ ] **Step 3: Write `plugins/nanobot-graphiti/nanobot_graphiti/config.py`**
+
+```python
+"""GraphitiConfig — configuration for the nanobot-graphiti memory backend."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    pass
+
+
+class GraphitiConfig(BaseModel):
+    """Configuration for the Graphiti memory backend."""
+
+    graph_db: Literal["kuzu", "neo4j", "falkordb"] = "kuzu"
+    kuzu_path: str = "~/.nanobot/workspace/memory/graph"
+    neo4j_uri: str = "bolt://localhost:7687"
+    neo4j_user: str = "neo4j"
+    neo4j_password: str = ""
+    falkordb_host: str = "localhost"
+    falkordb_port: int = 6379
+    top_k: int = 5
+    scope: Literal["user", "session"] = "user"
+    embedding_model: str = "text-embedding-3-small"
+
+    @classmethod
+    def _from_nanobot_config(cls, config: Any) -> "GraphitiConfig":
+        """Extract and validate Graphiti config from nanobot's Config object."""
+        raw: Any = getattr(config.memory, "model_extra", {}).get("graphiti") or {}
+        if hasattr(raw, "model_dump"):
+            raw = raw.model_dump()
+        return cls(**(raw if isinstance(raw, dict) else {}))
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "config"
+```
+Expected: 4 passed.
+
+- [ ] **Commit**
+
+```
+feat(nanobot-graphiti): add GraphitiConfig pydantic model with _from_nanobot_config factory
+```
+
+---
+
+## Task 3: `GraphitiMemoryBackend` — Constructor, `consolidates_per_turn`, `start()`, `stop()`
+
+**Files:**
+- Create: `plugins/nanobot-graphiti/nanobot_graphiti/backend.py`
+- Create: `plugins/nanobot-graphiti/tests/conftest.py`
+- Modify: `plugins/nanobot-graphiti/tests/test_backend.py` (add backend contract tests)
+
+**Context:** `start(provider)` creates the Graphiti client from nanobot's `LLMProvider`. For OpenAI-compatible providers, it reads `provider.api_key`, `provider.api_base`, and `provider.get_default_model()` to construct Graphiti's `OpenAIClient` and `OpenAIEmbedder`. For Anthropic providers (which don't expose an OpenAI-compat base URL), `start()` raises `RuntimeError` with a clear message. `stop()` calls `await graphiti.close()`. The Graphiti client is injectable via `_graphiti_factory` for testing.
+
+- [ ] **Step 1: Write conftest.py with shared fixtures**
+
+Create `plugins/nanobot-graphiti/tests/conftest.py`:
+```python
+"""Shared fixtures for nanobot-graphiti tests."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+@pytest.fixture
+def mock_graphiti():
+    """A fully mocked Graphiti client."""
+    g = MagicMock()
+    g.build_indices_and_constraints = AsyncMock()
+    g.add_episode = AsyncMock()
+    g.search = AsyncMock(return_value=[])
+    g.close = AsyncMock()
+    g.driver = MagicMock()
+    return g
+
+
+@pytest.fixture
+def mock_provider():
+    """A minimal nanobot LLMProvider mock."""
+    p = MagicMock()
+    p.api_key = "test-key"
+    p.api_base = "https://api.openai.com/v1"
+    p.get_default_model.return_value = "gpt-4o-mini"
+    return p
+
+
+@pytest.fixture
+def session_key():
+    return "telegram:123456"
+```
+
+- [ ] **Step 2: Write failing backend contract tests**
+
+Add to `plugins/nanobot-graphiti/tests/test_backend.py`:
+```python
+# ── Backend contract ─────────────────────────────────────────────────────────
+
+def test_graphiti_backend_is_memory_backend():
+    from nanobot.agent.memory import MemoryBackend
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+    assert issubclass(GraphitiMemoryBackend, MemoryBackend)
+
+
+def test_graphiti_backend_consolidates_per_turn_is_true():
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig())
+    assert backend.consolidates_per_turn is True
+
+
+async def test_graphiti_backend_start_calls_build_indices(mock_graphiti, mock_provider):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    mock_graphiti.build_indices_and_constraints.assert_awaited_once()
+
+
+async def test_graphiti_backend_stop_closes_client(mock_graphiti, mock_provider):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+    await backend.stop()
+
+    mock_graphiti.close.assert_awaited_once()
+
+
+async def test_graphiti_backend_stop_is_safe_before_start():
+    """stop() before start() must not raise."""
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig())
+    await backend.stop()  # no exception
+```
+
+- [ ] **Step 3: Run — verify FAILED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "backend" 2>&1 | head -30
+```
+Expected: `FAILED` — `cannot import name 'GraphitiMemoryBackend'`
+
+- [ ] **Step 4: Write `plugins/nanobot-graphiti/nanobot_graphiti/backend.py` (start/stop only)**
+
+```python
+"""GraphitiMemoryBackend — Graphiti temporal memory backend for nanobot."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Callable
+
+from nanobot.agent.memory import MemoryBackend
+from nanobot.agent.tools.base import Tool
+from nanobot_graphiti.config import GraphitiConfig
+
+if TYPE_CHECKING:
+    from nanobot.providers.base import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+def _build_driver(config: GraphitiConfig) -> Any:
+    """Construct the graph DB driver for the configured backend."""
+    from pathlib import Path
+
+    if config.graph_db == "kuzu":
+        from graphiti_core.driver.kuzu_driver import KuzuDriver
+
+        db_path = str(Path(config.kuzu_path).expanduser())
+        Path(db_path).mkdir(parents=True, exist_ok=True)
+        return KuzuDriver(db=db_path)
+
+    if config.graph_db == "neo4j":
+        from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+        return Neo4jDriver(
+            uri=config.neo4j_uri,
+            user=config.neo4j_user,
+            password=config.neo4j_password,
+        )
+
+    if config.graph_db == "falkordb":
+        from graphiti_core.driver.falkordb_driver import FalkorDBDriver
+
+        return FalkorDBDriver(host=config.falkordb_host, port=config.falkordb_port)
+
+    raise ValueError(f"Unknown graph_db: {config.graph_db!r}")
+
+
+def _build_graphiti(config: GraphitiConfig, provider: "LLMProvider") -> Any:
+    """Build a Graphiti client wired to nanobot's LLM provider."""
+    from openai import AsyncOpenAI
+    from graphiti_core import Graphiti
+    from graphiti_core.llm_client.openai_client import OpenAIClient as GraphitiLLMClient
+    from graphiti_core.embedder.openai import OpenAIEmbedder
+
+    if not provider.api_base:
+        raise RuntimeError(
+            "nanobot-graphiti requires an OpenAI-compatible provider (api_base must be set). "
+            "Anthropic's native endpoint is not supported. "
+            "Use an OpenAI-compat model (openrouter, openai, etc.) for Graphiti memory."
+        )
+
+    openai_client = AsyncOpenAI(
+        api_key=provider.api_key or "no-key",
+        base_url=provider.api_base,
+    )
+    llm_client = GraphitiLLMClient(
+        client=openai_client,
+        model=provider.get_default_model(),
+    )
+    embedder = OpenAIEmbedder(
+        client=openai_client,
+        model=config.embedding_model,
+    )
+    driver = _build_driver(config)
+    return Graphiti(graph_driver=driver, llm_client=llm_client, embedder=embedder)
+
+
+class GraphitiMemoryBackend(MemoryBackend):
+    """Graphiti temporal knowledge graph memory backend."""
+
+    consolidates_per_turn = True
+
+    def __init__(
+        self,
+        config: GraphitiConfig,
+        *,
+        _graphiti_factory: Callable[..., Any] | None = None,
+    ) -> None:
+        self._config = config
+        self._graphiti: Any | None = None
+        self._graphiti_factory = _graphiti_factory
+
+    @classmethod
+    def from_nanobot_config(cls, nanobot_config: Any) -> "GraphitiMemoryBackend":
+        """Instantiate from a nanobot Config object (entry-point discovery path)."""
+        return cls(GraphitiConfig._from_nanobot_config(nanobot_config))
+
+    async def start(self, provider: "LLMProvider") -> None:
+        if self._graphiti_factory is not None:
+            self._graphiti = self._graphiti_factory(config=self._config, provider=provider)
+        else:
+            self._graphiti = _build_graphiti(self._config, provider)
+        await self._graphiti.build_indices_and_constraints()
+
+    async def stop(self) -> None:
+        if self._graphiti is not None:
+            await self._graphiti.close()
+            self._graphiti = None
+
+    def _get_group_id(self, session_key: str) -> str:
+        if self._config.scope == "user":
+            _, _, chat_id = session_key.partition(":")
+            return chat_id or session_key
+        return session_key
+
+    async def consolidate(self, messages: list[dict], session_key: str) -> None:
+        raise NotImplementedError  # implemented in Task 4
+
+    async def retrieve(self, query: str, session_key: str, top_k: int = 5) -> str:
+        raise NotImplementedError  # implemented in Task 5
+
+    def get_tools(self) -> list[Tool]:
+        return []  # implemented in Task 7
+```
+
+- [ ] **Step 5: Run — verify PASSED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "backend"
+```
+Expected: 5 passed (`is_memory_backend`, `consolidates_per_turn`, `start_calls_build_indices`, `stop_closes_client`, `stop_is_safe_before_start`).
+
+- [ ] **Commit**
+
+```
+feat(nanobot-graphiti): add GraphitiMemoryBackend skeleton with start/stop lifecycle
+```
+
+---
+
+## Task 4: `consolidate()` — Episode Ingestion
+
+**Files:**
+- Modify: `plugins/nanobot-graphiti/nanobot_graphiti/backend.py`
+- Modify: `plugins/nanobot-graphiti/tests/test_backend.py`
+
+**Context:** `consolidate()` formats `messages` (list of `{"role": ..., "content": ...}` dicts) as a conversational text string and calls `graphiti.add_episode()`. Errors are caught and logged — never raised (the agent loop must never be blocked by a memory error). `group_id` is derived from `session_key` via `_get_group_id()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `plugins/nanobot-graphiti/tests/test_backend.py`:
+```python
+# ── consolidate() ────────────────────────────────────────────────────────────
+
+async def test_consolidate_calls_add_episode(mock_graphiti, mock_provider, session_key):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+    await backend.consolidate(messages, session_key)
+
+    mock_graphiti.add_episode.assert_awaited_once()
+    call_kwargs = mock_graphiti.add_episode.call_args.kwargs
+    assert call_kwargs["group_id"] == "123456"   # scope="user" strips "telegram:"
+    assert "Hello" in call_kwargs["episode_body"]
+    assert "Hi there!" in call_kwargs["episode_body"]
+
+
+async def test_consolidate_uses_session_scope(mock_graphiti, mock_provider):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(
+        GraphitiConfig(scope="session"),
+        _graphiti_factory=lambda **kw: mock_graphiti,
+    )
+    await backend.start(mock_provider)
+    await backend.consolidate([{"role": "user", "content": "hi"}], "telegram:123456")
+
+    call_kwargs = mock_graphiti.add_episode.call_args.kwargs
+    assert call_kwargs["group_id"] == "telegram:123456"
+
+
+async def test_consolidate_swallows_errors(mock_graphiti, mock_provider, session_key):
+    """consolidate() must not raise even if graphiti.add_episode() fails."""
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    mock_graphiti.add_episode.side_effect = RuntimeError("graph unavailable")
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+    await backend.consolidate([{"role": "user", "content": "hi"}], session_key)
+    # No exception raised — test passes if we reach here
+
+
+async def test_consolidate_skips_empty_messages(mock_graphiti, mock_provider, session_key):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+    await backend.consolidate([], session_key)
+
+    mock_graphiti.add_episode.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "consolidate"
+```
+Expected: `FAILED` — `NotImplementedError` from the stub.
+
+- [ ] **Step 3: Implement `consolidate()` in `backend.py`**
+
+Replace the `consolidate` stub in `GraphitiMemoryBackend`:
+```python
+async def consolidate(self, messages: list[dict], session_key: str) -> None:
+    if not messages or self._graphiti is None:
+        return
+    try:
+        from graphiti_core.nodes import EpisodeType
+
+        lines = []
+        for msg in messages:
+            role = msg.get("role", "unknown").capitalize()
+            content = msg.get("content") or ""
+            if isinstance(content, list):
+                # Handle multi-part content blocks (e.g. tool results)
+                content = " ".join(
+                    part.get("text", "") if isinstance(part, dict) else str(part)
+                    for part in content
+                )
+            if content:
+                lines.append(f"{role}: {content}")
+
+        episode_body = "\n".join(lines)
+        if not episode_body.strip():
+            return
+
+        group_id = self._get_group_id(session_key)
+        await self._graphiti.add_episode(
+            name=session_key,
+            episode_body=episode_body,
+            source_description="nanobot conversation",
+            reference_time=datetime.now(timezone.utc),
+            source=EpisodeType.message,
+            group_id=group_id,
+        )
+    except Exception:
+        logger.exception("GraphitiMemoryBackend.consolidate() failed — memory not updated")
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "consolidate"
+```
+Expected: 4 passed.
+
+- [ ] **Commit**
+
+```
+feat(nanobot-graphiti): implement consolidate() — episode ingestion with error swallowing
+```
+
+---
+
+## Task 5: `retrieve()` — Search and Format
+
+**Files:**
+- Modify: `plugins/nanobot-graphiti/nanobot_graphiti/backend.py`
+- Modify: `plugins/nanobot-graphiti/tests/test_backend.py`
+
+**Context:** `retrieve()` calls `graphiti.search()` with `group_ids=[group_id]` and `num_results=top_k`. Results are `list[EntityEdge]` — each has `.fact` (text) and a `created_at` or `updated_at` datetime. The output is formatted as a `[Memory — N relevant facts]` block. When search returns no results, returns `""` (no block injected).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `plugins/nanobot-graphiti/tests/test_backend.py`:
+```python
+# ── retrieve() ───────────────────────────────────────────────────────────────
+
+async def test_retrieve_calls_search_with_group_id(mock_graphiti, mock_provider, session_key):
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    edge = MagicMock()
+    edge.fact = "User likes coffee"
+    edge.uuid = "abc-123"
+    mock_graphiti.search.return_value = [edge]
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    result = await backend.retrieve("coffee", session_key, top_k=3)
+
+    mock_graphiti.search.assert_awaited_once_with("coffee", group_ids=["123456"], num_results=3)
+    assert "User likes coffee" in result
+    assert "[Memory" in result
+
+
+async def test_retrieve_returns_empty_string_when_no_results(mock_graphiti, mock_provider, session_key):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    mock_graphiti.search.return_value = []
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    result = await backend.retrieve("anything", session_key)
+    assert result == ""
+
+
+async def test_retrieve_uses_config_top_k_as_default(mock_graphiti, mock_provider, session_key):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(
+        GraphitiConfig(top_k=7),
+        _graphiti_factory=lambda **kw: mock_graphiti,
+    )
+    await backend.start(mock_provider)
+    await backend.retrieve("query", session_key)
+
+    call_kwargs = mock_graphiti.search.call_args.kwargs
+    assert call_kwargs["num_results"] == 5  # retrieve() top_k param default, not config
+
+
+async def test_retrieve_formats_multiple_facts(mock_graphiti, mock_provider, session_key):
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    edges = []
+    for i, fact in enumerate(["Likes coffee", "Works in Berlin", "Has a cat"]):
+        edge = MagicMock()
+        edge.fact = fact
+        edge.uuid = f"uuid-{i}"
+        edges.append(edge)
+    mock_graphiti.search.return_value = edges
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    result = await backend.retrieve("tell me about user", session_key)
+    assert "Likes coffee" in result
+    assert "Works in Berlin" in result
+    assert "Has a cat" in result
+    assert "[Memory — 3 relevant facts]" in result
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "retrieve"
+```
+Expected: `FAILED` — `NotImplementedError` from the stub.
+
+- [ ] **Step 3: Implement `retrieve()` in `backend.py`**
+
+Replace the `retrieve` stub in `GraphitiMemoryBackend`:
+```python
+async def retrieve(self, query: str, session_key: str, top_k: int = 5) -> str:
+    if self._graphiti is None:
+        return ""
+    try:
+        group_id = self._get_group_id(session_key)
+        results = await self._graphiti.search(query, group_ids=[group_id], num_results=top_k)
+        if not results:
+            return ""
+        lines = [f"[Memory — {len(results)} relevant facts]"]
+        for edge in results:
+            lines.append(f"• {edge.fact}")
+        return "\n".join(lines)
+    except Exception:
+        logger.exception("GraphitiMemoryBackend.retrieve() failed — no memory injected")
+        return ""
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "retrieve"
+```
+Expected: 4 passed.
+
+**Note on `test_retrieve_uses_config_top_k_as_default`:** The test asserts `num_results=5` (the `retrieve()` param default), not `top_k=7` from config. This is correct — `retrieve(query, session_key)` is called by `AgentLoop` with no explicit `top_k`, so it uses the parameter default of 5. The `config.top_k` is used by tools (e.g. `MemorySearchTool`), not here.
+
+- [ ] **Commit**
+
+```
+feat(nanobot-graphiti): implement retrieve() — semantic search with [Memory] block formatting
+```
+
+---
+
+## Task 6: Three Memory Tools
+
+**Files:**
+- Create: `plugins/nanobot-graphiti/nanobot_graphiti/tools.py`
+- Create: `plugins/nanobot-graphiti/tests/test_tools.py`
+
+**Context:** All three tools hold a reference to the `GraphitiMemoryBackend` instance (passed at construction time). This gives them access to `backend._graphiti` and `backend._get_group_id()`. Each subclasses nanobot's `Tool` ABC.
+
+- `MemorySearchTool` — calls `backend._graphiti.search(query, group_ids=[group_id], num_results=top_k)` and returns formatted text.
+- `MemoryForgetTool` — calls `EntityEdge.delete_by_uuids(backend._graphiti.driver, [fact_id])`.
+- `MemoryListTool` — calls `backend._graphiti.search("", group_ids=[group_id], num_results=limit)` (empty query returns all facts).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `plugins/nanobot-graphiti/tests/test_tools.py`:
+```python
+"""Tests for memory tools."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def backend_with_mock_graphiti(mock_graphiti, mock_provider):
+    """A started GraphitiMemoryBackend with an injected mock graphiti client."""
+    import asyncio
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    asyncio.get_event_loop().run_until_complete(backend.start(mock_provider))
+    return backend, mock_graphiti
+
+
+def _make_edge(fact: str, uuid: str = "test-uuid") -> MagicMock:
+    edge = MagicMock()
+    edge.fact = fact
+    edge.uuid = uuid
+    return edge
+
+
+# ── MemorySearchTool ─────────────────────────────────────────────────────────
+
+async def test_memory_search_tool_name():
+    from nanobot_graphiti.tools import MemorySearchTool
+
+    tool = MemorySearchTool(backend=MagicMock())
+    assert tool.name == "memory_search"
+
+
+async def test_memory_search_calls_graphiti_search(mock_graphiti):
+    from nanobot_graphiti.tools import MemorySearchTool
+
+    mock_graphiti.search.return_value = [_make_edge("User prefers dark mode")]
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
+
+    tool = MemorySearchTool(backend=backend)
+    result = await tool.execute(query="UI preferences", top_k=5, session_key="telegram:123456")
+
+    mock_graphiti.search.assert_awaited_once_with("UI preferences", group_ids=["123456"], num_results=5)
+    assert "User prefers dark mode" in result
+
+
+async def test_memory_search_returns_no_results_message(mock_graphiti):
+    from nanobot_graphiti.tools import MemorySearchTool
+
+    mock_graphiti.search.return_value = []
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
+
+    tool = MemorySearchTool(backend=backend)
+    result = await tool.execute(query="nonexistent", top_k=5, session_key="telegram:123456")
+
+    assert "no" in result.lower() or "0" in result
+
+
+# ── MemoryForgetTool ─────────────────────────────────────────────────────────
+
+async def test_memory_forget_tool_name():
+    from nanobot_graphiti.tools import MemoryForgetTool
+
+    tool = MemoryForgetTool(backend=MagicMock())
+    assert tool.name == "memory_forget"
+
+
+async def test_memory_forget_calls_delete_by_uuids(mock_graphiti):
+    from nanobot_graphiti.tools import MemoryForgetTool
+    from graphiti_core.nodes import EntityEdge
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+
+    with patch.object(EntityEdge, "delete_by_uuids", new_callable=AsyncMock) as mock_delete:
+        tool = MemoryForgetTool(backend=backend)
+        result = await tool.execute(fact_id="abc-123", reason="incorrect info", session_key="telegram:123456")
+
+    mock_delete.assert_awaited_once_with(mock_graphiti.driver, ["abc-123"])
+    assert "abc-123" in result or "deleted" in result.lower() or "forgotten" in result.lower()
+
+
+# ── MemoryListTool ───────────────────────────────────────────────────────────
+
+async def test_memory_list_tool_name():
+    from nanobot_graphiti.tools import MemoryListTool
+
+    tool = MemoryListTool(backend=MagicMock())
+    assert tool.name == "memory_list"
+
+
+async def test_memory_list_calls_search_with_empty_query(mock_graphiti):
+    from nanobot_graphiti.tools import MemoryListTool
+
+    edges = [_make_edge("Fact 1", "u1"), _make_edge("Fact 2", "u2")]
+    mock_graphiti.search.return_value = edges
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
+
+    tool = MemoryListTool(backend=backend)
+    result = await tool.execute(limit=20, session_key="telegram:123456")
+
+    mock_graphiti.search.assert_awaited_once_with("", group_ids=["123456"], num_results=20)
+    assert "Fact 1" in result
+    assert "Fact 2" in result
+
+
+async def test_memory_list_shows_uuids_for_reference(mock_graphiti):
+    """memory_list output includes fact_id so user can reference it in memory_forget."""
+    from nanobot_graphiti.tools import MemoryListTool
+
+    mock_graphiti.search.return_value = [_make_edge("I have a dog", "edge-uuid-xyz")]
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
+
+    tool = MemoryListTool(backend=backend)
+    result = await tool.execute(limit=50, session_key="telegram:123456")
+
+    assert "edge-uuid-xyz" in result
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_tools.py -v 2>&1 | head -30
+```
+Expected: `FAILED` — `cannot import name 'MemorySearchTool'`
+
+- [ ] **Step 3: Write `plugins/nanobot-graphiti/nanobot_graphiti/tools.py`**
+
+```python
+"""Memory tools for the Graphiti memory backend."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from nanobot.agent.tools.base import Tool
+
+if TYPE_CHECKING:
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+
+class MemorySearchTool(Tool):
+    """Semantic search over the Graphiti memory graph."""
+
+    def __init__(self, backend: "GraphitiMemoryBackend") -> None:
+        self._backend = backend
+
+    @property
+    def name(self) -> str:
+        return "memory_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search your memory for facts about the current user. "
+            "Use when asked about past conversations, preferences, or history."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Natural language search query"},
+                "top_k": {"type": "integer", "description": "Max results to return", "default": 10},
+                "session_key": {"type": "string", "description": "Current session key (e.g. telegram:123456)"},
+            },
+            "required": ["query", "session_key"],
+        }
+
+    async def execute(self, query: str, session_key: str, top_k: int = 10, **_: Any) -> str:
+        graphiti = self._backend._graphiti
+        if graphiti is None:
+            return "Memory backend not started."
+        group_id = self._backend._get_group_id(session_key)
+        results = await graphiti.search(query, group_ids=[group_id], num_results=top_k)
+        if not results:
+            return f"No memories found for query: {query!r}"
+        lines = [f"Found {len(results)} fact(s):"]
+        for edge in results:
+            lines.append(f"• [{edge.uuid}] {edge.fact}")
+        return "\n".join(lines)
+
+
+class MemoryForgetTool(Tool):
+    """Delete a specific fact from the memory graph by its ID."""
+
+    def __init__(self, backend: "GraphitiMemoryBackend") -> None:
+        self._backend = backend
+
+    @property
+    def name(self) -> str:
+        return "memory_forget"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Delete a specific memory fact by its ID. "
+            "Use when a user says 'you have that wrong' or asks you to forget something. "
+            "Get the fact_id from memory_search or memory_list first."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "fact_id": {"type": "string", "description": "The UUID of the fact to delete"},
+                "reason": {"type": "string", "description": "Why this fact is being removed"},
+                "session_key": {"type": "string", "description": "Current session key"},
+            },
+            "required": ["fact_id", "reason", "session_key"],
+        }
+
+    async def execute(self, fact_id: str, reason: str, session_key: str, **_: Any) -> str:
+        from graphiti_core.nodes import EntityEdge
+
+        graphiti = self._backend._graphiti
+        if graphiti is None:
+            return "Memory backend not started."
+        await EntityEdge.delete_by_uuids(graphiti.driver, [fact_id])
+        return f"Fact {fact_id!r} deleted. Reason: {reason}"
+
+
+class MemoryListTool(Tool):
+    """List all stored memory facts for the current user."""
+
+    def __init__(self, backend: "GraphitiMemoryBackend") -> None:
+        self._backend = backend
+
+    @property
+    def name(self) -> str:
+        return "memory_list"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List all stored memory facts for the current user. "
+            "Use when asked 'what do you know about me?' or to audit stored memories."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Max facts to return", "default": 50},
+                "session_key": {"type": "string", "description": "Current session key"},
+            },
+            "required": ["session_key"],
+        }
+
+    async def execute(self, session_key: str, limit: int = 50, **_: Any) -> str:
+        graphiti = self._backend._graphiti
+        if graphiti is None:
+            return "Memory backend not started."
+        group_id = self._backend._get_group_id(session_key)
+        results = await graphiti.search("", group_ids=[group_id], num_results=limit)
+        if not results:
+            return "No memories stored for this user."
+        lines = [f"Stored memories ({len(results)} fact(s)):"]
+        for edge in results:
+            lines.append(f"• [{edge.uuid}] {edge.fact}")
+        return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_tools.py -v
+```
+Expected: 9 passed.
+
+- [ ] **Commit**
+
+```
+feat(nanobot-graphiti): add MemorySearchTool, MemoryForgetTool, MemoryListTool
+```
+
+---
+
+## Task 7: `get_tools()` Wiring + Session Scoping Tests
+
+**Files:**
+- Modify: `plugins/nanobot-graphiti/nanobot_graphiti/backend.py`
+- Modify: `plugins/nanobot-graphiti/tests/test_backend.py`
+
+**Context:** `get_tools()` returns instances of all three tools bound to `self`. The session scoping logic (`_get_group_id`) is already tested indirectly in Task 4/5, but this task adds explicit tests for the two scope modes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `plugins/nanobot-graphiti/tests/test_backend.py`:
+```python
+# ── get_tools() ───────────────────────────────────────────────────────────────
+
+def test_get_tools_returns_three_tools(mock_graphiti, mock_provider):
+    import asyncio
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    asyncio.get_event_loop().run_until_complete(backend.start(mock_provider))
+
+    tools = backend.get_tools()
+    tool_names = {t.name for t in tools}
+
+    assert len(tools) == 3
+    assert tool_names == {"memory_search", "memory_forget", "memory_list"}
+
+
+def test_get_tools_returns_tool_instances_bound_to_backend(mock_graphiti, mock_provider):
+    import asyncio
+    from nanobot.agent.tools.base import Tool
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    asyncio.get_event_loop().run_until_complete(backend.start(mock_provider))
+
+    for tool in backend.get_tools():
+        assert isinstance(tool, Tool)
+        assert tool._backend is backend
+
+
+# ── Session scoping ───────────────────────────────────────────────────────────
+
+def test_group_id_user_scope_strips_channel_prefix():
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(scope="user"))
+    assert backend._get_group_id("telegram:123456") == "123456"
+    assert backend._get_group_id("discord:789") == "789"
+
+
+def test_group_id_session_scope_preserves_full_key():
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(scope="session"))
+    assert backend._get_group_id("telegram:123456") == "telegram:123456"
+    assert backend._get_group_id("discord:789") == "discord:789"
+
+
+def test_group_id_user_scope_handles_key_without_colon():
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(scope="user"))
+    # Falls back to full key if no colon present
+    assert backend._get_group_id("directuser") == "directuser"
+```
+
+- [ ] **Step 2: Run — verify FAILED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "get_tools or group_id or session_scoping or scope"
+```
+Expected: `FAILED` — `get_tools()` returns `[]` (stub from Task 3).
+
+- [ ] **Step 3: Implement `get_tools()` in `backend.py`**
+
+Replace the `get_tools` stub in `GraphitiMemoryBackend`:
+```python
+def get_tools(self) -> list[Tool]:
+    from nanobot_graphiti.tools import MemoryForgetTool, MemoryListTool, MemorySearchTool
+
+    return [
+        MemorySearchTool(backend=self),
+        MemoryForgetTool(backend=self),
+        MemoryListTool(backend=self),
+    ]
+```
+
+- [ ] **Step 4: Run — verify PASSED**
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "get_tools or group_id or scope"
+```
+Expected: 5 passed.
+
+- [ ] **Step 5: Run full plugin test suite**
+
+```bash
+cd plugins/nanobot-graphiti && pytest -v
+```
+Expected: all tests pass (backend + tools).
+
+- [ ] **Step 6: Run nanobot core suite from repo root**
+
+```bash
+cd /path/to/repo && pytest --tb=short -q
+```
+Expected: no regressions.
+
+- [ ] **Commit**
+
+```
+feat(nanobot-graphiti): wire get_tools() — all three memory tools registered from backend
+```
+
+---
+
+## Task 8: `from_nanobot_config()` Entry-Point Wiring
+
+**Files:**
+- Modify: `plugins/nanobot-graphiti/nanobot_graphiti/backend.py` (verify `from_nanobot_config` classmethod)
+- Modify: `plugins/nanobot-graphiti/tests/test_backend.py`
+
+**Context:** The `nanobot.memory` entry-point discovery in Plan 1 calls `backend_class(config)` where `config` is the nanobot `Config` object. `GraphitiMemoryBackend.__init__` takes a `GraphitiConfig`, not a nanobot `Config`. The `from_nanobot_config` classmethod handles this. Plan 1's `load_memory_backend` needs to call `cls.from_nanobot_config(config)` if the method exists — or we change `load_memory_backend` to always call `cls(config)` and override `__init__` to handle both types. The cleaner path: add `from_nanobot_config` as the entry-point target by registering it differently, OR adjust Plan 1's `load_memory_backend` to detect the factory method.
+
+The spec says the entry-point value is `"nanobot_graphiti:GraphitiMemoryBackend"` — a class, not a factory method. Plan 1's `load_memory_backend` should call `cls.from_nanobot_config(config)` when the classmethod exists, falling back to `cls(config)` for simpler backends. Test this interaction here.
+
+- [ ] **Step 1: Write the integration test**
+
+Add to `plugins/nanobot-graphiti/tests/test_backend.py`:
+```python
+# ── Entry-point factory ───────────────────────────────────────────────────────
+
+def test_from_nanobot_config_creates_backend_with_correct_config():
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+    nanobot_config = MagicMock()
+    nanobot_config.memory.model_extra = {
+        "graphiti": {"graph_db": "kuzu", "top_k": 8, "scope": "session"}
+    }
+
+    backend = GraphitiMemoryBackend.from_nanobot_config(nanobot_config)
+
+    assert isinstance(backend, GraphitiMemoryBackend)
+    assert backend._config.graph_db == "kuzu"
+    assert backend._config.top_k == 8
+    assert backend._config.scope == "session"
+
+
+def test_from_nanobot_config_falls_back_to_defaults_on_empty_config():
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+    nanobot_config = MagicMock()
+    nanobot_config.memory.model_extra = {}
+
+    backend = GraphitiMemoryBackend.from_nanobot_config(nanobot_config)
+    assert backend._config.graph_db == "kuzu"
+    assert backend._config.top_k == 5
+```
+
+- [ ] **Step 2: Run — verify PASSED** (classmethod was written in Task 3)
+
+```bash
+cd plugins/nanobot-graphiti && pytest tests/test_backend.py -v -k "from_nanobot_config"
+```
+Expected: 2 passed (classmethod was implemented in Task 3 — these tests just confirm the full config parsing round-trip works).
+
+- [ ] **Step 3: Verify Plan 1's `load_memory_backend` calls `from_nanobot_config`**
+
+In `nanobot/cli/commands.py`, the `load_memory_backend(config)` function (added in Plan 1) should check for `from_nanobot_config`. If Plan 1's implementation calls `cls(config)` instead, update `load_memory_backend`:
+
+```python
+def load_memory_backend(config: Config) -> MemoryBackend:
+    """Discover and instantiate the configured memory backend."""
+    from importlib.metadata import entry_points
+    from nanobot.agent.memory import MemoryStore
+
+    backend_name = config.memory.backend
+    if backend_name == "default":
+        return MemoryStore(Path(config.agents.defaults.workspace).expanduser())
+
+    for ep in entry_points(group="nanobot.memory"):
+        if ep.name == backend_name:
+            cls = ep.load()
+            if hasattr(cls, "from_nanobot_config"):
+                return cls.from_nanobot_config(config)
+            return cls(config)
+
+    logger.warning(f"Memory backend {backend_name!r} not found; falling back to MemoryStore")
+    return MemoryStore(Path(config.agents.defaults.workspace).expanduser())
+```
+
+- [ ] **Step 4: Run the nanobot core backend-discovery test from Plan 1**
+
+```bash
+pytest tests/agent/test_loop_memory_backend.py -v
+```
+Expected: all existing tests pass.
+
+- [ ] **Step 5: Run full suite (root + plugin)**
+
+```bash
+pytest --tb=short -q && cd plugins/nanobot-graphiti && pytest -v
+```
+Expected: all tests pass.
+
+- [ ] **Commit**
+
+```
+feat(nanobot-graphiti): verify from_nanobot_config entry-point factory + load_memory_backend wiring
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Covered |
+|---|---|
+| `MemoryBackend` registered under `nanobot.memory` entry-point | Task 1 (pyproject.toml) |
+| `consolidates_per_turn = True` | Task 3 |
+| `start(provider)` builds Graphiti client from nanobot provider | Task 3 |
+| `consolidate()` calls `add_episode()` with correct `group_id` | Task 4 |
+| `consolidate()` errors swallowed + logged | Task 4 |
+| `retrieve()` calls `search()` and formats `[Memory — N facts]` block | Task 5 |
+| `retrieve()` returns `""` when no results | Task 5 |
+| `scope: "user"` strips channel prefix | Task 7 |
+| `scope: "session"` preserves full session key | Task 7 |
+| `get_tools()` returns exactly `memory_search`, `memory_forget`, `memory_list` | Task 7 |
+| `memory_search` calls `graphiti.search()` with session-scoped `group_id` | Task 6 |
+| `memory_forget` calls `EntityEdge.delete_by_uuids()` | Task 6 |
+| `memory_list` lists all facts with UUIDs | Task 6 |
+| `GraphitiConfig` defaults: `graph_db="kuzu"`, `top_k=5`, `scope="user"` | Task 2 |
+| Kuzu, Neo4j, FalkorDB driver dispatch | Task 3 (`_build_driver`) |
+
+**All spec requirements covered.**

--- a/docs/superpowers/plans/2026-03-29-pr3-qmd-sidecar.md
+++ b/docs/superpowers/plans/2026-03-29-pr3-qmd-sidecar.md
@@ -1,0 +1,598 @@
+# PR 3: QMD Sidecar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional QMD (query-time model decomposition) backend to the memory index. When `backend = "qmd"` is configured and the `qmd` binary is available, `IndexService.search()` retrieves a larger candidate pool via the existing SQLite pipeline, then passes the candidates to the QMD CLI for LLM re-ranking. Absent binary → silent fallback to the existing SQLite search.
+
+**Architecture:** `QMDSearcher` (new `nanobot/memory_index/qmd.py`) is a thin async subprocess wrapper. `IndexService.__init__` constructs one when `cfg.backend == "qmd"`. `IndexService.search()` becomes backend-aware: if QMD is available, retrieve `min(top_k * 3, 30)` candidates then call `QMDSearcher.rerank()`; otherwise delegate directly to `MemoryIndex.search()` as before. `context.py` and `loop.py` are **not** touched — `IndexService.search()` is the only public entry point.
+
+**Tech Stack:** Python 3.11+, asyncio subprocess (`asyncio.create_subprocess_exec`), `shutil.which` for binary detection. No new dependencies.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `nanobot/config/schema.py` | Add `backend: Literal["sqlite", "qmd"] = "sqlite"` and `qmd_binary: str = "qmd"` to `MemoryIndexConfig` |
+| `nanobot/memory_index/qmd.py` | **New** — `QMDSearcher`: `is_available()`, `async rerank()`, subprocess JSON protocol |
+| `nanobot/memory_index/service.py` | Construct `QMDSearcher` in `__init__` when backend="qmd"; make `search()` backend-aware |
+| `tests/test_memory_index/test_qmd_config.py` | **New** — config field defaults and overrides |
+| `tests/test_memory_index/test_qmd.py` | **New** — `QMDSearcher` unit tests (mocked subprocess) |
+| `tests/test_memory_index/test_service_qmd.py` | **New** — `IndexService` backend routing integration tests |
+
+---
+
+## QMD Subprocess Protocol
+
+**stdin** (UTF-8 JSON, single line):
+```json
+{
+  "query": "user query text",
+  "candidates": [
+    {"id": 0, "text": "...", "source": "MEMORY.md", "start_line": 10, "end_line": 20, "score": 0.85},
+    {"id": 1, "text": "...", "source": "HISTORY.md", "start_line": 5, "end_line": 15, "score": 0.72}
+  ]
+}
+```
+
+**stdout** (UTF-8 JSON):
+```json
+{"ranked": [1, 0]}
+```
+`ranked` is a list of candidate `id` values in best-first order. IDs not present in candidates are ignored. Subprocess timeout: 10 seconds.
+
+---
+
+## Task 1: Config Additions
+
+**Files:**
+- Modify: `nanobot/config/schema.py` (around line 166)
+- Create: `tests/test_memory_index/test_qmd_config.py`
+
+**Context:** `MemoryIndexConfig` currently has `enabled`, `embedding`, `query`, `inject_top_k`, `watch_files`. Add two more fields with `Literal` type annotation from `typing`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_memory_index/test_qmd_config.py`:
+```python
+def test_memory_index_config_defaults_backend_sqlite():
+    from nanobot.config.schema import MemoryIndexConfig
+
+    cfg = MemoryIndexConfig()
+    assert cfg.backend == "sqlite"
+    assert cfg.qmd_binary == "qmd"
+
+
+def test_memory_index_config_backend_can_be_qmd():
+    from nanobot.config.schema import MemoryIndexConfig
+
+    cfg = MemoryIndexConfig(backend="qmd")
+    assert cfg.backend == "qmd"
+
+
+def test_memory_index_config_qmd_binary_can_be_custom_path():
+    from nanobot.config.schema import MemoryIndexConfig
+
+    cfg = MemoryIndexConfig(backend="qmd", qmd_binary="/usr/local/bin/qmd")
+    assert cfg.qmd_binary == "/usr/local/bin/qmd"
+```
+
+- [ ] **Step 2: Run tests — verify FAILED**
+
+```bash
+pytest tests/test_memory_index/test_qmd_config.py -v
+```
+
+Expected: `FAILED` — `MemoryIndexConfig` has no attribute `backend`.
+
+- [ ] **Step 3: Add fields to `MemoryIndexConfig`**
+
+```python
+from typing import Literal  # already imported elsewhere; add if not present
+
+class MemoryIndexConfig(Base):
+    """Semantic memory index configuration. Off by default."""
+
+    enabled: bool = False
+    embedding: MemoryIndexEmbeddingConfig = Field(default_factory=MemoryIndexEmbeddingConfig)
+    query: MemoryIndexQueryConfig = Field(default_factory=MemoryIndexQueryConfig)
+    inject_top_k: int = 3        # chunks auto-injected per turn; 0 = disabled
+    watch_files: bool = True     # enable watchdog file watcher
+    backend: Literal["sqlite", "qmd"] = "sqlite"  # search backend
+    qmd_binary: str = "qmd"      # path or name resolved via shutil.which
+```
+
+- [ ] **Step 4: Run tests — verify PASSED**
+
+```bash
+pytest tests/test_memory_index/test_qmd_config.py -v
+```
+
+- [ ] **Step 5: Run full suite — verify no regressions**
+
+```bash
+pytest --tb=short -q
+```
+
+Expected: 652 passed (649 + 3 new), 1 skipped.
+
+- [ ] **Commit**
+
+```
+feat(memory_index): add backend + qmd_binary fields to MemoryIndexConfig
+```
+
+---
+
+## Task 2: `nanobot/memory_index/qmd.py` — QMDSearcher
+
+**Files:**
+- Create: `nanobot/memory_index/qmd.py`
+- Create: `tests/test_memory_index/test_qmd.py`
+
+**Context:** `SearchResult` is a dataclass in `nanobot/memory_index/search.py` with fields: `text: str`, `source: str`, `start_line: int`, `end_line: int`, `score: float`. The module must not import anything from `nanobot` at module level (keep it inside functions or `TYPE_CHECKING` guard) — follow the same pattern as `service.py` which guards `from nanobot.config.schema import MemoryIndexConfig` under `TYPE_CHECKING`.
+
+```python
+# nanobot/memory_index/qmd.py
+"""QMDSearcher — async subprocess wrapper for the QMD re-ranking CLI."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from nanobot.memory_index.search import SearchResult
+
+
+class QMDSearcher:
+    """Thin async wrapper around an external QMD binary for LLM-based re-ranking.
+
+    Protocol: send JSON to stdin, read ranked IDs from stdout. Falls back
+    silently to the original candidate order on any error or if the binary
+    is not installed.
+    """
+
+    _TIMEOUT = 10.0  # seconds
+
+    def __init__(self, binary: str) -> None:
+        self._binary = binary
+
+    def is_available(self) -> bool:
+        """Return True if the QMD binary can be found on PATH (or is an absolute path)."""
+        import shutil
+        return shutil.which(self._binary) is not None
+
+    async def rerank(
+        self,
+        query: str,
+        candidates: list[SearchResult],
+        top_k: int,
+    ) -> list[SearchResult]:
+        """Re-rank candidates via the QMD subprocess; fallback on any failure.
+
+        If the binary is unavailable or the subprocess fails, returns
+        candidates[:top_k] unchanged.
+        """
+        if not candidates:
+            return []
+        if not self.is_available():
+            logger.debug("QMD binary '{}' not found, skipping re-rank", self._binary)
+            return candidates[:top_k]
+
+        payload = {
+            "query": query,
+            "candidates": [
+                {
+                    "id": i,
+                    "text": r.text,
+                    "source": r.source,
+                    "start_line": r.start_line,
+                    "end_line": r.end_line,
+                    "score": r.score,
+                }
+                for i, r in enumerate(candidates)
+            ],
+        }
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self._binary,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(
+                proc.communicate(json.dumps(payload).encode()),
+                timeout=self._TIMEOUT,
+            )
+            data = json.loads(stdout)
+            ranked_ids: list[int] = data["ranked"]
+        except Exception:
+            logger.warning("QMD reranking failed, falling back to original order")
+            return candidates[:top_k]
+
+        id_to_result = dict(enumerate(candidates))
+        reranked = [id_to_result[rid] for rid in ranked_ids if rid in id_to_result]
+        # Append any candidates not mentioned by QMD (safety net)
+        mentioned = set(ranked_ids)
+        for i, r in enumerate(candidates):
+            if i not in mentioned:
+                reranked.append(r)
+        return reranked[:top_k]
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_memory_index/test_qmd.py`:
+```python
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.memory_index.search import SearchResult
+
+
+def _make_result(text="chunk text", source="MEMORY.md", start=1, end=5, score=0.9):
+    return SearchResult(text=text, source=source, start_line=start, end_line=end, score=score)
+
+
+# --- is_available ---
+
+def test_is_available_returns_false_when_binary_absent():
+    from nanobot.memory_index.qmd import QMDSearcher
+
+    with patch("shutil.which", return_value=None):
+        searcher = QMDSearcher("qmd")
+        assert searcher.is_available() is False
+
+
+def test_is_available_returns_true_when_binary_present():
+    from nanobot.memory_index.qmd import QMDSearcher
+
+    with patch("shutil.which", return_value="/usr/local/bin/qmd"):
+        searcher = QMDSearcher("qmd")
+        assert searcher.is_available() is True
+
+
+# --- rerank: fallback paths ---
+
+async def test_rerank_returns_empty_list_for_empty_candidates():
+    from nanobot.memory_index.qmd import QMDSearcher
+
+    searcher = QMDSearcher("qmd")
+    result = await searcher.rerank("query", [], top_k=3)
+    assert result == []
+
+
+async def test_rerank_returns_candidates_sliced_when_binary_absent():
+    from nanobot.memory_index.qmd import QMDSearcher
+
+    candidates = [_make_result(text=f"chunk {i}") for i in range(5)]
+    with patch("shutil.which", return_value=None):
+        searcher = QMDSearcher("qmd")
+        result = await searcher.rerank("query", candidates, top_k=2)
+    assert result == candidates[:2]
+
+
+# --- rerank: happy path ---
+
+async def test_rerank_happy_path_respects_qmd_order():
+    from nanobot.memory_index.qmd import QMDSearcher
+
+    c0 = _make_result(text="chunk 0", score=0.9)
+    c1 = _make_result(text="chunk 1", score=0.8)
+    c2 = _make_result(text="chunk 2", score=0.7)
+    candidates = [c0, c1, c2]
+
+    # QMD says: best is c2, then c0 (c1 omitted → appended at end)
+    qmd_output = json.dumps({"ranked": [2, 0]}).encode()
+
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(return_value=(qmd_output, b""))
+
+    with patch("shutil.which", return_value="/usr/local/bin/qmd"), \
+         patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        searcher = QMDSearcher("qmd")
+        result = await searcher.rerank("query", candidates, top_k=3)
+
+    assert result[0] is c2
+    assert result[1] is c0
+    assert result[2] is c1  # appended as unmentioned candidate
+
+
+async def test_rerank_top_k_limits_output():
+    from nanobot.memory_index.qmd import QMDSearcher
+
+    candidates = [_make_result(text=f"chunk {i}") for i in range(5)]
+    qmd_output = json.dumps({"ranked": [4, 3, 2, 1, 0]}).encode()
+
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(return_value=(qmd_output, b""))
+
+    with patch("shutil.which", return_value="/usr/local/bin/qmd"), \
+         patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        searcher = QMDSearcher("qmd")
+        result = await searcher.rerank("query", candidates, top_k=2)
+
+    assert len(result) == 2
+    assert result[0] is candidates[4]
+    assert result[1] is candidates[3]
+
+
+# --- rerank: error handling ---
+
+async def test_rerank_falls_back_on_subprocess_exception():
+    from nanobot.memory_index.qmd import QMDSearcher
+
+    candidates = [_make_result(text=f"chunk {i}") for i in range(3)]
+
+    with patch("shutil.which", return_value="/usr/local/bin/qmd"), \
+         patch("asyncio.create_subprocess_exec", side_effect=OSError("no such file")):
+        searcher = QMDSearcher("qmd")
+        result = await searcher.rerank("query", candidates, top_k=2)
+
+    assert result == candidates[:2]
+
+
+async def test_rerank_falls_back_on_invalid_json_response():
+    from nanobot.memory_index.qmd import QMDSearcher
+
+    candidates = [_make_result(text=f"chunk {i}") for i in range(3)]
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"not-valid-json", b""))
+
+    with patch("shutil.which", return_value="/usr/local/bin/qmd"), \
+         patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        searcher = QMDSearcher("qmd")
+        result = await searcher.rerank("query", candidates, top_k=2)
+
+    assert result == candidates[:2]
+
+
+async def test_rerank_falls_back_on_timeout():
+    from nanobot.memory_index.qmd import QMDSearcher
+
+    candidates = [_make_result(text=f"chunk {i}") for i in range(3)]
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    with patch("shutil.which", return_value="/usr/local/bin/qmd"), \
+         patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        searcher = QMDSearcher("qmd")
+        result = await searcher.rerank("query", candidates, top_k=2)
+
+    assert result == candidates[:2]
+```
+
+- [ ] **Step 2: Run tests — verify FAILED (module not found)**
+
+```bash
+pytest tests/test_memory_index/test_qmd.py -v
+```
+
+- [ ] **Step 3: Create `nanobot/memory_index/qmd.py`** (full implementation as shown in Context above)
+
+- [ ] **Step 4: Run tests — verify PASSED**
+
+```bash
+pytest tests/test_memory_index/test_qmd.py -v
+```
+
+- [ ] **Step 5: Run full suite — verify no regressions**
+
+```bash
+pytest --tb=short -q
+```
+
+Expected: 663 passed (652 + 9 new), 1 skipped.
+
+- [ ] **Commit**
+
+```
+feat(memory_index): add QMDSearcher subprocess wrapper for LLM re-ranking
+```
+
+---
+
+## Task 3: Wire QMDSearcher into IndexService
+
+**Files:**
+- Modify: `nanobot/memory_index/service.py`
+- Create: `tests/test_memory_index/test_service_qmd.py`
+
+**Context:** Current `IndexService.search()` (service.py line 43) delegates directly to `self.index.search(query, top_k=top_k)`. Need to:
+1. Add `self._qmd: QMDSearcher | None = None` to `__init__`, constructed when `cfg.backend == "qmd"`.
+2. In `search()`, resolve `k` from `top_k` or config default, then branch: if `_qmd is not None and _qmd.is_available()` → get `min(k * 3, 30)` candidates from SQLite, rerank via QMD; else → delegate as before.
+
+Add `TYPE_CHECKING` guard for the `QMDSearcher` import (consistent with existing pattern in `service.py`).
+
+Modified `service.py` structure:
+
+```python
+if TYPE_CHECKING:
+    from nanobot.config.schema import MemoryIndexConfig
+    from nanobot.memory_index.qmd import QMDSearcher
+    from nanobot.memory_index.search import SearchResult
+
+class IndexService:
+    def __init__(self, workspace: Path, cfg: MemoryIndexConfig) -> None:
+        from nanobot.memory_index.index import MemoryIndex
+
+        self.index = MemoryIndex(workspace, cfg)
+        self._cfg = cfg
+        self._observer = None
+        self._qmd: QMDSearcher | None = None
+        if cfg.backend == "qmd":
+            from nanobot.memory_index.qmd import QMDSearcher
+            self._qmd = QMDSearcher(cfg.qmd_binary)
+
+    # ... start/stop/inject_top_k unchanged ...
+
+    async def search(self, query: str, top_k: int | None = None) -> list[SearchResult]:
+        """Backend-aware search: SQLite with optional QMD re-ranking."""
+        k = top_k if top_k is not None else self._cfg.query.top_k
+        if self._qmd is not None and self._qmd.is_available():
+            candidate_k = min(k * 3, 30)
+            candidates = await self.index.search(query, top_k=candidate_k)
+            return await self._qmd.rerank(query, candidates, top_k=k)
+        return await self.index.search(query, top_k=top_k)
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_memory_index/test_service_qmd.py`:
+```python
+"""Integration tests for IndexService QMD backend routing."""
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.config.schema import MemoryIndexConfig
+from nanobot.memory_index.search import SearchResult
+
+
+def _make_results(n):
+    return [SearchResult(text=f"chunk {i}", source="MEMORY.md", start_line=i, end_line=i+5, score=0.9-i*0.1) for i in range(n)]
+
+
+def _make_cfg(backend="sqlite", qmd_binary="qmd", **kwargs):
+    cfg = MemoryIndexConfig(**kwargs)
+    cfg.backend = backend
+    cfg.qmd_binary = qmd_binary
+    return cfg
+
+
+# --- backend=sqlite (default) ---
+
+async def test_sqlite_backend_delegates_to_index_search(tmp_path):
+    from nanobot.memory_index.service import IndexService
+
+    cfg = _make_cfg(backend="sqlite")
+    with patch("nanobot.memory_index.index.MemoryIndex.__init__", return_value=None), \
+         patch.object(IndexService, "start", new_callable=AsyncMock):
+        svc = IndexService.__new__(IndexService)
+        svc._cfg = cfg
+        svc._observer = None
+        svc._qmd = None
+        mock_index = MagicMock()
+        mock_index.search = AsyncMock(return_value=_make_results(3))
+        svc.index = mock_index
+
+        result = await svc.search("test query", top_k=3)
+
+    mock_index.search.assert_called_once_with("test query", top_k=3)
+    assert len(result) == 3
+
+
+# --- backend=qmd, binary absent → fallback ---
+
+async def test_qmd_backend_falls_back_to_sqlite_when_binary_absent(tmp_path):
+    from nanobot.memory_index.qmd import QMDSearcher
+    from nanobot.memory_index.service import IndexService
+
+    cfg = _make_cfg(backend="qmd", qmd_binary="qmd-missing")
+
+    with patch("shutil.which", return_value=None):
+        svc = IndexService.__new__(IndexService)
+        svc._cfg = cfg
+        svc._observer = None
+        svc._qmd = QMDSearcher("qmd-missing")
+        mock_index = MagicMock()
+        mock_index.search = AsyncMock(return_value=_make_results(3))
+        svc.index = mock_index
+
+        result = await svc.search("test query", top_k=3)
+
+    # Falls back: calls index.search with original top_k
+    mock_index.search.assert_called_once_with("test query", top_k=3)
+    assert len(result) == 3
+
+
+# --- backend=qmd, binary present → QMD reranking ---
+
+async def test_qmd_backend_calls_rerank_with_larger_candidate_pool(tmp_path):
+    from nanobot.memory_index.qmd import QMDSearcher
+    from nanobot.memory_index.service import IndexService
+
+    cfg = _make_cfg(backend="qmd", qmd_binary="qmd")
+    candidates = _make_results(9)  # candidate_k = min(3*3, 30) = 9
+    reranked = candidates[:3]
+
+    with patch("shutil.which", return_value="/usr/local/bin/qmd"):
+        svc = IndexService.__new__(IndexService)
+        svc._cfg = cfg
+        svc._observer = None
+        mock_index = MagicMock()
+        mock_index.search = AsyncMock(return_value=candidates)
+        svc.index = mock_index
+        mock_qmd = MagicMock(spec=QMDSearcher)
+        mock_qmd.is_available.return_value = True
+        mock_qmd.rerank = AsyncMock(return_value=reranked)
+        svc._qmd = mock_qmd
+
+        result = await svc.search("test query", top_k=3)
+
+    # SQLite called with candidate_k = min(3*3, 30) = 9
+    mock_index.search.assert_called_once_with("test query", top_k=9)
+    mock_qmd.rerank.assert_called_once_with("test query", candidates, top_k=3)
+    assert result is reranked
+
+
+# --- IndexService.__init__ constructs QMDSearcher when backend=qmd ---
+
+def test_index_service_init_creates_qmd_searcher_when_backend_qmd(tmp_path):
+    from nanobot.memory_index.qmd import QMDSearcher
+    from nanobot.memory_index.service import IndexService
+
+    cfg = _make_cfg(backend="qmd", qmd_binary="qmd")
+    with patch("nanobot.memory_index.index.MemoryIndex.__init__", return_value=None):
+        svc = IndexService(tmp_path, cfg)
+
+    assert isinstance(svc._qmd, QMDSearcher)
+
+
+def test_index_service_init_no_qmd_when_backend_sqlite(tmp_path):
+    from nanobot.memory_index.service import IndexService
+
+    cfg = _make_cfg(backend="sqlite")
+    with patch("nanobot.memory_index.index.MemoryIndex.__init__", return_value=None):
+        svc = IndexService(tmp_path, cfg)
+
+    assert svc._qmd is None
+```
+
+- [ ] **Step 2: Run tests — verify FAILED**
+
+```bash
+pytest tests/test_memory_index/test_service_qmd.py -v
+```
+
+- [ ] **Step 3: Modify `nanobot/memory_index/service.py`** (as shown in Context above)
+
+- [ ] **Step 4: Run tests — verify PASSED**
+
+```bash
+pytest tests/test_memory_index/test_service_qmd.py -v
+```
+
+- [ ] **Step 5: Run full suite — verify no regressions**
+
+```bash
+pytest --tb=short -q
+```
+
+Expected: 668 passed (663 + 5 new), 1 skipped.
+
+- [ ] **Commit**
+
+```
+feat(memory_index): wire QMDSearcher into IndexService for backend-aware re-ranking
+```

--- a/docs/superpowers/specs/2026-03-29-graphiti-memory-lobe-design.md
+++ b/docs/superpowers/specs/2026-03-29-graphiti-memory-lobe-design.md
@@ -1,0 +1,239 @@
+# Graphiti Memory Lobe — Design Spec
+
+**Date:** 2026-03-29
+**Status:** Approved for implementation planning
+
+## Goal
+
+Replace nanobot's flat-file memory system (MEMORY.md + HISTORY.md + LLM consolidation) with a temporal knowledge graph backed by Graphiti. Memory becomes an ambient "lobe" — automatically capturing facts from every conversation turn and pre-retrieving relevant context before every turn — rather than a file the agent reads and writes manually.
+
+---
+
+## Background & Motivation
+
+nanobot's current memory system has three structural weaknesses:
+
+1. **Unbounded context bloat.** The entire MEMORY.md is injected into every system prompt. As memory grows, attention degrades and token costs rise linearly.
+2. **LLM-dependent consolidation.** `MemoryConsolidator` calls the LLM after every consolidation window to summarize conversations into MEMORY.md. Failures produce stale or missing memories with no audit trail.
+3. **No temporal reasoning.** Facts are overwritten or appended with no record of when they became true or false. A corrected fact coexists with its contradiction.
+
+Graphiti (Apache 2.0, `graphiti-core` on PyPI) addresses all three:
+- Retrieval is query-scoped: only relevant facts are injected per turn (solves #1)
+- Extraction runs on raw episodes, not LLM summaries, and marks stale facts invalid rather than deleting them (solves #2 and #3)
+- LongMemEval benchmark: Graphiti 63.8% vs mem0 49.0% vs full-context baseline 60.2% at 29s latency
+
+---
+
+## Architecture
+
+### Data Flow
+
+```
+Inbound turn:
+  GraphitiBackend.retrieve(current_message, group_id)
+    → hybrid semantic + BM25 search over temporal graph
+    → top-k facts injected as a context block before LLM sees the message
+
+Outbound turn (background, non-blocking):
+  GraphitiBackend.consolidate(turn_messages, group_id)
+    → graphiti.add_episode() extracts entities + relationships
+    → new facts added; stale facts marked invalid with timestamp
+    → raw episode preserved in Graphiti's episode store (replaces HISTORY.md)
+```
+
+### What Is Replaced
+
+| Old component | Replaced by |
+|---|---|
+| `MemoryStore` (MEMORY.md + HISTORY.md writes) | `GraphitiMemoryBackend.consolidate()` |
+| `MemoryStore.get_memory_context()` (full-file injection) | `GraphitiMemoryBackend.retrieve()` (query-scoped injection) |
+| `MemoryConsolidator` LLM summarization call | Graphiti's entity extraction on raw episodes |
+| `MemoryConsolidator.maybe_consolidate_by_tokens()` LLM step | Simple session message drop (facts already in graph) |
+| HISTORY.md grep audit trail | Graphiti episode store (richer, timestamped, queryable) |
+
+Token-based session pruning (dropping old messages when context window fills) is **retained** but simplified: it no longer calls the LLM since facts are captured continuously by Graphiti.
+
+---
+
+## Component 1: `MemoryBackend` ABC (nanobot core)
+
+Added to `nanobot/agent/memory.py`. Minimal interface — five methods:
+
+```python
+class MemoryBackend(ABC):
+    async def start(self, provider: LLMProvider) -> None: ...  # lifecycle: connect, build indices
+    async def stop(self) -> None: ...                          # lifecycle: graceful shutdown
+    async def consolidate(
+        self,
+        messages: list[dict],
+        session_key: str,
+    ) -> None: ...                              # post-turn: extract + store facts
+    async def retrieve(
+        self,
+        query: str,
+        session_key: str,
+        top_k: int = 5,
+    ) -> str: ...                               # pre-turn: return formatted context block
+    def get_tools(self) -> list[Tool]: ...      # tools this backend exposes to the agent (default: [])
+
+    @property
+    def consolidates_per_turn(self) -> bool:    # True = consolidate every turn; False = token-pressure only
+        return False
+```
+
+`start()` receives the nanobot `LLMProvider` instance so backends that need LLM access (e.g. Graphiti's entity extraction) reuse the same configured provider rather than requiring a separate API key.
+
+`MemoryStore` implements `MemoryBackend` so existing users see no behavior change when the plugin is not installed.
+
+Entry-point group: `nanobot.memory`. `AgentLoop` scans at startup; config field `memory.backend` (string) selects which registered backend to use. Falls back to the built-in `MemoryStore` implementation if the field is absent or `"default"`.
+
+---
+
+## Component 2: nanobot Core Changes
+
+**`nanobot/agent/memory.py`**
+- Add `MemoryBackend` ABC (as above)
+- `MemoryStore` implements `MemoryBackend`: `consolidates_per_turn = False`; `get_tools()` returns `[]`; `start()` ignores the provider (file-based, no LLM needed at init); `consolidate()` and `retrieve()` wrap the existing `MemoryStore.consolidate()` and `get_memory_context()` methods — zero behavior change for existing users
+- `MemoryConsolidator.maybe_consolidate_by_tokens()`: session message-drop loop is retained unchanged; the LLM summarization call (`store.consolidate()`) is gated on `backend.consolidates_per_turn == False` — when a per-turn backend (Graphiti) is active, the pruning loop only drops old messages without calling the LLM, since facts were already captured episode-by-episode
+
+**`nanobot/agent/context.py`**
+- `ContextBuilder.__init__` accepts `memory_backend: MemoryBackend | None = None`
+- `build_messages()` becomes `async`; when `memory_backend` is set, calls `await memory_backend.retrieve(current_message, session_key, top_k)` and injects the returned string as a system-role block immediately before the conversation history
+- `build_system_prompt()` no longer reads or injects MEMORY.md; workspace description in `_get_identity()` drops MEMORY.md/HISTORY.md mentions and instead describes the memory tool surface:
+  > Relevant memories from past conversations are automatically surfaced. Use `memory_search` for targeted recall, `memory_forget` to correct errors, `memory_list` to audit stored facts.
+
+**`nanobot/agent/loop.py`**
+- `AgentLoop.__init__` discovers backend via `nanobot.memory` entry-point and `config.memory.backend`; calls `await backend.start(self.provider)` in `run()`/`process_direct()` (same deferred-init pattern as `startup_index()` in the QMD branch — not in `__init__` to avoid event loop issues); passes backend to `ContextBuilder`; registers `backend.get_tools()` into the tool registry
+- `_process_message()`: when `backend.consolidates_per_turn` is True, fires `backend.consolidate(turn_messages, session_key)` as a background task after the agent loop completes; when False, the existing `maybe_consolidate_by_tokens()` path governs (no change for `MemoryStore`)
+- `await self.context.build_messages(...)` — updated call site for the now-async signature
+
+**`nanobot/config/schema.py`**
+- Add `MemoryConfig(Base)` with `backend: str = "default"`
+- Add `Config.memory: MemoryConfig = Field(default_factory=MemoryConfig)`
+
+---
+
+## Component 3: `nanobot-graphiti` Plugin Package
+
+Separate installable package. Installs alongside nanobot:
+
+```
+pip install nanobot-graphiti
+```
+
+Registers under `nanobot.memory` entry-point in its `pyproject.toml`:
+
+```toml
+[project.entry-points."nanobot.memory"]
+graphiti = "nanobot_graphiti:GraphitiMemoryBackend"
+```
+
+### Package Structure
+
+```
+nanobot_graphiti/
+  __init__.py        # exports GraphitiMemoryBackend
+  backend.py         # GraphitiMemoryBackend(MemoryBackend)
+  tools.py           # MemorySearchTool, MemoryForgetTool, MemoryListTool
+  config.py          # GraphitiConfig pydantic model
+```
+
+### `GraphitiMemoryBackend`
+
+- **`start(provider)`**: receives nanobot's `LLMProvider`; constructs a Graphiti-compatible LLM/embedding client adapter from it (Graphiti accepts any OpenAI-compatible endpoint, which nanobot's `openai_compat_provider` already speaks); constructs `graphiti_core.Graphiti` client with configured graph DB; calls `await graphiti.build_indices_and_constraints()`
+- **`consolidate(messages, session_key)`**: formats the turn's messages into a `graphiti_core.EpisodeBody`; calls `await graphiti.add_episode(name=session_key, episode_body=..., group_id=group_id_from(session_key))`; errors are caught and logged — never block the main loop
+- **`retrieve(query, session_key, top_k)`**: calls `await graphiti.search(query, group_ids=[group_id], num_results=top_k)`; formats results as:
+  ```
+  [Memory — {N} relevant facts]
+  • {fact text} ({source date})
+  ...
+  ```
+  Returns empty string if no results — no block injected
+
+### Session Key → `group_id` Scoping
+
+Session key format: `channel:chat_id` (e.g., `telegram:123456`).
+
+Default (`scope: "user"`): `group_id = chat_id` — memories are **user-level**, shared across channels. A user's Telegram and Discord conversations accumulate one memory graph.
+
+Alternative (`scope: "session"`): `group_id = session_key` — memories are **session-scoped**, isolated per channel+chat. Useful for multi-user or shared-channel deployments.
+
+Configured via `memory.graphiti.scope`.
+
+### Config Schema (`GraphitiConfig`)
+
+```python
+class GraphitiConfig(Base):
+    graph_db: Literal["kuzu", "neo4j", "falkordb"] = "kuzu"
+    kuzu_path: str = "~/.nanobot/workspace/memory/graph"  # kuzu only
+    neo4j_uri: str = "bolt://localhost:7687"               # neo4j only
+    neo4j_user: str = "neo4j"                              # neo4j only
+    neo4j_password: str = ""                               # neo4j only
+    falkordb_host: str = "localhost"                       # falkordb only
+    falkordb_port: int = 6379                              # falkordb only
+    top_k: int = 5
+    scope: Literal["user", "session"] = "user"
+```
+
+**Kuzu is the default** — embedded graph DB (no server process, file on disk). Users who want a persistent server-backed graph switch to `neo4j` or `falkordb`.
+
+In `config.yaml`:
+
+```yaml
+memory:
+  backend: graphiti
+  graphiti:
+    graph_db: kuzu
+    top_k: 5
+    scope: user
+```
+
+---
+
+## Component 4: Tool Surface
+
+Three tools returned by `GraphitiMemoryBackend.get_tools()` and registered by `AgentLoop` via `self.tools.register(t)` for each tool in `backend.get_tools()` during `_register_default_tools()`. The base `MemoryBackend.get_tools()` returns `[]`, so no tools are added for the default `MemoryStore` backend.
+
+| Tool | Description | Key parameters |
+|---|---|---|
+| `memory_search` | Semantic search over the memory graph | `query: str`, `top_k: int = 10` |
+| `memory_forget` | Delete a specific fact by its graph node ID | `fact_id: str`, `reason: str` |
+| `memory_list` | List all stored facts for the current user | `limit: int = 50` |
+
+`memory_forget` and `memory_list` use the session's `group_id` to scope results to the current user.
+
+The agent uses these tools reactively — e.g., when a user says "you have that wrong" or "what do you remember about me?" The automatic pre-retrieval injection handles the common case without any tool call.
+
+---
+
+## What Is Not in Scope (v1)
+
+- Graph memory visualization / admin UI
+- Multi-agent shared memory (cross-session writes)
+- Custom entity type schemas
+- Memory export/import tooling
+- FalkorDB or Amazon Neptune as tested backends (supported by config, not validated)
+- Gradual migration path from existing MEMORY.md files (out of scope; users start fresh)
+
+---
+
+## Testing Strategy
+
+**nanobot core tests** (no new dependencies):
+- `MemoryBackend` ABC can be implemented and registered via entry-point
+- `MemoryStore` implements `MemoryBackend`: `consolidates_per_turn` is False, `get_tools()` returns `[]`
+- `build_messages()` async signature produces correct message list with and without an injected context block
+- `AgentLoop` falls back to `MemoryStore` when no `nanobot.memory` entry-point is registered
+- `AgentLoop` fires `backend.consolidate()` post-turn only when `backend.consolidates_per_turn` is True
+- Token-based session pruning skips LLM call when `backend.consolidates_per_turn` is True; retains it when False
+
+**`nanobot-graphiti` plugin tests** (mocked Graphiti client):
+- `GraphitiMemoryBackend.consolidates_per_turn` is True
+- `GraphitiMemoryBackend.get_tools()` returns exactly three tools: `memory_search`, `memory_forget`, `memory_list`
+- `GraphitiMemoryBackend.consolidate()` calls `graphiti.add_episode()` with correct `group_id`
+- `GraphitiMemoryBackend.retrieve()` calls `graphiti.search()` and formats output correctly
+- `retrieve()` returns empty string when search returns no results
+- `consolidate()` errors are swallowed and logged, never raised
+- `scope: "user"` strips channel prefix from session key; `scope: "session"` preserves it
+- `GraphitiConfig` defaults: `graph_db="kuzu"`, `top_k=5`, `scope="user"`
+- Tool tests: `memory_search`, `memory_forget`, `memory_list` call correct Graphiti methods with session-scoped `group_id`

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -19,9 +19,16 @@ class ContextBuilder:
     BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"]
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
 
-    def __init__(self, workspace: Path, timezone: str | None = None):
+    def __init__(
+        self,
+        workspace: Path,
+        timezone: str | None = None,
+        memory_backend=None,  # MemoryBackend | None
+    ):
         self.workspace = workspace
         self.timezone = timezone
+        self.memory_backend = memory_backend
+        # Keep self.memory for MemoryConsolidator probe calls that still need MemoryStore
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
 
@@ -32,10 +39,6 @@ class ContextBuilder:
         bootstrap = self._load_bootstrap_files()
         if bootstrap:
             parts.append(bootstrap)
-
-        memory = self.memory.get_memory_context()
-        if memory:
-            parts.append(f"# Memory\n\n{memory}")
 
         always_skills = self.skills.get_always_skills()
         if always_skills:
@@ -73,6 +76,11 @@ Skills with available="false" need dependencies installed first - you can try in
 - Use file tools when they are simpler or more reliable than shell commands.
 """
 
+        if self.memory_backend is not None and self.memory_backend.consolidates_per_turn:
+            memory_tip = "- Memory: Relevant facts from past conversations are automatically surfaced each turn.\n  Use memory_search for targeted recall, memory_forget to correct errors, memory_list to audit stored facts."
+        else:
+            memory_tip = f"- Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)\n- History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM]."
+
         return f"""# nanobot 🐈
 
 You are nanobot, a helpful AI assistant.
@@ -82,8 +90,7 @@ You are nanobot, a helpful AI assistant.
 
 ## Workspace
 Your workspace is at: {workspace_path}
-- Long-term memory: {workspace_path}/memory/MEMORY.md (write important facts here)
-- History log: {workspace_path}/memory/HISTORY.md (grep-searchable). Each entry starts with [YYYY-MM-DD HH:MM].
+{memory_tip}
 - Custom skills: {workspace_path}/skills/{{skill-name}}/SKILL.md
 
 {platform_policy}
@@ -122,7 +129,7 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
 
         return "\n\n".join(parts) if parts else ""
 
-    def build_messages(
+    async def build_messages(
         self,
         history: list[dict[str, Any]],
         current_message: str,
@@ -131,6 +138,7 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
         channel: str | None = None,
         chat_id: str | None = None,
         current_role: str = "user",
+        session_key: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
         runtime_ctx = self._build_runtime_context(channel, chat_id, self.timezone)
@@ -143,8 +151,15 @@ IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST
         else:
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
 
+        memory_block: list[dict[str, Any]] = []
+        if self.memory_backend is not None and session_key is not None:
+            retrieved = await self.memory_backend.retrieve(current_message, session_key, 5)
+            if retrieved:
+                memory_block = [{"role": "system", "content": retrieved}]
+
         return [
             {"role": "system", "content": self.build_system_prompt(skill_names)},
+            *memory_block,
             *history,
             {"role": current_role, "content": merged},
         ]

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -33,6 +33,7 @@ from nanobot.providers.base import LLMProvider
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
+    from nanobot.agent.memory import MemoryBackend
     from nanobot.config.schema import ChannelsConfig, ExecToolConfig, WebSearchConfig
     from nanobot.cron.service import CronService
 
@@ -68,6 +69,7 @@ class AgentLoop:
         mcp_servers: dict | None = None,
         channels_config: ChannelsConfig | None = None,
         timezone: str | None = None,
+        memory_backend: "MemoryBackend | None" = None,  # NEW
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -86,7 +88,11 @@ class AgentLoop:
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
 
-        self.context = ContextBuilder(workspace, timezone=timezone)
+        from nanobot.agent.memory import MemoryStore
+        self.memory_backend = memory_backend if memory_backend is not None else MemoryStore(workspace)
+        self._backend_started = False
+
+        self.context = ContextBuilder(workspace, timezone=timezone, memory_backend=self.memory_backend)
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
         self.runner = AgentRunner(provider)
@@ -125,6 +131,8 @@ class AgentLoop:
             max_completion_tokens=provider.generation.max_tokens,
         )
         self._register_default_tools()
+        for tool in self.memory_backend.get_tools():
+            self.tools.register(tool)
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
 
@@ -150,6 +158,12 @@ class AgentLoop:
             self.tools.register(
                 CronTool(self.cron_service, default_timezone=self.context.timezone or "UTC")
             )
+
+    async def _start_backend(self) -> None:
+        """Start the memory backend once (deferred to avoid event-loop issues at __init__)."""
+        if not self._backend_started:
+            await self.memory_backend.start(self.provider)
+            self._backend_started = True
 
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""
@@ -277,6 +291,7 @@ class AgentLoop:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
         self._running = True
         await self._connect_mcp()
+        await self._start_backend()
         logger.info("Agent loop started")
 
         while self._running:
@@ -418,7 +433,16 @@ class AgentLoop:
             )
             self._save_turn(session, all_msgs, 1 + len(history))
             self.sessions.save(session)
-            self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
+            if self.memory_backend.consolidates_per_turn:
+                turn_messages = all_msgs[1 + len(history):]
+                self._schedule_background(
+                    self.memory_backend.consolidate(turn_messages, key)
+                )
+            self._schedule_background(
+                self.memory_consolidator.maybe_consolidate_by_tokens(
+                    session, skip_llm=self.memory_backend.consolidates_per_turn
+                )
+            )
             return OutboundMessage(channel=channel, chat_id=chat_id,
                                   content=final_content or "Background task completed.")
 
@@ -472,7 +496,16 @@ class AgentLoop:
 
         self._save_turn(session, all_msgs, 1 + len(history))
         self.sessions.save(session)
-        self._schedule_background(self.memory_consolidator.maybe_consolidate_by_tokens(session))
+        if self.memory_backend.consolidates_per_turn:
+            turn_messages = all_msgs[1 + len(history):]
+            self._schedule_background(
+                self.memory_backend.consolidate(turn_messages, key)
+            )
+        self._schedule_background(
+            self.memory_consolidator.maybe_consolidate_by_tokens(
+                session, skip_llm=self.memory_backend.consolidates_per_turn
+            )
+        )
 
         if (mt := self.tools.get("message")) and isinstance(mt, MessageTool) and mt._sent_in_turn:
             return None
@@ -579,6 +612,7 @@ class AgentLoop:
     ) -> OutboundMessage | None:
         """Process a message directly and return the outbound payload."""
         await self._connect_mcp()
+        await self._start_backend()
         msg = InboundMessage(channel=channel, sender_id="user", chat_id=chat_id, content=content)
         return await self._process_message(
             msg, session_key=session_key, on_progress=on_progress,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -38,6 +38,35 @@ if TYPE_CHECKING:
     from nanobot.cron.service import CronService
 
 
+def load_memory_backend(config: Any) -> "MemoryBackend":
+    """Discover and instantiate the configured memory backend from installed entry-points.
+
+    Falls back to the built-in MemoryStore when:
+    - ``config.memory.backend`` is ``"default"``
+    - No matching entry-point is registered
+    """
+    from importlib.metadata import entry_points
+    from nanobot.agent.memory import MemoryStore
+
+    backend_name = getattr(getattr(config, "memory", None), "backend", "default")
+    if backend_name == "default":
+        return MemoryStore(config.workspace_path)
+
+    for ep in entry_points(group="nanobot.memory"):
+        if ep.name == backend_name:
+            backend_cls = ep.load()
+            if hasattr(backend_cls, "from_nanobot_config"):
+                return backend_cls.from_nanobot_config(config)
+            return backend_cls(config)
+
+    logger.warning(
+        "Memory backend '{}' not found in nanobot.memory entry-points; "
+        "falling back to default MemoryStore",
+        backend_name,
+    )
+    return MemoryStore(config.workspace_path)
+
+
 class AgentLoop:
     """
     The agent loop is the core processing engine.

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -406,10 +406,11 @@ class AgentLoop:
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
             history = session.get_history(max_messages=0)
             current_role = "assistant" if msg.sender_id == "subagent" else "user"
-            messages = self.context.build_messages(
+            messages = await self.context.build_messages(
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
                 current_role=current_role,
+                session_key=key,
             )
             final_content, _, all_msgs = await self._run_agent_loop(
                 messages, channel=channel, chat_id=chat_id,
@@ -441,11 +442,12 @@ class AgentLoop:
                 message_tool.start_turn()
 
         history = session.get_history(max_messages=0)
-        initial_messages = self.context.build_messages(
+        initial_messages = await self.context.build_messages(
             history=history,
             current_message=msg.content,
             media=msg.media if msg.media else None,
             channel=msg.channel, chat_id=msg.chat_id,
+            session_key=key,
         )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -324,11 +324,11 @@ class MemoryConsolidator:
 
         return last_boundary
 
-    def estimate_session_prompt_tokens(self, session: Session) -> tuple[int, str]:
+    async def estimate_session_prompt_tokens(self, session: Session) -> tuple[int, str]:
         """Estimate current prompt size for the normal session history view."""
         history = session.get_history(max_messages=0)
         channel, chat_id = (session.key.split(":", 1) if ":" in session.key else (None, None))
-        probe_messages = self._build_messages(
+        probe_messages = await self._build_messages(
             history=history,
             current_message="[token-probe]",
             channel=channel,
@@ -363,7 +363,7 @@ class MemoryConsolidator:
         async with lock:
             budget = self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
             target = budget // 2
-            estimated, source = self.estimate_session_prompt_tokens(session)
+            estimated, source = await self.estimate_session_prompt_tokens(session)
             if estimated <= 0:
                 return
             if estimated < budget:
@@ -408,6 +408,6 @@ class MemoryConsolidator:
                 session.last_consolidated = end_idx
                 self.sessions.save(session)
 
-                estimated, source = self.estimate_session_prompt_tokens(session)
+                estimated, source = await self.estimate_session_prompt_tokens(session)
                 if estimated <= 0:
                     return

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import weakref
+from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
@@ -72,7 +73,44 @@ def _is_tool_choice_unsupported(content: str | None) -> bool:
     return any(m in text for m in _TOOL_CHOICE_ERROR_MARKERS)
 
 
-class MemoryStore:
+class MemoryBackend(ABC):
+    """Abstract base class for nanobot memory backends.
+
+    Backends are discovered via the ``nanobot.memory`` entry-point group.
+    The default backend is ``MemoryStore`` (flat-file MEMORY.md).
+    """
+
+    @property
+    def consolidates_per_turn(self) -> bool:
+        """True if this backend captures facts after every turn.
+
+        When True, AgentLoop fires ``consolidate()`` as a background task
+        after each turn, and MemoryConsolidator skips its LLM archival step.
+        When False (default), MemoryConsolidator governs consolidation under
+        token-pressure.
+        """
+        return False
+
+    def get_tools(self) -> list:
+        """Return extra Tool instances to register in AgentLoop. Default: none."""
+        return []
+
+    async def start(self, provider: Any) -> None:
+        """Lifecycle: called once at agent startup (after the event loop is running)."""
+
+    async def stop(self) -> None:
+        """Lifecycle: called on graceful shutdown."""
+
+    @abstractmethod
+    async def consolidate(self, messages: list[dict], session_key: str) -> None:
+        """Post-turn: extract and store facts from the completed turn's messages."""
+
+    @abstractmethod
+    async def retrieve(self, query: str, session_key: str, top_k: int = 5) -> str:
+        """Pre-turn: return a formatted context block of relevant memories, or '' if none."""
+
+
+class MemoryStore(MemoryBackend):
     """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
 
     _MAX_FAILURES_BEFORE_RAW_ARCHIVE = 3
@@ -111,7 +149,7 @@ class MemoryStore:
             )
         return "\n".join(lines)
 
-    async def consolidate(
+    async def _consolidate_with_provider(
         self,
         messages: list[dict],
         provider: LLMProvider,
@@ -218,6 +256,15 @@ class MemoryStore:
             "Memory consolidation degraded: raw-archived {} messages", len(messages)
         )
 
+    # --- MemoryBackend interface ---
+
+    async def consolidate(self, messages: list[dict], session_key: str) -> None:
+        """No-op: MemoryConsolidator handles consolidation for the MemoryStore path."""
+
+    async def retrieve(self, query: str, session_key: str, top_k: int = 5) -> str:
+        """Return full MEMORY.md content (query-independent, preserves current behaviour)."""
+        return self.get_memory_context()
+
 
 class MemoryConsolidator:
     """Owns consolidation policy, locking, and session offset updates."""
@@ -253,7 +300,7 @@ class MemoryConsolidator:
 
     async def consolidate_messages(self, messages: list[dict[str, object]]) -> bool:
         """Archive a selected message chunk into persistent memory."""
-        return await self.store.consolidate(messages, self.provider, self.model)
+        return await self.store._consolidate_with_provider(messages, self.provider, self.model)
 
     def pick_consolidation_boundary(
         self,

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -350,11 +350,15 @@ class MemoryConsolidator:
                 return True
         return True
 
-    async def maybe_consolidate_by_tokens(self, session: Session) -> None:
+    async def maybe_consolidate_by_tokens(self, session: Session, skip_llm: bool = False) -> None:
         """Loop: archive old messages until prompt fits within safe budget.
 
         The budget reserves space for completion tokens and a safety buffer
         so the LLM request never exceeds the context window.
+
+        Args:
+            session: The session to consolidate.
+            skip_llm: If True, prune messages without calling LLM consolidation.
         """
         if not session.messages or self.context_window_tokens <= 0:
             return
@@ -403,8 +407,9 @@ class MemoryConsolidator:
                     source,
                     len(chunk),
                 )
-                if not await self.consolidate_messages(chunk):
-                    return
+                if not skip_llm:
+                    if not await self.consolidate_messages(chunk):
+                        return
                 session.last_consolidated = end_idx
                 self.sessions.save(session)
 

--- a/nanobot/agent/tools/discord_tools.py
+++ b/nanobot/agent/tools/discord_tools.py
@@ -1,0 +1,404 @@
+"""Discord API tools for the agent."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from nanobot.agent.tools.base import Tool
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+
+
+class DiscordBaseTool(Tool):
+    """Base class for Discord API tools."""
+
+    def __init__(self, http_client: httpx.AsyncClient, token: str) -> None:
+        self._http = http_client
+        self._headers = {
+            "Authorization": f"Bot {token}",
+            "Content-Type": "application/json",
+        }
+
+    async def _api(
+        self,
+        method: str,
+        path: str,
+        json_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Make a Discord API call. Returns response JSON dict."""
+        url = f"{DISCORD_API_BASE}{path}"
+        try:
+            resp = await self._http.request(
+                method,
+                url,
+                headers=self._headers,
+                content=json.dumps(json_data).encode() if json_data is not None else None,
+            )
+            resp.raise_for_status()
+            if resp.content:
+                return resp.json()
+            return {}
+        except httpx.HTTPStatusError as e:
+            error_body = ""
+            try:
+                error_body = e.response.json().get("message", "")
+            except Exception:
+                pass
+            return {"error": f"HTTP {e.response.status_code}: {error_body or str(e)}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+
+class DiscordSendTool(DiscordBaseTool):
+    """Send a message to a Discord channel."""
+
+    @property
+    def name(self) -> str:
+        return "discord_send"
+
+    @property
+    def description(self) -> str:
+        return "Send a message to a Discord channel. Supports plain text or embed."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "channel_id": {"type": "string", "description": "Discord channel ID"},
+                "content": {"type": "string", "description": "Text content to send"},
+                "embed_title": {"type": "string", "description": "Optional embed title"},
+                "embed_description": {"type": "string", "description": "Optional embed description"},
+                "embed_color": {
+                    "type": "integer",
+                    "description": "Optional embed color (hex int, e.g. 0xFF0000)",
+                },
+            },
+            "required": ["channel_id"],
+        }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        channel_id = kwargs["channel_id"]
+        payload: dict[str, Any] = {}
+        if kwargs.get("content"):
+            payload["content"] = kwargs["content"]
+        if kwargs.get("embed_title") or kwargs.get("embed_description"):
+            embed: dict[str, Any] = {}
+            if kwargs.get("embed_title"):
+                embed["title"] = kwargs["embed_title"]
+            if kwargs.get("embed_description"):
+                embed["description"] = kwargs["embed_description"]
+            if kwargs.get("embed_color") is not None:
+                embed["color"] = kwargs["embed_color"]
+            payload["embeds"] = [embed]
+        if not payload:
+            return "Error: must provide content or embed_title/embed_description"
+        result = await self._api("POST", f"/channels/{channel_id}/messages", payload)
+        if "error" in result:
+            return f"Error: {result['error']}"
+        return f"Message sent (id={result.get('id', '?')})"
+
+
+class DiscordCreateThreadTool(DiscordBaseTool):
+    """Create a thread in a Discord channel."""
+
+    @property
+    def name(self) -> str:
+        return "discord_create_thread"
+
+    @property
+    def description(self) -> str:
+        return "Create a thread in a Discord channel, optionally from an existing message."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "channel_id": {"type": "string", "description": "Discord channel ID"},
+                "name": {"type": "string", "description": "Thread name (max 100 chars)"},
+                "message_id": {
+                    "type": "string",
+                    "description": "Optional message ID to create thread from",
+                },
+                "auto_archive_duration": {
+                    "type": "integer",
+                    "description": "Minutes until auto-archive: 60, 1440, 4320, or 10080 (default 1440)",
+                },
+            },
+            "required": ["channel_id", "name"],
+        }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        channel_id = kwargs["channel_id"]
+        name = kwargs["name"][:100]
+        archive = kwargs.get("auto_archive_duration", 1440)
+        payload: dict[str, Any] = {"name": name, "auto_archive_duration": archive}
+        if kwargs.get("message_id"):
+            path = f"/channels/{channel_id}/messages/{kwargs['message_id']}/threads"
+        else:
+            payload["type"] = 11  # GUILD_PUBLIC_THREAD
+            path = f"/channels/{channel_id}/threads"
+        result = await self._api("POST", path, payload)
+        if "error" in result:
+            return f"Error: {result['error']}"
+        return f"Thread created (id={result.get('id', '?')}, name={result.get('name', '?')})"
+
+
+class DiscordCreateChannelTool(DiscordBaseTool):
+    """Create a channel in a Discord guild."""
+
+    @property
+    def name(self) -> str:
+        return "discord_create_channel"
+
+    @property
+    def description(self) -> str:
+        return "Create a channel in a Discord guild."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "guild_id": {"type": "string", "description": "Discord guild (server) ID"},
+                "name": {"type": "string", "description": "Channel name"},
+                "type": {
+                    "type": "integer",
+                    "description": "Channel type: 0=text, 2=voice, 4=category (default 0)",
+                },
+                "topic": {"type": "string", "description": "Optional channel topic"},
+                "parent_id": {
+                    "type": "string",
+                    "description": "Optional category channel ID to nest under",
+                },
+            },
+            "required": ["guild_id", "name"],
+        }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        guild_id = kwargs["guild_id"]
+        payload: dict[str, Any] = {
+            "name": kwargs["name"],
+            "type": kwargs.get("type", 0),
+        }
+        if kwargs.get("topic"):
+            payload["topic"] = kwargs["topic"]
+        if kwargs.get("parent_id"):
+            payload["parent_id"] = kwargs["parent_id"]
+        result = await self._api("POST", f"/guilds/{guild_id}/channels", payload)
+        if "error" in result:
+            return f"Error: {result['error']}"
+        return f"Channel created (id={result.get('id', '?')}, name={result.get('name', '?')})"
+
+
+class DiscordManageRolesTool(DiscordBaseTool):
+    """Add or remove a role from a Discord guild member."""
+
+    @property
+    def name(self) -> str:
+        return "discord_manage_roles"
+
+    @property
+    def description(self) -> str:
+        return "Add or remove a role from a Discord guild member."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "guild_id": {"type": "string", "description": "Discord guild ID"},
+                "user_id": {"type": "string", "description": "Discord user ID"},
+                "role_id": {"type": "string", "description": "Discord role ID"},
+                "action": {
+                    "type": "string",
+                    "description": "Action to perform",
+                    "enum": ["add", "remove"],
+                },
+            },
+            "required": ["guild_id", "user_id", "role_id", "action"],
+        }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        guild_id = kwargs["guild_id"]
+        user_id = kwargs["user_id"]
+        role_id = kwargs["role_id"]
+        action = kwargs["action"]
+        path = f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}"
+        if action == "add":
+            result = await self._api("PUT", path)
+        elif action == "remove":
+            result = await self._api("DELETE", path)
+        else:
+            return f"Error: unknown action '{action}', must be 'add' or 'remove'"
+        if "error" in result:
+            return f"Error: {result['error']}"
+        verb = "added to" if action == "add" else "removed from"
+        return f"Role {role_id} {verb} user {user_id} successfully"
+
+
+class DiscordCreateEmbedTool(DiscordBaseTool):
+    """Send a rich embed message to a Discord channel."""
+
+    @property
+    def name(self) -> str:
+        return "discord_create_embed"
+
+    @property
+    def description(self) -> str:
+        return "Send a rich embed message to a Discord channel."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "channel_id": {"type": "string", "description": "Discord channel ID"},
+                "title": {"type": "string", "description": "Embed title"},
+                "description": {"type": "string", "description": "Embed description"},
+                "color": {"type": "integer", "description": "Embed color as integer (e.g. 0xFF0000)"},
+                "fields": {
+                    "type": "array",
+                    "description": "List of embed fields",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "value": {"type": "string"},
+                            "inline": {"type": "boolean"},
+                        },
+                        "required": ["name", "value"],
+                    },
+                },
+                "footer": {"type": "string", "description": "Footer text"},
+                "image_url": {"type": "string", "description": "URL of image to display in embed"},
+            },
+            "required": ["channel_id"],
+        }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        channel_id = kwargs["channel_id"]
+        embed: dict[str, Any] = {}
+        if kwargs.get("title"):
+            embed["title"] = kwargs["title"]
+        if kwargs.get("description"):
+            embed["description"] = kwargs["description"]
+        if kwargs.get("color") is not None:
+            embed["color"] = kwargs["color"]
+        if kwargs.get("fields"):
+            embed["fields"] = kwargs["fields"]
+        if kwargs.get("footer"):
+            embed["footer"] = {"text": kwargs["footer"]}
+        if kwargs.get("image_url"):
+            embed["image"] = {"url": kwargs["image_url"]}
+        if not embed:
+            return "Error: must provide at least one embed field (title, description, etc.)"
+        result = await self._api("POST", f"/channels/{channel_id}/messages", {"embeds": [embed]})
+        if "error" in result:
+            return f"Error: {result['error']}"
+        return f"Embed sent (id={result.get('id', '?')})"
+
+
+class DiscordPinMessageTool(DiscordBaseTool):
+    """Pin or unpin a message in a Discord channel."""
+
+    @property
+    def name(self) -> str:
+        return "discord_pin_message"
+
+    @property
+    def description(self) -> str:
+        return "Pin or unpin a message in a Discord channel."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "channel_id": {"type": "string", "description": "Discord channel ID"},
+                "message_id": {"type": "string", "description": "Discord message ID"},
+                "unpin": {
+                    "type": "boolean",
+                    "description": "If true, unpin the message instead (default false)",
+                },
+            },
+            "required": ["channel_id", "message_id"],
+        }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        channel_id = kwargs["channel_id"]
+        message_id = kwargs["message_id"]
+        unpin = kwargs.get("unpin", False)
+        path = f"/channels/{channel_id}/pins/{message_id}"
+        if unpin:
+            result = await self._api("DELETE", path)
+            action = "unpinned"
+        else:
+            result = await self._api("PUT", path)
+            action = "pinned"
+        if "error" in result:
+            return f"Error: {result['error']}"
+        return f"Message {message_id} {action} successfully"
+
+
+class DiscordPollTool(DiscordBaseTool):
+    """Create a poll message in a Discord channel."""
+
+    @property
+    def name(self) -> str:
+        return "discord_poll"
+
+    @property
+    def description(self) -> str:
+        return "Create a poll message in a Discord channel."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "channel_id": {"type": "string", "description": "Discord channel ID"},
+                "question": {"type": "string", "description": "Poll question"},
+                "answers": {
+                    "type": "array",
+                    "description": "List of answer options (2-10 items)",
+                    "items": {"type": "string"},
+                },
+                "duration_hours": {
+                    "type": "integer",
+                    "description": "Poll duration in hours (default 24, max 168)",
+                },
+                "allow_multiselect": {
+                    "type": "boolean",
+                    "description": "Allow users to select multiple answers (default false)",
+                },
+            },
+            "required": ["channel_id", "question", "answers"],
+        }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        channel_id = kwargs["channel_id"]
+        question = kwargs["question"]
+        answers = kwargs["answers"]
+        duration_hours = kwargs.get("duration_hours", 24)
+        allow_multiselect = kwargs.get("allow_multiselect", False)
+
+        if len(answers) < 2:
+            return "Error: poll requires at least 2 answers"
+
+        payload = {
+            "poll": {
+                "question": {"text": question},
+                "answers": [{"poll_media": {"text": a}} for a in answers[:10]],
+                "duration": duration_hours,
+                "allow_multiselect": allow_multiselect,
+            }
+        }
+        result = await self._api("POST", f"/channels/{channel_id}/messages", payload)
+        if "error" in result:
+            return f"Error: {result['error']}"
+        return f"Poll created (id={result.get('id', '?')})"

--- a/nanobot/agent/tools/discord_tools.py
+++ b/nanobot/agent/tools/discord_tools.py
@@ -281,6 +281,8 @@ class DiscordCreateEmbedTool(DiscordBaseTool):
         }
 
     async def execute(self, **kwargs: Any) -> Any:
+        from nanobot.security.network import validate_url_target
+
         channel_id = kwargs["channel_id"]
         embed: dict[str, Any] = {}
         if kwargs.get("title"):
@@ -294,6 +296,9 @@ class DiscordCreateEmbedTool(DiscordBaseTool):
         if kwargs.get("footer"):
             embed["footer"] = {"text": kwargs["footer"]}
         if kwargs.get("image_url"):
+            ok, reason = validate_url_target(kwargs["image_url"])
+            if not ok:
+                return f"Error: image_url rejected — {reason}"
             embed["image"] = {"url": kwargs["image_url"]}
         if not embed:
             return "Error: must provide at least one embed field (title, description, etc.)"

--- a/nanobot/agent/tools/discord_tools.py
+++ b/nanobot/agent/tools/discord_tools.py
@@ -389,7 +389,7 @@ class DiscordPollTool(DiscordBaseTool):
         channel_id = kwargs["channel_id"]
         question = kwargs["question"]
         answers = kwargs["answers"]
-        duration_hours = kwargs.get("duration_hours", 24)
+        duration_hours = min(kwargs.get("duration_hours", 24), 168)
         allow_multiselect = kwargs.get("allow_multiselect", False)
 
         if len(answers) < 2:

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -29,6 +29,12 @@ class DiscordConfig(Base):
     gateway_url: str = "wss://gateway.discord.gg/?v=10&encoding=json"
     intents: int = 37377
     group_policy: Literal["mention", "open"] = "mention"
+    slash_commands_enabled: bool = True
+    threads_per_conversation: bool = False
+    ephemeral_commands: bool = True
+    admin_role_ids: list[str] = Field(default_factory=list)
+    application_id: str = ""
+    guild_ids: list[str] = Field(default_factory=list)
 
 
 class DiscordChannel(BaseChannel):
@@ -50,6 +56,8 @@ class DiscordChannel(BaseChannel):
         self._typing_tasks: dict[str, asyncio.Task] = {}
         self._http: httpx.AsyncClient | None = None
         self._bot_user_id: str | None = None
+        self._tree: discord.app_commands.CommandTree | None = None
+        self._pending_interactions: dict[str, discord.Interaction] = {}
 
     async def start(self) -> None:
         """Start the Discord client."""
@@ -61,11 +69,42 @@ class DiscordChannel(BaseChannel):
         self._http = httpx.AsyncClient(timeout=30.0)
         intents = discord.Intents._from_value(self.config.intents)
         self._client = discord.Client(intents=intents)
+        self._tree = discord.app_commands.CommandTree(self._client)
+
+        @self._tree.command(name="stop", description="Stop the current agent task")
+        async def slash_stop(interaction: discord.Interaction) -> None:
+            await self._inject_slash_as_message(interaction, "/stop")
+
+        @self._tree.command(name="restart", description="Restart the agent")
+        async def slash_restart(interaction: discord.Interaction) -> None:
+            await self._inject_slash_as_message(interaction, "/restart")
+
+        @self._tree.command(name="new", description="Start a new conversation")
+        async def slash_new(interaction: discord.Interaction) -> None:
+            await self._inject_slash_as_message(interaction, "/new")
+
+        @self._tree.command(name="status", description="Show agent status")
+        async def slash_status(interaction: discord.Interaction) -> None:
+            await self._inject_slash_as_message(interaction, "/status")
+
+        @self._tree.command(name="help", description="Show help information")
+        async def slash_help(interaction: discord.Interaction) -> None:
+            await self._inject_slash_as_message(interaction, "/help")
 
         @self._client.event
         async def on_ready() -> None:
             self._bot_user_id = str(self._client.user.id)
             logger.info("Discord ready as {}", self._client.user)
+            if self.config.slash_commands_enabled:
+                if self.config.guild_ids:
+                    for gid in self.config.guild_ids:
+                        guild_obj = discord.Object(id=int(gid))
+                        self._tree.copy_global_to(guild=guild_obj)
+                        await self._tree.sync(guild=guild_obj)
+                    logger.info("Discord slash commands synced to {} guilds", len(self.config.guild_ids))
+                else:
+                    await self._tree.sync()
+                    logger.warning("Discord slash commands synced globally (up to 1hr propagation delay)")
 
         @self._client.event
         async def on_message(message: discord.Message) -> None:
@@ -84,6 +123,7 @@ class DiscordChannel(BaseChannel):
         if self._typing_tasks:
             await asyncio.gather(*self._typing_tasks.values(), return_exceptions=True)
         self._typing_tasks.clear()
+        self._pending_interactions.clear()
         if self._client:
             await self._client.close()
             self._client = None
@@ -93,17 +133,20 @@ class DiscordChannel(BaseChannel):
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message via discord.py, including file attachments."""
+        interaction = self._pending_interactions.pop(msg.chat_id, None)
+
         if not self._client:
             logger.warning("Discord client not initialized")
             return
 
-        channel = self._client.get_channel(int(msg.chat_id))
-        if channel is None:
-            try:
-                channel = await self._client.fetch_channel(int(msg.chat_id))
-            except Exception as e:
-                logger.error("Discord channel {} not found: {}", msg.chat_id, e)
-                return
+        if interaction is None:
+            channel = self._client.get_channel(int(msg.chat_id))
+            if channel is None:
+                try:
+                    channel = await self._client.fetch_channel(int(msg.chat_id))
+                except Exception as e:
+                    logger.error("Discord channel {} not found: {}", msg.chat_id, e)
+                    return
 
         try:
             sent_media = False
@@ -121,18 +164,21 @@ class DiscordChannel(BaseChannel):
                     failed_media.append(path.name)
                     continue
                 try:
-                    reference = None
-                    if msg.reply_to and not sent_media:
-                        reference = discord.MessageReference(
-                            message_id=int(msg.reply_to),
-                            channel_id=int(msg.chat_id),
-                            fail_if_not_exists=False,
+                    if interaction is not None:
+                        await interaction.followup.send(file=discord.File(path))
+                    else:
+                        reference = None
+                        if msg.reply_to and not sent_media:
+                            reference = discord.MessageReference(
+                                message_id=int(msg.reply_to),
+                                channel_id=int(msg.chat_id),
+                                fail_if_not_exists=False,
+                            )
+                        await channel.send(
+                            file=discord.File(path),
+                            reference=reference,
+                            mention_author=False,
                         )
-                    await channel.send(
-                        file=discord.File(path),
-                        reference=reference,
-                        mention_author=False,
-                    )
                     sent_media = True
                     logger.info("Discord file sent: {}", path.name)
                 except Exception as e:
@@ -150,24 +196,47 @@ class DiscordChannel(BaseChannel):
                 return
 
             for i, chunk in enumerate(chunks):
-                reference = None
-                if i == 0 and msg.reply_to and not sent_media:
-                    reference = discord.MessageReference(
-                        message_id=int(msg.reply_to),
-                        channel_id=int(msg.chat_id),
-                        fail_if_not_exists=False,
-                    )
                 try:
-                    await channel.send(
-                        content=chunk,
-                        reference=reference,
-                        mention_author=False,
-                    )
+                    if interaction is not None:
+                        await interaction.followup.send(content=chunk)
+                    else:
+                        reference = None
+                        if i == 0 and msg.reply_to and not sent_media:
+                            reference = discord.MessageReference(
+                                message_id=int(msg.reply_to),
+                                channel_id=int(msg.chat_id),
+                                fail_if_not_exists=False,
+                            )
+                        await channel.send(
+                            content=chunk,
+                            reference=reference,
+                            mention_author=False,
+                        )
                 except Exception as e:
                     logger.error("Error sending Discord message: {}", e)
                     break  # Abort remaining chunks on failure
         finally:
             await self._stop_typing(msg.chat_id)
+
+    async def _inject_slash_as_message(
+        self,
+        interaction: discord.Interaction,
+        text: str,
+    ) -> None:
+        """Defer interaction and inject text as InboundMessage to bus."""
+        channel_id = str(interaction.channel_id)
+        await interaction.response.defer(ephemeral=False)
+        self._pending_interactions[channel_id] = interaction
+        await self._handle_message(
+            sender_id=str(interaction.user.id),
+            chat_id=channel_id,
+            content=text,
+            metadata={
+                "message_id": "",
+                "guild_id": str(interaction.guild_id) if interaction.guild_id else None,
+                "reply_to": None,
+            },
+        )
 
     async def _handle_message_create(self, message: discord.Message) -> None:
         """Handle incoming Discord messages."""

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -62,6 +62,7 @@ class DiscordChannel(BaseChannel):
         self._tree: discord.app_commands.CommandTree | None = None
         self._pending_interactions: dict[str, discord.Interaction] = {}
         self._attach_stop_button: set[str] = set()
+        self._thread_map: dict[str, str] = {}  # original channel_id -> thread_id
 
     async def start(self) -> None:
         """Start the Discord client."""
@@ -229,6 +230,7 @@ class DiscordChannel(BaseChannel):
         self._typing_tasks.clear()
         self._pending_interactions.clear()
         self._attach_stop_button.clear()
+        self._thread_map.clear()
         if self._client:
             await self._client.close()
             self._client = None
@@ -392,6 +394,25 @@ class DiscordChannel(BaseChannel):
             if not self._should_respond_in_group(message, content):
                 return
 
+        # Thread-per-conversation: create a thread for each new conversation in a text channel
+        thread_id: str | None = None
+        if self.config.threads_per_conversation and guild_id is not None:
+            # Don't create a thread if we're already in one (message.channel is a Thread)
+            if not isinstance(message.channel, discord.Thread):
+                # Reuse existing thread for this channel if we have one
+                if channel_id in self._thread_map:
+                    thread_id = self._thread_map[channel_id]
+                else:
+                    try:
+                        thread = await message.create_thread(
+                            name=f"Chat with {message.author.display_name}"[:100]
+                        )
+                        thread_id = str(thread.id)
+                        self._thread_map[channel_id] = thread_id
+                        logger.info("Discord: created thread {} for channel {}", thread_id, channel_id)
+                    except Exception as e:
+                        logger.warning("Discord: failed to create thread: {}", e)
+
         content_parts = [content] if content else []
         media_paths: list[str] = []
         media_dir = get_media_dir("discord")
@@ -423,12 +444,20 @@ class DiscordChannel(BaseChannel):
             else None
         )
 
-        await self._start_typing(message.channel)
+        effective_chat_id = thread_id if thread_id else channel_id
+        session_key = f"discord:{effective_chat_id}" if thread_id else None
 
-        self._attach_stop_button.add(channel_id)
+        typing_target = message.channel
+        if thread_id:
+            thread_channel = self._client.get_channel(int(thread_id)) if self._client else None
+            if thread_channel:
+                typing_target = thread_channel
+        await self._start_typing(typing_target)
+
+        self._attach_stop_button.add(effective_chat_id)
         await self._handle_message(
             sender_id=sender_id,
-            chat_id=channel_id,
+            chat_id=effective_chat_id,
             content="\n".join(p for p in content_parts if p) or "[empty message]",
             media=media_paths,
             metadata={
@@ -436,6 +465,7 @@ class DiscordChannel(BaseChannel):
                 "guild_id": guild_id,
                 "reply_to": reply_to,
             },
+            session_key=session_key,
         )
 
     def _should_respond_in_group(self, message: discord.Message, content: str) -> bool:

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -12,8 +12,10 @@ from pydantic import Field
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
+from nanobot.channels.discord_ui import McpView, ModelPickerView, StatusView
 from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
+from nanobot.providers.registry import PROVIDERS
 from nanobot.utils.helpers import split_message
 
 MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024  # 20MB
@@ -58,6 +60,7 @@ class DiscordChannel(BaseChannel):
         self._bot_user_id: str | None = None
         self._tree: discord.app_commands.CommandTree | None = None
         self._pending_interactions: dict[str, discord.Interaction] = {}
+        self._attach_stop_button: set[str] = set()
 
     async def start(self) -> None:
         """Start the Discord client."""
@@ -88,9 +91,97 @@ class DiscordChannel(BaseChannel):
             async def slash_status(interaction: discord.Interaction) -> None:
                 await self._inject_slash_as_message(interaction, "/status")
 
-            @self._tree.command(name="help", description="Show help information")
+            @self._tree.command(name="help", description="Show available commands")
             async def slash_help(interaction: discord.Interaction) -> None:
-                await self._inject_slash_as_message(interaction, "/help")
+                embed = discord.Embed(title="nanobot Commands", color=discord.Color.blurple())
+                embed.add_field(name="/stop", value="Stop the current agent task", inline=False)
+                embed.add_field(name="/restart", value="Restart the bot process", inline=False)
+                embed.add_field(name="/new", value="Start a new conversation session", inline=False)
+                embed.add_field(name="/status", value="Show bot status", inline=False)
+                embed.add_field(name="/model [model]", value="View or change the LLM model", inline=False)
+                embed.add_field(name="/config", value="View Discord channel configuration (admin)", inline=False)
+                embed.add_field(name="/mcp", value="List registered MCP servers (admin)", inline=False)
+                await interaction.response.send_message(embed=embed, ephemeral=self.config.ephemeral_commands)
+
+            @self._tree.command(name="model", description="View or change the LLM model")
+            @discord.app_commands.describe(model="Model name (e.g. claude-opus-4-6)")
+            async def slash_model(interaction: discord.Interaction, model: str | None = None) -> None:
+                if model:
+                    await self._inject_slash_as_message(interaction, f"/model {model}")
+                    return
+                providers = [(spec.name, spec.label) for spec in PROVIDERS][:20]
+
+                async def on_model_confirm(provider: str, model_name: str) -> None:
+                    pass  # Phase 6 can wire to config update; UI confirmation shown by ModelModal itself
+
+                view = ModelPickerView(providers=providers, on_confirm=on_model_confirm)
+                embed = discord.Embed(
+                    title="Model Picker",
+                    description="Select a provider then click **Set Model** to enter a model name.",
+                    color=discord.Color.blurple(),
+                )
+                await interaction.response.send_message(
+                    embed=embed, view=view, ephemeral=self.config.ephemeral_commands
+                )
+
+            @slash_model.autocomplete("model")
+            async def model_autocomplete(
+                interaction: discord.Interaction, current: str
+            ) -> list[discord.app_commands.Choice[str]]:
+                suggestions = [
+                    "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5",
+                    "gpt-4o", "gpt-4o-mini",
+                    "gemini-2.5-pro", "gemini-2.0-flash",
+                    "deepseek-chat", "deepseek-reasoner",
+                ]
+                filtered = [s for s in suggestions if current.lower() in s.lower()][:25]
+                return [discord.app_commands.Choice(name=s, value=s) for s in filtered]
+
+            @self._tree.command(name="config", description="View Discord channel configuration")
+            async def slash_config(interaction: discord.Interaction) -> None:
+                if self.config.admin_role_ids:
+                    member_roles = [
+                        str(r.id)
+                        for r in (interaction.user.roles if hasattr(interaction.user, "roles") else [])
+                    ]
+                    if not any(r in member_roles for r in self.config.admin_role_ids):
+                        await interaction.response.send_message("Admin access required.", ephemeral=True)
+                        return
+                embed = discord.Embed(title="Discord Channel Config", color=discord.Color.blue())
+                embed.add_field(name="group_policy", value=self.config.group_policy, inline=True)
+                embed.add_field(name="slash_commands_enabled", value=str(self.config.slash_commands_enabled), inline=True)
+                embed.add_field(name="ephemeral_commands", value=str(self.config.ephemeral_commands), inline=True)
+                embed.add_field(name="threads_per_conversation", value=str(self.config.threads_per_conversation), inline=True)
+                embed.add_field(name="guild_ids", value=", ".join(self.config.guild_ids) or "(global)", inline=True)
+                embed.add_field(name="admin_role_ids", value=", ".join(self.config.admin_role_ids) or "(none)", inline=True)
+                await interaction.response.send_message(embed=embed, ephemeral=self.config.ephemeral_commands)
+
+            @self._tree.command(name="mcp", description="List registered MCP servers")
+            async def slash_mcp(interaction: discord.Interaction) -> None:
+                if self.config.admin_role_ids:
+                    member_roles = [
+                        str(r.id)
+                        for r in (interaction.user.roles if hasattr(interaction.user, "roles") else [])
+                    ]
+                    if not any(r in member_roles for r in self.config.admin_role_ids):
+                        await interaction.response.send_message("Admin access required.", ephemeral=True)
+                        return
+                mcp_servers: list[str] = []
+                try:
+                    from nanobot.config.loader import load_config  # noqa: PLC0415
+                    cfg = load_config()
+                    if hasattr(cfg, "mcp") and cfg.mcp:
+                        mcp_servers = list(cfg.mcp.keys())
+                except Exception:
+                    pass
+                view = McpView(mcp_servers)
+                embed = discord.Embed(title="MCP Servers", color=discord.Color.green())
+                if mcp_servers:
+                    for name in mcp_servers:
+                        embed.add_field(name=name, value="registered", inline=True)
+                else:
+                    embed.description = "No MCP servers configured."
+                await interaction.response.send_message(embed=embed, view=view, ephemeral=self.config.ephemeral_commands)
 
         @self._client.event
         async def on_ready() -> None:
@@ -125,6 +216,7 @@ class DiscordChannel(BaseChannel):
             await asyncio.gather(*self._typing_tasks.values(), return_exceptions=True)
         self._typing_tasks.clear()
         self._pending_interactions.clear()
+        self._attach_stop_button.clear()
         if self._client:
             await self._client.close()
             self._client = None
@@ -134,6 +226,8 @@ class DiscordChannel(BaseChannel):
 
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message via discord.py, including file attachments."""
+        attach_stop = msg.chat_id in self._attach_stop_button
+        self._attach_stop_button.discard(msg.chat_id)
         interaction = self._pending_interactions.pop(msg.chat_id, None)
 
         if not self._client:
@@ -210,10 +304,26 @@ class DiscordChannel(BaseChannel):
                                 channel_id=int(msg.chat_id),
                                 fail_if_not_exists=False,
                             )
+                        view: discord.ui.View | None = None
+                        if i == 0 and attach_stop:
+                            chat_id_capture = msg.chat_id
+
+                            async def _stop_cb() -> None:
+                                from nanobot.bus.events import InboundMessage  # noqa: PLC0415
+                                await self.bus.publish_inbound(InboundMessage(
+                                    channel=self.name,
+                                    sender_id="",
+                                    chat_id=chat_id_capture,
+                                    content="/stop",
+                                    metadata={"message_id": "", "guild_id": None, "reply_to": None},
+                                ))
+
+                            view = StatusView(on_stop=_stop_cb)
                         await channel.send(
                             content=chunk,
                             reference=reference,
                             mention_author=False,
+                            view=view,
                         )
                 except Exception as e:
                     logger.error("Error sending Discord message: {}", e)
@@ -312,6 +422,7 @@ class DiscordChannel(BaseChannel):
                 "reply_to": reply_to,
             },
         )
+        self._attach_stop_button.add(channel_id)
 
     def _should_respond_in_group(self, message: discord.Message, content: str) -> bool:
         """Check if bot should respond in a group channel based on policy."""

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -61,6 +61,8 @@ class DiscordChannel(BaseChannel):
         self._bot_user_id: str | None = None
         self._tree: discord.app_commands.CommandTree | None = None
         self._pending_interactions: dict[str, discord.Interaction] = {}
+        self._interaction_timestamps: dict[str, float] = {}
+        self._cleanup_interactions_task: asyncio.Task | None = None
         self._attach_stop_button: set[str] = set()
         self._thread_map: dict[str, str] = {}  # original channel_id -> thread_id
         self._tool_registry: Any = None
@@ -100,6 +102,7 @@ class DiscordChannel(BaseChannel):
 
             @self._tree.command(name="help", description="Show available commands")
             async def slash_help(interaction: discord.Interaction) -> None:
+                logger.info("Discord slash command: /help from user={} channel={}", interaction.user.id, interaction.channel_id)
                 embed = discord.Embed(title="nanobot Commands", color=discord.Color.blurple())
                 embed.add_field(name="/stop", value="Stop the current agent task", inline=False)
                 embed.add_field(name="/restart", value="Restart the bot process", inline=False)
@@ -113,6 +116,7 @@ class DiscordChannel(BaseChannel):
             @self._tree.command(name="model", description="View or change the LLM model")
             @discord.app_commands.describe(model="Model name (e.g. claude-opus-4-6)")
             async def slash_model(interaction: discord.Interaction, model: str | None = None) -> None:
+                logger.info("Discord slash command: /model from user={} channel={}", interaction.user.id, interaction.channel_id)
                 if model:
                     await self._inject_slash_as_message(interaction, f"/model {model}")
                     return
@@ -163,6 +167,7 @@ class DiscordChannel(BaseChannel):
                     if not any(r in member_roles for r in self.config.admin_role_ids):
                         await interaction.response.send_message("Admin access required.", ephemeral=True)
                         return
+                logger.info("Discord slash command: /config from user={} channel={}", interaction.user.id, interaction.channel_id)
                 embed = discord.Embed(title="Discord Channel Config", color=discord.Color.blue())
                 embed.add_field(name="group_policy", value=self.config.group_policy, inline=True)
                 embed.add_field(name="slash_commands_enabled", value=str(self.config.slash_commands_enabled), inline=True)
@@ -184,6 +189,7 @@ class DiscordChannel(BaseChannel):
                     if not any(r in member_roles for r in self.config.admin_role_ids):
                         await interaction.response.send_message("Admin access required.", ephemeral=True)
                         return
+                logger.info("Discord slash command: /mcp from user={} channel={}", interaction.user.id, interaction.channel_id)
                 mcp_servers: list[str] = []
                 try:
                     from nanobot.config.loader import load_config  # noqa: PLC0415
@@ -205,6 +211,7 @@ class DiscordChannel(BaseChannel):
         async def on_ready() -> None:
             self._bot_user_id = str(self._client.user.id)
             logger.info("Discord ready as {}", self._client.user)
+            self._cleanup_interactions_task = asyncio.ensure_future(self._cleanup_interactions())
             self._register_discord_tools()
             if self.config.slash_commands_enabled:
                 if self.config.guild_ids:
@@ -267,9 +274,33 @@ class DiscordChannel(BaseChannel):
         ]:
             self._tool_registry.unregister(name)
 
+    async def _cleanup_interactions(self) -> None:
+        """Periodically remove stale pending interactions (>840s old)."""
+        while True:
+            try:
+                await asyncio.sleep(60)
+                now = asyncio.get_running_loop().time()
+                stale = [cid for cid, ts in self._interaction_timestamps.items() if now - ts > 840]
+                for cid in stale:
+                    self._pending_interactions.pop(cid, None)
+                    self._interaction_timestamps.pop(cid, None)
+                    logger.debug("Discord: expired stale interaction for channel {}", cid)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warning("Discord: interaction cleanup error: {}", e)
+
     async def stop(self) -> None:
         """Stop the Discord channel."""
         self._running = False
+        if self._cleanup_interactions_task:
+            self._cleanup_interactions_task.cancel()
+            try:
+                await self._cleanup_interactions_task
+            except asyncio.CancelledError:
+                pass
+            self._cleanup_interactions_task = None
+        self._interaction_timestamps.clear()
         self._unregister_discord_tools()
         for task in self._typing_tasks.values():
             task.cancel()
@@ -404,9 +435,11 @@ class DiscordChannel(BaseChannel):
         if not self.is_allowed(str(interaction.user.id)):
             await interaction.response.send_message("Not authorized.", ephemeral=True)
             return
+        logger.info("Discord slash command: {} from user={} channel={}", text, interaction.user.id, interaction.channel_id)
         channel_id = str(interaction.channel_id)
         await interaction.response.defer(thinking=True, ephemeral=self.config.ephemeral_commands)
         self._pending_interactions[channel_id] = interaction
+        self._interaction_timestamps[channel_id] = asyncio.get_running_loop().time()
         # TODO: Phase 3 — if two slash commands fire before the first is answered, the second
         # overwrites _pending_interactions[channel_id] and the first deferred interaction
         # will never get a followup (Discord marks it failed). Consider per-channel locking.

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -396,18 +396,20 @@ class DiscordChannel(BaseChannel):
 
         # Thread-per-conversation: create a thread for each new conversation in a text channel
         thread_id: str | None = None
+        created_thread: discord.Thread | None = None
         if self.config.threads_per_conversation and guild_id is not None:
             # Don't create a thread if we're already in one (message.channel is a Thread)
             if not isinstance(message.channel, discord.Thread):
-                # Reuse existing thread for this channel if we have one
+                # Note: thread reuse is per-channel (one thread per text channel), not per-user.
+                # All users sending in the same channel share one conversation thread.
                 if channel_id in self._thread_map:
                     thread_id = self._thread_map[channel_id]
                 else:
                     try:
-                        thread = await message.create_thread(
+                        created_thread = await message.create_thread(
                             name=f"Chat with {message.author.display_name}"[:100]
                         )
-                        thread_id = str(thread.id)
+                        thread_id = str(created_thread.id)
                         self._thread_map[channel_id] = thread_id
                         logger.info("Discord: created thread {} for channel {}", thread_id, channel_id)
                     except Exception as e:
@@ -449,9 +451,14 @@ class DiscordChannel(BaseChannel):
 
         typing_target = message.channel
         if thread_id:
-            thread_channel = self._client.get_channel(int(thread_id)) if self._client else None
-            if thread_channel:
-                typing_target = thread_channel
+            if created_thread is not None:
+                # Use the newly-created thread object directly (get_channel may not have it cached yet)
+                typing_target = created_thread
+            else:
+                # Reusing an existing thread — try the cache
+                thread_channel = self._client.get_channel(int(thread_id)) if self._client else None
+                if thread_channel:
+                    typing_target = thread_channel
         await self._start_typing(typing_target)
 
         self._attach_stop_button.add(effective_chat_id)

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -1,14 +1,13 @@
-"""Discord channel implementation using Discord Gateway websocket."""
+"""Discord channel implementation using discord.py 2.x."""
 
 import asyncio
-import json
 from pathlib import Path
 from typing import Any, Literal
 
+import discord
 import httpx
-from pydantic import Field
-import websockets
 from loguru import logger
+from pydantic import Field
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -34,7 +33,7 @@ class DiscordConfig(Base):
 
 
 class DiscordChannel(BaseChannel):
-    """Discord channel using Gateway websocket."""
+    """Discord channel using discord.py 2.x."""
 
     name = "discord"
     display_name = "Discord"
@@ -48,60 +47,59 @@ class DiscordChannel(BaseChannel):
             config = DiscordConfig.model_validate(config)
         super().__init__(config, bus)
         self.config: DiscordConfig = config
-        self._ws: websockets.WebSocketClientProtocol | None = None
-        self._seq: int | None = None
-        self._heartbeat_task: asyncio.Task | None = None
+        self._client: discord.Client | None = None
         self._typing_tasks: dict[str, asyncio.Task] = {}
         self._http: httpx.AsyncClient | None = None
         self._bot_user_id: str | None = None
 
     async def start(self) -> None:
-        """Start the Discord gateway connection."""
+        """Start the Discord client."""
         if not self.config.token:
             logger.error("Discord bot token not configured")
             return
 
         self._running = True
         self._http = httpx.AsyncClient(timeout=30.0)
+        intents = discord.Intents(value=self.config.intents)
+        self._client = discord.Client(intents=intents)
 
-        while self._running:
-            try:
-                logger.info("Connecting to Discord gateway...")
-                async with websockets.connect(self.config.gateway_url) as ws:
-                    self._ws = ws
-                    await self._gateway_loop()
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.warning("Discord gateway error: {}", e)
-                if self._running:
-                    logger.info("Reconnecting to Discord gateway in 5 seconds...")
-                    await asyncio.sleep(5)
+        @self._client.event
+        async def on_ready() -> None:
+            self._bot_user_id = str(self._client.user.id)
+            logger.info("Discord ready as {}", self._client.user)
+
+        @self._client.event
+        async def on_message(message: discord.Message) -> None:
+            await self._handle_message_create(message)
+
+        try:
+            await self._client.start(self.config.token)
+        except asyncio.CancelledError:
+            pass
 
     async def stop(self) -> None:
         """Stop the Discord channel."""
         self._running = False
-        if self._heartbeat_task:
-            self._heartbeat_task.cancel()
-            self._heartbeat_task = None
         for task in self._typing_tasks.values():
             task.cancel()
         self._typing_tasks.clear()
-        if self._ws:
-            await self._ws.close()
-            self._ws = None
+        if self._client:
+            await self._client.close()
+            self._client = None
         if self._http:
             await self._http.aclose()
             self._http = None
 
     async def send(self, msg: OutboundMessage) -> None:
-        """Send a message through Discord REST API, including file attachments."""
-        if not self._http:
-            logger.warning("Discord HTTP client not initialized")
+        """Send a message via discord.py, including file attachments."""
+        if not self._client:
+            logger.warning("Discord client not initialized")
             return
 
-        url = f"{DISCORD_API_BASE}/channels/{msg.chat_id}/messages"
-        headers = {"Authorization": f"Bot {self.config.token}"}
+        channel = self._client.get_channel(int(msg.chat_id))
+        if not channel:
+            logger.warning("Discord channel {} not found in cache", msg.chat_id)
+            return
 
         try:
             sent_media = False
@@ -109,10 +107,33 @@ class DiscordChannel(BaseChannel):
 
             # Send file attachments first
             for media_path in msg.media or []:
-                if await self._send_file(url, headers, media_path, reply_to=msg.reply_to):
+                path = Path(media_path)
+                if not path.is_file():
+                    logger.warning("Discord file not found, skipping: {}", media_path)
+                    failed_media.append(path.name)
+                    continue
+                if path.stat().st_size > MAX_ATTACHMENT_BYTES:
+                    logger.warning("Discord file too large (>20MB), skipping: {}", path.name)
+                    failed_media.append(path.name)
+                    continue
+                try:
+                    reference = None
+                    if msg.reply_to and not sent_media:
+                        reference = discord.MessageReference(
+                            message_id=int(msg.reply_to),
+                            channel_id=int(msg.chat_id),
+                            fail_if_not_exists=False,
+                        )
+                    await channel.send(
+                        file=discord.File(path),
+                        reference=reference,
+                        mention_author=False,
+                    )
                     sent_media = True
-                else:
-                    failed_media.append(Path(media_path).name)
+                    logger.info("Discord file sent: {}", path.name)
+                except Exception as e:
+                    logger.error("Error sending Discord file {}: {}", path.name, e)
+                    failed_media.append(path.name)
 
             # Send text content
             chunks = split_message(msg.content or "", MAX_MESSAGE_LEN)
@@ -125,176 +146,34 @@ class DiscordChannel(BaseChannel):
                 return
 
             for i, chunk in enumerate(chunks):
-                payload: dict[str, Any] = {"content": chunk}
-
-                # Let the first successful attachment carry the reply if present.
+                reference = None
                 if i == 0 and msg.reply_to and not sent_media:
-                    payload["message_reference"] = {"message_id": msg.reply_to}
-                    payload["allowed_mentions"] = {"replied_user": False}
-
-                if not await self._send_payload(url, headers, payload):
+                    reference = discord.MessageReference(
+                        message_id=int(msg.reply_to),
+                        channel_id=int(msg.chat_id),
+                        fail_if_not_exists=False,
+                    )
+                try:
+                    await channel.send(
+                        content=chunk,
+                        reference=reference,
+                        mention_author=False,
+                    )
+                except Exception as e:
+                    logger.error("Error sending Discord message: {}", e)
                     break  # Abort remaining chunks on failure
         finally:
             await self._stop_typing(msg.chat_id)
 
-    async def _send_payload(
-        self, url: str, headers: dict[str, str], payload: dict[str, Any]
-    ) -> bool:
-        """Send a single Discord API payload with retry on rate-limit. Returns True on success."""
-        for attempt in range(3):
-            try:
-                response = await self._http.post(url, headers=headers, json=payload)
-                if response.status_code == 429:
-                    data = response.json()
-                    retry_after = float(data.get("retry_after", 1.0))
-                    logger.warning("Discord rate limited, retrying in {}s", retry_after)
-                    await asyncio.sleep(retry_after)
-                    continue
-                response.raise_for_status()
-                return True
-            except Exception as e:
-                if attempt == 2:
-                    logger.error("Error sending Discord message: {}", e)
-                else:
-                    await asyncio.sleep(1)
-        return False
-
-    async def _send_file(
-        self,
-        url: str,
-        headers: dict[str, str],
-        file_path: str,
-        reply_to: str | None = None,
-    ) -> bool:
-        """Send a file attachment via Discord REST API using multipart/form-data."""
-        path = Path(file_path)
-        if not path.is_file():
-            logger.warning("Discord file not found, skipping: {}", file_path)
-            return False
-
-        if path.stat().st_size > MAX_ATTACHMENT_BYTES:
-            logger.warning("Discord file too large (>20MB), skipping: {}", path.name)
-            return False
-
-        payload_json: dict[str, Any] = {}
-        if reply_to:
-            payload_json["message_reference"] = {"message_id": reply_to}
-            payload_json["allowed_mentions"] = {"replied_user": False}
-
-        for attempt in range(3):
-            try:
-                with open(path, "rb") as f:
-                    files = {"files[0]": (path.name, f, "application/octet-stream")}
-                    data: dict[str, Any] = {}
-                    if payload_json:
-                        data["payload_json"] = json.dumps(payload_json)
-                    response = await self._http.post(
-                        url, headers=headers, files=files, data=data
-                    )
-                if response.status_code == 429:
-                    resp_data = response.json()
-                    retry_after = float(resp_data.get("retry_after", 1.0))
-                    logger.warning("Discord rate limited, retrying in {}s", retry_after)
-                    await asyncio.sleep(retry_after)
-                    continue
-                response.raise_for_status()
-                logger.info("Discord file sent: {}", path.name)
-                return True
-            except Exception as e:
-                if attempt == 2:
-                    logger.error("Error sending Discord file {}: {}", path.name, e)
-                else:
-                    await asyncio.sleep(1)
-        return False
-
-    async def _gateway_loop(self) -> None:
-        """Main gateway loop: identify, heartbeat, dispatch events."""
-        if not self._ws:
-            return
-
-        async for raw in self._ws:
-            try:
-                data = json.loads(raw)
-            except json.JSONDecodeError:
-                logger.warning("Invalid JSON from Discord gateway: {}", raw[:100])
-                continue
-
-            op = data.get("op")
-            event_type = data.get("t")
-            seq = data.get("s")
-            payload = data.get("d")
-
-            if seq is not None:
-                self._seq = seq
-
-            if op == 10:
-                # HELLO: start heartbeat and identify
-                interval_ms = payload.get("heartbeat_interval", 45000)
-                await self._start_heartbeat(interval_ms / 1000)
-                await self._identify()
-            elif op == 0 and event_type == "READY":
-                logger.info("Discord gateway READY")
-                # Capture bot user ID for mention detection
-                user_data = payload.get("user") or {}
-                self._bot_user_id = user_data.get("id")
-                logger.info("Discord bot connected as user {}", self._bot_user_id)
-            elif op == 0 and event_type == "MESSAGE_CREATE":
-                await self._handle_message_create(payload)
-            elif op == 7:
-                # RECONNECT: exit loop to reconnect
-                logger.info("Discord gateway requested reconnect")
-                break
-            elif op == 9:
-                # INVALID_SESSION: reconnect
-                logger.warning("Discord gateway invalid session")
-                break
-
-    async def _identify(self) -> None:
-        """Send IDENTIFY payload."""
-        if not self._ws:
-            return
-
-        identify = {
-            "op": 2,
-            "d": {
-                "token": self.config.token,
-                "intents": self.config.intents,
-                "properties": {
-                    "os": "nanobot",
-                    "browser": "nanobot",
-                    "device": "nanobot",
-                },
-            },
-        }
-        await self._ws.send(json.dumps(identify))
-
-    async def _start_heartbeat(self, interval_s: float) -> None:
-        """Start or restart the heartbeat loop."""
-        if self._heartbeat_task:
-            self._heartbeat_task.cancel()
-
-        async def heartbeat_loop() -> None:
-            while self._running and self._ws:
-                payload = {"op": 1, "d": self._seq}
-                try:
-                    await self._ws.send(json.dumps(payload))
-                except Exception as e:
-                    logger.warning("Discord heartbeat failed: {}", e)
-                    break
-                await asyncio.sleep(interval_s)
-
-        self._heartbeat_task = asyncio.create_task(heartbeat_loop())
-
-    async def _handle_message_create(self, payload: dict[str, Any]) -> None:
+    async def _handle_message_create(self, message: discord.Message) -> None:
         """Handle incoming Discord messages."""
-        author = payload.get("author") or {}
-        if author.get("bot"):
+        if message.author.bot:
             return
 
-        sender_id = str(author.get("id", ""))
-        channel_id = str(payload.get("channel_id", ""))
-        content = payload.get("content") or ""
-        guild_id = payload.get("guild_id")
+        sender_id = str(message.author.id)
+        channel_id = str(message.channel.id)
+        content = message.content or ""
+        guild_id = str(message.guild.id) if message.guild else None
 
         if not sender_id or not channel_id:
             return
@@ -304,17 +183,17 @@ class DiscordChannel(BaseChannel):
 
         # Check group channel policy (DMs always respond if is_allowed passes)
         if guild_id is not None:
-            if not self._should_respond_in_group(payload, content):
+            if not self._should_respond_in_group(message, content):
                 return
 
         content_parts = [content] if content else []
         media_paths: list[str] = []
         media_dir = get_media_dir("discord")
 
-        for attachment in payload.get("attachments") or []:
-            url = attachment.get("url")
-            filename = attachment.get("filename") or "attachment"
-            size = attachment.get("size") or 0
+        for attachment in message.attachments:
+            url = attachment.url
+            filename = attachment.filename or "attachment"
+            size = attachment.size or 0
             if not url or not self._http:
                 continue
             if size and size > MAX_ATTACHMENT_BYTES:
@@ -322,7 +201,7 @@ class DiscordChannel(BaseChannel):
                 continue
             try:
                 media_dir.mkdir(parents=True, exist_ok=True)
-                file_path = media_dir / f"{attachment.get('id', 'file')}_{filename.replace('/', '_')}"
+                file_path = media_dir / f"{attachment.id}_{filename.replace('/', '_')}"
                 resp = await self._http.get(url)
                 resp.raise_for_status()
                 file_path.write_bytes(resp.content)
@@ -332,9 +211,9 @@ class DiscordChannel(BaseChannel):
                 logger.warning("Failed to download Discord attachment: {}", e)
                 content_parts.append(f"[attachment: {filename} - download failed]")
 
-        reply_to = (payload.get("referenced_message") or {}).get("id")
+        reply_to = str(message.reference.message_id) if message.reference else None
 
-        await self._start_typing(channel_id)
+        await self._start_typing(message.channel, channel_id)
 
         await self._handle_message(
             sender_id=sender_id,
@@ -342,13 +221,13 @@ class DiscordChannel(BaseChannel):
             content="\n".join(p for p in content_parts if p) or "[empty message]",
             media=media_paths,
             metadata={
-                "message_id": str(payload.get("id", "")),
+                "message_id": str(message.id),
                 "guild_id": guild_id,
                 "reply_to": reply_to,
             },
         )
 
-    def _should_respond_in_group(self, payload: dict[str, Any], content: str) -> bool:
+    def _should_respond_in_group(self, message: discord.Message, content: str) -> bool:
         """Check if bot should respond in a group channel based on policy."""
         if self.config.group_policy == "open":
             return True
@@ -356,35 +235,26 @@ class DiscordChannel(BaseChannel):
         if self.config.group_policy == "mention":
             # Check if bot was mentioned in the message
             if self._bot_user_id:
-                # Check mentions array
-                mentions = payload.get("mentions") or []
-                for mention in mentions:
-                    if str(mention.get("id")) == self._bot_user_id:
-                        return True
+                if any(str(m.id) == self._bot_user_id for m in message.mentions):
+                    return True
                 # Also check content for mention format <@USER_ID>
                 if f"<@{self._bot_user_id}>" in content or f"<@!{self._bot_user_id}>" in content:
                     return True
-            logger.debug("Discord message in {} ignored (bot not mentioned)", payload.get("channel_id"))
+            logger.debug("Discord message in {} ignored (bot not mentioned)", str(message.channel.id))
             return False
 
         return True
 
-    async def _start_typing(self, channel_id: str) -> None:
-        """Start periodic typing indicator for a channel."""
+    async def _start_typing(self, channel: discord.abc.Messageable, channel_id: str) -> None:
+        """Start typing indicator for a channel using discord.py context manager."""
         await self._stop_typing(channel_id)
 
         async def typing_loop() -> None:
-            url = f"{DISCORD_API_BASE}/channels/{channel_id}/typing"
-            headers = {"Authorization": f"Bot {self.config.token}"}
-            while self._running:
-                try:
-                    await self._http.post(url, headers=headers)
-                except asyncio.CancelledError:
-                    return
-                except Exception as e:
-                    logger.debug("Discord typing indicator failed for {}: {}", channel_id, e)
-                    return
-                await asyncio.sleep(8)
+            try:
+                async with channel.typing():
+                    await asyncio.sleep(float("inf"))  # keeps typing context open
+            except (asyncio.CancelledError, Exception):
+                pass
 
         self._typing_tasks[channel_id] = asyncio.create_task(typing_loop())
 

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -63,6 +63,11 @@ class DiscordChannel(BaseChannel):
         self._pending_interactions: dict[str, discord.Interaction] = {}
         self._attach_stop_button: set[str] = set()
         self._thread_map: dict[str, str] = {}  # original channel_id -> thread_id
+        self._tool_registry: Any = None
+
+    def set_tool_registry(self, registry: Any) -> None:
+        """Inject the agent's ToolRegistry so Discord tools can be registered."""
+        self._tool_registry = registry
 
     async def start(self) -> None:
         """Start the Discord client."""
@@ -200,6 +205,7 @@ class DiscordChannel(BaseChannel):
         async def on_ready() -> None:
             self._bot_user_id = str(self._client.user.id)
             logger.info("Discord ready as {}", self._client.user)
+            self._register_discord_tools()
             if self.config.slash_commands_enabled:
                 if self.config.guild_ids:
                     for gid in self.config.guild_ids:
@@ -220,9 +226,51 @@ class DiscordChannel(BaseChannel):
         except asyncio.CancelledError:
             pass
 
+    def _register_discord_tools(self) -> None:
+        """Register Discord API tools into the tool registry."""
+        if self._tool_registry is None or self._http is None:
+            return
+        from nanobot.agent.tools.discord_tools import (  # noqa: PLC0415
+            DiscordCreateChannelTool,
+            DiscordCreateEmbedTool,
+            DiscordCreateThreadTool,
+            DiscordManageRolesTool,
+            DiscordPinMessageTool,
+            DiscordPollTool,
+            DiscordSendTool,
+        )
+        token = self.config.token
+        for tool in [
+            DiscordSendTool(self._http, token),
+            DiscordCreateThreadTool(self._http, token),
+            DiscordCreateChannelTool(self._http, token),
+            DiscordManageRolesTool(self._http, token),
+            DiscordCreateEmbedTool(self._http, token),
+            DiscordPinMessageTool(self._http, token),
+            DiscordPollTool(self._http, token),
+        ]:
+            self._tool_registry.register(tool)
+        logger.info("Discord: registered {} agent tools", 7)
+
+    def _unregister_discord_tools(self) -> None:
+        """Unregister Discord API tools from the tool registry."""
+        if self._tool_registry is None:
+            return
+        for name in [
+            "discord_send",
+            "discord_create_thread",
+            "discord_create_channel",
+            "discord_manage_roles",
+            "discord_create_embed",
+            "discord_pin_message",
+            "discord_poll",
+        ]:
+            self._tool_registry.unregister(name)
+
     async def stop(self) -> None:
         """Stop the Discord channel."""
         self._running = False
+        self._unregister_discord_tools()
         for task in self._typing_tasks.values():
             task.cancel()
         if self._typing_tasks:

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -30,10 +30,10 @@ class DiscordConfig(Base):
     intents: int = 37377
     group_policy: Literal["mention", "open"] = "mention"
     slash_commands_enabled: bool = True
-    threads_per_conversation: bool = False
+    threads_per_conversation: bool = False  # used in Phase 4: thread-per-conversation feature
     ephemeral_commands: bool = True
-    admin_role_ids: list[str] = Field(default_factory=list)
-    application_id: str = ""
+    admin_role_ids: list[str] = Field(default_factory=list)  # used in Phase 3: Path B admin commands
+    application_id: str = ""    # reserved for Phase 3 introspection
     guild_ids: list[str] = Field(default_factory=list)
 
 
@@ -71,25 +71,26 @@ class DiscordChannel(BaseChannel):
         self._client = discord.Client(intents=intents)
         self._tree = discord.app_commands.CommandTree(self._client)
 
-        @self._tree.command(name="stop", description="Stop the current agent task")
-        async def slash_stop(interaction: discord.Interaction) -> None:
-            await self._inject_slash_as_message(interaction, "/stop")
+        if self.config.slash_commands_enabled:
+            @self._tree.command(name="stop", description="Stop the current agent task")
+            async def slash_stop(interaction: discord.Interaction) -> None:
+                await self._inject_slash_as_message(interaction, "/stop")
 
-        @self._tree.command(name="restart", description="Restart the agent")
-        async def slash_restart(interaction: discord.Interaction) -> None:
-            await self._inject_slash_as_message(interaction, "/restart")
+            @self._tree.command(name="restart", description="Restart the agent")
+            async def slash_restart(interaction: discord.Interaction) -> None:
+                await self._inject_slash_as_message(interaction, "/restart")
 
-        @self._tree.command(name="new", description="Start a new conversation")
-        async def slash_new(interaction: discord.Interaction) -> None:
-            await self._inject_slash_as_message(interaction, "/new")
+            @self._tree.command(name="new", description="Start a new conversation")
+            async def slash_new(interaction: discord.Interaction) -> None:
+                await self._inject_slash_as_message(interaction, "/new")
 
-        @self._tree.command(name="status", description="Show agent status")
-        async def slash_status(interaction: discord.Interaction) -> None:
-            await self._inject_slash_as_message(interaction, "/status")
+            @self._tree.command(name="status", description="Show agent status")
+            async def slash_status(interaction: discord.Interaction) -> None:
+                await self._inject_slash_as_message(interaction, "/status")
 
-        @self._tree.command(name="help", description="Show help information")
-        async def slash_help(interaction: discord.Interaction) -> None:
-            await self._inject_slash_as_message(interaction, "/help")
+            @self._tree.command(name="help", description="Show help information")
+            async def slash_help(interaction: discord.Interaction) -> None:
+                await self._inject_slash_as_message(interaction, "/help")
 
         @self._client.event
         async def on_ready() -> None:
@@ -193,6 +194,8 @@ class DiscordChannel(BaseChannel):
                     MAX_MESSAGE_LEN,
                 )
             if not chunks:
+                if interaction is not None:
+                    await interaction.followup.send(content="✓", ephemeral=self.config.ephemeral_commands)
                 return
 
             for i, chunk in enumerate(chunks):
@@ -224,9 +227,15 @@ class DiscordChannel(BaseChannel):
         text: str,
     ) -> None:
         """Defer interaction and inject text as InboundMessage to bus."""
+        if not self.is_allowed(str(interaction.user.id)):
+            await interaction.response.send_message("Not authorized.", ephemeral=True)
+            return
         channel_id = str(interaction.channel_id)
-        await interaction.response.defer(ephemeral=False)
+        await interaction.response.defer(thinking=True, ephemeral=self.config.ephemeral_commands)
         self._pending_interactions[channel_id] = interaction
+        # TODO: Phase 3 — if two slash commands fire before the first is answered, the second
+        # overwrites _pending_interactions[channel_id] and the first deferred interaction
+        # will never get a followup (Discord marks it failed). Consider per-channel locking.
         await self._handle_message(
             sender_id=str(interaction.user.id),
             chat_id=channel_id,

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -34,7 +34,8 @@ class DiscordConfig(Base):
     slash_commands_enabled: bool = True
     threads_per_conversation: bool = False  # used in Phase 4: thread-per-conversation feature
     ephemeral_commands: bool = True
-    admin_role_ids: list[str] = Field(default_factory=list)  # used in Phase 3: Path B admin commands
+    admin_role_ids: list[str] = Field(default_factory=list)
+    # used in Phase 3: Path B admin commands. Empty = open access to all users.
     application_id: str = ""    # reserved for Phase 3 introspection
     guild_ids: list[str] = Field(default_factory=list)
 
@@ -112,7 +113,14 @@ class DiscordChannel(BaseChannel):
                 providers = [(spec.name, spec.label) for spec in PROVIDERS][:20]
 
                 async def on_model_confirm(provider: str, model_name: str) -> None:
-                    pass  # Phase 6 can wire to config update; UI confirmation shown by ModelModal itself
+                    from nanobot.bus.events import InboundMessage  # noqa: PLC0415
+                    await self.bus.publish_inbound(InboundMessage(
+                        channel=self.name,
+                        sender_id="__model_picker__",
+                        chat_id=str(interaction.channel_id),
+                        content=f"/model {provider}/{model_name}",
+                        metadata={"message_id": "", "guild_id": str(interaction.guild_id) if interaction.guild_id else None, "reply_to": None},
+                    ))
 
                 view = ModelPickerView(providers=providers, on_confirm=on_model_confirm)
                 embed = discord.Embed(
@@ -139,6 +147,8 @@ class DiscordChannel(BaseChannel):
 
             @self._tree.command(name="config", description="View Discord channel configuration")
             async def slash_config(interaction: discord.Interaction) -> None:
+                # admin_role_ids guard: empty list = open access. In DMs, user has no roles, so DM users
+                # always pass when admin_role_ids is non-empty (user.roles is []).
                 if self.config.admin_role_ids:
                     member_roles = [
                         str(r.id)
@@ -158,6 +168,8 @@ class DiscordChannel(BaseChannel):
 
             @self._tree.command(name="mcp", description="List registered MCP servers")
             async def slash_mcp(interaction: discord.Interaction) -> None:
+                # admin_role_ids guard: empty list = open access. In DMs, user has no roles, so DM users
+                # always pass when admin_role_ids is non-empty (user.roles is []).
                 if self.config.admin_role_ids:
                     member_roles = [
                         str(r.id)
@@ -310,9 +322,11 @@ class DiscordChannel(BaseChannel):
 
                             async def _stop_cb() -> None:
                                 from nanobot.bus.events import InboundMessage  # noqa: PLC0415
+                                # sender_id is a sentinel — stop is a priority command processed before is_allowed()
+                                # in AgentLoop.run(), so no real user ID is needed here.
                                 await self.bus.publish_inbound(InboundMessage(
                                     channel=self.name,
-                                    sender_id="",
+                                    sender_id="__stop_button__",
                                     chat_id=chat_id_capture,
                                     content="/stop",
                                     metadata={"message_id": "", "guild_id": None, "reply_to": None},
@@ -411,6 +425,7 @@ class DiscordChannel(BaseChannel):
 
         await self._start_typing(message.channel)
 
+        self._attach_stop_button.add(channel_id)
         await self._handle_message(
             sender_id=sender_id,
             chat_id=channel_id,
@@ -422,7 +437,6 @@ class DiscordChannel(BaseChannel):
                 "reply_to": reply_to,
             },
         )
-        self._attach_stop_button.add(channel_id)
 
     def _should_respond_in_group(self, message: discord.Message, content: str) -> bool:
         """Check if bot should respond in a group channel based on policy."""

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -16,7 +16,6 @@ from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 from nanobot.utils.helpers import split_message
 
-DISCORD_API_BASE = "https://discord.com/api/v10"
 MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024  # 20MB
 MAX_MESSAGE_LEN = 2000  # Discord message character limit
 
@@ -60,7 +59,7 @@ class DiscordChannel(BaseChannel):
 
         self._running = True
         self._http = httpx.AsyncClient(timeout=30.0)
-        intents = discord.Intents(value=self.config.intents)
+        intents = discord.Intents._from_value(self.config.intents)
         self._client = discord.Client(intents=intents)
 
         @self._client.event
@@ -82,6 +81,8 @@ class DiscordChannel(BaseChannel):
         self._running = False
         for task in self._typing_tasks.values():
             task.cancel()
+        if self._typing_tasks:
+            await asyncio.gather(*self._typing_tasks.values(), return_exceptions=True)
         self._typing_tasks.clear()
         if self._client:
             await self._client.close()
@@ -97,9 +98,12 @@ class DiscordChannel(BaseChannel):
             return
 
         channel = self._client.get_channel(int(msg.chat_id))
-        if not channel:
-            logger.warning("Discord channel {} not found in cache", msg.chat_id)
-            return
+        if channel is None:
+            try:
+                channel = await self._client.fetch_channel(int(msg.chat_id))
+            except Exception as e:
+                logger.error("Discord channel {} not found: {}", msg.chat_id, e)
+                return
 
         try:
             sent_media = False
@@ -211,9 +215,13 @@ class DiscordChannel(BaseChannel):
                 logger.warning("Failed to download Discord attachment: {}", e)
                 content_parts.append(f"[attachment: {filename} - download failed]")
 
-        reply_to = str(message.reference.message_id) if message.reference else None
+        reply_to = (
+            str(message.reference.message_id)
+            if message.reference and message.reference.message_id is not None
+            else None
+        )
 
-        await self._start_typing(message.channel, channel_id)
+        await self._start_typing(message.channel)
 
         await self._handle_message(
             sender_id=sender_id,
@@ -243,10 +251,11 @@ class DiscordChannel(BaseChannel):
             logger.debug("Discord message in {} ignored (bot not mentioned)", str(message.channel.id))
             return False
 
-        return True
+        return False
 
-    async def _start_typing(self, channel: discord.abc.Messageable, channel_id: str) -> None:
+    async def _start_typing(self, channel: discord.abc.Messageable) -> None:
         """Start typing indicator for a channel using discord.py context manager."""
+        channel_id = str(channel.id)  # type: ignore[attr-defined]
         await self._stop_typing(channel_id)
 
         async def typing_loop() -> None:

--- a/nanobot/channels/discord_ui.py
+++ b/nanobot/channels/discord_ui.py
@@ -1,0 +1,111 @@
+"""Discord UI components for nanobot slash commands."""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import discord
+
+
+class ModelModal(discord.ui.Modal, title="Set Model"):
+    model_name: discord.ui.TextInput = discord.ui.TextInput(
+        label="Model name",
+        placeholder="e.g. claude-opus-4-6",
+        required=True,
+        max_length=200,
+    )
+
+    def __init__(self, provider: str, on_confirm: Callable[[str, str], Awaitable[None]]) -> None:
+        super().__init__()
+        self._provider = provider
+        self._on_confirm = on_confirm
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await self._on_confirm(self._provider, self.model_name.value)
+        await interaction.followup.send(
+            f"✓ Model set to `{self._provider}/{self.model_name.value}`",
+            ephemeral=True,
+        )
+
+
+class ProviderSelect(discord.ui.Select):
+    def __init__(self, providers: list[tuple[str, str]], parent_view: "ModelPickerView") -> None:
+        # providers = [(name, display_label), ...]
+        options = [discord.SelectOption(label=label, value=name) for name, label in providers[:25]]
+        super().__init__(placeholder="Select provider…", options=options, min_values=1, max_values=1)
+        self._parent = parent_view
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        self._parent._selected_provider = self.values[0]
+        await interaction.response.defer()
+
+
+class ModelPickerView(discord.ui.View):
+    def __init__(
+        self,
+        providers: list[tuple[str, str]],
+        on_confirm: Callable[[str, str], Awaitable[None]],
+    ) -> None:
+        super().__init__(timeout=600.0)
+        self._selected_provider: str | None = None
+        self._on_confirm = on_confirm
+        self._select = ProviderSelect(providers, self)
+        self.add_item(self._select)
+
+    @discord.ui.button(label="Set Model", style=discord.ButtonStyle.primary, row=1)
+    async def confirm_button(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        if not self._selected_provider:
+            await interaction.response.send_message(
+                "Please select a provider first.", ephemeral=True
+            )
+            return
+        modal = ModelModal(provider=self._selected_provider, on_confirm=self._on_confirm)
+        await interaction.response.send_modal(modal)
+
+
+class StopButton(discord.ui.Button):
+    def __init__(self, on_stop: Callable[[], Awaitable[None]]) -> None:
+        super().__init__(label="Stop", style=discord.ButtonStyle.danger, emoji="⏹️")
+        self._on_stop = on_stop
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        asyncio.create_task(self._on_stop())
+        self.disabled = True
+        if self.view:
+            await interaction.message.edit(view=self.view)
+        await interaction.followup.send("Stopping…", ephemeral=True)
+
+
+class StatusView(discord.ui.View):
+    def __init__(self, on_stop: Callable[[], Awaitable[None]]) -> None:
+        super().__init__(timeout=300.0)
+        self.add_item(StopButton(on_stop))
+
+
+class McpServerSelect(discord.ui.Select):
+    def __init__(self, servers: list[str]) -> None:
+        if servers:
+            options = [discord.SelectOption(label=s, value=s) for s in servers[:25]]
+            disabled = False
+        else:
+            options = [discord.SelectOption(label="(no servers configured)", value="none")]
+            disabled = True
+        super().__init__(
+            placeholder="Select MCP server…",
+            options=options,
+            min_values=1,
+            max_values=1,
+            disabled=disabled,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer()
+
+
+class McpView(discord.ui.View):
+    def __init__(self, servers: list[str]) -> None:
+        super().__init__(timeout=300.0)
+        self.add_item(McpServerSelect(servers))

--- a/nanobot/channels/discord_ui.py
+++ b/nanobot/channels/discord_ui.py
@@ -1,6 +1,5 @@
 """Discord UI components for nanobot slash commands."""
 
-import asyncio
 from collections.abc import Awaitable, Callable
 
 import discord
@@ -52,6 +51,10 @@ class ModelPickerView(discord.ui.View):
         self._select = ProviderSelect(providers, self)
         self.add_item(self._select)
 
+    async def on_timeout(self) -> None:
+        for item in self.children:
+            item.disabled = True  # type: ignore[union-attr]
+
     @discord.ui.button(label="Set Model", style=discord.ButtonStyle.primary, row=1)
     async def confirm_button(
         self, interaction: discord.Interaction, button: discord.ui.Button
@@ -72,10 +75,10 @@ class StopButton(discord.ui.Button):
 
     async def callback(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=True)
-        asyncio.create_task(self._on_stop())
         self.disabled = True
         if self.view:
             await interaction.message.edit(view=self.view)
+        await self._on_stop()
         await interaction.followup.send("Stopping…", ephemeral=True)
 
 
@@ -83,6 +86,10 @@ class StatusView(discord.ui.View):
     def __init__(self, on_stop: Callable[[], Awaitable[None]]) -> None:
         super().__init__(timeout=300.0)
         self.add_item(StopButton(on_stop))
+
+    async def on_timeout(self) -> None:
+        for item in self.children:
+            item.disabled = True  # type: ignore[union-attr]
 
 
 class McpServerSelect(discord.ui.Select):

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -504,7 +504,7 @@ def gateway(
     config: str | None = typer.Option(None, "--config", "-c", help="Path to config file"),
 ):
     """Start the nanobot gateway."""
-    from nanobot.agent.loop import AgentLoop
+    from nanobot.agent.loop import AgentLoop, load_memory_backend
     from nanobot.bus.queue import MessageBus
     from nanobot.channels.manager import ChannelManager
     from nanobot.cron.service import CronService
@@ -550,6 +550,7 @@ def gateway(
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
         timezone=config.agents.defaults.timezone,
+        memory_backend=load_memory_backend(config),
     )
 
     # Set cron callback (needs agent)
@@ -717,7 +718,7 @@ def agent(
     """Interact with the agent directly."""
     from loguru import logger
 
-    from nanobot.agent.loop import AgentLoop
+    from nanobot.agent.loop import AgentLoop, load_memory_backend
     from nanobot.bus.queue import MessageBus
     from nanobot.cron.service import CronService
 
@@ -755,6 +756,7 @@ def agent(
         mcp_servers=config.tools.mcp_servers,
         channels_config=config.channels,
         timezone=config.agents.defaults.timezone,
+        memory_backend=load_memory_backend(config),
     )
 
     # Shared reference for progress callbacks

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -47,7 +47,7 @@ async def cmd_status(ctx: CommandContext) -> OutboundMessage:
     session = ctx.session or loop.sessions.get_or_create(ctx.key)
     ctx_est = 0
     try:
-        ctx_est, _ = loop.memory_consolidator.estimate_session_prompt_tokens(session)
+        ctx_est, _ = await loop.memory_consolidator.estimate_session_prompt_tokens(session)
     except Exception:
         pass
     if ctx_est <= 0:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -150,6 +150,12 @@ class ToolsConfig(Base):
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
 
+class MemoryConfig(Base):
+    """Memory backend configuration."""
+
+    backend: str = "default"
+
+
 class Config(BaseSettings):
     """Root configuration for nanobot."""
 
@@ -158,6 +164,7 @@ class Config(BaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    memory: MemoryConfig = Field(default_factory=MemoryConfig)
 
     @property
     def workspace_path(self) -> Path:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -153,6 +153,8 @@ class ToolsConfig(Base):
 class MemoryConfig(Base):
     """Memory backend configuration."""
 
+    model_config = ConfigDict(extra="allow")
+
     backend: str = "default"
 
 

--- a/plugins/nanobot-graphiti/nanobot_graphiti/__init__.py
+++ b/plugins/nanobot-graphiti/nanobot_graphiti/__init__.py
@@ -1,0 +1,1 @@
+"""nanobot-graphiti — Graphiti temporal memory backend for nanobot."""

--- a/plugins/nanobot-graphiti/nanobot_graphiti/__init__.py
+++ b/plugins/nanobot-graphiti/nanobot_graphiti/__init__.py
@@ -1,1 +1,5 @@
 """nanobot-graphiti — Graphiti temporal memory backend for nanobot."""
+
+from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+__all__ = ["GraphitiMemoryBackend"]

--- a/plugins/nanobot-graphiti/nanobot_graphiti/backend.py
+++ b/plugins/nanobot-graphiti/nanobot_graphiti/backend.py
@@ -116,13 +116,7 @@ class GraphitiMemoryBackend(MemoryBackend):
         if not messages or self._graphiti is None:
             return
         try:
-            # Lazy-import EpisodeType to avoid hard dependency at module load time
-            try:
-                from graphiti_core.nodes import EpisodeType
-                episode_source = EpisodeType.message
-            except ImportError:
-                # If graphiti_core is not available, use a string sentinel
-                episode_source = "message"
+            from graphiti_core.nodes import EpisodeType
 
             lines = []
             for msg in messages:
@@ -147,7 +141,7 @@ class GraphitiMemoryBackend(MemoryBackend):
                 episode_body=episode_body,
                 source_description="nanobot conversation",
                 reference_time=datetime.now(timezone.utc),
-                source=episode_source,
+                source=EpisodeType.message,
                 group_id=group_id,
             )
         except Exception:
@@ -170,4 +164,10 @@ class GraphitiMemoryBackend(MemoryBackend):
             return ""
 
     def get_tools(self) -> list[Tool]:
-        return []  # implemented in Task 7
+        from nanobot_graphiti.tools import MemoryForgetTool, MemoryListTool, MemorySearchTool
+
+        return [
+            MemorySearchTool(backend=self),
+            MemoryForgetTool(backend=self),
+            MemoryListTool(backend=self),
+        ]

--- a/plugins/nanobot-graphiti/nanobot_graphiti/backend.py
+++ b/plugins/nanobot-graphiti/nanobot_graphiti/backend.py
@@ -1,0 +1,122 @@
+"""GraphitiMemoryBackend — Graphiti temporal knowledge graph memory backend for nanobot."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Callable
+
+from nanobot.agent.memory import MemoryBackend
+from nanobot.agent.tools.base import Tool
+from nanobot_graphiti.config import GraphitiConfig
+
+if TYPE_CHECKING:
+    from nanobot.providers.base import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+def _build_driver(config: GraphitiConfig) -> Any:
+    """Construct the graph DB driver for the configured backend."""
+    from pathlib import Path
+
+    if config.graph_db == "kuzu":
+        from graphiti_core.driver.kuzu_driver import KuzuDriver
+
+        db_path = str(Path(config.kuzu_path).expanduser())
+        Path(db_path).mkdir(parents=True, exist_ok=True)
+        return KuzuDriver(db=db_path)
+
+    if config.graph_db == "neo4j":
+        from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+        return Neo4jDriver(
+            uri=config.neo4j_uri,
+            user=config.neo4j_user,
+            password=config.neo4j_password,
+        )
+
+    if config.graph_db == "falkordb":
+        from graphiti_core.driver.falkordb_driver import FalkorDBDriver
+
+        return FalkorDBDriver(host=config.falkordb_host, port=config.falkordb_port)
+
+    raise ValueError(f"Unknown graph_db: {config.graph_db!r}")
+
+
+def _build_graphiti(config: GraphitiConfig, provider: "LLMProvider") -> Any:
+    """Build a Graphiti client wired to nanobot's LLM provider."""
+    from openai import AsyncOpenAI
+    from graphiti_core import Graphiti
+    from graphiti_core.llm_client.openai_client import OpenAIClient as GraphitiLLMClient
+    from graphiti_core.embedder.openai import OpenAIEmbedder
+
+    if not provider.api_base:
+        raise RuntimeError(
+            "nanobot-graphiti requires an OpenAI-compatible provider (api_base must be set). "
+            "Anthropic's native endpoint is not supported. "
+            "Use an OpenAI-compat model (openrouter, openai, etc.) for Graphiti memory."
+        )
+
+    openai_client = AsyncOpenAI(
+        api_key=provider.api_key or "no-key",
+        base_url=provider.api_base,
+    )
+    llm_client = GraphitiLLMClient(
+        client=openai_client,
+        model=provider.get_default_model(),
+    )
+    embedder = OpenAIEmbedder(
+        client=openai_client,
+        model=config.embedding_model,
+    )
+    driver = _build_driver(config)
+    return Graphiti(graph_driver=driver, llm_client=llm_client, embedder=embedder)
+
+
+class GraphitiMemoryBackend(MemoryBackend):
+    """Graphiti temporal knowledge graph memory backend."""
+
+    consolidates_per_turn = True
+
+    def __init__(
+        self,
+        config: GraphitiConfig,
+        *,
+        _graphiti_factory: Callable[..., Any] | None = None,
+    ) -> None:
+        self._config = config
+        self._graphiti: Any | None = None
+        self._graphiti_factory = _graphiti_factory
+
+    @classmethod
+    def from_nanobot_config(cls, nanobot_config: Any) -> "GraphitiMemoryBackend":
+        """Instantiate from a nanobot Config object (entry-point discovery path)."""
+        return cls(GraphitiConfig._from_nanobot_config(nanobot_config))
+
+    async def start(self, provider: "LLMProvider") -> None:
+        if self._graphiti_factory is not None:
+            self._graphiti = self._graphiti_factory(config=self._config, provider=provider)
+        else:
+            self._graphiti = _build_graphiti(self._config, provider)
+        await self._graphiti.build_indices_and_constraints()
+
+    async def stop(self) -> None:
+        if self._graphiti is not None:
+            await self._graphiti.close()
+            self._graphiti = None
+
+    def _get_group_id(self, session_key: str) -> str:
+        if self._config.scope == "user":
+            _, _, chat_id = session_key.partition(":")
+            return chat_id or session_key
+        return session_key
+
+    async def consolidate(self, messages: list[dict], session_key: str) -> None:
+        raise NotImplementedError  # implemented in Task 4
+
+    async def retrieve(self, query: str, session_key: str, top_k: int = 5) -> str:
+        raise NotImplementedError  # implemented in Task 5
+
+    def get_tools(self) -> list[Tool]:
+        return []  # implemented in Task 7

--- a/plugins/nanobot-graphiti/nanobot_graphiti/backend.py
+++ b/plugins/nanobot-graphiti/nanobot_graphiti/backend.py
@@ -113,10 +113,61 @@ class GraphitiMemoryBackend(MemoryBackend):
         return session_key
 
     async def consolidate(self, messages: list[dict], session_key: str) -> None:
-        raise NotImplementedError  # implemented in Task 4
+        if not messages or self._graphiti is None:
+            return
+        try:
+            # Lazy-import EpisodeType to avoid hard dependency at module load time
+            try:
+                from graphiti_core.nodes import EpisodeType
+                episode_source = EpisodeType.message
+            except ImportError:
+                # If graphiti_core is not available, use a string sentinel
+                episode_source = "message"
+
+            lines = []
+            for msg in messages:
+                role = msg.get("role", "unknown").capitalize()
+                content = msg.get("content") or ""
+                if isinstance(content, list):
+                    # Handle multi-part content blocks (e.g. tool results)
+                    content = " ".join(
+                        part.get("text", "") if isinstance(part, dict) else str(part)
+                        for part in content
+                    )
+                if content:
+                    lines.append(f"{role}: {content}")
+
+            episode_body = "\n".join(lines)
+            if not episode_body.strip():
+                return
+
+            group_id = self._get_group_id(session_key)
+            await self._graphiti.add_episode(
+                name=session_key,
+                episode_body=episode_body,
+                source_description="nanobot conversation",
+                reference_time=datetime.now(timezone.utc),
+                source=episode_source,
+                group_id=group_id,
+            )
+        except Exception:
+            logger.exception("GraphitiMemoryBackend.consolidate() failed — memory not updated")
 
     async def retrieve(self, query: str, session_key: str, top_k: int = 5) -> str:
-        raise NotImplementedError  # implemented in Task 5
+        if self._graphiti is None:
+            return ""
+        try:
+            group_id = self._get_group_id(session_key)
+            results = await self._graphiti.search(query, group_ids=[group_id], num_results=top_k)
+            if not results:
+                return ""
+            lines = [f"[Memory — {len(results)} relevant facts]"]
+            for edge in results:
+                lines.append(f"• {edge.fact}")
+            return "\n".join(lines)
+        except Exception:
+            logger.exception("GraphitiMemoryBackend.retrieve() failed — no memory injected")
+            return ""
 
     def get_tools(self) -> list[Tool]:
         return []  # implemented in Task 7

--- a/plugins/nanobot-graphiti/nanobot_graphiti/config.py
+++ b/plugins/nanobot-graphiti/nanobot_graphiti/config.py
@@ -1,0 +1,30 @@
+"""GraphitiConfig — configuration for the nanobot-graphiti memory backend."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class GraphitiConfig(BaseModel):
+    """Configuration for the Graphiti memory backend."""
+
+    graph_db: Literal["kuzu", "neo4j", "falkordb"] = "kuzu"
+    kuzu_path: str = "~/.nanobot/workspace/memory/graph"
+    neo4j_uri: str = "bolt://localhost:7687"
+    neo4j_user: str = "neo4j"
+    neo4j_password: str = ""
+    falkordb_host: str = "localhost"
+    falkordb_port: int = 6379
+    top_k: int = 5
+    scope: Literal["user", "session"] = "user"
+    embedding_model: str = "text-embedding-3-small"
+
+    @classmethod
+    def _from_nanobot_config(cls, config: Any) -> "GraphitiConfig":
+        """Extract and validate Graphiti config from nanobot's Config object."""
+        raw: Any = getattr(config.memory, "model_extra", {}).get("graphiti") or {}
+        if hasattr(raw, "model_dump"):
+            raw = raw.model_dump()
+        return cls(**(raw if isinstance(raw, dict) else {}))

--- a/plugins/nanobot-graphiti/nanobot_graphiti/tools.py
+++ b/plugins/nanobot-graphiti/nanobot_graphiti/tools.py
@@ -84,14 +84,18 @@ class MemoryForgetTool(Tool):
         }
 
     async def execute(self, fact_id: str, reason: str, session_key: str, **_: Any) -> str:
+        from graphiti_core.nodes import EntityEdge
+
         graphiti = self._backend._graphiti
         if graphiti is None:
             return "Memory backend not started."
-        try:
-            from graphiti_core.nodes import EntityEdge
-            await EntityEdge.delete_by_uuids(graphiti.driver, [fact_id])
-        except Exception as e:
-            return f"Error deleting fact {fact_id!r}: {e}"
+        group_id = self._backend._get_group_id(session_key)
+        # Verify ownership: ensure fact_id belongs to this session's group
+        results = await graphiti.search(fact_id, group_ids=[group_id], num_results=50)
+        owned = any(e.uuid == fact_id for e in results)
+        if not owned:
+            return f"Fact {fact_id!r} not found in your memory."
+        await EntityEdge.delete_by_uuids(graphiti.driver, [fact_id])
         return f"Fact {fact_id!r} deleted. Reason: {reason}"
 
 

--- a/plugins/nanobot-graphiti/nanobot_graphiti/tools.py
+++ b/plugins/nanobot-graphiti/nanobot_graphiti/tools.py
@@ -1,0 +1,137 @@
+"""Memory tools for the Graphiti memory backend."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from nanobot.agent.tools.base import Tool
+
+if TYPE_CHECKING:
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+
+class MemorySearchTool(Tool):
+    """Semantic search over the Graphiti memory graph."""
+
+    def __init__(self, backend: "GraphitiMemoryBackend") -> None:
+        self._backend = backend
+
+    @property
+    def name(self) -> str:
+        return "memory_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search your memory for facts about the current user. "
+            "Use when asked about past conversations, preferences, or history."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Natural language search query"},
+                "top_k": {"type": "integer", "description": "Max results to return", "default": 10},
+                "session_key": {"type": "string", "description": "Current session key (e.g. telegram:123456)"},
+            },
+            "required": ["query", "session_key"],
+        }
+
+    async def execute(self, query: str, session_key: str, top_k: int = 10, **_: Any) -> str:
+        graphiti = self._backend._graphiti
+        if graphiti is None:
+            return "Memory backend not started."
+        group_id = self._backend._get_group_id(session_key)
+        results = await graphiti.search(query, group_ids=[group_id], num_results=top_k)
+        if not results:
+            return f"No memories found for query: {query!r}"
+        lines = [f"Found {len(results)} fact(s):"]
+        for edge in results:
+            lines.append(f"• [{edge.uuid}] {edge.fact}")
+        return "\n".join(lines)
+
+
+class MemoryForgetTool(Tool):
+    """Delete a specific fact from the memory graph by its ID."""
+
+    def __init__(self, backend: "GraphitiMemoryBackend") -> None:
+        self._backend = backend
+
+    @property
+    def name(self) -> str:
+        return "memory_forget"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Delete a specific memory fact by its ID. "
+            "Use when a user says 'you have that wrong' or asks you to forget something. "
+            "Get the fact_id from memory_search or memory_list first."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "fact_id": {"type": "string", "description": "The UUID of the fact to delete"},
+                "reason": {"type": "string", "description": "Why this fact is being removed"},
+                "session_key": {"type": "string", "description": "Current session key"},
+            },
+            "required": ["fact_id", "reason", "session_key"],
+        }
+
+    async def execute(self, fact_id: str, reason: str, session_key: str, **_: Any) -> str:
+        graphiti = self._backend._graphiti
+        if graphiti is None:
+            return "Memory backend not started."
+        try:
+            from graphiti_core.nodes import EntityEdge
+            await EntityEdge.delete_by_uuids(graphiti.driver, [fact_id])
+        except Exception as e:
+            return f"Error deleting fact {fact_id!r}: {e}"
+        return f"Fact {fact_id!r} deleted. Reason: {reason}"
+
+
+class MemoryListTool(Tool):
+    """List all stored memory facts for the current user."""
+
+    def __init__(self, backend: "GraphitiMemoryBackend") -> None:
+        self._backend = backend
+
+    @property
+    def name(self) -> str:
+        return "memory_list"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List all stored memory facts for the current user. "
+            "Use when asked 'what do you know about me?' or to audit stored memories."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Max facts to return", "default": 50},
+                "session_key": {"type": "string", "description": "Current session key"},
+            },
+            "required": ["session_key"],
+        }
+
+    async def execute(self, session_key: str, limit: int = 50, **_: Any) -> str:
+        graphiti = self._backend._graphiti
+        if graphiti is None:
+            return "Memory backend not started."
+        group_id = self._backend._get_group_id(session_key)
+        results = await graphiti.search("", group_ids=[group_id], num_results=limit)
+        if not results:
+            return "No memories stored for this user."
+        lines = [f"Stored memories ({len(results)} fact(s)):"]
+        for edge in results:
+            lines.append(f"• [{edge.uuid}] {edge.fact}")
+        return "\n".join(lines)

--- a/plugins/nanobot-graphiti/pyproject.toml
+++ b/plugins/nanobot-graphiti/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "nanobot-graphiti"
+version = "0.1.0"
+description = "Graphiti temporal memory backend for nanobot"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+dependencies = [
+    "nanobot-ai>=0.1.4",
+    "graphiti-core>=0.3",
+    "kuzu>=0.9",
+]
+
+[project.entry-points."nanobot.memory"]
+graphiti = "nanobot_graphiti:GraphitiMemoryBackend"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nanobot_graphiti"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/plugins/nanobot-graphiti/tests/conftest.py
+++ b/plugins/nanobot-graphiti/tests/conftest.py
@@ -1,7 +1,67 @@
 """Shared fixtures for nanobot-graphiti tests."""
 
-import pytest
+import sys
+import types
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Ensure the worktree's nanobot package takes priority over the installed one.
+# The editable install adds /home/empty/PaiBot to sys.path via a .pth file, but
+# the site-packages nanobot/ namespace package causes the wrong version to be
+# found when MemoryBackend hasn't been added to main yet. We insert the
+# worktree root at position 0 so the worktree's nanobot/__init__.py wins.
+# ---------------------------------------------------------------------------
+_WORKTREE_ROOT = str(Path(__file__).resolve().parents[4])  # .../graphiti-memory
+if _WORKTREE_ROOT not in sys.path:
+    sys.path.insert(0, _WORKTREE_ROOT)
+from enum import Enum
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out graphiti_core.nodes so that `from graphiti_core.nodes import
+# EpisodeType` works in tests without installing the real graphiti_core
+# package.  The real EpisodeType is a string-enum; we mirror that here so
+# tests can assert source=EpisodeType.message.
+# ---------------------------------------------------------------------------
+
+
+class _EpisodeType(str, Enum):
+    message = "message"
+    text = "text"
+    json = "json"
+
+
+class _EntityEdge:
+    """Minimal stub for graphiti_core.nodes.EntityEdge used in MemoryForgetTool tests."""
+
+    @staticmethod
+    async def delete_by_uuids(driver: Any, uuids: list[str]) -> None:
+        pass  # no-op in tests
+
+
+def _ensure_graphiti_stubs() -> None:
+    """Insert minimal stub modules into sys.modules if graphiti_core is absent."""
+    if "graphiti_core" not in sys.modules:
+        graphiti_core = types.ModuleType("graphiti_core")
+        sys.modules["graphiti_core"] = graphiti_core
+
+    if "graphiti_core.nodes" not in sys.modules:
+        nodes_mod = types.ModuleType("graphiti_core.nodes")
+        nodes_mod.EpisodeType = _EpisodeType  # type: ignore[attr-defined]
+        nodes_mod.EntityEdge = _EntityEdge  # type: ignore[attr-defined]
+        sys.modules["graphiti_core.nodes"] = nodes_mod
+    else:
+        # If the real package IS installed, expose our alias for test assertions.
+        pass
+
+
+_ensure_graphiti_stubs()
+
+# Re-export EpisodeType so tests can import it from conftest if needed.
+EpisodeType = sys.modules["graphiti_core.nodes"].EpisodeType
 
 
 @pytest.fixture

--- a/plugins/nanobot-graphiti/tests/conftest.py
+++ b/plugins/nanobot-graphiti/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared fixtures for nanobot-graphiti tests."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+@pytest.fixture
+def mock_graphiti():
+    """A fully mocked Graphiti client."""
+    g = MagicMock()
+    g.build_indices_and_constraints = AsyncMock()
+    g.add_episode = AsyncMock()
+    g.search = AsyncMock(return_value=[])
+    g.close = AsyncMock()
+    g.driver = MagicMock()
+    return g
+
+
+@pytest.fixture
+def mock_provider():
+    """A minimal nanobot LLMProvider mock."""
+    p = MagicMock()
+    p.api_key = "test-key"
+    p.api_base = "https://api.openai.com/v1"
+    p.get_default_model.return_value = "gpt-4o-mini"
+    return p
+
+
+@pytest.fixture
+def session_key():
+    return "telegram:123456"

--- a/plugins/nanobot-graphiti/tests/test_backend.py
+++ b/plugins/nanobot-graphiti/tests/test_backend.py
@@ -95,3 +95,122 @@ async def test_graphiti_backend_stop_is_safe_before_start():
 
     backend = GraphitiMemoryBackend(GraphitiConfig())
     await backend.stop()  # no exception
+
+
+# ── consolidate() ────────────────────────────────────────────────────────────
+
+async def test_consolidate_calls_add_episode(mock_graphiti, mock_provider, session_key):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+    await backend.consolidate(messages, session_key)
+
+    mock_graphiti.add_episode.assert_awaited_once()
+    call_kwargs = mock_graphiti.add_episode.call_args.kwargs
+    assert call_kwargs["group_id"] == "123456"   # scope="user" strips "telegram:"
+    assert "Hello" in call_kwargs["episode_body"]
+    assert "Hi there!" in call_kwargs["episode_body"]
+
+
+async def test_consolidate_uses_session_scope(mock_graphiti, mock_provider):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(
+        GraphitiConfig(scope="session"),
+        _graphiti_factory=lambda **kw: mock_graphiti,
+    )
+    await backend.start(mock_provider)
+    await backend.consolidate([{"role": "user", "content": "hi"}], "telegram:123456")
+
+    call_kwargs = mock_graphiti.add_episode.call_args.kwargs
+    assert call_kwargs["group_id"] == "telegram:123456"
+
+
+async def test_consolidate_swallows_errors(mock_graphiti, mock_provider, session_key):
+    """consolidate() must not raise even if graphiti.add_episode() fails."""
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    mock_graphiti.add_episode.side_effect = RuntimeError("graph unavailable")
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+    await backend.consolidate([{"role": "user", "content": "hi"}], session_key)
+    # No exception raised — test passes if we reach here
+
+
+async def test_consolidate_skips_empty_messages(mock_graphiti, mock_provider, session_key):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+    await backend.consolidate([], session_key)
+
+    mock_graphiti.add_episode.assert_not_awaited()
+
+
+# ── retrieve() ───────────────────────────────────────────────────────────────
+
+async def test_retrieve_calls_search_with_group_id(mock_graphiti, mock_provider, session_key):
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    edge = MagicMock()
+    edge.fact = "User likes coffee"
+    edge.uuid = "abc-123"
+    mock_graphiti.search.return_value = [edge]
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    result = await backend.retrieve("coffee", session_key, top_k=3)
+
+    mock_graphiti.search.assert_awaited_once_with("coffee", group_ids=["123456"], num_results=3)
+    assert "User likes coffee" in result
+    assert "[Memory" in result
+
+
+async def test_retrieve_returns_empty_string_when_no_results(mock_graphiti, mock_provider, session_key):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    mock_graphiti.search.return_value = []
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    result = await backend.retrieve("anything", session_key)
+    assert result == ""
+
+
+async def test_retrieve_formats_multiple_facts(mock_graphiti, mock_provider, session_key):
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    edges = []
+    for i, fact in enumerate(["Likes coffee", "Works in Berlin", "Has a cat"]):
+        edge = MagicMock()
+        edge.fact = fact
+        edge.uuid = f"uuid-{i}"
+        edges.append(edge)
+    mock_graphiti.search.return_value = edges
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    result = await backend.retrieve("tell me about user", session_key)
+    assert "Likes coffee" in result
+    assert "Works in Berlin" in result
+    assert "Has a cat" in result
+    assert "[Memory — 3 relevant facts]" in result

--- a/plugins/nanobot-graphiti/tests/test_backend.py
+++ b/plugins/nanobot-graphiti/tests/test_backend.py
@@ -100,6 +100,7 @@ async def test_graphiti_backend_stop_is_safe_before_start():
 # ── consolidate() ────────────────────────────────────────────────────────────
 
 async def test_consolidate_calls_add_episode(mock_graphiti, mock_provider, session_key):
+    from graphiti_core.nodes import EpisodeType
     from nanobot_graphiti.backend import GraphitiMemoryBackend
     from nanobot_graphiti.config import GraphitiConfig
 
@@ -117,6 +118,9 @@ async def test_consolidate_calls_add_episode(mock_graphiti, mock_provider, sessi
     assert call_kwargs["group_id"] == "123456"   # scope="user" strips "telegram:"
     assert "Hello" in call_kwargs["episode_body"]
     assert "Hi there!" in call_kwargs["episode_body"]
+    assert call_kwargs["source"] is EpisodeType.message
+    assert call_kwargs["source_description"] == "nanobot conversation"
+    assert call_kwargs["name"] == session_key
 
 
 async def test_consolidate_uses_session_scope(mock_graphiti, mock_provider):
@@ -214,3 +218,60 @@ async def test_retrieve_formats_multiple_facts(mock_graphiti, mock_provider, ses
     assert "Works in Berlin" in result
     assert "Has a cat" in result
     assert "[Memory — 3 relevant facts]" in result
+
+
+# ── get_tools() ───────────────────────────────────────────────────────────────
+
+async def test_get_tools_returns_three_tools(mock_graphiti, mock_provider):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    tools = backend.get_tools()
+    tool_names = {t.name for t in tools}
+
+    assert len(tools) == 3
+    assert tool_names == {"memory_search", "memory_forget", "memory_list"}
+
+
+async def test_get_tools_returns_tool_instances_bound_to_backend(mock_graphiti, mock_provider):
+    from nanobot.agent.tools.base import Tool
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    for tool in backend.get_tools():
+        assert isinstance(tool, Tool)
+        assert tool._backend is backend
+
+
+# ── Session scoping ───────────────────────────────────────────────────────────
+
+def test_group_id_user_scope_strips_channel_prefix():
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(scope="user"))
+    assert backend._get_group_id("telegram:123456") == "123456"
+    assert backend._get_group_id("discord:789") == "789"
+
+
+def test_group_id_session_scope_preserves_full_key():
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(scope="session"))
+    assert backend._get_group_id("telegram:123456") == "telegram:123456"
+    assert backend._get_group_id("discord:789") == "discord:789"
+
+
+def test_group_id_user_scope_handles_key_without_colon():
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(scope="user"))
+    assert backend._get_group_id("directuser") == "directuser"

--- a/plugins/nanobot-graphiti/tests/test_backend.py
+++ b/plugins/nanobot-graphiti/tests/test_backend.py
@@ -275,3 +275,34 @@ def test_group_id_user_scope_handles_key_without_colon():
 
     backend = GraphitiMemoryBackend(GraphitiConfig(scope="user"))
     assert backend._get_group_id("directuser") == "directuser"
+
+
+# ── Entry-point factory ───────────────────────────────────────────────────────
+
+def test_from_nanobot_config_creates_backend_with_correct_config():
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+    nanobot_config = MagicMock()
+    nanobot_config.memory.model_extra = {
+        "graphiti": {"graph_db": "kuzu", "top_k": 8, "scope": "session"}
+    }
+
+    backend = GraphitiMemoryBackend.from_nanobot_config(nanobot_config)
+
+    assert isinstance(backend, GraphitiMemoryBackend)
+    assert backend._config.graph_db == "kuzu"
+    assert backend._config.top_k == 8
+    assert backend._config.scope == "session"
+
+
+def test_from_nanobot_config_falls_back_to_defaults_on_empty_config():
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+    nanobot_config = MagicMock()
+    nanobot_config.memory.model_extra = {}
+
+    backend = GraphitiMemoryBackend.from_nanobot_config(nanobot_config)
+    assert backend._config.graph_db == "kuzu"
+    assert backend._config.top_k == 5

--- a/plugins/nanobot-graphiti/tests/test_backend.py
+++ b/plugins/nanobot-graphiti/tests/test_backend.py
@@ -48,3 +48,50 @@ def test_graphiti_config_from_nanobot_config_missing_section():
     cfg = GraphitiConfig._from_nanobot_config(nanobot_config)
     assert cfg.graph_db == "kuzu"
     assert cfg.top_k == 5
+
+
+# ── Backend contract ─────────────────────────────────────────────────────────
+
+def test_graphiti_backend_is_memory_backend():
+    from nanobot.agent.memory import MemoryBackend
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+
+    assert issubclass(GraphitiMemoryBackend, MemoryBackend)
+
+
+def test_graphiti_backend_consolidates_per_turn_is_true():
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig())
+    assert backend.consolidates_per_turn is True
+
+
+async def test_graphiti_backend_start_calls_build_indices(mock_graphiti, mock_provider):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+
+    mock_graphiti.build_indices_and_constraints.assert_awaited_once()
+
+
+async def test_graphiti_backend_stop_closes_client(mock_graphiti, mock_provider):
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+    await backend.stop()
+
+    mock_graphiti.close.assert_awaited_once()
+
+
+async def test_graphiti_backend_stop_is_safe_before_start():
+    """stop() before start() must not raise."""
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig())
+    await backend.stop()  # no exception

--- a/plugins/nanobot-graphiti/tests/test_backend.py
+++ b/plugins/nanobot-graphiti/tests/test_backend.py
@@ -1,0 +1,50 @@
+"""Tests for GraphitiMemoryBackend and GraphitiConfig."""
+
+import pytest
+
+
+# ── Config ──────────────────────────────────────────────────────────────────
+
+def test_graphiti_config_defaults():
+    from nanobot_graphiti.config import GraphitiConfig
+
+    cfg = GraphitiConfig()
+    assert cfg.graph_db == "kuzu"
+    assert cfg.kuzu_path == "~/.nanobot/workspace/memory/graph"
+    assert cfg.top_k == 5
+    assert cfg.scope == "user"
+    assert cfg.embedding_model == "text-embedding-3-small"
+
+
+def test_graphiti_config_accepts_neo4j():
+    from nanobot_graphiti.config import GraphitiConfig
+
+    cfg = GraphitiConfig(graph_db="neo4j", neo4j_uri="bolt://myhost:7687", neo4j_password="secret")
+    assert cfg.graph_db == "neo4j"
+    assert cfg.neo4j_uri == "bolt://myhost:7687"
+
+
+def test_graphiti_config_from_nanobot_config_kuzu():
+    """_from_nanobot_config() parses memory.model_extra["graphiti"] section."""
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.config import GraphitiConfig
+
+    nanobot_config = MagicMock()
+    nanobot_config.memory.model_extra = {"graphiti": {"graph_db": "kuzu", "top_k": 10}}
+
+    cfg = GraphitiConfig._from_nanobot_config(nanobot_config)
+    assert cfg.graph_db == "kuzu"
+    assert cfg.top_k == 10
+
+
+def test_graphiti_config_from_nanobot_config_missing_section():
+    """_from_nanobot_config() falls back to defaults when section absent."""
+    from unittest.mock import MagicMock
+    from nanobot_graphiti.config import GraphitiConfig
+
+    nanobot_config = MagicMock()
+    nanobot_config.memory.model_extra = {}
+
+    cfg = GraphitiConfig._from_nanobot_config(nanobot_config)
+    assert cfg.graph_db == "kuzu"
+    assert cfg.top_k == 5

--- a/plugins/nanobot-graphiti/tests/test_tools.py
+++ b/plugins/nanobot-graphiti/tests/test_tools.py
@@ -1,7 +1,7 @@
 """Tests for memory tools."""
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 @pytest.fixture
@@ -71,18 +71,41 @@ async def test_memory_forget_tool_name():
     assert tool.name == "memory_forget"
 
 
-async def test_memory_forget_calls_delete(mock_graphiti):
-    """memory_forget deletes the fact by UUID."""
+async def test_memory_forget_calls_delete_by_uuids(mock_graphiti):
     from nanobot_graphiti.tools import MemoryForgetTool
+    from graphiti_core.nodes import EntityEdge
+
+    # Stub search to return an edge owned by this group
+    owned_edge = _make_edge("Some fact", "abc-123")
+    mock_graphiti.search.return_value = [owned_edge]
 
     backend = MagicMock()
     backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
+
+    with patch.object(EntityEdge, "delete_by_uuids", new_callable=AsyncMock) as mock_delete:
+        tool = MemoryForgetTool(backend=backend)
+        result = await tool.execute(fact_id="abc-123", reason="incorrect info", session_key="telegram:123456")
+
+    mock_delete.assert_awaited_once_with(mock_graphiti.driver, ["abc-123"])
+    assert "abc-123" in result
+
+
+async def test_memory_forget_rejects_unowned_uuid(mock_graphiti):
+    from nanobot_graphiti.tools import MemoryForgetTool
+
+    # Search returns nothing — UUID not in this session's group
+    mock_graphiti.search.return_value = []
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
 
     tool = MemoryForgetTool(backend=backend)
-    result = await tool.execute(fact_id="abc-123", reason="incorrect info", session_key="telegram:123456")
+    result = await tool.execute(fact_id="foreign-uuid", reason="test", session_key="telegram:123456")
 
-    # Should have called some delete method on graphiti or its driver
-    assert "abc-123" in result or "deleted" in result.lower() or "forgotten" in result.lower()
+    assert "not found" in result.lower()
+    mock_graphiti.delete_fact = MagicMock()  # ensure no delete was attempted
 
 
 # ── MemoryListTool ───────────────────────────────────────────────────────────

--- a/plugins/nanobot-graphiti/tests/test_tools.py
+++ b/plugins/nanobot-graphiti/tests/test_tools.py
@@ -1,0 +1,128 @@
+"""Tests for memory tools."""
+
+import pytest
+from unittest.mock import MagicMock
+
+
+@pytest.fixture
+async def backend_with_mock_graphiti(mock_graphiti, mock_provider):
+    """A started GraphitiMemoryBackend with an injected mock graphiti client."""
+    from nanobot_graphiti.backend import GraphitiMemoryBackend
+    from nanobot_graphiti.config import GraphitiConfig
+
+    backend = GraphitiMemoryBackend(GraphitiConfig(), _graphiti_factory=lambda **kw: mock_graphiti)
+    await backend.start(mock_provider)
+    return backend, mock_graphiti
+
+
+def _make_edge(fact: str, uuid: str = "test-uuid") -> MagicMock:
+    edge = MagicMock()
+    edge.fact = fact
+    edge.uuid = uuid
+    return edge
+
+
+# ── MemorySearchTool ─────────────────────────────────────────────────────────
+
+async def test_memory_search_tool_name():
+    from nanobot_graphiti.tools import MemorySearchTool
+
+    tool = MemorySearchTool(backend=MagicMock())
+    assert tool.name == "memory_search"
+
+
+async def test_memory_search_calls_graphiti_search(mock_graphiti):
+    from nanobot_graphiti.tools import MemorySearchTool
+
+    mock_graphiti.search.return_value = [_make_edge("User prefers dark mode")]
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
+
+    tool = MemorySearchTool(backend=backend)
+    result = await tool.execute(query="UI preferences", top_k=5, session_key="telegram:123456")
+
+    mock_graphiti.search.assert_awaited_once_with("UI preferences", group_ids=["123456"], num_results=5)
+    assert "User prefers dark mode" in result
+
+
+async def test_memory_search_returns_no_results_message(mock_graphiti):
+    from nanobot_graphiti.tools import MemorySearchTool
+
+    mock_graphiti.search.return_value = []
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
+
+    tool = MemorySearchTool(backend=backend)
+    result = await tool.execute(query="nonexistent", top_k=5, session_key="telegram:123456")
+
+    assert "no" in result.lower() or "0" in result
+
+
+# ── MemoryForgetTool ─────────────────────────────────────────────────────────
+
+async def test_memory_forget_tool_name():
+    from nanobot_graphiti.tools import MemoryForgetTool
+
+    tool = MemoryForgetTool(backend=MagicMock())
+    assert tool.name == "memory_forget"
+
+
+async def test_memory_forget_calls_delete(mock_graphiti):
+    """memory_forget deletes the fact by UUID."""
+    from nanobot_graphiti.tools import MemoryForgetTool
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+
+    tool = MemoryForgetTool(backend=backend)
+    result = await tool.execute(fact_id="abc-123", reason="incorrect info", session_key="telegram:123456")
+
+    # Should have called some delete method on graphiti or its driver
+    assert "abc-123" in result or "deleted" in result.lower() or "forgotten" in result.lower()
+
+
+# ── MemoryListTool ───────────────────────────────────────────────────────────
+
+async def test_memory_list_tool_name():
+    from nanobot_graphiti.tools import MemoryListTool
+
+    tool = MemoryListTool(backend=MagicMock())
+    assert tool.name == "memory_list"
+
+
+async def test_memory_list_calls_search_with_empty_query(mock_graphiti):
+    from nanobot_graphiti.tools import MemoryListTool
+
+    edges = [_make_edge("Fact 1", "u1"), _make_edge("Fact 2", "u2")]
+    mock_graphiti.search.return_value = edges
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
+
+    tool = MemoryListTool(backend=backend)
+    result = await tool.execute(limit=20, session_key="telegram:123456")
+
+    mock_graphiti.search.assert_awaited_once_with("", group_ids=["123456"], num_results=20)
+    assert "Fact 1" in result
+    assert "Fact 2" in result
+
+
+async def test_memory_list_shows_uuids_for_reference(mock_graphiti):
+    """memory_list output includes fact_id so user can reference it in memory_forget."""
+    from nanobot_graphiti.tools import MemoryListTool
+
+    mock_graphiti.search.return_value = [_make_edge("I have a dog", "edge-uuid-xyz")]
+
+    backend = MagicMock()
+    backend._graphiti = mock_graphiti
+    backend._get_group_id.return_value = "123456"
+
+    tool = MemoryListTool(backend=backend)
+    result = await tool.execute(limit=50, session_key="telegram:123456")
+
+    assert "edge-uuid-xyz" in result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 
 dependencies = [
     "typer>=0.20.0,<1.0.0",
+    "discord.py>=2.4.0,<3.0.0",
     "anthropic>=0.45.0,<1.0.0",
     "pydantic>=2.12.0,<3.0.0",
     "pydantic-settings>=2.12.0,<3.0.0",
@@ -51,6 +52,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+discord = [
+    "discord.py>=2.4.0,<3.0.0",
+]
 wecom = [
     "wecom-aibot-sdk-python>=0.1.5",
 ]

--- a/tests/agent/test_context_memory_inject.py
+++ b/tests/agent/test_context_memory_inject.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from nanobot.agent.context import ContextBuilder
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    return ws
+
+
+async def test_build_messages_returns_list(tmp_path):
+    ws = _make_workspace(tmp_path)
+    ctx = ContextBuilder(ws)
+    result = await ctx.build_messages(history=[], current_message="hi")
+    assert isinstance(result, list)
+    assert result[-1]["role"] == "user"
+
+
+async def test_build_messages_no_backend_no_injection(tmp_path):
+    ws = _make_workspace(tmp_path)
+    ctx = ContextBuilder(ws)
+    result = await ctx.build_messages(
+        history=[], current_message="hi", session_key="telegram:123"
+    )
+    # Without a backend there is no memory block
+    roles = [m["role"] for m in result]
+    assert roles.count("system") == 1  # only the main system prompt
+
+
+async def test_build_messages_with_backend_injects_memory_block(tmp_path):
+    ws = _make_workspace(tmp_path)
+    mock_backend = MagicMock()
+    mock_backend.retrieve = AsyncMock(return_value="[Memory — 1 relevant facts]\n• you like tea (2026-01-01)")
+    ctx = ContextBuilder(ws, memory_backend=mock_backend)
+
+    result = await ctx.build_messages(
+        history=[], current_message="hi", session_key="telegram:123"
+    )
+
+    memory_blocks = [m for m in result if m.get("role") == "system" and "[Memory" in (m.get("content") or "")]
+    assert len(memory_blocks) == 1
+    mock_backend.retrieve.assert_awaited_once_with("hi", "telegram:123", 5)
+
+
+async def test_build_messages_empty_retrieve_skips_injection(tmp_path):
+    ws = _make_workspace(tmp_path)
+    mock_backend = MagicMock()
+    mock_backend.retrieve = AsyncMock(return_value="")
+    ctx = ContextBuilder(ws, memory_backend=mock_backend)
+
+    result = await ctx.build_messages(
+        history=[], current_message="hi", session_key="telegram:123"
+    )
+
+    roles = [m["role"] for m in result]
+    assert roles.count("system") == 1
+
+
+async def test_build_messages_no_session_key_skips_retrieval(tmp_path):
+    ws = _make_workspace(tmp_path)
+    mock_backend = MagicMock()
+    mock_backend.retrieve = AsyncMock(return_value="some memory")
+    ctx = ContextBuilder(ws, memory_backend=mock_backend)
+
+    await ctx.build_messages(history=[], current_message="probe", session_key=None)
+
+    mock_backend.retrieve.assert_not_awaited()
+
+
+async def test_memory_block_inserted_before_history(tmp_path):
+    ws = _make_workspace(tmp_path)
+    mock_backend = MagicMock()
+    mock_backend.retrieve = AsyncMock(return_value="[Memory — 1 relevant facts]\n• you like tea")
+    ctx = ContextBuilder(ws, memory_backend=mock_backend)
+    history = [{"role": "user", "content": "old message"}, {"role": "assistant", "content": "old reply"}]
+
+    result = await ctx.build_messages(
+        history=history, current_message="new message", session_key="telegram:123"
+    )
+
+    # Order: system_prompt, memory_block, history..., current_user_message
+    system_indices = [i for i, m in enumerate(result) if m["role"] == "system"]
+    first_history_idx = next(i for i, m in enumerate(result) if m.get("content") == "old message")
+    assert system_indices[-1] < first_history_idx

--- a/tests/agent/test_context_prompt_cache.py
+++ b/tests/agent/test_context_prompt_cache.py
@@ -47,12 +47,12 @@ def test_system_prompt_stays_stable_when_clock_changes(tmp_path, monkeypatch) ->
     assert prompt1 == prompt2
 
 
-def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
+async def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
     """Runtime metadata should be merged with the user message."""
     workspace = _make_workspace(tmp_path)
     builder = ContextBuilder(workspace)
 
-    messages = builder.build_messages(
+    messages = await builder.build_messages(
         history=[],
         current_message="Return exactly: OK",
         channel="cli",

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -102,7 +102,7 @@ async def test_consolidation_loops_until_target_met(tmp_path, monkeypatch) -> No
     loop.sessions.save(session)
 
     call_count = [0]
-    def mock_estimate(_session):
+    async def mock_estimate(_session):
         call_count[0] += 1
         if call_count[0] == 1:
             return (500, "test")
@@ -139,7 +139,7 @@ async def test_consolidation_continues_below_trigger_until_half_target(tmp_path,
 
     call_count = [0]
 
-    def mock_estimate(_session):
+    async def mock_estimate(_session):
         call_count[0] += 1
         if call_count[0] == 1:
             return (500, "test")
@@ -184,7 +184,7 @@ async def test_preflight_consolidation_before_llm_call(tmp_path, monkeypatch) ->
     monkeypatch.setattr(memory_module, "estimate_message_tokens", lambda _m: 500)
 
     call_count = [0]
-    def mock_estimate(_session):
+    async def mock_estimate(_session):
         call_count[0] += 1
         return (1000 if call_count[0] <= 1 else 80, "test")
     loop.memory_consolidator.estimate_session_prompt_tokens = mock_estimate  # type: ignore[method-assign]

--- a/tests/agent/test_loop_memory_backend.py
+++ b/tests/agent/test_loop_memory_backend.py
@@ -91,3 +91,92 @@ async def test_per_turn_backend_consolidate_called_after_message(tmp_path):
     import asyncio
     await asyncio.sleep(0)
     assert "telegram:123" in backend.consolidate_calls
+
+
+# ── load_memory_backend entry-point wiring ────────────────────────────────────
+
+def test_load_memory_backend_calls_from_nanobot_config_when_present(tmp_path):
+    """load_memory_backend() must call cls.from_nanobot_config(config) when the classmethod exists."""
+    from unittest.mock import MagicMock, patch
+    from nanobot.agent.loop import load_memory_backend
+
+    class BackendWithFactory(MemoryBackend):
+        @classmethod
+        def from_nanobot_config(cls, cfg):
+            instance = cls.__new__(cls)
+            instance._used_factory = True
+            instance._received_config = cfg
+            return instance
+
+        async def consolidate(self, messages, session_key): pass
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    mock_ep = MagicMock()
+    mock_ep.name = "graphiti"
+    mock_ep.load.return_value = BackendWithFactory
+
+    config = MagicMock()
+    config.memory.backend = "graphiti"
+    config.workspace_path = tmp_path
+
+    with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+        backend = load_memory_backend(config)
+
+    assert isinstance(backend, BackendWithFactory)
+    assert backend._used_factory is True
+    assert backend._received_config is config
+
+
+def test_load_memory_backend_falls_back_to_cls_init_when_no_factory(tmp_path):
+    """load_memory_backend() must fall back to cls(config) when from_nanobot_config is absent."""
+    from unittest.mock import MagicMock, patch
+    from nanobot.agent.loop import load_memory_backend
+
+    class SimpleBackend(MemoryBackend):
+        def __init__(self, cfg):
+            self._cfg = cfg
+
+        async def consolidate(self, messages, session_key): pass
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    mock_ep = MagicMock()
+    mock_ep.name = "simple"
+    mock_ep.load.return_value = SimpleBackend
+
+    config = MagicMock()
+    config.memory.backend = "simple"
+    config.workspace_path = tmp_path
+
+    with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+        backend = load_memory_backend(config)
+
+    assert isinstance(backend, SimpleBackend)
+    assert backend._cfg is config
+
+
+def test_load_memory_backend_defaults_to_memory_store_when_backend_is_default(tmp_path):
+    """load_memory_backend() must return MemoryStore when backend is 'default'."""
+    from unittest.mock import MagicMock
+    from nanobot.agent.loop import load_memory_backend
+
+    config = MagicMock()
+    config.memory.backend = "default"
+    config.workspace_path = tmp_path
+
+    backend = load_memory_backend(config)
+    assert isinstance(backend, MemoryStore)
+
+
+def test_load_memory_backend_falls_back_to_memory_store_on_unknown_backend(tmp_path):
+    """load_memory_backend() must fall back to MemoryStore when entry-point not found."""
+    from unittest.mock import MagicMock, patch
+    from nanobot.agent.loop import load_memory_backend
+
+    config = MagicMock()
+    config.memory.backend = "nonexistent-backend"
+    config.workspace_path = tmp_path
+
+    with patch("importlib.metadata.entry_points", return_value=[]):
+        backend = load_memory_backend(config)
+
+    assert isinstance(backend, MemoryStore)

--- a/tests/agent/test_loop_memory_backend.py
+++ b/tests/agent/test_loop_memory_backend.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.memory import MemoryBackend, MemoryStore
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import LLMResponse, GenerationSettings
+
+
+def _make_loop(tmp_path, memory_backend=None):
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings(max_tokens=0)
+    provider.estimate_prompt_tokens.return_value = (50, "test")
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+    provider.chat_stream_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+
+    return AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        memory_backend=memory_backend,
+    )
+
+
+def test_agent_loop_defaults_to_memory_store_backend(tmp_path):
+    loop = _make_loop(tmp_path)
+    assert isinstance(loop.memory_backend, MemoryStore)
+
+
+def test_agent_loop_accepts_custom_backend(tmp_path):
+    class FakeBackend(MemoryBackend):
+        async def consolidate(self, messages, session_key): pass
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    backend = FakeBackend()
+    loop = _make_loop(tmp_path, memory_backend=backend)
+    assert loop.memory_backend is backend
+
+
+def test_agent_loop_registers_backend_tools(tmp_path):
+    from nanobot.agent.tools.base import Tool
+
+    class FakeTool(Tool):
+        @property
+        def name(self): return "fake_tool"
+        @property
+        def description(self): return "fake"
+        @property
+        def parameters(self): return {"type": "object", "properties": {}}
+        async def execute(self, **kwargs): return "ok"
+
+    class FakeBackend(MemoryBackend):
+        def get_tools(self): return [FakeTool()]
+        async def consolidate(self, messages, session_key): pass
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    loop = _make_loop(tmp_path, memory_backend=FakeBackend())
+    assert loop.tools.get("fake_tool") is not None
+
+
+async def test_agent_loop_calls_backend_start_before_first_message(tmp_path):
+    class FakeBackend(MemoryBackend):
+        started = False
+        async def start(self, provider): self.started = True
+        async def consolidate(self, messages, session_key): pass
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    backend = FakeBackend()
+    loop = _make_loop(tmp_path, memory_backend=backend)
+    await loop.process_direct("hello", session_key="cli:test")
+    assert backend.started is True
+
+
+async def test_per_turn_backend_consolidate_called_after_message(tmp_path):
+    class FakeBackend(MemoryBackend):
+        consolidate_calls = []
+        @property
+        def consolidates_per_turn(self): return True
+        async def start(self, provider): pass
+        async def consolidate(self, messages, session_key):
+            self.consolidate_calls.append(session_key)
+        async def retrieve(self, query, session_key, top_k=5): return ""
+
+    backend = FakeBackend()
+    loop = _make_loop(tmp_path, memory_backend=backend)
+    await loop.process_direct("hello", session_key="telegram:123")
+    # Allow background task to complete
+    import asyncio
+    await asyncio.sleep(0)
+    assert "telegram:123" in backend.consolidate_calls

--- a/tests/agent/test_memory_backend.py
+++ b/tests/agent/test_memory_backend.py
@@ -79,3 +79,88 @@ async def test_memory_store_consolidate_is_noop(tmp_path):
     # Should not raise and should not create any files
     await store.consolidate([{"role": "user", "content": "hello"}], "telegram:123")
     assert not (tmp_path / "memory" / "MEMORY.md").exists()
+
+
+async def test_consolidator_skip_llm_drops_messages_without_llm_call(tmp_path):
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from nanobot.agent.memory import MemoryConsolidator, MemoryStore
+    from nanobot.agent.context import ContextBuilder
+    from nanobot.session.manager import SessionManager
+    from nanobot.providers.base import GenerationSettings
+
+    provider = MagicMock()
+    provider.generation = GenerationSettings(max_tokens=0)
+    provider.estimate_prompt_tokens = MagicMock(return_value=(50, "test"))
+
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    ctx = ContextBuilder(ws)
+    sessions = SessionManager(ws)
+
+    consolidator = MemoryConsolidator(
+        workspace=ws,
+        provider=provider,
+        model="test-model",
+        sessions=sessions,
+        context_window_tokens=200,
+        build_messages=ctx.build_messages,
+        get_tool_definitions=MagicMock(return_value=[]),
+    )
+    consolidator.consolidate_messages = AsyncMock(return_value=True)
+    consolidator._SAFETY_BUFFER = 0
+
+    session = sessions.get_or_create("telegram:123")
+    session.messages = [
+        {"role": "user", "content": "u1", "timestamp": "2026-01-01T00:00:00"},
+        {"role": "assistant", "content": "a1", "timestamp": "2026-01-01T00:00:01"},
+        {"role": "user", "content": "u2", "timestamp": "2026-01-01T00:00:02"},
+        {"role": "assistant", "content": "a2", "timestamp": "2026-01-01T00:00:03"},
+    ]
+
+    await consolidator.maybe_consolidate_by_tokens(session, skip_llm=True)
+
+    # LLM consolidation must NOT have been called
+    consolidator.consolidate_messages.assert_not_awaited()
+    # But session must have been pruned (last_consolidated advanced)
+    assert session.last_consolidated > 0
+
+
+async def test_consolidator_skip_llm_false_still_calls_llm(tmp_path):
+    from unittest.mock import AsyncMock, MagicMock
+    from nanobot.agent.memory import MemoryConsolidator
+    from nanobot.agent.context import ContextBuilder
+    from nanobot.session.manager import SessionManager
+    from nanobot.providers.base import GenerationSettings
+
+    provider = MagicMock()
+    provider.generation = GenerationSettings(max_tokens=0)
+    provider.estimate_prompt_tokens = MagicMock(return_value=(1000, "test"))
+
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    ctx = ContextBuilder(ws)
+    sessions = SessionManager(ws)
+
+    consolidator = MemoryConsolidator(
+        workspace=ws,
+        provider=provider,
+        model="test-model",
+        sessions=sessions,
+        context_window_tokens=200,
+        build_messages=ctx.build_messages,
+        get_tool_definitions=MagicMock(return_value=[]),
+    )
+    consolidator.consolidate_messages = AsyncMock(return_value=True)
+    consolidator._SAFETY_BUFFER = 0
+
+    session = sessions.get_or_create("telegram:123")
+    session.messages = [
+        {"role": "user", "content": "u1", "timestamp": "2026-01-01T00:00:00"},
+        {"role": "assistant", "content": "a1", "timestamp": "2026-01-01T00:00:01"},
+        {"role": "user", "content": "u2", "timestamp": "2026-01-01T00:00:02"},
+        {"role": "assistant", "content": "a2", "timestamp": "2026-01-01T00:00:03"},
+    ]
+
+    await consolidator.maybe_consolidate_by_tokens(session, skip_llm=False)
+
+    consolidator.consolidate_messages.assert_awaited()

--- a/tests/agent/test_memory_backend.py
+++ b/tests/agent/test_memory_backend.py
@@ -1,0 +1,22 @@
+"""Tests for memory backend configuration."""
+
+
+def test_memory_config_defaults():
+    from nanobot.config.schema import MemoryConfig
+
+    cfg = MemoryConfig()
+    assert cfg.backend == "default"
+
+
+def test_memory_config_backend_can_be_set():
+    from nanobot.config.schema import MemoryConfig
+
+    cfg = MemoryConfig(backend="graphiti")
+    assert cfg.backend == "graphiti"
+
+
+def test_config_has_memory_field():
+    from nanobot.config.schema import Config
+
+    cfg = Config()
+    assert cfg.memory.backend == "default"

--- a/tests/agent/test_memory_backend.py
+++ b/tests/agent/test_memory_backend.py
@@ -1,5 +1,7 @@
 """Tests for memory backend configuration."""
 
+import pytest
+
 
 def test_memory_config_defaults():
     from nanobot.config.schema import MemoryConfig
@@ -20,3 +22,60 @@ def test_config_has_memory_field():
 
     cfg = Config()
     assert cfg.memory.backend == "default"
+
+
+def test_memory_backend_abc_cannot_be_instantiated_directly():
+    from nanobot.agent.memory import MemoryBackend
+
+    with pytest.raises(TypeError):
+        MemoryBackend()
+
+
+def test_memory_store_is_memory_backend(tmp_path):
+    from nanobot.agent.memory import MemoryBackend, MemoryStore
+
+    store = MemoryStore(tmp_path)
+    assert isinstance(store, MemoryBackend)
+
+
+def test_memory_store_consolidates_per_turn_is_false(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    assert store.consolidates_per_turn is False
+
+
+def test_memory_store_get_tools_returns_empty_list(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    assert store.get_tools() == []
+
+
+async def test_memory_store_retrieve_returns_memory_context(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir(exist_ok=True)
+    (memory_dir / "MEMORY.md").write_text("I like coffee")
+
+    result = await store.retrieve("anything", "telegram:123")
+    assert "I like coffee" in result
+
+
+async def test_memory_store_retrieve_returns_empty_string_when_no_file(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    result = await store.retrieve("anything", "telegram:123")
+    assert result == ""
+
+
+async def test_memory_store_consolidate_is_noop(tmp_path):
+    from nanobot.agent.memory import MemoryStore
+
+    store = MemoryStore(tmp_path)
+    # Should not raise and should not create any files
+    await store.consolidate([{"role": "user", "content": "hello"}], "telegram:123")
+    assert not (tmp_path / "memory" / "MEMORY.md").exists()

--- a/tests/agent/test_memory_backend.py
+++ b/tests/agent/test_memory_backend.py
@@ -17,6 +17,13 @@ def test_memory_config_backend_can_be_set():
     assert cfg.backend == "graphiti"
 
 
+def test_memory_config_accepts_extra_graphiti_section():
+    from nanobot.config.schema import MemoryConfig
+
+    cfg = MemoryConfig(**{"backend": "graphiti", "graphiti": {"graph_db": "kuzu", "top_k": 10}})
+    assert cfg.model_extra["graphiti"] == {"graph_db": "kuzu", "top_k": 10}
+
+
 def test_config_has_memory_field():
     from nanobot.config.schema import Config
 

--- a/tests/agent/test_memory_consolidation_types.py
+++ b/tests/agent/test_memory_consolidation_types.py
@@ -73,7 +73,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = provider.chat
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is True
         assert store.history_file.exists()
@@ -94,7 +94,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = provider.chat
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is True
         assert store.history_file.exists()
@@ -129,7 +129,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = provider.chat
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is True
         assert "User discussed testing." in store.history_file.read_text()
@@ -145,7 +145,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = provider.chat
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is False
         assert not store.history_file.exists()
@@ -158,7 +158,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = provider.chat
         messages: list[dict] = []
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is True
         provider.chat.assert_not_called()
@@ -186,7 +186,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = provider.chat
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is True
         assert "User discussed testing." in store.history_file.read_text()
@@ -212,7 +212,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = provider.chat
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is False
 
@@ -236,7 +236,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = provider.chat
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is False
 
@@ -259,7 +259,7 @@ class TestMemoryConsolidationTypeHandling:
         )
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is False
         assert not store.history_file.exists()
@@ -284,7 +284,7 @@ class TestMemoryConsolidationTypeHandling:
         )
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is False
         assert not store.history_file.exists()
@@ -303,7 +303,7 @@ class TestMemoryConsolidationTypeHandling:
         )
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is False
         assert not store.history_file.exists()
@@ -322,7 +322,7 @@ class TestMemoryConsolidationTypeHandling:
         )
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is False
         assert not store.history_file.exists()
@@ -346,7 +346,7 @@ class TestMemoryConsolidationTypeHandling:
 
         monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", _fake_sleep)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is True
         assert provider.calls == 2
@@ -365,7 +365,7 @@ class TestMemoryConsolidationTypeHandling:
         )
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is True
         provider.chat_with_retry.assert_awaited_once()
@@ -400,7 +400,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = AsyncMock(side_effect=_tracking_chat)
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is True
         assert len(call_log) == 2
@@ -427,7 +427,7 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = AsyncMock(side_effect=[error_resp, no_tool_resp])
         messages = _make_messages(message_count=60)
 
-        result = await store.consolidate(messages, provider, "test-model")
+        result = await store._consolidate_with_provider(messages, provider, "test-model")
 
         assert result is False
         assert not store.history_file.exists()
@@ -441,9 +441,9 @@ class TestMemoryConsolidationTypeHandling:
         provider.chat_with_retry = AsyncMock(return_value=no_tool)
         messages = _make_messages(message_count=10)
 
-        assert await store.consolidate(messages, provider, "m") is False
-        assert await store.consolidate(messages, provider, "m") is False
-        assert await store.consolidate(messages, provider, "m") is True
+        assert await store._consolidate_with_provider(messages, provider, "m") is False
+        assert await store._consolidate_with_provider(messages, provider, "m") is False
+        assert await store._consolidate_with_provider(messages, provider, "m") is True
 
         assert store.history_file.exists()
         content = store.history_file.read_text()
@@ -465,14 +465,14 @@ class TestMemoryConsolidationTypeHandling:
 
         provider = AsyncMock()
         provider.chat_with_retry = AsyncMock(return_value=no_tool)
-        assert await store.consolidate(messages, provider, "m") is False
-        assert await store.consolidate(messages, provider, "m") is False
+        assert await store._consolidate_with_provider(messages, provider, "m") is False
+        assert await store._consolidate_with_provider(messages, provider, "m") is False
         assert store._consecutive_failures == 2
 
         provider.chat_with_retry = AsyncMock(return_value=ok_resp)
-        assert await store.consolidate(messages, provider, "m") is True
+        assert await store._consolidate_with_provider(messages, provider, "m") is True
         assert store._consecutive_failures == 0
 
         provider.chat_with_retry = AsyncMock(return_value=no_tool)
-        assert await store.consolidate(messages, provider, "m") is False
+        assert await store._consolidate_with_provider(messages, provider, "m") is False
         assert store._consecutive_failures == 1

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -264,7 +264,8 @@ async def test_slash_stop_injects_to_bus() -> None:
 
     await channel._inject_slash_as_message(interaction, "/stop")
 
-    interaction.response.defer.assert_called_once_with(ephemeral=False)
+    interaction.response.defer.assert_called_once_with(thinking=True, ephemeral=True)
+    # (True because DiscordConfig.ephemeral_commands defaults to True)
     assert bus.inbound.qsize() == 1
     msg = await bus.consume_inbound()
     assert msg.content == "/stop"
@@ -280,3 +281,60 @@ async def test_slash_new_injects_to_bus() -> None:
     assert bus.inbound.qsize() == 1
     msg = await bus.consume_inbound()
     assert msg.content == "/new"
+
+
+@pytest.mark.asyncio
+async def test_slash_denied_sender_does_not_inject_or_store_interaction():
+    bus = MessageBus()
+    channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["999"]), bus)
+
+    interaction = AsyncMock()
+    interaction.user.id = 456  # not in allow_from
+    interaction.channel_id = 789
+    interaction.guild_id = None
+
+    await channel._inject_slash_as_message(interaction, "/stop")
+
+    # No bus message published
+    assert bus.inbound.qsize() == 0
+    # No stale interaction stored
+    assert "789" not in channel._pending_interactions
+    # Ephemeral "Not authorized" response sent
+    interaction.response.send_message.assert_called_once_with("Not authorized.", ephemeral=True)
+
+
+@pytest.mark.asyncio
+async def test_send_with_interaction_followup_and_file(tmp_path):
+    """Interaction followup path must also route file attachments."""
+    bus = MessageBus()
+    channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), bus)
+
+    # Set up fake client with a channel
+    mock_client = MagicMock()
+    mock_discord_channel = MagicMock()
+    mock_discord_channel.send = AsyncMock()
+    mock_client.get_channel.return_value = mock_discord_channel
+    channel._client = mock_client
+
+    # Create a real temp file
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("hello")
+
+    # Pre-populate pending interaction
+    mock_interaction = AsyncMock()
+    mock_interaction.followup.send = AsyncMock()
+    channel._pending_interactions["123"] = mock_interaction
+
+    await channel.send(
+        OutboundMessage(
+            channel="discord",
+            chat_id="123",
+            content="here is your file",
+            media=[str(test_file)],
+        )
+    )
+
+    # channel.send should NOT be called (interaction path)
+    mock_discord_channel.send.assert_not_called()
+    # followup.send should be called for both file and text
+    assert mock_interaction.followup.send.call_count == 2

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -338,3 +338,117 @@ async def test_send_with_interaction_followup_and_file(tmp_path):
     mock_discord_channel.send.assert_not_called()
     # followup.send should be called for both file and text
     assert mock_interaction.followup.send.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Group 5 — Thread-per-conversation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_thread_per_conversation_creates_thread_for_guild_message():
+    """When threads_per_conversation=True, a thread is created for non-thread guild messages."""
+    bus = MessageBus()
+    channel = DiscordChannel(
+        DiscordConfig(enabled=True, allow_from=["*"], threads_per_conversation=True, group_policy="open"),
+        bus,
+    )
+    channel._bot_user_id = "999"
+
+    # Create a mock guild message (not a thread)
+    message = MagicMock(spec=discord.Message)
+    message.author.bot = False
+    message.author.id = 123
+    message.author.display_name = "TestUser"
+    message.channel = MagicMock(spec=discord.TextChannel)  # NOT a Thread
+    message.channel.id = 456
+    message.channel.typing = MagicMock(return_value=AsyncMock().__aenter__.return_value)
+    message.channel.typing.return_value.__aenter__ = AsyncMock(return_value=None)
+    message.channel.typing.return_value.__aexit__ = AsyncMock(return_value=None)
+    message.guild.id = 789
+    message.content = "Hello"
+    message.attachments = []
+    message.mentions = []
+    message.reference = None
+
+    # Mock thread creation
+    mock_thread = MagicMock()
+    mock_thread.id = 1001
+    message.create_thread = AsyncMock(return_value=mock_thread)
+
+    await channel._handle_message_create(message)
+
+    # Thread was created
+    message.create_thread.assert_called_once()
+    # Thread id stored in map
+    assert channel._thread_map["456"] == "1001"
+    # Message was published with thread_id as chat_id
+    assert bus.inbound.qsize() == 1
+    msg = await bus.consume_inbound()
+    assert msg.chat_id == "1001"
+    assert msg.session_key == "discord:1001"
+
+
+@pytest.mark.asyncio
+async def test_thread_per_conversation_reuses_existing_thread():
+    """When a thread already exists for a channel, it reuses it."""
+    bus = MessageBus()
+    channel = DiscordChannel(
+        DiscordConfig(enabled=True, allow_from=["*"], threads_per_conversation=True, group_policy="open"),
+        bus,
+    )
+    channel._bot_user_id = "999"
+    channel._thread_map["456"] = "1001"  # Pre-existing thread
+
+    message = MagicMock(spec=discord.Message)
+    message.author.bot = False
+    message.author.id = 123
+    message.author.display_name = "TestUser"
+    message.channel = MagicMock(spec=discord.TextChannel)
+    message.channel.id = 456
+    message.channel.typing = MagicMock()
+    message.channel.typing.return_value.__aenter__ = AsyncMock(return_value=None)
+    message.channel.typing.return_value.__aexit__ = AsyncMock(return_value=None)
+    message.guild.id = 789
+    message.content = "Hello again"
+    message.attachments = []
+    message.mentions = []
+    message.reference = None
+    message.create_thread = AsyncMock()  # Should NOT be called
+
+    await channel._handle_message_create(message)
+
+    message.create_thread.assert_not_called()
+    msg = await bus.consume_inbound()
+    assert msg.chat_id == "1001"
+
+
+@pytest.mark.asyncio
+async def test_thread_per_conversation_disabled_uses_channel():
+    """When threads_per_conversation=False, the original channel_id is used."""
+    bus = MessageBus()
+    channel = DiscordChannel(
+        DiscordConfig(enabled=True, allow_from=["*"], threads_per_conversation=False, group_policy="open"),
+        bus,
+    )
+    channel._bot_user_id = "999"
+
+    message = MagicMock(spec=discord.Message)
+    message.author.bot = False
+    message.author.id = 123
+    message.author.display_name = "TestUser"
+    message.channel = MagicMock(spec=discord.TextChannel)
+    message.channel.id = 456
+    message.channel.typing.return_value.__aenter__ = AsyncMock(return_value=None)
+    message.channel.typing.return_value.__aexit__ = AsyncMock(return_value=None)
+    message.guild.id = 789
+    message.content = "Hello"
+    message.attachments = []
+    message.mentions = []
+    message.reference = None
+    message.create_thread = AsyncMock()
+
+    await channel._handle_message_create(message)
+
+    message.create_thread.assert_not_called()
+    msg = await bus.consume_inbound()
+    assert msg.chat_id == "456"

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -1,0 +1,282 @@
+"""Tests for the Discord channel implementation."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import discord
+except ImportError:
+    pytest.skip("discord.py not installed", allow_module_level=True)
+
+from unittest.mock import AsyncMock, MagicMock
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.discord import DiscordChannel, DiscordConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_discord_channel(
+    allow_from: list[str] | None = None,
+    group_policy: str = "mention",
+    slash_commands_enabled: bool = True,
+) -> tuple[DiscordChannel, MessageBus]:
+    """Return a DiscordChannel + MessageBus with no real Discord client."""
+    bus = MessageBus()
+    cfg = DiscordConfig(
+        enabled=True,
+        token="test-token",
+        allow_from=allow_from or ["*"],
+        group_policy=group_policy,  # type: ignore[arg-type]
+        slash_commands_enabled=slash_commands_enabled,
+    )
+    channel = DiscordChannel(cfg, bus)
+    return channel, bus
+
+
+def _make_discord_message(
+    author_id: int = 123,
+    channel_id: int = 456,
+    content: str = "hello",
+    author_bot: bool = False,
+    guild_id: int | None = None,
+    mentions: list | None = None,
+) -> MagicMock:
+    """Build a fake discord.Message MagicMock."""
+    message = MagicMock(spec=discord.Message)
+    message.author.bot = author_bot
+    message.author.id = author_id
+    message.channel.id = channel_id
+    message.content = content
+    message.attachments = []
+    message.mentions = mentions or []
+    message.reference = None
+
+    # typing() must be an async context manager
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=AsyncMock())
+    async_ctx.__aexit__ = AsyncMock(return_value=False)
+    message.channel.typing = MagicMock(return_value=async_ctx)
+
+    if guild_id is not None:
+        guild = MagicMock()
+        guild.id = guild_id
+        message.guild = guild
+    else:
+        message.guild = None
+
+    return message
+
+
+def _make_interaction(
+    channel_id: int = 789,
+    user_id: int = 123,
+    guild_id: int | None = None,
+) -> MagicMock:
+    """Build a fake discord.Interaction MagicMock."""
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel_id = channel_id
+    interaction.user = MagicMock()
+    interaction.user.id = user_id
+    interaction.guild_id = guild_id
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Group 1 — Config tests
+# ---------------------------------------------------------------------------
+
+def test_discord_config_defaults() -> None:
+    cfg = DiscordConfig()
+    assert cfg.slash_commands_enabled is True
+    assert cfg.threads_per_conversation is False
+    assert cfg.ephemeral_commands is True
+    assert cfg.admin_role_ids == []
+    assert cfg.application_id == ""
+    assert cfg.guild_ids == []
+
+
+def test_discord_config_snake_case() -> None:
+    cfg = DiscordConfig.model_validate(
+        {"enabled": True, "slash_commands_enabled": False, "admin_role_ids": ["123"]}
+    )
+    assert cfg.enabled is True
+    assert cfg.slash_commands_enabled is False
+    assert cfg.admin_role_ids == ["123"]
+
+
+def test_discord_config_camel_case() -> None:
+    cfg = DiscordConfig.model_validate(
+        {"enabled": True, "slashCommandsEnabled": False, "adminRoleIds": ["456"]}
+    )
+    assert cfg.enabled is True
+    assert cfg.slash_commands_enabled is False
+    assert cfg.admin_role_ids == ["456"]
+
+
+# ---------------------------------------------------------------------------
+# Group 2 — Message handling
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_handle_message_allowed_sender() -> None:
+    channel, bus = _make_discord_channel(allow_from=["123"])
+    channel._bot_user_id = "999"
+    message = _make_discord_message(author_id=123, guild_id=None)
+    await channel._handle_message_create(message)
+    assert bus.inbound.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_message_denied_sender() -> None:
+    channel, bus = _make_discord_channel(allow_from=["123"])
+    channel._bot_user_id = "999"
+    message = _make_discord_message(author_id=456, guild_id=None)
+    await channel._handle_message_create(message)
+    assert bus.inbound.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_message_bot_ignored() -> None:
+    channel, bus = _make_discord_channel(allow_from=["*"])
+    message = _make_discord_message(author_bot=True, guild_id=None)
+    await channel._handle_message_create(message)
+    assert bus.inbound.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_message_group_mention_policy() -> None:
+    channel, bus = _make_discord_channel(allow_from=["*"], group_policy="mention")
+    channel._bot_user_id = "999"
+    # Guild message, no mention
+    message = _make_discord_message(author_id=123, channel_id=456, guild_id=111, mentions=[])
+    await channel._handle_message_create(message)
+    assert bus.inbound.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_message_group_open_policy() -> None:
+    channel, bus = _make_discord_channel(allow_from=["*"], group_policy="open")
+    channel._bot_user_id = "999"
+    message = _make_discord_message(author_id=123, channel_id=456, guild_id=111)
+    await channel._handle_message_create(message)
+    assert bus.inbound.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_message_dm_bypasses_group_policy() -> None:
+    channel, bus = _make_discord_channel(allow_from=["*"], group_policy="mention")
+    channel._bot_user_id = "999"
+    # DM: guild=None
+    message = _make_discord_message(author_id=123, channel_id=456, guild_id=None)
+    await channel._handle_message_create(message)
+    assert bus.inbound.qsize() == 1
+
+
+# ---------------------------------------------------------------------------
+# Group 3 — send() tests
+# ---------------------------------------------------------------------------
+
+def _make_channel_with_mock_client() -> tuple[DiscordChannel, MessageBus, MagicMock]:
+    """Return channel + bus + fake_channel mock wired to client."""
+    channel, bus = _make_discord_channel()
+
+    fake_discord_channel = MagicMock()
+    fake_discord_channel.send = AsyncMock()
+
+    mock_client = MagicMock()
+    mock_client.get_channel = MagicMock(return_value=fake_discord_channel)
+    mock_client.fetch_channel = AsyncMock(return_value=fake_discord_channel)
+
+    channel._client = mock_client
+    return channel, bus, fake_discord_channel
+
+
+@pytest.mark.asyncio
+async def test_send_plain_text() -> None:
+    channel, bus, fake_discord_channel = _make_channel_with_mock_client()
+    await channel.send(OutboundMessage(channel="discord", chat_id="123", content="hello"))
+    fake_discord_channel.send.assert_called_once()
+    call_kwargs = fake_discord_channel.send.call_args
+    assert call_kwargs.kwargs.get("content") == "hello"
+
+
+@pytest.mark.asyncio
+async def test_send_chunked_long_message() -> None:
+    channel, bus, fake_discord_channel = _make_channel_with_mock_client()
+    long_content = "x" * 2500
+    await channel.send(OutboundMessage(channel="discord", chat_id="123", content=long_content))
+    assert fake_discord_channel.send.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_send_with_reply_to() -> None:
+    channel, bus, fake_discord_channel = _make_channel_with_mock_client()
+    await channel.send(
+        OutboundMessage(channel="discord", chat_id="123", content="hi", reply_to="555")
+    )
+    fake_discord_channel.send.assert_called_once()
+    call_kwargs = fake_discord_channel.send.call_args.kwargs
+    reference = call_kwargs.get("reference")
+    assert reference is not None
+    assert reference.message_id == 555
+
+
+@pytest.mark.asyncio
+async def test_send_with_interaction_followup() -> None:
+    channel, bus, fake_discord_channel = _make_channel_with_mock_client()
+    mock_interaction = _make_interaction(channel_id=123)
+    channel._pending_interactions["123"] = mock_interaction
+
+    await channel.send(OutboundMessage(channel="discord", chat_id="123", content="response"))
+
+    mock_interaction.followup.send.assert_called_once()
+    # channel.send should NOT be called when using followup
+    fake_discord_channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_clears_pending_interaction() -> None:
+    channel, bus, fake_discord_channel = _make_channel_with_mock_client()
+    mock_interaction = _make_interaction(channel_id=123)
+    channel._pending_interactions["123"] = mock_interaction
+
+    await channel.send(OutboundMessage(channel="discord", chat_id="123", content="done"))
+
+    assert "123" not in channel._pending_interactions
+
+
+# ---------------------------------------------------------------------------
+# Group 4 partial — Slash command injection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_slash_stop_injects_to_bus() -> None:
+    channel, bus = _make_discord_channel(allow_from=["*"])
+    interaction = _make_interaction(channel_id=789, user_id=123, guild_id=None)
+
+    await channel._inject_slash_as_message(interaction, "/stop")
+
+    interaction.response.defer.assert_called_once_with(ephemeral=False)
+    assert bus.inbound.qsize() == 1
+    msg = await bus.consume_inbound()
+    assert msg.content == "/stop"
+
+
+@pytest.mark.asyncio
+async def test_slash_new_injects_to_bus() -> None:
+    channel, bus = _make_discord_channel(allow_from=["*"])
+    interaction = _make_interaction(channel_id=789, user_id=123, guild_id=None)
+
+    await channel._inject_slash_as_message(interaction, "/new")
+
+    assert bus.inbound.qsize() == 1
+    msg = await bus.consume_inbound()
+    assert msg.content == "/new"

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -361,7 +361,6 @@ async def test_thread_per_conversation_creates_thread_for_guild_message():
     message.author.display_name = "TestUser"
     message.channel = MagicMock(spec=discord.TextChannel)  # NOT a Thread
     message.channel.id = 456
-    message.channel.typing = MagicMock(return_value=AsyncMock().__aenter__.return_value)
     message.channel.typing.return_value.__aenter__ = AsyncMock(return_value=None)
     message.channel.typing.return_value.__aexit__ = AsyncMock(return_value=None)
     message.guild.id = 789

--- a/tests/channels/test_discord_smoke.py
+++ b/tests/channels/test_discord_smoke.py
@@ -1,0 +1,38 @@
+"""Smoke tests for DiscordChannel initialization and basic wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+discord = pytest.importorskip("discord")
+
+from nanobot.bus.queue import MessageBus  # noqa: E402
+from nanobot.channels.discord import DiscordChannel, DiscordConfig  # noqa: E402
+
+
+def _make_channel() -> DiscordChannel:
+    config = DiscordConfig(token="fake-token")
+    bus = MessageBus()
+    return DiscordChannel(config, bus)
+
+
+def test_discord_channel_name():
+    ch = _make_channel()
+    assert ch.name == "discord"
+
+
+def test_discord_channel_pending_interactions_starts_empty():
+    ch = _make_channel()
+    assert ch._pending_interactions == {}
+
+
+def test_discord_channel_interaction_timestamps_starts_empty():
+    ch = _make_channel()
+    assert ch._interaction_timestamps == {}
+
+
+def test_discord_channel_set_tool_registry():
+    ch = _make_channel()
+    mock_registry = object()
+    ch.set_tool_registry(mock_registry)
+    assert ch._tool_registry is mock_registry

--- a/tests/channels/test_discord_ui.py
+++ b/tests/channels/test_discord_ui.py
@@ -1,0 +1,72 @@
+"""Tests for discord UI components."""
+from __future__ import annotations
+
+import pytest
+
+try:
+    import discord
+except ImportError:
+    pytest.skip("discord.py not installed", allow_module_level=True)
+
+from unittest.mock import AsyncMock, MagicMock
+
+from nanobot.channels.discord_ui import (
+    McpServerSelect,
+    McpView,
+    ModelPickerView,
+    StatusView,
+    StopButton,
+)
+
+
+async def test_model_picker_view_has_provider_select():
+    on_confirm = AsyncMock()
+    view = ModelPickerView(providers=[("anthropic", "Anthropic"), ("openai", "OpenAI")], on_confirm=on_confirm)
+    # Has at least one item (ProviderSelect) + one button
+    assert len(view.children) >= 2
+    # Timeout is 600s
+    assert view.timeout == 600.0
+
+
+async def test_model_picker_confirm_without_selection_sends_error():
+    on_confirm = AsyncMock()
+    view = ModelPickerView(providers=[("anthropic", "Anthropic")], on_confirm=on_confirm)
+    interaction = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    # Find and call the confirm button callback directly
+    button = next(item for item in view.children if isinstance(item, discord.ui.Button))
+    await button.callback(interaction)
+    interaction.response.send_message.assert_called_once()
+    args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("ephemeral") is True
+    on_confirm.assert_not_called()
+
+
+async def test_stop_button_triggers_callback():
+    on_stop = AsyncMock()
+    button = StopButton(on_stop=on_stop)
+    interaction = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.message.edit = AsyncMock()
+    # Give the button a parent view so self.view is not None
+    StatusView(on_stop=on_stop)
+    await button.callback(interaction)
+    interaction.response.defer.assert_called_once_with(ephemeral=True)
+    assert button.disabled is True
+
+
+async def test_mcp_view_with_empty_servers():
+    view = McpView(servers=[])
+    assert len(view.children) == 1
+    select = view.children[0]
+    assert isinstance(select, McpServerSelect)
+    assert select.disabled is True
+
+
+async def test_mcp_view_with_servers():
+    view = McpView(servers=["server1", "server2"])
+    select = view.children[0]
+    assert isinstance(select, McpServerSelect)
+    assert select.disabled is False
+    assert len(select.options) == 2

--- a/tests/channels/test_discord_ui.py
+++ b/tests/channels/test_discord_ui.py
@@ -15,7 +15,6 @@ from nanobot.channels.discord_ui import (
     McpView,
     ModelPickerView,
     StatusView,
-    StopButton,
 )
 
 
@@ -44,16 +43,21 @@ async def test_model_picker_confirm_without_selection_sends_error():
 
 async def test_stop_button_triggers_callback():
     on_stop = AsyncMock()
-    button = StopButton(on_stop=on_stop)
+    # Use a real StatusView so the button has a proper parent
+    view = StatusView(on_stop=on_stop)
+    button = next(item for item in view.children if isinstance(item, discord.ui.Button))
+
     interaction = MagicMock()
     interaction.response.defer = AsyncMock()
     interaction.followup.send = AsyncMock()
     interaction.message.edit = AsyncMock()
-    # Give the button a parent view so self.view is not None
-    StatusView(on_stop=on_stop)
+
     await button.callback(interaction)
+
+    # Verify defer called, button disabled, and stop callback invoked
     interaction.response.defer.assert_called_once_with(ephemeral=True)
     assert button.disabled is True
+    on_stop.assert_called_once()
 
 
 async def test_mcp_view_with_empty_servers():

--- a/tests/cli/test_restart_command.py
+++ b/tests/cli/test_restart_command.py
@@ -127,7 +127,7 @@ class TestRestartCommand:
         loop.sessions.get_or_create.return_value = session
         loop._start_time = time.time() - 125
         loop._last_usage = {"prompt_tokens": 0, "completion_tokens": 0}
-        loop.memory_consolidator.estimate_session_prompt_tokens = MagicMock(
+        loop.memory_consolidator.estimate_session_prompt_tokens = AsyncMock(
             return_value=(20500, "tiktoken")
         )
 
@@ -164,7 +164,7 @@ class TestRestartCommand:
         session.get_history.return_value = [{"role": "user"}]
         loop.sessions.get_or_create.return_value = session
         loop._last_usage = {"prompt_tokens": 1200, "completion_tokens": 34}
-        loop.memory_consolidator.estimate_session_prompt_tokens = MagicMock(
+        loop.memory_consolidator.estimate_session_prompt_tokens = AsyncMock(
             return_value=(0, "none")
         )
 

--- a/tests/tools/test_discord_tools.py
+++ b/tests/tools/test_discord_tools.py
@@ -6,6 +6,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+# Skip entire module if discord.py is not installed
+pytest.importorskip("discord")
+
 from nanobot.agent.tools.discord_tools import (
     DiscordCreateThreadTool,
     DiscordManageRolesTool,

--- a/tests/tools/test_discord_tools.py
+++ b/tests/tools/test_discord_tools.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
-# Skip entire module if discord.py is not installed
-pytest.importorskip("discord")
-
 from nanobot.agent.tools.discord_tools import (
+    DiscordCreateChannelTool,
+    DiscordCreateEmbedTool,
     DiscordCreateThreadTool,
     DiscordManageRolesTool,
     DiscordPinMessageTool,
@@ -68,7 +65,7 @@ async def test_discord_manage_roles_remove():
         raise_for_status=MagicMock(),
     )
     tool = DiscordManageRolesTool(mock_http, "token")
-    result = await tool.execute(guild_id="g1", user_id="u1", role_id="r1", action="remove")
+    await tool.execute(guild_id="g1", user_id="u1", role_id="r1", action="remove")
     call = mock_http.request.call_args[0]
     assert call[0] == "DELETE"
 
@@ -90,7 +87,7 @@ async def test_discord_pin_message_uses_put():
         raise_for_status=MagicMock(),
     )
     tool = DiscordPinMessageTool(mock_http, "token")
-    result = await tool.execute(channel_id="c1", message_id="m1")
+    await tool.execute(channel_id="c1", message_id="m1")
     call = mock_http.request.call_args[0]
     assert call[0] == "PUT"
     assert "/channels/c1/pins/m1" in call[1]
@@ -109,3 +106,54 @@ async def test_discord_create_thread_from_message():
     assert "t1" in result
     call = mock_http.request.call_args[0]
     assert "/messages/msg1/threads" in call[1]
+
+
+async def test_discord_create_embed_sends_rich_embed():
+    mock_http = AsyncMock()
+    mock_http.request.return_value = MagicMock(
+        status_code=200,
+        content=b'{"id": "e1"}',
+        json=MagicMock(return_value={"id": "e1"}),
+        raise_for_status=MagicMock(),
+    )
+    tool = DiscordCreateEmbedTool(mock_http, "token")
+    result = await tool.execute(
+        channel_id="c1",
+        title="Hello",
+        description="World",
+        footer="Bot",
+        fields=[{"name": "f1", "value": "v1"}],
+    )
+    assert "e1" in result
+    call = mock_http.request.call_args[0]
+    assert call[0] == "POST"
+    assert "/channels/c1/messages" in call[1]
+
+
+async def test_discord_create_embed_rejects_private_image_url(monkeypatch):
+    mock_http = AsyncMock()
+    tool = DiscordCreateEmbedTool(mock_http, "token")
+    # Patch validate_url_target to simulate SSRF rejection
+    import nanobot.security.network as net_mod
+
+    monkeypatch.setattr(net_mod, "validate_url_target", lambda url: (False, "private IP blocked"))
+    result = await tool.execute(channel_id="c1", title="t", image_url="http://169.254.169.254/")
+    assert "Error" in result
+    assert "image_url" in result
+    mock_http.request.assert_not_called()
+
+
+async def test_discord_create_channel_posts_to_guild():
+    mock_http = AsyncMock()
+    mock_http.request.return_value = MagicMock(
+        status_code=200,
+        content=b'{"id": "ch1", "name": "general"}',
+        json=MagicMock(return_value={"id": "ch1", "name": "general"}),
+        raise_for_status=MagicMock(),
+    )
+    tool = DiscordCreateChannelTool(mock_http, "token")
+    result = await tool.execute(guild_id="g1", name="general")
+    assert "ch1" in result
+    call = mock_http.request.call_args[0]
+    assert call[0] == "POST"
+    assert "/guilds/g1/channels" in call[1]

--- a/tests/tools/test_discord_tools.py
+++ b/tests/tools/test_discord_tools.py
@@ -1,0 +1,108 @@
+"""Tests for Discord API tools."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.tools.discord_tools import (
+    DiscordCreateThreadTool,
+    DiscordManageRolesTool,
+    DiscordPinMessageTool,
+    DiscordPollTool,
+    DiscordSendTool,
+)
+
+
+async def test_discord_send_posts_plain_text():
+    mock_http = AsyncMock()
+    mock_http.request.return_value = MagicMock(
+        status_code=200,
+        content=b'{"id": "111"}',
+        json=MagicMock(return_value={"id": "111"}),
+        raise_for_status=MagicMock(),
+    )
+    tool = DiscordSendTool(mock_http, "fake_token")
+    result = await tool.execute(channel_id="123", content="hello")
+    assert "111" in result
+    mock_http.request.assert_called_once()
+    call_kwargs = mock_http.request.call_args
+    assert call_kwargs[0][0] == "POST"
+    assert "/channels/123/messages" in call_kwargs[0][1]
+
+
+async def test_discord_send_requires_content_or_embed():
+    mock_http = AsyncMock()
+    tool = DiscordSendTool(mock_http, "fake_token")
+    result = await tool.execute(channel_id="123")
+    assert "Error" in result
+    mock_http.request.assert_not_called()
+
+
+async def test_discord_manage_roles_add():
+    mock_http = AsyncMock()
+    mock_http.request.return_value = MagicMock(
+        status_code=204,
+        content=b"",
+        json=MagicMock(return_value={}),
+        raise_for_status=MagicMock(),
+    )
+    tool = DiscordManageRolesTool(mock_http, "token")
+    result = await tool.execute(guild_id="g1", user_id="u1", role_id="r1", action="add")
+    assert "success" in result.lower() or "added" in result.lower()
+    call = mock_http.request.call_args[0]
+    assert call[0] == "PUT"
+    assert "/guilds/g1/members/u1/roles/r1" in call[1]
+
+
+async def test_discord_manage_roles_remove():
+    mock_http = AsyncMock()
+    mock_http.request.return_value = MagicMock(
+        status_code=204,
+        content=b"",
+        json=MagicMock(return_value={}),
+        raise_for_status=MagicMock(),
+    )
+    tool = DiscordManageRolesTool(mock_http, "token")
+    result = await tool.execute(guild_id="g1", user_id="u1", role_id="r1", action="remove")
+    call = mock_http.request.call_args[0]
+    assert call[0] == "DELETE"
+
+
+async def test_discord_poll_validates_min_answers():
+    mock_http = AsyncMock()
+    tool = DiscordPollTool(mock_http, "token")
+    result = await tool.execute(channel_id="123", question="Vote?", answers=["only one"])
+    assert "Error" in result or "error" in result.lower()
+    mock_http.request.assert_not_called()
+
+
+async def test_discord_pin_message_uses_put():
+    mock_http = AsyncMock()
+    mock_http.request.return_value = MagicMock(
+        status_code=204,
+        content=b"",
+        json=MagicMock(return_value={}),
+        raise_for_status=MagicMock(),
+    )
+    tool = DiscordPinMessageTool(mock_http, "token")
+    result = await tool.execute(channel_id="c1", message_id="m1")
+    call = mock_http.request.call_args[0]
+    assert call[0] == "PUT"
+    assert "/channels/c1/pins/m1" in call[1]
+
+
+async def test_discord_create_thread_from_message():
+    mock_http = AsyncMock()
+    mock_http.request.return_value = MagicMock(
+        status_code=200,
+        content=b'{"id": "t1", "name": "my-thread"}',
+        json=MagicMock(return_value={"id": "t1", "name": "my-thread"}),
+        raise_for_status=MagicMock(),
+    )
+    tool = DiscordCreateThreadTool(mock_http, "token")
+    result = await tool.execute(channel_id="c1", name="my-thread", message_id="msg1")
+    assert "t1" in result
+    call = mock_http.request.call_args[0]
+    assert "/messages/msg1/threads" in call[1]


### PR DESCRIPTION
## Summary

Alternative long-term memory implementation to #2618 / #2619 / #2620. Closes #80. Relates to #135, #97.

Instead of a flat-file semantic index, this approach replaces nanobot's MEMORY.md with a **Graphiti temporal knowledge graph** — enabling per-turn entity extraction, relationship tracking, and time-aware retrieval. Memory becomes a first-class "lobe" of the agent's brain rather than a document to search.

**Disabled by default** — no behavior change unless `memory.backend = "graphiti"` in config.

## What's included

### Core changes (`nanobot/`)

- **`MemoryBackend` ABC** (`nanobot/agent/memory.py`) — abstract interface all memory backends implement:
  - `consolidates_per_turn: bool` — gates whether `AgentLoop` fires per-turn background consolidation
  - `async consolidate(messages, session_key)` — ingest a turn into the backend
  - `async retrieve(query, session_key, top_k)` — fetch relevant facts before each user message
  - `get_tools() -> list[Tool]` — register backend-specific tools into the agent's tool registry

- **`MemoryConfig`** (`nanobot/config/schema.py`) — `memory.backend` field + `extra="allow"` for plugin-specific config sections (same pattern as `ChannelsConfig`)

- **Async `build_messages()`** (`nanobot/agent/context.py`) — awaits `backend.retrieve()` and injects a `[Memory — N relevant facts]` block as a system message before history

- **`load_memory_backend()`** (`nanobot/agent/loop.py`) — discovers backends via `importlib.metadata.entry_points(group="nanobot.memory")`; calls `cls.from_nanobot_config(config)` when present

- **`AgentLoop` per-turn dispatch** — fires `backend.consolidate()` as a background task after each turn when `consolidates_per_turn is True`; otherwise defers to token-pressure MemoryConsolidator

### Plugin (`plugins/nanobot-graphiti/`)

Standalone installable package. Entry-point: `nanobot.memory = graphiti`.

- **`GraphitiMemoryBackend`** — full implementation:
  - `start(provider)` builds Graphiti client from nanobot's `LLMProvider` (OpenAI-compat required; raises `RuntimeError` for Anthropic native)
  - `consolidate()` calls `graphiti.add_episode()` with `EpisodeType.message`; errors swallowed + logged
  - `retrieve()` calls `graphiti.search()` and formats `[Memory — N relevant facts]` block
  - `get_tools()` returns all three memory tools bound to backend

- **Three memory tools**:
  - `memory_search` — semantic search with session-scoped `group_id`
  - `memory_forget` — deletes a fact by UUID via `EntityEdge.delete_by_uuids`; ownership-verified before delete
  - `memory_list` — lists all stored facts with UUIDs for reference

- **Session scoping** — `scope: "user"` (default) merges memory across channels (strips channel prefix); `scope: "session"` keeps per-channel isolation

- **Graph DB drivers** — Kuzu (embedded, default), Neo4j, FalkorDB

## Comparison with #2618–#2620

| | This PR (Graphiti) | PRs #2618–#2620 (memory_index) |
|---|---|---|
| Storage | Temporal knowledge graph (Kuzu/Neo4j) | SQLite FTS5 + optional vector |
| Extraction | LLM entity/relationship extraction per turn | Markdown-aware chunking |
| Retrieval | Graph search with temporal decay | BM25 + cosine RRF fusion + MMR |
| Memory format | Structured entities + relationships | Raw text chunks |
| Extra deps | `graphiti-core`, `kuzu` | `sqlite-vec` (optional) |
| Architecture | Plugin package (`nanobot-graphiti`) | Embedded `nanobot/memory_index/` |

Both approaches implement the same `MemoryBackend` ABC introduced here — they are interchangeable backends, not competing rewrites.

## Config

```yaml
memory:
  backend: graphiti
  graphiti:
    graph_db: kuzu           # or neo4j / falkordb
    scope: user              # or session
    top_k: 5
    embedding_model: text-embedding-3-small
```

## Test plan

- [x] `pytest` — 672 core tests pass, 1 skipped
- [x] `cd plugins/nanobot-graphiti && pytest` — 32 plugin tests pass
- [x] No regressions — `MemoryBackend` defaults to `MemoryStore` (existing behavior) when `memory.backend = "default"`
- [ ] Manual: install plugin, set `memory.backend = "graphiti"`, run a multi-turn chat, verify facts are extracted and injected on subsequent turns
- [ ] Manual: test `memory_forget` tool removes a specific fact

🤖 Generated with [Claude Code](https://claude.com/claude-code)