### PR TITLE
fix(email): guard against self-reply loop when bot emails itself

### DIFF
--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -387,6 +387,32 @@ class EmailChannel(BaseChannel):
                         client.store(imap_id, "+FLAGS", "\\Seen")
                     continue
 
+                # --- Self-reply loop guard (issue #3215) ---
+                # Skip emails that look like they came from this bot's own
+                # address; otherwise replying to them produces an infinite
+                # reply loop. Mark seen and dedupe so we don't re-poll them.
+                own_addresses = {
+                    parseaddr(addr)[1].strip().lower()
+                    for addr in (
+                        self.config.from_address,
+                        self.config.smtp_username,
+                        self.config.imap_username,
+                    )
+                    if addr
+                }
+                if sender in own_addresses:
+                    logger.debug(
+                        "Email from {} skipped: matches bot's own address (self-reply loop guard)",
+                        sender,
+                    )
+                    if mark_seen:
+                        client.store(imap_id, "+FLAGS", "\\Seen")
+                    if uid:
+                        cycle_uids.add(uid)
+                        if dedupe:
+                            self._processed_uids.add(uid)
+                    continue
+
                 # --- Anti-spoofing: verify Authentication-Results ---
                 spf_pass, dkim_pass = self._check_authentication_results(parsed)
                 if self.config.verify_spf and not spf_pass:

--- a/tests/channels/test_email_channel.py
+++ b/tests/channels/test_email_channel.py
@@ -689,6 +689,63 @@ def test_backward_compat_verify_disabled(monkeypatch) -> None:
     assert len(items) == 1, "With verification disabled, emails should be accepted as before"
 
 
+def test_self_reply_loop_guard_skips_from_address(monkeypatch) -> None:
+    """Emails whose sender matches from_address are skipped and marked seen (issue #3215)."""
+    raw = _make_raw_email(from_addr="bot@example.com", subject="Self", body="I am the bot")
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    cfg = _make_config(from_address="bot@example.com")
+    channel = EmailChannel(cfg, MessageBus())
+    items = channel._fetch_new_messages()
+
+    assert items == [], "Self-email must not be processed (would cause reply loop)"
+    assert fake.store_calls == [(b"1", "+FLAGS", "\\Seen")], (
+        "Skipped self-email should still be marked seen to avoid re-polling"
+    )
+
+
+def test_self_reply_loop_guard_matches_named_from_address(monkeypatch) -> None:
+    """Self-reply guard must extract the email from 'Name <addr>' form on both sides."""
+    raw = _make_raw_email(from_addr="Agent Bot <bot@example.com>", subject="Named", body="x")
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    # from_address configured with a display name too
+    cfg = _make_config(from_address="Nanobot <bot@example.com>")
+    channel = EmailChannel(cfg, MessageBus())
+    items = channel._fetch_new_messages()
+
+    assert items == [], "Display-name form must still be recognized as self"
+
+
+def test_self_reply_loop_guard_falls_back_to_smtp_username(monkeypatch) -> None:
+    """When from_address is empty, smtp_username is also treated as an own-address."""
+    raw = _make_raw_email(from_addr="bot@example.com", subject="Self", body="x")
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    cfg = _make_config(from_address="", smtp_username="bot@example.com")
+    channel = EmailChannel(cfg, MessageBus())
+    items = channel._fetch_new_messages()
+
+    assert items == [], "smtp_username must also guard against self-reply loops"
+
+
+def test_external_sender_not_affected_by_loop_guard(monkeypatch) -> None:
+    """Emails from an external sender must still be accepted when from_address is set."""
+    raw = _make_raw_email(from_addr="alice@example.com", subject="Hi", body="external")
+    fake = _make_fake_imap(raw)
+    monkeypatch.setattr("nanobot.channels.email.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    cfg = _make_config(from_address="bot@example.com")
+    channel = EmailChannel(cfg, MessageBus())
+    items = channel._fetch_new_messages()
+
+    assert len(items) == 1
+    assert items[0]["sender"] == "alice@example.com"
+
+
 def test_email_content_tagged_with_email_context(monkeypatch) -> None:
     """Email content should be prefixed with [EMAIL-CONTEXT] for LLM isolation."""
     raw = _make_raw_email(subject="Tagged", body="Check the tag")


### PR DESCRIPTION
## Summary

- When the bot's IMAP account can also receive the bot's own outgoing SMTP mail, the poller picks up the bot's own messages and replies to them, producing an infinite reply loop (#3215).
- Skip any inbound whose sender address matches `from_address`, `smtp_username`, or `imap_username`.
- Mark the skipped message seen and dedupe its UID so it is not re-polled every cycle.

## Changes

- `nanobot/channels/email.py` — in `_fetch_messages_once`, after the sender is parsed, compare it against the bot's own addresses (normalized via `parseaddr`) and skip before any reply is generated. Placed before the SPF/DKIM check since self-origin is a more fundamental reject reason.
- `tests/channels/test_email_channel.py` — 4 regression tests:
  - skip when sender matches `from_address` (and verify `\Seen` is set)
  - skip when both sides use `Name <addr>` display-name form
  - skip when sender matches `smtp_username` (and `from_address` is empty)
  - external sender still accepted when `from_address` is set

## Backward compatibility

No API or config changes. Behavior change is limited to the single case that already produces a runaway loop. External senders, SPF/DKIM verification, attachment handling, and dedupe logic are untouched.

## Test plan

- [x] `uv run pytest tests/channels/test_email_channel.py` — 29 passed (25 existing + 4 new)
- [x] `uv run pytest tests/channels` — 421 passed, 3 skipped
- [x] New lint warnings on changed code: none (pre-existing `I001` in this test module predates this PR)

## Refs

- Closes #3215