### PR TITLE
feat(provider): add LongCat via OpenAI-compatible backend

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,7 @@ IMAP_PASSWORD=your-password-here
 | `moonshot` | LLM (Moonshot/Kimi) | [platform.moonshot.cn](https://platform.moonshot.cn) |
 | `zhipu` | LLM (Zhipu GLM) | [open.bigmodel.cn](https://open.bigmodel.cn) |
 | `mimo` | LLM (MiMo) | [platform.xiaomimimo.com](https://platform.xiaomimimo.com) |
+| `longcat` | LLM (LongCat) | [longcat.chat](https://longcat.chat/platform/docs/zh/) |
 | `ollama` | LLM (local, Ollama) | — |
 | `lm_studio` | LLM (local, LM Studio) | — |
 | `mistral` | LLM | [docs.mistral.ai](https://docs.mistral.ai/) |
@@ -157,6 +158,34 @@ nanobot agent -c ~/.nanobot-telegram/config.json -w /tmp/nanobot-telegram-test -
 ```
 
 > Docker users: use `docker run -it` for interactive OAuth login.
+
+</details>
+
+<details>
+<summary><b>LongCat (OpenAI-compatible)</b></summary>
+
+LongCat is available through nanobot's built-in OpenAI-compatible provider flow.
+The default API base already points to `https://api.longcat.chat/openai`, so you
+usually only need to set `apiKey`.
+
+```json
+{
+  "providers": {
+    "longcat": {
+      "apiKey": "${LONGCAT_API_KEY}"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "provider": "longcat",
+      "model": "LongCat-Flash-Chat"
+    }
+  }
+}
+```
+
+Official model names include `LongCat-Flash-Chat`, `LongCat-Flash-Thinking`,
+`LongCat-Flash-Thinking-2601`, and `LongCat-Flash-Lite`.
 
 </details>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,7 @@ nanobot agent -c ~/.nanobot-telegram/config.json -w /tmp/nanobot-telegram-test -
 <summary><b>LongCat (OpenAI-compatible)</b></summary>
 
 LongCat is available through nanobot's built-in OpenAI-compatible provider flow.
-The default API base already points to `https://api.longcat.chat/openai`, so you
+The default API base already points to `https://api.longcat.chat/openai/v1`, so you
 usually only need to set `apiKey`.
 
 ```json

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -129,6 +129,7 @@ class ProvidersConfig(Base):
     mistral: ProviderConfig = Field(default_factory=ProviderConfig)
     stepfun: ProviderConfig = Field(default_factory=ProviderConfig)  # Step Fun (阶跃星辰)
     xiaomi_mimo: ProviderConfig = Field(default_factory=ProviderConfig)  # Xiaomi MIMO (小米)
+    longcat: ProviderConfig = Field(default_factory=ProviderConfig)  # LongCat
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -316,6 +316,15 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         default_api_base="https://api.xiaomimimo.com/v1",
     ),
+    # LongCat: OpenAI-compatible API
+    ProviderSpec(
+        name="longcat",
+        keywords=("longcat",),
+        env_key="LONGCAT_API_KEY",
+        display_name="LongCat",
+        backend="openai_compat",
+        default_api_base="https://api.longcat.chat/openai",
+    ),
     # === Local deployment (matched by config key, NOT by api_base) =========
     # vLLM / any OpenAI-compatible local server
     ProviderSpec(

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -323,7 +323,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="LONGCAT_API_KEY",
         display_name="LongCat",
         backend="openai_compat",
-        default_api_base="https://api.longcat.chat/openai",
+        default_api_base="https://api.longcat.chat/openai/v1",
     ),
     # === Local deployment (matched by config key, NOT by api_base) =========
     # vLLM / any OpenAI-compatible local server

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -284,6 +284,39 @@ def test_find_by_name_accepts_camel_case_and_hyphen_aliases():
     assert find_by_name("volcengineCodingPlan").name == "volcengine_coding_plan"
     assert find_by_name("github-copilot") is not None
     assert find_by_name("github-copilot").name == "github_copilot"
+    assert find_by_name("longcat") is not None
+    assert find_by_name("longcat").name == "longcat"
+
+
+def test_config_explicit_longcat_provider_resolves_provider_name():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "longcat",
+                    "model": "LongCat-Flash-Chat",
+                }
+            },
+            "providers": {
+                "longcat": {
+                    "apiKey": "test-key",
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "longcat"
+
+
+def test_config_auto_detects_longcat_from_model_keyword():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "longcat/LongCat-Flash-Chat"}},
+            "providers": {"longcat": {"apiKey": "test-key"}},
+        }
+    )
+
+    assert config.get_provider_name() == "longcat"
 
 
 def test_config_explicit_xiaomi_mimo_provider_uses_default_api_base():

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -306,6 +306,7 @@ def test_config_explicit_longcat_provider_resolves_provider_name():
     )
 
     assert config.get_provider_name() == "longcat"
+    assert config.get_api_base() == "https://api.longcat.chat/openai/v1"
 
 
 def test_config_auto_detects_longcat_from_model_keyword():

--- a/tests/providers/test_longcat_provider.py
+++ b/tests/providers/test_longcat_provider.py
@@ -18,7 +18,7 @@ def test_longcat_provider_in_registry():
     longcat = specs["longcat"]
     assert longcat.backend == "openai_compat"
     assert longcat.env_key == "LONGCAT_API_KEY"
-    assert longcat.default_api_base == "https://api.longcat.chat/openai"
+    assert longcat.default_api_base == "https://api.longcat.chat/openai/v1"
 
 
 def test_find_by_name_longcat():

--- a/tests/providers/test_longcat_provider.py
+++ b/tests/providers/test_longcat_provider.py
@@ -1,0 +1,29 @@
+"""Tests for the LongCat provider registration."""
+
+from nanobot.config.schema import ProvidersConfig
+from nanobot.providers.registry import PROVIDERS, find_by_name
+
+
+def test_longcat_config_field_exists():
+    """ProvidersConfig should have a longcat field."""
+    config = ProvidersConfig()
+    assert hasattr(config, "longcat")
+
+
+def test_longcat_provider_in_registry():
+    """LongCat should be registered in the provider registry."""
+    specs = {s.name: s for s in PROVIDERS}
+    assert "longcat" in specs
+
+    longcat = specs["longcat"]
+    assert longcat.backend == "openai_compat"
+    assert longcat.env_key == "LONGCAT_API_KEY"
+    assert longcat.default_api_base == "https://api.longcat.chat/openai"
+
+
+def test_find_by_name_longcat():
+    """find_by_name should resolve the LongCat provider."""
+    spec = find_by_name("longcat")
+
+    assert spec is not None
+    assert spec.name == "longcat"


### PR DESCRIPTION
## Summary

Add LongCat as a registry-based OpenAI-compatible provider.

## Changes

- register `longcat` in `nanobot/providers/registry.py`
- add `providers.longcat` to `nanobot/config/schema.py`
- document LongCat usage in `docs/configuration.md`
- add targeted tests for registry and config resolution
- align `Config.get_api_base()` with provider defaults so config resolution matches runtime behavior

## Test Plan

- [x] `pytest tests/providers/test_longcat_provider.py -q`
- [x] `pytest tests/cli/test_commands.py -q`

## Notes

- no new provider class was added
- LongCat uses the existing `openai_compat` backend
- the default API base is `https://api.longcat.chat/openai`
- official model names are used in docs
- this PR does not add Anthropic-compatible LongCat support
- PR targets `main` per maintainer direction
