### PR TITLE
fix(cron): 修复定时任务不触发和重复执行的问题

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -19,10 +19,19 @@ def _now_ms() -> int:
     return int(time.time() * 1000)
 
 
+_AT_GRACE_MS = 300_000  # 5 min grace window for "at" jobs created with a slightly past timestamp
+
+
 def _compute_next_run(schedule: CronSchedule, now_ms: int) -> int | None:
     """Compute next run time in ms."""
     if schedule.kind == "at":
-        return schedule.at_ms if schedule.at_ms and schedule.at_ms > now_ms else None
+        if not schedule.at_ms:
+            return None
+        if schedule.at_ms > now_ms:
+            return schedule.at_ms
+        if now_ms - schedule.at_ms <= _AT_GRACE_MS:
+            return now_ms + 1000
+        return None
 
     if schedule.kind == "every":
         if not schedule.every_ms or schedule.every_ms <= 0:
@@ -80,6 +89,7 @@ class CronService:
         self._store: CronStore | None = None
         self._timer_task: asyncio.Task | None = None
         self._running = False
+        self._timer_active = False
         self.max_sleep_ms = max_sleep_ms
 
     def _load_jobs(self) -> tuple[list[CronJob], int]:
@@ -171,7 +181,11 @@ class CronService:
     def _load_store(self) -> CronStore:
         """Load jobs from disk. Reloads automatically if file was modified externally.
         - Reload every time because it needs to merge operations on the jobs object from other instances.
+        - During _on_timer execution, return the existing store to prevent concurrent
+          _load_store calls (e.g. from list_jobs polling) from replacing it mid-execution.
         """
+        if self._timer_active and self._store:
+            return self._store
         jobs, version = self._load_jobs()
         self._store = CronStore(version=version, jobs=jobs)
         self._merge_action()
@@ -290,18 +304,23 @@ class CronService:
         """Handle timer tick - run due jobs."""
         self._load_store()
         if not self._store:
+            self._arm_timer()
             return
 
-        now = _now_ms()
-        due_jobs = [
-            j for j in self._store.jobs
-            if j.enabled and j.state.next_run_at_ms and now >= j.state.next_run_at_ms
-        ]
+        self._timer_active = True
+        try:
+            now = _now_ms()
+            due_jobs = [
+                j for j in self._store.jobs
+                if j.enabled and j.state.next_run_at_ms and now >= j.state.next_run_at_ms
+            ]
 
-        for job in due_jobs:
-            await self._execute_job(job)
+            for job in due_jobs:
+                await self._execute_job(job)
 
-        self._save_store()
+            self._save_store()
+        finally:
+            self._timer_active = False
         self._arm_timer()
 
     async def _execute_job(self, job: CronJob) -> None:


### PR DESCRIPTION
## Summary

- **at 类型任务不触发**：LLM 处理延迟导致 `atMs` 在 `add_job` 实际执行时已过期，`_compute_next_run` 返回 `None`，任务永远不会被调度。添加 5 分钟 grace window，过期但在窗口内的任务延迟 1 秒立即执行。
- **固定间隔任务重复执行**：`_on_timer` 中 `await self._execute_job()` 让出控制权期间，前端轮询触发的 `list_jobs` 调用 `_load_store()` 从磁盘重新加载覆盖 `self._store`，已执行任务的状态被旧值回退，导致再次触发。引入 `_timer_active` 标志位，在任务执行期间阻止并发 `_load_store` 替换 store。
- **timer 停止**：`_on_timer` 中 store 为空时直接 return 未重新 arm timer，补充了 `_arm_timer()` 调用。

## Test plan

- [x] 全部 24 个现有单元测试通过（`pytest tests/cron/test_cron_service.py`）
- [ ] 手动创建 at 类型定时任务（如"30秒后提醒"），验证任务正常触发
- [ ] 创建固定间隔任务（如每5分钟），验证每次只触发一次，不重复执行


Made with [Cursor](https://cursor.com)