### PR TITLE
feat(channels/feishu): add domain config for Lark global support

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,8 @@ Uses **WebSocket** long connection — no public IP required.
       "groupPolicy": "mention",
       "reactEmoji": "OnIt",
       "doneEmoji": "DONE",
-      "streaming": true
+      "streaming": true,
+      "domain": "feishu"
     }
   }
 }
@@ -572,6 +573,7 @@ Uses **WebSocket** long connection — no public IP required.
 > `groupPolicy`: `"mention"` (default — respond only when @mentioned), `"open"` (respond to all group messages). Private chats always respond.
 > `reactEmoji`: Emoji for "processing" status (default: `OnIt`). See [available emojis](https://open.larkoffice.com/document/server-docs/im-v1/message-reaction/emojis-introduce).
 > `doneEmoji`: Optional emoji for "completed" status (e.g., `DONE`, `OK`, `HEART`). When set, bot adds this reaction after removing `reactEmoji`.
+> `domain`: `"feishu"` (default) for China (open.feishu.cn), `"lark"` for international Lark (open.larksuite.com).
 
 **3. Run**
 

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -22,6 +22,8 @@ from nanobot.channels.base import BaseChannel
 from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 
+from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
+
 FEISHU_AVAILABLE = importlib.util.find_spec("lark_oapi") is not None
 
 # Message type display mapping
@@ -255,6 +257,7 @@ class FeishuConfig(Base):
     group_policy: Literal["open", "mention"] = "mention"
     reply_to_message: bool = False  # If True, bot replies quote the user's original message
     streaming: bool = True
+    domain: Literal["feishu", "lark"] = "feishu"  # Set to "lark" for international Lark
 
 
 _STREAM_ELEMENT_ID = "streaming_md"
@@ -328,10 +331,12 @@ class FeishuChannel(BaseChannel):
         self._loop = asyncio.get_running_loop()
 
         # Create Lark client for sending messages
+        domain = LARK_DOMAIN if self.config.domain == "lark" else FEISHU_DOMAIN
         self._client = (
             lark.Client.builder()
             .app_id(self.config.app_id)
             .app_secret(self.config.app_secret)
+            .domain(domain)
             .log_level(lark.LogLevel.INFO)
             .build()
         )
@@ -359,6 +364,7 @@ class FeishuChannel(BaseChannel):
         self._ws_client = lark.ws.Client(
             self.config.app_id,
             self.config.app_secret,
+            domain=domain,
             event_handler=event_handler,
             log_level=lark.LogLevel.INFO,
         )

--- a/tests/channels/test_feishu_domain.py
+++ b/tests/channels/test_feishu_domain.py
@@ -1,0 +1,48 @@
+"""Tests for Feishu/Lark domain configuration."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.feishu import FeishuChannel, FeishuConfig
+
+
+def _make_channel(domain: str = "feishu") -> FeishuChannel:
+    config = FeishuConfig(
+        enabled=True,
+        app_id="cli_test",
+        app_secret="secret",
+        allow_from=["*"],
+        domain=domain,
+    )
+    ch = FeishuChannel(config, MessageBus())
+    ch._client = MagicMock()
+    ch._loop = None
+    return ch
+
+
+class TestFeishuConfigDomain:
+    def test_domain_default_is_feishu(self):
+        config = FeishuConfig()
+        assert config.domain == "feishu"
+
+    def test_domain_accepts_lark(self):
+        config = FeishuConfig(domain="lark")
+        assert config.domain == "lark"
+
+    def test_domain_accepts_feishu(self):
+        config = FeishuConfig(domain="feishu")
+        assert config.domain == "feishu"
+
+    def test_default_config_includes_domain(self):
+        default_cfg = FeishuChannel.default_config()
+        assert "domain" in default_cfg
+        assert default_cfg["domain"] == "feishu"
+
+    def test_channel_persists_domain_from_config(self):
+        ch = _make_channel(domain="lark")
+        assert ch.config.domain == "lark"
+
+    def test_channel_persists_feishu_domain_from_config(self):
+        ch = _make_channel(domain="feishu")
+        assert ch.config.domain == "feishu"


### PR DESCRIPTION
## Summary

- Add `domain` config field to FeishuConfig (`"feishu"` or `"lark"`, default `"feishu"`)
- Pass domain to both REST client (`lark.Client.builder()`) and WebSocket client (`lark.ws.Client`)

This enables nanobot to work with Lark global (open.larksuite.com) in addition to Feishu China (open.feishu.cn).

## Changes

```
nanobot/channels/feishu.py   | 6 +++
tests/channels/              | 54 +++++++++++++++++++++++++++
```

**Only 6 lines added to feishu.py:**
1. Import `FEISHU_DOMAIN`, `LARK_DOMAIN` from `lark_oapi.core.const`
2. Add `domain` field to `FeishuConfig`
3. Resolve domain based on config
4. Pass `.domain(domain)` to REST client builder
5. Pass `domain=domain` to WebSocket client

## Backward Compatibility

- Existing configs without `domain` field default to `"feishu"` (Feishu China behavior unchanged)
- Onboarding adds `domain: "feishu"` automatically via `_merge_missing_defaults`

## Testing

- 6 new domain tests pass
- Existing Feishu streaming tests pass (regression check)

## Notes

Following the same pattern used by OpenClaw and Hermes-1 for Feishu/Lark domain configuration.