### PR TITLE
fix(security): restrict ExecTool to workspace for all paths and working directories

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -175,7 +175,12 @@ class ExecTool(Tool):
             if "..\\" in cmd or "../" in cmd:
                 return "Error: Command blocked by safety guard (path traversal detected)"
 
+            # If a base working_dir is configured, it acts as the workspace boundary.
+            workspace = Path(self.working_dir).resolve() if self.working_dir else None
             cwd_path = Path(cwd).resolve()
+
+            if workspace and workspace != cwd_path and workspace not in cwd_path.parents:
+                return "Error: Command blocked by safety guard (working_dir outside workspace)"
 
             for raw in self._extract_absolute_paths(cmd):
                 try:
@@ -185,9 +190,10 @@ class ExecTool(Tool):
                     continue
 
                 media_path = get_media_dir().resolve()
+                boundary = workspace or cwd_path
                 if (p.is_absolute() 
-                    and cwd_path not in p.parents 
-                    and p != cwd_path
+                    and boundary not in p.parents 
+                    and p != boundary
                     and media_path not in p.parents
                     and p != media_path
                 ):

--- a/tests/security/test_exec_workspace.py
+++ b/tests/security/test_exec_workspace.py
@@ -1,0 +1,75 @@
+import pytest
+import os
+import shutil
+from pathlib import Path
+from nanobot.agent.tools.shell import ExecTool
+
+@pytest.mark.asyncio
+async def test_exec_workspace_bypass(tmp_path):
+    # Setup workspace
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    
+    # Create a file outside the workspace
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    secret_file = outside_dir / "secret.txt"
+    secret_file.write_text("sensitive")
+    
+    # Initialize tool with restriction
+    tool = ExecTool(
+        working_dir=str(workspace),
+        restrict_to_workspace=True
+    )
+    
+    # Attempt bypass via working_dir argument
+    command = "rm secret.txt"
+    result = await tool.execute(command, working_dir=str(outside_dir))
+    
+    assert "Error: Command blocked by safety guard (working_dir outside workspace)" in result
+    assert secret_file.exists()
+
+@pytest.mark.asyncio
+async def test_exec_workspace_absolute_path(tmp_path):
+    # Setup workspace
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    
+    # Create a file outside the workspace
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("sensitive")
+    
+    # Initialize tool with restriction
+    tool = ExecTool(
+        working_dir=str(workspace),
+        restrict_to_workspace=True
+    )
+    
+    # Attempt bypass via absolute path
+    command = f"rm {outside_file}"
+    result = await tool.execute(command, working_dir=str(workspace))
+    
+    assert "Error: Command blocked by safety guard (path outside working dir)" in result
+    assert outside_file.exists()
+
+@pytest.mark.asyncio
+async def test_exec_workspace_safe_command(tmp_path):
+    # Setup workspace
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    
+    safe_file = workspace / "safe.txt"
+    safe_file.write_text("safe")
+    
+    # Initialize tool with restriction
+    tool = ExecTool(
+        working_dir=str(workspace),
+        restrict_to_workspace=True
+    )
+    
+    # Command inside workspace should work
+    command = f"rm {safe_file}"
+    result = await tool.execute(command, working_dir=str(workspace))
+    
+    assert "Exit code: 0" in result
+    assert not safe_file.exists()


### PR DESCRIPTION
This PR addresses a security issue in the ExecTool where the restrict_to_workspace setting could be bypassed by explicitly passing a working_dir outside the configured workspace in the tool call.

The current implementation allowed any command to execute as long as the absolute paths within the command matched the caller-provided cwd. By setting working_dir to a location outside the workspace, an LLM could manipulate files anywhere on the system it has access to.

Changes:
- Added a check in _guard_command to ensure the effective cwd is within the configured base working_dir when restrict_to_workspace is enabled.
- Updated absolute path validation to use the configured workspace as the boundary instead of just the provided cwd.
- Added a new test suite in tests/security/test_exec_workspace.py covering these bypass scenarios.

This ensures that the restrict_to_workspace setting is strictly enforced regardless of the tool call arguments.