### PR TITLE
fix(discord): remove duplicate channel_id assignment in message handler

### DIFF
--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -450,7 +450,6 @@ class DiscordChannel(BaseChannel):
         await self._start_typing(message.channel)
 
         # Add read receipt reaction immediately, working emoji after delay
-        channel_id = self._channel_key(message.channel)
         try:
             await message.add_reaction(self.config.read_receipt_emoji)
             self._pending_reactions[channel_id] = message


### PR DESCRIPTION
## Summary

In ,  is assigned twice with the identical expression :

- Line 440: first assignment (used throughout the function)
- Line 453: second assignment immediately before the reaction block (dead code)

No code modifies  or  between the two assignments. The duplicate is a copy-paste leftover.

## Change

****



## Test plan
- [ ] Send a message to a Discord channel — read receipt reaction still appears correctly