### PR TITLE
feat(providers): record LLM token usage to workspace JSONL and streamline completion hooks

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -474,6 +474,9 @@ def _make_provider(config: Config):
         max_tokens=defaults.max_tokens,
         reasoning_effort=defaults.reasoning_effort,
     )
+    from nanobot.utils.usage import attach_token_usage_jsonl
+
+    attach_token_usage_jsonl(provider, config.workspace_path)
     return provider
 
 

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -176,4 +176,7 @@ def _make_provider(config: Any) -> Any:
         max_tokens=defaults.max_tokens,
         reasoning_effort=defaults.reasoning_effort,
     )
+    from nanobot.utils.usage import attach_token_usage_jsonl
+
+    attach_token_usage_jsonl(provider, config.workspace_path)
     return provider

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -1,5 +1,7 @@
 """Base LLM provider interface."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import re
@@ -66,6 +68,9 @@ class LLMResponse:
     def has_tool_calls(self) -> bool:
         """Check if response contains tool calls."""
         return len(self.tool_calls) > 0
+
+
+LLMCompletionCallback = Callable[[LLMResponse, dict[str, Any]], Awaitable[None]]
 
 
 @dataclass(frozen=True)
@@ -151,6 +156,24 @@ class LLMProvider(ABC):
         self.api_key = api_key
         self.api_base = api_base
         self.generation: GenerationSettings = GenerationSettings()
+        self.on_completion: list[LLMCompletionCallback] = []
+
+    def add_on_completion(self, callback: LLMCompletionCallback) -> None:
+        """Append *callback*; invoked after each successful (non-error) completion."""
+
+        self.on_completion.append(callback)
+
+    async def _notify_on_completion(
+        self, response: LLMResponse, request_kw: dict[str, Any]
+    ) -> LLMResponse:
+        if response.finish_reason != "error" and self.on_completion:
+            meta = dict(request_kw)
+            for completion_callback in self.on_completion:
+                try:
+                    await completion_callback(response, meta)
+                except Exception:
+                    logger.exception("LLM on_completion: %s callback failed", completion_callback.__name__)
+        return response
 
     @staticmethod
     def _sanitize_empty_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -687,7 +710,7 @@ class LLMProvider(ABC):
             attempt += 1
             response = await call(**kw)
             if response.finish_reason != "error":
-                return response
+                return await self._notify_on_completion(response, kw)
             last_response = response
             error_key = ((response.content or "").strip().lower() or None)
             if error_key and error_key == last_error_key:
@@ -704,12 +727,12 @@ class LLMProvider(ABC):
                     )
                     retry_kw = dict(kw)
                     retry_kw["messages"] = stripped
-                    result = await call(**retry_kw)
+                    retry_response = await call(**retry_kw)
                     # Permanently strip images from the original messages so
                     # subsequent iterations do not repeat the error-retry cycle.
-                    if result.finish_reason != "error":
+                    if retry_response.finish_reason != "error":
                         self._strip_image_content_inplace(original_messages)
-                    return result
+                    return await self._notify_on_completion(retry_response, retry_kw)
                 return response
 
             if persistent and identical_error_count >= self._PERSISTENT_IDENTICAL_ERROR_LIMIT:
@@ -742,7 +765,8 @@ class LLMProvider(ABC):
                 on_retry_wait=on_retry_wait,
             )
 
-        return last_response if last_response is not None else await call(**kw)
+        final = last_response if last_response is not None else await call(**kw)
+        return await self._notify_on_completion(final, kw)
 
     @abstractmethod
     def get_default_model(self) -> str:

--- a/nanobot/utils/usage.py
+++ b/nanobot/utils/usage.py
@@ -1,0 +1,88 @@
+"""JSONL token usage recording for LLM completions.
+
+Concurrency model (per process):
+
+- **Coroutines**: A single ``asyncio.Lock`` per JSONL file path serializes appends
+  within one event loop.
+- **Threads**: The lock registry is guarded by a ``threading.Lock`` so concurrent
+  first-time lookups cannot create duplicate ``asyncio.Lock`` objects for the same
+  path. Callbacks should run on the same event loop that owns the provider (typical
+  for nanobot).
+- **Processes**: Each process has its own ``asyncio.Lock`` table. On POSIX,
+  ``fcntl.flock`` on the open file coordinates writers across processes; on Windows
+  where ``fcntl`` is unavailable, append is best-effort (small JSON lines are often
+  atomic, but concurrent multi-process writers are not fully serialized).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from nanobot.providers.base import LLMCompletionCallback, LLMProvider, LLMResponse
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None  # type: ignore[assignment, unused-ignore]
+
+_jsonl_path_lock_registry: dict[str, asyncio.Lock] = {}
+_registry_lock = threading.Lock()
+
+
+def _lock_for_usage_jsonl_path(path: Path) -> asyncio.Lock:
+    key = str(path.resolve())
+    with _registry_lock:
+        if key not in _jsonl_path_lock_registry:
+            _jsonl_path_lock_registry[key] = asyncio.Lock()
+        return _jsonl_path_lock_registry[key]
+
+
+def make_token_usage_jsonl_handler(usage_dir: Path | str) -> LLMCompletionCallback:
+    """Build an async callback that appends one JSON line per successful LLM completion."""
+
+    resolved_dir = Path(usage_dir).expanduser().resolve()
+
+    async def on_llm_completion(response: LLMResponse, request_meta: dict[str, Any]) -> None:
+        if response.finish_reason == "error":
+            return
+        model = str(request_meta.get("model", ""))
+        payload: dict[str, Any] = {
+            "event": "llm_call",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "model": model.strip(),
+            "finish_reason": response.finish_reason,
+        }
+        payload.update(response.usage or {})
+        line = json.dumps(payload, ensure_ascii=False)
+        date_str = datetime.now(timezone.utc).date().isoformat()
+        path = resolved_dir / f"token_usage_{date_str}.jsonl"
+        lock = _lock_for_usage_jsonl_path(path)
+
+        def _write() -> None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as handle:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX) if fcntl else None
+                try:
+                    handle.write(line + "\n")
+                    handle.flush()
+                finally:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN) if fcntl else None
+
+        async with lock:
+            await asyncio.to_thread(_write)
+
+    return on_llm_completion
+
+
+def attach_token_usage_jsonl(provider: LLMProvider, workspace: Path | str) -> LLMCompletionCallback:
+    """Register JSONL logging on *provider* for each successful LLM completion."""
+
+    root = Path(workspace).expanduser().resolve()
+    handler = make_token_usage_jsonl_handler(root / "usage")
+    provider.add_on_completion(handler)
+    return handler

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import os
 import time
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,7 +14,7 @@ import pytest
 from nanobot.config.schema import AgentDefaults
 from nanobot.agent.tools.base import Tool
 from nanobot.agent.tools.registry import ToolRegistry
-from nanobot.providers.base import LLMResponse, ToolCallRequest
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 
 _MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
 
@@ -2732,3 +2733,80 @@ async def test_injection_cycle_cap_on_error_path():
     # Should cap: _MAX_INJECTION_CYCLES drained rounds + 1 final round that breaks
     assert call_count["n"] == _MAX_INJECTION_CYCLES + 1
     assert drain_count["n"] == _MAX_INJECTION_CYCLES
+
+
+# ---------------------------------------------------------------------------
+# Token usage JSONL (workspace logging)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_usage_jsonl_records_each_llm_call(tmp_path):
+    """JSONL: one llm_call per successful provider completion."""
+    import json
+
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+    from nanobot.utils.usage import attach_token_usage_jsonl
+
+    class SequenceProvider(LLMProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self._step = 0
+
+        async def chat(self, **kwargs) -> LLMResponse:
+            del kwargs
+            self._step += 1
+            if self._step == 1:
+                return LLMResponse(
+                    content="thinking",
+                    tool_calls=[ToolCallRequest(id="call_1", name="list_dir", arguments={"path": "."})],
+                    usage={"prompt_tokens": 100, "completion_tokens": 10, "cached_tokens": 80},
+                )
+            return LLMResponse(
+                content="done",
+                tool_calls=[],
+                usage={"prompt_tokens": 200, "completion_tokens": 20, "cached_tokens": 150},
+            )
+
+        def get_default_model(self) -> str:
+            return "test-model"
+
+    usage_dir = tmp_path / "usage"
+    log_path = usage_dir / f"token_usage_{datetime.now(timezone.utc).date().isoformat()}.jsonl"
+    provider = SequenceProvider()
+    attach_token_usage_jsonl(provider, tmp_path)
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="tool result")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "do task"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        session_key="cli:unit",
+    ))
+
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    first_row = json.loads(lines[0])
+    second_row = json.loads(lines[1])
+
+    assert first_row["event"] == "llm_call"
+    assert first_row["prompt_tokens"] == 100
+    assert first_row["completion_tokens"] == 10
+    assert first_row["cached_tokens"] == 80
+    assert first_row["model"] == "test-model"
+    assert first_row["finish_reason"] != "error"
+    assert "session_key" not in first_row
+    assert "run_id" not in first_row
+
+    assert second_row["event"] == "llm_call"
+    assert second_row["prompt_tokens"] == 200
+    assert second_row["completion_tokens"] == 20
+    assert second_row["cached_tokens"] == 150
+
+    assert result.usage["prompt_tokens"] == 300
+    assert result.usage["completion_tokens"] == 30

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -317,6 +317,7 @@ def test_openai_compat_provider_passes_model_through():
 def test_make_provider_uses_github_copilot_backend():
     from nanobot.cli.commands import _make_provider
     from nanobot.config.schema import Config
+    from nanobot.utils.usage import make_token_usage_jsonl_handler
 
     config = Config.model_validate(
         {
@@ -329,10 +330,22 @@ def test_make_provider_uses_github_copilot_backend():
         }
     )
 
-    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
-        provider = _make_provider(config)
+    captured_usage_dirs: list[Path] = []
+
+    def traced_make_token_usage_jsonl_handler(usage_dir):
+        captured_usage_dirs.append(Path(usage_dir).expanduser().resolve())
+        return make_token_usage_jsonl_handler(usage_dir)
+
+    with patch(
+        "nanobot.utils.usage.make_token_usage_jsonl_handler",
+        side_effect=traced_make_token_usage_jsonl_handler,
+    ):
+        with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+            provider = _make_provider(config)
 
     assert provider.__class__.__name__ == "GitHubCopilotProvider"
+    assert len(provider.on_completion) == 1
+    assert captured_usage_dirs == [config.workspace_path.resolve() / "usage"]
 
 
 def test_github_copilot_provider_strips_prefixed_model_name():
@@ -424,7 +437,7 @@ def mock_agent_runtime(tmp_path):
     with patch("nanobot.config.loader.load_config", return_value=config) as mock_load_config, \
          patch("nanobot.config.loader.resolve_config_env_vars", side_effect=lambda c: c), \
          patch("nanobot.cli.commands.sync_workspace_templates") as mock_sync_templates, \
-         patch("nanobot.cli.commands._make_provider", return_value=object()), \
+         patch("nanobot.cli.commands._make_provider", return_value=MagicMock()), \
          patch("nanobot.cli.commands._print_agent_response") as mock_print_response, \
          patch("nanobot.bus.queue.MessageBus"), \
          patch("nanobot.cron.service.CronService"), \
@@ -499,7 +512,7 @@ def test_agent_config_sets_active_path(monkeypatch, tmp_path: Path) -> None:
     )
     monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
-    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
+    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: MagicMock())
     monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: object())
     monkeypatch.setattr("nanobot.cron.service.CronService", lambda _store: object())
 
@@ -534,7 +547,7 @@ def test_agent_uses_workspace_directory_for_cron_store(monkeypatch, tmp_path: Pa
     monkeypatch.setattr("nanobot.config.loader.set_config_path", lambda _path: None)
     monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
-    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
+    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: MagicMock())
     monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: object())
 
     class _FakeCron:
@@ -580,7 +593,7 @@ def test_agent_workspace_override_does_not_migrate_legacy_cron(
     monkeypatch.setattr("nanobot.config.loader.set_config_path", lambda _path: None)
     monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
-    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
+    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: MagicMock())
     monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: object())
     monkeypatch.setattr("nanobot.config.paths.get_cron_dir", lambda: legacy_dir)
 
@@ -633,7 +646,7 @@ def test_agent_custom_config_workspace_does_not_migrate_legacy_cron(
     monkeypatch.setattr("nanobot.config.loader.set_config_path", lambda _path: None)
     monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
-    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
+    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: MagicMock())
     monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: object())
     monkeypatch.setattr("nanobot.config.paths.get_cron_dir", lambda: legacy_dir)
 
@@ -745,7 +758,7 @@ def _patch_cli_command_runtime(
     )
     monkeypatch.setattr(
         "nanobot.cli.commands._make_provider",
-        make_provider or (lambda _config: object()),
+        make_provider or (lambda _config: MagicMock()),
     )
 
     if message_bus is not None:
@@ -877,7 +890,7 @@ def test_gateway_cron_evaluator_receives_scheduled_reminder_context(
 
     config = Config()
     config.agents.defaults.workspace = str(tmp_path / "config-workspace")
-    provider = object()
+    provider = MagicMock()
     bus = MagicMock()
     bus.publish_outbound = AsyncMock()
     seen: dict[str, object] = {}

--- a/tests/providers/test_usage_concurrency.py
+++ b/tests/providers/test_usage_concurrency.py
@@ -1,0 +1,180 @@
+"""Concurrency tests for JSONL token usage recording (async, threads, processes)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nanobot.providers.base import LLMResponse
+from nanobot.utils.usage import (
+    _lock_for_usage_jsonl_path,
+    make_token_usage_jsonl_handler,
+)
+
+
+def _process_write_one_completion(usage_dir: str, completion_tokens: int) -> None:
+    """Run in a child process: one handler invocation writing a single JSONL line."""
+    import asyncio
+    from pathlib import Path
+
+    from nanobot.providers.base import LLMResponse
+    from nanobot.utils.usage import make_token_usage_jsonl_handler
+
+    handler = make_token_usage_jsonl_handler(Path(usage_dir))
+
+    async def _run() -> None:
+        await handler(
+            LLMResponse(
+                content="x",
+                finish_reason="stop",
+                usage={"completion_tokens": completion_tokens},
+            ),
+            {"model": "mp-stress"},
+        )
+
+    asyncio.run(_run())
+
+
+@pytest.mark.asyncio
+async def test_lock_registry_single_asyncio_lock_per_resolved_path(tmp_path: Path) -> None:
+    """Concurrent lookups must not install two different locks for the same file path."""
+    log_path = tmp_path / "token_usage_2099-01-01.jsonl"
+
+    async def _lookup() -> asyncio.Lock:
+        return _lock_for_usage_jsonl_path(log_path)
+
+    locks = await asyncio.gather(*(_lookup() for _ in range(64)))
+    first = locks[0]
+    assert all(lock is first for lock in locks)
+
+
+@pytest.mark.asyncio
+async def test_many_concurrent_async_writes_all_lines_are_valid_json(
+    tmp_path: Path,
+) -> None:
+    """Many coroutines appending the same daily file: each line must be one JSON object."""
+    usage_dir = tmp_path / "usage"
+    handler = make_token_usage_jsonl_handler(usage_dir)
+
+    async def _one_call(index: int) -> None:
+        await handler(
+            LLMResponse(
+                content="ok",
+                finish_reason="stop",
+                usage={"prompt_tokens": index, "completion_tokens": index + 1},
+            ),
+            {"model": f"model-{index}"},
+        )
+
+    await asyncio.gather(*(_one_call(index) for index in range(200)))
+
+    date_str = datetime.now(timezone.utc).date().isoformat()
+    log_path = usage_dir / f"token_usage_{date_str}.jsonl"
+    raw = log_path.read_text(encoding="utf-8")
+    lines = [line for line in raw.splitlines() if line.strip()]
+    assert len(lines) == 200
+    prompt_values: set[int] = set()
+    for line in lines:
+        row = json.loads(line)
+        assert row["event"] == "llm_call"
+        assert row["finish_reason"] == "stop"
+        assert isinstance(row["prompt_tokens"], int)
+        prompt_values.add(row["prompt_tokens"])
+    assert prompt_values == set(range(200))
+
+
+def test_thread_pool_concurrent_first_touch_same_path_unifies_lock(tmp_path: Path) -> None:
+    """Threads racing on first _lock_for_usage_jsonl_path must still share one asyncio.Lock."""
+
+    log_path = tmp_path / "token_usage_2099-06-15.jsonl"
+
+    def _sync_lookup() -> asyncio.Lock:
+        return _lock_for_usage_jsonl_path(log_path)
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        futures = [pool.submit(_sync_lookup) for _ in range(32)]
+        locks = [future.result() for future in as_completed(futures)]
+
+    assert len({id(lock) for lock in locks}) == 1
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fcntl unavailable; cross-process file locking not implemented for Windows",
+)
+def test_multiprocess_writes_yield_distinct_valid_json_lines(tmp_path: Path) -> None:
+    """POSIX: fcntl + per-process asyncio lock; lines must not be interleaved mid-record."""
+    usage_dir = tmp_path / "usage"
+    usage_dir.mkdir()
+    token_values = list(range(24))
+
+    with ProcessPoolExecutor(max_workers=6) as pool:
+        futures = [
+            pool.submit(_process_write_one_completion, str(usage_dir), token)
+            for token in token_values
+        ]
+        for future in futures:
+            future.result()
+
+    date_str = datetime.now(timezone.utc).date().isoformat()
+    log_path = usage_dir / f"token_usage_{date_str}.jsonl"
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == len(token_values)
+    seen_tokens: set[int] = set()
+    for line in lines:
+        row = json.loads(line)
+        assert row["event"] == "llm_call"
+        seen_tokens.add(row["completion_tokens"])
+    assert seen_tokens == set(token_values)
+
+
+@pytest.mark.asyncio
+async def test_error_finish_reason_skips_write_no_empty_corruption(tmp_path: Path) -> None:
+    """Skipped writes should not leave partial lines (regression guard)."""
+    usage_dir = tmp_path / "usage"
+    handler = make_token_usage_jsonl_handler(usage_dir)
+
+    await handler(
+        LLMResponse(content=None, finish_reason="error", usage={}),
+        {"model": "x"},
+    )
+
+    date_str = datetime.now(timezone.utc).date().isoformat()
+    log_path = usage_dir / f"token_usage_{date_str}.jsonl"
+    assert not log_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_fcntl_write_path_used_when_fcntl_available(tmp_path: Path) -> None:
+    """Ensure the fcntl branch runs on POSIX (mock fcntl to count lock calls)."""
+    usage_dir = tmp_path / "usage"
+    handler = make_token_usage_jsonl_handler(usage_dir)
+
+    lock_calls: list[str] = []
+
+    class _FakeFcntl:
+        LOCK_EX = 2
+        LOCK_UN = 8
+
+        def flock(self, fd: int, op: int) -> None:  # noqa: ARG002
+            lock_calls.append("EX" if op == self.LOCK_EX else "UN")
+
+    fake = _FakeFcntl()
+    with patch("nanobot.utils.usage.fcntl", fake):
+        await handler(
+            LLMResponse(
+                content="ok",
+                finish_reason="stop",
+                usage={"prompt_tokens": 1, "completion_tokens": 2},
+            ),
+            {"model": "mock-fcntl"},
+        )
+
+    assert "EX" in lock_calls and "UN" in lock_calls

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -128,6 +128,7 @@ def test_workspace_override(tmp_path):
 def test_sdk_make_provider_uses_github_copilot_backend():
     from nanobot.config.schema import Config
     from nanobot.nanobot import _make_provider
+    from nanobot.utils.usage import make_token_usage_jsonl_handler
 
     config = Config.model_validate(
         {
@@ -140,10 +141,22 @@ def test_sdk_make_provider_uses_github_copilot_backend():
         }
     )
 
-    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
-        provider = _make_provider(config)
+    captured_usage_dirs: list[Path] = []
+
+    def traced_make_token_usage_jsonl_handler(usage_dir):
+        captured_usage_dirs.append(Path(usage_dir).expanduser().resolve())
+        return make_token_usage_jsonl_handler(usage_dir)
+
+    with patch(
+        "nanobot.utils.usage.make_token_usage_jsonl_handler",
+        side_effect=traced_make_token_usage_jsonl_handler,
+    ):
+        with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+            provider = _make_provider(config)
 
     assert provider.__class__.__name__ == "GitHubCopilotProvider"
+    assert len(provider.on_completion) == 1
+    assert captured_usage_dirs == [config.workspace_path.resolve() / "usage"]
 
 
 @pytest.mark.asyncio
@@ -166,3 +179,74 @@ def test_import_from_top_level():
     from nanobot import Nanobot as N, RunResult as R
     assert N is Nanobot
     assert R is RunResult
+
+
+@pytest.mark.asyncio
+async def test_attach_token_usage_jsonl_registers_callback_on_provider(tmp_path):
+    from datetime import datetime, timezone
+
+    from nanobot.providers.base import LLMResponse
+    from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+    from nanobot.utils.usage import attach_token_usage_jsonl
+
+    provider = OpenAICompatProvider(default_model="gpt-4o")
+    handler = attach_token_usage_jsonl(provider, tmp_path)
+    assert len(provider.on_completion) == 1
+    assert provider.on_completion[0] is handler
+
+    response = LLMResponse(
+        content="ok", finish_reason="stop", usage={"prompt_tokens": 3, "completion_tokens": 1}
+    )
+    await handler(response, {"model": "gpt-4o"})
+    date_str = datetime.now(timezone.utc).date().isoformat()
+    jsonl_path = tmp_path.resolve() / "usage" / f"token_usage_{date_str}.jsonl"
+    assert jsonl_path.is_file()
+    payload = json.loads(jsonl_path.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert payload["model"] == "gpt-4o"
+    assert payload["prompt_tokens"] == 3
+    assert payload["completion_tokens"] == 1
+
+
+def test_add_on_completion_appends_in_order():
+    from nanobot.providers.base import LLMResponse
+    from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+    provider = OpenAICompatProvider(default_model="gpt-4o")
+
+    async def first_callback(response: LLMResponse, request_meta: dict) -> None:
+        del response, request_meta
+
+    async def second_callback(response: LLMResponse, request_meta: dict) -> None:
+        del response, request_meta
+
+    provider.add_on_completion(first_callback)
+    provider.add_on_completion(second_callback)
+
+    assert provider.on_completion == [first_callback, second_callback]
+
+
+@pytest.mark.asyncio
+async def test_notify_on_completion_invokes_each_callback_in_order():
+    from nanobot.providers.base import LLMResponse
+    from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+    provider = OpenAICompatProvider(default_model="gpt-4o")
+    invocation_order: list[str] = []
+
+    async def first_callback(response: LLMResponse, request_meta: dict) -> None:
+        invocation_order.append("first")
+        assert request_meta.get("model") == "test-model"
+        assert response.usage.get("prompt_tokens") == 5
+
+    async def second_callback(response: LLMResponse, request_meta: dict) -> None:
+        invocation_order.append("second")
+        assert request_meta.get("model") == "test-model"
+        assert response.usage.get("prompt_tokens") == 5
+
+    provider.add_on_completion(first_callback)
+    provider.add_on_completion(second_callback)
+
+    response = LLMResponse(content="ok", usage={"prompt_tokens": 5})
+    await provider._notify_on_completion(response, {"model": "test-model"})
+
+    assert invocation_order == ["first", "second"]


### PR DESCRIPTION


- Attach Recorder on LLMProvider; persist usage after successful completions (retry paths included).
- Add TokenUsageJsonlRecorder writing usage/token_usage_YYYY-MM-DD.jsonl per call.
- Wire attach_token_usage_jsonl in Nanobot facade and CLI (agent, serve, gateway).
- Consolidate completion notification into _notify_on_completion; log failing callback by name; notify only when finish_reason is not error and callbacks are registered.
- Tests: JSONL rows and concurrency; CLI/facade integration.