### PR TITLE
feat(llm-wiki): enhance llm-wiki functionality with auto-archiving and management commands

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -16,7 +16,7 @@ It separates memory into layers, because different kinds of remembering deserve 
 
 - `session.messages` holds the living short-term conversation.
 - `memory/history.jsonl` is the running archive of compressed past turns.
-- `SOUL.md`, `USER.md`, and `memory/MEMORY.md` are the durable knowledge files.
+- `SOUL.md`, `USER.md`, `memory/MEMORY.md`, and `wiki/*.md` are the durable knowledge files (multi-page topics live under `wiki/`).
 - `GitStore` records how those durable files change over time.
 
 This keeps the system light in the moment, but reflective over time.
@@ -69,9 +69,27 @@ This is why nanobot's memory is not just archival. It is interpretive.
 workspace/
 ├── SOUL.md              # The bot's long-term voice and communication style
 ├── USER.md              # Stable knowledge about the user
+├── raw/                 # Optional immutable sources (read-only for the agent)
+│   ├── sources/         # Documents for `/wiki-ingest` (.md, .txt, …)
+│   ├── articles/        # Optional web clippings / articles (same ingest rules)
+│   ├── papers/          # Optional papers / long reads
+│   ├── transcripts/     # Optional transcripts / interview notes
+│   └── assets/          # Optional images / attachments
+├── wiki/                # Optional multi-page knowledge (index + topic pages)
+│   ├── index.md
+│   ├── log.md           # Append-only timeline (wiki-archive, Dream, wiki-lint, …)
+│   ├── schema.md        # Optional: structural rules; injected first, then index, then recent log tail
+│   ├── entities/        # People, orgs, products (typed pages)
+│   ├── concepts/        # Theories, methods, patterns
+│   ├── sources/         # Source-backed summaries
+│   ├── comparisons/     # Side-by-side analyses
+│   └── queries/         # Optional: `/wiki-save-answer` snapshots
 └── memory/
     ├── MEMORY.md        # Project facts, decisions, and durable context
     ├── history.jsonl    # Append-only history summaries
+    ├── wiki_archive_dedup.json  # Fingerprints for /wiki-archive (skip duplicate transcript/body)
+    ├── wiki_ingest_state.json   # Last successful /wiki-ingest raw bundle hash + body fingerprints
+    ├── wiki_automation.json     # Optional: auto wiki-ingest/lint scheduler state (gateway)
     ├── .cursor          # Consolidator write cursor
     ├── .dream_cursor    # Dream consumption cursor
     └── .git/            # Version history for long-term memory files
@@ -82,6 +100,9 @@ These files play different roles:
 - `SOUL.md` remembers how nanobot should sound.
 - `USER.md` remembers who the user is and what they prefer.
 - `MEMORY.md` remembers what remains true about the work itself.
+- `wiki/` holds structured, cross-linked topic pages when a single file is not enough.
+- `wiki/log.md` is a human-readable, append-only timeline of wiki actions (complementary to Git history).
+- Optional **automatic wiki** (gateway / interactive CLI): see `agents.defaults.autoWikiIngestIntervalMinutes`, `autoWikiLintIntervalMinutes`, `autoWikiLintAfterWikiWrite` in config; state in `memory/wiki_automation.json`.
 - `history.jsonl` remembers what happened on the way there.
 
 ## Why `history.jsonl`
@@ -125,8 +146,24 @@ Memory is not hidden behind the curtain. Users can inspect and guide it.
 | `/dream-log <sha>` | Show a specific Dream change |
 | `/dream-restore` | List recent Dream memory versions |
 | `/dream-restore <sha>` | Restore memory to the state before a specific change |
+| `/wiki-archive` | Model outputs JSON: **one or more** `{category_slug, display_title, page_kind, entry_markdown}` — **`page_kind`** routes to `wiki/<slug>.md` (`topic`) or `wiki/entities|concepts|sources/<slug>.md`. Updates **Topic archives** in `wiki/index.md`, appends **`wiki/log.md`**, clears session, injects full index |
+| `/wiki-ingest` | Read file(s) from `raw/sources/` (immutable) and merge structured notes into `wiki/` via the model |
+| `/wiki-lint` | Scan `wiki/` for broken `[[wikilinks]]` and optional orphan pages; appends **`wiki/log.md`** |
+| `/wiki-save-answer` | Save the last assistant reply under `wiki/queries/` (optional knowledge compounding) |
 
 These commands exist for a reason: automatic memory is powerful, but users should always retain the right to inspect, understand, and restore it.
+
+## Wiki revision strategy
+
+Canonical wiki pages are not write-once. Updates are intentional and map to different inputs:
+
+- **Chat-derived corrections or new facts** — Run **`/wiki-archive`** again with the same `category_slug`. The store **appends** a new dated section to the existing file; earlier sections remain for traceability.
+- **Source-of-truth in `raw/sources/`** — Add or change files there, then **`/wiki-ingest`**. Raw stays immutable; only `wiki/` is updated.
+- **Broad consistency** (several pages, or alignment with `history.jsonl` / `MEMORY.md`) — **Dream** (`/dream` or scheduled).
+- **Precise local edits** — Edit markdown in the workspace; **`/wiki-lint`** after link or structure changes.
+- **Saving a standalone Q&A artifact** — **`/wiki-save-answer`** writes under `wiki/queries/`, not under `entities/` / `concepts/` / `sources/`.
+
+`/wiki-archive` and `/wiki-ingest` use **merge** semantics (additive). Replacing a block without keeping history is a **manual** or **Dream** edit.
 
 ## Versioned Memory
 

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -32,6 +32,7 @@ class ContextBuilder:
         self,
         skill_names: list[str] | None = None,
         channel: str | None = None,
+        wiki_relevance_query: str | None = None,
     ) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
         parts = [self._get_identity(channel=channel)]
@@ -43,6 +44,10 @@ class ContextBuilder:
         memory = self.memory.get_memory_context()
         if memory:
             parts.append(f"# Memory\n\n{memory}")
+
+        wiki = self.memory.get_wiki_context(relevance_query=wiki_relevance_query)
+        if wiki:
+            parts.append(f"# Wiki\n\n{wiki}")
 
         always_skills = self.skills.get_always_skills()
         if always_skills:
@@ -126,6 +131,7 @@ class ContextBuilder:
         chat_id: str | None = None,
         current_role: str = "user",
         session_summary: str | None = None,
+        wiki_relevance_query: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build the complete message list for an LLM call."""
         runtime_ctx = self._build_runtime_context(channel, chat_id, self.timezone, session_summary=session_summary)
@@ -137,8 +143,16 @@ class ContextBuilder:
             merged = f"{runtime_ctx}\n\n{user_content}"
         else:
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
+        wiki_q = wiki_relevance_query
+        if wiki_q is None and isinstance(current_message, str) and current_message.strip():
+            wiki_q = current_message.strip()[:8000]
         messages = [
-            {"role": "system", "content": self.build_system_prompt(skill_names, channel=channel)},
+            {
+                "role": "system",
+                "content": self.build_system_prompt(
+                    skill_names, channel=channel, wiki_relevance_query=wiki_q
+                ),
+            },
             *history,
         ]
         if messages[-1].get("role") == current_role:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -35,12 +35,20 @@ from nanobot.bus.queue import MessageBus
 from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import LLMProvider
 from nanobot.session.manager import Session, SessionManager
-from nanobot.utils.helpers import image_placeholder_text, truncate_text as truncate_text_fn
+from nanobot.utils.helpers import (
+    estimate_prompt_tokens_chain,
+    image_placeholder_text,
+    truncate_text as truncate_text_fn,
+)
 from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
 
 if TYPE_CHECKING:
     from nanobot.config.schema import ChannelsConfig, ExecToolConfig, WebToolsConfig
     from nanobot.cron.service import CronService
+
+# Distinguish "caller omitted auto_wiki_archive_at_context_fraction" (use schema default)
+# from "caller passed None" (disable; matches AgentDefaults field semantics).
+_AGENT_LOOP_UNSET = object()
 
 
 UNIFIED_SESSION_KEY = "unified:default"
@@ -153,10 +161,32 @@ class AgentLoop:
         hooks: list[AgentHook] | None = None,
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
+        auto_wiki_archive_at_context_fraction: Any = _AGENT_LOOP_UNSET,
+        auto_wiki_ingest_interval_minutes: Any = _AGENT_LOOP_UNSET,
+        auto_wiki_lint_interval_minutes: Any = _AGENT_LOOP_UNSET,
+        auto_wiki_lint_after_wiki_write: Any = _AGENT_LOOP_UNSET,
     ):
         from nanobot.config.schema import ExecToolConfig, WebToolsConfig
 
         defaults = AgentDefaults()
+        if auto_wiki_archive_at_context_fraction is _AGENT_LOOP_UNSET:
+            self.auto_wiki_archive_at_context_fraction = (
+                defaults.auto_wiki_archive_at_context_fraction
+            )
+        else:
+            self.auto_wiki_archive_at_context_fraction = auto_wiki_archive_at_context_fraction
+        if auto_wiki_ingest_interval_minutes is _AGENT_LOOP_UNSET:
+            self.auto_wiki_ingest_interval_minutes = defaults.auto_wiki_ingest_interval_minutes
+        else:
+            self.auto_wiki_ingest_interval_minutes = auto_wiki_ingest_interval_minutes
+        if auto_wiki_lint_interval_minutes is _AGENT_LOOP_UNSET:
+            self.auto_wiki_lint_interval_minutes = defaults.auto_wiki_lint_interval_minutes
+        else:
+            self.auto_wiki_lint_interval_minutes = auto_wiki_lint_interval_minutes
+        if auto_wiki_lint_after_wiki_write is _AGENT_LOOP_UNSET:
+            self.auto_wiki_lint_after_wiki_write = defaults.auto_wiki_lint_after_wiki_write
+        else:
+            self.auto_wiki_lint_after_wiki_write = auto_wiki_lint_after_wiki_write
         self.bus = bus
         self.channels_config = channels_config
         self.provider = provider
@@ -208,6 +238,7 @@ class AgentLoop:
         self._mcp_connecting = False
         self._active_tasks: dict[str, list[asyncio.Task]] = {}  # session_key -> tasks
         self._background_tasks: list[asyncio.Task] = []
+        self._wiki_automation_task: asyncio.Task | None = None
         self._session_locks: dict[str, asyncio.Lock] = {}
         # Per-session pending queues for mid-turn message injection.
         # When a session has an active task, new messages for that session
@@ -223,7 +254,7 @@ class AgentLoop:
             provider=provider,
             model=self.model,
             sessions=self.sessions,
-            context_window_tokens=context_window_tokens,
+            context_window_tokens=self.context_window_tokens,
             build_messages=self.context.build_messages,
             get_tool_definitions=self.tools.get_definitions,
             max_completion_tokens=provider.generation.max_tokens,
@@ -423,10 +454,41 @@ class AgentLoop:
             logger.error("LLM returned error: {}", (result.final_content or "")[:200])
         return result.final_content, result.tools_used, result.messages, result.stop_reason, result.had_injections
 
+    async def _wiki_automation_loop(self) -> None:
+        """Poll raw/ and optionally run scheduled wiki-lint (gateway / long-running loops)."""
+        from nanobot.llm_wiki.automation import tick_wiki_automation
+
+        while self._running:
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                break
+            if not self._running:
+                break
+            try:
+                await tick_wiki_automation(
+                    self,
+                    ingest_interval_minutes=self.auto_wiki_ingest_interval_minutes,
+                    lint_interval_minutes=self.auto_wiki_lint_interval_minutes,
+                )
+            except Exception:
+                logger.exception("Wiki automation tick failed")
+
     async def run(self) -> None:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
         self._running = True
         await self._connect_mcp()
+        if self.auto_wiki_ingest_interval_minutes is not None or self.auto_wiki_lint_interval_minutes is not None:
+            self._wiki_automation_task = asyncio.create_task(self._wiki_automation_loop())
+            self._background_tasks.append(self._wiki_automation_task)
+
+            def _drop_wiki_task(t: asyncio.Task) -> None:
+                try:
+                    self._background_tasks.remove(t)
+                except ValueError:
+                    pass
+
+            self._wiki_automation_task.add_done_callback(_drop_wiki_task)
         logger.info("Agent loop started")
 
         while self._running:
@@ -596,7 +658,63 @@ class AgentLoop:
     def stop(self) -> None:
         """Stop the agent loop."""
         self._running = False
+        if self._wiki_automation_task and not self._wiki_automation_task.done():
+            self._wiki_automation_task.cancel()
         logger.info("Agent loop stopping")
+
+    def _estimate_inbound_prompt_tokens(
+        self,
+        session: Session,
+        msg: InboundMessage,
+        pending_summary: str | None,
+    ) -> tuple[int, str]:
+        """Estimate prompt size for the upcoming turn (session history + this inbound message)."""
+        history = session.get_history(max_messages=0)
+        messages = self.context.build_messages(
+            history=history,
+            current_message=msg.content,
+            session_summary=pending_summary,
+            media=msg.media if msg.media else None,
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+        )
+        return estimate_prompt_tokens_chain(
+            self.provider,
+            self.model,
+            messages,
+            self.tools.get_definitions(),
+        )
+
+    async def _maybe_auto_wiki_archive(
+        self,
+        msg: InboundMessage,
+        session: Session,
+        pending_summary: str | None,
+    ) -> OutboundMessage | None:
+        """If configured, run wiki-archive when estimated tokens reach the context fraction threshold."""
+        frac = self.auto_wiki_archive_at_context_fraction
+        if frac is None or frac <= 0:
+            return None
+        if self.context_window_tokens <= 0:
+            return None
+        est, _src = self._estimate_inbound_prompt_tokens(session, msg, pending_summary)
+        threshold = max(1, int(self.context_window_tokens * frac))
+        if est < threshold:
+            return None
+        from datetime import datetime
+
+        from nanobot.command.wiki_archive import run_wiki_archive_for_session
+
+        tail = [{"role": "user", "content": msg.content, "timestamp": datetime.now().isoformat()}]
+        return await run_wiki_archive_for_session(
+            self,
+            session,
+            msg,
+            append_transcript_messages=tail,
+            brief_success=True,
+            estimated_tokens=est,
+            threshold_tokens=threshold,
+        )
 
     async def _process_message(
         self,
@@ -661,6 +779,12 @@ class AgentLoop:
         ctx = CommandContext(msg=msg, session=session, key=key, raw=raw, loop=self)
         if result := await self.commands.dispatch(ctx):
             return result
+
+        frac = self.auto_wiki_archive_at_context_fraction
+        if frac is not None and frac > 0:
+            auto_note = await self._maybe_auto_wiki_archive(msg, session, pending)
+            if auto_note is not None:
+                await self.bus.publish_outbound(auto_note)
 
         await self.consolidator.maybe_consolidate_by_tokens(session)
 

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import difflib
+import hashlib
 import json
 import re
 import weakref
@@ -12,6 +14,14 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from loguru import logger
 
+from nanobot.llm_wiki import (
+    WIKI_DIR_NAME,
+    build_wiki_context,
+    ensure_standard_wiki_dirs,
+    list_wiki_page_paths,
+    read_schema,
+)
+from nanobot.llm_wiki.catalog import extract_markdown_h1
 from nanobot.utils.prompt_templates import render_template
 from nanobot.utils.helpers import ensure_dir, estimate_message_tokens, estimate_prompt_tokens_chain, strip_think
 
@@ -49,9 +59,11 @@ class MemoryStore:
         self.user_file = workspace / "USER.md"
         self._cursor_file = self.memory_dir / ".cursor"
         self._dream_cursor_file = self.memory_dir / ".dream_cursor"
-        self._git = GitStore(workspace, tracked_files=[
-            "SOUL.md", "USER.md", "memory/MEMORY.md",
-        ])
+        self._git = GitStore(
+            workspace,
+            tracked_files=["SOUL.md", "USER.md", "memory/MEMORY.md"],
+            track_wiki_markdown=True,
+        )
         self._maybe_migrate_legacy_history()
 
     @property
@@ -218,6 +230,211 @@ class MemoryStore:
         long_term = self.read_memory()
         return f"## Long-term Memory\n{long_term}" if long_term else ""
 
+    # -- wiki/ — multi-page LLM-compiled knowledge ---------------------------
+
+    WIKI_DIR = WIKI_DIR_NAME
+    WIKI_LOG_FILENAME = "log.md"
+    WIKI_TITLE_REMAP_MIN_RATIO = 0.92
+    WIKI_TITLE_REMAP_MIN_LEN = 8
+    _WIKI_INGEST_STATE_FILE = "wiki_ingest_state.json"
+    _WIKI_INGEST_BODY_HASH_CAP = 4000
+    _WIKI_ROOT_PAGE_SKIP_STEMS = frozenset({"index", "schema", "log"})
+
+    @property
+    def wiki_dir(self) -> Path:
+        return self.workspace / self.WIKI_DIR
+
+    def append_wiki_log_line(self, kind: str, summary: str, *, when: str | None = None) -> None:
+        """Append one section to ``wiki/log.md`` (append-only human timeline)."""
+        ts = when or datetime.now().strftime("%Y-%m-%d %H:%M")
+        one_line = re.sub(r"\s+", " ", summary.strip())
+        if len(one_line) > 400:
+            one_line = one_line[:397] + "…"
+        line = f"## [{ts}] {kind} | {one_line}\n\n"
+        self.wiki_dir.mkdir(parents=True, exist_ok=True)
+        ensure_standard_wiki_dirs(self.workspace, wiki_dir=self.WIKI_DIR)
+        path = self.wiki_dir / self.WIKI_LOG_FILENAME
+        if not path.is_file():
+            path.write_text(
+                "# Wiki log\n\n"
+                "Append-only timeline of wiki actions (`/wiki-archive`, Dream, `/wiki-lint`, …).\n\n"
+                "---\n\n",
+                encoding="utf-8",
+            )
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line)
+
+    def read_wiki_schema(self) -> str:
+        """Return ``wiki/schema.md`` text, or empty string if missing."""
+        return read_schema(self.workspace, wiki_dir=self.WIKI_DIR)
+
+    def list_wiki_page_paths(self) -> list[str]:
+        """Sorted relative paths ``wiki/**/*.md`` (posix). ``wiki/index.md`` first if present."""
+        return list_wiki_page_paths(self.workspace, wiki_dir=self.WIKI_DIR)
+
+    def get_wiki_context(
+        self,
+        max_total_chars: int = 24_000,
+        *,
+        relevance_query: str | None = None,
+    ) -> str:
+        """Concatenate wiki markdown for system prompt injection (token-bounded).
+
+        Delegates to :func:`nanobot.llm_wiki.build_wiki_context` (schema first).
+        When *relevance_query* is set, pages are ranked by token overlap before truncation.
+        """
+        return build_wiki_context(
+            self.workspace,
+            wiki_dir=self.WIKI_DIR,
+            max_total_chars=max_total_chars,
+            relevance_query=relevance_query,
+        )
+
+    @staticmethod
+    def coalesce_wiki_archive_entries(
+        entries: list[tuple[str, str, str, str]],
+    ) -> list[tuple[str, str, str, str]]:
+        """Merge same-batch rows that share normalized slug + ``page_kind`` (single index line per page)."""
+        groups: dict[tuple[str, str], list[tuple[str, str, str, str]]] = {}
+        order: list[tuple[str, str]] = []
+        for slug, display_title, entry_md, page_kind in entries:
+            safe = MemoryStore.normalize_wiki_category_slug(slug)
+            kind = MemoryStore._normalize_wiki_page_kind(page_kind)
+            key = (safe, kind)
+            if key not in groups:
+                groups[key] = []
+                order.append(key)
+            groups[key].append((slug, display_title, entry_md, kind))
+        out: list[tuple[str, str, str, str]] = []
+        for key in order:
+            bucket = groups[key]
+            merged_slug = key[0]
+            titles = [t for _, t, _, _ in bucket if str(t).strip()]
+            display_title = titles[0] if titles else ""
+            parts = [em for _, _, em, _ in bucket]
+            merged_md = "\n\n---\n\n".join(p.strip() for p in parts if p and str(p).strip())
+            kind = key[1]
+            out.append((merged_slug, display_title, merged_md, kind))
+        return out
+
+    @staticmethod
+    def _wiki_rel_path_for_kind(kind: str, safe_slug: str) -> str:
+        kind_n = MemoryStore._normalize_wiki_page_kind(kind)
+        subdir = {
+            "entity": "entities",
+            "concept": "concepts",
+            "source": "sources",
+            "comparison": "comparisons",
+        }.get(kind_n)
+        if subdir:
+            return f"{subdir}/{safe_slug}.md"
+        return f"{safe_slug}.md"
+
+    def _wiki_page_exists_for_kind_slug(self, kind: str, safe_slug: str) -> bool:
+        rel = MemoryStore._wiki_rel_path_for_kind(kind, safe_slug)
+        return (self.wiki_dir / rel).is_file()
+
+    def _load_wiki_titles_by_kind(self) -> dict[str, list[tuple[str, str]]]:
+        """Map page kind to ``(stem_slug, h1)`` for existing markdown files."""
+        out: dict[str, list[tuple[str, str]]] = {
+            "topic": [],
+            "entity": [],
+            "concept": [],
+            "source": [],
+            "comparison": [],
+        }
+        root = self.wiki_dir
+        if not root.is_dir():
+            return out
+        for p in root.glob("*.md"):
+            stem = p.stem.lower()
+            if stem in self._WIKI_ROOT_PAGE_SKIP_STEMS:
+                continue
+            try:
+                text = p.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            out["topic"].append((stem, extract_markdown_h1(text)))
+        submap = {
+            "entities": "entity",
+            "concepts": "concept",
+            "sources": "source",
+            "comparisons": "comparison",
+        }
+        for sub, kind in submap.items():
+            d = root / sub
+            if not d.is_dir():
+                continue
+            for p in d.glob("*.md"):
+                try:
+                    text = p.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue
+                out[kind].append((p.stem.lower(), extract_markdown_h1(text)))
+        return out
+
+    def remap_wiki_archive_slugs_by_existing_titles(
+        self,
+        entries: list[tuple[str, str, str, str]],
+    ) -> tuple[list[tuple[str, str, str, str]], list[str]]:
+        """When a new slug has no file but ``display_title`` matches an existing page H1, reuse that slug."""
+        titles_by_kind = self._load_wiki_titles_by_kind()
+        logs: list[str] = []
+        out: list[tuple[str, str, str, str]] = []
+        for slug, display_title, em, page_kind in entries:
+            kind = MemoryStore._normalize_wiki_page_kind(page_kind)
+            safe = MemoryStore.normalize_wiki_category_slug(slug)
+            if self._wiki_page_exists_for_kind_slug(kind, safe):
+                out.append((slug, display_title, em, kind))
+                continue
+            title_norm = MemoryStore._normalize_wiki_body_for_dedup(display_title or "")
+            if len(title_norm) < self.WIKI_TITLE_REMAP_MIN_LEN:
+                out.append((slug, display_title, em, kind))
+                continue
+            best_slug: str | None = None
+            best_r = 0.0
+            for cand_slug, h1_raw in titles_by_kind.get(kind, []):
+                if cand_slug == safe:
+                    continue
+                h1_norm = MemoryStore._normalize_wiki_body_for_dedup(h1_raw)
+                if len(h1_norm) < self.WIKI_TITLE_REMAP_MIN_LEN:
+                    continue
+                r = difflib.SequenceMatcher(None, title_norm, h1_norm).ratio()
+                if r > best_r:
+                    best_r = r
+                    best_slug = cand_slug
+            if best_slug is not None and best_r >= self.WIKI_TITLE_REMAP_MIN_RATIO:
+                logs.append(f"title-remap {kind} {safe}->{best_slug} sim={best_r:.2f}")
+                out.append((best_slug, display_title, em, kind))
+            else:
+                out.append((slug, display_title, em, kind))
+        return out, logs
+
+    def merge_wiki_entries_from_archive(
+        self,
+        entries: list[tuple[str, str, str, str]],
+        when: str,
+    ) -> list[str]:
+        """Merge archivable wiki entries (merge files + topic index lines). Returns written paths under ``wiki/``."""
+        merged = MemoryStore.coalesce_wiki_archive_entries(entries)
+        merged, remap_logs = self.remap_wiki_archive_slugs_by_existing_titles(merged)
+        merged = MemoryStore.coalesce_wiki_archive_entries(merged)
+        for line in remap_logs:
+            self.append_wiki_log_line("wiki-dedup", line, when=when)
+        written: list[str] = []
+        for slug, display_title, entry_md, page_kind in merged:
+            idx_title, idx_blurb = MemoryStore.summarize_wiki_topic_entry_for_index(
+                entry_md, display_title,
+            )
+            fname = self.merge_wiki_category_document(
+                slug, display_title, entry_md, when, page_kind=page_kind,
+            )
+            self.append_session_archive_to_index(
+                fname, when, title=idx_title, blurb=idx_blurb,
+            )
+            written.append(fname)
+        return written
+
     # -- history.jsonl — append-only, JSONL format ---------------------------
 
     def append_history(self, entry: str) -> int:
@@ -325,6 +542,616 @@ class MemoryStore:
                 f"[{message.get('timestamp', '?')[:16]}] {message['role'].upper()}{tools}: {message['content']}"
             )
         return "\n".join(lines)
+
+    @staticmethod
+    def _textify_message_content(content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(str(block.get("text", "")))
+            return "\n".join(parts)
+        return str(content)
+
+    @staticmethod
+    def format_messages_for_archive(messages: list[dict[str, Any]]) -> str:
+        """Flatten session messages to plain text for wiki archiving (includes tools)."""
+        lines: list[str] = []
+        for message in messages:
+            role = message.get("role", "?")
+            ts = str(message.get("timestamp", ""))[:19]
+            extra = ""
+            if role == "assistant" and message.get("tool_calls"):
+                names: list[str] = []
+                for tc in message.get("tool_calls") or []:
+                    if isinstance(tc, dict):
+                        names.append(str(tc.get("name", "?")))
+                    else:
+                        names.append(str(getattr(tc, "name", "?")))
+                extra = f" [tools: {', '.join(names)}]"
+            body = MemoryStore._textify_message_content(message.get("content"))
+            if role == "tool":
+                name = message.get("name", "tool")
+                clipped = body if len(body) <= 12_000 else body[:12_000] + "\n… *(truncated)*"
+                lines.append(f"[{ts}] TOOL {name}: {clipped}")
+                continue
+            if not body.strip():
+                if role == "assistant" and message.get("tool_calls"):
+                    lines.append(f"[{ts}] ASSISTANT{extra}: *(no text)*")
+                continue
+            lines.append(f"[{ts}] {role.upper()}{extra}: {body}")
+        return "\n".join(lines)
+
+    def write_wiki_page(self, relative_path: str, content: str) -> Path:
+        """Write ``content`` to ``wiki/<relative_path>`` (creates parent dirs)."""
+        rel = relative_path.replace("\\", "/").lstrip("/")
+        if any(part == ".." for part in rel.split("/")):
+            raise ValueError("Invalid wiki path")
+        ensure_standard_wiki_dirs(self.workspace, wiki_dir=self.WIKI_DIR)
+        path = self.wiki_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    @staticmethod
+    def parse_wiki_archive_response(text: str) -> tuple[str, str, str]:
+        """Parse legacy ``CATEGORY_SLUG`` / ``DISPLAY_TITLE`` headers. Returns ``(slug, display_title, entry_md)``."""
+        t = text.strip().replace("\r\n", "\n")
+        if not t:
+            return "", "", ""
+        lines = t.split("\n")
+        slug = ""
+        display = ""
+        i = 0
+        while i < len(lines):
+            s = lines[i].strip()
+            if not s:
+                i += 1
+                continue
+            m = re.match(r"^CATEGORY_SLUG:\s*([a-z0-9][a-z0-9-]{0,78})\s*$", s, re.I)
+            if m:
+                slug = m.group(1).lower()
+                i += 1
+                continue
+            m = re.match(r"^DISPLAY_TITLE:\s*(.+)$", s, re.I)
+            if m:
+                display = m.group(1).strip()
+                i += 1
+                continue
+            break
+        entry = "\n".join(lines[i:]).strip()
+        return slug, display, entry
+
+    @staticmethod
+    def _extract_json_wiki_payload(text: str) -> Any | None:
+        """Parse JSON array/object from model output (optionally inside a ```json fence)."""
+        t = text.strip()
+        m = re.search(r"```(?:json)?\s*([\s\S]*?)```", t, re.IGNORECASE)
+        candidate = m.group(1).strip() if m else t
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            pass
+        i = t.find("[")
+        j = t.rfind("]")
+        if i >= 0 and j > i:
+            try:
+                return json.loads(t[i : j + 1])
+            except json.JSONDecodeError:
+                return None
+        return None
+
+    @staticmethod
+    def _normalize_wiki_page_kind(raw: Any) -> str:
+        """Map model output to ``topic`` | ``entity`` | ``concept`` | ``source``."""
+        if raw is None:
+            return "topic"
+        s = str(raw).strip().lower()
+        aliases = {
+            "entities": "entity",
+            "concepts": "concept",
+            "sources": "source",
+            "comparisons": "comparison",
+            "topics": "topic",
+            "general": "topic",
+            "root": "topic",
+            "mixed": "topic",
+        }
+        s = aliases.get(s, s)
+        if s in ("topic", "entity", "concept", "source", "comparison"):
+            return s
+        return "topic"
+
+    @staticmethod
+    def _wiki_entries_from_json(data: Any) -> list[tuple[str, str, str, str]]:
+        """Build entry tuples from parsed JSON: ``(slug, display_title, entry_md, page_kind)``."""
+        if isinstance(data, dict):
+            if isinstance(data.get("entries"), list):
+                data = data["entries"]
+            elif data.get("category_slug") is not None or data.get("category") is not None:
+                data = [data]
+            else:
+                return []
+        if not isinstance(data, list):
+            return []
+        out: list[tuple[str, str, str, str]] = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            slug = str(
+                item.get("category_slug") or item.get("category") or "",
+            ).strip()
+            title = str(
+                item.get("display_title") or item.get("title") or "",
+            ).strip()
+            em = str(
+                item.get("entry_markdown") or item.get("body") or item.get("content") or "",
+            ).strip()
+            kind_raw = (
+                item.get("page_kind")
+                or item.get("kind")
+                or item.get("wiki_kind")
+                or item.get("archive_kind")
+            )
+            kind = MemoryStore._normalize_wiki_page_kind(kind_raw)
+            if not slug:
+                continue
+            out.append((slug.lower(), title, em, kind))
+        return out
+
+    @staticmethod
+    def parse_wiki_archive_entries(text: str) -> list[tuple[str, str, str, str]]:
+        """Parse JSON (preferred) or legacy header format.
+
+        Returns ``(slug, display_title, entry_md, page_kind)``; *page_kind* is
+        ``topic`` for legacy text format (wiki root) or when omitted in JSON.
+        """
+        t = text.strip().replace("\r\n", "\n")
+        if not t:
+            return []
+        blob = MemoryStore._extract_json_wiki_payload(t)
+        if blob is not None:
+            return MemoryStore._wiki_entries_from_json(blob)
+        slug, display, entry = MemoryStore.parse_wiki_archive_response(t)
+        if slug:
+            return [(slug, display, entry, "topic")]
+        return []
+
+    @staticmethod
+    def _wiki_entry_is_empty_session_marker(entry_md: str) -> bool:
+        for line in entry_md.split("\n"):
+            s = line.strip()
+            if not s:
+                continue
+            m = re.match(r"^#\s+(.+)$", s)
+            if m:
+                return m.group(1).strip().lower() in ("(empty session)", "empty session")
+            break
+        return False
+
+    @staticmethod
+    def filter_archivable_wiki_entries(
+        entries: list[tuple[str, str, str, str]],
+    ) -> list[tuple[str, str, str, str]]:
+        """Drop empty-session markers and blank entries."""
+        out: list[tuple[str, str, str, str]] = []
+        for slug, title, em, kind in entries:
+            if slug.strip().lower() in ("empty-session", "empty-ingest"):
+                continue
+            if not em.strip():
+                continue
+            if MemoryStore._wiki_entry_is_empty_session_marker(em):
+                continue
+            out.append((slug, title, em, kind))
+        return out
+
+    @staticmethod
+    def normalize_wiki_category_slug(slug: str) -> str:
+        """Sanitize category slug for ``wiki/<slug>.md`` filenames."""
+        s = slug.strip().lower()
+        s = re.sub(r"[^a-z0-9-]+", "-", s)
+        s = re.sub(r"-+", "-", s).strip("-")
+        if not s:
+            s = "general"
+        if s in ("index",):
+            s = "index-notes"
+        if len(s) > 80:
+            s = s[:80].rstrip("-")
+        return s
+
+    def merge_wiki_category_document(
+        self,
+        slug: str,
+        display_title: str,
+        entry_markdown: str,
+        when: str,
+        *,
+        page_kind: str = "topic",
+    ) -> str:
+        """Append an entry into a wiki page. Returns relative path under ``wiki/``.
+
+        *page_kind* ``topic`` → ``wiki/<slug>.md``; ``entity`` | ``concept`` | ``source``
+        | ``comparison`` → ``wiki/{entities|concepts|sources|comparisons}/<slug>.md``.
+        """
+        safe = MemoryStore.normalize_wiki_category_slug(slug)
+        kind = MemoryStore._normalize_wiki_page_kind(page_kind)
+        self.wiki_dir.mkdir(parents=True, exist_ok=True)
+        ensure_standard_wiki_dirs(self.workspace, wiki_dir=self.WIKI_DIR)
+        subdir = {
+            "entity": "entities",
+            "concept": "concepts",
+            "source": "sources",
+            "comparison": "comparisons",
+        }.get(kind)
+        if subdir:
+            dest = self.wiki_dir / subdir
+            dest.mkdir(parents=True, exist_ok=True)
+            path = dest / f"{safe}.md"
+            rel_return = f"{subdir}/{safe}.md"
+        else:
+            path = self.wiki_dir / f"{safe}.md"
+            rel_return = f"{safe}.md"
+        entry = entry_markdown.strip()
+        block = f"\n\n---\n\n## {when}\n\n{entry}\n"
+        title_line = (display_title.strip() or safe.replace("-", " ").title())
+        if path.is_file():
+            existing = path.read_text(encoding="utf-8", errors="replace").rstrip()
+            path.write_text(existing + block, encoding="utf-8")
+        else:
+            header = (
+                f"# {title_line}\n\n"
+                "> One wiki file per knowledge category; new `/wiki-archive` runs append below.\n\n"
+                f"---{block}"
+            )
+            path.write_text(header, encoding="utf-8")
+        return rel_return
+
+    @staticmethod
+    def summarize_wiki_topic_entry_for_index(
+        entry_markdown: str,
+        display_title: str,
+        *,
+        blurb_max: int = 180,
+    ) -> tuple[str, str]:
+        """Index link label + blurb from a category entry (uses ``## Summary`` in *entry_markdown*)."""
+        title = display_title.strip() or "(untitled)"
+        blurb = MemoryStore._extract_index_blurb(entry_markdown.strip(), blurb_max)
+        return title, blurb
+
+    @staticmethod
+    def is_wiki_archive_body_insufficient(body: str) -> bool:
+        """True when there is nothing worth writing (empty output or only empty-session markers)."""
+        return (
+            len(
+                MemoryStore.filter_archivable_wiki_entries(
+                    MemoryStore.parse_wiki_archive_entries(body),
+                ),
+            )
+            == 0
+        )
+
+    @staticmethod
+    def summarize_wiki_archive_for_index(
+        body: str,
+        *,
+        title_max: int = 100,
+        blurb_max: int = 180,
+    ) -> tuple[str, str]:
+        """Derive (link title, one-line blurb) from archived wiki markdown for index.md."""
+        text = body.strip().replace("\r\n", "\n")
+        if not text:
+            return "(empty)", ""
+
+        lines = text.split("\n")
+        title = ""
+        start_idx = 0
+        for i, raw in enumerate(lines):
+            s = raw.strip()
+            if not s:
+                continue
+            m = re.match(r"^#\s+(.+)$", s)
+            if m:
+                title = m.group(1).strip()
+                start_idx = i + 1
+                break
+            if s.startswith("#"):
+                title = s.lstrip("#").strip()
+                start_idx = i + 1
+                break
+
+        if not title:
+            title = "(untitled)"
+        if len(title) > title_max:
+            title = title[: title_max - 1] + "…"
+
+        remainder = "\n".join(lines[start_idx:])
+        blurb = MemoryStore._extract_index_blurb(remainder, blurb_max)
+        return title, blurb
+
+    @staticmethod
+    def _extract_summary_section_after_h1(remainder: str) -> str | None:
+        """Return body under ``## Summary`` until the next ``##`` heading at level 2."""
+        lines = remainder.split("\n")
+        for i, line in enumerate(lines):
+            if re.match(r"^##\s+summary\s*$", line.strip(), re.IGNORECASE):
+                parts: list[str] = []
+                for j in range(i + 1, len(lines)):
+                    L = lines[j].strip()
+                    if re.match(r"^##\s+", L):
+                        break
+                    parts.append(lines[j])
+                block = "\n".join(parts).strip()
+                return block or None
+        return None
+
+    @staticmethod
+    def _extract_index_blurb(remainder: str, max_len: int) -> str:
+        """First substantive lines after the H1, flattened to one line."""
+        summary_block = MemoryStore._extract_summary_section_after_h1(remainder)
+        scan = summary_block if summary_block is not None else remainder
+
+        chunks: list[str] = []
+        total = 0
+        for raw in scan.split("\n"):
+            s = raw.strip()
+            if not s or s == "---":
+                continue
+            if s.startswith("#"):
+                continue
+            if s.startswith(("- ", "* ")):
+                s = re.sub(r"^[\-\*]\s+", "", s)
+            elif re.match(r"^\d+\.\s+", s):
+                s = re.sub(r"^\d+\.\s+", "", s)
+            s = re.sub(r"\s+", " ", s).strip()
+            if not s:
+                continue
+            chunks.append(s)
+            total += len(s) + 2
+            if total >= max_len:
+                break
+
+        if not chunks:
+            for raw in remainder.split("\n"):
+                s = raw.strip()
+                if s and not s.startswith("#"):
+                    chunks.append(re.sub(r"\s+", " ", s))
+                    break
+
+        if not chunks:
+            return ""
+
+        out = " · ".join(chunks)
+        if len(out) > max_len:
+            return out[: max_len - 1] + "…"
+        return out
+
+    def append_session_archive_to_index(
+        self,
+        wiki_filename: str,
+        when: str,
+        *,
+        title: str = "",
+        blurb: str = "",
+    ) -> None:
+        """Append a bullet under ``## Topic archives`` (or legacy ``## Session archives``).
+
+        *title* is the link label. *blurb* is a short plain-text summary for search.
+        """
+        self.wiki_dir.mkdir(parents=True, exist_ok=True)
+        ensure_standard_wiki_dirs(self.workspace, wiki_dir=self.WIKI_DIR)
+        index_path = self.wiki_dir / "index.md"
+        label = title.strip() or wiki_filename
+        line = f"- {when} — [{label}]({wiki_filename})"
+        if blurb.strip():
+            line += f" — {blurb.strip()}"
+        marker_primary = "## Topic archives"
+        marker_legacy = "## Session archives"
+        if not index_path.exists():
+            index_path.write_text(
+                "# Wiki index\n\n"
+                "Multi-page knowledge.\n\n"
+                "---\n\n"
+                f"{marker_primary}\n\n"
+                f"{line}\n",
+                encoding="utf-8",
+            )
+            return
+        text = index_path.read_text(encoding="utf-8")
+        for marker in (marker_primary, marker_legacy):
+            if marker in text:
+                head, sep, tail = text.partition(marker)
+                new_text = head + sep + tail.rstrip() + "\n" + line + "\n"
+                index_path.write_text(new_text, encoding="utf-8")
+                return
+        new_text = text.rstrip() + "\n\n---\n\n" + marker_primary + "\n\n" + line + "\n"
+        index_path.write_text(new_text, encoding="utf-8")
+
+    def read_wiki_index(self) -> str:
+        """Return ``wiki/index.md`` text, or empty string if missing."""
+        p = self.wiki_dir / "index.md"
+        if not p.is_file():
+            return ""
+        try:
+            return p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return ""
+
+    _WIKI_ARCHIVE_DEDUP_FILE = "wiki_archive_dedup.json"
+    _WIKI_ARCHIVE_DEDUP_CAP = 4000
+
+    def _wiki_archive_dedup_path(self) -> Path:
+        return self.memory_dir / self._WIKI_ARCHIVE_DEDUP_FILE
+
+    def _load_wiki_archive_dedup(self) -> dict[str, Any]:
+        p = self._wiki_archive_dedup_path()
+        if not p.is_file():
+            return {"transcript_sha256": [], "body_sha256": []}
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {"transcript_sha256": [], "body_sha256": []}
+        data.setdefault("transcript_sha256", [])
+        data.setdefault("body_sha256", [])
+        return data
+
+    def _save_wiki_archive_dedup(self, data: dict[str, Any]) -> None:
+        p = self._wiki_archive_dedup_path()
+        p.write_text(json.dumps(data, ensure_ascii=False, indent=0) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _normalize_wiki_body_for_dedup(text: str) -> str:
+        t = text.strip().lower()
+        return re.sub(r"\s+", " ", t)
+
+    def wiki_archive_transcript_already_archived(self, transcript_sha256: str) -> bool:
+        """True if this exact session transcript was already successfully archived."""
+        return transcript_sha256 in self._load_wiki_archive_dedup().get("transcript_sha256", [])
+
+    def wiki_archive_should_skip_duplicate_body(
+        self,
+        body: str,
+        *,
+        similarity_threshold: float = 0.94,
+    ) -> bool:
+        """True when generated markdown matches a prior archive (hash or high similarity)."""
+        norm = MemoryStore._normalize_wiki_body_for_dedup(body)
+        if len(norm) < 32:
+            return False
+        digest = hashlib.sha256(norm.encode("utf-8")).hexdigest()
+        if digest in self._load_wiki_archive_dedup().get("body_sha256", []):
+            return True
+        return self._wiki_archive_near_duplicate_file(norm, similarity_threshold=similarity_threshold)
+
+    def _wiki_archive_near_duplicate_file(self, norm_new: str, *, similarity_threshold: float) -> bool:
+        root = self.wiki_dir
+        if not root.is_dir():
+            return False
+        candidates: list[Path] = []
+        for p in root.rglob("*.md"):
+            rel = p.relative_to(root)
+            if rel.name.lower() == "index.md":
+                continue
+            if rel.parts == ("schema.md",):
+                continue
+            candidates.append(p)
+        paths = sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True)[:40]
+        for path in paths:
+            try:
+                raw = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            norm_o = MemoryStore._normalize_wiki_body_for_dedup(raw)
+            if len(norm_o) < 32:
+                continue
+            # Avoid comparing a short new entry to a long accumulated category page.
+            if len(norm_o) > max(3500, len(norm_new) * 12):
+                continue
+            ratio = difflib.SequenceMatcher(None, norm_new, norm_o).ratio()
+            if ratio >= similarity_threshold:
+                return True
+        return False
+
+    def wiki_archive_remember_success(self, transcript_sha256: str, body: str) -> None:
+        """Record transcript and body fingerprints after a successful wiki-archive write."""
+        data = self._load_wiki_archive_dedup()
+        ts: list[str] = data.setdefault("transcript_sha256", [])
+        if transcript_sha256 not in ts:
+            ts.append(transcript_sha256)
+        while len(ts) > self._WIKI_ARCHIVE_DEDUP_CAP:
+            ts.pop(0)
+
+        norm = MemoryStore._normalize_wiki_body_for_dedup(body)
+        bh = hashlib.sha256(norm.encode("utf-8")).hexdigest()
+        bs: list[str] = data.setdefault("body_sha256", [])
+        if bh not in bs:
+            bs.append(bh)
+        while len(bs) > self._WIKI_ARCHIVE_DEDUP_CAP:
+            bs.pop(0)
+
+        self._save_wiki_archive_dedup(data)
+
+    def wiki_archive_remember_transcript_only(self, transcript_sha256: str) -> None:
+        """Remember transcript hash when skipping duplicate body so the same window is not reprocessed."""
+        data = self._load_wiki_archive_dedup()
+        ts: list[str] = data.setdefault("transcript_sha256", [])
+        if transcript_sha256 not in ts:
+            ts.append(transcript_sha256)
+        while len(ts) > self._WIKI_ARCHIVE_DEDUP_CAP:
+            ts.pop(0)
+        self._save_wiki_archive_dedup(data)
+
+    def _wiki_ingest_state_path(self) -> Path:
+        return self.memory_dir / self._WIKI_INGEST_STATE_FILE
+
+    def _load_wiki_ingest_state(self) -> dict[str, Any]:
+        p = self._wiki_ingest_state_path()
+        if not p.is_file():
+            return {"last_success_bundle_sha256": "", "body_sha256": []}
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {"last_success_bundle_sha256": "", "body_sha256": []}
+        if not isinstance(data, dict):
+            return {"last_success_bundle_sha256": "", "body_sha256": []}
+        data.setdefault("last_success_bundle_sha256", "")
+        data.setdefault("body_sha256", [])
+        return data
+
+    def _save_wiki_ingest_state(self, data: dict[str, Any]) -> None:
+        p = self._wiki_ingest_state_path()
+        p.write_text(json.dumps(data, ensure_ascii=False, indent=0) + "\n", encoding="utf-8")
+
+    def wiki_ingest_bundle_matches_last_success(self, bundle_sha256: str) -> bool:
+        """True when raw file bundle matches the last successful wiki-ingest."""
+        if not bundle_sha256:
+            return False
+        prev = str(self._load_wiki_ingest_state().get("last_success_bundle_sha256") or "")
+        return prev != "" and prev == bundle_sha256
+
+    def wiki_ingest_should_skip_duplicate_body(
+        self,
+        body: str,
+        *,
+        similarity_threshold: float = 0.94,
+    ) -> bool:
+        """True when ingest JSON output matches a prior ingest or existing wiki (hash or high similarity)."""
+        norm = MemoryStore._normalize_wiki_body_for_dedup(body)
+        if len(norm) < 32:
+            return False
+        digest = hashlib.sha256(norm.encode("utf-8")).hexdigest()
+        if digest in self._load_wiki_ingest_state().get("body_sha256", []):
+            return True
+        return self._wiki_archive_near_duplicate_file(norm, similarity_threshold=similarity_threshold)
+
+    def wiki_ingest_remember_success(self, bundle_sha256: str, body: str) -> None:
+        """Record bundle + body fingerprints after a successful wiki-ingest write."""
+        data = self._load_wiki_ingest_state()
+        data["last_success_bundle_sha256"] = bundle_sha256
+        norm = MemoryStore._normalize_wiki_body_for_dedup(body)
+        bh = hashlib.sha256(norm.encode("utf-8")).hexdigest()
+        bs: list[str] = data.setdefault("body_sha256", [])
+        if bh not in bs:
+            bs.append(bh)
+        while len(bs) > self._WIKI_INGEST_BODY_HASH_CAP:
+            bs.pop(0)
+        self._save_wiki_ingest_state(data)
+
+    def wiki_ingest_remember_duplicate_body_skip(self, bundle_sha256: str, body: str) -> None:
+        """Record state when skipping ingest because output is a near-duplicate."""
+        data = self._load_wiki_ingest_state()
+        data["last_success_bundle_sha256"] = bundle_sha256
+        norm = MemoryStore._normalize_wiki_body_for_dedup(body)
+        bh = hashlib.sha256(norm.encode("utf-8")).hexdigest()
+        bs: list[str] = data.setdefault("body_sha256", [])
+        if bh not in bs:
+            bs.append(bh)
+        while len(bs) > self._WIKI_INGEST_BODY_HASH_CAP:
+            bs.pop(0)
+        self._save_wiki_ingest_state(data)
 
     def raw_archive(self, messages: list[dict]) -> None:
         """Fallback: dump raw messages to history.jsonl without LLM summarization."""
@@ -657,12 +1484,18 @@ class Dream:
         current_memory = self.store.read_memory() or "(empty)"
         current_soul = self.store.read_soul() or "(empty)"
         current_user = self.store.read_user() or "(empty)"
-
+        wiki_snapshot = self.store.get_wiki_context(max_total_chars=32_000)
+        wiki_block = (
+            f"\n\n## Wiki (`{MemoryStore.WIKI_DIR}/`) — {len(wiki_snapshot)} chars\n{wiki_snapshot}"
+            if wiki_snapshot
+            else ""
+        )
         file_context = (
             f"## Current Date\n{current_date}\n\n"
             f"## Current MEMORY.md ({len(current_memory)} chars)\n{current_memory}\n\n"
             f"## Current SOUL.md ({len(current_soul)} chars)\n{current_soul}\n\n"
             f"## Current USER.md ({len(current_user)} chars)\n{current_user}"
+            f"{wiki_block}"
         )
 
         # Phase 1: Analyze (no skills list — dedup is Phase 2's job)
@@ -762,5 +1595,11 @@ class Dream:
             sha = self.store.git.auto_commit(f"dream: {ts}, {len(changelog)} change(s)")
             if sha:
                 logger.info("Dream commit: {}", sha)
+
+        if changelog:
+            dream_summary = f"{len(changelog)} change(s): " + "; ".join(changelog[:6])
+            if len(changelog) > 6:
+                dream_summary += " …"
+            self.store.append_wiki_log_line("dream", dream_summary)
 
         return True

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -593,6 +593,10 @@ def serve(
         unified_session=runtime_config.agents.defaults.unified_session,
         disabled_skills=runtime_config.agents.defaults.disabled_skills,
         session_ttl_minutes=runtime_config.agents.defaults.session_ttl_minutes,
+        auto_wiki_archive_at_context_fraction=runtime_config.agents.defaults.auto_wiki_archive_at_context_fraction,
+        auto_wiki_ingest_interval_minutes=runtime_config.agents.defaults.auto_wiki_ingest_interval_minutes,
+        auto_wiki_lint_interval_minutes=runtime_config.agents.defaults.auto_wiki_lint_interval_minutes,
+        auto_wiki_lint_after_wiki_write=runtime_config.agents.defaults.auto_wiki_lint_after_wiki_write,
     )
 
     model_name = runtime_config.agents.defaults.model
@@ -687,6 +691,10 @@ def gateway(
         unified_session=config.agents.defaults.unified_session,
         disabled_skills=config.agents.defaults.disabled_skills,
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
+        auto_wiki_archive_at_context_fraction=config.agents.defaults.auto_wiki_archive_at_context_fraction,
+        auto_wiki_ingest_interval_minutes=config.agents.defaults.auto_wiki_ingest_interval_minutes,
+        auto_wiki_lint_interval_minutes=config.agents.defaults.auto_wiki_lint_interval_minutes,
+        auto_wiki_lint_after_wiki_write=config.agents.defaults.auto_wiki_lint_after_wiki_write,
     )
 
     # Set cron callback (needs agent)
@@ -921,6 +929,10 @@ def agent(
         unified_session=config.agents.defaults.unified_session,
         disabled_skills=config.agents.defaults.disabled_skills,
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
+        auto_wiki_archive_at_context_fraction=config.agents.defaults.auto_wiki_archive_at_context_fraction,
+        auto_wiki_ingest_interval_minutes=config.agents.defaults.auto_wiki_ingest_interval_minutes,
+        auto_wiki_lint_interval_minutes=config.agents.defaults.auto_wiki_lint_interval_minutes,
+        auto_wiki_lint_after_wiki_write=config.agents.defaults.auto_wiki_lint_after_wiki_write,
     )
     restart_notice = consume_restart_notice_from_env()
     if restart_notice and should_show_cli_restart_notice(restart_notice, session_id):

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+from datetime import datetime
 
 from nanobot import __version__
+from nanobot.agent.memory import MemoryStore
 from nanobot.bus.events import OutboundMessage
 from nanobot.command.router import CommandContext, CommandRouter
 from nanobot.utils.helpers import build_status_content
@@ -87,6 +89,24 @@ async def cmd_status(ctx: CommandContext) -> OutboundMessage:
         ),
         metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
     )
+
+
+async def cmd_wiki_archive(ctx: CommandContext) -> OutboundMessage:
+    """Summarize the current session window into ``wiki/``, then replace history with the index."""
+    from nanobot.command.wiki_archive import run_wiki_archive_for_session
+
+    loop = ctx.loop
+    msg = ctx.msg
+    session = ctx.session or loop.sessions.get_or_create(ctx.key)
+    out = await run_wiki_archive_for_session(
+        loop,
+        session,
+        msg,
+        append_transcript_messages=None,
+        brief_success=False,
+    )
+    assert out is not None
+    return out
 
 
 async def cmd_new(ctx: CommandContext) -> OutboundMessage:
@@ -303,6 +323,135 @@ async def cmd_dream_restore(ctx: CommandContext) -> OutboundMessage:
     )
 
 
+async def cmd_wiki_ingest(ctx: CommandContext) -> OutboundMessage:
+    """Read text files from ``raw/`` and merge structured notes into ``wiki/``."""
+    from nanobot.command.wiki_ingest import run_wiki_ingest
+    from nanobot.llm_wiki.automation import maybe_lint_after_wiki_write
+    from nanobot.llm_wiki.raw import ensure_raw_directories, list_raw_source_files
+
+    loop = ctx.loop
+    msg = ctx.msg
+    store = loop.consolidator.store
+    ws = store.workspace
+    ensure_raw_directories(ws)
+    paths = list_raw_source_files(ws)
+    raw_arg = (ctx.args or "").strip()
+    parts = raw_arg.split(None, 1)
+    force = bool(parts and parts[0].lower() in ("force", "--force"))
+    arg = parts[1].strip() if force and len(parts) > 1 else ("" if force else raw_arg)
+    if arg:
+        paths = [p for p in paths if arg.lower() in p.lower()]
+    if not paths:
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content=(
+                "No ingestable text files (.md/.txt, etc.) under `raw/sources/`, `raw/articles/`, "
+                "`raw/papers/`, or `raw/transcripts/`. "
+                "Add sources there (immutable), or use `/wiki-ingest <keyword>` to filter by path."
+            ),
+            metadata=dict(msg.metadata or {}),
+        )
+
+    result = await run_wiki_ingest(loop, workspace=ws, path_filter=arg, force_refresh=force)
+    if not result.ok:
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content=result.message,
+            metadata=dict(msg.metadata or {}),
+        )
+    maybe_lint_after_wiki_write(
+        store,
+        enabled=getattr(loop, "auto_wiki_lint_after_wiki_write", False),
+        source="wiki-ingest",
+    )
+    return OutboundMessage(
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=result.message,
+        metadata=dict(msg.metadata or {}),
+    )
+
+
+async def cmd_wiki_lint(ctx: CommandContext) -> OutboundMessage:
+    """Scan wiki for broken wikilinks and orphan pages."""
+    from nanobot.llm_wiki.lint import format_wiki_lint_message, run_wiki_lint
+
+    store = ctx.loop.consolidator.store
+    report = run_wiki_lint(store.workspace)
+    text = format_wiki_lint_message(report)
+    summary = f"{len(report.dead_links)} dead link(s), {len(report.orphan_pages)} orphan(s)"
+    store.append_wiki_log_line("wiki-lint", summary)
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=text,
+        metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
+    )
+
+
+async def cmd_wiki_save_answer(ctx: CommandContext) -> OutboundMessage:
+    """Save the last assistant message to ``wiki/queries/<slug>.md``."""
+    from nanobot.utils.helpers import strip_think
+
+    loop = ctx.loop
+    msg = ctx.msg
+    session = ctx.session or loop.sessions.get_or_create(ctx.key)
+    store = loop.consolidator.store
+
+    assistant_text = ""
+    for m in reversed(session.messages or []):
+        if m.get("role") != "assistant":
+            continue
+        raw = m.get("content")
+        if isinstance(raw, str) and raw.strip():
+            assistant_text = strip_think(raw).strip()
+            break
+    if not assistant_text:
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="No previous assistant reply to save.",
+            metadata=dict(msg.metadata or {}),
+        )
+
+    arg = (ctx.args or "").strip()
+    if arg:
+        safe = MemoryStore.normalize_wiki_category_slug(arg)
+    else:
+        safe = f"answer-{datetime.now().strftime('%Y%m%d-%H%M')}"
+
+    qdir = store.wiki_dir / "queries"
+    qdir.mkdir(parents=True, exist_ok=True)
+    path = qdir / f"{safe}.md"
+    when = datetime.now().strftime("%Y-%m-%d %H:%M")
+    new_section = f"## {when}\n\n{assistant_text}\n"
+    if path.is_file():
+        existing = path.read_text(encoding="utf-8", errors="replace").rstrip()
+        content = existing + "\n\n---\n\n" + new_section
+    else:
+        content = (
+            "# Saved answer\n\n"
+            "> Captured with `/wiki-save-answer`.\n\n"
+            + new_section
+        )
+    path.write_text(content, encoding="utf-8")
+
+    rel = f"queries/{safe}.md"
+    store.append_wiki_log_line("wiki-save-answer", rel, when=when)
+    git = store.git
+    if git.is_initialized():
+        git.auto_commit(f"wiki-save-answer: {safe}")
+
+    return OutboundMessage(
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=f"Saved to `wiki/{rel}`.",
+        metadata=dict(msg.metadata or {}),
+    )
+
+
 async def cmd_help(ctx: CommandContext) -> OutboundMessage:
     """Return available slash commands."""
     return OutboundMessage(
@@ -324,6 +473,10 @@ def build_help_text() -> str:
         "/dream — Manually trigger Dream consolidation",
         "/dream-log — Show what the last Dream changed",
         "/dream-restore — Revert memory to a previous state",
+        "/wiki-archive — Write the current session to wiki and replace session context with the index",
+        "/wiki-ingest — Import text from raw/sources/ into wiki (`<keyword>` path filter; `force` re-runs if raw unchanged)",
+        "/wiki-lint — Report broken [[wikilinks]] and orphan pages in wiki/",
+        "/wiki-save-answer — Save the last assistant reply under wiki/queries/ (optional `/wiki-save-answer <slug>`)",
         "/help — Show available commands",
     ]
     return "\n".join(lines)
@@ -341,4 +494,10 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.prefix("/dream-log ", cmd_dream_log)
     router.exact("/dream-restore", cmd_dream_restore)
     router.prefix("/dream-restore ", cmd_dream_restore)
+    router.exact("/wiki-archive", cmd_wiki_archive)
+    router.exact("/wiki-ingest", cmd_wiki_ingest)
+    router.prefix("/wiki-ingest ", cmd_wiki_ingest)
+    router.exact("/wiki-lint", cmd_wiki_lint)
+    router.exact("/wiki-save-answer", cmd_wiki_save_answer)
+    router.prefix("/wiki-save-answer ", cmd_wiki_save_answer)
     router.exact("/help", cmd_help)

--- a/nanobot/command/wiki_archive.py
+++ b/nanobot/command/wiki_archive.py
@@ -1,0 +1,208 @@
+"""Shared wiki-archive execution (manual /wiki-archive and auto threshold trigger)."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.llm_wiki import read_schema
+from nanobot.llm_wiki.automation import maybe_lint_after_wiki_write
+
+if TYPE_CHECKING:
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.session.manager import Session
+
+
+async def run_wiki_archive_for_session(
+    loop: AgentLoop,
+    session: Session,
+    msg: InboundMessage,
+    *,
+    append_transcript_messages: list[dict[str, Any]] | None = None,
+    brief_success: bool = False,
+    estimated_tokens: int | None = None,
+    threshold_tokens: int | None = None,
+) -> OutboundMessage | None:
+    """Archive unconsolidated session messages into ``wiki/`` and reset session to the index.
+
+    *append_transcript_messages* — optional extra messages (e.g. the inbound user turn not yet
+    persisted) included in the transcript hash and model prompt only.
+
+    Returns *None* only if there is nothing to archive (empty chunk and no append). Otherwise
+    returns an :class:`OutboundMessage` (success, skip, or error).
+    """
+    from nanobot.utils.helpers import strip_think
+    from nanobot.utils.prompt_templates import render_template
+
+    store = loop.consolidator.store
+
+    chunk = session.messages[session.last_consolidated :]
+    extra = append_transcript_messages or []
+    effective = list(chunk) + list(extra)
+    if not effective:
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content=(
+                "No messages to archive in the current window (older content may already be in "
+                "memory/history.jsonl, or the session is empty)."
+            ),
+            metadata=dict(msg.metadata or {}),
+        )
+
+    transcript_raw = MemoryStore.format_messages_for_archive(effective)
+    if not transcript_raw.strip():
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="No substantive conversation content to archive.",
+            metadata=dict(msg.metadata or {}),
+        )
+
+    transcript_sha256 = hashlib.sha256(transcript_raw.encode("utf-8")).hexdigest()
+    if store.wiki_archive_transcript_already_archived(transcript_sha256):
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="This session matches content already archived; skipped duplicate archive.",
+            metadata=dict(msg.metadata or {}),
+        )
+
+    transcript = transcript_raw
+    max_chars = 120_000
+    if len(transcript) > max_chars:
+        half = max_chars // 2
+        transcript = (
+            transcript[:half]
+            + "\n\n… *[transcript truncated for archiving]*\n\n"
+            + transcript[-half:]
+        )
+
+    pre_notice = (
+        "Auto wiki-archive: context threshold reached. Starting archive (calling the model). "
+        "This may take a moment."
+        if brief_success
+        else "Starting wiki archive (calling the model). This may take a moment."
+    )
+    meta = {**dict(msg.metadata or {}), "render_as": "text"}
+    await loop.bus.publish_outbound(
+        OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content=pre_notice,
+            metadata=meta,
+        )
+    )
+
+    try:
+        wiki_schema = read_schema(store.workspace).strip()
+        response = await loop.provider.chat_with_retry(
+            model=loop.model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": render_template(
+                        "agent/wiki_archive.md",
+                        strip=True,
+                        wiki_schema=wiki_schema,
+                    ),
+                },
+                {"role": "user", "content": f"## Transcript\n\n{transcript}"},
+            ],
+            tools=None,
+            tool_choice=None,
+        )
+    except Exception as e:
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content=f"Archive failed: {e}",
+            metadata=dict(msg.metadata or {}),
+        )
+
+    body = strip_think(response.content or "").strip()
+    if body.startswith("```"):
+        lines = body.split("\n")
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        body = "\n".join(lines).strip()
+
+    if store.wiki_archive_should_skip_duplicate_body(body):
+        store.wiki_archive_remember_transcript_only(transcript_sha256)
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="Generated result is too similar to an existing wiki archive; skipped write.",
+            metadata=dict(msg.metadata or {}),
+        )
+
+    entries = MemoryStore.filter_archivable_wiki_entries(
+        MemoryStore.parse_wiki_archive_entries(body),
+    )
+    if not entries:
+        return OutboundMessage(
+            channel=msg.channel,
+            chat_id=msg.chat_id,
+            content="Nothing to archive: no substantive content to save (empty session or nothing to distill).",
+            metadata=dict(msg.metadata or {}),
+        )
+
+    when = datetime.now().strftime("%Y-%m-%d %H:%M")
+    written_fnames = store.merge_wiki_entries_from_archive(entries, when)
+    slug_set = {MemoryStore.normalize_wiki_category_slug(sl) for sl, _, _, _ in entries}
+
+    git = store.git
+    if git.is_initialized():
+        git.auto_commit(f"wiki-archive: {', '.join(sorted(slug_set))}")
+
+    store.wiki_archive_remember_success(transcript_sha256, body)
+
+    log_summary = f"{len(written_fnames)} file(s): {', '.join(sorted(written_fnames))}"
+    if brief_success:
+        log_summary = f"auto threshold: {log_summary}"
+    store.append_wiki_log_line("wiki-archive", log_summary, when=when)
+
+    maybe_lint_after_wiki_write(
+        store,
+        enabled=getattr(loop, "auto_wiki_lint_after_wiki_write", False),
+        source="wiki-archive",
+    )
+
+    files_list = ", ".join(f"`wiki/{f}`" for f in written_fnames)
+    index_text = store.read_wiki_index()
+    replacement = (
+        f"[Session context archived to {files_list} — prior messages cleared.]\n\n"
+        "Below is the full **wiki/index.md** as the anchor for continuing this conversation:\n\n"
+        f"{index_text if index_text else '*(index empty)*'}"
+    )
+
+    n = len(effective)
+    session.clear()
+    session.add_message("user", replacement)
+    loop.sessions.save(session)
+    loop.sessions.invalidate(session.key)
+
+    n_topics = len(entries)
+    if brief_success:
+        est = estimated_tokens if estimated_tokens is not None else 0
+        thr = threshold_tokens if threshold_tokens is not None else 0
+        content = (
+            f"[Auto wiki-archive] Estimated prompt ~{est} tokens (≥ threshold ~{thr} tokens). "
+            f"Wrote {n_topics} topic(s) to {files_list}. Session replaced with wiki index."
+        )
+    else:
+        content = (
+            f"Wrote {n_topics} topic(s) from {n} message(s) to {files_list} and updated the index; "
+            "session replaced with the full index (one placeholder message)."
+        )
+    return OutboundMessage(
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content=content,
+        metadata=dict(msg.metadata or {}),
+    )

--- a/nanobot/command/wiki_ingest.py
+++ b/nanobot/command/wiki_ingest.py
@@ -1,0 +1,176 @@
+"""Shared wiki-ingest execution (manual `/wiki-ingest` and scheduled automation)."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.llm_wiki import read_schema
+from nanobot.llm_wiki.catalog import build_wiki_existing_pages_catalog
+from nanobot.utils.helpers import strip_think
+from nanobot.utils.prompt_templates import render_template
+
+if TYPE_CHECKING:
+    from nanobot.agent.loop import AgentLoop
+
+
+@dataclass
+class WikiIngestResult:
+    """Outcome of a wiki-ingest run (model may be skipped when there is nothing to read)."""
+
+    ok: bool
+    message: str
+    written_paths: list[str]
+    called_model: bool
+
+
+def compute_wiki_ingest_bundle_sha256(workspace: Path, rel_paths: list[str]) -> str:
+    """Stable hash of sorted ``path\\tsha256(content)`` lines for selected raw files."""
+    lines: list[str] = []
+    for rel in sorted(rel_paths):
+        p = workspace / rel
+        try:
+            digest = hashlib.sha256(p.read_bytes()).hexdigest()
+        except OSError:
+            digest = hashlib.sha256(b"").hexdigest()
+        lines.append(f"{rel}\t{digest}")
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+async def run_wiki_ingest(
+    loop: AgentLoop,
+    *,
+    workspace: Path,
+    path_filter: str = "",
+    force_refresh: bool = False,
+) -> WikiIngestResult:
+    """Read text from ``raw/`` roots, call the model, merge into ``wiki/``.
+
+    *path_filter* — if non-empty, only include source paths whose relative path contains
+    this substring (case-insensitive).
+
+    *force_refresh* — when false (default), skip the model call if the raw bundle matches
+    the last successful ingest; use true to always run (e.g. ``/wiki-ingest force``).
+    """
+    from nanobot.llm_wiki.raw import ensure_raw_directories, list_raw_source_files
+
+    store = loop.consolidator.store
+    ensure_raw_directories(workspace)
+    paths = list_raw_source_files(workspace)
+    pf = path_filter.strip()
+    if pf:
+        paths = [p for p in paths if pf.lower() in p.lower()]
+    if not paths:
+        return WikiIngestResult(
+            ok=True,
+            message="no raw text files to ingest",
+            written_paths=[],
+            called_model=False,
+        )
+
+    max_files, max_chars = 12, 100_000
+    bundle_paths = paths[:max_files]
+    bundle_sha = compute_wiki_ingest_bundle_sha256(workspace, bundle_paths)
+    if not force_refresh and store.wiki_ingest_bundle_matches_last_success(bundle_sha):
+        return WikiIngestResult(
+            ok=True,
+            message=(
+                "wiki-ingest: raw bundle unchanged since last successful ingest; skipped. "
+                "Use `/wiki-ingest force` to run anyway."
+            ),
+            written_paths=[],
+            called_model=False,
+        )
+
+    chunks: list[str] = []
+    for rel in bundle_paths:
+        p = workspace / rel
+        try:
+            body = p.read_text(encoding="utf-8", errors="replace")
+        except OSError as e:
+            chunks.append(f"## {rel}\n\n*(unreadable: {e})*")
+            continue
+        if len(body) > max_chars:
+            body = body[:max_chars] + "\n\n… *(truncated)*\n"
+        chunks.append(f"## {rel}\n\n{body}")
+    bundle = "\n\n---\n\n".join(chunks)
+
+    wiki_schema = read_schema(workspace).strip()
+    wiki_catalog = build_wiki_existing_pages_catalog(workspace, max_chars=6000)
+    try:
+        response = await loop.provider.chat_with_retry(
+            model=loop.model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": render_template(
+                        "agent/wiki_ingest.md",
+                        strip=True,
+                        wiki_schema=wiki_schema,
+                        wiki_catalog=wiki_catalog,
+                    ),
+                },
+                {"role": "user", "content": f"## Raw files\n\n{bundle}"},
+            ],
+            tools=None,
+            tool_choice=None,
+        )
+    except Exception as e:
+        return WikiIngestResult(
+            ok=False,
+            message=f"wiki-ingest: model call failed: {e}",
+            written_paths=[],
+            called_model=True,
+        )
+
+    body = strip_think(response.content or "").strip()
+    if body.startswith("```"):
+        lines = body.split("\n")
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        body = "\n".join(lines).strip()
+
+    if store.wiki_ingest_should_skip_duplicate_body(body):
+        store.wiki_ingest_remember_duplicate_body_skip(bundle_sha, body)
+        return WikiIngestResult(
+            ok=True,
+            message="wiki-ingest: model output matches a previous ingest or existing wiki; skipped duplicate write.",
+            written_paths=[],
+            called_model=True,
+        )
+
+    entries = MemoryStore.filter_archivable_wiki_entries(
+        MemoryStore.parse_wiki_archive_entries(body),
+    )
+    if not entries:
+        return WikiIngestResult(
+            ok=False,
+            message="wiki-ingest: the model did not return any writable entries.",
+            written_paths=[],
+            called_model=True,
+        )
+
+    when = datetime.now().strftime("%Y-%m-%d %H:%M")
+    written_fnames = store.merge_wiki_entries_from_archive(entries, when)
+    store.wiki_ingest_remember_success(bundle_sha, body)
+    slug_set = {MemoryStore.normalize_wiki_category_slug(sl) for sl, _, _, _ in entries}
+    log_summary = f"{len(written_fnames)} page(s): {', '.join(sorted(written_fnames))}"
+    store.append_wiki_log_line("wiki-ingest", log_summary, when=when)
+
+    git = store.git
+    if git.is_initialized():
+        git.auto_commit(f"wiki-ingest: {', '.join(sorted(slug_set))}")
+
+    files_list = ", ".join(f"`wiki/{f}`" for f in written_fnames)
+    return WikiIngestResult(
+        ok=True,
+        message=f"Ingested {len(written_fnames)} wiki page(s) from raw/ text sources: {files_list}.",
+        written_paths=list(written_fnames),
+        called_model=True,
+    )

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
 
@@ -85,6 +85,53 @@ class AgentDefaults(Base):
         serialization_alias="idleCompactAfterMinutes",
     )  # Auto-compact idle threshold in minutes (0 = disabled)
     dream: DreamConfig = Field(default_factory=DreamConfig)
+    auto_wiki_archive_at_context_fraction: float | None = Field(
+        default=0.8,
+        description=(
+            "If set (e.g. 0.8), run wiki-archive automatically when the estimated prompt tokens "
+            "(including the current inbound message) reach this fraction of context_window_tokens. "
+            "None disables automatic wiki-archive."
+        ),
+    )
+    auto_wiki_ingest_interval_minutes: float | None = Field(
+        default=None,
+        description=(
+            "When set (e.g. 15), the gateway polls raw/ for changes; after a fingerprint change, "
+            "runs wiki-ingest at most once per this many minutes. None disables auto ingest."
+        ),
+    )
+    auto_wiki_lint_interval_minutes: float | None = Field(
+        default=None,
+        description=(
+            "When set (e.g. 1440), run wiki-lint on this interval and append wiki/log.md if issues "
+            "are found. None disables scheduled lint."
+        ),
+    )
+    auto_wiki_lint_after_wiki_write: bool = Field(
+        default=False,
+        description=(
+            "If true, run a lightweight wiki-lint after successful wiki-archive, wiki-ingest "
+            "(manual or auto), and append wiki/log.md only when broken links or orphans exist."
+        ),
+    )
+
+    @field_validator("auto_wiki_archive_at_context_fraction")
+    @classmethod
+    def _auto_wiki_frac_in_range(cls, v: float | None) -> float | None:
+        if v is None:
+            return None
+        if not (0.0 < v <= 1.0):
+            raise ValueError("auto_wiki_archive_at_context_fraction must be in (0, 1] or None")
+        return v
+
+    @field_validator("auto_wiki_ingest_interval_minutes", "auto_wiki_lint_interval_minutes")
+    @classmethod
+    def _auto_wiki_interval_positive(cls, v: float | None) -> float | None:
+        if v is None:
+            return None
+        if v <= 0:
+            raise ValueError("wiki automation intervals must be > 0 or None")
+        return v
 
 
 class AgentsConfig(Base):

--- a/nanobot/llm_wiki/__init__.py
+++ b/nanobot/llm_wiki/__init__.py
@@ -1,0 +1,89 @@
+"""LLM Wiki — standalone filesystem helpers (schema + wiki context assembly).
+
+This package encodes the Karpathy / llm-wiki layout: optional structural rules in
+``wiki/schema.md``, topic pages under ``wiki/``, ``index.md`` as catalog, optional
+layered ``raw/`` text roots for immutable inputs. It does not depend on
+:class:`~nanobot.agent.memory.MemoryStore`; callers pass a workspace
+:class:`~pathlib.Path`.
+
+Public API
+----------
+
+- :data:`WIKI_DIR_NAME`, :data:`SCHEMA_FILENAME` — path segments
+- :func:`wiki_schema_rel` — relative path string for the schema file
+- :func:`read_schema` — load ``wiki/schema.md``
+- :func:`list_wiki_page_paths` — ordered list of wiki markdown paths
+- :func:`ensure_standard_wiki_dirs` — create ``entities/``, ``concepts/``, ``sources/``, ``comparisons/``
+- :func:`build_wiki_context` — bounded prompt text (schema → index → recent ``log.md`` tail → other pages; optional relevance ranking)
+- Raw helpers in :mod:`nanobot.llm_wiki.raw`
+- Lint in :mod:`nanobot.llm_wiki.lint`
+- :func:`build_wiki_existing_pages_catalog` — compact page list for prompts
+"""
+
+from nanobot.llm_wiki.catalog import (
+    build_wiki_existing_pages_catalog,
+    extract_markdown_h1,
+)
+from nanobot.llm_wiki.context import (
+    DEFAULT_INDEX_CONTEXT_CAP,
+    DEFAULT_LOG_CONTEXT_CAP,
+    DEFAULT_LOG_TAIL_LINES,
+    DEFAULT_MAX_TOTAL_CHARS,
+    DEFAULT_SCHEMA_CONTEXT_CAP,
+    INDEX_FILENAME,
+    LOG_FILENAME,
+    SCHEMA_FILENAME,
+    STANDARD_WIKI_SUBDIRS,
+    WIKI_DIR_NAME,
+    build_wiki_context,
+    ensure_standard_wiki_dirs,
+    list_wiki_page_paths,
+    read_schema,
+    wiki_schema_rel,
+)
+from nanobot.llm_wiki.lint import WikiLintReport, format_wiki_lint_message, run_wiki_lint
+from nanobot.llm_wiki.raw import (
+    RAW_ARTICLES_REL,
+    RAW_ASSETS_REL,
+    RAW_DIR_NAME,
+    RAW_PAPERS_REL,
+    RAW_SOURCES_REL,
+    RAW_TEXT_SOURCE_RELS,
+    RAW_TRANSCRIPTS_REL,
+    RAW_SOURCE_TEXT_EXTENSIONS,
+    ensure_raw_directories,
+    list_raw_source_files,
+)
+
+__all__ = [
+    "build_wiki_existing_pages_catalog",
+    "DEFAULT_INDEX_CONTEXT_CAP",
+    "DEFAULT_LOG_CONTEXT_CAP",
+    "DEFAULT_LOG_TAIL_LINES",
+    "DEFAULT_MAX_TOTAL_CHARS",
+    "DEFAULT_SCHEMA_CONTEXT_CAP",
+    "INDEX_FILENAME",
+    "LOG_FILENAME",
+    "RAW_ARTICLES_REL",
+    "RAW_ASSETS_REL",
+    "RAW_DIR_NAME",
+    "RAW_PAPERS_REL",
+    "RAW_SOURCES_REL",
+    "RAW_TEXT_SOURCE_RELS",
+    "RAW_TRANSCRIPTS_REL",
+    "RAW_SOURCE_TEXT_EXTENSIONS",
+    "SCHEMA_FILENAME",
+    "STANDARD_WIKI_SUBDIRS",
+    "WIKI_DIR_NAME",
+    "WikiLintReport",
+    "build_wiki_context",
+    "extract_markdown_h1",
+    "ensure_raw_directories",
+    "ensure_standard_wiki_dirs",
+    "format_wiki_lint_message",
+    "list_raw_source_files",
+    "list_wiki_page_paths",
+    "read_schema",
+    "run_wiki_lint",
+    "wiki_schema_rel",
+]

--- a/nanobot/llm_wiki/automation.py
+++ b/nanobot/llm_wiki/automation.py
@@ -1,0 +1,157 @@
+"""Wiki automation: fingerprints, scheduled ingest/lint, optional lint after wiki writes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.llm_wiki.lint import format_wiki_lint_message, run_wiki_lint
+from nanobot.llm_wiki.raw import list_raw_source_files
+
+if TYPE_CHECKING:
+    from nanobot.agent.loop import AgentLoop
+
+_STATE_FILENAME = "wiki_automation.json"
+
+
+def wiki_automation_state_path(workspace: Path) -> Path:
+    return workspace / "memory" / _STATE_FILENAME
+
+
+def compute_raw_fingerprint(workspace: Path) -> str:
+    """Stable hash of raw text source paths + mtime + size (sorted)."""
+    paths = list_raw_source_files(workspace)
+    lines: list[str] = []
+    for rel in paths:
+        p = workspace / rel
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        lines.append(f"{rel}\t{st.st_mtime_ns}\t{st.st_size}\n")
+    raw = "".join(lines).encode("utf-8", errors="replace")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _load_state(workspace: Path) -> dict[str, Any]:
+    p = wiki_automation_state_path(workspace)
+    if not p.is_file():
+        return {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_state(workspace: Path, data: dict[str, Any]) -> None:
+    p = wiki_automation_state_path(workspace)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def maybe_lint_after_wiki_write(
+    store: MemoryStore,
+    *,
+    enabled: bool,
+    source: str = "after-write",
+) -> None:
+    """Run wiki lint synchronously; append ``wiki/log.md`` only when there are issues."""
+    if not enabled:
+        return
+    report = run_wiki_lint(store.workspace)
+    n_dead = len(report.dead_links)
+    n_orphan = len(report.orphan_pages)
+    if n_dead == 0 and n_orphan == 0:
+        logger.debug("wiki lint ({}): clean", source)
+        return
+    summary = f"{n_dead} dead link(s), {n_orphan} orphan(s)"
+    store.append_wiki_log_line(f"auto-wiki-lint-{source}", summary)
+    logger.info("wiki lint ({}): {}", source, summary)
+
+
+async def tick_wiki_automation(
+    loop: AgentLoop,
+    *,
+    ingest_interval_minutes: float | None,
+    lint_interval_minutes: float | None,
+) -> None:
+    """One scheduler tick: optional auto-ingest when raw changes, optional periodic lint."""
+    ws = loop.workspace
+    state = _load_state(ws)
+    now_m = time.monotonic()
+    now_utc = datetime.now(timezone.utc).isoformat()
+
+    fp = compute_raw_fingerprint(ws)
+    stored_fp = str(state.get("raw_fingerprint") or "")
+
+    # Baseline periodic lint timer so the first run waits a full interval after gateway start.
+    if (
+        lint_interval_minutes is not None
+        and lint_interval_minutes > 0
+        and "last_auto_lint_monotonic" not in state
+    ):
+        state["last_auto_lint_monotonic"] = now_m
+        _save_state(ws, state)
+
+    # --- auto ingest when fingerprint changed and cooldown elapsed ---
+    if ingest_interval_minutes is not None and ingest_interval_minutes > 0:
+        last_ingest_mono = float(state.get("last_auto_ingest_monotonic") or 0.0)
+        cooldown_s = max(60.0, float(ingest_interval_minutes) * 60.0)
+        cooldown_elapsed = last_ingest_mono <= 0 or (now_m - last_ingest_mono) >= cooldown_s
+        if fp != stored_fp and cooldown_elapsed:
+            from nanobot.command.wiki_ingest import run_wiki_ingest
+
+            logger.info("Auto wiki-ingest: raw fingerprint changed, running ingest")
+            result = await run_wiki_ingest(loop, workspace=ws, path_filter="")
+            state["last_auto_ingest_monotonic"] = now_m
+            state["last_auto_wiki_ingest_utc"] = now_utc
+            if result.ok and result.called_model:
+                state["raw_fingerprint"] = fp
+                _save_state(ws, state)
+                if getattr(loop, "auto_wiki_lint_after_wiki_write", False):
+                    maybe_lint_after_wiki_write(
+                        loop.consolidator.store,
+                        enabled=True,
+                        source="auto-ingest",
+                    )
+            elif result.ok and not result.called_model:
+                state["raw_fingerprint"] = fp
+                _save_state(ws, state)
+            elif "did not return any writable" in result.message:
+                # Nothing to distill — advance fingerprint to avoid tight retry loops
+                state["raw_fingerprint"] = fp
+                _save_state(ws, state)
+            else:
+                logger.warning("Auto wiki-ingest failed: {}", result.message)
+                _save_state(ws, state)
+
+    # --- periodic lint ---
+    if lint_interval_minutes is not None and lint_interval_minutes > 0:
+        last_lint_mono = float(state.get("last_auto_lint_monotonic") or 0.0)
+        lint_cooldown_s = max(60.0, float(lint_interval_minutes) * 60.0)
+        if last_lint_mono > 0 and (now_m - last_lint_mono) >= lint_cooldown_s:
+            report = run_wiki_lint(ws)
+            state["last_auto_lint_monotonic"] = now_m
+            state["last_auto_wiki_lint_utc"] = now_utc
+            _save_state(ws, state)
+            n_dead = len(report.dead_links)
+            n_orphan = len(report.orphan_pages)
+            if n_dead or n_orphan:
+                logger.info(
+                    "Scheduled wiki-lint: {}",
+                    format_wiki_lint_message(report, max_lines=10).replace("\n", " ")[:200],
+                )
+                loop.consolidator.store.append_wiki_log_line(
+                    "auto-wiki-lint-scheduled",
+                    f"{n_dead} dead link(s), {n_orphan} orphan(s)",
+                )
+            else:
+                logger.debug("Scheduled wiki-lint: no issues")

--- a/nanobot/llm_wiki/catalog.py
+++ b/nanobot/llm_wiki/catalog.py
@@ -1,0 +1,64 @@
+"""Compact listing of existing wiki pages for ingest/archive prompts."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from nanobot.llm_wiki.context import WIKI_DIR_NAME, list_wiki_page_paths
+
+_SKIP_NAMES = frozenset(
+    {
+        "index.md",
+        "schema.md",
+        "log.md",
+    },
+)
+
+
+def extract_markdown_h1(text: str) -> str:
+    """First markdown H1 heading text, or empty."""
+    for line in text.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        m = re.match(r"^#\s+(.+)$", s)
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
+def build_wiki_existing_pages_catalog(
+    workspace: Path,
+    *,
+    wiki_dir: str = WIKI_DIR_NAME,
+    max_chars: int = 6000,
+    per_file_read_cap: int = 8192,
+) -> str:
+    """Human-readable lines ``relative_path — H1`` for prompt injection (capped)."""
+    paths = list_wiki_page_paths(workspace, wiki_dir=wiki_dir)
+    lines: list[str] = []
+    total = 0
+    prefix = f"{wiki_dir}/"
+    for rel in paths:
+        if not rel.startswith(prefix):
+            continue
+        tail = rel[len(prefix) :]
+        if tail in _SKIP_NAMES or tail.startswith("queries/"):
+            continue
+        p = workspace / rel
+        try:
+            chunk = p.read_text(encoding="utf-8", errors="replace")[:per_file_read_cap]
+        except OSError:
+            continue
+        h1 = extract_markdown_h1(chunk)
+        label = h1 if h1 else "(no H1)"
+        line = f"- `{tail}` — {label}"
+        if total + len(line) + 1 > max_chars:
+            lines.append("… *(catalog truncated)*")
+            break
+        lines.append(line)
+        total += len(line) + 1
+    if not lines:
+        return "(No wiki pages yet besides index/schema.)"
+    return "\n".join(lines)

--- a/nanobot/llm_wiki/context.py
+++ b/nanobot/llm_wiki/context.py
@@ -1,0 +1,226 @@
+"""LLM Wiki filesystem layout: schema-first context assembly for prompt injection.
+
+Implements the Karpathy-style convention: optional ``wiki/schema.md`` defines
+structure; standard subdirs ``entities/``, ``concepts/``, ``sources/``,
+``comparisons/`` hold typed pages; other markdown may live at ``wiki/`` root.
+``index.md`` is the catalog entry.
+This module is intentionally free of MemoryStore / agent / channel imports.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WIKI_DIR_NAME = "wiki"
+SCHEMA_FILENAME = "schema.md"
+# Karpathy / llm-wiki style layout: typed pages under these subdirectories.
+STANDARD_WIKI_SUBDIRS: tuple[str, ...] = ("entities", "concepts", "sources", "comparisons")
+INDEX_FILENAME = "index.md"
+LOG_FILENAME = "log.md"
+DEFAULT_MAX_TOTAL_CHARS = 24_000
+DEFAULT_SCHEMA_CONTEXT_CAP = 12_000
+DEFAULT_INDEX_CONTEXT_CAP = 8_000
+DEFAULT_LOG_TAIL_LINES = 32
+DEFAULT_LOG_CONTEXT_CAP = 6_000
+
+
+def wiki_schema_rel(*, wiki_dir: str = WIKI_DIR_NAME) -> str:
+    """Relative posix path ``wiki/schema.md`` (or ``<wiki_dir>/schema.md``)."""
+    return f"{wiki_dir}/{SCHEMA_FILENAME}"
+
+
+def ensure_standard_wiki_dirs(workspace: Path, *, wiki_dir: str = WIKI_DIR_NAME) -> None:
+    """Create ``wiki/entities``, ``wiki/concepts``, ``wiki/sources``, ``wiki/comparisons`` if missing."""
+    base = workspace / wiki_dir
+    for name in STANDARD_WIKI_SUBDIRS:
+        (base / name).mkdir(parents=True, exist_ok=True)
+
+
+def read_schema(workspace: Path, *, wiki_dir: str = WIKI_DIR_NAME) -> str:
+    """Return ``wiki/schema.md`` text, or empty string if missing or unreadable."""
+    p = workspace / wiki_dir / SCHEMA_FILENAME
+    if not p.is_file():
+        return ""
+    try:
+        return p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def list_wiki_page_paths(workspace: Path, *, wiki_dir: str = WIKI_DIR_NAME) -> list[str]:
+    """Sorted relative paths ``wiki/**/*.md`` (posix). ``wiki/index.md`` first if present."""
+    root = workspace / wiki_dir
+    if not root.is_dir():
+        return []
+    paths = [
+        str(p.relative_to(workspace)).replace("\\", "/")
+        for p in root.rglob("*.md")
+    ]
+    paths.sort()
+    idx_key = f"{wiki_dir}/index.md"
+    if idx_key in paths:
+        paths.remove(idx_key)
+        paths.insert(0, idx_key)
+    return paths
+
+
+def _tokenize_for_relevance(text: str) -> set[str]:
+    return {x.lower() for x in re.findall(r"[a-zA-Z0-9\u4e00-\u9fff]+", text) if len(x) >= 2}
+
+
+def _score_wiki_page(rel: str, body: str, query_tokens: set[str]) -> int:
+    if not query_tokens:
+        return 0
+    hay = (rel + "\n" + body[:12000]).lower()
+    return sum(2 for t in query_tokens if t in hay)
+
+
+def _read_text_tail_lines(path: Path, *, max_lines: int) -> str:
+    """Return full text if *max_lines* covers the file, else the last *max_lines* lines."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    if not text.strip():
+        return ""
+    lines = text.splitlines()
+    if len(lines) <= max_lines:
+        return text
+    return "\n".join(lines[-max_lines:]) + "\n"
+
+
+def _append_capped_block(
+    parts: list[str],
+    *,
+    rel: str,
+    body: str,
+    remaining: int,
+    cap: int,
+) -> int:
+    """Append ``## rel`` + truncated *body*; return new *remaining* (best-effort)."""
+    header = f"## {rel}\n\n"
+    if remaining <= len(header) + 20:
+        return remaining
+    budget = min(cap, remaining - len(header))
+    if budget < 40:
+        return remaining
+    chunk = body
+    if len(chunk) > budget:
+        chunk = chunk[: max(0, budget - 40)].rstrip() + "\n\n… *(truncated)*"
+    block = header + chunk
+    parts.append(block)
+    return remaining - len(block)
+
+
+def build_wiki_context(
+    workspace: Path,
+    *,
+    wiki_dir: str = WIKI_DIR_NAME,
+    max_total_chars: int = DEFAULT_MAX_TOTAL_CHARS,
+    schema_context_cap: int = DEFAULT_SCHEMA_CONTEXT_CAP,
+    index_context_cap: int = DEFAULT_INDEX_CONTEXT_CAP,
+    log_tail_lines: int = DEFAULT_LOG_TAIL_LINES,
+    log_context_cap: int = DEFAULT_LOG_CONTEXT_CAP,
+    relevance_query: str | None = None,
+) -> str:
+    """Concatenate wiki markdown for system prompt injection (token-bounded).
+
+    Order (Karpathy / Hermes orientation):
+
+    1. ``wiki/schema.md`` when present (up to *schema_context_cap*).
+    2. ``wiki/index.md`` when present (up to *index_context_cap*).
+    3. Last *log_tail_lines* lines of ``wiki/log.md`` (up to *log_context_cap*), labeled as recent activity.
+    4. Remaining ``*.md`` files: *relevance_query* ranks by token overlap; otherwise sorted path order.
+       ``index.md`` and ``log.md`` are not duplicated in this step.
+    """
+    parts: list[str] = []
+    remaining = max_total_chars
+    schema_rel = wiki_schema_rel(wiki_dir=wiki_dir)
+    index_rel = f"{wiki_dir}/{INDEX_FILENAME}"
+    log_rel = f"{wiki_dir}/{LOG_FILENAME}"
+    schema_path = workspace / wiki_dir / SCHEMA_FILENAME
+    index_path = workspace / wiki_dir / INDEX_FILENAME
+    log_path = workspace / wiki_dir / LOG_FILENAME
+    query_tokens = _tokenize_for_relevance(relevance_query) if relevance_query else set()
+
+    if schema_path.is_file():
+        try:
+            body = schema_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            body = ""
+        if body.strip():
+            header = f"## {schema_rel}\n\n"
+            cap = min(schema_context_cap, max(0, remaining - len(header)))
+            if cap >= 40:
+                chunk = body
+                if len(chunk) > cap:
+                    chunk = chunk[: max(0, cap - 40)].rstrip() + "\n\n… *(truncated)*"
+                block = header + chunk
+                parts.append(block)
+                remaining -= len(block)
+
+    if index_path.is_file():
+        try:
+            idx_body = index_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            idx_body = ""
+        if idx_body.strip():
+            remaining = _append_capped_block(
+                parts,
+                rel=index_rel,
+                body=idx_body,
+                remaining=remaining,
+                cap=index_context_cap,
+            )
+
+    if log_path.is_file():
+        tail = _read_text_tail_lines(log_path, max_lines=log_tail_lines)
+        if tail.strip():
+            log_display_rel = f"{wiki_dir}/{LOG_FILENAME} (recent)"
+            remaining = _append_capped_block(
+                parts,
+                rel=log_display_rel,
+                body=tail,
+                remaining=remaining,
+                cap=log_context_cap,
+            )
+
+    skip_rests = {schema_rel, index_rel, log_rel}
+    page_paths = [p for p in list_wiki_page_paths(workspace, wiki_dir=wiki_dir) if p not in skip_rests]
+    if query_tokens:
+        scored: list[tuple[int, str, str]] = []
+        for rel in page_paths:
+            path = workspace / rel
+            try:
+                body = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            sc = _score_wiki_page(rel, body, query_tokens)
+            scored.append((sc, rel, body))
+        scored.sort(key=lambda x: (-x[0], x[1]))
+        ordered = [(rel, body) for _, rel, body in scored]
+    else:
+        ordered = []
+        for rel in page_paths:
+            path = workspace / rel
+            try:
+                body = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            ordered.append((rel, body))
+
+    for rel, body in ordered:
+        header = f"## {rel}\n\n"
+        if remaining <= len(header) + 20:
+            break
+        budget = remaining - len(header)
+        chunk = body
+        if len(chunk) > budget:
+            chunk = chunk[: max(0, budget - 40)].rstrip() + "\n\n… *(truncated)*"
+        block = header + chunk
+        parts.append(block)
+        remaining -= len(block)
+        if remaining < 100:
+            break
+    return "\n\n".join(parts).strip()

--- a/nanobot/llm_wiki/lint.py
+++ b/nanobot/llm_wiki/lint.py
@@ -1,0 +1,117 @@
+"""Lightweight wiki lint: wikilink targets and optional orphan pages."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from nanobot.llm_wiki.context import WIKI_DIR_NAME
+
+# [[Page]] or [[Page|label]]
+_WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+
+
+def _slug_from_link_text(text: str) -> str:
+    s = text.strip().lower()
+    s = re.sub(r"[^a-z0-9-]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")
+    return s or "page"
+
+
+def _wiki_page_paths(workspace: Path, wiki_dir: str) -> set[str]:
+    """Paths relative to *wiki_dir*: ``foo.md``, ``entities/bar.md``."""
+    root = workspace / wiki_dir
+    if not root.is_dir():
+        return set()
+    out: set[str] = set()
+    for p in root.rglob("*.md"):
+        rel = p.relative_to(root).as_posix()
+        if rel in ("index.md", "log.md", "schema.md"):
+            continue
+        if rel.endswith("/README.md") or rel == "README.md":
+            continue
+        out.add(rel)
+    return out
+
+
+def _resolve_wikilink_to_page(slug: str, wiki_paths: set[str]) -> str | None:
+    """Return wiki-relative path if *slug* matches an existing page."""
+    candidates = (
+        f"{slug}.md",
+        f"entities/{slug}.md",
+        f"concepts/{slug}.md",
+        f"sources/{slug}.md",
+        f"comparisons/{slug}.md",
+        f"queries/{slug}.md",
+    )
+    for c in candidates:
+        if c in wiki_paths:
+            return c
+    for p in wiki_paths:
+        stem = Path(p).stem.lower().replace(" ", "-")
+        if stem == slug:
+            return p
+    return None
+
+
+@dataclass
+class WikiLintReport:
+    dead_links: list[tuple[str, str]] = field(default_factory=list)  # (workspace_rel, link_text)
+    orphan_pages: list[str] = field(default_factory=list)  # workspace-relative wiki paths
+
+
+def run_wiki_lint(workspace: Path, *, wiki_dir: str = WIKI_DIR_NAME) -> WikiLintReport:
+    """Scan ``wiki/**/*.md`` for broken ``[[wikilinks]]`` and pages with no inbound wikilinks."""
+    wiki_root = workspace / wiki_dir
+    report = WikiLintReport()
+    if not wiki_root.is_dir():
+        return report
+
+    wiki_paths = _wiki_page_paths(workspace, wiki_dir)
+    inbound: dict[str, set[str]] = {p: set() for p in wiki_paths}
+
+    for p in wiki_root.rglob("*.md"):
+        rel_wiki = p.relative_to(wiki_root).as_posix()
+        rel_ws = str(p.relative_to(workspace)).replace("\\", "/")
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for m in _WIKILINK_RE.finditer(text):
+            raw = m.group(1).strip()
+            slug = _slug_from_link_text(raw)
+            target = _resolve_wikilink_to_page(slug, wiki_paths)
+            if target is None:
+                report.dead_links.append((rel_ws, raw))
+            else:
+                inbound.setdefault(target, set()).add(rel_wiki)
+
+    for rel, srcs in inbound.items():
+        if srcs:
+            continue
+        full = f"{wiki_dir}/{rel}".replace("\\", "/")
+        report.orphan_pages.append(full)
+
+    report.orphan_pages.sort()
+    return report
+
+
+def format_wiki_lint_message(report: WikiLintReport, *, max_lines: int = 30) -> str:
+    """Human-readable summary for channels."""
+    lines: list[str] = []
+    if report.dead_links:
+        lines.append(f"Broken wikilinks ({len(report.dead_links)}):")
+        for f, link in report.dead_links[:max_lines]:
+            lines.append(f"  - {f}: [[{link}]]")
+        if len(report.dead_links) > max_lines:
+            lines.append(f"  … and {len(report.dead_links) - max_lines} more")
+    if report.orphan_pages:
+        lines.append(f"Orphan pages (no inbound [[wikilink]], {len(report.orphan_pages)}):")
+        for p in report.orphan_pages[:max_lines]:
+            lines.append(f"  - {p}")
+        if len(report.orphan_pages) > max_lines:
+            lines.append(f"  … and {len(report.orphan_pages) - max_lines} more")
+    if not lines:
+        return "Wiki lint: no broken wikilinks; no orphan pages detected (or wiki empty)."
+    return "\n".join(lines)

--- a/nanobot/llm_wiki/raw.py
+++ b/nanobot/llm_wiki/raw.py
@@ -1,0 +1,67 @@
+"""Immutable raw sources layer (Karpathy llm-wiki): layered ``raw/`` + ``raw/assets``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+RAW_DIR_NAME = "raw"
+RAW_SOURCES_REL = f"{RAW_DIR_NAME}/sources"
+RAW_ARTICLES_REL = f"{RAW_DIR_NAME}/articles"
+RAW_PAPERS_REL = f"{RAW_DIR_NAME}/papers"
+RAW_TRANSCRIPTS_REL = f"{RAW_DIR_NAME}/transcripts"
+RAW_ASSETS_REL = f"{RAW_DIR_NAME}/assets"
+# Roots scanned for text ingest (articles, papers, transcripts, legacy flat ``sources``).
+RAW_TEXT_SOURCE_RELS: tuple[str, ...] = (
+    RAW_SOURCES_REL,
+    RAW_ARTICLES_REL,
+    RAW_PAPERS_REL,
+    RAW_TRANSCRIPTS_REL,
+)
+# Text-like sources ingest reads; binary formats require separate tooling.
+RAW_SOURCE_TEXT_EXTENSIONS: frozenset[str] = frozenset({".md", ".markdown", ".txt", ".rst"})
+
+
+def ensure_raw_directories(workspace: Path) -> None:
+    """Create ``raw/sources``, ``raw/articles``, ``raw/papers``, ``raw/transcripts``, ``raw/assets``."""
+    for rel in RAW_TEXT_SOURCE_RELS:
+        (workspace / rel).mkdir(parents=True, exist_ok=True)
+    (workspace / RAW_ASSETS_REL).mkdir(parents=True, exist_ok=True)
+
+
+def _collect_text_files_under(workspace: Path, root_rel: str, ext: frozenset[str]) -> list[str]:
+    root = workspace / root_rel
+    if not root.is_dir():
+        return []
+    out: list[str] = []
+    for p in sorted(root.rglob("*")):
+        if not p.is_file():
+            continue
+        if p.name.startswith("."):
+            continue
+        suf = p.suffix.lower()
+        if suf not in ext:
+            continue
+        out.append(str(p.relative_to(workspace)).replace("\\", "/"))
+    return out
+
+
+def list_raw_source_files(
+    workspace: Path,
+    *,
+    extensions: frozenset[str] | None = None,
+) -> list[str]:
+    """Sorted relative posix paths under all text source roots (see ``RAW_TEXT_SOURCE_RELS``).
+
+    Only includes files whose suffix matches *extensions* (default: text-like).
+    Does not read file contents.
+    """
+    ext = extensions if extensions is not None else RAW_SOURCE_TEXT_EXTENSIONS
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for rel in RAW_TEXT_SOURCE_RELS:
+        for p in _collect_text_files_under(workspace, rel, ext):
+            if p not in seen:
+                seen.add(p)
+                ordered.append(p)
+    ordered.sort()
+    return ordered

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -84,6 +84,10 @@ class Nanobot:
             unified_session=defaults.unified_session,
             disabled_skills=defaults.disabled_skills,
             session_ttl_minutes=defaults.session_ttl_minutes,
+            auto_wiki_archive_at_context_fraction=defaults.auto_wiki_archive_at_context_fraction,
+            auto_wiki_ingest_interval_minutes=defaults.auto_wiki_ingest_interval_minutes,
+            auto_wiki_lint_interval_minutes=defaults.auto_wiki_lint_interval_minutes,
+            auto_wiki_lint_after_wiki_write=defaults.auto_wiki_lint_after_wiki_write,
         )
         return cls(loop)
 

--- a/nanobot/skills/memory/SKILL.md
+++ b/nanobot/skills/memory/SKILL.md
@@ -11,6 +11,8 @@ always: true
 - `SOUL.md` — Bot personality and communication style. **Managed by Dream.** Do NOT edit.
 - `USER.md` — User profile and preferences. **Managed by Dream.** Do NOT edit.
 - `memory/MEMORY.md` — Long-term facts (project context, important events). **Managed by Dream.** Do NOT edit.
+- **`raw/sources/`** (and optional **`raw/articles/`**, **`raw/papers/`**, **`raw/transcripts/`**) — Immutable source files for **`/wiki-ingest`**; the agent must not modify `raw/`. Optional **`raw/assets/`** for attachments.
+- `wiki/` — Multi-page compiled knowledge (`wiki/index.md`, optional **`wiki/log.md`** timeline, topic pages). Standard subdirs **`wiki/entities/`**, **`wiki/concepts/`**, **`wiki/sources/`**, **`wiki/comparisons/`** (created on first wiki write). Optional **`wiki/schema.md`** defines structure; when present it is injected first into wiki context (Dream, agent, `/wiki-archive`). Layout helpers: **`nanobot.llm_wiki`**. **Managed by Dream** (except user-driven commands). Do NOT edit wiki unless the user explicitly asks you to change a page.
 - `memory/history.jsonl` — append-only JSONL, not loaded into context. Prefer the built-in `grep` tool to search it.
 
 ## Search Past Events
@@ -28,6 +30,35 @@ Examples (replace `keyword`):
 - `grep(pattern="2026-04-02 10:00", path="memory/history.jsonl", fixed_strings=true)`
 - `grep(pattern="keyword", path="memory", glob="*.jsonl", output_mode="count", case_insensitive=true)`
 - `grep(pattern="oauth|token", path="memory", glob="*.jsonl", output_mode="content", case_insensitive=true)`
+
+## Manual archive
+
+- **`/wiki-archive`** — Model returns **JSON** (array of `{ category_slug, display_title, page_kind, entry_markdown }`). **`page_kind`** routes into `wiki/` subdirs (`entity` / `concept` / `source` / `comparison`) or root (`topic`). Updates **Topic archives** and **`wiki/log.md`**, then **clears** the session and injects the full index. Dedup: `memory/wiki_archive_dedup.json`. Legacy plain-text `CATEGORY_SLUG:` lines still imply **topic** (root).
+
+## Automatic wiki (gateway / `nanobot agent` interactive)
+
+Configured under **`agents.defaults`** in config (JSON / YAML):
+
+| Key | Meaning |
+|-----|---------|
+| `autoWikiArchiveAtContextFraction` | Already default `0.8` — auto **`/wiki-archive`** when estimated prompt tokens exceed this fraction of the context window. Set `null` to disable. |
+| `autoWikiIngestIntervalMinutes` | When set (e.g. `15`), the loop polls every ~60s; if **`raw/`** text fingerprint changed and the cooldown elapsed, runs **`/wiki-ingest`** once. State: `memory/wiki_automation.json`. `null` = off (default). |
+| `autoWikiLintIntervalMinutes` | When set (e.g. `1440`), scheduled **`wiki-lint`** on that interval; appends **`wiki/log.md`** only if broken links or orphans exist. First run waits one full interval after gateway start. `null` = off (default). |
+| `autoWikiLintAfterWikiWrite` | Default `false` — set `true` to run lint after successful **wiki-archive** or **wiki-ingest** (manual or auto) and append `wiki/log.md` only if there are issues. |
+
+**`/wiki-save-answer`** is not automated (you must choose what to save). OpenAI-compatible **API-only** mode does not run the long-lived `agent.run()` loop, so these automations apply to **gateway** and **CLI interactive** sessions.
+- **`/wiki-ingest`** — Reads text files from **`raw/sources/`** (optional filter substring) and merges model output into `wiki/` the same way as archive. Appends **`wiki/log.md`**.
+- **`/wiki-lint`** — Reports broken `[[wikilinks]]` and orphan pages; appends **`wiki/log.md`**.
+- **`/wiki-save-answer`** — Saves the last assistant reply under **`wiki/queries/<slug>.md`** (optional slug argument).
+
+## Wiki revision (when the user wants to update existing pages)
+
+- **New facts in chat** — Prefer **`/wiki-archive`** with the same `category_slug` (appends a dated section). Do not rely on `/wiki-save-answer` to fix a wrong `wiki/entities/` page.
+- **Updated material under `raw/sources/`** — User adds or changes files, then **`/wiki-ingest`**.
+- **Multi-page or narrative coherence** — **Dream** may edit `wiki/`; do not fight Dream’s ownership unless the user asks for a direct file edit.
+- **Tiny fixes** — User may edit markdown directly; suggest **`/wiki-lint`** after link changes.
+
+Archive and ingest **merge** into existing slugs; full section replacement without history is **manual edit** or **Dream**, not a separate slash command.
 
 ## Important
 

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -1,11 +1,11 @@
-Compare conversation history against current memory files. Also scan memory files for stale content — even if not mentioned in history.
+Compare conversation history against current memory files and wiki pages. Also scan memory files and `wiki/` for stale content — even if not mentioned in history.
 
 Output one line per finding:
 [FILE] atomic fact (not already in memory)
 [FILE-REMOVE] reason for removal
 [SKILL] kebab-case-name: one-line description of the reusable pattern
 
-Files: USER (identity, preferences), SOUL (bot behavior, tone), MEMORY (knowledge, project context)
+Files: USER (identity, preferences), SOUL (bot behavior, tone), MEMORY (knowledge, project context), wiki/schema.md (optional — structural rules for `wiki/`, prepended to wiki context when present), wiki/**/*.md including `wiki/entities/`, `wiki/concepts/`, `wiki/sources/` (use paths like `wiki/concepts/Topic.md` instead of [FILE] when adding to wiki)
 
 Rules:
 - Atomic facts: "has a cat named Luna" not "discussed pet care"

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -8,10 +8,12 @@ Update memory files based on the analysis below.
 - USER.md
 - memory/MEMORY.md
 - skills/<name>/SKILL.md (for [SKILL] entries only)
+- wiki/**/*.md — multi-page topics; prefer `wiki/entities/`, `wiki/concepts/`, `wiki/sources/` for typed pages; root `wiki/<slug>.md` is common for `/wiki-archive` category files. Update `wiki/index.md` when adding major pages.
 
 Do NOT guess paths.
 
 ## Editing rules
+- If `wiki/schema.md` exists, follow it for any create/edit under `wiki/`.
 - Edit directly — file contents provided below, no read_file needed
 - Use exact text as old_text, include surrounding blank lines for unique match
 - Batch changes to the same file into one edit_file call

--- a/nanobot/templates/agent/wiki_archive.md
+++ b/nanobot/templates/agent/wiki_archive.md
@@ -1,0 +1,52 @@
+{% if wiki_schema %}
+## Workspace wiki schema (must follow)
+
+{{ wiki_schema }}
+
+---
+
+{% endif %}
+You classify lines from a chat transcript into **one or more knowledge categories**. For each category you assign a **page kind** so the entry is stored automatically under the right folder (Karpathy-style layout).
+
+| `page_kind` | Stored as |
+|-------------|-----------|
+| `entity` | `wiki/entities/<category-slug>.md` — people, organizations, products, named tools |
+| `concept` | `wiki/concepts/<category-slug>.md` — methods, patterns, theories, technical ideas |
+| `source` | `wiki/sources/<category-slug>.md` — digest of a specific document, paper, or transcript line of inquiry |
+| `comparison` | `wiki/comparisons/<category-slug>.md` — side-by-side analyses, A-vs-B, tradeoff tables |
+| `topic` | `wiki/<category-slug>.md` — mixed notes, procedures, or when classification is unclear |
+
+One slug still maps to **one file over time** (append-only within that file). Choose the best `page_kind` from the transcript; use `topic` if unsure.
+
+## Output format (required)
+
+Output **only** a JSON array (no markdown outside the array, or wrap the array in a single ` ```json ` fenced block if you prefer).
+
+Each element must be an object with:
+
+| Field | Meaning |
+|-------|---------|
+| `category_slug` | `kebab-case`, English: lowercase letters, digits, hyphens only (e.g. `auth-oauth`, `db-postgres`). One slug = one wiki file over time. |
+| `display_title` | Short human-readable title (Chinese or English) for `wiki/index.md`. |
+| `page_kind` | One of `entity`, `concept`, `source`, `comparison`, `topic` (see table above). |
+| `entry_markdown` | Markdown for **this archive only** for that category: start with `## Summary` (1–2 factual sentences for the index blurb), then optional `## Details`, bullets, etc. No level-1 `#` heading inside the entry. |
+
+### Multiple topics
+
+If the transcript clearly contains **several independent knowledge domains** (e.g. authentication **and** database schema **and** deployment), emit **one object per domain** with a **different** `category_slug` for each. Split rather than stuffing unrelated content into one slug.
+
+If everything belongs to one domain, emit **a single-element array**.
+
+### Rules
+
+- Keep claims tied to the transcript; do not invent facts.
+- Summarize tool results; do not paste huge raw logs.
+- Do not duplicate the same semantic content under two slugs unless the user explicitly discussed two separate tracks.
+
+### Empty transcript
+
+If there is nothing to save, output exactly:
+
+```json
+[{"category_slug": "empty-session", "display_title": "", "page_kind": "topic", "entry_markdown": "# (empty session)"}]
+```

--- a/nanobot/templates/agent/wiki_ingest.md
+++ b/nanobot/templates/agent/wiki_ingest.md
@@ -1,0 +1,40 @@
+{% if wiki_schema %}
+## Workspace wiki schema (must follow)
+
+{{ wiki_schema }}
+
+---
+
+{% endif %}
+{% if wiki_catalog %}
+## Existing wiki pages (reuse slugs when the topic matches)
+
+Prefer **`category_slug`** values that already appear below (same file = same slug over time). Do **not** create a new near-duplicate slug (e.g. `foo` vs `foo-overview`) for the same subject; merge into the existing slug and matching `page_kind`.
+
+{{ wiki_catalog }}
+
+---
+
+{% endif %}
+You ingest **immutable raw text files** from `raw/` (paths under `raw/sources/`, `raw/articles/`, `raw/papers/`, or `raw/transcripts/` are provided in the user message). Produce structured wiki updates as **JSON only** — same schema as `/wiki-archive`.
+
+Classify each extracted topic with **`page_kind`**: `entity` | `concept` | `source` | `comparison` | `topic` (see `agent/wiki_archive.md`).
+
+## Output format (required)
+
+Output **only** a JSON array. Each element:
+
+| Field | Meaning |
+|-------|---------|
+| `category_slug` | `kebab-case` English filename stem |
+| `display_title` | Short title for `wiki/index.md` |
+| `page_kind` | `entity` / `concept` / `source` / `comparison` / `topic` |
+| `entry_markdown` | Start with `## Summary`, then optional details. No level-1 `#` inside the entry. |
+
+Do not invent facts not supported by the raw text. Summarize; do not paste entire sources.
+
+If nothing usable is present, output:
+
+```json
+[{"category_slug": "empty-ingest", "display_title": "", "page_kind": "topic", "entry_markdown": "# (empty)"}]
+```

--- a/nanobot/templates/raw/assets/README.md
+++ b/nanobot/templates/raw/assets/README.md
@@ -1,0 +1,3 @@
+# Raw assets
+
+Optional images or attachments referenced from sources. Keep large binaries here; text extraction for ingest focuses on `raw/sources/`.

--- a/nanobot/templates/raw/sources/README.md
+++ b/nanobot/templates/raw/sources/README.md
@@ -1,0 +1,3 @@
+# Raw sources
+
+Place **immutable** source documents here (`.md`, `.txt`, …). The LLM reads them for **`/wiki-ingest`** and must **not** modify files under `raw/` — all compiled knowledge goes under `wiki/` only.

--- a/nanobot/templates/wiki/comparisons/README.md
+++ b/nanobot/templates/wiki/comparisons/README.md
@@ -1,0 +1,3 @@
+# Comparisons
+
+Place **side-by-side analyses** here (e.g. `wiki/comparisons/postgres-vs-mysql.md`). Prefer one markdown file per comparison topic; append new dated sections when facts evolve.

--- a/nanobot/templates/wiki/concepts/README.md
+++ b/nanobot/templates/wiki/concepts/README.md
@@ -1,0 +1,3 @@
+# Concepts
+
+Place **abstract knowledge** here: theories, methods, techniques, patterns. Prefer one concept per file when it grows beyond a few bullets (e.g. `wiki/concepts/oauth-flow.md`).

--- a/nanobot/templates/wiki/entities/README.md
+++ b/nanobot/templates/wiki/entities/README.md
@@ -1,0 +1,3 @@
+# Entities
+
+Place **named things** here: people, organizations, products, services. Prefer one markdown file per entity (e.g. `wiki/entities/acme-corp.md`).

--- a/nanobot/templates/wiki/index.md
+++ b/nanobot/templates/wiki/index.md
@@ -1,0 +1,29 @@
+# Wiki index
+
+- **Raw sources** — Put immutable documents in `raw/sources/` and/or `raw/articles/`, `raw/papers/`, `raw/transcripts/` (see `nanobot/templates/raw/`) and run **`/wiki-ingest`** to compile into `wiki/` without modifying `raw/`.
+- **Layout** — `wiki/entities/` (people, orgs, products), `wiki/concepts/` (theories, methods), `wiki/sources/` (source-backed summaries), `wiki/comparisons/` (side-by-side analyses). These dirs are created automatically on first wiki write; copy `README.md` stubs from `nanobot/templates/wiki/<dir>/` if you want the same hints in your vault.
+- **Queries** — Optional `wiki/queries/` holds answers saved with **`/wiki-save-answer`**.
+- **Log** — `wiki/log.md` is append-only: each `/wiki-archive`, Dream run (with edits), `/wiki-lint`, etc. adds a short `## [date] kind | summary` line. Use it as a human timeline alongside Git.
+- **Schema (optional)** — `wiki/schema.md` defines how pages should be shaped (linking, frontmatter). When present, it is loaded before other wiki files for Dream, the agent, and `/wiki-archive`. Start from `nanobot/templates/wiki/schema.md` if you need a template.
+- **Topic archives** — `/wiki-archive` asks the model for **`page_kind`** per entry (`entity` / `concept` / `source` / `comparison` / `topic`) so files go under `wiki/entities/`, `wiki/concepts/`, `wiki/sources/`, `wiki/comparisons/`, or wiki root automatically. Entries in each file are separated by `---` and `## YYYY-MM-DD HH:MM`.
+- **Dream** may add or edit pages under `wiki/`, including `entities/`, `concepts/`, and `sources/`.
+
+## Revision strategy
+
+How to **update** canonical pages (`wiki/entities/`, `wiki/concepts/`, `wiki/sources/`, or root topic files) depends on where the new truth comes from:
+
+| Situation | Prefer |
+|-----------|--------|
+| New or corrected facts appeared **in the current chat** | **`/wiki-archive`** — reuse the same `category_slug` to **append** a new dated `##` section. Older sections stay as history. |
+| Truth lives in **files under `raw/sources/`** | **`/wiki-ingest`** — re-run after you add or change raw files; ingest only writes `wiki/`, never `raw/`. |
+| Cross-file coherence, or tie wiki to **`memory/history.jsonl`** / **`memory/MEMORY.md`** | **Dream** — scheduled or `/dream`; it may edit several wiki files in one pass. |
+| Small fix (typo, link, wording) | **Edit the `.md` file** in the workspace; Git records it. Run **`/wiki-lint`** if wikilinks moved. |
+| Preserve a **good assistant answer** as a snapshot | **`/wiki-save-answer`** — writes under **`wiki/queries/`** only; it does not replace entity/concept pages. |
+
+**Semantics:** `/wiki-archive` and `/wiki-ingest` **merge** entries into existing slugs (append by timestamp). To **replace** a whole section without keeping the old text, edit the file directly or ask Dream for a surgical rewrite.
+
+Link related pages with wikilinks, e.g. `[[OAuth flow]]` → `wiki/concepts/oauth-flow.md` (path rules in `wiki/schema.md`).
+
+## Topic archives
+
+- *(`/wiki-archive` appends a searchable line here for each merge.)*

--- a/nanobot/templates/wiki/schema.md
+++ b/nanobot/templates/wiki/schema.md
@@ -1,0 +1,46 @@
+# Wiki schema (nanobot)
+
+Copy or merge this file to **`wiki/schema.md`** in your workspace. It is **prepended** to wiki context for the agent, Dream, and `/wiki-archive` when present. Edit it to match your project.
+
+## Purpose
+
+- **SOUL.md** / **USER.md** — who the bot is and who the user is.
+- **This file** — how pages under `wiki/` should be shaped (structure, linking, optional frontmatter).
+
+## Domain (optional, Karpathy-style)
+
+Describe what this wiki is *for* (e.g. “this repo”, “ML reading notes”, “client project X”). Helps the agent and Dream stay in scope. Skip if obvious.
+
+## Raw sources (immutable)
+
+- Place curated documents under **`raw/sources/`** and/or **`raw/articles/`**, **`raw/papers/`**, **`raw/transcripts/`** (and optional **`raw/assets/`**). The LLM **reads** them for `/wiki-ingest` and **must not edit** anything under `raw/` — only write compiled notes under `wiki/`.
+- Version-control `raw/` like the rest of the workspace so sources stay reproducible.
+
+## Conventions
+
+- **Directories**: keep **entities** under `wiki/entities/`, **concepts** under `wiki/concepts/`, **source-backed summaries** under `wiki/sources/`, **comparisons** under `wiki/comparisons/`. Topic archive merges from `/wiki-archive` stay at `wiki/<category-slug>.md` (root) unless you adopt a different rule here.
+- **Wikilinks**: use `[[Page Name]]` for cross-references; resolve paths consistently (e.g. `wiki/concepts/<slug>.md`). Match Dream / `wiki/index.md` guidance.
+- **Topic archives**: `/wiki-archive` appends dated blocks under `wiki/<category-slug>.md`; keep `## Summary` at the start of each entry for a good index blurb.
+- **Optional YAML frontmatter** on hand-written pages, for Obsidian or tooling, for example:
+
+```yaml
+---
+title: "Short title"
+type: concept
+updated: 2026-04-11
+---
+```
+
+- **Stable slugs**: category slugs stay `kebab-case` ASCII; display titles may be any language.
+
+## Tag and page thresholds (optional)
+
+If you use tags in frontmatter, list allowed values here to avoid tag sprawl. Suggested rules (tweak freely):
+
+- Create a new **entity/concept** page when a name appears in multiple sources or is central to one.
+- Prefer **updating** an existing page over duplicating topics.
+- Split a page when it grows past ~200 lines; link related pages with `[[wikilinks]]`.
+
+## Out of scope
+
+Do not put secrets, API keys, or one-off session noise here — those belong in `memory/history.jsonl` or ephemeral chat, not durable wiki rules.

--- a/nanobot/templates/wiki/sources/README.md
+++ b/nanobot/templates/wiki/sources/README.md
@@ -1,0 +1,3 @@
+# Sources
+
+Place **source-linked summaries** here: papers, articles, design docs, or transcript-backed digests. Use frontmatter `sources:` when you track raw paths or URLs (see `wiki/schema.md`).

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -27,9 +27,32 @@ class CommitInfo:
 class GitStore:
     """Git-backed version control for memory files."""
 
-    def __init__(self, workspace: Path, tracked_files: list[str]):
+    def __init__(
+        self,
+        workspace: Path,
+        tracked_files: list[str],
+        *,
+        track_wiki_markdown: bool = True,
+    ):
         self._workspace = workspace
         self._tracked_files = tracked_files
+        self._track_wiki_markdown = track_wiki_markdown
+
+    def _expanded_tracked_files(self) -> list[str]:
+        """Base tracked files plus every ``wiki/**/*.md`` under the workspace."""
+        paths = {str(p).replace("\\", "/") for p in self._tracked_files}
+        if self._track_wiki_markdown:
+            wiki_root = self._workspace / "wiki"
+            if wiki_root.is_dir():
+                for p in wiki_root.rglob("*.md"):
+                    rel = p.relative_to(self._workspace)
+                    paths.add(str(rel).replace("\\", "/"))
+        return sorted(paths)
+
+    def _write_gitignore_file(self) -> None:
+        """Rewrite ``.gitignore`` from the current expanded tracked set."""
+        gi = self._workspace / ".gitignore"
+        gi.write_text(self._build_gitignore(), encoding="utf-8")
 
     def is_initialized(self) -> bool:
         """Check if the git repo has been initialized."""
@@ -51,20 +74,22 @@ class GitStore:
 
             porcelain.init(str(self._workspace))
 
-            # Write .gitignore
-            gitignore = self._workspace / ".gitignore"
-            gitignore.write_text(self._build_gitignore(), encoding="utf-8")
+            # Write .gitignore (includes wiki/**/*.md when present)
+            self._write_gitignore_file()
 
             # Ensure tracked files exist (touch them if missing) so the initial
             # commit has something to track.
-            for rel in self._tracked_files:
+            for rel in self._expanded_tracked_files():
                 p = self._workspace / rel
                 p.parent.mkdir(parents=True, exist_ok=True)
                 if not p.exists():
                     p.write_text("", encoding="utf-8")
 
             # Initial commit
-            porcelain.add(str(self._workspace), paths=[".gitignore"] + self._tracked_files)
+            porcelain.add(
+                str(self._workspace),
+                paths=[".gitignore"] + self._expanded_tracked_files(),
+            )
             porcelain.commit(
                 str(self._workspace),
                 message=b"init: nanobot memory store",
@@ -90,6 +115,9 @@ class GitStore:
         try:
             from dulwich import porcelain
 
+            # New wiki pages must be listed in .gitignore before `add` sees them.
+            self._write_gitignore_file()
+
             # .gitignore excludes everything except tracked files,
             # so any staged/unstaged change must be in our files.
             st = porcelain.status(str(self._workspace))
@@ -97,7 +125,7 @@ class GitStore:
                 return None
 
             msg_bytes = message.encode("utf-8") if isinstance(message, str) else message
-            porcelain.add(str(self._workspace), paths=self._tracked_files)
+            porcelain.add(str(self._workspace), paths=self._expanded_tracked_files())
             sha_bytes = porcelain.commit(
                 str(self._workspace),
                 message=msg_bytes,
@@ -140,14 +168,14 @@ class GitStore:
     def _build_gitignore(self) -> str:
         """Generate .gitignore content from tracked files."""
         dirs: set[str] = set()
-        for f in self._tracked_files:
+        for f in self._expanded_tracked_files():
             parent = str(Path(f).parent)
             if parent != ".":
                 dirs.add(parent)
         lines = ["/*"]
         for d in sorted(dirs):
             lines.append(f"!{d}/")
-        for f in self._tracked_files:
+        for f in self._expanded_tracked_files():
             lines.append(f"!{f}")
         lines.append("!.gitignore")
         return "\n".join(lines) + "\n"
@@ -270,7 +298,7 @@ class GitStore:
                 tree = repo[parent_obj.tree]
 
                 restored: list[str] = []
-                for filepath in self._tracked_files:
+                for filepath in self._expanded_tracked_files():
                     content = self._read_blob_from_tree(repo, tree, filepath)
                     if content is not None:
                         dest = self._workspace / filepath

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -460,6 +460,7 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
         if item.name.endswith(".md") and not item.name.startswith("."):
             _write(item, workspace / item.name)
     _write(tpl / "memory" / "MEMORY.md", workspace / "memory" / "MEMORY.md")
+    _write(tpl / "wiki" / "index.md", workspace / "wiki" / "index.md")
     _write(None, workspace / "memory" / "history.jsonl")
     (workspace / "skills").mkdir(exist_ok=True)
 
@@ -471,9 +472,11 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
     # Initialize git for memory version control
     try:
         from nanobot.utils.gitstore import GitStore
-        gs = GitStore(workspace, tracked_files=[
-            "SOUL.md", "USER.md", "memory/MEMORY.md",
-        ])
+        gs = GitStore(
+            workspace,
+            tracked_files=["SOUL.md", "USER.md", "memory/MEMORY.md"],
+            track_wiki_markdown=True,
+        )
         gs.init()
     except Exception:
         logger.warning("Failed to initialize git store for {}", workspace)

--- a/tests/agent/test_auto_wiki_archive_threshold.py
+++ b/tests/agent/test_auto_wiki_archive_threshold.py
@@ -1,0 +1,91 @@
+"""Tests for auto wiki-archive when estimated prompt crosses a context fraction threshold."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.session.manager import Session
+
+
+@pytest.mark.asyncio
+async def test_maybe_auto_wiki_archive_disabled_returns_none(tmp_path) -> None:
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.generation.max_tokens = 4096
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test/model",
+        context_window_tokens=100_000,
+        auto_wiki_archive_at_context_fraction=None,
+    )
+    sess = Session(key="cli:t")
+    sess.messages = [{"role": "user", "content": "hi", "timestamp": "2026-01-01T00:00:00"}]
+    msg = InboundMessage(channel="cli", sender_id="u", chat_id="t", content="hello")
+    out = await loop._maybe_auto_wiki_archive(msg, sess, None)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_auto_wiki_archive_skips_when_below_threshold(tmp_path) -> None:
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.generation.max_tokens = 4096
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test/model",
+        context_window_tokens=10_000,
+        auto_wiki_archive_at_context_fraction=0.8,
+    )
+    loop._estimate_inbound_prompt_tokens = MagicMock(return_value=(100, "mock"))  # type: ignore[method-assign]
+
+    sess = Session(key="cli:t")
+    msg = InboundMessage(channel="cli", sender_id="u", chat_id="t", content="hello")
+    out = await loop._maybe_auto_wiki_archive(msg, sess, None)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_auto_wiki_archive_triggers_ingest_path(tmp_path) -> None:
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.generation.max_tokens = 4096
+    provider.chat_with_retry = AsyncMock(
+        return_value=MagicMock(
+            content='[{"category_slug": "t1", "display_title": "T", "entry_markdown": "## Summary\\n\\nBody."}]',
+        ),
+    )
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test/model",
+        context_window_tokens=1000,
+        auto_wiki_archive_at_context_fraction=0.5,
+    )
+    loop._estimate_inbound_prompt_tokens = MagicMock(return_value=(900, "mock"))  # type: ignore[method-assign]
+
+    sess = Session(key="cli:t")
+    sess.messages = [{"role": "user", "content": "prior", "timestamp": "2026-01-01T00:00:00"}]
+    msg = InboundMessage(channel="cli", sender_id="u", chat_id="t", content="current turn")
+    out = await loop._maybe_auto_wiki_archive(msg, sess, None)
+    assert out is not None
+    assert "Auto wiki-archive" in (out.content or "")
+    assert (tmp_path / "wiki" / "t1.md").is_file()
+
+
+def test_agent_defaults_rejects_invalid_auto_wiki_fraction() -> None:
+    from pydantic import ValidationError
+
+    from nanobot.config.schema import AgentDefaults
+
+    with pytest.raises(ValidationError):
+        AgentDefaults(auto_wiki_archive_at_context_fraction=0.0)
+    with pytest.raises(ValidationError):
+        AgentDefaults(auto_wiki_archive_at_context_fraction=1.1)

--- a/tests/agent/test_git_store.py
+++ b/tests/agent/test_git_store.py
@@ -94,6 +94,16 @@ class TestAutoCommit:
         git_ready.auto_commit("nothing 2")
         assert len(git_ready.log()) == 1  # only init commit
 
+    def test_commits_new_wiki_page(self, git_ready):
+        ws = git_ready._workspace
+        wiki = ws / "wiki"
+        wiki.mkdir(parents=True)
+        (wiki / "note.md").write_text("hello wiki", encoding="utf-8")
+        sha = git_ready.auto_commit("add wiki page")
+        assert sha is not None
+        gi = (ws / ".gitignore").read_text(encoding="utf-8")
+        assert "!wiki/note.md" in gi
+
 
 class TestLog:
     def test_empty_when_not_initialized(self, git):

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -24,6 +24,7 @@ def _make_loop(tmp_path, *, estimated_tokens: int, context_window_tokens: int) -
         workspace=tmp_path,
         model="test-model",
         context_window_tokens=context_window_tokens,
+        auto_wiki_archive_at_context_fraction=None,
     )
     loop.tools.get_definitions = MagicMock(return_value=[])
     loop.consolidator._SAFETY_BUFFER = 0

--- a/tests/agent/test_wiki_archive_dedup.py
+++ b/tests/agent/test_wiki_archive_dedup.py
@@ -1,0 +1,32 @@
+"""Tests for /wiki-archive duplicate detection (MemoryStore)."""
+
+from pathlib import Path
+
+from nanobot.agent.memory import MemoryStore
+
+
+def test_wiki_archive_transcript_dedup_roundtrip(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    h = "deadbeef" * 8  # 64 hex-like id
+    assert not store.wiki_archive_transcript_already_archived(h)
+    store.wiki_archive_remember_success(h, "# Page\n\n## Summary\n\nUnique content here.")
+    assert store.wiki_archive_transcript_already_archived(h)
+    p = tmp_path / "memory" / "wiki_archive_dedup.json"
+    assert p.is_file()
+
+
+def test_wiki_archive_skips_same_body_hash(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    body = "# Same\n\n## Summary\n\nIdentical archive text."
+    store.wiki_archive_remember_success("transcript_hash_aaa", body)
+    assert store.wiki_archive_should_skip_duplicate_body(body)
+
+
+def test_wiki_archive_near_duplicate_file(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    (store.wiki_dir).mkdir(parents=True)
+    slight = "# Topic\n\n## Summary\n\nHello world and more text for length."
+    (store.wiki_dir / "legacy-topic.md").write_text(slight, encoding="utf-8")
+    # Almost the same normalized text -> high ratio
+    body = "# Topic\n\n## Summary\n\nHello world and more text for length!"
+    assert store.wiki_archive_should_skip_duplicate_body(body, similarity_threshold=0.90)

--- a/tests/agent/test_wiki_memory.py
+++ b/tests/agent/test_wiki_memory.py
@@ -1,0 +1,185 @@
+"""Tests for multi-page wiki context in MemoryStore."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.llm_wiki import (
+    STANDARD_WIKI_SUBDIRS,
+    build_wiki_context,
+    list_wiki_page_paths,
+    read_schema,
+)
+
+
+def test_merge_wiki_entries_from_archive_writes_index(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    when = "2026-04-11 12:00"
+    entries = [
+        ("alpha-topic", "Alpha", "## Summary\n\nOne.", "topic"),
+        ("beta-corp", "Beta", "## Summary\n\nTwo.", "entity"),
+    ]
+    out = store.merge_wiki_entries_from_archive(entries, when)
+    assert "alpha-topic.md" in out
+    assert "entities/beta-corp.md" in out
+    assert (tmp_path / "wiki" / "alpha-topic.md").is_file()
+    assert (tmp_path / "wiki" / "entities" / "beta-corp.md").is_file()
+    idx = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert "Alpha" in idx and "Beta" in idx
+
+
+def test_coalesce_wiki_archive_entries_merges_same_slug_in_batch() -> None:
+    entries = [
+        ("dup", "D", "## Summary\n\nOne", "topic"),
+        ("dup", "D", "## Summary\n\nTwo", "topic"),
+    ]
+    out = MemoryStore.coalesce_wiki_archive_entries(entries)
+    assert len(out) == 1
+    assert out[0][0] == "dup"
+    assert "One" in out[0][2] and "Two" in out[0][2]
+
+
+def test_merge_wiki_entries_single_index_line_for_batch_duplicate_slug(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    when = "2026-04-11 12:00"
+    entries = [
+        ("dup-topic", "Dup", "## Summary\n\nOne", "topic"),
+        ("dup-topic", "Dup", "## Summary\n\nTwo", "topic"),
+    ]
+    store.merge_wiki_entries_from_archive(entries, when)
+    idx = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert idx.count("dup-topic.md") == 1
+
+
+def test_remap_wiki_slug_to_existing_h1(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    store.wiki_dir.mkdir(parents=True)
+    (store.wiki_dir / "concepts").mkdir(parents=True)
+    (store.wiki_dir / "concepts" / "tensorflow.md").write_text(
+        "# TensorFlow\n\n> notes\n",
+        encoding="utf-8",
+    )
+    when = "2026-04-11 12:00"
+    entries = [
+        ("tensorflow-alt-slug", "TensorFlow", "## Summary\n\nExtra.", "concept"),
+    ]
+    store.merge_wiki_entries_from_archive(entries, when)
+    assert not (store.wiki_dir / "concepts" / "tensorflow-alt-slug.md").is_file()
+    text = (store.wiki_dir / "concepts" / "tensorflow.md").read_text(encoding="utf-8")
+    assert "Extra." in text
+
+
+def test_append_wiki_log_line_creates_file(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    store.append_wiki_log_line("test-kind", "short summary", when="2026-01-01 00:00")
+    log = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+    assert "test-kind" in log and "short summary" in log
+
+
+def test_memory_store_wiki_delegates_to_llm_wiki(tmp_path: Path) -> None:
+    """MemoryStore wiki helpers must stay thin wrappers around :mod:`nanobot.llm_wiki`."""
+    ws = tmp_path / "ws"
+    (ws / "wiki").mkdir(parents=True)
+    (ws / "wiki" / "schema.md").write_text("schema line\n", encoding="utf-8")
+    (ws / "wiki" / "index.md").write_text("index\n", encoding="utf-8")
+    (ws / "wiki" / "z.md").write_text("z\n", encoding="utf-8")
+
+    store = MemoryStore(ws)
+    assert store.list_wiki_page_paths() == list_wiki_page_paths(ws, wiki_dir=store.WIKI_DIR)
+    assert store.read_wiki_schema() == read_schema(ws, wiki_dir=store.WIKI_DIR)
+    for budget in (200, 800, 4000):
+        assert store.get_wiki_context(max_total_chars=budget) == build_wiki_context(
+            ws, wiki_dir=store.WIKI_DIR, max_total_chars=budget,
+        )
+
+
+def test_append_session_archive_to_index_creates_section(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    store.append_session_archive_to_index(
+        "context-test.md",
+        "2026-04-11 12:00",
+        title="Auth notes",
+        blurb="OAuth migration and callback URLs.",
+    )
+    for name in STANDARD_WIKI_SUBDIRS:
+        assert (tmp_path / "wiki" / name).is_dir()
+    idx = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert "Topic archives" in idx
+    assert "context-test.md" in idx
+    assert "[Auth notes]" in idx
+    assert "OAuth migration" in idx
+
+
+def test_is_wiki_archive_body_insufficient() -> None:
+    assert MemoryStore.is_wiki_archive_body_insufficient("")
+    assert MemoryStore.is_wiki_archive_body_insufficient("   ")
+    assert MemoryStore.is_wiki_archive_body_insufficient("# (empty session)\n")
+    assert MemoryStore.is_wiki_archive_body_insufficient(
+        "CATEGORY_SLUG: empty-session\n\n# (empty session)\n",
+    )
+    assert MemoryStore.is_wiki_archive_body_insufficient("No heading but text")
+    assert not MemoryStore.is_wiki_archive_body_insufficient(
+        "CATEGORY_SLUG: foo\nDISPLAY_TITLE: Bar\n\n## Summary\n\nHello.\n",
+    )
+
+
+def test_parse_wiki_archive_entries_json_multi() -> None:
+    payload = [
+        {"category_slug": "a", "display_title": "A", "entry_markdown": "## Summary\n\none"},
+        {"category_slug": "b", "display_title": "B", "page_kind": "concept", "entry_markdown": "## Summary\n\ntwo"},
+    ]
+    raw = "```json\n" + json.dumps(payload, ensure_ascii=False) + "\n```"
+    entries = MemoryStore.parse_wiki_archive_entries(raw)
+    assert len(entries) == 2
+    assert entries[0][:4] == ("a", "A", "## Summary\n\none", "topic")
+    assert entries[1][:4] == ("b", "B", "## Summary\n\ntwo", "concept")
+
+
+def test_merge_wiki_category_document_respects_page_kind(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    store.merge_wiki_category_document(
+        "acme", "Acme", "## Summary\n\nx", "2026-04-11 10:00", page_kind="entity",
+    )
+    assert (tmp_path / "wiki" / "entities" / "acme.md").is_file()
+    store.merge_wiki_category_document(
+        "oauth", "OAuth", "## Summary\n\ny", "2026-04-11 11:00", page_kind="concept",
+    )
+    assert (tmp_path / "wiki" / "concepts" / "oauth.md").is_file()
+    store.merge_wiki_category_document(
+        "pg-vs-mysql", "Postgres vs MySQL", "## Summary\n\nz", "2026-04-11 12:00", page_kind="comparison",
+    )
+    assert (tmp_path / "wiki" / "comparisons" / "pg-vs-mysql.md").is_file()
+
+
+def test_merge_wiki_category_document_appends_same_file(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    store.merge_wiki_category_document("alpha", "Alpha", "## Summary\n\nFirst.", "2026-04-11 10:00", page_kind="topic")
+    store.merge_wiki_category_document("alpha", "Alpha", "## Summary\n\nSecond.", "2026-04-11 11:00", page_kind="topic")
+    text = (tmp_path / "wiki" / "alpha.md").read_text(encoding="utf-8")
+    assert "First." in text and "Second." in text
+    assert text.count("## 2026-04-11") == 2
+
+
+def test_summarize_wiki_archive_for_index_prefers_summary_section(tmp_path: Path) -> None:
+    body = """# Project Alpha
+
+## Summary
+
+First production deploy succeeded. Monitoring enabled.
+
+## Details
+
+- Rollout plan
+"""
+    title, blurb = MemoryStore.summarize_wiki_archive_for_index(body)
+    assert title == "Project Alpha"
+    assert "production deploy" in blurb.lower()
+    assert "Monitoring" in blurb
+
+
+def test_write_wiki_page_rejects_traversal(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    with pytest.raises(ValueError):
+        store.write_wiki_page("../evil.md", "x")

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -1114,6 +1114,7 @@ async def test_on_help_includes_restart_command() -> None:
     assert "/dream" in help_text
     assert "/dream-log" in help_text
     assert "/dream-restore" in help_text
+    assert "/wiki-archive" in help_text
 
 
 @pytest.mark.asyncio

--- a/tests/command/test_wiki_archive.py
+++ b/tests/command/test_wiki_archive.py
@@ -1,0 +1,199 @@
+"""Tests for /wiki-archive command."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.command.builtin import cmd_wiki_archive
+from nanobot.command.router import CommandContext
+from nanobot.session.manager import Session
+
+
+def _mock_loop_bus(loop: MagicMock) -> None:
+    loop.bus = MagicMock()
+    loop.bus.publish_outbound = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_cmd_wiki_archive_skips_empty_model_output(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    loop = MagicMock()
+    _mock_loop_bus(loop)
+    loop.consolidator.store = store
+    loop.model = "test/model"
+    loop.provider.chat_with_retry = AsyncMock(
+        return_value=MagicMock(
+            content="CATEGORY_SLUG: empty-session\n\n# (empty session)\n",
+        ),
+    )
+    sess = Session(key="cli:t")
+    sess.messages = [{"role": "user", "content": "x", "timestamp": "2026-04-11T10:00:00"}]
+    sess.last_consolidated = 0
+    loop.sessions.get_or_create.return_value = sess
+
+    msg = MagicMock(channel="cli", chat_id="t", session_key="cli:t", metadata={})
+    ctx = CommandContext(msg=msg, session=sess, key="cli:t", raw="/wiki-archive", loop=loop)
+
+    out = await cmd_wiki_archive(ctx)
+    assert "Nothing to archive" in out.content
+    assert not list((tmp_path / "wiki").glob("*.md"))
+
+
+@pytest.mark.asyncio
+async def test_cmd_wiki_archive_empty_session(tmp_path: Path) -> None:
+    loop = MagicMock()
+    loop.sessions.get_or_create.return_value = MagicMock(
+        messages=[], last_consolidated=0,
+    )
+    msg = MagicMock(channel="cli", chat_id="t", session_key="cli:t", metadata={})
+    ctx = CommandContext(msg=msg, session=None, key="cli:t", raw="/wiki-archive", loop=loop)
+
+    out = await cmd_wiki_archive(ctx)
+    assert "No messages to archive" in out.content
+
+
+@pytest.mark.asyncio
+async def test_cmd_wiki_archive_writes_wiki_and_replaces_session(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    loop = MagicMock()
+    _mock_loop_bus(loop)
+    loop.consolidator.store = store
+    loop.model = "test/model"
+
+    async def chat_with_retry(**kwargs):
+        r = MagicMock()
+        r.content = (
+            "CATEGORY_SLUG: routing-db\n"
+            "DISPLAY_TITLE: Routing discussion\n"
+            "\n"
+            "## Summary\n\n"
+            "Chose PostgreSQL over SQLite for concurrent writes.\n\n"
+            "## Notes\n\n"
+            "- See `db/migrate`\n"
+        )
+        return r
+
+    loop.provider.chat_with_retry = AsyncMock(side_effect=chat_with_retry)
+
+    sess = Session(key="cli:t")
+    sess.messages = [
+        {"role": "user", "content": "hi", "timestamp": "2026-04-11T10:00:00"},
+    ]
+    sess.last_consolidated = 0
+    loop.sessions.get_or_create.return_value = sess
+    loop.sessions.save = MagicMock()
+    loop.sessions.invalidate = MagicMock()
+
+    msg = MagicMock(channel="cli", chat_id="t", session_key="cli:t", metadata={})
+    ctx = CommandContext(msg=msg, session=sess, key="cli:t", raw="/wiki-archive", loop=loop)
+
+    out = await cmd_wiki_archive(ctx)
+    assert "Wrote" in out.content
+    assert "wiki/routing-db.md" in out.content
+    assert (tmp_path / "wiki" / "routing-db.md").is_file()
+    log_text = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+    assert "wiki-archive" in log_text and "routing-db.md" in log_text
+    index_text = (tmp_path / "wiki" / "index.md").read_text(encoding="utf-8")
+    assert "[Routing discussion]" in index_text
+    assert "PostgreSQL" in index_text
+
+    assert len(sess.messages) == 1
+    assert sess.messages[0]["role"] == "user"
+    assert "wiki/index.md" in str(sess.messages[0]["content"])
+    assert sess.last_consolidated == 0
+    loop.sessions.save.assert_called_once_with(sess)
+    loop.sessions.invalidate.assert_called_once_with(sess.key)
+
+
+@pytest.mark.asyncio
+async def test_cmd_wiki_archive_json_splits_two_topics(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    loop = MagicMock()
+    _mock_loop_bus(loop)
+    loop.consolidator.store = store
+    loop.model = "test/model"
+
+    payload = [
+        {
+            "category_slug": "auth-oauth",
+            "display_title": "OAuth",
+            "entry_markdown": "## Summary\n\nDevice flow.",
+        },
+        {
+            "category_slug": "db-schema",
+            "display_title": "Schema",
+            "entry_markdown": "## Summary\n\nAdded users table.",
+        },
+    ]
+
+    async def chat_with_retry(**kwargs):
+        r = MagicMock()
+        r.content = "```json\n" + json.dumps(payload, ensure_ascii=False) + "\n```"
+        return r
+
+    loop.provider.chat_with_retry = AsyncMock(side_effect=chat_with_retry)
+
+    sess = Session(key="cli:t")
+    sess.messages = [{"role": "user", "content": "hi", "timestamp": "2026-04-11T10:00:00"}]
+    sess.last_consolidated = 0
+    loop.sessions.get_or_create.return_value = sess
+    loop.sessions.save = MagicMock()
+    loop.sessions.invalidate = MagicMock()
+
+    msg = MagicMock(channel="cli", chat_id="t", session_key="cli:t", metadata={})
+    ctx = CommandContext(msg=msg, session=sess, key="cli:t", raw="/wiki-archive", loop=loop)
+
+    out = await cmd_wiki_archive(ctx)
+    assert "2 topic(s)" in out.content
+    assert (tmp_path / "wiki" / "auth-oauth.md").is_file()
+    assert (tmp_path / "wiki" / "db-schema.md").is_file()
+
+
+@pytest.mark.asyncio
+async def test_cmd_wiki_archive_json_page_kind_routes_to_subdir(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    loop = MagicMock()
+    _mock_loop_bus(loop)
+    loop.consolidator.store = store
+    loop.model = "test/model"
+
+    payload = [
+        {
+            "category_slug": "acme-corp",
+            "display_title": "Acme",
+            "page_kind": "entity",
+            "entry_markdown": "## Summary\n\nVendor for widgets.",
+        },
+        {
+            "category_slug": "widget-pattern",
+            "display_title": "Widget pattern",
+            "page_kind": "concept",
+            "entry_markdown": "## Summary\n\nFactory + adapter.",
+        },
+    ]
+
+    async def chat_with_retry(**kwargs):
+        r = MagicMock()
+        r.content = "```json\n" + json.dumps(payload, ensure_ascii=False) + "\n```"
+        return r
+
+    loop.provider.chat_with_retry = AsyncMock(side_effect=chat_with_retry)
+
+    sess = Session(key="cli:t")
+    sess.messages = [{"role": "user", "content": "hi", "timestamp": "2026-04-11T10:00:00"}]
+    sess.last_consolidated = 0
+    loop.sessions.get_or_create.return_value = sess
+    loop.sessions.save = MagicMock()
+    loop.sessions.invalidate = MagicMock()
+
+    msg = MagicMock(channel="cli", chat_id="t", session_key="cli:t", metadata={})
+    ctx = CommandContext(msg=msg, session=sess, key="cli:t", raw="/wiki-archive", loop=loop)
+
+    out = await cmd_wiki_archive(ctx)
+    assert "2 topic(s)" in out.content
+    assert (tmp_path / "wiki" / "entities" / "acme-corp.md").is_file()
+    assert (tmp_path / "wiki" / "concepts" / "widget-pattern.md").is_file()
+    assert "wiki/entities/acme-corp.md" in out.content or "entities/acme-corp.md" in out.content

--- a/tests/command/test_wiki_commands_extra.py
+++ b/tests/command/test_wiki_commands_extra.py
@@ -1,0 +1,163 @@
+"""Tests for /wiki-lint, /wiki-save-answer, /wiki-ingest."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.memory import MemoryStore
+from nanobot.command.builtin import cmd_wiki_ingest, cmd_wiki_lint, cmd_wiki_save_answer
+from nanobot.command.wiki_ingest import compute_wiki_ingest_bundle_sha256, run_wiki_ingest
+from nanobot.command.router import CommandContext
+from nanobot.session.manager import Session
+
+
+@pytest.mark.asyncio
+async def test_cmd_wiki_lint_reports_and_logs(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "x.md").write_text("Broken [[nope]] link.\n", encoding="utf-8")
+
+    store = MemoryStore(tmp_path)
+    loop = MagicMock()
+    loop.consolidator.store = store
+
+    msg = MagicMock(channel="cli", chat_id="t", session_key="cli:t", metadata={})
+    ctx = CommandContext(msg=msg, session=None, key="cli:t", raw="/wiki-lint", loop=loop)
+
+    out = await cmd_wiki_lint(ctx)
+    assert "Broken wikilink" in out.content or "dead" in out.content.lower()
+    log = (wiki / "log.md").read_text(encoding="utf-8")
+    assert "wiki-lint" in log
+
+
+@pytest.mark.asyncio
+async def test_cmd_wiki_save_answer_writes_queries(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    loop = MagicMock()
+    loop.consolidator.store = store
+    loop.sessions.get_or_create = MagicMock()
+
+    sess = Session(key="cli:t")
+    sess.messages = [
+        {"role": "user", "content": "q", "timestamp": "2026-04-11T10:00:00"},
+        {"role": "assistant", "content": "The answer is 42.", "timestamp": "2026-04-11T10:00:01"},
+    ]
+
+    msg = MagicMock(channel="cli", chat_id="t", session_key="cli:t", metadata={})
+    ctx = CommandContext(
+        msg=msg, session=sess, key="cli:t", raw="/wiki-save-answer my-answer", loop=loop,
+        args="my-answer ",
+    )
+    # Prefix handler sets args — simulate exact match with slug via args
+    ctx.args = "my-answer"
+
+    out = await cmd_wiki_save_answer(ctx)
+    assert "wiki/queries/my-answer.md" in out.content
+    text = (tmp_path / "wiki" / "queries" / "my-answer.md").read_text(encoding="utf-8")
+    assert "42" in text
+
+
+@pytest.mark.asyncio
+async def test_cmd_wiki_ingest_from_raw_sources(tmp_path: Path) -> None:
+    raw = tmp_path / "raw" / "sources"
+    raw.mkdir(parents=True)
+    (raw / "note.md").write_text("# Note\n\nHello ingest world unique-xyz.\n", encoding="utf-8")
+
+    store = MemoryStore(tmp_path)
+    loop = MagicMock()
+    loop.consolidator.store = store
+    loop.model = "test/model"
+
+    payload = [
+        {
+            "category_slug": "ingest-note",
+            "display_title": "Note",
+            "page_kind": "topic",
+            "entry_markdown": "## Summary\n\nunique-xyz captured.",
+        },
+    ]
+
+    async def chat_with_retry(**kwargs):
+        r = MagicMock()
+        r.content = "```json\n" + json.dumps(payload, ensure_ascii=False) + "\n```"
+        return r
+
+    loop.provider.chat_with_retry = AsyncMock(side_effect=chat_with_retry)
+
+    msg = MagicMock(channel="cli", chat_id="t", session_key="cli:t", metadata={})
+    ctx = CommandContext(msg=msg, session=None, key="cli:t", raw="/wiki-ingest", loop=loop)
+
+    out = await cmd_wiki_ingest(ctx)
+    assert "ingest-note.md" in out.content or "wiki/" in out.content
+    assert (tmp_path / "wiki" / "ingest-note.md").is_file()
+    log = (tmp_path / "wiki" / "log.md").read_text(encoding="utf-8")
+    assert "wiki-ingest" in log
+
+
+@pytest.mark.asyncio
+async def test_run_wiki_ingest_skips_model_when_raw_bundle_unchanged(tmp_path: Path) -> None:
+    raw = tmp_path / "raw" / "sources"
+    raw.mkdir(parents=True)
+    (raw / "n.md").write_text("hello bundle", encoding="utf-8")
+
+    paths = ["raw/sources/n.md"]
+    bundle_sha = compute_wiki_ingest_bundle_sha256(tmp_path, paths)
+    (tmp_path / "memory").mkdir(exist_ok=True)
+    (tmp_path / "memory" / "wiki_ingest_state.json").write_text(
+        json.dumps({"last_success_bundle_sha256": bundle_sha, "body_sha256": []}),
+        encoding="utf-8",
+    )
+
+    store = MemoryStore(tmp_path)
+    loop = MagicMock()
+    loop.consolidator.store = store
+    loop.model = "x"
+    chat = AsyncMock()
+    loop.provider.chat_with_retry = chat
+
+    result = await run_wiki_ingest(loop, workspace=tmp_path)
+    assert result.ok
+    assert not result.called_model
+    chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_wiki_ingest_force_bypasses_bundle_skip(tmp_path: Path) -> None:
+    raw = tmp_path / "raw" / "sources"
+    raw.mkdir(parents=True)
+    (raw / "n.md").write_text("hello bundle", encoding="utf-8")
+
+    paths = ["raw/sources/n.md"]
+    bundle_sha = compute_wiki_ingest_bundle_sha256(tmp_path, paths)
+    (tmp_path / "memory").mkdir(exist_ok=True)
+    (tmp_path / "memory" / "wiki_ingest_state.json").write_text(
+        json.dumps({"last_success_bundle_sha256": bundle_sha, "body_sha256": []}),
+        encoding="utf-8",
+    )
+
+    store = MemoryStore(tmp_path)
+    loop = MagicMock()
+    loop.consolidator.store = store
+    loop.model = "x"
+    payload = [
+        {
+            "category_slug": "force-ingest",
+            "display_title": "Force",
+            "page_kind": "topic",
+            "entry_markdown": "## Summary\n\nforced run unique.",
+        },
+    ]
+
+    async def chat_with_retry(**kwargs):
+        r = MagicMock()
+        r.content = "```json\n" + json.dumps(payload, ensure_ascii=False) + "\n```"
+        return r
+
+    loop.provider.chat_with_retry = AsyncMock(side_effect=chat_with_retry)
+
+    result = await run_wiki_ingest(loop, workspace=tmp_path, force_refresh=True)
+    assert result.called_model
+    assert result.ok
+    assert (tmp_path / "wiki" / "force-ingest.md").is_file()

--- a/tests/llm_wiki/test_automation.py
+++ b/tests/llm_wiki/test_automation.py
@@ -1,0 +1,20 @@
+"""Tests for wiki automation fingerprints and state."""
+
+from pathlib import Path
+
+from nanobot.llm_wiki.automation import compute_raw_fingerprint, wiki_automation_state_path
+from nanobot.llm_wiki.raw import ensure_raw_directories
+
+
+def test_compute_raw_fingerprint_changes_with_mtime(tmp_path: Path) -> None:
+    ensure_raw_directories(tmp_path)
+    p = tmp_path / "raw" / "sources" / "a.md"
+    p.write_text("v1", encoding="utf-8")
+    fp1 = compute_raw_fingerprint(tmp_path)
+    p.write_text("v2", encoding="utf-8")
+    fp2 = compute_raw_fingerprint(tmp_path)
+    assert fp1 != fp2
+
+
+def test_wiki_automation_state_under_memory(tmp_path: Path) -> None:
+    assert wiki_automation_state_path(tmp_path) == tmp_path / "memory" / "wiki_automation.json"

--- a/tests/llm_wiki/test_catalog.py
+++ b/tests/llm_wiki/test_catalog.py
@@ -1,0 +1,22 @@
+"""Tests for wiki page catalog helper."""
+
+from pathlib import Path
+
+from nanobot.llm_wiki.catalog import build_wiki_existing_pages_catalog, extract_markdown_h1
+
+
+def test_extract_markdown_h1() -> None:
+    assert extract_markdown_h1("# Hello\n\nx") == "Hello"
+    assert extract_markdown_h1("no heading") == ""
+
+
+def test_build_wiki_existing_pages_catalog_skips_special_pages(tmp_path: Path) -> None:
+    w = tmp_path / "wiki"
+    w.mkdir()
+    (w / "index.md").write_text("# Index\n", encoding="utf-8")
+    (w / "schema.md").write_text("# Schema\n", encoding="utf-8")
+    (w / "note.md").write_text("# My Note\n\nx\n", encoding="utf-8")
+    cat = build_wiki_existing_pages_catalog(tmp_path, max_chars=4000)
+    assert "index.md" not in cat
+    assert "note.md" in cat
+    assert "My Note" in cat

--- a/tests/llm_wiki/test_context.py
+++ b/tests/llm_wiki/test_context.py
@@ -1,0 +1,92 @@
+"""Unit tests for :mod:`nanobot.llm_wiki` (no MemoryStore)."""
+
+from pathlib import Path
+
+from nanobot.llm_wiki import (
+    STANDARD_WIKI_SUBDIRS,
+    build_wiki_context,
+    ensure_standard_wiki_dirs,
+    list_wiki_page_paths,
+    read_schema,
+    wiki_schema_rel,
+)
+
+
+def test_wiki_schema_rel_default() -> None:
+    assert wiki_schema_rel() == "wiki/schema.md"
+
+
+def test_ensure_standard_wiki_dirs_creates_layout(tmp_path: Path) -> None:
+    ensure_standard_wiki_dirs(tmp_path)
+    for name in STANDARD_WIKI_SUBDIRS:
+        assert (tmp_path / "wiki" / name).is_dir()
+    ensure_standard_wiki_dirs(tmp_path)  # idempotent
+    assert (tmp_path / "wiki" / "entities").is_dir()
+
+
+def test_list_wiki_page_paths_orders_index_first(tmp_path: Path) -> None:
+    (tmp_path / "wiki").mkdir(parents=True)
+    (tmp_path / "wiki" / "zebra.md").write_text("z", encoding="utf-8")
+    (tmp_path / "wiki" / "index.md").write_text("i", encoding="utf-8")
+    (tmp_path / "wiki" / "sub").mkdir()
+    (tmp_path / "wiki" / "sub" / "a.md").write_text("a", encoding="utf-8")
+
+    paths = list_wiki_page_paths(tmp_path)
+    assert paths[0].endswith("wiki/index.md")
+    assert "wiki/sub/a.md" in paths
+    assert "wiki/zebra.md" in paths
+
+
+def test_build_wiki_context_prepends_schema_before_other_pages(tmp_path: Path) -> None:
+    (tmp_path / "wiki").mkdir(parents=True)
+    (tmp_path / "wiki" / "schema.md").write_text(
+        "SCHEMA-RULE: prefer wikilinks.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "wiki" / "index.md").write_text("y" * 8000, encoding="utf-8")
+
+    out = build_wiki_context(tmp_path, max_total_chars=600)
+    assert "SCHEMA-RULE" in out
+    assert "wiki/schema.md" in out
+    assert out.find("SCHEMA-RULE") < out.find("wiki/index.md")
+    assert out.count("wiki/schema.md") == 1
+
+
+def test_build_wiki_context_orientation_schema_index_log_before_rest(tmp_path: Path) -> None:
+    (tmp_path / "wiki").mkdir(parents=True)
+    (tmp_path / "wiki" / "schema.md").write_text("SCHEMA-XYZ\n", encoding="utf-8")
+    (tmp_path / "wiki" / "index.md").write_text("INDEX-ABC\n", encoding="utf-8")
+    (tmp_path / "wiki" / "log.md").write_text("old\n" * 40 + "RECENT-TAIL-LINE\n", encoding="utf-8")
+    (tmp_path / "wiki" / "zebra.md").write_text("z" * 400, encoding="utf-8")
+
+    out = build_wiki_context(tmp_path, max_total_chars=4000)
+    assert out.find("SCHEMA-XYZ") < out.find("wiki/index.md")
+    assert out.find("wiki/index.md") < out.find("wiki/log.md (recent)")
+    assert "RECENT-TAIL-LINE" in out
+    assert out.find("wiki/log.md (recent)") < out.find("wiki/zebra.md")
+
+
+def test_read_schema_empty_when_missing(tmp_path: Path) -> None:
+    assert read_schema(tmp_path / "ws") == ""
+
+
+def test_build_wiki_context_truncates_by_budget(tmp_path: Path) -> None:
+    (tmp_path / "wiki").mkdir(parents=True)
+    (tmp_path / "wiki" / "index.md").write_text("x" * 500, encoding="utf-8")
+
+    out = build_wiki_context(tmp_path, max_total_chars=120)
+    assert "wiki/index.md" in out
+    assert "truncated" in out.lower()
+
+
+def test_build_wiki_context_empty_when_no_wiki(tmp_path: Path) -> None:
+    assert build_wiki_context(tmp_path / "ws") == ""
+
+
+def test_custom_wiki_dir_name(tmp_path: Path) -> None:
+    (tmp_path / "notes").mkdir(parents=True)
+    (tmp_path / "notes" / "index.md").write_text("hi", encoding="utf-8")
+    out = build_wiki_context(tmp_path, wiki_dir="notes", max_total_chars=500)
+    assert "notes/index.md" in out
+    assert read_schema(tmp_path, wiki_dir="notes") == ""
+    assert wiki_schema_rel(wiki_dir="notes") == "notes/schema.md"

--- a/tests/llm_wiki/test_lint.py
+++ b/tests/llm_wiki/test_lint.py
@@ -1,0 +1,42 @@
+"""Tests for nanobot.llm_wiki.lint."""
+
+from pathlib import Path
+
+from nanobot.llm_wiki.lint import run_wiki_lint
+
+
+def test_run_wiki_lint_dead_link(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "a.md").write_text("See [[missing-page]] for details.\n", encoding="utf-8")
+    r = run_wiki_lint(tmp_path)
+    assert len(r.dead_links) == 1
+    assert r.dead_links[0][1] == "missing-page"
+
+
+def test_run_wiki_lint_resolves_entity_page(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    (wiki / "entities").mkdir(parents=True)
+    (wiki / "entities" / "acme.md").write_text("ok\n", encoding="utf-8")
+    (wiki / "b.md").write_text("Link [[acme]] here.\n", encoding="utf-8")
+    r = run_wiki_lint(tmp_path)
+    assert r.dead_links == []
+
+
+def test_run_wiki_lint_resolves_comparison_page(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    (wiki / "comparisons").mkdir(parents=True)
+    (wiki / "comparisons" / "a-vs-b.md").write_text("ok\n", encoding="utf-8")
+    (wiki / "note.md").write_text("See [[a-vs-b]] for tradeoffs.\n", encoding="utf-8")
+    r = run_wiki_lint(tmp_path)
+    assert r.dead_links == []
+
+
+def test_run_wiki_lint_orphan(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    (wiki / "entities").mkdir(parents=True)
+    (wiki / "entities" / "lonely.md").write_text("no links in\n", encoding="utf-8")
+    (wiki / "index.md").write_text("# Index\n", encoding="utf-8")
+    r = run_wiki_lint(tmp_path)
+    orphan_rels = [p for p in r.orphan_pages if "lonely" in p]
+    assert len(orphan_rels) == 1

--- a/tests/llm_wiki/test_raw.py
+++ b/tests/llm_wiki/test_raw.py
@@ -1,0 +1,27 @@
+"""Tests for nanobot.llm_wiki.raw."""
+
+from pathlib import Path
+
+from nanobot.llm_wiki.raw import ensure_raw_directories, list_raw_source_files
+
+
+def test_ensure_raw_directories(tmp_path: Path) -> None:
+    ensure_raw_directories(tmp_path)
+    assert (tmp_path / "raw" / "sources").is_dir()
+    assert (tmp_path / "raw" / "articles").is_dir()
+    assert (tmp_path / "raw" / "papers").is_dir()
+    assert (tmp_path / "raw" / "transcripts").is_dir()
+    assert (tmp_path / "raw" / "assets").is_dir()
+
+
+def test_list_raw_source_files_sorted(tmp_path: Path) -> None:
+    ensure_raw_directories(tmp_path)
+    (tmp_path / "raw" / "sources" / "z.md").write_text("z", encoding="utf-8")
+    (tmp_path / "raw" / "sources" / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "raw" / "articles" / "clip.md").write_text("c", encoding="utf-8")
+    paths = list_raw_source_files(tmp_path)
+    assert paths == [
+        "raw/articles/clip.md",
+        "raw/sources/a.txt",
+        "raw/sources/z.md",
+    ]

--- a/tests/llm_wiki/test_relevance.py
+++ b/tests/llm_wiki/test_relevance.py
@@ -1,0 +1,24 @@
+"""Tests for relevance-ranked wiki context."""
+
+from pathlib import Path
+
+from nanobot.llm_wiki import build_wiki_context
+
+
+def test_build_wiki_context_relevance_orders_matching_page_first(tmp_path: Path) -> None:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "zebra.md").write_text("# Z\n\napple banana discussion.\n", encoding="utf-8")
+    (wiki / "match.md").write_text("# M\n\nuniquekeyword-xyz rare token here.\n", encoding="utf-8")
+
+    out_default = build_wiki_context(tmp_path, max_total_chars=8000)
+    out_ranked = build_wiki_context(
+        tmp_path,
+        max_total_chars=8000,
+        relevance_query="uniquekeyword-xyz",
+    )
+    assert "uniquekeyword-xyz" in out_ranked
+    pos_match = out_ranked.find("wiki/match.md")
+    pos_zebra = out_ranked.find("wiki/zebra.md")
+    assert pos_match < pos_zebra
+    assert out_default  # alphabetical / default path order still includes both files


### PR DESCRIPTION
- Introduced automatic wiki archiving triggered by context token thresholds, allowing for seamless integration of session content into the wiki.
- Added commands for manual wiki operations: `/wiki-archive` to summarize sessions, `/wiki-ingest` to merge raw sources into the wiki, `/wiki-lint` to check for broken links, and `/wiki-save-answer` to store assistant replies.
- Enhanced memory management to support multi-page topics and structured knowledge organization within the wiki directory.
- Updated configuration to include `auto_wiki_archive_at_context_fraction` for customizable archiving behavior.

This update significantly improves the usability and functionality of the wiki system, ensuring that knowledge is efficiently captured and maintained.