### PR TITLE
fix(channel.wecom): inbound mixed msg parse

### DIFF
--- a/nanobot/channels/wecom.py
+++ b/nanobot/channels/wecom.py
@@ -302,13 +302,22 @@ class WecomChannel(BaseChannel):
 
             elif msg_type == "mixed":
                 # Mixed content contains multiple message items
-                msg_items = body.get("mixed", {}).get("item", [])
+                msg_items = body.get("mixed", {}).get("msg_item", [])
                 for item in msg_items:
-                    item_type = item.get("type", "")
+                    item_type = item.get("msgtype", "")
                     if item_type == "text":
                         text = item.get("text", {}).get("content", "")
                         if text:
                             content_parts.append(text)
+                    elif item_type == "image":
+                        file_url = item.get("image", {}).get("url", "")
+                        aes_key = item.get("image", {}).get("aeskey", "")
+                        if file_url and aes_key:
+                            file_path = await self._download_and_save_media(file_url, aes_key, "image")
+                            if file_path:
+                                filename = os.path.basename(file_path)
+                                content_parts.append(f"[image: {filename}]")
+                                media_paths.append(file_path)
                     else:
                         content_parts.append(MSG_TYPE_MAP.get(item_type, f"[{item_type}]"))
 

--- a/tests/channels/test_wecom_channel.py
+++ b/tests/channels/test_wecom_channel.py
@@ -573,7 +573,7 @@ async def test_process_mixed_message() -> None:
         msg = await channel.bus.consume_inbound()
         assert msg.sender_id == "user1"
         assert msg.chat_id == "chat1"
-        assert msg.content == "hello wecom"
+        assert msg.content.startswith("hello wecom")
         assert msg.metadata["msg_type"] == "text"
         assert len(msg.media) == 1
         assert msg.media[0].endswith("photo.png")

--- a/tests/channels/test_wecom_channel.py
+++ b/tests/channels/test_wecom_channel.py
@@ -542,6 +542,50 @@ async def test_process_voice_message() -> None:
 
 
 @pytest.mark.asyncio
+async def test_process_mixed_message() -> None:
+    """Mixed message: contains picture and text message types."""
+    channel = WecomChannel(WecomConfig(bot_id="b", secret="s", allow_from=["user1"]), MessageBus())
+    client = _FakeWeComClient()
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        f.write(b"\x89PNG\r\n")
+        saved = f.name
+
+    client.download_file.return_value = (b"\x89PNG\r\n", "photo.png")
+    channel._client = client
+
+    try:
+        with patch("nanobot.channels.wecom.get_media_dir", return_value=Path(os.path.dirname(saved))):
+            frame = _FakeFrame(body={
+                "msgid": "msg_mixed_1",
+                "chatid": "chat1",
+                "msgtype": "mixed",
+                "from": {"userid": "user1"},
+                "mixed": {
+                    "msg_item": [
+                        {"msgtype": "text", "text": {"content": "hello wecom"}},
+                        {"msgtype": "image", "image": {"url": "https://example.com/img.png", "aeskey": "key123"}}
+                    ]
+                }
+            })
+            await channel._process_message(frame, "mixed")
+
+        msg = await channel.bus.consume_inbound()
+        assert msg.sender_id == "user1"
+        assert msg.chat_id == "chat1"
+        assert msg.content == "hello wecom"
+        assert msg.metadata["msg_type"] == "text"
+        assert len(msg.media) == 1
+        assert msg.media[0].endswith("photo.png")
+        assert "[image:" in msg.content
+    finally:
+        # Clean up any photo.png in tempdir
+        p = os.path.join(os.path.dirname(saved), "photo.png")
+        if os.path.exists(p):
+            os.unlink(p)
+
+
+@pytest.mark.asyncio
 async def test_process_message_deduplication() -> None:
     """Same msg_id is not processed twice."""
     channel = WecomChannel(WecomConfig(bot_id="b", secret="s", allow_from=["user1"]), MessageBus())

--- a/tests/channels/test_wecom_channel.py
+++ b/tests/channels/test_wecom_channel.py
@@ -574,7 +574,7 @@ async def test_process_mixed_message() -> None:
         assert msg.sender_id == "user1"
         assert msg.chat_id == "chat1"
         assert msg.content.startswith("hello wecom")
-        assert msg.metadata["msg_type"] == "text"
+        assert msg.metadata["msg_type"] == "mixed"
         assert len(msg.media) == 1
         assert msg.media[0].endswith("photo.png")
         assert "[image:" in msg.content


### PR DESCRIPTION
I found that wecom's mixed text and image messages are not being processed correctly by nanobot because the message structure is not parsed correctly. 

See the wecom documentation for reference： https://developer.work.weixin.qq.com/document/path/100719#%E5%9B%BE%E6%96%87%E6%B7%B7%E6%8E%92%E6%B6%88%E6%81%AF

So I fixed that. And It works well on my mac book