### PR TITLE
feat(agent): add model routing support via AgentHookContext

### DIFF
--- a/nanobot/agent/hook.py
+++ b/nanobot/agent/hook.py
@@ -24,6 +24,9 @@ class AgentHookContext:
     final_content: str | None = None
     stop_reason: str | None = None
     error: str | None = None
+    # Model routing: hook can override the model for this iteration.
+    # Set this in before_iteration() to switch models dynamically.
+    model: str | None = None
 
 
 class AgentHook:

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -264,7 +264,7 @@ class AgentRunner:
                     messages_for_model = self._backfill_missing_tool_results(messages_for_model)
                 except Exception:
                     messages_for_model = messages
-            context = AgentHookContext(iteration=iteration, messages=messages)
+            context = AgentHookContext(iteration=iteration, messages=messages, model=spec.model)
             await hook.before_iteration(context)
             response = await self._request_model(spec, messages_for_model, hook, context)
             raw_usage = self._usage_dict(response.usage)
@@ -567,6 +567,9 @@ class AgentRunner:
             messages,
             tools=spec.tools.get_definitions(),
         )
+        # Allow hook to override model via context.model
+        if context.model is not None and context.model != spec.model:
+            kwargs["model"] = context.model
         if hook.wants_streaming():
             async def _stream(delta: str) -> None:
                 await hook.on_stream(context, delta)

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -178,6 +178,130 @@ async def test_runner_calls_hooks_in_order():
 
 
 @pytest.mark.asyncio
+async def test_runner_hook_can_override_model():
+    """Hook can dynamically switch models via context.model."""
+    from nanobot.agent.hook import AgentHook, AgentHookContext
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    captured_models: list[str] = []
+
+    async def chat_with_retry(*, model, **kwargs):
+        captured_models.append(model)
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    class ModelRouterHook(AgentHook):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        async def before_iteration(self, context: AgentHookContext) -> None:
+            # Switch model based on iteration
+            self.calls += 1
+            if context.iteration == 0:
+                context.model = "cheap-model"
+            else:
+                context.model = "expensive-model"
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "hi"}],
+        tools=tools,
+        model="default-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        hook=ModelRouterHook(),
+    ))
+
+    assert result.final_content == "done"
+    assert captured_models == ["cheap-model"]
+
+
+@pytest.mark.asyncio
+async def test_runner_hook_model_routing_per_iteration():
+    """Hook can switch models between iterations."""
+    from nanobot.agent.hook import AgentHook, AgentHookContext
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    captured_models: list[str] = []
+    call_count = {"n": 0}
+
+    async def chat_with_retry(*, model, **kwargs):
+        call_count["n"] += 1
+        captured_models.append(model)
+        if call_count["n"] == 1:
+            return LLMResponse(
+                content="need more",
+                tool_calls=[ToolCallRequest(id="tc1", name="read_file", arguments={})],
+            )
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="file content")
+
+    class IterationRouterHook(AgentHook):
+        async def before_iteration(self, context: AgentHookContext) -> None:
+            # First iteration: cheap model, subsequent: expensive
+            if context.iteration == 0:
+                context.model = "haiku"
+            else:
+                context.model = "opus"
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "read file"}],
+        tools=tools,
+        model="default",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        hook=IterationRouterHook(),
+    ))
+
+    assert result.final_content == "done"
+    assert captured_models == ["haiku", "opus"]
+
+
+@pytest.mark.asyncio
+async def test_runner_hook_context_model_initialized_from_spec():
+    """context.model starts with spec.model before hook runs."""
+    from nanobot.agent.hook import AgentHook, AgentHookContext
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    captured_initial_model: list[str] = []
+
+    async def chat_with_retry(*, model, **kwargs):
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    class InspectHook(AgentHook):
+        async def before_iteration(self, context: AgentHookContext) -> None:
+            captured_initial_model.append(context.model)
+
+    runner = AgentRunner(provider)
+    await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "hi"}],
+        tools=tools,
+        model="original-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        hook=InspectHook(),
+    ))
+
+    assert captured_initial_model == ["original-model"]
+
+
+@pytest.mark.asyncio
 async def test_runner_streaming_hook_receives_deltas_and_end_signal():
     from nanobot.agent.hook import AgentHook, AgentHookContext
     from nanobot.agent.runner import AgentRunSpec, AgentRunner


### PR DESCRIPTION
## Summary

This PR adds support for dynamic model routing via the existing hook mechanism, enabling users to implement custom routing logic without modifying nanobot core code.

Related issue: #3070

## Changes

- Add `model` field to `AgentHookContext`, initialized from `spec.model`
- In `_request_model`, use `context.model` if hook overrides it
- Add tests for model routing scenarios

## Usage

Users can now implement custom model routing by setting `context.model` in `before_iteration()`:

```python
from nanobot.agent.hook import AgentHook, AgentHookContext

class ModelRouterHook(AgentHook):
    """Smart model router - choose model based on task complexity"""
    
    def __init__(self):
        super().__init__()
        self.cheap_model = "claude-3-haiku"
        self.expensive_model = "claude-3-opus"
    
    async def before_iteration(self, context: AgentHookContext) -> None:
        # Example 1: Route by iteration
        if context.iteration == 0:
            context.model = self.cheap_model
        else:
            context.model = self.expensive_model
```

## Custom Routing Strategies

### 1. Keyword-based Routing

```python
class KeywordRouterHook(AgentHook):
    def __init__(self):
        super().__init__()
        self.complex_keywords = ["分析", "比较", "总结", "代码", "debug", "refactor"]
    
    async def before_iteration(self, context: AgentHookContext) -> None:
        user_msg = self._get_first_user_message(context.messages)
        if user_msg:
            content = str(user_msg.get("content", ""))
            if any(kw in content for kw in self.complex_keywords):
                context.model = "claude-3-opus"
            else:
                context.model = "claude-3-haiku"
```

### 2. Token-based Routing

```python
class TokenBasedRouterHook(AgentHook):
    async def before_iteration(self, context: AgentHookContext) -> None:
        prompt_tokens = context.usage.get("prompt_tokens", 0)
        completion_tokens = context.usage.get("completion_tokens", 0)
        total = prompt_tokens + completion_tokens
        
        if total < 5000:
            context.model = "haiku"
        elif total < 20000:
            context.model = "sonnet"
        else:
            context.model = "opus"
```

### 3. Tool-based Routing

```python
class ToolBasedRouterHook(AgentHook):
    """Switch to capable model when certain tools are used"""
    
    async def before_iteration(self, context: AgentHookContext) -> None:
        tool_names = [tc.name for tc in context.tool_calls]
        
        if "web_search" in tool_names or "read_file" in tool_names:
            context.model = "sonnet"  # Better for research
        else:
            context.model = "haiku"
```

### 4. Message Count Routing

```python
class MessageCountRouterHook(AgentHook):
    """Simple tasks = few messages, complex tasks = many messages"""
    
    async def before_iteration(self, context: AgentHookContext) -> None:
        msg_count = len(context.messages)
        
        if msg_count <= 3:
            context.model = "haiku"
        elif msg_count <= 10:
            context.model = "sonnet"
        else:
            context.model = "opus"
```

### 5. LLM-based Routing (Advanced)

```python
class LLMRouterHook(AgentHook):
    """Use a cheap LLM to decide which model to use"""
    
    def __init__(self, provider):
        super().__init__()
        self.provider = provider
    
    async def before_iteration(self, context: AgentHookContext) -> None:
        if context.iteration > 0:
            return  # Only route on first iteration
        
        user_msg = self._get_first_user_message(context.messages)
        if not user_msg:
            return
        
        # Ask a cheap model to classify complexity
        response = await self.provider.chat_with_retry(
            model="haiku",
            messages=[
                {"role": "system", "content": "Classify task complexity: simple/complex"},
                {"role": "user", "content": str(user_msg.get("content", ""))[:500]},
            ],
        )
        
        if "complex" in (response.content or "").lower():
            context.model = "opus"
        else:
            context.model = "haiku"
```

### 6. Cost Optimization Router

```python
class CostOptimizerHook(AgentHook):
    """Track costs and route to balance quality/cost"""
    
    def __init__(self, budget_limit: float = 1.0):
        super().__init__()
        self.budget_limit = budget_limit
        self.spent = 0.0
        self.model_costs = {
            "haiku": 0.00025,   # per 1K tokens
            "sonnet": 0.003,
            "opus": 0.015,
        }
    
    async def before_iteration(self, context: AgentHookContext) -> None:
        remaining = self.budget_limit - self.spent
        
        if remaining > 0.5:
            context.model = "opus"
        elif remaining > 0.1:
            context.model = "sonnet"
        else:
            context.model = "haiku"
    
    async def after_iteration(self, context: AgentHookContext) -> None:
        tokens = context.usage.get("prompt_tokens", 0) + context.usage.get("completion_tokens", 0)
        cost_per_k = self.model_costs.get(context.model or "haiku", 0.00025)
        self.spent += (tokens / 1000) * cost_per_k
```

## Benefits

- ✅ **Zero built-in routing logic** - All routing rules are user-defined
- ✅ **Minimal changes** - Only 2 small modifications to core code
- ✅ **Flexible** - Supports any routing strategy
- ✅ **Familiar API** - Reuses existing Hook interface

## Testing

```
tests/agent/test_runner.py::test_runner_hook_can_override_model PASSED
tests/agent/test_runner.py::test_runner_hook_model_routing_per_iteration PASSED
tests/agent/test_runner.py::test_runner_hook_context_model_initialized_from_spec PASSED
```