### PR TITLE
fix(providers): make custom_responses resilient to empty completed responses

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -437,6 +437,15 @@ def _make_provider(config: Config):
         from nanobot.providers.openai_codex_provider import OpenAICodexProvider
 
         provider = OpenAICodexProvider(default_model=model)
+    elif backend == "custom_responses":
+        from nanobot.providers.custom_responses_provider import CustomResponsesProvider
+
+        provider = CustomResponsesProvider(
+            api_key=p.api_key if p else None,
+            api_base=config.get_api_base(model),
+            default_model=model,
+            extra_headers=p.extra_headers if p else None,
+        )
     elif backend == "azure_openai":
         from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -97,6 +97,7 @@ class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
+    custom_responses: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI Responses endpoint
     azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -141,6 +141,20 @@ def _make_provider(config: Any) -> Any:
         from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
 
         provider = GitHubCopilotProvider(default_model=model)
+    elif backend == "custom_responses":
+        from importlib import import_module
+
+        CustomResponsesProvider = getattr(
+            import_module("nanobot.providers.custom_responses_provider"),
+            "CustomResponsesProvider",
+        )
+
+        provider = CustomResponsesProvider(
+            api_key=p.api_key if p else None,
+            api_base=config.get_api_base(model),
+            default_model=model,
+            extra_headers=p.extra_headers if p else None,
+        )
     elif backend == "azure_openai":
         from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
 

--- a/nanobot/providers/custom_responses_provider.py
+++ b/nanobot/providers/custom_responses_provider.py
@@ -1,0 +1,270 @@
+"""Custom provider using OpenAI SDK Responses API."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from openai import AsyncOpenAI
+
+from nanobot.providers.base import LLMProvider, LLMResponse
+from nanobot.providers.openai_responses import (
+    consume_sdk_stream,
+    convert_messages,
+    convert_tools,
+    parse_response_output,
+)
+
+
+class CustomResponsesProvider(LLMProvider):
+    """Direct OpenAI-compatible Responses provider.
+
+    Uses ``AsyncOpenAI`` with ``base_url=api_base`` and calls
+    ``client.responses.create(...)`` for both non-streaming and streaming paths.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        default_model: str = "gpt-4.1",
+        extra_headers: dict[str, str] | None = None,
+    ):
+        super().__init__(api_key, api_base)
+        self.default_model = default_model
+        self.extra_headers = extra_headers or {}
+
+        default_headers = {"x-session-affinity": uuid.uuid4().hex}
+        if extra_headers:
+            default_headers.update(extra_headers)
+
+        self._client = AsyncOpenAI(
+            api_key=api_key or "no-key",
+            base_url=api_base,
+            default_headers=default_headers,
+            max_retries=0,
+        )
+
+    def _build_body(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        model: str | None,
+        max_tokens: int,
+        reasoning_effort: str | None,
+        tool_choice: str | dict[str, Any] | None,
+        parallel_tool_calls: bool | None,
+    ) -> dict[str, Any]:
+        model_name = model or self.default_model
+        sanitized_messages = self._sanitize_empty_content(messages)
+        instructions, input_items = convert_messages(sanitized_messages)
+        instructions = self._with_developer_instructions(sanitized_messages, instructions)
+
+        body: dict[str, Any] = {
+            "model": model_name,
+            "instructions": instructions or None,
+            "input": input_items,
+            "max_output_tokens": max(1, max_tokens),
+        }
+
+        if tools:
+            body["tools"] = convert_tools(tools)
+            body["tool_choice"] = tool_choice or "auto"
+
+        if parallel_tool_calls is not None:
+            body["parallel_tool_calls"] = parallel_tool_calls
+
+        if reasoning_effort:
+            body["reasoning"] = {"effort": reasoning_effort}
+
+        return body
+
+    @staticmethod
+    def _with_developer_instructions(
+        messages: list[dict[str, Any]],
+        base_instructions: str,
+    ) -> str:
+        developer_parts: list[str] = []
+        for message in messages:
+            if message.get("role") != "developer":
+                continue
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                developer_parts.append(content)
+
+        developer_text = "\n\n".join(developer_parts).strip()
+        if not developer_text:
+            return base_instructions
+        if not base_instructions:
+            return developer_text
+        return f"{base_instructions}\n\n{developer_text}"
+
+    @staticmethod
+    def _handle_error(e: Exception) -> LLMResponse:
+        response = getattr(e, "response", None)
+        body = getattr(e, "body", None) or getattr(response, "text", None)
+        body_text = str(body).strip() if body is not None else ""
+        msg = f"Error: {body_text[:500]}" if body_text else f"Error calling LLM: {e}"
+        retry_after = LLMProvider._extract_retry_after_from_headers(
+            getattr(response, "headers", None)
+        )
+        if retry_after is None:
+            retry_after = LLMProvider._extract_retry_after(msg)
+        return LLMResponse(content=msg, finish_reason="error", retry_after=retry_after)
+
+    @staticmethod
+    def _normalize_stream_result(response: LLMResponse) -> LLMResponse:
+        """Apply deterministic finish-reason policy for stream-first assembly.
+
+        Rules:
+        - Tool-bearing turns are never treated as empty-final failures.
+        - ``length`` with no text and no tool calls is escalated to ``error``.
+        - ``stop`` with no text and no tool calls is:
+          - ``empty`` when completion metadata exists (genuine empty success),
+          - ``error`` when completion metadata is missing (parser/stream loss).
+        """
+        content = response.content.strip() if isinstance(response.content, str) else ""
+        has_text = bool(content)
+        has_tool_calls = bool(response.tool_calls)
+        has_completion_metadata = bool(response.usage)
+
+        if has_tool_calls:
+            return LLMResponse(
+                content=content or None,
+                tool_calls=response.tool_calls,
+                finish_reason=response.finish_reason,
+                usage=response.usage,
+                retry_after=response.retry_after,
+                reasoning_content=response.reasoning_content,
+                thinking_blocks=response.thinking_blocks,
+                error_status_code=response.error_status_code,
+                error_kind=response.error_kind,
+                error_type=response.error_type,
+                error_code=response.error_code,
+                error_retry_after_s=response.error_retry_after_s,
+                error_should_retry=response.error_should_retry,
+            )
+
+        if response.finish_reason == "length" and not has_text:
+            return LLMResponse(
+                content="Error: incomplete stream with no content or tool calls",
+                finish_reason="error",
+                usage=response.usage,
+                reasoning_content=response.reasoning_content,
+            )
+
+        if response.finish_reason == "stop" and not has_text:
+            if has_completion_metadata:
+                return LLMResponse(
+                    content=None,
+                    finish_reason="empty",
+                    usage=response.usage,
+                    reasoning_content=response.reasoning_content,
+                )
+            return LLMResponse(
+                content="Error: stream ended without completion metadata",
+                finish_reason="error",
+                usage=response.usage,
+                reasoning_content=response.reasoning_content,
+            )
+
+        return LLMResponse(
+            content=content or None,
+            tool_calls=response.tool_calls,
+            finish_reason=response.finish_reason,
+            usage=response.usage,
+            retry_after=response.retry_after,
+            reasoning_content=response.reasoning_content,
+            thinking_blocks=response.thinking_blocks,
+            error_status_code=response.error_status_code,
+            error_kind=response.error_kind,
+            error_type=response.error_type,
+            error_code=response.error_code,
+            error_retry_after_s=response.error_retry_after_s,
+            error_should_retry=response.error_should_retry,
+        )
+
+    async def _chat_via_stream(
+        self,
+        body: dict[str, Any],
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        request_body = dict(body)
+        request_body["stream"] = True
+        stream_or_response = await self._client.responses.create(**request_body)
+
+        # Compatibility fallback for mocked/non-stream SDK objects.
+        if callable(getattr(stream_or_response, "model_dump", None)) or isinstance(
+            stream_or_response,
+            dict,
+        ):
+            return self._normalize_stream_result(parse_response_output(stream_or_response))
+
+        content, tool_calls, finish_reason, usage, reasoning_content = await consume_sdk_stream(
+            stream_or_response,
+            on_content_delta,
+        )
+        return self._normalize_stream_result(
+            LLMResponse(
+                content=content or None,
+                tool_calls=tool_calls,
+                finish_reason=finish_reason,
+                usage=usage,
+                reasoning_content=reasoning_content,
+            )
+        )
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        parallel_tool_calls: bool | None = None,
+    ) -> LLMResponse:
+        body = self._build_body(
+            messages=messages,
+            tools=tools,
+            model=model,
+            max_tokens=max_tokens,
+            reasoning_effort=reasoning_effort,
+            tool_choice=tool_choice,
+            parallel_tool_calls=parallel_tool_calls,
+        )
+        try:
+            return await self._chat_via_stream(body)
+        except Exception as e:
+            return self._handle_error(e)
+
+    async def chat_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        parallel_tool_calls: bool | None = None,
+    ) -> LLMResponse:
+        body = self._build_body(
+            messages=messages,
+            tools=tools,
+            model=model,
+            max_tokens=max_tokens,
+            reasoning_effort=reasoning_effort,
+            tool_choice=tool_choice,
+            parallel_tool_calls=parallel_tool_calls,
+        )
+        try:
+            return await self._chat_via_stream(body, on_content_delta=on_content_delta)
+        except Exception as e:
+            return self._handle_error(e)
+
+    def get_default_model(self) -> str:
+        return self.default_model

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -82,7 +82,15 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         is_direct=True,
     ),
-
+    # === Custom Responses (direct OpenAI Responses endpoint) ===============
+    ProviderSpec(
+        name="custom_responses",
+        keywords=(),
+        env_key="",
+        display_name="Custom Responses",
+        backend="custom_responses",
+        is_direct=True,
+    ),
     # === Azure OpenAI (direct API calls with API version 2024-10-21) =====
     ProviderSpec(
         name="azure_openai",

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -415,6 +415,25 @@ def test_make_provider_passes_extra_headers_to_custom_provider():
     assert kwargs["default_headers"]["x-session-affinity"] == "sticky-session"
 
 
+def test_make_provider_uses_custom_responses_backend():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "custom_responses", "model": "gpt-4.1"}},
+            "providers": {
+                "custom_responses": {
+                    "apiKey": "test-key",
+                    "apiBase": "https://example.com/v1",
+                }
+            },
+        }
+    )
+
+    with patch("nanobot.providers.custom_responses_provider.AsyncOpenAI"):
+        provider = _make_provider(config)
+
+    assert provider.__class__.__name__ == "CustomResponsesProvider"
+
+
 @pytest.fixture
 def mock_agent_runtime(tmp_path):
     """Mock agent command dependencies for focused CLI tests."""

--- a/tests/providers/test_custom_responses_provider.py
+++ b/tests/providers/test_custom_responses_provider.py
@@ -1,0 +1,452 @@
+"""Tests for custom Responses provider (OpenAI SDK Responses API)."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.providers.base import LLMResponse
+from nanobot.providers.custom_responses_provider import CustomResponsesProvider
+
+
+def _make_sdk_response(
+    content: str = "Hello!",
+    *,
+    status: str = "completed",
+    usage: dict[str, int] | None = None,
+    output: list[dict[str, object]] | None = None,
+    extra_fields: dict[str, object] | None = None,
+) -> MagicMock:
+    """Build a minimal SDK-like Response object."""
+    resp = MagicMock()
+    output_items = output or [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": content}],
+        }
+    ]
+    payload: dict[str, object] = {
+        "output": output_items,
+        "status": status,
+        "usage": usage or {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+    }
+    if extra_fields:
+        payload.update(extra_fields)
+    resp.model_dump = MagicMock(return_value=payload)
+    return resp
+
+
+def test_init_base_url_with_v1_no_trailing_slash() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+    assert str(provider._client.base_url).rstrip("/").endswith("/v1")
+
+
+def test_init_base_url_with_v1_trailing_slash() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1/")
+    assert str(provider._client.base_url).rstrip("/").endswith("/v1")
+
+
+def test_init_passes_extra_headers() -> None:
+    provider = CustomResponsesProvider(
+        api_key="k",
+        api_base="https://api.example.com/v1",
+        extra_headers={"X-Custom-Header": "demo"},
+    )
+    assert provider._client.default_headers["X-Custom-Header"] == "demo"
+    assert "x-session-affinity" in provider._client.default_headers
+
+
+@pytest.mark.asyncio
+async def test_chat_non_streaming_uses_responses_create_and_maps_request_fields() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    responses_create = AsyncMock(return_value=_make_sdk_response("ok"))
+    chat_create = AsyncMock()
+    with (
+        patch.object(provider._client.responses, "create", responses_create),
+        patch.object(provider._client.chat.completions, "create", chat_create),
+    ):
+        result = await provider.chat(
+            messages=[
+                {"role": "system", "content": "Be concise."},
+                {"role": "developer", "content": "Use short bullets."},
+                {"role": "user", "content": "Hello"},
+            ],
+            tools=[{"type": "function", "function": {"name": "echo", "parameters": {}}}],
+            max_tokens=128,
+            tool_choice="required",
+            reasoning_effort="medium",
+            parallel_tool_calls=True,
+        )
+
+    assert isinstance(result, LLMResponse)
+    assert result.content == "ok"
+
+    responses_create.assert_awaited_once()
+    chat_create.assert_not_awaited()
+
+    req = cast(dict[str, Any], responses_create.call_args[1])
+    assert req["instructions"] == "Be concise.\n\nUse short bullets."
+    assert req["input"][0]["role"] == "user"
+    assert req["max_output_tokens"] == 128
+    assert req["tools"] == [
+        {"type": "function", "name": "echo", "description": "", "parameters": {}}
+    ]
+    assert req["tool_choice"] == "required"
+    assert req["parallel_tool_calls"] is True
+    assert req["reasoning"] == {"effort": "medium"}
+    assert "messages" not in req
+    assert "max_tokens" not in req
+    assert "temperature" not in req
+    for excluded in (
+        "previous_response_id",
+        "store",
+        "include",
+        "conversation",
+        "background",
+        "metadata",
+    ):
+        assert excluded not in req
+    assert result.usage == {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+
+@pytest.mark.asyncio
+async def test_chat_non_streaming_parses_tool_call_and_incomplete_status() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    tool_output: list[dict[str, object]] = [
+        {
+            "type": "function_call",
+            "id": "fc_42",
+            "call_id": "call_42",
+            "name": "echo",
+            "arguments": '{"msg":"hi"}',
+        }
+    ]
+    responses_create = AsyncMock(
+        return_value=_make_sdk_response(
+            status="incomplete",
+            usage={"input_tokens": 8, "output_tokens": 0, "total_tokens": 8},
+            output=tool_output,
+        )
+    )
+    with patch.object(provider._client.responses, "create", responses_create):
+        result = await provider.chat(
+            messages=[{"role": "user", "content": "Call echo"}],
+            tools=[{"type": "function", "function": {"name": "echo", "parameters": {}}}],
+        )
+
+    assert result.finish_reason == "length"
+    assert result.content is None
+    assert result.usage == {"prompt_tokens": 8, "completion_tokens": 0, "total_tokens": 8}
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].id == "call_42|fc_42"
+    assert result.tool_calls[0].name == "echo"
+    assert result.tool_calls[0].arguments == {"msg": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_first_uses_deltas_when_completed_payload_is_empty() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    delta_1 = SimpleNamespace(type="response.output_text.delta", delta="Hello")
+    delta_2 = SimpleNamespace(type="response.output_text.delta", delta=" from stream")
+    usage_obj = SimpleNamespace(input_tokens=11, output_tokens=3, total_tokens=14)
+    completed_response = SimpleNamespace(
+        status="completed",
+        usage=usage_obj,
+        output_text=None,
+        output=[],
+    )
+    completed = SimpleNamespace(type="response.completed", response=completed_response)
+
+    async def mock_stream():
+        for event in [delta_1, delta_2, completed]:
+            yield event
+
+    responses_create = AsyncMock(return_value=mock_stream())
+    with patch.object(provider._client.responses, "create", responses_create):
+        result = await provider.chat(messages=[{"role": "user", "content": "Hi"}])
+
+    req = responses_create.call_args[1]
+    assert req["stream"] is True
+    assert req["input"][0]["role"] == "user"
+    assert "messages" not in req
+    assert "max_tokens" not in req
+    assert "temperature" not in req
+    for excluded in (
+        "previous_response_id",
+        "store",
+        "include",
+        "conversation",
+        "background",
+        "metadata",
+    ):
+        assert excluded not in req
+
+    assert result.finish_reason == "stop"
+    assert result.content == "Hello from stream"
+    assert result.usage == {"prompt_tokens": 11, "completion_tokens": 3, "total_tokens": 14}
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_first_finalizes_tool_call_arguments_from_stream_events() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    item_added = SimpleNamespace(
+        type="response.output_item.added",
+        item=SimpleNamespace(
+            type="function_call",
+            id="fc_77",
+            call_id="call_77",
+            name="weather",
+            arguments="",
+        ),
+    )
+    args_delta = SimpleNamespace(
+        type="response.function_call_arguments.delta",
+        call_id="call_77",
+        delta='{"city":"Bei',
+    )
+    args_done = SimpleNamespace(
+        type="response.function_call_arguments.done",
+        call_id="call_77",
+        arguments='{"city":"Beijing"}',
+    )
+    item_done = SimpleNamespace(
+        type="response.output_item.done",
+        item=SimpleNamespace(
+            type="function_call",
+            id="fc_77",
+            call_id="call_77",
+            name="weather",
+            arguments="{}",
+        ),
+    )
+    completed_response = SimpleNamespace(
+        status="completed", usage=None, output_text=None, output=[]
+    )
+    completed = SimpleNamespace(type="response.completed", response=completed_response)
+
+    async def mock_stream():
+        for event in [item_added, args_delta, args_done, item_done, completed]:
+            yield event
+
+    responses_create = AsyncMock(return_value=mock_stream())
+    with patch.object(provider._client.responses, "create", responses_create):
+        result = await provider.chat(
+            messages=[{"role": "user", "content": "Call weather"}],
+            tools=[{"type": "function", "function": {"name": "weather", "parameters": {}}}],
+        )
+
+    assert result.finish_reason == "stop"
+    assert result.content is None
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].id == "call_77|fc_77"
+    assert result.tool_calls[0].name == "weather"
+    assert result.tool_calls[0].arguments == {"city": "Beijing"}
+
+
+@pytest.mark.asyncio
+async def test_chat_non_streaming_failed_status_with_error_shape_maps_to_error() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    responses_create = AsyncMock(
+        return_value=_make_sdk_response(
+            content="",
+            status="failed",
+            output=[],
+            usage={"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+            extra_fields={
+                "error": {"code": "server_error", "message": "boom"},
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+        )
+    )
+
+    with patch.object(provider._client.responses, "create", responses_create):
+        result = await provider.chat(messages=[{"role": "user", "content": "Hi"}])
+
+    assert result.finish_reason == "error"
+    assert result.content is None
+    assert result.usage == {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1}
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_uses_responses_create_and_emits_deltas() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    ev1 = MagicMock(type="response.output_text.delta", delta="Hello")
+    ev2 = MagicMock(type="response.output_text.delta", delta=" world")
+    resp_obj = MagicMock(status="completed", usage=None, output=[])
+    ev3 = MagicMock(type="response.completed", response=resp_obj)
+
+    async def mock_stream():
+        for event in [ev1, ev2, ev3]:
+            yield event
+
+    responses_create = AsyncMock(return_value=mock_stream())
+    chat_create = AsyncMock()
+
+    deltas: list[str] = []
+
+    async def on_delta(text: str) -> None:
+        deltas.append(text)
+
+    with (
+        patch.object(provider._client.responses, "create", responses_create),
+        patch.object(provider._client.chat.completions, "create", chat_create),
+    ):
+        result = await provider.chat_stream(
+            [{"role": "user", "content": "Hi"}],
+            on_content_delta=on_delta,
+        )
+
+    assert result.content == "Hello world"
+    assert result.finish_reason == "stop"
+    assert deltas == ["Hello", " world"]
+    responses_create.assert_awaited_once()
+    chat_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_parses_tool_calls_usage_reasoning_and_incomplete_status() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    item_added = SimpleNamespace(
+        type="response.output_item.added",
+        item=SimpleNamespace(
+            type="function_call", id="fc_9", call_id="call_9", name="echo", arguments=""
+        ),
+    )
+    args_delta = MagicMock(
+        type="response.function_call_arguments.delta",
+        call_id="call_9",
+        delta='{"msg":"partial"}',
+    )
+    args_done = MagicMock(
+        type="response.function_call_arguments.done",
+        call_id="call_9",
+        arguments='{"msg":"done"}',
+    )
+    item_done = SimpleNamespace(
+        type="response.output_item.done",
+        item=SimpleNamespace(
+            type="function_call", id="fc_9", call_id="call_9", name="echo", arguments=""
+        ),
+    )
+    reasoning_summary = SimpleNamespace(type="summary_text", text="Reasoning summary")
+    reasoning_item = SimpleNamespace(type="reasoning", summary=[reasoning_summary])
+    usage_obj = SimpleNamespace(input_tokens=10, output_tokens=4, total_tokens=14)
+    completed_response = SimpleNamespace(
+        status="incomplete", usage=usage_obj, output=[reasoning_item]
+    )
+    completed = SimpleNamespace(type="response.completed", response=completed_response)
+
+    async def mock_stream():
+        for event in [item_added, args_delta, args_done, item_done, completed]:
+            yield event
+
+    responses_create = AsyncMock(return_value=mock_stream())
+    with patch.object(provider._client.responses, "create", responses_create):
+        result = await provider.chat_stream([{"role": "user", "content": "Hi"}])
+
+    assert result.finish_reason == "length"
+    assert result.usage == {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14}
+    assert result.reasoning_content == "Reasoning summary"
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].id == "call_9|fc_9"
+    assert result.tool_calls[0].name == "echo"
+    assert result.tool_calls[0].arguments == {"msg": "done"}
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_failed_event_returns_error_response() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    failed_event = MagicMock(type="response.failed", error={"message": "upstream failed"})
+
+    async def mock_stream():
+        yield failed_event
+
+    responses_create = AsyncMock(return_value=mock_stream())
+    with patch.object(provider._client.responses, "create", responses_create):
+        result = await provider.chat_stream([{"role": "user", "content": "Hi"}])
+
+    assert result.finish_reason == "error"
+    assert "Response failed" in (result.content or "")
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_incomplete_without_content_or_tools_maps_to_error() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    completed_response = SimpleNamespace(status="incomplete", usage=None, output=[])
+    completed = SimpleNamespace(type="response.completed", response=completed_response)
+
+    async def mock_stream():
+        yield completed
+
+    responses_create = AsyncMock(return_value=mock_stream())
+    with patch.object(provider._client.responses, "create", responses_create):
+        result = await provider.chat_stream([{"role": "user", "content": "Hi"}])
+
+    assert result.finish_reason == "error"
+    assert "incomplete stream" in (result.content or "")
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_empty_completed_turn_maps_to_explicit_empty() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    usage_obj = SimpleNamespace(input_tokens=2, output_tokens=0, total_tokens=2)
+    completed_response = SimpleNamespace(status="completed", usage=usage_obj, output=[])
+    completed = SimpleNamespace(type="response.completed", response=completed_response)
+
+    async def mock_stream():
+        yield completed
+
+    responses_create = AsyncMock(return_value=mock_stream())
+    with patch.object(provider._client.responses, "create", responses_create):
+        result = await provider.chat_stream([{"role": "user", "content": "Hi"}])
+
+    assert result.finish_reason == "empty"
+    assert result.content is None
+    assert result.usage == {"prompt_tokens": 2, "completion_tokens": 0, "total_tokens": 2}
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_without_completion_metadata_maps_to_error() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    async def mock_stream():
+        if False:
+            yield None
+
+    responses_create = AsyncMock(return_value=mock_stream())
+    with patch.object(provider._client.responses, "create", responses_create):
+        result = await provider.chat_stream([{"role": "user", "content": "Hi"}])
+
+    assert result.finish_reason == "error"
+    assert "without completion metadata" in (result.content or "")
+
+
+@pytest.mark.asyncio
+async def test_chat_failure_returns_error_response() -> None:
+    provider = CustomResponsesProvider(api_key="k", api_base="https://api.example.com/v1")
+
+    responses_create = AsyncMock(side_effect=Exception("Connection failed"))
+    chat_create = AsyncMock()
+    with (
+        patch.object(provider._client.responses, "create", responses_create),
+        patch.object(provider._client.chat.completions, "create", chat_create),
+    ):
+        result = await provider.chat([{"role": "user", "content": "Hi"}])
+
+    assert isinstance(result, LLMResponse)
+    assert result.finish_reason == "error"
+    assert "Connection failed" in (result.content or "")
+    responses_create.assert_awaited_once()
+    chat_create.assert_not_awaited()

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -146,6 +146,33 @@ def test_sdk_make_provider_uses_github_copilot_backend():
     assert provider.__class__.__name__ == "GitHubCopilotProvider"
 
 
+def test_sdk_make_provider_uses_custom_responses_backend():
+    from nanobot.config.schema import Config
+    from nanobot.nanobot import _make_provider
+
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "custom_responses",
+                    "model": "gpt-4.1",
+                }
+            },
+            "providers": {
+                "custom_responses": {
+                    "apiKey": "test-key",
+                    "apiBase": "https://example.com/v1",
+                }
+            },
+        }
+    )
+
+    with patch("nanobot.providers.custom_responses_provider.AsyncOpenAI"):
+        provider = _make_provider(config)
+
+    assert provider.__class__.__name__ == "CustomResponsesProvider"
+
+
 @pytest.mark.asyncio
 async def test_run_custom_session_key(tmp_path):
     from nanobot.bus.events import OutboundMessage


### PR DESCRIPTION
# custom_responses Change Summary

## 1. Why this document exists

This summary covers the full evolution across two implementation phases.

1. Phase 1 added `custom_responses` as a new provider and backend path.
2. Phase 2 changed that provider to internal stream-first aggregation.

The goal here is to make the timeline clear for teammates who did not follow each commit in real time.

## 2. Phase 1, introducing `custom_responses` as a separate provider

Phase 1 did not modify existing `custom` behavior in place. It introduced `custom_responses` as a distinct provider path.

### 2.1 Provider surface in registry and config

`custom_responses` was added to the provider registry and to the config schema so it can be declared explicitly and discovered through normal provider resolution.

### 2.2 Runtime and CLI wiring

Runtime factory and CLI entry paths were updated so `custom_responses` can be selected and instantiated through normal startup and command flows.

### 2.3 Dedicated provider implementation

A dedicated `custom_responses` provider implementation was added, rather than reusing `custom` with hidden conditionals. This kept behavior boundaries clear and made future fixes local to one provider.

### 2.4 Provider and factory test coverage

Tests were added and updated so provider selection, factory wiring, and CLI level paths all recognize `custom_responses` correctly.

## 3. Phase 2, stream-first internal aggregation refactor

After Phase 1 landed, upstream behavior exposed a reliability gap in non streaming response extraction.

### 3.1 Confirmed upstream bug

In non streaming calls to `/v1/responses`, upstream could return:

1. `status=completed`
2. `output_text=null`
3. `output=[]`

So the completed object could claim success while containing no final text.

### 3.2 Why stream deltas became the source of truth

Streaming events still carried valid text deltas, especially `response.output_text.delta`, even when the non streaming completed object was empty. Because of that mismatch, stream deltas became the reliable source for final text assembly.

### 3.3 What changed in the provider

`custom_responses` was refactored to aggregate text inside the provider from streaming deltas first, then return the assembled final text to upper layers.

This moved fallback logic into one internal location and removed dependence on an unreliable completed payload.

## 4. External compatibility after Phase 2

Public behavior stayed compatible.

1. Runner and channel call patterns did not require interface changes.
2. Non streaming callers, including existing integrations, kept the same calling contract.
3. The fix stayed provider local, so external call sites remained stable.

## 5. Files touched across the two phases

Main files involved:

1. `nanobot/providers/custom_responses_provider.py`
2. `nanobot/providers/registry.py`
3. `nanobot/config/schema.py`
4. `nanobot/nanobot.py`
5. `nanobot/cli/commands.py`
6. `tests/providers/test_custom_responses_provider.py`
7. `tests/cli/test_commands.py`
8. `tests/test_nanobot_facade.py`

Role mapping:

1. Provider file, dedicated implementation and stream-first aggregation behavior.
2. Registry and schema, provider declaration and config surface.
3. Runtime and CLI files, provider factory wiring and command path connectivity.
4. Test files, provider behavior plus runtime and CLI integration coverage.

## 6. Validation summary

Validation covered both the introduction and the refactor outcomes.

1. `custom_responses` can be resolved through registry, config, runtime factory, and CLI paths.
2. Provider and factory related tests cover the new provider path.
3. When non streaming `/v1/responses` returns `status=completed` with `output_text=null` and `output=[]`, provider output still resolves from stream deltas.
4. `response.output_text.delta` aggregation produces stable final text.
5. External caller contracts remain unchanged.

## 7. One line takeaway

`custom_responses` was first added as a separate provider, then hardened with provider-local stream-first aggregation so it still returns final text when upstream non streaming completed objects are empty.
