### PR TITLE
chore(gitignore): add Node.js and frontend framework cache entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,24 @@ build/
 pip-wheel-metadata/
 share/python-wheels/
 
+# Frontend (Node.js / npm / yarn / pnpm)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.pnpm-store/
+
+# Frontend bundler & framework caches
+.vite/
+.turbo/
+.next/
+.nuxt/
+.parcel-cache/
+.svelte-kit/
+storybook-static/
+.eslintcache
+
 # Test & coverage
 .coverage
 .coverage.*


### PR DESCRIPTION
Included entries for node_modules, npm, yarn, pnpm, and various frontend build caches to improve project cleanliness and prevent unnecessary files from being tracked.