### PR TITLE
fix(consolidator): prevent silent failure when boundary not found

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -411,9 +411,16 @@ class Consolidator:
             return end_idx
 
         capped_end = start + self._MAX_CHUNK_MESSAGES
-        for idx in range(capped_end, start, -1):
+        for idx in range(capped_end - 1, start, -1):
             if session.messages[idx].get("role") == "user":
                 return idx
+
+        if capped_end - 1 > start:
+            logger.debug(
+                "Consolidation boundary cap: no user-turn found, using capped_end-1 for {}",
+                session.key,
+            )
+            return capped_end - 1
         return None
 
     def estimate_session_prompt_tokens(self, session: Session) -> tuple[int, str]:
@@ -534,6 +541,8 @@ class Consolidator:
                     len(chunk),
                 )
                 if not await self.archive(chunk):
+                    session.last_consolidated = end_idx
+                    self.sessions.save(session)
                     return
                 session.last_consolidated = end_idx
                 self.sessions.save(session)
@@ -545,6 +554,42 @@ class Consolidator:
                     estimated, source = 0, "error"
                 if estimated <= 0:
                     return
+
+    async def force_consolidate(self, session: Session) -> tuple[int, str]:
+        """Force consolidation of one chunk, ignoring budget check.
+
+        Returns (archived_count, status_message).
+        """
+        if not session.messages or self.context_window_tokens <= 0:
+            return 0, "nothing to consolidate"
+
+        lock = self.get_lock(session.key)
+        async with lock:
+            unconsolidated = len(session.messages) - session.last_consolidated
+            if unconsolidated <= 0:
+                return 0, "nothing new to consolidate"
+
+            boundary = self.pick_consolidation_boundary(session, max(1, unconsolidated))
+            if boundary is None:
+                return 0, "no safe boundary found"
+
+            end_idx = boundary[0]
+            end_idx = self._cap_consolidation_boundary(session, end_idx)
+            if end_idx is None:
+                return 0, "no capped boundary found"
+
+            chunk = session.messages[session.last_consolidated : end_idx]
+            if not chunk:
+                return 0, "empty chunk"
+
+            if not await self.archive(chunk):
+                session.last_consolidated = end_idx
+                self.sessions.save(session)
+                return len(chunk), "archived (raw dump)"
+
+            session.last_consolidated = end_idx
+            self.sessions.save(session)
+            return len(chunk), "archived (summarized)"
 
 
 # ---------------------------------------------------------------------------

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -135,6 +135,37 @@ async def cmd_dream(ctx: CommandContext) -> OutboundMessage:
     )
 
 
+async def cmd_compact(ctx: CommandContext) -> OutboundMessage:
+    """Manually trigger a lightweight consolidation (Stage 1)."""
+    loop = ctx.loop
+    session = ctx.session or loop.sessions.get_or_create(ctx.key)
+    msg = ctx.msg
+
+    async def _run_compact():
+        try:
+            count, status = await loop.consolidator.force_consolidate(session)
+            if count > 0:
+                content = f"Compact: {count} messages {status}."
+            else:
+                content = f"Compact: {status}."
+        except Exception as e:
+            content = f"Compact failed: {e}"
+        await loop.bus.publish_outbound(
+            OutboundMessage(
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+                content=content,
+            )
+        )
+
+    asyncio.create_task(_run_compact())
+    return OutboundMessage(
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        content="Compacting...",
+    )
+
+
 def _extract_changed_files(diff: str) -> list[str]:
     """Extract changed file paths from a unified diff."""
     files: list[str] = []
@@ -321,6 +352,7 @@ def build_help_text() -> str:
         "/stop — Stop the current task",
         "/restart — Restart the bot",
         "/status — Show bot status",
+        "/compact — Force lightweight consolidation",
         "/dream — Manually trigger Dream consolidation",
         "/dream-log — Show what the last Dream changed",
         "/dream-restore — Revert memory to a previous state",
@@ -337,6 +369,7 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.exact("/new", cmd_new)
     router.exact("/status", cmd_status)
     router.exact("/dream", cmd_dream)
+    router.exact("/compact", cmd_compact)
     router.exact("/dream-log", cmd_dream_log)
     router.prefix("/dream-log ", cmd_dream_log)
     router.exact("/dream-restore", cmd_dream_restore)

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -104,8 +104,8 @@ class TestConsolidatorTokenBudget:
         assert archived_chunk[-1]["content"] == "m49"
         assert session.last_consolidated == 50
 
-    async def test_chunk_cap_skips_when_no_user_boundary_within_cap(self, consolidator):
-        """If the cap would cut mid-turn, consolidation should skip that round."""
+    async def test_chunk_cap_falls_back_to_capped_end_when_no_user_boundary(self, consolidator):
+        """When no user-turn found within cap, use capped_end-1 to avoid infinite loop."""
         consolidator._SAFETY_BUFFER = 0
         session = MagicMock()
         session.last_consolidated = 0
@@ -123,5 +123,8 @@ class TestConsolidatorTokenBudget:
 
         await consolidator.maybe_consolidate_by_tokens(session)
 
-        consolidator.archive.assert_not_awaited()
+        consolidator.archive.assert_awaited_once()
+        archived_chunk = consolidator.archive.await_args.args[0]
+        assert len(archived_chunk) == 59
+        assert session.last_consolidated == 59
         assert session.last_consolidated == 0

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -1,8 +1,8 @@
 """Tests for the lightweight Consolidator — append-only to HISTORY.md."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from nanobot.agent.memory import Consolidator, MemoryStore
 
@@ -117,7 +117,15 @@ class TestConsolidatorTokenBudget:
             }
             for i in range(70)
         ]
-        consolidator.estimate_session_prompt_tokens = MagicMock(return_value=(1200, "tiktoken"))
+        call_count = [0]
+
+        def mock_estimate(_session):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return (1200, "tiktoken")
+            return (400, "tiktoken")
+
+        consolidator.estimate_session_prompt_tokens = mock_estimate
         consolidator.pick_consolidation_boundary = MagicMock(return_value=(61, 999))
         consolidator.archive = AsyncMock(return_value=True)
 
@@ -127,4 +135,3 @@ class TestConsolidatorTokenBudget:
         archived_chunk = consolidator.archive.await_args.args[0]
         assert len(archived_chunk) == 59
         assert session.last_consolidated == 59
-        assert session.last_consolidated == 0


### PR DESCRIPTION
## Summary

The consolidator should archive old messages to `history.jsonl` when context tokens exceed `context_window_tokens`, but it was silently failing due to two issues:

1. **`_cap_consolidation_boundary` returning `None`**: When no user-turn boundary is found within the first 60 messages after `last_consolidated`, the function returns `None`, causing the consolidation loop to indefinitely skip.

2. **`archive()` returning `None` without updating `last_consolidated`**: Even when raw dump succeeds and writes to `history.jsonl`, `last_consolidated` is not advanced, creating an infinite loop.

## Changes

### 1. `nanobot/agent/memory.py:413-435`
- `_cap_consolidation_boundary` now falls back to `capped_end - 1` instead of returning `None`
- Added debug log when fallback is used

### 2. `nanobot/agent/memory.py:549-556`
- Even when `archive()` fails, `last_consolidated` is now advanced

### 3. `nanobot/agent/memory.py:567-604`
- Added `force_consolidate()` method for manual Stage 1 consolidation triggering

### 4. `nanobot/command/builtin.py:154-178,389,405`
- Added `/compact` command for manual Stage 1 consolidation
- Registered and added to help text

### 5. `tests/agent/test_consolidator.py:107-127`
- Updated test to reflect new fallback behavior

## Testing

- 35 non-async tests pass ✓
- ruff check passes ✓

## Related

Fixes the issue where consolidation does not occur when tokens exceed 100% of context window.