### PR TITLE
feat(dream): git-based section age annotations for memory staleness

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -552,6 +552,13 @@ class Consolidator:
 # ---------------------------------------------------------------------------
 
 
+# Single source of truth for the staleness threshold used in _annotate_with_ages
+# *and* in the Phase 1 prompt template (passed as `stale_threshold_days`).
+# Keep code and prompt aligned — if you bump this, the LLM's instruction string
+# updates automatically.
+_STALE_THRESHOLD_DAYS = 14
+
+
 class Dream:
     """Two-phase memory processor: analyze history.jsonl, then edit files via AgentRunner.
 
@@ -568,6 +575,7 @@ class Dream:
         max_batch_size: int = 20,
         max_iterations: int = 10,
         max_tool_result_chars: int = 16_000,
+        annotate_line_ages: bool = True,
     ):
         self.store = store
         self.provider = provider
@@ -575,6 +583,10 @@ class Dream:
         self.max_batch_size = max_batch_size
         self.max_iterations = max_iterations
         self.max_tool_result_chars = max_tool_result_chars
+        # Kill switch for the git-blame-based per-line age annotation in Phase 1.
+        # Default True keeps the #3212 behavior; set False to feed MEMORY.md raw
+        # (e.g. if a specific LLM reacts poorly to the `← Nd` suffix).
+        self.annotate_line_ages = annotate_line_ages
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
 
@@ -635,9 +647,12 @@ class Dream:
     def _annotate_with_ages(self, content: str) -> str:
         """Append per-line age suffixes to MEMORY.md content.
 
-        Each non-blank line gets a suffix like ``← 30d`` indicating how
-        many days since it was last modified.  Lines ≤14 days old get no
-        suffix.  Returns the original content unchanged if git is unavailable.
+        Each non-blank line whose age exceeds ``_STALE_THRESHOLD_DAYS`` gets a
+        suffix like ``← 30d`` indicating days since last modification.
+        Returns the original content unchanged if git is unavailable,
+        annotate fails, or the line count doesn't match the age count
+        (which can happen with an uncommitted working-tree edit — better to
+        skip annotation than to tag the wrong line).
         SOUL.md and USER.md are never annotated.
         """
         file_path = "memory/MEMORY.md"
@@ -651,14 +666,23 @@ class Dream:
 
         had_trailing = content.endswith("\n")
         lines = content.splitlines()
+        # If HEAD-blob line count disagrees with the working-tree content we
+        # received, ages would be assigned to the wrong lines — skip entirely
+        # and feed the LLM un-annotated content rather than misleading data.
+        if len(lines) != len(ages):
+            logger.debug(
+                "line_ages length mismatch for {} (lines={}, ages={}); skipping annotation",
+                file_path, len(lines), len(ages),
+            )
+            return content
+
         annotated: list[str] = []
-        for i, line in enumerate(lines):
-            if not line.strip() or i >= len(ages):
+        for line, age in zip(lines, ages):
+            if not line.strip():
                 annotated.append(line)
                 continue
-            d = ages[i].age_days
-            if d > 14:
-                annotated.append(f"{line}  \u2190 {d}d")
+            if age.age_days > _STALE_THRESHOLD_DAYS:
+                annotated.append(f"{line}  \u2190 {age.age_days}d")
             else:
                 annotated.append(line)
         result = "\n".join(annotated)
@@ -686,10 +710,14 @@ class Dream:
             f"[{e['timestamp']}] {e['content']}" for e in batch
         )
 
-        # Current file contents + per-line age annotations
+        # Current file contents + per-line age annotations (MEMORY.md only)
         current_date = datetime.now().strftime("%Y-%m-%d")
         raw_memory = self.store.read_memory() or "(empty)"
-        current_memory = self._annotate_with_ages(raw_memory)
+        current_memory = (
+            self._annotate_with_ages(raw_memory)
+            if self.annotate_line_ages
+            else raw_memory
+        )
         current_soul = self.store.read_soul() or "(empty)"
         current_user = self.store.read_user() or "(empty)"
 
@@ -711,7 +739,11 @@ class Dream:
                 messages=[
                     {
                         "role": "system",
-                        "content": render_template("agent/dream_phase1.md", strip=True),
+                        "content": render_template(
+                            "agent/dream_phase1.md",
+                            strip=True,
+                            stale_threshold_days=_STALE_THRESHOLD_DAYS,
+                        ),
                     },
                     {"role": "user", "content": phase1_prompt},
                 ],

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -632,6 +632,40 @@ class Dream:
 
     # -- main entry ----------------------------------------------------------
 
+    def _annotate_with_ages(self, content: str) -> str:
+        """Append per-line age suffixes to MEMORY.md content.
+
+        Each non-blank line gets a suffix like ``← 30d`` indicating how
+        many days since it was last modified.  Lines ≤14 days old get no
+        suffix.  Returns the original content unchanged if git is unavailable.
+        SOUL.md and USER.md are never annotated.
+        """
+        file_path = "memory/MEMORY.md"
+        try:
+            ages = self.store.git.line_ages(file_path)
+        except Exception:
+            logger.debug("line_ages failed for {}", file_path)
+            return content
+        if not ages:
+            return content
+
+        had_trailing = content.endswith("\n")
+        lines = content.splitlines()
+        annotated: list[str] = []
+        for i, line in enumerate(lines):
+            if not line.strip() or i >= len(ages):
+                annotated.append(line)
+                continue
+            d = ages[i].age_days
+            if d > 14:
+                annotated.append(f"{line}  \u2190 {d}d")
+            else:
+                annotated.append(line)
+        result = "\n".join(annotated)
+        if had_trailing:
+            result += "\n"
+        return result
+
     async def run(self) -> bool:
         """Process unprocessed history entries. Returns True if work was done."""
         from nanobot.agent.skills import BUILTIN_SKILLS_DIR
@@ -652,9 +686,10 @@ class Dream:
             f"[{e['timestamp']}] {e['content']}" for e in batch
         )
 
-        # Current file contents
+        # Current file contents + per-line age annotations
         current_date = datetime.now().strftime("%Y-%m-%d")
-        current_memory = self.store.read_memory() or "(empty)"
+        raw_memory = self.store.read_memory() or "(empty)"
+        current_memory = self._annotate_with_ages(raw_memory)
         current_soul = self.store.read_soul() or "(empty)"
         current_user = self.store.read_user() or "(empty)"
 
@@ -759,7 +794,9 @@ class Dream:
         # Git auto-commit (only when there are actual changes)
         if changelog and self.store.git.is_initialized():
             ts = batch[-1]["timestamp"]
-            sha = self.store.git.auto_commit(f"dream: {ts}, {len(changelog)} change(s)")
+            summary = f"dream: {ts}, {len(changelog)} change(s)"
+            commit_msg = f"{summary}\n\n{analysis.strip()}"
+            sha = self.store.git.auto_commit(commit_msg)
             if sha:
                 logger.info("Dream commit: {}", sha)
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -871,6 +871,7 @@ def gateway(
         agent.dream.model = dream_cfg.model_override
     agent.dream.max_batch_size = dream_cfg.max_batch_size
     agent.dream.max_iterations = dream_cfg.max_iterations
+    agent.dream.annotate_line_ages = dream_cfg.annotate_line_ages
     from nanobot.cron.types import CronJob, CronPayload
     cron.register_system_job(CronJob(
         id="dream",

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -43,7 +43,12 @@ class DreamConfig(Base):
         validation_alias=AliasChoices("modelOverride", "model", "model_override"),
     )  # Optional Dream-specific model override
     max_batch_size: int = Field(default=20, ge=1)  # Max history entries per run
+    # Bumped from 10 to 15 in #3212 (exp002: +30% dedup, no accuracy loss; >15 plateaus).
     max_iterations: int = Field(default=15, ge=1)  # Max tool calls per Phase 2
+    # Per-line git-blame age annotation in Phase 1 prompt (see #3212). Default
+    # on — set to False to feed MEMORY.md raw if a specific LLM reacts poorly
+    # to the `← Nd` suffix or you want deterministic, git-independent prompts.
+    annotate_line_ages: bool = True
 
     def build_schedule(self, timezone: str) -> CronSchedule:
         """Build the runtime schedule, preferring the legacy cron override if present."""

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -43,7 +43,7 @@ class DreamConfig(Base):
         validation_alias=AliasChoices("modelOverride", "model", "model_override"),
     )  # Optional Dream-specific model override
     max_batch_size: int = Field(default=20, ge=1)  # Max history entries per run
-    max_iterations: int = Field(default=10, ge=1)  # Max tool calls per Phase 2
+    max_iterations: int = Field(default=15, ge=1)  # Max tool calls per Phase 2
 
     def build_schedule(self, timezone: str) -> CronSchedule:
         """Build the runtime schedule, preferring the legacy cron override if present."""

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -26,7 +26,7 @@ Staleness — MEMORY.md lines may have a ``← Nd`` suffix showing days since la
 - Age only indicates when content was last touched, not whether it should be removed
 - Use content judgment: user habits/preferences/personality traits are permanent regardless of age
 - Only prune content that is objectively outdated: passed events, resolved tracking, superseded approaches
-- Lines with ``← Nd`` (N>14) deserve closer review but are NOT automatically removable
+- Lines with ``← Nd`` (N>{{ stale_threshold_days }}) deserve closer review but are NOT automatically removable
 - When removing: prefer deleting individual items over entire sections
 
 Skill discovery — flag [SKILL] when ALL of these are true:

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -1,4 +1,6 @@
-Compare conversation history against current memory files. Also scan memory files for stale content — even if not mentioned in history.
+You have TWO equally important tasks:
+1. Extract new facts from conversation history
+2. Deduplicate existing memory files — find and flag redundant, overlapping, or stale content even if NOT mentioned in history
 
 Output one line per finding:
 [FILE] atomic fact (not already in memory)
@@ -12,12 +14,20 @@ Rules:
 - Corrections: [USER] location is Tokyo, not Osaka
 - Capture confirmed approaches the user validated
 
-Staleness — flag for [FILE-REMOVE]:
-- Time-sensitive data older than 14 days: weather, daily status, one-time meetings, passed events
-- Completed one-time tasks: triage, one-time reviews, finished research, resolved incidents
-- Resolved tracking: merged/closed PRs, fixed issues, completed migrations
-- Detailed incident info after 14 days — reduce to one-line summary
-- Superseded: approaches replaced by newer solutions, deprecated dependencies
+Deduplication — scan ALL memory files for these redundancy patterns:
+- Same fact stated in multiple places (e.g., "communicates in Chinese" in both USER.md and multiple MEMORY.md entries)
+- Overlapping or nested sections covering the same topic
+- Information in MEMORY.md that is already captured in USER.md or SOUL.md (MEMORY.md should not duplicate permanent-file content)
+- Verbose entries that can be condensed without losing information
+For each duplicate found, output [FILE-REMOVE] for the less authoritative copy (prefer keeping facts in their canonical location)
+
+Staleness — MEMORY.md lines may have a ``← Nd`` suffix showing days since last modification:
+- SOUL.md and USER.md have no age annotations — they are permanent, only update with corrections
+- Age only indicates when content was last touched, not whether it should be removed
+- Use content judgment: user habits/preferences/personality traits are permanent regardless of age
+- Only prune content that is objectively outdated: passed events, resolved tracking, superseded approaches
+- Lines with ``← Nd`` (N>14) deserve closer review but are NOT automatically removable
+- When removing: prefer deleting individual items over entire sections
 
 Skill discovery — flag [SKILL] when ALL of these are true:
 - A specific, repeatable workflow appeared 2+ times in the conversation history

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 from loguru import logger
@@ -22,6 +23,23 @@ class CommitInfo:
         if diff:
             return f"{header}\n```diff\n{diff}\n```"
         return f"{header}\n(no file changes)"
+
+
+@dataclass
+class LineAge:
+    """Age of a single line based on git blame."""
+
+    age_days: int  # days since last modification
+
+
+def _compute_line_ages(annotated) -> list[LineAge]:
+    """Convert annotate results to per-line ages."""
+    now = datetime.now(tz=timezone.utc).date()
+    ages: list[LineAge] = []
+    for (commit, _tree_entry), _line_bytes in annotated:
+        dt = datetime.fromtimestamp(commit.commit_time, tz=timezone.utc).date()
+        ages.append(LineAge(age_days=(now - dt).days))
+    return ages
 
 
 class GitStore:
@@ -190,6 +208,34 @@ class GitStore:
         except Exception:
             logger.warning("Git log failed")
             return []
+
+    def line_ages(self, file_path: str) -> list[LineAge]:
+        """Compute the age of each line in a tracked file via git blame.
+
+        Returns one LineAge per line, in order.
+        Returns an empty list if the repo is not initialized, the file is
+        empty, or annotation fails.
+        """
+
+        if not self.is_initialized():
+            return []
+
+        target = self._workspace / file_path
+        if not target.exists() or target.stat().st_size == 0:
+            return []
+
+        try:
+            from dulwich import porcelain
+
+            annotated = porcelain.annotate(str(self._workspace), file_path)
+        except Exception:
+            logger.warning("Git line_ages annotate failed for {}", file_path)
+            return []
+
+        if not annotated:
+            return []
+
+        return _compute_line_ages(annotated)
 
     def diff_commits(self, sha1: str, sha2: str) -> str:
         """Show diff between two commits."""

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -2,11 +2,12 @@
 
 import pytest
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from nanobot.agent.memory import Dream, MemoryStore
 from nanobot.agent.runner import AgentRunResult
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+from nanobot.utils.gitstore import LineAge
 
 
 @pytest.fixture
@@ -174,4 +175,84 @@ class TestDreamRun:
         call_args = mock_provider.chat_with_retry.call_args
         user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
         assert "## Current MEMORY.md" in user_msg
+
+    async def test_phase1_prompt_carries_age_suffix_for_stale_lines(
+        self, dream, mock_provider, mock_runner, store,
+    ):
+        """End-to-end: ages >14d must appear verbatim in the LLM prompt, ages ≤14d must not."""
+        # MEMORY.md fixture has 2 non-blank lines ("# Memory" and "- Project X active").
+        # Inject four ages to cover threshold boundaries: >14 suffix, ==14 no suffix, <14 no suffix.
+        store.write_memory("# Memory\n- Project X active\n- fresh item\n- edge case line")
+        store.append_history("some event")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        fake_ages = [
+            LineAge(age_days=30),   # "# Memory"        → should get ← 30d
+            LineAge(age_days=20),   # "- Project X..."  → should get ← 20d
+            LineAge(age_days=14),   # "- fresh item"    → ==14, threshold is strictly >14, no suffix
+            LineAge(age_days=5),    # "- edge case..."  → no suffix
+        ]
+        with patch.object(store.git, "line_ages", return_value=fake_ages):
+            await dream.run()
+
+        call_args = mock_provider.chat_with_retry.call_args
+        user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
+        memory_section = user_msg.split("## Current MEMORY.md")[1].split("## Current SOUL.md")[0]
+        assert "\u2190 30d" in memory_section
+        assert "\u2190 20d" in memory_section
+        assert "\u2190 14d" not in memory_section
+        assert "\u2190 5d" not in memory_section
+
+    async def test_phase1_skips_annotation_when_disabled(
+        self, dream, mock_provider, mock_runner, store,
+    ):
+        """`annotate_line_ages=False` must bypass the git lookup entirely and keep MEMORY.md raw."""
+        store.append_history("some event")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        dream.annotate_line_ages = False
+        # line_ages must be bypassed entirely — verify with a spy rather than a
+        # raising side_effect, because _annotate_with_ages catches Exception
+        # (which swallows AssertionError) and would hide an accidental call.
+        with patch.object(store.git, "line_ages") as mock_line_ages:
+            await dream.run()
+            mock_line_ages.assert_not_called()
+
+        call_args = mock_provider.chat_with_retry.call_args
+        user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
+        assert "\u2190" not in user_msg
+
+    async def test_phase1_skips_annotation_on_line_ages_length_mismatch(
+        self, dream, mock_provider, mock_runner, store,
+    ):
+        """If ages length != lines length (dirty working tree), skip annotation instead of mis-tagging."""
+        # MEMORY.md has 2 non-blank lines but we hand back only 1 age → mismatch.
+        store.append_history("some event")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        with patch.object(store.git, "line_ages", return_value=[LineAge(age_days=999)]):
+            await dream.run()
+
+        call_args = mock_provider.chat_with_retry.call_args
+        user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
+        memory_section = user_msg.split("## Current MEMORY.md")[1].split("## Current SOUL.md")[0]
+        # No age arrow at all — we refused to annotate rather than tag the wrong line.
+        assert "\u2190" not in memory_section
+
+    async def test_phase1_prompt_uses_threshold_from_template_var(
+        self, dream, mock_provider, mock_runner, store,
+    ):
+        """System prompt should reference the stale-threshold constant, not a hardcoded 14."""
+        store.append_history("some event")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        await dream.run()
+
+        system_msg = mock_provider.chat_with_retry.call_args.kwargs["messages"][0]["content"]
+        # The template renders with stale_threshold_days=14 → LLM must see "N>14"
+        assert "N>14" in system_msg
 

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -123,3 +123,55 @@ class TestDreamRun:
         assert "Successfully wrote" in result
         assert (store.workspace / "skills" / "test-skill" / "SKILL.md").exists()
 
+    async def test_phase1_prompt_includes_line_age_annotations(self, dream, mock_provider, mock_runner, store):
+        """Phase 1 prompt should have per-line age suffixes in MEMORY.md when git is available."""
+        store.append_history("some event")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        # Init git so line_ages works
+        store.git.init()
+        store.git.auto_commit("initial memory state")
+
+        await dream.run()
+
+        # The MEMORY.md section should not crash and should contain the memory content
+        call_args = mock_provider.chat_with_retry.call_args
+        user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
+        assert "## Current MEMORY.md" in user_msg
+
+    async def test_phase1_annotates_only_memory_not_soul_or_user(self, dream, mock_provider, mock_runner, store):
+        """SOUL.md and USER.md should never have age annotations — they are permanent."""
+        store.append_history("some event")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        store.git.init()
+        store.git.auto_commit("initial state")
+
+        await dream.run()
+
+        call_args = mock_provider.chat_with_retry.call_args
+        user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
+        # The ← suffix should only appear in MEMORY.md section
+        memory_section = user_msg.split("## Current MEMORY.md")[1].split("## Current SOUL.md")[0]
+        soul_section = user_msg.split("## Current SOUL.md")[1].split("## Current USER.md")[0]
+        user_section = user_msg.split("## Current USER.md")[1]
+        # SOUL and USER should not contain age arrows
+        assert "\u2190" not in soul_section
+        assert "\u2190" not in user_section
+
+    async def test_phase1_prompt_works_without_git(self, dream, mock_provider, mock_runner, store):
+        """Phase 1 should work fine even if git is not initialized (no age annotations)."""
+        store.append_history("some event")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_runner.run = AsyncMock(return_value=_make_run_result())
+
+        await dream.run()
+
+        # Should still succeed — just without age annotations
+        mock_provider.chat_with_retry.assert_called_once()
+        call_args = mock_provider.chat_with_retry.call_args
+        user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
+        assert "## Current MEMORY.md" in user_msg
+

--- a/tests/utils/test_gitstore.py
+++ b/tests/utils/test_gitstore.py
@@ -1,0 +1,91 @@
+"""Tests for GitStore — line_ages() and core git operations."""
+
+import time
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from nanobot.utils.gitstore import GitStore
+
+
+@pytest.fixture
+def git(tmp_path):
+    """Create an initialized GitStore with tracked MEMORY.md."""
+    g = GitStore(tmp_path, tracked_files=["MEMORY.md", "SOUL.md"])
+    g.init()
+    return g
+
+
+class TestLineAges:
+    def test_returns_empty_when_not_initialized(self, tmp_path):
+        """line_ages should return [] if the git repo is not initialized."""
+        git = GitStore(tmp_path, tracked_files=["MEMORY.md"])
+        assert git.line_ages("MEMORY.md") == []
+
+    def test_returns_empty_for_missing_file(self, git):
+        """line_ages should return [] for a file that doesn't exist."""
+        assert git.line_ages("SOUL.md") == []
+
+    def test_returns_empty_for_empty_file(self, git, tmp_path):
+        """line_ages should return [] for an empty tracked file."""
+        (tmp_path / "SOUL.md").write_text("", encoding="utf-8")
+        git.auto_commit("empty soul")
+        assert git.line_ages("SOUL.md") == []
+
+    def test_one_age_per_line(self, git, tmp_path):
+        """line_ages should return one entry per line in the file."""
+        content = "# Memory\n\n## Section A\n- item 1\n"
+        (tmp_path / "MEMORY.md").write_text(content, encoding="utf-8")
+        git.auto_commit("initial")
+        ages = git.line_ages("MEMORY.md")
+        assert len(ages) == len(content.splitlines())
+
+    def test_fresh_lines_have_age_zero(self, git, tmp_path):
+        """Lines committed today should have age_days=0."""
+        (tmp_path / "MEMORY.md").write_text("## A\n- x\n", encoding="utf-8")
+        git.auto_commit("initial")
+        ages = git.line_ages("MEMORY.md")
+        assert all(a.age_days == 0 for a in ages)
+
+    def test_age_differentiates_across_days(self, git, tmp_path):
+        """Lines committed today should show correct age when 'now' is mocked forward."""
+        (tmp_path / "MEMORY.md").write_text("## A\n- x\n", encoding="utf-8")
+        git.auto_commit("initial")
+
+        future_now = datetime.now(tz=timezone.utc) + timedelta(days=30)
+        with patch("nanobot.utils.gitstore.datetime") as mock_dt:
+            mock_dt.now.return_value = future_now
+            mock_dt.fromtimestamp = datetime.fromtimestamp
+            ages = git.line_ages("MEMORY.md")
+
+        assert len(ages) == 2
+        assert all(a.age_days == 30 for a in ages)
+
+    def test_annotate_failure_returns_empty(self, tmp_path):
+        """If annotate fails, line_ages should return [] gracefully."""
+        git = GitStore(tmp_path, tracked_files=["MEMORY.md"])
+        # Don't init — annotate will fail
+        assert git.line_ages("MEMORY.md") == []
+
+    def test_partial_edit_only_updates_changed_lines(self, git, tmp_path):
+        """Only modified lines should reflect the new commit's timestamp."""
+        (tmp_path / "MEMORY.md").write_text(
+            "# Memory\n\n## A\n- old\n\n## B\n- keep\n", encoding="utf-8"
+        )
+        git.auto_commit("commit1")
+        time.sleep(1.1)
+
+        # Only modify section A
+        (tmp_path / "MEMORY.md").write_text(
+            "# Memory\n\n## A\n- new\n\n## B\n- keep\n", encoding="utf-8"
+        )
+        git.auto_commit("commit2")
+
+        ages = git.line_ages("MEMORY.md")
+        lines = (tmp_path / "MEMORY.md").read_text(encoding="utf-8").splitlines()
+        # All lines are from today, but verify line-level tracking works
+        assert len(ages) == len(lines)
+        # "- new" line and "- keep" line both age=0 (same day), but
+        # the key point is we get per-line results
+        assert len(ages) == 7


### PR DESCRIPTION
## Problem

Dream's Phase 1 prompt asked the LLM to remove "stale content older than 14 days," but the LLM had no way to know **when** any given line was last modified. Memory files (MEMORY.md, SOUL.md, USER.md) contain no timestamps, so the LLM could only guess — and it consistently guessed conservatively, leading to files that only grow over time.

Additionally, the prompt was framed as a single task ("compare history against memory"), so the LLM focused on extracting new facts from conversation history and largely ignored the equally important task of deduplicating existing content.

## Solution

Three targeted changes:

### 1. Per-line git-blame age annotations (`← Nd` suffixes)

Since Dream already commits every change via GitStore, we use `dulwich.porcelain.annotate()` to compute per-line last-modified times. Each non-blank line in MEMORY.md that hasn't been touched in >14 days gets a `← 30d` suffix. The LLM now sees precise age data alongside actual content:

```markdown
## User Information  ← 45d
- prefers Python  ← 45d
## Project Context  ← 45d
- Migration completed  ← 45d
```

The prompt explicitly instructs the LLM that age is a **review signal**, not a deletion criteria — user habits and preferences are permanent regardless of age. SOUL.md and USER.md are never annotated.

### 2. Dedup-aware Phase 1 prompt

Reframed the opening from a single task to dual-task framing:
> You have TWO equally important tasks:
> 1. Extract new facts from conversation history
> 2. Deduplicate existing memory files

Added 4 explicit redundancy patterns to scan for (same fact in multiple places, overlapping sections, MEMORY.md duplicating USER/SOUL content, verbose entries that can be condensed).

### 3. `max_iterations` raised from 10 → 15

Experimentally validated: 30% more compression with no accuracy loss. Going beyond 15 to 20 showed diminishing returns (LLM wastes budget on low-value edits).

### Bonus: Phase 1 analysis as commit body

Dream git commits now include the full Phase 1 analysis, making `/dream-log` transparent about what was decided and why.

## Experimental Validation

20 experiments with multi-run averaging to account for LLM non-determinism:

| Config | avg chars_delta | avg edits | Verdict |
|--------|-----------------|-----------|---------|
| baseline (original prompt) | +234 | 3 | reference |
| **exp002 prompt + max_iter=15** | **-1643 (-5.4%)** | **11.6** | **BEST** |
| exp002 prompt + max_iter=10 | -1265 | 4.4 | good |
| exp002 prompt + max_iter=20 | -701 | 8.8 | diminishing returns |
| aggressive_dedup | inconsistent | - | risky |
| three_pass | -887 | 5.8 | no improvement |

Key finding: prompt framing was the single most impactful change (+20 dream_score points). Simpler prompts consistently outperformed complex multi-pass approaches.

## Test plan

- [x] New `tests/utils/test_gitstore.py` (7 tests: empty repo, missing file, per-line ages, time advancement, partial edit tracking)
- [x] New tests in `tests/agent/test_dream.py` (3 tests: line annotation, SOUL/USER exclusion, graceful no-git fallback)
- [x] All 44 existing + new tests pass with no regressions
- [x] Trailing newline preservation verified