### PR TITLE
feat(stop): summarize interrupted tasks for resume

### DIFF
--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
 from loguru import logger
+
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
 
 class AutoCompact:
     _RECENT_SUFFIX_MESSAGES = 8
+    _LAST_SUMMARY_KEY = "_last_summary"
+    _RESUME_SUMMARY_KEY = "_resume_summary"
 
     def __init__(self, sessions: SessionManager, consolidator: Consolidator,
                  session_ttl_minutes: int = 0):
@@ -23,6 +26,7 @@ class AutoCompact:
         self._ttl = session_ttl_minutes
         self._archiving: set[str] = set()
         self._summaries: dict[str, tuple[str, datetime]] = {}
+        self._resume_summaries: dict[str, str] = {}
 
     def _is_expired(self, ts: datetime | str | None,
                     now: datetime | None = None) -> bool:
@@ -36,6 +40,10 @@ class AutoCompact:
     def _format_summary(text: str, last_active: datetime) -> str:
         idle_min = int((datetime.now() - last_active).total_seconds() / 60)
         return f"Inactive for {idle_min} minutes.\nPrevious conversation summary: {text}"
+
+    @staticmethod
+    def _format_resume_summary(text: str) -> str:
+        return f"Previous task was stopped before completion.\nInterrupted task summary: {text}"
 
     def _split_unconsolidated(
         self, session: Session,
@@ -88,7 +96,10 @@ class AutoCompact:
                 summary = await self.consolidator.archive(archive_msgs) or ""
             if summary and summary != "(nothing)":
                 self._summaries[key] = (summary, last_active)
-                session.metadata["_last_summary"] = {"text": summary, "last_active": last_active.isoformat()}
+                session.metadata[self._LAST_SUMMARY_KEY] = {
+                    "text": summary,
+                    "last_active": last_active.isoformat(),
+                }
             session.messages = kept_msgs
             session.last_consolidated = 0
             session.updated_at = datetime.now()
@@ -106,18 +117,48 @@ class AutoCompact:
         finally:
             self._archiving.discard(key)
 
+    def stash_resume_summary(self, session: Session, key: str, summary: str) -> None:
+        """Persist a one-shot interrupted-task summary for the next turn."""
+        text = summary.strip()
+        if not text or text == "(nothing)":
+            return
+        self._resume_summaries[key] = text
+        session.metadata[self._RESUME_SUMMARY_KEY] = {"text": text}
+
+    def _consume_resume_summary(self, session: Session, key: str) -> str | None:
+        text = self._resume_summaries.pop(key, None)
+        if text:
+            session.metadata.pop(self._RESUME_SUMMARY_KEY, None)
+            return self._format_resume_summary(text)
+        if self._RESUME_SUMMARY_KEY not in session.metadata:
+            return None
+        meta = session.metadata.pop(self._RESUME_SUMMARY_KEY)
+        self.sessions.save(session)
+        return self._format_resume_summary(meta["text"])
+
+    def _consume_idle_summary(self, session: Session, key: str) -> str | None:
+        # Hot path: summary from in-memory dict (process hasn't restarted).
+        # Also clean metadata copy so stale summary never leaks to disk.
+        entry = self._summaries.pop(key, None)
+        if entry:
+            session.metadata.pop(self._LAST_SUMMARY_KEY, None)
+            return self._format_summary(entry[0], entry[1])
+        if self._LAST_SUMMARY_KEY not in session.metadata:
+            return None
+        meta = session.metadata.pop(self._LAST_SUMMARY_KEY)
+        self.sessions.save(session)
+        return self._format_summary(meta["text"], datetime.fromisoformat(meta["last_active"]))
+
     def prepare_session(self, session: Session, key: str) -> tuple[Session, str | None]:
         if key in self._archiving or self._is_expired(session.updated_at):
             logger.info("Auto-compact: reloading session {} (archiving={})", key, key in self._archiving)
             session = self.sessions.get_or_create(key)
-        # Hot path: summary from in-memory dict (process hasn't restarted).
-        # Also clean metadata copy so stale _last_summary never leaks to disk.
-        entry = self._summaries.pop(key, None)
-        if entry:
-            session.metadata.pop("_last_summary", None)
-            return session, self._format_summary(entry[0], entry[1])
-        if "_last_summary" in session.metadata:
-            meta = session.metadata.pop("_last_summary")
-            self.sessions.save(session)
-            return session, self._format_summary(meta["text"], datetime.fromisoformat(meta["last_active"]))
-        return session, None
+        summaries = [
+            text
+            for text in (
+                self._consume_resume_summary(session, key),
+                self._consume_idle_summary(session, key),
+            )
+            if text
+        ]
+        return session, "\n\n".join(summaries) if summaries else None

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -17,10 +17,10 @@ from nanobot.agent.autocompact import AutoCompact
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.hook import AgentHook, AgentHookContext, CompositeHook
 from nanobot.agent.memory import Consolidator, Dream
-from nanobot.agent.runner import _MAX_INJECTIONS_PER_TURN, AgentRunSpec, AgentRunner
+from nanobot.agent.runner import _MAX_INJECTIONS_PER_TURN, AgentRunner, AgentRunSpec
+from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.cron import CronTool
-from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.notebook import NotebookEditTool
@@ -30,12 +30,13 @@ from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
-from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.bus.queue import MessageBus
+from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import LLMProvider
 from nanobot.session.manager import Session, SessionManager
-from nanobot.utils.helpers import image_placeholder_text, truncate_text as truncate_text_fn
+from nanobot.utils.helpers import image_placeholder_text
+from nanobot.utils.helpers import truncate_text as truncate_text_fn
 from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
 
 if TYPE_CHECKING:
@@ -872,13 +873,12 @@ class AgentLoop:
             message.get("thinking_blocks"),
         )
 
-    def _restore_runtime_checkpoint(self, session: Session) -> bool:
-        """Materialize an unfinished turn into session history before a new request."""
+    def _materialize_runtime_checkpoint_messages(
+        self,
+        checkpoint: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Expand checkpoint metadata into restorable assistant/tool messages."""
         from datetime import datetime
-
-        checkpoint = session.metadata.get(self._RUNTIME_CHECKPOINT_KEY)
-        if not isinstance(checkpoint, dict):
-            return False
 
         assistant_message = checkpoint.get("assistant_message")
         completed_tool_results = checkpoint.get("completed_tool_results") or []
@@ -908,6 +908,15 @@ class AgentLoop:
                     "timestamp": datetime.now().isoformat(),
                 }
             )
+        return restored_messages
+
+    def _restore_runtime_checkpoint(self, session: Session) -> bool:
+        """Materialize an unfinished turn into session history before a new request."""
+        checkpoint = session.metadata.get(self._RUNTIME_CHECKPOINT_KEY)
+        if not isinstance(checkpoint, dict):
+            return False
+
+        restored_messages = self._materialize_runtime_checkpoint_messages(checkpoint)
 
         overlap = 0
         max_overlap = min(len(session.messages), len(restored_messages))
@@ -925,6 +934,67 @@ class AgentLoop:
         self._clear_pending_user_turn(session)
         self._clear_runtime_checkpoint(session)
         return True
+
+    def _interrupted_turn_messages(self, session: Session) -> list[dict[str, Any]]:
+        """Collect the current interrupted turn for resume summarization."""
+        checkpoint = session.metadata.get(self._RUNTIME_CHECKPOINT_KEY)
+        pending_user = bool(session.metadata.get(self._PENDING_USER_TURN_KEY))
+        if not pending_user and not isinstance(checkpoint, dict):
+            return []
+
+        user_start = next(
+            (index for index in range(len(session.messages) - 1, -1, -1)
+             if session.messages[index].get("role") == "user"),
+            None,
+        )
+        current_turn = (
+            [dict(message) for message in session.messages[user_start:]]
+            if user_start is not None
+            else []
+        )
+
+        checkpoint_messages = (
+            self._materialize_runtime_checkpoint_messages(checkpoint)
+            if isinstance(checkpoint, dict)
+            else []
+        )
+        overlap = 0
+        max_overlap = min(len(current_turn), len(checkpoint_messages))
+        for size in range(max_overlap, 0, -1):
+            existing = current_turn[-size:]
+            restored = checkpoint_messages[:size]
+            if all(
+                self._checkpoint_message_key(left) == self._checkpoint_message_key(right)
+                for left, right in zip(existing, restored)
+            ):
+                overlap = size
+                break
+        combined = current_turn + checkpoint_messages[overlap:]
+        if pending_user and not checkpoint_messages:
+            combined.append(
+                {
+                    "role": "assistant",
+                    "content": "Error: Task interrupted before a response was generated.",
+                }
+            )
+        return combined
+
+    async def capture_resume_summary(self, key: str) -> bool:
+        """Persist a one-shot summary for the next turn after `/stop` interrupts work."""
+        session = self.sessions.get_or_create(key)
+        interrupted = self._interrupted_turn_messages(session)
+        if not interrupted:
+            return False
+
+        summary = await self.consolidator.summarize_interrupted(interrupted)
+        if summary:
+            self.auto_compact.stash_resume_summary(session, key, summary)
+
+        restored = self._restore_runtime_checkpoint(session)
+        if not restored:
+            self._restore_pending_user_turn(session)
+        self.sessions.save(session)
+        return bool(summary)
 
     def _restore_pending_user_turn(self, session: Session) -> bool:
         """Close a turn that only persisted the user message before crashing."""

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -12,12 +12,17 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from loguru import logger
 
-from nanobot.utils.prompt_templates import render_template
-from nanobot.utils.helpers import ensure_dir, estimate_message_tokens, estimate_prompt_tokens_chain, strip_think
-
-from nanobot.agent.runner import AgentRunSpec, AgentRunner
+from nanobot.agent.runner import AgentRunner, AgentRunSpec
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.utils.gitstore import GitStore
+from nanobot.utils.helpers import (
+    ensure_dir,
+    estimate_message_tokens,
+    estimate_prompt_tokens_chain,
+    strip_think,
+    truncate_text,
+)
+from nanobot.utils.prompt_templates import render_template
 
 if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
@@ -433,6 +438,59 @@ class Consolidator:
             self._get_tool_definitions(),
         )
 
+    @staticmethod
+    def _fallback_interrupted_summary(messages: list[dict]) -> str | None:
+        """Best-effort structured summary when the LLM summary call fails."""
+
+        def _content_preview(content: Any) -> str:
+            if isinstance(content, str):
+                return truncate_text(content.strip(), 400)
+            if isinstance(content, list):
+                parts: list[str] = []
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") == "text" and isinstance(block.get("text"), str):
+                        parts.append(block["text"].strip())
+                return truncate_text("\n".join(part for part in parts if part), 400)
+            return ""
+
+        user_goal = ""
+        assistant_state = ""
+        completed_tools: list[str] = []
+        pending_tools: list[str] = []
+        seen_tools: set[str] = set()
+
+        for message in messages:
+            role = message.get("role")
+            if role == "user" and not user_goal:
+                user_goal = _content_preview(message.get("content"))
+            elif role == "assistant":
+                assistant_state = _content_preview(message.get("content")) or assistant_state
+            elif role == "tool":
+                name = str(message.get("name") or "tool")
+                preview = _content_preview(message.get("content"))
+                line = f"{name}: {preview}" if preview else name
+                if "interrupted before this tool finished" in preview.lower():
+                    pending_tools.append(line)
+                    continue
+                if line not in seen_tools:
+                    seen_tools.add(line)
+                    completed_tools.append(line)
+
+        lines: list[str] = []
+        if user_goal:
+            lines.append(f"- User goal: {user_goal}")
+        if assistant_state:
+            lines.append(f"- Last assistant state: {assistant_state}")
+        if completed_tools:
+            lines.append("- Completed tool results: " + "; ".join(completed_tools[:4]))
+        if pending_tools:
+            lines.append("- Pending tool calls: " + "; ".join(pending_tools[:4]))
+        if not pending_tools and not completed_tools:
+            lines.append("- Task status: The turn was interrupted before it fully completed.")
+        return "\n".join(lines) if lines else None
+
     async def archive(self, messages: list[dict]) -> str | None:
         """Summarize messages via LLM and append to history.jsonl.
 
@@ -464,6 +522,33 @@ class Consolidator:
             logger.warning("Consolidation LLM call failed, raw-dumping to history")
             self.store.raw_archive(messages)
             return None
+
+    async def summarize_interrupted(self, messages: list[dict]) -> str | None:
+        """Summarize an interrupted in-flight task for one-shot resume injection."""
+        if not messages:
+            return None
+        formatted = MemoryStore._format_messages(messages)
+        try:
+            response = await self.provider.chat_with_retry(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": render_template(
+                            "agent/interrupted_resume_summary.md",
+                            strip=True,
+                        ),
+                    },
+                    {"role": "user", "content": formatted},
+                ],
+                tools=None,
+                tool_choice=None,
+            )
+            summary = (response.content or "").strip()
+            return summary or None
+        except Exception:
+            logger.warning("Interrupted-task summary failed; using deterministic fallback")
+            return self._fallback_interrupted_summary(messages)
 
     async def maybe_consolidate_by_tokens(self, session: Session) -> None:
         """Loop: archive old messages until prompt fits within safe budget.

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -17,16 +17,22 @@ async def cmd_stop(ctx: CommandContext) -> OutboundMessage:
     """Cancel all active tasks and subagents for the session."""
     loop = ctx.loop
     msg = ctx.msg
-    tasks = loop._active_tasks.pop(msg.session_key, [])
+    tasks = loop._active_tasks.pop(ctx.key, [])
     cancelled = sum(1 for t in tasks if not t.done() and t.cancel())
     for t in tasks:
         try:
             await t
         except (asyncio.CancelledError, Exception):
             pass
-    sub_cancelled = await loop.subagents.cancel_by_session(msg.session_key)
+    sub_cancelled = await loop.subagents.cancel_by_session(ctx.key)
     total = cancelled + sub_cancelled
-    content = f"Stopped {total} task(s)." if total else "No active task to stop."
+    saved_resume = False
+    if total:
+        saved_resume = await loop.capture_resume_summary(ctx.key)
+    if total and saved_resume:
+        content = f"Stopped {total} task(s). Saved resume context for the next turn."
+    else:
+        content = f"Stopped {total} task(s)." if total else "No active task to stop."
     return OutboundMessage(
         channel=msg.channel, chat_id=msg.chat_id, content=content,
         metadata=dict(msg.metadata or {})

--- a/nanobot/templates/agent/interrupted_resume_summary.md
+++ b/nanobot/templates/agent/interrupted_resume_summary.md
@@ -1,0 +1,16 @@
+You are compressing an interrupted agent task so a future turn can resume it quickly.
+
+Summarize the transcript into concise bullet points that cover only:
+- The user's current goal
+- What has already been completed or observed
+- Important tool outputs, side effects, or blockers
+- Any unfinished or interrupted tool calls
+- The most sensible next step
+
+Rules:
+- Be factual and concrete
+- Prefer specifics over generic wording
+- Do not invent progress that did not happen
+- Keep it short enough to fit comfortably into a runtime context block
+- Output bullets only, no preamble
+- If there is nothing useful to preserve, output: (nothing)

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -2,16 +2,16 @@
 
 import asyncio
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from nanobot.agent.loop import AgentLoop
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
-from nanobot.config.schema import AgentDefaults
 from nanobot.command import CommandContext
+from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import LLMResponse
 
 
@@ -187,7 +187,7 @@ class TestAutoCompact:
     async def test_auto_compact_empty_session(self, tmp_path):
         """_archive on empty session should not archive."""
         loop = _make_loop(tmp_path, session_ttl_minutes=15)
-        session = loop.sessions.get_or_create("cli:test")
+        loop.sessions.get_or_create("cli:test")
 
         archive_called = False
 
@@ -1007,4 +1007,58 @@ class TestSummaryPersistence:
         assert summary is not None
         # Metadata should also be cleaned up
         assert "_last_summary" not in reloaded.metadata
+        await loop.close_mcp()
+
+
+class TestResumeSummaryPersistence:
+    """Test that interrupted-task summaries survive until the next turn."""
+
+    @pytest.mark.asyncio
+    async def test_resume_summary_recovered_after_restart(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:test")
+        loop.auto_compact.stash_resume_summary(
+            session,
+            "cli:test",
+            "- User goal: finish the interrupted task",
+        )
+        loop.sessions.save(session)
+
+        loop.auto_compact._resume_summaries.clear()
+        loop.sessions.invalidate("cli:test")
+        reloaded = loop.sessions.get_or_create("cli:test")
+
+        _, summary = loop.auto_compact.prepare_session(reloaded, "cli:test")
+
+        assert summary is not None
+        assert "Previous task was stopped before completion." in summary
+        assert "finish the interrupted task" in summary
+        assert "_resume_summary" not in reloaded.metadata
+        await loop.close_mcp()
+
+    @pytest.mark.asyncio
+    async def test_prepare_session_combines_resume_and_idle_summaries(self, tmp_path):
+        loop = _make_loop(tmp_path, session_ttl_minutes=15)
+        session = loop.sessions.get_or_create("cli:test")
+        session.metadata["_last_summary"] = {
+            "text": "Old conversation summary.",
+            "last_active": (datetime.now() - timedelta(minutes=20)).isoformat(),
+        }
+        loop.auto_compact.stash_resume_summary(
+            session,
+            "cli:test",
+            "- Pending tool call: exec",
+        )
+        loop.auto_compact._summaries.clear()
+        loop.sessions.save(session)
+
+        _, summary = loop.auto_compact.prepare_session(session, "cli:test")
+
+        assert summary is not None
+        assert "Previous task was stopped before completion." in summary
+        assert "Pending tool call: exec" in summary
+        assert "Inactive for" in summary
+        assert "Old conversation summary." in summary
+        assert "_resume_summary" not in session.metadata
+        assert "_last_summary" not in session.metadata
         await loop.close_mcp()

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -8,6 +8,8 @@ from nanobot.agent.context import ContextBuilder
 from nanobot.agent.loop import AgentLoop
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.command import CommandContext
+from nanobot.command.builtin import cmd_stop
 from nanobot.session.manager import Session
 
 
@@ -312,6 +314,111 @@ async def test_next_turn_after_crash_closes_pending_user_turn_before_new_input(t
 
 
 @pytest.mark.asyncio
+async def test_capture_resume_summary_restores_checkpoint_and_stashes_summary(tmp_path: Path) -> None:
+    loop = _make_full_loop(tmp_path)
+    loop.consolidator.summarize_interrupted = AsyncMock(return_value="- User goal: finish the task")  # type: ignore[method-assign]
+    session = loop.sessions.get_or_create("cli:test")
+    session.add_message("user", "finish the task")
+    session.metadata[AgentLoop._RUNTIME_CHECKPOINT_KEY] = {
+        "assistant_message": {
+            "role": "assistant",
+            "content": "Working on it",
+            "tool_calls": [
+                {
+                    "id": "call_pending",
+                    "type": "function",
+                    "function": {"name": "exec", "arguments": "{}"},
+                }
+            ],
+        },
+        "completed_tool_results": [],
+        "pending_tool_calls": [
+            {
+                "id": "call_pending",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{}"},
+            }
+        ],
+    }
+    loop.sessions.save(session)
+
+    saved = await loop.capture_resume_summary("cli:test")
+
+    assert saved is True
+    reloaded = loop.sessions.get_or_create("cli:test")
+    assert reloaded.metadata["_resume_summary"]["text"] == "- User goal: finish the task"
+    assert AgentLoop._RUNTIME_CHECKPOINT_KEY not in reloaded.metadata
+    assert reloaded.messages[-2]["role"] == "assistant"
+    assert reloaded.messages[-1]["role"] == "tool"
+    assert "interrupted before this tool finished" in reloaded.messages[-1]["content"].lower()
+
+
+@pytest.mark.asyncio
+async def test_next_turn_consumes_resume_summary_from_stop(tmp_path: Path) -> None:
+    loop = _make_full_loop(tmp_path)
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+    loop.consolidator.summarize_interrupted = AsyncMock(return_value="- Next step: inspect failing command output")  # type: ignore[method-assign]
+    session = loop.sessions.get_or_create("cli:test")
+    session.add_message("user", "debug the failing command")
+    session.metadata[AgentLoop._RUNTIME_CHECKPOINT_KEY] = {
+        "assistant_message": {"role": "assistant", "content": "Inspecting logs"},
+        "completed_tool_results": [],
+        "pending_tool_calls": [],
+    }
+    loop.sessions.save(session)
+
+    async def long_running():
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(long_running())
+    loop._active_tasks["cli:test"] = [task]
+
+    stop_msg = InboundMessage(channel="cli", sender_id="user", chat_id="test", content="/stop")
+    stop_ctx = CommandContext(msg=stop_msg, session=session, key="cli:test", raw="/stop", loop=loop)
+    stop_result = await cmd_stop(stop_ctx)
+
+    assert "Saved resume context" in stop_result.content
+    assert task.cancelled() or task.done()
+
+    captured_messages: list[dict] = []
+
+    async def _fake_run_agent_loop(
+        initial_messages,
+        on_progress=None,
+        on_stream=None,
+        on_stream_end=None,
+        *,
+        session=None,
+        channel="cli",
+        chat_id="direct",
+        message_id=None,
+        pending_queue=None,
+    ):
+        nonlocal captured_messages
+        captured_messages = initial_messages
+        return (
+            "done",
+            [],
+            initial_messages + [{"role": "assistant", "content": "done"}],
+            "completed",
+            False,
+        )
+
+    loop._run_agent_loop = _fake_run_agent_loop  # type: ignore[method-assign]
+
+    result = await loop._process_message(
+        InboundMessage(channel="cli", sender_id="user", chat_id="test", content="continue")
+    )
+
+    assert result is not None
+    assert result.content == "done"
+    assert captured_messages[-1]["role"] == "user"
+    assert "[Resumed Session]" in captured_messages[-1]["content"]
+    assert "Previous task was stopped before completion." in captured_messages[-1]["content"]
+    assert "Next step: inspect failing command output" in captured_messages[-1]["content"]
+
+
+@pytest.mark.asyncio
 async def test_stop_preserves_runtime_checkpoint_for_next_turn(tmp_path: Path) -> None:
     from nanobot.command.builtin import cmd_stop
     from nanobot.command.router import CommandContext
@@ -373,13 +480,28 @@ async def test_stop_preserves_runtime_checkpoint_for_next_turn(tmp_path: Path) -
     stop_ctx = CommandContext(msg=stop_msg, session=None, key=stop_msg.session_key, raw="/stop", loop=loop)
     stop_result = await cmd_stop(stop_ctx)
 
-    assert "Stopped 1 task" in stop_result.content
+    assert "Saved resume context" in stop_result.content
     assert task.done()
 
     loop.sessions.invalidate("feishu:c4")
     interrupted = loop.sessions.get_or_create("feishu:c4")
-    assert interrupted.metadata.get(AgentLoop._PENDING_USER_TURN_KEY) is True
-    assert interrupted.metadata.get(AgentLoop._RUNTIME_CHECKPOINT_KEY) is not None
+    assert AgentLoop._PENDING_USER_TURN_KEY not in interrupted.metadata
+    assert AgentLoop._RUNTIME_CHECKPOINT_KEY not in interrupted.metadata
+    assert interrupted.metadata.get("_resume_summary") is not None
+    assert [
+        {k: v for k, v in m.items() if k in {"role", "content", "tool_call_id", "name"}}
+        for m in interrupted.messages
+    ] == [
+        {"role": "user", "content": "keep progress"},
+        {"role": "assistant", "content": "working"},
+        {"role": "tool", "tool_call_id": "call_done", "name": "read_file", "content": "ok"},
+        {
+            "role": "tool",
+            "tool_call_id": "call_pending",
+            "name": "exec",
+            "content": "Error: Task interrupted before this tool finished.",
+        },
+    ]
 
     async def resumed_run_agent_loop(initial_messages, **_kwargs):
         return (


### PR DESCRIPTION
## Summary
- capture a one-shot interrupted-task summary when `/stop` cancels an active turn
- restore the raw checkpoint immediately, then inject the summary on the next turn via runtime context
- add resume-summary persistence tests plus `/stop` recovery coverage

## Testing
- ./.venv312/bin/python -m pytest tests/agent/test_loop_save_turn.py tests/agent/test_auto_compact.py -q
- ./.venv312/bin/python -m pytest tests/agent/test_unified_session.py -q
- ./.venv312/bin/ruff check nanobot/agent/autocompact.py nanobot/agent/memory.py nanobot/agent/loop.py nanobot/command/builtin.py tests/agent/test_auto_compact.py tests/agent/test_loop_save_turn.py --select I,F

Closes #3027