### PR TITLE
feat: add full <thought> block support for Gemma 4 and similar models

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -83,6 +83,21 @@ class _LoopHook(AgentHook):
     async def on_stream_end(self, context: AgentHookContext, *, resuming: bool) -> None:
         if self._on_stream_end:
             await self._on_stream_end(resuming=resuming)
+        if self._stream_buf:
+            from nanobot.utils.helpers import (
+                extract_think_blocks,
+                extract_thought_blocks,
+            )
+
+            thoughts = extract_thought_blocks(self._stream_buf) or extract_think_blocks(
+                self._stream_buf
+            )
+            if thoughts:
+                logger.debug(
+                    "Model thought blocks ({}): {}",
+                    len(thoughts),
+                    "...".join(t[:100] for t in thoughts),
+                )
         self._stream_buf = ""
 
     async def before_execute_tools(self, context: AgentHookContext) -> None:
@@ -678,6 +693,7 @@ class AgentLoop:
             message.get("tool_calls"),
             message.get("reasoning_content"),
             message.get("thinking_blocks"),
+            message.get("thought_content"),
         )
 
     def _restore_runtime_checkpoint(self, session: Session) -> bool:

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -131,6 +131,7 @@ class AgentRunner:
                     tool_calls=[tc.to_openai_tool_call() for tc in response.tool_calls],
                     reasoning_content=response.reasoning_content,
                     thinking_blocks=response.thinking_blocks,
+                    thought_content=response.thought_content,
                 )
                 messages.append(assistant_message)
                 tools_used.extend(tc.name for tc in response.tool_calls)
@@ -245,6 +246,7 @@ class AgentRunner:
                         clean,
                         reasoning_content=response.reasoning_content,
                         thinking_blocks=response.thinking_blocks,
+                        thought_content=response.thought_content,
                     ))
                     messages.append(build_length_recovery_message())
                     await hook.after_iteration(context)
@@ -278,6 +280,7 @@ class AgentRunner:
                 clean,
                 reasoning_content=response.reasoning_content,
                 thinking_blocks=response.thinking_blocks,
+                thought_content=response.thought_content,
             ))
             await self._emit_checkpoint(
                 spec,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -75,6 +75,7 @@ class AgentDefaults(Base):
     max_tool_result_chars: int = 16_000
     provider_retry_mode: Literal["standard", "persistent"] = "standard"
     reasoning_effort: str | None = None  # low / medium / high / adaptive - enables LLM thinking mode
+    log_thought_blocks: bool = False  # Log model thought content (<thought>, <think>) at DEBUG level
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
     unified_session: bool = False  # Share one session across all channels (single-user multi-device)
     dream: DreamConfig = Field(default_factory=DreamConfig)

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -54,6 +54,7 @@ class LLMResponse:
     retry_after: float | None = None  # Provider supplied retry wait in seconds.
     reasoning_content: str | None = None  # Kimi, DeepSeek-R1, MiMo etc.
     thinking_blocks: list[dict] | None = None  # Anthropic extended thinking
+    thought_content: list[str] | None = None  # Extracted <thought>/<|thought|> blocks (Gemma 4 etc.)
     # Structured error metadata used by retry policy when finish_reason == "error".
     error_status_code: int | None = None
     error_kind: str | None = None  # e.g. "timeout", "connection"

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -32,6 +32,7 @@ from nanobot.providers.openai_responses import (
     convert_tools,
     parse_response_output,
 )
+from nanobot.utils.helpers import extract_thought_blocks
 
 if TYPE_CHECKING:
     from nanobot.providers.registry import ProviderSpec
@@ -543,6 +544,7 @@ class OpenAICompatProvider(LLMProvider):
                         reasoning_content=reasoning_content,
                         finish_reason=str(response_map.get("finish_reason") or "stop"),
                         usage=self._extract_usage(response_map),
+                        thought_content=(extract_thought_blocks(content) or None) if content else None,
                     )
                 return LLMResponse(content="Error: API returned empty choices.", finish_reason="error")
 
@@ -594,6 +596,7 @@ class OpenAICompatProvider(LLMProvider):
                 finish_reason=finish_reason,
                 usage=self._extract_usage(response_map),
                 reasoning_content=reasoning_content if isinstance(reasoning_content, str) else None,
+                thought_content=(extract_thought_blocks(content) or None) if content else None,
             )
 
         if not response.choices:
@@ -641,6 +644,7 @@ class OpenAICompatProvider(LLMProvider):
             finish_reason=finish_reason or "stop",
             usage=self._extract_usage(response),
             reasoning_content=reasoning_content,
+            thought_content=(extract_thought_blocks(content) or None) if content else None,
         )
 
     @classmethod
@@ -728,8 +732,9 @@ class OpenAICompatProvider(LLMProvider):
             for tc in (delta.tool_calls or []) if delta else []:
                 _accum_tc(tc, getattr(tc, "index", 0))
 
+        final_content = "".join(content_parts) or None
         return LLMResponse(
-            content="".join(content_parts) or None,
+            content=final_content,
             tool_calls=[
                 ToolCallRequest(
                     id=b["id"] or _short_tool_id(),
@@ -744,6 +749,7 @@ class OpenAICompatProvider(LLMProvider):
             finish_reason=finish_reason,
             usage=usage,
             reasoning_content="".join(reasoning_parts) or None,
+            thought_content=(extract_thought_blocks(final_content) or None) if final_content else None,
         )
 
     @classmethod

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -15,10 +15,33 @@ from loguru import logger
 
 
 def strip_think(text: str) -> str:
-    """Remove <think>…</think> blocks and any unclosed trailing <think> tag."""
+    """Remove <think>…</think> blocks, <thought>…</thought> blocks, and any unclosed trailing tags."""
     text = re.sub(r"<think>[\s\S]*?</think>", "", text)
     text = re.sub(r"<think>[\s\S]*$", "", text)
+    text = re.sub(r"<thought>[\s\S]*?</thought>", "", text)
+    text = re.sub(r"<thought>[\s\S]*$", "", text)
     return text.strip()
+
+
+def extract_thought_blocks(text: str) -> list[str]:
+    """Extract all <thought>…</thought> block contents from text (for debugging/logging)."""
+    blocks: list[str] = re.findall(r"<thought>([\s\S]*?)</thought>", text)
+    remaining = re.sub(r"<thought>[\s\S]*?</thought>", "", text)
+    unclosed = re.findall(r"<thought>([\s\S]*)$", remaining)
+    return blocks + [u for u in unclosed if u]
+
+
+def extract_think_blocks(text: str) -> list[str]:
+    """Extract all <think>…</think> block contents from text (for debugging/logging)."""
+    blocks: list[str] = re.findall(r"<think>([\s\S]*?)</think>", text)
+    remaining = re.sub(r"<think>[\s\S]*?</think>", "", text)
+    unclosed = re.findall(r"<think>([\s\S]*)$", remaining)
+    return blocks + [u for u in unclosed if u]
+
+
+def has_thought_content(text: str) -> bool:
+    """Check if text contains any <thought> or <think> blocks."""
+    return bool(re.search(r"<thought>|<think>", text))
 
 
 def detect_image_mime(data: bytes) -> str | None:
@@ -270,15 +293,18 @@ def build_assistant_message(
     tool_calls: list[dict[str, Any]] | None = None,
     reasoning_content: str | None = None,
     thinking_blocks: list[dict] | None = None,
+    thought_content: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build a provider-safe assistant message with optional reasoning fields."""
     msg: dict[str, Any] = {"role": "assistant", "content": content or ""}
     if tool_calls:
         msg["tool_calls"] = tool_calls
-    if reasoning_content is not None or thinking_blocks:
+    if reasoning_content is not None or thinking_blocks or thought_content:
         msg["reasoning_content"] = reasoning_content if reasoning_content is not None else ""
     if thinking_blocks:
         msg["thinking_blocks"] = thinking_blocks
+    if thought_content:
+        msg["thought_content"] = thought_content
     return msg
 
 

--- a/tests/providers/test_thought_content_extraction.py
+++ b/tests/providers/test_thought_content_extraction.py
@@ -1,0 +1,196 @@
+"""Tests for thought_content extraction in OpenAICompatProvider.
+
+Covers non-streaming (_parse) and streaming (_parse_chunks) paths for
+providers that emit <thought>…</thought> blocks (e.g. Gemma 4).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+
+# ── _parse: non-streaming dict branch (top-level content) ────────────────
+
+
+def test_parse_dict_top_level_extracts_thought_content() -> None:
+    """<thought> blocks in top-level content are extracted."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response = {
+        "content": "Answer.<thought>reasoning</thought>",
+        "finish_reason": "stop",
+        "usage": {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15},
+    }
+
+    result = provider._parse(response)
+
+    assert result.content == "Answer.<thought>reasoning</thought>"
+    assert result.thought_content == ["reasoning"]
+
+
+def test_parse_dict_top_level_no_thought_when_absent() -> None:
+    """thought_content is None when content has no <thought> tags."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response = {
+        "content": "Just text.",
+        "finish_reason": "stop",
+    }
+
+    result = provider._parse(response)
+
+    assert result.thought_content is None
+
+
+# ── _parse: non-streaming dict branch (choices[].message) ────────────────
+
+
+def test_parse_choices_extracts_thought_content() -> None:
+    """<thought> blocks in message content are extracted."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response = {
+        "choices": [{
+            "message": {
+                "content": "Hi<thought>internal</thought>bye",
+            },
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 2, "completion_tokens": 5, "total_tokens": 7},
+    }
+
+    result = provider._parse(response)
+
+    assert result.content == "Hi<thought>internal</thought>bye"
+    assert result.thought_content == ["internal"]
+
+
+def test_parse_choices_multiple_thought_blocks() -> None:
+    """Multiple <thought> blocks are all extracted."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response = {
+        "choices": [{
+            "message": {
+                "content": "<thought>step1</thought>A<thought>step2</thought>",
+            },
+            "finish_reason": "stop",
+        }],
+    }
+
+    result = provider._parse(response)
+
+    assert result.thought_content == ["step1", "step2"]
+
+
+def test_parse_choices_no_thought_when_absent() -> None:
+    """thought_content is None when message has no <thought> tags."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response = {
+        "choices": [{
+            "message": {"content": "hello"},
+            "finish_reason": "stop",
+        }],
+    }
+
+    result = provider._parse(response)
+
+    assert result.thought_content is None
+
+
+# ── _parse: non-streaming SDK-object branch ──────────────────────────────
+
+
+def test_parse_sdk_object_extracts_thought_content() -> None:
+    """<thought> blocks in SDK message.content are extracted."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    msg = SimpleNamespace(content="Reply<thought>hidden</thought>")
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    response = SimpleNamespace(choices=[choice], usage=None)
+
+    result = provider._parse(response)
+
+    assert result.content == "Reply<thought>hidden</thought>"
+    assert result.thought_content == ["hidden"]
+
+
+def test_parse_sdk_object_no_thought_when_absent() -> None:
+    """thought_content is None when SDK content has no <thought> tags."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    msg = SimpleNamespace(content="plain")
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    response = SimpleNamespace(choices=[choice], usage=None)
+
+    result = provider._parse(response)
+
+    assert result.thought_content is None
+
+
+# ── _parse_chunks: streaming dict branch ─────────────────────────────────
+
+
+def test_parse_chunks_dict_extracts_thought_content() -> None:
+    """<thought> blocks in streamed dict content are extracted."""
+    chunks = [
+        {"choices": [{"finish_reason": None, "delta": {"content": "A<thought>r"}}]},
+        {"choices": [{"finish_reason": None, "delta": {"content": "easoning</thought>B"}}]},
+        {"choices": [{"finish_reason": "stop", "delta": {"content": ""}}]},
+    ]
+
+    result = OpenAICompatProvider._parse_chunks(chunks)
+
+    assert result.content == "A<thought>reasoning</thought>B"
+    assert result.thought_content == ["reasoning"]
+
+
+def test_parse_chunks_dict_no_thought_when_absent() -> None:
+    """thought_content is None when streamed dict content has no <thought>."""
+    chunks = [
+        {"choices": [{"finish_reason": "stop", "delta": {"content": "hi"}}]},
+    ]
+
+    result = OpenAICompatProvider._parse_chunks(chunks)
+
+    assert result.thought_content is None
+
+
+# ── _parse_chunks: streaming SDK-object branch ───────────────────────────
+
+
+def _make_chunk(content: str | None, finish: str | None):
+    delta = SimpleNamespace(content=content, reasoning_content=None, tool_calls=None)
+    choice = SimpleNamespace(finish_reason=finish, delta=delta)
+    return SimpleNamespace(choices=[choice], usage=None)
+
+
+def test_parse_chunks_sdk_extracts_thought_content() -> None:
+    """<thought> blocks in streamed SDK content are extracted."""
+    chunks = [
+        _make_chunk("Start<thought>mid", None),
+        _make_chunk("dle</thought>End", "stop"),
+    ]
+
+    result = OpenAICompatProvider._parse_chunks(chunks)
+
+    assert result.content == "Start<thought>middle</thought>End"
+    assert result.thought_content == ["middle"]
+
+
+def test_parse_chunks_sdk_no_thought_when_absent() -> None:
+    """thought_content is None when SDK streamed content has no <thought>."""
+    chunks = [_make_chunk("hello", "stop")]
+
+    result = OpenAICompatProvider._parse_chunks(chunks)
+
+    assert result.thought_content is None

--- a/tests/utils/test_thought_blocks.py
+++ b/tests/utils/test_thought_blocks.py
@@ -1,0 +1,166 @@
+"""Tests for <thought> block handling helpers and build_assistant_message."""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.utils.helpers import (
+    strip_think,
+    extract_thought_blocks,
+    extract_think_blocks,
+    has_thought_content,
+    build_assistant_message,
+)
+
+
+# ---------------------------------------------------------------------------
+# strip_think
+# ---------------------------------------------------------------------------
+
+class TestStripThink:
+    def test_removes_thought_blocks(self):
+        text = "Hello<thought>internal reasoning</thought>World"
+        assert strip_think(text) == "HelloWorld"
+
+    def test_removes_multiple_thought_blocks(self):
+        text = "<thought>a</thought>mid<thought>b</thought>"
+        assert strip_think(text) == "mid"
+
+    def test_removes_unclosed_trailing_thought(self):
+        text = "visible<thought>unclosed"
+        assert strip_think(text) == "visible"
+
+    def test_removes_think_blocks(self):
+        text = "before<think>secret</think>after"
+        assert strip_think(text) == "beforeafter"
+
+    def test_removes_unclosed_trailing_think(self):
+        text = "ok<think>partial"
+        assert strip_think(text) == "ok"
+
+    def test_strips_result(self):
+        text = "  <thought>x</thought>  hello  "
+        assert strip_think(text) == "hello"
+
+    def test_no_change_when_no_tags(self):
+        assert strip_think("just plain text") == "just plain text"
+
+
+# ---------------------------------------------------------------------------
+# extract_thought_blocks
+# ---------------------------------------------------------------------------
+
+class TestExtractThoughtBlocks:
+    def test_single_block(self):
+        text = "prefix<thought>reasoning here</thought>suffix"
+        assert extract_thought_blocks(text) == ["reasoning here"]
+
+    def test_multiple_blocks(self):
+        text = "<thought>first</thought>gap<thought>second</thought>"
+        assert extract_thought_blocks(text) == ["first", "second"]
+
+    def test_multiline_block(self):
+        text = "<thought>\nline1\nline2\n</thought>"
+        assert extract_thought_blocks(text) == ["\nline1\nline2\n"]
+
+    def test_unclosed_trailing_block(self):
+        text = "visible<thought>unclosed tail"
+        assert extract_thought_blocks(text) == ["unclosed tail"]
+
+    def test_empty_block(self):
+        assert extract_thought_blocks("<thought></thought>") == [""]
+
+    def test_no_blocks_returns_empty(self):
+        assert extract_thought_blocks("no tags here") == []
+
+
+# ---------------------------------------------------------------------------
+# extract_think_blocks
+# ---------------------------------------------------------------------------
+
+class TestExtractThinkBlocks:
+    def test_single_block(self):
+        text = "a<think>secret</think>b"
+        assert extract_think_blocks(text) == ["secret"]
+
+    def test_multiple_blocks(self):
+        text = "<think>one</think>x<think>two</think>"
+        assert extract_think_blocks(text) == ["one", "two"]
+
+    def test_unclosed_trailing_block(self):
+        text = "ok<think>partial"
+        assert extract_think_blocks(text) == ["partial"]
+
+    def test_no_blocks_returns_empty(self):
+        assert extract_think_blocks("nothing") == []
+
+
+# ---------------------------------------------------------------------------
+# has_thought_content
+# ---------------------------------------------------------------------------
+
+class TestHasThoughtContent:
+    def test_detects_thought_tag(self):
+        assert has_thought_content("<thought>x</thought>") is True
+
+    def test_detects_think_tag(self):
+        assert has_thought_content("<think>y</think>") is True
+
+    def test_false_when_no_tags(self):
+        assert has_thought_content("plain text") is False
+
+    def test_false_on_empty_string(self):
+        assert has_thought_content("") is False
+
+
+# ---------------------------------------------------------------------------
+# build_assistant_message
+# ---------------------------------------------------------------------------
+
+class TestBuildAssistantMessage:
+    def test_minimal_message(self):
+        msg = build_assistant_message("hello")
+        assert msg == {"role": "assistant", "content": "hello"}
+
+    def test_none_content_becomes_empty_string(self):
+        msg = build_assistant_message(None)
+        assert msg["content"] == ""
+
+    def test_with_tool_calls(self):
+        tc = [{"id": "1", "type": "function"}]
+        msg = build_assistant_message("ok", tool_calls=tc)
+        assert msg["tool_calls"] == tc
+
+    def test_with_reasoning_content(self):
+        msg = build_assistant_message("hi", reasoning_content="thinking…")
+        assert msg["reasoning_content"] == "thinking…"
+
+    def test_with_thought_content(self):
+        msg = build_assistant_message("hi", thought_content=["step 1", "step 2"])
+        assert msg["thought_content"] == ["step 1", "step 2"]
+
+    def test_with_thinking_blocks(self):
+        blocks = [{"type": "thinking", "thinking": "deep"}]
+        msg = build_assistant_message("hi", thinking_blocks=blocks)
+        assert msg["thinking_blocks"] == blocks
+
+    def test_all_optional_fields(self):
+        msg = build_assistant_message(
+            "answer",
+            tool_calls=[{"id": "1"}],
+            reasoning_content="r",
+            thinking_blocks=[{"type": "x"}],
+            thought_content=["t1"],
+        )
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "answer"
+        assert msg["tool_calls"] == [{"id": "1"}]
+        assert msg["reasoning_content"] == "r"
+        assert msg["thinking_blocks"] == [{"type": "x"}]
+        assert msg["thought_content"] == ["t1"]
+
+    def test_reasoning_content_added_when_thought_content_present(self):
+        """reasoning_content key is injected even when only thought_content is set."""
+        msg = build_assistant_message("hi", thought_content=["x"])
+        assert "reasoning_content" in msg
+        assert msg["reasoning_content"] == ""


### PR DESCRIPTION
## Summary

- **Extends `strip_think()`** to handle `<thought>` tags (Gemma 4) alongside existing `<think>` support
- **Adds extraction helpers** (`extract_thought_blocks`, `extract_think_blocks`, `has_thought_content`) for debugging/observability
- **Adds `thought_content` field** to `LLMResponse` to preserve extracted thought blocks for session history and debugging
- **Extracts thought blocks** in OpenAI-compatible provider (`_parse`, `_parse_chunks`) — works for any model emitting `<thought>` tags
- **Propagates `thought_content`** through the agent runner and session persistence pipeline
- **Adds debug logging** of thought blocks in the streaming hook (`on_stream_end`) at DEBUG level
- **Adds `log_thought_blocks` config option** for toggling thought logging
- **39 new tests** covering stripping, extraction, message building, and provider parsing

## Why

Gemma 4 (and similar models) emit reasoning inside `<thought>...</thought>` blocks inline in the content field. Without this change, those blocks leak to users in chat channels (Telegram, Discord, CLI, etc.).

## Behavior

- `<thought>` content is **stripped** from all user-facing output
- `<thought>` content is **logged** at DEBUG level for debugging
- `<thought>` content is **preserved** in session history as `thought_content` for model continuity
- Backward compatible — existing `<think>` handling unchanged
