### PR TITLE
fix(feishu): use BaseRequest instead of RawRequest for bot info API

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -410,15 +410,19 @@ class FeishuChannel(BaseChannel):
         """Fetch the bot's own open_id via GET /open-apis/bot/v3/info."""
         try:
             import lark_oapi as lark
-            request = lark.RawRequest.builder() \
-                .http_method(lark.HttpMethod.GET) \
-                .uri("/open-apis/bot/v3/info") \
+
+            request = (
+                lark.BaseRequest.builder()
+                .http_method(lark.HttpMethod.GET)
+                .uri("/open-apis/bot/v3/info")
+                .token_types({lark.AccessTokenType.TENANT})
                 .build()
+            )
             response = self._client.request(request)
             if response.success():
                 import json
                 data = json.loads(response.raw.content)
-                bot = (data.get("data") or data).get("bot") or data.get("bot") or {}
+                bot = data.get("bot", {})
                 return bot.get("open_id")
             logger.warning("Failed to get bot info: code={}, msg={}", response.code, response.msg)
             return None


### PR DESCRIPTION
## Problem
The `_fetch_bot_open_id()` method was failing silently because `RawRequest` doesn't support the `http_method` attribute, resulting in the warning:
```
Could not fetch bot open_id; @mention matching may be inaccurate
```

## Root Cause
`RawRequest` class only has `uri`, `headers`, and `body` attributes, missing `http_method` and `token_types` required by the Transport layer.

## Solution
Use `BaseRequest` instead, which has full builder pattern support:
- `.http_method(HttpMethod.GET)` - explicitly set GET method
- `.token_types({AccessTokenType.TENANT})` - proper auth token handling

Also fixed response parsing: `bot` field is directly in response JSON, not nested under `data`.

## Testing
- [x] Verified bot open_id is successfully fetched on startup
- [x] No more "Could not fetch bot open_id" warning
- [x] @mention matching works correctly with accurate open_id