### PR TITLE
feat: add hook after dream completion

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -234,10 +234,15 @@ class AgentLoop:
             consolidator=self.consolidator,
             session_ttl_minutes=session_ttl_minutes,
         )
+        dream_config = defaults.dream
         self.dream = Dream(
             store=self.context.memory,
             provider=provider,
             model=self.model,
+            max_batch_size=dream_config.max_batch_size,
+            max_iterations=dream_config.max_iterations,
+            max_tool_result_chars=defaults.max_tool_result_chars,
+            hook_script=dream_config.hook_script,
         )
         self._register_default_tools()
         self.commands = CommandRouter()

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -568,6 +568,7 @@ class Dream:
         max_batch_size: int = 20,
         max_iterations: int = 10,
         max_tool_result_chars: int = 16_000,
+        hook_script: str | None = None,
     ):
         self.store = store
         self.provider = provider
@@ -575,6 +576,7 @@ class Dream:
         self.max_batch_size = max_batch_size
         self.max_iterations = max_iterations
         self.max_tool_result_chars = max_tool_result_chars
+        self.hook_script = hook_script
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
 
@@ -763,4 +765,53 @@ class Dream:
             if sha:
                 logger.info("Dream commit: {}", sha)
 
+        # Invoke hook script if configured or default exists
+        self._invoke_hook(changelog, batch, result)
+
         return True
+
+    def _invoke_hook(
+        self,
+        changelog: list[str],
+        batch: list[dict[str, Any]],
+        result: Any | None,
+    ) -> None:
+        """Invoke user-defined hook script after Dream completion."""
+        import importlib.util
+        from pathlib import Path
+
+        # Determine script path: use configured path or default location
+        if self.hook_script:
+            script_path = Path(self.hook_script).expanduser()
+        else:
+            workspace_root = Path.home() / ".nanobot" / "workspace"
+            script_path = workspace_root / "hooks" / "hook_after_dreaming.py"
+
+        if not script_path.exists():
+            logger.debug("Hook script not found: {}", script_path)
+            return
+
+        try:
+            spec = importlib.util.spec_from_file_location("hook_module", script_path)
+            if spec is None or spec.loader is None:
+                logger.warning("Failed to load hook script: {}", script_path)
+                return
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+            # Build context dictionary
+            ctx = {
+                "changelog": changelog,
+                "cursor": batch[-1]["cursor"] if batch else None,
+                "batch": batch,
+                "result": result,
+            }
+
+            # Call run function if it exists
+            if hasattr(module, "run") and callable(module.run):
+                module.run(ctx)
+                logger.info("Hook script executed successfully: {}", script_path)
+            else:
+                logger.warning("Hook script missing 'run' function: {}", script_path)
+        except Exception:
+            logger.exception("Hook script execution failed: {}", script_path)

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -44,6 +44,7 @@ class DreamConfig(Base):
     )  # Optional Dream-specific model override
     max_batch_size: int = Field(default=20, ge=1)  # Max history entries per run
     max_iterations: int = Field(default=10, ge=1)  # Max tool calls per Phase 2
+    hook_script: str | None = Field(default=None)  # Optional path to custom hook script
 
     def build_schedule(self, timezone: str) -> CronSchedule:
         """Build the runtime schedule, preferring the legacy cron override if present."""

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -463,6 +463,64 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
     _write(None, workspace / "memory" / "history.jsonl")
     (workspace / "skills").mkdir(exist_ok=True)
 
+    # Initialize hooks directory and default hook script
+    hooks_dir = workspace / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    default_hook = hooks_dir / "hook_after_dreaming.py"
+    if not default_hook.exists():
+        default_hook.write_text('''"""Hook script executed after Dream completion.
+
+This script is called automatically after each Dream processing cycle.
+Implement your custom logic in the functions below.
+"""
+
+
+def run(ctx: dict) -> None:
+    """Main entry point called after Dream completion.
+    
+    Args:
+        ctx: Dictionary containing:
+            - changelog: List of change descriptions
+            - cursor: Current dream cursor position
+            - batch: List of processed history entries
+            - result: AgentRunner result object
+    """
+    _validate_result(ctx)
+    _notify_user(ctx)
+    _save_to_external(ctx)
+
+
+def _validate_result(ctx: dict) -> None:
+    """Validate that result contains required memory keywords.
+    
+    TODO: Add your own validation logic here to check if the result
+    contains 'memory' and other required keywords from the original memory.
+    Example:
+        if "memory" not in str(ctx.get("result", "")):
+            raise ValueError("Result missing memory keyword")
+    """
+    pass
+
+
+def _notify_user(ctx: dict) -> None:
+    """Notify user about Dream completion.
+    
+    TODO: Implement your own notification logic here.
+    Example: Send email, Slack message, or other notifications.
+    """
+    pass
+
+
+def _save_to_external(ctx: dict) -> None:
+    """Save memory changes to external storage.
+    
+    TODO: Implement your own logic to save to external documents.
+    Example: Save to Feishu/Lark docs, Tencent Docs, Notion, etc.
+    """
+    pass
+''', encoding="utf-8")
+        added.append("hooks/hook_after_dreaming.py")
+
     if added and not silent:
         from rich.console import Console
         for name in added:


### PR DESCRIPTION
Add hook interface after Dream completion to allow custom logic (e.g., saving memories to external storage like Lark Docs, Tencent Docs).

Related issue: #3103