### PR TITLE
feat: show active task count in /status output

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -262,3 +262,11 @@ class SubagentManager:
     def get_running_count(self) -> int:
         """Return the number of currently running subagents."""
         return len(self._running_tasks)
+
+    def get_running_count_by_session(self, session_key: str) -> int:
+        """Return the number of currently running subagents for a session."""
+        tids = self._session_tasks.get(session_key, set())
+        return sum(
+            1 for tid in tids
+            if tid in self._running_tasks and not self._running_tasks[tid].done()
+        )

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -74,6 +74,12 @@ async def cmd_status(ctx: CommandContext) -> OutboundMessage:
             search_usage_text = usage.format()
     except Exception:
         pass  # Never let usage fetch break /status
+    active_tasks = loop._active_tasks.get(ctx.key, [])
+    task_count = sum(1 for t in active_tasks if not t.done())
+    try:
+        task_count += loop.subagents.get_running_count_by_session(ctx.key)
+    except Exception:
+        pass
     return OutboundMessage(
         channel=ctx.msg.channel,
         chat_id=ctx.msg.chat_id,
@@ -84,6 +90,7 @@ async def cmd_status(ctx: CommandContext) -> OutboundMessage:
             session_msg_count=len(session.get_history(max_messages=0)),
             context_tokens_estimate=ctx_est,
             search_usage_text=search_usage_text,
+            active_task_count=task_count,
         ),
         metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
     )

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -400,6 +400,7 @@ def build_status_content(
     session_msg_count: int,
     context_tokens_estimate: int,
     search_usage_text: str | None = None,
+    active_task_count: int = 0,
 ) -> str:
     """Build a human-readable runtime status snapshot.
     
@@ -431,6 +432,7 @@ def build_status_content(
         f"\U0001f4da Context: {ctx_used_str}/{ctx_total_str} ({ctx_pct}%)",
         f"\U0001f4ac Session: {session_msg_count} messages",
         f"\u23f1 Uptime: {uptime}",
+        f"\u26a1 Tasks: {active_task_count} active",
     ]
     if search_usage_text:
         lines.append(search_usage_text)

--- a/tests/cli/test_restart_command.py
+++ b/tests/cli/test_restart_command.py
@@ -140,6 +140,7 @@ class TestRestartCommand:
         loop.consolidator.estimate_session_prompt_tokens = MagicMock(
             return_value=(20500, "tiktoken")
         )
+        loop.subagents.get_running_count_by_session.return_value = 0
 
         msg = InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="/status")
 
@@ -151,6 +152,7 @@ class TestRestartCommand:
         assert "Context: 20k/65k (31%)" in response.content
         assert "Session: 3 messages" in response.content
         assert "Uptime: 2m 5s" in response.content
+        assert "Tasks: 0 active" in response.content
         assert response.metadata == {"render_as": "text"}
 
     @pytest.mark.asyncio
@@ -179,6 +181,7 @@ class TestRestartCommand:
         loop.consolidator.estimate_session_prompt_tokens = MagicMock(
             return_value=(0, "none")
         )
+        loop.subagents.get_running_count_by_session.return_value = 0
 
         response = await loop._process_message(
             InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="/status")
@@ -187,6 +190,7 @@ class TestRestartCommand:
         assert response is not None
         assert "Tokens: 1200 in / 34 out" in response.content
         assert "Context: 1k/65k (1%)" in response.content
+        assert "Tasks: 0 active" in response.content
 
     @pytest.mark.asyncio
     async def test_process_direct_preserves_render_metadata(self):
@@ -195,6 +199,7 @@ class TestRestartCommand:
         session.get_history.return_value = []
         loop.sessions.get_or_create.return_value = session
         loop.subagents.get_running_count.return_value = 0
+        loop.subagents.get_running_count_by_session.return_value = 0
 
         response = await loop.process_direct("/status", session_key="cli:test")
 

--- a/tests/cli/test_restart_command.py
+++ b/tests/cli/test_restart_command.py
@@ -156,6 +156,30 @@ class TestRestartCommand:
         assert response.metadata == {"render_as": "text"}
 
     @pytest.mark.asyncio
+    async def test_status_counts_running_dispatch_and_subagent_tasks(self):
+        loop, _bus = _make_loop()
+        session = MagicMock()
+        session.get_history.return_value = [{"role": "user"}]
+        loop.sessions.get_or_create.return_value = session
+        loop.consolidator.estimate_session_prompt_tokens = MagicMock(
+            return_value=(1000, "tiktoken")
+        )
+
+        running_task = MagicMock()
+        running_task.done.return_value = False
+        finished_task = MagicMock()
+        finished_task.done.return_value = True
+
+        msg = InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="/status")
+        loop._active_tasks[msg.session_key] = [running_task, finished_task]
+        loop.subagents.get_running_count_by_session.return_value = 2
+
+        response = await loop._process_message(msg)
+
+        assert response is not None
+        assert "Tasks: 3 active" in response.content
+
+    @pytest.mark.asyncio
     async def test_run_agent_loop_resets_usage_when_provider_omits_it(self):
         loop, _bus = _make_loop()
         loop.provider.chat_with_retry = AsyncMock(side_effect=[

--- a/tests/test_build_status.py
+++ b/tests/test_build_status.py
@@ -15,6 +15,7 @@ def test_status_shows_cache_hit_rate():
     )
     assert "60% cached" in content
     assert "2000 in / 300 out" in content
+    assert "Tasks: 0 active" in content
 
 
 def test_status_no_cache_info():
@@ -30,6 +31,7 @@ def test_status_no_cache_info():
     )
     assert "cached" not in content.lower()
     assert "2000 in / 300 out" in content
+    assert "Tasks: 0 active" in content
 
 
 def test_status_zero_cached_tokens():


### PR DESCRIPTION
## Summary

- 在 `/status` 输出中新增 `⚡ Tasks: {n} active` 行，显示当前 session 的活跃 task 数量
- task 数 = dispatch tasks（`_active_tasks`）+ subagent tasks，与 `/stop` 取消的范围完全对应
- 用户可以通过该数值判断 bot 是否卡死（如 `Tasks: 1 active` 长时间不变，则可执行 `/stop` 干预）

## Changes

| File | Change |
|------|--------|
| `nanobot/agent/subagent.py` | 新增 `get_running_count_by_session()` 方法 |
| `nanobot/utils/helpers.py` | `build_status_content` 新增 `active_task_count` 参数 |
| `nanobot/command/builtin.py` | `cmd_status` 计算 task 数并传入 |
| `tests/cli/test_restart_command.py` | 补充 mock 和断言 |
| `tests/test_build_status.py` | 补充断言 |

## Test plan

- [x] 39 个相关测试全部通过
- [ ] 手动验证：空闲时显示 `Tasks: 0 active`
- [ ] 手动验证：bot 处理消息中时显示 `Tasks: 1 active`
- [ ] 手动验证：`/stop` 后再 `/status` 回到 `Tasks: 0 active`

Assisted-by: opencode (glm-5.1)