### PR TITLE
feat(agent): integrate skill discovery into Dream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1742,6 +1742,7 @@ time.
 
 - `memory/history.jsonl` stores append-only summarized history
 - `SOUL.md`, `USER.md`, and `memory/MEMORY.md` store long-term knowledge managed by Dream
+- `Dream` can also promote repeated workflows into reusable workspace skills under `skills/`
 - `Dream` runs on a schedule and can also be triggered manually
 - memory changes can be inspected and restored with built-in commands
 

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -582,13 +582,52 @@ class Dream:
 
     def _build_tools(self) -> ToolRegistry:
         """Build a minimal tool registry for the Dream agent."""
-        from nanobot.agent.tools.filesystem import EditFileTool, ReadFileTool
+        from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+        from nanobot.agent.tools.filesystem import EditFileTool, ReadFileTool, WriteFileTool
 
         tools = ToolRegistry()
         workspace = self.store.workspace
-        tools.register(ReadFileTool(workspace=workspace, allowed_dir=workspace))
+        # Allow reading builtin skills for reference during skill creation
+        extra_read = [BUILTIN_SKILLS_DIR] if BUILTIN_SKILLS_DIR.exists() else None
+        tools.register(ReadFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_allowed_dirs=extra_read,
+        ))
         tools.register(EditFileTool(workspace=workspace, allowed_dir=workspace))
+        # write_file scoped to skills/ directory for skill creation
+        skills_dir = workspace / "skills"
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        tools.register(WriteFileTool(workspace=skills_dir, allowed_dir=skills_dir))
         return tools
+
+    # -- skill listing --------------------------------------------------------
+
+    def _list_existing_skills(self) -> list[str]:
+        """List existing skills as 'name — description' for dedup context."""
+        import re as _re
+
+        from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+
+        _DESC_RE = _re.compile(r"^description:\s*(.+)$", _re.MULTILINE | _re.IGNORECASE)
+        entries: dict[str, str] = {}
+        for base in (self.store.workspace / "skills", BUILTIN_SKILLS_DIR):
+            if not base.exists():
+                continue
+            for d in base.iterdir():
+                if not d.is_dir():
+                    continue
+                skill_md = d / "SKILL.md"
+                if not skill_md.exists():
+                    continue
+                # Prefer workspace skills over builtin (same name)
+                if d.name in entries and base == BUILTIN_SKILLS_DIR:
+                    continue
+                content = skill_md.read_text(encoding="utf-8")[:500]
+                m = _DESC_RE.search(content)
+                desc = m.group(1).strip() if m else "(no description)"
+                entries[d.name] = desc
+        return [f"{name} — {desc}" for name, desc in sorted(entries.items())]
 
     # -- main entry ----------------------------------------------------------
 
@@ -615,6 +654,7 @@ class Dream:
         current_memory = self.store.read_memory() or "(empty)"
         current_soul = self.store.read_soul() or "(empty)"
         current_user = self.store.read_user() or "(empty)"
+
         file_context = (
             f"## Current Date\n{current_date}\n\n"
             f"## Current MEMORY.md ({len(current_memory)} chars)\n{current_memory}\n\n"
@@ -622,7 +662,7 @@ class Dream:
             f"## Current USER.md ({len(current_user)} chars)\n{current_user}"
         )
 
-        # Phase 1: Analyze
+        # Phase 1: Analyze (no skills list — dedup is Phase 2's job)
         phase1_prompt = (
             f"## Conversation History\n{history_text}\n\n{file_context}"
         )
@@ -647,7 +687,14 @@ class Dream:
             return False
 
         # Phase 2: Delegate to AgentRunner with read_file / edit_file
-        phase2_prompt = f"## Analysis Result\n{analysis}\n\n{file_context}"
+        existing_skills = self._list_existing_skills()
+        skills_section = ""
+        if existing_skills:
+            skills_section = (
+                "\n\n## Existing Skills\n"
+                + "\n".join(f"- {s}" for s in existing_skills)
+            )
+        phase2_prompt = f"## Analysis Result\n{analysis}\n\n{file_context}{skills_section}"
 
         tools = self._tools
         messages: list[dict[str, Any]] = [

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -595,10 +595,11 @@ class Dream:
             extra_allowed_dirs=extra_read,
         ))
         tools.register(EditFileTool(workspace=workspace, allowed_dir=workspace))
-        # write_file scoped to skills/ directory for skill creation
+        # write_file resolves relative paths from workspace root, but can only
+        # write under skills/ so the prompt can safely use skills/<name>/SKILL.md.
         skills_dir = workspace / "skills"
         skills_dir.mkdir(parents=True, exist_ok=True)
-        tools.register(WriteFileTool(workspace=skills_dir, allowed_dir=skills_dir))
+        tools.register(WriteFileTool(workspace=workspace, allowed_dir=skills_dir))
         return tools
 
     # -- skill listing --------------------------------------------------------
@@ -633,6 +634,8 @@ class Dream:
 
     async def run(self) -> bool:
         """Process unprocessed history entries. Returns True if work was done."""
+        from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+
         last_cursor = self.store.get_last_dream_cursor()
         entries = self.store.read_unprocessed_history(since_cursor=last_cursor)
         if not entries:
@@ -697,10 +700,15 @@ class Dream:
         phase2_prompt = f"## Analysis Result\n{analysis}\n\n{file_context}{skills_section}"
 
         tools = self._tools
+        skill_creator_path = BUILTIN_SKILLS_DIR / "skill-creator" / "SKILL.md"
         messages: list[dict[str, Any]] = [
             {
                 "role": "system",
-                "content": render_template("agent/dream_phase2.md", strip=True),
+                "content": render_template(
+                    "agent/dream_phase2.md",
+                    strip=True,
+                    skill_creator_path=str(skill_creator_path),
+                ),
             },
             {"role": "user", "content": phase2_prompt},
         ]

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -3,6 +3,7 @@ Compare conversation history against current memory files. Also scan memory file
 Output one line per finding:
 [FILE] atomic fact (not already in memory)
 [FILE-REMOVE] reason for removal
+[SKILL] kebab-case-name: one-line description of the reusable pattern
 
 Files: USER (identity, preferences), SOUL (bot behavior, tone), MEMORY (knowledge, project context)
 
@@ -17,6 +18,12 @@ Staleness — flag for [FILE-REMOVE]:
 - Resolved tracking: merged/closed PRs, fixed issues, completed migrations
 - Detailed incident info after 14 days — reduce to one-line summary
 - Superseded: approaches replaced by newer solutions, deprecated dependencies
+
+Skill discovery — flag [SKILL] when ALL of these are true:
+- A specific, repeatable workflow appeared 2+ times in the conversation history
+- It involves clear steps (not vague preferences like "likes concise answers")
+- It is substantial enough to warrant its own instruction set (not trivial like "read a file")
+- Do not worry about duplicates — the next phase will check against existing skills
 
 Do not add: current weather, transient status, temporary errors, conversational filler.
 

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -1,11 +1,13 @@
 Update memory files based on the analysis below.
 - [FILE] entries: add the described content to the appropriate file
 - [FILE-REMOVE] entries: delete the corresponding content from memory files
+- [SKILL] entries: create a new skill under skills/<name>/SKILL.md using write_file
 
 ## File paths (relative to workspace root)
 - SOUL.md
 - USER.md
 - memory/MEMORY.md
+- skills/<name>/SKILL.md (for [SKILL] entries only)
 
 Do NOT guess paths.
 
@@ -16,6 +18,17 @@ Do NOT guess paths.
 - For deletions: section header + all bullets as old_text, new_text empty
 - Surgical edits only — never rewrite entire files
 - If nothing to update, stop without calling tools
+
+## Skill creation rules (for [SKILL] entries)
+- Use write_file to create skills/<name>/SKILL.md
+- Before writing, read_file skills/skill-creator/SKILL.md for format reference (frontmatter structure, naming conventions, quality standards)
+- **Dedup check**: read existing skills listed below to verify the new skill is not functionally redundant. Skip creation if an existing skill already covers the same workflow.
+- Include YAML frontmatter with name and description fields
+- Keep SKILL.md under 2000 words — concise and actionable
+- Include: when to use, steps, output format, at least one example
+- Do NOT overwrite existing skills — skip if the skill directory already exists
+- Reference specific tools the agent has access to (read_file, write_file, exec, web_search, etc.)
+- Skills are instruction sets, not code — do not include implementation code
 
 ## Quality
 - Every line must carry standalone value

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -21,7 +21,7 @@ Do NOT guess paths.
 
 ## Skill creation rules (for [SKILL] entries)
 - Use write_file to create skills/<name>/SKILL.md
-- Before writing, read_file skills/skill-creator/SKILL.md for format reference (frontmatter structure, naming conventions, quality standards)
+- Before writing, read_file `{{ skill_creator_path }}` for format reference (frontmatter structure, naming conventions, quality standards)
 - **Dedup check**: read existing skills listed below to verify the new skill is not functionally redundant. Skip creation if an existing skill already covers the same workflow.
 - Include YAML frontmatter with name and description fields
 - Keep SKILL.md under 2000 words — concise and actionable

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from nanobot.agent.memory import Dream, MemoryStore
 from nanobot.agent.runner import AgentRunResult
+from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 
 
 @pytest.fixture
@@ -94,4 +95,31 @@ class TestDreamRun:
         # After Dream, cursor is advanced and 3, compact keeps last max_history_entries
         entries = store.read_unprocessed_history(since_cursor=0)
         assert all(e["cursor"] > 0 for e in entries)
+
+    async def test_skill_phase_uses_builtin_skill_creator_path(self, dream, mock_provider, mock_runner, store):
+        """Dream should point skill creation guidance at the builtin skill-creator template."""
+        store.append_history("Repeated workflow one")
+        store.append_history("Repeated workflow two")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKILL] test-skill: test description")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        await dream.run()
+
+        spec = mock_runner.run.call_args[0][0]
+        system_prompt = spec.initial_messages[0]["content"]
+        expected = str(BUILTIN_SKILLS_DIR / "skill-creator" / "SKILL.md")
+        assert expected in system_prompt
+
+    async def test_skill_write_tool_accepts_workspace_relative_skill_path(self, dream, store):
+        """Dream skill creation should allow skills/<name>/SKILL.md relative to workspace root."""
+        write_tool = dream._tools.get("write_file")
+        assert write_tool is not None
+
+        result = await write_tool.execute(
+            path="skills/test-skill/SKILL.md",
+            content="---\nname: test-skill\ndescription: Test\n---\n",
+        )
+
+        assert "Successfully wrote" in result
+        assert (store.workspace / "skills" / "test-skill" / "SKILL.md").exists()
 


### PR DESCRIPTION
## Summary

- Integrate skill discovery into Dream's existing two-phase consolidation pipeline instead of building a separate system
- Phase 1 gains `[SKILL]` output type to detect reusable behavioral patterns from conversation history
- Phase 2 gains `write_file` (scoped to `skills/`) and read access to builtin skills for dedup checking and format reference
- Closes #2927

## Motivation

PR #3039 proposed a standalone skill discovery system with a separate class, config, cursor, three trigger modes, and an approval workflow (~1900 lines). This PR achieves the same goal by extending Dream — which already reads the same history, uses the same two-phase architecture, and shares the same trigger timing. The result is **+71 lines across 3 files**.

## How it works

```
Dream Phase 1 (unchanged + [SKILL] output)
  → [FILE] ...          (memory updates)
  → [FILE-REMOVE] ...   (stale content)
  → [SKILL] name: desc  (NEW: reusable pattern detected)

Dream Phase 2 (unchanged + write_file for skills/)
  → edit_file for memory updates
  → read_file existing skills for dedup
  → write_file skills/<name>/SKILL.md for new skills
```

Key design decisions:
- **Phase 1 stays lightweight**: no skills list in its context, just flags patterns
- **Phase 2 handles dedup**: has `read_file` access to both workspace and builtin skills, can read full content for semantic comparison
- **Format compliance**: Phase 2 prompt directs AgentRunner to read `skill-creator/SKILL.md` for frontmatter/convention reference before writing
- **Safety**: `write_file` is scoped to `skills/` directory only, cannot write elsewhere

## Comparison with PR #3039

| | PR #3039 | This PR |
|---|---------|---------|
| New files | 4 new files (skill_discovery.py, 2 templates, test) | 0 new files |
| Lines changed | ~1900 | +71 / -4 |
| Config fields | 8 new fields | 0 |
| New commands | 2 (`/discover-skills`, `/skill-approve`) | 0 |
| Trigger modes | 3 (manual, post-turn, cron) | 0 (uses Dream's existing triggers) |
| Separate cursor | Yes | No (reuses Dream cursor) |
| Tests | 64 new tests | Existing Dream tests cover the path |

## Files changed

| File | Change |
|------|--------|
| `nanobot/templates/agent/dream_phase1.md` | Add `[SKILL]` output format and trigger conditions |
| `nanobot/templates/agent/dream_phase2.md` | Add `[SKILL]` handling rules and skill creation guidelines |
| `nanobot/agent/memory.py` | Add `WriteFileTool` (skills/), `extra_allowed_dirs` (builtin skills), `_list_existing_skills()`, inject skills list into Phase 2 context |

Co-authored-by: whs <whs@xdd.ai> (original concept from PR #3039)