### PR TITLE
fix(dingtalk): downloaded files missing extension and overwriting each other

### DIFF
--- a/nanobot/channels/dingtalk.py
+++ b/nanobot/channels/dingtalk.py
@@ -597,6 +597,18 @@ class DingTalkChannel(BaseChannel):
                 logger.error("DingTalk file download failed: status={}", file_resp.status_code)
                 return None
 
+            # Fix missing extension using Content-Type header
+            content_type = (file_resp.headers.get("content-type") or "").split(";")[0].strip()
+            if not Path(filename).suffix and content_type:
+                ext = mimetypes.guess_extension(content_type)
+                if ext:
+                    filename = f"{filename}{ext}"
+
+            # Prepend millisecond timestamp so files are never overwritten
+            stem = Path(filename).stem or "file"
+            suffix = Path(filename).suffix
+            filename = f"{stem}_{int(time.time() * 1000)}{suffix}"
+
             # Save to media directory (accessible under workspace)
             download_dir = get_media_dir("dingtalk") / sender_id
             download_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/channels/test_dingtalk_channel.py
+++ b/tests/channels/test_dingtalk_channel.py
@@ -228,18 +228,52 @@ async def test_download_dingtalk_file(tmp_path, monkeypatch) -> None:
         "nanobot.config.paths.get_media_dir",
         lambda channel_name=None: tmp_path / channel_name if channel_name else tmp_path,
     )
+    monkeypatch.setattr(dingtalk_module.time, "time", lambda: 1712345678.901)
 
     result = await channel._download_dingtalk_file("code123", "test.xlsx", "user1")
 
     assert result is not None
-    assert result.endswith("test.xlsx")
-    assert (tmp_path / "dingtalk" / "user1" / "test.xlsx").read_bytes() == file_content
+    assert result.endswith("test_1712345678901.xlsx")
+    assert (tmp_path / "dingtalk" / "user1" / "test_1712345678901.xlsx").read_bytes() == file_content
 
     # Verify API calls
     assert channel._http.calls[0]["method"] == "POST"
     assert "messageFiles/download" in channel._http.calls[0]["url"]
     assert channel._http.calls[0]["json"]["downloadCode"] == "code123"
     assert channel._http.calls[1]["method"] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_download_dingtalk_file_infers_extension_from_content_type(tmp_path, monkeypatch) -> None:
+    channel = DingTalkChannel(
+        DingTalkConfig(client_id="app", client_secret="secret", allow_from=["*"]),
+        MessageBus(),
+    )
+
+    async def fake_get_token():
+        return "test-token"
+
+    monkeypatch.setattr(channel, "_get_access_token", fake_get_token)
+
+    file_content = b"fake jpeg content"
+    channel._http = _FakeHttp(responses=[
+        _FakeResponse(200, {"downloadUrl": "https://example.com/tmpfile"}),
+        _FakeResponse(200),
+    ])
+    channel._http._responses[1].content = file_content
+    channel._http._responses[1].headers = {"content-type": "image/jpeg"}
+
+    monkeypatch.setattr(
+        "nanobot.config.paths.get_media_dir",
+        lambda channel_name=None: tmp_path / channel_name if channel_name else tmp_path,
+    )
+    monkeypatch.setattr(dingtalk_module.time, "time", lambda: 1712345678.902)
+
+    result = await channel._download_dingtalk_file("code123", "file", "user1")
+
+    assert result is not None
+    assert result.endswith("file_1712345678902.jpg")
+    assert (tmp_path / "dingtalk" / "user1" / "file_1712345678902.jpg").read_bytes() == file_content
 
 
 def test_normalize_upload_payload_zips_html_attachment() -> None:


### PR DESCRIPTION
## Problem

When users send images in DingTalk, the SDK sometimes delivers them as `message_type = "file"` instead of `"picture"`. In this case the SDK provides no `fileName`, so the code falls back to the bare string `"file"` with no extension. This causes three problems:

1. **Missing extension** — images are saved as `file` instead of `file.jpg`. When this file is later sent to the LLM, the API cannot determine the file type and returns `Error: {'message': 'Not Found', 'code': 404}`, breaking the image understanding pipeline.
2. **Overwriting** — every subsequent download saves to the same path (`<media_dir>/<sender_id>/file`), silently overwriting the previous file. Only the last received file survives.
3. **Lost context** — because earlier files are overwritten, the LLM never sees them, even if the user sent multiple images in a conversation.

## Changes

Two fixes in `_download_dingtalk_file()`:

- **Infer extension from Content-Type**: when the filename has no suffix, use the HTTP `Content-Type` response header to guess the extension (e.g. `image/jpeg` → `.jpg`), so the LLM can correctly identify the file type.
- **Unique filenames**: append a millisecond timestamp to every downloaded filename (e.g. `file_1712345678901.jpg`) so files are never overwritten.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Image (delivered as "file" type) | `file` — no ext, LLM 404 | `file_1712345678901.jpg` |
| Same image sent again | overwrites previous `file` | `file_1712345678902.jpg` |
| PDF with fileName | `report.pdf` — overwritten on resend | `report_1712345678903.pdf` |
| Image (delivered as "picture" type) | `image.jpg` — overwritten on resend | `image_1712345678904.jpg` |

## Test plan

- [ ] Send an image in DingTalk 1:1 chat → verify file saved with `.jpg` extension and LLM processes it without 404
- [ ] Send the same image again → verify a new file is created, not overwritten
- [ ] Send a PDF/Word file → verify original fileName preserved with timestamp appended
- [ ] Send an image in group chat → verify same behavior