### PR TITLE
fix(provider): ensure max_tokens and max_completion_tokens are mutually exclusive after model_overrides

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -258,6 +258,9 @@ class OpenAICompatProvider(LLMProvider):
                     kwargs.update(overrides)
                     break
 
+        if "max_completion_tokens" in kwargs and "max_tokens" in kwargs:
+            del kwargs["max_tokens"]
+
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
 

--- a/tests/providers/test_custom_provider.py
+++ b/tests/providers/test_custom_provider.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.providers.registry import ProviderSpec
 
 
 def test_custom_provider_parse_handles_empty_choices() -> None:
@@ -53,3 +54,58 @@ def test_custom_provider_parse_chunks_accepts_plain_text_chunks() -> None:
 
     assert result.finish_reason == "stop"
     assert result.content == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# _build_kwargs: max_tokens / max_completion_tokens mutual exclusion
+# ---------------------------------------------------------------------------
+
+
+def _build(model: str, *, spec: ProviderSpec | None = None) -> dict:
+    """Build kwargs via the provider without hitting the network."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+    provider._spec = spec
+    return provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model=model,
+        max_tokens=1024,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+
+def test_model_overrides_injects_max_completion_tokens_removes_max_tokens() -> None:
+    """model_overrides adding max_completion_tokens must drop max_tokens."""
+    spec = ProviderSpec(
+        name="test",
+        keywords=(),
+        env_key="",
+        model_overrides=(("o3", {"max_completion_tokens": 8192}),),
+    )
+    kwargs = _build("o3-mini", spec=spec)
+    assert "max_completion_tokens" in kwargs
+    assert "max_tokens" not in kwargs
+    assert kwargs["max_completion_tokens"] == 8192
+
+
+def test_no_overrides_keeps_max_tokens_only() -> None:
+    """Without overrides, max_tokens is set and max_completion_tokens absent."""
+    kwargs = _build("gpt-4o")
+    assert "max_tokens" in kwargs
+    assert "max_completion_tokens" not in kwargs
+
+
+def test_supports_max_completion_tokens_flag() -> None:
+    """When spec sets supports_max_completion_tokens, use that param."""
+    spec = ProviderSpec(
+        name="test",
+        keywords=(),
+        env_key="",
+        supports_max_completion_tokens=True,
+    )
+    kwargs = _build("any-model", spec=spec)
+    assert "max_completion_tokens" in kwargs
+    assert "max_tokens" not in kwargs


### PR DESCRIPTION
## 问题

在 `OpenAICompatProvider._build_kwargs` 中，构建 API 请求参数的流程是：

1. 根据 `spec.supports_max_completion_tokens` 标志决定写入 `max_tokens` 或 `max_completion_tokens`
2. 遍历 `spec.model_overrides`，对匹配的模型执行 `kwargs.update(overrides)` 覆盖参数

**当前所有内置 provider 的 `supports_max_completion_tokens` 均为 `False`**，所以第 1 步始终写入 `max_tokens`。

当用户通过 `model_overrides` 为 reasoning 模型（如 o1/o3/o4）正确配置了 `max_completion_tokens` 时，第 2 步的 `kwargs.update()` 只会**追加** `max_completion_tokens`，不会**删除**已有的 `max_tokens`。两个参数同时存在，导致 OpenAI API 报错：

> *"Setting 'max_tokens' and 'max_completion_tokens' at the same time is not allowed"*

这是 `_build_kwargs` 的逻辑缺陷 — `update()` 之后缺少互斥清理。

## 修复

在 `model_overrides` 应用之后增加互斥检查：如果 `max_completion_tokens` 和 `max_tokens` 同时存在，删除 `max_tokens`（`max_completion_tokens` 是 OpenAI 更新的参数规范，应优先保留）。

改动 2 行，无硬编码模型名，无新增标志位，完全依赖已有的 `model_overrides` 和 `supports_max_completion_tokens` 机制。

## 测试

新增 3 个测试用例：
- `model_overrides` 注入 `max_completion_tokens` 后，`max_tokens` 被正确移除
- 无 overrides 时，`max_tokens` 保持不变
- `supports_max_completion_tokens=True` 标志正常工作

Made with [Cursor](https://cursor.com)