### PR TITLE
fix(agent): keep runtime context out of user message

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -26,7 +26,11 @@ class ContextBuilder:
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
 
-    def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
+    def build_system_prompt(
+        self,
+        skill_names: list[str] | None = None,
+        runtime_context: str | None = None,
+    ) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
         parts = [self._get_identity()]
 
@@ -47,6 +51,9 @@ class ContextBuilder:
         skills_summary = self.skills.build_skills_summary()
         if skills_summary:
             parts.append(render_template("agent/skills_section.md", skills_summary=skills_summary))
+
+        if runtime_context:
+            parts.append(runtime_context)
 
         return "\n\n---\n\n".join(parts)
 
@@ -112,23 +119,16 @@ class ContextBuilder:
         """Build the complete message list for an LLM call."""
         runtime_ctx = self._build_runtime_context(channel, chat_id, self.timezone)
         user_content = self._build_user_content(current_message, media)
-
-        # Merge runtime context and user content into a single user message
-        # to avoid consecutive same-role messages that some providers reject.
-        if isinstance(user_content, str):
-            merged = f"{runtime_ctx}\n\n{user_content}"
-        else:
-            merged = [{"type": "text", "text": runtime_ctx}] + user_content
         messages = [
-            {"role": "system", "content": self.build_system_prompt(skill_names)},
+            {"role": "system", "content": self.build_system_prompt(skill_names, runtime_context=runtime_ctx)},
             *history,
         ]
         if messages[-1].get("role") == current_role:
             last = dict(messages[-1])
-            last["content"] = self._merge_message_content(last.get("content"), merged)
+            last["content"] = self._merge_message_content(last.get("content"), user_content)
             messages[-1] = last
             return messages
-        messages.append({"role": current_role, "content": merged})
+        messages.append({"role": current_role, "content": user_content})
         return messages
 
     def _build_user_content(self, text: str, media: list[str] | None) -> str | list[dict[str, Any]]:

--- a/tests/agent/test_context_prompt_cache.py
+++ b/tests/agent/test_context_prompt_cache.py
@@ -60,8 +60,8 @@ def test_system_prompt_reflects_current_dream_memory_contract(tmp_path) -> None:
     assert "write important facts here" not in prompt
 
 
-def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
-    """Runtime metadata should be merged with the user message."""
+def test_runtime_context_is_kept_out_of_user_message(tmp_path) -> None:
+    """Runtime metadata should live in the system prompt, not the user message."""
     workspace = _make_workspace(tmp_path)
     builder = ContextBuilder(workspace)
 
@@ -73,17 +73,14 @@ def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
     )
 
     assert messages[0]["role"] == "system"
-    assert "## Current Session" not in messages[0]["content"]
+    system_content = messages[0]["content"]
+    assert ContextBuilder._RUNTIME_CONTEXT_TAG in system_content
+    assert "Current Time:" in system_content
+    assert "Channel: cli" in system_content
+    assert "Chat ID: direct" in system_content
 
-    # Runtime context is now merged with user message into a single message
     assert messages[-1]["role"] == "user"
-    user_content = messages[-1]["content"]
-    assert isinstance(user_content, str)
-    assert ContextBuilder._RUNTIME_CONTEXT_TAG in user_content
-    assert "Current Time:" in user_content
-    assert "Channel: cli" in user_content
-    assert "Chat ID: direct" in user_content
-    assert "Return exactly: OK" in user_content
+    assert messages[-1]["content"] == "Return exactly: OK"
 
 
 def test_subagent_result_does_not_create_consecutive_assistant_messages(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Fixes #2132.

Move runtime context out of the model-facing user message and place it in the system prompt for the current turn instead.

This keeps actual user content clean while still preserving the runtime metadata for the turn.

## Problem

`ContextBuilder.build_messages()` was merging runtime metadata directly into the current user message, which polluted the model-facing user content with internal metadata like:

- current time
- channel
- chat id

## Changes

- update `nanobot/agent/context.py`
  - allow `build_system_prompt()` to accept turn runtime context
  - include runtime context in the system prompt for the turn
  - stop merging runtime context into the user message content
  - keep existing same-role merge behavior for actual user content

- update `tests/agent/test_context_prompt_cache.py`
  - replace the prior assertion that runtime context is merged into the user message
  - assert that runtime context is present in the system message
  - assert that the user message contains only the real user text

## Why this approach

The previous merge was introduced to avoid providers rejecting consecutive same-role messages, but it changed prompt semantics by making runtime metadata part of the user message.

This keeps the provider-safe message shape while restoring a clean separation between:
- system/runtime context
- actual user content

## Validation

Local verification completed:

- `uv run pytest -q tests/agent/test_context_prompt_cache.py`
- result: `5 passed`

Also verified locally by inspecting the built `messages` payload directly:
- runtime context appears in the `system` message
- the `user` message contains only the original user text

## Scope

This is a focused fix for issue #2132 only.