### PR TITLE
fix(runner): warn when context is trimmed

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
 import inspect
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
 from nanobot.agent.hook import AgentHook, AgentHookContext
-from nanobot.utils.prompt_templates import render_template
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.providers.base import LLMProvider, ToolCallRequest
 from nanobot.utils.helpers import (
@@ -22,6 +21,7 @@ from nanobot.utils.helpers import (
     maybe_persist_tool_result,
     truncate_text,
 )
+from nanobot.utils.prompt_templates import render_template
 from nanobot.utils.runtime import (
     EMPTY_FINAL_RESPONSE_MESSAGE,
     build_finalization_retry_message,
@@ -45,6 +45,10 @@ _COMPACTABLE_TOOLS = frozenset({
     "web_search", "web_fetch", "list_dir",
 })
 _BACKFILL_CONTENT = "[Tool result unavailable — call was interrupted or lost]"
+_CONTEXT_TRIM_WARNING = (
+    "Context window nearly full; using a shortened view of older history and tool output "
+    "to continue. If something seems missing, ask me to revisit it."
+)
 
 
 
@@ -237,8 +241,11 @@ class AgentRunner:
         length_recovery_count = 0
         had_injections = False
         injection_cycles = 0
+        context_trim_warned = False
 
         for iteration in range(spec.max_iterations):
+            microcompacted = False
+            snipped = False
             try:
                 # Keep the persisted conversation untouched. Context governance
                 # may repair or compact historical messages for the model, but
@@ -246,9 +253,13 @@ class AgentRunner:
                 # later when the caller saves only the new turn.
                 messages_for_model = self._drop_orphan_tool_results(messages)
                 messages_for_model = self._backfill_missing_tool_results(messages_for_model)
-                messages_for_model = self._microcompact(messages_for_model)
+                compacted_messages = self._microcompact(messages_for_model)
+                microcompacted = compacted_messages != messages_for_model
+                messages_for_model = compacted_messages
                 messages_for_model = self._apply_tool_result_budget(spec, messages_for_model)
+                pre_snip_messages = messages_for_model
                 messages_for_model = self._snip_history(spec, messages_for_model)
+                snipped = messages_for_model != pre_snip_messages
                 # Snipping may have created new orphans; clean them up.
                 messages_for_model = self._drop_orphan_tool_results(messages_for_model)
                 messages_for_model = self._backfill_missing_tool_results(messages_for_model)
@@ -264,6 +275,13 @@ class AgentRunner:
                     messages_for_model = self._backfill_missing_tool_results(messages_for_model)
                 except Exception:
                     messages_for_model = messages
+            if not context_trim_warned:
+                context_trim_warned = await self._maybe_warn_context_trim(
+                    spec,
+                    warned=context_trim_warned,
+                    microcompacted=microcompacted,
+                    snipped=snipped,
+                )
             context = AgentHookContext(iteration=iteration, messages=messages)
             await hook.before_iteration(context)
             response = await self._request_model(spec, messages_for_model, hook, context)
@@ -645,7 +663,7 @@ class AgentRunner:
         tool_call: ToolCallRequest,
         external_lookup_counts: dict[str, int],
     ) -> tuple[Any, dict[str, str], BaseException | None]:
-        _HINT = "\n\n[Analyze the error above and try a different approach.]"
+        hint = "\n\n[Analyze the error above and try a different approach.]"
         lookup_error = repeated_external_lookup_error(
             tool_call.name,
             tool_call.arguments,
@@ -658,8 +676,8 @@ class AgentRunner:
                 "detail": "repeated external lookup blocked",
             }
             if spec.fail_on_tool_error:
-                return lookup_error + _HINT, event, RuntimeError(lookup_error)
-            return lookup_error + _HINT, event, None
+                return lookup_error + hint, event, RuntimeError(lookup_error)
+            return lookup_error + hint, event, None
         prepare_call = getattr(spec.tools, "prepare_call", None)
         tool, params, prep_error = None, tool_call.arguments, None
         if callable(prepare_call):
@@ -675,7 +693,7 @@ class AgentRunner:
                 "status": "error",
                 "detail": prep_error.split(": ", 1)[-1][:120],
             }
-            return prep_error + _HINT, event, RuntimeError(prep_error) if spec.fail_on_tool_error else None
+            return prep_error + hint, event, RuntimeError(prep_error) if spec.fail_on_tool_error else None
         try:
             if tool is not None:
                 result = await tool.execute(**params)
@@ -700,8 +718,8 @@ class AgentRunner:
                 "detail": result.replace("\n", " ").strip()[:120],
             }
             if spec.fail_on_tool_error:
-                return result + _HINT, event, RuntimeError(result)
-            return result + _HINT, event, None
+                return result + hint, event, RuntimeError(result)
+            return result + hint, event, None
 
         detail = "" if result is None else str(result)
         detail = detail.replace("\n", " ").strip()
@@ -719,6 +737,19 @@ class AgentRunner:
         callback = spec.checkpoint_callback
         if callback is not None:
             await callback(payload)
+
+    @staticmethod
+    async def _maybe_warn_context_trim(
+        spec: AgentRunSpec,
+        *,
+        warned: bool,
+        microcompacted: bool,
+        snipped: bool,
+    ) -> bool:
+        if warned or spec.progress_callback is None or not (microcompacted or snipped):
+            return warned
+        await spec.progress_callback(_CONTEXT_TRIM_WARNING)
+        return True
 
     @staticmethod
     def _append_final_message(messages: list[dict[str, Any]], content: str | None) -> None:
@@ -966,4 +997,3 @@ class AgentRunner:
         if current:
             batches.append(current)
         return batches
-

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -1686,18 +1686,6 @@ def test_governance_repairs_orphans_after_snip():
     _drop_orphan_tool_results pass must clean up the resulting orphans."""
     from nanobot.agent.runner import AgentRunner
 
-    messages = [
-        {"role": "system", "content": "system"},
-        {"role": "user", "content": "old msg"},
-        {"role": "assistant", "content": None,
-         "tool_calls": [{"id": "tc_old", "type": "function",
-                         "function": {"name": "search", "arguments": "{}"}}]},
-        {"role": "tool", "tool_call_id": "tc_old", "name": "search",
-         "content": "old result"},
-        {"role": "assistant", "content": "old answer"},
-        {"role": "user", "content": "new msg"},
-    ]
-
     # Simulate snipping that keeps only the tail: drop the assistant with
     # tool_calls but keep its tool result (orphan).
     snipped = [
@@ -1733,6 +1721,75 @@ def test_governance_fallback_still_repairs_orphans():
     repaired = AgentRunner._backfill_missing_tool_results(repaired)
     # Orphan tool result should be gone.
     assert not any(m.get("tool_call_id") == "orphan_tc" for m in repaired)
+
+
+@pytest.mark.asyncio
+async def test_runner_warns_once_when_context_is_trimmed(monkeypatch):
+    """When history is compacted/snipped to fit budget, emit one visible warning."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner, _CONTEXT_TRIM_WARNING
+
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="done", tool_calls=[], usage={}))
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    progress = AsyncMock()
+
+    monkeypatch.setattr("nanobot.agent.runner.estimate_prompt_tokens_chain", lambda *args, **kwargs: (1000, "test"))
+    monkeypatch.setattr("nanobot.agent.runner.estimate_message_tokens", lambda _message: 60)
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "older user"},
+            {"role": "assistant", "content": "older assistant"},
+            {"role": "user", "content": "newer user"},
+            {"role": "assistant", "content": "newer assistant"},
+            {"role": "user", "content": "latest user"},
+        ],
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=4000,
+        context_block_limit=180,
+        progress_callback=progress,
+    ))
+
+    assert result.final_content == "done"
+    progress.assert_awaited_once_with(_CONTEXT_TRIM_WARNING)
+
+
+@pytest.mark.asyncio
+async def test_runner_does_not_warn_when_context_fits(monkeypatch):
+    """No warning should be emitted when governance leaves history unchanged."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="done", tool_calls=[], usage={}))
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    progress = AsyncMock()
+
+    monkeypatch.setattr("nanobot.agent.runner.estimate_prompt_tokens_chain", lambda *args, **kwargs: (80, "test"))
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "hello"},
+        ],
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=4000,
+        context_block_limit=180,
+        progress_callback=progress,
+    ))
+
+    assert result.final_content == "done"
+    progress.assert_not_awaited()
 # ── Mid-turn injection tests ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- emit a one-time visible warning when runner context governance has to microcompact or snip older history/tool output
- keep the warning out of normal turns where the full context still fits
- add runner regression tests for both the warning and no-warning paths

## Testing
- ./.venv312/bin/python -m pytest tests/agent/test_runner.py -q
- ./.venv312/bin/python -m pytest tests/agent/test_runner.py -q -k "context_is_trimmed or context_fits or empty_final_response or microcompact or snip_history"
- ./.venv312/bin/ruff check nanobot/agent/runner.py tests/agent/test_runner.py --select F
- ./.venv312/bin/ruff check nanobot/agent/runner.py --select I,F,N

Refs #3029