### PR TITLE
feat(command): add /clear, /skills, /mcp slash commands

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -966,3 +966,63 @@ class AgentLoop:
             on_stream=on_stream,
             on_stream_end=on_stream_end,
         )
+
+    # -- /clear, /skills, /mcp helpers -----------------------------------------
+
+    def _list_skills(self) -> str:
+        """List available skills from workspace."""
+        skills_dir = self.workspace / "skills"
+        if not skills_dir.exists():
+            return "No skills directory found."
+        skills: list[str] = []
+        for skill_path in sorted(skills_dir.iterdir()):
+            if not skill_path.is_dir():
+                continue
+            skill_md = skill_path / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            skill_name = skill_path.name
+            description = ""
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+                if content.startswith("---"):
+                    end = content.find("---", 3)
+                    if end != -1:
+                        for line in content[3:end].split("\n"):
+                            line = line.strip()
+                            if line.startswith("description:"):
+                                description = line[len("description:"):].strip().strip("\"'")
+                                break
+            except Exception:
+                pass
+            if len(description) > 80:
+                description = description[:77] + "..."
+            entry = f"  {skill_name}" + (f" - {description}" if description else "")
+            skills.append(entry)
+        if not skills:
+            return "No skills found."
+        return "Available skills:\n" + "\n".join(skills)
+
+    def _list_mcp_servers(self) -> str:
+        """List configured MCP servers and connection status."""
+        if not self._mcp_servers:
+            return "No MCP servers configured."
+        lines: list[str] = []
+        for name, cfg in self._mcp_servers.items():
+            if hasattr(cfg, "url") and cfg.url:
+                lines.append(f"  {name} — {cfg.url}")
+            elif hasattr(cfg, "command") and cfg.command:
+                args = " ".join(cfg.args) if hasattr(cfg, "args") and cfg.args else ""
+                lines.append(f"  {name} — {cfg.command} {args}".rstrip())
+            else:
+                url = cfg.get("url", "") if isinstance(cfg, dict) else ""
+                cmd = cfg.get("command", "") if isinstance(cfg, dict) else ""
+                if url:
+                    lines.append(f"  {name} — {url}")
+                elif cmd:
+                    args = " ".join(cfg.get("args", []))
+                    lines.append(f"  {name} — {cmd} {args}".rstrip())
+                else:
+                    lines.append(f"  {name}")
+        status = " (connected)" if self._mcp_connected else ""
+        return f"MCP servers{status}:\n" + "\n".join(lines)

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -303,6 +303,41 @@ async def cmd_dream_restore(ctx: CommandContext) -> OutboundMessage:
     )
 
 
+async def cmd_clear(ctx: CommandContext) -> OutboundMessage:
+    """Clear conversation history without archiving."""
+    loop = ctx.loop
+    session = ctx.session or loop.sessions.get_or_create(ctx.key)
+    msg_count = len(session.messages)
+    session.clear()
+    loop.sessions.save(session)
+    from loguru import logger
+
+    logger.info("Session cleared for {} (cleared {} messages)", ctx.key, msg_count)
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content="Conversation history cleared. Let's start fresh!",
+    )
+
+
+async def cmd_skills(ctx: CommandContext) -> OutboundMessage:
+    """List available workspace skills."""
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=ctx.loop._list_skills(),
+    )
+
+
+async def cmd_mcp(ctx: CommandContext) -> OutboundMessage:
+    """List configured MCP servers."""
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=ctx.loop._list_mcp_servers(),
+    )
+
+
 async def cmd_help(ctx: CommandContext) -> OutboundMessage:
     """Return available slash commands."""
     return OutboundMessage(
@@ -318,9 +353,12 @@ def build_help_text() -> str:
     lines = [
         "🐈 nanobot commands:",
         "/new — Start a new conversation",
+        "/clear — Clear conversation history",
+        "/skills — List available skills",
+        "/mcp — List configured MCP servers",
+        "/status — Show bot status",
         "/stop — Stop the current task",
         "/restart — Restart the bot",
-        "/status — Show bot status",
         "/dream — Manually trigger Dream consolidation",
         "/dream-log — Show what the last Dream changed",
         "/dream-restore — Revert memory to a previous state",
@@ -335,6 +373,9 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.priority("/restart", cmd_restart)
     router.priority("/status", cmd_status)
     router.exact("/new", cmd_new)
+    router.exact("/clear", cmd_clear)
+    router.exact("/skills", cmd_skills)
+    router.exact("/mcp", cmd_mcp)
     router.exact("/status", cmd_status)
     router.exact("/dream", cmd_dream)
     router.exact("/dream-log", cmd_dream_log)


### PR DESCRIPTION
## Summary

Adds three informational slash commands that are useful for daily operation:

- **`/clear`** — Clear conversation history without archiving (unlike `/new` which starts a fresh session, `/clear` wipes the current one)
- **`/skills`** — List available workspace skills with descriptions parsed from SKILL.md frontmatter
- **`/mcp`** — List configured MCP servers and their connection status

Also adds `_list_skills()` and `_list_mcp_servers()` helper methods to `AgentLoop`, and updates `/help` output to include the new commands.

## Changes

- `nanobot/command/builtin.py` — New command handlers + registration + help text
- `nanobot/agent/loop.py` — Helper methods for skill/MCP listing

## Test plan

- [x] All existing tests pass (1609 passed, 3 skipped)
- [ ] Manual verification of `/clear`, `/skills`, `/mcp` via interactive session