### PR TITLE
fix(provider): recover trailing assistant as user to prevent Zhipu 1214

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -392,8 +392,22 @@ class LLMProvider(ABC):
             else:
                 merged.append(dict(msg))
 
+        last_popped = None
         while merged and merged[-1].get("role") == "assistant":
-            merged.pop()
+            last_popped = merged.pop()
+
+        # If removing trailing assistant messages left only system messages,
+        # the request would be invalid for most providers (e.g. Zhipu/GLM
+        # error 1214).  Recover by converting the last popped assistant
+        # message to a user message so the LLM can still see the content.
+        if (
+            merged
+            and last_popped is not None
+            and not any(m.get("role") in ("user", "tool") for m in merged)
+        ):
+            recovered = dict(last_popped)
+            recovered["role"] = "user"
+            merged.append(recovered)
 
         return merged
 

--- a/tests/providers/test_enforce_role_alternation.py
+++ b/tests/providers/test_enforce_role_alternation.py
@@ -131,6 +131,47 @@ class TestEnforceRoleAlternation:
         assert msgs[0] == original_first
         assert len(msgs) == 2
 
+    def test_trailing_assistant_recovered_as_user_when_only_system_remains(self):
+        """Subagent result injected as assistant message must not be silently dropped.
+
+        When build_messages(current_role="assistant") produces [system, assistant],
+        _enforce_role_alternation would drop the assistant, leaving only [system].
+        Most providers (e.g. Zhipu/GLM error 1214) reject such requests.
+        The trailing assistant should be recovered as a user message instead.
+        """
+        msgs = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "assistant", "content": "Subagent completed successfully."},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert len(result) == 2
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "user"
+        assert "Subagent completed successfully." in result[1]["content"]
+
+    def test_trailing_assistant_not_recovered_when_user_message_present(self):
+        """Recovery should NOT happen when a user message already exists."""
+        msgs = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert len(result) == 2
+        assert result[-1]["role"] == "user"
+
+    def test_trailing_assistant_recovered_with_tool_result_preceding(self):
+        """When only [system, tool, assistant] remains, recovery is not needed
+        because tool messages are valid non-system content."""
+        msgs = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "tool", "content": "result", "tool_call_id": "1"},
+            {"role": "assistant", "content": "Done."},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert len(result) == 2
+        assert result[-1]["role"] == "tool"
+
     def test_only_assistant_messages(self):
         msgs = [
             {"role": "assistant", "content": "A"},


### PR DESCRIPTION
## Summary

Cherry-pick of #3082 — fix Zhipu/GLM error `1214 ("messages 参数非法")` triggered when a subagent result is the only content injected into a conversation.

- `_enforce_role_alternation` now recovers the last popped assistant message as a user message when no user/tool messages remain
- Add 3 regression tests covering the subagent injection, normal, and tool-result scenarios

## Root Cause

When a subagent completes, `loop.py:627` sets `current_role="assistant"` and `build_messages()` appends an assistant message. `_enforce_role_alternation()` drops all trailing assistant messages, leaving only the system prompt, which providers like Zhipu reject with error 1214.

## Reproduction

```python
import asyncio, httpx

async def reproduce():
    async with httpx.AsyncClient(timeout=30) as client:
        resp = await client.post(
            "https://open.bigmodel.cn/api/paas/v4/chat/completions",
            headers={
                "Authorization": "Bearer YOUR_ZHIPU_API_KEY",
                "Content-Type": "application/json",
            },
            json={
                "model": "glm-4-flash",
                "messages": [
                    {"role": "system", "content": "You are helpful."}
                ],
                "max_tokens": 100,
            },
        )
        print(resp.status_code, resp.json())

asyncio.run(reproduce())
# Output: 400 {"error":{"code":"1214","message":"messages 参数非法。请检查文档。"}}
```