### PR TITLE
添加 Langfuse 观测平台的集成支持

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -11,7 +11,15 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 import json_repair
-from openai import AsyncOpenAI
+
+if os.environ.get("LANGFUSE_SECRET_KEY"):
+    LANGFUSE_AVAILABLE  = importlib.util.find_spec("langfuse") is not None
+    if not LANGFUSE_AVAILABLE:
+        raise ImportError("Langfuse is not available; please install it with `pip install langfuse`")
+
+    from langfuse.openai import AsyncOpenAI  # type: ignore[import-untyped]
+else:
+    from openai import AsyncOpenAI
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 


### PR DESCRIPTION
feat(provider): 添加 Langfuse 观测平台的集成支持

添加了对 Langfuse 的可选集成支持，当环境变量LANGFUSE_SECRET_KEY 存在时，自动导入 langfuse.openai 模块以提供 Langfuse 监测功能。 如果 Langfuse不可用则抛出相应的导入错误提示用户安装依赖包。

- 必要性:

做为一个科研型项目, 针对LLM的交互有一个清晰明确的监测方式十分有必要, 方便学习者更清楚直观的观察与理解LLM交互的运作方式。

- 生效范围:

只针对 `backend` 为 `openai_compat` 的 registry , 详情请查看 `nanobot/providers/registry.py`

- 添加环境变量使功能生效:

```
LANGFUSE_SECRET_KEY = "sk-lf-..."
LANGFUSE_PUBLIC_KEY = "pk-lf-..."
LANGFUSE_BASE_URL = "https://cloud.langfuse.com" # 🇪🇺 EU region
# LANGFUSE_BASE_URL = "https://us.cloud.langfuse.com" # 🇺🇸 US region
```

> 详情查看langfuse官方文档: [get-started#ingest-your-first-trace](https://langfuse.com/docs/observability/get-started#ingest-your-first-trace)