### PR TITLE
ci: add ruff lint check for unused imports and variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
     - name: Install all dependencies
       run: uv sync --all-extras
 
+    - name: Lint with ruff
+      run: uv run ruff check nanobot --select F401,F841
+
     - name: Run tests
       run: uv run pytest tests/

--- a/nanobot/agent/__init__.py
+++ b/nanobot/agent/__init__.py
@@ -3,7 +3,7 @@
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.hook import AgentHook, AgentHookContext, CompositeHook
 from nanobot.agent.loop import AgentLoop
-from nanobot.agent.memory import Consolidator, Dream, MemoryStore
+from nanobot.agent.memory import Dream, MemoryStore
 from nanobot.agent.skills import SkillsLoader
 from nanobot.agent.subagent import SubagentManager
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import re
 import os
 import time
 from contextlib import AsyncExitStack, nullcontext

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -9,7 +9,6 @@ import time
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Literal
 
 from loguru import logger

--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -18,7 +18,6 @@ try:
     from nio import (
         AsyncClient,
         AsyncClientConfig,
-        ContentRepositoryConfigError,
         DownloadError,
         InviteEvent,
         JoinError,

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -6,14 +6,14 @@ import asyncio
 import re
 import time
 import unicodedata
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from loguru import logger
 from pydantic import Field
 from telegram import BotCommand, ReactionTypeEmoji, ReplyParameters, Update
 from telegram.error import BadRequest, NetworkError, TimedOut
-from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
+from telegram.ext import Application, ContextTypes, MessageHandler, filters
 from telegram.request import HTTPXRequest
 
 from nanobot.bus.events import OutboundMessage

--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -484,7 +484,7 @@ class WeixinChannel(BaseChannel):
             except httpx.TimeoutException:
                 # Normal for long-poll, just retry
                 continue
-            except Exception as e:
+            except Exception:
                 if not self._running:
                     break
                 consecutive_failures += 1


### PR DESCRIPTION
Add CI step to detect unused imports (F401) and unused variables (F841) with ruff. Clean up existing violations:

- Remove unused Consolidator import in agent/__init__.py
- Remove unused re import in agent/loop.py
- Remove unused Path import in channels/feishu.py
- Remove unused ContentRepositoryConfigError import in channels/matrix.py
- Remove unused field and CommandHandler imports in channels/telegram.py
- Remove unused exception variable in channels/weixin.py