### PR TITLE
fix(cron): respect deliver flag when agent produces output

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -729,7 +729,7 @@ def gateway(
         response = resp.content if resp else ""
 
         message_tool = agent.tools.get("message")
-        if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
+        if job.payload.deliver and isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
             return response
 
         if job.payload.deliver and job.payload.to and response:


### PR DESCRIPTION
## Summary

When `deliver: false` is set in cron job payload, suppress all output even when agent calls message tool during the turn.

## Problem

Previously, the `_sent_in_turn` bypass would return response before evaluating the `deliver` flag:
```python
if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
    return response  # returns regardless of deliver flag
```

## Fix

Move the `deliver` gate before the `_sent_in_turn` check:
```python
if job.payload.deliver and isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
    return response
```

Now `deliver: false` correctly suppresses all output from cron job turns.

Closes #3115