### PR TITLE
fix(cron): suppress duplicate delivery acks

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -34,6 +34,7 @@ class MessageTool(Tool):
         self._default_chat_id = default_chat_id
         self._default_message_id = default_message_id
         self._sent_in_turn: bool = False
+        self._any_sent_in_turn: bool = False
 
     def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
         """Set the current message context."""
@@ -48,6 +49,7 @@ class MessageTool(Tool):
     def start_turn(self) -> None:
         """Reset per-turn send tracking."""
         self._sent_in_turn = False
+        self._any_sent_in_turn = False
 
     @property
     def name(self) -> str:
@@ -104,6 +106,7 @@ class MessageTool(Tool):
 
         try:
             await self._send_callback(msg)
+            self._any_sent_in_turn = True
             if channel == self._default_channel and chat_id == self._default_chat_id:
                 self._sent_in_turn = True
             media_info = f" with {len(media)} attachments" if media else ""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -729,7 +729,7 @@ def gateway(
         response = resp.content if resp else ""
 
         message_tool = agent.tools.get("message")
-        if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
+        if isinstance(message_tool, MessageTool) and message_tool._any_sent_in_turn:
             return response
 
         if job.payload.deliver and job.payload.to and response:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -977,6 +977,88 @@ def test_gateway_cron_evaluator_receives_scheduled_reminder_context(
     )
 
 
+def test_gateway_cron_skips_duplicate_delivery_when_message_tool_sent_cross_channel(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_file = _write_instance_config(tmp_path)
+    config = Config()
+    seen: dict[str, object] = {}
+
+    class _FakeCron:
+        def __init__(self, *args, **kwargs) -> None:
+            self.on_job = None
+            seen["cron"] = self
+
+        def status(self):
+            return {"jobs": 0}
+
+        async def start(self):
+            return None
+
+        def stop(self):
+            return None
+
+    class _FakeAgentLoop:
+        def __init__(self, *args, **kwargs) -> None:
+            from nanobot.agent.tools.message import MessageTool
+            from nanobot.agent.tools.registry import ToolRegistry
+
+            self.model = "test-model"
+            self.tools = ToolRegistry()
+            self._message_tool = MessageTool(send_callback=AsyncMock())
+            self.tools.register(self._message_tool)
+
+        async def process_direct(self, *args, **kwargs):
+            self._message_tool.start_turn()
+            self._message_tool.set_context("telegram", "user-1")
+            await self._message_tool.execute(
+                "Forwarded update",
+                channel="discord",
+                chat_id="channel:123",
+            )
+            from nanobot.bus.events import OutboundMessage
+            return OutboundMessage(channel="telegram", chat_id="user-1", content="Message sent to discord:channel:123")
+
+    class _StopAfterCronSetup:
+        def __init__(self, *args, **kwargs) -> None:
+            raise _StopGatewayError("stop")
+
+    bus = AsyncMock()
+    provider = object()
+
+    _patch_cli_command_runtime(
+        monkeypatch,
+        config,
+        message_bus=lambda: bus,
+        make_provider=lambda _cfg: provider,
+        cron_service=_FakeCron,
+    )
+    monkeypatch.setattr("nanobot.agent.loop.AgentLoop", _FakeAgentLoop)
+    monkeypatch.setattr("nanobot.channels.manager.ChannelManager", _StopAfterCronSetup)
+
+    result = runner.invoke(app, ["gateway", "--config", str(config_file)])
+
+    assert isinstance(result.exception, _StopGatewayError)
+    cron = seen["cron"]
+    assert cron.on_job is not None
+
+    job = CronJob(
+        id="cron-2",
+        name="forward-update",
+        payload=CronPayload(
+            message="Send a message to Discord.",
+            deliver=True,
+            channel="telegram",
+            to="user-1",
+        ),
+    )
+
+    response = asyncio.run(cron.on_job(job))
+
+    assert response == "Message sent to discord:channel:123"
+    bus.publish_outbound.assert_not_awaited()
+
+
 def test_gateway_workspace_override_does_not_migrate_legacy_cron(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/tools/test_message_tool_suppress.py
+++ b/tests/tools/test_message_tool_suppress.py
@@ -155,15 +155,22 @@ class TestMessageToolSuppressLogic:
 
 class TestMessageToolTurnTracking:
 
-    def test_sent_in_turn_tracks_same_target(self) -> None:
-        tool = MessageTool()
+    @pytest.mark.asyncio
+    async def test_sent_in_turn_only_tracks_same_target(self) -> None:
+        sent: list[OutboundMessage] = []
+        tool = MessageTool(send_callback=AsyncMock(side_effect=lambda m: sent.append(m)))
         tool.set_context("feishu", "chat1")
+
+        await tool.execute("hello", channel="email", chat_id="user@example.com")
+
+        assert len(sent) == 1
         assert not tool._sent_in_turn
-        tool._sent_in_turn = True
-        assert tool._sent_in_turn
+        assert tool._any_sent_in_turn
 
     def test_start_turn_resets(self) -> None:
         tool = MessageTool()
         tool._sent_in_turn = True
+        tool._any_sent_in_turn = True
         tool.start_turn()
         assert not tool._sent_in_turn
+        assert not tool._any_sent_in_turn


### PR DESCRIPTION
## Summary
- track whether the message tool sent any message during a turn, not just same-chat replies
- use that broader signal in cron delivery so scheduled cross-channel sends do not echo a duplicate "Message sent..." ack back to the original chat
- keep same-target suppression semantics unchanged for normal interactive turns

## Related Issues
Fixes #3066

## Testing
- `PYTHONPATH=/home/node/.openclaw/workspace/repos/nanobot pytest -q tests/tools/test_message_tool_suppress.py tests/cli/test_commands.py -k "message_tool or cron_skips_duplicate_delivery"`
