### PR TITLE
fix(shell): tighten exec safety guards (#2989, #2826)

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -61,6 +61,14 @@ class ExecTool(Tool):
             r">\s*/dev/sd",                  # write to disk
             r"\b(shutdown|reboot|poweroff)\b",  # system power
             r":\(\)\s*\{.*\};\s*:",          # fork bomb
+            # Block writes to nanobot internal state files (#2989).
+            # history.jsonl / .dream_cursor are managed by append_history();
+            # direct writes corrupt the cursor format and crash /dream.
+            r">>?\s*\S*(?:history\.jsonl|\.dream_cursor)",            # > / >> redirect
+            r"\btee\b[^|;&<>]*(?:history\.jsonl|\.dream_cursor)",     # tee / tee -a
+            r"\b(?:cp|mv)\b[^|;&<>]*(?:history\.jsonl|\.dream_cursor)",  # cp/mv target
+            r"\bdd\b[^|;&<>]*\bof=\S*(?:history\.jsonl|\.dream_cursor)",  # dd of=
+            r"\bsed\s+-i[^|;&<>]*(?:history\.jsonl|\.dream_cursor)",  # sed -i
         ]
         self.allow_patterns = allow_patterns or []
         self.restrict_to_workspace = restrict_to_workspace

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -66,7 +66,7 @@ class ExecTool(Tool):
             # direct writes corrupt the cursor format and crash /dream.
             r">>?\s*\S*(?:history\.jsonl|\.dream_cursor)",            # > / >> redirect
             r"\btee\b[^|;&<>]*(?:history\.jsonl|\.dream_cursor)",     # tee / tee -a
-            r"\b(?:cp|mv)\b[^|;&<>]*(?:history\.jsonl|\.dream_cursor)",  # cp/mv target
+            r"\b(?:cp|mv)\b(?:\s+[^\s|;&<>]+)+\s+\S*(?:history\.jsonl|\.dream_cursor)",  # cp/mv target
             r"\bdd\b[^|;&<>]*\bof=\S*(?:history\.jsonl|\.dream_cursor)",  # dd of=
             r"\bsed\s+-i[^|;&<>]*(?:history\.jsonl|\.dream_cursor)",  # sed -i
         ]

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -101,6 +101,21 @@ class ExecTool(Tool):
         timeout: int | None = None, **kwargs: Any,
     ) -> str:
         cwd = working_dir or self.working_dir or os.getcwd()
+
+        # Prevent an LLM-supplied working_dir from escaping the configured
+        # workspace when restrict_to_workspace is enabled (#2826). Without
+        # this, a caller can pass working_dir="/etc" and then all absolute
+        # paths under /etc would pass the _guard_command check that anchors
+        # on cwd.
+        if self.restrict_to_workspace and self.working_dir:
+            try:
+                requested = Path(cwd).expanduser().resolve()
+                workspace_root = Path(self.working_dir).expanduser().resolve()
+            except Exception:
+                return "Error: working_dir could not be resolved"
+            if requested != workspace_root and workspace_root not in requested.parents:
+                return "Error: working_dir is outside the configured workspace"
+
         guard_error = self._guard_command(command, cwd)
         if guard_error:
             return guard_error

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -67,3 +67,49 @@ async def test_exec_blocks_chained_internal_url():
             command="echo start && curl http://169.254.169.254/latest/meta-data/ && echo done"
         )
     assert "Error" in result
+
+
+# --- #2989: block writes to nanobot internal state files -----------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat foo >> history.jsonl",
+        "echo '{}' > history.jsonl",
+        "echo '{}' > memory/history.jsonl",
+        "echo '{}' > ./workspace/memory/history.jsonl",
+        "tee -a history.jsonl < foo",
+        "tee history.jsonl",
+        "cp /tmp/fake.jsonl history.jsonl",
+        "mv backup.jsonl memory/history.jsonl",
+        "dd if=/dev/zero of=memory/history.jsonl",
+        "sed -i 's/old/new/' history.jsonl",
+        "echo x > .dream_cursor",
+        "cp /tmp/x memory/.dream_cursor",
+    ],
+)
+def test_exec_blocks_writes_to_history_jsonl(command):
+    """Direct writes to history.jsonl / .dream_cursor must be blocked (#2989)."""
+    tool = ExecTool()
+    result = tool._guard_command(command, "/tmp")
+    assert result is not None
+    assert "dangerous pattern" in result.lower()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat history.jsonl",
+        "wc -l history.jsonl",
+        "tail -n 5 history.jsonl",
+        "grep foo history.jsonl",
+        "ls memory/",
+        "echo history.jsonl",
+    ],
+)
+def test_exec_allows_reads_of_history_jsonl(command):
+    """Read-only access to history.jsonl must still be allowed."""
+    tool = ExecTool()
+    result = tool._guard_command(command, "/tmp")
+    assert result is None

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -104,6 +104,7 @@ def test_exec_blocks_writes_to_history_jsonl(command):
         "wc -l history.jsonl",
         "tail -n 5 history.jsonl",
         "grep foo history.jsonl",
+        "cp history.jsonl /tmp/history.backup",
         "ls memory/",
         "echo history.jsonl",
     ],

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -113,3 +113,71 @@ def test_exec_allows_reads_of_history_jsonl(command):
     tool = ExecTool()
     result = tool._guard_command(command, "/tmp")
     assert result is None
+
+
+# --- #2826: working_dir must not escape the configured workspace ---------
+
+
+@pytest.mark.asyncio
+async def test_exec_blocks_working_dir_outside_workspace(tmp_path):
+    """An LLM-supplied working_dir outside the workspace must be rejected."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=True)
+    result = await tool.execute(command="rm calendar.ics", working_dir="/etc")
+    assert "outside the configured workspace" in result
+
+
+@pytest.mark.asyncio
+async def test_exec_blocks_absolute_rm_via_hijacked_working_dir(tmp_path):
+    """Regression for #2826: `rm /abs/path` via working_dir hijack."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    victim_dir = tmp_path / "outside"
+    victim_dir.mkdir()
+    victim = victim_dir / "file.ics"
+    victim.write_text("data")
+
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=True)
+    result = await tool.execute(
+        command=f"rm {victim}",
+        working_dir=str(victim_dir),
+    )
+    assert "outside the configured workspace" in result
+    assert victim.exists(), "victim file must not have been deleted"
+
+
+@pytest.mark.asyncio
+async def test_exec_allows_working_dir_within_workspace(tmp_path):
+    """A working_dir that is a subdirectory of the workspace is fine."""
+    workspace = tmp_path / "workspace"
+    subdir = workspace / "project"
+    subdir.mkdir(parents=True)
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=True, timeout=5)
+    result = await tool.execute(command="echo ok", working_dir=str(subdir))
+    assert "ok" in result
+    assert "outside the configured workspace" not in result
+
+
+@pytest.mark.asyncio
+async def test_exec_allows_working_dir_equal_to_workspace(tmp_path):
+    """Passing working_dir equal to the workspace root must be allowed."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=True, timeout=5)
+    result = await tool.execute(command="echo ok", working_dir=str(workspace))
+    assert "ok" in result
+    assert "outside the configured workspace" not in result
+
+
+@pytest.mark.asyncio
+async def test_exec_ignores_workspace_check_when_not_restricted(tmp_path):
+    """Without restrict_to_workspace, the LLM may still choose any working_dir."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=False, timeout=5)
+    result = await tool.execute(command="echo ok", working_dir=str(other))
+    assert "ok" in result
+    assert "outside the configured workspace" not in result


### PR DESCRIPTION
Closes #2989, #2826
 
- Block exec writes to `history.jsonl` / `.dream_cursor` via `>`, `tee`, `cp`/`mv`, `dd of=`, `sed -i`. Reads still allowed. #2989
- When `restrict_to_workspace` is on, reject LLM-supplied `working_dir` that resolves outside
  the configured workspace root. #2826