### PR TITLE
feat(channels): Web App and Mobile APIs

### DIFF
--- a/nanobot/channels/web.py
+++ b/nanobot/channels/web.py
@@ -1,0 +1,594 @@
+"""Web UI channel — browser-based chat via WebSocket.
+
+Starts an aiohttp server that serves a static chat frontend and communicates
+with clients over WebSocket.  No Node.js required — pure Python backend with
+vanilla HTML/CSS/JS on the frontend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from aiohttp import WSMsgType, web
+from loguru import logger
+from pydantic import Field as PydanticField
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
+
+# ---------------------------------------------------------------------------
+# Static assets directory (shipped alongside this module)
+# ---------------------------------------------------------------------------
+_STATIC_DIR = Path(__file__).resolve().parent / "web_static"
+
+# ---------------------------------------------------------------------------
+# Media directories for upload/download
+# ---------------------------------------------------------------------------
+_MEDIA_DIR = Path.home() / ".nanobot" / "media"
+_MEDIA_SEARCH_DIRS = [
+    Path.home() / ".nanobot" / "media",
+    Path.home() / ".nanobot" / "workspace",
+]
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class WebConfig(Base):
+    """Web channel configuration."""
+
+    enabled: bool = False
+    host: str = "0.0.0.0"
+    port: int = 8080
+    allow_from: list[str] = PydanticField(default_factory=lambda: ["*"])
+    streaming: bool = True
+    bearer_token: str = ""  # Set explicitly, or a random token is generated at startup
+
+
+# ---------------------------------------------------------------------------
+# Per-client streaming accumulator
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _StreamBuf:
+    text: str = ""
+    stream_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# File-based message history (persists across gateway restarts)
+# Each chat_id gets ~/.nanobot/web_history/{chat_id}.jsonl
+# Each line: {"ts": float, "type": "message"|"user_message", "content": "...", "media": [...]}
+# ---------------------------------------------------------------------------
+
+_HISTORY_MAX = 200  # max lines to keep per file
+_HISTORY_DIR = Path.home() / ".nanobot" / "web_history"
+
+
+def _history_file(chat_id: str) -> Path:
+    return _HISTORY_DIR / f"{chat_id}.jsonl"
+
+
+def _append_history(chat_id: str, entry: dict[str, Any]) -> None:
+    """Append one entry to the history file, trimming to _HISTORY_MAX lines."""
+    _HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    path = _history_file(chat_id)
+    with open(path, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+    # Trim if over limit — read, slice, rewrite
+    with open(path) as f:
+        lines = f.readlines()
+    if len(lines) > _HISTORY_MAX:
+        with open(path, "w") as f:
+            f.writelines(lines[-_HISTORY_MAX:])
+
+
+def _read_history_since(chat_id: str, last_seen: float) -> list[dict[str, Any]]:
+    """Return all history entries with ts > last_seen (up to _HISTORY_MAX)."""
+    path = _history_file(chat_id)
+    if not path.exists():
+        return []
+    results = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                if entry.get("ts", 0) > last_seen:
+                    results.append(entry)
+            except json.JSONDecodeError:
+                pass
+    return results
+
+
+def _name_file(chat_id: str) -> Path:
+    return _HISTORY_DIR / f"{chat_id}.name"
+
+
+def _get_chat_name(chat_id: str) -> str | None:
+    path = _name_file(chat_id)
+    if path.exists():
+        return path.read_text().strip() or None
+    return None
+
+
+def _set_chat_name(chat_id: str, name: str) -> None:
+    _HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    _name_file(chat_id).write_text(name.strip()[:80])
+
+
+_RENAME_PREFIX = "rename chat:"
+
+
+def _check_rename(chat_id: str, content: str) -> str | None:
+    """If content starts with 'rename chat: ...', save the name and return it."""
+    lower = content.strip().lower()
+    if lower.startswith(_RENAME_PREFIX):
+        name = content.strip()[len(_RENAME_PREFIX):].strip()
+        if name:
+            _set_chat_name(chat_id, name)
+            return name
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Channel
+# ---------------------------------------------------------------------------
+
+class WebChannel(BaseChannel):
+    """Browser-based chat channel served over HTTP + WebSocket."""
+
+    name = "web"
+    display_name = "Web"
+
+    @classmethod
+    def default_config(cls) -> dict[str, Any]:
+        return WebConfig().model_dump(by_alias=True)
+
+    def __init__(self, config: Any, bus: MessageBus):
+        if isinstance(config, dict):
+            config = WebConfig.model_validate(config)
+        super().__init__(config, bus)
+        self.config: WebConfig = config
+
+        # WebSocket connections: chat_id → {client_id: ws}
+        # Multiple devices can subscribe to the same chat_id.
+        self._clients: dict[str, dict[str, web.WebSocketResponse]] = {}
+        # Streaming buffers keyed by chat_id
+        self._stream_bufs: dict[str, _StreamBuf] = {}
+
+        self._app: web.Application | None = None
+        self._runner: web.AppRunner | None = None
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+
+    def _check_auth(self, request: web.Request) -> bool:
+        """Validate bearer token. Always required — generated at startup if not configured.
+
+        Uses constant-time comparison to avoid leaking the token through
+        per-byte timing differences.
+        """
+        token = self.config.bearer_token
+
+        # Check Authorization header first, then query param fallback (for browser WebSocket)
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer ") and hmac.compare_digest(auth_header[7:], token):
+            return True
+
+        if hmac.compare_digest(request.query.get("token", ""), token):
+            return True
+
+        return False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        self._running = True
+
+        # Fail closed: generate a token if none was configured
+        if not self.config.bearer_token:
+            self.config.bearer_token = uuid.uuid4().hex
+            from nanobot.config.loader import get_config_path
+            logger.error(
+                "No bearer_token configured — generated ephemeral token (will change on restart): {}\n"
+                "  Set channels.web.bearerToken in {} for a persistent key.",
+                self.config.bearer_token,
+                get_config_path(),
+            )
+
+        @web.middleware
+        async def auth_middleware(request: web.Request, handler):
+            # Allow static assets and index page without auth
+            path = request.path
+            if path == "/" or path.startswith("/static"):
+                return await handler(request)
+            if not self._check_auth(request):
+                raise web.HTTPUnauthorized(text="Invalid or missing bearer token")
+            return await handler(request)
+
+        # 16 MiB request body cap sized for media uploads (1920px JPEGs are
+        # typically 200-500 KB, voice notes up to a few MB). aiohttp's default
+        # is 1 MiB which silently rejects longer voice notes.
+        self._app = web.Application(
+            middlewares=[auth_middleware],
+            client_max_size=16 * 1024 * 1024,
+        )
+        self._app.router.add_get("/ws", self._ws_handler)
+        self._app.router.add_post("/upload", self._upload_handler)
+        self._app.router.add_get("/media/{filename}", self._media_handler)
+        self._app.router.add_get("/history/{chat_id}", self._history_handler)
+        self._app.router.add_get("/chats", self._chats_handler)
+        self._app.router.add_post("/chats/{chat_id}/rename", self._rename_handler)
+        # Serve static frontend
+        if _STATIC_DIR.is_dir():
+            self._app.router.add_get("/", self._index_handler)
+            self._app.router.add_static("/static", _STATIC_DIR, show_index=False)
+
+        self._runner = web.AppRunner(self._app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.config.host, self.config.port)
+        await site.start()
+        logger.info("Web UI listening on http://{}:{}", self.config.host, self.config.port)
+
+        # Keep the channel alive until stopped
+        try:
+            while self._running:
+                await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            pass
+
+    async def stop(self) -> None:
+        self._running = False
+        # Close all WebSocket connections
+        for conns in list(self._clients.values()):
+            for ws in list(conns.values()):
+                await ws.close()
+        self._clients.clear()
+        if self._runner:
+            await self._runner.cleanup()
+        logger.info("Web UI stopped")
+
+    # ------------------------------------------------------------------
+    # HTTP handlers
+    # ------------------------------------------------------------------
+
+    async def _index_handler(self, request: web.Request) -> web.FileResponse:
+        return web.FileResponse(_STATIC_DIR / "index.html")
+
+    async def _upload_handler(self, request: web.Request) -> web.Response:
+        """Accept multipart file upload, save to media directory."""
+        _MEDIA_DIR.mkdir(parents=True, exist_ok=True)
+        try:
+            reader = await request.multipart()
+        except Exception:
+            return web.Response(status=400, text="Expected multipart/form-data")
+
+        field = await reader.next()
+        if field is None or field.name != "file":
+            return web.Response(status=400, text="Expected 'file' field")
+
+        original = field.filename or "upload.bin"
+        safe_name = Path(original).name  # strip any directory components
+        unique_name = f"{uuid.uuid4().hex[:8]}_{safe_name}"
+        dest = _MEDIA_DIR / unique_name
+
+        with open(dest, "wb") as f:
+            while True:
+                chunk = await field.read_chunk()
+                if not chunk:
+                    break
+                f.write(chunk)
+
+        logger.info("Media uploaded: {}", dest)
+        return web.json_response({
+            "path": str(dest),
+            "url": f"/media/{unique_name}",
+        })
+
+    async def _media_handler(self, request: web.Request) -> web.FileResponse:
+        """Serve a media file by filename, searching known directories."""
+        filename = request.match_info["filename"]
+        if ".." in filename or filename.startswith("/"):
+            raise web.HTTPForbidden()
+
+        for search_dir in _MEDIA_SEARCH_DIRS:
+            filepath = search_dir / filename
+            if filepath.is_file():
+                return web.FileResponse(filepath)
+
+        raise web.HTTPNotFound()
+
+    async def _history_handler(self, request: web.Request) -> web.Response:
+        """REST endpoint: GET /history/{chat_id}?since=<timestamp>"""
+        chat_id = request.match_info["chat_id"]
+        since = float(request.query.get("since", "0"))
+        messages = _read_history_since(chat_id, since)
+        return web.json_response({"messages": messages})
+
+    async def _chats_handler(self, request: web.Request) -> web.Response:
+        """REST endpoint: GET /chats?ids=id1,id2,...
+
+        Returns metadata for the requested chat IDs (preview, timestamps).
+        Only returns data for IDs the client claims to own — no enumeration.
+        """
+        ids_param = request.query.get("ids", "")
+        if not ids_param:
+            return web.json_response({"chats": []})
+
+        requested_ids = [i.strip() for i in ids_param.split(",") if i.strip()]
+        chats = []
+        for cid in requested_ids:
+            path = _history_file(cid)
+            if not path.exists():
+                continue
+            try:
+                first_user_msg = ""
+                first_ts = 0.0
+                last_ts = 0.0
+                msg_count = 0
+                with open(path) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            entry = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        msg_count += 1
+                        ts = entry.get("ts", 0)
+                        if first_ts == 0:
+                            first_ts = ts
+                        if ts > last_ts:
+                            last_ts = ts
+                        if not first_user_msg and entry.get("type") == "user_message":
+                            first_user_msg = (entry.get("content") or "")[:80]
+                custom_name = _get_chat_name(cid)
+                chats.append({
+                    "id": cid,
+                    "name": custom_name or "",
+                    "preview": first_user_msg or "(no messages)",
+                    "first_ts": first_ts,
+                    "last_ts": last_ts,
+                    "count": msg_count,
+                })
+            except Exception:
+                continue
+
+        # Sort by most recent first
+        chats.sort(key=lambda c: c["last_ts"], reverse=True)
+        return web.json_response({"chats": chats})
+
+    async def _rename_handler(self, request: web.Request) -> web.Response:
+        """REST endpoint: POST /chats/{chat_id}/rename  body: {"name": "..."}"""
+        chat_id = request.match_info["chat_id"]
+        try:
+            data = await request.json()
+        except Exception:
+            return web.Response(status=400, text="Expected JSON body")
+        new_name = (data.get("name") or "").strip()[:80]
+        if not new_name:
+            return web.Response(status=400, text="Missing name")
+        _set_chat_name(chat_id, new_name)
+        # Notify any connected clients on this chat
+        rename_payload = {"type": "chat_renamed", "name": new_name}
+        for peer in list(self._clients.get(chat_id, {}).values()):
+            if not peer.closed:
+                await peer.send_json(rename_payload)
+        return web.json_response({"ok": True, "name": new_name})
+
+    async def _ws_handler(self, request: web.Request) -> web.WebSocketResponse:
+        # max_msg_size caps inbound frames at 1 MiB (defense against a rogue
+        # client sending a huge frame to exhaust memory — real chat frames
+        # are KB, and media uploads go through POST /upload separately).
+        # heartbeat enables transport-level ping/pong so half-dead TCP
+        # connections get noticed promptly instead of lingering until the
+        # OS keepalive fires.
+        ws = web.WebSocketResponse(max_msg_size=1_048_576, heartbeat=20.0)
+        await ws.prepare(request)
+
+        # client_id identifies the device/connection, chat_id identifies the conversation.
+        # Multiple devices can subscribe to the same chat_id.
+        client_id: str | None = request.query.get("client_id")
+        if client_id and len(client_id) > 128:
+            client_id = client_id[:128]
+        if not client_id:
+            client_id = uuid.uuid4().hex[:12]
+
+        chat_id: str | None = request.query.get("chat_id")
+        if chat_id and len(chat_id) > 128:
+            chat_id = chat_id[:128]
+        if not chat_id:
+            # Backwards-compat: if no chat_id provided, use client_id as both
+            chat_id = client_id
+
+        sender_id = client_id
+
+        # Register connection — replace any stale ws for this same device
+        conns = self._clients.setdefault(chat_id, {})
+        old = conns.get(client_id)
+        if old and not old.closed:
+            await old.close()
+        conns[client_id] = ws
+
+        # Confirm connection with both IDs so clients can persist them
+        await ws.send_json({"type": "connected", "client_id": client_id, "chat_id": chat_id})
+        logger.info("Web client connected: {} (chat {})", client_id, chat_id)
+
+        try:
+            async for raw in ws:
+                if raw.type == WSMsgType.TEXT:
+                    try:
+                        data = json.loads(raw.data)
+                    except json.JSONDecodeError:
+                        await ws.send_json({"type": "error", "error": "Invalid JSON"})
+                        continue
+
+                    msg_type = data.get("type", "message")
+                    if msg_type == "message":
+                        content = data.get("content", "").strip()
+                        media = data.get("media") or []
+                        if not content and not media:
+                            continue
+                        # Record user message in history
+                        ts = time.time()
+                        user_payload = {
+                            "ts": ts,
+                            "type": "user_message",
+                            "content": content,
+                            "media": media,
+                        }
+                        _append_history(chat_id, user_payload)
+                        # Broadcast to other devices on this chat
+                        for cid, peer in list(self._clients.get(chat_id, {}).items()):
+                            if cid != client_id and not peer.closed:
+                                await peer.send_json(user_payload)
+                        await self._handle_message(
+                            sender_id=sender_id,
+                            chat_id=chat_id,
+                            content=content,
+                            media=media,
+                            metadata={},
+                        )
+                    elif msg_type == "sync":
+                        # Client requests missed messages since a timestamp
+                        last_seen = float(data.get("last_seen", 0))
+                        missed = _read_history_since(chat_id, last_seen)
+                        await ws.send_json({"type": "sync", "messages": missed})
+                        logger.info("Web client {} synced: {} messages since {}", client_id, len(missed), last_seen)
+                    elif msg_type == "ping":
+                        await ws.send_json({"type": "pong"})
+                    elif msg_type == "rename":
+                        new_name = (data.get("name") or data.get("content") or "").strip()[:80]
+                        if new_name:
+                            _set_chat_name(chat_id, new_name)
+                            # Notify all devices on this chat
+                            rename_payload = {"type": "chat_renamed", "name": new_name}
+                            for peer in list(self._clients.get(chat_id, {}).values()):
+                                if not peer.closed:
+                                    await peer.send_json(rename_payload)
+                elif raw.type in (WSMsgType.ERROR, WSMsgType.CLOSE):
+                    break
+        except asyncio.CancelledError:
+            pass
+        finally:
+            # Only remove our entry if it hasn't been replaced by a reconnect
+            conns = self._clients.get(chat_id, {})
+            is_current = conns.get(client_id) is ws
+            logger.debug("Web cleanup: {} (chat {}), is_current={}, conns_before={}",
+                         client_id, chat_id, is_current, len(conns))
+            if is_current:
+                conns.pop(client_id, None)
+            # Clean up empty chat entries and stream buffers
+            if chat_id in self._clients and not self._clients[chat_id]:
+                del self._clients[chat_id]
+                self._stream_bufs.pop(chat_id, None)
+            logger.info("Web client disconnected: {} (chat {}), removed={}", client_id, chat_id, is_current)
+
+        return ws
+
+    # ------------------------------------------------------------------
+    # Outbound: send full message
+    # ------------------------------------------------------------------
+
+    async def send(self, msg: OutboundMessage) -> None:
+        conns_for_chat = self._clients.get(msg.chat_id, {})
+        live_count = sum(1 for ws in conns_for_chat.values() if not ws.closed)
+        logger.info("Web.send() chat_id={}, all_chats={}, conns_for_chat={}, live={}",
+                     msg.chat_id, list(self._clients.keys()), list(conns_for_chat.keys()), live_count)
+        ts = time.time()
+        payload = {
+            "ts": ts,
+            "type": "message",
+            "content": msg.content,
+            "media": msg.media,
+        }
+        # Always persist to disk so reconnecting clients can catch up
+        _append_history(msg.chat_id, payload)
+
+        # Check if the bot is renaming the chat
+        new_name = _check_rename(msg.chat_id, msg.content)
+
+        conns = self._clients.get(msg.chat_id, {})
+        if not conns:
+            logger.debug("Web: no active connection for chat_id={}, message buffered", msg.chat_id)
+            return
+        for ws in list(conns.values()):
+            if not ws.closed:
+                await ws.send_json(payload)
+                if new_name:
+                    await ws.send_json({"type": "chat_renamed", "name": new_name})
+
+    # ------------------------------------------------------------------
+    # Outbound: streaming deltas
+    # ------------------------------------------------------------------
+
+    async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None) -> None:
+        meta = metadata or {}
+        stream_id = meta.get("_stream_id")
+        is_end = meta.get("_stream_end", False)
+        conns_for_chat = self._clients.get(chat_id, {})
+        live_count = sum(1 for ws in conns_for_chat.values() if not ws.closed)
+        logger.debug("Web.send_delta() chat_id={}, stream_end={}, all_chats={}, live={}",
+                      chat_id, is_end, list(self._clients.keys()), live_count)
+
+        if meta.get("_stream_end"):
+            buf = self._stream_bufs.pop(chat_id, None)
+            final_text = (buf.text if buf else "") + delta
+            if final_text:
+                ts = time.time()
+                # Persist the completed streamed message
+                _append_history(chat_id, {
+                    "ts": ts,
+                    "type": "message",
+                    "content": final_text,
+                    "media": [],
+                })
+                new_name = _check_rename(chat_id, final_text)
+                for ws in list(self._clients.get(chat_id, {}).values()):
+                    if not ws.closed:
+                        await ws.send_json({
+                            "type": "stream_end",
+                            "content": final_text,
+                            "ts": ts,
+                        })
+                        if new_name:
+                            await ws.send_json({"type": "chat_renamed", "name": new_name})
+            return
+
+        # Accumulate streaming text even if client is disconnected
+        buf = self._stream_bufs.get(chat_id)
+        if buf is None or (stream_id is not None and buf.stream_id is not None and buf.stream_id != stream_id):
+            buf = _StreamBuf(stream_id=stream_id)
+            self._stream_bufs[chat_id] = buf
+        elif buf.stream_id is None:
+            buf.stream_id = stream_id
+
+        buf.text += delta
+
+        for ws in list(self._clients.get(chat_id, {}).values()):
+            if not ws.closed:
+                await ws.send_json({
+                    "type": "stream_delta",
+                    "delta": delta,
+                })
+
+    @property
+    def supports_streaming(self) -> bool:
+        return super().supports_streaming

--- a/nanobot/channels/web_static/app.js
+++ b/nanobot/channels/web_static/app.js
@@ -1,0 +1,809 @@
+// ── Nanobot Web UI ──
+// Pure vanilla JS — no build tools, no Node.js.
+
+(function () {
+  "use strict";
+
+  // ── Elements ──
+  const messagesEl = document.getElementById("messages");
+  const inputEl    = document.getElementById("input");
+  const formEl     = document.getElementById("chat-form");
+  const sendBtn    = document.getElementById("btn-send");
+  const statusEl   = document.getElementById("status");
+  const newBtn     = document.getElementById("btn-new");
+  const chatsBtn   = document.getElementById("btn-chats");
+  const chatMenu   = document.getElementById("chat-menu");
+  const chatListEl = document.getElementById("chat-list");
+  const headerTitle = document.getElementById("header-title");
+
+  // ── State ──
+  let ws = null;
+  let streamBubble = null;   // currently streaming bot message element
+  let streamText   = "";     // accumulated raw markdown during stream
+  let connected    = false;
+  let syncing      = false;  // true while replaying missed messages
+
+  // ── Device ID (unique per browser, never changes) ──
+  var deviceId = localStorage.getItem("nanobot_device_id");
+  if (!deviceId) {
+    deviceId = crypto.randomUUID ? crypto.randomUUID().replace(/-/g, "").slice(0, 12) : Math.random().toString(36).slice(2, 14);
+    localStorage.setItem("nanobot_device_id", deviceId);
+  }
+
+  // ── Bearer token (stored in localStorage, prompted on 401) ──
+  var authToken = localStorage.getItem("nanobot_token") || "";
+
+  function authHeaders() {
+    var h = {};
+    if (authToken) h["Authorization"] = "Bearer " + authToken;
+    return h;
+  }
+
+  function promptForToken() {
+    var t = prompt("This server requires a bearer token. Paste it here:");
+    if (t !== null) {
+      authToken = t.trim();
+      localStorage.setItem("nanobot_token", authToken);
+      return true;
+    }
+    return false;
+  }
+
+  // ── URL-based chat ID ──
+  // Check hash first (e.g. /#abc123def456), then fall back to localStorage.
+  // This lets users share a URL to pick up a conversation on another device.
+
+  function getChatIdFromHash() {
+    var hash = location.hash.replace(/^#\/?/, "").trim();
+    return hash || null;
+  }
+
+  function setHash(id) {
+    if (id) {
+      history.replaceState(null, "", "#" + id);
+    }
+  }
+
+  var hashId = getChatIdFromHash();
+  var chatId = hashId || localStorage.getItem("nanobot_chat_id") || null;
+  var lastSeenTs = 0;
+
+  // If we got a chat ID from the URL, adopt it — even if it's new to this browser
+  if (hashId) {
+    chatId = hashId;
+    localStorage.setItem("nanobot_chat_id", chatId);
+    // Use 0 so we fetch full history from server for this chat
+    lastSeenTs = 0;
+    localStorage.setItem("nanobot_last_seen", "0");
+  } else {
+    lastSeenTs = parseFloat(localStorage.getItem("nanobot_last_seen") || "0");
+  }
+
+  // ── Chat History (localStorage) ──
+  // Stores known chat IDs with local metadata: { id, preview, lastTs }
+  // Key: "nanobot_chats" → JSON array
+
+  function getKnownChats() {
+    try {
+      return JSON.parse(localStorage.getItem("nanobot_chats") || "[]");
+    } catch (_) { return []; }
+  }
+
+  function saveKnownChats(chats) {
+    localStorage.setItem("nanobot_chats", JSON.stringify(chats));
+  }
+
+  function upsertChat(id, preview, lastTs) {
+    var chats = getKnownChats();
+    var existing = chats.find(function (c) { return c.id === id; });
+    if (existing) {
+      if (preview) existing.preview = preview;
+      if (lastTs > (existing.lastTs || 0)) existing.lastTs = lastTs;
+    } else {
+      chats.push({ id: id, preview: preview || "(new chat)", lastTs: lastTs || 0 });
+    }
+    // Sort by most recent
+    chats.sort(function (a, b) { return (b.lastTs || 0) - (a.lastTs || 0); });
+    // Keep last 20
+    if (chats.length > 20) chats = chats.slice(0, 20);
+    saveKnownChats(chats);
+  }
+
+  function removeChat(id) {
+    var chats = getKnownChats().filter(function (c) { return c.id !== id; });
+    saveKnownChats(chats);
+  }
+
+  // Make sure current chat is tracked
+  if (chatId) {
+    upsertChat(chatId, null, lastSeenTs);
+  }
+
+  // ── Lightweight Markdown ──
+  // Converts a subset of Markdown to HTML (code blocks, inline code, bold,
+  // italic, links, headers, lists, blockquotes, tables).  Good enough for
+  // chat — no external library needed.
+
+  function escapeHtml(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  function renderMarkdown(src) {
+    // Protect code blocks
+    var blocks = [];
+    src = src.replace(/```(\w*)\n?([\s\S]*?)```/g, function (_, lang, code) {
+      blocks.push('<pre><code class="lang-' + escapeHtml(lang) + '">' + escapeHtml(code.replace(/\n$/, "")) + "</code></pre>");
+      return "\x00CB" + (blocks.length - 1) + "\x00";
+    });
+
+    // Protect inline code
+    var inlines = [];
+    src = src.replace(/`([^`]+)`/g, function (_, code) {
+      inlines.push("<code>" + escapeHtml(code) + "</code>");
+      return "\x00IC" + (inlines.length - 1) + "\x00";
+    });
+
+    // Split into lines for block-level processing
+    var lines = src.split("\n");
+    var html = [];
+    var inList = null; // "ul" | "ol" | null
+    var inBlockquote = false;
+    var tableRows = [];
+
+    function flushList() {
+      if (inList) { html.push("</" + inList + ">"); inList = null; }
+    }
+    function flushBlockquote() {
+      if (inBlockquote) { html.push("</blockquote>"); inBlockquote = false; }
+    }
+    function flushTable() {
+      if (tableRows.length === 0) return;
+      var thead = tableRows[0];
+      var tbody = tableRows.slice(2); // skip separator row
+      var out = "<table><thead><tr>";
+      thead.forEach(function (c) { out += "<th>" + processInline(c.trim()) + "</th>"; });
+      out += "</tr></thead><tbody>";
+      tbody.forEach(function (row) {
+        out += "<tr>";
+        row.forEach(function (c) { out += "<td>" + processInline(c.trim()) + "</td>"; });
+        out += "</tr>";
+      });
+      out += "</tbody></table>";
+      html.push(out);
+      tableRows = [];
+    }
+
+    function processInline(s) {
+      // Bold
+      s = s.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+      s = s.replace(/__(.+?)__/g, "<strong>$1</strong>");
+      // Italic
+      s = s.replace(/(?<![a-zA-Z0-9])\*([^*]+)\*(?![a-zA-Z0-9])/g, "<em>$1</em>");
+      s = s.replace(/(?<![a-zA-Z0-9])_([^_]+)_(?![a-zA-Z0-9])/g, "<em>$1</em>");
+      // Strikethrough
+      s = s.replace(/~~(.+?)~~/g, "<del>$1</del>");
+      // Links [text](url)
+      s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+      return s;
+    }
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+
+      // Code block placeholder — pass through
+      if (/^\x00CB\d+\x00$/.test(line.trim())) {
+        flushList(); flushBlockquote(); flushTable();
+        var idx = parseInt(line.trim().replace(/\x00CB|\x00/g, ""), 10);
+        html.push(blocks[idx]);
+        continue;
+      }
+
+      // Table row (pipes)
+      if (/^\s*\|.+\|/.test(line)) {
+        flushList(); flushBlockquote();
+        var cells = line.trim().replace(/^\||\|$/g, "").split("|");
+        // Separator row?
+        if (cells.every(function (c) { return /^[\s:-]+$/.test(c); })) {
+          tableRows.push(cells); // keep as marker
+        } else {
+          tableRows.push(cells);
+        }
+        continue;
+      } else {
+        flushTable();
+      }
+
+      // Headers
+      var hm = line.match(/^(#{1,6})\s+(.+)$/);
+      if (hm) {
+        flushList(); flushBlockquote();
+        var level = hm[1].length;
+        html.push("<h" + level + ">" + processInline(escapeHtml(hm[2])) + "</h" + level + ">");
+        continue;
+      }
+
+      // Blockquote
+      if (/^>\s?(.*)$/.test(line)) {
+        flushList(); flushTable();
+        if (!inBlockquote) { html.push("<blockquote>"); inBlockquote = true; }
+        html.push(processInline(escapeHtml(line.replace(/^>\s?/, ""))) + "<br>");
+        continue;
+      } else {
+        flushBlockquote();
+      }
+
+      // Unordered list
+      if (/^[\s]*[-*+]\s+(.+)$/.test(line)) {
+        flushBlockquote(); flushTable();
+        if (inList !== "ul") { flushList(); html.push("<ul>"); inList = "ul"; }
+        var content = line.replace(/^[\s]*[-*+]\s+/, "");
+        html.push("<li>" + processInline(escapeHtml(content)) + "</li>");
+        continue;
+      }
+
+      // Ordered list
+      var olm = line.match(/^[\s]*(\d+)\.\s+(.+)$/);
+      if (olm) {
+        flushBlockquote(); flushTable();
+        if (inList !== "ol") { flushList(); html.push("<ol>"); inList = "ol"; }
+        html.push("<li>" + processInline(escapeHtml(olm[2])) + "</li>");
+        continue;
+      }
+
+      flushList();
+
+      // Empty line
+      if (line.trim() === "") {
+        continue;
+      }
+
+      // Normal paragraph
+      html.push("<p>" + processInline(escapeHtml(line)) + "</p>");
+    }
+
+    flushList();
+    flushBlockquote();
+    flushTable();
+
+    var result = html.join("\n");
+
+    // Restore inline code
+    inlines.forEach(function (repl, j) {
+      result = result.replace("\x00IC" + j + "\x00", repl);
+    });
+    // Restore code blocks (any remaining in inline context)
+    blocks.forEach(function (repl, j) {
+      result = result.replace("\x00CB" + j + "\x00", repl);
+    });
+
+    return result;
+  }
+
+  // ── UI Helpers ──
+
+  function scrollToBottom() {
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  function setStatus(state) {
+    statusEl.className = "status " + state;
+    statusEl.textContent = state;
+    connected = state === "connected";
+    sendBtn.disabled = !connected;
+  }
+
+  function updateHeaderTitle() {
+    var chats = getKnownChats();
+    var current = chats.find(function (c) { return c.id === chatId; });
+    headerTitle.textContent = (current && current.name) || "Nanobot";
+  }
+
+  function addMessage(role, content) {
+    var el = document.createElement("div");
+    el.className = "msg " + role;
+    if (role === "bot") {
+      var inner = document.createElement("div");
+      inner.className = "rendered";
+      inner.innerHTML = renderMarkdown(content);
+      el.appendChild(inner);
+    } else {
+      el.textContent = content;
+    }
+    messagesEl.appendChild(el);
+    scrollToBottom();
+    return el;
+  }
+
+  function showThinking() {
+    var el = document.createElement("div");
+    el.className = "thinking";
+    el.id = "thinking";
+    el.innerHTML = 'Thinking<span class="dots"></span>';
+    messagesEl.appendChild(el);
+    scrollToBottom();
+  }
+
+  function hideThinking() {
+    var el = document.getElementById("thinking");
+    if (el) el.remove();
+  }
+
+  function startStream() {
+    hideThinking();
+    streamText = "";
+    var el = document.createElement("div");
+    el.className = "msg bot streaming";
+    var inner = document.createElement("div");
+    inner.className = "rendered";
+    el.appendChild(inner);
+    messagesEl.appendChild(el);
+    streamBubble = el;
+    scrollToBottom();
+  }
+
+  function appendStream(delta) {
+    if (!streamBubble) startStream();
+    streamText += delta;
+    var inner = streamBubble.querySelector(".rendered");
+    inner.innerHTML = renderMarkdown(streamText);
+    scrollToBottom();
+  }
+
+  function endStream(finalContent) {
+    hideThinking();
+    if (streamBubble) {
+      streamBubble.classList.remove("streaming");
+      if (finalContent) {
+        var inner = streamBubble.querySelector(".rendered");
+        inner.innerHTML = renderMarkdown(finalContent);
+      }
+      streamBubble = null;
+      streamText = "";
+      scrollToBottom();
+    }
+  }
+
+  // ── Time formatting ──
+
+  function formatTime(epochSecs) {
+    if (!epochSecs) return "";
+    var d = new Date(epochSecs * 1000);
+    var now = new Date();
+    var diffMs = now - d;
+    var diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffDays === 0) {
+      // Today — show time
+      return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+    } else if (diffDays === 1) {
+      return "Yesterday";
+    } else if (diffDays < 7) {
+      return d.toLocaleDateString([], { weekday: "short" });
+    } else {
+      return d.toLocaleDateString([], { month: "short", day: "numeric" });
+    }
+  }
+
+  // ── Chat Switcher ──
+
+  var menuOpen = false;
+
+  function toggleMenu() {
+    menuOpen = !menuOpen;
+    chatMenu.classList.toggle("hidden", !menuOpen);
+    if (menuOpen) {
+      refreshChatList();
+    }
+  }
+
+  function closeMenu() {
+    menuOpen = false;
+    chatMenu.classList.add("hidden");
+  }
+
+  chatsBtn.addEventListener("click", function (e) {
+    e.stopPropagation();
+    toggleMenu();
+  });
+
+  // Close menu when clicking outside
+  document.addEventListener("click", function (e) {
+    if (menuOpen && !chatMenu.contains(e.target) && e.target !== chatsBtn) {
+      closeMenu();
+    }
+  });
+
+  function refreshChatList() {
+    var chats = getKnownChats();
+    chatListEl.innerHTML = "";
+
+    if (chats.length === 0) {
+      var empty = document.createElement("div");
+      empty.className = "chat-menu-item";
+      empty.style.color = "var(--text-dim)";
+      empty.style.textAlign = "center";
+      empty.style.cursor = "default";
+      empty.textContent = "No previous chats";
+      chatListEl.appendChild(empty);
+      return;
+    }
+
+    // Fetch server-side metadata to enrich previews
+    var ids = chats.map(function (c) { return c.id; }).join(",");
+    fetch("/chats?ids=" + encodeURIComponent(ids), { headers: authHeaders() })
+      .then(function (r) {
+        if (r.status === 401) {
+          if (promptForToken()) refreshChatList();
+          return null;
+        }
+        return r.json();
+      })
+      .then(function (data) {
+        if (!data) return;
+        var serverMap = {};
+        (data.chats || []).forEach(function (c) { serverMap[c.id] = c; });
+
+        // Merge server data into local chats
+        chats.forEach(function (c) {
+          var s = serverMap[c.id];
+          if (s) {
+            if (s.name) c.name = s.name;
+            c.preview = s.preview || c.preview;
+            c.lastTs = s.last_ts || c.lastTs;
+            c.count = s.count;
+          }
+        });
+        // Re-sort after merge
+        chats.sort(function (a, b) { return (b.lastTs || 0) - (a.lastTs || 0); });
+        saveKnownChats(chats);
+
+        renderChatItems(chats);
+      })
+      .catch(function () {
+        // Offline — render from local data
+        renderChatItems(chats);
+      });
+  }
+
+  function renderChatItems(chats) {
+    chatListEl.innerHTML = "";
+    updateHeaderTitle();
+    chats.forEach(function (chat) {
+      var row = document.createElement("div");
+      row.className = "chat-menu-row";
+
+      var btn = document.createElement("button");
+      btn.className = "chat-menu-item";
+      if (chat.id === chatId) btn.classList.add("active");
+
+      var timeSpan = document.createElement("span");
+      timeSpan.className = "chat-time";
+      timeSpan.textContent = formatTime(chat.lastTs);
+      btn.appendChild(timeSpan);
+
+      var title = document.createElement("span");
+      title.className = "chat-title";
+      title.textContent = chat.name || chat.preview || "(no messages)";
+      btn.appendChild(title);
+
+      // Show preview as subtitle when a custom name exists
+      if (chat.name) {
+        var preview = document.createElement("span");
+        preview.className = "chat-preview";
+        preview.textContent = chat.preview || "";
+        btn.appendChild(preview);
+      }
+
+      btn.addEventListener("click", function () {
+        closeMenu();
+        switchToChat(chat.id);
+      });
+
+      btn.addEventListener("dblclick", function (e) {
+        e.stopPropagation();
+        var newName = prompt("Rename conversation:", chat.name || chat.preview || "");
+        if (newName !== null && newName.trim()) {
+          chat.name = newName.trim();
+          saveKnownChats(chats);
+          // Tell server so other devices see it too
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            // Send rename for this chat — need to be connected to it or use REST
+            // For simplicity, send via current ws if it's the same chat
+            if (chat.id === chatId) {
+              ws.send(JSON.stringify({ type: "rename", name: newName.trim() }));
+            }
+          }
+          refreshChatList();
+        }
+      });
+
+      var delBtn = document.createElement("button");
+      delBtn.className = "chat-delete-btn";
+      delBtn.title = "Remove conversation";
+      delBtn.textContent = "\u00d7"; // × multiplication sign
+      delBtn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        if (confirm("Remove this conversation from the list?")) {
+          removeChat(chat.id);
+          refreshChatList();
+        }
+      });
+
+      row.appendChild(delBtn);
+      row.appendChild(btn);
+      chatListEl.appendChild(row);
+    });
+  }
+
+  function switchToChat(newId) {
+    if (newId === chatId) return; // already on this chat
+
+    // Save current state
+    if (chatId) {
+      upsertChat(chatId, getFirstUserMessage(), lastSeenTs);
+    }
+
+    // Switch
+    chatId = newId;
+    localStorage.setItem("nanobot_chat_id", chatId);
+    setHash(chatId);
+
+    // Load the lastSeenTs for this chat from localStorage
+    var chatTs = getKnownChats().find(function (c) { return c.id === newId; });
+    lastSeenTs = (chatTs && chatTs.lastTs) ? chatTs.lastTs : 0;
+    // We'll use 0 to get full history from server
+    lastSeenTs = 0;
+    localStorage.setItem("nanobot_last_seen", "0");
+
+    // Clear screen and reconnect
+    messagesEl.innerHTML = "";
+    streamBubble = null;
+    streamText = "";
+    if (ws) ws.close();
+    connect();
+  }
+
+  function getFirstUserMessage() {
+    var msgs = messagesEl.querySelectorAll(".msg.user");
+    if (msgs.length > 0) {
+      return msgs[0].textContent.substring(0, 80);
+    }
+    return null;
+  }
+
+  // ── Auto-resize textarea ──
+
+  inputEl.addEventListener("input", function () {
+    this.style.height = "auto";
+    this.style.height = Math.min(this.scrollHeight, 150) + "px";
+  });
+
+  // Submit on Enter (Shift+Enter for newline)
+  inputEl.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      formEl.dispatchEvent(new Event("submit"));
+    }
+  });
+
+  // ── Send Message ──
+
+  formEl.addEventListener("submit", function (e) {
+    e.preventDefault();
+    var text = inputEl.value.trim();
+    if (!text || !connected) return;
+
+    addMessage("user", text);
+    ws.send(JSON.stringify({ type: "message", content: text }));
+    // Track that we've seen up to now (our own message)
+    lastSeenTs = Date.now() / 1000;
+    localStorage.setItem("nanobot_last_seen", String(lastSeenTs));
+    // Update chat preview with first user message
+    upsertChat(chatId, getFirstUserMessage(), lastSeenTs);
+    inputEl.value = "";
+    inputEl.style.height = "auto";
+    showThinking();
+  });
+
+  // ── New Chat ──
+
+  newBtn.addEventListener("click", function () {
+    closeMenu();
+    // Save current chat
+    if (chatId) {
+      upsertChat(chatId, getFirstUserMessage(), lastSeenTs);
+    }
+
+    messagesEl.innerHTML = "";
+    // Generate new client id for a fresh session
+    chatId = crypto.randomUUID ? crypto.randomUUID().replace(/-/g, "").slice(0, 12) : Math.random().toString(36).slice(2, 14);
+    localStorage.setItem("nanobot_chat_id", chatId);
+    setHash(chatId);
+    lastSeenTs = 0;
+    localStorage.setItem("nanobot_last_seen", "0");
+    // Track the new chat
+    upsertChat(chatId, "(new chat)", 0);
+    headerTitle.textContent = "Nanobot";
+    // Reconnect with new id
+    if (ws) ws.close();
+    connect();
+  });
+
+  // ── WebSocket ──
+
+  var reconnectDelay = 1000;
+  var maxReconnectDelay = 30000;
+  var pingInterval = null;
+
+  function connect() {
+    // Close any existing connection without triggering auto-reconnect —
+    // the old ws's onclose will see ws !== thisWs and bail out.
+    if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+      ws.close();
+    }
+
+    setStatus("connecting");
+
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    var url = proto + "//" + location.host + "/ws";
+    url += "?client_id=" + encodeURIComponent(deviceId);
+    if (chatId) url += "&chat_id=" + encodeURIComponent(chatId);
+    if (authToken) url += "&token=" + encodeURIComponent(authToken);
+
+    var thisWs = new WebSocket(url);
+    ws = thisWs;
+
+    thisWs.onopen = function () {
+      reconnectDelay = 1000;
+    };
+
+    thisWs.onmessage = function (ev) {
+      var data;
+      try { data = JSON.parse(ev.data); } catch (_) { return; }
+
+      switch (data.type) {
+        case "connected":
+          didConnect = true;
+          chatId = data.chat_id || data.client_id;
+          localStorage.setItem("nanobot_chat_id", chatId);
+          setHash(chatId);
+          setStatus("connected");
+          // Make sure this chat is tracked
+          upsertChat(chatId, null, lastSeenTs);
+          updateHeaderTitle();
+          // Start keepalive
+          clearInterval(pingInterval);
+          pingInterval = setInterval(function () {
+            if (thisWs.readyState === WebSocket.OPEN) {
+              thisWs.send(JSON.stringify({ type: "ping" }));
+            }
+          }, 25000);
+          // Request history sync — always, so page refresh restores the conversation
+          thisWs.send(JSON.stringify({ type: "sync", last_seen: lastSeenTs }));
+          break;
+
+        case "sync":
+          // Replay missed messages
+          if (data.messages && data.messages.length > 0) {
+            syncing = true;
+            data.messages.forEach(function (m) {
+              if (m.type === "user_message") {
+                addMessage("user", m.content || "");
+              } else if (m.type === "message") {
+                addMessage("bot", m.content || "");
+              }
+              if (m.ts) {
+                lastSeenTs = Math.max(lastSeenTs, m.ts);
+                localStorage.setItem("nanobot_last_seen", String(lastSeenTs));
+              }
+            });
+            syncing = false;
+            scrollToBottom();
+            // Update chat preview after sync
+            upsertChat(chatId, getFirstUserMessage(), lastSeenTs);
+          }
+          break;
+
+        case "user_message":
+          // Another device sent a message on this chat
+          addMessage("user", data.content || "");
+          if (data.ts) {
+            lastSeenTs = Math.max(lastSeenTs, data.ts);
+            localStorage.setItem("nanobot_last_seen", String(lastSeenTs));
+          }
+          showThinking();
+          break;
+
+        case "message":
+          hideThinking();
+          endStream();  // finalize any in-progress stream
+          addMessage("bot", data.content || "");
+          if (data.ts) {
+            lastSeenTs = Math.max(lastSeenTs, data.ts);
+            localStorage.setItem("nanobot_last_seen", String(lastSeenTs));
+            upsertChat(chatId, getFirstUserMessage(), lastSeenTs);
+          }
+          break;
+
+        case "stream_delta":
+          appendStream(data.delta || "");
+          break;
+
+        case "stream_end":
+          endStream(data.content || null);
+          if (data.ts) {
+            lastSeenTs = Math.max(lastSeenTs, data.ts);
+            localStorage.setItem("nanobot_last_seen", String(lastSeenTs));
+            upsertChat(chatId, getFirstUserMessage(), lastSeenTs);
+          }
+          break;
+
+        case "chat_renamed":
+          // Server (or another device) renamed this chat
+          if (data.name) {
+            var knownChats = getKnownChats();
+            var c = knownChats.find(function (x) { return x.id === chatId; });
+            if (c) {
+              c.name = data.name;
+              saveKnownChats(knownChats);
+            }
+            updateHeaderTitle();
+          }
+          break;
+
+        case "pong":
+          break;
+
+        case "error":
+          hideThinking();
+          addMessage("bot", "[Error] " + (data.error || "Unknown error"));
+          break;
+      }
+    };
+
+    var didConnect = false;
+
+    thisWs.onclose = function (ev) {
+      // If a newer connect() already replaced us, don't touch state or reconnect
+      if (ws !== thisWs) return;
+
+      setStatus("disconnected");
+      clearInterval(pingInterval);
+      streamBubble = null;
+      streamText = "";
+
+      // If we never got "connected" and the close code suggests auth failure,
+      // prompt for a token instead of silently retrying forever.
+      if (!didConnect && (ev.code === 1008 || ev.code === 1006)) {
+        if (promptForToken()) {
+          connect();
+          return;
+        }
+      }
+
+      // Auto-reconnect with backoff
+      setTimeout(function () {
+        if (ws !== thisWs) return; // another connect() happened while we waited
+        reconnectDelay = Math.min(reconnectDelay * 2, maxReconnectDelay);
+        connect();
+      }, reconnectDelay);
+    };
+
+    thisWs.onerror = function () {
+      // onclose will fire after this
+    };
+  }
+
+  // ── Handle URL hash changes (back/forward, manual edit) ──
+  window.addEventListener("hashchange", function () {
+    var newId = getChatIdFromHash();
+    if (newId && newId !== chatId) {
+      switchToChat(newId);
+    }
+  });
+
+  // ── Boot ──
+  // Set the hash on initial load if we have a client ID
+  if (chatId) setHash(chatId);
+  connect();
+})();

--- a/nanobot/channels/web_static/index.html
+++ b/nanobot/channels/web_static/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nanobot</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <div id="app">
+    <header id="header">
+      <div class="header-left">
+        <h1 id="header-title">Nanobot</h1>
+      </div>
+      <div class="header-right">
+        <span id="status" class="status disconnected">disconnected</span>
+        <div id="chat-switcher">
+          <button id="btn-chats" title="Switch conversation">Chats ▾</button>
+          <div id="chat-menu" class="chat-menu hidden">
+            <div id="chat-list"></div>
+            <div class="chat-menu-divider"></div>
+            <button id="btn-new" class="chat-menu-item new-chat">＋ New Chat</button>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main id="messages"></main>
+
+    <footer id="input-area">
+      <form id="chat-form">
+        <textarea id="input" placeholder="Type a message..." rows="1" autofocus></textarea>
+        <button type="submit" id="btn-send" disabled>Send</button>
+      </form>
+    </footer>
+  </div>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/nanobot/channels/web_static/style.css
+++ b/nanobot/channels/web_static/style.css
@@ -1,0 +1,366 @@
+/* ── Reset & Base ── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:        #1a1a2e;
+  --bg-surface:#16213e;
+  --bg-input:  #0f3460;
+  --accent:    #e94560;
+  --accent-dim:#c23152;
+  --text:      #eee;
+  --text-dim:  #999;
+  --user-bg:   #0f3460;
+  --bot-bg:    #16213e;
+  --border:    #233554;
+  --radius:    8px;
+  --max-width: 860px;
+}
+
+html, body {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+/* ── Layout ── */
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+/* ── Header ── */
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+header h1 {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.status {
+  font-size: 0.75rem;
+  padding: 3px 8px;
+  border-radius: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.status.connected    { background: #064e3b; color: #6ee7b7; }
+.status.disconnected { background: #7f1d1d; color: #fca5a5; }
+.status.connecting   { background: #78350f; color: #fde68a; }
+
+/* ── Chat Switcher ── */
+#chat-switcher {
+  position: relative;
+}
+
+#btn-chats {
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  padding: 5px 12px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.15s;
+}
+#btn-chats:hover { color: var(--text); border-color: var(--text-dim); }
+
+.chat-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 280px;
+  max-width: 360px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  z-index: 100;
+  overflow: hidden;
+}
+
+.chat-menu.hidden { display: none; }
+
+.chat-menu-divider {
+  height: 1px;
+  background: var(--border);
+}
+
+.chat-menu-row {
+  display: flex;
+  align-items: stretch;
+}
+.chat-menu-row .chat-menu-item { flex: 1; min-width: 0; }
+.chat-delete-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 0 6px 0 8px;
+  font-size: 0.9rem;
+  line-height: 1;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+}
+.chat-delete-btn:hover { opacity: 1; color: var(--accent); }
+
+.chat-menu-item {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 0.82rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.chat-menu-item:hover { background: var(--bg-input); }
+
+.chat-menu-item.active {
+  border-left: 3px solid var(--accent);
+  background: rgba(233, 69, 96, 0.08);
+}
+
+.chat-menu-item .chat-title {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.chat-menu-item .chat-preview {
+  display: block;
+  color: var(--text-dim);
+  font-size: 0.7rem;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-menu-item .chat-time {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  float: right;
+  margin-top: 2px;
+}
+
+.chat-menu-item.new-chat {
+  color: var(--accent);
+  font-weight: 600;
+  text-align: center;
+  padding: 12px 14px;
+}
+
+/* ── Messages ── */
+main {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.msg {
+  max-width: 85%;
+  padding: 10px 14px;
+  border-radius: var(--radius);
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-size: 0.92rem;
+  position: relative;
+}
+
+.msg.user {
+  align-self: flex-end;
+  background: var(--user-bg);
+  border-bottom-right-radius: 2px;
+}
+
+.msg.bot {
+  align-self: flex-start;
+  background: var(--bot-bg);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 2px;
+}
+
+.msg.bot .rendered { white-space: normal; }
+
+/* Markdown-rendered elements inside bot messages */
+.msg.bot .rendered h1,
+.msg.bot .rendered h2,
+.msg.bot .rendered h3 {
+  margin: 0.6em 0 0.3em;
+  font-weight: 600;
+}
+.msg.bot .rendered h1 { font-size: 1.15em; }
+.msg.bot .rendered h2 { font-size: 1.05em; }
+.msg.bot .rendered h3 { font-size: 0.95em; }
+
+.msg.bot .rendered p { margin: 0.35em 0; }
+
+.msg.bot .rendered ul,
+.msg.bot .rendered ol {
+  margin: 0.3em 0;
+  padding-left: 1.5em;
+}
+
+.msg.bot .rendered code {
+  background: rgba(255,255,255,0.08);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 0.88em;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
+}
+
+.msg.bot .rendered pre {
+  background: #0d1117;
+  padding: 10px 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin: 0.5em 0;
+}
+
+.msg.bot .rendered pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.85em;
+  line-height: 1.5;
+}
+
+.msg.bot .rendered blockquote {
+  border-left: 3px solid var(--accent);
+  padding-left: 10px;
+  margin: 0.4em 0;
+  color: var(--text-dim);
+}
+
+.msg.bot .rendered a {
+  color: #60a5fa;
+  text-decoration: none;
+}
+.msg.bot .rendered a:hover { text-decoration: underline; }
+
+.msg.bot .rendered table {
+  border-collapse: collapse;
+  margin: 0.5em 0;
+  font-size: 0.88em;
+}
+.msg.bot .rendered th,
+.msg.bot .rendered td {
+  border: 1px solid var(--border);
+  padding: 4px 10px;
+}
+.msg.bot .rendered th { background: rgba(255,255,255,0.05); }
+
+/* Streaming cursor */
+.streaming::after {
+  content: "";
+  display: inline-block;
+  width: 7px;
+  height: 1em;
+  background: var(--accent);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: blink 0.7s step-end infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+/* Thinking indicator */
+.thinking {
+  align-self: flex-start;
+  color: var(--text-dim);
+  font-style: italic;
+  font-size: 0.85rem;
+  padding: 6px 0;
+}
+
+.thinking .dots::after {
+  content: "";
+  animation: dots 1.4s steps(4, end) infinite;
+}
+@keyframes dots {
+  0%  { content: ""; }
+  25% { content: "."; }
+  50% { content: ".."; }
+  75% { content: "..."; }
+}
+
+/* ── Input Area ── */
+footer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+#chat-form {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+#input {
+  flex: 1;
+  resize: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  font-size: 0.92rem;
+  font-family: inherit;
+  background: var(--bg-input);
+  color: var(--text);
+  outline: none;
+  max-height: 150px;
+  line-height: 1.4;
+  transition: border-color 0.15s;
+}
+#input:focus { border-color: var(--accent); }
+#input::placeholder { color: var(--text-dim); }
+
+#btn-send {
+  padding: 10px 18px;
+  border: none;
+  border-radius: var(--radius);
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+#btn-send:hover:not(:disabled) { background: var(--accent-dim); }
+#btn-send:disabled { opacity: 0.4; cursor: default; }
+
+/* ── Scrollbar ── */
+main::-webkit-scrollbar { width: 6px; }
+main::-webkit-scrollbar-track { background: transparent; }
+main::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+/* ── Responsive ── */
+@media (max-width: 600px) {
+  :root { --max-width: 100%; }
+  .msg { max-width: 92%; }
+  header { padding: 10px 12px; }
+  footer { padding: 10px 12px; }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ dependencies = [
 api = [
     "aiohttp>=3.9.0,<4.0.0",
 ]
+web = [
+    "aiohttp>=3.9.0,<4.0.0",
+]
 wecom = [
     "wecom-aibot-sdk-python>=0.1.5",
 ]
@@ -113,6 +116,7 @@ include = [
     "nanobot/templates/**/*.md",
     "nanobot/skills/**/*.md",
     "nanobot/skills/**/*.sh",
+    "nanobot/channels/web_static/**",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/channels/test_web_channel.py
+++ b/tests/channels/test_web_channel.py
@@ -1,0 +1,397 @@
+"""Tests for the Web channel.
+
+Covers the module-level history/name helpers as unit tests, and the aiohttp
+server endpoints + WebSocket handler as lightweight integration tests backed
+by a real running WebChannel on a random loopback port.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from nanobot.channels import web as web_module
+from nanobot.channels.web import WebChannel
+
+# --- Fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture()
+def bus() -> MagicMock:
+    b = MagicMock()
+    b.publish_inbound = AsyncMock()
+    b.publish_outbound = AsyncMock()
+    return b
+
+
+@pytest.fixture()
+def tmp_history(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the module-level history directory into tmp_path.
+
+    All helpers read the module-level ``_HISTORY_DIR`` each call, so swapping
+    it here keeps tests hermetic without touching ``~/.nanobot``.
+    """
+    monkeypatch.setattr(web_module, "_HISTORY_DIR", tmp_path)
+    return tmp_path
+
+
+def _make_channel(bus: Any, port: int, **overrides: Any) -> WebChannel:
+    cfg: dict[str, Any] = {
+        "enabled": True,
+        "host": "127.0.0.1",
+        "port": port,
+        "allow_from": ["*"],
+        "bearer_token": "test-token",
+        "streaming": False,  # avoid the streaming _wants_stream path for these tests
+    }
+    cfg.update(overrides)
+    return WebChannel(cfg, bus)
+
+
+async def _start(channel: WebChannel) -> asyncio.Task:
+    task = asyncio.create_task(channel.start())
+    # Give the aiohttp site a moment to bind.
+    for _ in range(20):
+        await asyncio.sleep(0.05)
+        if channel._runner is not None:
+            return task
+    return task
+
+
+async def _stop(channel: WebChannel, task: asyncio.Task) -> None:
+    await channel.stop()
+    try:
+        await asyncio.wait_for(task, timeout=2.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        task.cancel()
+
+
+# --- Unit tests: history helpers -------------------------------------------
+
+
+def test_append_and_read_history_since(tmp_history: Path) -> None:
+    cid = "chat1"
+    web_module._append_history(cid, {"ts": 100.0, "type": "user_message", "content": "a"})
+    web_module._append_history(cid, {"ts": 200.0, "type": "message", "content": "b"})
+    web_module._append_history(cid, {"ts": 300.0, "type": "message", "content": "c"})
+
+    all_entries = web_module._read_history_since(cid, 0)
+    assert [e["content"] for e in all_entries] == ["a", "b", "c"]
+
+    recent = web_module._read_history_since(cid, 150.0)
+    assert [e["content"] for e in recent] == ["b", "c"]
+
+    nothing = web_module._read_history_since(cid, 999.0)
+    assert nothing == []
+
+
+def test_read_history_missing_file_returns_empty(tmp_history: Path) -> None:
+    assert web_module._read_history_since("never-written", 0) == []
+
+
+def test_history_trims_to_max(tmp_history: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(web_module, "_HISTORY_MAX", 5)
+    cid = "chat2"
+    for i in range(12):
+        web_module._append_history(cid, {"ts": float(i), "type": "message", "content": f"m{i}"})
+
+    entries = web_module._read_history_since(cid, 0)
+    assert len(entries) == 5
+    # Only the newest 5 survive.
+    assert [e["content"] for e in entries] == ["m7", "m8", "m9", "m10", "m11"]
+
+
+def test_chat_name_roundtrip(tmp_history: Path) -> None:
+    assert web_module._get_chat_name("c") is None
+    web_module._set_chat_name("c", "  My Chat  ")
+    assert web_module._get_chat_name("c") == "My Chat"
+
+
+def test_chat_name_truncates_to_80_chars(tmp_history: Path) -> None:
+    long = "x" * 200
+    web_module._set_chat_name("c", long)
+    stored = web_module._get_chat_name("c")
+    assert stored is not None and len(stored) == 80
+
+
+def test_check_rename_prefix(tmp_history: Path) -> None:
+    assert web_module._check_rename("c", "hello world") is None
+    assert web_module._check_rename("c", "rename chat: Groceries") == "Groceries"
+    assert web_module._get_chat_name("c") == "Groceries"
+    # Case-insensitive prefix
+    assert web_module._check_rename("c", "RENAME CHAT: Todo") == "Todo"
+
+
+# --- Integration tests: HTTP endpoints -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_chats_endpoint_rejected(
+    bus: MagicMock, tmp_history: Path
+) -> None:
+    ch = _make_channel(bus, 29951)
+    task = await _start(ch)
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get("http://127.0.0.1:29951/chats?ids=abc") as resp:
+                assert resp.status == 401
+    finally:
+        await _stop(ch, task)
+
+
+@pytest.mark.asyncio
+async def test_chats_endpoint_returns_metadata_for_known_chat(
+    bus: MagicMock, tmp_history: Path
+) -> None:
+    web_module._append_history("cidA", {
+        "ts": 100.0, "type": "user_message", "content": "hello there friend"
+    })
+    web_module._append_history("cidA", {
+        "ts": 150.0, "type": "message", "content": "hi back"
+    })
+    web_module._set_chat_name("cidA", "Test Chat")
+
+    ch = _make_channel(bus, 29952)
+    task = await _start(ch)
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                "http://127.0.0.1:29952/chats?ids=cidA,unknownChat",
+                headers={"Authorization": "Bearer test-token"},
+            ) as resp:
+                assert resp.status == 200
+                body = await resp.json()
+
+        assert "chats" in body
+        # Unknown chat is dropped silently; only cidA comes back.
+        assert [c["id"] for c in body["chats"]] == ["cidA"]
+        entry = body["chats"][0]
+        assert entry["name"] == "Test Chat"
+        assert entry["preview"].startswith("hello there")
+        assert entry["count"] == 2
+        assert entry["first_ts"] == 100.0
+        assert entry["last_ts"] == 150.0
+    finally:
+        await _stop(ch, task)
+
+
+@pytest.mark.asyncio
+async def test_rename_endpoint_persists_and_surfaces_in_chats(
+    bus: MagicMock, tmp_history: Path
+) -> None:
+    web_module._append_history("cidB", {
+        "ts": 1.0, "type": "user_message", "content": "seed"
+    })
+
+    ch = _make_channel(bus, 29953)
+    task = await _start(ch)
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                "http://127.0.0.1:29953/chats/cidB/rename",
+                headers={"Authorization": "Bearer test-token"},
+                json={"name": "Project Fleet"},
+            ) as resp:
+                assert resp.status == 200
+                result = await resp.json()
+                assert result["ok"] is True
+                assert result["name"] == "Project Fleet"
+
+            async with session.get(
+                "http://127.0.0.1:29953/chats?ids=cidB",
+                headers={"Authorization": "Bearer test-token"},
+            ) as resp:
+                body = await resp.json()
+
+        assert body["chats"][0]["name"] == "Project Fleet"
+    finally:
+        await _stop(ch, task)
+
+
+# --- Hardening ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upload_accepts_file_above_legacy_1mib_cap(
+    bus: MagicMock, tmp_history: Path, tmp_path: Path
+) -> None:
+    """aiohttp's default client_max_size is 1 MiB, which would silently
+    reject voice notes longer than ~60 seconds. The channel bumps it to
+    16 MiB via web.Application(client_max_size=...). This test uploads
+    a 2 MiB payload and asserts it completes successfully."""
+    ch = _make_channel(bus, 29959)
+    task = await _start(ch)
+    try:
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"\x00" * (2 * 1024 * 1024))
+        async with aiohttp.ClientSession() as session:
+            data = aiohttp.FormData()
+            data.add_field("file", big.open("rb"), filename="big.bin",
+                           content_type="application/octet-stream")
+            async with session.post(
+                "http://127.0.0.1:29959/upload",
+                headers={"Authorization": "Bearer test-token"},
+                data=data,
+            ) as resp:
+                assert resp.status == 200
+                body = await resp.json()
+                assert "path" in body and "url" in body
+    finally:
+        await _stop(ch, task)
+
+
+@pytest.mark.asyncio
+async def test_websocket_client_id_clamped_to_128_chars(
+    bus: MagicMock, tmp_history: Path
+) -> None:
+    """A rogue client with a giant client_id query param should not be
+    able to inject an unbounded dict key into self._clients. The channel
+    truncates client_id (and chat_id) to 128 characters at connect time."""
+    ch = _make_channel(bus, 29960)
+    task = await _start(ch)
+    try:
+        oversized = "x" * 500
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(
+                f"http://127.0.0.1:29960/ws?token=test-token&client_id={oversized}"
+            ) as ws:
+                msg = await asyncio.wait_for(ws.receive(), timeout=2.0)
+                payload = json.loads(msg.data)
+                # Length clamp applied.
+                assert len(payload["client_id"]) == 128
+                assert payload["client_id"] == oversized[:128]
+    finally:
+        await _stop(ch, task)
+
+
+# --- Integration tests: WebSocket ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_websocket_connect_announces_ids(bus: MagicMock, tmp_history: Path) -> None:
+    ch = _make_channel(bus, 29954)
+    task = await _start(ch)
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(
+                "http://127.0.0.1:29954/ws?token=test-token&client_id=dev1&chat_id=chatX"
+            ) as ws:
+                msg = await asyncio.wait_for(ws.receive(), timeout=2.0)
+                assert msg.type == aiohttp.WSMsgType.TEXT
+                payload = json.loads(msg.data)
+                assert payload == {
+                    "type": "connected",
+                    "client_id": "dev1",
+                    "chat_id": "chatX",
+                }
+    finally:
+        await _stop(ch, task)
+
+
+@pytest.mark.asyncio
+async def test_websocket_rejects_missing_token(bus: MagicMock, tmp_history: Path) -> None:
+    ch = _make_channel(bus, 29955)
+    task = await _start(ch)
+    try:
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(aiohttp.WSServerHandshakeError) as excinfo:
+                await session.ws_connect("http://127.0.0.1:29955/ws?client_id=dev1")
+            assert excinfo.value.status == 401
+    finally:
+        await _stop(ch, task)
+
+
+@pytest.mark.asyncio
+async def test_message_published_to_bus_and_persisted(
+    bus: MagicMock, tmp_history: Path
+) -> None:
+    ch = _make_channel(bus, 29956)
+    task = await _start(ch)
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(
+                "http://127.0.0.1:29956/ws?token=test-token&client_id=dev1&chat_id=chatY"
+            ) as ws:
+                await ws.receive()  # discard "connected"
+                await ws.send_json({"type": "message", "content": "hello agent"})
+                # Give the server a tick to publish and persist.
+                await asyncio.sleep(0.1)
+
+        # The bus should have seen exactly one InboundMessage from this chat.
+        bus.publish_inbound.assert_called()
+        inbound = bus.publish_inbound.call_args[0][0]
+        assert inbound.channel == "web"
+        assert inbound.chat_id == "chatY"
+        assert inbound.content == "hello agent"
+
+        # And the history file should carry it.
+        persisted = web_module._read_history_since("chatY", 0)
+        assert len(persisted) == 1
+        assert persisted[0]["type"] == "user_message"
+        assert persisted[0]["content"] == "hello agent"
+    finally:
+        await _stop(ch, task)
+
+
+@pytest.mark.asyncio
+async def test_sync_replays_history_since_timestamp(
+    bus: MagicMock, tmp_history: Path
+) -> None:
+    # Seed three entries: one old, two newer than the client's last_seen.
+    web_module._append_history("chatZ", {
+        "ts": 10.0, "type": "user_message", "content": "ancient"
+    })
+    web_module._append_history("chatZ", {
+        "ts": 50.0, "type": "message", "content": "mid"
+    })
+    web_module._append_history("chatZ", {
+        "ts": 90.0, "type": "message", "content": "recent"
+    })
+
+    ch = _make_channel(bus, 29957)
+    task = await _start(ch)
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(
+                "http://127.0.0.1:29957/ws?token=test-token&client_id=dev&chat_id=chatZ"
+            ) as ws:
+                await ws.receive()  # "connected"
+                await ws.send_json({"type": "sync", "last_seen": 30.0})
+                raw = await asyncio.wait_for(ws.receive(), timeout=2.0)
+                payload = json.loads(raw.data)
+
+        assert payload["type"] == "sync"
+        assert [m["content"] for m in payload["messages"]] == ["mid", "recent"]
+    finally:
+        await _stop(ch, task)
+
+
+@pytest.mark.asyncio
+async def test_multi_device_message_broadcast(bus: MagicMock, tmp_history: Path) -> None:
+    """A message from device A on a chat is mirrored to device B on the same chat."""
+    ch = _make_channel(bus, 29958)
+    task = await _start(ch)
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(
+                "http://127.0.0.1:29958/ws?token=test-token&client_id=devA&chat_id=shared"
+            ) as ws_a, session.ws_connect(
+                "http://127.0.0.1:29958/ws?token=test-token&client_id=devB&chat_id=shared"
+            ) as ws_b:
+                await ws_a.receive()  # "connected" for A
+                await ws_b.receive()  # "connected" for B
+
+                await ws_a.send_json({"type": "message", "content": "from A"})
+                raw = await asyncio.wait_for(ws_b.receive(), timeout=2.0)
+                payload = json.loads(raw.data)
+
+        assert payload["type"] == "user_message"
+        assert payload["content"] == "from A"
+    finally:
+        await _stop(ch, task)


### PR DESCRIPTION
Adds a web channel — a hosted chat platform serving a browser UI and backing the nanobot-ios companion app. One module
  * (nanobot/channels/web.py, ~594 lines) + bundled vanilla HTML/CSS/JS + tests. Core runtime untouched; all code lives under channels/.                                                                                                      
                                                                  
  How it differs from the websocket channel (0.1.5.post1): that one is a thin backend WS API — ephemeral chat per       
  connection, no persistence, no REST, no UI. This one is a platform: durable chat IDs, JSONL history with
  sync-on-reconnect, /chats /history /upload /media /rename REST endpoints, multi-device fanout on a single chat,       
  browser UI. They occupy different niches and don't replace each other.

  Hardening adopted from the websocket channel's review (56a5906): hmac.compare_digest for bearer compare, max_msg_size and heartbeat on WS, client_id/chat_id length clamp, client_max_size=16 MiB on uploads to accept voice notes.                                                                                          
                                                                  
  Wire protocol documented in the comment below.                                             
                                                                  
  No new deps — aiohttp is already used by nanobot/api/.                                                                
   
  Not in this PR: push notifications to mobile (follow-up PR), TLS termination (use a reverse proxy), multi-user auth.  