### PR TITLE
feat(cron): add deliver parameter to support silent jobs

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -97,12 +97,12 @@ class CronTool(Tool):
                         f"(e.g. '2026-02-12T10:30:00'). Naive values default to {self._default_timezone}."
                     ),
                 },
-                 "job_id": {"type": "string", "description": "Job ID (for remove)"},
                  "deliver": {
                      "type": "boolean",
                      "description": "Whether to deliver the execution result to the user channel (default true)",
                      "default": True
                  },
+                 "job_id": {"type": "string", "description": "Job ID (for remove)"},
              },
              "required": ["action"],
         }

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -97,12 +97,12 @@ class CronTool(Tool):
                         f"(e.g. '2026-02-12T10:30:00'). Naive values default to {self._default_timezone}."
                     ),
                 },
-                 "deliver": {
-                     "type": "boolean",
-                     "description": "Whether to deliver the execution result to the user channel (default true)",
-                     "default": True
-                 },
-                 "job_id": {"type": "string", "description": "Job ID (for remove)"},
+                "deliver": {
+                    "type": "boolean",
+                    "description": "Whether to deliver the execution result to the user channel (default true)",
+                    "default": True
+                },
+                "job_id": {"type": "string", "description": "Job ID (for remove)"},
              },
              "required": ["action"],
         }

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -101,7 +101,7 @@ class CronTool(Tool):
                  "deliver": {
                      "type": "boolean",
                      "description": "Whether to deliver the execution result to the user channel (default true)",
-                     "default": true
+                     "default": True
                  },
              },
              "required": ["action"],

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -103,8 +103,8 @@ class CronTool(Tool):
                     "default": True
                 },
                 "job_id": {"type": "string", "description": "Job ID (for remove)"},
-             },
-             "required": ["action"],
+            },
+            "required": ["action"],
         }
 
     async def execute(

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -97,9 +97,14 @@ class CronTool(Tool):
                         f"(e.g. '2026-02-12T10:30:00'). Naive values default to {self._default_timezone}."
                     ),
                 },
-                "job_id": {"type": "string", "description": "Job ID (for remove)"},
-            },
-            "required": ["action"],
+                 "job_id": {"type": "string", "description": "Job ID (for remove)"},
+                 "deliver": {
+                     "type": "boolean",
+                     "description": "Whether to deliver the execution result to the user channel (default true)",
+                     "default": true
+                 },
+             },
+             "required": ["action"],
         }
 
     async def execute(
@@ -111,12 +116,13 @@ class CronTool(Tool):
         tz: str | None = None,
         at: str | None = None,
         job_id: str | None = None,
+        deliver: bool = True,
         **kwargs: Any,
     ) -> str:
         if action == "add":
             if self._in_cron_context.get():
                 return "Error: cannot schedule new jobs from within a cron job execution"
-            return self._add_job(message, every_seconds, cron_expr, tz, at)
+            return self._add_job(message, every_seconds, cron_expr, tz, at, deliver)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
@@ -130,6 +136,7 @@ class CronTool(Tool):
         cron_expr: str | None,
         tz: str | None,
         at: str | None,
+        deliver: bool = True,
     ) -> str:
         if not message:
             return "Error: message is required for add"
@@ -171,7 +178,7 @@ class CronTool(Tool):
             name=message[:30],
             schedule=schedule,
             message=message,
-            deliver=True,
+            deliver=deliver,
             channel=self._channel,
             to=self._chat_id,
             delete_after_run=delete_after,

--- a/tests/cron/test_cron_tool_list.py
+++ b/tests/cron/test_cron_tool_list.py
@@ -285,6 +285,28 @@ def test_add_at_job_uses_default_timezone_for_naive_datetime(tmp_path) -> None:
     assert job.schedule.at_ms == expected
 
 
+def test_add_job_delivers_by_default(tmp_path) -> None:
+    tool = _make_tool(tmp_path)
+    tool.set_context("telegram", "chat-1")
+
+    result = tool._add_job("Morning standup", 60, None, None, None)
+
+    assert result.startswith("Created job")
+    job = tool._cron.list_jobs()[0]
+    assert job.payload.deliver is True
+
+
+def test_add_job_can_disable_delivery(tmp_path) -> None:
+    tool = _make_tool(tmp_path)
+    tool.set_context("telegram", "chat-1")
+
+    result = tool._add_job("Background refresh", 60, None, None, None, deliver=False)
+
+    assert result.startswith("Created job")
+    job = tool._cron.list_jobs()[0]
+    assert job.payload.deliver is False
+
+
 def test_list_excludes_disabled_jobs(tmp_path) -> None:
     tool = _make_tool(tmp_path)
     job = tool._cron.add_job(


### PR DESCRIPTION
问题：
创建定时任务时，无法指定 deliver 参数选择是否推送任务结果

解决方案：
支持指定 deliver 参数，可创建静默定时任务