### PR TITLE
feat: add nanobot auth command

### DIFF
--- a/nanobot/auth/__init__.py
+++ b/nanobot/auth/__init__.py
@@ -1,0 +1,56 @@
+"""Token storage for nanobot auth."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from dataclasses import dataclass
+
+
+@dataclass
+class AuthInfo:
+    token: str
+    server_url: str
+    expires_at: float | None = None
+
+
+def _auth_file_path() -> Path:
+    return Path.home() / ".nanobot" / "auth.json"
+
+
+def load_auth() -> AuthInfo | None:
+    """Load saved auth info from disk."""
+    path = _auth_file_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return AuthInfo(
+            token=data["token"],
+            server_url=data["server_url"],
+            expires_at=data.get("expires_at"),
+        )
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+def save_auth(info: AuthInfo) -> None:
+    """Save auth info to disk."""
+    path = _auth_file_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "token": info.token,
+        "server_url": info.server_url,
+    }
+    if info.expires_at is not None:
+        data["expires_at"] = info.expires_at
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def delete_auth() -> bool:
+    """Delete saved auth info. Returns True if file was deleted."""
+    path = _auth_file_path()
+    if path.exists():
+        path.unlink()
+        return True
+    return False

--- a/nanobot/auth/__init__.py
+++ b/nanobot/auth/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -45,6 +46,7 @@ def save_auth(info: AuthInfo) -> None:
     if info.expires_at is not None:
         data["expires_at"] = info.expires_at
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    path.chmod(0o600)
 
 
 def delete_auth() -> bool:

--- a/nanobot/cli/auth.py
+++ b/nanobot/cli/auth.py
@@ -23,7 +23,7 @@ def _write_provider_config(token: str, server_url: str) -> None:
     """Write token, server URL, and set nanobot as default provider."""
     config = load_config()
     config.providers.nanobot.api_key = token
-    config.providers.nanobot.api_base = server_url
+    config.providers.nanobot.api_base = f"{server_url}/v1"
 
     # Switch default provider to nanobot so `nanobot agent` works directly
     config.agents.defaults.provider = "nanobot"

--- a/nanobot/cli/auth.py
+++ b/nanobot/cli/auth.py
@@ -20,10 +20,32 @@ DEFAULT_SERVER_URL = "http://127.0.0.1:18791"
 
 
 def _write_provider_config(token: str, server_url: str) -> None:
-    """Write token and server URL into nanobot config as the 'nanobot' provider."""
+    """Write token, server URL, and set nanobot as default provider."""
     config = load_config()
     config.providers.nanobot.api_key = token
     config.providers.nanobot.api_base = server_url
+
+    # Switch default provider to nanobot so `nanobot agent` works directly
+    config.agents.defaults.provider = "nanobot"
+
+    # Fetch the server's default model name
+    try:
+        resp = httpx.get(
+            f"{server_url}/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        models = resp.json().get("data", [])
+        if models:
+            config.agents.defaults.model = models[0]["id"]
+        else:
+            console.print("[yellow]Warning: server returned no models. Default model not updated.[/yellow]")
+    except httpx.HTTPStatusError as e:
+        console.print(f"[yellow]Warning: failed to fetch models from server ({e.response.status_code}). Default model not updated.[/yellow]")
+    except httpx.ConnectError:
+        console.print(f"[yellow]Warning: cannot reach server to fetch models. Default model not updated.[/yellow]")
+
     save_config(config)
     logger.debug(f"Updated config: providers.nanobot -> {server_url}")
 

--- a/nanobot/cli/auth.py
+++ b/nanobot/cli/auth.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-import sys
 import time
 import webbrowser
 
@@ -79,7 +77,7 @@ def _cmd_status() -> None:
     try:
         resp = httpx.get(
             f"{info.server_url}/auth/verify",
-            params={"token": info.token},
+            headers={"Authorization": f"Bearer {info.token}"},
             timeout=10,
         )
         data = resp.json()
@@ -111,7 +109,7 @@ def _cmd_auth_key(key: str, server_url: str | None = None) -> None:
     try:
         resp = httpx.get(
             f"{url}/auth/verify",
-            params={"token": key},
+            headers={"Authorization": f"Bearer {key}"},
             timeout=10,
         )
         data = resp.json()

--- a/nanobot/cli/auth.py
+++ b/nanobot/cli/auth.py
@@ -1,0 +1,164 @@
+"""nanobot auth command: device flow + auth_key authentication."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import webbrowser
+
+import httpx
+from loguru import logger
+from rich.console import Console
+
+from nanobot.auth import AuthInfo, delete_auth, load_auth, save_auth
+from nanobot.config.loader import load_config, save_config
+
+console = Console()
+
+DEFAULT_SERVER_URL = "http://127.0.0.1:18791"
+
+
+def _write_provider_config(token: str, server_url: str) -> None:
+    """Write token and server URL into nanobot config as the 'nanobot' provider."""
+    config = load_config()
+    config.providers.nanobot.api_key = token
+    config.providers.nanobot.api_base = server_url
+    save_config(config)
+    logger.debug(f"Updated config: providers.nanobot -> {server_url}")
+
+
+def cmd_auth(
+    auth_key: str | None = None,
+    server_url: str | None = None,
+    status: bool = False,
+    logout: bool = False,
+) -> None:
+    """Execute the auth command."""
+    if logout:
+        _cmd_logout()
+        return
+    if status:
+        _cmd_status()
+        return
+    if auth_key:
+        _cmd_auth_key(auth_key, server_url)
+        return
+    _cmd_device_flow(server_url)
+
+
+def _cmd_status() -> None:
+    """Show current auth status."""
+    info = load_auth()
+    if not info:
+        console.print("[yellow]Not authenticated.[/yellow]  Run [cyan]nanobot auth[/cyan] to sign in.")
+        return
+    # Verify token is still valid
+    try:
+        resp = httpx.get(
+            f"{info.server_url}/auth/verify",
+            params={"token": info.token},
+            timeout=10,
+        )
+        data = resp.json()
+        if data.get("valid"):
+            console.print(f"[green]✓ Authenticated[/green]  Server: {info.server_url}")
+        else:
+            console.print("[red]✗ Token invalid or expired[/red]  Run [cyan]nanobot auth[/cyan] to re-authenticate.")
+    except httpx.ConnectError:
+        console.print(f"[yellow]? Cannot reach server {info.server_url}[/yellow]  Token saved locally but unverified.")
+
+
+def _cmd_logout() -> None:
+    """Remove saved auth."""
+    if delete_auth():
+        console.print("[green]✓ Logged out[/green]")
+    else:
+        console.print("[yellow]Not logged in[/yellow]")
+
+
+def _cmd_auth_key(key: str, server_url: str | None = None) -> None:
+    """Authenticate with a pre-generated auth key."""
+    url = server_url or DEFAULT_SERVER_URL
+
+    if not key.startswith("nb_"):
+        console.print("[red]Invalid auth key format. Expected 'nb_...' prefix.[/red]")
+        raise SystemExit(1)
+
+    # Verify key
+    try:
+        resp = httpx.get(
+            f"{url}/auth/verify",
+            params={"token": key},
+            timeout=10,
+        )
+        data = resp.json()
+        if not data.get("valid"):
+            console.print("[red]✗ Auth key is invalid or expired[/red]")
+            raise SystemExit(1)
+    except httpx.ConnectError:
+        console.print(f"[red]Cannot reach server at {url}[/red]")
+        raise SystemExit(1)
+
+    save_auth(AuthInfo(token=key, server_url=url))
+    _write_provider_config(key, url)
+    console.print(f"[green]✓ Authenticated[/green]  Server: {url}")
+
+
+def _cmd_device_flow(server_url: str | None = None) -> None:
+    """Run the OAuth Device Flow."""
+    url = server_url or DEFAULT_SERVER_URL
+
+    # Step 1: Request device code
+    try:
+        resp = httpx.post(f"{url}/auth/device/code", timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.ConnectError:
+        console.print(f"[red]Cannot reach server at {url}[/red]")
+        raise SystemExit(1)
+
+    device_code = data["device_code"]
+    user_code = data["user_code"]
+    verification_uri = data["verification_uri"]
+    interval = data.get("interval", 5)
+    expires_in = data.get("expires_in", 900)
+
+    # Step 2: Open browser or display URL
+    full_url = f"{verification_uri}?code={user_code}"
+    opened = webbrowser.open(full_url)
+
+    if opened:
+        console.print(f"[cyan]Browser opened. Confirm authorization in the browser.[/cyan]")
+    else:
+        console.print(f"[cyan]Open this URL in your browser:[/cyan]")
+        console.print(f"  {full_url}")
+    console.print(f"  Code: [bold]{user_code}[/bold]")
+
+    # Step 3: Poll for token
+    deadline = time.time() + expires_in
+    with console.status("Waiting for authorization..."):
+        while time.time() < deadline:
+            time.sleep(interval)
+            try:
+                resp = httpx.post(
+                    f"{url}/auth/device/token",
+                    json={"device_code": device_code},
+                    timeout=10,
+                )
+                if resp.status_code == 200:
+                    token_data = resp.json()
+                    token = token_data["token"]
+                    expires_at = token_data.get("expires_at")
+
+                    save_auth(AuthInfo(token=token, server_url=url, expires_at=expires_at))
+                    _write_provider_config(token, url)
+                    console.print(f"[green]✓ Authenticated[/green]  Server: {url}")
+                    return
+                # 429 = still pending, keep polling
+            except httpx.ConnectError:
+                console.print("[red]Lost connection to server[/red]")
+                raise SystemExit(1)
+
+    console.print("[red]✗ Authorization timed out[/red]  Please try again.")
+    raise SystemExit(1)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1367,6 +1367,24 @@ def status():
 
 
 # ============================================================================
+# Auth
+# ============================================================================
+
+
+@app.command()
+def auth(
+    auth_key: str | None = typer.Option(None, "--auth-key", help="Authenticate with a pre-generated key"),
+    server_url: str | None = typer.Option(None, "--server", help="Auth server URL"),
+    status: bool = typer.Option(False, "--status", help="Show authentication status"),
+    logout: bool = typer.Option(False, "--logout", help="Log out"),
+):
+    """Authenticate with nanobot auth server."""
+    from nanobot.cli.auth import cmd_auth
+
+    cmd_auth(auth_key=auth_key, server_url=server_url, status=status, logout=logout)
+
+
+# ============================================================================
 # OAuth Login
 # ============================================================================
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -133,6 +133,7 @@ class ProvidersConfig(Base):
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
+    nanobot: ProviderConfig = Field(default_factory=ProviderConfig)  # nanobot Auth Server
 
 
 class HeartbeatConfig(Base):

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -378,6 +378,16 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         default_api_base="https://qianfan.baidubce.com/v2"
     ),
+    # === nanobot Auth Server (gateway, auto-configured by `nanobot auth`) ===
+    ProviderSpec(
+        name="nanobot",
+        keywords=(),
+        env_key="NANOBOT_AUTH_TOKEN",
+        display_name="nanobot",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_key_prefix="nb_",
+    ),
 )
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,196 @@
+"""Tests for nanobot auth module and CLI command."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from nanobot.auth import AuthInfo, delete_auth, load_auth, save_auth
+
+
+# ---------------------------------------------------------------------------
+# Token storage tests (nanobot/auth/__init__.py)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthStorage:
+    """Test save/load/delete cycle and edge cases."""
+
+    def test_save_and_load(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            info = AuthInfo(token="nb_abc123", server_url="http://localhost:9999")
+            save_auth(info)
+
+            loaded = load_auth()
+            assert loaded is not None
+            assert loaded.token == "nb_abc123"
+            assert loaded.server_url == "http://localhost:9999"
+            assert loaded.expires_at is None
+
+    def test_save_with_expires_at(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            info = AuthInfo(token="nb_test", server_url="http://test", expires_at=1234567890.0)
+            save_auth(info)
+
+            loaded = load_auth()
+            assert loaded.expires_at == 1234567890.0
+
+    def test_load_missing_file(self, tmp_path):
+        auth_file = tmp_path / "nonexistent.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            assert load_auth() is None
+
+    def test_load_corrupt_json(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        auth_file.write_text("{bad json", encoding="utf-8")
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            assert load_auth() is None
+
+    def test_load_missing_token_key(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        auth_file.write_text('{"server_url": "http://test"}', encoding="utf-8")
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            assert load_auth() is None
+
+    def test_delete_existing(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        auth_file.write_text("{}", encoding="utf-8")
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            assert delete_auth() is True
+            assert not auth_file.exists()
+
+    def test_delete_nonexistent(self, tmp_path):
+        auth_file = tmp_path / "nonexistent.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            assert delete_auth() is False
+
+    def test_save_creates_parent_dir(self, tmp_path):
+        auth_file = tmp_path / "nested" / "dir" / "auth.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            save_auth(AuthInfo(token="nb_test", server_url="http://test"))
+            assert auth_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI auth command tests (nanobot/cli/auth.py)
+# ---------------------------------------------------------------------------
+
+
+def _mock_httpx_response(status_code=200, json_data=None):
+    """Create a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+class TestCmdStatus:
+    def test_not_authenticated(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            from nanobot.cli.auth import cmd_auth
+            # Should not raise, just print
+            cmd_auth(status=True)
+
+    def test_authenticated_valid_token(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            save_auth(AuthInfo(token="nb_valid", server_url="http://localhost:9999"))
+
+        mock_resp = _mock_httpx_response(json_data={"valid": True, "token": "nb_valid"})
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file), \
+             patch("httpx.get", return_value=mock_resp) as mock_get:
+            from nanobot.cli.auth import cmd_auth
+            cmd_auth(status=True)
+            mock_get.assert_called_once_with(
+                "http://localhost:9999/auth/verify",
+                headers={"Authorization": "Bearer nb_valid"},
+                timeout=10,
+            )
+
+    def test_authenticated_invalid_token(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            save_auth(AuthInfo(token="nb_expired", server_url="http://localhost:9999"))
+
+        mock_resp = _mock_httpx_response(json_data={"valid": False, "token": None})
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file), \
+             patch("httpx.get", return_value=mock_resp):
+            from nanobot.cli.auth import cmd_auth
+            cmd_auth(status=True)  # Should print invalid message, not crash
+
+
+class TestCmdLogout:
+    def test_logout_when_authenticated(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            save_auth(AuthInfo(token="nb_test", server_url="http://test"))
+            assert auth_file.exists()
+
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            from nanobot.cli.auth import cmd_auth
+            cmd_auth(logout=True)
+            assert not auth_file.exists()
+
+    def test_logout_when_not_authenticated(self, tmp_path):
+        auth_file = tmp_path / "nonexistent.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file):
+            from nanobot.cli.auth import cmd_auth
+            cmd_auth(logout=True)  # Should print "Not logged in", not crash
+
+
+class TestCmdAuthKey:
+    def test_invalid_prefix(self):
+        from nanobot.cli.auth import cmd_auth
+        with pytest.raises(SystemExit):
+            cmd_auth(auth_key="invalid_key")
+
+    def test_valid_key(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        mock_resp = _mock_httpx_response(json_data={"valid": True, "token": "nb_goodkey"})
+        mock_models_resp = _mock_httpx_response(json_data={
+            "object": "list", "data": [{"id": "glm-5.1", "object": "model", "owned_by": "nanobot"}]
+        })
+
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file), \
+             patch("nanobot.config.loader.load_config", return_value=MagicMock()), \
+             patch("nanobot.config.loader.save_config"), \
+             patch("httpx.get", side_effect=[mock_resp, mock_models_resp]) as mock_get:
+            from nanobot.cli.auth import cmd_auth
+            cmd_auth(auth_key="nb_goodkey", server_url="http://localhost:9999")
+
+            # First call: verify key
+            first_call = mock_get.call_args_list[0]
+            assert first_call[0][0] == "http://localhost:9999/auth/verify"
+            assert first_call[1]["headers"] == {"Authorization": "Bearer nb_goodkey"}
+            assert first_call[1]["timeout"] == 10
+            # Auth file saved
+            loaded = load_auth()
+            assert loaded.token == "nb_goodkey"
+
+    def test_invalid_key_rejected(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        mock_resp = _mock_httpx_response(json_data={"valid": False, "token": None})
+
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file), \
+             patch("httpx.get", return_value=mock_resp):
+            from nanobot.cli.auth import cmd_auth
+            with pytest.raises(SystemExit):
+                cmd_auth(auth_key="nb_badkey", server_url="http://localhost:9999")
+
+    def test_server_unreachable(self, tmp_path):
+        auth_file = tmp_path / "auth.json"
+        with patch("nanobot.auth._auth_file_path", return_value=auth_file), \
+             patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+            from nanobot.cli.auth import cmd_auth
+            with pytest.raises(SystemExit):
+                cmd_auth(auth_key="nb_test", server_url="http://localhost:9999")


### PR DESCRIPTION
## Summary

- Add `nanobot auth` command with OAuth Device Flow and `--auth-key` support
- Register `nanobot` as a gateway provider in the registry
- Auth automatically configures default provider/model so `nanobot agent` works directly
- Add token storage module (`~/.nanobot/auth.json`)

## Usage

```bash
nanobot auth              # browser-based device flow
nanobot auth --auth-key nb_xxx  # direct key auth
nanobot auth --status     # check auth status
nanobot auth --logout     # logout
```

## Companion

Requires [nanobot-auth-server](https://github.com/chengyongru/nanobot-auth-server) (private repo) running as the backend.

## Known Issues (to fix before merge)

- [ ] C1: Token transmitted via query string in `/auth/verify` — should use header
- [ ] C2: `auth.json` stored world-readable — should restrict to 600
- [ ] C3: No test coverage for auth module
- [ ] I3: Logout does not clear provider config defaults
- [ ] I4: Inconsistent HTTP error handling across subcommands
- [ ] I1: Unused imports (`json`, `sys`)

## Test plan

- [ ] `nanobot auth --status` shows "Not authenticated" when not logged in
- [ ] `nanobot auth` opens browser, completes device flow
- [ ] `nanobot auth --auth-key nb_xxx` authenticates with valid key
- [ ] `nanobot auth --status` shows authenticated after login
- [ ] `nanobot auth --logout` clears credentials
- [ ] After auth, `nanobot agent` uses nanobot provider directly
- [ ] LLM requests proxied through auth-server work end-to-end