### PR TITLE
feat(web_search): support custom base_url for Tavily provider

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -146,10 +146,12 @@ class WebSearchTool(Tool):
         if not api_key:
             logger.warning("TAVILY_API_KEY not set, falling back to DuckDuckGo")
             return await self._search_duckduckgo(query, n)
+        base_url = (self.config.base_url or "").strip() or "https://api.tavily.com"
+        endpoint = f"{base_url.rstrip('/')}/search"
         try:
             async with httpx.AsyncClient(proxy=self.proxy) as client:
                 r = await client.post(
-                    "https://api.tavily.com/search",
+                    endpoint,
                     headers={"Authorization": f"Bearer {api_key}"},
                     json={"query": query, "max_results": n},
                     timeout=15.0,

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -70,7 +70,8 @@ async def cmd_status(ctx: CommandContext) -> OutboundMessage:
         if search_cfg is not None:
             provider = getattr(search_cfg, "provider", "duckduckgo")
             api_key = getattr(search_cfg, "api_key", "") or None
-            usage = await fetch_search_usage(provider=provider, api_key=api_key)
+            base_url = getattr(search_cfg, "base_url", "") or None
+            usage = await fetch_search_usage(provider=provider, api_key=api_key, base_url=base_url)
             search_usage_text = usage.format()
     except Exception:
         pass  # Never let usage fetch break /status

--- a/nanobot/utils/searchusage.py
+++ b/nanobot/utils/searchusage.py
@@ -66,6 +66,7 @@ class SearchUsageInfo:
 async def fetch_search_usage(
     provider: str,
     api_key: str | None = None,
+    base_url: str | None = None,
 ) -> SearchUsageInfo:
     """
     Fetch usage info for the configured web search provider.
@@ -73,6 +74,7 @@ async def fetch_search_usage(
     Args:
         provider: Provider name (e.g. "tavily", "brave", "duckduckgo").
         api_key:  API key for the provider (falls back to env vars).
+        base_url: Optional custom base URL for the provider.
 
     Returns:
         SearchUsageInfo with populated fields where available.
@@ -80,7 +82,7 @@ async def fetch_search_usage(
     p = (provider or "duckduckgo").strip().lower()
 
     if p == "tavily":
-        return await _fetch_tavily_usage(api_key)
+        return await _fetch_tavily_usage(api_key, base_url)
     else:
         # brave, duckduckgo, searxng, jina, unknown — no usage API
         return SearchUsageInfo(provider=p, supported=False)
@@ -90,8 +92,8 @@ async def fetch_search_usage(
 # Tavily
 # ---------------------------------------------------------------------------
 
-async def _fetch_tavily_usage(api_key: str | None) -> SearchUsageInfo:
-    """Fetch usage from GET https://api.tavily.com/usage."""
+async def _fetch_tavily_usage(api_key: str | None, base_url: str | None = None) -> SearchUsageInfo:
+    """Fetch usage from GET {base_url}/usage."""
     import httpx
 
     key = api_key or os.environ.get("TAVILY_API_KEY", "")
@@ -102,10 +104,11 @@ async def _fetch_tavily_usage(api_key: str | None) -> SearchUsageInfo:
             error="TAVILY_API_KEY not configured",
         )
 
+    base = (base_url or "").strip() or "https://api.tavily.com"
     try:
         async with httpx.AsyncClient(timeout=8.0) as client:
             r = await client.get(
-                "https://api.tavily.com/usage",
+                f"{base}/usage",
                 headers={"Authorization": f"Bearer {key}"},
             )
             r.raise_for_status()

--- a/tests/tools/test_web_search_tool.py
+++ b/tests/tools/test_web_search_tool.py
@@ -267,3 +267,43 @@ async def test_duckduckgo_timeout_returns_error(monkeypatch):
     assert "Error" in result
 
 
+@pytest.mark.asyncio
+async def test_tavily_custom_base_url(monkeypatch):
+    """Tavily search should POST to the custom base_url when provided."""
+    captured_url = []
+
+    async def mock_post(self, url, **kw):
+        captured_url.append(url)
+        assert kw["headers"]["Authorization"] == "Bearer tavily-key"
+        return _response(json={
+            "results": [{"title": "Custom Base", "url": "https://example.com", "content": "Test"}]
+        })
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    tool = _tool(provider="tavily", api_key="tavily-key", base_url="https://custom.proxy.com")
+    result = await tool.execute(query="test")
+    assert "Custom Base" in result
+    assert len(captured_url) == 1
+    assert captured_url[0].startswith("https://custom.proxy.com/")
+    assert "/search" in captured_url[0]
+
+
+@pytest.mark.asyncio
+async def test_tavily_empty_base_url_falls_back(monkeypatch):
+    """Empty base_url should fall back to https://api.tavily.com."""
+    captured_url = []
+
+    async def mock_post(self, url, **kw):
+        captured_url.append(url)
+        assert kw["headers"]["Authorization"] == "Bearer tavily-key"
+        return _response(json={
+            "results": [{"title": "Default", "url": "https://example.com", "content": "Test"}]
+        })
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    tool = _tool(provider="tavily", api_key="tavily-key", base_url="")
+    result = await tool.execute(query="test")
+    assert "Default" in result
+    assert len(captured_url) == 1
+    assert captured_url[0].startswith("https://api.tavily.com/")
+

--- a/tests/utils/test_searchusage.py
+++ b/tests/utils/test_searchusage.py
@@ -245,6 +245,59 @@ class TestFetchSearchUsageRouting:
         assert info.provider == "tavily"
         assert info.supported is True
 
+    @pytest.mark.asyncio
+    async def test_tavily_custom_base_url(self):
+        """Tavily usage fetch should use the custom base_url when provided."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "account": {"plan_usage": 10, "plan_limit": 100},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        captured_url = []
+
+        async def mock_get(self, url, **kw):
+            captured_url.append(url)
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = mock_get
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await fetch_search_usage("tavily", api_key="test-key", base_url="https://custom.proxy.com")
+
+        assert len(captured_url) == 1
+        assert captured_url[0].startswith("https://custom.proxy.com/")
+        assert "/usage" in captured_url[0]
+
+    @pytest.mark.asyncio
+    async def test_tavily_empty_base_url_falls_back(self):
+        """Empty base_url should fall back to https://api.tavily.com."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"account": {"plan_usage": 5, "plan_limit": 50}}
+        mock_response.raise_for_status = MagicMock()
+
+        captured_url = []
+
+        async def mock_get(self, url, **kw):
+            captured_url.append(url)
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = mock_get
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await fetch_search_usage("tavily", api_key="test-key", base_url="")
+
+        assert len(captured_url) == 1
+        assert captured_url[0].startswith("https://api.tavily.com/")
+
 
 # ---------------------------------------------------------------------------
 # build_status_content integration tests


### PR DESCRIPTION
## Summary

Allow custom base_url in config for Tavily search API, useful when using a proxy/mirror server.

## Problem

Previously, the Tavily search endpoint was hardcoded to the official API URL, ignoring the base_url field in WebSearchConfig. This made it impossible for users behind restricted networks to use a proxy/mirror for Tavily API access.

## Changes

### nanobot/agent/tools/web.py
- Read base_url from config, fall back to default when empty
- Defense against whitespace/empty-string edge cases (.strip() + truthy check)
- Construct dynamic endpoint: {base_url}/search

### nanobot/utils/searchusage.py
- fetch_search_usage() now accepts optional base_url parameter
- _fetch_tavily_usage() also respects custom base_url for the GET /usage endpoint

### nanobot/command/builtin.py
- Pass search_cfg.base_url through to fetch_search_usage() so /status command shows correct usage info for proxied setups

## Config Example

When base_url is empty or unset, it defaults to the official API (fully backward compatible).

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New/updated tests: No (config-level change, verified manually via web_search tool)
- [x] Documentation: No (existing config field comment already present)