### PR TITLE
fix(discord): preserve forwarded referenced messages

### DIFF
--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -562,12 +562,27 @@ class DiscordChannel(BaseChannel):
         channel_id = self._channel_key(message.channel)
         self._remember_channel(message.channel)
         content = message.content or ""
+        forwarded_message = self._resolve_forwarded_message(message)
 
         if not self._should_accept_inbound(message, sender_id, content):
             return
 
         media_paths, attachment_markers = await self._download_attachments(message.attachments)
         full_content = self._compose_inbound_content(content, attachment_markers)
+        if forwarded_message is not None:
+            forwarded_media_paths, forwarded_attachment_markers = await self._download_attachments(
+                forwarded_message.attachments,
+            )
+            media_paths.extend(forwarded_media_paths)
+            forwarded_content = self._compose_forwarded_content(
+                forwarded_message.content or "",
+                forwarded_attachment_markers,
+            )
+            if forwarded_content:
+                if full_content == "[empty message]":
+                    full_content = forwarded_content
+                else:
+                    full_content = "\n".join(part for part in [full_content, forwarded_content] if part)
         metadata = self._build_inbound_metadata(message)
         parent_channel_id = self._channel_parent_key(message.channel)
         session_key = None
@@ -717,6 +732,14 @@ class DiscordChannel(BaseChannel):
         return message_type not in {discord.MessageType.default, discord.MessageType.reply}
 
     @staticmethod
+    def _compose_forwarded_content(content: str, attachment_markers: list[str]) -> str:
+        """Combine forwarded message text with a visible forwarded prefix."""
+        forwarded_content = DiscordChannel._compose_inbound_content(content, attachment_markers)
+        if not forwarded_content:
+            return ""
+        return "\n".join(("[forwarded message]", forwarded_content))
+
+    @staticmethod
     def _build_inbound_metadata(message: discord.Message) -> dict[str, str | None]:
         """Build metadata for inbound Discord messages."""
         reply_to = (
@@ -729,6 +752,30 @@ class DiscordChannel(BaseChannel):
             "guild_id": str(message.guild.id) if message.guild else None,
             "reply_to": reply_to,
         }
+
+    @staticmethod
+    def _resolve_forwarded_message(message: discord.Message) -> discord.Message | None:
+        """Return the referenced forward payload when Discord marks the message as forwarded."""
+        reference = getattr(message, "reference", None)
+        if reference is None:
+            return None
+        if not DiscordChannel._is_forward_reference_type(getattr(reference, "type", None)):
+            return None
+        referenced_message = getattr(message, "referenced_message", None)
+        return referenced_message if referenced_message is not None else None
+
+    @staticmethod
+    def _is_forward_reference_type(reference_type: object) -> bool:
+        """Check whether a Discord message reference represents a forward."""
+        if reference_type is None:
+            return False
+        if reference_type == 1:
+            return True
+        name = getattr(reference_type, "name", None)
+        if isinstance(name, str):
+            return name.lower() == "forward"
+        type_name = str(reference_type).lower()
+        return type_name.endswith("forward")
 
     def _should_respond_in_group(self, message: discord.Message, content: str) -> bool:
         """Check if the bot should respond in a guild channel based on policy."""

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -186,17 +186,17 @@ def _make_message(
     reply_to: int | None = None,
     reply_author_id: int | None = None,
     message_type=None,
+    message_reference_type: object | None = None,
+    referenced_message: object | None = None,
 ):
     # Factory for incoming Discord message objects with optional guild/reply/attachments.
     guild = SimpleNamespace(id=guild_id) if guild_id is not None else None
-    referenced_message = (
-        SimpleNamespace(author=SimpleNamespace(id=reply_author_id))
-        if reply_author_id is not None
-        else None
-    )
+    if referenced_message is None and reply_author_id is not None:
+        referenced_message = SimpleNamespace(author=SimpleNamespace(id=reply_author_id))
+        
     reference = (
-        SimpleNamespace(message_id=reply_to, resolved=referenced_message)
-        if reply_to is not None
+        SimpleNamespace(message_id=reply_to, type=message_reference_type, resolved=referenced_message)
+        if reply_to is not None or message_reference_type is not None
         else None
     )
     return SimpleNamespace(
@@ -208,6 +208,7 @@ def _make_message(
         raw_mentions=[],
         attachments=attachments or [],
         reference=reference,
+        referenced_message=referenced_message,
         id=message_id,
         type=message_type or discord.MessageType.default,
     )
@@ -612,6 +613,64 @@ async def test_on_message_downloads_attachments(tmp_path, monkeypatch) -> None:
     assert len(handled) == 1
     assert handled[0]["media"] == [str(tmp_path / "12_photo.png")]
     assert "[attachment:" in handled[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_on_message_includes_forwarded_referenced_message_content(tmp_path, monkeypatch) -> None:
+    # Forwarded messages should surface referenced text and attachments when Discord omits snapshots.
+    channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), MessageBus())
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle  # type: ignore[method-assign]
+    monkeypatch.setattr("nanobot.channels.discord.get_media_dir", lambda _name: tmp_path)
+
+    forwarded_attachment = _FakeAttachment(99, "forwarded.png")
+    await channel._on_message(
+        _make_message(
+            content="",
+            message_reference_type=1,
+            referenced_message=SimpleNamespace(
+                content="forwarded body",
+                attachments=[forwarded_attachment],
+            ),
+        )
+    )
+
+    assert len(handled) == 1
+    assert handled[0]["media"] == [str(tmp_path / "99_forwarded.png")]
+    assert handled[0]["content"] == "[forwarded message]\nforwarded body\n[attachment: 99_forwarded.png]"
+
+
+@pytest.mark.asyncio
+async def test_on_message_does_not_treat_ordinary_reply_as_forward(tmp_path, monkeypatch) -> None:
+    # Ordinary replies must keep their current behavior even if referenced_message is present.
+    channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), MessageBus())
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle  # type: ignore[method-assign]
+    monkeypatch.setattr("nanobot.channels.discord.get_media_dir", lambda _name: tmp_path)
+
+    await channel._on_message(
+        _make_message(
+            content="reply body",
+            reply_to=321,
+            referenced_message=SimpleNamespace(
+                content="should be ignored",
+                attachments=[_FakeAttachment(101, "ignored.png")],
+            ),
+        )
+    )
+
+    assert len(handled) == 1
+    assert handled[0]["content"] == "reply body"
+    assert handled[0]["media"] == []
+    assert handled[0]["metadata"]["reply_to"] == "321"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This fixes Discord inbound normalization so forwarded messages that arrive via `referenced_message` still surface their body text and attachments to the agent, even when `message_snapshots` are absent. Ordinary replies keep their existing behavior. The change is covered by regression tests for forwarded text, forwarded attachments, and non-forward reply handling.