### PR TITLE
feat(runner): add soft consolidation to _snip_history

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -884,63 +884,105 @@ class AgentRunner:
         return updated
 
     def _snip_history(
-        self,
-        spec: AgentRunSpec,
-        messages: list[dict[str, Any]],
+        self, spec: AgentRunSpec, messages: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
         if not messages or not spec.context_window_tokens:
             return messages
-
-        provider_max_tokens = getattr(getattr(self.provider, "generation", None), "max_tokens", 4096)
-        max_output = spec.max_tokens if isinstance(spec.max_tokens, int) else (
-            provider_max_tokens if isinstance(provider_max_tokens, int) else 4096
-        )
-        budget = spec.context_block_limit or (
-            spec.context_window_tokens - max_output - _SNIP_SAFETY_BUFFER
-        )
+        provider_max = getattr(getattr(self.provider, "generation", None), "max_tokens", 4096)
+        max_output = spec.max_tokens if isinstance(spec.max_tokens, int) else (provider_max if isinstance(provider_max, int) else 4096)
+        budget = spec.context_block_limit or (spec.context_window_tokens - max_output - _SNIP_SAFETY_BUFFER)
         if budget <= 0:
             return messages
-
-        estimate, _ = estimate_prompt_tokens_chain(
-            self.provider,
-            spec.model,
-            messages,
-            spec.tools.get_definitions(),
-        )
+        estimate, _ = estimate_prompt_tokens_chain(self.provider, spec.model, messages, spec.tools.get_definitions())
         if estimate <= budget:
             return messages
 
-        system_messages = [dict(msg) for msg in messages if msg.get("role") == "system"]
-        non_system = [dict(msg) for msg in messages if msg.get("role") != "system"]
-        if not non_system:
+        sys_msgs = [dict(m) for m in messages if m.get("role") == "system"]
+        non_sys = [dict(m) for m in messages if m.get("role") != "system"]
+        if not non_sys:
             return messages
 
-        system_tokens = sum(estimate_message_tokens(msg) for msg in system_messages)
-        remaining_budget = max(128, budget - system_tokens)
-        kept: list[dict[str, Any]] = []
-        kept_tokens = 0
-        for message in reversed(non_system):
-            msg_tokens = estimate_message_tokens(message)
-            if kept and kept_tokens + msg_tokens > remaining_budget:
-                break
-            kept.append(message)
-            kept_tokens += msg_tokens
-        kept.reverse()
+        # Try soft consolidation: summarize older half, keep newer half
+        mid = len(non_sys) // 2
+        if mid > 0:
+            summary = self._summarize_evicted(non_sys[:mid], spec)
+            if summary:
+                consolidated = [{"role": "user", "content": f"[Previous conversation summary]\n{summary}"}] + non_sys[mid:]
+                consolidated = self._fixup_messages(consolidated)
+                result = sys_msgs + consolidated
+                new_est, _ = estimate_prompt_tokens_chain(self.provider, spec.model, result, spec.tools.get_definitions())
+                if new_est <= budget:
+                    logger.info("Soft consolidation: {} msgs summarized for {} ({}/{} → {}/{})", mid, spec.session_key or "default", estimate, budget, new_est, budget)
+                    return result
+                non_sys = consolidated  # use consolidated for hard snip
 
-        if kept:
-            for i, message in enumerate(kept):
-                if message.get("role") == "user":
-                    kept = kept[i:]
-                    break
-            start = find_legal_message_start(kept)
-            if start:
-                kept = kept[start:]
-        if not kept:
-            kept = non_system[-min(len(non_system), 4) :]
-            start = find_legal_message_start(kept)
-            if start:
-                kept = kept[start:]
-        return system_messages + kept
+        # Hard snip: keep newest messages that fit
+        sys_tokens = sum(estimate_message_tokens(m) for m in sys_msgs)
+        remaining = max(128, budget - sys_tokens)
+        kept, kept_tokens = [], 0
+        for msg in reversed(non_sys):
+            t = estimate_message_tokens(msg)
+            if kept and kept_tokens + t > remaining:
+                break
+            kept.append(msg)
+            kept_tokens += t
+        kept.reverse()
+        kept = self._fixup_messages(kept or non_sys[-4:])
+        logger.info("Hard snip: {} → {} msgs for {}", len(non_sys), len(kept), spec.session_key or "default")
+        return sys_msgs + kept
+
+    @staticmethod
+    def _fixup_messages(msgs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Ensure legal message start and at least one user message."""
+        start = find_legal_message_start(msgs)
+        if start:
+            msgs = msgs[start:]
+        for i, m in enumerate(msgs):
+            if m.get("role") == "user":
+                return msgs[i:] if i else msgs
+        if msgs:
+            msgs.insert(0, {"role": "user", "content": "(continuing previous conversation)"})
+        return msgs
+
+    _CONSOLIDATION_PROMPT = (
+        "Summarize the following conversation excerpt concisely. "
+        "Preserve key facts, decisions, data, and any important context. "
+        "Use the same language as the conversation. "
+        "Keep the summary under 500 tokens."
+    )
+
+    def _summarize_evicted(self, evicted: list[dict[str, Any]], spec: AgentRunSpec) -> str | None:
+        try:
+            import asyncio, concurrent.futures
+            parts = []
+            for msg in evicted:
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    content = "\n".join(b.get("text", "") if isinstance(b, dict) and b.get("type") == "text" else (b if isinstance(b, str) else "") for b in content)
+                if content:
+                    parts.append(f"[{msg.get('role', '?')}]: {content[:2000]}")
+            text = "\n\n".join(parts)
+            if not text:
+                return None
+            if len(text) <= 1500:
+                return text
+            summary_msgs = [{"role": "system", "content": self._CONSOLIDATION_PROMPT}, {"role": "user", "content": text}]
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    return pool.submit(asyncio.run, self._do_summary(spec, summary_msgs)).result(timeout=30)
+            return loop.run_until_complete(self._do_summary(spec, summary_msgs))
+        except Exception:
+            logger.debug("Summary failed, falling back to hard snip")
+            return None
+
+    async def _do_summary(self, spec: AgentRunSpec, msgs: list[dict[str, Any]]) -> str | None:
+        try:
+            resp = await self.provider.chat(messages=msgs, model=spec.model, max_tokens=1024, temperature=0.1)
+            c = resp.content.strip() if resp and resp.content else ""
+            return c if len(c) > 20 else None
+        except Exception:
+            return None
 
     def _partition_tool_batches(
         self,

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -643,10 +643,208 @@ def test_snip_history_drops_orphaned_tool_results_from_trimmed_slice(monkeypatch
 
     trimmed = runner._snip_history(spec, messages)
 
-    assert trimmed == [
+    assert trimmed[0] == {"role": "system", "content": "system"}
+    # _fixup_messages inserts a user placeholder when no user message exists
+    assert any(m.get("role") == "user" for m in trimmed)
+    assert trimmed[-1] == {"role": "assistant", "content": "after tool"}
+
+
+def test_snip_history_soft_consolidation_when_summary_fits(monkeypatch):
+    """When over budget, _snip_history should try soft consolidation first:
+    summarize the older half and keep the newer half."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    # _summarize_evicted calls provider.chat — mock it
+    provider.chat = AsyncMock(return_value=LLMResponse(content="Summary of older conversation.", tool_calls=[]))
+
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    runner = AgentRunner(provider)
+
+    messages = [
         {"role": "system", "content": "system"},
-        {"role": "assistant", "content": "after tool"},
+        {"role": "user", "content": "old user 1"},
+        {"role": "assistant", "content": "old assistant 1"},
+        {"role": "user", "content": "old user 2"},
+        {"role": "assistant", "content": "old assistant 2"},
+        {"role": "user", "content": "new user 1"},
+        {"role": "assistant", "content": "new assistant 1"},
+        {"role": "user", "content": "new user 2"},
+        {"role": "assistant", "content": "new assistant 2"},
     ]
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=2000,
+        context_block_limit=500,
+    )
+
+    call_count = [0]
+
+    def fake_estimate_chain(*_args, **_kwargs):
+        call_count[0] += 1
+        # First call: over budget (600 > 500)
+        # Second call (after consolidation): fits (300 <= 500)
+        return (600, None) if call_count[0] == 1 else (300, None)
+
+    monkeypatch.setattr("nanobot.agent.runner.estimate_prompt_tokens_chain", fake_estimate_chain)
+    monkeypatch.setattr("nanobot.agent.runner.estimate_message_tokens", lambda msg: 50)
+
+    trimmed = runner._snip_history(spec, messages)
+
+    # Should contain a summary message and the newer half
+    assert any("[Previous conversation summary]" in m.get("content", "") for m in trimmed)
+    # The system message should still be first
+    assert trimmed[0]["role"] == "system"
+    # Newer messages should be preserved
+    assert any(m.get("content") == "new assistant 2" for m in trimmed)
+
+
+def test_snip_history_falls_back_to_hard_snip_when_summary_still_over_budget(monkeypatch):
+    """When soft consolidation result is still over budget, should fall back to hard snip."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    provider.chat = AsyncMock(return_value=LLMResponse(
+        content="This is a very long summary that doesn't help reduce size enough " * 10,
+        tool_calls=[],
+    ))
+
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    runner = AgentRunner(provider)
+
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old user"},
+        {"role": "assistant", "content": "old assistant"},
+        {"role": "user", "content": "new user"},
+        {"role": "assistant", "content": "new assistant"},
+    ]
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=2000,
+        context_block_limit=200,
+    )
+
+    # Always return over budget
+    monkeypatch.setattr("nanobot.agent.runner.estimate_prompt_tokens_chain", lambda *_a, **_k: (600, None))
+    monkeypatch.setattr("nanobot.agent.runner.estimate_message_tokens", lambda msg: 50)
+
+    trimmed = runner._snip_history(spec, messages)
+
+    # Should have applied hard snip — result must be shorter than input
+    non_sys_trimmed = [m for m in trimmed if m.get("role") != "system"]
+    non_sys_original = [m for m in messages if m.get("role") != "system"]
+    assert len(non_sys_trimmed) <= len(non_sys_original)
+    # Must have at least one user message
+    assert any(m.get("role") == "user" for m in trimmed)
+
+
+def test_snip_history_hard_snip_when_summary_fails(monkeypatch):
+    """When _summarize_evicted returns None, should fall back to pure hard snip."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    provider.chat = AsyncMock(side_effect=Exception("LLM unavailable"))
+
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    runner = AgentRunner(provider)
+
+    # Make messages long enough (>1500 chars) so _summarize_evicted actually calls LLM
+    long_content = "x" * 800
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": f"old user {long_content}"},
+        {"role": "assistant", "content": f"old assistant {long_content}"},
+        {"role": "user", "content": "new user"},
+        {"role": "assistant", "content": "new assistant"},
+    ]
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=2000,
+        context_block_limit=200,
+    )
+
+    monkeypatch.setattr("nanobot.agent.runner.estimate_prompt_tokens_chain", lambda *_a, **_k: (600, None))
+    monkeypatch.setattr("nanobot.agent.runner.estimate_message_tokens", lambda msg: 50)
+
+    trimmed = runner._snip_history(spec, messages)
+
+    # No summary message should exist (LLM call failed)
+    assert not any("[Previous conversation summary]" in m.get("content", "") for m in trimmed)
+    # Should still have system + some messages
+    assert trimmed[0]["role"] == "system"
+    assert any(m.get("role") == "user" for m in trimmed)
+
+
+def test_fixup_messages_inserts_user_placeholder():
+    """_fixup_messages should insert a user placeholder when no user message exists."""
+    from nanobot.agent.runner import AgentRunner
+
+    msgs = [
+        {"role": "assistant", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+    ]
+    result = AgentRunner._fixup_messages(msgs)
+    assert result[0]["role"] == "user"
+    assert "(continuing previous conversation)" in result[0]["content"]
+
+
+def test_fixup_messages_preserves_user_start():
+    """_fixup_messages should not insert a placeholder when user message exists."""
+    from nanobot.agent.runner import AgentRunner
+
+    msgs = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+    ]
+    result = AgentRunner._fixup_messages(msgs)
+    assert result[0] == {"role": "user", "content": "hello"}
+    assert len(result) == 2
+
+
+def test_snip_history_returns_original_when_under_budget(monkeypatch):
+    """When estimate is under budget, messages should be returned unchanged."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    runner = AgentRunner(provider)
+
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+    ]
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=2000,
+        context_block_limit=500,
+    )
+
+    monkeypatch.setattr("nanobot.agent.runner.estimate_prompt_tokens_chain", lambda *_a, **_k: (100, None))
+
+    result = runner._snip_history(spec, messages)
+    assert result is messages  # identity check — no modification
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Before hard-truncating messages that exceed the context budget, this PR adds a soft consolidation step that summarizes the older half of the conversation via LLM and keeps the newer half intact. If summarization fails or the result still exceeds the budget, it falls back to hard truncation.

## Motivation

The current `_snip_history` method simply drops older messages when the context budget is exceeded, which can cause abrupt loss of important context. Soft consolidation preserves a summary of the evicted messages, giving the model better continuity.

## Changes

### `nanobot/agent/runner.py`
- **`_snip_history`**: Try soft consolidation (LLM summary of evicted messages) before falling back to hard truncation
- **`_summarize_evicted`**: Synchronous wrapper that summarizes evicted messages via LLM; short text (<1500 chars) returned as-is, longer text summarized with 30s timeout
- **`_do_summary`**: Async LLM call for summarization using consolidation prompt
- **`_fixup_messages`**: Helper ensuring legal message start (no orphaned tool results) and at least one user message (inserts placeholder if missing)
- **`_CONSOLIDATION_PROMPT`**: Prompt template for summarizing conversation history

### `tests/agent/test_runner.py`
- `test_snip_history_soft_consolidation_when_summary_fits` — verifies soft consolidation works when summary fits budget
- `test_snip_history_falls_back_to_hard_snip_when_summary_still_over_budget` — verifies hard snip fallback when summary still over budget
- `test_snip_history_hard_snip_when_summary_fails` — verifies hard snip fallback when LLM fails
- `test_fixup_messages_inserts_user_placeholder` — verifies user placeholder insertion
- `test_fixup_messages_preserves_user_start` — verifies no extra insertion when user exists
- `test_snip_history_returns_original_when_under_budget` — verifies no modification when under budget
- Adapted existing orphaned-tool-result test for `_fixup_messages` behavior

## Relationship to Existing Summary Mechanisms

This soft consolidation is complementary to—not redundant with—existing mechanisms:
- **Consolidator** (memory.py): Async persistent summarization of memory; runs on a schedule
- **AutoCompact**: Idle session archival; proactive compression
- **Dream**: Cron-based deep analysis; generates insight memories

These all operate independently. Soft consolidation in `_snip_history` is a **reactive, last-resort** measure when the context budget is about to be exceeded, ensuring that evicted messages are not simply discarded but summarized.