### PR TITLE
fix(matrix): correct e2eeEnabled camelCase alias mapping

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -209,7 +209,7 @@ class MatrixConfig(Base):
     password: str = ""
     access_token: str = ""
     device_id: str = ""
-    e2ee_enabled: bool = True
+    e2ee_enabled: bool = Field(default=True, alias="e2eeEnabled")
     sync_stop_grace_seconds: int = 2
     max_media_bytes: int = 20 * 1024 * 1024
     allow_from: list[str] = Field(default_factory=list)


### PR DESCRIPTION
Fixes #2851

## Problem

Pydantic's `to_camel` function generates `e2EeEnabled` (treating 'ee' as a Word boundary) for the field `e2ee_enabled`. Users writing `e2eeEnabled` in their JSON config (the natural/intuitive Spelling) get the Default value instead of `false`.

## Root Cause

`to_camel('e2ee_enabled')` → `e2EeEnabled` (incorrect)
`to_camel('e2eeEnabled')` → `e2eeEnabled` (What users Expect)

The pydantic `alias_generator=to_camel` treats `ee` as a Word boundary, generating `e2EeEnabled` instead of the intuitive `e2eeEnabled`.

## Fix

Add explicit `alias='e2eeEnabled'` to the `e2ee_enabled` field to override the incorrect auto-generated alias. Both `e2eeEnabled` and `e2ee_enabled` now work.

## Test

```python
c1 = TestConfig.model_validate({'e2eeEnabled': False})
print(c1.e2ee_enabled)  # False ✅

C2 = TestConfig.model_validate({'e2ee_enabled': False})
print(C2.e2ee_enabled)  # False ✅

C3 = TestConfig.model_validate({})
print(C3.e2ee_enabled)  # True (default) ✅
```

## Changes

1 file, 1 line changed