### PR TITLE
fix(anthropic): normalize tool_result content blocks

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import re
 import secrets
@@ -160,18 +161,48 @@ class AnthropicProvider(LLMProvider):
 
         return system, self._merge_consecutive(raw)
 
-    @staticmethod
-    def _tool_result_block(msg: dict[str, Any]) -> dict[str, Any]:
+    def _tool_result_block(self, msg: dict[str, Any]) -> dict[str, Any]:
         content = msg.get("content")
         block: dict[str, Any] = {
             "type": "tool_result",
             "tool_use_id": msg.get("tool_call_id", ""),
         }
-        if isinstance(content, (str, list)):
-            block["content"] = content
-        else:
-            block["content"] = str(content) if content else ""
+        block["content"] = self._normalize_tool_result_content(content)
         return block
+
+    def _normalize_tool_result_content(self, content: Any) -> str | list[dict[str, Any]]:
+        """Normalize tool_result payloads to Anthropic-supported content blocks."""
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return str(content) if content else ""
+
+        normalized: list[dict[str, Any]] = []
+        for item in content:
+            if isinstance(item, str):
+                normalized.append({"type": "text", "text": item})
+                continue
+            if not isinstance(item, dict):
+                normalized.append({"type": "text", "text": str(item)})
+                continue
+
+            item_type = item.get("type")
+            if item_type in {"text", "input_text", "output_text"}:
+                text = item.get("text", "")
+                normalized.append({"type": "text", "text": text if isinstance(text, str) else str(text)})
+                continue
+            if item_type == "image_url":
+                converted = self._convert_image_block(item)
+                if converted:
+                    normalized.append(converted)
+                    continue
+            if item_type in {"image", "document"}:
+                normalized.append(dict(item))
+                continue
+
+            normalized.append({"type": "text", "text": json.dumps(item, ensure_ascii=False)})
+
+        return normalized or ""
 
     @staticmethod
     def _assistant_blocks(msg: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/providers/test_anthropic_tool_result_blocks.py
+++ b/tests/providers/test_anthropic_tool_result_blocks.py
@@ -1,0 +1,71 @@
+"""Anthropic provider tool_result block normalization tests."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from nanobot.providers.anthropic_provider import AnthropicProvider
+
+
+def _make_provider() -> AnthropicProvider:
+    with patch("anthropic.AsyncAnthropic"):
+        return AnthropicProvider(api_key="sk-test", default_model="claude-sonnet-4-6")
+
+
+def test_tool_result_block_normalizes_untyped_dict_items() -> None:
+    provider = _make_provider()
+
+    block = provider._tool_result_block({
+        "tool_call_id": "call_1",
+        "content": [{"phase": "done", "ok": True}],
+    })
+
+    assert block["type"] == "tool_result"
+    assert block["tool_use_id"] == "call_1"
+    assert block["content"] == [
+        {"type": "text", "text": '{"phase": "done", "ok": true}'},
+    ]
+
+
+def test_tool_result_block_normalizes_openai_text_variants() -> None:
+    provider = _make_provider()
+
+    block = provider._tool_result_block({
+        "tool_call_id": "call_2",
+        "content": [
+            {"type": "output_text", "text": "done"},
+            {"type": "input_text", "text": "next"},
+        ],
+    })
+
+    assert block["content"] == [
+        {"type": "text", "text": "done"},
+        {"type": "text", "text": "next"},
+    ]
+
+
+def test_convert_messages_keeps_tool_result_content_anthropic_safe() -> None:
+    provider = _make_provider()
+
+    _, messages = provider._convert_messages([
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_1",
+                "function": {"name": "demo_tool", "arguments": "{}"},
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "name": "demo_tool",
+            "content": [{"status": "ok"}],
+        },
+    ])
+
+    assert messages[0]["role"] == "assistant"
+    assert messages[1]["role"] == "user"
+    tool_result = messages[1]["content"][0]
+    assert tool_result["type"] == "tool_result"
+    assert tool_result["content"] == [{"type": "text", "text": '{"status": "ok"}'}]


### PR DESCRIPTION
## Summary
- normalize Anthropic `tool_result` payloads before building Messages API requests
- convert OpenAI-style text variants (`input_text` / `output_text`) into Anthropic `text` blocks
- degrade unknown structured items to JSON text instead of sending invalid block shapes

## Root Cause
`AnthropicProvider._tool_result_block()` previously passed list payloads through unchanged. When a tool returned structured list items without an Anthropic block `type`, the API rejected the request with `tool_result.content[*].type: Field required`.

## Impact
This fixes a provider-layer compatibility bug for any workflow that sends structured tool outputs through the Anthropic Messages API. The change is generic and not specific to `ava`.

## Validation
- `pytest tests/providers/test_anthropic_tool_result_blocks.py -q`
- `pytest tests/providers/test_anthropic_thinking.py tests/providers/test_provider_error_metadata.py tests/providers/test_provider_sdk_retry_defaults.py -q`
