### PR TITLE
fix(test): fix flaky test_fixed_session_requests_are_serialized

### DIFF
--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -235,15 +235,10 @@ async def test_followup_requests_share_same_session_key(aiohttp_client) -> None:
 @pytest.mark.asyncio
 async def test_fixed_session_requests_are_serialized(aiohttp_client) -> None:
     order: list[str] = []
-    barrier = asyncio.Event()
 
     async def slow_process(content, session_key="", channel="", chat_id=""):
         order.append(f"start:{content}")
-        if content == "first":
-            barrier.set()
-            await asyncio.sleep(0.1)
-        else:
-            await barrier.wait()
+        await asyncio.sleep(0.1)
         order.append(f"end:{content}")
         return content
 
@@ -264,7 +259,11 @@ async def test_fixed_session_requests_are_serialized(aiohttp_client) -> None:
     r1, r2 = await asyncio.gather(send("first"), send("second"))
     assert r1.status == 200
     assert r2.status == 200
-    assert order.index("end:first") < order.index("start:second")
+    # Verify serialization: one process must fully finish before the other starts
+    if order[0] == "start:first":
+        assert order.index("end:first") < order.index("start:second")
+    else:
+        assert order.index("end:second") < order.index("start:first")
 
 
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")


### PR DESCRIPTION
## Summary
- Fix flaky `test_fixed_session_requests_are_serialized` by removing the fragile `asyncio.Event` barrier that could cause a deadlock when the "second" request is scheduled before "first" sets the barrier
- Simplify `slow_process` to just sleep, relying on the session lock for serialization
- Handle both possible execution orders in assertions instead of assuming "first" always starts first

## Test plan
- [x] `pytest tests/test_openai_api.py::test_fixed_session_requests_are_serialized` passes