### PR TITLE
fix(matrix): compact loose list paragraphs

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -1,6 +1,8 @@
 """Matrix (Element) channel — inbound sync + outbound message/media delivery."""
 
 import asyncio
+from html import escape as _html_escape
+from html.parser import HTMLParser
 import json
 import logging
 import mimetypes
@@ -101,6 +103,135 @@ MATRIX_HTML_CLEANER = nh3.Cleaner(
     link_rel="noopener noreferrer",
 )
 
+
+@dataclass
+class _ListItemHTMLState:
+    parts: list[str]
+    depth: int = 0
+    top_level_p_count: int = 0
+    has_other_top_level_content: bool = False
+
+
+class _CompactLooseListHTMLParser(HTMLParser):
+    """Remove a single paragraph wrapper from simple list items.
+
+    Matrix clients render loose list items with default paragraph margins.
+    We only compact the safe case where the entire list item is one paragraph,
+    which keeps nested lists and multi-paragraph items unchanged.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self.parts: list[str] = []
+        self._stack: list[_ListItemHTMLState] = []
+
+    def _start_tag(self, tag: str, attrs: list[tuple[str, str | None]]) -> str:
+        chunks = [f"<{tag}"]
+        for attr_name, attr_value in attrs:
+            if attr_value is None:
+                chunks.append(f" {attr_name}")
+            else:
+                chunks.append(f' {attr_name}="{_html_escape(attr_value, quote=True)}"')
+        chunks.append(">")
+        return "".join(chunks)
+
+    def _start_end_tag(self, tag: str, attrs: list[tuple[str, str | None]]) -> str:
+        chunks = [f"<{tag}"]
+        for attr_name, attr_value in attrs:
+            if attr_value is None:
+                chunks.append(f" {attr_name}")
+            else:
+                chunks.append(f' {attr_name}="{_html_escape(attr_value, quote=True)}"')
+        chunks.append(" />")
+        return "".join(chunks)
+
+    def _append(self, fragment: str) -> None:
+        if self._stack:
+            self._stack[-1].parts.append(fragment)
+        else:
+            self.parts.append(fragment)
+
+    def _current_state(self) -> _ListItemHTMLState | None:
+        if not self._stack:
+            return None
+        return self._stack[-1]
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "li":
+            self._stack.append(_ListItemHTMLState(parts=[self._start_tag(tag, attrs)]))
+            return
+
+        state = self._current_state()
+        fragment = self._start_tag(tag, attrs)
+        self._append(fragment)
+        if state is None:
+            return
+        if state.depth == 0:
+            if tag == "p":
+                state.top_level_p_count += 1
+            else:
+                state.has_other_top_level_content = True
+        state.depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "li":
+            if not self._stack:
+                return
+            state = self._stack.pop()
+            state.parts.append("</li>")
+            html = "".join(state.parts)
+            if (
+                state.top_level_p_count == 1
+                and not state.has_other_top_level_content
+                and html.startswith("<li><p>")
+                and html.endswith("</p></li>")
+            ):
+                html = "<li>" + html[len("<li><p>") : -len("</p></li>")] + "</li>"
+            self._append(html)
+            return
+
+        state = self._current_state()
+        self._append(f"</{tag}>")
+        if state is None:
+            return
+        if state.depth > 0:
+            state.depth -= 1
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        state = self._current_state()
+        self._append(self._start_end_tag(tag, attrs))
+        if state is not None and state.depth == 0:
+            state.has_other_top_level_content = True
+
+    def handle_data(self, data: str) -> None:
+        state = self._current_state()
+        self._append(data)
+        if state is not None and state.depth == 0 and data.strip():
+            state.has_other_top_level_content = True
+
+    def handle_entityref(self, name: str) -> None:
+        self._append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        self._append(f"&#{name};")
+
+    def handle_comment(self, data: str) -> None:
+        state = self._current_state()
+        self._append(f"<!--{data}-->")
+        if state is not None and state.depth == 0:
+            state.has_other_top_level_content = True
+
+
+def _compact_loose_list_html(html: str) -> str:
+    """Collapse loose list paragraph wrappers without changing other HTML."""
+    parser = _CompactLooseListHTMLParser()
+    try:
+        parser.feed(html)
+        parser.close()
+    except Exception:
+        return html
+    return "".join(parser.parts)
+
 @dataclass
 class _StreamBuf:
     """
@@ -121,7 +252,9 @@ class _StreamBuf:
 def _render_markdown_html(text: str) -> str | None:
     """Render markdown to sanitized HTML; returns None for plain text."""
     try:
-        formatted = MATRIX_HTML_CLEANER.clean(MATRIX_MARKDOWN(text)).strip()
+        formatted = _compact_loose_list_html(
+            MATRIX_HTML_CLEANER.clean(MATRIX_MARKDOWN(text)).strip()
+        )
     except Exception:
         return None
     if not formatted:

--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -6,6 +6,7 @@ from html.parser import HTMLParser
 import json
 import logging
 import mimetypes
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -103,7 +104,6 @@ MATRIX_HTML_CLEANER = nh3.Cleaner(
     link_rel="noopener noreferrer",
 )
 
-
 @dataclass
 class _ListItemHTMLState:
     parts: list[str]
@@ -180,6 +180,7 @@ class _CompactLooseListHTMLParser(HTMLParser):
             state = self._stack.pop()
             state.parts.append("</li>")
             html = "".join(state.parts)
+            html = re.sub(r"</p>\s*</li>$", "</p></li>", html)
             if (
                 state.top_level_p_count == 1
                 and not state.has_other_top_level_content

--- a/tests/channels/test_matrix_channel.py
+++ b/tests/channels/test_matrix_channel.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1224,6 +1225,27 @@ async def test_send_adds_formatted_body_for_markdown() -> None:
     assert "<h1>Headline</h1>" in str(content["formatted_body"])
     assert "<table>" in str(content["formatted_body"])
     assert "<li>[x] done</li>" in str(content["formatted_body"])
+
+
+@pytest.mark.asyncio
+async def test_send_compacts_loose_list_paragraphs() -> None:
+    channel = MatrixChannel(_make_config(), MessageBus())
+    client = _FakeAsyncClient("", "", "", None)
+    channel.client = client
+
+    markdown_text = "1. First item\n\n2. Second item"
+    await channel.send(
+        OutboundMessage(channel="matrix", chat_id="!room:matrix.org", content=markdown_text)
+    )
+
+    formatted_body = str(client.room_send_calls[0]["content"]["formatted_body"])
+    normalized = re.sub(r"\s+", " ", formatted_body)
+
+    assert "<li><p>" not in formatted_body
+    assert "<p>First item</p>" not in formatted_body
+    assert "<p>Second item</p>" not in formatted_body
+    assert "<li>First item</li>" in normalized
+    assert "<li>Second item</li>" in normalized
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This fixes a Matrix HTML rendering bug where loose Markdown lists could show extra paragraph spacing inside list items, making the marker and text appear separated in clients like Element.

The change stays local to Matrix outbound HTML rendering, and the regression test covers the loose-list case so it should not affect other channels or existing formatting behavior.