### PR TITLE
feat(provider): switch to fallback providers on rate-limit instead of retrying same

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -381,36 +381,20 @@ def _onboard_plugins(config_path: Path) -> None:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
-def _make_provider(config: Config):
-    """Create the appropriate LLM provider from config.
+def _build_provider_for_model(config: Config, model: str):
+    """Instantiate an LLMProvider for *model* using keys already in *config*.
 
-    Routing is driven by ``ProviderSpec.backend`` in the registry.
+    Raises on misconfiguration (missing key for a non-exempt backend) so callers
+    can decide whether to abort or just skip the provider.
     """
     from nanobot.providers.base import GenerationSettings
     from nanobot.providers.registry import find_by_name
 
-    model = config.agents.defaults.model
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
     spec = find_by_name(provider_name) if provider_name else None
     backend = spec.backend if spec else "openai_compat"
 
-    # --- validation ---
-    if backend == "azure_openai":
-        if not p or not p.api_key or not p.api_base:
-            console.print("[red]Error: Azure OpenAI requires api_key and api_base.[/red]")
-            console.print("Set them in ~/.nanobot/config.json under providers.azure_openai section")
-            console.print("Use the model field to specify the deployment name.")
-            raise typer.Exit(1)
-    elif backend == "openai_compat" and not model.startswith("bedrock/"):
-        needs_key = not (p and p.api_key)
-        exempt = spec and (spec.is_oauth or spec.is_local or spec.is_direct)
-        if needs_key and not exempt:
-            console.print("[red]Error: No API key configured.[/red]")
-            console.print("Set one in ~/.nanobot/config.json under providers section")
-            raise typer.Exit(1)
-
-    # --- instantiation by backend ---
     if backend == "openai_codex":
         from nanobot.providers.openai_codex_provider import OpenAICodexProvider
         provider = OpenAICodexProvider(default_model=model)
@@ -448,6 +432,48 @@ def _make_provider(config: Config):
         max_tokens=defaults.max_tokens,
         reasoning_effort=defaults.reasoning_effort,
     )
+    return provider
+
+
+def _make_provider(config: Config):
+    """Create the primary LLM provider from config, with fallback providers attached.
+
+    Routing is driven by ``ProviderSpec.backend`` in the registry.
+    Fallback providers are built from ``agents.defaults.fallbackModels`` and tried
+    in order when the primary is rate-limited (429).
+    """
+    model = config.agents.defaults.model
+
+    # --- validation for primary model ---
+    from nanobot.providers.registry import find_by_name
+    provider_name = config.get_provider_name(model)
+    p = config.get_provider(model)
+    spec = find_by_name(provider_name) if provider_name else None
+    backend = spec.backend if spec else "openai_compat"
+
+    if backend == "azure_openai":
+        if not p or not p.api_key or not p.api_base:
+            console.print("[red]Error: Azure OpenAI requires api_key and api_base.[/red]")
+            console.print("Set them in ~/.nanobot/config.json under providers.azure_openai section")
+            console.print("Use the model field to specify the deployment name.")
+            raise typer.Exit(1)
+    elif backend == "openai_compat" and not model.startswith("bedrock/"):
+        needs_key = not (p and p.api_key)
+        exempt = spec and (spec.is_oauth or spec.is_local or spec.is_direct)
+        if needs_key and not exempt:
+            console.print("[red]Error: No API key configured.[/red]")
+            console.print("Set one in ~/.nanobot/config.json under providers section")
+            raise typer.Exit(1)
+
+    provider = _build_provider_for_model(config, model)
+
+    # --- attach fallback providers ---
+    for fb_model in config.agents.defaults.fallback_models:
+        try:
+            provider.fallback_providers.append(_build_provider_for_model(config, fb_model))
+        except Exception as exc:
+            console.print(f"[yellow]Warning: could not build fallback provider for '{fb_model}': {exc}[/yellow]")
+
     return provider
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -75,6 +75,7 @@ class AgentDefaults(Base):
     provider_retry_mode: Literal["standard", "persistent"] = "standard"
     reasoning_effort: str | None = None  # low / medium / high - enables LLM thinking mode
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
+    fallback_models: list[str] = Field(default_factory=list)  # tried in order when primary is rate-limited
     dream: DreamConfig = Field(default_factory=DreamConfig)
 
 

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -98,6 +98,7 @@ class LLMProvider(ABC):
         self.api_key = api_key
         self.api_base = api_base
         self.generation: GenerationSettings = GenerationSettings()
+        self.fallback_providers: list["LLMProvider"] = []
 
     @staticmethod
     def _sanitize_empty_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -479,6 +480,21 @@ class LLMProvider(ABC):
                     retry_kw["messages"] = stripped
                     return await call(**retry_kw)
                 return response
+
+            for i, fallback in enumerate(self.fallback_providers):
+                logger.info(
+                    "Primary rate-limited, trying fallback provider {} of {}",
+                    i + 1, len(self.fallback_providers),
+                )
+                fb_response = await getattr(fallback, call.__name__)(**{**kw, "model": None})
+                if fb_response.finish_reason != "error":
+                    return fb_response
+                if not self._is_transient_error(fb_response.content):
+                    return fb_response
+                logger.warning(
+                    "Fallback provider {} also rate-limited: {}",
+                    i + 1, (fb_response.content or "")[:120].lower(),
+                )
 
             if persistent and identical_error_count >= self._PERSISTENT_IDENTICAL_ERROR_LIMIT:
                 logger.warning(

--- a/tests/providers/test_provider_retry.py
+++ b/tests/providers/test_provider_retry.py
@@ -296,3 +296,113 @@ async def test_persistent_retry_aborts_after_ten_identical_transient_errors(monk
     assert provider.calls == 10
     assert delays == [1, 2, 4, 4, 4, 4, 4, 4, 4]
 
+
+# ---------------------------------------------------------------------------
+# Fallback provider tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_with_retry_uses_fallback_on_429(monkeypatch) -> None:
+    """When primary fails with 429, tries fallback before sleeping."""
+    primary = ScriptedProvider([
+        LLMResponse(content="429 rate limit", finish_reason="error"),
+    ])
+    fallback = ScriptedProvider([LLMResponse(content="ok from fallback")])
+    primary.fallback_providers = [fallback]
+
+    delays: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", _fake_sleep)
+
+    response = await primary.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.content == "ok from fallback"
+    assert primary.calls == 1
+    assert fallback.calls == 1
+    assert delays == []  # no sleep: fallback succeeded immediately
+
+
+@pytest.mark.asyncio
+async def test_chat_with_retry_fallback_uses_own_default_model(monkeypatch) -> None:
+    """Fallback is called with model=None so it uses its own default, not the primary's."""
+    primary = ScriptedProvider([
+        LLMResponse(content="429 rate limit", finish_reason="error"),
+    ])
+    fallback = ScriptedProvider([LLMResponse(content="ok")])
+    primary.fallback_providers = [fallback]
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", lambda _: None)
+
+    await primary.chat_with_retry(
+        messages=[{"role": "user", "content": "hello"}],
+        model="primary-model-v2",
+    )
+
+    assert fallback.last_kwargs["model"] is None
+
+
+@pytest.mark.asyncio
+async def test_chat_with_retry_sleeps_if_all_fallbacks_also_rate_limited(monkeypatch) -> None:
+    """If every fallback is also rate-limited, falls back to the existing sleep+retry."""
+    primary = ScriptedProvider([
+        LLMResponse(content="429 rate limit", finish_reason="error"),
+        LLMResponse(content="ok after retry"),
+    ])
+    fallback = ScriptedProvider([
+        LLMResponse(content="429 fallback limited", finish_reason="error"),
+    ])
+    primary.fallback_providers = [fallback]
+
+    delays: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", _fake_sleep)
+
+    response = await primary.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.content == "ok after retry"
+    assert primary.calls == 2
+    assert fallback.calls == 1
+    assert delays == [1]
+
+
+@pytest.mark.asyncio
+async def test_chat_with_retry_returns_fallback_non_transient_error(monkeypatch) -> None:
+    """A non-transient error from a fallback is returned immediately (no further retries)."""
+    primary = ScriptedProvider([
+        LLMResponse(content="429 rate limit", finish_reason="error"),
+    ])
+    fallback = ScriptedProvider([
+        LLMResponse(content="401 unauthorized", finish_reason="error"),
+    ])
+    primary.fallback_providers = [fallback]
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", lambda _: None)
+
+    response = await primary.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.content == "401 unauthorized"
+    assert primary.calls == 1
+    assert fallback.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_with_retry_tries_multiple_fallbacks_in_order(monkeypatch) -> None:
+    """With multiple fallbacks, they are tried in order until one succeeds."""
+    primary = ScriptedProvider([
+        LLMResponse(content="429 rate limit", finish_reason="error"),
+    ])
+    fallback1 = ScriptedProvider([LLMResponse(content="429 also limited", finish_reason="error")])
+    fallback2 = ScriptedProvider([LLMResponse(content="ok from fallback2")])
+    primary.fallback_providers = [fallback1, fallback2]
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", lambda _: None)
+
+    response = await primary.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.content == "ok from fallback2"
+    assert primary.calls == 1
+    assert fallback1.calls == 1
+    assert fallback2.calls == 1


### PR DESCRIPTION
## Problem

When the primary provider returns 429, nanobot retries the same one three times with backoff. On free-tier APIs this doesn't help much, the model can be down for several minutes, so all three retries fail for the same reason. If you have other providers configured, there's no way to use them automatically.

## Solution

Add `fallbackModels` under `agents.defaults`. Each entry is resolved against the existing providers config and used as a fallback when the primary is rate-limited. On a transient error (429, 503, timeout), nanobot tries each fallback in order before sleeping and retrying the primary.

- Fallback succeeds: returned immediately, no sleep.
- Fallback returns a non-transient error (e.g. 401): returned immediately.
- All fallbacks also rate-limited: existing sleep+retry on primary continues as before.

## Config example

```json
{
  "agents": {
    "defaults": {
      "model": "gemini/gemini-2.5-flash",
      "fallbackModels": [
        "groq/llama-3.3-70b-versatile",
        "cerebras/llama-3.3-70b"
      ]
    }
  }
}
```

## Changes

- `providers/base.py`: adds `fallback_providers: list[LLMProvider]` to `LLMProvider.__init__`; both `chat_with_retry` and `chat_stream_with_retry` try fallbacks before sleeping
- `config/schema.py`: adds `fallback_models: list[str]` to `AgentDefaults`
- `cli/commands.py`: extracts `_build_provider_for_model()` helper; `_make_provider` builds and attaches fallback providers from config
- `tests/providers/test_provider_retry.py`: 5 new tests covering fallback success, model isolation, sleep fallback, non-transient error from fallback, and multi-fallback ordering

## Testing

```
649 passed in 15.72s
```