### PR TITLE
fix: respect deliver:false flag in cron job output

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -729,7 +729,7 @@ def gateway(
         response = resp.content if resp else ""
 
         message_tool = agent.tools.get("message")
-        if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
+        if job.payload.deliver and isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
             return response
 
         if job.payload.deliver and job.payload.to and response:


### PR DESCRIPTION
## Summary

Fix `deliver: false` cron jobs that still publish output to the user when the agent calls the message tool.

Fixes #3115

## Root Cause

In `nanobot/cli/commands.py`, the `_sent_in_turn` check caused an early return **before** evaluating the `deliver` flag:

```python
if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
    return response  # returned regardless of deliver flag
```

## Fix

Add the `deliver` gate to the early return:
```python
if job.payload.deliver and isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
    return response
```

Now when `deliver: false`, all output from the cron job turn is suppressed, regardless of what the agent produces.