### PR TITLE
fix(message): avoid leaking default reply target across chats

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -84,39 +84,39 @@ class MessageTool(Tool):
         media: list[str] | None = None,
         **kwargs: Any
     ) -> str:
-        channel = channel or self._default_channel
-        chat_id = chat_id or self._default_chat_id
-        # Only inherit default message_id when targeting the same channel+chat.
-        # Cross-chat sends must not carry the original message_id, because
-        # some channels (e.g. Feishu) use it to determine the target
-        # conversation via their Reply API, which would route the message
-        # to the wrong chat entirely.
-        if channel == self._default_channel and chat_id == self._default_chat_id:
-            message_id = message_id or self._default_message_id
-        else:
-            message_id = None
+        target_channel = channel or self._default_channel
+        target_chat_id = chat_id or self._default_chat_id
+        same_target = (
+            target_channel == self._default_channel and target_chat_id == self._default_chat_id
+        )
+        # Only inherit the context message_id when we stay in the same chat.
+        # For cross-chat sends, keep an explicitly provided message_id, but
+        # never leak the current conversation's default reply target.
+        target_message_id = message_id if message_id is not None else (
+            self._default_message_id if same_target else None
+        )
 
-        if not channel or not chat_id:
+        if not target_channel or not target_chat_id:
             return "Error: No target channel/chat specified"
 
         if not self._send_callback:
             return "Error: Message sending not configured"
 
         msg = OutboundMessage(
-            channel=channel,
-            chat_id=chat_id,
+            channel=target_channel,
+            chat_id=target_chat_id,
             content=content,
             media=media or [],
             metadata={
-                "message_id": message_id,
-            } if message_id else {},
+                "message_id": target_message_id,
+            } if target_message_id else {},
         )
 
         try:
             await self._send_callback(msg)
-            if channel == self._default_channel and chat_id == self._default_chat_id:
+            if same_target:
                 self._sent_in_turn = True
             media_info = f" with {len(media)} attachments" if media else ""
-            return f"Message sent to {channel}:{chat_id}{media_info}"
+            return f"Message sent to {target_channel}:{target_chat_id}{media_info}"
         except Exception as e:
             return f"Error sending message: {str(e)}"

--- a/tests/tools/test_message_tool.py
+++ b/tests/tools/test_message_tool.py
@@ -1,6 +1,9 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
 from nanobot.agent.tools.message import MessageTool
+from nanobot.bus.events import OutboundMessage
 
 
 @pytest.mark.asyncio
@@ -8,3 +11,51 @@ async def test_message_tool_returns_error_when_no_target_context() -> None:
     tool = MessageTool()
     result = await tool.execute(content="test")
     assert result == "Error: No target channel/chat specified"
+
+
+@pytest.mark.asyncio
+async def test_message_tool_keeps_default_message_id_for_same_target() -> None:
+    sent: list[OutboundMessage] = []
+    tool = MessageTool(send_callback=AsyncMock(side_effect=lambda m: sent.append(m)))
+    tool.set_context("feishu", "chat-a", "msg-1")
+
+    result = await tool.execute(content="hello")
+
+    assert result == "Message sent to feishu:chat-a"
+    assert sent[0].metadata["message_id"] == "msg-1"
+
+
+@pytest.mark.asyncio
+async def test_message_tool_drops_default_message_id_for_different_chat() -> None:
+    sent: list[OutboundMessage] = []
+    tool = MessageTool(send_callback=AsyncMock(side_effect=lambda m: sent.append(m)))
+    tool.set_context("feishu", "chat-a", "msg-1")
+
+    result = await tool.execute(content="hello", chat_id="chat-b")
+
+    assert result == "Message sent to feishu:chat-b"
+    assert sent[0].metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_message_tool_drops_default_message_id_for_different_channel() -> None:
+    sent: list[OutboundMessage] = []
+    tool = MessageTool(send_callback=AsyncMock(side_effect=lambda m: sent.append(m)))
+    tool.set_context("feishu", "chat-a", "msg-1")
+
+    result = await tool.execute(content="hello", channel="discord", chat_id="chat-a")
+
+    assert result == "Message sent to discord:chat-a"
+    assert sent[0].metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_message_tool_preserves_explicit_message_id_for_different_target() -> None:
+    sent: list[OutboundMessage] = []
+    tool = MessageTool(send_callback=AsyncMock(side_effect=lambda m: sent.append(m)))
+    tool.set_context("feishu", "chat-a", "msg-1")
+
+    result = await tool.execute(content="hello", chat_id="chat-b", message_id="msg-2")
+
+    assert result == "Message sent to feishu:chat-b"
+    assert sent[0].metadata["message_id"] == "msg-2"


### PR DESCRIPTION
## Summary\n- only inherit the current context's default message_id when sending back to the same channel/chat\n- keep explicitly provided message_id values for cross-chat sends\n- add focused coverage for same-target inheritance and cross-target isolation\n\n## Testing\n- python -m pytest tests/tools/test_message_tool.py tests/tools/test_message_tool_suppress.py -q\n- python -m ruff check nanobot/agent/tools/message.py tests/tools/test_message_tool.py\n\nFixes #2542