### PR TITLE
fix(docker): Windows CRLF breaks entrypoint.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure shell scripts always use LF line endings (Docker/Linux compat)
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN useradd -m -u 1000 -s /bin/bash nanobot && \
     chown -R nanobot:nanobot /home/nanobot /app
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh && chmod +x /usr/local/bin/entrypoint.sh
 
 USER nanobot
 ENV HOME=/home/nanobot


### PR DESCRIPTION
## Summary

Fixes #2878 — Docker build on Windows fails with `exec /usr/local/bin/entrypoint.sh: no such file or directory`.

## Root cause

`COPY entrypoint.sh` in Docker preserves the host's CRLF line endings on Windows. The shebang `#!/bin/sh\r` is interpreted literally — Linux can't find `/bin/sh\r`, hence "no such file or directory".

## Fix

1. **`.gitattributes`** — enforce LF for `*.sh` files so git always stores them with Unix line endings regardless of OS
2. **`Dockerfile`** — `sed -i 's/\r$//'` before `chmod` as a belt-and-suspenders guard (covers cases where someone clones without gitattributes)

## Testing

- Reproduces on Windows with `docker compose run --rm nanobot-cli onboard` (all layers cached, then fails at entrypoint)
- After fix: entrypoint executes correctly

