### PR TITLE
fix(memory): harden consolidation with try/except on token estimation and chunk size cap

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -400,6 +400,22 @@ class Consolidator:
 
         return last_boundary
 
+    def _cap_consolidation_boundary(
+        self,
+        session: Session,
+        end_idx: int,
+    ) -> int | None:
+        """Clamp the chunk size without breaking the user-turn boundary."""
+        start = session.last_consolidated
+        if end_idx - start <= self._MAX_CHUNK_MESSAGES:
+            return end_idx
+
+        capped_end = start + self._MAX_CHUNK_MESSAGES
+        for idx in range(capped_end, start, -1):
+            if session.messages[idx].get("role") == "user":
+                return idx
+        return None
+
     def estimate_session_prompt_tokens(self, session: Session) -> tuple[int, str]:
         """Estimate current prompt size for the normal session history view."""
         history = session.get_history(max_messages=0)
@@ -495,13 +511,18 @@ class Consolidator:
                     return
 
                 end_idx = boundary[0]
+                end_idx = self._cap_consolidation_boundary(session, end_idx)
+                if end_idx is None:
+                    logger.debug(
+                        "Token consolidation: no capped boundary for {} (round {})",
+                        session.key,
+                        round_num,
+                    )
+                    return
+
                 chunk = session.messages[session.last_consolidated:end_idx]
                 if not chunk:
                     return
-
-                if len(chunk) > self._MAX_CHUNK_MESSAGES:
-                    chunk = chunk[:self._MAX_CHUNK_MESSAGES]
-                    end_idx = session.last_consolidated + len(chunk)
 
                 logger.info(
                     "Token consolidation round {} for {}: {}/{} via {}, chunk={} msgs",

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -347,6 +347,7 @@ class Consolidator:
     """Lightweight consolidation: summarizes evicted messages into history.jsonl."""
 
     _MAX_CONSOLIDATION_ROUNDS = 5
+    _MAX_CHUNK_MESSAGES = 60  # hard cap per consolidation round
 
     _SAFETY_BUFFER = 1024  # extra headroom for tokenizer estimation drift
 
@@ -461,16 +462,22 @@ class Consolidator:
         async with lock:
             budget = self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
             target = budget // 2
-            estimated, source = self.estimate_session_prompt_tokens(session)
+            try:
+                estimated, source = self.estimate_session_prompt_tokens(session)
+            except Exception:
+                logger.exception("Token estimation failed for {}", session.key)
+                estimated, source = 0, "error"
             if estimated <= 0:
                 return
             if estimated < budget:
+                unconsolidated_count = len(session.messages) - session.last_consolidated
                 logger.debug(
-                    "Token consolidation idle {}: {}/{} via {}",
+                    "Token consolidation idle {}: {}/{} via {}, msgs={}",
                     session.key,
                     estimated,
                     self.context_window_tokens,
                     source,
+                    unconsolidated_count,
                 )
                 return
 
@@ -492,6 +499,10 @@ class Consolidator:
                 if not chunk:
                     return
 
+                if len(chunk) > self._MAX_CHUNK_MESSAGES:
+                    chunk = chunk[:self._MAX_CHUNK_MESSAGES]
+                    end_idx = session.last_consolidated + len(chunk)
+
                 logger.info(
                     "Token consolidation round {} for {}: {}/{} via {}, chunk={} msgs",
                     round_num,
@@ -506,7 +517,11 @@ class Consolidator:
                 session.last_consolidated = end_idx
                 self.sessions.save(session)
 
-                estimated, source = self.estimate_session_prompt_tokens(session)
+                try:
+                    estimated, source = self.estimate_session_prompt_tokens(session)
+                except Exception:
+                    logger.exception("Token estimation failed for {}", session.key)
+                    estimated, source = 0, "error"
                 if estimated <= 0:
                     return
 

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -76,3 +76,52 @@ class TestConsolidatorTokenBudget:
         consolidator.archive = AsyncMock(return_value=True)
         await consolidator.maybe_consolidate_by_tokens(session)
         consolidator.archive.assert_not_called()
+
+    async def test_chunk_cap_preserves_user_turn_boundary(self, consolidator):
+        """Chunk cap should rewind to the last user boundary within the cap."""
+        consolidator._SAFETY_BUFFER = 0
+        session = MagicMock()
+        session.last_consolidated = 0
+        session.key = "test:key"
+        session.messages = [
+            {
+                "role": "user" if i in {0, 50, 61} else "assistant",
+                "content": f"m{i}",
+            }
+            for i in range(70)
+        ]
+        consolidator.estimate_session_prompt_tokens = MagicMock(
+            side_effect=[(1200, "tiktoken"), (400, "tiktoken")]
+        )
+        consolidator.pick_consolidation_boundary = MagicMock(return_value=(61, 999))
+        consolidator.archive = AsyncMock(return_value=True)
+
+        await consolidator.maybe_consolidate_by_tokens(session)
+
+        archived_chunk = consolidator.archive.await_args.args[0]
+        assert len(archived_chunk) == 50
+        assert archived_chunk[0]["content"] == "m0"
+        assert archived_chunk[-1]["content"] == "m49"
+        assert session.last_consolidated == 50
+
+    async def test_chunk_cap_skips_when_no_user_boundary_within_cap(self, consolidator):
+        """If the cap would cut mid-turn, consolidation should skip that round."""
+        consolidator._SAFETY_BUFFER = 0
+        session = MagicMock()
+        session.last_consolidated = 0
+        session.key = "test:key"
+        session.messages = [
+            {
+                "role": "user" if i in {0, 61} else "assistant",
+                "content": f"m{i}",
+            }
+            for i in range(70)
+        ]
+        consolidator.estimate_session_prompt_tokens = MagicMock(return_value=(1200, "tiktoken"))
+        consolidator.pick_consolidation_boundary = MagicMock(return_value=(61, 999))
+        consolidator.archive = AsyncMock(return_value=True)
+
+        await consolidator.maybe_consolidate_by_tokens(session)
+
+        consolidator.archive.assert_not_awaited()
+        assert session.last_consolidated == 0


### PR DESCRIPTION
## What

Purely defensive improvements to the consolidation cycle — no behaviour change for normal sessions.

### Changes

- **try/except on both token estimation calls**: `estimate_session_prompt_tokens()` can raise if the session is in an unexpected state. Without this guard, a single exception silently aborts the entire consolidation cycle and `last_consolidated` never advances. Now it logs the exception and returns gracefully.
- **`_MAX_CHUNK_MESSAGES = 60`**: caps the number of messages sent to the consolidation LLM per round. Without this, a session with 500+ unconsolidated messages could send a single enormous chunk, overwhelming the consolidation model or hitting its own context limit.
- **Improved idle log**: includes unconsolidated message count alongside token estimates, making it easier to diagnose sessions that are growing without consolidating.

## Why now

These are low-risk, standalone improvements that are useful regardless of any debate about message-count triggers. They make the consolidation path more robust and observable.

## Test plan

- Existing tests pass (37/37)
- No behaviour change for sessions that consolidate normally by token pressure