### PR TITLE
fix(cron): respect deliver flag when agent produces output

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -729,7 +729,7 @@ def gateway(
         response = resp.content if resp else ""
 
         message_tool = agent.tools.get("message")
-        if isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
+        if job.payload.deliver and isinstance(message_tool, MessageTool) and message_tool._sent_in_turn:
             return response
 
         if job.payload.deliver and job.payload.to and response:


### PR DESCRIPTION
## Summary

When `deliver: false` is set in cron job payload, suppress all output even when agent calls message tool during the turn.

### Cron

- **fix(cron): respect deliver flag before message tool check** — Move the `deliver` gate before the `_sent_in_turn` check so that `deliver: false` correctly suppresses all output from cron job turns. (#3120)

@JiajunBernoulli thanks for your contribution