### PR TITLE
feat(docker): add nanobot-api service with isolated workspace

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       ["serve", "--host", "0.0.0.0", "-w", "/home/nanobot/.nanobot/api-workspace"]
     restart: unless-stopped
     ports:
-      - 8900:8900
+      - 127.0.0.1:8900:8900
     deploy:
       resources:
         limits:


### PR DESCRIPTION
- Add nanobot-api service (OpenAI-compatible HTTP API on port 8900)
- Uses isolated workspace (/root/.nanobot/api-workspace) to avoid session/memory conflicts with nanobot-gateway