### PR TITLE
Add support for nullable API keys and LM Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ IMAP_PASSWORD=your-password-here
 | `zhipu` | LLM (Zhipu GLM) | [open.bigmodel.cn](https://open.bigmodel.cn) |
 | `mimo` | LLM (MiMo) | [platform.xiaomimimo.com](https://platform.xiaomimimo.com) |
 | `ollama` | LLM (local, Ollama) | — |
+| `lm_studio` | LLM (local, LM Studio) | — |
 | `mistral` | LLM | [docs.mistral.ai](https://docs.mistral.ai/) |
 | `stepfun` | LLM (Step Fun/阶跃星辰) | [platform.stepfun.com](https://platform.stepfun.com) |
 | `ovms` | LLM (local, OpenVINO Model Server) | [docs.openvino.ai](https://docs.openvino.ai/2026/model-server/ovms_docs_llm_quickstart.html) |
@@ -1034,7 +1035,7 @@ nanobot agent -c ~/.nanobot-telegram/config.json -w /tmp/nanobot-telegram-test -
 <details>
 <summary><b>Custom Provider (Any OpenAI-compatible API)</b></summary>
 
-Connects directly to any OpenAI-compatible endpoint — LM Studio, llama.cpp, Together AI, Fireworks, Azure OpenAI, or any self-hosted server. Model name is passed as-is.
+Connects directly to any OpenAI-compatible endpoint — llama.cpp, Together AI, Fireworks, Azure OpenAI, or any self-hosted server. Model name is passed as-is.
 
 ```json
 {
@@ -1052,7 +1053,7 @@ Connects directly to any OpenAI-compatible endpoint — LM Studio, llama.cpp, To
 }
 ```
 
-> For local servers that don't require a key, set `apiKey` to any non-empty string (e.g. `"no-key"`).
+> For local servers that don't require authentication, set `apiKey` to `null`.
 >
 > `custom` is the right choice for providers that expose an OpenAI-compatible **chat completions** API. It does **not** force third-party endpoints onto the OpenAI/Azure **Responses API**.
 >
@@ -1108,6 +1109,40 @@ ollama run llama3.2
 ```
 
 > `provider: "auto"` also works when `providers.ollama.apiBase` is configured, but setting `"provider": "ollama"` is the clearest option.
+
+</details>
+
+<details>
+<summary><b>LM Studio (local)</b></summary>
+
+[LM Studio](https://lmstudio.ai/) provides a local OpenAI-compatible server for running LLMs. Download models through the LM Studio UI, then start the local server.
+
+**1. Start LM Studio server:**
+- Launch LM Studio
+- Go to the "Local Server" tab
+- Load a model (e.g., Llama, Mistral, Qwen)
+- Click "Start Server" (default port: 1234)
+
+**2. Add to config** (partial — merge into `~/.nanobot/config.json`):
+```json
+{
+  "providers": {
+    "lm_studio": {
+      "apiKey": null,
+      "apiBase": "http://localhost:1234/v1"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "provider": "lm_studio",
+      "model": "local-model"
+    }
+  }
+}
+```
+
+> **Note:** Set `apiKey` to `null` for LM Studio since it runs locally and doesn't require authentication. The model name should match what's shown in the LM Studio UI.
+> `provider: "auto"` also works when `providers.lm_studio.apiBase` is configured, but setting `"provider": "lm_studio"` is the clearest option.
 
 </details>
 
@@ -1198,12 +1233,12 @@ vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000
 
 **2. Add to config** (partial — merge into `~/.nanobot/config.json`):
 
-*Provider (key can be any non-empty string for local):*
+*Provider (set API key to null for local servers):*
 ```json
 {
   "providers": {
     "vllm": {
-      "apiKey": "dummy",
+      "apiKey": null,
       "apiBase": "http://localhost:8000/v1"
     }
   }

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -96,7 +96,7 @@ class AgentsConfig(Base):
 class ProviderConfig(Base):
     """LLM provider configuration."""
 
-    api_key: str = ""
+    api_key: str | None = None
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
 
@@ -115,6 +115,7 @@ class ProvidersConfig(Base):
     dashscope: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     ollama: ProviderConfig = Field(default_factory=ProviderConfig)  # Ollama local models
+    lm_studio: ProviderConfig = Field(default_factory=ProviderConfig)  # LM Studio local models
     ovms: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenVINO Model Server (OVMS)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -328,6 +328,17 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_base_keyword="11434",
         default_api_base="http://localhost:11434/v1",
     ),
+    # LM Studio (local, OpenAI-compatible)
+    ProviderSpec(
+        name="lm_studio",
+        keywords=("lm-studio", "lmstudio", "lm_studio"),
+        env_key="LM_STUDIO_API_KEY",
+        display_name="LM Studio",
+        backend="openai_compat",
+        is_local=True,
+        detect_by_base_keyword="1234",
+        default_api_base="http://localhost:1234/v1",
+    ),
     # === OpenVINO Model Server (direct, local, OpenAI-compatible at /v3) ===
     ProviderSpec(
         name="ovms",

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -257,6 +257,28 @@ def test_config_accepts_camel_case_explicit_provider_name_for_coding_plan():
     assert config.get_api_base() == "https://ark.cn-beijing.volces.com/api/coding/v3"
 
 
+def test_config_accepts_lm_studio_without_api_key_and_uses_default_localhost_api_base():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "lm_studio",
+                    "model": "local-model",
+                }
+            },
+            "providers": {
+                "lmStudio": {
+                    "apiKey": None,
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "lm_studio"
+    assert config.get_api_key() is None
+    assert config.get_api_base() == "http://localhost:1234/v1"
+
+
 def test_find_by_name_accepts_camel_case_and_hyphen_aliases():
     assert find_by_name("volcengineCodingPlan") is not None
     assert find_by_name("volcengineCodingPlan").name == "volcengine_coding_plan"


### PR DESCRIPTION
Addresses #3185.

Adds support for nullable API keys and LM Studio as a first-class provider, improving the experience for local LLM users.

## Key Changes

- Nullable API keys: apiKey can now be set to null for local providers that don't require authentication (previously required dummy strings like "no-key" or "dummy")
- LM Studio provider: Added lm_studio as a built-in provider with auto-detection via port 1234
- Documentation updates: Updated examples for Custom Provider, vLLM, and added comprehensive LM Studio
setup guide

## Motivation

Local LLM servers (LM Studio, vLLM, llama.cpp, etc.) don't require API keys, but the previous schema required a non-empty string. This forced users to use dummy values like "dummy" or "no-key", which was confusing and inelegant. Additionally, LM Studio is a popular desktop app for running local models, and adding it as a first-class provider improves discoverability.

## Changes

### Core Changes

nanobot/config/schema.py:
- Changed ProviderConfig.api_key type from str to str | None to support null values
- Added lm_studio field to ProvidersConfig

nanobot/providers/registry.py:
- Added lm_studio provider spec with:
  - Aliases: lm-studio, lmstudio, lm_studio
  - Default base URL: http://localhost:1234/v1
  - Auto-detection via port 1234
  - Backend: openai_compat

### Documentation Updates

README.md:
- Custom Provider: Updated guidance to recommend apiKey: null instead of dummy strings for local servers
- vLLM: Updated example to use apiKey: null instead of "dummy"
- LM Studio: Added comprehensive setup guide with:
  - Installation instructions
  - Server startup steps
  - Configuration examples
  - Usage notes
- Provider table: Added LM Studio to the list of supported providers

## Test Plan

- Verify apiKey: null works with existing local providers (ollama, vllm, custom)
- Verify LM Studio provider auto-detection with http://localhost:1234/v1 endpoint
- Verify explicit provider: "lm_studio" configuration works
- Verify backward compatibility: existing configs with non-null API keys still work
- Test with actual LM Studio instance (if available)
- Verify documentation examples are accurate

## Breaking Changes

None. This is backward compatible:
- Existing configs with string API keys continue to work
- The change is purely additive (nullable type extends the existing string type)
