### PR TITLE
feat(providers): support dynamic LLM providers and fix cron test import

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -104,6 +104,12 @@ class ProviderConfig(Base):
 class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="allow",
+    )
+
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
     azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -223,6 +229,21 @@ class Config(BaseSettings):
         """Get expanded workspace path."""
         return Path(self.agents.defaults.workspace).expanduser()
 
+    def _get_provider_config(self, name: str) -> ProviderConfig | None:
+        """Helper to retrieve provider config from both fixed and dynamic fields."""
+        # 1. Check fixed fields
+        val = getattr(self.providers, name, None)
+        if isinstance(val, ProviderConfig):
+            return val
+        # 2. Check dynamic fields in model_extra
+        if self.providers.model_extra and name in self.providers.model_extra:
+            extra = self.providers.model_extra[name]
+            if isinstance(extra, ProviderConfig):
+                return extra
+            if isinstance(extra, dict):
+                return ProviderConfig(**extra)
+        return None
+
     def _match_provider(
         self, model: str | None = None
     ) -> tuple["ProviderConfig | None", str | None]:
@@ -233,7 +254,7 @@ class Config(BaseSettings):
         if forced != "auto":
             spec = find_by_name(forced)
             if spec:
-                p = getattr(self.providers, spec.name, None)
+                p = self._get_provider_config(spec.name)
                 return (p, spec.name) if p else (None, None)
             return None, None
 
@@ -248,14 +269,20 @@ class Config(BaseSettings):
 
         # Explicit provider prefix wins — prevents `github-copilot/...codex` matching openai_codex.
         for spec in PROVIDERS:
-            p = getattr(self.providers, spec.name, None)
+            p = self._get_provider_config(spec.name)
             if p and model_prefix and normalized_prefix == spec.name:
                 if spec.is_oauth or spec.is_local or p.api_key:
                     return p, spec.name
 
+        # Also check dynamic providers by prefix if not in static registry
+        if model_prefix:
+            p = self._get_provider_config(normalized_prefix)
+            if p and p.api_key:
+                return p, normalized_prefix
+
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
-            p = getattr(self.providers, spec.name, None)
+            p = self._get_provider_config(spec.name)
             if p and any(_kw_matches(kw) for kw in spec.keywords):
                 if spec.is_oauth or spec.is_local or p.api_key:
                     return p, spec.name
@@ -268,7 +295,7 @@ class Config(BaseSettings):
         for spec in PROVIDERS:
             if not spec.is_local:
                 continue
-            p = getattr(self.providers, spec.name, None)
+            p = self._get_provider_config(spec.name)
             if not (p and p.api_base):
                 continue
             if spec.detect_by_base_keyword and spec.detect_by_base_keyword in p.api_base:
@@ -283,7 +310,7 @@ class Config(BaseSettings):
         for spec in PROVIDERS:
             if spec.is_oauth:
                 continue
-            p = getattr(self.providers, spec.name, None)
+            p = self._get_provider_config(spec.name)
             if p and p.api_key:
                 return p, spec.name
         return None, None

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -372,4 +372,14 @@ def find_by_name(name: str) -> ProviderSpec | None:
     for spec in PROVIDERS:
         if spec.name == normalized:
             return spec
-    return None
+
+    # Fallback for dynamic/custom providers not in the static registry.
+    # Defaults to openai_compat backend.
+    return ProviderSpec(
+        name=normalized,
+        keywords=(),
+        env_key="",
+        display_name=name.replace("_", " ").title(),
+        backend="openai_compat",
+        is_direct=True,
+    )

--- a/tests/config/test_dynamic_providers.py
+++ b/tests/config/test_dynamic_providers.py
@@ -1,0 +1,98 @@
+import json
+from nanobot.config.loader import load_config
+from nanobot.providers.registry import find_by_name
+
+def test_dynamic_provider_loading(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "defaults": {
+                        "provider": "my_new_ai",
+                        "model": "gpt-4o"
+                    }
+                },
+                "providers": {
+                    "my_new_ai": {
+                        "apiKey": "sk-dynamic-key",
+                        "apiBase": "https://api.dynamic.ai/v1"
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+    
+    # 1. Test find_by_name synthesizes for unknown names
+    spec = find_by_name("my_new_ai")
+    assert spec is not None
+    assert spec.name == "my_new_ai"
+    assert spec.display_name == "My New Ai"
+    assert spec.backend == "openai_compat"
+    
+    # 2. Test _get_provider_config retrieves from model_extra
+    p_conf = config._get_provider_config("my_new_ai")
+    assert p_conf is not None
+    assert p_conf.api_key == "sk-dynamic-key"
+    assert p_conf.api_base == "https://api.dynamic.ai/v1"
+
+    # 3. Test _match_provider with forced provider
+    matched_p, matched_name = config._match_provider()
+    assert matched_name == "my_new_ai"
+    assert matched_p is not None
+    assert matched_p.api_key == "sk-dynamic-key"
+
+def test_dynamic_provider_prefix_matching(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "defaults": {
+                        "provider": "auto",
+                        "model": "another_ai/fast-model"
+                    }
+                },
+                "providers": {
+                    "another_ai": {
+                        "apiKey": "sk-another-key",
+                        "apiBase": "https://api.another.ai/v1"
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+    
+    # Test that prefix "another_ai" matches the dynamic provider
+    matched_p, matched_name = config._match_provider()
+    assert matched_name == "another_ai"
+    assert matched_p is not None
+    assert matched_p.api_key == "sk-another-key"
+
+def test_dynamic_provider_fallback(tmp_path) -> None:
+    # Test that it doesn't match if no key is provided
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "empty_ai": {
+                        "apiBase": "https://api.empty.ai/v1"
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+    matched_p, matched_name = config._match_provider(model="empty_ai/model")
+    
+    # It should NOT match empty_ai because it has no api_key and is not local
+    assert matched_name != "empty_ai"

--- a/tests/cron/test_cron_tool_list.py
+++ b/tests/cron/test_cron_tool_list.py
@@ -7,7 +7,7 @@ import pytest
 from nanobot.agent.tools.cron import CronTool
 from nanobot.cron.service import CronService
 from nanobot.cron.types import CronJob, CronJobState, CronPayload, CronSchedule
-from tests.test_openai_api import pytest_plugins
+pytest_plugins = ("pytest_asyncio",)
 
 
 def _make_tool(tmp_path) -> CronTool:


### PR DESCRIPTION
This PR adds support for dynamic LLM providers from configuration and fixes a ModuleNotFoundError in the cron test suite by replacing a failing absolute import with a literal definition.