### PR TITLE
feat(memory):dream enhancement (#2887)

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -575,13 +575,15 @@ class Dream:
         )
 
         # Current file contents
+        current_date = datetime.now().strftime("%Y-%m-%d")
         current_memory = self.store.read_memory() or "(empty)"
         current_soul = self.store.read_soul() or "(empty)"
         current_user = self.store.read_user() or "(empty)"
         file_context = (
-            f"## Current MEMORY.md\n{current_memory}\n\n"
-            f"## Current SOUL.md\n{current_soul}\n\n"
-            f"## Current USER.md\n{current_user}"
+            f"## Current Date\n{current_date}\n\n"
+            f"## Current MEMORY.md ({len(current_memory)} chars)\n{current_memory}\n\n"
+            f"## Current SOUL.md ({len(current_soul)} chars)\n{current_soul}\n\n"
+            f"## Current USER.md ({len(current_user)} chars)\n{current_user}"
         )
 
         # Phase 1: Analyze
@@ -603,7 +605,7 @@ class Dream:
                 tool_choice=None,
             )
             analysis = phase1_response.content or ""
-            logger.debug("Dream Phase 1 complete ({} chars)", len(analysis))
+            logger.debug("Dream Phase 1 analysis ({} chars): {}", len(analysis), analysis[:500])
         except Exception:
             logger.exception("Dream Phase 1 failed")
             return False
@@ -633,6 +635,8 @@ class Dream:
                 "Dream Phase 2 complete: stop_reason={}, tool_events={}",
                 result.stop_reason, len(result.tool_events),
             )
+            for ev in (result.tool_events or []):
+                logger.info("Dream tool_event: name={}, status={}, detail={}", ev.get("name"), ev.get("status"), ev.get("detail", "")[:200])
         except Exception:
             logger.exception("Dream Phase 2 failed")
             result = None

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -1,13 +1,23 @@
-Compare conversation history against current memory files.
-Output one line per finding:
-[FILE] atomic fact or change description
+Compare conversation history against current memory files. Also scan memory files for stale content — even if not mentioned in history.
 
-Files: USER (identity, preferences, habits), SOUL (bot behavior, tone), MEMORY (knowledge, project context, tool patterns)
+Output one line per finding:
+[FILE] atomic fact (not already in memory)
+[FILE-REMOVE] reason for removal
+
+Files: USER (identity, preferences), SOUL (bot behavior, tone), MEMORY (knowledge, project context)
 
 Rules:
-- Only new or conflicting information — skip duplicates and ephemera
-- Prefer atomic facts: "has a cat named Luna" not "discussed pet care"
+- Atomic facts: "has a cat named Luna" not "discussed pet care"
 - Corrections: [USER] location is Tokyo, not Osaka
-- Also capture confirmed approaches: if the user validated a non-obvious choice, note it
+- Capture confirmed approaches the user validated
 
-If nothing needs updating: [SKIP] no new information
+Staleness — flag for [FILE-REMOVE]:
+- Time-sensitive data older than 14 days: weather, daily status, one-time meetings, passed events
+- Completed one-time tasks: triage, one-time reviews, finished research, resolved incidents
+- Resolved tracking: merged/closed PRs, fixed issues, completed migrations
+- Detailed incident info after 14 days — reduce to one-line summary
+- Superseded: approaches replaced by newer solutions, deprecated dependencies
+
+Do not add: current weather, transient status, temporary errors, conversational filler.
+
+[SKIP] if nothing needs updating.

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -1,13 +1,24 @@
 Update memory files based on the analysis below.
+- [FILE] entries: add the described content to the appropriate file
+- [FILE-REMOVE] entries: delete the corresponding content from memory files
 
-## Quality standards
-- Every line must carry standalone value — no filler
-- Concise bullet points under clear headers
-- Remove outdated or contradicted information
+## File paths (relative to workspace root)
+- SOUL.md
+- USER.md
+- memory/MEMORY.md
 
-## Editing
-- File contents provided below — edit directly, no read_file needed
+Do NOT guess paths.
+
+## Editing rules
+- Edit directly — file contents provided below, no read_file needed
+- Use exact text as old_text, include surrounding blank lines for unique match
 - Batch changes to the same file into one edit_file call
+- For deletions: section header + all bullets as old_text, new_text empty
 - Surgical edits only — never rewrite entire files
-- Do NOT overwrite correct entries — only add, update, or remove
 - If nothing to update, stop without calling tools
+
+## Quality
+- Every line must carry standalone value
+- Concise bullets under clear headers
+- When reducing (not deleting): keep essential facts, drop verbose details
+- If uncertain whether to delete, keep but add "(verify currency)"


### PR DESCRIPTION
## Summary

- **Dream memory cleanup**: enhance Phase 1/Phase 2 prompts with staleness detection so Dream actively removes outdated content from MEMORY.md instead of only appending new information

## Motivation

MEMORY.md accumulates indefinitely because Dream Phase 1 only detected new/conflicting information, never stale content. Over time this leads to outdated triage snapshots, expired server configs, resolved PRs, and verbose incident details that waste context window tokens.

## Changes

### Phase 1 prompt (`dream_phase1.md`)
- Add `[FILE-REMOVE]` directive for staleness detection (14-day threshold, completed tasks, resolved PRs, superseded info, detailed incidents)
- Make stale scan independent of conversation history — scans all memory files even when history doesn't reference them
- Prompt size reduced ~45% by removing redundant rules

### Phase 2 prompt (`dream_phase2.md`)
- Add explicit `[FILE]` → add, `[FILE-REMOVE]` → delete mapping so Phase 2 acts on both directive types
- Add file paths section to prevent LLM path guessing (`memory/MEMORY.md` not `MEMORY.md`)
- Add deletion guidance: section header + bullets as `old_text`, empty `new_text`

### Code (`memory.py`)
- Inject `current_date` into Phase 1 context for age-aware staleness evaluation
- Log Phase 1 analysis (truncated) and Phase 2 tool events for observability

## Test results

Tested with `glm-5-turbo` on real workspace data (149 lines accumulated):

| Run | Before | After | Reduction |
|-----|--------|-------|-----------|
| Streamlined prompts | 149 lines | 100 lines | **-33%** |

Correctly removed: weather data, detailed incident info (→ one-line summaries), completed triage snapshots, stale server configs, resolved PR tracking entries. Added: new information from conversation history.