### PR TITLE
fix: enforce hard context budget and handle token estimation failure

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -6,11 +6,9 @@ import platform
 from pathlib import Path
 from typing import Any
 
-from nanobot.utils.helpers import current_time_str
-
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
-from nanobot.utils.helpers import build_assistant_message, detect_image_mime
+from nanobot.utils.helpers import build_assistant_message, current_time_str, detect_image_mime
 
 
 class ContextBuilder:
@@ -35,6 +33,10 @@ class ContextBuilder:
 
         memory = self.memory.get_memory_context()
         if memory:
+            # Memory could grow very large. Truncate if it exceeds 16KB (~4K-6K tokens).
+            # This is a safety measure; actual consolidation should keep it smaller.
+            if len(memory) > 16384:
+                memory = memory[:16384] + "\n\n...(truncated. Full content in memory/MEMORY.md)"
             parts.append(f"# Memory\n\n{memory}")
 
         always_skills = self.skills.get_always_skills()

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import re
 import os
 import time
 from contextlib import AsyncExitStack, nullcontext
@@ -16,10 +15,10 @@ from loguru import logger
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.hook import AgentHook, AgentHookContext, CompositeHook
 from nanobot.agent.memory import MemoryConsolidator
-from nanobot.agent.runner import AgentRunSpec, AgentRunner
+from nanobot.agent.runner import AgentRunner, AgentRunSpec
+from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
-from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.registry import ToolRegistry
@@ -27,8 +26,8 @@ from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
-from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.bus.queue import MessageBus
+from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.providers.base import LLMProvider
 from nanobot.session.manager import Session, SessionManager
 
@@ -485,6 +484,7 @@ class AgentLoop:
             key = f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
             await self.memory_consolidator.maybe_consolidate_by_tokens(session)
+            self._enforce_session_budget(session)
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
             history = session.get_history(max_messages=0)
             current_role = "assistant" if msg.sender_id == "subagent" else "user"
@@ -516,6 +516,7 @@ class AgentLoop:
             return result
 
         await self.memory_consolidator.maybe_consolidate_by_tokens(session)
+        self._enforce_session_budget(session)  # ← Hard safety net
 
         self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
         if message_tool := self.tools.get("message"):
@@ -567,6 +568,46 @@ class AgentLoop:
             channel=msg.channel, chat_id=msg.chat_id, content=final_content,
             metadata=meta,
         )
+
+    def _enforce_session_budget(self, session: Session) -> None:
+        """Hard-truncate session history if it would exceed the context window.
+
+        This is the safety net when soft consolidation fails or is insufficient.
+        Instead of deleting messages, it advances last_consolidated (which
+        causes get_history() to skip them) and archives them to HISTORY.md.
+        """
+        if self.context_window_tokens <= 0:
+            return
+
+        estimated, _ = self.memory_consolidator.estimate_session_prompt_tokens(session)
+        if estimated <= 0:
+            unconsolidated = len(session.messages) - session.last_consolidated
+            if unconsolidated <= 50:
+                return
+            estimated = unconsolidated * 200 # rough guess
+
+        # Hard cap: context window - generation buffer - safety buffer
+        hard_cap = self.context_window_tokens - self.runner.provider.generation.max_tokens - 1024
+        if estimated <= hard_cap:
+            return
+
+        # Calculate how many messages to keep (target 50% of hard cap)
+        target = hard_cap // 2
+        boundary = self.memory_consolidator.pick_consolidation_boundary(
+            session, max(1, estimated - target)
+        )
+        if boundary:
+            end_idx = boundary[0]
+            chunk = session.messages[session.last_consolidated:end_idx]
+            if chunk:
+                logger.warning(
+                    "Hard budget enforcement for {}: {}/{} tokens. "
+                    "Truncating {} messages to HISTORY.md (consolidation failed).",
+                    session.key, estimated, self.context_window_tokens, len(chunk)
+                )
+                self.memory_consolidator.store._raw_archive(chunk)
+                session.last_consolidated = end_idx
+                self.sessions.save(session)
 
     @staticmethod
     def _image_placeholder(block: dict[str, Any]) -> dict[str, str]:

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -318,7 +318,14 @@ class MemoryConsolidator:
             target = budget // 2
             estimated, source = self.estimate_session_prompt_tokens(session)
             if estimated <= 0:
-                return
+                # Token estimation unavailable — fall back to message count heuristic
+                unconsolidated = len(session.messages) - session.last_consolidated
+                if unconsolidated < 50:
+                    return
+                # Rough guess: 1 message is ~200 tokens. Target removing the oldest 20 messages.
+                estimated = unconsolidated * 200
+                source = "heuristic"
+
             if estimated < budget:
                 logger.debug(
                     "Token consolidation idle {}: {}/{} via {}",

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -173,7 +173,9 @@ def estimate_prompt_tokens(
         per_message_overhead = len(messages) * 4
         return len(enc.encode("\n".join(parts))) + per_message_overhead
     except Exception:
-        return 0
+        # Fallback to rough heuristic: 1 token ~= 4 chars for ASCII text
+        payload = "\n".join(parts)
+        return len(payload) // 4 + (len(messages) * 4)
 
 
 def estimate_message_tokens(message: dict[str, Any]) -> int:

--- a/tests/agent/test_issue_2638.py
+++ b/tests/agent/test_issue_2638.py
@@ -1,0 +1,103 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import nanobot.agent.memory as memory_module
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.queue import MessageBus
+from nanobot.providers.base import GenerationSettings, LLMResponse
+
+
+def _make_loop(tmp_path, *, estimated_tokens: int, context_window_tokens: int) -> AgentLoop:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings(max_tokens=100) # Small generation budget
+    provider.estimate_prompt_tokens.return_value = (estimated_tokens, "test-counter")
+    _response = LLMResponse(content="ok", tool_calls=[])
+    provider.chat_with_retry = AsyncMock(return_value=_response)
+    provider.chat_stream_with_retry = AsyncMock(return_value=_response)
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        context_window_tokens=context_window_tokens,
+    )
+    loop.tools.get_definitions = MagicMock(return_value=[])
+    loop.memory_consolidator._SAFETY_BUFFER = 0
+    return loop
+
+@pytest.mark.asyncio
+async def test_consolidation_falls_back_on_token_estimation_failure(tmp_path, monkeypatch) -> None:
+    # Fix for Issue 2
+    loop = _make_loop(tmp_path, estimated_tokens=0, context_window_tokens=20000)
+    loop.memory_consolidator.consolidate_messages = AsyncMock(return_value=True)
+
+    session = loop.sessions.get_or_create("cli:test")
+    # Add enough messages to trigger heuristic fallback (needs > 50)
+    session.messages = [{"role": "user", "content": "u", "timestamp": "2026-01-01T00:00:00"}] * 100
+    loop.sessions.save(session)
+
+    # Mock estimate_session_prompt_tokens to return 0 (simulating tiktoken failure)
+    loop.memory_consolidator.estimate_session_prompt_tokens = MagicMock(return_value=(0, "none"))
+
+    # Mock boundary picking since estimate is 0 (we manually set it to 100*200 in the code)
+    # boundary should be found.
+
+    await loop.memory_consolidator.maybe_consolidate_by_tokens(session)
+
+    # Should have triggered consolidation using heuristic
+    assert loop.memory_consolidator.consolidate_messages.await_count >= 1
+    assert session.last_consolidated > 0
+
+@pytest.mark.asyncio
+async def test_hard_budget_enforcement_works(tmp_path, monkeypatch) -> None:
+    # Fix for Issue 1
+    # context window 5000, generation budget 100, safety 1024. Hard cap is ~3876.
+    loop = _make_loop(tmp_path, estimated_tokens=5000, context_window_tokens=5000)
+
+    # Mock consolidation to always fail (forcing hard budget enforcement)
+    loop.memory_consolidator.maybe_consolidate_by_tokens = AsyncMock()
+
+    session = loop.sessions.get_or_create("cli:test")
+    # Add many messages
+    session.messages = [
+        {"role": "user", "content": f"u{i}", "timestamp": "2026-01-01T00:00:00"}
+        for i in range(100)
+    ]
+    loop.sessions.save(session)
+
+    # Mock estimate_session_prompt_tokens to return 5000
+    loop.memory_consolidator.estimate_session_prompt_tokens = MagicMock(return_value=(5000, "test"))
+
+    # Mock message token estimation
+    monkeypatch.setattr(memory_module, "estimate_message_tokens", lambda _m: 100)
+
+    from nanobot.bus.events import InboundMessage
+    msg = InboundMessage(channel="cli", sender_id="user", chat_id="direct", content="hi")
+
+    # This should trigger _enforce_session_budget and advance last_consolidated
+    await loop._process_message(msg, session_key="cli:test")
+
+    assert session.last_consolidated > 0
+
+    # Check if HISTORY.md got the raw dump
+    history_file = tmp_path / "memory" / "HISTORY.md"
+    assert history_file.exists()
+    assert "[RAW]" in history_file.read_text()
+
+@pytest.mark.asyncio
+async def test_memory_context_truncation(tmp_path) -> None:
+    # Fix for Issue 4
+    from nanobot.agent.context import ContextBuilder
+    builder = ContextBuilder(tmp_path)
+
+    large_memory = "X" * 20000
+    builder.memory.write_long_term(large_memory)
+
+    prompt = builder.build_system_prompt()
+    assert "Memory" in prompt
+    assert "...(truncated. Full content in memory/MEMORY.md)" in prompt
+    # Baseline prompt is ~5K, memory truncated to 16K.
+    assert len(prompt) < 25000


### PR DESCRIPTION
This PR addresses Issue #2638, where session history could grow unbounded if memory consolidation failed or if token estimation was unavailable. This often resulted in the agent becoming completely unresponsive once the prompt size exceeded the LLM's context window.

### Changes

1. **Hard Budget Enforcement**: Added `_enforce_session_budget` in `AgentLoop` as a final safety net. If consolidation doesn't reduce the prompt size enough (e.g., due to repeated LLM failures), the loop now force-truncates the oldest history entries to `HISTORY.md` and advances the consolidation offset.
2. **Graceful Token Estimation Fallback**:
    - `MemoryConsolidator.maybe_consolidate_by_tokens` now uses a message-count heuristic if `estimate_session_prompt_tokens` returns 0.
    - `estimate_prompt_tokens` in `helpers.py` now falls back to a character-based count if `tiktoken` is unavailable.
3. **Memory Truncation**: Capped the size of `MEMORY.md` injected into the system prompt to 16KB. This prevents a very large long-term memory from consuming the entire context window, which was identified as a contributing factor in the original issue.

### Verification

Added a new test suite `tests/agent/test_issue_2638.py` covering:
- Heuristic fallback when token estimation fails.
- Hard budget enforcement when consolidation fails.
- Memory context truncation.

All tests passed on Python 3.12.