### PR TITLE
feat(providers): split zhipu into Z.AI CN/Global/Coding Plan providers

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -117,7 +117,11 @@ class ProvidersConfig(Base):
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
     deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
     groq: ProviderConfig = Field(default_factory=ProviderConfig)
-    zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
+    zai_cn: ProviderConfig = Field(default_factory=ProviderConfig)  # Z.AI CN (China mainland)
+    zai_gb: ProviderConfig = Field(default_factory=ProviderConfig)  # Z.AI Global
+    zai_coding_cn: ProviderConfig = Field(default_factory=ProviderConfig)  # Z.AI Coding Plan CN
+    zai_coding_gb: ProviderConfig = Field(default_factory=ProviderConfig)  # Z.AI Coding Plan Global
+    zhipu: ProviderConfig = Field(default_factory=ProviderConfig)  # deprecated -> use zai_cn
     dashscope: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     ollama: ProviderConfig = Field(default_factory=ProviderConfig)  # Ollama local models

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -243,12 +243,56 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         default_api_base="https://generativelanguage.googleapis.com/v1beta/openai/",
     ),
-    # Zhipu (智谱): OpenAI-compatible at open.bigmodel.cn
+    # Z.AI General CN (China mainland): OpenAI-compatible at open.bigmodel.cn
+    ProviderSpec(
+        name="zai_cn",
+        keywords=("glm",),
+        env_key="ZAI_API_KEY",
+        display_name="Z.AI (CN)",
+        backend="openai_compat",
+        env_extras=(("ZHIPUAI_API_KEY", "{api_key}"),),
+        default_api_base="https://open.bigmodel.cn/api/paas/v4",
+    ),
+    # Z.AI General Global: OpenAI-compatible at api.z.ai
+    ProviderSpec(
+        name="zai_gb",
+        keywords=("zai_gb",),
+        env_key="ZAI_API_KEY",
+        display_name="Z.AI (Global)",
+        backend="openai_compat",
+        env_extras=(("ZHIPUAI_API_KEY", "{api_key}"),),
+        default_api_base="https://api.z.ai/api/paas/v4",
+    ),
+    # Z.AI Coding Plan CN: same key as zai_cn, gateway with prefix stripping
+    ProviderSpec(
+        name="zai_coding_cn",
+        keywords=("zai-coding",),
+        env_key="ZAI_API_KEY",
+        display_name="Z.AI Coding Plan (CN)",
+        backend="openai_compat",
+        is_gateway=True,
+        default_api_base="https://open.bigmodel.cn/api/coding/paas/v4",
+        strip_model_prefix=True,
+        env_extras=(("ZHIPUAI_API_KEY", "{api_key}"),),
+    ),
+    # Z.AI Coding Plan Global: same key as zai_gb, gateway with prefix stripping
+    ProviderSpec(
+        name="zai_coding_gb",
+        keywords=("zai-coding-plan",),
+        env_key="ZAI_API_KEY",
+        display_name="Z.AI Coding Plan (Global)",
+        backend="openai_compat",
+        is_gateway=True,
+        default_api_base="https://api.z.ai/api/coding/paas/v4",
+        strip_model_prefix=True,
+        env_extras=(("ZHIPUAI_API_KEY", "{api_key}"),),
+    ),
+    # Zhipu (deprecated -> use zai_cn instead)
     ProviderSpec(
         name="zhipu",
-        keywords=("zhipu", "glm", "zai"),
+        keywords=("zhipu",),
         env_key="ZAI_API_KEY",
-        display_name="Zhipu AI",
+        display_name="Zhipu AI (deprecated - use zai_cn)",
         backend="openai_compat",
         env_extras=(("ZHIPUAI_API_KEY", "{api_key}"),),
         default_api_base="https://open.bigmodel.cn/api/paas/v4",

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1485,3 +1485,179 @@ def test_channels_login_requires_channel_name() -> None:
     result = runner.invoke(app, ["channels", "login"])
 
     assert result.exit_code == 2
+
+
+# --- Z.AI provider tests (zhipu split into 4 providers) ---
+
+
+def test_config_accepts_zai_cn_explicit_provider():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "zaiCn",
+                    "model": "glm-4-plus",
+                }
+            },
+            "providers": {
+                "zaiCn": {
+                    "apiKey": "test-key",
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "zai_cn"
+
+
+def test_config_accepts_zai_gb_explicit_provider():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "zaiGb",
+                    "model": "glm-4-plus",
+                }
+            },
+            "providers": {
+                "zaiGb": {
+                    "apiKey": "test-key",
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "zai_gb"
+
+
+def test_config_accepts_zai_coding_cn_explicit_provider():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "zaiCodingCn",
+                    "model": "glm-4-plus",
+                }
+            },
+            "providers": {
+                "zaiCodingCn": {
+                    "apiKey": "test-key",
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "zai_coding_cn"
+
+
+def test_config_accepts_zai_coding_gb_explicit_provider():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "zaiCodingGb",
+                    "model": "glm-4-plus",
+                }
+            },
+            "providers": {
+                "zaiCodingGb": {
+                    "apiKey": "test-key",
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "zai_coding_gb"
+
+
+def test_zai_cn_auto_matches_glm_model_by_keyword():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "glm-4-plus"}},
+            "providers": {
+                "zaiCn": {"apiKey": "test-key"},
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "zai_cn"
+
+
+def test_zhipu_deprecated_alias_still_works():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "zhipu",
+                    "model": "glm-4-plus",
+                }
+            },
+            "providers": {
+                "zhipu": {
+                    "apiKey": "test-key",
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "zhipu"
+
+
+def test_find_by_name_accepts_zai_camel_case_and_hyphen_aliases():
+    assert find_by_name("zaiCn") is not None
+    assert find_by_name("zaiCn").name == "zai_cn"
+    assert find_by_name("zaiGb") is not None
+    assert find_by_name("zaiGb").name == "zai_gb"
+    assert find_by_name("zaiCodingCn") is not None
+    assert find_by_name("zaiCodingCn").name == "zai_coding_cn"
+    assert find_by_name("zaiCodingGb") is not None
+    assert find_by_name("zaiCodingGb").name == "zai_coding_gb"
+
+
+def test_zai_coding_plan_specs_are_gateways_with_prefix_stripping():
+    cn = find_by_name("zai_coding_cn")
+    gb = find_by_name("zai_coding_gb")
+
+    assert cn is not None
+    assert cn.is_gateway is True
+    assert cn.strip_model_prefix is True
+    assert "coding" in cn.default_api_base
+
+    assert gb is not None
+    assert gb.is_gateway is True
+    assert gb.strip_model_prefix is True
+    assert "coding" in gb.default_api_base
+
+
+def test_zai_gb_does_not_auto_match_glm_models():
+    """GLM models should auto-match zai_cn, not zai_gb."""
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "glm-4-plus"}},
+            "providers": {
+                "zaiCn": {"apiKey": "test-key-cn"},
+                "zaiGb": {"apiKey": "test-key-gb"},
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "zai_cn"
+
+
+def test_zai_cn_keyword_does_not_over_match_coding_plan():
+    """zai-coding model names should not match zai_cn via 'zai' keyword."""
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "zai-coding-glm-4"}},
+            "providers": {
+                "zaiCn": {"apiKey": "test-key-cn"},
+                "zaiCodingCn": {"apiKey": "test-key-coding"},
+            },
+        }
+    )
+
+    # zai_cn has keywords=("glm",) so "zai-coding-glm-4" matches zai_cn via "glm".
+    # This is expected: coding plans require explicit provider selection.
+    # The keyword "zai-coding" in zai_coding_cn won't win because PROVIDERS
+    # order puts zai_cn first and "glm" matches.
+    assert config.get_provider_name() == "zai_cn"

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1604,14 +1604,19 @@ def test_zhipu_deprecated_alias_still_works():
 
 
 def test_find_by_name_accepts_zai_camel_case_and_hyphen_aliases():
-    assert find_by_name("zaiCn") is not None
-    assert find_by_name("zaiCn").name == "zai_cn"
-    assert find_by_name("zaiGb") is not None
-    assert find_by_name("zaiGb").name == "zai_gb"
-    assert find_by_name("zaiCodingCn") is not None
-    assert find_by_name("zaiCodingCn").name == "zai_coding_cn"
-    assert find_by_name("zaiCodingGb") is not None
-    assert find_by_name("zaiCodingGb").name == "zai_coding_gb"
+    zai_cn = find_by_name("zaiCn")
+    zai_gb = find_by_name("zaiGb")
+    zai_coding_cn = find_by_name("zaiCodingCn")
+    zai_coding_gb = find_by_name("zaiCodingGb")
+
+    assert zai_cn is not None
+    assert zai_cn.name == "zai_cn"
+    assert zai_gb is not None
+    assert zai_gb.name == "zai_gb"
+    assert zai_coding_cn is not None
+    assert zai_coding_cn.name == "zai_coding_cn"
+    assert zai_coding_gb is not None
+    assert zai_coding_gb.name == "zai_coding_gb"
 
 
 def test_zai_coding_plan_specs_are_gateways_with_prefix_stripping():


### PR DESCRIPTION
## Summary

- Split the single `zhipu` provider into 4 dedicated providers reflecting the company rebrand from Zhipu to Z.AI, with separate endpoints for China mainland and Global regions plus Coding Plan variants
- Keep the original `zhipu` as a deprecated alias for backward compatibility

### New Providers

| Provider | Base URL | Purpose |
|----------|----------|---------|
| `zai_cn` | `https://open.bigmodel.cn/api/paas/v4` | Z.AI General (China mainland) |
| `zai_gb` | `https://api.z.ai/api/paas/v4` | Z.AI General (Global) |
| `zai_coding_cn` | `https://open.bigmodel.cn/api/coding/paas/v4` | GLM Coding Plan (CN) |
| `zai_coding_gb` | `https://api.z.ai/api/coding/paas/v4` | GLM Coding Plan (Global) |
| `zhipu` *(deprecated)* | same as `zai_cn` | Backward compatibility |

### Changes

- **`registry.py`**: Replace single zhipu `ProviderSpec` with 5 entries (4 new + 1 deprecated)
- **`schema.py`**: Add 4 new fields to `ProvidersConfig`, keep `zhipu` as deprecated
- **`README.md`**: Update provider table and tips
- **`test_commands.py`**: Add 10 tests covering explicit selection, auto-matching, deprecated alias, and gateway attributes

### Design Decisions

- `zai_cn` uses `keywords=("glm",)` only — avoids over-matching `"zai"` that would route Global users to CN
- `zai_gb` requires explicit provider selection (same pattern as `byteplus` vs `volcengine`)
- Coding Plan variants are gateways with `strip_model_prefix=True` (matches `volcengine_coding_plan` pattern)
- All 4 providers share the same `ZAI_API_KEY` and set `ZHIPUAI_API_KEY` via `env_extras`

## Test plan

- [x] 60/60 tests pass in `tests/cli/test_commands.py`
- [x] Explicit provider selection works for all 4 providers
- [x] GLM models auto-match to `zai_cn` by keyword
- [x] `zai_gb` does not steal GLM model auto-matching
- [x] `zhipu` deprecated alias still works
- [x] `find_by_name()` handles camelCase/hyphen variants
- [x] Coding Plan specs have correct gateway and prefix stripping flags