### PR TITLE
feat(agent): add entry_points-based hook discovery with routing context

### DIFF
--- a/nanobot/agent/hook.py
+++ b/nanobot/agent/hook.py
@@ -16,6 +16,12 @@ class AgentHookContext:
 
     iteration: int
     messages: list[dict[str, Any]]
+    # Routing fields (set from contextvars by the runner)
+    channel: str = "cli"
+    chat_id: str = "direct"
+    session_key: str | None = None
+    message_id: str | None = None
+    sender_id: str | None = None
     response: LLMResponse | None = None
     usage: dict[str, int] = field(default_factory=dict)
     tool_calls: list[ToolCallRequest] = field(default_factory=list)

--- a/nanobot/agent/hooks_registry.py
+++ b/nanobot/agent/hooks_registry.py
@@ -1,0 +1,34 @@
+"""Auto-discovery for AgentHook plugins via entry_points."""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+from loguru import logger
+from nanobot.agent.hook import AgentHook
+
+
+def discover_hooks() -> list[AgentHook]:
+    """Discover AgentHook plugins registered via nanobot.hooks entry_points."""
+    hooks: list[AgentHook] = []
+    for ep in entry_points(group="nanobot.hooks"):
+        try:
+            obj = ep.load()
+            # Support both class and factory/instance patterns
+            if isinstance(obj, type) and issubclass(obj, AgentHook):
+                hooks.append(obj())
+                logger.info("Loaded hook plugin: {}", ep.name)
+            elif isinstance(obj, AgentHook):
+                hooks.append(obj)
+                logger.info("Loaded hook plugin (instance): {}", ep.name)
+            elif callable(obj):
+                instance = obj()
+                if isinstance(instance, AgentHook):
+                    hooks.append(instance)
+                    logger.info("Loaded hook plugin (factory): {}", ep.name)
+                else:
+                    logger.warning("Hook factory '{}' did not return AgentHook instance", ep.name)
+            else:
+                logger.warning("Hook entry point '{}' is not an AgentHook", ep.name)
+        except Exception:
+            logger.exception("Failed to load hook plugin '{}'", ep.name)
+    return hooks

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json
 import os
 import time
@@ -38,6 +39,12 @@ from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
 if TYPE_CHECKING:
     from nanobot.config.schema import ChannelsConfig, ExecToolConfig, WebToolsConfig
     from nanobot.cron.service import CronService
+
+_channel: contextvars.ContextVar[str] = contextvars.ContextVar("_channel", default="cli")
+_chat_id: contextvars.ContextVar[str] = contextvars.ContextVar("_chat_id", default="direct")
+_session_key: contextvars.ContextVar[str | None] = contextvars.ContextVar("_session_key", default=None)
+_message_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("_message_id", default=None)
+_sender_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("_sender_id", default=None)
 
 
 class _LoopHook(AgentHook):
@@ -210,7 +217,10 @@ class AgentLoop:
         self.restrict_to_workspace = restrict_to_workspace
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
-        self._extra_hooks: list[AgentHook] = hooks or []
+        from nanobot.agent.hooks_registry import discover_hooks
+
+        discovered = discover_hooks()
+        self._extra_hooks: list[AgentHook] = (hooks or []) + discovered
 
         self.context = ContextBuilder(workspace, timezone=timezone)
         self.sessions = session_manager or SessionManager(workspace)
@@ -349,6 +359,11 @@ class AgentLoop:
         ``resuming=True`` means tool calls follow (spinner should restart);
         ``resuming=False`` means this is the final response.
         """
+        _channel.set(channel)
+        _chat_id.set(chat_id)
+        _session_key.set(session.key if session else None)
+        _message_id.set(message_id)
+
         loop_hook = _LoopHook(
             self,
             on_progress=on_progress,

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -101,7 +101,16 @@ class AgentRunner:
                     exc,
                 )
                 messages_for_model = messages
-            context = AgentHookContext(iteration=iteration, messages=messages)
+            from nanobot.agent.loop import _channel, _chat_id, _session_key, _message_id, _sender_id
+            context = AgentHookContext(
+                iteration=iteration,
+                messages=messages,
+                channel=_channel.get(),
+                chat_id=_chat_id.get(),
+                session_key=_session_key.get(),
+                message_id=_message_id.get(),
+                sender_id=_sender_id.get(),
+            )
             await hook.before_iteration(context)
             response = await self._request_model(spec, messages_for_model, hook, context)
             raw_usage = self._usage_dict(response.usage)

--- a/tests/unit/test_hooks_registry.py
+++ b/tests/unit/test_hooks_registry.py
@@ -1,0 +1,211 @@
+"""Tests for nanobot.agent.hooks_registry.discover_hooks and AgentHookContext routing fields."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nanobot.agent.hook import AgentHook, AgentHookContext
+from nanobot.agent.hooks_registry import discover_hooks
+
+
+# ---------------------------------------------------------------------------
+# discover_hooks: empty entry points
+# ---------------------------------------------------------------------------
+
+
+def test_discover_hooks_empty() -> None:
+    """No entry points registered → returns empty list."""
+    with patch("nanobot.agent.hooks_registry.entry_points") as mock_ep:
+        mock_ep.return_value = []
+        result = discover_hooks()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# discover_hooks: class pattern
+# ---------------------------------------------------------------------------
+
+
+def test_discover_hooks_class_pattern() -> None:
+    """Entry point returns an AgentHook subclass → instantiates it."""
+
+    class MyHook(AgentHook):
+        pass
+
+    mock_entry = MagicMock()
+    mock_entry.name = "my-hook"
+    mock_entry.load.return_value = MyHook
+
+    with patch("nanobot.agent.hooks_registry.entry_points") as mock_ep:
+        mock_ep.return_value = [mock_entry]
+        result = discover_hooks()
+
+    assert len(result) == 1
+    assert isinstance(result[0], MyHook)
+    assert isinstance(result[0], AgentHook)
+
+
+# ---------------------------------------------------------------------------
+# discover_hooks: instance pattern
+# ---------------------------------------------------------------------------
+
+
+def test_discover_hooks_instance_pattern() -> None:
+    """Entry point returns an AgentHook instance → uses it directly."""
+
+    instance = AgentHook()
+
+    mock_entry = MagicMock()
+    mock_entry.name = "my-instance-hook"
+    mock_entry.load.return_value = instance
+
+    with patch("nanobot.agent.hooks_registry.entry_points") as mock_ep:
+        mock_ep.return_value = [mock_entry]
+        result = discover_hooks()
+
+    assert len(result) == 1
+    assert result[0] is instance
+
+
+# ---------------------------------------------------------------------------
+# discover_hooks: factory pattern
+# ---------------------------------------------------------------------------
+
+
+def test_discover_hooks_factory_pattern() -> None:
+    """Entry point returns a callable that returns an AgentHook → calls it."""
+
+    class FactoryHook(AgentHook):
+        pass
+
+    mock_entry = MagicMock()
+    mock_entry.name = "my-factory-hook"
+    mock_entry.load.return_value = FactoryHook  # class is callable, but not isinstance(AgentHook) — wait...
+
+    # Actually, a class *is* isinstance(type) and issubclass(AgentHook), so it
+    # would hit the class branch. Use a plain function instead.
+    def factory() -> AgentHook:
+        return FactoryHook()
+
+    mock_entry.load.return_value = factory
+
+    with patch("nanobot.agent.hooks_registry.entry_points") as mock_ep:
+        mock_ep.return_value = [mock_entry]
+        result = discover_hooks()
+
+    assert len(result) == 1
+    assert isinstance(result[0], FactoryHook)
+
+
+# ---------------------------------------------------------------------------
+# discover_hooks: factory returns non-hook
+# ---------------------------------------------------------------------------
+
+
+def test_discover_hooks_factory_bad_return() -> None:
+    """Factory returns a non-AgentHook → logs warning, skips entry."""
+
+    def bad_factory():
+        return "not a hook"
+
+    mock_entry = MagicMock()
+    mock_entry.name = "bad-factory"
+    mock_entry.load.return_value = bad_factory
+
+    with patch("nanobot.agent.hooks_registry.entry_points") as mock_ep:
+        mock_ep.return_value = [mock_entry]
+        result = discover_hooks()
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# discover_hooks: load error
+# ---------------------------------------------------------------------------
+
+
+def test_discover_hooks_load_error() -> None:
+    """Entry point raises during load → logs exception, continues to next."""
+
+    class GoodHook(AgentHook):
+        pass
+
+    bad_entry = MagicMock()
+    bad_entry.name = "broken-hook"
+    bad_entry.load.side_effect = RuntimeError("import exploded")
+
+    good_entry = MagicMock()
+    good_entry.name = "good-hook"
+    good_entry.load.return_value = GoodHook
+
+    with patch("nanobot.agent.hooks_registry.entry_points") as mock_ep:
+        mock_ep.return_value = [bad_entry, good_entry]
+        result = discover_hooks()
+
+    assert len(result) == 1
+    assert isinstance(result[0], GoodHook)
+
+
+# ---------------------------------------------------------------------------
+# discover_hooks: invalid type (not class, not instance, not callable)
+# ---------------------------------------------------------------------------
+
+
+def test_discover_hooks_invalid_type() -> None:
+    """Entry point returns an int → logs warning, skips entry."""
+
+    mock_entry = MagicMock()
+    mock_entry.name = "weird-hook"
+    mock_entry.load.return_value = 42
+
+    with patch("nanobot.agent.hooks_registry.entry_points") as mock_ep:
+        mock_ep.return_value = [mock_entry]
+        result = discover_hooks()
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# AgentHookContext routing fields
+# ---------------------------------------------------------------------------
+
+
+def test_agent_hook_context_routing_fields() -> None:
+    """Default values are set correctly and fields are mutable."""
+    ctx = AgentHookContext(iteration=1, messages=[])
+
+    # Defaults
+    assert ctx.channel == "cli"
+    assert ctx.chat_id == "direct"
+    assert ctx.session_key is None
+    assert ctx.message_id is None
+    assert ctx.sender_id is None
+
+    # Assignment
+    ctx.channel = "slack"
+    ctx.chat_id = "C123"
+    ctx.session_key = "slack:C123"
+    ctx.message_id = "msg1"
+    ctx.sender_id = "U123"
+
+    assert ctx.channel == "slack"
+    assert ctx.chat_id == "C123"
+    assert ctx.session_key == "slack:C123"
+    assert ctx.message_id == "msg1"
+    assert ctx.sender_id == "U123"
+
+
+def test_agent_hook_context_other_defaults() -> None:
+    """Non-routing fields also have correct defaults."""
+    ctx = AgentHookContext(iteration=0, messages=[])
+
+    assert ctx.response is None
+    assert ctx.usage == {}
+    assert ctx.tool_calls == []
+    assert ctx.tool_results == []
+    assert ctx.tool_events == []
+    assert ctx.final_content is None
+    assert ctx.stop_reason is None
+    assert ctx.error is None


### PR DESCRIPTION
## Summary

Adds plugin-based hook discovery via `entry_points(group="nanobot.hooks")` so external packages can register `AgentHook` instances that fire on every agent loop iteration.

## Changes

| File | Description |
|------|-------------|
| `nanobot/agent/hooks_registry.py` | **New** — `discover_hooks()` scans entry_points, supports class/instance/factory patterns |
| `nanobot/agent/hook.py` | Added routing fields to `AgentHookContext`: `channel`, `chat_id`, `session_key`, `message_id`, `sender_id` |
| `nanobot/agent/loop.py` | Contextvars for routing data, auto-discovery in `__init__`, vars set in `_run_agent_loop` |
| `nanobot/agent/runner.py` | `AgentHookContext` populated from contextvars (lazy import avoids circular deps) |

## Usage

Any package can register hooks:

```toml
[project.entry-points."nanobot.hooks"]
session-buddy = "session_buddy.nanobot_hook:SessionBuddyHook"
```

## Design notes

- Follows existing channel plugin pattern (`nanobot.channels` entry_points in `channels/registry.py`)
- `CompositeHook` error isolation protects the agent loop from faulty plugins
- Contextvars thread routing data without modifying `AgentRunSpec` or passing extra params
- Backward compatible — no hooks discovered = no behavior change