### PR TITLE
feat(security): add ssrfAllowedSubnets config for private network access

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -36,18 +36,23 @@ def load_config(config_path: Path | None = None) -> Config:
         Loaded configuration object.
     """
     path = config_path or get_config_path()
+    config = Config()
 
     if path.exists():
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
             data = _migrate_config(data)
-            return Config.model_validate(data)
+            config = Config.model_validate(data)
         except (json.JSONDecodeError, ValueError, pydantic.ValidationError) as e:
             logger.warning(f"Failed to load config from {path}: {e}")
             logger.warning("Using default configuration.")
 
-    return Config()
+    from nanobot.security.network import configure_allowed_subnets
+
+    configure_allowed_subnets(config.security.ssrf_allowed_subnets)
+
+    return config
 
 
 def save_config(config: Config, config_path: Path | None = None) -> None:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -168,6 +168,12 @@ class ToolsConfig(Base):
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
 
+class SecurityConfig(Base):
+    """Security configuration."""
+
+    ssrf_allowed_subnets: list[str] = Field(default_factory=list)
+
+
 class Config(BaseSettings):
     """Root configuration for nanobot."""
 
@@ -177,6 +183,7 @@ class Config(BaseSettings):
     api: ApiConfig = Field(default_factory=ApiConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    security: SecurityConfig = Field(default_factory=SecurityConfig)
 
     @property
     def workspace_path(self) -> Path:

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -7,6 +7,8 @@ import re
 import socket
 from urllib.parse import urlparse
 
+from loguru import logger
+
 _BLOCKED_NETWORKS = [
     ipaddress.ip_network("0.0.0.0/8"),
     ipaddress.ip_network("10.0.0.0/8"),
@@ -20,10 +22,53 @@ _BLOCKED_NETWORKS = [
     ipaddress.ip_network("fe80::/10"),         # link-local v6
 ]
 
+# Networks that are ALWAYS blocked regardless of allowlist
+_ALWAYS_BLOCKED = [
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+_allowed_subnets: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+
 _URL_RE = re.compile(r"https?://[^\s\"'`;|<>]+", re.IGNORECASE)
 
 
+def configure_allowed_subnets(subnets: list[str]) -> None:
+    """Parse and validate CIDR allowlist for SSRF bypass.
+
+    Raises ValueError for invalid CIDR strings.
+    Silently skips subnets that overlap with always-blocked ranges (with warning).
+    """
+    global _allowed_subnets
+    parsed: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for cidr in subnets:
+        try:
+            net = ipaddress.ip_network(cidr, strict=False)
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid CIDR in ssrfAllowedSubnets: {cidr!r}: {e}"
+            ) from e
+        if any(net.overlaps(blocked) for blocked in _ALWAYS_BLOCKED):
+            logger.warning(
+                "ssrfAllowedSubnets: ignoring {!r}"
+                " — overlaps with always-blocked range",
+                cidr,
+            )
+            continue
+        parsed.append(net)
+    _allowed_subnets = parsed
+
+
 def _is_private(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    # Always block loopback and link-local
+    if any(addr in net for net in _ALWAYS_BLOCKED):
+        return True
+    # Check allowlist
+    if _allowed_subnets and any(addr in net for net in _allowed_subnets):
+        return False
     return any(addr in net for net in _BLOCKED_NETWORKS)
 
 

--- a/tests/security/test_security_network.py
+++ b/tests/security/test_security_network.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from nanobot.security.network import contains_internal_url, validate_url_target
+from nanobot.security.network import (
+    configure_allowed_subnets,
+    contains_internal_url,
+    validate_url_target,
+)
 
 
 def _fake_resolve(host: str, results: list[str]):
@@ -99,3 +103,81 @@ def test_allows_normal_curl():
 
 def test_no_urls_returns_false():
     assert not contains_internal_url("echo hello && ls -la")
+
+
+# ---------------------------------------------------------------------------
+# ssrfAllowedSubnets — subnet-based allowlist
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_allowed_subnets():
+    """Reset SSRF allowlist between tests."""
+    yield
+    configure_allowed_subnets([])
+
+
+def test_allowed_subnet_bypasses_private_block():
+    configure_allowed_subnets(["172.16.0.0/12"])
+    with patch(
+        "nanobot.security.network.socket.getaddrinfo",
+        _fake_resolve("internal.corp", ["172.16.5.1"]),
+    ):
+        ok, err = validate_url_target("http://internal.corp/api")
+        assert ok, f"172.16.5.1 should be allowed, got: {err}"
+
+
+def test_private_ip_not_in_allowlist_still_blocked():
+    configure_allowed_subnets(["172.16.0.0/12"])
+    with patch(
+        "nanobot.security.network.socket.getaddrinfo",
+        _fake_resolve("evil.com", ["10.0.0.1"]),
+    ):
+        ok, err = validate_url_target("http://evil.com/path")
+        assert not ok, "10.0.0.1 should still be blocked"
+
+
+def test_empty_allowlist_blocks_all_private():
+    configure_allowed_subnets([])
+    for ip in ["10.0.0.1", "172.16.5.1", "192.168.1.1"]:
+        with patch(
+            "nanobot.security.network.socket.getaddrinfo",
+            _fake_resolve("evil.com", [ip]),
+        ):
+            ok, _ = validate_url_target("http://evil.com/path")
+            assert not ok, f"{ip} should be blocked with empty allowlist"
+
+
+def test_invalid_cidr_raises_error():
+    with pytest.raises(ValueError, match="Invalid CIDR"):
+        configure_allowed_subnets(["not-a-cidr"])
+
+
+def test_loopback_blocked_even_if_allowlisted():
+    configure_allowed_subnets(["127.0.0.0/8"])
+    with patch(
+        "nanobot.security.network.socket.getaddrinfo",
+        _fake_resolve("evil.com", ["127.0.0.1"]),
+    ):
+        ok, _ = validate_url_target("http://evil.com/path")
+        assert not ok, "127.0.0.1 must always be blocked"
+
+
+def test_multiple_subnets_configured():
+    configure_allowed_subnets(["10.0.0.0/8", "172.16.0.0/12"])
+    for ip in ["10.0.0.1", "172.16.5.1"]:
+        with patch(
+            "nanobot.security.network.socket.getaddrinfo",
+            _fake_resolve("internal.corp", [ip]),
+        ):
+            ok, err = validate_url_target("http://internal.corp/api")
+            assert ok, f"{ip} should be allowed, got: {err}"
+
+
+def test_link_local_blocked_even_if_allowlisted():
+    configure_allowed_subnets(["169.254.0.0/16"])
+    with patch(
+        "nanobot.security.network.socket.getaddrinfo",
+        _fake_resolve("evil.com", ["169.254.169.254"]),
+    ):
+        ok, _ = validate_url_target("http://evil.com/path")
+        assert not ok, "169.254.169.254 must always be blocked"


### PR DESCRIPTION
## Summary

Adds `security.ssrfAllowedSubnets` to config, allowing operators to
specify CIDR ranges that bypass the SSRF private-network guard.

## Motivation

Air-gapped and internal-only deployments need to reach services on RFC
1918 ranges. Per-hostname allowlisting is insufficient for volatile cluster
environments where hostnames vary per deployment. A CIDR allowlist is
deployment-stable.

## Config

```json
{
  "security": {
    "ssrfAllowedSubnets": ["172.16.0.0/12"]
  }
}
```

Default: `[]` — no change to existing behaviour.

## Security properties

- Default is unchanged: all private IPs are blocked unless explicitly listed
- Loopback and link-local remain blocked regardless of config
- CIDR validation happens at startup; invalid entries fail loudly
- Check occurs post-DNS-resolution to prevent rebinding bypasses

## Changes

- **`nanobot/config/schema.py`**: Added `SecurityConfig` with `ssrf_allowed_subnets` field
- **`nanobot/security/network.py`**: Added `_ALWAYS_BLOCKED`, `configure_allowed_subnets()`, updated `_is_private()` to check allowlist
- **`nanobot/config/loader.py`**: Calls `configure_allowed_subnets()` after loading config

## Testing

- `test_allowed_subnet_bypasses_private_block` — IP in allowed subnet passes
- `test_private_ip_not_in_allowlist_still_blocked` — uncovered private IP blocked
- `test_empty_allowlist_blocks_all_private` — default behaviour unchanged
- `test_invalid_cidr_raises_error` — bad CIDR fails at config time
- `test_loopback_blocked_even_if_allowlisted` — 127.x always blocked
- `test_multiple_subnets_configured` — multiple CIDR ranges work
- `test_link_local_blocked_even_if_allowlisted` — 169.254.x always blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)