### PR TITLE
feat(telegram): make drop_pending_updates default to False

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -310,7 +310,7 @@ class TelegramChannel(BaseChannel):
         # Start polling (this runs until stopped)
         await self._app.updater.start_polling(
             allowed_updates=["message"],
-            drop_pending_updates=True  # Ignore old messages on startup
+            drop_pending_updates=False  # Process pending messages on startup
         )
 
         # Keep running until stopped


### PR DESCRIPTION
This PR addresses #2652 by changing `drop_pending_updates` to `False` on startup.

This ensures that messages sent while the bot is offline or restarting are no longer permanently ignored, aligning with the expected behavior of most bot frameworks.