### PR TITLE
fix: handle dict config in is_allowed() and _validate_allow_from()

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -116,7 +116,10 @@ class BaseChannel(ABC):
 
     def is_allowed(self, sender_id: str) -> bool:
         """Check if *sender_id* is permitted.  Empty list → deny all; ``"*"`` → allow all."""
-        allow_list = getattr(self.config, "allow_from", [])
+        if isinstance(self.config, dict):
+            allow_list = self.config.get("allow_from") or self.config.get("allowFrom") or []
+        else:
+            allow_list = getattr(self.config, "allow_from", [])
         if not allow_list:
             logger.warning("{}: allow_from is empty — all access denied", self.name)
             return False

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -117,7 +117,10 @@ class BaseChannel(ABC):
     def is_allowed(self, sender_id: str) -> bool:
         """Check if *sender_id* is permitted.  Empty list → deny all; ``"*"`` → allow all."""
         if isinstance(self.config, dict):
-            allow_list = self.config.get("allow_from") or self.config.get("allowFrom") or []
+            if "allow_from" in self.config:
+                allow_list = self.config.get("allow_from")
+            else:
+                allow_list = self.config.get("allowFrom", [])
         else:
             allow_list = getattr(self.config, "allow_from", [])
         if not allow_list:

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -75,7 +75,12 @@ class ChannelManager:
 
     def _validate_allow_from(self) -> None:
         for name, ch in self.channels.items():
-            if getattr(ch.config, "allow_from", None) == []:
+            cfg = ch.config
+            if isinstance(cfg, dict):
+                allow = cfg.get("allow_from") or cfg.get("allowFrom")
+            else:
+                allow = getattr(cfg, "allow_from", None)
+            if allow == []:
                 raise SystemExit(
                     f'Error: "{name}" has empty allowFrom (denies all). '
                     f'Set ["*"] to allow everyone, or add specific user IDs.'

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -77,7 +77,10 @@ class ChannelManager:
         for name, ch in self.channels.items():
             cfg = ch.config
             if isinstance(cfg, dict):
-                allow = cfg.get("allow_from") or cfg.get("allowFrom")
+                if "allow_from" in cfg:
+                    allow = cfg.get("allow_from")
+                else:
+                    allow = cfg.get("allowFrom")
             else:
                 allow = getattr(cfg, "allow_from", None)
             if allow == []:

--- a/tests/channels/test_base_channel.py
+++ b/tests/channels/test_base_channel.py
@@ -23,3 +23,15 @@ def test_is_allowed_requires_exact_match() -> None:
 
     assert channel.is_allowed("allow@email.com") is True
     assert channel.is_allowed("attacker|allow@email.com") is False
+
+
+def test_is_allowed_supports_dict_allow_from_alias() -> None:
+    channel = _DummyChannel({"allowFrom": ["alice"]}, MessageBus())
+
+    assert channel.is_allowed("alice") is True
+
+
+def test_is_allowed_denies_empty_dict_allow_from() -> None:
+    channel = _DummyChannel({"allow_from": []}, MessageBus())
+
+    assert channel.is_allowed("alice") is False

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -646,7 +646,10 @@ class _ChannelWithAllowFrom(BaseChannel):
 
     def __init__(self, config, bus, allow_from):
         super().__init__(config, bus)
-        self.config.allow_from = allow_from
+        if isinstance(self.config, dict):
+            self.config["allow_from"] = allow_from
+        else:
+            self.config.allow_from = allow_from
 
     async def start(self) -> None:
         pass
@@ -712,6 +715,25 @@ async def test_validate_allow_from_passes_with_asterisk():
 
     # Should not raise
     mgr._validate_allow_from()
+
+
+@pytest.mark.asyncio
+async def test_validate_allow_from_raises_on_empty_dict_allow_from():
+    """_validate_allow_from should reject empty dict-backed allow_from lists."""
+    fake_config = SimpleNamespace(
+        channels=ChannelsConfig(),
+        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+    )
+
+    mgr = ChannelManager.__new__(ChannelManager)
+    mgr.config = fake_config
+    mgr.channels = {"test": _ChannelWithAllowFrom({"enabled": True}, None, [])}
+    mgr._dispatch_task = None
+
+    with pytest.raises(SystemExit) as exc_info:
+        mgr._validate_allow_from()
+
+    assert "empty allowFrom" in str(exc_info.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #3152

### Problem

`getattr()` on a `dict` never finds custom keys — it only searches object attributes. When channel config is a Pydantic extra field (plain dict), `is_allowed()` always returns `False` and `_validate_allow_from()` never catches empty lists.

### Changes

- **`base.py`**: `is_allowed()` now uses `isinstance` check + `dict.get()` for dict configs, with both `allow_from` and `allowFrom` key support
- **`manager.py`**: `_validate_allow_from()` applies the same dict-compatible pattern

### Testing

Verified with channel configured via `allowFrom: ["*"]` — access now correctly granted.
