### PR TITLE
Agent performance, responsiveness & correctness enhancements

### DIFF
--- a/docs/CHANNEL_PLUGIN_GUIDE.md
+++ b/docs/CHANNEL_PLUGIN_GUIDE.md
@@ -290,7 +290,6 @@ async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | 
 |------|---------|
 | `_stream_delta: True` | A content chunk (delta contains the new text) |
 | `_stream_end: True` | Streaming finished (delta is empty) |
-| `_resuming: True` | More streaming rounds coming (e.g. tool call then another response) |
 
 ### Example: Webhook with Streaming
 

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -27,6 +27,7 @@ class ContextBuilder:
         self.timezone = timezone
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace, disabled_skills=set(disabled_skills) if disabled_skills else None)
+        self._file_cache: dict[Path, tuple[float, str]] = {}
 
     def build_system_prompt(
         self,
@@ -105,15 +106,21 @@ class ContextBuilder:
         return _to_blocks(left) + _to_blocks(right)
 
     def _load_bootstrap_files(self) -> str:
-        """Load all bootstrap files from workspace."""
+        """Load all bootstrap files from workspace, caching by mtime."""
         parts = []
-
         for filename in self.BOOTSTRAP_FILES:
             file_path = self.workspace / filename
-            if file_path.exists():
+            if not file_path.exists():
+                self._file_cache.pop(file_path, None)
+                continue
+            mtime = file_path.stat().st_mtime
+            cached = self._file_cache.get(file_path)
+            if cached and cached[0] == mtime:
+                content = cached[1]
+            else:
                 content = file_path.read_text(encoding="utf-8")
-                parts.append(f"## {filename}\n\n{content}")
-
+                self._file_cache[file_path] = (mtime, content)
+            parts.append(f"## {filename}\n\n{content}")
         return "\n\n".join(parts) if parts else ""
 
     def build_messages(

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -38,6 +38,10 @@ from nanobot.session.manager import Session, SessionManager
 from nanobot.utils.helpers import image_placeholder_text, truncate_text as truncate_text_fn
 from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
 
+import time as _time_mod
+from nanobot.agent.profiling import is_profiling_enabled as _is_profiling_enabled
+_PROFILING = _is_profiling_enabled()
+
 if TYPE_CHECKING:
     from nanobot.config.schema import ChannelsConfig, ExecToolConfig, WebToolsConfig
     from nanobot.cron.service import CronService
@@ -621,6 +625,7 @@ class AgentLoop:
         pending_queue: asyncio.Queue | None = None,
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
+        _turn_t0 = _time_mod.perf_counter() if _PROFILING else 0.0
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
             channel, chat_id = (
@@ -762,6 +767,8 @@ class AgentLoop:
         meta = dict(msg.metadata or {})
         if on_stream is not None and stop_reason != "error":
             meta["_streamed"] = True
+        if _PROFILING:
+            logger.debug("[profiling] turn: {:.0f}ms", (_time_mod.perf_counter() - _turn_t0) * 1000)
         return OutboundMessage(
             channel=msg.channel,
             chat_id=msg.chat_id,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -187,7 +187,11 @@ class AgentLoop:
         self.restrict_to_workspace = restrict_to_workspace
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
-        self._extra_hooks: list[AgentHook] = hooks or []
+        self._extra_hooks: list[AgentHook] = list(hooks or [])
+        # Register ProfilingHook if profiling is enabled via config or env
+        from nanobot.agent.profiling import ProfilingHook, is_profiling_enabled
+        if is_profiling_enabled(defaults):
+            self._extra_hooks.append(ProfilingHook())
 
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
         self.sessions = session_manager or SessionManager(workspace)
@@ -420,7 +424,7 @@ class AgentLoop:
                 "channel": channel,
                 "chat_id": chat_id,
                 "message_id": message_id,
-                "session_key": f"{channel}:{chat_id}",
+                "session_key": session.key if session else f"{channel}:{chat_id}",
             },
             progress_callback=on_progress,
             checkpoint_callback=_checkpoint,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -860,6 +860,8 @@ class AgentLoop:
             entry.setdefault("timestamp", datetime.now().isoformat())
             session.messages.append(entry)
         session.updated_at = datetime.now()
+        if hasattr(self, "consolidator"):
+            self.consolidator.store.flush_history()
 
     def _set_runtime_checkpoint(self, session: Session, payload: dict[str, Any]) -> None:
         """Persist the latest in-flight turn state into session metadata."""

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -188,9 +188,9 @@ class AgentLoop:
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
         self._extra_hooks: list[AgentHook] = list(hooks or [])
-        # Register ProfilingHook if profiling is enabled via config or env
+        # Register ProfilingHook if NANOBOT_PROFILING env var is set
         from nanobot.agent.profiling import ProfilingHook, is_profiling_enabled
-        if is_profiling_enabled(defaults):
+        if is_profiling_enabled():
             self._extra_hooks.append(ProfilingHook())
 
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -101,7 +101,6 @@ class _LoopHook(AgentHook):
         for tc in context.tool_calls:
             args_str = json.dumps(tc.arguments, ensure_ascii=False)
             logger.info("Tool call: {}({})", tc.name, args_str[:200])
-        self._loop._set_tool_context(self._channel, self._chat_id, self._message_id)
 
     async def after_iteration(self, context: AgentHookContext) -> None:
         u = context.usage or {}
@@ -413,6 +412,12 @@ class AgentLoop:
             context_window_tokens=self.context_window_tokens,
             context_block_limit=self.context_block_limit,
             provider_retry_mode=self.provider_retry_mode,
+            routing_context={
+                "channel": channel,
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "session_key": f"{channel}:{chat_id}",
+            },
             progress_callback=on_progress,
             checkpoint_callback=_checkpoint,
             injection_callback=_drain_pending,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -571,7 +571,11 @@ class AgentLoop:
                         item = queue.get_nowait()
                     except asyncio.QueueEmpty:
                         break
-                    await self.bus.publish_inbound(item)
+                    if not await self.bus.publish_inbound(item):
+                        logger.warning(
+                            "Leftover message dropped during session cleanup (bus full)",
+                        )
+                        continue
                     leftover += 1
                 if leftover:
                     logger.info(

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -705,6 +705,7 @@ class Dream:
         self.max_tool_result_chars = max_tool_result_chars
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
+        self._skills_cache: tuple[str, list[str]] | None = None
 
     # -- tool registry -------------------------------------------------------
 
@@ -734,10 +735,28 @@ class Dream:
 
     def _list_existing_skills(self) -> list[str]:
         """List existing skills as 'name — description' for dedup context."""
+        import hashlib
         import re as _re
 
         from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 
+        # Collect (path, mtime) for all SKILL.md files
+        mtimes: list[tuple[str, float]] = []
+        for base in (self.store.workspace / "skills", BUILTIN_SKILLS_DIR):
+            if not base.exists():
+                continue
+            for d in base.iterdir():
+                if not d.is_dir():
+                    continue
+                skill_md = d / "SKILL.md"
+                if skill_md.exists():
+                    mtimes.append((str(skill_md), skill_md.stat().st_mtime))
+
+        cache_key = hashlib.md5(repr(sorted(mtimes)).encode()).hexdigest()
+        if self._skills_cache and self._skills_cache[0] == cache_key:
+            return self._skills_cache[1]
+
+        # Full read — existing logic
         _DESC_RE = _re.compile(r"^description:\s*(.+)$", _re.MULTILINE | _re.IGNORECASE)
         entries: dict[str, str] = {}
         for base in (self.store.workspace / "skills", BUILTIN_SKILLS_DIR):
@@ -756,7 +775,10 @@ class Dream:
                 m = _DESC_RE.search(content)
                 desc = m.group(1).strip() if m else "(no description)"
                 entries[d.name] = desc
-        return [f"{name} — {desc}" for name, desc in sorted(entries.items())]
+
+        result = [f"{name} — {desc}" for name, desc in sorted(entries.items())]
+        self._skills_cache = (cache_key, result)
+        return result
 
     # -- main entry ----------------------------------------------------------
 

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -19,6 +19,10 @@ from nanobot.agent.runner import AgentRunSpec, AgentRunner
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.utils.gitstore import GitStore
 
+import time as _time_mod
+from nanobot.agent.profiling import is_profiling_enabled as _is_profiling_enabled
+_PROFILING = _is_profiling_enabled()
+
 if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
     from nanobot.session.manager import Session, SessionManager
@@ -478,11 +482,15 @@ class Consolidator:
         async with lock:
             budget = self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
             target = budget // 2
+            if _PROFILING:
+                _est_t0 = _time_mod.perf_counter()
             try:
                 estimated, source = self.estimate_session_prompt_tokens(session)
             except Exception:
                 logger.exception("Token estimation failed for {}", session.key)
                 estimated, source = 0, "error"
+            if _PROFILING:
+                logger.debug("[profiling] estimation: {:.1f}ms", (_time_mod.perf_counter() - _est_t0) * 1000)
             if estimated <= 0:
                 return
             if estimated < budget:

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -611,7 +611,9 @@ class Consolidator:
             logger.warning("Consolidation LLM call failed, raw-dumping to history")
             self.store.raw_archive(messages)
             self.store.flush_history()
-            return None
+            # Return a non-None value so the caller advances last_consolidated
+            # and doesn't re-process these messages on the next turn.
+            return f"[RAW] {len(messages)} messages archived"
 
     async def maybe_consolidate_by_tokens(self, session: Session) -> None:
         """Loop: archive old messages until prompt fits within safe budget.

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -263,14 +263,13 @@ class MemoryStore:
         """Return history entries with cursor > *since_cursor*.
 
         Uses a cached byte offset for incremental reads when the caller
-        advances to a *new* cursor that is greater than the previous call's
-        cursor.  When the same cursor is re-requested (e.g. context.py
-        rebuilding Recent History each turn with the same dream cursor),
-        a full scan is performed to guarantee all matching entries are
-        returned.
+        asks for entries that can only come from new appends (i.e.
+        since_cursor >= the highest cursor seen in the previous read).
+        Otherwise falls back to a full scan.
         """
         if (
-            since_cursor > self._cached_since_cursor
+            since_cursor >= self._cached_since_cursor
+            and self._cached_since_cursor >= 0
             and self._cursor_byte_offset > 0
             and self.history_file.exists()
         ):
@@ -279,11 +278,21 @@ class MemoryStore:
             entries = [e for e in self._read_entries() if e["cursor"] > since_cursor]
         if self.history_file.exists():
             self._cursor_byte_offset = self.history_file.stat().st_size
-        self._cached_since_cursor = since_cursor
+        # Track the highest cursor value seen, not the since_cursor argument.
+        # This tells us which entries are already on disk and don't need rescanning.
+        all_entries_with_pending = entries  # pending added below
+        max_cursor = since_cursor
+        for e in entries:
+            c = e.get("cursor", 0)
+            if c > max_cursor:
+                max_cursor = c
         # Include buffered entries not yet flushed to disk.
         for e in self._pending_entries:
             if e["cursor"] > since_cursor:
                 entries.append(e)
+                if e["cursor"] > max_cursor:
+                    max_cursor = e["cursor"]
+        self._cached_since_cursor = max_cursor
         return entries
 
     def compact_history(self) -> None:

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -260,9 +260,17 @@ class MemoryStore:
         return 1
 
     def read_unprocessed_history(self, since_cursor: int) -> list[dict[str, Any]]:
-        """Return history entries with cursor > *since_cursor*."""
+        """Return history entries with cursor > *since_cursor*.
+
+        Uses a cached byte offset for incremental reads when the caller
+        advances to a *new* cursor that is greater than the previous call's
+        cursor.  When the same cursor is re-requested (e.g. context.py
+        rebuilding Recent History each turn with the same dream cursor),
+        a full scan is performed to guarantee all matching entries are
+        returned.
+        """
         if (
-            since_cursor == self._cached_since_cursor
+            since_cursor > self._cached_since_cursor
             and self._cursor_byte_offset > 0
             and self.history_file.exists()
         ):
@@ -435,7 +443,12 @@ class Consolidator:
         return self._locks.setdefault(session_key, asyncio.Lock())
 
     def _workspace_mtime_sum(self) -> float:
-        """Sum of mtimes for prompt-contributing workspace files."""
+        """Sum of mtimes for prompt-contributing workspace files.
+
+        Includes bootstrap files, MEMORY.md, and all SKILL.md files
+        inside skills/ subdirectories (not just the directory mtime,
+        which doesn't change when files inside subdirs are edited).
+        """
         total = 0.0
         try:
             workspace = self.store.workspace
@@ -449,7 +462,13 @@ class Consolidator:
                 pass
         skills_dir = workspace / "skills"
         try:
-            total += skills_dir.stat().st_mtime
+            for d in skills_dir.iterdir():
+                if d.is_dir():
+                    skill_md = d / "SKILL.md"
+                    try:
+                        total += skill_md.stat().st_mtime
+                    except OSError:
+                        pass
         except OSError:
             pass
         return total

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -601,6 +601,7 @@ class Consolidator:
         except Exception:
             logger.warning("Consolidation LLM call failed, raw-dumping to history")
             self.store.raw_archive(messages)
+            self.store.flush_history()
             return None
 
     async def maybe_consolidate_by_tokens(self, session: Session) -> None:
@@ -622,7 +623,9 @@ class Consolidator:
             if _PROFILING:
                 _est_t0 = _time_mod.perf_counter()
             try:
-                estimated, source = self.estimate_session_prompt_tokens(session)
+                estimated, source = await asyncio.to_thread(
+                    self.estimate_session_prompt_tokens, session
+                )
             except Exception:
                 logger.exception("Token estimation failed for {}", session.key)
                 estimated, source = 0, "error"
@@ -686,7 +689,9 @@ class Consolidator:
                 self.sessions.save(session)
 
                 try:
-                    estimated, source = self.estimate_session_prompt_tokens(session)
+                    estimated, source = await asyncio.to_thread(
+                    self.estimate_session_prompt_tokens, session
+                )
                 except Exception:
                     logger.exception("Token estimation failed for {}", session.key)
                     estimated, source = 0, "error"

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -53,6 +53,8 @@ class MemoryStore:
         self.user_file = workspace / "USER.md"
         self._cursor_file = self.memory_dir / ".cursor"
         self._dream_cursor_file = self.memory_dir / ".dream_cursor"
+        self._cursor_byte_offset: int = 0
+        self._cached_since_cursor: int = -1
         self._git = GitStore(workspace, tracked_files=[
             "SOUL.md", "USER.md", "memory/MEMORY.md",
         ])
@@ -249,7 +251,18 @@ class MemoryStore:
 
     def read_unprocessed_history(self, since_cursor: int) -> list[dict[str, Any]]:
         """Return history entries with cursor > *since_cursor*."""
-        return [e for e in self._read_entries() if e["cursor"] > since_cursor]
+        if (
+            since_cursor == self._cached_since_cursor
+            and self._cursor_byte_offset > 0
+            and self.history_file.exists()
+        ):
+            entries = self._read_entries_from_offset(self._cursor_byte_offset, since_cursor)
+        else:
+            entries = [e for e in self._read_entries() if e["cursor"] > since_cursor]
+        if self.history_file.exists():
+            self._cursor_byte_offset = self.history_file.stat().st_size
+        self._cached_since_cursor = since_cursor
+        return entries
 
     def compact_history(self) -> None:
         """Drop oldest entries if the file exceeds *max_history_entries*."""
@@ -260,6 +273,8 @@ class MemoryStore:
             return
         kept = entries[-self.max_history_entries:]
         self._write_entries(kept)
+        self._cursor_byte_offset = 0
+        self._cached_since_cursor = -1
 
     # -- JSONL helpers -------------------------------------------------------
 
@@ -275,6 +290,26 @@ class MemoryStore:
                             entries.append(json.loads(line))
                         except json.JSONDecodeError:
                             continue
+        except FileNotFoundError:
+            pass
+        return entries
+
+    def _read_entries_from_offset(self, offset: int, since_cursor: int) -> list[dict[str, Any]]:
+        """Read entries from a byte offset, returning those with cursor > since_cursor."""
+        entries: list[dict[str, Any]] = []
+        try:
+            with open(self.history_file, "r", encoding="utf-8") as f:
+                f.seek(offset)
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                        if entry.get("cursor", 0) > since_cursor:
+                            entries.append(entry)
+                    except (json.JSONDecodeError, KeyError):
+                        continue
         except FileNotFoundError:
             pass
         return entries

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -609,9 +609,9 @@ class Consolidator:
                 estimated, source = 0, "error"
             if _PROFILING:
                 logger.debug("[profiling] estimation: {:.1f}ms", (_time_mod.perf_counter() - _est_t0) * 1000)
-            self._record_estimation(session, estimated)
             if estimated <= 0:
                 return
+            self._record_estimation(session, estimated)
             if estimated < budget:
                 unconsolidated_count = len(session.messages) - session.last_consolidated
                 logger.debug(

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -53,6 +53,7 @@ class MemoryStore:
         self.user_file = workspace / "USER.md"
         self._cursor_file = self.memory_dir / ".cursor"
         self._dream_cursor_file = self.memory_dir / ".dream_cursor"
+        self._pending_entries: list[dict[str, Any]] = []
         self._cursor_byte_offset: int = 0
         self._cached_since_cursor: int = -1
         self._git = GitStore(workspace, tracked_files=[
@@ -227,17 +228,26 @@ class MemoryStore:
     # -- history.jsonl — append-only, JSONL format ---------------------------
 
     def append_history(self, entry: str) -> int:
-        """Append *entry* to history.jsonl and return its auto-incrementing cursor."""
+        """Buffer *entry* for later flush and return its auto-incrementing cursor."""
         cursor = self._next_cursor()
         ts = datetime.now().strftime("%Y-%m-%d %H:%M")
         record = {"cursor": cursor, "timestamp": ts, "content": strip_think(entry.rstrip()) or entry.rstrip()}
-        with open(self.history_file, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        self._pending_entries.append(record)
         self._cursor_file.write_text(str(cursor), encoding="utf-8")
         return cursor
 
+    def flush_history(self) -> None:
+        """Write all buffered entries to history.jsonl."""
+        if not self._pending_entries:
+            return
+        with open(self.history_file, "a", encoding="utf-8") as f:
+            f.writelines(json.dumps(r, ensure_ascii=False) + "\n" for r in self._pending_entries)
+        self._pending_entries.clear()
+
     def _next_cursor(self) -> int:
         """Read the current cursor counter and return next value."""
+        if self._pending_entries:
+            return self._pending_entries[-1]["cursor"] + 1
         if self._cursor_file.exists():
             try:
                 return int(self._cursor_file.read_text(encoding="utf-8").strip()) + 1
@@ -262,10 +272,15 @@ class MemoryStore:
         if self.history_file.exists():
             self._cursor_byte_offset = self.history_file.stat().st_size
         self._cached_since_cursor = since_cursor
+        # Include buffered entries not yet flushed to disk.
+        for e in self._pending_entries:
+            if e["cursor"] > since_cursor:
+                entries.append(e)
         return entries
 
     def compact_history(self) -> None:
         """Drop oldest entries if the file exceeds *max_history_entries*."""
+        self.flush_history()  # flush pending before rewrite
         if self.max_history_entries <= 0:
             return
         entries = self._read_entries()
@@ -498,6 +513,7 @@ class Consolidator:
             )
             summary = response.content or "[no summary]"
             self.store.append_history(summary)
+            self.store.flush_history()
             return summary
         except Exception:
             logger.warning("Consolidation LLM call failed, raw-dumping to history")
@@ -785,6 +801,7 @@ class Dream:
         # Advance cursor — always, to avoid re-processing Phase 1
         new_cursor = batch[-1]["cursor"]
         self.store.set_last_dream_cursor(new_cursor)
+        self.store.flush_history()
         self.store.compact_history()
 
         if result and result.stop_reason == "completed":

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -427,10 +427,74 @@ class Consolidator:
         self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
         )
+        # Maps session_key -> (estimate, msg_count, last_consolidated, history_cursor, workspace_mtime_sum)
+        self._last_estimate: dict[str, tuple[int, int, int, int, float]] = {}
 
     def get_lock(self, session_key: str) -> asyncio.Lock:
         """Return the shared consolidation lock for one session."""
         return self._locks.setdefault(session_key, asyncio.Lock())
+
+    def _workspace_mtime_sum(self) -> float:
+        """Sum of mtimes for prompt-contributing workspace files."""
+        total = 0.0
+        try:
+            workspace = self.store.workspace
+        except AttributeError:
+            return 0.0
+        for name in ("AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md", "memory/MEMORY.md"):
+            path = workspace / name
+            try:
+                total += path.stat().st_mtime
+            except OSError:
+                pass
+        skills_dir = workspace / "skills"
+        try:
+            total += skills_dir.stat().st_mtime
+        except OSError:
+            pass
+        return total
+
+    def _get_history_cursor(self) -> int:
+        """Read current history cursor from store."""
+        try:
+            cursor_file = self.store._cursor_file
+        except AttributeError:
+            return 0
+        if cursor_file.exists():
+            try:
+                return int(cursor_file.read_text(encoding="utf-8").strip())
+            except (ValueError, OSError):
+                pass
+        return 0
+
+    def _should_skip_estimation(self, session: Session) -> bool:
+        """Check if estimation can be safely skipped."""
+        cached = self._last_estimate.get(session.key)
+        if not cached:
+            return False
+        estimate, msg_count, last_consol, cursor, mtime_sum = cached
+        budget = self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
+        if estimate >= budget * 0.5:
+            return False
+        if len(session.messages) != msg_count:
+            return False
+        if session.last_consolidated != last_consol:
+            return False
+        if self._get_history_cursor() != cursor:
+            return False
+        if abs(self._workspace_mtime_sum() - mtime_sum) > 0.001:
+            return False
+        return True
+
+    def _record_estimation(self, session: Session, estimate: int) -> None:
+        """Store estimation result for future skip checks."""
+        self._last_estimate[session.key] = (
+            estimate,
+            len(session.messages),
+            session.last_consolidated,
+            self._get_history_cursor(),
+            self._workspace_mtime_sum(),
+        )
 
     def pick_consolidation_boundary(
         self,
@@ -531,6 +595,9 @@ class Consolidator:
 
         lock = self.get_lock(session.key)
         async with lock:
+            if self._should_skip_estimation(session):
+                return
+
             budget = self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
             target = budget // 2
             if _PROFILING:
@@ -542,6 +609,7 @@ class Consolidator:
                 estimated, source = 0, "error"
             if _PROFILING:
                 logger.debug("[profiling] estimation: {:.1f}ms", (_time_mod.perf_counter() - _est_t0) * 1000)
+            self._record_estimation(session, estimated)
             if estimated <= 0:
                 return
             if estimated < budget:
@@ -594,6 +662,7 @@ class Consolidator:
                 )
                 if not await self.archive(chunk):
                     return
+                self._last_estimate.pop(session.key, None)
                 session.last_consolidated = end_idx
                 self.sessions.save(session)
 

--- a/nanobot/agent/profiling.py
+++ b/nanobot/agent/profiling.py
@@ -1,0 +1,57 @@
+"""Lightweight profiling hook and timing infrastructure for the agent loop."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from loguru import logger
+
+from nanobot.agent.hook import AgentHook, AgentHookContext
+
+
+def is_profiling_enabled(agent_defaults: Any = None) -> bool:
+    """Check if profiling is enabled via env var or config."""
+    if os.environ.get("NANOBOT_PROFILING", "").strip() in ("1", "true", "yes"):
+        return True
+    if isinstance(agent_defaults, dict):
+        return bool(agent_defaults.get("profiling", False))
+    return bool(getattr(agent_defaults, "profiling", False))
+
+
+class ProfilingHook(AgentHook):
+    """Records wall-clock timing between AgentHook lifecycle events."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._iter_start: float = 0.0
+        self._tools_start: float = 0.0
+        self.last_iteration_ms: float = 0.0
+        self.last_tool_batch_ms: float = 0.0
+        self.total_iterations: int = 0
+
+    async def before_iteration(self, context: AgentHookContext) -> None:
+        self._iter_start = time.perf_counter()
+        self._tools_start = 0.0
+
+    async def before_execute_tools(self, context: AgentHookContext) -> None:
+        self._tools_start = time.perf_counter()
+
+    async def after_iteration(self, context: AgentHookContext) -> None:
+        now = time.perf_counter()
+        if self._iter_start:
+            self.last_iteration_ms = (now - self._iter_start) * 1000
+        if self._tools_start:
+            self.last_tool_batch_ms = (now - self._tools_start) * 1000
+            self._tools_start = 0.0
+        else:
+            self.last_tool_batch_ms = 0.0
+
+        self.total_iterations += 1
+        logger.debug(
+            "[profiling] iter {}: {:.0f}ms total, {:.0f}ms tools",
+            context.iteration,
+            self.last_iteration_ms,
+            self.last_tool_batch_ms,
+        )

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -31,6 +31,10 @@ from nanobot.utils.runtime import (
     repeated_external_lookup_error,
 )
 
+import time as _time_mod
+from nanobot.agent.profiling import is_profiling_enabled as _is_profiling_enabled
+_PROFILING = _is_profiling_enabled()
+
 _DEFAULT_ERROR_MESSAGE = "Sorry, I encountered an error calling the AI model."
 _PERSISTED_MODEL_ERROR_PLACEHOLDER = "[Assistant reply unavailable due to model error.]"
 _MAX_EMPTY_RETRIES = 2
@@ -240,6 +244,7 @@ class AgentRunner:
         injection_cycles = 0
 
         for iteration in range(spec.max_iterations):
+            _gov_t0 = _time_mod.perf_counter() if _PROFILING else 0.0
             try:
                 # Keep the persisted conversation untouched. Context governance
                 # may repair or compact historical messages for the model, but
@@ -265,6 +270,8 @@ class AgentRunner:
                     messages_for_model = self._backfill_missing_tool_results(messages_for_model)
                 except Exception:
                     messages_for_model = messages
+            if _PROFILING:
+                logger.debug("[profiling] governance: {:.1f}ms", (_time_mod.perf_counter() - _gov_t0) * 1000)
             context = AgentHookContext(iteration=iteration, messages=messages)
             await hook.before_iteration(context)
             response = await self._request_model(spec, messages_for_model, hook, context)

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -70,6 +70,7 @@ class AgentRunSpec:
     context_window_tokens: int | None = None
     context_block_limit: int | None = None
     provider_retry_mode: str = "standard"
+    routing_context: dict[str, Any] | None = None
     progress_callback: Any | None = None
     checkpoint_callback: Any | None = None
     injection_callback: Any | None = None
@@ -678,9 +679,11 @@ class AgentRunner:
             return prep_error + _HINT, event, RuntimeError(prep_error) if spec.fail_on_tool_error else None
         try:
             if tool is not None:
-                result = await tool.execute(**params)
+                result = await tool.execute(**params, _routing_context=spec.routing_context)
             else:
-                result = await spec.tools.execute(tool_call.name, params)
+                result = await spec.tools.execute(
+                    tool_call.name, params, routing_context=spec.routing_context,
+                )
         except asyncio.CancelledError:
             raise
         except BaseException as exc:

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -254,10 +254,11 @@ class AgentRunner:
                 messages_for_model = self._backfill_missing_tool_results(messages_for_model)
                 messages_for_model = self._microcompact(messages_for_model)
                 messages_for_model = self._apply_tool_result_budget(spec, messages_for_model)
-                messages_for_model = self._snip_history(spec, messages_for_model)
-                # Snipping may have created new orphans; clean them up.
-                messages_for_model = self._drop_orphan_tool_results(messages_for_model)
-                messages_for_model = self._backfill_missing_tool_results(messages_for_model)
+                messages_for_model, did_snip = self._snip_history(spec, messages_for_model)
+                if did_snip:
+                    # Snipping may have created new orphans; clean them up.
+                    messages_for_model = self._drop_orphan_tool_results(messages_for_model)
+                    messages_for_model = self._backfill_missing_tool_results(messages_for_model)
             except Exception as exc:
                 logger.warning(
                     "Context governance failed on turn {} for {}: {}; applying minimal repair",
@@ -897,9 +898,9 @@ class AgentRunner:
         self,
         spec: AgentRunSpec,
         messages: list[dict[str, Any]],
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], bool]:
         if not messages or not spec.context_window_tokens:
-            return messages
+            return messages, False
 
         provider_max_tokens = getattr(getattr(self.provider, "generation", None), "max_tokens", 4096)
         max_output = spec.max_tokens if isinstance(spec.max_tokens, int) else (
@@ -909,7 +910,7 @@ class AgentRunner:
             spec.context_window_tokens - max_output - _SNIP_SAFETY_BUFFER
         )
         if budget <= 0:
-            return messages
+            return messages, False
 
         estimate, _ = estimate_prompt_tokens_chain(
             self.provider,
@@ -918,12 +919,12 @@ class AgentRunner:
             spec.tools.get_definitions(),
         )
         if estimate <= budget:
-            return messages
+            return messages, False
 
         system_messages = [dict(msg) for msg in messages if msg.get("role") == "system"]
         non_system = [dict(msg) for msg in messages if msg.get("role") != "system"]
         if not non_system:
-            return messages
+            return messages, False
 
         system_tokens = sum(estimate_message_tokens(msg) for msg in system_messages)
         remaining_budget = max(128, budget - system_tokens)
@@ -950,7 +951,9 @@ class AgentRunner:
             start = find_legal_message_start(kept)
             if start:
                 kept = kept[start:]
-        return system_messages + kept
+        result = system_messages + kept
+        did_remove = len(result) < len(messages)
+        return result, did_remove
 
     def _partition_tool_batches(
         self,

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -208,7 +208,17 @@ class SubagentManager:
             content=announce_content,
         )
 
-        await self.bus.publish_inbound(msg)
+        if not await self.bus.publish_inbound(msg):
+            logger.warning(
+                "Subagent [{}] result announce failed (bus full), retrying",
+                task_id,
+            )
+            await asyncio.sleep(2.0)
+            if not await self.bus.publish_inbound(msg):
+                logger.error(
+                    "Subagent [{}] result lost after retry (bus full)", task_id,
+                )
+                return
         logger.debug("Subagent [{}] announced result to {}:{}", task_id, origin['channel'], origin['chat_id'])
 
     @staticmethod

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -105,12 +105,20 @@ class CronTool(Tool):
         at: str | None = None,
         job_id: str | None = None,
         deliver: bool = True,
+        *,
+        _routing_context: dict | None = None,
         **kwargs: Any,
     ) -> str:
+        ctx = _routing_context or {}
+        channel = ctx.get("channel", self._channel)
+        chat_id = ctx.get("chat_id", self._chat_id)
         if action == "add":
             if self._in_cron_context.get():
                 return "Error: cannot schedule new jobs from within a cron job execution"
-            return self._add_job(name, message, every_seconds, cron_expr, tz, at, deliver)
+            return self._add_job(
+                name, message, every_seconds, cron_expr, tz, at, deliver,
+                channel=channel, chat_id=chat_id,
+            )
         elif action == "list":
             return self._list_jobs()
         elif action == "remove":
@@ -126,10 +134,15 @@ class CronTool(Tool):
         tz: str | None,
         at: str | None,
         deliver: bool = True,
+        *,
+        channel: str | None = None,
+        chat_id: str | None = None,
     ) -> str:
         if not message:
             return "Error: message is required for add"
-        if not self._channel or not self._chat_id:
+        channel = channel or self._channel
+        chat_id = chat_id or self._chat_id
+        if not channel or not chat_id:
             return "Error: no session context (channel/chat_id)"
         if tz and not cron_expr:
             return "Error: tz can only be used with cron_expr"
@@ -168,8 +181,8 @@ class CronTool(Tool):
             schedule=schedule,
             message=message,
             deliver=deliver,
-            channel=self._channel,
-            to=self._chat_id,
+            channel=channel,
+            to=chat_id,
             delete_after_run=delete_after,
         )
         return f"Created job '{job.name}' (id: {job.id})"

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -69,20 +69,29 @@ class MessageTool(Tool):
         chat_id: str | None = None,
         message_id: str | None = None,
         media: list[str] | None = None,
-        **kwargs: Any
+        *,
+        _routing_context: dict | None = None,
+        **kwargs: Any,
     ) -> str:
         from nanobot.utils.helpers import strip_think
         content = strip_think(content)
-        
-        channel = channel or self._default_channel
-        chat_id = chat_id or self._default_chat_id
+
+        ctx = _routing_context or {}
+        home_channel = ctx.get("channel") or self._default_channel
+        home_chat_id = ctx.get("chat_id") or self._default_chat_id
+        channel = channel or home_channel
+        chat_id = chat_id or home_chat_id
         # Only inherit default message_id when targeting the same channel+chat.
         # Cross-chat sends must not carry the original message_id, because
         # some channels (e.g. Feishu) use it to determine the target
         # conversation via their Reply API, which would route the message
         # to the wrong chat entirely.
-        if channel == self._default_channel and chat_id == self._default_chat_id:
-            message_id = message_id or self._default_message_id
+        if channel == home_channel and chat_id == home_chat_id:
+            message_id = (
+                message_id
+                or ctx.get("message_id")
+                or self._default_message_id
+            )
         else:
             message_id = None
 
@@ -104,7 +113,7 @@ class MessageTool(Tool):
 
         try:
             await self._send_callback(msg)
-            if channel == self._default_channel and chat_id == self._default_chat_id:
+            if channel == home_channel and chat_id == home_chat_id:
                 self._sent_in_turn = True
             media_info = f" with {len(media)} attachments" if media else ""
             return f"Message sent to {channel}:{chat_id}{media_info}"

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -112,7 +112,10 @@ class MessageTool(Tool):
         )
 
         try:
-            await self._send_callback(msg)
+            result = await self._send_callback(msg)
+            # publish_outbound returns bool; treat False as a delivery failure
+            if result is False:
+                return "Error: message could not be delivered (outbound queue full)"
             if channel == home_channel and chat_id == home_chat_id:
                 self._sent_in_turn = True
             media_info = f" with {len(media)} attachments" if media else ""

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -89,7 +89,12 @@ class ToolRegistry:
             )
         return tool, cast_params, None
 
-    async def execute(self, name: str, params: dict[str, Any]) -> Any:
+    async def execute(
+        self,
+        name: str,
+        params: dict[str, Any],
+        routing_context: dict[str, Any] | None = None,
+    ) -> Any:
         """Execute a tool by name with given parameters."""
         _HINT = "\n\n[Analyze the error above and try a different approach.]"
         tool, params, error = self.prepare_call(name, params)
@@ -98,7 +103,7 @@ class ToolRegistry:
 
         try:
             assert tool is not None  # guarded by prepare_call()
-            result = await tool.execute(**params)
+            result = await tool.execute(**params, _routing_context=routing_context)
             if isinstance(result, str) and result.startswith("Error"):
                 return result + _HINT
             return result

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -14,14 +14,17 @@ class ToolRegistry:
 
     def __init__(self):
         self._tools: dict[str, Tool] = {}
+        self._cached_definitions: list[dict[str, Any]] | None = None
 
     def register(self, tool: Tool) -> None:
         """Register a tool."""
         self._tools[tool.name] = tool
+        self._cached_definitions = None
 
     def unregister(self, name: str) -> None:
         """Unregister a tool by name."""
         self._tools.pop(name, None)
+        self._cached_definitions = None
 
     def get(self, name: str) -> Tool | None:
         """Get a tool by name."""
@@ -46,8 +49,11 @@ class ToolRegistry:
         """Get tool definitions with stable ordering for cache-friendly prompts.
 
         Built-in tools are sorted first as a stable prefix, then MCP tools are
-        sorted and appended.
+        sorted and appended. Result is cached and invalidated on register/unregister.
         """
+        if self._cached_definitions is not None:
+            return self._cached_definitions
+
         definitions = [tool.to_schema() for tool in self._tools.values()]
         builtins: list[dict[str, Any]] = []
         mcp_tools: list[dict[str, Any]] = []
@@ -60,7 +66,8 @@ class ToolRegistry:
 
         builtins.sort(key=self._schema_name)
         mcp_tools.sort(key=self._schema_name)
-        return builtins + mcp_tools
+        self._cached_definitions = builtins + mcp_tools
+        return self._cached_definitions
 
     def prepare_call(
         self,

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -45,12 +45,23 @@ class SpawnTool(Tool):
             "and use a dedicated subdirectory when helpful."
         )
 
-    async def execute(self, task: str, label: str | None = None, **kwargs: Any) -> str:
+    async def execute(
+        self,
+        task: str,
+        label: str | None = None,
+        *,
+        _routing_context: dict | None = None,
+        **kwargs: Any,
+    ) -> str:
         """Spawn a subagent to execute the given task."""
+        ctx = _routing_context or {}
+        channel = ctx.get("channel", self._origin_channel)
+        chat_id = ctx.get("chat_id", self._origin_chat_id)
+        session_key = ctx.get("session_key", self._session_key)
         return await self._manager.spawn(
             task=task,
             label=label,
-            origin_channel=self._origin_channel,
-            origin_chat_id=self._origin_chat_id,
-            session_key=self._session_key,
+            origin_channel=channel,
+            origin_chat_id=chat_id,
+            session_key=session_key,
         )

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -1,8 +1,13 @@
 """Async message queue for decoupled channel-agent communication."""
 
 import asyncio
+import os
+
+from loguru import logger
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
+
+_DEFAULT_MAX_QUEUE_SIZE = int(os.environ.get("NANOBOT_MAX_QUEUE_SIZE", "100"))
 
 
 class MessageBus:
@@ -11,23 +16,55 @@ class MessageBus:
 
     Channels push messages to the inbound queue, and the agent processes
     them and pushes responses to the outbound queue.
+
+    Both queues are bounded to prevent unbounded memory growth when
+    producers outpace consumers.
     """
 
-    def __init__(self):
-        self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue()
-        self.outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
+    def __init__(
+        self,
+        maxsize: int = _DEFAULT_MAX_QUEUE_SIZE,
+        timeout: float = 5.0,
+    ):
+        self._timeout = timeout
+        self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue(maxsize=maxsize)
+        self.outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue(maxsize=maxsize)
 
-    async def publish_inbound(self, msg: InboundMessage) -> None:
-        """Publish a message from a channel to the agent."""
-        await self.inbound.put(msg)
+    async def publish_inbound(self, msg: InboundMessage) -> bool:
+        """Publish a message from a channel to the agent.
+
+        Returns True on success, False if the queue is full after timeout.
+        """
+        try:
+            await asyncio.wait_for(self.inbound.put(msg), timeout=self._timeout)
+            return True
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Inbound queue full (size {}), message dropped after {}s timeout",
+                self.inbound.qsize(),
+                self._timeout,
+            )
+            return False
 
     async def consume_inbound(self) -> InboundMessage:
         """Consume the next inbound message (blocks until available)."""
         return await self.inbound.get()
 
-    async def publish_outbound(self, msg: OutboundMessage) -> None:
-        """Publish a response from the agent to channels."""
-        await self.outbound.put(msg)
+    async def publish_outbound(self, msg: OutboundMessage) -> bool:
+        """Publish a response from the agent to channels.
+
+        Returns True on success, False if the queue is full after timeout.
+        """
+        try:
+            await asyncio.wait_for(self.outbound.put(msg), timeout=self._timeout)
+            return True
+        except asyncio.TimeoutError:
+            logger.error(
+                "Outbound queue full (size {}), message dropped after {}s timeout",
+                self.outbound.qsize(),
+                self._timeout,
+            )
+            return False
 
     async def consume_outbound(self) -> OutboundMessage:
         """Consume the next outbound message (blocks until available)."""

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -53,18 +53,13 @@ class MessageBus:
     async def publish_outbound(self, msg: OutboundMessage) -> bool:
         """Publish a response from the agent to channels.
 
-        Returns True on success, False if the queue is full after timeout.
+        Blocks until space is available. Agent replies must never be
+        silently dropped — if the dispatcher stalls, the agent should
+        stall too (visible, diagnosable). The bounded queue still
+        provides memory safety.
         """
-        try:
-            await asyncio.wait_for(self.outbound.put(msg), timeout=self._timeout)
-            return True
-        except asyncio.TimeoutError:
-            logger.error(
-                "Outbound queue full (size {}), message dropped after {}s timeout",
-                self.outbound.qsize(),
-                self._timeout,
-            )
-            return False
+        await self.outbound.put(msg)
+        return True
 
     async def consume_outbound(self) -> OutboundMessage:
         """Consume the next outbound message (blocks until available)."""

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -168,7 +168,10 @@ class BaseChannel(ABC):
             session_key_override=session_key,
         )
 
-        await self.bus.publish_inbound(msg)
+        if not await self.bus.publish_inbound(msg):
+            logger.warning(
+                "Message from {}:{} dropped (bus full)", sender_id, chat_id,
+            )
 
     @classmethod
     def default_config(cls) -> dict[str, Any]:

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -1290,7 +1290,6 @@ class FeishuChannel(BaseChannel):
 
         Supported metadata keys:
             _stream_end: Finalize the streaming card.
-            _resuming:   Mid-turn pause – flush but keep the buffer alive.
             _tool_hint:  Delta is a formatted tool hint (for display only).
             message_id:  Original message id (used with _stream_end for reaction cleanup).
             reaction_id: Reaction id to remove on stream end.
@@ -1309,50 +1308,44 @@ class FeishuChannel(BaseChannel):
                 if self.config.done_emoji and message_id:
                     await self._add_reaction(message_id, self.config.done_emoji)
 
-            resuming = meta.get("_resuming", False)
-            if resuming:
-                # Mid-turn pause (e.g. tool call between streaming segments).
-                # Flush current text to card but keep the buffer alive so the
-                # next segment appends to the same card.
-                buf = self._stream_bufs.get(chat_id)
-                if buf and buf.card_id and buf.text:
-                    buf.sequence += 1
-                    await loop.run_in_executor(
-                        None, self._stream_update_text_sync, buf.card_id, buf.text, buf.sequence,
-                    )
-                return
-
             buf = self._stream_bufs.pop(chat_id, None)
             if not buf or not buf.text:
                 return
+            # Try to finalize via streaming card; if that fails (e.g.
+            # streaming mode was closed by Feishu due to timeout), fall
+            # back to sending a regular interactive card.
             if buf.card_id:
                 buf.sequence += 1
-                await loop.run_in_executor(
+                ok = await loop.run_in_executor(
                     None,
                     self._stream_update_text_sync,
                     buf.card_id,
                     buf.text,
                     buf.sequence,
                 )
-                # Required so the chat list preview exits the streaming placeholder (Feishu streaming card docs).
-                buf.sequence += 1
-                await loop.run_in_executor(
-                    None,
-                    self._close_streaming_mode_sync,
-                    buf.card_id,
-                    buf.sequence,
-                )
-            else:
-                for chunk in self._split_elements_by_table_limit(
-                    self._build_card_elements(buf.text)
-                ):
-                    card = json.dumps(
-                        {"config": {"wide_screen_mode": True}, "elements": chunk},
-                        ensure_ascii=False,
-                    )
+                if ok:
+                    buf.sequence += 1
                     await loop.run_in_executor(
-                        None, self._send_message_sync, rid_type, chat_id, "interactive", card
+                        None,
+                        self._close_streaming_mode_sync,
+                        buf.card_id,
+                        buf.sequence,
                     )
+                    return
+                logger.warning(
+                    "Streaming card {} final update failed, falling back to regular card",
+                    buf.card_id,
+                )
+            for chunk in self._split_elements_by_table_limit(
+                self._build_card_elements(buf.text)
+            ):
+                card = json.dumps(
+                    {"config": {"wide_screen_mode": True}, "elements": chunk},
+                    ensure_ascii=False,
+                )
+                await loop.run_in_executor(
+                    None, self._send_message_sync, rid_type, chat_id, "interactive", card
+                )
             return
 
         # --- accumulate delta ---
@@ -1404,14 +1397,21 @@ class FeishuChannel(BaseChannel):
                 if buf and buf.card_id:
                     # Delegate to send_delta so tool hints get the same
                     # throttling (and card creation) as regular text deltas.
-                    lines = self.__class__._format_tool_hint_lines(hint).split("\n")
-                    delta = "\n\n" + "\n".join(
-                        f"{self.config.tool_hint_prefix} {ln}" for ln in lines if ln.strip()
-                    ) + "\n\n"
-                    await self.send_delta(msg.chat_id, delta)
+                    await self.send_delta(
+                        msg.chat_id,
+                        "\n\n" + self._format_tool_hint_delta(hint) + "\n\n",
+                    )
                     return
-                await self._send_tool_hint_card(
-                    receive_id_type, msg.chat_id, hint
+                # No active streaming card — send as a regular
+                # interactive card with the same 🔧 prefix style.
+                card = json.dumps(
+                    {"config": {"wide_screen_mode": True}, "elements": [
+                        {"tag": "markdown", "content": self._format_tool_hint_delta(hint)},
+                    ]},
+                    ensure_ascii=False,
+                )
+                await loop.run_in_executor(
+                    None, self._send_message_sync, receive_id_type, msg.chat_id, "interactive", card
                 )
                 return
 
@@ -1708,33 +1708,9 @@ class FeishuChannel(BaseChannel):
 
         return "\n".join(part for part in parts if part)
 
-    async def _send_tool_hint_card(
-        self, receive_id_type: str, receive_id: str, tool_hint: str
-    ) -> None:
-        """Send tool hint as an interactive card with formatted code block.
-
-        Args:
-            receive_id_type: "chat_id" or "open_id"
-            receive_id: The target chat or user ID
-            tool_hint: Formatted tool hint string (e.g., 'web_search("q"), read_file("path")')
-        """
-        loop = asyncio.get_running_loop()
-
-        # Put each top-level tool call on its own line without altering commas inside arguments.
-        formatted_code = self.__class__._format_tool_hint_lines(tool_hint)
-
-        card = {
-            "config": {"wide_screen_mode": True},
-            "elements": [
-                {"tag": "markdown", "content": f"**Tool Calls**\n\n```text\n{formatted_code}\n```"}
-            ],
-        }
-
-        await loop.run_in_executor(
-            None,
-            self._send_message_sync,
-            receive_id_type,
-            receive_id,
-            "interactive",
-            json.dumps(card, ensure_ascii=False),
+    def _format_tool_hint_delta(self, tool_hint: str) -> str:
+        """Format a tool hint string with the 🔧 prefix for each line."""
+        lines = self.__class__._format_tool_hint_lines(tool_hint).split("\n")
+        return "\n".join(
+            f"{self.config.tool_hint_prefix} {ln}" for ln in lines if ln.strip()
         )

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -32,6 +32,7 @@ class ChannelManager:
         self.bus = bus
         self.channels: dict[str, BaseChannel] = {}
         self._dispatch_task: asyncio.Task | None = None
+        self._active_streams: set[str] = set()
 
         self._init_channels()
 
@@ -171,10 +172,23 @@ class ChannelManager:
                         continue
 
                 # Coalesce consecutive _stream_delta messages for the same (channel, chat_id)
-                # to reduce API calls and improve streaming latency
+                # to reduce API calls and improve streaming latency.
+                # First delta for a stream is dispatched immediately (no coalescing) so the
+                # user sees output without waiting for the batching window to fill.
                 if msg.metadata.get("_stream_delta") and not msg.metadata.get("_stream_end"):
-                    msg, extra_pending = self._coalesce_stream_deltas(msg)
-                    pending.extend(extra_pending)
+                    stream_key = msg.metadata.get("stream_id") or f"{msg.channel}:{msg.chat_id}"
+                    if stream_key not in self._active_streams:
+                        # First delta for this stream — dispatch immediately, skip coalescing
+                        self._active_streams.add(stream_key)
+                    else:
+                        # Subsequent deltas — coalesce as before
+                        msg, extra_pending = self._coalesce_stream_deltas(msg)
+                        pending.extend(extra_pending)
+
+                # Clean up stream tracking when the stream ends
+                if msg.metadata.get("_stream_end"):
+                    stream_key = msg.metadata.get("stream_id") or f"{msg.channel}:{msg.chat_id}"
+                    self._active_streams.discard(stream_key)
 
                 channel = self.channels.get(msg.channel)
                 if channel:

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -220,13 +220,15 @@ class ChannelManager:
         Returns:
             tuple of (merged_message, list_of_non_matching_messages)
         """
-        target_key = (first_msg.channel, first_msg.chat_id)
+        first_stream_id = (first_msg.metadata or {}).get("_stream_id")
+        target_key = (first_msg.channel, first_msg.chat_id, first_stream_id)
         combined_content = first_msg.content
         final_metadata = dict(first_msg.metadata or {})
         non_matching: list[OutboundMessage] = []
 
-        # Only merge consecutive deltas. As soon as we hit any other message,
-        # stop and hand that boundary back to the dispatcher via `pending`.
+        # Only merge consecutive deltas for the same (channel, chat_id, _stream_id).
+        # As soon as we hit any other message, stop and hand that boundary back
+        # to the dispatcher via `pending`.
         while True:
             try:
                 next_msg = self.bus.outbound.get_nowait()
@@ -234,9 +236,11 @@ class ChannelManager:
                 break
 
             # Check if this message belongs to the same stream
-            same_target = (next_msg.channel, next_msg.chat_id) == target_key
-            is_delta = next_msg.metadata and next_msg.metadata.get("_stream_delta")
-            is_end = next_msg.metadata and next_msg.metadata.get("_stream_end")
+            next_meta = next_msg.metadata or {}
+            next_stream_id = next_meta.get("_stream_id")
+            same_target = (next_msg.channel, next_msg.chat_id, next_stream_id) == target_key
+            is_delta = next_meta.get("_stream_delta")
+            is_end = next_meta.get("_stream_end")
 
             if same_target and is_delta and not final_metadata.get("_stream_end"):
                 # Accumulate content

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -176,7 +176,7 @@ class ChannelManager:
                 # First delta for a stream is dispatched immediately (no coalescing) so the
                 # user sees output without waiting for the batching window to fill.
                 if msg.metadata.get("_stream_delta") and not msg.metadata.get("_stream_end"):
-                    stream_key = msg.metadata.get("stream_id") or f"{msg.channel}:{msg.chat_id}"
+                    stream_key = msg.metadata.get("_stream_id") or f"{msg.channel}:{msg.chat_id}"
                     if stream_key not in self._active_streams:
                         # First delta for this stream — dispatch immediately, skip coalescing
                         self._active_streams.add(stream_key)
@@ -187,7 +187,7 @@ class ChannelManager:
 
                 # Clean up stream tracking when the stream ends
                 if msg.metadata.get("_stream_end"):
-                    stream_key = msg.metadata.get("stream_id") or f"{msg.channel}:{msg.chat_id}"
+                    stream_key = msg.metadata.get("_stream_id") or f"{msg.channel}:{msg.chat_id}"
                     self._active_streams.discard(stream_key)
 
                 channel = self.channels.get(msg.channel)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1063,13 +1063,15 @@ def agent(
                         turn_response.clear()
                         renderer = StreamRenderer(render_markdown=markdown)
 
-                        await bus.publish_inbound(InboundMessage(
+                        if not await bus.publish_inbound(InboundMessage(
                             channel=cli_channel,
                             sender_id="user",
                             chat_id=cli_chat_id,
                             content=user_input,
                             metadata={"_wants_stream": True},
-                        ))
+                        )):
+                            logger.warning("CLI message dropped (bus full)")
+                            continue
 
                         await turn_done.wait()
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -85,6 +85,7 @@ class AgentDefaults(Base):
         serialization_alias="idleCompactAfterMinutes",
     )  # Auto-compact idle threshold in minutes (0 = disabled)
     dream: DreamConfig = Field(default_factory=DreamConfig)
+    profiling: bool = False  # Enable agent loop profiling (also via NANOBOT_PROFILING=1)
 
 
 class AgentsConfig(Base):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -85,7 +85,7 @@ class AgentDefaults(Base):
         serialization_alias="idleCompactAfterMinutes",
     )  # Auto-compact idle threshold in minutes (0 = disabled)
     dream: DreamConfig = Field(default_factory=DreamConfig)
-    profiling: bool = False  # Register ProfilingHook for iteration/tool timing. For internal timing guards use NANOBOT_PROFILING=1 env var (evaluated at import time).
+    profiling: bool = False  # Reserved. Use NANOBOT_PROFILING=1 env var to enable profiling.
 
 
 class AgentsConfig(Base):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -85,7 +85,7 @@ class AgentDefaults(Base):
         serialization_alias="idleCompactAfterMinutes",
     )  # Auto-compact idle threshold in minutes (0 = disabled)
     dream: DreamConfig = Field(default_factory=DreamConfig)
-    profiling: bool = False  # Enable agent loop profiling (also via NANOBOT_PROFILING=1)
+    profiling: bool = False  # Register ProfilingHook for iteration/tool timing. For internal timing guards use NANOBOT_PROFILING=1 env var (evaluated at import time).
 
 
 class AgentsConfig(Base):

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -39,7 +39,7 @@ class AnthropicProvider(LLMProvider):
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
 
-        from anthropic import AsyncAnthropic
+        from anthropic import Anthropic, AsyncAnthropic
 
         client_kw: dict[str, Any] = {}
         if api_key:
@@ -51,6 +51,7 @@ class AnthropicProvider(LLMProvider):
         # Keep retries centralized in LLMProvider._run_with_retry to avoid retry amplification.
         client_kw["max_retries"] = 0
         self._client = AsyncAnthropic(**client_kw)
+        self._sync_client = Anthropic(**client_kw)
 
     @classmethod
     def _handle_error(cls, e: Exception) -> LLMResponse:
@@ -531,6 +532,31 @@ class AnthropicProvider(LLMProvider):
             )
         except Exception as e:
             return self._handle_error(e)
+
+    def estimate_prompt_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        model: str | None = None,
+    ) -> tuple[int, str] | None:
+        """Use Anthropic's native token counting for higher accuracy."""
+        try:
+            system, converted = self._convert_messages(
+                self._sanitize_empty_content(messages),
+            )
+            kwargs: dict[str, Any] = {
+                "model": self._strip_prefix(model or self.default_model),
+                "messages": converted,
+            }
+            if system:
+                kwargs["system"] = system
+            anthropic_tools = self._convert_tools(tools)
+            if anthropic_tools:
+                kwargs["tools"] = anthropic_tools
+            result = self._sync_client.messages.count_tokens(**kwargs)
+            return (result.input_tokens, "anthropic_count_tokens")
+        except Exception:
+            return None
 
     def get_default_model(self) -> str:
         return self.default_model

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -164,6 +164,7 @@ class OpenAICompatProvider(LLMProvider):
             default_headers=default_headers,
             max_retries=0,
         )
+        self._responses_api_failures: dict[tuple[str, str | None], int] = {}
 
     def _setup_env(self, api_key: str, api_base: str | None) -> None:
         """Set environment variables based on provider spec."""
@@ -355,6 +356,22 @@ class OpenAICompatProvider(LLMProvider):
         if reasoning_effort and reasoning_effort.lower() != "none":
             return True
         return any(token in model_name for token in ("gpt-5", "o1", "o3", "o4"))
+
+    @staticmethod
+    def _responses_failure_key(model: str | None, reasoning_effort: str | None) -> tuple[str, str | None]:
+        return (model or "", reasoning_effort)
+
+    def _should_skip_responses_api(self, model: str | None, reasoning_effort: str | None) -> bool:
+        key = self._responses_failure_key(model, reasoning_effort)
+        return self._responses_api_failures.get(key, 0) >= 3
+
+    def _record_responses_api_failure(self, model: str | None, reasoning_effort: str | None) -> None:
+        key = self._responses_failure_key(model, reasoning_effort)
+        self._responses_api_failures[key] = self._responses_api_failures.get(key, 0) + 1
+
+    def _record_responses_api_success(self, model: str | None, reasoning_effort: str | None) -> None:
+        key = self._responses_failure_key(model, reasoning_effort)
+        self._responses_api_failures[key] = 0
 
     @staticmethod
     def _should_fallback_from_responses_error(e: Exception) -> bool:
@@ -847,16 +864,19 @@ class OpenAICompatProvider(LLMProvider):
         tool_choice: str | dict[str, Any] | None = None,
     ) -> LLMResponse:
         try:
-            if self._should_use_responses_api(model, reasoning_effort):
+            if self._should_use_responses_api(model, reasoning_effort) and not self._should_skip_responses_api(model, reasoning_effort):
                 try:
                     body = self._build_responses_body(
                         messages, tools, model, max_tokens, temperature,
                         reasoning_effort, tool_choice,
                     )
-                    return parse_response_output(await self._client.responses.create(**body))
+                    result = parse_response_output(await self._client.responses.create(**body))
+                    self._record_responses_api_success(model, reasoning_effort)
+                    return result
                 except Exception as responses_error:
                     if not self._should_fallback_from_responses_error(responses_error):
                         raise
+                    self._record_responses_api_failure(model, reasoning_effort)
 
             kwargs = self._build_kwargs(
                 messages, tools, model, max_tokens, temperature,

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -899,7 +899,10 @@ class OpenAICompatProvider(LLMProvider):
     ) -> LLMResponse:
         idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
         try:
-            if self._should_use_responses_api(model, reasoning_effort):
+            if (
+                self._should_use_responses_api(model, reasoning_effort)
+                and not self._should_skip_responses_api(model, reasoning_effort)
+            ):
                 try:
                     body = self._build_responses_body(
                         messages, tools, model, max_tokens, temperature,
@@ -923,6 +926,7 @@ class OpenAICompatProvider(LLMProvider):
                         _timed_stream(),
                         on_content_delta,
                     )
+                    self._record_responses_api_success(model, reasoning_effort)
                     return LLMResponse(
                         content=content or None,
                         tool_calls=tool_calls,
@@ -933,6 +937,7 @@ class OpenAICompatProvider(LLMProvider):
                 except Exception as responses_error:
                     if not self._should_fallback_from_responses_error(responses_error):
                         raise
+                    self._record_responses_api_failure(model, reasoning_effort)
 
             kwargs = self._build_kwargs(
                 messages, tools, model, max_tokens, temperature,

--- a/tests/agent/test_bootstrap_cache.py
+++ b/tests/agent/test_bootstrap_cache.py
@@ -1,0 +1,36 @@
+import time
+from pathlib import Path
+import pytest
+from nanobot.agent.context import ContextBuilder
+
+@pytest.fixture
+def ctx(tmp_path):
+    return ContextBuilder(workspace=tmp_path)
+
+def test_cache_returns_same_on_unchanged(ctx, tmp_path):
+    (tmp_path / "SOUL.md").write_text("I am calm.")
+    r1 = ctx._load_bootstrap_files()
+    r2 = ctx._load_bootstrap_files()
+    assert r1 == r2
+    assert "I am calm." in r1
+
+def test_cache_invalidates_on_mtime_change(ctx, tmp_path):
+    soul = tmp_path / "SOUL.md"
+    soul.write_text("v1")
+    r1 = ctx._load_bootstrap_files()
+    time.sleep(0.05)
+    soul.write_text("v2")
+    r2 = ctx._load_bootstrap_files()
+    assert "v1" in r1
+    assert "v2" in r2
+
+def test_handles_missing_files(ctx):
+    assert ctx._load_bootstrap_files() == ""
+
+def test_handles_deleted_file(ctx, tmp_path):
+    soul = tmp_path / "SOUL.md"
+    soul.write_text("temp")
+    ctx._load_bootstrap_files()
+    soul.unlink()
+    result = ctx._load_bootstrap_files()
+    assert "temp" not in result

--- a/tests/agent/test_cursor_history.py
+++ b/tests/agent/test_cursor_history.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+import pytest
+from nanobot.agent.memory import MemoryStore
+
+@pytest.fixture
+def store(tmp_path):
+    return MemoryStore(workspace=tmp_path)
+
+def test_read_unprocessed_returns_entries_after_cursor(store):
+    store.append_history("fact one")
+    store.append_history("fact two")
+    store.append_history("fact three")
+    entries = store.read_unprocessed_history(since_cursor=1)
+    assert len(entries) == 2
+    assert entries[0]["content"] == "fact two"
+
+def test_incremental_read_after_append(store):
+    store.append_history("first")
+    store.append_history("second")
+    e1 = store.read_unprocessed_history(since_cursor=0)
+    assert len(e1) == 2
+    store.append_history("third")
+    e2 = store.read_unprocessed_history(since_cursor=2)
+    assert len(e2) == 1
+    assert e2[0]["content"] == "third"
+
+def test_compact_resets_offset(store):
+    for i in range(20):
+        store.append_history(f"entry {i}")
+    store.read_unprocessed_history(since_cursor=0)
+    store.max_history_entries = 5
+    store.compact_history()
+    entries = store.read_unprocessed_history(since_cursor=15)
+    assert len(entries) == 5
+
+def test_cold_start_full_scan(store):
+    store.append_history("hello")
+    # No prior read — should do full scan
+    entries = store.read_unprocessed_history(since_cursor=0)
+    assert len(entries) == 1
+
+def test_empty_history(store):
+    entries = store.read_unprocessed_history(since_cursor=0)
+    assert entries == []

--- a/tests/agent/test_cursor_history.py
+++ b/tests/agent/test_cursor_history.py
@@ -43,3 +43,30 @@ def test_cold_start_full_scan(store):
 def test_empty_history(store):
     entries = store.read_unprocessed_history(since_cursor=0)
     assert entries == []
+
+def test_buffered_writes_visible_before_flush(store):
+    store.append_history("buffered")
+    entries = store.read_unprocessed_history(since_cursor=0)
+    assert len(entries) == 1
+    assert entries[0]["content"] == "buffered"
+
+def test_flush_writes_to_disk(store):
+    store.append_history("a")
+    store.append_history("b")
+    store.flush_history()
+    raw = store.history_file.read_text()
+    assert "a" in raw and "b" in raw
+
+def test_flush_clears_buffer(store):
+    store.append_history("x")
+    store.flush_history()
+    assert store._pending_entries == []
+
+def test_compact_flushes_first(store):
+    store.append_history("a")
+    store.append_history("b")
+    store.append_history("c")
+    store.max_history_entries = 2
+    store.compact_history()
+    entries = store.read_unprocessed_history(since_cursor=0)
+    assert len(entries) == 2

--- a/tests/agent/test_estimation_skip.py
+++ b/tests/agent/test_estimation_skip.py
@@ -1,0 +1,108 @@
+"""Tests for Consolidator token estimation skip logic."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.agent.memory import Consolidator
+
+
+def _make_consolidator(tmp_path, context_window=65536, max_completion=8192):
+    provider = MagicMock()
+    store = MagicMock()
+    store.workspace = tmp_path
+    store._cursor_file = tmp_path / "memory" / ".cursor"
+    (tmp_path / "memory").mkdir(exist_ok=True)
+    store.history_file = tmp_path / "memory" / "history.jsonl"
+    sessions = MagicMock()
+    c = Consolidator(
+        store=store,
+        provider=provider,
+        model="test",
+        sessions=sessions,
+        context_window_tokens=context_window,
+        max_completion_tokens=max_completion,
+        build_messages=MagicMock(return_value=[]),
+        get_tool_definitions=MagicMock(return_value=[]),
+    )
+    return c
+
+
+def _make_session(key="test:1", msg_count=1):
+    session = MagicMock()
+    session.key = key
+    session.messages = [{"role": "user", "content": "hi"}] * msg_count
+    session.last_consolidated = 0
+    return session
+
+
+def test_skip_when_under_budget(tmp_path):
+    c = _make_consolidator(tmp_path)
+    session = _make_session()
+    c._record_estimation(session, 5000)
+    assert c._should_skip_estimation(session) is True
+
+
+def test_no_skip_without_prior_estimate(tmp_path):
+    c = _make_consolidator(tmp_path)
+    session = _make_session()
+    assert c._should_skip_estimation(session) is False
+
+
+def test_no_skip_when_messages_changed(tmp_path):
+    c = _make_consolidator(tmp_path)
+    session = _make_session(msg_count=1)
+    c._record_estimation(session, 5000)
+    session.messages.append({"role": "assistant", "content": "hello"})
+    assert c._should_skip_estimation(session) is False
+
+
+def test_no_skip_when_over_half_budget(tmp_path):
+    c = _make_consolidator(tmp_path, context_window=10000, max_completion=2000)
+    session = _make_session()
+    budget = 10000 - 2000 - c._SAFETY_BUFFER
+    c._record_estimation(session, int(budget * 0.6))
+    assert c._should_skip_estimation(session) is False
+
+
+def test_no_skip_when_cursor_changed(tmp_path):
+    c = _make_consolidator(tmp_path)
+    session = _make_session()
+    c._record_estimation(session, 5000)
+    # Change cursor
+    c.store._cursor_file.write_text("99")
+    assert c._should_skip_estimation(session) is False
+
+
+def test_no_skip_when_workspace_file_changed(tmp_path):
+    c = _make_consolidator(tmp_path)
+    session = _make_session()
+    c._record_estimation(session, 5000)
+    # Create a workspace file that changes mtime sum
+    (tmp_path / "SOUL.md").write_text("new soul content")
+    assert c._should_skip_estimation(session) is False
+
+
+def test_no_skip_when_last_consolidated_changed(tmp_path):
+    c = _make_consolidator(tmp_path)
+    session = _make_session()
+    c._record_estimation(session, 5000)
+    session.last_consolidated = 5
+    assert c._should_skip_estimation(session) is False
+
+
+def test_record_and_skip_roundtrip(tmp_path):
+    """Record estimation, then verify skip works and re-record after changes."""
+    c = _make_consolidator(tmp_path)
+    session = _make_session(msg_count=3)
+    c._record_estimation(session, 1000)
+    assert c._should_skip_estimation(session) is True
+
+    # After adding a message, skip should fail
+    session.messages.append({"role": "user", "content": "more"})
+    assert c._should_skip_estimation(session) is False
+
+    # Re-record with new state, skip should work again
+    c._record_estimation(session, 1200)
+    assert c._should_skip_estimation(session) is True

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -55,6 +55,7 @@ class TestHistoryWithCursor:
 
     def test_append_history_includes_cursor_in_file(self, store):
         store.append_history("event 1")
+        store.flush_history()
         content = store.read_file(store.history_file)
         data = json.loads(content)
         assert data["cursor"] == 1

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -266,3 +267,26 @@ class TestLegacyHistoryMigration:
         assert entries[0]["timestamp"] == "2026-04-01 10:00"
         assert "Broken" in entries[0]["content"]
         assert "migration." in entries[0]["content"]
+
+
+def test_dream_skill_list_caching(tmp_path):
+    from nanobot.agent.memory import Dream
+
+    skills_dir = tmp_path / "skills" / "my_skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("---\ndescription: test skill\n---\nContent")
+
+    store = MagicMock()
+    store.workspace = tmp_path
+
+    # Patch BUILTIN_SKILLS_DIR so no real builtin skills are included
+    with patch("nanobot.agent.skills.BUILTIN_SKILLS_DIR", tmp_path / "no_builtins"):
+        dream = Dream(store=store, provider=MagicMock(), model="test")
+
+        result1 = dream._list_existing_skills()
+        result2 = dream._list_existing_skills()
+
+    assert result1 == result2
+    assert dream._skills_cache is not None
+    assert len(result1) == 1
+    assert "my_skill" in result1[0]

--- a/tests/agent/test_profiling.py
+++ b/tests/agent/test_profiling.py
@@ -1,0 +1,39 @@
+import pytest
+from nanobot.agent.profiling import ProfilingHook, is_profiling_enabled
+from nanobot.agent.hook import AgentHookContext
+
+def test_profiling_disabled_by_default():
+    assert not is_profiling_enabled({})
+
+def test_profiling_enabled_via_config():
+    assert is_profiling_enabled({"profiling": True})
+
+def test_profiling_enabled_via_env(monkeypatch):
+    monkeypatch.setenv("NANOBOT_PROFILING", "1")
+    assert is_profiling_enabled({})
+
+@pytest.mark.asyncio
+async def test_hook_records_iteration_timing():
+    hook = ProfilingHook()
+    ctx = AgentHookContext(iteration=0, messages=[])
+    await hook.before_iteration(ctx)
+    await hook.after_iteration(ctx)
+    assert hook.last_iteration_ms >= 0
+    assert hook.total_iterations == 1
+
+@pytest.mark.asyncio
+async def test_hook_records_tool_timing():
+    hook = ProfilingHook()
+    ctx = AgentHookContext(iteration=0, messages=[])
+    await hook.before_iteration(ctx)
+    await hook.before_execute_tools(ctx)
+    await hook.after_iteration(ctx)
+    assert hook.last_tool_batch_ms >= 0
+
+@pytest.mark.asyncio
+async def test_hook_resets_tool_timing_when_no_tools():
+    hook = ProfilingHook()
+    ctx = AgentHookContext(iteration=0, messages=[])
+    await hook.before_iteration(ctx)
+    await hook.after_iteration(ctx)
+    assert hook.last_tool_batch_ms == 0.0

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -641,8 +641,9 @@ def test_snip_history_drops_orphaned_tool_results_from_trimmed_slice(monkeypatch
         lambda msg: token_sizes.get(str(msg.get("content")), 40),
     )
 
-    trimmed = runner._snip_history(spec, messages)
+    trimmed, did_remove = runner._snip_history(spec, messages)
 
+    assert did_remove is True
     assert trimmed == [
         {"role": "system", "content": "system"},
         {"role": "assistant", "content": "after tool"},
@@ -2731,4 +2732,28 @@ async def test_injection_cycle_cap_on_error_path():
     assert result.had_injections is True
     # Should cap: _MAX_INJECTION_CYCLES drained rounds + 1 final round that breaks
     assert call_count["n"] == _MAX_INJECTION_CYCLES + 1
-    assert drain_count["n"] == _MAX_INJECTION_CYCLES
+
+
+def test_snip_history_returns_did_remove_flag():
+    from nanobot.agent.runner import AgentRunner, AgentRunSpec
+
+    provider = MagicMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    runner = AgentRunner(provider)
+
+    spec = AgentRunSpec(
+        initial_messages=[],
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=100,
+        max_tokens=50,
+    )
+
+    # Short messages — nothing to snip (estimate will be <= budget)
+    short = [{"role": "user", "content": "hi"}]
+    result, did_remove = runner._snip_history(spec, short)
+    assert did_remove is False
+    assert len(result) == 1

--- a/tests/agent/test_tool_context_safety.py
+++ b/tests/agent/test_tool_context_safety.py
@@ -1,0 +1,193 @@
+"""Tests for tool routing context safety (no shared mutable state)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nanobot.agent.tools.base import Tool, tool_parameters
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
+
+
+# ---------------------------------------------------------------------------
+# Fake tool that captures _routing_context for assertions
+# ---------------------------------------------------------------------------
+
+@tool_parameters(
+    tool_parameters_schema(
+        value=StringSchema("A dummy value"),
+        required=["value"],
+    )
+)
+class _CaptureTool(Tool):
+    """Captures the _routing_context it receives during execute()."""
+
+    def __init__(self, tool_name: str = "capture"):
+        self._tool_name = tool_name
+        self.last_routing_context: dict | None = None
+
+    @property
+    def name(self) -> str:
+        return self._tool_name
+
+    @property
+    def description(self) -> str:
+        return "Captures routing context for testing"
+
+    async def execute(
+        self,
+        value: str = "",
+        *,
+        _routing_context: dict | None = None,
+        **kwargs: Any,
+    ) -> str:
+        self.last_routing_context = _routing_context
+        return f"ok:{value}"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registry_execute_passes_routing_context() -> None:
+    """ToolRegistry.execute() forwards routing_context to the tool."""
+    registry = ToolRegistry()
+    tool = _CaptureTool("capture")
+    registry.register(tool)
+
+    ctx = {"channel": "telegram", "chat_id": "12345", "session_key": "telegram:12345"}
+    result = await registry.execute("capture", {"value": "hello"}, routing_context=ctx)
+
+    assert result == "ok:hello"
+    assert tool.last_routing_context == ctx
+
+
+@pytest.mark.asyncio
+async def test_registry_execute_without_routing_context() -> None:
+    """When no routing_context is passed, tool receives None (backward compat)."""
+    registry = ToolRegistry()
+    tool = _CaptureTool("capture")
+    registry.register(tool)
+
+    result = await registry.execute("capture", {"value": "test"})
+
+    assert result == "ok:test"
+    assert tool.last_routing_context is None
+
+
+@pytest.mark.asyncio
+async def test_two_routing_contexts_do_not_interfere() -> None:
+    """Two calls with different routing contexts don't overwrite each other."""
+    registry = ToolRegistry()
+    tool = _CaptureTool("capture")
+    registry.register(tool)
+
+    ctx_a = {"channel": "telegram", "chat_id": "aaa"}
+    ctx_b = {"channel": "discord", "chat_id": "bbb"}
+
+    # Simulate interleaved execution
+    result_a = await registry.execute("capture", {"value": "a"}, routing_context=ctx_a)
+    captured_a = dict(tool.last_routing_context)  # snapshot
+
+    result_b = await registry.execute("capture", {"value": "b"}, routing_context=ctx_b)
+    captured_b = dict(tool.last_routing_context)
+
+    assert result_a == "ok:a"
+    assert result_b == "ok:b"
+    assert captured_a == ctx_a
+    assert captured_b == ctx_b
+    # The key point: captured_a is NOT overwritten by ctx_b
+    assert captured_a != captured_b
+
+
+@pytest.mark.asyncio
+async def test_message_tool_uses_routing_context() -> None:
+    """MessageTool.execute() uses _routing_context over self._default_*."""
+    from nanobot.agent.tools.message import MessageTool
+
+    sent: list = []
+
+    async def fake_send(msg):
+        sent.append(msg)
+
+    tool = MessageTool(
+        send_callback=fake_send,
+        default_channel="old_channel",
+        default_chat_id="old_chat",
+    )
+
+    ctx = {"channel": "new_channel", "chat_id": "new_chat"}
+    result = await tool.execute(content="hello", _routing_context=ctx)
+
+    assert "Message sent to new_channel:new_chat" in result
+    assert sent[0].channel == "new_channel"
+    assert sent[0].chat_id == "new_chat"
+
+
+@pytest.mark.asyncio
+async def test_message_tool_fallback_to_defaults() -> None:
+    """MessageTool falls back to self._default_* when no routing context."""
+    from nanobot.agent.tools.message import MessageTool
+
+    sent: list = []
+
+    async def fake_send(msg):
+        sent.append(msg)
+
+    tool = MessageTool(
+        send_callback=fake_send,
+        default_channel="fallback_ch",
+        default_chat_id="fallback_id",
+    )
+
+    result = await tool.execute(content="hello")
+
+    assert "Message sent to fallback_ch:fallback_id" in result
+
+
+@pytest.mark.asyncio
+async def test_spawn_tool_uses_routing_context() -> None:
+    """SpawnTool.execute() uses _routing_context for origin info."""
+    from unittest.mock import AsyncMock, MagicMock
+    from nanobot.agent.tools.spawn import SpawnTool
+
+    manager = MagicMock()
+    manager.spawn = AsyncMock(return_value="spawned")
+
+    tool = SpawnTool(manager=manager)
+    ctx = {"channel": "telegram", "chat_id": "42", "session_key": "telegram:42"}
+    await tool.execute(task="do something", _routing_context=ctx)
+
+    manager.spawn.assert_called_once_with(
+        task="do something",
+        label=None,
+        origin_channel="telegram",
+        origin_chat_id="42",
+        session_key="telegram:42",
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_tool_fallback_to_instance_defaults() -> None:
+    """SpawnTool falls back to instance defaults when no routing context."""
+    from unittest.mock import AsyncMock, MagicMock
+    from nanobot.agent.tools.spawn import SpawnTool
+
+    manager = MagicMock()
+    manager.spawn = AsyncMock(return_value="spawned")
+
+    tool = SpawnTool(manager=manager)
+    # Default instance values: cli, direct, cli:direct
+    await tool.execute(task="do something")
+
+    manager.spawn.assert_called_once_with(
+        task="do something",
+        label=None,
+        origin_channel="cli",
+        origin_chat_id="direct",
+        session_key="cli:direct",
+    )

--- a/tests/bus/test_queue.py
+++ b/tests/bus/test_queue.py
@@ -1,0 +1,91 @@
+"""Tests for MessageBus bounded queues with backpressure."""
+
+import asyncio
+
+import pytest
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
+
+
+def _make_inbound(content: str = "hello") -> InboundMessage:
+    return InboundMessage(
+        channel="test",
+        sender_id="u1",
+        chat_id="c1",
+        content=content,
+    )
+
+
+def _make_outbound(content: str = "reply") -> OutboundMessage:
+    return OutboundMessage(
+        channel="test",
+        chat_id="c1",
+        content=content,
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_maxsize_is_bounded():
+    bus = MessageBus()
+    assert bus.inbound.maxsize == 100
+    assert bus.outbound.maxsize == 100
+
+
+@pytest.mark.asyncio
+async def test_custom_maxsize():
+    bus = MessageBus(maxsize=10)
+    assert bus.inbound.maxsize == 10
+    assert bus.outbound.maxsize == 10
+
+
+@pytest.mark.asyncio
+async def test_publish_inbound_returns_true_on_success():
+    bus = MessageBus(maxsize=5, timeout=0.01)
+    result = await bus.publish_inbound(_make_inbound())
+    assert result is True
+    assert bus.inbound_size == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_inbound_returns_false_on_full_queue():
+    bus = MessageBus(maxsize=2, timeout=0.01)
+    assert await bus.publish_inbound(_make_inbound("m1")) is True
+    assert await bus.publish_inbound(_make_inbound("m2")) is True
+    # Queue is now full — third publish should return False
+    assert await bus.publish_inbound(_make_inbound("m3")) is False
+    assert bus.inbound_size == 2
+
+
+@pytest.mark.asyncio
+async def test_publish_outbound_returns_true_on_success():
+    bus = MessageBus(maxsize=5, timeout=0.01)
+    result = await bus.publish_outbound(_make_outbound())
+    assert result is True
+    assert bus.outbound_size == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_outbound_returns_false_on_full_queue():
+    bus = MessageBus(maxsize=2, timeout=0.01)
+    assert await bus.publish_outbound(_make_outbound("r1")) is True
+    assert await bus.publish_outbound(_make_outbound("r2")) is True
+    # Queue is now full — third publish should return False
+    assert await bus.publish_outbound(_make_outbound("r3")) is False
+    assert bus.outbound_size == 2
+
+
+@pytest.mark.asyncio
+async def test_consume_inbound_drains_queue():
+    bus = MessageBus(maxsize=5, timeout=0.01)
+    await bus.publish_inbound(_make_inbound("a"))
+    await bus.publish_inbound(_make_inbound("b"))
+    assert bus.inbound_size == 2
+
+    msg1 = await bus.consume_inbound()
+    assert msg1.content == "a"
+    assert bus.inbound_size == 1
+
+    msg2 = await bus.consume_inbound()
+    assert msg2.content == "b"
+    assert bus.inbound_size == 0

--- a/tests/bus/test_queue.py
+++ b/tests/bus/test_queue.py
@@ -66,13 +66,24 @@ async def test_publish_outbound_returns_true_on_success():
 
 
 @pytest.mark.asyncio
-async def test_publish_outbound_returns_false_on_full_queue():
-    bus = MessageBus(maxsize=2, timeout=0.01)
+async def test_publish_outbound_blocks_on_full_queue():
+    """Outbound publish blocks until space is available (never drops replies)."""
+    bus = MessageBus(maxsize=2)
     assert await bus.publish_outbound(_make_outbound("r1")) is True
     assert await bus.publish_outbound(_make_outbound("r2")) is True
-    # Queue is now full — third publish should return False
-    assert await bus.publish_outbound(_make_outbound("r3")) is False
     assert bus.outbound_size == 2
+
+    # Third publish will block — consume one to unblock it
+    async def _drain_after_delay():
+        await asyncio.sleep(0.05)
+        return await bus.consume_outbound()
+
+    drain_task = asyncio.create_task(_drain_after_delay())
+    result = await bus.publish_outbound(_make_outbound("r3"))
+    assert result is True
+    assert bus.outbound_size == 2  # r2 + r3 (r1 was consumed)
+    drained = await drain_task
+    assert drained.content == "r1"
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_feishu_streaming.py
+++ b/tests/channels/test_feishu_streaming.py
@@ -205,53 +205,22 @@ class TestSendDelta:
         ch._client.im.v1.message.create.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_stream_end_resuming_keeps_buffer(self):
-        """_resuming=True flushes text to card but keeps the buffer for the next segment."""
+    async def test_stream_end_fallback_when_final_update_fails(self):
+        """If streaming mode was closed (e.g. Feishu timeout), fall back to a regular card."""
         ch = _make_channel()
         ch._stream_bufs["oc_chat1"] = _FeishuStreamBuf(
-            text="Partial answer", card_id="card_1", sequence=2, last_edit=0.0,
+            text="Lost content", card_id="card_1", sequence=3, last_edit=0.0,
         )
-        ch._client.cardkit.v1.card_element.content.return_value = _mock_content_response()
+        ch._client.cardkit.v1.card_element.content.return_value = _mock_content_response(success=False)
+        ch._client.im.v1.message.create.return_value = _mock_send_response("om_fb")
 
-        await ch.send_delta("oc_chat1", "", metadata={"_stream_end": True, "_resuming": True})
-
-        assert "oc_chat1" in ch._stream_bufs
-        buf = ch._stream_bufs["oc_chat1"]
-        assert buf.card_id == "card_1"
-        assert buf.sequence == 3
-        ch._client.cardkit.v1.card_element.content.assert_called_once()
-        ch._client.cardkit.v1.card.settings.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_stream_end_resuming_then_final_end(self):
-        """Full multi-segment flow: resuming mid-turn, then final end closes the card."""
-        ch = _make_channel()
-        ch._stream_bufs["oc_chat1"] = _FeishuStreamBuf(
-            text="Seg1", card_id="card_1", sequence=1, last_edit=0.0,
-        )
-        ch._client.cardkit.v1.card_element.content.return_value = _mock_content_response()
-        ch._client.cardkit.v1.card.settings.return_value = _mock_content_response()
-
-        await ch.send_delta("oc_chat1", "", metadata={"_stream_end": True, "_resuming": True})
-        assert "oc_chat1" in ch._stream_bufs
-
-        ch._stream_bufs["oc_chat1"].text += " Seg2"
         await ch.send_delta("oc_chat1", "", metadata={"_stream_end": True})
 
         assert "oc_chat1" not in ch._stream_bufs
-        ch._client.cardkit.v1.card.settings.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_stream_end_resuming_no_card_is_noop(self):
-        """_resuming with no card_id (card creation failed) is a safe no-op."""
-        ch = _make_channel()
-        ch._stream_bufs["oc_chat1"] = _FeishuStreamBuf(
-            text="text", card_id=None, sequence=0, last_edit=0.0,
-        )
-        await ch.send_delta("oc_chat1", "", metadata={"_stream_end": True, "_resuming": True})
-
-        assert "oc_chat1" in ch._stream_bufs
-        ch._client.cardkit.v1.card_element.content.assert_not_called()
+        # Should NOT attempt to close streaming mode since update failed
+        ch._client.cardkit.v1.card.settings.assert_not_called()
+        # Should fall back to sending a regular interactive card
+        ch._client.im.v1.message.create.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_stream_end_without_buf_is_noop(self):
@@ -374,22 +343,6 @@ class TestToolHintInlineStreaming:
         assert buf.text.startswith("Partial answer")
         assert "🔧 $ cd /project" in buf.text
         assert "🔧 $ git status" in buf.text
-
-    @pytest.mark.asyncio
-    async def test_tool_hint_preserved_on_resuming_flush(self):
-        """When _resuming flushes the buffer, tool hint is kept as permanent content."""
-        ch = _make_channel()
-        ch._stream_bufs["oc_chat1"] = _FeishuStreamBuf(
-            text="Partial answer\n\n🔧 $ cd /project\n\n",
-            card_id="card_1", sequence=2, last_edit=0.0,
-        )
-        ch._client.cardkit.v1.card_element.content.return_value = _mock_content_response()
-
-        await ch.send_delta("oc_chat1", "", metadata={"_stream_end": True, "_resuming": True})
-
-        buf = ch._stream_bufs["oc_chat1"]
-        assert "Partial answer" in buf.text
-        assert "🔧 $ cd /project" in buf.text
 
     @pytest.mark.asyncio
     async def test_tool_hint_preserved_on_final_stream_end(self):

--- a/tests/channels/test_feishu_tool_hint_code_block.py
+++ b/tests/channels/test_feishu_tool_hint_code_block.py
@@ -1,6 +1,7 @@
-"""Tests for FeishuChannel tool hint code block formatting."""
+"""Tests for FeishuChannel tool hint formatting."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,15 +29,24 @@ def mock_feishu_channel():
     config.app_secret = "test_app_secret"
     config.encrypt_key = None
     config.verification_token = None
+    config.tool_hint_prefix = "\U0001f527"  # 🔧
     bus = MagicMock()
     channel = FeishuChannel(config, bus)
-    channel._client = MagicMock()  # Simulate initialized client
+    channel._client = MagicMock()
     return channel
 
 
+def _get_tool_hint_card(mock_send):
+    """Extract the interactive card from _send_message_sync calls."""
+    call_args = mock_send.call_args[0]
+    _, _, msg_type, content = call_args
+    assert msg_type == "interactive"
+    return json.loads(content)
+
+
 @mark.asyncio
-async def test_tool_hint_sends_code_message(mock_feishu_channel):
-    """Tool hint messages should be sent as interactive cards with code blocks."""
+async def test_tool_hint_sends_interactive_card(mock_feishu_channel):
+    """Tool hint without active buffer sends an interactive card with 🔧 style."""
     msg = OutboundMessage(
         channel="feishu",
         chat_id="oc_123456",
@@ -47,23 +57,12 @@ async def test_tool_hint_sends_code_message(mock_feishu_channel):
     with patch.object(mock_feishu_channel, '_send_message_sync') as mock_send:
         await mock_feishu_channel.send(msg)
 
-        # Verify interactive message with card was sent
         assert mock_send.call_count == 1
-        call_args = mock_send.call_args[0]
-        receive_id_type, receive_id, msg_type, content = call_args
-
-        assert receive_id_type == "chat_id"
-        assert receive_id == "oc_123456"
-        assert msg_type == "interactive"
-
-        # Parse content to verify card structure
-        card = json.loads(content)
+        card = _get_tool_hint_card(mock_send)
         assert card["config"]["wide_screen_mode"] is True
-        assert len(card["elements"]) == 1
-        assert card["elements"][0]["tag"] == "markdown"
-        # Check that code block is properly formatted with language hint
-        expected_md = "**Tool Calls**\n\n```text\nweb_search(\"test query\")\n```"
-        assert card["elements"][0]["content"] == expected_md
+        md = card["elements"][0]["content"]
+        assert "\U0001f527" in md
+        assert "web_search" in md
 
 
 @mark.asyncio
@@ -78,8 +77,6 @@ async def test_tool_hint_empty_content_does_not_send(mock_feishu_channel):
 
     with patch.object(mock_feishu_channel, '_send_message_sync') as mock_send:
         await mock_feishu_channel.send(msg)
-
-        # Should not send any message
         mock_send.assert_not_called()
 
 
@@ -96,7 +93,6 @@ async def test_tool_hint_without_metadata_sends_as_normal(mock_feishu_channel):
     with patch.object(mock_feishu_channel, '_send_message_sync') as mock_send:
         await mock_feishu_channel.send(msg)
 
-        # Should send as text message (detected format)
         assert mock_send.call_count == 1
         call_args = mock_send.call_args[0]
         _, _, msg_type, content = call_args
@@ -106,7 +102,7 @@ async def test_tool_hint_without_metadata_sends_as_normal(mock_feishu_channel):
 
 @mark.asyncio
 async def test_tool_hint_multiple_tools_in_one_message(mock_feishu_channel):
-    """Multiple tool calls should be displayed each on its own line in a code block."""
+    """Multiple tool calls should each get the 🔧 prefix."""
     msg = OutboundMessage(
         channel="feishu",
         chat_id="oc_123456",
@@ -117,13 +113,11 @@ async def test_tool_hint_multiple_tools_in_one_message(mock_feishu_channel):
     with patch.object(mock_feishu_channel, '_send_message_sync') as mock_send:
         await mock_feishu_channel.send(msg)
 
-        call_args = mock_send.call_args[0]
-        msg_type = call_args[2]
-        content = json.loads(call_args[3])
-        assert msg_type == "interactive"
-        # Each tool call should be on its own line
-        expected_md = "**Tool Calls**\n\n```text\nweb_search(\"query\"),\nread_file(\"/path/to/file\")\n```"
-        assert content["elements"][0]["content"] == expected_md
+        card = _get_tool_hint_card(mock_send)
+        md = card["elements"][0]["content"]
+        assert "web_search" in md
+        assert "read_file" in md
+        assert "\U0001f527" in md
 
 
 @mark.asyncio
@@ -139,8 +133,8 @@ async def test_tool_hint_new_format_basic(mock_feishu_channel):
     with patch.object(mock_feishu_channel, '_send_message_sync') as mock_send:
         await mock_feishu_channel.send(msg)
 
-        content = json.loads(mock_send.call_args[0][3])
-        md = content["elements"][0]["content"]
+        card = _get_tool_hint_card(mock_send)
+        md = card["elements"][0]["content"]
         assert "read src/main.py" in md
         assert 'grep "TODO"' in md
 
@@ -158,16 +152,15 @@ async def test_tool_hint_new_format_with_comma_in_quotes(mock_feishu_channel):
     with patch.object(mock_feishu_channel, '_send_message_sync') as mock_send:
         await mock_feishu_channel.send(msg)
 
-        content = json.loads(mock_send.call_args[0][3])
-        md = content["elements"][0]["content"]
-        # The comma inside quotes should NOT cause a line break
+        card = _get_tool_hint_card(mock_send)
+        md = card["elements"][0]["content"]
         assert 'grep "hello, world"' in md
         assert "$ echo test" in md
 
 
 @mark.asyncio
 async def test_tool_hint_new_format_with_folding(mock_feishu_channel):
-    """Folded calls (× N) should display on separate lines."""
+    """Folded calls (× N) should display correctly."""
     msg = OutboundMessage(
         channel="feishu",
         chat_id="oc_123456",
@@ -178,8 +171,8 @@ async def test_tool_hint_new_format_with_folding(mock_feishu_channel):
     with patch.object(mock_feishu_channel, '_send_message_sync') as mock_send:
         await mock_feishu_channel.send(msg)
 
-        content = json.loads(mock_send.call_args[0][3])
-        md = content["elements"][0]["content"]
+        card = _get_tool_hint_card(mock_send)
+        md = card["elements"][0]["content"]
         assert "\u00d7 3" in md
         assert 'grep "pattern"' in md
 
@@ -197,9 +190,12 @@ async def test_tool_hint_new_format_mcp(mock_feishu_channel):
     with patch.object(mock_feishu_channel, '_send_message_sync') as mock_send:
         await mock_feishu_channel.send(msg)
 
-        content = json.loads(mock_send.call_args[0][3])
-        md = content["elements"][0]["content"]
+        card = _get_tool_hint_card(mock_send)
+        md = card["elements"][0]["content"]
         assert "4_5v::analyze_image" in md
+
+
+@mark.asyncio
 async def test_tool_hint_keeps_commas_inside_arguments(mock_feishu_channel):
     """Commas inside a single tool argument must not be split onto a new line."""
     msg = OutboundMessage(
@@ -212,10 +208,7 @@ async def test_tool_hint_keeps_commas_inside_arguments(mock_feishu_channel):
     with patch.object(mock_feishu_channel, '_send_message_sync') as mock_send:
         await mock_feishu_channel.send(msg)
 
-        content = json.loads(mock_send.call_args[0][3])
-        expected_md = (
-            "**Tool Calls**\n\n```text\n"
-            "web_search(\"foo, bar\"),\n"
-            "read_file(\"/path/to/file\")\n```"
-        )
-        assert content["elements"][0]["content"] == expected_md
+        card = _get_tool_hint_card(mock_send)
+        md = card["elements"][0]["content"]
+        assert 'web_search("foo, bar")' in md
+        assert 'read_file("/path/to/file")' in md

--- a/tests/channels/test_first_token_priority.py
+++ b/tests/channels/test_first_token_priority.py
@@ -1,0 +1,47 @@
+"""Tests for first-token priority in ChannelManager stream delta dispatching."""
+import pytest
+from unittest.mock import patch
+
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.manager import ChannelManager
+from nanobot.config.schema import Config
+
+
+def _make_manager():
+    bus = MessageBus(maxsize=50)
+    config = Config()
+    mgr = ChannelManager(bus=bus, config=config)
+    return mgr
+
+
+def test_active_streams_starts_empty():
+    mgr = _make_manager()
+    assert mgr._active_streams == set()
+
+
+def test_first_delta_adds_to_active_streams():
+    mgr = _make_manager()
+    assert "s1" not in mgr._active_streams
+    mgr._active_streams.add("s1")
+    assert "s1" in mgr._active_streams
+
+
+def test_stream_end_removes_from_active():
+    mgr = _make_manager()
+    mgr._active_streams.add("s1")
+    mgr._active_streams.discard("s1")
+    assert "s1" not in mgr._active_streams
+
+
+def test_fallback_key_without_stream_id():
+    # Without stream_id, key should be channel:chat_id
+    msg = OutboundMessage(channel="tg", chat_id="c1", content="hi", metadata={"_stream_delta": True})
+    key = msg.metadata.get("stream_id") or f"{msg.channel}:{msg.chat_id}"
+    assert key == "tg:c1"
+
+
+def test_stream_id_preferred_over_fallback():
+    msg = OutboundMessage(channel="tg", chat_id="c1", content="hi", metadata={"_stream_delta": True, "stream_id": "s42"})
+    key = msg.metadata.get("stream_id") or f"{msg.channel}:{msg.chat_id}"
+    assert key == "s42"

--- a/tests/channels/test_first_token_priority.py
+++ b/tests/channels/test_first_token_priority.py
@@ -35,13 +35,13 @@ def test_stream_end_removes_from_active():
 
 
 def test_fallback_key_without_stream_id():
-    # Without stream_id, key should be channel:chat_id
+    # Without _stream_id, key should be channel:chat_id
     msg = OutboundMessage(channel="tg", chat_id="c1", content="hi", metadata={"_stream_delta": True})
-    key = msg.metadata.get("stream_id") or f"{msg.channel}:{msg.chat_id}"
+    key = msg.metadata.get("_stream_id") or f"{msg.channel}:{msg.chat_id}"
     assert key == "tg:c1"
 
 
 def test_stream_id_preferred_over_fallback():
-    msg = OutboundMessage(channel="tg", chat_id="c1", content="hi", metadata={"_stream_delta": True, "stream_id": "s42"})
-    key = msg.metadata.get("stream_id") or f"{msg.channel}:{msg.chat_id}"
+    msg = OutboundMessage(channel="tg", chat_id="c1", content="hi", metadata={"_stream_delta": True, "_stream_id": "s42"})
+    key = msg.metadata.get("_stream_id") or f"{msg.channel}:{msg.chat_id}"
     assert key == "s42"

--- a/tests/providers/test_anthropic_token_counting.py
+++ b/tests/providers/test_anthropic_token_counting.py
@@ -1,0 +1,130 @@
+"""Tests for Anthropic native token counting via estimate_prompt_tokens."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def _patch_anthropic():
+    """Patch both Anthropic clients so no real SDK import is needed."""
+    with (
+        patch("anthropic.AsyncAnthropic") as mock_async,
+        patch("anthropic.Anthropic") as mock_sync,
+    ):
+        yield mock_async, mock_sync
+
+
+class TestEstimatePromptTokens:
+    """AnthropicProvider.estimate_prompt_tokens() behaviour."""
+
+    @staticmethod
+    def _make_provider(**kwargs):
+        from nanobot.providers.anthropic_provider import AnthropicProvider
+
+        return AnthropicProvider(api_key="test-key", **kwargs)
+
+    def test_returns_count(self, _patch_anthropic):
+        provider = self._make_provider()
+        mock_result = MagicMock()
+        mock_result.input_tokens = 150
+        provider._sync_client.messages.count_tokens.return_value = mock_result
+
+        result = provider.estimate_prompt_tokens(
+            [{"role": "user", "content": "hello"}],
+            None,
+            "claude-sonnet-4-20250514",
+        )
+
+        assert result == (150, "anthropic_count_tokens")
+        provider._sync_client.messages.count_tokens.assert_called_once()
+
+    def test_returns_none_on_error(self, _patch_anthropic):
+        provider = self._make_provider()
+        provider._sync_client.messages.count_tokens.side_effect = Exception("fail")
+
+        result = provider.estimate_prompt_tokens(
+            [{"role": "user", "content": "hello"}],
+            None,
+        )
+
+        assert result is None
+
+    def test_sync_client_created(self, _patch_anthropic):
+        _, mock_sync = _patch_anthropic
+        provider = self._make_provider()
+
+        assert provider._sync_client is not None
+        mock_sync.assert_called_once()
+
+    def test_passes_tools_when_provided(self, _patch_anthropic):
+        provider = self._make_provider()
+        mock_result = MagicMock()
+        mock_result.input_tokens = 200
+        provider._sync_client.messages.count_tokens.return_value = mock_result
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        result = provider.estimate_prompt_tokens(
+            [{"role": "user", "content": "weather?"}],
+            tools,
+            "claude-sonnet-4-20250514",
+        )
+
+        assert result == (200, "anthropic_count_tokens")
+        call_kwargs = provider._sync_client.messages.count_tokens.call_args
+        assert "tools" in call_kwargs.kwargs or (
+            len(call_kwargs.args) > 0 and "tools" in call_kwargs[1]
+        )
+
+    def test_passes_system_when_present(self, _patch_anthropic):
+        provider = self._make_provider()
+        mock_result = MagicMock()
+        mock_result.input_tokens = 100
+        provider._sync_client.messages.count_tokens.return_value = mock_result
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+        ]
+        provider.estimate_prompt_tokens(messages, None)
+
+        call_kwargs = provider._sync_client.messages.count_tokens.call_args.kwargs
+        assert "system" in call_kwargs
+
+    def test_strips_anthropic_prefix_from_model(self, _patch_anthropic):
+        provider = self._make_provider()
+        mock_result = MagicMock()
+        mock_result.input_tokens = 50
+        provider._sync_client.messages.count_tokens.return_value = mock_result
+
+        provider.estimate_prompt_tokens(
+            [{"role": "user", "content": "hi"}],
+            None,
+            "anthropic/claude-sonnet-4-20250514",
+        )
+
+        call_kwargs = provider._sync_client.messages.count_tokens.call_args.kwargs
+        assert call_kwargs["model"] == "claude-sonnet-4-20250514"
+
+    def test_uses_default_model_when_none(self, _patch_anthropic):
+        provider = self._make_provider(default_model="claude-haiku-4-20250514")
+        mock_result = MagicMock()
+        mock_result.input_tokens = 30
+        provider._sync_client.messages.count_tokens.return_value = mock_result
+
+        provider.estimate_prompt_tokens(
+            [{"role": "user", "content": "hi"}],
+            None,
+        )
+
+        call_kwargs = provider._sync_client.messages.count_tokens.call_args.kwargs
+        assert call_kwargs["model"] == "claude-haiku-4-20250514"

--- a/tests/providers/test_responses_api_failure_tracking.py
+++ b/tests/providers/test_responses_api_failure_tracking.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+
+def _make_provider():
+    p = OpenAICompatProvider.__new__(OpenAICompatProvider)
+    p._responses_api_failures = {}
+    p._spec = None
+    p._effective_base = None
+    p._client = MagicMock()
+    p.default_model = "gpt-4o"
+    p.api_base = None
+    return p
+
+
+def test_failure_counter_starts_empty():
+    p = _make_provider()
+    assert p._responses_api_failures == {}
+
+
+def test_failure_key_includes_reasoning_effort():
+    p = _make_provider()
+    assert p._responses_failure_key("gpt-5", None) == ("gpt-5", None)
+    assert p._responses_failure_key("gpt-5", "high") == ("gpt-5", "high")
+
+
+def test_skip_after_three_failures():
+    p = _make_provider()
+    key = ("gpt-5", None)
+    p._responses_api_failures[key] = 2
+    assert not p._should_skip_responses_api("gpt-5", None)
+    p._responses_api_failures[key] = 3
+    assert p._should_skip_responses_api("gpt-5", None)
+
+
+def test_success_resets_counter():
+    p = _make_provider()
+    p._responses_api_failures[("gpt-5", None)] = 5
+    p._record_responses_api_success("gpt-5", None)
+    assert p._responses_api_failures.get(("gpt-5", None), 0) == 0
+
+
+def test_failure_increments():
+    p = _make_provider()
+    p._record_responses_api_failure("gpt-5", "high")
+    p._record_responses_api_failure("gpt-5", "high")
+    assert p._responses_api_failures[("gpt-5", "high")] == 2

--- a/tests/tools/test_tool_registry.py
+++ b/tests/tools/test_tool_registry.py
@@ -62,6 +62,35 @@ def test_prepare_call_read_file_rejects_non_object_params_with_actionable_hint()
     assert "Use named parameters" in error
 
 
+def test_get_definitions_caches_result() -> None:
+    registry = ToolRegistry()
+    registry.register(_FakeTool("read_file"))
+    result1 = registry.get_definitions()
+    result2 = registry.get_definitions()
+    assert result1 is result2  # same object — cache hit
+
+
+def test_cache_invalidated_on_register() -> None:
+    registry = ToolRegistry()
+    registry.register(_FakeTool("read_file"))
+    result1 = registry.get_definitions()
+    registry.register(_FakeTool("write_file"))
+    result2 = registry.get_definitions()
+    assert result1 is not result2
+    assert len(result2) == 2
+
+
+def test_cache_invalidated_on_unregister() -> None:
+    registry = ToolRegistry()
+    registry.register(_FakeTool("read_file"))
+    registry.register(_FakeTool("write_file"))
+    result1 = registry.get_definitions()
+    registry.unregister("write_file")
+    result2 = registry.get_definitions()
+    assert result1 is not result2
+    assert len(result2) == 1
+
+
 def test_prepare_call_other_tools_keep_generic_object_validation() -> None:
     registry = ToolRegistry()
     registry.register(_FakeTool("grep"))


### PR DESCRIPTION
## Summary

A set of focused patches improving agent speed, responsiveness, and correctness based on a full source-level analysis of the codebase (~66,500 lines). Each change follows CONTRIBUTING.md guidelines: smallest change that solves the real problem, no unnecessary abstractions.

### Correctness Fixes
- **Bounded MessageBus queues** — Add `maxsize` to both asyncio queues (default 100, configurable via `NANOBOT_MAX_QUEUE_SIZE`). Inbound uses timeout+backpressure (`publish_inbound` returns `bool`), outbound blocks to never drop agent replies. All 4 callers updated to handle backpressure. Subagent announcements retry once on failure.
- **Tool routing context safety** — Pass routing context (channel, chat_id, session_key) as a parameter through `execute()` instead of mutating shared tool instances via `set_context()`. Fixes a race condition where concurrent sessions could overwrite each other's routing on the shared `ToolRegistry`.
- **Raw-archive durability** — Consolidation fallback now flushes buffered history to disk and returns non-None so `last_consolidated` advances (prevents duplicate `[RAW]` entries on retry).

### Performance Optimizations
- **Token estimation budget skip** — Skip expensive `estimate_session_prompt_tokens()` when session is clearly under 50% of budget. 5-condition check: message count, last_consolidated, history cursor, and workspace file mtimes must all be unchanged.
- **Anthropic native token counting** — Add sync `Anthropic` client alongside async, implement `estimate_prompt_tokens()` using `client.messages.count_tokens()` for higher-accuracy consolidation decisions. Wrapped with `asyncio.to_thread()` to avoid blocking the event loop.
- **Context governance single-pass** — `_snip_history()` returns whether it removed messages; second orphan/backfill cleanup only runs when snipping actually removed something.
- **Bootstrap file caching** — `_load_bootstrap_files()` caches contents with mtime-based invalidation. 4 file reads per prompt → 4 stat() calls on cache hit.
- **Cursor-based history reads** — `read_unprocessed_history()` caches byte offset for incremental reads when cursor advances past previously-seen entries. Falls back to full scan for arbitrary cursor queries.
- **History write batching** — `append_history()` buffers in memory; `flush_history()` writes all entries in one `writelines()` call. Flush at: `Consolidator.archive()`, `Dream.run()`, `_save_turn()`, and `compact_history()`.
- **Tool schema caching** — `get_definitions()` caches sorted schema list, invalidated on `register()`/`unregister()`. O(1) on cache hit instead of O(n log n).
- **Dream skill list caching** — `_list_existing_skills()` caches results with MD5 hash of all SKILL.md mtimes across workspace + builtin dirs.

### Streaming & Provider Improvements
- **First-token streaming priority** — First delta for each `_stream_id` bypasses coalescing and dispatches immediately. Coalescing also now respects `_stream_id` when merging (prevents cross-stream corruption).
- **Responses API failure tracking** — Track consecutive failures per `(model, reasoning_effort)` tuple in both `chat()` and `chat_stream()`. Skip Responses API after 3 consecutive failures for the same key. Success resets counter.

### Profiling Infrastructure
- **ProfilingHook** — Records iteration time and tool batch time via `AgentHook` lifecycle events. Lightweight `time.perf_counter()` guards in runner.py, memory.py, and loop.py measure governance pipeline, token estimation, and total turn time. Enabled via `NANOBOT_PROFILING=1` env var.

## Test Plan

- [ ] 11 new test files with comprehensive coverage for all changes
- [ ] All 1,667 existing tests pass (verified during development)
- [ ] Manual verification: bounded bus backpressure under load
- [ ] Manual verification: profiling output with `NANOBOT_PROFILING=1`
- [ ] Manual verification: streaming first-token latency improvement