### PR TITLE
chore(tests): fix ruff F541 + I001 in test_security_network

### DIFF
--- a/tests/security/test_security_network.py
+++ b/tests/security/test_security_network.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from nanobot.security.network import configure_ssrf_whitelist, contains_internal_url, validate_url_target
+from nanobot.security.network import (
+    configure_ssrf_whitelist,
+    contains_internal_url,
+    validate_url_target,
+)
 
 
 def _fake_resolve(host: str, results: list[str]):
@@ -49,7 +53,7 @@ def test_rejects_missing_domain():
 ])
 def test_blocks_private_ipv4(ip: str, label: str):
     with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve("evil.com", [ip])):
-        ok, err = validate_url_target(f"http://evil.com/path")
+        ok, err = validate_url_target("http://evil.com/path")
         assert not ok, f"Should block {label} ({ip})"
         assert "private" in err.lower() or "blocked" in err.lower()
 


### PR DESCRIPTION
## Summary

Pure lint cleanup in `tests/security/test_security_network.py`:

- **F541** — `f\"http://evil.com/path\"` has no placeholders; drop the `f` prefix.
- **I001** — reformat the `nanobot.security.network` import as a multi-line parenthesized block so `ruff check` is clean on this file.

## Backward compatibility

No behavior change. Tests still pass.

## Test plan

- [x] `uv run ruff check tests/security/test_security_network.py` — clean
- [x] `uv run pytest tests/security/test_security_network.py` — 20 passed