### PR TITLE
fix(email): break SMTP self-reply loop on self-addressed mail (#3215)

### DIFF
--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -222,6 +222,15 @@ class EmailChannel(BaseChannel):
             logger.error("Error sending email to {}: {}", to_addr, e)
             raise
 
+    def _own_addresses(self) -> set[str]:
+        """Return the bot's own email addresses (lowercased) for self-loop detection."""
+        candidates = (
+            self.config.from_address,
+            self.config.smtp_username,
+            self.config.imap_username,
+        )
+        return {addr.strip().lower() for addr in candidates if addr and "@" in addr}
+
     def _validate_config(self) -> bool:
         missing = []
         if not self.config.imap_host:
@@ -378,6 +387,22 @@ class EmailChannel(BaseChannel):
                 parsed = BytesParser(policy=policy.default).parsebytes(raw_bytes)
                 sender = parseaddr(parsed.get("From", ""))[1].strip().lower()
                 if not sender:
+                    continue
+
+                # Skip mail authored by ourselves to prevent self-reply loops
+                # (e.g. user emails the bot from the bot's own address, or the
+                # outbound reply lands back in the same INBOX via aliasing).
+                if sender in self._own_addresses():
+                    if mark_seen:
+                        client.store(imap_id, "+FLAGS", "\\Seen")
+                    if uid:
+                        cycle_uids.add(uid)
+                    if dedupe and uid:
+                        self._processed_uids.add(uid)
+                    logger.info(
+                        "Email from {} skipped: matches bot's own address (self-loop guard)",
+                        sender,
+                    )
                     continue
 
                 # --- Anti-spoofing: verify Authentication-Results ---

--- a/tests/channels/test_email_channel.py
+++ b/tests/channels/test_email_channel.py
@@ -206,6 +206,44 @@ def test_fetch_new_messages_skips_missing_mailbox(monkeypatch) -> None:
     assert channel._fetch_new_messages() == []
 
 
+def test_fetch_new_messages_skips_self_to_prevent_reply_loop(monkeypatch) -> None:
+    """Mail from the bot's own address must be skipped to avoid self-reply loops."""
+    raw = _make_raw_email(from_addr="bot@example.com", subject="Self", body="Loop bait")
+
+    class FakeIMAP:
+        def __init__(self) -> None:
+            self.store_calls: list[tuple[bytes, str, str]] = []
+
+        def login(self, _user: str, _pw: str):
+            return "OK", [b"logged in"]
+
+        def select(self, _mailbox: str):
+            return "OK", [b"1"]
+
+        def search(self, *_args):
+            return "OK", [b"1"]
+
+        def fetch(self, _imap_id: bytes, _parts: str):
+            return "OK", [(b"1 (UID 777 BODY[] {200})", raw), b")"]
+
+        def store(self, imap_id: bytes, op: str, flags: str):
+            self.store_calls.append((imap_id, op, flags))
+            return "OK", [b""]
+
+        def logout(self):
+            return "BYE", [b""]
+
+    fake = FakeIMAP()
+    monkeypatch.setattr("nanobot.channels.email.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    channel = EmailChannel(_make_config(from_address="bot@example.com"), MessageBus())
+    items = channel._fetch_new_messages()
+
+    assert items == []
+    # Still flagged Seen so the same message is not re-fetched on the next poll.
+    assert fake.store_calls == [(b"1", "+FLAGS", "\\Seen")]
+
+
 def test_extract_text_body_falls_back_to_html() -> None:
     msg = EmailMessage()
     msg["From"] = "alice@example.com"


### PR DESCRIPTION
Closes #3215

Skip inbound mail whose `From` matches the bot's own address (`from_address` / `smtp_username` / `imap_username`) to prevent the thousand-reply loop, while still marking it `\Seen` and deduping so itisn't re-fetched.