### PR TITLE
fix(copilot): trim large prompts to avoid gateway 400 Bad Request

### DIFF
--- a/nanobot/providers/github_copilot_provider.py
+++ b/nanobot/providers/github_copilot_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 import webbrowser
 from collections.abc import Callable
@@ -26,6 +27,8 @@ EDITOR_VERSION = "vscode/1.99.0"
 EDITOR_PLUGIN_VERSION = "copilot-chat/0.26.0"
 _EXPIRY_SKEW_SECONDS = 60
 _LONG_LIVED_TOKEN_SECONDS = 315360000
+# Copilot API gateway rejects request bodies exceeding ~1 MB.
+_MAX_REQUEST_BODY_BYTES = 950_000
 
 
 def _storage() -> FileTokenStorage:
@@ -211,6 +214,52 @@ class GitHubCopilotProvider(OpenAICompatProvider):
         self.api_key = token
         self._client.api_key = token
         return token
+
+    @staticmethod
+    def _trim_kwargs_body(
+        kwargs: dict[str, object],
+        max_body_bytes: int = _MAX_REQUEST_BODY_BYTES,
+    ) -> dict[str, object]:
+        """Drop oldest non-system messages from kwargs when body exceeds the size limit.
+
+        Called after _build_kwargs so all sanitization / cache-control fields
+        are already applied and the byte estimate is accurate.
+        """
+        body_bytes = len(json.dumps(kwargs, ensure_ascii=False, default=str).encode())
+        if body_bytes <= max_body_bytes:
+            return kwargs
+
+        messages: list[dict[str, object]] = list(kwargs.get("messages") or [])  # type: ignore[arg-type]
+
+        # Separate system messages (keep all) from conversation messages
+        system_msgs = [m for m in messages if m.get("role") == "system"]
+        conv_msgs = [m for m in messages if m.get("role") != "system"]
+
+        # Pre-compute per-message byte sizes for O(n) trimming
+        msg_sizes = [len(json.dumps(m, ensure_ascii=False, default=str).encode()) for m in conv_msgs]
+        conv_total = sum(msg_sizes)
+        non_conv_bytes = body_bytes - conv_total
+        target = max_body_bytes - non_conv_bytes
+
+        # Drop from the front until conversation fits within target
+        removed = 0
+        drop_count = 0
+        while drop_count < len(msg_sizes) and conv_total - removed > target:
+            removed += msg_sizes[drop_count]
+            drop_count += 1
+        conv_msgs = conv_msgs[drop_count:]
+
+        # Ensure we start on a user message to avoid orphan tool results
+        while conv_msgs and conv_msgs[0].get("role") not in ("user", "system"):
+            conv_msgs.pop(0)
+
+        kwargs = dict(kwargs)
+        kwargs["messages"] = system_msgs + conv_msgs
+        return kwargs
+
+    def _build_kwargs(self, *args: object, **kw: object) -> dict[str, object]:
+        kwargs = super()._build_kwargs(*args, **kw)  # type: ignore[arg-type]
+        return self._trim_kwargs_body(kwargs)
 
     async def chat(
         self,

--- a/tests/providers/test_copilot_trim.py
+++ b/tests/providers/test_copilot_trim.py
@@ -1,0 +1,154 @@
+"""Tests for GitHubCopilotProvider._trim_kwargs_body."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nanobot.providers.github_copilot_provider import (
+    GitHubCopilotProvider,
+    _MAX_REQUEST_BODY_BYTES,
+)
+
+
+def _make_messages(
+    n_pairs: int,
+    content_size: int = 100,
+    system_content: str = "You are helpful.",
+) -> list[dict[str, object]]:
+    """Build a system message + n_pairs of (user, assistant) messages."""
+    msgs: list[dict[str, object]] = [{"role": "system", "content": system_content}]
+    for i in range(n_pairs):
+        msgs.append({"role": "user", "content": f"msg-{i} " + "x" * content_size})
+        msgs.append({"role": "assistant", "content": f"reply-{i} " + "y" * content_size})
+    return msgs
+
+
+def _make_tools(n: int = 5) -> list[dict[str, object]]:
+    return [
+        {
+            "type": "function",
+            "function": {"name": f"tool_{i}", "description": "desc", "parameters": {}},
+        }
+        for i in range(n)
+    ]
+
+
+def _make_kwargs(
+    n_pairs: int = 10,
+    content_size: int = 100,
+    n_tools: int = 0,
+) -> dict[str, object]:
+    """Build a kwargs dict mimicking _build_kwargs output."""
+    kwargs: dict[str, object] = {
+        "model": "claude-sonnet-4.6",
+        "messages": _make_messages(n_pairs, content_size),
+        "temperature": 0.1,
+        "max_tokens": 8192,
+    }
+    if n_tools:
+        kwargs["tools"] = _make_tools(n_tools)
+        kwargs["tool_choice"] = "auto"
+    return kwargs
+
+
+def _body_size(kwargs: dict[str, object]) -> int:
+    return len(json.dumps(kwargs, ensure_ascii=False, default=str).encode())
+
+
+class TestTrimKwargsBody:
+    """Test suite for _trim_kwargs_body."""
+
+    def test_no_trim_when_under_limit(self) -> None:
+        """kwargs under the limit are returned unchanged."""
+        kwargs = _make_kwargs(3, content_size=10)
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs)
+        assert result is kwargs
+
+    def test_trims_when_over_limit(self) -> None:
+        """kwargs over the limit have messages trimmed."""
+        kwargs = _make_kwargs(200, content_size=3000, n_tools=12)
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs)
+        assert len(result["messages"]) < len(kwargs["messages"])
+
+    def test_system_messages_preserved(self) -> None:
+        """System messages are never dropped."""
+        kwargs = _make_kwargs(200, content_size=3000)
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs)
+        system_msgs = [m for m in result["messages"] if m.get("role") == "system"]
+        assert len(system_msgs) == 1
+        assert system_msgs[0]["content"] == "You are helpful."
+
+    def test_starts_with_user_after_system(self) -> None:
+        """After trimming, conversation starts with a user message."""
+        kwargs = _make_kwargs(200, content_size=3000)
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs)
+        non_system = [m for m in result["messages"] if m.get("role") != "system"]
+        assert non_system[0]["role"] == "user"
+
+    def test_result_under_body_limit(self) -> None:
+        """Trimmed result body size stays within the byte limit."""
+        kwargs = _make_kwargs(200, content_size=3000, n_tools=12)
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs)
+        assert _body_size(result) <= _MAX_REQUEST_BODY_BYTES
+
+    def test_custom_byte_limit(self) -> None:
+        """A custom max_body_bytes is respected."""
+        kwargs = _make_kwargs(50, content_size=500, n_tools=3)
+        limit = 10_000
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs, max_body_bytes=limit)
+        assert len(result["messages"]) < len(kwargs["messages"])
+        assert _body_size(result) <= limit
+
+    def test_no_tools(self) -> None:
+        """Works correctly when tools is absent."""
+        kwargs = _make_kwargs(200, content_size=3000)
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs)
+        assert len(result["messages"]) < len(kwargs["messages"])
+        assert result["messages"][0]["role"] == "system"
+
+    def test_orphan_tool_result_skipped(self) -> None:
+        """Tool result messages at the trim boundary are skipped."""
+        msgs: list[dict[str, object]] = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1", "tool_calls": [
+                {"id": "tc1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ]},
+            {"role": "tool", "content": "result1", "tool_call_id": "tc1"},
+            {"role": "assistant", "content": "done1"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+        kwargs: dict[str, object] = {"model": "test", "messages": msgs, "max_tokens": 100}
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs, max_body_bytes=200)
+        non_system = [m for m in result["messages"] if m.get("role") != "system"]
+        if non_system:
+            assert non_system[0]["role"] == "user"
+
+    def test_empty_messages(self) -> None:
+        """Empty message list is handled gracefully."""
+        kwargs: dict[str, object] = {"model": "test", "messages": [], "max_tokens": 100}
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs)
+        assert result["messages"] == []
+
+    def test_only_system_message(self) -> None:
+        """A single system message is returned as-is."""
+        kwargs: dict[str, object] = {
+            "model": "test",
+            "messages": [{"role": "system", "content": "hello"}],
+            "max_tokens": 100,
+        }
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs)
+        assert len(result["messages"]) == 1
+
+    def test_non_message_fields_preserved(self) -> None:
+        """Non-message kwargs fields (model, tools, temperature) are preserved."""
+        kwargs = _make_kwargs(200, content_size=3000, n_tools=5)
+        result = GitHubCopilotProvider._trim_kwargs_body(kwargs)
+        assert result["model"] == "claude-sonnet-4.6"
+        assert result["temperature"] == 0.1
+        assert result["max_tokens"] == 8192
+        assert result["tools"] == kwargs["tools"]
+


### PR DESCRIPTION
## Problem

The Copilot API gateway rejects requests with bodies exceeding ~1 MB, returning a bare \	ext/plain\ \Bad Request\ (HTTP 400) with no JSON error detail. When conversation history grows large (e.g. 248 messages / 1.38 MB), the request body exceeds this limit even though the token-based consolidation has not yet triggered.

## Root Cause

The existing \context_window_tokens\ consolidation budget (~56k tokens) controls the model context window, but the Copilot API gateway has a separate HTTP body size limit (~1 MB) that can be reached first  especially with tool definitions, tool_call fields, and JSON overhead inflating the serialized body far beyond the token count.

## Solution

Override \_build_kwargs\ in \GitHubCopilotProvider\ to call \_trim_kwargs_body\ **after** all parent-class transforms (sanitization, cache-control, role alternation) are applied. This ensures the byte estimate is accurate against the final serialized request body.

When the serialized kwargs exceed 950 KB (\_MAX_REQUEST_BODY_BYTES\):
- Compute exact body size via \json.dumps\ on the complete kwargs dict
- Drop oldest non-system messages from the front
- Preserve all system messages
- Align trim boundary to user messages to avoid orphan tool results

## Changes

- \
anobot/providers/github_copilot_provider.py\: Add \_trim_kwargs_body()\ static method and override \_build_kwargs()\ (2 lines)
- \	ests/providers/test_copilot_trim.py\: 11 test cases covering no-trim fast path, over-limit trimming, system message preservation, user-message alignment, custom limits, orphan tool result handling, and edge cases