### PR TITLE
feat: add channel-based filtering for Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ If you prefer to configure manually, add the following to `~/.nanobot/config.jso
       "enabled": true,
       "token": "YOUR_BOT_TOKEN",
       "allowFrom": ["YOUR_USER_ID"],
+      "allowChannels": [],
       "groupPolicy": "mention",
       "streaming": true
     }
@@ -414,6 +415,7 @@ If you prefer to configure manually, add the following to `~/.nanobot/config.jso
 > - `"open"` — Respond to all messages
 > DMs always respond when the sender is in `allowFrom`.
 > - If you set group policy to open create new threads as private threads and then @ the bot into it. Otherwise the thread itself and the channel in which you spawned it will spawn a bot session.
+> `allowChannels` restricts the bot to specific Discord channel IDs. Empty (default) means respond in every channel the bot can see. Example: `["1234567890", "0987654321"]`. The filter applies after `allowFrom`, so both must pass.
 > `streaming` defaults to `true`. Disable it only if you explicitly want non-streaming replies.
 
 **5. Invite the bot**

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -53,6 +53,7 @@ class DiscordConfig(Base):
     enabled: bool = False
     token: str = ""
     allow_from: list[str] = Field(default_factory=list)
+    allow_channels: list[str] = Field(default_factory=list)  # Allowed channel IDs (empty = all)
     intents: int = 37377
     group_policy: Literal["mention", "open"] = "mention"
     read_receipt_emoji: str = "👀"
@@ -534,6 +535,12 @@ class DiscordChannel(BaseChannel):
         """Check if inbound Discord message should be processed."""
         if not self.is_allowed(sender_id):
             return False
+        # Channel-based filtering: only respond in allowed channels
+        allow_channels = self.config.allow_channels
+        if allow_channels:
+            channel_id = self._channel_key(message.channel)
+            if channel_id not in allow_channels:
+                return False
         if message.guild is not None and not self._should_respond_in_group(message, content):
             return False
         return True

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -314,6 +314,45 @@ async def test_on_message_accepts_allowlisted_dm() -> None:
 
 
 @pytest.mark.asyncio
+async def test_on_message_accepts_when_channel_in_allow_channels() -> None:
+    # When allow_channels is set, messages from listed channels should be forwarded.
+    channel = DiscordChannel(
+        DiscordConfig(enabled=True, allow_from=["*"], allow_channels=["456"]),
+        MessageBus(),
+    )
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle  # type: ignore[method-assign]
+
+    await channel._on_message(_make_message(author_id=123, channel_id=456))
+
+    assert len(handled) == 1
+    assert handled[0]["chat_id"] == "456"
+
+
+@pytest.mark.asyncio
+async def test_on_message_drops_when_channel_not_in_allow_channels() -> None:
+    # When allow_channels is set and incoming channel is not listed, drop silently.
+    channel = DiscordChannel(
+        DiscordConfig(enabled=True, allow_from=["*"], allow_channels=["999"]),
+        MessageBus(),
+    )
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle  # type: ignore[method-assign]
+
+    await channel._on_message(_make_message(author_id=123, channel_id=456))
+
+    assert handled == []
+
+
+@pytest.mark.asyncio
 async def test_on_message_ignores_unmentioned_guild_message() -> None:
     # With mention-only group policy, guild messages without a bot mention are dropped.
     channel = DiscordChannel(


### PR DESCRIPTION
## Summary

Add `allowChannels` config option to `DiscordConfig` that restricts bot responses to specific Discord channels. When the list is empty (default), the bot responds in all channels (backward compatible).

Replaces #791 — addressed review feedback (dropped loader.py change, rebased onto current `main`).

## Changes

Only **1 file, 7 lines**:

- `nanobot/channels/discord.py`:
  - Add `allow_channels: list[str]` field to `DiscordConfig`
  - Add channel ID check in `_should_accept_inbound` after user filtering

## Config Example

```json
"discord": {
  "enabled": true,
  "token": "...",
  "allowFrom": ["user_id"],
  "allowChannels": ["channel_id_1", "channel_id_2"]
}
```

- `allowChannels: []` (default) → responds in all channels
- `allowChannels: ["123"]` → only responds in that specific channel

## Test Plan

- [x] Verified bot only responds in specified channels when allowChannels is set
- [x] Verified bot responds in all channels when allowChannels is empty (backward compatibility)