### PR TITLE
feat: custom provider names and extensible commands

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -225,6 +225,25 @@ class AgentLoop:
         self._register_default_tools()
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
+        self._load_custom_commands()
+
+    def _load_custom_commands(self) -> None:
+        """Load custom command handlers from workspace/commands/*.py files."""
+        commands_dir = self.workspace / "commands"
+        if not commands_dir.exists():
+            return
+        import importlib.util
+        for cmd_file in sorted(commands_dir.glob("*.py")):
+            if cmd_file.stem.startswith("_"):
+                continue
+            try:
+                spec = importlib.util.spec_from_file_location(cmd_file.stem, cmd_file)
+                mod = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
+                if hasattr(mod, "register"):
+                    mod.register(self.commands)
+            except Exception:
+                pass  # Skip broken command files silently
 
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -324,6 +324,9 @@ def build_help_text() -> str:
         "/dream — Manually trigger Dream consolidation",
         "/dream-log — Show what the last Dream changed",
         "/dream-restore — Revert memory to a previous state",
+        "/providers — List configured providers",
+        "/switch <name> — Switch to a provider",
+        "/model <name> — Show or change model name",
         "/help — Show available commands",
     ]
     return "\n".join(lines)

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -97,6 +97,8 @@ class ProviderConfig(Base):
 class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
+    model_config = ConfigDict(extra="allow")  # Allow custom provider names (e.g. myapi1, myapi2)
+
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
     azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -228,6 +230,10 @@ class Config(BaseSettings):
             if spec:
                 p = getattr(self.providers, spec.name, None)
                 return (p, spec.name) if p else (None, None)
+            # Fallback: try custom provider name not in registry
+            custom_p = getattr(self.providers, forced, None)
+            if custom_p and (custom_p.api_key or custom_p.api_base):
+                return custom_p, forced
             return None, None
 
         model_lower = (model or self.agents.defaults.model).lower()
@@ -245,6 +251,12 @@ class Config(BaseSettings):
             if p and model_prefix and normalized_prefix == spec.name:
                 if spec.is_oauth or spec.is_local or p.api_key:
                     return p, spec.name
+
+        # Fallback: try custom provider name not in registry
+        if model_prefix:
+            custom_p = getattr(self.providers, model_prefix, None)
+            if custom_p and (custom_p.api_key or custom_p.api_base):
+                return custom_p, model_prefix
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
@@ -310,5 +322,27 @@ class Config(BaseSettings):
             if spec and (spec.is_gateway or spec.is_local) and spec.default_api_base:
                 return spec.default_api_base
         return None
+
+    def get_custom_providers(self) -> list[tuple[str, "ProviderConfig"]]:
+        """List all configured providers that have api_key or api_base.
+
+        Returns list of (provider_name, config) tuples, with the current active one first.
+        """
+        from nanobot.providers.registry import PROVIDERS
+
+        all_configured = set(self.providers.model_dump().keys())
+        result: list[tuple[str, ProviderConfig]] = []
+        current_provider = self.agents.defaults.provider
+
+        for name in sorted(all_configured):
+            if name.startswith("_"):
+                continue
+            p = getattr(self.providers, name, None)
+            if p and hasattr(p, "api_key") and (getattr(p, "api_key", None) or getattr(p, "api_base", None)):
+                result.append((name, p))
+
+        # Sort: current provider first
+        result.sort(key=lambda x: (0 if x[0] == current_provider else 1, x[0]))
+        return result
 
     model_config = ConfigDict(env_prefix="NANOBOT_", env_nested_delimiter="__")

--- a/workspace/commands/switch_provider.py
+++ b/workspace/commands/switch_provider.py
@@ -1,0 +1,222 @@
+"""
+Custom command: provider switcher
+Commands: /providers, /switch, /add-provider, /model
+
+Register with: register(CommandRouter)
+"""
+
+from __future__ import annotations
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.command.router import CommandRouter
+
+
+def register(router: CommandRouter) -> None:
+    """Register custom provider management commands."""
+    router.exact("/providers", cmd_providers)
+    router.exact("/model", cmd_model)
+    router.prefix("/model ", cmd_model)
+    router.prefix("/switch ", cmd_switch)
+    router.prefix("/add-provider ", cmd_add_provider)
+
+
+def _get_runtime_config():
+    """Load the current runtime config (Config type)."""
+    from nanobot.config.loader import load_config
+    return load_config()
+
+
+def _get_provider_list(config):
+    """Get list of (name, has_config, is_current) tuples."""
+    current_provider = config.agents.defaults.provider
+    all_configured = set(config.providers.model_dump().keys())
+
+    result = []
+    for name in sorted(all_configured):
+        if name.startswith("_"):
+            continue
+        p = getattr(config.providers, name, None)
+        has_config = p and (getattr(p, "api_key", None) or getattr(p, "api_base", None))
+        if not has_config:
+            continue
+        is_current = (name == current_provider)
+        result.append((name, p, is_current))
+
+    # Sort: current provider first
+    result.sort(key=lambda x: (0 if x[2] else 1, x[0]))
+    return result
+
+
+def _get_host(api_base: str | None) -> str:
+    """Extract hostname from api_base for display."""
+    if not api_base:
+        return "unconfigured"
+    try:
+        from urllib.parse import urlparse
+        parsed = urlparse(api_base)
+        return parsed.hostname or api_base[:40]
+    except Exception:
+        return api_base[:40]
+
+
+def _save_config(config) -> None:
+    """Persist config using nanobot's built-in save_config."""
+    from nanobot.config.loader import save_config as nanobot_save
+    nanobot_save(config)
+
+
+def _reply(ctx, content: str) -> OutboundMessage:
+    """Build a reply OutboundMessage from the command context."""
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=content,
+        metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
+    )
+
+
+async def cmd_providers(ctx) -> OutboundMessage:
+    """List all configured providers and mark the active one."""
+    config = _get_runtime_config()
+    providers = _get_provider_list(config)
+
+    if not providers:
+        return _reply(ctx,
+            "[none] No providers configured\n\nUse: /add-provider <name> <api_base> <api_key>",
+        )
+
+    lines = ["Configured Providers:"]
+    for name, p, is_current in providers:
+        marker = "[*]" if is_current else "[ ]"
+        key_status = "yes" if getattr(p, "api_key", None) else "no"
+        host = _get_host(getattr(p, "api_base", None))
+        lines.append(f"  {marker} {name} -- {host} (key: {key_status})")
+
+    lines.append("")
+    lines.append("Tip: /switch <name> to switch, /add-provider <name> <url> to add")
+
+    return _reply(ctx, "\n".join(lines))
+
+
+async def cmd_switch(ctx) -> OutboundMessage:
+    """Switch to a specific provider, optionally also changing the model."""
+    parts = ctx.msg.content.split()
+    # /switch <provider_name> [model]
+    if len(parts) < 2 or not parts[1].strip():
+        return _reply(ctx,
+            "Usage: /switch <provider_name> [model]\n\nUse /providers to see available providers",
+        )
+
+    name = parts[1].strip()
+    model = parts[2] if len(parts) > 2 else ""
+    config = _get_runtime_config()
+    providers = _get_provider_list(config)
+    available = [n for n, _, _ in providers]
+
+    if name not in available:
+        return _reply(ctx,
+            f"Error: provider \"{name}\" is not configured\n\nAvailable: {', '.join(available)}",
+        )
+
+    # Determine model: use provided model if given, otherwise keep current
+    if model:
+        target_model = model
+    else:
+        target_model = config.agents.defaults.model
+
+    # Update config
+    config.agents.defaults.provider = name
+    config.agents.defaults.model = target_model
+
+    # Save to config file
+    _save_config(config)
+
+    output = f"Switched to {name}\n   model: {target_model}"
+    if model:
+        output += "\n\nRequires /restart to take effect."
+    else:
+        output += "\n\nRequires /restart to take effect."
+
+    return _reply(ctx, output)
+
+
+async def cmd_add_provider(ctx) -> OutboundMessage:
+    """Add a new custom provider with optional default model."""
+    parts = ctx.msg.content.split()
+    # /add-provider <name> <api_base> [api_key] [model]
+    if len(parts) < 4:
+        return _reply(ctx,
+            "Usage: /add-provider <name> <api_base> [api_key] [model]\n\nExample: /add-provider myapi https://api.example.com/v1 sk-xxx qwen/qwen3.6-plus",
+        )
+
+    name = parts[1]
+    api_base = parts[2]
+    api_key = parts[3] if len(parts) > 3 else ""
+    model = parts[4] if len(parts) > 4 else ""
+
+    # Validate name (alphanumeric + underscore only)
+    import re
+    if not re.match(r"^[a-zA-Z0-9_]+$", name):
+        return _reply(ctx, "Error: name must contain only letters, digits, and underscores")
+
+    config = _get_runtime_config()
+
+    # Check if provider already exists and has config
+    existing = getattr(config.providers, name, None)
+    if existing and (getattr(existing, "api_key", None) or getattr(existing, "api_base", None)):
+        return _reply(ctx,
+            f"Provider \"{name}\" already exists. Use /switch {name} to activate it",
+        )
+
+    # Create provider config
+    from nanobot.config.schema import ProviderConfig
+    provider_config = ProviderConfig(api_key=api_key, api_base=api_base)
+
+    # Set on providers object
+    setattr(config.providers, name, provider_config)
+
+    # If a model was provided, also set the default model and activate this provider
+    if model:
+        config.agents.defaults.provider = name
+        config.agents.defaults.model = model
+
+    # Save to config file
+    _save_config(config)
+
+    lines = [f"Added provider: {name}", f"   api_base: {api_base}"]
+    if model:
+        lines.append(f"   model: {model}")
+        lines.append("")
+        lines.append(f"Activated as current provider. Requires /restart to take effect.")
+    else:
+        lines.append("")
+        lines.append(f"Use /switch {name} to activate.")
+
+    return _reply(ctx, "\n".join(lines))
+
+
+async def cmd_model(ctx) -> OutboundMessage:
+    """Show or change the current model name, preserving the full input."""
+    config = _get_runtime_config()
+    current_model = config.agents.defaults.model
+    current_provider = config.agents.defaults.provider
+
+    # No argument -- show current model
+    parts = ctx.msg.content.split(None, 1)
+    if len(parts) < 2 or not parts[1].strip():
+        return _reply(ctx,
+            f"Current model: {current_model}\n   provider: {current_provider}\n\n"
+            f"Usage: /model <model_name>  (e.g. /model gpt-4o or /model qwen/qwen3.6-plus)\n"
+            f"Requires /restart to take effect",
+        )
+
+    new_model = parts[1].strip()
+
+    # Keep full input as-is, do not strip prefix
+    config.agents.defaults.model = new_model
+    _save_config(config)
+
+    return _reply(ctx,
+        f"Model changed to: {new_model}\n   provider: {current_provider}\n\n"
+        f"Requires /restart to take effect",
+    )


### PR DESCRIPTION
## Summary

Three changes:

1. **Custom provider names** -- `ProvidersConfig` now supports arbitrary provider names (e.g. `myapi1`, `myapi2`) via `extra="allow"`. Users are no longer restricted to registry-defined names.

2. **`_match_provider()` fallback** -- Two fallback paths added so custom provider names work via both the `provider` config field and the `provider/model-name` prefix syntax.

3. **Custom commands** -- `AgentLoop` now auto-loads `.py` files from `workspace/commands/` at startup. A `register(CommandRouter)` entry point lets plugins add commands without touching core code.

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `nanobot/config/schema.py` | +34 | `extra="allow"`, `_match_provider` fallbacks, `get_custom_providers()` |
| `nanobot/agent/loop.py` | +19 | `_load_custom_commands()` auto-loader |
| `nanobot/command/builtin.py` | +3 | help text for new commands |
| `workspace/commands/switch_provider.py` | +222 | NEW: `/providers`, `/switch`, `/add-provider`, `/model` commands |

## Usage

### Config

```json
{
  "agents": {
    "defaults": {
      "model": "qwen3.6-plus",
      "provider": "myapi1"
    }
  },
  "providers": {
    "myapi1": {
      "apiKey": "sk-xxx",
      "apiBase": "https://api.provider1.com/v1"
    },
    "myapi2": {
      "apiKey": "sk-yyy",
      "apiBase": "https://api.provider2.com/v1"
    }
  }
}
```

### Commands

```
/providers                              -- list configured providers, mark active one
/switch myapi2                          -- switch provider, keep current model
/switch myapi2 qwen/qwen3.6-plus        -- switch provider AND set model
/model                                  -- show current model
/model gpt-4o                           -- change model (keeps current provider)
/add-provider foo https://api.foo.com/v1 sk-key qwen/qwen3.6-plus  -- add provider and activate
/add-provider foo https://api.foo.com/v1                             -- add provider only
```

## Backward Compatibility

- Fully backward compatible. Existing configs with registry provider names continue to work unchanged.
- `extra="allow"` only affects `ProvidersConfig`; no other schema classes are modified.
- Custom command loading silently skips missing/broken files -- no crash risk.