### PR TITLE
feat(spawn): add spawn_status, spawn_cancel tools and spawn params

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -29,6 +29,7 @@ from nanobot.agent.tools.search import GlobTool, GrepTool
 from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.self import MyTool
 from nanobot.agent.tools.spawn import SpawnTool
+from nanobot.agent.tools.spawn_status import SpawnStatusTool, SpawnCancelTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -289,6 +290,8 @@ class AgentLoop:
             self.tools.register(WebFetchTool(proxy=self.web_config.proxy))
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
         self.tools.register(SpawnTool(manager=self.subagents))
+        self.tools.register(SpawnStatusTool(manager=self.subagents))
+        self.tools.register(SpawnCancelTool(manager=self.subagents))
         if self.cron_service:
             self.tools.register(
                 CronTool(self.cron_service, default_timezone=self.context.timezone or "UTC")

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -103,6 +103,9 @@ class SubagentManager:
         origin_channel: str = "cli",
         origin_chat_id: str = "direct",
         session_key: str | None = None,
+        max_iterations: int = 15,
+        timeout_seconds: int = 300,
+        expected_files: list[str] | None = None,
     ) -> str:
         """Spawn a subagent to execute a task in the background."""
         task_id = str(uuid.uuid4())[:8]
@@ -118,7 +121,12 @@ class SubagentManager:
         self._task_statuses[task_id] = status
 
         bg_task = asyncio.create_task(
-            self._run_subagent(task_id, task, display_label, origin, status)
+            self._run_subagent(
+                task_id, task, display_label, origin, status,
+                max_iterations=max_iterations,
+                timeout_seconds=timeout_seconds,
+                expected_files=expected_files,
+            )
         )
         self._running_tasks[task_id] = bg_task
         if session_key:
@@ -144,6 +152,9 @@ class SubagentManager:
         label: str,
         origin: dict[str, str],
         status: SubagentStatus,
+        max_iterations: int = 15,
+        timeout_seconds: int = 300,
+        expected_files: list[str] | None = None,
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
@@ -180,20 +191,38 @@ class SubagentManager:
                 {"role": "user", "content": task},
             ]
 
-            result = await self.runner.run(AgentRunSpec(
-                initial_messages=messages,
-                tools=tools,
-                model=self.model,
-                max_iterations=15,
-                max_tool_result_chars=self.max_tool_result_chars,
-                hook=_SubagentHook(task_id, status),
-                max_iterations_message="Task completed but no final response was generated.",
-                error_message=None,
-                fail_on_tool_error=True,
-                checkpoint_callback=_on_checkpoint,
-            ))
+            result = await asyncio.wait_for(
+                self.runner.run(AgentRunSpec(
+                    initial_messages=messages,
+                    tools=tools,
+                    model=self.model,
+                    max_iterations=max_iterations,
+                    max_tool_result_chars=self.max_tool_result_chars,
+                    hook=_SubagentHook(task_id, status),
+                    max_iterations_message="Task completed but no final response was generated.",
+                    error_message=None,
+                    fail_on_tool_error=True,
+                    checkpoint_callback=_on_checkpoint,
+                )),
+                timeout=timeout_seconds,
+            )
             status.phase = "done"
             status.stop_reason = result.stop_reason
+
+            # Verify expected files were created
+            if expected_files:
+                missing = [f for f in expected_files if not Path(self.workspace, f).exists()]
+                if missing:
+                    warning = f"Warning: expected files not created: {', '.join(missing)}"
+                    logger.warning("Subagent [{}] {}", task_id, warning)
+                    if result.final_content:
+                        result = AgentRunResult(
+                            final_content=result.final_content + "\n\n" + warning,
+                            stop_reason=result.stop_reason,
+                            tool_events=result.tool_events,
+                            usage=result.usage,
+                            error=result.error,
+                        )
 
             if result.stop_reason == "tool_error":
                 status.tool_events = list(result.tool_events)
@@ -212,6 +241,16 @@ class SubagentManager:
                 final_result = result.final_content or "Task completed but no final response was generated."
                 logger.info("Subagent [{}] completed successfully", task_id)
                 await self._announce_result(task_id, label, task, final_result, origin, "ok")
+
+        except asyncio.TimeoutError:
+            status.phase = "error"
+            status.error = f"Timed out after {timeout_seconds}s"
+            logger.warning("Subagent [{}] timed out after {}s", task_id, timeout_seconds)
+            await self._announce_result(
+                task_id, label, task,
+                f"Error: subagent timed out after {timeout_seconds}s.",
+                origin, "error",
+            )
 
         except Exception as e:
             status.phase = "error"
@@ -309,3 +348,53 @@ class SubagentManager:
             1 for tid in tids
             if tid in self._running_tasks and not self._running_tasks[tid].done()
         )
+
+    def get_status_summary(self, task_id: str | None = None) -> str:
+        """Return a human-readable summary of subagent status(es)."""
+        if task_id:
+            status = self._task_statuses.get(task_id)
+            if not status:
+                return f"No subagent found with id: {task_id}"
+            elapsed = time.monotonic() - status.started_at
+            return (
+                f"Task: {status.label}\n"
+                f"ID: {status.task_id}\n"
+                f"Status: {status.phase}\n"
+                f"Elapsed: {elapsed:.0f}s\n"
+                f"Iteration: {status.iteration}\n"
+                f"Stop reason: {status.stop_reason or 'N/A'}\n"
+                f"Error: {status.error or 'None'}"
+            )
+
+        # List all tasks
+        if not self._task_statuses and not self._running_tasks:
+            return "No subagents running or completed."
+
+        lines = []
+        for tid, status in self._task_statuses.items():
+            elapsed = time.monotonic() - status.started_at
+            is_running = tid in self._running_tasks and not self._running_tasks[tid].done()
+            state = "running" if is_running else status.phase
+            lines.append(
+                f"- [{tid}] {status.label}: {state} ({elapsed:.0f}s, iter {status.iteration})"
+            )
+        return "\n".join(lines)
+
+    async def cancel_task(self, task_id: str) -> str:
+        """Cancel a running subagent by task ID. Returns status message."""
+        task = self._running_tasks.get(task_id)
+        if not task:
+            return f"No running subagent found with id: {task_id}"
+        if task.done():
+            status = self._task_statuses.get(task_id)
+            phase = status.phase if status else "unknown"
+            return f"Subagent [{task_id}] already finished (status: {phase})."
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        if task_id in self._task_statuses:
+            self._task_statuses[task_id].phase = "cancelled"
+        return f"Subagent [{task_id}] cancelled."
+

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -3,16 +3,31 @@
 from typing import TYPE_CHECKING, Any
 
 from nanobot.agent.tools.base import Tool, tool_parameters
-from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
+from nanobot.agent.tools.schema import StringSchema, IntegerSchema, tool_parameters_schema
 
 if TYPE_CHECKING:
     from nanobot.agent.subagent import SubagentManager
+
+# Default values matching AgentLoop defaults
+_DEFAULT_MAX_ITERATIONS = 15
+_DEFAULT_TIMEOUT_SECONDS = 300
 
 
 @tool_parameters(
     tool_parameters_schema(
         task=StringSchema("The task for the subagent to complete"),
         label=StringSchema("Optional short label for the task (for display)"),
+        max_iterations=IntegerSchema(
+            description="Optional maximum model iterations for the subagent (default 15)",
+            minimum=1, maximum=100,
+        ),
+        timeout_seconds=IntegerSchema(
+            description="Optional maximum wall-clock time in seconds before the subagent is cancelled (default 300)",
+            minimum=1, maximum=3600,
+        ),
+        expected_files=StringSchema(
+            "Optional comma-separated list of file paths the subagent must create",
+        ),
         required=["task"],
     )
 )
@@ -27,6 +42,7 @@ class SpawnTool(Tool):
 
     def set_context(self, channel: str, chat_id: str) -> None:
         """Set the origin context for subagent announcements."""
+        self._origin_channel = channel
         self._origin_channel = channel
         self._origin_chat_id = chat_id
         self._session_key = f"{channel}:{chat_id}"
@@ -47,10 +63,19 @@ class SpawnTool(Tool):
 
     async def execute(self, task: str, label: str | None = None, **kwargs: Any) -> str:
         """Spawn a subagent to execute the given task."""
+        max_iterations = kwargs.get("max_iterations") or _DEFAULT_MAX_ITERATIONS
+        timeout_seconds = kwargs.get("timeout_seconds") or _DEFAULT_TIMEOUT_SECONDS
+        expected_files = kwargs.get("expected_files")
+        if isinstance(expected_files, str):
+            expected_files = [f.strip() for f in expected_files.split(",") if f.strip()]
+
         return await self._manager.spawn(
             task=task,
             label=label,
             origin_channel=self._origin_channel,
             origin_chat_id=self._origin_chat_id,
             session_key=self._session_key,
+            max_iterations=max_iterations,
+            timeout_seconds=timeout_seconds,
+            expected_files=expected_files,
         )

--- a/nanobot/agent/tools/spawn_status.py
+++ b/nanobot/agent/tools/spawn_status.py
@@ -1,0 +1,65 @@
+"""Spawn status and cancel tools for managing background subagents."""
+
+from typing import TYPE_CHECKING, Any
+
+from nanobot.agent.tools.base import Tool, tool_parameters
+from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
+
+if TYPE_CHECKING:
+    from nanobot.agent.subagent import SubagentManager
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        task_id=StringSchema("Optional task ID to check status of specific subagent (omit to list all)"),
+        required=[],
+    )
+)
+class SpawnStatusTool(Tool):
+    """Tool to check the status of spawned subagents."""
+
+    def __init__(self, manager: "SubagentManager"):
+        self._manager = manager
+
+    @property
+    def name(self) -> str:
+        return "spawn_status"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Check the status of spawned subagents. Returns task ID, label, "
+            "elapsed time, and status (running/done/error). "
+            "Use without arguments to list all subagents, or pass a specific task_id."
+        )
+
+    async def execute(self, **kwargs: Any) -> str:
+        task_id = kwargs.get("task_id")
+        return self._manager.get_status_summary(task_id=task_id)
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        task_id=StringSchema("Task ID of the subagent to cancel"),
+        required=["task_id"],
+    )
+)
+class SpawnCancelTool(Tool):
+    """Tool to cancel a running subagent."""
+
+    def __init__(self, manager: "SubagentManager"):
+        self._manager = manager
+
+    @property
+    def name(self) -> str:
+        return "spawn_cancel"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Cancel a running subagent by its task ID. "
+            "Use spawn_status first to see running tasks and their IDs."
+        )
+
+    async def execute(self, task_id: str, **kwargs: Any) -> str:
+        return await self._manager.cancel_task(task_id)


### PR DESCRIPTION
## Summary

Adds agent-callable tools for managing subagents and configurable spawn parameters.

### Changes

**New tools:**
- `spawn_status` — query subagent status by ID or list all running/completed subagents
- `spawn_cancel` — cancel a running subagent by task ID

**Enhanced spawn params:**
- `max_iterations` — configurable iteration budget per spawn (default: 15)
- `timeout_seconds` — wall-clock timeout via asyncio.wait_for (default: 300)
- `expected_files` — comma-separated file paths to verify after completion

**SubagentManager additions:**
- `get_status_summary()` — returns human-readable status for one or all subagents
- `cancel_task()` — cancels a running asyncio task and updates status

### Why

Previously, subagent status was only accessible via the `/stop` CLI command. Agents had no way to query or cancel their own subagents. This gives agents autonomy to manage background tasks.

### Testing

- All imports resolve cleanly
- No merge conflicts with current main
- AgentLoop wires all three tools (spawn, spawn_status, spawn_cancel)