### PR TITLE
feat(providers): add minimax_anthropic provider for native thinking support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -119,6 +119,7 @@ class ProvidersConfig(Base):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
+    minimax_anthropic: ProviderConfig = Field(default_factory=ProviderConfig)  # MiniMax Anthropic-compatible API
     mistral: ProviderConfig = Field(default_factory=ProviderConfig)
     stepfun: ProviderConfig = Field(default_factory=ProviderConfig)  # Step Fun (阶跃星辰)
     xiaomi_mimo: ProviderConfig = Field(default_factory=ProviderConfig)  # Xiaomi MIMO (小米)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -280,6 +280,15 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         default_api_base="https://api.minimax.io/v1",
     ),
+    # MiniMax (Anthropic): Anthropic-compatible API for M2.x thinking/reasoning
+    ProviderSpec(
+        name="minimax_anthropic",
+        keywords=("minimax-anthropic",),
+        env_key="MINIMAX_API_KEY",
+        display_name="MiniMax (Anthropic)",
+        backend="anthropic",
+        default_api_base="https://api.minimax.io/anthropic",
+    ),
     # Mistral AI: OpenAI-compatible API
     ProviderSpec(
         name="mistral",


### PR DESCRIPTION
## Summary

- Add `minimax_anthropic` ProviderSpec (`backend="anthropic"`, endpoint `https://api.minimax.io/anthropic`) to `registry.py`
- Add corresponding `minimax_anthropic` field to `ProvidersConfig` in `schema.py`

## Context

MiniMax M2.x models officially recommend the Anthropic-compatible API for thinking/reasoning. The existing `minimax` provider (OpenAI backend) silently ignores `reasoning_effort` and embeds thinking in `<think/>` tags. This new provider routes through the Anthropic backend, enabling:

- **Native `thinking` blocks** in responses
- **Proper `reasoning_effort` translation** (`adaptive`/`budget_tokens`)
- **Interleaved thinking** between tool calls (M2.7)

Closes #3068

## Test plan

- [x] Verified new `minimax_anthropic` ProviderSpec loads correctly with expected backend, env_key, and api_base
- [x] Verified `ProvidersConfig.minimax_anthropic` field exists
- [x] All existing provider tests pass (2 pre-existing failures unrelated to this change)