### PR TITLE
feat(api): route message tool sends to channels

### DIFF
--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
+from contextlib import suppress
 from typing import Any
 
 from aiohttp import web
@@ -175,21 +176,48 @@ async def handle_health(request: web.Request) -> web.Response:
 # App factory
 # ---------------------------------------------------------------------------
 
-def create_app(agent_loop, model_name: str = "nanobot", request_timeout: float = 120.0) -> web.Application:
+def create_app(
+    agent_loop,
+    model_name: str = "nanobot",
+    request_timeout: float = 120.0,
+    channel_manager: Any | None = None,
+) -> web.Application:
     """Create the aiohttp application.
 
     Args:
         agent_loop: An initialized AgentLoop instance.
         model_name: Model name reported in responses.
         request_timeout: Per-request timeout in seconds.
+        channel_manager: Optional ChannelManager used to dispatch outbound
+            message-tool sends to real chat channels while the API server runs.
     """
     app = web.Application()
     app["agent_loop"] = agent_loop
     app["model_name"] = model_name
     app["request_timeout"] = request_timeout
     app["session_locks"] = {}  # per-user locks, keyed by session_key
+    app["channel_manager"] = channel_manager
+    app["channel_manager_task"] = None
+
+    async def _start_channels(_app: web.Application) -> None:
+        manager = _app.get("channel_manager")
+        if manager is None:
+            return
+        _app["channel_manager_task"] = asyncio.create_task(manager.start_all())
+
+    async def _stop_channels(_app: web.Application) -> None:
+        manager = _app.get("channel_manager")
+        task = _app.get("channel_manager_task")
+        if manager is not None:
+            await manager.stop_all()
+        if task is not None:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
 
     app.router.add_post("/v1/chat/completions", handle_chat_completions)
     app.router.add_get("/v1/models", handle_models)
     app.router.add_get("/health", handle_health)
+    app.on_startup.append(_start_channels)
+    app.on_cleanup.append(_stop_channels)
     return app

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -554,9 +554,11 @@ def serve(
         raise typer.Exit(1)
 
     from loguru import logger
+
     from nanobot.agent.loop import AgentLoop
     from nanobot.api.server import create_app
     from nanobot.bus.queue import MessageBus
+    from nanobot.channels.manager import ChannelManager
     from nanobot.session.manager import SessionManager
 
     if verbose:
@@ -594,6 +596,7 @@ def serve(
         disabled_skills=runtime_config.agents.defaults.disabled_skills,
         session_ttl_minutes=runtime_config.agents.defaults.session_ttl_minutes,
     )
+    channel_manager = ChannelManager(runtime_config, bus)
 
     model_name = runtime_config.agents.defaults.model
     console.print(f"{__logo__} Starting OpenAI-compatible API server")
@@ -601,6 +604,11 @@ def serve(
     console.print(f"  [cyan]Model[/cyan]    : {model_name}")
     console.print("  [cyan]Session[/cyan]  : api:default")
     console.print(f"  [cyan]Timeout[/cyan]  : {timeout}s")
+    if channel_manager.enabled_channels:
+        console.print(
+            f"  [cyan]Outbound[/cyan] : channels enabled for message tool delivery "
+            f"({', '.join(channel_manager.enabled_channels)})"
+        )
     if host in {"0.0.0.0", "::"}:
         console.print(
             "[yellow]Warning:[/yellow] API is bound to all interfaces. "
@@ -608,7 +616,12 @@ def serve(
         )
     console.print()
 
-    api_app = create_app(agent_loop, model_name=model_name, request_timeout=timeout)
+    api_app = create_app(
+        agent_loop,
+        model_name=model_name,
+        request_timeout=timeout,
+        channel_manager=channel_manager,
+    )
 
     async def on_startup(_app):
         await agent_loop._connect_mcp()

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -776,10 +776,16 @@ def _patch_serve_runtime(monkeypatch, config: Config, seen: dict[str, object]) -
         async def close_mcp(self) -> None:
             return None
 
-    def _fake_create_app(agent_loop, model_name: str, request_timeout: float):
+    class _FakeChannelManager:
+        def __init__(self, _config, _bus) -> None:
+            self.enabled_channels = ["email"]
+            seen["channel_manager"] = self
+
+    def _fake_create_app(agent_loop, model_name: str, request_timeout: float, channel_manager=None):
         seen["agent_loop"] = agent_loop
         seen["model_name"] = model_name
         seen["request_timeout"] = request_timeout
+        seen["create_app_channel_manager"] = channel_manager
         return _FakeApiApp()
 
     def _fake_run_app(api_app, host: str, port: int, print):
@@ -794,6 +800,7 @@ def _patch_serve_runtime(monkeypatch, config: Config, seen: dict[str, object]) -
         session_manager=lambda _workspace: object(),
     )
     monkeypatch.setattr("nanobot.agent.loop.AgentLoop", _FakeAgentLoop)
+    monkeypatch.setattr("nanobot.channels.manager.ChannelManager", _FakeChannelManager)
     monkeypatch.setattr("nanobot.api.server.create_app", _fake_create_app)
     monkeypatch.setattr("aiohttp.web.run_app", _fake_run_app)
 
@@ -817,6 +824,19 @@ def test_gateway_uses_workspace_from_config_by_default(monkeypatch, tmp_path: Pa
     assert isinstance(result.exception, _StopGatewayError)
     assert seen["config_path"] == config_file.resolve()
     assert seen["workspace"] == Path(config.agents.defaults.workspace)
+
+
+def test_serve_passes_channel_manager_to_api_app(monkeypatch, tmp_path: Path) -> None:
+    config_file = _write_instance_config(tmp_path)
+    config = Config()
+    seen: dict[str, object] = {}
+
+    _patch_serve_runtime(monkeypatch, config, seen)
+
+    result = runner.invoke(app, ["serve", "--config", str(config_file)])
+
+    assert result.exit_code == 0
+    assert seen["create_app_channel_manager"] is seen["channel_manager"]
 
 
 def test_gateway_workspace_option_overrides_config(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -17,6 +17,8 @@ from nanobot.api.server import (
     create_app,
     handle_chat_completions,
 )
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
 
 try:
     from aiohttp.test_utils import TestClient, TestServer
@@ -285,6 +287,86 @@ async def test_health_endpoint(aiohttp_client, app) -> None:
     assert resp.status == 200
     body = await resp.json()
     assert body["status"] == "ok"
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_channel_manager_lifecycle_runs_with_app(aiohttp_client, mock_agent) -> None:
+    class _FakeChannelManager:
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.stopped = asyncio.Event()
+
+        async def start_all(self) -> None:
+            self.started.set()
+            await asyncio.Event().wait()
+
+        async def stop_all(self) -> None:
+            self.stopped.set()
+
+    manager = _FakeChannelManager()
+    app = create_app(mock_agent, model_name="m", channel_manager=manager)
+    client = await aiohttp_client(app)
+    await asyncio.wait_for(manager.started.wait(), timeout=1.0)
+    await client.close()
+    await asyncio.wait_for(manager.stopped.wait(), timeout=1.0)
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_api_server_dispatches_outbound_messages_through_channel_manager(aiohttp_client) -> None:
+    bus = MessageBus()
+
+    class _FakeChannelManager:
+        def __init__(self, bus: MessageBus) -> None:
+            self.bus = bus
+            self.sent: list[OutboundMessage] = []
+            self._running = True
+
+        async def start_all(self) -> None:
+            while self._running:
+                msg = await self.bus.consume_outbound()
+                self.sent.append(msg)
+
+        async def stop_all(self) -> None:
+            self._running = False
+
+    async def fake_process(content, session_key="", channel="", chat_id=""):
+        await bus.publish_outbound(
+            OutboundMessage(
+                channel="email",
+                chat_id="user@example.com",
+                content=f"forwarded:{content}",
+            )
+        )
+        return "ok"
+
+    agent = MagicMock()
+    agent.process_direct = fake_process
+    agent._connect_mcp = AsyncMock()
+    agent.close_mcp = AsyncMock()
+
+    manager = _FakeChannelManager(bus)
+    app = create_app(agent, model_name="m", channel_manager=manager)
+    client = await aiohttp_client(app)
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    assert resp.status == 200
+    for _ in range(20):
+        if manager.sent:
+            break
+        await asyncio.sleep(0.01)
+    assert manager.sent == [
+        OutboundMessage(
+            channel="email",
+            chat_id="user@example.com",
+            content="forwarded:hello",
+        )
+    ]
 
 
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")


### PR DESCRIPTION
## Summary
- start a background `ChannelManager` in `nanobot serve` so message-tool outbound traffic can be dispatched while the API server is running
- pass the shared bus-backed channel manager into the API app lifecycle and stop it cleanly on shutdown
- add API and CLI regression coverage for startup wiring and queued outbound delivery

## Testing
- ./.venv312/bin/python -m pytest tests/test_openai_api.py -q
- ./.venv312/bin/python -m pytest tests/cli/test_commands.py -q
- ./.venv312/bin/python -m pytest tests/test_openai_api.py tests/cli/test_commands.py -q
- ./.venv312/bin/ruff check nanobot/api/server.py nanobot/cli/commands.py tests/test_openai_api.py tests/cli/test_commands.py --select I,F

Refs #3074