### PR TITLE
refactor: consolidate tool registration into a unified function

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -20,13 +20,9 @@ from nanobot.agent.runner import AgentRunSpec, AgentRunner
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
-from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.message import MessageTool
-from nanobot.agent.tools.registry import ToolRegistry
-from nanobot.agent.tools.search import GlobTool, GrepTool
-from nanobot.agent.tools.shell import ExecTool
+from nanobot.agent.tools.builtin import build_default_tool_registry
 from nanobot.agent.tools.spawn import SpawnTool
-from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.bus.queue import MessageBus
@@ -215,7 +211,6 @@ class AgentLoop:
 
         self.context = ContextBuilder(workspace, timezone=timezone)
         self.sessions = session_manager or SessionManager(workspace)
-        self.tools = ToolRegistry()
         self.runner = AgentRunner(provider)
         self.subagents = SubagentManager(
             provider=provider,
@@ -227,7 +222,6 @@ class AgentLoop:
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
         )
-
         self._running = False
         self._mcp_servers = mcp_servers or {}
         self._mcp_stack: AsyncExitStack | None = None
@@ -240,6 +234,27 @@ class AgentLoop:
         _max = int(os.environ.get("NANOBOT_MAX_CONCURRENT_REQUESTS", "3"))
         self._concurrency_gate: asyncio.Semaphore | None = (
             asyncio.Semaphore(_max) if _max > 0 else None
+        )
+        allowed_dir = (
+            self.workspace if (self.restrict_to_workspace or self.exec_config.sandbox) else None
+        )
+        extra_read = [BUILTIN_SKILLS_DIR] if allowed_dir else None
+        self.tools = build_default_tool_registry(
+            self.workspace,
+            allowed_dir=allowed_dir,
+            extra_read=extra_read,
+            exec_config=self.exec_config,
+            web_config=self.web_config,
+            restrict_to_workspace=self.restrict_to_workspace,
+            extra_tools=[
+                MessageTool(send_callback=self.bus.publish_outbound),
+                SpawnTool(manager=self.subagents),
+                CronTool(
+                    self.cron_service,
+                    default_timezone=self.context.timezone or "UTC",
+                    enable=self.cron_service is not None,
+                ),
+            ],
         )
         self.consolidator = Consolidator(
             store=self.context.memory,
@@ -256,36 +271,8 @@ class AgentLoop:
             provider=provider,
             model=self.model,
         )
-        self._register_default_tools()
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
-
-    def _register_default_tools(self) -> None:
-        """Register the default set of tools."""
-        allowed_dir = self.workspace if (self.restrict_to_workspace or self.exec_config.sandbox) else None
-        extra_read = [BUILTIN_SKILLS_DIR] if allowed_dir else None
-        self.tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir, extra_allowed_dirs=extra_read))
-        for cls in (WriteFileTool, EditFileTool, ListDirTool):
-            self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
-        for cls in (GlobTool, GrepTool):
-            self.tools.register(cls(workspace=self.workspace, allowed_dir=allowed_dir))
-        if self.exec_config.enable:
-            self.tools.register(ExecTool(
-                working_dir=str(self.workspace),
-                timeout=self.exec_config.timeout,
-                restrict_to_workspace=self.restrict_to_workspace,
-                sandbox=self.exec_config.sandbox,
-                path_append=self.exec_config.path_append,
-            ))
-        if self.web_config.enable:
-            self.tools.register(WebSearchTool(config=self.web_config.search, proxy=self.web_config.proxy))
-            self.tools.register(WebFetchTool(proxy=self.web_config.proxy))
-        self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
-        self.tools.register(SpawnTool(manager=self.subagents))
-        if self.cron_service:
-            self.tools.register(
-                CronTool(self.cron_service, default_timezone=self.context.timezone or "UTC")
-            )
 
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -12,11 +12,7 @@ from nanobot.agent.hook import AgentHook, AgentHookContext
 from nanobot.utils.prompt_templates import render_template
 from nanobot.agent.runner import AgentRunSpec, AgentRunner
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
-from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
-from nanobot.agent.tools.registry import ToolRegistry
-from nanobot.agent.tools.search import GlobTool, GrepTool
-from nanobot.agent.tools.shell import ExecTool
-from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
+from nanobot.agent.tools.builtin import build_default_tool_registry
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.config.schema import ExecToolConfig, WebToolsConfig
@@ -110,26 +106,18 @@ class SubagentManager:
 
         try:
             # Build subagent tools (no message tool, no spawn tool)
-            tools = ToolRegistry()
-            allowed_dir = self.workspace if (self.restrict_to_workspace or self.exec_config.sandbox) else None
+            allowed_dir = (
+                self.workspace if (self.restrict_to_workspace or self.exec_config.sandbox) else None
+            )
             extra_read = [BUILTIN_SKILLS_DIR] if allowed_dir else None
-            tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir, extra_allowed_dirs=extra_read))
-            tools.register(WriteFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(EditFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(GlobTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            tools.register(GrepTool(workspace=self.workspace, allowed_dir=allowed_dir))
-            if self.exec_config.enable:
-                tools.register(ExecTool(
-                    working_dir=str(self.workspace),
-                    timeout=self.exec_config.timeout,
-                    restrict_to_workspace=self.restrict_to_workspace,
-                    sandbox=self.exec_config.sandbox,
-                    path_append=self.exec_config.path_append,
-                ))
-            if self.web_config.enable:
-                tools.register(WebSearchTool(config=self.web_config.search, proxy=self.web_config.proxy))
-                tools.register(WebFetchTool(proxy=self.web_config.proxy))
+            tools = build_default_tool_registry(
+                self.workspace,
+                allowed_dir=allowed_dir,
+                extra_read=extra_read,
+                exec_config=self.exec_config,
+                web_config=self.web_config,
+                restrict_to_workspace=self.restrict_to_workspace,
+            )
             system_prompt = self._build_subagent_prompt()
             messages: list[dict[str, Any]] = [
                 {"role": "system", "content": system_prompt},

--- a/nanobot/agent/tools/base.py
+++ b/nanobot/agent/tools/base.py
@@ -117,6 +117,10 @@ class Schema(ABC):
 class Tool(ABC):
     """Agent capability: read files, run commands, etc."""
 
+    def __init__(self, enable: bool = True) -> None:
+        """If ``enable`` is False, the tool is omitted from definitions and cannot be executed."""
+        self.enable = enable
+
     _TYPE_MAP = {
         "string": str,
         "integer": int,
@@ -176,6 +180,10 @@ class Tool(ABC):
             return obj
         props = schema.get("properties", {})
         return {k: self._cast_value(v, props[k]) if k in props else v for k, v in obj.items()}
+
+    def is_available(self) -> bool:
+        """Whether this tool is usable in the current environment (not per-call argument checks)."""
+        return self.enable
 
     def cast_params(self, params: dict[str, Any]) -> dict[str, Any]:
         """Apply safe schema-driven casts before validation."""

--- a/nanobot/agent/tools/builtin.py
+++ b/nanobot/agent/tools/builtin.py
@@ -1,0 +1,57 @@
+"""Default tool sets for the agent loop and subagents (composition lives here, not in registry)."""
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.agent.tools.search import GlobTool, GrepTool
+from nanobot.agent.tools.shell import ExecTool
+from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
+from nanobot.config.schema import ExecToolConfig, WebToolsConfig
+
+
+def build_default_tool_registry(
+    workspace: Path,
+    *,
+    allowed_dir: Path | None,
+    extra_read: list[Path] | None,
+    exec_config: ExecToolConfig,
+    web_config: WebToolsConfig,
+    restrict_to_workspace: bool,
+    extra_tools: Iterable[Tool] | None = None,
+) -> ToolRegistry:
+    """
+    Core filesystem, shell, and web tools shared by the main agent loop and subagents.
+
+    Pass ``extra_tools`` for loop-only tools (message, spawn, cron, etc.).
+    """
+    tools: list[Tool] = [
+        ReadFileTool(
+            workspace=workspace,
+            allowed_dir=allowed_dir,
+            extra_allowed_dirs=extra_read,
+        ),
+        WriteFileTool(workspace=workspace, allowed_dir=allowed_dir),
+        EditFileTool(workspace=workspace, allowed_dir=allowed_dir),
+        ListDirTool(workspace=workspace, allowed_dir=allowed_dir),
+        GlobTool(workspace=workspace, allowed_dir=allowed_dir),
+        GrepTool(workspace=workspace, allowed_dir=allowed_dir),
+        ExecTool(
+            timeout=exec_config.timeout,
+            working_dir=str(workspace),
+            restrict_to_workspace=restrict_to_workspace,
+            path_append=exec_config.path_append,
+            enable=exec_config.enable,
+        ),
+        WebSearchTool(
+            config=web_config.search,
+            proxy=web_config.proxy,
+            enable=web_config.enable,
+        ),
+        WebFetchTool(proxy=web_config.proxy, enable=web_config.enable),
+    ]
+    if extra_tools:
+        tools.extend(extra_tools)
+    return ToolRegistry(tools)

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -38,7 +38,13 @@ from nanobot.cron.types import CronJob, CronJobState, CronSchedule
 class CronTool(Tool):
     """Tool to schedule reminders and recurring tasks."""
 
-    def __init__(self, cron_service: CronService, default_timezone: str = "UTC"):
+    def __init__(
+        self,
+        cron_service: CronService,
+        default_timezone: str = "UTC",
+        enable: bool = True,
+    ):
+        super().__init__(enable=enable)
         self._cron = cron_service
         self._default_timezone = default_timezone
         self._channel = ""

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -46,7 +46,9 @@ class _FsTool(Tool):
         workspace: Path | None = None,
         allowed_dir: Path | None = None,
         extra_allowed_dirs: list[Path] | None = None,
+        enable: bool = True,
     ):
+        super().__init__(enable=enable)
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._extra_allowed_dirs = extra_allowed_dirs

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -77,7 +77,15 @@ def _normalize_schema_for_openai(schema: Any) -> dict[str, Any]:
 class MCPToolWrapper(Tool):
     """Wraps a single MCP server tool as a nanobot Tool."""
 
-    def __init__(self, session, server_name: str, tool_def, tool_timeout: int = 30):
+    def __init__(
+        self,
+        session,
+        server_name: str,
+        tool_def,
+        tool_timeout: int = 30,
+        enable: bool = True,
+    ):
+        super().__init__(enable=enable)
         self._session = session
         self._original_name = tool_def.name
         self._name = f"mcp_{server_name}_{tool_def.name}"

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -28,7 +28,9 @@ class MessageTool(Tool):
         default_channel: str = "",
         default_chat_id: str = "",
         default_message_id: str | None = None,
+        enable: bool = True,
     ):
+        super().__init__(enable=enable)
         self._send_callback = send_callback
         self._default_channel = default_channel
         self._default_chat_id = default_chat_id

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -12,8 +12,8 @@ class ToolRegistry:
     Allows dynamic registration and execution of tools.
     """
 
-    def __init__(self):
-        self._tools: dict[str, Tool] = {}
+    def __init__(self, tools: list[Tool] | None = None):
+        self._tools: dict[str, Tool] = {} if tools is None else {tool.name: tool for tool in tools}
 
     def register(self, tool: Tool) -> None:
         """Register a tool."""
@@ -45,10 +45,12 @@ class ToolRegistry:
     def get_definitions(self) -> list[dict[str, Any]]:
         """Get tool definitions with stable ordering for cache-friendly prompts.
 
-        Built-in tools are sorted first as a stable prefix, then MCP tools are
-        sorted and appended.
+        Only enabled and available tools are included. Built-in tools are sorted
+        first as a stable prefix, then MCP tools are sorted and appended.
         """
-        definitions = [tool.to_schema() for tool in self._tools.values()]
+        definitions = [
+            tool.to_schema() for tool in self._tools.values() if tool.is_available()
+        ]
         builtins: list[dict[str, Any]] = []
         mcp_tools: list[dict[str, Any]] = []
         for schema in definitions:
@@ -73,6 +75,9 @@ class ToolRegistry:
             return None, params, (
                 f"Error: Tool '{name}' not found. Available: {', '.join(self.tool_names)}"
             )
+
+        if not tool.is_available():
+            return None, params, f"Error: Tool '{name}' is not available."
 
         cast_params = tool.cast_params(params)
         errors = tool.validate_params(cast_params)

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -44,7 +44,9 @@ class ExecTool(Tool):
         restrict_to_workspace: bool = False,
         sandbox: str = "",
         path_append: str = "",
+        enable: bool = True,
     ):
+        super().__init__(enable=enable)
         self.timeout = timeout
         self.working_dir = working_dir
         self.sandbox = sandbox

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -19,7 +19,8 @@ if TYPE_CHECKING:
 class SpawnTool(Tool):
     """Tool to spawn a subagent for background task execution."""
 
-    def __init__(self, manager: "SubagentManager"):
+    def __init__(self, manager: "SubagentManager", enable: bool = True):
+        super().__init__(enable=enable)
         self._manager = manager
         self._origin_channel = "cli"
         self._origin_chat_id = "direct"

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -86,9 +86,15 @@ class WebSearchTool(Tool):
     name = "web_search"
     description = "Search the web. Returns titles, URLs, and snippets."
 
-    def __init__(self, config: WebSearchConfig | None = None, proxy: str | None = None):
+    def __init__(
+        self,
+        config: WebSearchConfig | None = None,
+        proxy: str | None = None,
+        enable: bool = True,
+    ):
         from nanobot.config.schema import WebSearchConfig
 
+        super().__init__(enable=enable)
         self.config = config if config is not None else WebSearchConfig()
         self.proxy = proxy
 
@@ -222,6 +228,28 @@ class WebSearchTool(Tool):
             logger.warning("DuckDuckGo search failed: {}", e)
             return f"Error: DuckDuckGo search failed ({e})"
 
+    def _provider_credentials_configured(self) -> bool:
+        """True when config + env provide required secrets/URLs for the resolved provider."""
+        provider = (self.config.provider or "").strip().lower() or "brave"
+        api = (self.config.api_key or "").strip()
+        if provider == "duckduckgo":
+            return True
+        if provider == "brave":
+            return bool(api or (os.environ.get("BRAVE_API_KEY") or "").strip())
+        if provider == "tavily":
+            return bool(api or (os.environ.get("TAVILY_API_KEY") or "").strip())
+        if provider == "jina":
+            return bool(api or (os.environ.get("JINA_API_KEY") or "").strip())
+        if provider == "searxng":
+            base = (self.config.base_url or os.environ.get("SEARXNG_BASE_URL", "")).strip()
+            return bool(base)
+        return False
+
+    def is_available(self) -> bool:
+        if not super().is_available():
+            return False
+        return self._provider_credentials_configured()
+
 
 @tool_parameters(
     tool_parameters_schema(
@@ -241,7 +269,8 @@ class WebFetchTool(Tool):
     name = "web_fetch"
     description = "Fetch URL and extract readable content (HTML → markdown/text)."
 
-    def __init__(self, max_chars: int = 50000, proxy: str | None = None):
+    def __init__(self, max_chars: int = 50000, proxy: str | None = None, enable: bool = True):
+        super().__init__(enable=enable)
         self.max_chars = max_chars
         self.proxy = proxy
 
@@ -374,3 +403,15 @@ class WebFetchTool(Tool):
         text = re.sub(r'</(p|div|section|article)>', '\n\n', text, flags=re.I)
         text = re.sub(r'<(br|hr)\s*/?>', '\n', text, flags=re.I)
         return _normalize(_strip_tags(text))
+
+    def _provider_credentials_configured(self) -> bool:
+        """True when config + env provide required secrets/URLs for the resolved provider."""
+        jina_key = os.environ.get("JINA_API_KEY", "")
+        if not jina_key:
+            return False
+        return True
+
+    def is_available(self) -> bool:
+        if not super().is_available():
+            return False
+        return self._provider_credentials_configured()

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -614,7 +614,16 @@ async def test_runner_keeps_going_when_tool_result_persistence_fails():
 
 
 class _DelayTool(Tool):
-    def __init__(self, name: str, *, delay: float, read_only: bool, shared_events: list[str]):
+    def __init__(
+        self,
+        name: str,
+        *,
+        delay: float,
+        read_only: bool,
+        shared_events: list[str],
+        enable: bool = True,
+    ):
+        super().__init__(enable=enable)
         self._name = name
         self._delay = delay
         self._read_only = read_only

--- a/tests/agent/test_task_cancel.py
+++ b/tests/agent/test_task_cancel.py
@@ -101,12 +101,14 @@ class TestHandleStop:
 
 
 class TestDispatch:
-    def test_exec_tool_not_registered_when_disabled(self):
+    def test_exec_tool_unavailable_when_disabled(self):
         from nanobot.config.schema import ExecToolConfig
 
         loop, _bus = _make_loop(exec_config=ExecToolConfig(enable=False))
 
-        assert loop.tools.get("exec") is None
+        exec_tool = loop.tools.get("exec")
+        assert exec_tool is not None
+        assert exec_tool.is_available() is False
 
     @pytest.mark.asyncio
     async def test_dispatch_processes_and_publishes(self):
@@ -280,7 +282,7 @@ class TestSubagentCancellation:
         assert assistant_messages[0]["thinking_blocks"] == [{"type": "thinking", "thinking": "step"}]
 
     @pytest.mark.asyncio
-    async def test_subagent_exec_tool_not_registered_when_disabled(self, tmp_path):
+    async def test_subagent_exec_tool_unavailable_when_disabled(self, tmp_path):
         from nanobot.agent.subagent import SubagentManager
         from nanobot.bus.queue import MessageBus
         from nanobot.config.schema import ExecToolConfig
@@ -298,7 +300,9 @@ class TestSubagentCancellation:
         mgr._announce_result = AsyncMock()
 
         async def fake_run(spec):
-            assert spec.tools.get("exec") is None
+            exec_tool = spec.tools.get("exec")
+            assert exec_tool is not None
+            assert exec_tool.is_available() is False
             return SimpleNamespace(
                 stop_reason="done",
                 final_content="done",

--- a/tests/tools/test_tool_registry.py
+++ b/tests/tools/test_tool_registry.py
@@ -8,6 +8,7 @@ from nanobot.agent.tools.registry import ToolRegistry
 
 class _FakeTool(Tool):
     def __init__(self, name: str):
+        super().__init__()
         self._name = name
 
     @property

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -198,6 +198,19 @@ async def test_registry_returns_validation_error() -> None:
     assert "Invalid parameters" in result
 
 
+def test_tool_disable_omits_from_definitions() -> None:
+    reg = ToolRegistry()
+    reg.register(SampleTool(enable=False))
+    assert reg.get_definitions() == []
+
+
+async def test_tool_disable_execute_returns_error() -> None:
+    reg = ToolRegistry()
+    reg.register(SampleTool(enable=False))
+    result = await reg.execute("sample", {"query": "hi", "count": 2})
+    assert "not available" in result
+
+
 def test_exec_extract_absolute_paths_keeps_full_windows_path() -> None:
     cmd = r"type C:\user\workspace\txt"
     paths = ExecTool._extract_absolute_paths(cmd)
@@ -309,7 +322,8 @@ def test_exec_guard_blocks_windows_drive_root_outside_workspace(monkeypatch) -> 
 class CastTestTool(Tool):
     """Minimal tool for testing cast_params."""
 
-    def __init__(self, schema: dict[str, Any]) -> None:
+    def __init__(self, schema: dict[str, Any], enable: bool = True) -> None:
+        super().__init__(enable=enable)
         self._schema = schema
 
     @property

--- a/tests/tools/test_web_search_tool.py
+++ b/tests/tools/test_web_search_tool.py
@@ -229,3 +229,28 @@ async def test_duckduckgo_timeout_returns_error(monkeypatch):
     assert "Error" in result
 
 
+def test_is_available_requires_credentials_per_provider(monkeypatch):
+    assert _tool(provider="duckduckgo").is_available() is True
+
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    assert _tool(provider="brave", api_key="").is_available() is False
+    assert _tool(provider="brave", api_key="k").is_available() is True
+    monkeypatch.setenv("BRAVE_API_KEY", "env-key")
+    assert _tool(provider="brave", api_key="").is_available() is True
+
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    assert _tool(provider="tavily", api_key="").is_available() is False
+    assert _tool(provider="tavily", api_key="tv").is_available() is True
+
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+    assert _tool(provider="jina", api_key="").is_available() is False
+
+    monkeypatch.delenv("SEARXNG_BASE_URL", raising=False)
+    assert _tool(provider="searxng", base_url="").is_available() is False
+    assert _tool(provider="searxng", base_url="https://sx.example").is_available() is True
+
+    assert _tool(provider="unknown").is_available() is False
+
+
+def test_is_available_respects_enable_flag():
+    assert WebSearchTool(config=WebSearchConfig(provider="duckduckgo"), enable=False).is_available() is False


### PR DESCRIPTION
This update introduces a new `build_default_tool_registry` function to streamline the registration of tools in both the agent loop and subagents. The previous individual tool registrations have been replaced, enhancing maintainability and reducing redundancy. Additionally, tools now support an `enable` flag to control their availability, ensuring that disabled tools are omitted from definitions and execution.