### PR TITLE
fix(memory): add message-count trigger for consolidation on large context windows

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -347,6 +347,7 @@ class Consolidator:
     """Lightweight consolidation: summarizes evicted messages into history.jsonl."""
 
     _MAX_CONSOLIDATION_ROUNDS = 5
+    _MAX_UNCONSOLIDATED_MESSAGES = 150  # trigger consolidation by message count too
 
     _SAFETY_BUFFER = 1024  # extra headroom for tokenizer estimation drift
 
@@ -464,21 +465,25 @@ class Consolidator:
             estimated, source = self.estimate_session_prompt_tokens(session)
             if estimated <= 0:
                 return
-            if estimated < budget:
+            unconsolidated_count = len(session.messages) - session.last_consolidated
+            if estimated < budget and unconsolidated_count < self._MAX_UNCONSOLIDATED_MESSAGES:
                 logger.debug(
-                    "Token consolidation idle {}: {}/{} via {}",
+                    "Token consolidation idle {}: {}/{} via {}, msgs={}",
                     session.key,
                     estimated,
                     self.context_window_tokens,
                     source,
+                    unconsolidated_count,
                 )
                 return
 
             for round_num in range(self._MAX_CONSOLIDATION_ROUNDS):
-                if estimated <= target:
+                remaining_unconsolidated = len(session.messages) - session.last_consolidated
+                if estimated <= target and remaining_unconsolidated < self._MAX_UNCONSOLIDATED_MESSAGES:
                     return
 
-                boundary = self.pick_consolidation_boundary(session, max(1, estimated - target))
+                tokens_to_remove = max(1, estimated - target) if estimated > target else max(1, estimated // 4)
+                boundary = self.pick_consolidation_boundary(session, tokens_to_remove)
                 if boundary is None:
                     logger.debug(
                         "Token consolidation: no safe boundary for {} (round {})",


### PR DESCRIPTION
## Problem

With models that have 1M+ token context windows (e.g. Claude Sonnet 4.6 or Gemini 2.5 Pro), `maybe_consolidate_by_tokens()` **never fires** because `estimated < budget` is always true — the session never fills the token budget.

The result: sessions grow to **700+ messages** without ever being archived to long-term memory. The LLM receives the full raw history on every turn, which degrades response quality as the model loses focus across a very long, varied conversation.

### Root cause

The consolidation loop has a second early-exit that kills it even when entered via message overload:

```python
for round_num in range(self._MAX_CONSOLIDATION_ROUNDS):
    if estimated <= target:  # 300K <= 495K → True → RETURN immediately
        return
```

The loop enters via message overload but exits on the first iteration because the token estimate (300K) is well below the token target (50% of 990K = 495K).

## Solution

- **`_MAX_UNCONSOLIDATED_MESSAGES = 150`**: triggers consolidation when unconsolidated message count exceeds this threshold, regardless of token count. Added to both the entry condition and the loop exit condition.
- When consolidation fires via message count (not token pressure), `tokens_to_remove` is computed as `estimated // 4` to still make meaningful progress through the archive cycle.

## Relationship to #2978

This PR builds on the defensive improvements in #2978 (try/except on token estimation, chunk size cap). It can be reviewed independently but works best applied together.

## Why not just lower `context_window_tokens`?

As raised in the discussion on #2971: yes, users *could* set `context_window_tokens` lower. But:

1. The default is the model's advertised maximum, which is what most users expect to use
2. Users with 700-message sessions over 20+ days are not misconfigured — they are using the product as intended
3. A hard-coded message cap is a safety net, not an override. It fires only when the token-based path has already failed to act

## Test plan

- Existing tests pass (37/37)
- Verified on a production session with 740 messages, last_consolidated=0. After fix, consolidation rounds execute and last_consolidated advances to 300 within one cycle.