### PR TITLE
docs: fix channel plugin guide — require Pydantic config model

### DIFF
--- a/docs/CHANNEL_PLUGIN_GUIDE.md
+++ b/docs/CHANNEL_PLUGIN_GUIDE.md
@@ -352,7 +352,7 @@ When `streaming` is `false` (default) or omitted, only `send()` is called — no
 
 ### Why Pydantic model is required
 
-`BaseChannel.is_allowed()` and the `supports_streaming` property access config fields via `getattr()` (e.g. `getattr(self.config, "allow_from", [])`). This works for Pydantic models where `allow_from` is a real Python attribute, but **fails silently for plain `dict`** — `dict` has no `allow_from` attribute, so `getattr` always returns the default `[]`, causing all messages to be denied.
+`BaseChannel.is_allowed()` reads the permission list via `getattr(self.config, "allow_from", [])`. This works for Pydantic models where `allow_from` is a real Python attribute, but **fails silently for plain `dict`** — `dict` has no `allow_from` attribute, so `getattr` always returns the default `[]`, causing all messages to be denied.
 
 Built-in channels use Pydantic config models (subclassing `Base` from `nanobot.config.schema`). Plugin channels **must do the same**.
 


### PR DESCRIPTION
### Problem

（和 https://github.com/HKUDS/nanobot/pull/2848 同样的问题）

XXXXChannel 启动时报 `XXXX: allow_from is empty — all access denied`，所有消息被拒绝。

即使 `config.json` 中正确配置了 `"allow_from": ["*"]`，权限检查仍然失败。

### Root Cause

BaseChannel.is_allowed() 通过 getattr(self.config, "allow_from", []) 读取权限列表。这对 Pydantic model 是正确的（allow_from 是 Python 属性），但插件 channel 的 self.config 是原始 dict——getattr(dict, "allow_from") 查找的是对象属性而非字典 key，因此始终返回默认值 []。

内置 channel（Telegram、Discord 等）不受影响，因为它们的 config 是继承 nanobot.config.schema.Base 的 Pydantic model。

### Fix

[#2848](https://github.com/HKUDS/nanobot/pull/2848) 提供的方式是修改 `is_allowed` 源码，但建议在 `XXXXChannel.__init__` 中将 dict config 转换为 Pydantic model，使得外部channel插件的管理方式与内部channel保持一致性
