### PR TITLE
fix(log): remove noisy no-op logs from auto-compact

### DIFF
--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -61,7 +61,6 @@ class AutoCompact:
             key = info.get("key", "")
             if key and key not in self._archiving and self._is_expired(info.get("updated_at")):
                 self._archiving.add(key)
-                logger.debug("Auto-compact: scheduling archival for {} (idle > {} min)", key, self._ttl)
                 schedule_background(self._archive(key))
 
     async def _archive(self, key: str) -> None:
@@ -70,7 +69,6 @@ class AutoCompact:
             session = self.sessions.get_or_create(key)
             archive_msgs, kept_msgs = self._split_unconsolidated(session)
             if not archive_msgs and not kept_msgs:
-                logger.debug("Auto-compact: skipping {}, no un-consolidated messages", key)
                 session.updated_at = datetime.now()
                 self.sessions.save(session)
                 return


### PR DESCRIPTION
## Summary
- Remove `"scheduling archival"` debug log (fires before knowing if there's work)
- Remove `"skipping, no un-consolidated messages"` debug log (common no-op path)
- Keep `"archived"` info log (only fires on real archival work)

Cherry-pick of #3093.

## Test plan
- [x] `pytest tests/agent/test_auto_compact.py` — 38 passed