### PR TITLE
feat: add hook after dream completion with customizable script

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -242,7 +242,7 @@ class AgentLoop:
             max_batch_size=dream_config.max_batch_size,
             max_iterations=dream_config.max_iterations,
             max_tool_result_chars=defaults.max_tool_result_chars,
-            hook_script=dream_config.hook_script,
+            after_hook_script=dream_config.after_hook_script,
         )
         self._register_default_tools()
         self.commands = CommandRouter()

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -234,10 +234,15 @@ class AgentLoop:
             consolidator=self.consolidator,
             session_ttl_minutes=session_ttl_minutes,
         )
+        dream_config = defaults.dream
         self.dream = Dream(
             store=self.context.memory,
             provider=provider,
             model=self.model,
+            max_batch_size=dream_config.max_batch_size,
+            max_iterations=dream_config.max_iterations,
+            max_tool_result_chars=defaults.max_tool_result_chars,
+            hook_script=dream_config.hook_script,
         )
         self._register_default_tools()
         self.commands = CommandRouter()

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -568,7 +568,7 @@ class Dream:
         max_batch_size: int = 20,
         max_iterations: int = 10,
         max_tool_result_chars: int = 16_000,
-        hook_script: str | None = None,
+        after_hook_script: str | None = None,
     ):
         self.store = store
         self.provider = provider
@@ -576,7 +576,7 @@ class Dream:
         self.max_batch_size = max_batch_size
         self.max_iterations = max_iterations
         self.max_tool_result_chars = max_tool_result_chars
-        self.hook_script = hook_script
+        self.after_hook_script = after_hook_script
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
 
@@ -765,13 +765,13 @@ class Dream:
             if sha:
                 logger.info("Dream commit: {}", sha)
 
-        # Invoke hook script if configured
-        if self.hook_script:
-            await self._invoke_hook_async(changelog, batch, result)
+        # Invoke after hook script if configured
+        if self.after_hook_script:
+            await self._invoke_after_hook_async(changelog, batch, result)
 
         return True
 
-    async def _invoke_hook_async(
+    async def _invoke_after_hook_async(
         self,
         changelog: list[str],
         batch: list[dict[str, Any]],
@@ -782,7 +782,7 @@ class Dream:
         import importlib.util
         from pathlib import Path
 
-        script_path = Path(self.hook_script).expanduser()
+        script_path = Path(self.after_hook_script).expanduser()
         if not script_path.exists():
             logger.debug("Hook script not found: {}", script_path)
             return

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -568,6 +568,7 @@ class Dream:
         max_batch_size: int = 20,
         max_iterations: int = 10,
         max_tool_result_chars: int = 16_000,
+        hook_script: str | None = None,
     ):
         self.store = store
         self.provider = provider
@@ -575,6 +576,7 @@ class Dream:
         self.max_batch_size = max_batch_size
         self.max_iterations = max_iterations
         self.max_tool_result_chars = max_tool_result_chars
+        self.hook_script = hook_script
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
 
@@ -763,4 +765,54 @@ class Dream:
             if sha:
                 logger.info("Dream commit: {}", sha)
 
+        # Invoke hook script if configured
+        if self.hook_script:
+            await self._invoke_hook_async(changelog, batch, result)
+
         return True
+
+    async def _invoke_hook_async(
+        self,
+        changelog: list[str],
+        batch: list[dict[str, Any]],
+        result: Any | None,
+    ) -> None:
+        """Invoke user-defined hook script after Dream completion (non-blocking)."""
+        import asyncio
+        import importlib.util
+        from pathlib import Path
+
+        script_path = Path(self.hook_script).expanduser()
+        if not script_path.exists():
+            logger.debug("Hook script not found: {}", script_path)
+            return
+
+        # Build context dictionary with safe cursor access
+        ctx = {
+            "changelog": changelog,
+            "cursor": batch[-1].get("cursor") if batch else None,
+            "batch": batch,
+            "result": result,
+        }
+
+        def _run_hook() -> None:
+            """Execute hook in thread pool."""
+            try:
+                spec = importlib.util.spec_from_file_location("hook_module", script_path)
+                if spec is None or spec.loader is None:
+                    logger.warning("Failed to load hook script: {}", script_path)
+                    return
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+                # Call run function if it exists
+                if hasattr(module, "run") and callable(module.run):
+                    module.run(ctx)
+                    logger.info("Hook script executed successfully: {}", script_path)
+                else:
+                    logger.warning("Hook script missing 'run' function: {}", script_path)
+            except Exception:
+                logger.exception("Hook script execution failed: {}", script_path)
+
+        # Run in thread pool to avoid blocking event loop
+        await asyncio.get_running_loop().run_in_executor(None, _run_hook)

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -44,7 +44,7 @@ class DreamConfig(Base):
     )  # Optional Dream-specific model override
     max_batch_size: int = Field(default=20, ge=1)  # Max history entries per run
     max_iterations: int = Field(default=10, ge=1)  # Max tool calls per Phase 2
-    hook_script: str | None = Field(default=None)  # Optional path to custom hook script
+    after_hook_script: str | None = Field(default=None)  # Optional path to hook script after Dream
 
     def build_schedule(self, timezone: str) -> CronSchedule:
         """Build the runtime schedule, preferring the legacy cron override if present."""

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -44,6 +44,7 @@ class DreamConfig(Base):
     )  # Optional Dream-specific model override
     max_batch_size: int = Field(default=20, ge=1)  # Max history entries per run
     max_iterations: int = Field(default=10, ge=1)  # Max tool calls per Phase 2
+    hook_script: str | None = Field(default=None)  # Optional path to custom hook script
 
     def build_schedule(self, timezone: str) -> CronSchedule:
         """Build the runtime schedule, preferring the legacy cron override if present."""

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -463,6 +463,64 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
     _write(None, workspace / "memory" / "history.jsonl")
     (workspace / "skills").mkdir(exist_ok=True)
 
+    # Initialize hooks directory and default hook script
+    hooks_dir = workspace / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    default_hook = hooks_dir / "hook_after_dreaming.py"
+    if not default_hook.exists():
+        default_hook.write_text('''"""Hook script executed after Dream completion.
+
+This script is called automatically after each Dream processing cycle.
+Implement your custom logic in the functions below.
+"""
+
+
+def run(ctx: dict) -> None:
+    """Main entry point called after Dream completion.
+    
+    Args:
+        ctx: Dictionary containing:
+            - changelog: List of change descriptions
+            - cursor: Current dream cursor position
+            - batch: List of processed history entries
+            - result: AgentRunner result object
+    """
+    _validate_result(ctx)
+    _notify_user(ctx)
+    _save_to_external(ctx)
+
+
+def _validate_result(ctx: dict) -> None:
+    """Validate that result contains required memory keywords.
+    
+    TODO: Add your own validation logic here to check if the result
+    contains 'memory' and other required keywords from the original memory.
+    Example:
+        if "memory" not in str(ctx.get("result", "")):
+            raise ValueError("Result missing memory keyword")
+    """
+    pass
+
+
+def _notify_user(ctx: dict) -> None:
+    """Notify user about Dream completion.
+    
+    TODO: Implement your own notification logic here.
+    Example: Send email, Feishu/Lark message, or other notifications.
+    """
+    pass
+
+
+def _save_to_external(ctx: dict) -> None:
+    """Save memory changes to external storage.
+    
+    TODO: Implement your own logic to save to external documents.
+    Example: Save to Feishu/Lark docs, Tencent Docs, Notion, etc.
+    """
+    pass
+''', encoding="utf-8")
+        added.append("hooks/hook_after_dreaming.py")
+
     if added and not silent:
         from rich.console import Console
         for name in added:

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -61,13 +61,17 @@ class TestDreamRun:
         mock_provider.chat_with_retry.assert_not_called()
         mock_runner.run.assert_not_called()
 
-    async def test_calls_runner_for_unprocessed_entries(self, dream, mock_provider, mock_runner, store):
+    async def test_calls_runner_for_unprocessed_entries(
+        self, dream, mock_provider, mock_runner, store
+    ):
         """Dream should call AgentRunner when there are unprocessed history entries."""
         store.append_history("User prefers dark mode")
         mock_provider.chat_with_retry.return_value = MagicMock(content="New fact")
-        mock_runner.run = AsyncMock(return_value=_make_run_result(
-            tool_events=[{"name": "edit_file", "status": "ok", "detail": "memory/MEMORY.md"}],
-        ))
+        mock_runner.run = AsyncMock(
+            return_value=_make_run_result(
+                tool_events=[{"name": "edit_file", "status": "ok", "detail": "memory/MEMORY.md"}],
+            )
+        )
         result = await dream.run()
         assert result is True
         mock_runner.run.assert_called_once()
@@ -96,11 +100,15 @@ class TestDreamRun:
         entries = store.read_unprocessed_history(since_cursor=0)
         assert all(e["cursor"] > 0 for e in entries)
 
-    async def test_skill_phase_uses_builtin_skill_creator_path(self, dream, mock_provider, mock_runner, store):
+    async def test_skill_phase_uses_builtin_skill_creator_path(
+        self, dream, mock_provider, mock_runner, store
+    ):
         """Dream should point skill creation guidance at the builtin skill-creator template."""
         store.append_history("Repeated workflow one")
         store.append_history("Repeated workflow two")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKILL] test-skill: test description")
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="[SKILL] test-skill: test description"
+        )
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
@@ -123,3 +131,217 @@ class TestDreamRun:
         assert "Successfully wrote" in result
         assert (store.workspace / "skills" / "test-skill" / "SKILL.md").exists()
 
+
+class TestDreamHook:
+    """Tests for the hook script feature after Dream completion."""
+
+    async def test_no_hook_when_not_configured(self, store, mock_provider, mock_runner):
+        """Dream should not invoke hook when after_hook_script is not configured."""
+        dream = Dream(store=store, provider=mock_provider, model="test-model")
+        dream._runner = mock_runner
+
+        store.append_history("event 1")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="Done")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        await dream.run()
+        # No exception should be raised; hook is simply not invoked
+
+    async def test_hook_invoked_when_configured_and_script_exists(
+        self, store, mock_provider, mock_runner, tmp_path
+    ):
+        """Dream should invoke hook script when configured and script exists."""
+        marker = tmp_path / "hook_executed.txt"
+        after_hook_script = tmp_path / "hook.py"
+        after_hook_script.write_text(
+            f"""
+import pathlib
+def run(ctx):
+    pathlib.Path("{marker}").write_text("ok")
+""",
+            encoding="utf-8",
+        )
+
+        dream = Dream(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            after_hook_script=str(after_hook_script),
+        )
+        dream._runner = mock_runner
+
+        store.append_history("event 1")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="Done")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        await dream.run()
+        # Wait for thread pool to complete
+        import asyncio
+
+        await asyncio.sleep(0.1)
+
+        # Hook should have created the marker file
+        assert marker.exists()
+        assert marker.read_text() == "ok"
+
+    async def test_hook_missing_script_no_error(self, store, mock_provider, mock_runner, tmp_path):
+        """Dream should complete without error when configured script does not exist."""
+        dream = Dream(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            after_hook_script=str(tmp_path / "nonexistent.py"),
+        )
+        dream._runner = mock_runner
+
+        store.append_history("event 1")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="Done")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        # Should complete without raising any error
+        result = await dream.run()
+        assert result is True
+
+    async def test_hook_missing_run_function_no_crash(
+        self, store, mock_provider, mock_runner, tmp_path
+    ):
+        """Dream should not crash when hook script has no run function."""
+        after_hook_script = tmp_path / "hook_no_run.py"
+        after_hook_script.write_text(
+            """
+def other_function(ctx):
+    pass
+""",
+            encoding="utf-8",
+        )
+
+        dream = Dream(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            after_hook_script=str(after_hook_script),
+        )
+        dream._runner = mock_runner
+
+        store.append_history("event 1")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="Done")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        # Should complete without raising
+        result = await dream.run()
+        assert result is True
+
+    async def test_hook_exception_does_not_crash_dream(
+        self, store, mock_provider, mock_runner, tmp_path
+    ):
+        """Dream should catch hook exceptions and continue without crashing."""
+        after_hook_script = tmp_path / "hook_crash.py"
+        after_hook_script.write_text(
+            """
+def run(ctx):
+    raise ValueError("Hook error!")
+""",
+            encoding="utf-8",
+        )
+
+        dream = Dream(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            after_hook_script=str(after_hook_script),
+        )
+        dream._runner = mock_runner
+
+        store.append_history("event 1")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="Done")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        # Should not raise; exception is caught and logged
+        result = await dream.run()
+        assert result is True  # Dream still completes successfully
+
+    async def test_hook_context_contains_expected_keys(
+        self, store, mock_provider, mock_runner, tmp_path
+    ):
+        """Dream should pass correct context to hook script."""
+        ctx_file = tmp_path / "ctx.json"
+        after_hook_script = tmp_path / "hook_capture.py"
+        after_hook_script.write_text(
+            f"""
+import json
+import pathlib
+def run(ctx):
+    pathlib.Path("{ctx_file}").write_text(
+        json.dumps({{k: str(v)[:100] for k, v in ctx.items()}})
+    )
+""",
+            encoding="utf-8",
+        )
+
+        dream = Dream(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            after_hook_script=str(after_hook_script),
+        )
+        dream._runner = mock_runner
+
+        store.append_history("event 1")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="Done")
+        mock_runner.run = AsyncMock(
+            return_value=_make_run_result(
+                tool_events=[{"name": "edit_file", "status": "ok", "detail": "test"}]
+            )
+        )
+
+        await dream.run()
+        # Wait for thread pool to complete
+        import asyncio
+
+        await asyncio.sleep(0.1)
+
+        import json
+
+        assert ctx_file.exists()
+        captured_ctx = json.loads(ctx_file.read_text())
+        assert "changelog" in captured_ctx
+        assert "cursor" in captured_ctx
+        assert "batch" in captured_ctx
+        assert "result" in captured_ctx
+
+    async def test_hook_handles_batch_cursor_safely(
+        self, store, mock_provider, mock_runner, tmp_path
+    ):
+        """Dream should pass cursor from batch to hook context."""
+        cursor_file = tmp_path / "cursor.txt"
+        after_hook_script = tmp_path / "hook_cursor.py"
+        after_hook_script.write_text(
+            f"""
+import pathlib
+def run(ctx):
+    pathlib.Path("{cursor_file}").write_text(str(ctx.get("cursor")))
+""",
+            encoding="utf-8",
+        )
+
+        dream = Dream(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            after_hook_script=str(after_hook_script),
+        )
+        dream._runner = mock_runner
+
+        store.append_history("event 1")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="Done")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        await dream.run()
+        # Wait for thread pool to complete
+        import asyncio
+
+        await asyncio.sleep(0.1)
+
+        assert cursor_file.exists()
+        # Cursor should be a number (from batch[-1].get("cursor"))
+        assert cursor_file.read_text() == "1"


### PR DESCRIPTION
## Summary

- Add `after_hook_script` config option to `DreamConfig` for custom post-dream processing
- Invoke user-defined hook script after Dream completion (async, non-blocking)
- Initialize default hook template in `workspace/hooks/hook_after_dreaming.py`
- Hook receives context with `changelog`, `cursor`, `batch`, and `result`
- Template includes three customizable functions: `_validate_result`, `_notify_user`, `_save_to_external`

## Changes

- `nanobot/config/schema.py`: Add `after_hook_script: str | None` to `DreamConfig`
- `nanobot/agent/loop.py`: Pass dream config (including after_hook_script) to Dream
- `nanobot/agent/memory.py`: 
  - Add `_invoke_hook_async` method for async hook execution in thread pool
  - Only invoke hook when `after_hook_script` is configured
  - Safe cursor access with `.get()`
- `nanobot/utils/helpers.py`: Initialize default hook template on workspace setup

## Tests

Added comprehensive test suite in `tests/agent/test_dream.py::TestDreamHook`:
- Hook not invoked when not configured
- Hook invoked when configured and script exists
- Missing script handled gracefully (debug log)
- Missing `run` function handled gracefully
- Hook exceptions don't crash Dream
- Context contains expected keys
- Batch cursor handled safely

Part1 in #3103