### PR TITLE
fix(transcription): honor api_base for OpenAI transcription provider

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -45,7 +45,10 @@ class BaseChannel(ABC):
         try:
             if self.transcription_provider == "openai":
                 from nanobot.providers.transcription import OpenAITranscriptionProvider
-                provider = OpenAITranscriptionProvider(api_key=self.transcription_api_key)
+                provider = OpenAITranscriptionProvider(
+                    api_key=self.transcription_api_key,
+                    api_base=self.transcription_api_base or None,
+                )
             else:
                 from nanobot.providers.transcription import GroqTranscriptionProvider
                 provider = GroqTranscriptionProvider(

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -10,9 +10,13 @@ from loguru import logger
 class OpenAITranscriptionProvider:
     """Voice transcription provider using OpenAI's Whisper API."""
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, api_base: str | None = None):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
-        self.api_url = "https://api.openai.com/v1/audio/transcriptions"
+        self.api_url = (
+            api_base
+            or os.environ.get("OPENAI_TRANSCRIPTION_BASE_URL")
+            or "https://api.openai.com/v1/audio/transcriptions"
+        )
 
     async def transcribe(self, file_path: str | Path) -> str:
         if not self.api_key:

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -225,6 +225,81 @@ async def test_manager_propagates_groq_transcription_api_base_to_channels():
     assert channel.transcription_api_base == "http://proxy.local/v1/audio/transcriptions"
 
 
+@pytest.mark.asyncio
+async def test_manager_propagates_openai_transcription_api_base_to_channels():
+    from nanobot.channels.manager import ChannelManager
+
+    fake_config = SimpleNamespace(
+        channels=ChannelsConfig.model_validate({
+            "fakeplugin": {"enabled": True, "allowFrom": ["*"]},
+            "transcriptionProvider": "openai",
+        }),
+        providers=SimpleNamespace(
+            openai=SimpleNamespace(
+                api_key="openai-key",
+                api_base="http://proxy.local/v1/audio/transcriptions",
+            ),
+            groq=SimpleNamespace(api_key="groq-key", api_base=""),
+        ),
+    )
+
+    with patch(
+        "nanobot.channels.registry.discover_all",
+        return_value={"fakeplugin": _FakePlugin},
+    ):
+        mgr = ChannelManager.__new__(ChannelManager)
+        mgr.config = fake_config
+        mgr.bus = MessageBus()
+        mgr.channels = {}
+        mgr._dispatch_task = None
+        mgr._init_channels()
+
+    channel = mgr.channels["fakeplugin"]
+    assert channel.transcription_provider == "openai"
+    assert channel.transcription_api_key == "openai-key"
+    assert channel.transcription_api_base == "http://proxy.local/v1/audio/transcriptions"
+
+
+@pytest.mark.asyncio
+async def test_base_channel_passes_api_base_to_openai_transcription_provider():
+    """BaseChannel.transcribe_audio must forward transcription_api_base to OpenAI."""
+    from nanobot.providers import transcription as transcription_mod
+
+    channel = _FakePlugin({"enabled": True, "allowFrom": ["*"]}, MessageBus())
+    channel.transcription_provider = "openai"
+    channel.transcription_api_key = "k"
+    channel.transcription_api_base = "http://override/v1/audio/transcriptions"
+
+    captured: dict[str, object] = {}
+
+    class _StubOpenAI:
+        def __init__(self, api_key=None, api_base=None):
+            captured["api_key"] = api_key
+            captured["api_base"] = api_base
+
+        async def transcribe(self, file_path):
+            return "ok"
+
+    with patch.object(transcription_mod, "OpenAITranscriptionProvider", _StubOpenAI):
+        result = await channel.transcribe_audio("/tmp/does-not-matter.wav")
+
+    assert result == "ok"
+    assert captured["api_key"] == "k"
+    assert captured["api_base"] == "http://override/v1/audio/transcriptions"
+
+
+def test_openai_transcription_provider_honors_api_base_argument():
+    from nanobot.providers.transcription import OpenAITranscriptionProvider
+
+    default = OpenAITranscriptionProvider(api_key="k")
+    assert default.api_url == "https://api.openai.com/v1/audio/transcriptions"
+
+    custom = OpenAITranscriptionProvider(
+        api_key="k", api_base="http://override/v1/audio/transcriptions"
+    )
+    assert custom.api_url == "http://override/v1/audio/transcriptions"
+
+
 def test_channels_login_uses_discovered_plugin_class(monkeypatch):
     from nanobot.cli.commands import app
     from nanobot.config.schema import Config


### PR DESCRIPTION
## Summary

Completes the symmetry left by #3214 for the OpenAI transcription backend.

`ChannelManager._resolve_transcription_base()` already returns `providers.openai.api_base`, but:

1. `BaseChannel.transcribe_audio()` instantiated `OpenAITranscriptionProvider` without forwarding `transcription_api_base`
2. `OpenAITranscriptionProvider.__init__` did not accept `api_base` — URL was hardcoded

The Groq path was wired end-to-end in #3214; the OpenAI path silently dropped the resolved base URL. This PR closes that gap so self-hosted OpenAI-compatible Whisper endpoints (LiteLLM, vLLM, proxies) configured via `config.json` work for both backends.

## Changes

- `nanobot/providers/transcription.py` — `OpenAITranscriptionProvider.__init__` accepts `api_base` with `OPENAI_TRANSCRIPTION_BASE_URL` env fallback, matching the pattern established for Groq in #3214.
- `nanobot/channels/base.py` — `transcribe_audio()` forwards `self.transcription_api_base` to the OpenAI provider.
- `tests/channels/test_channel_plugins.py` — three new tests mirroring the existing Groq coverage:
  - Manager propagation when `transcription_provider="openai"`
  - `BaseChannel.transcribe_audio` passes `api_base` to the OpenAI provider
  - `OpenAITranscriptionProvider` default vs explicit `api_base`

## Backward compatibility

Fully backward-compatible. When `api_base=None` and the env var is unset, the default `https://api.openai.com/v1/audio/transcriptions` is used.

## Test plan

- [x] `pytest tests/channels/test_channel_plugins.py` — 39 passed
- [x] `pytest tests/providers tests/channels` — 622 passed, 3 skipped
- [x] `ruff check` on changed files — clean on my additions (pre-existing I001 in unrelated tests left untouched per "focused patches" guideline)

## Refs

- Closes part of #3213 (OpenAI side; Groq side fixed in #3214)
- Follow-up to #3214