### PR TITLE
feat: Add Gradio UI and LLM request tracing

### DIFF
--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -82,6 +82,40 @@ async def cmd_new(ctx: CommandContext) -> OutboundMessage:
     )
 
 
+async def cmd_model(ctx: CommandContext) -> OutboundMessage:
+    """Get or set the current model."""
+    args = ctx.args.strip()
+
+    if not args:
+        # Show current model
+        return OutboundMessage(
+            channel=ctx.msg.channel,
+            chat_id=ctx.msg.chat_id,
+            content=f"Current model: {ctx.loop.model}",
+            metadata={"render_as": "text"},
+        )
+
+    # Set new model
+    new_model = args
+    ctx.loop.model = new_model
+
+    # Update the subagent model as well
+    ctx.loop.subagents.model = new_model
+
+    # Update memory consolidator model
+    ctx.loop.memory_consolidator.model = new_model
+
+    # Update provider's default model
+    ctx.loop.provider.default_model = new_model
+
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=f"Set model to \x1b[1m{new_model}\x1b[22m",
+        metadata={"render_as": "text"},
+    )
+
+
 async def cmd_help(ctx: CommandContext) -> OutboundMessage:
     """Return available slash commands."""
     lines = [
@@ -90,6 +124,7 @@ async def cmd_help(ctx: CommandContext) -> OutboundMessage:
         "/stop — Stop the current task",
         "/restart — Restart the bot",
         "/status — Show bot status",
+        "/model [model_name] — Get or set the current model",
         "/help — Show available commands",
     ]
     return OutboundMessage(

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -337,6 +337,67 @@ class AnthropicProvider(LLMProvider):
         if self.extra_headers:
             kwargs["extra_headers"] = self.extra_headers
 
+        # ========== 打印请求参数（环境变量 NANOBOT_PRINT_LLM_REQUESTS 控制） ==========
+        import os
+        import json
+        import time
+        if os.environ.get("NANOBOT_PRINT_LLM_REQUESTS"):
+            # 用类变量保持请求计数器
+            cls = self.__class__
+            if not hasattr(cls, "_request_counter"):
+                cls._request_counter = 0
+            cls._request_counter += 1
+
+            # 打印时去掉 messages 里的大段内容，避免刷屏
+            debug_kwargs = dict(kwargs)
+            msg_count = 0
+            if "messages" in debug_kwargs:
+                debug_messages = []
+                for msg in debug_kwargs["messages"]:
+                    msg_count += 1
+                    debug_msg = dict(msg)
+                    content = debug_msg.get("content", "")
+                    if isinstance(content, str) and len(content) > 300:
+                        debug_msg["content"] = content[:300] + "... (truncated)"
+                    elif isinstance(content, list):
+                        debug_msg["content"] = f"[list with {len(content)} items]"
+                    debug_messages.append(debug_msg)
+                debug_kwargs["messages"] = debug_messages
+            if "system" in debug_kwargs:
+                sys_content = debug_kwargs["system"]
+                if isinstance(sys_content, str) and len(sys_content) > 300:
+                    debug_kwargs["system"] = sys_content[:300] + "... (truncated)"
+                elif isinstance(sys_content, list):
+                    debug_kwargs["system"] = f"[list with {len(sys_content)} items]"
+
+            # 简单打印关键参数（用 ANSI 颜色高亮）
+            ts = time.strftime("%H:%M:%S")
+            model = debug_kwargs.get("model", "unknown")
+            temp = debug_kwargs.get("temperature", "N/A")
+            max_t = debug_kwargs.get("max_tokens", "N/A")
+            tools_len = len(debug_kwargs.get("tools", [])) if debug_kwargs.get("tools") else 0
+
+            # ANSI 颜色代码
+            RED = "\033[91m"
+            GREEN = "\033[92m"
+            YELLOW = "\033[93m"
+            BLUE = "\033[94m"
+            MAGENTA = "\033[95m"
+            CYAN = "\033[96m"
+            BOLD = "\033[1m"
+            RESET = "\033[0m"
+
+            print(f"\n{BLUE}{BOLD}{'='*80}{RESET}")
+            print(f"{CYAN}{BOLD}🚀 [LLM 请求 #{cls._request_counter}][{ts}] 模型={model} | 温度={temp} | max_tokens={max_t} | 消息数={msg_count} | 工具数={tools_len}{RESET}")
+            print(f"{BLUE}{BOLD}{'='*80}{RESET}")
+
+            # 可选：打印完整参数（如果环境变量 NANOBOT_PRINT_FULL_REQUEST=1）
+            if os.environ.get("NANOBOT_PRINT_FULL_REQUEST"):
+                print(json.dumps(debug_kwargs, indent=2, ensure_ascii=False))
+                print(f"{BLUE}{BOLD}{'='*80}{RESET}")
+            print()
+        # ================================================================================
+
         return kwargs
 
     # ------------------------------------------------------------------
@@ -406,6 +467,34 @@ class AnthropicProvider(LLMProvider):
             messages, tools, model, max_tokens, temperature,
             reasoning_effort, tool_choice,
         )
+
+        # ========== 打印请求参数（环境变量 NANOBOT_PRINT_LLM_REQUESTS 控制） ==========
+        import os
+        import json
+        if os.environ.get("NANOBOT_PRINT_LLM_REQUESTS"):
+            # 打印时去掉 messages 里的大段内容，避免刷屏
+            debug_kwargs = dict(kwargs)
+            if "messages" in debug_kwargs:
+                debug_messages = []
+                for msg in debug_kwargs["messages"]:
+                    debug_msg = dict(msg)
+                    content = debug_msg.get("content", "")
+                    if isinstance(content, str) and len(content) > 500:
+                        debug_msg["content"] = content[:500] + "... (truncated)"
+                    elif isinstance(content, list):
+                        debug_msg["content"] = f"[list with {len(content)} items]"
+                    debug_messages.append(debug_msg)
+                debug_kwargs["messages"] = debug_messages
+            if "system" in debug_kwargs:
+                sys_content = debug_kwargs["system"]
+                if isinstance(sys_content, str) and len(sys_content) > 500:
+                    debug_kwargs["system"] = sys_content[:500] + "... (truncated)"
+                elif isinstance(sys_content, list):
+                    debug_kwargs["system"] = f"[list with {len(sys_content)} items]"
+            logger.info("========== LLM 请求参数 (Anthropic) ==========\n{}",
+                       json.dumps(debug_kwargs, indent=2, ensure_ascii=False))
+        # ================================================================================
+
         try:
             response = await self._client.messages.create(**kwargs)
             return self._parse_response(response)

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -11,6 +11,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 import json_repair
+from loguru import logger
 from openai import AsyncOpenAI
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
@@ -264,6 +265,61 @@ class OpenAICompatProvider(LLMProvider):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
+
+        # ========== 打印请求参数（环境变量 NANOBOT_PRINT_LLM_REQUESTS 控制） ==========
+        import os
+        import json
+        import time
+        if os.environ.get("NANOBOT_PRINT_LLM_REQUESTS"):
+            # 用类变量保持请求计数器
+            cls = self.__class__
+            if not hasattr(cls, "_request_counter"):
+                cls._request_counter = 0
+            cls._request_counter += 1
+
+            # 打印时去掉 messages 里的大段内容，避免刷屏
+            debug_kwargs = dict(kwargs)
+            msg_count = 0
+            if "messages" in debug_kwargs:
+                debug_messages = []
+                for msg in debug_kwargs["messages"]:
+                    msg_count += 1
+                    debug_msg = dict(msg)
+                    content = debug_msg.get("content", "")
+                    if isinstance(content, str) and len(content) > 300:
+                        debug_msg["content"] = content[:300] + "... (truncated)"
+                    elif isinstance(content, list):
+                        debug_msg["content"] = f"[list with {len(content)} items]"
+                    debug_messages.append(debug_msg)
+                debug_kwargs["messages"] = debug_messages
+
+            # 简单打印关键参数（用 ANSI 颜色高亮）
+            ts = time.strftime("%H:%M:%S")
+            model = debug_kwargs.get("model", "unknown")
+            temp = debug_kwargs.get("temperature", "N/A")
+            max_t = debug_kwargs.get("max_tokens") or debug_kwargs.get("max_completion_tokens", "N/A")
+            tools_len = len(debug_kwargs.get("tools", [])) if debug_kwargs.get("tools") else 0
+
+            # ANSI 颜色代码
+            RED = "\033[91m"
+            GREEN = "\033[92m"
+            YELLOW = "\033[93m"
+            BLUE = "\033[94m"
+            MAGENTA = "\033[95m"
+            CYAN = "\033[96m"
+            BOLD = "\033[1m"
+            RESET = "\033[0m"
+
+            print(f"\n{BLUE}{BOLD}{'='*80}{RESET}")
+            print(f"{CYAN}{BOLD}🚀 [LLM 请求 #{cls._request_counter}][{ts}] 模型={model} | 温度={temp} | max_tokens={max_t} | 消息数={msg_count} | 工具数={tools_len}{RESET}")
+            print(f"{BLUE}{BOLD}{'='*80}{RESET}")
+
+            # 可选：打印完整参数（如果环境变量 NANOBOT_PRINT_FULL_REQUEST=1）
+            if os.environ.get("NANOBOT_PRINT_FULL_REQUEST"):
+                print(json.dumps(debug_kwargs, indent=2, ensure_ascii=False))
+                print(f"{BLUE}{BOLD}{'='*80}{RESET}")
+            print()
+        # ================================================================================
 
         return kwargs
 
@@ -550,6 +606,28 @@ class OpenAICompatProvider(LLMProvider):
             messages, tools, model, max_tokens, temperature,
             reasoning_effort, tool_choice,
         )
+
+        # ========== 打印请求参数（环境变量 NANOBOT_PRINT_LLM_REQUESTS 控制） ==========
+        import os
+        import json
+        if os.environ.get("NANOBOT_PRINT_LLM_REQUESTS"):
+            # 打印时去掉 messages 里的大段内容，避免刷屏
+            debug_kwargs = dict(kwargs)
+            if "messages" in debug_kwargs:
+                debug_messages = []
+                for msg in debug_kwargs["messages"]:
+                    debug_msg = dict(msg)
+                    content = debug_msg.get("content", "")
+                    if isinstance(content, str) and len(content) > 500:
+                        debug_msg["content"] = content[:500] + "... (truncated)"
+                    elif isinstance(content, list):
+                        debug_msg["content"] = f"[list with {len(content)} items]"
+                    debug_messages.append(debug_msg)
+                debug_kwargs["messages"] = debug_messages
+            logger.info("========== LLM 请求参数 (OpenAICompat) ==========\n{}",
+                       json.dumps(debug_kwargs, indent=2, ensure_ascii=False))
+        # ================================================================================
+
         try:
             return self._parse(await self._client.chat.completions.create(**kwargs))
         except Exception as e:

--- a/nanobot_gradio.py
+++ b/nanobot_gradio.py
@@ -1,0 +1,311 @@
+"""
+nanobot Gradio 聊天界面封装
+
+使用方法：
+    1. 安装依赖：uv pip install gradio
+    2. 运行：uv run python nanobot_gradio.py
+    3. 打开浏览器访问 http://localhost:7860
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import Any
+
+import gradio as gr
+from loguru import logger
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.queue import MessageBus
+from nanobot.config.loader import load_config, set_config_path
+from nanobot.config.schema import Config
+from nanobot.cron.service import CronService
+from nanobot.utils.helpers import sync_workspace_templates
+
+
+# 全局状态
+_global: dict[str, Any] = {}
+
+
+def _make_provider(config: Config):
+    """Create the appropriate LLM provider from config."""
+    from nanobot.providers.base import GenerationSettings
+    from nanobot.providers.registry import find_by_name
+
+    model = config.agents.defaults.model
+    provider_name = config.get_provider_name(model)
+    p = config.get_provider(model)
+    spec = find_by_name(provider_name) if provider_name else None
+    backend = spec.backend if spec else "openai_compat"
+
+    # --- instantiation by backend ---
+    if backend == "openai_codex":
+        from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+        provider = OpenAICodexProvider(default_model=model)
+    elif backend == "azure_openai":
+        from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+        provider = AzureOpenAIProvider(
+            api_key=p.api_key,
+            api_base=p.api_base,
+            default_model=model,
+        )
+    elif backend == "anthropic":
+        from nanobot.providers.anthropic_provider import AnthropicProvider
+        provider = AnthropicProvider(
+            api_key=p.api_key if p else None,
+            api_base=config.get_api_base(model),
+            default_model=model,
+            extra_headers=p.extra_headers if p else None,
+        )
+    else:
+        from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+        provider = OpenAICompatProvider(
+            api_key=p.api_key if p else None,
+            api_base=config.get_api_base(model),
+            default_model=model,
+            extra_headers=p.extra_headers if p else None,
+            spec=spec,
+        )
+
+    defaults = config.agents.defaults
+    provider.generation = GenerationSettings(
+        temperature=defaults.temperature,
+        max_tokens=defaults.max_tokens,
+        reasoning_effort=defaults.reasoning_effort,
+    )
+    return provider
+
+
+def init_nanobot_sync(config_path: str | None = None):
+    """同步初始化 nanobot 核心组件"""
+    logger.info("正在初始化 nanobot...")
+
+    # 1. 加载配置
+    if config_path:
+        cfg_path = Path(config_path).expanduser().resolve()
+        set_config_path(cfg_path)
+    config = load_config()
+    workspace = config.workspace_path
+
+    # 2. 同步工作区模板
+    sync_workspace_templates(workspace)
+
+    # 3. 初始化消息总线
+    bus = MessageBus()
+
+    # 4. 创建 Provider
+    provider = _make_provider(config)
+
+    # 5. 创建 Cron 服务
+    cron_store_path = workspace / "cron" / "jobs.json"
+    cron = CronService(cron_store_path)
+
+    # 6. 创建 AgentLoop
+    agent_loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=workspace,
+        model=config.agents.defaults.model,
+        max_iterations=config.agents.defaults.max_tool_iterations,
+        context_window_tokens=config.agents.defaults.context_window_tokens,
+        web_search_config=config.tools.web.search,
+        web_proxy=config.tools.web.proxy or None,
+        exec_config=config.tools.exec,
+        cron_service=cron,
+        restrict_to_workspace=config.tools.restrict_to_workspace,
+        mcp_servers=config.tools.mcp_servers,
+        channels_config=config.channels,
+        timezone=config.agents.defaults.timezone,
+    )
+
+    # 存储全局状态
+    _global["config"] = config
+    _global["workspace"] = workspace
+    _global["bus"] = bus
+    _global["provider"] = provider
+    _global["agent_loop"] = agent_loop
+    _global["session_id"] = "gradio:direct"
+
+    logger.info("nanobot 初始化完成！")
+    return agent_loop
+
+
+def save_uploaded_file(file: Any) -> str:
+    """保存上传的文件到 workspace"""
+    if file is None:
+        return "❌ 请先选择文件"
+
+    workspace = _global["workspace"]
+
+    # 处理不同类型的文件对象
+    if hasattr(file, 'name'):
+        # Gradio 旧版本返回的是对象
+        src_path = file.name
+    elif isinstance(file, str):
+        # Gradio 新版本返回的是路径
+        src_path = file
+    else:
+        return "❌ 无法识别的文件格式"
+
+    filename = Path(src_path).name
+    dest_path = workspace / filename
+
+    # 复制文件
+    shutil.copy2(src_path, dest_path)
+    logger.info(f"文件已保存到: {dest_path}")
+
+    return f"✅ 文件已上传: {filename}\n📁 保存位置: {dest_path}"
+
+
+def list_workspace_files() -> list[str]:
+    """列出 workspace 中的文件"""
+    workspace = _global["workspace"]
+    files = []
+    for f in workspace.iterdir():
+        if f.is_file() and not f.name.startswith("."):
+            files.append(f.name)
+    logger.info(f"找到 {len(files)} 个文件: {files}")
+    return files
+
+
+def download_file(filename: str | list) -> str | None:
+    """下载文件 - 复制到临时目录以避免 Gradio 路径限制"""
+    # 处理可能的 list 输入
+    if isinstance(filename, list):
+        if len(filename) == 0:
+            logger.warning("没有选择文件")
+            return None
+        filename = filename[0]
+
+    if not filename:
+        logger.warning("没有选择文件")
+        return None
+
+    workspace = _global["workspace"]
+    src_path = workspace / filename
+
+    if not src_path.exists():
+        logger.warning(f"文件不存在: {src_path}")
+        return None
+
+    # 复制到临时目录，这样 Gradio 可以访问
+    import tempfile
+    temp_dir = Path(tempfile.gettempdir())
+    dest_path = temp_dir / filename
+
+    try:
+        shutil.copy2(src_path, dest_path)
+        logger.info(f"已复制文件到临时目录: {dest_path}")
+        return str(dest_path)
+    except Exception as e:
+        logger.error(f"复制文件失败: {e}")
+        return None
+
+
+def create_demo():
+    """创建 Gradio 界面 - 使用 ChatInterface"""
+
+    def chat_fn(message: str, history: Any):
+        """聊天函数"""
+        agent_loop = _global["agent_loop"]
+        session_id = _global["session_id"]
+
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        try:
+            response = loop.run_until_complete(
+                agent_loop.process_direct(message, session_id)
+            )
+            return response.content if response else "(没有回复)"
+        except Exception as e:
+            logger.exception("Chat failed")
+            return f"❌ 错误: {str(e)}"
+
+    with gr.Blocks(title="🚨舆情预警个人助手", theme=gr.themes.Soft()) as demo:
+        gr.Markdown("# 🚨舆情预警个人助手")
+        gr.Markdown("一个舆情预警自动化处理的个人AI助手🤖")
+
+        with gr.Row():
+            # 左侧：聊天界面
+            with gr.Column(scale=3):
+                gr.ChatInterface(
+                    fn=chat_fn,
+                    title="",
+                    description="",
+                    examples=["你好！", "帮我写个 Python 脚本"],
+                    cache_examples=False,
+                )
+
+            # 右侧：文件上传/下载
+            with gr.Column(scale=1):
+                gr.Markdown("## 📁 文件管理")
+
+                # 文件上传
+                gr.Markdown("### 上传文件")
+                file_upload = gr.File(
+                    label="上传 Excel/Word 文档",
+                    file_types=[".xlsx", ".xls", ".docx", ".doc", ".csv", ".pdf", ".txt"],
+                )
+                upload_output = gr.Textbox(
+                    label="上传状态",
+                    interactive=False,
+                )
+                upload_btn = gr.Button("上传文件", variant="secondary")
+
+                # 文件下载
+                gr.Markdown("### 下载文件")
+                filename_input = gr.Textbox(
+                    label="输入文件名",
+                    placeholder="例如：测试案例.xlsx",
+                    interactive=True,
+                )
+                download_btn = gr.Button("下载文件", variant="primary")
+                file_download = gr.File(
+                    label="下载",
+                )
+
+        # 文件上传事件
+        upload_btn.click(
+            save_uploaded_file,
+            inputs=[file_upload],
+            outputs=[upload_output],
+        )
+
+        # 文件下载事件
+        download_btn.click(
+            download_file,
+            inputs=[filename_input],
+            outputs=[file_download],
+        )
+
+    return demo
+
+
+def main():
+    """主函数 - 使用同步初始化"""
+    # 同步初始化
+    init_nanobot_sync()
+
+    # 获取 workspace 路径和临时目录并添加到 allowed_paths
+    import tempfile
+    workspace = str(_global["workspace"])
+    temp_dir = tempfile.gettempdir()
+
+    # 创建并启动 Gradio
+    demo = create_demo()
+    demo.launch(
+        server_name="0.0.0.0",
+        server_port=7860,
+        share=False,
+        allowed_paths=[workspace, temp_dir],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Features

1. **Gradio Chat Interface** (`nanobot_gradio.py`)
   - Web-based chat UI with file upload/download support
   - Supports Excel, Word, CSV, PDF, and TXT files
   - Files are saved to workspace directory
   - Uses ChatInterface for seamless chat experience

2. **LLM Request Tracing**
   - Add environment variable `NANOBOT_PRINT_LLM_REQUESTS` to print LLM requests
   - Color-coded output with request counter, model, temperature, max_tokens
   - Truncates long messages to avoid spam
   - Optional full request printing with `NANOBOT_PRINT_FULL_REQUEST=1`
   - Works with both OpenAICompatProvider and AnthropicProvider

3. **/model Command**
   - Add `/model` command to get or set current model
   - Updates model in AgentLoop, subagents, memory consolidator, and provider

## Usage

### Gradio UI
```bash
uv pip install gradio
uv run python nanobot_gradio.py
```

### LLM Tracing
```bash
NANOBOT_PRINT_LLM_REQUESTS=1 nanobot
NANOBOT_PRINT_LLM_REQUESTS=1 NANOBOT_PRINT_FULL_REQUEST=1 nanobot
```

### /model Command
```
/model                # Show current model
/model gpt-4o-mini   # Set new model
```