### PR TITLE
fix(telegram): guard against empty message content in send()

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -430,7 +430,7 @@ class TelegramChannel(BaseChannel):
                 )
 
         # Send text content
-        if msg.content and msg.content != "[empty message]":
+        if msg.content and msg.content.strip() and msg.content != "[empty message]":
             for chunk in split_message(msg.content, TELEGRAM_MAX_MESSAGE_LEN):
                 await self._send_text(chat_id, chunk, reply_params, thread_kwargs)
 


### PR DESCRIPTION
## Summary

Fixes #100

### Problem

When the LLM completes a tool call but generates no final text response, `send()` attempts to send an empty or whitespace-only string to Telegram. The `python-telegram-bot` library raises `BadRequest: Message text is empty`, which crashes the channel.

This happens more frequently with certain providers (e.g. Groq) that occasionally return empty strings after tool execution.

### Root Cause

The existing guard in `send()` checks `msg.content` for truthiness and the `"[empty message]"` sentinel, but does not check for whitespace-only content:
```python
if msg.content and msg.content != "[empty message]":
```

A string like `"   "` or `"\n"` passes this check but still triggers Telegram's `Message text is empty` error.

### Fix

Added `.strip()` check to skip whitespace-only content:
```python
if msg.content and msg.content.strip() and msg.content != "[empty message]":
```

### Impact

- Prevents `BadRequest: Message text is empty` crash in Telegram channel
- No behavior change for normal messages
- Single-line change, zero risk of regression

---

Built with the help of Claude Opus 4.6