### PR TITLE
feat(memory): per-user memory isolation via agents.defaults.per_user_memory

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -21,10 +21,11 @@ class ContextBuilder:
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
     _MAX_RECENT_HISTORY = 50
 
-    def __init__(self, workspace: Path, timezone: str | None = None):
+    def __init__(self, workspace: Path, timezone: str | None = None, user_id: str | None = None):
         self.workspace = workspace
         self.timezone = timezone
-        self.memory = MemoryStore(workspace)
+        self.user_id = user_id
+        self.memory = MemoryStore(workspace, user_id=user_id)
         self.skills = SkillsLoader(workspace)
 
     def build_system_prompt(
@@ -68,9 +69,17 @@ class ContextBuilder:
         system = platform.system()
         runtime = f"{'macOS' if system == 'Darwin' else system} {platform.machine()}, Python {platform.python_version()}"
 
+        # Memory path: per-user when user_id is set, shared otherwise
+        if self.user_id:
+            safe_id = "".join(c if c.isalnum() or c in "-_." else "_" for c in self.user_id)
+            memory_path = f"{workspace_path}/users/{safe_id}/memory"
+        else:
+            memory_path = f"{workspace_path}/memory"
+
         return render_template(
             "agent/identity.md",
             workspace_path=workspace_path,
+            memory_path=memory_path,
             runtime=runtime,
             platform_policy=render_template("agent/platform_policy.md", system=system),
             channel=channel or "",

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -147,6 +147,7 @@ class AgentLoop:
         timezone: str | None = None,
         hooks: list[AgentHook] | None = None,
         unified_session: bool = False,
+        per_user_memory: bool = False,
     ):
         from nanobot.config.schema import ExecToolConfig, WebToolsConfig
 
@@ -178,6 +179,8 @@ class AgentLoop:
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
         self._extra_hooks: list[AgentHook] = hooks or []
+        self._per_user_memory = per_user_memory
+        self._context_cache: dict[str, ContextBuilder] = {}
 
         self.context = ContextBuilder(workspace, timezone=timezone)
         self.sessions = session_manager or SessionManager(workspace)
@@ -207,6 +210,9 @@ class AgentLoop:
         self._concurrency_gate: asyncio.Semaphore | None = (
             asyncio.Semaphore(_max) if _max > 0 else None
         )
+        def _store_factory(user_id: str) -> "MemoryStore":
+            return self._get_context(user_id).memory
+
         self.consolidator = Consolidator(
             store=self.context.memory,
             provider=provider,
@@ -216,6 +222,7 @@ class AgentLoop:
             build_messages=self.context.build_messages,
             get_tool_definitions=self.tools.get_definitions,
             max_completion_tokens=provider.generation.max_tokens,
+            store_factory=_store_factory if per_user_memory else None,
         )
         self.dream = Dream(
             store=self.context.memory,
@@ -274,6 +281,21 @@ class AgentLoop:
                 self._mcp_stack = None
         finally:
             self._mcp_connecting = False
+
+    def _get_context(self, user_id: str | None = None) -> "ContextBuilder":
+        """Return the ContextBuilder for the given user.
+
+        When per_user_memory is enabled, each user gets an isolated ContextBuilder
+        (and therefore an isolated MemoryStore) keyed by user_id.
+        Falls back to the shared self.context when disabled or user_id is None.
+        """
+        if not self._per_user_memory or not user_id:
+            return self.context
+        if user_id not in self._context_cache:
+            self._context_cache[user_id] = ContextBuilder(
+                self.workspace, timezone=self.context.timezone, user_id=user_id
+            )
+        return self._context_cache[user_id]
 
     def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
         """Update context for all tools that need routing info."""
@@ -500,7 +522,7 @@ class AgentLoop:
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
             history = session.get_history(max_messages=0)
             current_role = "assistant" if msg.sender_id == "subagent" else "user"
-            messages = self.context.build_messages(
+            messages = self._get_context(chat_id).build_messages(
                 history=history,
                 current_message=msg.content, channel=channel, chat_id=chat_id,
                 current_role=current_role,
@@ -538,7 +560,7 @@ class AgentLoop:
                 message_tool.start_turn()
 
         history = session.get_history(max_messages=0)
-        initial_messages = self.context.build_messages(
+        initial_messages = self._get_context(msg.chat_id).build_messages(
             history=history,
             current_message=msg.content,
             media=msg.media if msg.media else None,

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -38,10 +38,25 @@ class MemoryStore:
         r"^\[\d{4}-\d{2}-\d{2}[^\]]*\]\s+[A-Z][A-Z0-9_]*(?:\s+\[tools:\s*[^\]]+\])?:"
     )
 
-    def __init__(self, workspace: Path, max_history_entries: int = _DEFAULT_MAX_HISTORY):
+    def __init__(
+        self,
+        workspace: Path,
+        max_history_entries: int = _DEFAULT_MAX_HISTORY,
+        user_id: str | None = None,
+    ):
         self.workspace = workspace
         self.max_history_entries = max_history_entries
-        self.memory_dir = ensure_dir(workspace / "memory")
+        self.user_id = user_id
+
+        # Per-user memory lives under workspace/users/{user_id}/memory/.
+        # Falls back to workspace/memory/ for single-user setups or when
+        # user_id is not provided (backwards compatible).
+        if user_id:
+            safe_id = "".join(c if c.isalnum() or c in "-_." else "_" for c in user_id)
+            self.memory_dir = ensure_dir(workspace / "users" / safe_id / "memory")
+        else:
+            self.memory_dir = ensure_dir(workspace / "memory")
+
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.history_file = self.memory_dir / "history.jsonl"
         self.legacy_history_file = self.memory_dir / "HISTORY.md"
@@ -360,8 +375,10 @@ class Consolidator:
         build_messages: Callable[..., list[dict[str, Any]]],
         get_tool_definitions: Callable[[], list[dict[str, Any]]],
         max_completion_tokens: int = 4096,
+        store_factory: Callable[[str], MemoryStore] | None = None,
     ):
         self.store = store
+        self._store_factory = store_factory
         self.provider = provider
         self.model = model
         self.sessions = sessions
@@ -376,6 +393,18 @@ class Consolidator:
     def get_lock(self, session_key: str) -> asyncio.Lock:
         """Return the shared consolidation lock for one session."""
         return self._locks.setdefault(session_key, asyncio.Lock())
+
+    def _get_store(self, session_key: str) -> MemoryStore:
+        """Return the MemoryStore for the given session.
+
+        When a store_factory is provided (per-user memory mode), the user_id
+        is extracted from the session key (format: 'channel:chat_id') and
+        used to get the per-user store. Falls back to the shared store.
+        """
+        if self._store_factory and session_key:
+            chat_id = session_key.split(":", 1)[-1] if ":" in session_key else session_key
+            return self._store_factory(chat_id)
+        return self.store
 
     def pick_consolidation_boundary(
         self,
@@ -416,13 +445,14 @@ class Consolidator:
             self._get_tool_definitions(),
         )
 
-    async def archive(self, messages: list[dict]) -> bool:
+    async def archive(self, messages: list[dict], session_key: str = "") -> bool:
         """Summarize messages via LLM and append to history.jsonl.
 
         Returns True on success (or degraded success), False if nothing to do.
         """
         if not messages:
             return False
+        store = self._get_store(session_key)
         try:
             formatted = MemoryStore._format_messages(messages)
             response = await self.provider.chat_with_retry(
@@ -441,11 +471,11 @@ class Consolidator:
                 tool_choice=None,
             )
             summary = response.content or "[no summary]"
-            self.store.append_history(summary)
+            store.append_history(summary)
             return True
         except Exception:
             logger.warning("Consolidation LLM call failed, raw-dumping to history")
-            self.store.raw_archive(messages)
+            store.raw_archive(messages)
             return True
 
     async def maybe_consolidate_by_tokens(self, session: Session) -> None:
@@ -501,7 +531,7 @@ class Consolidator:
                     source,
                     len(chunk),
                 )
-                if not await self.archive(chunk):
+                if not await self.archive(chunk, session_key=session.key):
                     return
                 session.last_consolidated = end_idx
                 self.sessions.save(session)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -591,6 +591,7 @@ def serve(
         channels_config=runtime_config.channels,
         timezone=runtime_config.agents.defaults.timezone,
         unified_session=runtime_config.agents.defaults.unified_session,
+        per_user_memory=runtime_config.agents.defaults.per_user_memory,
     )
 
     model_name = runtime_config.agents.defaults.model
@@ -683,6 +684,7 @@ def gateway(
         channels_config=config.channels,
         timezone=config.agents.defaults.timezone,
         unified_session=config.agents.defaults.unified_session,
+        per_user_memory=config.agents.defaults.per_user_memory,
     )
 
     # Set cron callback (needs agent)
@@ -915,6 +917,7 @@ def agent(
         channels_config=config.channels,
         timezone=config.agents.defaults.timezone,
         unified_session=config.agents.defaults.unified_session,
+        per_user_memory=config.agents.defaults.per_user_memory,
     )
     restart_notice = consume_restart_notice_from_env()
     if restart_notice and should_show_cli_restart_notice(restart_notice, session_id):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -77,6 +77,7 @@ class AgentDefaults(Base):
     reasoning_effort: str | None = None  # low / medium / high / adaptive - enables LLM thinking mode
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
     unified_session: bool = False  # Share one session across all channels (single-user multi-device)
+    per_user_memory: bool = False  # Isolate memory per user (workspace/users/{user_id}/memory/)
     dream: DreamConfig = Field(default_factory=DreamConfig)
 
 

--- a/nanobot/templates/agent/identity.md
+++ b/nanobot/templates/agent/identity.md
@@ -7,8 +7,8 @@ You are nanobot, a helpful AI assistant.
 
 ## Workspace
 Your workspace is at: {{ workspace_path }}
-- Long-term memory: {{ workspace_path }}/memory/MEMORY.md (automatically managed by Dream — do not edit directly)
-- History log: {{ workspace_path }}/memory/history.jsonl (append-only JSONL; prefer built-in `grep` for search).
+- Long-term memory: {{ memory_path }}/MEMORY.md (automatically managed by Dream — do not edit directly)
+- History log: {{ memory_path }}/history.jsonl (append-only JSONL; prefer built-in `grep` for search).
 - Custom skills: {{ workspace_path }}/skills/{% raw %}{skill-name}{% endraw %}/SKILL.md
 
 {{ platform_policy }}

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -163,7 +163,7 @@ async def test_preflight_consolidation_before_llm_call(tmp_path, monkeypatch) ->
 
     loop = _make_loop(tmp_path, estimated_tokens=0, context_window_tokens=200)
 
-    async def track_consolidate(messages):
+    async def track_consolidate(messages, session_key=""):
         order.append("consolidate")
         return True
     loop.consolidator.archive = track_consolidate  # type: ignore[method-assign]

--- a/tests/agent/test_per_user_memory.py
+++ b/tests/agent/test_per_user_memory.py
@@ -1,0 +1,119 @@
+"""Tests for per-user memory isolation (agents.defaults.per_user_memory)."""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.agent.context import ContextBuilder
+
+
+# ---------------------------------------------------------------------------
+# MemoryStore — path isolation
+# ---------------------------------------------------------------------------
+
+def test_memory_store_shared_path(tmp_path: Path) -> None:
+    """Without user_id, memory lives in workspace/memory/ (backwards compat)."""
+    store = MemoryStore(tmp_path)
+    assert store.memory_dir == tmp_path / "memory"
+
+
+def test_memory_store_per_user_path(tmp_path: Path) -> None:
+    """With user_id, memory lives in workspace/users/{user_id}/memory/."""
+    store = MemoryStore(tmp_path, user_id="593980378058")
+    assert store.memory_dir == tmp_path / "users" / "593980378058" / "memory"
+
+
+def test_memory_store_user_id_sanitized(tmp_path: Path) -> None:
+    """Special characters in user_id are replaced with underscores."""
+    store = MemoryStore(tmp_path, user_id="user@domain.com")
+    assert "@" not in str(store.memory_dir)
+    assert store.memory_dir.parent.parent == tmp_path / "users"
+
+
+def test_memory_store_users_are_isolated(tmp_path: Path) -> None:
+    """Two users get separate memory dirs and separate MEMORY.md files."""
+    store_a = MemoryStore(tmp_path, user_id="user_a")
+    store_b = MemoryStore(tmp_path, user_id="user_b")
+
+    store_a.write_memory("Alice's memory")
+    store_b.write_memory("Bob's memory")
+
+    assert store_a.read_memory() == "Alice's memory"
+    assert store_b.read_memory() == "Bob's memory"
+    assert store_a.memory_dir != store_b.memory_dir
+
+
+# ---------------------------------------------------------------------------
+# ContextBuilder — user_id propagation
+# ---------------------------------------------------------------------------
+
+def test_context_builder_shared_memory(tmp_path: Path) -> None:
+    """Without user_id, ContextBuilder uses shared memory."""
+    ctx = ContextBuilder(tmp_path)
+    assert ctx.memory.user_id is None
+    assert ctx.memory.memory_dir == tmp_path / "memory"
+
+
+def test_context_builder_per_user_memory(tmp_path: Path) -> None:
+    """With user_id, ContextBuilder uses per-user memory."""
+    ctx = ContextBuilder(tmp_path, user_id="593980378058")
+    assert ctx.memory.user_id == "593980378058"
+    assert "users" in str(ctx.memory.memory_dir)
+    assert "593980378058" in str(ctx.memory.memory_dir)
+
+
+# ---------------------------------------------------------------------------
+# Consolidator — store_factory routing
+# ---------------------------------------------------------------------------
+
+def test_consolidator_get_store_no_factory(tmp_path: Path) -> None:
+    """Without store_factory, _get_store always returns the shared store."""
+    from nanobot.agent.memory import Consolidator
+
+    shared_store = MemoryStore(tmp_path)
+    consolidator = Consolidator(
+        store=shared_store,
+        provider=MagicMock(),
+        model="test",
+        sessions=MagicMock(),
+        context_window_tokens=1000,
+        build_messages=MagicMock(),
+        get_tool_definitions=MagicMock(return_value=[]),
+    )
+    assert consolidator._get_store("whatsapp:user_a") is shared_store
+    assert consolidator._get_store("whatsapp:user_b") is shared_store
+
+
+def test_consolidator_get_store_with_factory(tmp_path: Path) -> None:
+    """With store_factory, _get_store returns the per-user store."""
+    from nanobot.agent.memory import Consolidator
+
+    shared_store = MemoryStore(tmp_path)
+    user_stores: dict[str, MemoryStore] = {}
+
+    def factory(user_id: str) -> MemoryStore:
+        if user_id not in user_stores:
+            user_stores[user_id] = MemoryStore(tmp_path, user_id=user_id)
+        return user_stores[user_id]
+
+    consolidator = Consolidator(
+        store=shared_store,
+        provider=MagicMock(),
+        model="test",
+        sessions=MagicMock(),
+        context_window_tokens=1000,
+        build_messages=MagicMock(),
+        get_tool_definitions=MagicMock(return_value=[]),
+        store_factory=factory,
+    )
+
+    store_a = consolidator._get_store("whatsapp:user_a")
+    store_b = consolidator._get_store("whatsapp:user_b")
+
+    assert store_a is not store_b
+    assert store_a.user_id == "user_a"
+    assert store_b.user_id == "user_b"
+    assert store_a is not shared_store


### PR DESCRIPTION
## Problem

In multi-user deployments all users share the same `workspace/memory/` directory — `MEMORY.md` and `history.jsonl` are shared across everyone. The agent mixes personal data, tasks and context from different people.

## Solution

New opt-in config flag: `agents.defaults.per_user_memory` (default: `false`)

When enabled, each user gets an isolated memory directory:
```
workspace/users/{chat_id}/memory/   ← per-user
workspace/memory/                   ← shared (default, unchanged)
```

The `user_id` is derived from the inbound message `chat_id` and sanitized to be filesystem-safe.

## Changes

- **MemoryStore**: accepts optional `user_id`, builds per-user path when set
- **ContextBuilder**: accepts optional `user_id`, propagates to MemoryStore
- **AgentLoop**: adds `_get_context(user_id)` that caches per-user ContextBuilders; used in `_process_message`
- **Consolidator**: accepts `store_factory` callable; `_get_store(session_key)` routes to per-user store
- **AgentDefaults**: new `per_user_memory: bool = False` config field
- **identity.md**: uses `memory_path` variable (set per-user when active)
- **8 new tests** covering path isolation, user isolation, and factory routing

## Backwards compatibility

Fully backwards compatible — `per_user_memory` defaults to `false`. Existing single-user deployments are unaffected.

## Config

```yaml
agents:
  defaults:
    per_user_memory: true
```