### PR TITLE
feat(telegram): change to mid-stream split in send_delta per review feedback(#2967 PR)

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -626,19 +626,59 @@ class TelegramChannel(BaseChannel):
                 logger.warning("Stream initial send failed: {}", e)
                 raise  # Let ChannelManager handle retry
         elif (now - buf.last_edit) >= self.config.stream_edit_interval:
-            try:
-                await self._call_with_retry(
-                    self._app.bot.edit_message_text,
-                    chat_id=int_chat_id, message_id=buf.message_id,
-                    text=buf.text,
-                )
-                buf.last_edit = now
-            except Exception as e:
-                if self._is_not_modified_error(e):
+            if len(buf.text) > TELEGRAM_MAX_MESSAGE_LEN:
+                # Finish current message
+                current_text = buf.text[:TELEGRAM_MAX_MESSAGE_LEN]
+                try:
+                    await self._call_with_retry(
+                        self._app.bot.edit_message_text,
+                        chat_id=int_chat_id,
+                        message_id=buf.message_id,
+                        text=current_text,
+                    )
+                except Exception as e:
+                    logger.warning("Failed to edit current message before splitting: {}", e)
+                    raise  # Let ChannelManager handle retry
+
+                # Prepare remaining content for a new message
+                remaining = buf.text[TELEGRAM_MAX_MESSAGE_LEN:]
+                logger.debug(f"[!] Splitting long message: {len(buf.text)} chars → new message with {len(remaining)} chars")
+
+                # Create new buffer for the next chunk
+                self._stream_bufs[chat_id] = _StreamBuf(stream_id=stream_id)
+                new_buf = self._stream_bufs[chat_id]
+                new_buf.text = remaining
+                new_buf.last_edit = now
+
+                # Immediately start the new message
+                if remaining.strip():
+                    try:
+                        sent = await self._call_with_retry(
+                            self._app.bot.send_message,
+                            chat_id=int_chat_id,
+                            text=remaining[:TELEGRAM_MAX_MESSAGE_LEN],
+                            **thread_kwargs
+                        )
+                        new_buf.message_id = sent.message_id
+                    except Exception as e:
+                        logger.error("Failed to send new message chunk after split: {}", e)
+                        raise  # Let ChannelManager handle retry
+            else:
+                # Normal edit (message is still under the limit)
+                try:
+                    await self._call_with_retry(
+                        self._app.bot.edit_message_text,
+                        chat_id=int_chat_id,
+                        message_id=buf.message_id,
+                        text=buf.text,
+                    )
                     buf.last_edit = now
-                    return
-                logger.warning("Stream edit failed: {}", e)
-                raise  # Let ChannelManager handle retry
+                except Exception as e:
+                    if self._is_not_modified_error(e):
+                        buf.last_edit = now
+                        return
+                    logger.warning("Stream edit failed: {}", e)
+                    raise  # Let ChannelManager handle retry
 
     async def _on_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /start command."""

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -638,58 +638,60 @@ class TelegramChannel(BaseChannel):
                 raise  # Let ChannelManager handle retry
         elif (now - buf.last_edit) >= self.config.stream_edit_interval:
             if len(buf.text) > TELEGRAM_MAX_MESSAGE_LEN:
-                # Finish current message
-                current_text = buf.text[:TELEGRAM_MAX_MESSAGE_LEN]
-                try:
-                    await self._call_with_retry(
-                        self._app.bot.edit_message_text,
-                        chat_id=int_chat_id,
-                        message_id=buf.message_id,
-                        text=current_text,
-                    )
-                except Exception as e:
-                    logger.warning("Failed to edit current message before splitting: {}", e)
-                    raise  # Let ChannelManager handle retry
-
-                # Prepare remaining content for a new message
-                remaining = buf.text[TELEGRAM_MAX_MESSAGE_LEN:]
-                logger.debug(f"[!] Splitting long message: {len(buf.text)} chars → new message with {len(remaining)} chars")
-
-                # Create new buffer for the next chunk
-                self._stream_bufs[chat_id] = _StreamBuf(stream_id=stream_id)
-                new_buf = self._stream_bufs[chat_id]
-                new_buf.text = remaining
-                new_buf.last_edit = now
-
-                # Immediately start the new message
-                if remaining.strip():
-                    try:
-                        sent = await self._call_with_retry(
-                            self._app.bot.send_message,
-                            chat_id=int_chat_id,
-                            text=remaining[:TELEGRAM_MAX_MESSAGE_LEN],
-                            **thread_kwargs
-                        )
-                        new_buf.message_id = sent.message_id
-                    except Exception as e:
-                        logger.error("Failed to send new message chunk after split: {}", e)
-                        raise  # Let ChannelManager handle retry
-            else:
-                # Normal edit (message is still under the limit)
-                try:
-                    await self._call_with_retry(
-                        self._app.bot.edit_message_text,
-                        chat_id=int_chat_id,
-                        message_id=buf.message_id,
-                        text=buf.text,
-                    )
+                await self._flush_stream_overflow(int_chat_id, buf, thread_kwargs)
+                buf.last_edit = now
+                return
+            try:
+                await self._call_with_retry(
+                    self._app.bot.edit_message_text,
+                    chat_id=int_chat_id, message_id=buf.message_id,
+                    text=buf.text,
+                )
+                buf.last_edit = now
+            except Exception as e:
+                if self._is_not_modified_error(e):
                     buf.last_edit = now
-                except Exception as e:
-                    if self._is_not_modified_error(e):
-                        buf.last_edit = now
-                        return
-                    logger.warning("Stream edit failed: {}", e)
-                    raise  # Let ChannelManager handle retry
+                    return
+                logger.warning("Stream edit failed: {}", e)
+                raise  # Let ChannelManager handle retry
+
+    async def _flush_stream_overflow(
+        self,
+        chat_id: int,
+        buf: "_StreamBuf",
+        thread_kwargs: dict,
+    ) -> None:
+        """Split an oversized stream buffer mid-flight.
+
+        Edits the current stream message with the first chunk, sends any
+        intermediate chunks as standalone messages, then opens a new message
+        for the tail so subsequent deltas continue streaming into it.
+        """
+        chunks = split_message(buf.text, TELEGRAM_MAX_MESSAGE_LEN)
+        if len(chunks) <= 1:
+            return
+        try:
+            await self._call_with_retry(
+                self._app.bot.edit_message_text,
+                chat_id=chat_id, message_id=buf.message_id,
+                text=chunks[0],
+            )
+        except Exception as e:
+            if not self._is_not_modified_error(e):
+                logger.warning("Stream overflow edit failed: {}", e)
+                raise
+        for chunk in chunks[1:-1]:
+            await self._call_with_retry(
+                self._app.bot.send_message,
+                chat_id=chat_id, text=chunk, **thread_kwargs,
+            )
+        tail = chunks[-1]
+        sent = await self._call_with_retry(
+            self._app.bot.send_message,
+            chat_id=chat_id, text=tail, **thread_kwargs,
+        )
+        buf.message_id = sent.message_id
+        buf.text = tail
 
     async def _on_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /start command."""

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -26,6 +26,11 @@ from nanobot.security.network import validate_url_target
 from nanobot.utils.helpers import split_message
 
 TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
+# Telegram's actual API limit is 4096; we split raw markdown at 4000 as a
+# safety margin for mid-stream edits (plain text).  For _stream_end, we
+# convert to HTML first and then split at the true 4096-char boundary so
+# the final rendered message never overflows.
+TELEGRAM_HTML_MAX_LEN = 4096
 TELEGRAM_REPLY_CONTEXT_MAX_LEN = TELEGRAM_MAX_MESSAGE_LEN  # Max length for reply context in user message
 
 
@@ -564,12 +569,13 @@ class TelegramChannel(BaseChannel):
             thread_kwargs = {}
             if message_thread_id := meta.get("message_thread_id"):
                 thread_kwargs["message_thread_id"] = message_thread_id
-            html = _markdown_to_telegram_html(buf.text)
-            if len(html) <= 4096:
+            raw_text = buf.text
+            html = _markdown_to_telegram_html(raw_text)
+            if len(html) <= TELEGRAM_HTML_MAX_LEN:
                 primary_html = html
                 extra_html_chunks = []
             else:
-                html_chunks = split_message(html, 4096)
+                html_chunks = split_message(html, TELEGRAM_HTML_MAX_LEN)
                 primary_html = html_chunks[0]
                 extra_html_chunks = html_chunks[1:]
             try:
@@ -587,11 +593,13 @@ class TelegramChannel(BaseChannel):
                     self._stream_bufs.pop(chat_id, None)
                     return
                 logger.debug("Final stream edit failed (HTML), trying plain: {}", e)
+                # Fall back to raw markdown (not HTML) so users don't see raw tags.
+                primary_plain = split_message(raw_text, TELEGRAM_MAX_MESSAGE_LEN)[0] if len(raw_text) > TELEGRAM_MAX_MESSAGE_LEN else raw_text
                 try:
                     await self._call_with_retry(
                         self._app.bot.edit_message_text,
                         chat_id=int_chat_id, message_id=buf.message_id,
-                        text=primary_html,
+                        text=primary_plain,
                     )
                 except Exception as e2:
                     if self._is_not_modified_error(e2):
@@ -600,12 +608,16 @@ class TelegramChannel(BaseChannel):
                         logger.warning("Final stream edit failed: {}", e2)
                         raise  # Let ChannelManager handle retry
             for extra_html_chunk in extra_html_chunks:
-                await self._call_with_retry(
-                    self._app.bot.send_message,
-                    chat_id=int_chat_id, text=extra_html_chunk,
-                    parse_mode="HTML",
-                    **thread_kwargs,
-                )
+                try:
+                    await self._call_with_retry(
+                        self._app.bot.send_message,
+                        chat_id=int_chat_id, text=extra_html_chunk,
+                        parse_mode="HTML",
+                        **thread_kwargs,
+                    )
+                except Exception:
+                    # Fall back to _send_text which handles HTML→plain gracefully.
+                    await self._send_text(int_chat_id, extra_html_chunk)
             self._stream_bufs.pop(chat_id, None)
             return
 

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -561,14 +561,22 @@ class TelegramChannel(BaseChannel):
                     await self._remove_reaction(chat_id, int(reply_to_message_id))
                 except ValueError:
                     pass
-            chunks = split_message(buf.text, TELEGRAM_MAX_MESSAGE_LEN)
-            primary_text = chunks[0] if chunks else buf.text
+            thread_kwargs = {}
+            if message_thread_id := meta.get("message_thread_id"):
+                thread_kwargs["message_thread_id"] = message_thread_id
+            html = _markdown_to_telegram_html(buf.text)
+            if len(html) <= 4096:
+                primary_html = html
+                extra_html_chunks = []
+            else:
+                html_chunks = split_message(html, 4096)
+                primary_html = html_chunks[0]
+                extra_html_chunks = html_chunks[1:]
             try:
-                html = _markdown_to_telegram_html(primary_text)
                 await self._call_with_retry(
                     self._app.bot.edit_message_text,
                     chat_id=int_chat_id, message_id=buf.message_id,
-                    text=html, parse_mode="HTML",
+                    text=primary_html, parse_mode="HTML",
                 )
             except BadRequest as e:
                 # Only fall back to plain text on actual HTML parse/format errors.
@@ -583,7 +591,7 @@ class TelegramChannel(BaseChannel):
                     await self._call_with_retry(
                         self._app.bot.edit_message_text,
                         chat_id=int_chat_id, message_id=buf.message_id,
-                        text=primary_text,
+                        text=primary_html,
                     )
                 except Exception as e2:
                     if self._is_not_modified_error(e2):
@@ -591,10 +599,13 @@ class TelegramChannel(BaseChannel):
                     else:
                         logger.warning("Final stream edit failed: {}", e2)
                         raise  # Let ChannelManager handle retry
-            # If final content exceeds Telegram limit, keep the first chunk in
-            # the edited stream message and send the rest as follow-up messages.
-            for extra_chunk in chunks[1:]:
-                await self._send_text(int_chat_id, extra_chunk)
+            for extra_html_chunk in extra_html_chunks:
+                await self._call_with_retry(
+                    self._app.bot.send_message,
+                    chat_id=int_chat_id, text=extra_html_chunk,
+                    parse_mode="HTML",
+                    **thread_kwargs,
+                )
             self._stream_bufs.pop(chat_id, None)
             return
 

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -575,6 +575,39 @@ async def test_send_delta_incremental_edit_treats_not_modified_as_success() -> N
 
 
 @pytest.mark.asyncio
+async def test_send_delta_incremental_edit_splits_oversized_buffer() -> None:
+    """Mid-stream overflow: once buf.text exceeds Telegram's limit, split into
+    chunks, edit the current message with the first chunk, and re-anchor the
+    buffer to a new message for the tail so further deltas keep streaming."""
+    from nanobot.channels.telegram import TELEGRAM_MAX_MESSAGE_LEN
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+    channel._app.bot.edit_message_text = AsyncMock()
+    channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
+
+    oversized = "x" * (TELEGRAM_MAX_MESSAGE_LEN + 500)
+    channel._stream_bufs["123"] = _StreamBuf(
+        text=oversized, message_id=7, last_edit=0.0, stream_id="s:0"
+    )
+
+    await channel.send_delta("123", "y", {"_stream_delta": True, "_stream_id": "s:0"})
+
+    channel._app.bot.edit_message_text.assert_called_once()
+    edit_text = channel._app.bot.edit_message_text.call_args.kwargs.get("text", "")
+    assert len(edit_text) <= TELEGRAM_MAX_MESSAGE_LEN
+
+    channel._app.bot.send_message.assert_called_once()
+    buf = channel._stream_bufs["123"]
+    assert buf.message_id == 99
+    assert len(buf.text) <= TELEGRAM_MAX_MESSAGE_LEN
+    assert buf.last_edit > 0.0
+
+
+@pytest.mark.asyncio
 async def test_send_delta_initial_send_keeps_message_in_thread() -> None:
     channel = TelegramChannel(
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -497,6 +497,7 @@ async def test_send_delta_stream_end_splits_oversized_reply() -> None:
     assert "123" not in channel._stream_bufs
 
 
+@pytest.mark.asyncio
 async def test_send_delta_stream_end_html_expansion_does_not_overflow() -> None:
     """Markdown that expands when converted to HTML is still split correctly.
 

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -467,8 +467,45 @@ async def test_send_delta_stream_end_falls_back_on_bad_request() -> None:
 
 @pytest.mark.asyncio
 async def test_send_delta_stream_end_splits_oversized_reply() -> None:
-    """Final streamed reply exceeding Telegram limit is split into chunks."""
-    from nanobot.channels.telegram import TELEGRAM_MAX_MESSAGE_LEN
+    """Final streamed reply exceeding Telegram limit is split into chunks.
+
+    The fix converts markdown to HTML first, then splits by 4096 (actual Telegram
+    limit), ensuring the edited message always fits within Telegram's constraint.
+    Previously, the code split by 4000 (TELEGRAM_MAX_MESSAGE_LEN) before HTML
+    conversion, which could still overflow when HTML tags were added.
+    """
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+    channel._app.bot.edit_message_text = AsyncMock()
+    channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
+
+    oversized = "x" * (4000 + 500)
+    channel._stream_bufs["123"] = _StreamBuf(text=oversized, message_id=7, last_edit=0.0)
+
+    await channel.send_delta("123", "", {"_stream_end": True})
+
+    channel._app.bot.edit_message_text.assert_called_once()
+    edit_text = channel._app.bot.edit_message_text.call_args.kwargs.get("text", "")
+    assert len(edit_text) <= 4096, f"edit_text length {len(edit_text)} exceeds Telegram's 4096 limit"
+
+    channel._app.bot.send_message.assert_called_once()
+    send_text = channel._app.bot.send_message.call_args.kwargs.get("text", "")
+    assert len(send_text) <= 4096
+    assert "123" not in channel._stream_bufs
+
+
+async def test_send_delta_stream_end_html_expansion_does_not_overflow() -> None:
+    """Markdown that expands when converted to HTML is still split correctly.
+
+    This is the actual bug from issue #3315: markdown like **bold** expands to
+    <b>bold</b>, adding ~33% characters. A 3600-char message with heavy markdown
+    could become 4800+ chars after HTML conversion, exceeding 4096 limit.
+    The fix converts to HTML first, THEN splits by 4096.
+    """
+    from nanobot.channels.telegram import _markdown_to_telegram_html
 
     channel = TelegramChannel(
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
@@ -478,14 +515,21 @@ async def test_send_delta_stream_end_splits_oversized_reply() -> None:
     channel._app.bot.edit_message_text = AsyncMock()
     channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
 
-    oversized = "x" * (TELEGRAM_MAX_MESSAGE_LEN + 500)
-    channel._stream_bufs["123"] = _StreamBuf(text=oversized, message_id=7, last_edit=0.0)
+    markdown_text = "**bold** " * 400  # 3600 chars raw, expands ~33% to 4800 HTML
+    raw_len = len(markdown_text)
+    html_len = len(_markdown_to_telegram_html(markdown_text))
+    assert html_len > 4096, f"Test precondition failed: HTML should exceed 4096 (was {html_len})"
+
+    channel._stream_bufs["123"] = _StreamBuf(text=markdown_text, message_id=7, last_edit=0.0)
 
     await channel.send_delta("123", "", {"_stream_end": True})
 
     channel._app.bot.edit_message_text.assert_called_once()
     edit_text = channel._app.bot.edit_message_text.call_args.kwargs.get("text", "")
-    assert len(edit_text) <= TELEGRAM_MAX_MESSAGE_LEN
+    assert len(edit_text) <= 4096, (
+        f"HTML text length {len(edit_text)} exceeds Telegram's 4096 limit. "
+        f"Raw was {raw_len}, HTML was {html_len}."
+    )
 
     channel._app.bot.send_message.assert_called_once()
     assert "123" not in channel._stream_bufs


### PR DESCRIPTION
## Description
This is a clean replacement for #2967. 
I had some technical issues with the commit history in the previous PR, so I've created this new one with a clean commit and correct author information.

## Changes
- Implemented mid-stream split in send_delta for Telegram as per review feedback from @chengyongru in #2967.

## refers
https://core.telegram.org/bots/api