### PR TITLE
fix(filesystem): correct write success message from bytes to characters

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -186,7 +186,7 @@ class WriteFileTool(_FsTool):
             fp = self._resolve(path)
             fp.parent.mkdir(parents=True, exist_ok=True)
             fp.write_text(content, encoding="utf-8")
-            return f"Successfully wrote {len(content)} bytes to {fp}"
+            return f"Successfully wrote {len(content)} characters to {fp}"
         except PermissionError as e:
             return f"Error: {e}"
         except Exception as e:


### PR DESCRIPTION
## Summary

`WriteFileTool.run()` reports the number of bytes written using `len(content)`, but `len()` on a Python `str` counts Unicode code points (characters), not UTF-8 bytes.

For non-ASCII content such as Chinese text or emoji, the two values diverge — a single Chinese character occupies 3 UTF-8 bytes but counts as 1 by `len()`. This misleads the agent about the actual file size.

## Change

**`nanobot/agent/tools/filesystem.py:189`**

```diff
-return f"Successfully wrote {len(content)} bytes to {fp}"
+return f"Successfully wrote {len(content)} characters to {fp}"
```

## Test plan
- [ ] Write a file containing Chinese/emoji content — success message now says "characters"
- [ ] Write an ASCII-only file — behavior unchanged