### PR TITLE
feat(agent): add ProfilingHook for opt-in iteration timing

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -192,7 +192,12 @@ class AgentLoop:
         self.restrict_to_workspace = restrict_to_workspace
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
-        self._extra_hooks: list[AgentHook] = hooks or []
+        self._extra_hooks: list[AgentHook] = list(hooks or [])
+
+        from nanobot.agent.profiling import ProfilingHook, is_profiling_enabled
+
+        if is_profiling_enabled():
+            self._extra_hooks.append(ProfilingHook())
 
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
         self.sessions = session_manager or SessionManager(workspace)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -27,8 +27,8 @@ from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.notebook import NotebookEditTool
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.search import GlobTool, GrepTool
-from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.self import MyTool
+from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -17,6 +17,7 @@ from nanobot.agent.autocompact import AutoCompact
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.hook import AgentHook, AgentHookContext, CompositeHook
 from nanobot.agent.memory import Consolidator, Dream
+from nanobot.agent.profiling import ProfilingHook, is_profiling_enabled
 from nanobot.agent.runner import _MAX_INJECTIONS_PER_TURN, AgentRunner, AgentRunSpec
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.subagent import SubagentManager
@@ -192,12 +193,11 @@ class AgentLoop:
         self.restrict_to_workspace = restrict_to_workspace
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
-        self._extra_hooks: list[AgentHook] = list(hooks or [])
-
-        from nanobot.agent.profiling import ProfilingHook, is_profiling_enabled
+        self._extra_hooks: list[AgentHook] = hooks or []
 
         if is_profiling_enabled():
-            self._extra_hooks.append(ProfilingHook())
+            # Append to a copy so we don't mutate the caller's list.
+            self._extra_hooks = list(self._extra_hooks) + [ProfilingHook()]
 
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
         self.sessions = session_manager or SessionManager(workspace)

--- a/nanobot/agent/profiling.py
+++ b/nanobot/agent/profiling.py
@@ -1,0 +1,42 @@
+"""Optional profiling hook for agent loop timing.
+
+Enable by setting the environment variable ``NANOBOT_PROFILING=1``.
+Timings are emitted at DEBUG level via loguru.
+"""
+
+import os
+import time
+
+from loguru import logger
+
+from nanobot.agent.hook import AgentHook, AgentHookContext
+
+
+def is_profiling_enabled() -> bool:
+    """Check at runtime whether profiling is active."""
+    return os.environ.get("NANOBOT_PROFILING", "").strip() in ("1", "true", "yes")
+
+
+class ProfilingHook(AgentHook):
+    """Logs wall-clock time for each LLM iteration and tool batch."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._iter_t0: float = 0.0
+
+    async def before_iteration(self, context: AgentHookContext) -> None:
+        self._iter_t0 = time.perf_counter()
+
+    async def after_iteration(self, context: AgentHookContext) -> None:
+        elapsed_ms = (time.perf_counter() - self._iter_t0) * 1000
+        tool_names = [tc.name for tc in context.tool_calls] if context.tool_calls else []
+        logger.debug(
+            "[profiling] iteration {}: {:.0f}ms | tools: {}",
+            context.iteration,
+            elapsed_ms,
+            tool_names or "none",
+        )
+
+    async def before_execute_tools(self, context: AgentHookContext) -> None:
+        tool_names = [tc.name for tc in context.tool_calls]
+        logger.debug("[profiling] executing tools: {}", tool_names)

--- a/nanobot/agent/profiling.py
+++ b/nanobot/agent/profiling.py
@@ -1,6 +1,9 @@
 """Optional profiling hook for agent loop timing.
 
 Enable by setting the environment variable ``NANOBOT_PROFILING=1``.
+The variable is read once when ``AgentLoop`` is instantiated, so it
+must be set before loop creation (not dynamically at runtime).
+
 Timings are emitted at DEBUG level via loguru.
 """
 
@@ -13,21 +16,23 @@ from nanobot.agent.hook import AgentHook, AgentHookContext
 
 
 def is_profiling_enabled() -> bool:
-    """Check at runtime whether profiling is active."""
+    """Check whether profiling is active."""
     return os.environ.get("NANOBOT_PROFILING", "").strip() in ("1", "true", "yes")
 
 
 class ProfilingHook(AgentHook):
-    """Logs wall-clock time for each LLM iteration and tool batch."""
+    """Logs wall-clock time for each LLM iteration."""
 
     def __init__(self) -> None:
         super().__init__()
-        self._iter_t0: float = 0.0
+        self._iter_t0: float | None = None
 
     async def before_iteration(self, context: AgentHookContext) -> None:
         self._iter_t0 = time.perf_counter()
 
     async def after_iteration(self, context: AgentHookContext) -> None:
+        if self._iter_t0 is None:
+            return
         elapsed_ms = (time.perf_counter() - self._iter_t0) * 1000
         tool_names = [tc.name for tc in context.tool_calls] if context.tool_calls else []
         logger.debug(
@@ -36,7 +41,3 @@ class ProfilingHook(AgentHook):
             elapsed_ms,
             tool_names or "none",
         )
-
-    async def before_execute_tools(self, context: AgentHookContext) -> None:
-        tool_names = [tc.name for tc in context.tool_calls]
-        logger.debug("[profiling] executing tools: {}", tool_names)

--- a/tests/agent/test_profiling.py
+++ b/tests/agent/test_profiling.py
@@ -1,5 +1,7 @@
 """Tests for the optional ProfilingHook."""
 
+from unittest.mock import patch
+
 import pytest
 
 from nanobot.agent.hook import AgentHookContext
@@ -17,21 +19,41 @@ def ctx():
 
 
 async def test_before_iteration_records_start_time(hook, ctx):
-    assert hook._iter_t0 == 0.0
+    assert hook._iter_t0 is None
     await hook.before_iteration(ctx)
-    assert hook._iter_t0 > 0.0
+    assert hook._iter_t0 is not None and hook._iter_t0 > 0.0
 
 
-async def test_after_iteration_runs_without_error(hook, ctx):
-    await hook.before_iteration(ctx)
-    await hook.after_iteration(ctx)  # should not raise
+async def test_after_iteration_logs_elapsed_time(hook, ctx, capfd):
+    """Verify after_iteration records a meaningful elapsed time."""
+    with patch("nanobot.agent.profiling.time.perf_counter", side_effect=[100.0, 100.05]):
+        await hook.before_iteration(ctx)
+        await hook.after_iteration(ctx)
+    # 50ms elapsed (0.05s * 1000)
+    # Logger writes to stderr; just verify no exception and the hook ran.
+    # The real assertion is that perf_counter was called correctly.
 
 
-async def test_before_execute_tools_runs_without_error(hook, ctx):
+async def test_after_iteration_without_before_is_safe(hook, ctx):
+    """Calling after_iteration before before_iteration must not crash."""
+    await hook.after_iteration(ctx)  # _iter_t0 is None — should be a no-op
+
+
+async def test_after_iteration_includes_tool_names(hook, ctx):
+    """Tool names from context are included in the log output."""
     from nanobot.providers.base import ToolCallRequest
 
-    ctx.tool_calls = [ToolCallRequest(id="t1", name="read_file", arguments="{}")]
-    await hook.before_execute_tools(ctx)  # should not raise
+    ctx.tool_calls = [
+        ToolCallRequest(id="t1", name="read_file", arguments="{}"),
+        ToolCallRequest(id="t2", name="exec", arguments="{}"),
+    ]
+    with patch("nanobot.agent.profiling.logger") as mock_logger:
+        with patch("nanobot.agent.profiling.time.perf_counter", side_effect=[1.0, 1.025]):
+            await hook.before_iteration(ctx)
+            await hook.after_iteration(ctx)
+        call_args = mock_logger.debug.call_args
+        assert "read_file" in str(call_args)
+        assert "exec" in str(call_args)
 
 
 def test_profiling_disabled_by_default(monkeypatch):

--- a/tests/agent/test_profiling.py
+++ b/tests/agent/test_profiling.py
@@ -1,0 +1,49 @@
+"""Tests for the optional ProfilingHook."""
+
+import pytest
+
+from nanobot.agent.hook import AgentHookContext
+from nanobot.agent.profiling import ProfilingHook, is_profiling_enabled
+
+
+@pytest.fixture()
+def hook():
+    return ProfilingHook()
+
+
+@pytest.fixture()
+def ctx():
+    return AgentHookContext(iteration=1, messages=[])
+
+
+async def test_before_iteration_records_start_time(hook, ctx):
+    assert hook._iter_t0 == 0.0
+    await hook.before_iteration(ctx)
+    assert hook._iter_t0 > 0.0
+
+
+async def test_after_iteration_runs_without_error(hook, ctx):
+    await hook.before_iteration(ctx)
+    await hook.after_iteration(ctx)  # should not raise
+
+
+async def test_before_execute_tools_runs_without_error(hook, ctx):
+    from nanobot.providers.base import ToolCallRequest
+
+    ctx.tool_calls = [ToolCallRequest(id="t1", name="read_file", arguments="{}")]
+    await hook.before_execute_tools(ctx)  # should not raise
+
+
+def test_profiling_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("NANOBOT_PROFILING", raising=False)
+    assert is_profiling_enabled() is False
+
+
+def test_profiling_enabled_with_env(monkeypatch):
+    monkeypatch.setenv("NANOBOT_PROFILING", "1")
+    assert is_profiling_enabled() is True
+
+
+def test_profiling_enabled_with_true_string(monkeypatch):
+    monkeypatch.setenv("NANOBOT_PROFILING", "true")
+    assert is_profiling_enabled() is True

--- a/tests/agent/test_profiling.py
+++ b/tests/agent/test_profiling.py
@@ -24,14 +24,17 @@ async def test_before_iteration_records_start_time(hook, ctx):
     assert hook._iter_t0 is not None and hook._iter_t0 > 0.0
 
 
-async def test_after_iteration_logs_elapsed_time(hook, ctx, capfd):
-    """Verify after_iteration records a meaningful elapsed time."""
-    with patch("nanobot.agent.profiling.time.perf_counter", side_effect=[100.0, 100.05]):
-        await hook.before_iteration(ctx)
-        await hook.after_iteration(ctx)
-    # 50ms elapsed (0.05s * 1000)
-    # Logger writes to stderr; just verify no exception and the hook ran.
-    # The real assertion is that perf_counter was called correctly.
+async def test_after_iteration_logs_elapsed_time(hook, ctx):
+    """after_iteration must log the elapsed ms derived from perf_counter."""
+    with patch("nanobot.agent.profiling.logger") as mock_logger:
+        with patch("nanobot.agent.profiling.time.perf_counter", side_effect=[100.0, 100.05]):
+            await hook.before_iteration(ctx)
+            await hook.after_iteration(ctx)
+    # perf_counter delta is 0.05s → 50ms. The hook formats with "{:.0f}ms",
+    # so the integer 50 must appear in the log args.
+    mock_logger.debug.assert_called_once()
+    args = mock_logger.debug.call_args.args
+    assert 50 == round(args[2])  # elapsed_ms positional arg
 
 
 async def test_after_iteration_without_before_is_safe(hook, ctx):


### PR DESCRIPTION
## Summary

- Add `ProfilingHook` (`nanobot/agent/profiling.py`) — an `AgentHook` that logs wall-clock time per LLM iteration and tool names at DEBUG level
- Enable via `NANOBOT_PROFILING=1` environment variable
- Env var is read once at `AgentLoop.__init__` time — must be set before loop creation, not dynamically togglable at runtime
- Hook-only approach: no inline timing scattered across runner/memory/loop files

## Changes after review

- Moved profiling import to module top level (no circular dependency)
- Reverted unrelated defensive `list()` copy of hooks
- Removed `before_execute_tools` — redundant with `after_iteration` which already logs tool names
- Changed `_iter_t0` sentinel from `0.0` to `None` with guard in `after_iteration`
- Added tests that verify actual timing behavior via mocked `perf_counter` and log output assertions
- Fixed import sorting (ruff I001)

## Test plan

- [x] 7 tests: start time recording, elapsed timing with mock, tool name logging, guard for missing before_iteration, env var checks
- [x] All 1715 tests pass (no regressions)
- [x] `ruff check` clean
