### PR TITLE
fix(tools): don't leak message_id when message tool targets a different chat

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -86,7 +86,15 @@ class MessageTool(Tool):
     ) -> str:
         channel = channel or self._default_channel
         chat_id = chat_id or self._default_chat_id
-        message_id = message_id or self._default_message_id
+        # Only inherit default message_id when targeting the same channel+chat.
+        # Cross-chat sends must not carry the original message_id, because
+        # some channels (e.g. Feishu) use it to determine the target
+        # conversation via their Reply API, which would route the message
+        # to the wrong chat entirely.
+        if channel == self._default_channel and chat_id == self._default_chat_id:
+            message_id = message_id or self._default_message_id
+        else:
+            message_id = None
 
         if not channel or not chat_id:
             return "Error: No target channel/chat specified"


### PR DESCRIPTION
Fixes #2542.

The message tool unconditionally inherited `message_id` from the current context. For Feishu, whose Reply API determines the target conversation solely by `message_id`, this caused cross-chat messages to be routed to the wrong conversation.

Now only inherit `message_id` when both `channel` and `chat_id` match the current context, consistent with the existing `_sent_in_turn` guard.