### PR TITLE
feat(provider): add Qianfan provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,8 @@ Config file: `~/.nanobot/config.json`
 | `vllm` | LLM (local, any OpenAI-compatible server) | — |
 | `openai_codex` | LLM (Codex, OAuth) | `nanobot provider login openai-codex` |
 | `github_copilot` | LLM (GitHub Copilot, OAuth) | `nanobot provider login github-copilot` |
+| `qianfan` | LLM (Baidu Qianfan) | [cloud.baidu.com](https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26) |
+
 
 <details>
 <summary><b>OpenAI Codex (OAuth)</b></summary>

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -121,6 +121,7 @@ class ProvidersConfig(Base):
     byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
+    qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
 
 
 class HeartbeatConfig(Base):

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -349,6 +349,15 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         default_api_base="https://api.groq.com/openai/v1",
     ),
+    # Qianfan (百度千帆): OpenAI-compatible API
+    ProviderSpec(
+        name="qianfan",
+        keywords=("qianfan", "ernie"),
+        env_key="QIANFAN_API_KEY",
+        display_name="Qianfan",
+        backend="openai_compat",
+        default_api_base="https://qianfan.baidubce.com/v2"
+    ),
 )
 
 


### PR DESCRIPTION
@JiajunBernoulli Thanks for your contribution!


## Summary
- Add Baidu Qianfan (百度千帆) as a built-in provider with OpenAI-compatible API backend
- Register provider in config schema and provider registry with `QIANFAN_API_KEY` env key
- Add Qianfan to README provider table
