### PR TITLE
feat(runner): add duration_ms to tool events

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 import inspect
+import time
 from pathlib import Path
 from typing import Any
 
@@ -602,6 +603,7 @@ class AgentRunner:
                 "name": tool_call.name,
                 "status": "error",
                 "detail": "repeated external lookup blocked",
+                "duration_ms": 0,
             }
             if spec.fail_on_tool_error:
                 return lookup_error + _HINT, event, RuntimeError(lookup_error)
@@ -620,8 +622,10 @@ class AgentRunner:
                 "name": tool_call.name,
                 "status": "error",
                 "detail": prep_error.split(": ", 1)[-1][:120],
+                "duration_ms": 0,
             }
             return prep_error + _HINT, event, RuntimeError(prep_error) if spec.fail_on_tool_error else None
+        t0 = time.time()
         try:
             if tool is not None:
                 result = await tool.execute(**params)
@@ -630,20 +634,24 @@ class AgentRunner:
         except asyncio.CancelledError:
             raise
         except BaseException as exc:
+            duration_ms = round((time.time() - t0) * 1000)
             event = {
                 "name": tool_call.name,
                 "status": "error",
                 "detail": str(exc),
+                "duration_ms": duration_ms,
             }
             if spec.fail_on_tool_error:
                 return f"Error: {type(exc).__name__}: {exc}", event, exc
             return f"Error: {type(exc).__name__}: {exc}", event, None
+        duration_ms = round((time.time() - t0) * 1000)
 
         if isinstance(result, str) and result.startswith("Error"):
             event = {
                 "name": tool_call.name,
                 "status": "error",
                 "detail": result.replace("\n", " ").strip()[:120],
+                "duration_ms": duration_ms,
             }
             if spec.fail_on_tool_error:
                 return result + _HINT, event, RuntimeError(result)
@@ -655,7 +663,7 @@ class AgentRunner:
             detail = "(empty)"
         elif len(detail) > 120:
             detail = detail[:120] + "..."
-        return result, {"name": tool_call.name, "status": "ok", "detail": detail}, None
+        return result, {"name": tool_call.name, "status": "ok", "detail": detail, "duration_ms": duration_ms}, None
 
     async def _emit_checkpoint(
         self,

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -74,9 +74,12 @@ async def test_runner_preserves_reasoning_fields_and_tool_results():
 
     assert result.final_content == "done"
     assert result.tools_used == ["list_dir"]
-    assert result.tool_events == [
-        {"name": "list_dir", "status": "ok", "detail": "tool result"}
-    ]
+    assert len(result.tool_events) == 1
+    evt = result.tool_events[0]
+    assert evt["name"] == "list_dir"
+    assert evt["status"] == "ok"
+    assert evt["detail"] == "tool result"
+    assert "duration_ms" in evt
 
     assistant_messages = [
         msg for msg in captured_second_call
@@ -126,12 +129,17 @@ async def test_runner_calls_hooks_in_order():
             ))
 
         async def after_iteration(self, context: AgentHookContext) -> None:
+            # Strip duration_ms from events for deterministic assertions
+            cleaned_events = [
+                {k: v for k, v in e.items() if k != "duration_ms"}
+                for e in context.tool_events
+            ]
             events.append((
                 "after_iteration",
                 context.iteration,
                 context.final_content,
                 list(context.tool_results),
-                list(context.tool_events),
+                cleaned_events,
                 context.stop_reason,
             ))
 
@@ -268,9 +276,12 @@ async def test_runner_returns_structured_tool_error():
 
     assert result.stop_reason == "tool_error"
     assert result.error == "Error: RuntimeError: boom"
-    assert result.tool_events == [
-        {"name": "list_dir", "status": "error", "detail": "boom"}
-    ]
+    assert len(result.tool_events) == 1
+    evt = result.tool_events[0]
+    assert evt["name"] == "list_dir"
+    assert evt["status"] == "error"
+    assert evt["detail"] == "boom"
+    assert "duration_ms" in evt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Add `duration_ms` to tool events

### Motivation

Understanding how long each tool call takes is essential for performance monitoring, debugging slow iterations, and building downstream analytics (e.g. dashboards, cost tracking). Previously, tool events only carried `name`, `status`, and `detail`, with no timing information at all.

### Approach

This PR records wall-clock execution time directly inside `AgentRunner._execute_tool_call()` and embeds `duration_ms` into every tool event dict. The timer wraps the exact `tool.execute()` / `mcp_manager.call_tool()` boundary, giving a clean measurement of the tool itself.

An alternative approach would be to measure timing through the hook system — for example, via `before_execute_tool` / `after_execute_tool` hooks. However, nanobot's hook interface currently does not expose per-tool-call lifecycle hooks, so this PR takes the in-runner approach instead. 

Happy to discuss which design fits better long-term.
