### PR TITLE
fix: strip <thought> blocks from Gemma 4 and similar models

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -15,9 +15,12 @@ from loguru import logger
 
 
 def strip_think(text: str) -> str:
-    """Remove <think>…</think> blocks and any unclosed trailing <think> tag."""
+    """Remove thinking blocks and any unclosed trailing tag."""
     text = re.sub(r"<think>[\s\S]*?</think>", "", text)
     text = re.sub(r"<think>[\s\S]*$", "", text)
+    # Gemma 4 and similar models use <thought>...</thought> blocks
+    text = re.sub(r"<thought>[\s\S]*?</thought>", "", text)
+    text = re.sub(r"<thought>[\s\S]*$", "", text)
     return text.strip()
 
 

--- a/tests/utils/test_strip_think.py
+++ b/tests/utils/test_strip_think.py
@@ -1,0 +1,36 @@
+import pytest
+
+from nanobot.utils.helpers import strip_think
+
+
+class TestStripThinkTag:
+    """Test <thought>...</thought> block stripping (Gemma 4 and similar models)."""
+
+    def test_closed_tag(self):
+        assert strip_think("Hello <thought>reasoning</thought> World") == "Hello  World"
+
+    def test_unclosed_trailing_tag(self):
+        assert strip_think("<thought>ongoing...") == ""
+
+    def test_multiline_tag(self):
+        assert strip_think("<thought>\nline1\nline2\n</thought>End") == "End"
+
+    def test_tag_with_nested_angle_brackets(self):
+        text = "<thought>a < 3 and b > 2</thought>result"
+        assert strip_think(text) == "result"
+
+    def test_multiple_tag_blocks(self):
+        text = "A<thought>x</thought>B<thought>y</thought>C"
+        assert strip_think(text) == "ABC"
+
+    def test_tag_only_whitespace_inside(self):
+        assert strip_think("before<thought>  </thought>after") == "beforeafter"
+
+    def test_self_closing_tag_not_matched(self):
+        assert strip_think("<thought/>some text") == "<thought/>some text"
+
+    def test_normal_text_unchanged(self):
+        assert strip_think("Just normal text") == "Just normal text"
+
+    def test_empty_string(self):
+        assert strip_think("") == ""


### PR DESCRIPTION
## Summary

Gemma 4 and similar models emit reasoning inside `<thought>...</thought>` tags inline in the content field. These blocks were leaking to users in Telegram, Discord, CLI and other channels. This PR adds regex handling to strip these tags in `strip_think()`.

### Core

- **fix: strip `<thought>` blocks from Gemma 4 and similar models** — Add regex patterns for closed and unclosed `<thought>` tags in `strip_think()`, alongside existing handling. (#2973)
- **test: add regression tests for `<thought>` tag stripping** — 9 test cases covering closed/unclosed tags, multiline, nested angle brackets, multiple blocks, edge cases.

@flobo3 thanks for your contribution