### PR TITLE
fix: stop leaking reasoning_content to stream output

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -671,9 +671,6 @@ class OpenAICompatProvider(LLMProvider):
                     break
                 chunks.append(chunk)
                 if on_content_delta and chunk.choices:
-                    text = getattr(chunk.choices[0].delta, "reasoning_content", None)
-                    if text:
-                        await on_content_delta(text)
                     text = getattr(chunk.choices[0].delta, "content", None)
                     if text:
                         await on_content_delta(text)


### PR DESCRIPTION
## Problem

In `OpenAICompatProvider.chat_stream()`, the streaming path forwards both `reasoning_content` and `content` deltas through `on_content_delta()`, causing the model's internal reasoning to be displayed to the user alongside the actual response.

This is particularly visible when using models like GLM with `reasoningEffort` enabled — the user sees reasoning text like "The user is saying they just wanted to know about X..." followed by the actual reply.

## Root Cause

```python
# Before (openai_compat_provider.py line 673-679)
if on_content_delta and chunk.choices:
    text = getattr(chunk.choices[0].delta, "reasoning_content", None)
    if text:
        await on_content_delta(text)  # ← leaks reasoning to user
    text = getattr(chunk.choices[0].delta, "content", None)
    if text:
        await on_content_delta(text)
```

## Fix

Remove the `reasoning_content` forwarding from the stream callback. `reasoning_content` is already correctly collected in `_parse_chunks()` and stored in `LLMResponse.reasoning_content` for session history — it just should never be pushed to the user-facing stream.

```python
# After
if on_content_delta and chunk.choices:
    text = getattr(chunk.choices[0].delta, "content", None)
    if text:
        await on_content_delta(text)
```

## Affected Providers

All providers using `OpenAICompatProvider` with models that return `reasoning_content` in streaming deltas (GLM, DeepSeek-R1, Kimi, etc.).