### PR TITLE
feat(mcp): expose MCP resources and prompts as read-only tools

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -228,7 +228,10 @@ class MCPPromptWrapper(Tool):
         properties: dict[str, Any] = {}
         required: list[str] = []
         for arg in prompt_def.arguments or []:
-            properties[arg.name] = {"type": "string"}
+            prop: dict[str, Any] = {"type": "string"}
+            if getattr(arg, "description", None):
+                prop["description"] = arg.description
+            properties[arg.name] = prop
             if arg.required:
                 required.append(arg.name)
         self._parameters: dict[str, Any] = {
@@ -284,7 +287,7 @@ class MCPPromptWrapper(Tool):
                 "MCP prompt '{}' failed: {}: {}",
                 self._name, type(exc).__name__, exc,
             )
-            return f"(MCP prompt call failed: {type(exc).__name__}: {exc})"
+            return f"(MCP prompt call failed: {type(exc).__name__})"
 
         parts: list[str] = []
         for message in result.messages:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -93,6 +93,18 @@ def _fake_mcp_module(
     monkeypatch.setitem(sys.modules, "mcp.client.sse", sse_mod)
     monkeypatch.setitem(sys.modules, "mcp.client.streamable_http", streamable_http_mod)
 
+    shared_mod = ModuleType("mcp.shared")
+    exc_mod = ModuleType("mcp.shared.exceptions")
+
+    class _FakeMcpError(Exception):
+        def __init__(self, code: int = -1, message: str = "error"):
+            self.error = SimpleNamespace(code=code, message=message)
+            super().__init__(message)
+
+    exc_mod.McpError = _FakeMcpError
+    monkeypatch.setitem(sys.modules, "mcp.shared", shared_mod)
+    monkeypatch.setitem(sys.modules, "mcp.shared.exceptions", exc_mod)
+
 
 def _make_wrapper(session: object, *, timeout: float = 0.1) -> MCPToolWrapper:
     tool_def = SimpleNamespace(
@@ -481,6 +493,15 @@ def test_prompt_wrapper_no_arguments() -> None:
     assert wrapper.parameters == {"type": "object", "properties": {}, "required": []}
 
 
+def test_prompt_wrapper_preserves_argument_descriptions() -> None:
+    arg = SimpleNamespace(name="topic", required=True, description="The subject to discuss")
+    wrapper = MCPPromptWrapper(None, "srv", _make_prompt_def(arguments=[arg]))
+    assert wrapper.parameters["properties"]["topic"] == {
+        "type": "string",
+        "description": "The subject to discuss",
+    }
+
+
 @pytest.mark.asyncio
 async def test_prompt_wrapper_execute_returns_text() -> None:
     async def get_prompt(name: str, arguments: dict | None = None) -> object:
@@ -512,6 +533,19 @@ async def test_prompt_wrapper_execute_handles_timeout() -> None:
     )
     result = await wrapper.execute()
     assert result == "(MCP prompt call timed out after 0.01s)"
+
+
+@pytest.mark.asyncio
+async def test_prompt_wrapper_execute_handles_mcp_error() -> None:
+    from mcp.shared.exceptions import McpError
+
+    async def get_prompt(name: str, arguments: dict | None = None) -> object:
+        raise McpError(code=42, message="invalid argument")
+
+    wrapper = _make_prompt_wrapper(SimpleNamespace(get_prompt=get_prompt))
+    result = await wrapper.execute()
+    assert "invalid argument" in result
+    assert "code 42" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Expose MCP server **resources** and **prompts** as native nanobot tools, enabling LLM agents to read MCP resources and invoke MCP prompts without custom integration code.
- `MCPResourceWrapper`: surfaces each MCP resource as a zero-parameter read-only tool. Handles text and blob content, with timeout & error resilience.
- `MCPPromptWrapper`: surfaces each MCP prompt as a tool whose parameters mirror the prompt's arguments (including descriptions). Returns the rendered multi-turn conversation as text.
- `connect_mcp_servers` extended to auto-discover resources and prompts alongside existing tools when capability flags are present.
- Standardised error message format across all three wrapper types (tool / resource / prompt).
- Prompt argument `description` fields are now forwarded into the JSON Schema so LLMs understand parameter semantics.
- Comprehensive test coverage (26 tests) including timeout, McpError, blob content, capability gating, and argument description preservation.

## Origin

Cherry-picked from PR #2861 (authored by @tobrien) and rebased onto `main` to produce a clean diff without unrelated nightly-only changes. Review fixes (description forwarding, error format alignment, expanded test mocks) are included as a separate commit.

## Test plan

- [x] `pytest tests/tools/test_mcp_tool.py` — 26/26 passed