### PR TITLE
fix(agent): detect and break out of infinite tool call loops

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
 import inspect
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
 from nanobot.agent.hook import AgentHook, AgentHookContext
-from nanobot.utils.prompt_templates import render_template
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.providers.base import LLMProvider, ToolCallRequest
 from nanobot.utils.helpers import (
@@ -22,6 +21,7 @@ from nanobot.utils.helpers import (
     maybe_persist_tool_result,
     truncate_text,
 )
+from nanobot.utils.prompt_templates import render_template
 from nanobot.utils.runtime import (
     EMPTY_FINAL_RESPONSE_MESSAGE,
     build_finalization_retry_message,
@@ -29,6 +29,7 @@ from nanobot.utils.runtime import (
     ensure_nonempty_tool_result,
     is_blank_text,
     repeated_external_lookup_error,
+    repeated_tool_call_error,
 )
 
 _DEFAULT_ERROR_MESSAGE = "Sorry, I encountered an error calling the AI model."
@@ -189,6 +190,7 @@ class AgentRunner:
         stop_reason = "completed"
         tool_events: list[dict[str, str]] = []
         external_lookup_counts: dict[str, int] = {}
+        tool_call_counts: dict[str, int] = {}
         empty_content_retries = 0
         length_recovery_count = 0
         had_injections = False
@@ -259,6 +261,7 @@ class AgentRunner:
                     spec,
                     response.tool_calls,
                     external_lookup_counts,
+                    tool_call_counts,
                 )
                 tool_events.extend(new_events)
                 context.tool_results = list(results)
@@ -562,18 +565,19 @@ class AgentRunner:
         spec: AgentRunSpec,
         tool_calls: list[ToolCallRequest],
         external_lookup_counts: dict[str, int],
+        tool_call_counts: dict[str, int] | None = None,
     ) -> tuple[list[Any], list[dict[str, str]], BaseException | None]:
         batches = self._partition_tool_batches(spec, tool_calls)
         tool_results: list[tuple[Any, dict[str, str], BaseException | None]] = []
         for batch in batches:
             if spec.concurrent_tools and len(batch) > 1:
                 tool_results.extend(await asyncio.gather(*(
-                    self._run_tool(spec, tool_call, external_lookup_counts)
+                    self._run_tool(spec, tool_call, external_lookup_counts, tool_call_counts)
                     for tool_call in batch
                 )))
             else:
                 for tool_call in batch:
-                    tool_results.append(await self._run_tool(spec, tool_call, external_lookup_counts))
+                    tool_results.append(await self._run_tool(spec, tool_call, external_lookup_counts, tool_call_counts))
 
         results: list[Any] = []
         events: list[dict[str, str]] = []
@@ -590,6 +594,7 @@ class AgentRunner:
         spec: AgentRunSpec,
         tool_call: ToolCallRequest,
         external_lookup_counts: dict[str, int],
+        tool_call_counts: dict[str, int] | None = None,
     ) -> tuple[Any, dict[str, str], BaseException | None]:
         _HINT = "\n\n[Analyze the error above and try a different approach.]"
         lookup_error = repeated_external_lookup_error(
@@ -606,6 +611,23 @@ class AgentRunner:
             if spec.fail_on_tool_error:
                 return lookup_error + _HINT, event, RuntimeError(lookup_error)
             return lookup_error + _HINT, event, None
+        # General stagnation guard: block any tool called with identical
+        # arguments more than _MAX_REPEAT_TOOL_CALLS times in a single run.
+        if tool_call_counts is not None:
+            stagnation_error = repeated_tool_call_error(
+                tool_call.name,
+                tool_call.arguments,
+                tool_call_counts,
+            )
+            if stagnation_error:
+                event = {
+                    "name": tool_call.name,
+                    "status": "error",
+                    "detail": "repeated tool call blocked (stagnation)",
+                }
+                if spec.fail_on_tool_error:
+                    return stagnation_error, event, RuntimeError(stagnation_error)
+                return stagnation_error, event, None
         prepare_call = getattr(spec.tools, "prepare_call", None)
         tool, params, prep_error = None, tool_call.arguments, None
         if callable(prepare_call):

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from loguru import logger
@@ -9,6 +10,7 @@ from loguru import logger
 from nanobot.utils.helpers import stringify_text_blocks
 
 _MAX_REPEAT_EXTERNAL_LOOKUPS = 2
+_MAX_REPEAT_TOOL_CALLS = 3
 
 EMPTY_FINAL_RESPONSE_MESSAGE = (
     "I completed the tool steps but couldn't produce a final answer. "
@@ -94,4 +96,59 @@ def repeated_external_lookup_error(
     return (
         "Error: repeated external lookup blocked. "
         "Use the results you already have to answer, or try a meaningfully different source."
+    )
+
+
+# ---------------------------------------------------------------------------
+# General tool-call stagnation detection
+# ---------------------------------------------------------------------------
+
+
+def tool_call_signature(tool_name: str, arguments: dict[str, Any]) -> str:
+    """Stable signature for a tool call (name + sorted arguments).
+
+    Returns a deterministic string key so the runner can detect when the
+    model is calling the same tool with the same arguments repeatedly —
+    a common symptom of the model getting stuck in a loop.
+    """
+    try:
+        args_key = json.dumps(arguments, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        args_key = str(arguments)
+    return f"{tool_name}:{args_key}"
+
+
+def repeated_tool_call_error(
+    tool_name: str,
+    arguments: dict[str, Any],
+    seen_counts: dict[str, int],
+    *,
+    max_repeats: int = _MAX_REPEAT_TOOL_CALLS,
+) -> str | None:
+    """Return an error string when the same tool+args combination repeats too many times.
+
+    This is a generalised version of :func:`repeated_external_lookup_error`
+    that covers **all** tools, not just web searches.  It catches the common
+    failure mode where the model enters an infinite loop calling the same
+    tool (e.g. ``read_file`` on ``history.jsonl``) without making progress.
+
+    The caller should maintain a ``seen_counts`` dict across the entire
+    ``AgentRunner.run()`` invocation and pass it on every tool execution.
+    """
+    sig = tool_call_signature(tool_name, arguments)
+    count = seen_counts.get(sig, 0) + 1
+    seen_counts[sig] = count
+    if count <= max_repeats:
+        return None
+    logger.warning(
+        "Blocking repeated tool call {} on attempt {} (max {})",
+        sig[:200],
+        count,
+        max_repeats,
+    )
+    return (
+        f"Error: you have already called {tool_name} with identical arguments "
+        f"{max_repeats} times. Summarize the information you already have "
+        "and provide your response to the user. Do not call this tool again "
+        "with the same arguments."
     )

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -1014,10 +1014,23 @@ async def test_subagent_max_iterations_announces_existing_fallback(tmp_path, mon
     bus = MessageBus()
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
-    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="working",
-        tool_calls=[ToolCallRequest(id="call_1", name="list_dir", arguments={"path": "."})],
-    ))
+    # Use different arguments on each call so the stagnation guard does not
+    # fire.  This tests the max_iterations path for a model that makes
+    # progress (different args each time) but never produces a final answer.
+    _call_n = {"n": 0}
+
+    async def _chat(*, messages, **kwargs):
+        _call_n["n"] += 1
+        return LLMResponse(
+            content="working",
+            tool_calls=[ToolCallRequest(
+                id=f"call_{_call_n['n']}",
+                name="list_dir",
+                arguments={"path": f"./dir_{_call_n['n']}"},
+            )],
+        )
+
+    provider.chat_with_retry = _chat
     mgr = SubagentManager(
         provider=provider,
         workspace=tmp_path,
@@ -2410,3 +2423,151 @@ async def test_dispatch_republishes_leftover_queue_messages(tmp_path):
     contents = [m.content for m in msgs]
     assert "leftover-1" in contents
     assert "leftover-2" in contents
+
+
+def test_tool_call_signature_deterministic():
+    """tool_call_signature produces the same key for the same name+args."""
+    from nanobot.utils.runtime import tool_call_signature
+
+    sig_a = tool_call_signature("read_file", {"path": "/tmp/a.txt", "limit": 50})
+    sig_b = tool_call_signature("read_file", {"limit": 50, "path": "/tmp/a.txt"})
+    assert sig_a == sig_b, "Argument order should not affect the signature"
+
+    sig_c = tool_call_signature("read_file", {"path": "/tmp/b.txt", "limit": 50})
+    assert sig_a != sig_c, "Different arguments should produce different signatures"
+
+    sig_d = tool_call_signature("grep", {"path": "/tmp/a.txt", "limit": 50})
+    assert sig_a != sig_d, "Different tool names should produce different signatures"
+
+
+def test_repeated_tool_call_error_blocks_after_threshold():
+    """repeated_tool_call_error should return None for the first N calls
+    and an error string after that."""
+    from nanobot.utils.runtime import repeated_tool_call_error
+
+    counts: dict[str, int] = {}
+    args = {"path": "history.jsonl", "limit": 50, "offset": 1}
+
+    # First 3 calls should pass (default max_repeats=3)
+    for _ in range(3):
+        result = repeated_tool_call_error("read_file", args, counts)
+        assert result is None
+
+    # 4th call should be blocked
+    result = repeated_tool_call_error("read_file", args, counts)
+    assert result is not None
+    assert "read_file" in result
+    assert "identical arguments" in result
+
+
+def test_repeated_tool_call_error_different_args_not_blocked():
+    """Different arguments for the same tool should not trigger blocking."""
+    from nanobot.utils.runtime import repeated_tool_call_error
+
+    counts: dict[str, int] = {}
+
+    for i in range(10):
+        result = repeated_tool_call_error("read_file", {"path": f"file_{i}.txt"}, counts)
+        assert result is None, f"Call {i} with unique args should not be blocked"
+
+
+@pytest.mark.asyncio
+async def test_runner_blocks_repeated_identical_tool_calls():
+    """The runner should detect when the model calls the same tool with
+    identical arguments repeatedly and block the call with a helpful error,
+    preventing infinite loops like the one described in issue #3073."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    call_count = {"n": 0}
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        # First 5 iterations: model stubbornly calls read_file with same args
+        if call_count["n"] <= 5:
+            return LLMResponse(
+                content="let me check",
+                tool_calls=[ToolCallRequest(
+                    id=f"call_{call_count['n']}",
+                    name="read_file",
+                    arguments={"path": "~/.nanobot/workspace/memory/history.jsonl", "limit": 50, "offset": 1},
+                )],
+                usage={"prompt_tokens": 100, "completion_tokens": 50},
+            )
+        # After getting the stagnation error, model produces final response
+        return LLMResponse(content="Here is a summary of recent events.", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="line 1: something happened\nline 2: another thing")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What happened recently?"},
+        ],
+        tools=tools,
+        model="test-model",
+        max_iterations=10,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    # The model should have been forced to produce a final response
+    assert result.final_content == "Here is a summary of recent events."
+    assert result.stop_reason == "completed"
+    # read_file should have been called but blocked after 3 repeats (default)
+    assert "read_file" in result.tools_used
+    # Check that at least one tool event records the stagnation block
+    stagnation_events = [
+        e for e in result.tool_events if "stagnation" in e.get("detail", "")
+    ]
+    assert len(stagnation_events) > 0
+
+
+@pytest.mark.asyncio
+async def test_runner_allows_same_tool_with_different_arguments():
+    """Calls to the same tool with *different* arguments should not be blocked."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    call_count = {"n": 0}
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] <= 4:
+            return LLMResponse(
+                content="reading",
+                tool_calls=[ToolCallRequest(
+                    id=f"call_{call_count['n']}",
+                    name="read_file",
+                    arguments={"path": f"file_{call_count['n']}.txt"},
+                )],
+                usage={"prompt_tokens": 100, "completion_tokens": 50},
+            )
+        return LLMResponse(content="done reading all files", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="file content")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "Read all files"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=10,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done reading all files"
+    assert result.stop_reason == "completed"
+    # All 4 reads should have succeeded since arguments differ
+    assert result.tools_used.count("read_file") == 4
+    # No stagnation events
+    stagnation_events = [
+        e for e in result.tool_events if "stagnation" in e.get("detail", "")
+    ]
+    assert len(stagnation_events) == 0


### PR DESCRIPTION
## Summary

Fixes #3073 — when the model repeatedly calls the same tool with identical arguments (e.g. `read_file` on `history.jsonl` with the same offset/limit), the agent now detects the stagnation after 3 repeats and returns an instructive error that forces the model to summarize what it already has and respond to the user.

## Problem

The agent runner loop has no mechanism to detect when the model is calling the same tool with the same arguments repeatedly without making progress. This causes the model to burn through all `max_iterations` doing nothing useful — wasting tokens, time, and leaving the user without a response.

Reported scenario: asking "what happened recently?" causes 15+ identical `read_file` calls on `history.jsonl` with the exact same `{"path": "~/.nanobot/workspace/memory/history.jsonl", "limit": 50, "offset": 1}` parameters every time.

## Solution

Generalise the existing `repeated_external_lookup_error` pattern (which only covers `web_fetch`/`web_search`) to **all** tools:

- **`tool_call_signature(name, args)`** — deterministic key from tool name + sorted JSON arguments
- **`repeated_tool_call_error(name, args, seen_counts)`** — blocks after 3 identical calls (configurable via `max_repeats`) with a clear error message instructing the model to stop repeating and respond

The guard is integrated into `AgentRunner._run_tool()` alongside the existing external lookup guard. It uses a separate counter dict (`tool_call_counts`) scoped to each `run()` invocation so it resets per turn.

### Key design decisions

- **Does not interfere with the existing `repeated_external_lookup_error`** — that guard fires first (at 2 repeats) for web tools; the general guard is a second line of defense
- **Different arguments = different signature** — calling `read_file` on 10 different files works fine; only identical name+args combos are blocked
- **Threshold of 3** — generous enough for legitimate retries, strict enough to catch the infinite loop quickly (saves 12+ wasted iterations in the reported case)

## Changes

| File | What changed |
|------|-------------|
| `nanobot/utils/runtime.py` | Added `tool_call_signature()` and `repeated_tool_call_error()` |
| `nanobot/agent/runner.py` | Track `tool_call_counts` in `run()`, pass to `_execute_tools`/`_run_tool`, check before execution |
| `tests/agent/test_runner.py` | 5 new tests: 3 unit tests for signature/blocking logic, 2 integration tests for runner behavior |

## Tests

All 65 tests in `test_runner.py` pass (including 5 new tests):

- `test_tool_call_signature_deterministic` — verifies key stability and argument-order independence
- `test_repeated_tool_call_error_blocks_after_threshold` — verifies blocking at N+1
- `test_repeated_tool_call_error_different_args_not_blocked` — verifies different args are not blocked
- `test_runner_blocks_repeated_identical_tool_calls` — end-to-end: model gets stuck, guard fires, model recovers
- `test_runner_allows_same_tool_with_different_arguments` — end-to-end: different args pass through

Full test suite (1595 tests) passes with 0 failures.