### PR TITLE
fix: strip <thought> blocks from Gemma 4 and similar models

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -15,9 +15,12 @@ from loguru import logger
 
 
 def strip_think(text: str) -> str:
-    """Remove <think>…</think> blocks and any unclosed trailing <think> tag."""
+    """Remove thinking blocks and any unclosed trailing tag."""
     text = re.sub(r"<think>[\s\S]*?</think>", "", text)
     text = re.sub(r"<think>[\s\S]*$", "", text)
+    # Gemma 4 and similar models use <thought>...</thought> blocks
+    text = re.sub(r"<thought>[\s\S]*?</thought>", "", text)
+    text = re.sub(r"<thought>[\s\S]*$", "", text)
     return text.strip()
 
 


### PR DESCRIPTION
Fixes #2944

## Problem

Gemma 4 and similar models emit reasoning inside `<thought>...</thought>` tags inline in the content field. These blocks were leaking to users in Telegram, Discord, CLI and other channels.

## Solution

Add regex handling for `<thought>` tags in `strip_think()`, alongside existing `riegel...riegel` handling.

Two patterns:
- Closed: `<thought>...</thought>` → removed
- Unclosed/trailing: `<thought>...` (no closing tag, e.g. streaming) → removed

## Changes

- `nanobot/utils/helpers.py` — 3 lines added to `strip_think()`

## Testing

```
strip_think("Hello <thought>reasoning</thought> World")  # → "Hello  World"
strip_think("<thought>ongoing...")                        # → ""
strip_think("Just normal text")                           # → "Just normal text"
strip_think("<thought>\nline1\nline2\n</thought>End")     # → "End"
```

## Why this over #2953

PR #2953 is comprehensive (418 additions, new config field, new `thought_content` field in `LLMResponse`, 39 tests) but:
- Adds a new config field (`log_thought_blocks`)
- Adds a new response field (`thought_content`)
- Modifies provider parsing, session persistence, and the agent runner

This PR takes the minimal approach: just strip the tags so they don't leak. 3 lines, zero API changes.