### PR TITLE
fix(docs): update channel plugin build backend to hatchling

### DIFF
--- a/docs/CHANNEL_PLUGIN_GUIDE.md
+++ b/docs/CHANNEL_PLUGIN_GUIDE.md
@@ -141,8 +141,11 @@ dependencies = ["nanobot", "aiohttp"]
 webhook = "nanobot_channel_webhook:WebhookChannel"
 
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.backends._legacy:_Backend"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nanobot_channel_webhook"]
 ```
 
 The key (`webhook`) becomes the config section name. The value points to your `BaseChannel` subclass.

--- a/docs/CHANNEL_PLUGIN_GUIDE.md
+++ b/docs/CHANNEL_PLUGIN_GUIDE.md
@@ -135,7 +135,7 @@ class WebhookChannel(BaseChannel):
 [project]
 name = "nanobot-channel-webhook"
 version = "0.1.0"
-dependencies = ["nanobot", "aiohttp"]
+dependencies = ["nanobot-ai", "aiohttp"]
 
 [project.entry-points."nanobot.channels"]
 webhook = "nanobot_channel_webhook:WebhookChannel"


### PR DESCRIPTION
## Problem

The `pyproject.toml` example in `docs/CHANNEL_PLUGIN_GUIDE.md` uses a deprecated setuptools backend:

```toml
build-backend = "setuptools.backends._legacy:_Backend"
```

This causes the following error on Python 3.14 with newer setuptools:

```
pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.backends.legacy'
```

## Solution

Replace the deprecated backend with `hatchling` (same as the main nanobot project):

```toml
[build-system]
requires = ["hatchling"]
build-backend = "hatchling.build"

[tool.hatch.build.targets.wheel]
packages = ["nanobot_channel_webhook"]
```

## Changes

- Updated `docs/CHANNEL_PLUGIN_GUIDE.md` pyproject.toml example
- Using hatchling ensures compatibility across all Python versions

Fixes #3188