### PR TITLE
fix(bus): bound inbound queue to prevent unbounded memory growth

### DIFF
--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -7,7 +7,13 @@ from loguru import logger
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
 
+# Reasonable default for chatbot workloads: 100 messages gives the agent
+# ample headroom to drain bursts without risking unbounded memory growth.
 _DEFAULT_INBOUND_MAXSIZE = 100
+
+# Seconds to wait for a slot before dropping a message.  Long enough for
+# the agent to finish an iteration under normal load.
+_DEFAULT_PUT_TIMEOUT_S = 5.0
 
 
 class MessageBus:
@@ -31,18 +37,24 @@ class MessageBus:
     async def publish_inbound(self, msg: InboundMessage) -> bool:
         """Publish a message from a channel to the agent.
 
+        Waits up to ``_DEFAULT_PUT_TIMEOUT_S`` seconds for a slot.
         Returns ``True`` if the message was enqueued, ``False`` if the
-        inbound queue is full and the message was dropped.
+        timeout expired and the message was dropped.
         """
         try:
-            self.inbound.put_nowait(msg)
+            await asyncio.wait_for(
+                self.inbound.put(msg),
+                timeout=_DEFAULT_PUT_TIMEOUT_S,
+            )
             return True
-        except asyncio.QueueFull:
+        except asyncio.TimeoutError:
             logger.warning(
-                "Inbound queue full ({} msgs) — dropped message from {}:{}",
+                "Inbound queue full ({} msgs) — dropped message from {}:{}"
+                " (waited {:.0f}s)",
                 self.inbound.qsize(),
                 msg.channel,
                 msg.chat_id,
+                _DEFAULT_PUT_TIMEOUT_S,
             )
             return False
 

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -1,8 +1,13 @@
 """Async message queue for decoupled channel-agent communication."""
 
 import asyncio
+import os
+
+from loguru import logger
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
+
+_DEFAULT_INBOUND_MAXSIZE = 100
 
 
 class MessageBus:
@@ -11,15 +16,35 @@ class MessageBus:
 
     Channels push messages to the inbound queue, and the agent processes
     them and pushes responses to the outbound queue.
+
+    The inbound queue is bounded (default 100, override via
+    ``NANOBOT_BUS_INBOUND_MAXSIZE``) to prevent unbounded memory growth
+    when the agent falls behind.  The outbound queue stays unbounded so
+    agent responses are never silently lost.
     """
 
     def __init__(self):
-        self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue()
+        maxsize = int(os.environ.get("NANOBOT_BUS_INBOUND_MAXSIZE", _DEFAULT_INBOUND_MAXSIZE))
+        self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue(maxsize=maxsize)
         self.outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
 
-    async def publish_inbound(self, msg: InboundMessage) -> None:
-        """Publish a message from a channel to the agent."""
-        await self.inbound.put(msg)
+    async def publish_inbound(self, msg: InboundMessage) -> bool:
+        """Publish a message from a channel to the agent.
+
+        Returns ``True`` if the message was enqueued, ``False`` if the
+        inbound queue is full and the message was dropped.
+        """
+        try:
+            self.inbound.put_nowait(msg)
+            return True
+        except asyncio.QueueFull:
+            logger.warning(
+                "Inbound queue full ({} msgs) — dropped message from {}:{}",
+                self.inbound.qsize(),
+                msg.channel,
+                msg.chat_id,
+            )
+            return False
 
     async def consume_inbound(self) -> InboundMessage:
         """Consume the next inbound message (blocks until available)."""

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -45,12 +45,14 @@ class BaseChannel(ABC):
         try:
             if self.transcription_provider == "openai":
                 from nanobot.providers.transcription import OpenAITranscriptionProvider
+
                 provider = OpenAITranscriptionProvider(
                     api_key=self.transcription_api_key,
                     api_base=self.transcription_api_base or None,
                 )
             else:
                 from nanobot.providers.transcription import GroqTranscriptionProvider
+
                 provider = GroqTranscriptionProvider(
                     api_key=self.transcription_api_key,
                     api_base=self.transcription_api_base or None,
@@ -102,7 +104,9 @@ class BaseChannel(ABC):
         """
         pass
 
-    async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None) -> None:
+    async def send_delta(
+        self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None
+    ) -> None:
         """Deliver a streaming text chunk.
 
         Override in subclasses to enable streaming. Implementations should
@@ -118,7 +122,11 @@ class BaseChannel(ABC):
     def supports_streaming(self) -> bool:
         """True when config enables streaming AND this subclass implements send_delta."""
         cfg = self.config
-        streaming = cfg.get("streaming", False) if isinstance(cfg, dict) else getattr(cfg, "streaming", False)
+        streaming = (
+            cfg.get("streaming", False)
+            if isinstance(cfg, dict)
+            else getattr(cfg, "streaming", False)
+        )
         return bool(streaming) and type(self).send_delta is not BaseChannel.send_delta
 
     def is_allowed(self, sender_id: str) -> bool:
@@ -163,7 +171,8 @@ class BaseChannel(ABC):
             logger.warning(
                 "Access denied for sender {} on channel {}. "
                 "Add them to allowFrom list in config to grant access.",
-                sender_id, self.name,
+                sender_id,
+                self.name,
             )
             return
 
@@ -181,7 +190,12 @@ class BaseChannel(ABC):
             session_key_override=session_key,
         )
 
-        await self.bus.publish_inbound(msg)
+        if not await self.bus.publish_inbound(msg):
+            logger.warning(
+                "{}: message from {} dropped (bus full)",
+                self.name,
+                sender_id,
+            )
 
     @classmethod
     def default_config(cls) -> dict[str, Any]:

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -104,9 +104,7 @@ class BaseChannel(ABC):
         """
         pass
 
-    async def send_delta(
-        self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None
-    ) -> None:
+    async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None) -> None:
         """Deliver a streaming text chunk.
 
         Override in subclasses to enable streaming. Implementations should
@@ -122,11 +120,7 @@ class BaseChannel(ABC):
     def supports_streaming(self) -> bool:
         """True when config enables streaming AND this subclass implements send_delta."""
         cfg = self.config
-        streaming = (
-            cfg.get("streaming", False)
-            if isinstance(cfg, dict)
-            else getattr(cfg, "streaming", False)
-        )
+        streaming = cfg.get("streaming", False) if isinstance(cfg, dict) else getattr(cfg, "streaming", False)
         return bool(streaming) and type(self).send_delta is not BaseChannel.send_delta
 
     def is_allowed(self, sender_id: str) -> bool:
@@ -171,8 +165,7 @@ class BaseChannel(ABC):
             logger.warning(
                 "Access denied for sender {} on channel {}. "
                 "Add them to allowFrom list in config to grant access.",
-                sender_id,
-                self.name,
+                sender_id, self.name,
             )
             return
 
@@ -193,8 +186,7 @@ class BaseChannel(ABC):
         if not await self.bus.publish_inbound(msg):
             logger.warning(
                 "{}: message from {} dropped (bus full)",
-                self.name,
-                sender_id,
+                self.name, sender_id,
             )
 
     @classmethod

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -45,14 +45,12 @@ class BaseChannel(ABC):
         try:
             if self.transcription_provider == "openai":
                 from nanobot.providers.transcription import OpenAITranscriptionProvider
-
                 provider = OpenAITranscriptionProvider(
                     api_key=self.transcription_api_key,
                     api_base=self.transcription_api_base or None,
                 )
             else:
                 from nanobot.providers.transcription import GroqTranscriptionProvider
-
                 provider = GroqTranscriptionProvider(
                     api_key=self.transcription_api_key,
                     api_base=self.transcription_api_base or None,

--- a/tests/bus/test_queue.py
+++ b/tests/bus/test_queue.py
@@ -1,5 +1,7 @@
 """Tests for bounded MessageBus inbound queue."""
 
+from unittest.mock import patch
+
 import pytest
 
 from nanobot.bus.events import InboundMessage
@@ -27,15 +29,19 @@ async def test_publish_returns_true_when_space(small_bus):
 
 
 async def test_publish_returns_false_when_full(small_bus):
+    """A full queue should drop the message after the timeout."""
     await small_bus.publish_inbound(_msg("a"))
     await small_bus.publish_inbound(_msg("b"))
-    assert await small_bus.publish_inbound(_msg("c")) is False
+    # Use a tiny timeout so the test doesn't wait 5 seconds.
+    with patch("nanobot.bus.queue._DEFAULT_PUT_TIMEOUT_S", 0.01):
+        assert await small_bus.publish_inbound(_msg("c")) is False
 
 
 async def test_queued_messages_preserved_on_overflow(small_bus):
     await small_bus.publish_inbound(_msg("a"))
     await small_bus.publish_inbound(_msg("b"))
-    await small_bus.publish_inbound(_msg("c"))  # dropped
+    with patch("nanobot.bus.queue._DEFAULT_PUT_TIMEOUT_S", 0.01):
+        await small_bus.publish_inbound(_msg("c"))  # dropped
     assert small_bus.inbound_size == 2
     first = await small_bus.consume_inbound()
     assert first.content == "a"
@@ -44,7 +50,8 @@ async def test_queued_messages_preserved_on_overflow(small_bus):
 async def test_space_after_consume(small_bus):
     await small_bus.publish_inbound(_msg("a"))
     await small_bus.publish_inbound(_msg("b"))
-    assert await small_bus.publish_inbound(_msg("c")) is False
+    with patch("nanobot.bus.queue._DEFAULT_PUT_TIMEOUT_S", 0.01):
+        assert await small_bus.publish_inbound(_msg("c")) is False
     await small_bus.consume_inbound()  # free a slot
     assert await small_bus.publish_inbound(_msg("d")) is True
 

--- a/tests/bus/test_queue.py
+++ b/tests/bus/test_queue.py
@@ -1,0 +1,64 @@
+"""Tests for bounded MessageBus inbound queue."""
+
+import pytest
+
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+
+
+def _msg(content: str = "hi") -> InboundMessage:
+    return InboundMessage(
+        channel="test",
+        sender_id="u1",
+        chat_id="c1",
+        content=content,
+    )
+
+
+@pytest.fixture()
+def small_bus(monkeypatch):
+    """A MessageBus with inbound maxsize=2 for fast overflow testing."""
+    monkeypatch.setenv("NANOBOT_BUS_INBOUND_MAXSIZE", "2")
+    return MessageBus()
+
+
+async def test_publish_returns_true_when_space(small_bus):
+    assert await small_bus.publish_inbound(_msg()) is True
+
+
+async def test_publish_returns_false_when_full(small_bus):
+    await small_bus.publish_inbound(_msg("a"))
+    await small_bus.publish_inbound(_msg("b"))
+    assert await small_bus.publish_inbound(_msg("c")) is False
+
+
+async def test_queued_messages_preserved_on_overflow(small_bus):
+    await small_bus.publish_inbound(_msg("a"))
+    await small_bus.publish_inbound(_msg("b"))
+    await small_bus.publish_inbound(_msg("c"))  # dropped
+    assert small_bus.inbound_size == 2
+    first = await small_bus.consume_inbound()
+    assert first.content == "a"
+
+
+async def test_space_after_consume(small_bus):
+    await small_bus.publish_inbound(_msg("a"))
+    await small_bus.publish_inbound(_msg("b"))
+    assert await small_bus.publish_inbound(_msg("c")) is False
+    await small_bus.consume_inbound()  # free a slot
+    assert await small_bus.publish_inbound(_msg("d")) is True
+
+
+async def test_outbound_stays_unbounded():
+    from nanobot.bus.events import OutboundMessage
+
+    bus = MessageBus()
+    for i in range(200):
+        await bus.publish_outbound(OutboundMessage(channel="t", chat_id="c", content=str(i)))
+    assert bus.outbound_size == 200
+
+
+async def test_default_maxsize(monkeypatch):
+    monkeypatch.delenv("NANOBOT_BUS_INBOUND_MAXSIZE", raising=False)
+    bus = MessageBus()
+    assert bus.inbound.maxsize == 100


### PR DESCRIPTION
## Summary

- Bound the inbound `MessageBus` queue (default 100, configurable via `NANOBOT_BUS_INBOUND_MAXSIZE`) to prevent unbounded memory growth when the agent falls behind
- Outbound queue stays unbounded so agent responses are never silently lost

## Changes after review

- **Critical fix**: replaced `put_nowait` (silent immediate drop) with `asyncio.wait_for(put(), timeout=5s)` — gives the agent time to drain the queue under normal load before dropping
- Reverted all formatting-only changes in `channels/base.py` to keep the diff focused on the functional change
- Added comments explaining default maxsize rationale and put timeout
- Updated tests to mock the timeout for fast overflow testing

## Test plan

- [x] 6 tests: enqueue success, timed drop on full, message preservation, slot recovery, unbounded outbound, default maxsize
- [x] All 1715 tests pass (no regressions)
- [x] `ruff check` clean
