### PR TITLE
fix(memory): consolidate by message count when token budget is not exceeded

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -347,6 +347,8 @@ class Consolidator:
     """Lightweight consolidation: summarizes evicted messages into history.jsonl."""
 
     _MAX_CONSOLIDATION_ROUNDS = 5
+    _MAX_UNCONSOLIDATED_MESSAGES = 150  # trigger consolidation by message count too
+    _MAX_CHUNK_MESSAGES = 60  # hard cap per consolidation round
 
     _SAFETY_BUFFER = 1024  # extra headroom for tokenizer estimation drift
 
@@ -461,24 +463,32 @@ class Consolidator:
         async with lock:
             budget = self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
             target = budget // 2
-            estimated, source = self.estimate_session_prompt_tokens(session)
+            try:
+                estimated, source = self.estimate_session_prompt_tokens(session)
+            except Exception:
+                logger.exception("Token estimation failed for {}", session.key)
+                estimated, source = 0, "error"
             if estimated <= 0:
                 return
-            if estimated < budget:
+            unconsolidated_count = len(session.messages) - session.last_consolidated
+            if estimated < budget and unconsolidated_count < self._MAX_UNCONSOLIDATED_MESSAGES:
                 logger.debug(
-                    "Token consolidation idle {}: {}/{} via {}",
+                    "Token consolidation idle {}: {}/{} via {}, msgs={}",
                     session.key,
                     estimated,
                     self.context_window_tokens,
                     source,
+                    unconsolidated_count,
                 )
                 return
 
             for round_num in range(self._MAX_CONSOLIDATION_ROUNDS):
-                if estimated <= target:
+                remaining_unconsolidated = len(session.messages) - session.last_consolidated
+                if estimated <= target and remaining_unconsolidated < self._MAX_UNCONSOLIDATED_MESSAGES:
                     return
 
-                boundary = self.pick_consolidation_boundary(session, max(1, estimated - target))
+                tokens_to_remove = max(1, estimated - target) if estimated > target else max(1, estimated // 4)
+                boundary = self.pick_consolidation_boundary(session, tokens_to_remove)
                 if boundary is None:
                     logger.debug(
                         "Token consolidation: no safe boundary for {} (round {})",
@@ -492,21 +502,30 @@ class Consolidator:
                 if not chunk:
                     return
 
+                if len(chunk) > self._MAX_CHUNK_MESSAGES:
+                    chunk = chunk[:self._MAX_CHUNK_MESSAGES]
+                    end_idx = session.last_consolidated + len(chunk)
+
                 logger.info(
-                    "Token consolidation round {} for {}: {}/{} via {}, chunk={} msgs",
+                    "Token consolidation round {} for {}: {}/{} via {}, chunk={} msgs, unconsolidated={}",
                     round_num,
                     session.key,
                     estimated,
                     self.context_window_tokens,
                     source,
                     len(chunk),
+                    remaining_unconsolidated,
                 )
                 if not await self.archive(chunk):
                     return
                 session.last_consolidated = end_idx
                 self.sessions.save(session)
 
-                estimated, source = self.estimate_session_prompt_tokens(session)
+                try:
+                    estimated, source = self.estimate_session_prompt_tokens(session)
+                except Exception:
+                    logger.exception("Token estimation failed for {}", session.key)
+                    estimated, source = 0, "error"
                 if estimated <= 0:
                     return
 


### PR DESCRIPTION
## Problem

With large context windows (e.g. 1M tokens on Claude Sonnet 4.6), `Consolidator.maybe_consolidate_by_tokens()` never fires because `estimated < budget` is always true — the session never fills the token budget. Sessions grow to 700+ messages without ever being archived to long-term memory, degrading response quality as the LLM loses focus in an ever-growing conversation history.

### Root cause

Even if a message-count trigger existed, the consolidation loop has a second early-exit that kills it:

```python
for round_num in range(self._MAX_CONSOLIDATION_ROUNDS):
    if estimated <= target:  # 300K <= 495K → True → RETURN immediately
        return
```

The loop enters via message overload but exits on the first iteration because the token estimate (300K) is well below the token target (50% of 990K = 495K).

## Solution

- **`_MAX_UNCONSOLIDATED_MESSAGES = 150`**: triggers consolidation when too many messages accumulate, regardless of token count. Added to both the entry condition and the loop exit condition.
- **`_MAX_CHUNK_MESSAGES = 60`**: caps messages per consolidation round to avoid sending huge chunks to the consolidation LLM.
- The consolidation loop now checks both token target AND message count before exiting early, so message-triggered consolidation actually executes.
- Token estimation wrapped in try/except to prevent silent failures.
- Enhanced log messages to include unconsolidated message count for debugging.

## Impact

Without this fix: a 1M-context session with 700+ messages and ~300K estimated tokens would **never** consolidate. `last_consolidated` stays at 0 forever.

With this fix: consolidation fires when unconsolidated messages exceed 150, processes 60 messages per round (5 rounds max per cycle), and stops when unconsolidated count drops below 150.

## Test plan

- Verified on a production session with 740 messages, last_consolidated=0. After fix, consolidation rounds execute and last_consolidated advances to 300 within one cycle.
- Pre-release tests pass (37/37)