### PR TITLE
refactor(config): migrate provider configuration to support list format

### DIFF
--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -68,8 +68,8 @@ class ChannelManager:
         """Pick the API key for the configured transcription provider."""
         try:
             if provider == "openai":
-                return self.config.providers.openai.api_key
-            return self.config.providers.groq.api_key
+                return self.config.providers.primary("openai").api_key
+            return self.config.providers.primary("groq").api_key
         except AttributeError:
             return ""
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1307,19 +1307,20 @@ def status():
 
         # Check API keys from registry
         for spec in PROVIDERS:
-            p = getattr(config.providers, spec.name, None)
-            if p is None:
+            entries = getattr(config.providers, spec.name, None) or []
+            if not entries:
                 continue
             if spec.is_oauth:
                 console.print(f"{spec.label}: [green]✓ (OAuth)[/green]")
             elif spec.is_local:
                 # Local deployments show api_base instead of api_key
-                if p.api_base:
-                    console.print(f"{spec.label}: [green]✓ {p.api_base}[/green]")
+                bases = [p.api_base for p in entries if p.api_base]
+                if bases:
+                    console.print(f"{spec.label}: [green]✓ {bases[0]}[/green]")
                 else:
                     console.print(f"{spec.label}: [dim]not set[/dim]")
             else:
-                has_key = bool(p.api_key)
+                has_key = any(p.api_key for p in entries)
                 console.print(f"{spec.label}: {'[green]✓[/green]' if has_key else '[dim]not set[/dim]'}")
 
 

--- a/nanobot/cli/onboard.py
+++ b/nanobot/cli/onboard.py
@@ -675,11 +675,12 @@ def _get_provider_names() -> dict[str, str]:
 
 
 def _configure_provider(config: Config, provider_name: str) -> None:
-    """Configure a single LLM provider."""
-    provider_config = getattr(config.providers, provider_name, None)
-    if provider_config is None:
+    """Configure a single LLM provider (edits the first entry in the list for that key)."""
+    entries = getattr(config.providers, provider_name, None)
+    if not entries:
         console.print(f"[red]Unknown provider: {provider_name}[/red]")
         return
+    provider_config = entries[0]
 
     display_name = _get_provider_names().get(provider_name, provider_name)
     info = _get_provider_info()
@@ -693,7 +694,9 @@ def _configure_provider(config: Config, provider_name: str) -> None:
         display_name,
     )
     if updated_provider is not None:
-        setattr(config.providers, provider_name, updated_provider)
+        new_entries = list(entries)
+        new_entries[0] = updated_provider
+        setattr(config.providers, provider_name, new_entries)
 
 
 def _configure_providers(config: Config) -> None:
@@ -704,7 +707,7 @@ def _configure_providers(config: Config) -> None:
         choices = []
         for name, display in _get_provider_names().items():
             provider = getattr(config.providers, name, None)
-            if provider and provider.api_key:
+            if provider and any(p.api_key for p in provider):
                 choices.append(f"{display} *")
             else:
                 choices.append(display)
@@ -892,7 +895,8 @@ def _show_summary(config: Config) -> None:
     provider_rows = []
     for name, display in _get_provider_names().items():
         provider = getattr(config.providers, name, None)
-        status = "[green]configured[/green]" if (provider and provider.api_key) else "[dim]not configured[/dim]"
+        configured = provider and any(p.api_key for p in provider)
+        status = "[green]configured[/green]" if configured else "[dim]not configured[/dim]"
         provider_rows.append((display, status))
     _print_summary_panel(provider_rows, "LLM Providers")
 

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -117,4 +117,19 @@ def _migrate_config(data: dict) -> dict:
     exec_cfg = tools.get("exec", {})
     if "restrictToWorkspace" in exec_cfg and "restrictToWorkspace" not in tools:
         tools["restrictToWorkspace"] = exec_cfg.pop("restrictToWorkspace")
+    _migrate_providers_legacy_objects_to_lists(data)
     return data
+
+
+def _migrate_providers_legacy_objects_to_lists(data: dict) -> None:
+    """Turn legacy ``providers.<name>: { ... }`` into ``providers.<name>: [ { ... } ]``.
+
+    New configs use a list per key for multiple endpoints; old files used one
+    object per key. Idempotent if values are already lists.
+    """
+    prov = data.get("providers")
+    if not isinstance(prov, dict):
+        return
+    for key, val in list(prov.items()):
+        if isinstance(val, dict):
+            prov[key] = [val]

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -1,9 +1,9 @@
 """Configuration schema using Pydantic."""
 
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, BeforeValidator, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
 
@@ -99,38 +99,92 @@ class ProviderConfig(Base):
     api_key: str = ""
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
+    models: list[str] = Field(default_factory=list)
+
+
+def _coerce_provider_entry_list(v: Any) -> Any:
+    """Normalize one provider object or a list per registry key (multi-endpoint).
+
+    Legacy JSON uses a single object; new JSON uses an array. Loader migration
+    may already wrap dicts in a list; this validator keeps both paths safe.
+    """
+    if v is None:
+        return [{}]
+    if isinstance(v, list):
+        return v if v else [{}]
+    return [v]
+
+
+ProviderEntryList = Annotated[
+    list[ProviderConfig],
+    BeforeValidator(_coerce_provider_entry_list),
+]
+
+
+def _provider_entries(providers: "ProvidersConfig", name: str) -> list[ProviderConfig]:
+    lst = getattr(providers, name, None)
+    return list(lst) if lst else []
 
 
 class ProvidersConfig(Base):
-    """Configuration for LLM providers."""
+    """Configuration for LLM providers.
 
-    custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
-    azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
-    anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
-    openai: ProviderConfig = Field(default_factory=ProviderConfig)
-    openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
-    deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
-    groq: ProviderConfig = Field(default_factory=ProviderConfig)
-    zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
-    dashscope: ProviderConfig = Field(default_factory=ProviderConfig)
-    vllm: ProviderConfig = Field(default_factory=ProviderConfig)
-    ollama: ProviderConfig = Field(default_factory=ProviderConfig)  # Ollama local models
-    ovms: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenVINO Model Server (OVMS)
-    gemini: ProviderConfig = Field(default_factory=ProviderConfig)
-    moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
-    minimax: ProviderConfig = Field(default_factory=ProviderConfig)
-    mistral: ProviderConfig = Field(default_factory=ProviderConfig)
-    stepfun: ProviderConfig = Field(default_factory=ProviderConfig)  # Step Fun (阶跃星辰)
-    xiaomi_mimo: ProviderConfig = Field(default_factory=ProviderConfig)  # Xiaomi MIMO (小米)
-    aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
-    siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
-    volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)
-    volcengine_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine Coding Plan
-    byteplus: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus (VolcEngine international)
-    byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
-    openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
-    github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
-    qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
+    **New format:** each registry key is a JSON array of provider blocks, e.g.
+    ``"openrouter": [ {"apiKey": "...", "models": [...]}, {...} ]``.
+
+    **Legacy format (still supported):** a single object per key,
+    ``"openrouter": {"apiKey": "..."}``, is accepted in JSON and via
+    :func:`nanobot.config.loader._migrate_config`; it is normalized to a
+    one-element list. :class:`ProviderConfig` also runs the same coercion at
+    parse time.
+
+    Runtime matching walks each list in registry order and uses the first
+    eligible block (see :meth:`Config._match_provider`).
+    """
+
+    custom: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # Any OpenAI-compatible endpoint
+    azure_openai: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # Azure OpenAI (model = deployment name)
+    anthropic: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    openai: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    openrouter: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    deepseek: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    groq: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    zhipu: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    dashscope: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    vllm: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    ollama: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # Ollama local models
+    ovms: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # OpenVINO Model Server (OVMS)
+    gemini: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    moonshot: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    minimax: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    mistral: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])
+    stepfun: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # Step Fun (阶跃星辰)
+    xiaomi_mimo: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # Xiaomi MIMO (小米)
+    aihubmix: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # AiHubMix API gateway
+    siliconflow: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # SiliconFlow (硅基流动)
+    volcengine: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # VolcEngine (火山引擎)
+    volcengine_coding_plan: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # VolcEngine Coding Plan
+    byteplus: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # BytePlus (VolcEngine international)
+    byteplus_coding_plan: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # BytePlus Coding Plan
+    openai_codex: ProviderEntryList = Field(
+        default_factory=lambda: [ProviderConfig()], exclude=True
+    )  # OpenAI Codex (OAuth)
+    github_copilot: ProviderEntryList = Field(
+        default_factory=lambda: [ProviderConfig()], exclude=True
+    )  # Github Copilot (OAuth)
+    qianfan: ProviderEntryList = Field(default_factory=lambda: [ProviderConfig()])  # Qianfan (百度千帆)
+
+    def primary(self, registry_name: str) -> ProviderConfig:
+        """First provider block for *registry_name* (same as legacy single-object access).
+
+        Use this when you only need the default/first endpoint. For multiple
+        entries, access the list attribute (e.g. ``config.providers.groq``) or
+        iterate.
+        """
+        lst = getattr(self, registry_name, None)
+        if lst:
+            return lst[0]
+        return ProviderConfig()
 
 
 class HeartbeatConfig(Base):
@@ -233,8 +287,9 @@ class Config(BaseSettings):
         if forced != "auto":
             spec = find_by_name(forced)
             if spec:
-                p = getattr(self.providers, spec.name, None)
-                return (p, spec.name) if p else (None, None)
+                for p in _provider_entries(self.providers, spec.name):
+                    if p is not None:
+                        return p, spec.name
             return None, None
 
         model_lower = (model or self.agents.defaults.model).lower()
@@ -246,19 +301,46 @@ class Config(BaseSettings):
             kw = kw.lower()
             return kw in model_lower or kw.replace("-", "_") in model_normalized
 
+        def _models_list_matches(models: list[str]) -> bool:
+            """True if the requested model equals a configured entry (case-insensitive; -/_ normalized)."""
+            for entry in models:
+                e = entry.strip().lower()
+                if not e:
+                    continue
+                e_norm = e.replace("-", "_")
+                if model_lower == e or model_normalized == e_norm:
+                    return True
+                if "/" in model_lower:
+                    tail = model_lower.split("/", 1)[1]
+                    tail_norm = tail.replace("-", "_")
+                    if tail == e or tail_norm == e_norm:
+                        return True
+            return False
+
         # Explicit provider prefix wins — prevents `github-copilot/...codex` matching openai_codex.
         for spec in PROVIDERS:
-            p = getattr(self.providers, spec.name, None)
-            if p and model_prefix and normalized_prefix == spec.name:
-                if spec.is_oauth or spec.is_local or p.api_key:
-                    return p, spec.name
+            for p in _provider_entries(self.providers, spec.name):
+                if not p:
+                    continue
+                if model_prefix and normalized_prefix == spec.name:
+                    if spec.is_oauth or spec.is_local or p.api_key:
+                        return p, spec.name
+
+        # Prefer providers that explicitly list this model (providers.<name>[].models); registry order breaks ties.
+        for spec in PROVIDERS:
+            for p in _provider_entries(self.providers, spec.name):
+                if not (p and p.models):
+                    continue
+                if _models_list_matches(p.models):
+                    if spec.is_oauth or spec.is_local or p.api_key:
+                        return p, spec.name
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
-            p = getattr(self.providers, spec.name, None)
-            if p and any(_kw_matches(kw) for kw in spec.keywords):
-                if spec.is_oauth or spec.is_local or p.api_key:
-                    return p, spec.name
+            for p in _provider_entries(self.providers, spec.name):
+                if p and any(_kw_matches(kw) for kw in spec.keywords):
+                    if spec.is_oauth or spec.is_local or p.api_key:
+                        return p, spec.name
 
         # Fallback: configured local providers can route models without
         # provider-specific keywords (for example plain "llama3.2" on Ollama).
@@ -268,13 +350,13 @@ class Config(BaseSettings):
         for spec in PROVIDERS:
             if not spec.is_local:
                 continue
-            p = getattr(self.providers, spec.name, None)
-            if not (p and p.api_base):
-                continue
-            if spec.detect_by_base_keyword and spec.detect_by_base_keyword in p.api_base:
-                return p, spec.name
-            if local_fallback is None:
-                local_fallback = (p, spec.name)
+            for p in _provider_entries(self.providers, spec.name):
+                if not (p and p.api_base):
+                    continue
+                if spec.detect_by_base_keyword and spec.detect_by_base_keyword in p.api_base:
+                    return p, spec.name
+                if local_fallback is None:
+                    local_fallback = (p, spec.name)
         if local_fallback:
             return local_fallback
 
@@ -283,9 +365,9 @@ class Config(BaseSettings):
         for spec in PROVIDERS:
             if spec.is_oauth:
                 continue
-            p = getattr(self.providers, spec.name, None)
-            if p and p.api_key:
-                return p, spec.name
+            for p in _provider_entries(self.providers, spec.name):
+                if p and p.api_key:
+                    return p, spec.name
         return None, None
 
     def get_provider(self, model: str | None = None) -> ProviderConfig | None:

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -175,7 +175,7 @@ async def test_manager_loads_plugin_from_dict_config():
         channels=ChannelsConfig.model_validate({
             "fakeplugin": {"enabled": True, "allowFrom": ["*"]},
         }),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     with patch(
@@ -278,7 +278,7 @@ async def test_manager_skips_disabled_plugin():
         channels=ChannelsConfig.model_validate({
             "fakeplugin": {"enabled": False},
         }),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     with patch(
@@ -374,7 +374,7 @@ async def test_send_with_retry_succeeds_first_try():
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(send_max_retries=3),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -411,7 +411,7 @@ async def test_send_with_retry_retries_on_failure():
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(send_max_retries=3),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -452,7 +452,7 @@ async def test_send_with_retry_no_retry_when_max_is_zero():
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(send_max_retries=0),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -493,7 +493,7 @@ async def test_send_with_retry_calls_send_delta():
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(send_max_retries=3),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -537,7 +537,7 @@ async def test_send_with_retry_skips_send_when_streamed():
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(send_max_retries=3),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -575,7 +575,7 @@ async def test_send_with_retry_propagates_cancelled_error():
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(send_max_retries=3),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -612,7 +612,7 @@ async def test_send_with_retry_propagates_cancelled_error_during_sleep():
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(send_max_retries=3),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -683,7 +683,7 @@ async def test_validate_allow_from_raises_on_empty_list():
     """_validate_allow_from should raise SystemExit when allow_from is empty list."""
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -702,7 +702,7 @@ async def test_validate_allow_from_passes_with_asterisk():
     """_validate_allow_from should not raise when allow_from contains '*'."""
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -719,7 +719,7 @@ async def test_get_channel_returns_channel_if_exists():
     """get_channel should return the channel if it exists."""
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -737,7 +737,7 @@ async def test_get_status_returns_running_state():
     """get_status should return enabled and running state for each channel."""
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -758,7 +758,7 @@ async def test_enabled_channels_returns_channel_names():
     """enabled_channels should return list of enabled channel names."""
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -782,7 +782,7 @@ async def test_stop_all_cancels_dispatcher_and_stops_channels():
     """stop_all should cancel the dispatch task and stop all channels."""
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -826,7 +826,7 @@ async def test_start_channel_logs_error_on_failure():
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -859,7 +859,7 @@ async def test_stop_all_handles_channel_exception():
 
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -877,7 +877,7 @@ async def test_start_all_no_channels_logs_warning():
     """start_all should log warning when no channels are enabled."""
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -897,7 +897,7 @@ async def test_start_all_creates_dispatch_task():
     """start_all should create the dispatch task when channels exist."""
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)
@@ -936,7 +936,7 @@ async def test_notify_restart_done_enqueues_outbound_message():
     """Restart notice should schedule send_with_retry for target channel."""
     fake_config = SimpleNamespace(
         channels=ChannelsConfig(),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=[SimpleNamespace(api_key="")]),
     )
 
     mgr = ChannelManager.__new__(ChannelManager)

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -276,6 +276,132 @@ def test_config_auto_detects_ollama_from_local_api_base():
     assert config.get_api_base() == "http://localhost:11434/v1"
 
 
+def test_config_prefers_provider_when_model_listed_in_models_over_registry_order():
+    """Explicit models[] should win over default gateway ordering when both have api_key."""
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "my-routed-model-xyz"}},
+            "providers": {
+                "openrouter": {"apiKey": "sk-or-test"},
+                "aihubmix": {"apiKey": "k", "models": ["my-routed-model-xyz"]},
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "aihubmix"
+
+
+def test_config_models_list_matches_tail_after_provider_slash():
+    """List entry can match the part after the first slash (not a registered provider prefix)."""
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "auto",
+                    "model": "gateway/anthropic/claude-3-haiku",
+                }
+            },
+            "providers": {
+                "openrouter": {"apiKey": "sk-or-test"},
+                "aihubmix": {"apiKey": "k", "models": ["anthropic/claude-3-haiku"]},
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "aihubmix"
+
+
+def test_config_models_list_normalizes_hyphen_and_underscore():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "MY-MODEL-ID"}},
+            "providers": {
+                "openrouter": {"apiKey": "sk-or-test"},
+                "siliconflow": {"apiKey": "sf", "models": ["my_model_id"]},
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "siliconflow"
+
+
+def test_config_models_list_registry_order_breaks_tie_when_same_model_configured_twice():
+    """Both list the same model and have keys; earlier PROVIDERS entry wins (openrouter before aihubmix)."""
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "duplicate-route-model"}},
+            "providers": {
+                "openrouter": {"apiKey": "sk-or-a"},
+                "aihubmix": {"apiKey": "k-b", "models": ["duplicate-route-model"]},
+            },
+        }
+    )
+    config.providers.openrouter[0].models = ["duplicate-route-model"]
+
+    assert config.get_provider_name() == "openrouter"
+
+
+def test_config_models_list_skips_provider_without_api_key():
+    """Match in models[] is ignored if that provider has no usable key; fallback applies."""
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "only-on-empty-key-provider"}},
+            "providers": {
+                "openrouter": {"apiKey": "sk-or-test"},
+                "aihubmix": {"apiKey": "", "models": ["only-on-empty-key-provider"]},
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "openrouter"
+
+
+def test_config_explicit_model_prefix_wins_before_models_list_on_other_provider():
+    """provider/model prefix is resolved before models[] on a different provider."""
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "openrouter/gpt-4o-mini"}},
+            "providers": {
+                "openrouter": {"apiKey": "sk-or-test"},
+                "aihubmix": {"apiKey": "k", "models": ["openrouter/gpt-4o-mini"]},
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "openrouter"
+
+
+def test_config_empty_models_array_does_not_trigger_explicit_model_routing():
+    """Empty models list is falsy; routing uses keyword/fallback as without models."""
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "no-keyword-fallback-model-zz"}},
+            "providers": {
+                "openrouter": {"apiKey": "sk-or-first"},
+                "aihubmix": {"apiKey": "k", "models": []},
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "openrouter"
+
+
+def test_config_get_provider_name_accepts_model_override_argument():
+    """Per-call model overrides agents.defaults.model for models[] matching."""
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "ignored-default"}},
+            "providers": {
+                "openrouter": {"apiKey": "sk-or-test"},
+                "siliconflow": {"apiKey": "sf", "models": ["override-model"]},
+            },
+        }
+    )
+
+    assert config.get_provider_name("override-model") == "siliconflow"
+    assert config.get_provider_name() == "openrouter"
+
+
 def test_config_prefers_ollama_over_vllm_when_both_local_providers_configured():
     config = Config.model_validate(
         {

--- a/tests/config/test_config_migration.py
+++ b/tests/config/test_config_migration.py
@@ -158,3 +158,35 @@ def test_load_config_resets_ssrf_whitelist_when_next_config_is_empty(tmp_path) -
     with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve("ts.local", ["100.100.1.1"])):
         ok, _ = validate_url_target("http://ts.local/api")
         assert not ok
+
+
+def test_migrate_config_wraps_legacy_provider_dict_as_list() -> None:
+    from nanobot.config.loader import _migrate_config
+
+    data = {"providers": {"groq": {"apiKey": "legacy-key"}}}
+    migrated = _migrate_config(data)
+    assert migrated["providers"]["groq"] == [{"apiKey": "legacy-key"}]
+
+
+def test_providers_legacy_object_and_new_list_load_equivalently(tmp_path) -> None:
+    """Old single-object and new array forms should parse to the same runtime shape."""
+    legacy = tmp_path / "legacy.json"
+    legacy.write_text(
+        json.dumps({"providers": {"groq": {"apiKey": "same", "apiBase": "https://x"}}}),
+        encoding="utf-8",
+    )
+    new_fmt = tmp_path / "new.json"
+    new_fmt.write_text(
+        json.dumps(
+            {"providers": {"groq": [{"apiKey": "same", "apiBase": "https://x"}]}}
+        ),
+        encoding="utf-8",
+    )
+
+    c1 = load_config(legacy)
+    c2 = load_config(new_fmt)
+
+    assert len(c1.providers.groq) == 1
+    assert c1.providers.groq[0].api_key == c2.providers.groq[0].api_key
+    assert c1.providers.groq[0].api_base == c2.providers.groq[0].api_base
+    assert c1.providers.primary("groq").api_key == c2.providers.primary("groq").api_key

--- a/tests/config/test_env_interpolation.py
+++ b/tests/config/test_env_interpolation.py
@@ -60,10 +60,12 @@ class TestResolveConfig:
         )
 
         raw = load_config(config_path)
-        assert raw.providers.groq.api_key == "${TEST_API_KEY}"
+        assert raw.providers.groq[0].api_key == "${TEST_API_KEY}"
+        assert raw.providers.primary("groq").api_key == "${TEST_API_KEY}"
 
         resolved = resolve_config_env_vars(raw)
-        assert resolved.providers.groq.api_key == "resolved-key"
+        assert resolved.providers.groq[0].api_key == "resolved-key"
+        assert resolved.providers.primary("groq").api_key == "resolved-key"
 
     def test_save_preserves_templates(self, tmp_path, monkeypatch):
         monkeypatch.setenv("MY_TOKEN", "real-token")


### PR DESCRIPTION
- Updated provider handling to transition from single object to list format for multiple endpoints.
- Adjusted related methods and tests to accommodate the new structure, ensuring backward compatibility with legacy configurations.
- Enhanced provider selection logic to prioritize entries based on the new list format.

This change improves flexibility in managing multiple provider configurations and aligns with the updated schema.