### PR TITLE
feat(bus): dedupe inbound messages per session while queued or in flight

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -398,63 +398,67 @@ class AgentLoop:
 
     async def _dispatch(self, msg: InboundMessage) -> None:
         """Process a message: per-session serial, cross-session concurrent."""
-        if self._unified_session and not msg.session_key_override:
-            msg = dataclasses.replace(msg, session_key_override=UNIFIED_SESSION_KEY)
-        lock = self._session_locks.setdefault(msg.session_key, asyncio.Lock())
-        gate = self._concurrency_gate or nullcontext()
-        async with lock, gate:
-            try:
-                on_stream = on_stream_end = None
-                if msg.metadata.get("_wants_stream"):
-                    # Split one answer into distinct stream segments.
-                    stream_base_id = f"{msg.session_key}:{time.time_ns()}"
-                    stream_segment = 0
+        dedup_release_msg = msg
+        try:
+            if self._unified_session and not msg.session_key_override:
+                msg = dataclasses.replace(msg, session_key_override=UNIFIED_SESSION_KEY)
+            lock = self._session_locks.setdefault(msg.session_key, asyncio.Lock())
+            gate = self._concurrency_gate or nullcontext()
+            async with lock, gate:
+                try:
+                    on_stream = on_stream_end = None
+                    if msg.metadata.get("_wants_stream"):
+                        # Split one answer into distinct stream segments.
+                        stream_base_id = f"{msg.session_key}:{time.time_ns()}"
+                        stream_segment = 0
 
-                    def _current_stream_id() -> str:
-                        return f"{stream_base_id}:{stream_segment}"
+                        def _current_stream_id() -> str:
+                            return f"{stream_base_id}:{stream_segment}"
 
-                    async def on_stream(delta: str) -> None:
-                        meta = dict(msg.metadata or {})
-                        meta["_stream_delta"] = True
-                        meta["_stream_id"] = _current_stream_id()
+                        async def on_stream(delta: str) -> None:
+                            meta = dict(msg.metadata or {})
+                            meta["_stream_delta"] = True
+                            meta["_stream_id"] = _current_stream_id()
+                            await self.bus.publish_outbound(OutboundMessage(
+                                channel=msg.channel, chat_id=msg.chat_id,
+                                content=delta,
+                                metadata=meta,
+                            ))
+
+                        async def on_stream_end(*, resuming: bool = False) -> None:
+                            nonlocal stream_segment
+                            meta = dict(msg.metadata or {})
+                            meta["_stream_end"] = True
+                            meta["_resuming"] = resuming
+                            meta["_stream_id"] = _current_stream_id()
+                            await self.bus.publish_outbound(OutboundMessage(
+                                channel=msg.channel, chat_id=msg.chat_id,
+                                content="",
+                                metadata=meta,
+                            ))
+                            stream_segment += 1
+
+                    response = await self._process_message(
+                        msg, on_stream=on_stream, on_stream_end=on_stream_end,
+                    )
+                    if response is not None:
+                        await self.bus.publish_outbound(response)
+                    elif msg.channel == "cli":
                         await self.bus.publish_outbound(OutboundMessage(
                             channel=msg.channel, chat_id=msg.chat_id,
-                            content=delta,
-                            metadata=meta,
+                            content="", metadata=msg.metadata or {},
                         ))
-
-                    async def on_stream_end(*, resuming: bool = False) -> None:
-                        nonlocal stream_segment
-                        meta = dict(msg.metadata or {})
-                        meta["_stream_end"] = True
-                        meta["_resuming"] = resuming
-                        meta["_stream_id"] = _current_stream_id()
-                        await self.bus.publish_outbound(OutboundMessage(
-                            channel=msg.channel, chat_id=msg.chat_id,
-                            content="",
-                            metadata=meta,
-                        ))
-                        stream_segment += 1
-
-                response = await self._process_message(
-                    msg, on_stream=on_stream, on_stream_end=on_stream_end,
-                )
-                if response is not None:
-                    await self.bus.publish_outbound(response)
-                elif msg.channel == "cli":
+                except asyncio.CancelledError:
+                    logger.info("Task cancelled for session {}", msg.session_key)
+                    raise
+                except Exception:
+                    logger.exception("Error processing message for session {}", msg.session_key)
                     await self.bus.publish_outbound(OutboundMessage(
                         channel=msg.channel, chat_id=msg.chat_id,
-                        content="", metadata=msg.metadata or {},
+                        content="Sorry, I encountered an error.",
                     ))
-            except asyncio.CancelledError:
-                logger.info("Task cancelled for session {}", msg.session_key)
-                raise
-            except Exception:
-                logger.exception("Error processing message for session {}", msg.session_key)
-                await self.bus.publish_outbound(OutboundMessage(
-                    channel=msg.channel, chat_id=msg.chat_id,
-                    content="Sorry, I encountered an error.",
-                ))
+        finally:
+            self.bus.release_inbound_dedup(dedup_release_msg)
 
     async def close_mcp(self) -> None:
         """Drain pending background archives, then close MCP connections."""

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -1,8 +1,14 @@
 """Async message queue for decoupled channel-agent communication."""
 
+from __future__ import annotations
+
 import asyncio
+import re
+from loguru import logger
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
+
+_WS_RE = re.compile(r"\s+")
 
 
 class MessageBus:
@@ -13,17 +19,62 @@ class MessageBus:
     them and pushes responses to the outbound queue.
     """
 
-    def __init__(self):
+    def __init__(self, *, inbound_queue_dedup: bool = True):
         self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue()
         self.outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
+        self._inbound_queue_dedup = inbound_queue_dedup
+        # (session_key, normalized_body): in inbound queue or being processed by the agent
+        self._inbound_dedup_keys: set[tuple[str, str]] = set()
+
+    @staticmethod
+    def _normalize_inbound_body(text: str) -> str:
+        s = text.strip()
+        if not s:
+            return ""
+        return _WS_RE.sub(" ", s).casefold()
+
+    @classmethod
+    def _inbound_dedup_key(cls, msg: InboundMessage) -> tuple[str, str] | None:
+        """Return a key for queue deduplication, or None when this message must not be coalesced."""
+        if msg.metadata.get("_skip_inbound_dedup"):
+            return None
+        raw = msg.content.strip()
+        if raw.startswith("/"):
+            return None
+        body = cls._normalize_inbound_body(msg.content)
+        if not body:
+            return None
+        return (msg.session_key, body)
 
     async def publish_inbound(self, msg: InboundMessage) -> None:
         """Publish a message from a channel to the agent."""
+        key = (
+            self._inbound_dedup_key(msg)
+            if self._inbound_queue_dedup
+            else None
+        )
+        if key is not None and key in self._inbound_dedup_keys:
+            logger.debug(
+                "Skipping duplicate inbound (same text queued or in flight): session={} preview={!r}",
+                key[0],
+                key[1][:80] + ("…" if len(key[1]) > 80 else ""),
+            )
+            return
+        if key is not None:
+            self._inbound_dedup_keys.add(key)
         await self.inbound.put(msg)
 
     async def consume_inbound(self) -> InboundMessage:
         """Consume the next inbound message (blocks until available)."""
         return await self.inbound.get()
+
+    def release_inbound_dedup(self, msg: InboundMessage) -> None:
+        """Clear the dedup slot after this message has finished processing (call from a finally block)."""
+        if not self._inbound_queue_dedup:
+            return
+        rk = self._inbound_dedup_key(msg)
+        if rk is not None:
+            self._inbound_dedup_keys.discard(rk)
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """Publish a response from the agent to channels."""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -570,7 +570,7 @@ def serve(
     port = port if port is not None else api_cfg.port
     timeout = timeout if timeout is not None else api_cfg.timeout
     sync_workspace_templates(runtime_config.workspace_path)
-    bus = MessageBus()
+    bus = MessageBus(inbound_queue_dedup=runtime_config.agents.defaults.inbound_queue_dedup)
     provider = _make_provider(runtime_config)
     session_manager = SessionManager(runtime_config.workspace_path)
     agent_loop = AgentLoop(
@@ -651,7 +651,7 @@ def gateway(
 
     console.print(f"{__logo__} Starting nanobot gateway version {__version__} on port {port}...")
     sync_workspace_templates(config.workspace_path)
-    bus = MessageBus()
+    bus = MessageBus(inbound_queue_dedup=config.agents.defaults.inbound_queue_dedup)
     provider = _make_provider(config)
     session_manager = SessionManager(config.workspace_path)
 
@@ -881,7 +881,7 @@ def agent(
     config = _load_runtime_config(config, workspace)
     sync_workspace_templates(config.workspace_path)
 
-    bus = MessageBus()
+    bus = MessageBus(inbound_queue_dedup=config.agents.defaults.inbound_queue_dedup)
     provider = _make_provider(config)
 
     # Preserve existing single-workspace installs, but keep custom workspaces clean.

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -77,6 +77,7 @@ class AgentDefaults(Base):
     reasoning_effort: str | None = None  # low / medium / high / adaptive - enables LLM thinking mode
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
     unified_session: bool = False  # Share one session across all channels (single-user multi-device)
+    inbound_queue_dedup: bool = True  # Drop duplicate user text while the same (session, body) is queued or being processed
     dream: DreamConfig = Field(default_factory=DreamConfig)
 
 

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -63,8 +63,8 @@ class Nanobot:
             )
 
         provider = _make_provider(config)
-        bus = MessageBus()
         defaults = config.agents.defaults
+        bus = MessageBus(inbound_queue_dedup=defaults.inbound_queue_dedup)
 
         loop = AgentLoop(
             bus=bus,

--- a/tests/bus/test_inbound_queue_dedup.py
+++ b/tests/bus/test_inbound_queue_dedup.py
@@ -1,0 +1,102 @@
+"""Tests for inbound queue deduplication."""
+
+import asyncio
+
+import pytest
+
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+
+
+def _msg(content: str, channel: str = "telegram", chat: str = "c1", **meta) -> InboundMessage:
+    return InboundMessage(
+        channel=channel,
+        sender_id="u1",
+        chat_id=chat,
+        content=content,
+        metadata=dict(meta),
+    )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_dropped_while_first_is_queued():
+    bus = MessageBus(inbound_queue_dedup=True)
+    m1 = _msg("What is 2+2?")
+    m2 = _msg("What   is  2+2?")  # same after normalize
+
+    await bus.publish_inbound(m1)
+    await bus.publish_inbound(m2)
+
+    assert bus.inbound_size == 1
+    got = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
+    assert got.content == m1.content
+    assert bus.inbound_size == 0
+    bus.release_inbound_dedup(got)
+
+
+@pytest.mark.asyncio
+async def test_triple_spam_only_one_queued_until_release():
+    """Same as rapid re-send while agent still processing: duplicates drop after first is taken."""
+    bus = MessageBus(inbound_queue_dedup=True)
+    m = _msg("hello")
+    await bus.publish_inbound(m)
+    await bus.publish_inbound(_msg("hello"))
+    await bus.publish_inbound(_msg("HELLO"))
+    assert bus.inbound_size == 1
+    got = await bus.consume_inbound()
+    assert got.content == "hello"
+    # Slot still held until release (simulates in-flight _dispatch)
+    await bus.publish_inbound(_msg("hello"))
+    assert bus.inbound_size == 0
+    bus.release_inbound_dedup(got)
+    await bus.publish_inbound(_msg("hello"))
+    assert bus.inbound_size == 1
+
+
+@pytest.mark.asyncio
+async def test_same_text_allowed_after_consume():
+    bus = MessageBus(inbound_queue_dedup=True)
+    m1 = _msg("ping")
+    m2 = _msg("ping")
+
+    await bus.publish_inbound(m1)
+    first = await bus.consume_inbound()
+    bus.release_inbound_dedup(first)
+    await bus.publish_inbound(m2)
+
+    assert bus.inbound_size == 1
+    got = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
+    assert got.content == "ping"
+    bus.release_inbound_dedup(got)
+
+
+@pytest.mark.asyncio
+async def test_slash_commands_not_deduped():
+    bus = MessageBus(inbound_queue_dedup=True)
+    await bus.publish_inbound(_msg("/stop"))
+    await bus.publish_inbound(_msg("/stop"))
+    assert bus.inbound_size == 2
+
+
+@pytest.mark.asyncio
+async def test_skip_metadata_bypasses_dedup():
+    bus = MessageBus(inbound_queue_dedup=True)
+    await bus.publish_inbound(_msg("x", _skip_inbound_dedup=True))
+    await bus.publish_inbound(_msg("x", _skip_inbound_dedup=True))
+    assert bus.inbound_size == 2
+
+
+@pytest.mark.asyncio
+async def test_dedup_disabled():
+    bus = MessageBus(inbound_queue_dedup=False)
+    await bus.publish_inbound(_msg("a"))
+    await bus.publish_inbound(_msg("a"))
+    assert bus.inbound_size == 2
+
+
+@pytest.mark.asyncio
+async def test_different_sessions_not_deduped():
+    bus = MessageBus(inbound_queue_dedup=True)
+    await bus.publish_inbound(_msg("hi", chat="room1"))
+    await bus.publish_inbound(_msg("hi", chat="room2"))
+    assert bus.inbound_size == 2

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -500,7 +500,7 @@ def test_agent_config_sets_active_path(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
     monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
-    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: object())
+    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda *_a, **_: object())
     monkeypatch.setattr("nanobot.cron.service.CronService", lambda _store: object())
 
     class _FakeAgentLoop:
@@ -535,7 +535,7 @@ def test_agent_uses_workspace_directory_for_cron_store(monkeypatch, tmp_path: Pa
     monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
     monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
-    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: object())
+    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda *_a, **_: object())
 
     class _FakeCron:
         def __init__(self, store_path: Path) -> None:
@@ -581,7 +581,7 @@ def test_agent_workspace_override_does_not_migrate_legacy_cron(
     monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
     monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
-    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: object())
+    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda *_a, **_: object())
     monkeypatch.setattr("nanobot.config.paths.get_cron_dir", lambda: legacy_dir)
 
     class _FakeCron:
@@ -634,7 +634,7 @@ def test_agent_custom_config_workspace_does_not_migrate_legacy_cron(
     monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
     monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
-    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: object())
+    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda *_a, **_: object())
     monkeypatch.setattr("nanobot.config.paths.get_cron_dir", lambda: legacy_dir)
 
     class _FakeCron:
@@ -790,7 +790,7 @@ def _patch_serve_runtime(monkeypatch, config: Config, seen: dict[str, object]) -
     _patch_cli_command_runtime(
         monkeypatch,
         config,
-        message_bus=lambda: object(),
+        message_bus=lambda *_a, **_: object(),
         session_manager=lambda _workspace: object(),
     )
     monkeypatch.setattr("nanobot.agent.loop.AgentLoop", _FakeAgentLoop)
@@ -857,7 +857,7 @@ def test_gateway_uses_workspace_directory_for_cron_store(monkeypatch, tmp_path: 
     _patch_cli_command_runtime(
         monkeypatch,
         config,
-        message_bus=lambda: object(),
+        message_bus=lambda *_a, **_: object(),
         session_manager=lambda _workspace: object(),
         cron_service=_StopCron,
     )
@@ -886,7 +886,7 @@ def test_gateway_cron_evaluator_receives_scheduled_reminder_context(
     monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
     monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: provider)
-    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: bus)
+    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda *_a, **_: bus)
     monkeypatch.setattr("nanobot.session.manager.SessionManager", lambda _workspace: object())
 
     class _FakeCron:
@@ -998,7 +998,7 @@ def test_gateway_workspace_override_does_not_migrate_legacy_cron(
     _patch_cli_command_runtime(
         monkeypatch,
         config,
-        message_bus=lambda: object(),
+        message_bus=lambda *_a, **_: object(),
         session_manager=lambda _workspace: object(),
         cron_service=_StopCron,
         get_cron_dir=lambda: legacy_dir,
@@ -1037,7 +1037,7 @@ def test_gateway_custom_config_workspace_does_not_migrate_legacy_cron(
     _patch_cli_command_runtime(
         monkeypatch,
         config,
-        message_bus=lambda: object(),
+        message_bus=lambda *_a, **_: object(),
         session_manager=lambda _workspace: object(),
         cron_service=_StopCron,
         get_cron_dir=lambda: legacy_dir,


### PR DESCRIPTION
- MessageBus dedupes by (session_key, normalized body) until _dispatch finishes, then releases
- Add agents.defaults.inbound_queue_dedup; wire through CLI/SDK when creating MessageBus
- Add unit tests under tests/bus