### PR TITLE
fix: keep cron runs silent until final output

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -1,5 +1,6 @@
 """Message tool for sending messages to users."""
 
+from contextvars import ContextVar
 from typing import Any, Awaitable, Callable
 
 from nanobot.agent.tools.base import Tool, tool_parameters
@@ -34,6 +35,10 @@ class MessageTool(Tool):
         self._default_chat_id = default_chat_id
         self._default_message_id = default_message_id
         self._sent_in_turn: bool = False
+        self._delivery_suppressed: ContextVar[bool] = ContextVar(
+            "message_delivery_suppressed",
+            default=False,
+        )
 
     def set_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
         """Set the current message context."""
@@ -48,6 +53,14 @@ class MessageTool(Tool):
     def start_turn(self) -> None:
         """Reset per-turn send tracking."""
         self._sent_in_turn = False
+
+    def set_delivery_suppressed(self, active: bool):
+        """Mute delivery for the current task without affecting other turns."""
+        return self._delivery_suppressed.set(active)
+
+    def reset_delivery_suppressed(self, token) -> None:
+        """Restore the previous delivery suppression state."""
+        self._delivery_suppressed.reset(token)
 
     @property
     def name(self) -> str:
@@ -73,7 +86,7 @@ class MessageTool(Tool):
     ) -> str:
         from nanobot.utils.helpers import strip_think
         content = strip_think(content)
-        
+
         channel = channel or self._default_channel
         chat_id = chat_id or self._default_chat_id
         # Only inherit default message_id when targeting the same channel+chat.
@@ -88,6 +101,9 @@ class MessageTool(Tool):
 
         if not channel or not chat_id:
             return "Error: No target channel/chat specified"
+
+        if self._delivery_suppressed.get():
+            return f"Message delivery suppressed for {channel}:{chat_id}"
 
         if not self._send_callback:
             return "Error: Message sending not configured"

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -730,7 +730,7 @@ def gateway(
                 session_key=f"cron:{job.id}",
                 channel=job.payload.channel or "cli",
                 chat_id=job.payload.to or "direct",
-                on_progress=_discard_progress if not job.payload.deliver else None,
+                on_progress=_discard_progress,
             )
         finally:
             if isinstance(cron_tool, CronTool) and cron_token is not None:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -33,6 +33,15 @@ from rich.table import Table
 from rich.text import Text
 
 from nanobot import __logo__, __version__
+from nanobot.cli.stream import StreamRenderer, ThinkingSpinner
+from nanobot.config.paths import get_workspace_path, is_default_workspace
+from nanobot.config.schema import Config
+from nanobot.utils.helpers import sync_workspace_templates
+from nanobot.utils.restart import (
+    consume_restart_notice_from_env,
+    format_restart_completed_message,
+    should_show_cli_restart_notice,
+)
 
 
 class SafeFileHistory(FileHistory):
@@ -46,15 +55,6 @@ class SafeFileHistory(FileHistory):
     def store_string(self, string: str) -> None:
         safe = string.encode("utf-8", errors="surrogateescape").decode("utf-8", errors="replace")
         super().store_string(safe)
-from nanobot.cli.stream import StreamRenderer, ThinkingSpinner
-from nanobot.config.paths import get_workspace_path, is_default_workspace
-from nanobot.config.schema import Config
-from nanobot.utils.helpers import sync_workspace_templates
-from nanobot.utils.restart import (
-    consume_restart_notice_from_env,
-    format_restart_completed_message,
-    should_show_cli_restart_notice,
-)
 
 app = typer.Typer(
     name="nanobot",
@@ -554,6 +554,7 @@ def serve(
         raise typer.Exit(1)
 
     from loguru import logger
+
     from nanobot.agent.loop import AgentLoop
     from nanobot.api.server import create_app
     from nanobot.bus.queue import MessageBus
@@ -712,24 +713,34 @@ def gateway(
         )
 
         cron_tool = agent.tools.get("cron")
+        message_tool = agent.tools.get("message")
         cron_token = None
+        message_token = None
         if isinstance(cron_tool, CronTool):
             cron_token = cron_tool.set_cron_context(True)
+        if not job.payload.deliver and isinstance(message_tool, MessageTool):
+            message_token = message_tool.set_delivery_suppressed(True)
+
+        async def _discard_progress(_content: str, **_kwargs: Any) -> None:
+            return None
+
         try:
             resp = await agent.process_direct(
                 reminder_note,
                 session_key=f"cron:{job.id}",
                 channel=job.payload.channel or "cli",
                 chat_id=job.payload.to or "direct",
+                on_progress=_discard_progress if not job.payload.deliver else None,
             )
         finally:
             if isinstance(cron_tool, CronTool) and cron_token is not None:
                 cron_tool.reset_cron_context(cron_token)
+            if isinstance(message_tool, MessageTool) and message_token is not None:
+                message_tool.reset_delivery_suppressed(message_token)
 
         response = resp.content if resp else ""
 
-        message_tool = agent.tools.get("message")
-        if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
+        if job.payload.deliver and isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
             return response
 
         if job.payload.deliver and job.payload.to and response:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1071,6 +1071,98 @@ def test_gateway_silent_cron_suppresses_progress_and_message_tool_output(
     eval_mock.assert_not_awaited()
 
 
+def test_gateway_cron_delivers_only_final_message_without_progress_noise(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_file = tmp_path / "instance" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text("{}")
+
+    config = Config()
+    config.agents.defaults.workspace = str(tmp_path / "config-workspace")
+    provider = object()
+    bus = MagicMock()
+    bus.publish_outbound = AsyncMock()
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr("nanobot.config.loader.set_config_path", lambda _path: None)
+    monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
+    monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
+    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: provider)
+    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: bus)
+    monkeypatch.setattr("nanobot.session.manager.SessionManager", lambda _workspace: object())
+
+    class _FakeCron:
+        def __init__(self, _store_path: Path) -> None:
+            self.on_job = None
+            seen["cron"] = self
+
+    class _FakeAgentLoop:
+        def __init__(self, *args, **kwargs) -> None:
+            self.model = "test-model"
+            self.tools = {}
+
+        async def process_direct(self, *_args, on_progress=None, **_kwargs):
+            if on_progress is not None:
+                await on_progress("thinking...", tool_hint=False)
+                await on_progress('read_file("memory/history.jsonl")', tool_hint=True)
+            return OutboundMessage(
+                channel="telegram",
+                chat_id="user-1",
+                content="Daily summary",
+            )
+
+        async def close_mcp(self) -> None:
+            return None
+
+        async def run(self) -> None:
+            return None
+
+        def stop(self) -> None:
+            return None
+
+    class _StopAfterCronSetup:
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise _StopGatewayError("stop")
+
+    async def _capture_evaluate_response(*_args, **_kwargs) -> bool:
+        return True
+
+    monkeypatch.setattr("nanobot.cron.service.CronService", _FakeCron)
+    monkeypatch.setattr("nanobot.agent.loop.AgentLoop", _FakeAgentLoop)
+    monkeypatch.setattr("nanobot.channels.manager.ChannelManager", _StopAfterCronSetup)
+    monkeypatch.setattr("nanobot.utils.evaluator.evaluate_response", _capture_evaluate_response)
+
+    result = runner.invoke(app, ["gateway", "--config", str(config_file)])
+
+    assert isinstance(result.exception, _StopGatewayError)
+    cron = seen["cron"]
+    assert isinstance(cron, _FakeCron)
+    assert cron.on_job is not None
+
+    job = CronJob(
+        id="cron-final-only-1",
+        name="daily-summary",
+        payload=CronPayload(
+            message="Summarize the latest activity.",
+            deliver=True,
+            channel="telegram",
+            to="user-1",
+        ),
+    )
+
+    response = asyncio.run(cron.on_job(job))
+
+    assert response == "Daily summary"
+    bus.publish_outbound.assert_awaited_once_with(
+        OutboundMessage(
+            channel="telegram",
+            chat_id="user-1",
+            content="Daily summary",
+        )
+    )
+
+
 def test_gateway_workspace_override_does_not_migrate_legacy_cron(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
+from nanobot.agent.tools.message import MessageTool
 from nanobot.bus.events import OutboundMessage
 from nanobot.cli.commands import _make_provider, app
 from nanobot.config.schema import Config
@@ -975,6 +976,99 @@ def test_gateway_cron_evaluator_receives_scheduled_reminder_context(
             content="Time to stretch.",
         )
     )
+
+
+def test_gateway_silent_cron_suppresses_progress_and_message_tool_output(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_file = tmp_path / "instance" / "config.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text("{}")
+
+    config = Config()
+    config.agents.defaults.workspace = str(tmp_path / "config-workspace")
+    bus = MagicMock()
+    bus.publish_outbound = AsyncMock()
+    seen: dict[str, object] = {}
+    sent: list[OutboundMessage] = []
+
+    monkeypatch.setattr("nanobot.config.loader.set_config_path", lambda _path: None)
+    monkeypatch.setattr("nanobot.config.loader.load_config", lambda _path=None: config)
+    monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
+    monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
+    monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: bus)
+    monkeypatch.setattr("nanobot.session.manager.SessionManager", lambda _workspace: object())
+
+    class _FakeCron:
+        def __init__(self, _store_path: Path) -> None:
+            self.on_job = None
+            seen["cron"] = self
+
+    class _FakeAgentLoop:
+        def __init__(self, *args, **kwargs) -> None:
+            self.model = "test-model"
+            self.message_tool = MessageTool(
+                send_callback=AsyncMock(side_effect=lambda msg: sent.append(msg)),
+                default_channel="telegram",
+                default_chat_id="user-1",
+            )
+            self.tools = {
+                "message": self.message_tool,
+            }
+
+        async def process_direct(self, *_args, on_progress=None, **_kwargs):
+            if on_progress is not None:
+                await on_progress('read_file("memory/history.jsonl")', tool_hint=True)
+            await self.message_tool.execute("Hidden internal send")
+            return OutboundMessage(
+                channel="telegram",
+                chat_id="user-1",
+                content="Silent final result",
+            )
+
+        async def close_mcp(self) -> None:
+            return None
+
+        async def run(self) -> None:
+            return None
+
+        def stop(self) -> None:
+            return None
+
+    class _StopAfterCronSetup:
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise _StopGatewayError("stop")
+
+    monkeypatch.setattr("nanobot.cron.service.CronService", _FakeCron)
+    monkeypatch.setattr("nanobot.agent.loop.AgentLoop", _FakeAgentLoop)
+    monkeypatch.setattr("nanobot.channels.manager.ChannelManager", _StopAfterCronSetup)
+    eval_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr("nanobot.utils.evaluator.evaluate_response", eval_mock)
+
+    result = runner.invoke(app, ["gateway", "--config", str(config_file)])
+
+    assert isinstance(result.exception, _StopGatewayError)
+    cron = seen["cron"]
+    assert isinstance(cron, _FakeCron)
+    assert cron.on_job is not None
+
+    job = CronJob(
+        id="cron-silent-1",
+        name="background-refresh",
+        payload=CronPayload(
+            message="Refresh internal cache.",
+            deliver=False,
+            channel="telegram",
+            to="user-1",
+        ),
+    )
+
+    response = asyncio.run(cron.on_job(job))
+
+    assert response == "Silent final result"
+    assert sent == []
+    bus.publish_outbound.assert_not_awaited()
+    eval_mock.assert_not_awaited()
 
 
 def test_gateway_workspace_override_does_not_migrate_legacy_cron(

--- a/tests/tools/test_message_tool_suppress.py
+++ b/tests/tools/test_message_tool_suppress.py
@@ -167,3 +167,18 @@ class TestMessageToolTurnTracking:
         tool._sent_in_turn = True
         tool.start_turn()
         assert not tool._sent_in_turn
+
+    @pytest.mark.asyncio
+    async def test_delivery_suppression_skips_send_callback(self) -> None:
+        send_callback = AsyncMock()
+        tool = MessageTool(send_callback=send_callback, default_channel="feishu", default_chat_id="chat1")
+
+        token = tool.set_delivery_suppressed(True)
+        try:
+            result = await tool.execute("Hello")
+        finally:
+            tool.reset_delivery_suppressed(token)
+
+        assert "suppressed" in result
+        send_callback.assert_not_awaited()
+        assert tool._sent_in_turn is False


### PR DESCRIPTION
## Summary
- make `deliver: false` cron jobs truly silent by suppressing progress/tool-hint output during the cron turn
- mute `message` tool delivery for the current silent cron task so internal sends do not leak to the user channel
- keep regular cron runs quiet too, so scheduled tasks only deliver the final result instead of intermediate thinking/progress noise
- preserve the existing no-duplicate-send shortcut when the message tool already delivered the final result

## Tests
- `.venv312/bin/pytest tests/cli/test_commands.py -k "gateway_cron_evaluator or silent_cron_suppresses_progress_and_message_tool_output or final_message_without_progress_noise" -q`
- `.venv312/bin/pytest tests/tools/test_message_tool_suppress.py -q`
- `.venv312/bin/ruff check nanobot/cli/commands.py nanobot/agent/tools/message.py tests/cli/test_commands.py tests/tools/test_message_tool_suppress.py`

Closes #3115
Closes #3064