### PR TITLE
fix: handle None max_tokens/temperature from provider generation settings

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -156,6 +156,8 @@ class AgentLoop:
         hooks: list[AgentHook] | None = None,
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebToolsConfig
 
@@ -179,6 +181,8 @@ class AgentLoop:
             if max_tool_result_chars is not None
             else defaults.max_tool_result_chars
         )
+        self.max_tokens = max_tokens
+        self.temperature = temperature
         self.provider_retry_mode = provider_retry_mode
         self.web_config = web_config or WebToolsConfig()
         self.exec_config = exec_config or ExecToolConfig()
@@ -403,12 +407,15 @@ class AgentLoop:
                 items.append({"role": "user", "content": merged})
             return items
 
+        provider_gen = getattr(self.provider, "generation", None)
         result = await self.runner.run(AgentRunSpec(
             initial_messages=initial_messages,
             tools=self.tools,
             model=self.model,
             max_iterations=self.max_iterations,
             max_tool_result_chars=self.max_tool_result_chars,
+            max_tokens=self.max_tokens if self.max_tokens is not None else getattr(provider_gen, "max_tokens", None),
+            temperature=self.temperature if self.temperature is not None else getattr(provider_gen, "temperature", None),
             hook=hook,
             error_message="Sorry, I encountered an error calling the AI model.",
             concurrent_tools=True,

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -368,7 +368,7 @@ class AnthropicProvider(LLMProvider):
                 system, anthropic_msgs, anthropic_tools,
             )
 
-        max_tokens = max(1, max_tokens)
+        max_tokens = max(1, max_tokens or 4096)
         thinking_enabled = bool(reasoning_effort)
 
         kwargs: dict[str, Any] = {

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -94,7 +94,7 @@ class AzureOpenAIProvider(LLMProvider):
             "model": deployment,
             "instructions": instructions or None,
             "input": input_items,
-            "max_output_tokens": max(1, max_tokens),
+            "max_output_tokens": max(1, max_tokens or 4096),
             "store": False,
             "stream": False,
         }

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -354,9 +354,9 @@ class OpenAICompatProvider(LLMProvider):
             kwargs["temperature"] = temperature
 
         if spec and getattr(spec, "supports_max_completion_tokens", False):
-            kwargs["max_completion_tokens"] = max(1, max_tokens)
+            kwargs["max_completion_tokens"] = max(1, max_tokens or 4096)
         else:
-            kwargs["max_tokens"] = max(1, max_tokens)
+            kwargs["max_tokens"] = max(1, max_tokens or 4096)
 
         if spec:
             model_lower = model_name.lower()
@@ -466,7 +466,7 @@ class OpenAICompatProvider(LLMProvider):
             "model": model_name,
             "instructions": instructions or None,
             "input": input_items,
-            "max_output_tokens": max(1, max_tokens),
+            "max_output_tokens": max(1, max_tokens or 4096),
             "store": False,
             "stream": False,
         }


### PR DESCRIPTION
## Summary

Fix crash when `max_tokens` is `None` in provider generation settings.

Fixes #3102

## Root Cause

`AgentRunSpec` was created with `max_tokens=None` (default), and providers called `max(1, max_tokens)` which fails with `TypeError: '>' not supported between instances of 'int' and 'NoneType'`.

## Changes

- **`nanobot/agent/loop.py`**: Add `max_tokens` and `temperature` parameters to `AgentLoop.__init__`, and pass them through to `AgentRunSpec` (with fallback to `provider.generation` values)
- **Providers** (`openai_compat_provider.py`, `azure_openai_provider.py`, `anthropic_provider.py`): Use `max_tokens or 4096` as fallback to prevent crash

## Impact

- No more crash when `max_tokens` is not explicitly configured
- Users can now override `max_tokens` and `temperature` per-agent via `AgentLoop` constructor