### PR TITLE
security: prevent exec tool from leaking process env vars

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 from typing import Any
@@ -93,13 +94,13 @@ class ExecTool(Tool):
 
         effective_timeout = min(timeout or self.timeout, self._MAX_TIMEOUT)
 
-        env = os.environ.copy()
-        if self.path_append:
-            env["PATH"] = env.get("PATH", "") + os.pathsep + self.path_append
+        env = self._build_env()
+
+        bash = shutil.which("bash") or "/bin/bash"
 
         try:
-            process = await asyncio.create_subprocess_shell(
-                command,
+            process = await asyncio.create_subprocess_exec(
+                bash, "-l", "-c", command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
@@ -153,6 +154,25 @@ class ExecTool(Tool):
 
         except Exception as e:
             return f"Error executing command: {str(e)}"
+
+    def _build_env(self) -> dict[str, str]:
+        """Build a minimal environment for subprocess execution.
+
+        Uses HOME so that ``bash -l`` sources the user's profile (which sets
+        PATH and other essentials).  Only PATH is extended with *path_append*;
+        the parent process's environment is **not** inherited, preventing
+        secrets in env vars from leaking to LLM-generated commands.
+        """
+        home = os.environ.get("HOME", "/tmp")
+        env: dict[str, str] = {
+            "HOME": home,
+            "LANG": os.environ.get("LANG", "C.UTF-8"),
+            "TERM": os.environ.get("TERM", "dumb"),
+        }
+        if self.path_append:
+            # Seed PATH so the login shell can append to it.
+            env["PATH"] = self.path_append
+        return env
 
     def _guard_command(self, command: str, cwd: str) -> str | None:
         """Best-effort safety guard for potentially destructive commands."""

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -96,6 +96,9 @@ class ExecTool(Tool):
 
         env = self._build_env()
 
+        if self.path_append:
+            command = f'export PATH="$PATH:{self.path_append}"; {command}'
+
         bash = shutil.which("bash") or "/bin/bash"
 
         try:
@@ -164,15 +167,11 @@ class ExecTool(Tool):
         secrets in env vars from leaking to LLM-generated commands.
         """
         home = os.environ.get("HOME", "/tmp")
-        env: dict[str, str] = {
+        return {
             "HOME": home,
             "LANG": os.environ.get("LANG", "C.UTF-8"),
             "TERM": os.environ.get("TERM", "dumb"),
         }
-        if self.path_append:
-            # Seed PATH so the login shell can append to it.
-            env["PATH"] = self.path_append
-        return env
 
     def _guard_command(self, command: str, cwd: str) -> str | None:
         """Best-effort safety guard for potentially destructive commands."""

--- a/tests/tools/test_exec_env.py
+++ b/tests/tools/test_exec_env.py
@@ -1,0 +1,30 @@
+"""Tests for exec tool environment isolation."""
+
+import pytest
+
+from nanobot.agent.tools.shell import ExecTool
+
+
+@pytest.mark.asyncio
+async def test_exec_does_not_leak_parent_env(monkeypatch):
+    """Env vars from the parent process must not be visible to commands."""
+    monkeypatch.setenv("NANOBOT_SECRET_TOKEN", "super-secret-value")
+    tool = ExecTool()
+    result = await tool.execute(command="printenv NANOBOT_SECRET_TOKEN")
+    assert "super-secret-value" not in result
+
+
+@pytest.mark.asyncio
+async def test_exec_has_working_path():
+    """Basic commands should be available via the login shell's PATH."""
+    tool = ExecTool()
+    result = await tool.execute(command="echo hello")
+    assert "hello" in result
+
+
+@pytest.mark.asyncio
+async def test_exec_path_append():
+    """The pathAppend config should be available in the command's PATH."""
+    tool = ExecTool(path_append="/opt/custom/bin")
+    result = await tool.execute(command="echo $PATH")
+    assert "/opt/custom/bin" in result

--- a/tests/tools/test_exec_env.py
+++ b/tests/tools/test_exec_env.py
@@ -28,3 +28,11 @@ async def test_exec_path_append():
     tool = ExecTool(path_append="/opt/custom/bin")
     result = await tool.execute(command="echo $PATH")
     assert "/opt/custom/bin" in result
+
+
+@pytest.mark.asyncio
+async def test_exec_path_append_preserves_system_path():
+    """pathAppend must not clobber standard system paths."""
+    tool = ExecTool(path_append="/opt/custom/bin")
+    result = await tool.execute(command="ls /")
+    assert "Exit code: 0" in result


### PR DESCRIPTION
## Why
The exec tool runs LLM-generated shell commands, which are untrusted. Previously it passed the full parent process environment to child processes via `os.environ.copy()`, leaking any secrets stored in env vars (API keys, tokens) to the LLM via commands like `printenv`.

The gateway process needs elevated privileges — it holds API keys, IMAP credentials, and channel tokens to connect to providers and services. But the agent's shell environment should be unprivileged: it executes untrusted LLM-generated commands and must not have access to the gateway's secrets. This separation of privilege between the gateway and the agent shell is a fundamental security boundary.

## Summary
- Replace `create_subprocess_shell` + full env inheritance with `create_subprocess_exec` running `bash -l -c` (login shell) with a minimal environment (HOME, LANG, TERM only)
- The login shell sources the user's `.profile` for PATH setup, so commands work naturally without inheriting the gateway's secrets
- `pathAppend` config still works as a fallback for custom PATH entries

Follow-up PR #2830 builds on this to support `${VAR}` env var interpolation in config, enabling secrets to be moved out of `config.json` into environment variables — where they belong.

## Test plan
- [x] New tests in `tests/tools/test_exec_env.py`:
  - Verifies parent env vars don't leak to commands
  - Verifies basic commands work via login shell PATH
  - Verifies `pathAppend` config is available in PATH
- [x] Full test suite passes (1005 tests)