### PR TITLE
feat: add lightweight model router to auto-route simple tasks to a cheaper model (#3070)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -161,6 +161,8 @@ class AgentLoop:
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
         tools_config: ToolsConfig | None = None,
+        light_model: str | None = None,
+        routing_strategy: str = "none",
     ):
         from nanobot.config.schema import ExecToolConfig, ToolsConfig, WebToolsConfig
 
@@ -171,6 +173,8 @@ class AgentLoop:
         self.provider = provider
         self.workspace = workspace
         self.model = model or provider.get_default_model()
+        self.light_model = light_model
+        self.routing_strategy = routing_strategy
         self.max_iterations = (
             max_iterations if max_iterations is not None else defaults.max_tool_iterations
         )
@@ -412,11 +416,16 @@ class AgentLoop:
                     merged = [{"type": "text", "text": runtime_ctx}] + user_content
                 items.append({"role": "user", "content": merged})
             return items
+        
+        from nanobot.agent.model_router import pick_model
+        routed_model = pick_model(
+            initial_messages, self.model, self.light_model, self.routing_strategy,
+        )
 
         result = await self.runner.run(AgentRunSpec(
             initial_messages=initial_messages,
             tools=self.tools,
-            model=self.model,
+            model=routed_model,
             max_iterations=self.max_iterations,
             max_tool_result_chars=self.max_tool_result_chars,
             hook=hook,

--- a/nanobot/agent/model_router.py
+++ b/nanobot/agent/model_router.py
@@ -1,0 +1,126 @@
+"""Lightweight model router — picks main vs light model per request.
+
+When ``routing_strategy`` is ``"auto"`` and a ``light_model`` is configured,
+simple conversational turns are routed to the cheaper model while complex
+tasks (code generation, debugging, multi-tool workflows) stay on the main
+model.  When routing is ``"none"`` (the default) or ``light_model`` is
+unset, the main model is always returned — zero behaviour change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# ── Complex-task keywords (any match → use main model) ──────────────
+_COMPLEX_KEYWORDS: tuple[str, ...] = (
+    # Chinese
+    "重构", "调试", "分析", "设计", "实现", "写代码", "修复", "部署", "审查",
+    "优化", "迁移", "架构", "测试", "编写",
+    # English
+    "refactor", "debug", "analyze", "analyse", "design", "implement",
+    "write code", "fix", "deploy", "review", "optimize", "migrate",
+    "architect", "test", "develop",
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+def _last_user_text(messages: list[dict[str, Any]]) -> str:
+    """Extract the text of the most recent user message (lowercased)."""
+    for msg in reversed(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            return content.lower()
+        # Multi-part content (text + images)
+        return " ".join(
+            block.get("text", "")
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        ).lower()
+    return ""
+
+
+def _last_user_length(messages: list[dict[str, Any]]) -> int:
+    """Character count of the most recent user message."""
+    for msg in reversed(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            return len(content)
+        return sum(
+            len(block.get("text", ""))
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+    return 0
+
+
+def _user_turn_count(messages: list[dict[str, Any]]) -> int:
+    """Count user turns in the conversation."""
+    return sum(1 for m in messages if m.get("role") == "user")
+
+
+def _has_tool_history(messages: list[dict[str, Any]]) -> bool:
+    """Whether the conversation already contains tool-call results."""
+    return any(m.get("role") == "tool" for m in messages)
+
+
+# ── Simple-task signals (ALL must be True to route to light model) ──
+
+_SIMPLE_SIGNALS = (
+    # Few user turns (early / short conversation)
+    lambda msgs: _user_turn_count(msgs) <= 2,
+    # Short latest message (< 200 chars — likely a quick question)
+    lambda msgs: _last_user_length(msgs) < 200,
+    # No prior tool usage (pure chat, no code/file operations yet)
+    lambda msgs: not _has_tool_history(msgs),
+)
+
+
+# ── Public API ───────────────────────────────────────────────────────
+
+def pick_model(
+    messages: list[dict[str, Any]],
+    main_model: str,
+    light_model: str | None,
+    strategy: str = "none",
+) -> str:
+    """Choose which model to use for this request.
+
+    Parameters
+    ----------
+    messages:
+        The full message list about to be sent to the LLM.
+    main_model:
+        The user-configured primary (expensive) model.
+    light_model:
+        The user-configured cheaper model.  ``None`` disables routing.
+    strategy:
+        ``"none"`` — always return *main_model* (default, backward-compat).
+        ``"auto"`` — return *light_model* when all simple signals match and
+        no complex keyword is detected.
+
+    Returns
+    -------
+    str
+        The model identifier to use for this request.
+    """
+    # Fast path: routing disabled, no light model, or empty conversation
+    if strategy == "none" or not light_model or not messages:
+        return main_model
+
+    # Complex keyword detected → main model
+    user_text = _last_user_text(messages)
+    if any(kw in user_text for kw in _COMPLEX_KEYWORDS):
+        return main_model
+
+    # All simple signals satisfied → light model
+    if all(signal(messages) for signal in _SIMPLE_SIGNALS):
+        return light_model
+
+    # Default: main model
+    return main_model

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -594,6 +594,8 @@ def serve(
         disabled_skills=runtime_config.agents.defaults.disabled_skills,
         session_ttl_minutes=runtime_config.agents.defaults.session_ttl_minutes,
         tools_config=runtime_config.tools,
+        light_model=runtime_config.agents.defaults.light_model,
+        routing_strategy=runtime_config.agents.defaults.routing_strategy,
     )
 
     model_name = runtime_config.agents.defaults.model
@@ -689,6 +691,8 @@ def gateway(
         disabled_skills=config.agents.defaults.disabled_skills,
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
         tools_config=config.tools,
+        light_model=config.agents.defaults.light_model,
+        routing_strategy=config.agents.defaults.routing_strategy,
     )
 
     # Set cron callback (needs agent)
@@ -968,6 +972,8 @@ def agent(
         disabled_skills=config.agents.defaults.disabled_skills,
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
         tools_config=config.tools,
+        light_model=config.agents.defaults.light_model,
+        routing_strategy=config.agents.defaults.routing_strategy,
     )
     restart_notice = consume_restart_notice_from_env()
     if restart_notice and should_show_cli_restart_notice(restart_notice, session_id):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -80,6 +80,8 @@ class AgentDefaults(Base):
     max_tool_result_chars: int = 16_000
     provider_retry_mode: Literal["standard", "persistent"] = "standard"
     reasoning_effort: str | None = None  # low / medium / high / adaptive - enables LLM thinking mode
+    light_model: str | None = None  # Cheaper model for simple tasks (e.g. "anthropic/claude-sonnet-4")
+    routing_strategy: Literal["none", "auto"] = "none"  # "none" = always use main model; "auto" = route simple tasks to light_model
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
     unified_session: bool = False  # Share one session across all channels (single-user multi-device)
     disabled_skills: list[str] = Field(default_factory=list)  # Skill names to exclude from loading (e.g. ["summarize", "skill-creator"])

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -85,6 +85,8 @@ class Nanobot:
             disabled_skills=defaults.disabled_skills,
             session_ttl_minutes=defaults.session_ttl_minutes,
             tools_config=config.tools,
+            light_model=defaults.light_model,
+            routing_strategy=defaults.routing_strategy,
         )
         return cls(loop)
 

--- a/tests/agent/test_model_router.py
+++ b/tests/agent/test_model_router.py
@@ -1,0 +1,284 @@
+"""Tests for the lightweight model router."""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.agent.model_router import (
+    pick_model,
+    _last_user_text,
+    _last_user_length,
+    _user_turn_count,
+    _has_tool_history,
+)
+
+MAIN = "anthropic/claude-opus-4-5"
+LIGHT = "anthropic/claude-sonnet-4"
+
+
+# ── Helper to build message lists ────────────────────────────────────
+
+def _user(text: str) -> dict:
+    return {"role": "user", "content": text}
+
+
+def _assistant(text: str) -> dict:
+    return {"role": "assistant", "content": text}
+
+
+def _tool_result(tool_call_id: str = "call_1", content: str = "ok") -> dict:
+    return {"role": "tool", "tool_call_id": tool_call_id, "content": content}
+
+
+def _user_multipart(text: str, image_url: str = "data:image/png;base64,abc") -> dict:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": image_url}},
+        ],
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. Routing disabled (strategy="none" or light_model=None)
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestRoutingDisabled:
+    """When routing is off, always return main model regardless of messages."""
+
+    def test_strategy_none_returns_main(self):
+        msgs = [_user("hello")]
+        assert pick_model(msgs, MAIN, LIGHT, "none") == MAIN
+
+    def test_light_model_none_returns_main(self):
+        msgs = [_user("hello")]
+        assert pick_model(msgs, MAIN, None, "auto") == MAIN
+
+    def test_light_model_empty_string_returns_main(self):
+        msgs = [_user("hello")]
+        assert pick_model(msgs, MAIN, "", "auto") == MAIN
+
+    def test_default_strategy_is_none(self):
+        msgs = [_user("hello")]
+        # default strategy parameter is "none"
+        assert pick_model(msgs, MAIN, LIGHT) == MAIN
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. Auto routing — simple tasks → light model
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestAutoRoutingSimple:
+    """Short, early, tool-free conversations should route to light model."""
+
+    def test_short_greeting(self):
+        msgs = [_user("你好")]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == LIGHT
+
+    def test_simple_question(self):
+        msgs = [_user("What time is it?")]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == LIGHT
+
+    def test_two_turn_simple_chat(self):
+        msgs = [
+            _user("hi"),
+            _assistant("Hello! How can I help?"),
+            _user("What's the weather?"),
+        ]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == LIGHT
+
+    def test_multipart_short_text(self):
+        msgs = [_user_multipart("What is this?")]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == LIGHT
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. Auto routing — complex tasks → main model
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestAutoRoutingComplex:
+    """Complex keyword or structural signals should keep main model."""
+
+    @pytest.mark.parametrize("keyword", [
+        "请帮我重构这段代码",
+        "debug this function",
+        "分析一下这个日志",
+        "implement a REST API",
+        "帮我写代码实现排序",
+        "fix the bug in line 42",
+        "deploy to production",
+        "review this PR",
+        "请帮我设计一个数据库架构",
+        "optimize the query performance",
+    ])
+    def test_complex_keywords_use_main(self, keyword):
+        msgs = [_user(keyword)]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+    def test_long_message_uses_main(self):
+        """A message > 200 chars should not be considered simple."""
+        long_text = "Please explain " + "x " * 150  # well over 200 chars
+        msgs = [_user(long_text)]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+    def test_many_user_turns_uses_main(self):
+        """More than 2 user turns → not simple."""
+        msgs = [
+            _user("hi"),
+            _assistant("hello"),
+            _user("how are you"),
+            _assistant("good"),
+            _user("tell me a joke"),
+        ]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+    def test_tool_history_uses_main(self):
+        """If there are tool results in history, it's a complex session."""
+        msgs = [
+            _user("list files"),
+            _assistant("Sure"),
+            _tool_result("call_1", "file1.py\nfile2.py"),
+            _assistant("Here are the files."),
+            _user("thanks"),
+        ]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+    def test_complex_keyword_overrides_short_message(self):
+        """Even a short message with a complex keyword → main model."""
+        msgs = [_user("debug it")]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+    def test_chinese_complex_keyword(self):
+        msgs = [_user("帮我修复")]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. Helper function unit tests
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestHelpers:
+
+    def test_last_user_text_string(self):
+        msgs = [_user("Hello World")]
+        assert _last_user_text(msgs) == "hello world"
+
+    def test_last_user_text_multipart(self):
+        msgs = [_user_multipart("Check This")]
+        assert "check this" in _last_user_text(msgs)
+
+    def test_last_user_text_empty(self):
+        msgs = [_assistant("hi")]
+        assert _last_user_text(msgs) == ""
+
+    def test_last_user_text_picks_last(self):
+        msgs = [_user("first"), _assistant("ok"), _user("second")]
+        assert _last_user_text(msgs) == "second"
+
+    def test_last_user_length_string(self):
+        msgs = [_user("abcde")]
+        assert _last_user_length(msgs) == 5
+
+    def test_last_user_length_multipart(self):
+        msgs = [_user_multipart("abcde")]
+        assert _last_user_length(msgs) == 5
+
+    def test_last_user_length_empty(self):
+        msgs = [_assistant("hi")]
+        assert _last_user_length(msgs) == 0
+
+    def test_user_turn_count(self):
+        msgs = [_user("a"), _assistant("b"), _user("c")]
+        assert _user_turn_count(msgs) == 2
+
+    def test_user_turn_count_zero(self):
+        msgs = [_assistant("b")]
+        assert _user_turn_count(msgs) == 0
+
+    def test_has_tool_history_true(self):
+        msgs = [_user("hi"), _tool_result()]
+        assert _has_tool_history(msgs) is True
+
+    def test_has_tool_history_false(self):
+        msgs = [_user("hi"), _assistant("hello")]
+        assert _has_tool_history(msgs) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. Edge cases
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestEdgeCases:
+
+    def test_empty_messages(self):
+        """Empty message list should return main model (safe default)."""
+        assert pick_model([], MAIN, LIGHT, "auto") == MAIN
+
+    def test_only_assistant_messages(self):
+        msgs = [_assistant("I'm ready")]
+        # No user message → _last_user_text returns "" → no complex keyword
+        # _user_turn_count = 0 (<=2 ✓), _last_user_length = 0 (<200 ✓), no tool ✓
+        # All simple signals pass → light model
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == LIGHT
+
+    def test_case_insensitive_keywords(self):
+        """Keywords should match case-insensitively."""
+        msgs = [_user("REFACTOR the module")]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+    def test_keyword_as_substring(self):
+        """Keywords embedded in longer words should still match."""
+        msgs = [_user("debugging")]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+    def test_exactly_200_chars_is_simple(self):
+        """Boundary: exactly 200 chars is NOT < 200, so not simple."""
+        text = "a" * 200
+        msgs = [_user(text)]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+    def test_199_chars_is_simple(self):
+        text = "a" * 199
+        msgs = [_user(text)]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == LIGHT
+
+    def test_exactly_2_user_turns_is_simple(self):
+        msgs = [_user("a"), _assistant("b"), _user("c")]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == LIGHT
+
+    def test_3_user_turns_is_complex(self):
+        msgs = [
+            _user("a"), _assistant("b"),
+            _user("c"), _assistant("d"),
+            _user("e"),
+        ]
+        assert pick_model(msgs, MAIN, LIGHT, "auto") == MAIN
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 6. Config schema integration
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestConfigSchema:
+    """Verify the new fields exist on AgentDefaults with correct defaults."""
+
+    def test_defaults_have_light_model_none(self):
+        from nanobot.config.schema import AgentDefaults
+        d = AgentDefaults()
+        assert d.light_model is None
+
+    def test_defaults_have_routing_strategy_none(self):
+        from nanobot.config.schema import AgentDefaults
+        d = AgentDefaults()
+        assert d.routing_strategy == "none"
+
+    def test_light_model_can_be_set(self):
+        from nanobot.config.schema import AgentDefaults
+        d = AgentDefaults(light_model="openai/gpt-4o-mini")
+        assert d.light_model == "openai/gpt-4o-mini"
+
+    def test_routing_strategy_auto(self):
+        from nanobot.config.schema import AgentDefaults
+        d = AgentDefaults(routing_strategy="auto")
+        assert d.routing_strategy == "auto"


### PR DESCRIPTION
## Summary

Close #3070.

 Implements a lightweight, zero-dependency model router that automatically  routes simple conversational tasks to a cheaper "light model" while keeping  complex tasks (code generation, debugging, multi-tool workflows) on the  primary model. 

 ## Routing Logic

 When `routingStrategy` is set to `"auto"` and a `lightModel` is configured,  the router evaluates three "simple-task signals" before each LLM request:

 1. **User turn count ≤ 2** — early/short conversations
 2. **Latest user message < 200 characters** — likely a quick question
 3. **No tool-call results in history** — pure chat, no code/file operations

 ALL three must be satisfied to route to the light model. Additionally, a  keyword blocklist (28 terms, Chinese + English) forces the main model for  any message containing complexity indicators such as "refactor", "debug",  "implement", "重构", "分析", "写代码", etc.

 When routing is disabled (`routingStrategy: "none"`, the default) or  `lightModel` is unset, behavior is identical to the current codebase — zero impact on existing users.

 ## Files Changed

 | File | Change |
 |------|--------|
 | `nanobot/agent/model_router.py` | **New.** Core routing logic (~120 lines). `pick_model()` returns which model to use based on message context and strategy. |
 | `nanobot/config/schema.py` | **+2 lines.** Added `light_model: str \| None = None` and `routing_strategy: Literal["none", "auto"] = "none"` to `AgentDefaults`. |
 | `nanobot/agent/loop.py` | **+8 lines.** Accept `light_model` / `routing_strategy` in `__init__`; call `pick_model()` before building `AgentRunSpec`. |
 | `nanobot/nanobot.py` | **+2 lines.** Pass new config fields to `AgentLoop(...)`. |
 | `nanobot/cli/commands.py` | **+6 lines.** Pass new config fields at all 3 `AgentLoop(...)` call sites (API server, channel runner, CLI REPL). |
 | `tests/agent/test_model_router.py` | **New.** 46 test cases covering 6 categories. |

 **Total: 1 new module + 1 test file + 4 files touched (~18 lines added to existing code)**

 ## Test Results


tests/agent/test_model_router.py — 46 passed in 0.45s



 Test categories:
 - **Routing disabled** (4 tests): strategy=none, light_model=None/empty, default params
 - **Auto → light model** (4 tests): short greeting, simple question, 2-turn chat, multipart
 - **Auto → main model** (14 tests): 10 complex keywords (parametrized), long message, many turns, tool history,
 Chinese keywords
 - **Helper functions** (12 tests): _last_user_text, _last_user_length, _user_turn_count, _has_tool_history
 - **Edge cases** (8 tests): empty messages, assistant-only, case-insensitive, substring match, 199/200 char boundary,
 2/3 turn boundary
 - **Config schema** (4 tests): default values, field assignment

 ## Configuration Example

 ```json
 {
   "agents": {
     "defaults": {
       "model": "anthropic/claude-opus-4-5",
       "lightModel": "anthropic/claude-sonnet-4",
       "routingStrategy": "auto"
     }
   }
 }
```

No new dependencies. Fully backward-compatible — omitting lightModel preserves current behavior.