### PR TITLE
test(matrix): skip cleanly when optional deps are missing

### DIFF
--- a/tests/channels/test_matrix_channel.py
+++ b/tests/channels/test_matrix_channel.py
@@ -3,15 +3,13 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+
+pytest.importorskip("nio")
+pytest.importorskip("nh3")
+pytest.importorskip("mistune")
 from nio import RoomSendResponse
 
 from nanobot.channels.matrix import _build_matrix_text_content
-
-# Check optional matrix dependencies before importing
-try:
-    import nh3  # noqa: F401
-except ImportError:
-    pytest.skip("Matrix dependencies not installed (nh3)", allow_module_level=True)
 
 import nanobot.channels.matrix as matrix_module
 from nanobot.bus.events import OutboundMessage


### PR DESCRIPTION
## Summary
- switch Matrix channel tests to module-level `pytest.importorskip()` checks for `nio`, `nh3`, and `mistune`
- avoid pytest collection failures when optional Matrix extras are not installed
- align Matrix test dependency gating with the existing Discord test pattern

## Testing
- `python -m pytest tests/channels/test_matrix_channel.py tests/channels/test_discord_channel.py -q`

Fixes #2695