### PR TITLE
fix(retry): strip images in-place to prevent repeated error-retry cycles

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -419,6 +419,26 @@ class LLMProvider(ABC):
                 result.append(msg)
         return result if found else None
 
+    @staticmethod
+    def _strip_image_content_inplace(messages: list[dict[str, Any]]) -> bool:
+        """Replace image_url blocks with text placeholder *in-place*.
+
+        Mutates the content lists of the original message dicts so that
+        callers holding references to those dicts also see the stripped
+        version.
+        """
+        found = False
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, list):
+                for i, b in enumerate(content):
+                    if isinstance(b, dict) and b.get("type") == "image_url":
+                        path = (b.get("_meta") or {}).get("path", "")
+                        placeholder = image_placeholder_text(path, empty="[image omitted]")
+                        content[i] = {"type": "text", "text": placeholder}
+                        found = True
+        return found
+
     async def _safe_chat(self, **kwargs: Any) -> LLMResponse:
         """Call chat() and convert unexpected exceptions to error responses."""
         try:
@@ -670,7 +690,12 @@ class LLMProvider(ABC):
                     )
                     retry_kw = dict(kw)
                     retry_kw["messages"] = stripped
-                    return await call(**retry_kw)
+                    result = await call(**retry_kw)
+                    # Permanently strip images from the original messages so
+                    # subsequent iterations do not repeat the error-retry cycle.
+                    if result.finish_reason != "error":
+                        self._strip_image_content_inplace(original_messages)
+                    return result
                 return response
 
             if persistent and identical_error_count >= self._PERSISTENT_IDENTICAL_ERROR_LIMIT:

--- a/tests/providers/test_provider_retry.py
+++ b/tests/providers/test_provider_retry.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 
 import pytest
 
@@ -152,7 +153,7 @@ async def test_non_transient_error_with_images_retries_without_images() -> None:
         LLMResponse(content="ok, no image"),
     ])
 
-    response = await provider.chat_with_retry(messages=_IMAGE_MSG)
+    response = await provider.chat_with_retry(messages=copy.deepcopy(_IMAGE_MSG))
 
     assert response.content == "ok, no image"
     assert provider.calls == 2
@@ -187,7 +188,7 @@ async def test_image_fallback_returns_error_on_second_failure() -> None:
         LLMResponse(content="still failing", finish_reason="error"),
     ])
 
-    response = await provider.chat_with_retry(messages=_IMAGE_MSG)
+    response = await provider.chat_with_retry(messages=copy.deepcopy(_IMAGE_MSG))
 
     assert provider.calls == 2
     assert response.content == "still failing"
@@ -202,7 +203,7 @@ async def test_image_fallback_without_meta_uses_default_placeholder() -> None:
         LLMResponse(content="ok"),
     ])
 
-    response = await provider.chat_with_retry(messages=_IMAGE_MSG_NO_META)
+    response = await provider.chat_with_retry(messages=copy.deepcopy(_IMAGE_MSG_NO_META))
 
     assert response.content == "ok"
     assert provider.calls == 2

--- a/tests/providers/test_provider_retry.py
+++ b/tests/providers/test_provider_retry.py
@@ -166,6 +166,24 @@ async def test_non_transient_error_with_images_retries_without_images() -> None:
 
 
 @pytest.mark.asyncio
+async def test_successful_image_retry_mutates_original_messages_in_place() -> None:
+    """Successful no-image retry should update the caller's message history."""
+    provider = ScriptedProvider([
+        LLMResponse(content="model does not support images", finish_reason="error"),
+        LLMResponse(content="ok, no image"),
+    ])
+    messages = copy.deepcopy(_IMAGE_MSG)
+
+    response = await provider.chat_with_retry(messages=messages)
+
+    assert response.content == "ok, no image"
+    content = messages[0]["content"]
+    assert isinstance(content, list)
+    assert all(block.get("type") != "image_url" for block in content)
+    assert any("[image: /media/test.png]" in (block.get("text") or "") for block in content)
+
+
+@pytest.mark.asyncio
 async def test_non_transient_error_without_images_no_retry() -> None:
     """Non-transient errors without image content are returned immediately."""
     provider = ScriptedProvider([


### PR DESCRIPTION
## Summary

- When a non-transient LLM error occurs with image content (e.g. a model that doesn't support images), `_run_with_retry` strips images from a **copy** for a single retry, but never updates the original conversation history. Subsequent agent loop iterations rebuild context from the unmodified history (still containing `image_url` blocks), causing the same error-retry cycle to repeat every iteration until `max_iterations` is reached — wasting tokens and time.
- Add `_strip_image_content_inplace()` that mutates the original message content lists **in-place** after a successful no-image retry, so all callers holding references to those dicts (e.g. `AgentRunner.messages`) see the stripped version immediately.
- Fix test isolation in `test_provider_retry.py` by using `copy.deepcopy()` for `_IMAGE_MSG` / `_IMAGE_MSG_NO_META` fixtures, since the new in-place mutation would otherwise corrupt module-level test data across tests.

## Root Cause

`_strip_image_content()` (non-mutating) creates new dicts/lists for the retry, but the runner's `messages` list still references the original message dicts with `image_url` blocks. On the next iteration, `_drop_orphan_tool_results` → `messages_for_model` chain shares those same content list objects, so the LLM sees images again and hits the same error.

The in-place approach works because `_drop_orphan_tool_results` either returns the same list or shallow-copies dicts that still share the inner content list references — so mutating `content[i]` propagates to the runner's history.

## Test plan

- [x] All 22 tests in `tests/providers/test_provider_retry.py` pass
- [x] Verified test isolation: `copy.deepcopy` prevents cross-test mutation from `_strip_image_content_inplace`
- [x] New method called only on the non-transient-error-with-images path, only after successful retry