### PR TITLE
fix(cron): 为 at 类型任务引入宽限窗口，轻微过期时立即执行

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -19,10 +19,19 @@ def _now_ms() -> int:
     return int(time.time() * 1000)
 
 
+_AT_GRACE_WINDOW_MS = 10 * 60 * 1000  # 10 minutes
+
+
 def _compute_next_run(schedule: CronSchedule, now_ms: int) -> int | None:
     """Compute next run time in ms."""
     if schedule.kind == "at":
-        return schedule.at_ms if schedule.at_ms and schedule.at_ms > now_ms else None
+        if not schedule.at_ms:
+            return None
+        if schedule.at_ms > now_ms:
+            return schedule.at_ms
+        if now_ms - schedule.at_ms <= _AT_GRACE_WINDOW_MS:
+            return now_ms + 1000
+        return None
 
     if schedule.kind == "every":
         if not schedule.every_ms or schedule.every_ms <= 0:

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -564,3 +564,79 @@ async def test_list_jobs_during_on_job_does_not_cause_stale_reload(tmp_path) -> 
         next_run = j["state"]["nextRunAtMs"]
         assert next_run is not None
         assert next_run > now_ms, f"Job '{j['name']}' next_run should be in the future"
+
+
+# ── at grace window tests ──
+
+
+def test_at_job_slightly_expired_is_scheduled(tmp_path) -> None:
+    """An at job whose at_ms is a few seconds in the past should still be scheduled."""
+    service = CronService(tmp_path / "cron" / "jobs.json")
+    now = int(time.time() * 1000)
+    job = service.add_job(
+        name="slightly-expired",
+        schedule=CronSchedule(kind="at", at_ms=now - 5_000),
+        message="hello",
+    )
+    assert job.state.next_run_at_ms is not None
+
+
+def test_at_job_long_expired_not_scheduled(tmp_path) -> None:
+    """An at job whose at_ms is far in the past should NOT be scheduled."""
+    service = CronService(tmp_path / "cron" / "jobs.json")
+    now = int(time.time() * 1000)
+    job = service.add_job(
+        name="long-expired",
+        schedule=CronSchedule(kind="at", at_ms=now - 3_600_000),
+        message="hello",
+    )
+    assert job.state.next_run_at_ms is None
+
+
+def test_at_grace_window_boundary_exact(tmp_path) -> None:
+    """at_ms exactly 10 minutes ago should be accepted; 10min+1ms should be rejected."""
+    from nanobot.cron.service import _AT_GRACE_WINDOW_MS, _compute_next_run
+
+    now = int(time.time() * 1000)
+
+    result_at_boundary = _compute_next_run(
+        CronSchedule(kind="at", at_ms=now - _AT_GRACE_WINDOW_MS), now
+    )
+    assert result_at_boundary is not None
+
+    result_past_boundary = _compute_next_run(
+        CronSchedule(kind="at", at_ms=now - _AT_GRACE_WINDOW_MS - 1), now
+    )
+    assert result_past_boundary is None
+
+
+def test_enable_job_slightly_expired_at_is_scheduled(tmp_path) -> None:
+    """Re-enabling a slightly expired at job should schedule it via the grace window."""
+    service = CronService(tmp_path / "cron" / "jobs.json")
+    now = int(time.time() * 1000)
+    job = service.add_job(
+        name="enable-grace",
+        schedule=CronSchedule(kind="at", at_ms=now - 5_000),
+        message="hello",
+    )
+    service.enable_job(job.id, enabled=False)
+    updated = service.enable_job(job.id, enabled=True)
+    assert updated is not None
+    assert updated.state.next_run_at_ms is not None
+
+
+def test_update_job_slightly_expired_at_is_scheduled(tmp_path) -> None:
+    """Updating schedule to a slightly expired at_ms should schedule via the grace window."""
+    service = CronService(tmp_path / "cron" / "jobs.json")
+    now = int(time.time() * 1000)
+    job = service.add_job(
+        name="update-grace",
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        message="hello",
+    )
+    result = service.update_job(
+        job.id,
+        schedule=CronSchedule(kind="at", at_ms=now - 5_000),
+    )
+    assert isinstance(result, CronJob)
+    assert result.state.next_run_at_ms is not None


### PR DESCRIPTION
## Summary

- LLM 处理延迟导致 `atMs` 在 `add_job` 实际执行时已轻微过期，原逻辑 `at_ms > now_ms` 判断直接返回 `None`，任务永远不会被调度
- 在 `_compute_next_run` 中引入 10 分钟宽限窗口（`_AT_GRACE_WINDOW_MS`）：
  - `at_ms` 在未来 → 返回 `at_ms`（原逻辑不变）
  - `at_ms` 过期但在 10 分钟内 → 返回 `now_ms + 1000`（1 秒后立即执行）
  - `at_ms` 过期超过 10 分钟 → 返回 `None`（不调度，防止明显过期的时间戳被意外放行）
- 由于 `add_job`、`enable_job`、`_recompute_next_runs`、`update_job`、`register_system_job` 均通过 `_compute_next_run` 计算，一处修改统一生效，所有路径行为一致

## Addresses review feedback

- ✅ 区分轻微过期（LLM 延迟）和明显过期（调用方传入过去时间），后者不再被意外触发
- ✅ `enable_job` 路径同步修复，重新启用已过期 at 任务时行为与 `add_job` 一致
- ✅ `update_job`、`_recompute_next_runs` 路径同样覆盖

## Test plan

- 全部现有单元测试通过（`pytest tests/cron/test_cron_service.py`，30 passed）
- 新增 5 个测试用例覆盖宽限窗口逻辑：
  - 轻微过期（5 秒前）→ 应被调度
  - 明显过期（1 小时前）→ 不应被调度
  - 边界值（恰好 10 分钟 vs 10 分钟 + 1ms）
  - `enable_job` 路径：重新启用轻微过期 at 任务
  - `update_job` 路径：更新 schedule 为轻微过期 at_ms