### PR TITLE
feat: add Bedrock AWS profile support

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -423,6 +423,20 @@ def _make_provider(config: Config):
             default_model=model,
             extra_headers=p.extra_headers if p else None,
         )
+    elif backend == "anthropic_bedrock":
+        from nanobot.providers.anthropic_provider import AnthropicProvider
+
+        aws_region = getattr(p, "aws_region", None) if p else None
+        if not aws_region and p:
+            aws_region = p.api_base
+
+        provider = AnthropicProvider(
+            default_model=model,
+            extra_headers=p.extra_headers if p else None,
+            use_bedrock=True,
+            aws_profile=(getattr(p, "aws_profile", "") or None) if p else None,
+            aws_region=aws_region,
+        )
     else:
         from nanobot.providers.openai_compat_provider import OpenAICompatProvider
         provider = OpenAICompatProvider(

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -58,11 +58,19 @@ class ProviderConfig(Base):
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
 
 
+class BedrockProviderConfig(ProviderConfig):
+    """AWS Bedrock provider configuration."""
+
+    aws_profile: str = ""
+    aws_region: str | None = None
+
+
 class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
     azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
+    bedrock: BedrockProviderConfig = Field(default_factory=BedrockProviderConfig)  # AWS Bedrock (IAM/shared profile)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -33,24 +33,39 @@ class AnthropicProvider(LLMProvider):
         api_base: str | None = None,
         default_model: str = "claude-sonnet-4-20250514",
         extra_headers: dict[str, str] | None = None,
+        use_bedrock: bool = False,
+        aws_profile: str | None = None,
+        aws_region: str | None = None,
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
 
-        from anthropic import AsyncAnthropic
-
         client_kw: dict[str, Any] = {}
-        if api_key:
-            client_kw["api_key"] = api_key
-        if api_base:
-            client_kw["base_url"] = api_base
         if extra_headers:
             client_kw["default_headers"] = extra_headers
-        self._client = AsyncAnthropic(**client_kw)
+
+        if use_bedrock:
+            from anthropic import AsyncAnthropicBedrock
+
+            if aws_profile:
+                client_kw["aws_profile"] = aws_profile
+            if aws_region:
+                client_kw["aws_region"] = aws_region
+            self._client = AsyncAnthropicBedrock(**client_kw)
+        else:
+            from anthropic import AsyncAnthropic
+
+            if api_key:
+                client_kw["api_key"] = api_key
+            if api_base:
+                client_kw["base_url"] = api_base
+            self._client = AsyncAnthropic(**client_kw)
 
     @staticmethod
     def _strip_prefix(model: str) -> str:
+        if model.startswith("bedrock/"):
+            return model[len("bedrock/"):]
         if model.startswith("anthropic/"):
             return model[len("anthropic/"):]
         return model

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -184,6 +184,14 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
 
 
     # === Standard providers (matched by model-name keywords) ===============
+    # AWS Bedrock: Claude via Anthropic's Bedrock SDK
+    ProviderSpec(
+        name="bedrock",
+        keywords=("bedrock",),
+        env_key="",
+        display_name="AWS Bedrock",
+        backend="anthropic_bedrock",
+    ),
     # Anthropic: native Anthropic SDK
     ProviderSpec(
         name="anthropic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "chardet>=3.0.2,<6.0.0",
     "openai>=2.8.0",
     "tiktoken>=0.12.0,<1.0.0",
+    "boto3>=1.42.78",
 ]
 
 [project.optional-dependencies]

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -265,6 +265,29 @@ def test_find_by_name_accepts_camel_case_and_hyphen_aliases():
     assert find_by_name("volcengineCodingPlan").name == "volcengine_coding_plan"
     assert find_by_name("github-copilot") is not None
     assert find_by_name("github-copilot").name == "github_copilot"
+    assert find_by_name("bedrock") is not None
+    assert find_by_name("bedrock").name == "bedrock"
+
+
+def test_config_accepts_explicit_bedrock_provider_without_api_key():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "bedrock",
+                    "model": "bedrock/arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/test",
+                }
+            },
+            "providers": {
+                "bedrock": {
+                    "awsProfile": "default",
+                    "awsRegion": "us-west-2",
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "bedrock"
 
 
 def test_config_auto_detects_ollama_from_local_api_base():
@@ -347,6 +370,37 @@ def test_make_provider_passes_extra_headers_to_custom_provider():
     assert kwargs["base_url"] == "https://example.com/v1"
     assert kwargs["default_headers"]["APP-Code"] == "demo-app"
     assert kwargs["default_headers"]["x-session-affinity"] == "sticky-session"
+
+
+def test_make_provider_passes_bedrock_profile_and_region():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "bedrock",
+                    "model": "bedrock/arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/test",
+                }
+            },
+            "providers": {
+                "bedrock": {
+                    "awsProfile": "default",
+                    "awsRegion": "us-west-2",
+                    "extraHeaders": {"x-test-header": "enabled"},
+                }
+            },
+        }
+    )
+
+    with patch("anthropic.AsyncAnthropicBedrock") as mock_bedrock:
+        provider = _make_provider(config)
+
+    kwargs = mock_bedrock.call_args.kwargs
+    assert kwargs["aws_profile"] == "default"
+    assert kwargs["aws_region"] == "us-west-2"
+    assert kwargs["default_headers"]["x-test-header"] == "enabled"
+    assert provider.get_default_model() == (
+        "bedrock/arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/test"
+    )
 
 
 @pytest.fixture

--- a/tests/providers/test_anthropic_bedrock_provider.py
+++ b/tests/providers/test_anthropic_bedrock_provider.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from nanobot.providers.anthropic_provider import AnthropicProvider
+
+
+def test_anthropic_provider_strips_bedrock_prefix():
+    model = "bedrock/arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/test"
+
+    assert AnthropicProvider._strip_prefix(model) == (
+        "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/test"
+    )
+
+
+def test_anthropic_provider_uses_bedrock_client_for_bedrock_mode():
+    with patch("anthropic.AsyncAnthropicBedrock") as mock_bedrock:
+        AnthropicProvider(
+            default_model="bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+            use_bedrock=True,
+            aws_profile="default",
+            aws_region="us-west-2",
+            extra_headers={"x-test-header": "enabled"},
+        )
+
+    kwargs = mock_bedrock.call_args.kwargs
+    assert kwargs["aws_profile"] == "default"
+    assert kwargs["aws_region"] == "us-west-2"
+    assert kwargs["default_headers"]["x-test-header"] == "enabled"


### PR DESCRIPTION
Route Bedrock models through Anthropic's Bedrock client so nanobot can use shared AWS profiles and inference profile ARNs. Add the AWS SDK dependency and focused tests to cover Bedrock profile and region config.

Made-with: Cursor