### PR TITLE
fix(gitstore): preserve existing .gitignore and add missing runtime excludes

### DIFF
--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -51,9 +51,21 @@ class GitStore:
 
             porcelain.init(str(self._workspace))
 
-            # Write .gitignore
+            # Write .gitignore (merge if already exists, write fresh if not)
             gitignore = self._workspace / ".gitignore"
-            gitignore.write_text(self._build_gitignore(), encoding="utf-8")
+            new_content = self._build_gitignore()
+            if not gitignore.exists():
+                gitignore.write_text(new_content, encoding="utf-8")
+            else:
+                existing = gitignore.read_text(encoding="utf-8")
+                existing_lines = set(existing.splitlines())
+                extra = [
+                    line for line in new_content.splitlines()
+                    if line not in existing_lines
+                ]
+                if extra:
+                    append_block = "\n" + "\n".join(extra) + "\n"
+                    gitignore.write_text(existing.rstrip("\n") + "\n" + append_block, encoding="utf-8")
 
             # Ensure tracked files exist (touch them if missing) so the initial
             # commit has something to track.
@@ -150,6 +162,11 @@ class GitStore:
         for f in self._tracked_files:
             lines.append(f"!{f}")
         lines.append("!.gitignore")
+        # Runtime-only files that should never be tracked
+        lines.append("memory/.cursor")
+        lines.append("memory/.dream_cursor")
+        lines.append("memory/HISTORY.md.bak")
+        lines.append("memory/history.jsonl")
         return "\n".join(lines) + "\n"
 
     # -- query -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #2980 — `GitStore.init()` was unconditionally overwriting `workspace/.gitignore`, destroying user-managed content and breaking parent git repositories.

**Changes to `nanobot/utils/gitstore.py`:**

1. **Preserve existing `.gitignore`** — if the file already exists, only append lines that aren't already present (merge strategy). No overwrite, no data loss.

2. **Add missing runtime excludes to `_build_gitignore()`** — the following nanobot runtime files were unintentionally tracked by the internal git store:
   - `memory/.cursor`
   - `memory/.dream_cursor`
   - `memory/HISTORY.md.bak`
   - `memory/history.jsonl`

## Test plan
- [ ] Fresh install: `.gitignore` created correctly with all entries
- [ ] Upgrade with existing `.gitignore`: file is not overwritten, only missing entries appended
- [ ] Runtime files (`memory/.cursor`, etc.) no longer appear as untracked in the workspace repo
- [ ] Parent repo `git status` is not polluted after nanobot init

Closes #2980