### PR TITLE
CronTool 新增 update tool. add tool放开非定时任务限制

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -320,7 +320,7 @@ class CronTool(Tool):
             job_id,
             name=name,
             schedule=schedule,
-            message=message,
+            message=message if message else None,
             deliver=deliver,
         )
 

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -113,8 +113,8 @@ class CronTool(Tool):
         **kwargs: Any,
     ) -> str:
         if action == "add":
-            if self._cron_job_id.get() is not None:
-                return "Error: cannot schedule new jobs from within a cron job execution"
+            # if self._cron_job_id.get() is not None:
+            #     return "Error: cannot schedule new jobs from within a cron job execution"
             return self._add_job(name, message, every_seconds, cron_expr, tz, at, deliver)
         elif action == "list":
             return self._list_jobs()

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -12,7 +12,7 @@ from nanobot.cron.types import CronJob, CronJobState, CronSchedule
 
 @tool_parameters(
     tool_parameters_schema(
-        action=StringSchema("Action to perform", enum=["add", "list", "remove"]),
+        action=StringSchema("Action to perform", enum=["add", "list", "remove", "update"]),
         name=StringSchema(
             "Optional short human-readable label for the job "
             "(e.g., 'weather-monitor', 'daily-standup'). Defaults to first 30 chars of message."
@@ -35,7 +35,7 @@ from nanobot.cron.types import CronJob, CronJobState, CronSchedule
             description="Whether to deliver the execution result to the user channel (default true)",
             default=True,
         ),
-        job_id=StringSchema("Job ID (for remove)"),
+        job_id=StringSchema("Job ID (for remove/update)"),
         required=["action"],
     )
 )
@@ -47,20 +47,25 @@ class CronTool(Tool):
         self._default_timezone = default_timezone
         self._channel = ""
         self._chat_id = ""
-        self._in_cron_context: ContextVar[bool] = ContextVar("cron_in_context", default=False)
+        # Stores current job_id when in cron context, None otherwise
+        self._cron_job_id: ContextVar[str | None] = ContextVar("cron_job_id", default=None)
 
     def set_context(self, channel: str, chat_id: str) -> None:
         """Set the current session context for delivery."""
         self._channel = channel
         self._chat_id = chat_id
 
-    def set_cron_context(self, active: bool):
-        """Mark whether the tool is executing inside a cron job callback."""
-        return self._in_cron_context.set(active)
+    def set_cron_context(self, job_id: str | None):
+        """Mark current job_id when executing inside a cron job callback.
+        
+        Args:
+            job_id: The ID of the cron job being executed, or None to clear.
+        """
+        return self._cron_job_id.set(job_id)
 
     def reset_cron_context(self, token) -> None:
         """Restore previous cron context."""
-        self._in_cron_context.reset(token)
+        self._cron_job_id.reset(token)
 
     @staticmethod
     def _validate_timezone(tz: str) -> str | None:
@@ -90,7 +95,7 @@ class CronTool(Tool):
     @property
     def description(self) -> str:
         return (
-            "Schedule reminders and recurring tasks. Actions: add, list, remove. "
+            "Schedule reminders and recurring tasks. Actions: add, list, remove, update. "
             f"If tz is omitted, cron expressions and naive ISO times default to {self._default_timezone}."
         )
 
@@ -108,13 +113,15 @@ class CronTool(Tool):
         **kwargs: Any,
     ) -> str:
         if action == "add":
-            if self._in_cron_context.get():
+            if self._cron_job_id.get() is not None:
                 return "Error: cannot schedule new jobs from within a cron job execution"
             return self._add_job(name, message, every_seconds, cron_expr, tz, at, deliver)
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
             return self._remove_job(job_id)
+        elif action == "update":
+            return self._update_job(job_id, name, message, deliver, every_seconds, cron_expr, tz, at)
         return f"Unknown action: {action}"
 
     def _add_job(
@@ -248,3 +255,91 @@ class CronTool(Tool):
                 "This is a protected system-managed cron job."
             )
         return f"Job {job_id} not found"
+
+    def _update_job(
+        self,
+        job_id: str | None,
+        name: str | None,
+        message: str | None,
+        deliver: bool | None,
+        every_seconds: int | None = None,
+        cron_expr: str | None = None,
+        tz: str | None = None,
+        at: str | None = None,
+    ) -> str:
+        """Update a cron job.
+
+        job_id is required to specify which job to update.
+        """
+        if not job_id:
+            return "Error: job_id is required for update"
+
+        job = self._cron.get_job(job_id)
+        if job is None:
+            return f"Error: job {job_id} not found"
+
+        # Prevent modification of system jobs
+        if job.payload.kind == "system_event":
+            return "Error: cannot modify protected system job"
+
+        # Validate timezone if provided
+        if tz and not cron_expr:
+            return "Error: tz can only be used with cron_expr"
+        if tz:
+            if err := self._validate_timezone(tz):
+                return err
+
+        # Build schedule if timing parameters provided
+        schedule: CronSchedule | None = None
+        timing_count = sum(x is not None for x in [every_seconds, cron_expr, at])
+        if timing_count > 1:
+            return "Error: only one of every_seconds, cron_expr, or at can be specified"
+        if timing_count == 1:
+            if every_seconds:
+                schedule = CronSchedule(kind="every", every_ms=every_seconds * 1000)
+            elif cron_expr:
+                effective_tz = tz or self._default_timezone
+                if err := self._validate_timezone(effective_tz):
+                    return err
+                schedule = CronSchedule(kind="cron", expr=cron_expr, tz=effective_tz)
+            elif at:
+                from zoneinfo import ZoneInfo
+                try:
+                    dt = datetime.fromisoformat(at)
+                except ValueError:
+                    return f"Error: invalid ISO datetime format '{at}'. Expected format: YYYY-MM-DDTHH:MM:SS"
+                if dt.tzinfo is None:
+                    if err := self._validate_timezone(self._default_timezone):
+                        return err
+                    dt = dt.replace(tzinfo=ZoneInfo(self._default_timezone))
+                at_ms = int(dt.timestamp() * 1000)
+                schedule = CronSchedule(kind="at", at_ms=at_ms)
+
+        # Build update parameters (None means don't change)
+        result = self._cron.update_job(
+            job_id,
+            name=name,
+            schedule=schedule,
+            message=message,
+            deliver=deliver,
+        )
+
+        if result == "not_found":
+            return f"Error: job {job_id} not found"
+        if result == "protected":
+            return "Error: cannot modify protected system job"
+
+        updated_fields = []
+        if name is not None:
+            updated_fields.append(f"name='{name}'")
+        if message:
+            updated_fields.append(f"message='{message[:30]}...'")
+        if deliver is not None:
+            updated_fields.append(f"deliver={deliver}")
+        if schedule is not None:
+            updated_fields.append(f"schedule='{self._format_timing(schedule)}'")
+
+        if not updated_fields:
+            return f"No changes made to job '{job.name}' (id: {job.id})"
+
+        return f"Updated job '{result.name}' (id: {result.id}): {', '.join(updated_fields)}"

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -714,7 +714,7 @@ def gateway(
         cron_tool = agent.tools.get("cron")
         cron_token = None
         if isinstance(cron_tool, CronTool):
-            cron_token = cron_tool.set_cron_context(True)
+            cron_token = cron_tool.set_cron_context(job.id)
         try:
             resp = await agent.process_direct(
                 reminder_note,

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -348,12 +348,14 @@ class CronService:
         if job.schedule.kind == "at":
             if job.delete_after_run:
                 self._store.jobs = [j for j in self._store.jobs if j.id != job.id]
+                logger.info(f"Cron: deleted job id: {job.id}, name: {job.name}")
             else:
                 job.enabled = False
                 job.state.next_run_at_ms = None
         else:
             # Compute next run
             job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
+        self._save_store()
 
     def _append_action(self, action: Literal["add", "del", "update"], params: dict):
         self.store_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
##测试记录
### Update工具
方便更改任务描述，而不是必须得删掉之前的任务。
<img width="513" height="309" alt="截屏2026-04-13 15 24 13" src="https://github.com/user-attachments/assets/68574af7-527c-4e82-ba98-94ec33215bdb" />
<img width="548" height="338" alt="截屏2026-04-13 15 24 19" src="https://github.com/user-attachments/assets/ef958b40-574c-4adf-b298-4e44a35eda7d" />
<img width="545" height="375" alt="image" src="https://github.com/user-attachments/assets/4da3ea77-2927-41ce-a7f0-cc7cb5089ec7" />


### add tool放开非定时任务限制
放开后，可以做更高级的流程调用。
当前任务 -3分钟后 -> B任务
                - or 30分钟后 -> C任务
<img width="526" height="478" alt="image" src="https://github.com/user-attachments/assets/93dd5788-3dca-444a-b54a-256f58042ddf" />
<img width="474" height="492" alt="image" src="https://github.com/user-attachments/assets/886054b1-fe8d-4262-aa12-7036bd6f3250" />
<img width="483" height="442" alt="image" src="https://github.com/user-attachments/assets/8f75fa4f-2a94-4eaf-a998-8deb1d91a79c" />