### PR TITLE
feat(agents): add agent plugin infrastructure

### DIFF
--- a/nanobot/agents/__init__.py
+++ b/nanobot/agents/__init__.py
@@ -1,0 +1,34 @@
+"""Agents module with plugin support."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nanobot.agent.hook import AgentHook
+
+
+class BaseAgent(ABC):
+    """Abstract base class for nanobot agents.
+
+    Agents extend the core agent loop with custom hooks, tools, and behaviors.
+    They are discovered via the `nanobot.agents` entry point group.
+    """
+
+    name: str = "base"
+    display_name: str = "Base Agent"
+
+    @classmethod
+    def default_config(cls) -> dict[str, Any]:
+        """Return default configuration for this agent."""
+        return {}
+
+    @classmethod
+    @abstractmethod
+    def create_hook(cls, **kwargs: Any) -> "AgentHook":
+        """Factory method to create the agent's hook instance."""
+        raise NotImplementedError
+
+
+__all__ = ["BaseAgent"]

--- a/nanobot/agents/registry.py
+++ b/nanobot/agents/registry.py
@@ -1,0 +1,80 @@
+"""Agent discovery via entry_points for external agent plugins."""
+
+from __future__ import annotations
+
+import pkgutil
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from nanobot.agents import BaseAgent
+
+_INTERNAL_AGENTS = frozenset({"__init__"})
+
+
+def discover_agents() -> dict[str, type["BaseAgent"]]:
+    """Discover all agents: built-in (pkgutil) merged with external (entry_points).
+
+    Built-in agents take priority — an external plugin cannot shadow a built-in name.
+    """
+    import nanobot.agents as agents_pkg
+
+    from nanobot.agents import BaseAgent
+
+    builtin: dict[str, type[BaseAgent]] = {}
+
+    for _, name, ispkg in pkgutil.iter_modules(agents_pkg.__path__):
+        if ispkg or name in _INTERNAL_AGENTS:
+            continue
+        try:
+            mod = __import__(f"nanobot.agents.{name}", fromlist=[name])
+            for attr_name in dir(mod):
+                attr = getattr(mod, attr_name)
+                if isinstance(attr, type) and issubclass(attr, BaseAgent) and attr is not BaseAgent:
+                    builtin[attr.name] = attr
+                    logger.debug("Discovered built-in agent: {}", attr.name)
+        except Exception as e:
+            logger.debug("Skipping agent '{}': {}", name, e)
+
+    return builtin
+
+
+def discover_plugins() -> dict[str, type["BaseAgent"]]:
+    """Discover external agent plugins registered via entry_points."""
+    from importlib.metadata import entry_points
+
+    from nanobot.agents import BaseAgent
+
+    plugins: dict[str, type[BaseAgent]] = {}
+
+    for ep in entry_points(group="nanobot.agents"):
+        try:
+            cls = ep.load()
+            if isinstance(cls, type) and issubclass(cls, BaseAgent):
+                plugins[ep.name] = cls
+                logger.info("Loaded agent plugin: {}", ep.name)
+            else:
+                logger.warning("Entry '{}' is not a BaseAgent subclass", ep.name)
+        except Exception as e:
+            logger.warning("Failed to load agent plugin '{}': {}", ep.name, e)
+
+    return plugins
+
+
+def discover_all() -> dict[str, type["BaseAgent"]]:
+    """Return all agents: built-in (pkgutil) merged with external (entry_points).
+
+    Built-in agents take priority — an external plugin cannot shadow a built-in name.
+    """
+    from nanobot.agents import BaseAgent
+
+    builtin = discover_agents()
+    external = discover_plugins()
+
+    builtin_names = set(builtin)
+    shadowed = set(external) & builtin_names
+    if shadowed:
+        logger.warning("Agent plugin(s) shadowed by built-in (ignored): {}", shadowed)
+
+    return {**external, **builtin}

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -1,7 +1,7 @@
 """Configuration schema using Pydantic."""
 
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
@@ -15,6 +15,7 @@ class Base(BaseModel):
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
+
 class ChannelsConfig(Base):
     """Configuration for chat channels.
 
@@ -27,7 +28,9 @@ class ChannelsConfig(Base):
 
     send_progress: bool = True  # stream agent's text progress to the channel
     send_tool_hints: bool = False  # stream tool-call hints (e.g. read_file("…"))
-    send_max_retries: int = Field(default=3, ge=0, le=10)  # Max delivery attempts (initial send included)
+    send_max_retries: int = Field(
+        default=3, ge=0, le=10
+    )  # Max delivery attempts (initial send included)
     transcription_provider: str = "groq"  # Voice transcription backend: "groq" or "openai"
 
 
@@ -74,10 +77,16 @@ class AgentDefaults(Base):
     max_tool_iterations: int = 200
     max_tool_result_chars: int = 16_000
     provider_retry_mode: Literal["standard", "persistent"] = "standard"
-    reasoning_effort: str | None = None  # low / medium / high / adaptive - enables LLM thinking mode
+    reasoning_effort: str | None = (
+        None  # low / medium / high / adaptive - enables LLM thinking mode
+    )
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
-    unified_session: bool = False  # Share one session across all channels (single-user multi-device)
-    disabled_skills: list[str] = Field(default_factory=list)  # Skill names to exclude from loading (e.g. ["summarize", "skill-creator"])
+    unified_session: bool = (
+        False  # Share one session across all channels (single-user multi-device)
+    )
+    disabled_skills: list[str] = Field(
+        default_factory=list
+    )  # Skill names to exclude from loading (e.g. ["summarize", "skill-creator"])
     session_ttl_minutes: int = Field(
         default=0,
         ge=0,
@@ -105,7 +114,9 @@ class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
-    azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
+    azure_openai: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -120,18 +131,30 @@ class ProvidersConfig(Base):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
-    minimax_anthropic: ProviderConfig = Field(default_factory=ProviderConfig)  # MiniMax Anthropic endpoint (thinking)
+    minimax_anthropic: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # MiniMax Anthropic endpoint (thinking)
     mistral: ProviderConfig = Field(default_factory=ProviderConfig)
     stepfun: ProviderConfig = Field(default_factory=ProviderConfig)  # Step Fun (阶跃星辰)
     xiaomi_mimo: ProviderConfig = Field(default_factory=ProviderConfig)  # Xiaomi MIMO (小米)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)
-    volcengine_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine Coding Plan
-    byteplus: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus (VolcEngine international)
-    byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
-    openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
-    github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
+    volcengine_coding_plan: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # VolcEngine Coding Plan
+    byteplus: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # BytePlus (VolcEngine international)
+    byteplus_coding_plan: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # BytePlus Coding Plan
+    openai_codex: ProviderConfig = Field(
+        default_factory=ProviderConfig, exclude=True
+    )  # OpenAI Codex (OAuth)
+    github_copilot: ProviderConfig = Field(
+        default_factory=ProviderConfig, exclude=True
+    )  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
 
 
@@ -141,6 +164,17 @@ class HeartbeatConfig(Base):
     enabled: bool = True
     interval_s: int = 30 * 60  # 30 minutes
     keep_recent_messages: int = 8
+
+
+class AgentConfig(Base):
+    """Agent plugin configuration.
+
+    This is a generic configuration for agent plugins.
+    Each plugin can define its own config schema and use this as a reference.
+    """
+
+    enabled: bool = False
+    plugins: dict[str, Any] = Field(default_factory=dict)  # plugin-name -> plugin config
 
 
 class ApiConfig(Base):
@@ -186,7 +220,10 @@ class ExecToolConfig(Base):
     timeout: int = 60
     path_append: str = ""
     sandbox: str = ""  # sandbox backend: "" (none) or "bwrap"
-    allowed_env_keys: list[str] = Field(default_factory=list)  # Env var names to pass through to subprocess (e.g. ["GOPATH", "JAVA_HOME"])
+    allowed_env_keys: list[str] = Field(
+        default_factory=list
+    )  # Env var names to pass through to subprocess (e.g. ["GOPATH", "JAVA_HOME"])
+
 
 class MCPServerConfig(Base):
     """MCP server connection configuration (stdio or HTTP)."""
@@ -198,7 +235,10 @@ class MCPServerConfig(Base):
     url: str = ""  # HTTP/SSE: endpoint URL
     headers: dict[str, str] = Field(default_factory=dict)  # HTTP/SSE: custom headers
     tool_timeout: int = 30  # seconds before a tool call is cancelled
-    enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+    enabled_tools: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+
 
 class ToolsConfig(Base):
     """Tools configuration."""
@@ -207,7 +247,9 @@ class ToolsConfig(Base):
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
     restrict_to_workspace: bool = False  # restrict all tool access to workspace directory
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
-    ssrf_whitelist: list[str] = Field(default_factory=list)  # CIDR ranges to exempt from SSRF blocking (e.g. ["100.64.0.0/10"] for Tailscale)
+    ssrf_whitelist: list[str] = Field(
+        default_factory=list
+    )  # CIDR ranges to exempt from SSRF blocking (e.g. ["100.64.0.0/10"] for Tailscale)
 
 
 class Config(BaseSettings):
@@ -219,6 +261,7 @@ class Config(BaseSettings):
     api: ApiConfig = Field(default_factory=ApiConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    plugins: AgentConfig = Field(default_factory=AgentConfig)
 
     @property
     def workspace_path(self) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,10 @@ dev = [
 [project.scripts]
 nanobot = "nanobot.cli.commands:app"
 
+[project.entry-points."nanobot.agents"]
+# Agent plugins are discovered via this entry point group.
+# Built-in agents are loaded via pkgutil automatically.
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/config/test_agent_plugin.py
+++ b/tests/config/test_agent_plugin.py
@@ -1,0 +1,142 @@
+"""Tests for nanobot.agents module - agent plugin infrastructure."""
+
+import pytest
+
+from nanobot.agents import BaseAgent
+from nanobot.config.schema import AgentConfig, Config
+
+
+class TestBaseAgent:
+    """Test BaseAgent abstract class."""
+
+    def test_base_agent_has_required_attributes(self):
+        """BaseAgent should have name and display_name attributes."""
+        assert hasattr(BaseAgent, "name")
+        assert hasattr(BaseAgent, "display_name")
+
+    def test_base_agent_has_default_config(self):
+        """BaseAgent should have default_config classmethod."""
+        assert hasattr(BaseAgent, "default_config")
+        config = BaseAgent.default_config()
+        assert isinstance(config, dict)
+
+    def test_base_agent_has_create_hook(self):
+        """BaseAgent should have create_hook classmethod."""
+        assert hasattr(BaseAgent, "create_hook")
+
+
+class TestConcreteAgent(BaseAgent):
+    """Concrete implementation of BaseAgent for testing."""
+
+    name = "test_agent"
+    display_name = "Test Agent"
+
+    @classmethod
+    def default_config(cls):
+        return {"test_option": True}
+
+    @classmethod
+    def create_hook(cls, **kwargs):
+        return kwargs.get("mock_hook", "mock_hook_instance")
+
+
+class TestBaseAgentSubclass:
+    """Test concrete agent implementation."""
+
+    def test_concrete_agent_name(self):
+        """Concrete agent should have correct name."""
+        assert TestConcreteAgent.name == "test_agent"
+
+    def test_concrete_agent_display_name(self):
+        """Concrete agent should have correct display_name."""
+        assert TestConcreteAgent.display_name == "Test Agent"
+
+    def test_concrete_agent_default_config(self):
+        """Concrete agent should return config from default_config."""
+        config = TestConcreteAgent.default_config()
+        assert config == {"test_option": True}
+
+    def test_concrete_agent_create_hook(self):
+        """Concrete agent should create hook via create_hook."""
+        hook = TestConcreteAgent.create_hook(mock_hook="test_hook")
+        assert hook == "test_hook"
+
+    def test_concrete_agent_is_subclass_of_base_agent(self):
+        """Concrete agent should be subclass of BaseAgent."""
+        assert issubclass(TestConcreteAgent, BaseAgent)
+
+
+class TestAgentConfig:
+    """Test AgentConfig schema."""
+
+    def test_agent_config_defaults(self):
+        """AgentConfig should have correct defaults."""
+        config = AgentConfig()
+        assert config.enabled is False
+        assert config.plugins == {}
+
+    def test_agent_config_accepts_enabled(self):
+        """AgentConfig should accept enabled field."""
+        config = AgentConfig(enabled=True)
+        assert config.enabled is True
+
+    def test_agent_config_accepts_plugins(self):
+        """AgentConfig should accept plugins dict."""
+        config = AgentConfig(plugins={"kosmos": {"host": "localhost"}})
+        assert config.plugins == {"kosmos": {"host": "localhost"}}
+
+
+class TestConfigHasPlugins:
+    """Test that Config includes plugins field."""
+
+    def test_config_has_plugins_field(self):
+        """Config should have plugins field."""
+        config = Config()
+        assert hasattr(config, "plugins")
+
+    def test_config_plugins_is_agent_config(self):
+        """Config.plugins should be AgentConfig instance."""
+        config = Config()
+        assert isinstance(config.plugins, AgentConfig)
+
+    def test_config_plugins_defaults(self):
+        """Config.plugins should have correct defaults."""
+        config = Config()
+        assert config.plugins.enabled is False
+        assert config.plugins.plugins == {}
+
+
+class TestAgentRegistry:
+    """Test agent registry functions."""
+
+    def test_discover_agents_returns_dict(self):
+        """discover_agents should return a dict."""
+        from nanobot.agents.registry import discover_agents
+
+        result = discover_agents()
+        assert isinstance(result, dict)
+
+    def test_discover_plugins_returns_dict(self):
+        """discover_plugins should return a dict."""
+        from nanobot.agents.registry import discover_plugins
+
+        result = discover_plugins()
+        assert isinstance(result, dict)
+
+    def test_discover_all_returns_dict(self):
+        """discover_all should return a dict."""
+        from nanobot.agents.registry import discover_all
+
+        result = discover_all()
+        assert isinstance(result, dict)
+
+    def test_discover_all_merges_builtin_and_plugins(self):
+        """discover_all should merge built-in and external plugins."""
+        from nanobot.agents.registry import discover_all
+
+        result = discover_all()
+        # Result should be dict of agent_name -> Agent class
+        for name, agent_cls in result.items():
+            assert isinstance(name, str)
+            assert isinstance(agent_cls, type)
+            assert issubclass(agent_cls, BaseAgent)


### PR DESCRIPTION
## Summary

Add generic agent plugin infrastructure to nanobot, enabling external packages to register custom agents via entry points.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Add `nanobot.agents` entry point group |
| `nanobot/agents/__init__.py` | Add `BaseAgent` abstract class |
| `nanobot/agents/registry.py` | Add agent discovery functions |
| `nanobot/config/schema.py` | Add `AgentConfig` + `Config.plugins` field |
| `tests/config/test_agent_plugin.py` | Add 18 tests |

## Motivation

This enables external packages to register agents via the `nanobot.agents` entry point, similar to how channels work with `nanobot.channels`.

## Usage Example

### Creating an Agent Plugin

1. **Create your agent class**:

```python
# my_agent.py
from nanobot.agents import BaseAgent
from nanobot.agent.hook import AgentHook

class MyAgent(BaseAgent):
    name = "myagent"
    display_name = "My Custom Agent"

    @classmethod
    def default_config(cls):
        return {"enabled": True}

    @classmethod
    def create_hook(cls, **kwargs) -> AgentHook:
        return MyAgentHook(
            agent_id=kwargs.get("agent_id", "main"),
            agent_name=kwargs.get("agent_name", "MyAgent"),
        )
```

2. **Configure entry point in `pyproject.toml`**:

```toml
[project.entry-points."nanobot.agents"]
myagent = "my_agent:MyAgent"
```

3. **Install the plugin**:

```bash
pip install -e .
```

### Discovering Agents

```bash
# Discover all registered agents
python -c "from nanobot.agents.registry import discover_all; print(discover_all())"
# Output: {'myagent': <class 'my_agent.MyAgent'>}
```

### Configuration

Agents can be configured in `config.json`:

```json
{
  "plugins": {
    "enabled": true,
    "plugins": {
      "myagent": {
        "option1": "value1"
      }
    }
  }
}
```

## Testing

```bash
# Run the new tests
pytest tests/config/test_agent_plugin.py -v

# Test agent discovery
python -c "from nanobot.agents.registry import discover_all; print(discover_all())"
```

## Backward Compatibility

- Existing agents continue to work unchanged
- Built-in agents take priority over external plugins (cannot be shadowed)
- The `AgentConfig` is optional and defaults to `enabled: false`