### PR TITLE
Make WhatsApp group replies configurable and suppressible

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -79,16 +79,43 @@ class ContextBuilder:
 
     @staticmethod
     def _build_runtime_context(
-        channel: str | None, chat_id: str | None, timezone: str | None = None,
+        channel: str | None,
+        chat_id: str | None,
+        timezone: str | None = None,
+        sender_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
         session_summary: str | None = None,
     ) -> str:
         """Build untrusted runtime metadata block for injection before the user message."""
         lines = [f"Current Time: {current_time_str(timezone)}"]
         if channel and chat_id:
             lines += [f"Channel: {channel}", f"Chat ID: {chat_id}"]
+        if sender_id:
+            lines.append(f"Sender ID: {sender_id}")
+        lines.extend(ContextBuilder._runtime_metadata_lines(metadata))
         if session_summary:
             lines += ["", "[Resumed Session]", session_summary]
-        return ContextBuilder._RUNTIME_CONTEXT_TAG + "\n" + "\n".join(lines) + "\n" + ContextBuilder._RUNTIME_CONTEXT_END
+        return (
+            ContextBuilder._RUNTIME_CONTEXT_TAG
+            + "\n"
+            + "\n".join(lines)
+            + "\n"
+            + ContextBuilder._RUNTIME_CONTEXT_END
+        )
+
+    @staticmethod
+    def _runtime_metadata_lines(metadata: dict[str, Any] | None) -> list[str]:
+        """Render selected channel metadata for the current LLM turn."""
+        if not metadata:
+            return []
+
+        lines: list[str] = []
+        is_group = metadata.get("is_group")
+        if is_group is not None:
+            lines.append(f"Conversation Type: {'group chat' if is_group else 'direct chat'}")
+        if "was_mentioned" in metadata:
+            lines.append(f"Was Mentioned: {bool(metadata.get('was_mentioned'))}")
+        return lines
 
     @staticmethod
     def _merge_message_content(left: Any, right: Any) -> str | list[dict[str, Any]]:
@@ -124,11 +151,20 @@ class ContextBuilder:
         media: list[str] | None = None,
         channel: str | None = None,
         chat_id: str | None = None,
+        sender_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
         current_role: str = "user",
         session_summary: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
-        runtime_ctx = self._build_runtime_context(channel, chat_id, self.timezone, session_summary=session_summary)
+        runtime_ctx = self._build_runtime_context(
+            channel,
+            chat_id,
+            self.timezone,
+            sender_id,
+            metadata,
+            session_summary=session_summary,
+        )
         user_content = self._build_user_content(current_message, media)
 
         # Merge runtime context and user content into a single user message

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -36,7 +36,10 @@ from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import LLMProvider
 from nanobot.session.manager import Session, SessionManager
 from nanobot.utils.helpers import image_placeholder_text, truncate_text as truncate_text_fn
-from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
+from nanobot.utils.runtime import (
+    EMPTY_FINAL_RESPONSE_MESSAGE,
+    NO_REPLY_SENTINEL,
+)
 
 if TYPE_CHECKING:
     from nanobot.config.schema import ChannelsConfig, ExecToolConfig, WebToolsConfig
@@ -674,8 +677,9 @@ class AgentLoop:
             current_message=msg.content,
             session_summary=pending,
             media=msg.media if msg.media else None,
-            channel=msg.channel,
-            chat_id=msg.chat_id,
+            channel=msg.channel, chat_id=msg.chat_id,
+            sender_id=msg.sender_id,
+            metadata=msg.metadata,
         )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
@@ -703,6 +707,8 @@ class AgentLoop:
             pending_queue=pending_queue,
         )
 
+        no_reply = isinstance(final_content, str) and final_content.strip() == NO_REPLY_SENTINEL
+
         if final_content is None or not final_content.strip():
             final_content = EMPTY_FINAL_RESPONSE_MESSAGE
 
@@ -711,6 +717,8 @@ class AgentLoop:
         self.sessions.save(session)
         self._schedule_background(self.consolidator.maybe_consolidate_by_tokens(session))
 
+        if no_reply:
+            return None
         # When follow-up messages were injected mid-turn, a later natural
         # language reply may address those follow-ups and should not be
         # suppressed just because MessageTool was used earlier in the turn.
@@ -781,6 +789,8 @@ class AgentLoop:
         for m in messages[skip:]:
             entry = dict(m)
             role, content = entry.get("role"), entry.get("content")
+            if role == "assistant" and isinstance(content, str) and content.strip() == NO_REPLY_SENTINEL:
+                continue
             if role == "assistant" and not content and not entry.get("tool_calls"):
                 continue  # skip empty assistant messages — they poison session context
             if role == "tool":

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -284,7 +284,8 @@ class WhatsAppChannel(BaseChannel):
                 metadata={
                     "message_id": message_id,
                     "timestamp": data.get("timestamp"),
-                    "is_group": data.get("isGroup", False),
+                    "is_group": is_group,
+                    "was_mentioned": was_mentioned,
                 },
             )
 

--- a/nanobot/templates/agent/identity.md
+++ b/nanobot/templates/agent/identity.md
@@ -41,4 +41,5 @@ Output is rendered in a terminal. Avoid markdown headings and tables. Use plain 
 {% include 'agent/_snippets/untrusted_content.md' %}
 
 Reply directly with text for conversations. Only use the 'message' tool to send to a specific chat channel.
+When runtime context says the current conversation is a WhatsApp group chat and a message is ordinary group chatter not addressed to you, reply with exactly `__NANOBOT_NO_REPLY__` and nothing else.
 IMPORTANT: To send files (images, documents, audio, video) to the user, you MUST call the 'message' tool with the 'media' parameter. Do NOT use read_file to "send" a file — reading a file only shows its content to you, it does NOT deliver the file to the user. Example: message(content="Here is the file", media=["/path/to/file.png"])

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -15,6 +15,8 @@ EMPTY_FINAL_RESPONSE_MESSAGE = (
     "Please try again or narrow the task."
 )
 
+NO_REPLY_SENTINEL = "__NANOBOT_NO_REPLY__"
+
 FINALIZATION_RETRY_PROMPT = (
     "Please provide your response to the user based on the conversation above."
 )

--- a/tests/agent/test_context_prompt_cache.py
+++ b/tests/agent/test_context_prompt_cache.py
@@ -87,6 +87,28 @@ def test_runtime_context_is_separate_untrusted_user_message(tmp_path) -> None:
     assert "Return exactly: OK" in user_content
 
 
+def test_runtime_context_includes_group_metadata(tmp_path) -> None:
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    messages = builder.build_messages(
+        history=[],
+        current_message="We are calling it",
+        channel="whatsapp",
+        chat_id="120@g.us",
+        sender_id="19145550100",
+        metadata={
+            "is_group": True,
+            "was_mentioned": False,
+        },
+    )
+
+    user_content = messages[-1]["content"]
+    assert "Channel: whatsapp" in user_content
+    assert "Conversation Type: group chat" in user_content
+    assert "Was Mentioned: False" in user_content
+
+
 def test_unprocessed_history_injected_into_system_prompt(tmp_path) -> None:
     """Entries in history.jsonl not yet consumed by Dream appear with timestamps."""
     workspace = _make_workspace(tmp_path)

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1,6 +1,15 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.loop import AgentLoop
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import ExecToolConfig, WebToolsConfig
+from nanobot.providers.base import LLMResponse
 from nanobot.session.manager import Session
+from nanobot.utils.runtime import NO_REPLY_SENTINEL
 
 
 def _mk_loop() -> AgentLoop:
@@ -60,6 +69,51 @@ def test_save_turn_keeps_image_placeholder_without_meta() -> None:
         skip=0,
     )
     assert session.messages[0]["content"] == [{"type": "text", "text": "[image]"}]
+
+
+def test_save_turn_skips_no_reply_sentinel() -> None:
+    loop = _mk_loop()
+    session = Session(key="whatsapp:120@g.us")
+
+    loop._save_turn(
+        session,
+        [{"role": "assistant", "content": NO_REPLY_SENTINEL}],
+        skip=0,
+    )
+
+    assert session.messages == []
+
+
+@pytest.mark.asyncio
+async def test_process_message_suppresses_no_reply_sentinel(tmp_path) -> None:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation.max_tokens = 1024
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content=NO_REPLY_SENTINEL, tool_calls=[]))
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        exec_config=ExecToolConfig(enable=False),
+        web_config=WebToolsConfig(enable=False),
+    )
+
+    msg = InboundMessage(
+        channel="whatsapp",
+        sender_id="19145550100",
+        chat_id="120@g.us",
+        content="We are calling it",
+        metadata={"is_group": True, "was_mentioned": False},
+    )
+
+    response = await loop._process_message(msg)
+
+    assert response is None
+    session = loop.sessions.get_or_create("whatsapp:120@g.us")
+    assert len(session.messages) == 1
+    assert session.messages[0]["role"] == "user"
+    assert session.messages[0]["content"] == "We are calling it"
+    await loop.close_mcp()
 
 
 def test_save_turn_keeps_tool_results_under_16k() -> None:

--- a/tests/channels/test_whatsapp_channel.py
+++ b/tests/channels/test_whatsapp_channel.py
@@ -161,6 +161,8 @@ async def test_group_policy_mention_accepts_mentioned_group_message():
     kwargs = ch._handle_message.await_args.kwargs
     assert kwargs["chat_id"] == "12345@g.us"
     assert kwargs["sender_id"] == "user"
+    assert kwargs["metadata"]["is_group"] is True
+    assert kwargs["metadata"]["was_mentioned"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

I found that one of my agents was replying to every single message in a WhatsApp group, which made it too noisy for normal group chats.

This change makes that behavior configurable by letting the agent detect WhatsApp group context and intentionally suppress a reply when the workspace instructions say the message is ordinary group chatter that is not addressed to the bot.

## What Changed

- pass WhatsApp group metadata (`is_group`, `was_mentioned`) through to the agent runtime context
- add a `__NANOBOT_NO_REPLY__` sentinel for channels that want to suppress a response intentionally
- suppress outbound delivery and assistant-history persistence when that sentinel is returned
- update the default identity template so WhatsApp group behavior can be made more selective in prompt instructions
- add tests covering runtime-context metadata, sentinel suppression, and WhatsApp channel metadata propagation

## Why

Before this, the agent could not distinguish between a direct WhatsApp conversation and general group chatter well enough to decline replying.

With this change, a workspace can tell the agent to stay silent in group chats unless it is mentioned or otherwise directly addressed, instead of replying to everything.

## Validation

I ran:

```bash
uv run pytest tests/agent/test_context_prompt_cache.py tests/agent/test_loop_save_turn.py tests/channels/test_whatsapp_channel.py
```

`tests/agent/test_loop_save_turn.py` and `tests/channels/test_whatsapp_channel.py` pass.

`tests/agent/test_context_prompt_cache.py` still has 5 failures, but those same failures are already present on upstream `main` before this commit, so they do not appear to be introduced by this change.
