### PR TITLE
 feat: add skill discovery — auto-extract reusable skillfeat: add skill discovery — auto-extract reusable skills from conversation historys from conver…

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -18,6 +18,8 @@ from nanobot.agent.context import ContextBuilder
 from nanobot.agent.hook import AgentHook, AgentHookContext, CompositeHook
 from nanobot.agent.memory import Consolidator, Dream
 from nanobot.agent.runner import _MAX_INJECTIONS_PER_TURN, AgentRunSpec, AgentRunner
+from nanobot.agent.skill_discovery import SkillDiscoverer
+from nanobot.agent.runner import AgentRunSpec, AgentRunner
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
@@ -236,6 +238,7 @@ class AgentLoop:
             provider=provider,
             model=self.model,
         )
+        self.skill_discoverer: SkillDiscoverer | None = None
         self._register_default_tools()
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
@@ -591,6 +594,29 @@ class AgentLoop:
         self._background_tasks.append(task)
         task.add_done_callback(self._background_tasks.remove)
 
+    def _maybe_trigger_skill_discovery(self, session_key: str) -> None:
+        """Trigger skill discovery after a turn if enabled."""
+        sd = self.skill_discoverer
+        if sd is None or not sd.config.enabled:
+            return
+        try:
+            sd.bump_turn_counter(session_key)
+            if sd.should_trigger(session_key):
+                async def _run():
+                    try:
+                        candidates = await sd.discover()
+                        if candidates:
+                            sd.save_pending(candidates)
+                            logger.info(
+                                "Skill Discovery (post-turn): {} candidate(s) pending",
+                                len(candidates),
+                            )
+                    except Exception:
+                        logger.exception("Skill Discovery post-turn failed")
+                self._schedule_background(_run())
+        except Exception:
+            logger.exception("Skill Discovery trigger check failed")
+    
     def stop(self) -> None:
         """Stop the agent loop."""
         self._running = False
@@ -710,6 +736,7 @@ class AgentLoop:
         self._clear_runtime_checkpoint(session)
         self.sessions.save(session)
         self._schedule_background(self.consolidator.maybe_consolidate_by_tokens(session))
+        self._maybe_trigger_skill_discovery(key)
 
         # When follow-up messages were injected mid-turn, a later natural
         # language reply may address those follow-ups and should not be

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -312,6 +312,23 @@ class MemoryStore:
     def set_last_dream_cursor(self, cursor: int) -> None:
         self._dream_cursor_file.write_text(str(cursor), encoding="utf-8")
 
+    # -- skill discovery cursor -----------------------------------------------
+
+    def get_skill_discovery_cursor(self) -> int:
+        """Read the skill discovery cursor position."""
+        path = self.workspace / ".skill_discovery_cursor"
+        if path.exists():
+            try:
+                return int(path.read_text(encoding="utf-8").strip())
+            except (ValueError, OSError):
+                pass
+        return 0
+
+    def set_skill_discovery_cursor(self, cursor: int) -> None:
+        """Save the skill discovery cursor position."""
+        path = self.workspace / ".skill_discovery_cursor"
+        path.write_text(str(cursor), encoding="utf-8")
+
     # -- message formatting utility ------------------------------------------
 
     @staticmethod

--- a/nanobot/agent/skill_discovery.py
+++ b/nanobot/agent/skill_discovery.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from loguru import logger
 

--- a/nanobot/agent/skill_discovery.py
+++ b/nanobot/agent/skill_discovery.py
@@ -1,0 +1,415 @@
+"""Skill discovery: analyze conversation history to find reusable behavioral patterns."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from nanobot.utils.prompt_templates import render_template
+
+if TYPE_CHECKING:
+    from nanobot.agent.memory import MemoryStore
+    from nanobot.agent.runner import AgentRunner
+    from nanobot.config.schema import SkillDiscoveryConfig
+    from nanobot.providers.base import LLMProvider
+
+
+@dataclass
+class SkillCandidate:
+    """A candidate skill discovered from conversation history."""
+
+    name: str
+    description: str
+    content: str  # Full SKILL.md content
+
+    def format_preview(self) -> str:
+        """Format a short preview for display."""
+        return f"**{self.name}** — {self.description}"
+
+
+class SkillDiscoverer:
+    """Discover reusable skills from conversation history.
+
+    Two-phase processing:
+      Phase 1: LLM analyzes history → structured JSON patterns
+      Phase 2: AgentRunner generates SKILL.md files using read_file + write_file
+
+    Quality gates:
+      - Name conflict check (skip if skill already exists)
+      - Deduplication (skip duplicate candidate names)
+      - max_candidates cap
+      - Weak recommendation filtering (Phase 2)
+    """
+
+    def __init__(
+        self,
+        store: MemoryStore,
+        provider: LLMProvider,
+        model: str,
+        config: SkillDiscoveryConfig,
+        skills_dir: Path | None = None,
+    ):
+        self.store = store
+        self.provider = provider
+        self.model = model
+        self.config = config
+        self.skills_dir = skills_dir or (store.workspace / "skills")
+        self.skills_dir.mkdir(parents=True, exist_ok=True)
+        self._pending_dir = store.workspace / ".pending_skills"
+
+        # Lazy-init AgentRunner for Phase 2
+        self._runner: AgentRunner | None = None
+
+        # Post-turn trigger state (in-memory, resets on restart)
+        self._turn_counters: dict[str, int] = {}
+
+    def _get_runner(self) -> AgentRunner:
+        """Lazy-initialize the AgentRunner for Phase 2."""
+        if self._runner is None:
+            from nanobot.agent.runner import AgentRunner
+            self._runner = AgentRunner(self.provider)
+        return self._runner
+
+    # -- main entry point ----------------------------------------------------
+
+    async def discover(self) -> list[SkillCandidate]:
+        """Two-phase skill discovery: analyze patterns, then generate skills.
+
+        Returns a list of SkillCandidate objects (may be empty).
+        Cursor is always advanced after processing, even if no candidates found.
+        """
+        # 1. Incremental history read
+        last_cursor = self.store.get_skill_discovery_cursor()
+        entries = self.store.read_unprocessed_history(since_cursor=last_cursor)
+        if not entries:
+            logger.info(
+                "Skill discovery: no new history entries since cursor {}",
+                last_cursor,
+            )
+            return []
+
+        batch = entries[: self.config.max_history_entries]
+
+        # 2. Build history text
+        history_text = "\n".join(
+            f"[{e['timestamp']}] {e['content']}" for e in batch
+        )
+
+        # 3. Build context (Memory + User + existing Skills)
+        context = self._build_context()
+
+        # ── Phase 1: Structured analysis ──
+        phase1_prompt = f"## Conversation History\n{history_text}\n\n{context}"
+        try:
+            phase1_response = await self.provider.chat_with_retry(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": render_template(
+                            "agent/skill_discovery_phase1.md", strip=True
+                        ),
+                    },
+                    {"role": "user", "content": phase1_prompt},
+                ],
+                tools=None,
+                tool_choice=None,
+            )
+            analysis = phase1_response.content or ""
+            logger.debug(
+                "Skill discovery Phase 1: {} chars", len(analysis)
+            )
+        except Exception:
+            logger.exception("Skill discovery Phase 1 failed")
+            # Phase 1 failed — do NOT advance cursor (preserve retry opportunity)
+            return []
+
+        # Parse Phase 1 result
+        patterns = self._parse_phase1_analysis(analysis)
+        if not patterns:
+            # No patterns found — advance cursor and return
+            new_cursor = batch[-1]["cursor"]
+            self.store.set_skill_discovery_cursor(new_cursor)
+            logger.info(
+                "Skill discovery: no patterns found in {} entries (cursor {}→{})",
+                len(batch), last_cursor, new_cursor,
+            )
+            return []
+
+        # Quality gate: filter weak recommendations
+        patterns = [p for p in patterns if p.get("recommendation") != "weak"]
+        if not patterns:
+            new_cursor = batch[-1]["cursor"]
+            self.store.set_skill_discovery_cursor(new_cursor)
+            logger.info(
+                "Skill discovery: all patterns filtered as weak (cursor {}→{})",
+                last_cursor, new_cursor,
+            )
+            return []
+
+        # ── Phase 2: AgentRunner generation ──
+        pending_dir = self._pending_dir
+        pending_dir.mkdir(parents=True, exist_ok=True)
+
+        phase2_prompt = (
+            f"## Analysis Result\n{json.dumps(patterns, indent=2, ensure_ascii=False)}\n\n{context}"
+        )
+        tools = self._build_tools(pending_dir)
+        messages = [
+            {
+                "role": "system",
+                "content": render_template(
+                    "agent/skill_discovery_phase2.md", strip=True
+                ),
+            },
+            {"role": "user", "content": phase2_prompt},
+        ]
+
+        try:
+            runner = self._get_runner()
+            from nanobot.agent.runner import AgentRunSpec
+            result = await runner.run(AgentRunSpec(
+                initial_messages=messages,
+                tools=tools,
+                model=self.model,
+                max_iterations=self.config.max_candidates * 3,  # ~3 rounds per candidate
+                max_tool_result_chars=16_000,
+                fail_on_tool_error=False,
+            ))
+            logger.debug(
+                "Skill discovery Phase 2: stop_reason={}, events={}",
+                result.stop_reason, len(result.tool_events or []),
+            )
+        except Exception:
+            logger.exception("Skill discovery Phase 2 failed")
+            result = None
+
+        # Collect generated candidates from pending directory
+        candidates = self._collect_pending_candidates(pending_dir)
+
+        # Apply quality gates: name conflict + dedup + max_candidates
+        candidates = self._filter_candidates(candidates)
+
+        # Advance cursor — always, to avoid re-processing
+        new_cursor = batch[-1]["cursor"]
+        self.store.set_skill_discovery_cursor(new_cursor)
+
+        logger.info(
+            "Skill discovery: analyzed {} entries (cursor {}→{}), found {} candidate(s)",
+            len(batch), last_cursor, new_cursor, len(candidates),
+        )
+        return candidates
+
+    # -- context building ----------------------------------------------------
+
+    def _build_context(self) -> str:
+        """Build context string with Memory, User profile, and existing skills."""
+        parts = []
+
+        # Memory context
+        memory = self.store.read_memory()
+        if memory:
+            parts.append(f"## Current MEMORY.md\n{memory}")
+
+        # User profile
+        user = self.store.read_user()
+        if user:
+            parts.append(f"## Current USER.md\n{user}")
+
+        # Existing Skills list (avoid duplicate generation)
+        existing = self._list_existing_skills()
+        if existing:
+            parts.append(
+                "## Existing Skills\n" + "\n".join(f"- {s}" for s in existing)
+            )
+
+        return "\n\n".join(parts)
+
+    def _list_existing_skills(self) -> list[str]:
+        """List names of all installed skills."""
+        if not self.skills_dir.exists():
+            return []
+        return [
+            d.name
+            for d in sorted(self.skills_dir.iterdir())
+            if d.is_dir() and (d / "SKILL.md").exists()
+        ]
+
+    # -- candidate filtering -------------------------------------------------
+
+    def _filter_candidates(self, candidates: list[SkillCandidate]) -> list[SkillCandidate]:
+        """Filter out invalid or duplicate candidates."""
+        existing = set(self._list_existing_skills())
+        seen_names: set[str] = set()
+        filtered: list[SkillCandidate] = []
+
+        for c in candidates:
+            # Name conflict check
+            if c.name in existing:
+                logger.debug(
+                    "Skill discovery: skipping '{}' — already exists", c.name
+                )
+                continue
+            # Dedup
+            if c.name in seen_names:
+                continue
+            seen_names.add(c.name)
+            filtered.append(c)
+
+        return filtered[: self.config.max_candidates]
+
+    # -- Phase 1 analysis parsing --------------------------------------------
+
+    @staticmethod
+    def _parse_phase1_analysis(analysis: str) -> list[dict]:
+        """Parse Phase 1 structured analysis into pattern dicts."""
+        # Try extracting JSON from markdown code block
+        json_match = re.search(
+            r"```(?:json)?\s*(\[.*?\])\s*```", analysis, re.DOTALL
+        )
+        if json_match:
+            try:
+                return json.loads(json_match.group(1))
+            except json.JSONDecodeError:
+                pass
+
+        # Try parsing the entire response as JSON
+        try:
+            parsed = json.loads(analysis)
+            if isinstance(parsed, list):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+
+        logger.warning("Skill discovery: failed to parse Phase 1 analysis")
+        return []
+
+    # -- Phase 2 tool building -----------------------------------------------
+
+    def _build_tools(self, target_dir: Path) -> "ToolRegistry":
+        """Build tool registry for Phase 2 AgentRunner."""
+        from nanobot.agent.tools.filesystem import ReadFileTool, WriteFileTool
+        from nanobot.agent.tools.registry import ToolRegistry
+
+        tools = ToolRegistry()
+        workspace = self.store.workspace
+        tools.register(ReadFileTool(workspace=workspace, allowed_dir=workspace))
+        tools.register(WriteFileTool(workspace=target_dir, allowed_dir=target_dir))
+        return tools
+
+    # -- pending candidate collection ----------------------------------------
+
+    def _collect_pending_candidates(self, pending_dir: Path) -> list[SkillCandidate]:
+        """Collect skill candidates from pending directory."""
+        candidates: list[SkillCandidate] = []
+        if not pending_dir.exists():
+            return candidates
+
+        for skill_dir in sorted(pending_dir.iterdir()):
+            if not skill_dir.is_dir():
+                continue
+            skill_md = skill_dir / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            content = skill_md.read_text(encoding="utf-8")
+            name = skill_dir.name
+            desc = self._extract_description(content)
+            candidates.append(SkillCandidate(
+                name=name,
+                description=desc,
+                content=content,
+            ))
+
+        return candidates
+
+    @staticmethod
+    def _extract_description(content: str) -> str:
+        """Extract a one-line description from SKILL.md content."""
+        # Try to find the first non-heading, non-empty line
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            return line[:200]  # Truncate long descriptions
+        return "(no description)"
+
+    # -- pending management --------------------------------------------------
+
+    def save_pending(self, candidates: list[SkillCandidate]) -> None:
+        """Save candidates to the pending directory for later approval."""
+        self._pending_dir.mkdir(parents=True, exist_ok=True)
+        for c in candidates:
+            skill_dir = self._pending_dir / c.name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(c.content, encoding="utf-8")
+        logger.info(
+            "Skill discovery: saved {} candidate(s) to pending", len(candidates)
+        )
+
+    def list_pending(self) -> list[SkillCandidate]:
+        """List all pending skill candidates."""
+        return self._collect_pending_candidates(self._pending_dir)
+
+    def remove_pending(self, name: str) -> None:
+        """Remove a specific pending skill candidate."""
+        skill_dir = self._pending_dir / name
+        if skill_dir.is_dir():
+            import shutil
+            shutil.rmtree(skill_dir, ignore_errors=True)
+
+    def clear_pending(self) -> None:
+        """Remove all pending skill candidates."""
+        if self._pending_dir.is_dir():
+            import shutil
+            shutil.rmtree(self._pending_dir, ignore_errors=True)
+
+    # -- approval / installation ---------------------------------------------
+
+    def approve(self, candidate: SkillCandidate) -> Path:
+        """Install a skill candidate to the skills directory."""
+        skill_dir = self.skills_dir / candidate.name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text(candidate.content, encoding="utf-8")
+
+        # Git commit
+        if self.store.git.is_initialized():
+            self.store.git.auto_commit(
+                f"skill-discovery: install '{candidate.name}'"
+            )
+
+        logger.info("Installed skill '{}' to {}", candidate.name, skill_path)
+        return skill_path
+
+    def approve_all(self, candidates: list[SkillCandidate]) -> list[Path]:
+        """Install all skill candidates."""
+        paths = []
+        for c in candidates:
+            paths.append(self.approve(c))
+        return paths
+
+    # -- post-turn trigger ---------------------------------------------------
+
+    def bump_turn_counter(self, session_key: str) -> None:
+        """Increment the turn counter for a session."""
+        self._turn_counters[session_key] = self._turn_counters.get(session_key, 0) + 1
+
+    def should_trigger(self, session_key: str) -> bool:
+        """Check if skill discovery should trigger for this session.
+
+        Triggers when the turn counter reaches `interval_turns`,
+        then resets the counter.
+        """
+        interval = self.config.interval_turns
+        if interval <= 0:
+            return False
+        count = self._turn_counters.get(session_key, 0)
+        if count >= interval:
+            self._turn_counters[session_key] = 0
+            return True
+        return False

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -698,6 +698,22 @@ def gateway(
             except Exception:
                 logger.exception("Dream cron job failed")
             return None
+        
+        # Skill Discovery is an internal job — run directly.
+        if job.name == "skill-discovery":
+            try:
+                if agent.skill_discoverer:
+                    candidates = await agent.skill_discoverer.discover()
+                    if candidates:
+                        agent.skill_discoverer.save_pending(candidates)
+                        logger.info(
+                            "Skill Discovery cron: {} candidate(s) pending",
+                            len(candidates),
+                        )
+                logger.info("Skill Discovery cron job completed")
+            except Exception:
+                logger.exception("Skill Discovery cron job failed")
+            return None
 
         from nanobot.agent.tools.cron import CronTool
         from nanobot.agent.tools.message import MessageTool
@@ -834,6 +850,28 @@ def gateway(
     ))
     console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
 
+    # Initialize Skill Discovery (if enabled)
+    sd_cfg = config.skill_discovery
+    if sd_cfg.enabled:
+        from nanobot.agent.skill_discovery import SkillDiscoverer
+        sd_model = sd_cfg.model_override or agent.model
+        agent.skill_discoverer = SkillDiscoverer(
+            store=agent.context.memory,
+            provider=provider,
+            model=sd_model,
+            config=sd_cfg,
+        )
+        if sd_cfg.cron:
+            cron.register_system_job(CronJob(
+                id="skill-discovery",
+                name="skill-discovery",
+                schedule=sd_cfg.build_schedule(config.agents.defaults.timezone),
+                payload=CronPayload(kind="system_event"),
+            ))
+        console.print(f"[green]✓[/green] Skill Discovery: enabled (model={sd_model})")
+    else:
+        console.print("[dim]Skill Discovery: disabled[/dim]")
+
     async def run():
         try:
             await cron.start()
@@ -919,6 +957,18 @@ def agent(
         unified_session=config.agents.defaults.unified_session,
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
     )
+    # Initialize Skill Discovery for CLI agent (post-turn trigger only, no cron)
+    sd_cfg = config.skill_discovery
+    if sd_cfg.enabled:
+        from nanobot.agent.skill_discovery import SkillDiscoverer
+        sd_model = sd_cfg.model_override or config.agents.defaults.model
+        agent_loop.skill_discoverer = SkillDiscoverer(
+            store=agent_loop.context.memory,
+            provider=provider,
+            model=sd_model,
+            config=sd_cfg,
+        )
+        
     restart_notice = consume_restart_notice_from_env()
     if restart_notice and should_show_cli_restart_notice(restart_notice, session_id):
         _print_agent_response(

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -312,6 +312,114 @@ async def cmd_help(ctx: CommandContext) -> OutboundMessage:
         metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
     )
 
+async def cmd_discover_skills(ctx: CommandContext) -> OutboundMessage:
+    """Analyze conversation history and suggest reusable skills."""
+    import time
+
+    loop = ctx.loop
+    msg = ctx.msg
+    discoverer = getattr(loop, "skill_discoverer", None)
+
+    if discoverer is None:
+        return OutboundMessage(
+            channel=msg.channel, chat_id=msg.chat_id,
+            content="Skill discovery is not enabled. Set `skillDiscovery.enabled: true` in config.",
+        )
+
+    async def _run_discovery():
+        t0 = time.monotonic()
+        try:
+            candidates = await discoverer.discover()
+            elapsed = time.monotonic() - t0
+
+            if not candidates:
+                content = f"Skill discovery completed in {elapsed:.1f}s — no new skills found."
+            else:
+                if discoverer.config.auto_approve:
+                    paths = discoverer.approve_all(candidates)
+                    parts = [
+                        f"Skill discovery completed in {elapsed:.1f}s — "
+                        f"installed {len(candidates)} skill(s):\n",
+                    ]
+                    for candidate, path in zip(candidates, paths):
+                        parts.append(candidate.format_preview())
+                        parts.append(f"📁 Installed to: `{path}`\n")
+                    parts.append("\n_Skills are active immediately._")
+                    content = "\n".join(parts)
+                else:
+                    # Save as pending, wait for user confirmation
+                    discoverer.save_pending(candidates)
+                    parts = [
+                        f"Skill discovery completed in {elapsed:.1f}s — "
+                        f"found {len(candidates)} candidate(s):\n",
+                    ]
+                    for i, c in enumerate(candidates, 1):
+                        parts.append(f"**{i}. {c.name}** — {c.description}")
+                    parts.append(
+                        "\nUse `/skill-approve <name>` to install, "
+                        "or `/skill-approve all` to install all."
+                    )
+                    content = "\n".join(parts)
+        except Exception as e:
+            elapsed = time.monotonic() - t0
+            content = f"Skill discovery failed after {elapsed:.1f}s: {e}"
+
+        await loop.bus.publish_outbound(OutboundMessage(
+            channel=msg.channel, chat_id=msg.chat_id, content=content,
+        ))
+
+    asyncio.create_task(_run_discovery())
+    return OutboundMessage(
+        channel=msg.channel, chat_id=msg.chat_id, content="Discovering skills...",
+    )
+
+
+async def cmd_skill_approve(ctx: CommandContext) -> OutboundMessage:
+    """Approve and install pending skill candidates."""
+    msg = ctx.msg
+    discoverer = getattr(ctx.loop, "skill_discoverer", None)
+    args = ctx.args.strip()
+
+    if not discoverer:
+        return OutboundMessage(
+            channel=msg.channel, chat_id=msg.chat_id,
+            content="Skill discovery is not enabled.",
+        )
+
+    pending = discoverer.list_pending()
+    if not pending:
+        return OutboundMessage(
+            channel=msg.channel, chat_id=msg.chat_id,
+            content="No pending skills to approve.",
+        )
+
+    if args.lower() == "all":
+        paths = [discoverer.approve(c) for c in pending]
+        discoverer.clear_pending()
+        content = f"Installed {len(paths)} skill(s):\n" + "\n".join(
+            f"- **{c.name}** → `{p}`" for c, p in zip(pending, paths)
+        )
+    elif args:
+        matched = [c for c in pending if c.name == args]
+        if not matched:
+            content = (
+                f"No pending skill named '{args}'. "
+                f"Available: {', '.join(c.name for c in pending)}"
+            )
+        else:
+            path = discoverer.approve(matched[0])
+            discoverer.remove_pending(matched[0].name)
+            content = f"Installed skill **{matched[0].name}** → `{path}`"
+    else:
+        parts = ["Pending skills:"]
+        for c in pending:
+            parts.append(f"- **{c.name}** — {c.description}")
+        parts.append("\nUse `/skill-approve <name>` or `/skill-approve all`")
+        content = "\n".join(parts)
+
+    return OutboundMessage(
+        channel=msg.channel, chat_id=msg.chat_id, content=content,
+    )
 
 def build_help_text() -> str:
     """Build canonical help text shared across channels."""
@@ -324,6 +432,8 @@ def build_help_text() -> str:
         "/dream — Manually trigger Dream consolidation",
         "/dream-log — Show what the last Dream changed",
         "/dream-restore — Revert memory to a previous state",
+        "/discover-skills — Analyze history and suggest reusable skills",
+        "/skill-approve — Approve and install pending skill candidates",
         "/help — Show available commands",
     ]
     return "\n".join(lines)
@@ -341,4 +451,7 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.prefix("/dream-log ", cmd_dream_log)
     router.exact("/dream-restore", cmd_dream_restore)
     router.prefix("/dream-restore ", cmd_dream_restore)
+    router.exact("/discover-skills", cmd_discover_skills)
+    router.exact("/skill-approve", cmd_skill_approve)
+    router.prefix("/skill-approve ", cmd_skill_approve)
     router.exact("/help", cmd_help)

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -132,6 +132,28 @@ class ProvidersConfig(Base):
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
 
 
+class SkillDiscoveryConfig(Base):
+    """Skill discovery configuration."""
+
+    enabled: bool = False  # opt-in, default off
+    model_override: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("modelOverride", "model", "model_override"),
+    )
+    max_history_entries: int = Field(default=50, ge=1)  # max history entries per analysis
+    max_candidates: int = Field(default=5, ge=1)  # max candidates per discovery run
+    auto_approve: bool = False  # skip user confirmation and install directly
+    # Phase 3 fields (safe to include now, used later)
+    interval_turns: int = Field(default=20, ge=1)  # auto-trigger every N turns
+    min_interval_s: int = Field(default=7200, ge=60)  # minimum interval between auto-triggers (seconds)
+    cron: str | None = Field(default=None, exclude=True)  # optional cron expression
+
+    def build_schedule(self, timezone: str) -> CronSchedule:
+        """Build the runtime schedule for cron-based skill discovery."""
+        if self.cron:
+            return CronSchedule(kind="cron", expr=self.cron, tz=timezone)
+        return CronSchedule(kind="every", every_ms=self.min_interval_s * 1000)
+
 class HeartbeatConfig(Base):
     """Heartbeat service configuration."""
 
@@ -216,6 +238,7 @@ class Config(BaseSettings):
     api: ApiConfig = Field(default_factory=ApiConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    skill_discovery: SkillDiscoveryConfig = Field(default_factory=SkillDiscoveryConfig)
 
     @property
     def workspace_path(self) -> Path:

--- a/nanobot/templates/agent/skill_discovery_phase1.md
+++ b/nanobot/templates/agent/skill_discovery_phase1.md
@@ -1,0 +1,37 @@
+You are a skill pattern analyzer for nanobot.
+
+## Task
+Analyze the conversation history below and identify **reusable behavioral patterns**
+that could be extracted into standalone skills.
+
+## What Makes a Good Skill
+- A task the user performs **repeatedly** (≥2 occurrences in history)
+- Involves a **specific, well-defined workflow** (not vague preferences)
+- Can be described as a **self-contained instruction set** with clear inputs/outputs
+- Is **NOT** already covered by an existing skill (see list below)
+
+## What to Exclude
+- One-time tasks or unique requests
+- Simple Q&A or factual lookups
+- Tasks already covered by existing skills
+- Personality traits or communication preferences (these belong in SOUL.md/USER.md)
+- Generic programming tasks without a specific pattern
+- Tasks that are too trivial to warrant a skill (e.g., "read a file")
+
+## Output Format
+Return a JSON array of candidate patterns. Each element:
+```json
+{
+  "name": "kebab-case-name",
+  "description": "One-line description of what this skill does",
+  "frequency": "how often this pattern appeared (e.g., '3 times in last 50 entries')",
+  "evidence": ["brief quote or reference from history entry 1", "...entry 2"],
+  "complexity": "low|medium|high",
+  "recommendation": "strong|moderate|weak",
+  "rationale": "Why this should/shouldn't be a skill"
+}
+```
+
+If no patterns are found, return an empty array: `[]`
+
+Do NOT invent patterns that aren't clearly supported by the history.

--- a/nanobot/templates/agent/skill_discovery_phase2.md
+++ b/nanobot/templates/agent/skill_discovery_phase2.md
@@ -1,0 +1,32 @@
+You are a skill generator for nanobot. You will create high-quality SKILL.md files
+based on the analysis from Phase 1.
+
+## Your Tools
+- `read_file(path)` — Read existing skill files for reference
+- `write_file(path, content)` — Write the generated SKILL.md file
+
+## Quality Standards for SKILL.md
+Every generated skill MUST include:
+
+1. **Title and Description** — Clear, concise name and one-paragraph description
+2. **When to Use** — Specific trigger conditions (not vague)
+3. **Inputs** — What information the skill needs from the user
+4. **Steps** — Numbered, actionable steps the agent should follow
+5. **Output Format** — What the user should receive
+6. **Examples** — At least one concrete example of usage
+7. **Edge Cases** — Known limitations or special handling
+
+## File Path Convention
+Write each skill to: `skills/{name}/SKILL.md`
+
+## Rules
+- Do NOT overwrite existing skills
+- Use kebab-case for skill directory names
+- Keep SKILL.md under 2000 words — concise and actionable
+- Reference specific tools the agent has access to (read_file, write_file, exec, web_search, etc.)
+- Do NOT include implementation code — skills are instruction sets, not code libraries
+- Each skill should be self-contained and independently usable
+
+## Analysis Result
+Process each recommended candidate from the analysis below.
+Skip candidates marked as "weak" recommendation.

--- a/tests/agent/test_skill_discovery.py
+++ b/tests/agent/test_skill_discovery.py
@@ -1,0 +1,1217 @@
+"""Tests for nanobot.agent.skill_discovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.skill_discovery import SkillCandidate, SkillDiscoverer
+from nanobot.config.schema import SkillDiscoveryConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_store(tmp_path: Path) -> MagicMock:
+    """Create a mock MemoryStore with a real workspace directory."""
+    store = MagicMock()
+    store.workspace = tmp_path
+    store.get_skill_discovery_cursor.return_value = 0
+    store.set_skill_discovery_cursor = MagicMock()
+    store.read_memory.return_value = ""
+    store.read_user.return_value = ""
+    # Git mock — not initialized by default
+    store.git.is_initialized.return_value = False
+    return store
+
+
+def _make_provider() -> MagicMock:
+    """Create a mock LLMProvider."""
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock()
+    return provider
+
+
+def _make_config(**overrides) -> SkillDiscoveryConfig:
+    """Create a SkillDiscoveryConfig with optional overrides."""
+    defaults = dict(
+        enabled=True,
+        max_history_entries=50,
+        max_candidates=5,
+        auto_approve=False,
+        interval_turns=20,
+        min_interval_s=7200,
+        cron=None,
+    )
+    defaults.update(overrides)
+    return SkillDiscoveryConfig(**defaults)
+
+
+def _write_skill(base: Path, name: str, content: str = "# Skill\nDescription here.") -> Path:
+    """Write a SKILL.md file under base/name/."""
+    skill_dir = base / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    path = skill_dir / "SKILL.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# SkillCandidate
+# ---------------------------------------------------------------------------
+
+
+class TestSkillCandidate:
+    def test_format_preview(self) -> None:
+        c = SkillCandidate(name="my-skill", description="Does something cool", content="# My Skill")
+        assert c.format_preview() == "**my-skill** — Does something cool"
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParsePhase1Analysis:
+    def test_parse_json_in_code_block(self) -> None:
+        analysis = '```json\n[{"name": "test-skill", "recommendation": "strong"}]\n```'
+        result = SkillDiscoverer._parse_phase1_analysis(analysis)
+        assert len(result) == 1
+        assert result[0]["name"] == "test-skill"
+
+    def test_parse_bare_json_array(self) -> None:
+        analysis = '[{"name": "test-skill", "recommendation": "moderate"}]'
+        result = SkillDiscoverer._parse_phase1_analysis(analysis)
+        assert len(result) == 1
+
+    def test_parse_empty_array(self) -> None:
+        result = SkillDiscoverer._parse_phase1_analysis("[]")
+        assert result == []
+
+    def test_parse_invalid_json_returns_empty(self) -> None:
+        result = SkillDiscoverer._parse_phase1_analysis("This is not JSON at all")
+        assert result == []
+
+    def test_parse_json_object_returns_empty(self) -> None:
+        """A JSON object (not array) should not be accepted."""
+        result = SkillDiscoverer._parse_phase1_analysis('{"name": "test"}')
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Description extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDescription:
+    def test_extracts_first_non_heading_line(self) -> None:
+        content = "# My Skill\n\nThis is the description.\n\n## Steps\nDo stuff."
+        assert SkillDiscoverer._extract_description(content) == "This is the description."
+
+    def test_skips_empty_lines(self) -> None:
+        content = "# Title\n\n\n\nActual description"
+        assert SkillDiscoverer._extract_description(content) == "Actual description"
+
+    def test_truncates_long_description(self) -> None:
+        long_line = "x" * 300
+        content = f"# Title\n{long_line}"
+        result = SkillDiscoverer._extract_description(content)
+        assert len(result) == 200
+
+    def test_no_description_fallback(self) -> None:
+        content = "# Just a heading\n## Another heading"
+        assert SkillDiscoverer._extract_description(content) == "(no description)"
+
+
+# ---------------------------------------------------------------------------
+# Candidate filtering
+# ---------------------------------------------------------------------------
+
+
+class TestFilterCandidates:
+    def test_filters_duplicate_names(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = [
+            SkillCandidate(name="dup", description="first", content="#1"),
+            SkillCandidate(name="dup", description="second", content="#2"),
+            SkillCandidate(name="unique", description="third", content="#3"),
+        ]
+        result = sd._filter_candidates(candidates)
+        assert len(result) == 2
+        assert result[0].name == "dup"
+        assert result[1].name == "unique"
+
+    def test_filters_existing_skills(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        # Pre-install a skill
+        _write_skill(sd.skills_dir, "existing-skill")
+
+        candidates = [
+            SkillCandidate(name="existing-skill", description="already there", content="#1"),
+            SkillCandidate(name="new-skill", description="brand new", content="#2"),
+        ]
+        result = sd._filter_candidates(candidates)
+        assert len(result) == 1
+        assert result[0].name == "new-skill"
+
+    def test_respects_max_candidates(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(max_candidates=2)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = [
+            SkillCandidate(name=f"skill-{i}", description=f"desc {i}", content=f"#{i}")
+            for i in range(5)
+        ]
+        result = sd._filter_candidates(candidates)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Pending management
+# ---------------------------------------------------------------------------
+
+
+class TestPendingManagement:
+    def test_save_and_list_pending(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = [
+            SkillCandidate(name="skill-a", description="Desc A", content="# Skill A\nDesc A."),
+            SkillCandidate(name="skill-b", description="Desc B", content="# Skill B\nDesc B."),
+        ]
+        sd.save_pending(candidates)
+
+        pending = sd.list_pending()
+        assert len(pending) == 2
+        names = {p.name for p in pending}
+        assert names == {"skill-a", "skill-b"}
+
+    def test_remove_pending(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = [
+            SkillCandidate(name="skill-a", description="Desc A", content="# A"),
+            SkillCandidate(name="skill-b", description="Desc B", content="# B"),
+        ]
+        sd.save_pending(candidates)
+        sd.remove_pending("skill-a")
+
+        pending = sd.list_pending()
+        assert len(pending) == 1
+        assert pending[0].name == "skill-b"
+
+    def test_clear_pending(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = [SkillCandidate(name="x", description="X", content="# X")]
+        sd.save_pending(candidates)
+        sd.clear_pending()
+
+        assert sd.list_pending() == []
+
+    def test_list_pending_empty_when_no_dir(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        assert sd.list_pending() == []
+
+
+# ---------------------------------------------------------------------------
+# Approval / installation
+# ---------------------------------------------------------------------------
+
+
+class TestApproval:
+    def test_approve_installs_skill(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidate = SkillCandidate(
+            name="my-skill", description="A great skill", content="# My Skill\nGreat stuff."
+        )
+        path = sd.approve(candidate)
+
+        assert path.exists()
+        assert path.read_text(encoding="utf-8") == "# My Skill\nGreat stuff."
+        assert (sd.skills_dir / "my-skill" / "SKILL.md").exists()
+
+    def test_approve_all(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = [
+            SkillCandidate(name="a", description="A", content="# A"),
+            SkillCandidate(name="b", description="B", content="# B"),
+        ]
+        paths = sd.approve_all(candidates)
+        assert len(paths) == 2
+        assert all(p.exists() for p in paths)
+
+    def test_approve_with_git_commit(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.git.is_initialized.return_value = True
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidate = SkillCandidate(name="git-skill", description="G", content="# G")
+        sd.approve(candidate)
+
+        store.git.auto_commit.assert_called_once_with(
+            "skill-discovery: install 'git-skill'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Post-turn trigger
+# ---------------------------------------------------------------------------
+
+
+class TestPostTurnTrigger:
+    def test_bump_turn_counter(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(interval_turns=3)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        sd.bump_turn_counter("session-1")
+        sd.bump_turn_counter("session-1")
+        assert sd._turn_counters["session-1"] == 2
+
+    def test_should_trigger_at_interval(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(interval_turns=3)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        assert not sd.should_trigger("session-1")  # 0 < 3
+        sd.bump_turn_counter("session-1")  # 1
+        assert not sd.should_trigger("session-1")  # 1 < 3
+        sd.bump_turn_counter("session-1")  # 2
+        assert not sd.should_trigger("session-1")  # 2 < 3
+        sd.bump_turn_counter("session-1")  # 3
+        assert sd.should_trigger("session-1")  # 3 >= 3 → trigger + reset
+        # Counter should be reset after trigger
+        assert sd._turn_counters["session-1"] == 0
+
+    def test_should_trigger_resets_counter(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(interval_turns=2)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        sd.bump_turn_counter("s1")  # 1
+        sd.bump_turn_counter("s1")  # 2
+        assert sd.should_trigger("s1")  # triggers, resets to 0
+        # Next check should not trigger
+        assert not sd.should_trigger("s1")
+
+    def test_should_trigger_disabled_with_zero_interval(self, tmp_path: Path) -> None:
+        """When interval_turns is 1, every turn triggers."""
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(interval_turns=1)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        sd.bump_turn_counter("s1")
+        assert sd.should_trigger("s1")  # 1 >= 1 → triggers
+
+    def test_independent_session_counters(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(interval_turns=2)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        sd.bump_turn_counter("s1")  # s1=1
+        sd.bump_turn_counter("s2")  # s2=1
+        sd.bump_turn_counter("s1")  # s1=2
+        assert sd.should_trigger("s1")  # s1 triggers
+        assert not sd.should_trigger("s2")  # s2 not yet
+
+
+# ---------------------------------------------------------------------------
+# Discover (integration-style with mocked LLM)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscover:
+    @pytest.mark.asyncio
+    async def test_discover_no_new_history(self, tmp_path: Path) -> None:
+        """When there's no unprocessed history, discover returns empty."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = []
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        result = await sd.discover()
+        assert result == []
+        provider.chat_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_discover_phase1_fails_returns_empty(self, tmp_path: Path) -> None:
+        """When Phase 1 LLM call fails, return empty without advancing cursor."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 1, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        provider.chat_with_retry.side_effect = RuntimeError("LLM error")
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        result = await sd.discover()
+        assert result == []
+        # Cursor should NOT be advanced on Phase 1 failure
+        store.set_skill_discovery_cursor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_discover_no_patterns_advances_cursor(self, tmp_path: Path) -> None:
+        """When Phase 1 returns no patterns, cursor is still advanced."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 5, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        provider.chat_with_retry.return_value = MagicMock(content="[]")
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        result = await sd.discover()
+        assert result == []
+        store.set_skill_discovery_cursor.assert_called_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_discover_weak_recommendations_filtered(self, tmp_path: Path) -> None:
+        """Weak recommendations are filtered out, cursor still advances."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 3, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        provider.chat_with_retry.return_value = MagicMock(
+            content=json.dumps([
+                {"name": "weak-skill", "recommendation": "weak", "description": "skip me"}
+            ])
+        )
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        result = await sd.discover()
+        assert result == []
+        store.set_skill_discovery_cursor.assert_called_once_with(3)
+
+
+# ---------------------------------------------------------------------------
+# Cron Schedule Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSchedule:
+    """Test SkillDiscoveryConfig.build_schedule() behavior."""
+
+    def test_default_schedule_is_every(self) -> None:
+        """Without cron, schedule is 'every' based on min_interval_s."""
+        config = _make_config(min_interval_s=3600)
+        schedule = config.build_schedule("UTC")
+        assert schedule.kind == "every"
+        assert schedule.every_ms == 3600 * 1000
+        assert schedule.expr is None
+
+    def test_cron_overrides_every(self) -> None:
+        """When cron is set, it takes precedence over interval-based schedule."""
+        config = _make_config(cron="0 9 * * *", min_interval_s=3600)
+        schedule = config.build_schedule("UTC")
+        assert schedule.kind == "cron"
+        assert schedule.expr == "0 9 * * *"
+        assert schedule.tz == "UTC"
+        assert schedule.every_ms is None
+
+    def test_cron_with_timezone(self) -> None:
+        """Cron schedule preserves the provided timezone."""
+        config = _make_config(cron="0 9 * * 1-5")
+        schedule = config.build_schedule("America/New_York")
+        assert schedule.kind == "cron"
+        assert schedule.expr == "0 9 * * 1-5"
+        assert schedule.tz == "America/New_York"
+
+    def test_min_interval_s_affects_every_ms(self) -> None:
+        """Different min_interval_s values produce correct every_ms."""
+        config = _make_config(min_interval_s=1800)
+        schedule = config.build_schedule("UTC")
+        assert schedule.kind == "every"
+        assert schedule.every_ms == 1_800_000  # 1800 * 1000
+
+    def test_cron_none_falls_back_to_every(self) -> None:
+        """cron=None (default) produces an 'every' schedule."""
+        config = _make_config(cron=None)
+        schedule = config.build_schedule("UTC")
+        assert schedule.kind == "every"
+
+    def test_cron_empty_string_falls_back_to_every(self) -> None:
+        """Empty string cron is falsy, so it falls back to 'every' schedule."""
+        config = _make_config(cron="")
+        schedule = config.build_schedule("UTC")
+        assert schedule.kind == "every"
+
+
+class TestCronJobRegistration:
+    """Test that Skill Discovery cron jobs are correctly constructed."""
+
+    def test_cron_job_fields(self) -> None:
+        """Verify CronJob for skill-discovery has correct id, name, and payload."""
+        from nanobot.cron.types import CronJob, CronPayload
+
+        config = _make_config(cron="0 */4 * * *")
+        schedule = config.build_schedule("UTC")
+
+        job = CronJob(
+            id="skill-discovery",
+            name="skill-discovery",
+            schedule=schedule,
+            payload=CronPayload(kind="system_event"),
+        )
+
+        assert job.id == "skill-discovery"
+        assert job.name == "skill-discovery"
+        assert job.schedule.kind == "cron"
+        assert job.schedule.expr == "0 */4 * * *"
+        assert job.payload.kind == "system_event"
+        assert job.enabled is True
+
+    def test_no_cron_job_when_cron_unset(self) -> None:
+        """When cron is not set, no CronJob should be registered."""
+        config = _make_config(cron=None)
+        # In commands.py, cron.register_system_job is only called if sd_cfg.cron
+        # This test verifies the condition logic
+        assert config.cron is None
+
+    def test_cron_job_every_schedule(self) -> None:
+        """When using interval-based schedule, CronJob uses 'every' kind."""
+        from nanobot.cron.types import CronJob, CronPayload
+
+        config = _make_config(min_interval_s=7200)
+        schedule = config.build_schedule("UTC")
+
+        job = CronJob(
+            id="skill-discovery",
+            name="skill-discovery",
+            schedule=schedule,
+            payload=CronPayload(kind="system_event"),
+        )
+
+        assert job.schedule.kind == "every"
+        assert job.schedule.every_ms == 7_200_000
+
+
+class TestCronDiscoveryExecution:
+    """Test the cron job execution path for skill discovery."""
+
+    @staticmethod
+    def _mock_runner_write(pending_dir: Path, skill_name: str, skill_content: str) -> MagicMock:
+        """Create a mock runner whose run() writes a SKILL.md to pending_dir.
+
+        This simulates Phase 2 AgentRunner using write_file tool to generate
+        skill files, without requiring a real AgentRunner + LLM round-trip.
+        """
+        mock_result = MagicMock()
+        mock_result.stop_reason = "max_iterations"
+        mock_result.tool_events = []
+
+        async def _fake_run(spec):
+            # Simulate what the real runner does: write SKILL.md via write_file
+            skill_dir = pending_dir / skill_name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(skill_content, encoding="utf-8")
+            return mock_result
+
+        runner = MagicMock()
+        runner.run = _fake_run
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_cron_discovers_and_saves_pending(self, tmp_path: Path) -> None:
+        """Cron trigger should call discover() and save_pending() for candidates."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 10, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        # Phase 1 returns one pattern
+        provider.chat_with_retry.return_value = MagicMock(
+            content=json.dumps([
+                {
+                    "name": "cron-skill",
+                    "description": "A skill found by cron",
+                    "recommendation": "strong",
+                    "frequency": "3 times",
+                    "evidence": ["entry 1"],
+                    "complexity": "medium",
+                    "rationale": "Repeated pattern",
+                }
+            ])
+        )
+        config = _make_config(cron="0 9 * * *")
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        # Mock Phase 2 runner to write SKILL.md to pending_dir
+        skill_content = "# cron-skill\nA skill found by cron"
+        sd._runner = self._mock_runner_write(
+            sd._pending_dir, "cron-skill", skill_content
+        )
+
+        # Simulate what commands.py does on cron trigger
+        candidates = await sd.discover()
+        if candidates:
+            sd.save_pending(candidates)
+
+        # Verify candidates were discovered and saved
+        assert len(candidates) == 1
+        assert candidates[0].name == "cron-skill"
+        pending = sd.list_pending()
+        assert len(pending) == 1
+        assert pending[0].name == "cron-skill"
+
+    @pytest.mark.asyncio
+    async def test_cron_discovers_no_candidates(self, tmp_path: Path) -> None:
+        """Cron trigger with no new history should return empty list."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = []
+        provider = _make_provider()
+        config = _make_config(cron="0 */6 * * *")
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = await sd.discover()
+        assert candidates == []
+
+    @pytest.mark.asyncio
+    async def test_cron_with_auto_approve(self, tmp_path: Path) -> None:
+        """Cron trigger with autoApprove should install candidates directly."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 10, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        provider.chat_with_retry.return_value = MagicMock(
+            content=json.dumps([
+                {
+                    "name": "auto-skill",
+                    "description": "Auto-approved skill",
+                    "recommendation": "strong",
+                    "frequency": "2 times",
+                    "evidence": ["entry 1", "entry 2"],
+                    "complexity": "low",
+                    "rationale": "Clear pattern",
+                }
+            ])
+        )
+        config = _make_config(cron="0 9 * * *", auto_approve=True)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        # Mock Phase 2 runner to write SKILL.md to pending_dir
+        skill_content = "# auto-skill\nAuto-approved skill"
+        sd._runner = self._mock_runner_write(
+            sd._pending_dir, "auto-skill", skill_content
+        )
+
+        # Simulate auto-approve path (as in cmd_discover_skills)
+        candidates = await sd.discover()
+        paths = []
+        if candidates and sd.config.auto_approve:
+            paths = sd.approve_all(candidates)
+
+        assert len(paths) == 1
+        # Verify SKILL.md was written to skills/ directory
+        skill_file = tmp_path / "skills" / "auto-skill" / "SKILL.md"
+        assert skill_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_cron_failure_does_not_advance_cursor(self, tmp_path: Path) -> None:
+        """If Phase 1 fails during cron execution, cursor should not advance."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 10, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        provider.chat_with_retry.side_effect = Exception("LLM timeout")
+        config = _make_config(cron="0 9 * * *")
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = await sd.discover()
+        assert candidates == []
+        # Cursor must NOT be advanced on Phase 1 failure
+        store.set_skill_discovery_cursor.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Trigger Mode Tests — Manual, Post-turn, Cron
+# ---------------------------------------------------------------------------
+
+
+def _make_inbound(channel: str = "cli", chat_id: str = "test") -> MagicMock:
+    """Create a mock InboundMessage."""
+    msg = MagicMock()
+    msg.channel = channel
+    msg.chat_id = chat_id
+    msg.content = "/discover-skills"
+    return msg
+
+
+def _make_command_context(loop_mock: MagicMock, msg: MagicMock = None, args: str = "") -> MagicMock:
+    """Create a mock CommandContext."""
+    ctx = MagicMock()
+    ctx.loop = loop_mock
+    ctx.msg = msg or _make_inbound()
+    ctx.args = args
+    return ctx
+
+
+class TestManualTrigger:
+    """Test /discover-skills command (manual trigger) behavior."""
+
+    @pytest.mark.asyncio
+    async def test_manual_trigger_disabled(self) -> None:
+        """When skill_discoverer is None, return disabled message."""
+        from nanobot.command.builtin import cmd_discover_skills
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = None
+        ctx = _make_command_context(loop_mock)
+
+        result = await cmd_discover_skills(ctx)
+        assert "not enabled" in result.content
+
+    @pytest.mark.asyncio
+    async def test_manual_trigger_returns_immediate_ack(self) -> None:
+        """Manual trigger returns 'Discovering skills...' immediately."""
+        from nanobot.command.builtin import cmd_discover_skills
+
+        loop_mock = MagicMock()
+        discoverer = MagicMock(spec=SkillDiscoverer)
+        discoverer.config = _make_config(enabled=True)
+        # Make discover() a long-running coroutine to verify immediate return
+        async def _slow_discover():
+            import asyncio
+            await asyncio.sleep(10)
+            return []
+        discoverer.discover = _slow_discover
+        loop_mock.skill_discoverer = discoverer
+        loop_mock.bus = MagicMock()
+        ctx = _make_command_context(loop_mock)
+
+        result = await cmd_discover_skills(ctx)
+        assert "Discovering" in result.content
+
+    @pytest.mark.asyncio
+    async def test_manual_trigger_no_candidates(self, tmp_path: Path) -> None:
+        """Manual trigger with no candidates publishes 'no new skills found'."""
+        from nanobot.command.builtin import cmd_discover_skills
+
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = []
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        bus_mock = MagicMock()
+        bus_mock.publish_outbound = AsyncMock()
+        loop_mock.bus = bus_mock
+        ctx = _make_command_context(loop_mock)
+
+        result = await cmd_discover_skills(ctx)
+        assert "Discovering" in result.content
+
+        # Wait for background task to complete
+        import asyncio
+        await asyncio.sleep(0.1)
+
+        # Bus should have published the result
+        bus_mock.publish_outbound.assert_called_once()
+        outbound = bus_mock.publish_outbound.call_args[0][0]
+        assert "no new skills found" in outbound.content
+
+    @pytest.mark.asyncio
+    async def test_manual_trigger_with_candidates_saves_pending(self, tmp_path: Path) -> None:
+        """Manual trigger with candidates saves them as pending (autoApprove=False)."""
+        from nanobot.command.builtin import cmd_discover_skills
+
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 10, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        provider.chat_with_retry.return_value = MagicMock(
+            content=json.dumps([
+                {
+                    "name": "manual-skill",
+                    "description": "Found manually",
+                    "recommendation": "strong",
+                    "frequency": "2 times",
+                    "evidence": ["e1"],
+                    "complexity": "low",
+                    "rationale": "test",
+                }
+            ])
+        )
+        config = _make_config(auto_approve=False)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        # Mock Phase 2 runner
+        skill_content = "# manual-skill\nFound manually"
+        sd._runner = TestCronDiscoveryExecution._mock_runner_write(
+            sd._pending_dir, "manual-skill", skill_content
+        )
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        bus_mock = MagicMock()
+        bus_mock.publish_outbound = AsyncMock()
+        loop_mock.bus = bus_mock
+        ctx = _make_command_context(loop_mock)
+
+        result = await cmd_discover_skills(ctx)
+        assert "Discovering" in result.content
+
+        import asyncio
+        await asyncio.sleep(0.2)
+
+        outbound = bus_mock.publish_outbound.call_args[0][0]
+        assert "1 candidate" in outbound.content
+        assert "manual-skill" in outbound.content
+        assert "/skill-approve" in outbound.content
+
+    @pytest.mark.asyncio
+    async def test_manual_trigger_auto_approve_installs(self, tmp_path: Path) -> None:
+        """Manual trigger with autoApprove=True installs skills directly."""
+        from nanobot.command.builtin import cmd_discover_skills
+
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 10, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        provider.chat_with_retry.return_value = MagicMock(
+            content=json.dumps([
+                {
+                    "name": "auto-manual-skill",
+                    "description": "Auto-installed",
+                    "recommendation": "strong",
+                    "frequency": "1 time",
+                    "evidence": ["e1"],
+                    "complexity": "low",
+                    "rationale": "test",
+                }
+            ])
+        )
+        config = _make_config(auto_approve=True)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        skill_content = "# auto-manual-skill\nAuto-installed"
+        sd._runner = TestCronDiscoveryExecution._mock_runner_write(
+            sd._pending_dir, "auto-manual-skill", skill_content
+        )
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        bus_mock = MagicMock()
+        bus_mock.publish_outbound = AsyncMock()
+        loop_mock.bus = bus_mock
+        ctx = _make_command_context(loop_mock)
+
+        result = await cmd_discover_skills(ctx)
+
+        import asyncio
+        await asyncio.sleep(0.2)
+
+        outbound = bus_mock.publish_outbound.call_args[0][0]
+        assert "installed" in outbound.content.lower()
+        assert "auto-manual-skill" in outbound.content
+        # Verify skill file was written to skills/ directory
+        skill_file = tmp_path / "skills" / "auto-manual-skill" / "SKILL.md"
+        assert skill_file.exists()
+
+
+class TestSkillApproveCommand:
+    """Test /skill-approve command behavior."""
+
+    @pytest.mark.asyncio
+    async def test_approve_disabled(self) -> None:
+        """When discoverer is None, return disabled message."""
+        from nanobot.command.builtin import cmd_skill_approve
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = None
+        ctx = _make_command_context(loop_mock, args="test-skill")
+
+        result = await cmd_skill_approve(ctx)
+        assert "not enabled" in result.content
+
+    @pytest.mark.asyncio
+    async def test_approve_no_pending(self, tmp_path: Path) -> None:
+        """When no pending skills, return appropriate message."""
+        from nanobot.command.builtin import cmd_skill_approve
+
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        ctx = _make_command_context(loop_mock, args="anything")
+
+        result = await cmd_skill_approve(ctx)
+        assert "No pending" in result.content
+
+    @pytest.mark.asyncio
+    async def test_approve_specific_skill(self, tmp_path: Path) -> None:
+        """Approve a specific skill by name."""
+        from nanobot.command.builtin import cmd_skill_approve
+
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        # Save a pending candidate
+        candidates = [
+            SkillCandidate(name="skill-a", description="First", content="# Skill A\nFirst skill"),
+            SkillCandidate(name="skill-b", description="Second", content="# Skill B\nSecond skill"),
+        ]
+        sd.save_pending(candidates)
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        ctx = _make_command_context(loop_mock, args="skill-a")
+
+        result = await cmd_skill_approve(ctx)
+        assert "skill-a" in result.content
+        assert "Installed" in result.content
+        # Verify only skill-a was installed
+        assert (tmp_path / "skills" / "skill-a" / "SKILL.md").exists()
+        assert not (tmp_path / "skills" / "skill-b" / "SKILL.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_approve_all(self, tmp_path: Path) -> None:
+        """Approve all pending skills."""
+        from nanobot.command.builtin import cmd_skill_approve
+
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = [
+            SkillCandidate(name="skill-x", description="X", content="# X"),
+            SkillCandidate(name="skill-y", description="Y", content="# Y"),
+        ]
+        sd.save_pending(candidates)
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        ctx = _make_command_context(loop_mock, args="all")
+
+        result = await cmd_skill_approve(ctx)
+        assert "2 skill" in result.content
+        assert (tmp_path / "skills" / "skill-x" / "SKILL.md").exists()
+        assert (tmp_path / "skills" / "skill-y" / "SKILL.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_approve_nonexistent_name(self, tmp_path: Path) -> None:
+        """Approve with a name that doesn't match any pending skill."""
+        from nanobot.command.builtin import cmd_skill_approve
+
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        sd.save_pending([
+            SkillCandidate(name="real-skill", description="Real", content="# Real"),
+        ])
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        ctx = _make_command_context(loop_mock, args="fake-skill")
+
+        result = await cmd_skill_approve(ctx)
+        assert "No pending skill named 'fake-skill'" in result.content
+        assert "real-skill" in result.content  # lists available
+
+    @pytest.mark.asyncio
+    async def test_approve_no_args_lists_pending(self, tmp_path: Path) -> None:
+        """Approve with no args lists pending skills."""
+        from nanobot.command.builtin import cmd_skill_approve
+
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config()
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        sd.save_pending([
+            SkillCandidate(name="list-skill", description="List me", content="# List"),
+        ])
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        ctx = _make_command_context(loop_mock, args="")
+
+        result = await cmd_skill_approve(ctx)
+        assert "Pending" in result.content
+        assert "list-skill" in result.content
+        assert "/skill-approve" in result.content
+
+
+class TestPostTurnTrigger:
+    """Test _maybe_trigger_skill_discovery (post-turn auto-trigger) behavior."""
+
+    def test_post_turn_disabled_when_discoverer_none(self) -> None:
+        """When skill_discoverer is None, no trigger occurs."""
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = None
+        loop_mock._schedule_background = MagicMock()
+
+        # Simulate _maybe_trigger_skill_discovery logic
+        sd = loop_mock.skill_discoverer
+        if sd is not None and sd.config.enabled:
+            sd.bump_turn_counter("s1")
+            if sd.should_trigger("s1"):
+                loop_mock._schedule_background(MagicMock())
+
+        loop_mock._schedule_background.assert_not_called()
+
+    def test_post_turn_disabled_when_config_disabled(self, tmp_path: Path) -> None:
+        """When enabled=False, no trigger occurs even after enough turns."""
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(enabled=False, interval_turns=1)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        loop_mock._schedule_background = MagicMock()
+
+        # Simulate _maybe_trigger_skill_discovery logic
+        if sd is not None and sd.config.enabled:
+            sd.bump_turn_counter("s1")
+            if sd.should_trigger("s1"):
+                loop_mock._schedule_background(MagicMock())
+
+        loop_mock._schedule_background.assert_not_called()
+
+    def test_post_turn_triggers_after_interval(self, tmp_path: Path) -> None:
+        """Post-turn triggers after interval_turns conversations."""
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(enabled=True, interval_turns=3)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        loop_mock._schedule_background = MagicMock()
+
+        # Simulate 3 turns
+        for _ in range(3):
+            sd.bump_turn_counter("s1")
+        if sd.should_trigger("s1"):
+            loop_mock._schedule_background(MagicMock())
+
+        loop_mock._schedule_background.assert_called_once()
+
+    def test_post_turn_no_trigger_before_interval(self, tmp_path: Path) -> None:
+        """Post-turn does NOT trigger before reaching interval_turns."""
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(enabled=True, interval_turns=5)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        loop_mock = MagicMock()
+        loop_mock.skill_discoverer = sd
+        loop_mock._schedule_background = MagicMock()
+
+        # Only 3 turns, need 5
+        for _ in range(3):
+            sd.bump_turn_counter("s1")
+        if sd.should_trigger("s1"):
+            loop_mock._schedule_background(MagicMock())
+
+        loop_mock._schedule_background.assert_not_called()
+
+    def test_post_turn_counter_resets_after_trigger(self, tmp_path: Path) -> None:
+        """After triggering, counter resets and next interval starts fresh."""
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(enabled=True, interval_turns=2)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        # First cycle: 2 turns → trigger
+        sd.bump_turn_counter("s1")
+        sd.bump_turn_counter("s1")
+        assert sd.should_trigger("s1")
+
+        # Counter reset, 1 more turn should NOT trigger
+        sd.bump_turn_counter("s1")
+        assert not sd.should_trigger("s1")
+
+    def test_post_turn_independent_sessions(self, tmp_path: Path) -> None:
+        """Different sessions have independent turn counters."""
+        store = _make_store(tmp_path)
+        provider = _make_provider()
+        config = _make_config(enabled=True, interval_turns=2)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        # Session A reaches threshold
+        sd.bump_turn_counter("session-a")
+        sd.bump_turn_counter("session-a")
+        assert sd.should_trigger("session-a")
+
+        # Session B has not
+        sd.bump_turn_counter("session-b")
+        assert not sd.should_trigger("session-b")
+
+    @pytest.mark.asyncio
+    async def test_post_turn_discover_failure_is_caught(self, tmp_path: Path) -> None:
+        """Post-turn discover() failure is caught and does not crash."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.side_effect = RuntimeError("DB error")
+        provider = _make_provider()
+        config = _make_config(enabled=True, interval_turns=1)
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        # Trigger should not raise
+        sd.bump_turn_counter("s1")
+        assert sd.should_trigger("s1")
+
+        # discover() should raise, but the caller (_maybe_trigger_skill_discovery)
+        # wraps it in try/except — verify the exception is raised from discover
+        with pytest.raises(RuntimeError, match="DB error"):
+            await sd.discover()
+
+
+class TestCronTriggerHandler:
+    """Test the cron job handler logic in commands.py for skill-discovery."""
+
+    @pytest.mark.asyncio
+    async def test_cron_handler_discovers_and_saves(self, tmp_path: Path) -> None:
+        """Cron handler calls discover() and save_pending() for candidates."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 10, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        provider.chat_with_retry.return_value = MagicMock(
+            content=json.dumps([
+                {
+                    "name": "cron-handler-skill",
+                    "description": "From cron handler",
+                    "recommendation": "strong",
+                    "frequency": "2 times",
+                    "evidence": ["e1"],
+                    "complexity": "low",
+                    "rationale": "test",
+                }
+            ])
+        )
+        config = _make_config(cron="0 9 * * *")
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        skill_content = "# cron-handler-skill\nFrom cron handler"
+        sd._runner = TestCronDiscoveryExecution._mock_runner_write(
+            sd._pending_dir, "cron-handler-skill", skill_content
+        )
+
+        # Simulate the cron handler logic from commands.py
+        candidates = await sd.discover()
+        if candidates:
+            sd.save_pending(candidates)
+
+        assert len(candidates) == 1
+        assert candidates[0].name == "cron-handler-skill"
+        pending = sd.list_pending()
+        assert len(pending) == 1
+
+    @pytest.mark.asyncio
+    async def test_cron_handler_no_discoverer(self) -> None:
+        """Cron handler with no discoverer skips gracefully."""
+        agent = MagicMock()
+        agent.skill_discoverer = None
+
+        # Simulate cron handler logic
+        if agent.skill_discoverer:
+            candidates = await agent.skill_discoverer.discover()
+        else:
+            candidates = []
+
+        assert candidates == []
+
+    @pytest.mark.asyncio
+    async def test_cron_handler_failure_is_caught(self, tmp_path: Path) -> None:
+        """Cron handler catches discover() exceptions."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = [
+            {"cursor": 10, "timestamp": "2026-01-01", "content": "test"}
+        ]
+        provider = _make_provider()
+        provider.chat_with_retry.side_effect = RuntimeError("LLM down")
+        config = _make_config(cron="0 9 * * *")
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        # Simulate cron handler with try/except (as in commands.py)
+        try:
+            candidates = await sd.discover()
+            if candidates:
+                sd.save_pending(candidates)
+        except Exception:
+            candidates = []
+
+        assert candidates == []
+
+    @pytest.mark.asyncio
+    async def test_cron_handler_empty_result(self, tmp_path: Path) -> None:
+        """Cron handler with no new history returns empty, no save_pending call."""
+        store = _make_store(tmp_path)
+        store.read_unprocessed_history.return_value = []
+        provider = _make_provider()
+        config = _make_config(cron="0 */6 * * *")
+        sd = SkillDiscoverer(store=store, provider=provider, model="test", config=config)
+
+        candidates = await sd.discover()
+        save_called = False
+        if candidates:
+            sd.save_pending(candidates)
+            save_called = True
+
+        assert candidates == []
+        assert not save_called


### PR DESCRIPTION
# PR Description

## Summary

Closes #2927
This PR introduces **Skill Discovery**, a feature that automatically analyzes conversation history to identify reusable behavioral patterns and extract them into standalone `SKILL.md` files. The system uses a two-phase LLM pipeline, supports three trigger modes, and includes a human-in-the-loop approval workflow.

## Motivation

nanobot already supports manually created skills (via `skills/<name>/SKILL.md`), but users must recognize and codify their own repetitive workflows. Skill Discovery closes this loop by **automatically detecting** when the agent performs a task repeatedly and proactively suggesting it as a reusable skill — reducing manual configuration and improving the agent's self-improvement capability.

## Architecture & Design Philosophy

### Two-Phase LLM Pipeline

Rather than asking a single LLM call to both analyze patterns *and* generate skill files, the pipeline is split into two focused phases:

| Phase | Role | Mechanism | Output |
|-------|------|-----------|--------|
| **Phase 1** | Pattern Analysis | Single LLM call with structured JSON output | Array of candidate patterns with name, description, frequency, evidence, recommendation strength |
| **Phase 2** | Skill Generation | AgentRunner with `read_file` + `write_file` tools | `SKILL.md` files written to `.pending_skills/` directory |

**Why two phases?**
- **Separation of concerns**: Analysis requires judgment (is this pattern worth extracting?), generation requires tool use (read existing skills for reference, write new files). Mixing both in one call degrades quality.
- **Quality gate insertion**: Weak recommendations are filtered between phases, saving LLM tokens on generation.
- **Tool isolation**: Phase 2's `write_file` is scoped to `.pending_skills/` only — it cannot overwrite existing skills or arbitrary workspace files.

### Incremental Cursor-Based Processing

Skill Discovery reads only **unprocessed** history entries using a persistent cursor (`.skill_discovery_cursor`):
- After each successful run, the cursor advances to the last processed entry.
- If Phase 1 fails, the cursor is **not** advanced — preserving the retry opportunity.
- This avoids re-analyzing the same history and ensures at-least-once processing semantics.

### Three Trigger Modes

| Mode | Mechanism | Config | Use Case |
|------|-----------|--------|----------|
| **Manual** | `/discover-skills` command | Always available when enabled | On-demand analysis |
| **Post-turn** | Turn counter per session | `interval_turns` (default: 20) | Automatic background discovery during active use |
| **Cron** | System cron job | `cron` expression or `min_interval_s` | Scheduled discovery in daemon mode |

Post-turn and cron triggers run discovery in the **background** — they never block the user's conversation.

### Human-in-the-Loop Approval

By default (`auto_approve: false`), discovered skills are saved to `.pending_skills/` and await explicit user approval:

```
/discover-skills          → discovers and lists candidates
/skill-approve <name>     → installs one candidate
/skill-approve all        → installs all candidates
/skill-approve            → lists pending candidates
```

With `auto_approve: true`, skills are installed immediately — suitable for trusted environments.

## Processing Flow

```
┌─────────────────────────────────────────────────────────────────┐
│                    Trigger (manual / post-turn / cron)          │
└──────────────────────────┬──────────────────────────────────────┘
                           ▼
┌─────────────────────────────────────────────────────────────────┐
│  Read unprocessed history entries (since last cursor)           │
│  → if empty: return []                                          │
└──────────────────────────┬──────────────────────────────────────┘
                           ▼
┌─────────────────────────────────────────────────────────────────┐
│  Phase 1: LLM Pattern Analysis                                 │
│  Input: history text + context (Memory, User, existing skills)  │
│  Output: JSON array of candidate patterns                       │
│  → if fails: return [] (cursor NOT advanced)                    │
│  → if empty/weak-only: advance cursor, return []                │
└──────────────────────────┬──────────────────────────────────────┘
                           ▼
┌─────────────────────────────────────────────────────────────────┐
│  Phase 2: AgentRunner Skill Generation                          │
│  Tools: read_file (workspace) + write_file (.pending_skills/)   │
│  → generates SKILL.md files into .pending_skills/<name>/        │
└──────────────────────────┬──────────────────────────────────────┘
                           ▼
┌─────────────────────────────────────────────────────────────────┐
│  Quality Gates                                                  │
│  - Name conflict: skip if skill already exists in skills/       │
│  - Deduplication: skip duplicate candidate names                │
│  - max_candidates cap (default: 5)                              │
└──────────────────────────┬──────────────────────────────────────┘
                           ▼
┌─────────────────────────────────────────────────────────────────┐
│  Advance cursor → return candidates                             │
│                                                                 │
│  Manual trigger:                                                │
│    auto_approve=true  → approve_all() → install to skills/      │
│    auto_approve=false → save_pending() → await /skill-approve   │
│  Post-turn / Cron:                                              │
│    → save_pending() (always, for later approval)                │
└─────────────────────────────────────────────────────────────────┘
```

## Files Changed

| File | Change |
|------|--------|
| `nanobot/agent/skill_discovery.py` | **New** — Core `SkillDiscoverer` class with two-phase pipeline, candidate filtering, pending management, approval, and post-turn trigger logic |
| `nanobot/agent/loop.py` | **Modified** — Import `SkillDiscoverer`, add `skill_discoverer` attribute, call `_maybe_trigger_skill_discovery()` after each turn |
| `nanobot/agent/memory.py` | **Modified** — Add `get_skill_discovery_cursor()` / `set_skill_discovery_cursor()` for persistent cursor tracking |
| `nanobot/command/builtin.py` | **Modified** — Add `cmd_discover_skills` and `cmd_skill_approve` command handlers, register `/discover-skills` and `/skill-approve` routes |
| `nanobot/config/schema.py` | **Modified** — Add `SkillDiscoveryConfig` with `enabled`, `model_override`, `max_history_entries`, `max_candidates`, `auto_approve`, `interval_turns`, `min_interval_s`, `cron` fields |
| `nanobot/cli/commands.py` | **Modified** — Initialize `SkillDiscoverer` in both daemon and CLI modes; register cron job for scheduled discovery; handle `skill-discovery` system_event in cron handler |
| `nanobot/templates/agent/skill_discovery_phase1.md` | **New** — Phase 1 prompt template (pattern analysis with structured JSON output) |
| `nanobot/templates/agent/skill_discovery_phase2.md` | **New** — Phase 2 prompt template (skill generation with quality standards) |
| `tests/agent/test_skill_discovery.py` | **New** — 64 test cases across 15 test classes |

## Configuration Example

```yaml
skillDiscovery:
  enabled: true
  modelOverride: null          # uses default agent model if not set
  maxHistoryEntries: 50        # max history entries per analysis
  maxCandidates: 5             # max candidates per discovery run
  autoApprove: false           # require /skill-approve confirmation
  intervalTurns: 20            # auto-trigger every 20 turns
  minIntervalS: 7200           # minimum 2h between auto-triggers
  cron: null                   # optional: "0 */4 * * *" for every 4 hours
```

## Test Coverage

**64 test cases** across **15 test classes**, covering all core components and trigger modes:

### Unit Tests — Core Components

| Class | Tests | Coverage |
|-------|-------|----------|
| `TestSkillCandidate` | 1 | `format_preview()` output format |
| `TestParsePhase1Analysis` | 5 | JSON in code block, bare JSON array, empty array, invalid JSON, JSON object rejection |
| `TestExtractDescription` | 4 | First non-heading line, skip empty lines, truncation, fallback |
| `TestFilterCandidates` | 3 | Duplicate names, existing skill conflict, max_candidates cap |
| `TestPendingManagement` | 4 | Save & list, remove, clear, empty directory |
| `TestApproval` | 3 | Install single, install all, git auto-commit |
| `TestPostTurnTrigger` | 5 | Bump counter, trigger at interval, counter reset, zero-interval disable, independent sessions |

### Integration Tests — Discover Flow

| Class | Tests | Coverage |
|-------|-------|----------|
| `TestDiscover` | 4 | No new history, Phase 1 failure (cursor not advanced), no patterns (cursor advanced), weak filtering |
| `TestBuildSchedule` | 6 | Default every-schedule, cron override, timezone, min_interval_s, null cron, empty cron |
| `TestCronJobRegistration` | 3 | CronJob field validation, no job when cron unset, every-schedule job |
| `TestCronDiscoveryExecution` | 4 | Discover & save pending, no candidates, auto-approve install, Phase 1 failure (cursor preserved) |

### End-to-End Tests — Command & Trigger Modes

| Class | Tests | Coverage |
|-------|-------|----------|
| `TestManualTrigger` | 5 | Disabled state, immediate ack, no candidates, pending save (autoApprove=false), direct install (autoApprove=true) |
| `TestSkillApproveCommand` | 6 | Disabled, no pending, approve by name, approve all, nonexistent name, no-args listing |
| `TestPostTurnTrigger` (loop) | 7 | Discoverer None, config disabled, trigger at interval, no trigger before interval, counter reset, independent sessions, discover failure tolerance |
| `TestCronTriggerHandler` | 4 | Discover & save flow, no discoverer skip, failure caught, empty result no-op |

### Key Test Scenarios

- **Cursor safety**: Phase 1 failure does **not** advance cursor (preserves retry); successful empty-result runs **do** advance cursor (avoids re-processing)
- **Tool isolation**: Phase 2 `write_file` is scoped to `.pending_skills/` only — cannot write outside
- **Name conflict prevention**: Candidates matching existing skill names are silently skipped
- **Weak recommendation filtering**: Patterns marked `"weak"` are dropped between Phase 1 and Phase 2
- **Per-session turn counters**: Post-turn triggers are isolated per session key; one session hitting the threshold does not affect another
- **Async non-blocking**: Manual trigger returns "Discovering skills..." immediately; actual discovery runs as a background `asyncio.Task`

## Edge Cases Handled

1. **No unprocessed history** → returns empty list, no LLM call
2. **Phase 1 LLM failure** → returns empty, cursor not advanced (retry on next trigger)
3. **Phase 1 returns non-JSON** → `_parse_phase1_analysis` falls back gracefully, returns `[]`
4. **All patterns are "weak"** → filtered out, cursor advanced, no Phase 2
5. **Phase 2 AgentRunner failure** → candidates collected from pending dir (partial results), cursor still advanced
6. **Duplicate candidate names** → first occurrence kept, rest deduplicated
7. **Candidate name conflicts with existing skill** → silently skipped
8. **Pending directory doesn't exist** → `list_pending()` returns `[]`
9. **`/skill-approve` with nonexistent name** → shows available pending skill names
10. **`/skill-approve` with no args** → lists pending skills with usage hint