### PR TITLE
fix: pass apiBase from config to transcription providers (Groq & OpenAI)

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -45,7 +45,10 @@ class BaseChannel(ABC):
         try:
             if self.transcription_provider == "openai":
                 from nanobot.providers.transcription import OpenAITranscriptionProvider
-                provider = OpenAITranscriptionProvider(api_key=self.transcription_api_key)
+                provider = OpenAITranscriptionProvider(
+                    api_key=self.transcription_api_key,
+                    api_base=self.transcription_api_base or None,
+                )
             else:
                 from nanobot.providers.transcription import GroqTranscriptionProvider
                 provider = GroqTranscriptionProvider(

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -24,6 +24,7 @@ class BaseChannel(ABC):
     display_name: str = "Base"
     transcription_provider: str = "groq"
     transcription_api_key: str = ""
+    transcription_api_base: str = ""
 
     def __init__(self, config: Any, bus: MessageBus):
         """
@@ -47,7 +48,10 @@ class BaseChannel(ABC):
                 provider = OpenAITranscriptionProvider(api_key=self.transcription_api_key)
             else:
                 from nanobot.providers.transcription import GroqTranscriptionProvider
-                provider = GroqTranscriptionProvider(api_key=self.transcription_api_key)
+                provider = GroqTranscriptionProvider(
+                    api_key=self.transcription_api_key,
+                    api_base=self.transcription_api_base or None,
+                )
             return await provider.transcribe(file_path)
         except Exception as e:
             logger.warning("{}: audio transcription failed: {}", self.name, e)

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -41,6 +41,7 @@ class ChannelManager:
 
         transcription_provider = self.config.channels.transcription_provider
         transcription_key = self._resolve_transcription_key(transcription_provider)
+        transcription_base = self._resolve_transcription_base(transcription_provider)
 
         for name, cls in discover_all().items():
             section = getattr(self.config.channels, name, None)
@@ -57,6 +58,7 @@ class ChannelManager:
                 channel = cls(section, self.bus)
                 channel.transcription_provider = transcription_provider
                 channel.transcription_api_key = transcription_key
+                channel.transcription_api_base = transcription_base
                 self.channels[name] = channel
                 logger.info("{} channel enabled", cls.display_name)
             except Exception as e:
@@ -70,6 +72,15 @@ class ChannelManager:
             if provider == "openai":
                 return self.config.providers.openai.api_key
             return self.config.providers.groq.api_key
+        except AttributeError:
+            return ""
+
+    def _resolve_transcription_base(self, provider: str) -> str:
+        """Pick the API base URL for the configured transcription provider."""
+        try:
+            if provider == "openai":
+                return self.config.providers.openai.api_base or ""
+            return self.config.providers.groq.api_base or ""
         except AttributeError:
             return ""
 

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -10,9 +10,13 @@ from loguru import logger
 class OpenAITranscriptionProvider:
     """Voice transcription provider using OpenAI's Whisper API."""
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, api_base: str | None = None):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
-        self.api_url = "https://api.openai.com/v1/audio/transcriptions"
+        self.api_url = (
+            api_base
+            or os.environ.get("OPENAI_TRANSCRIPTION_BASE_URL")
+            or "https://api.openai.com/v1/audio/transcriptions"
+        )
 
     async def transcribe(self, file_path: str | Path) -> str:
         if not self.api_key:

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -44,9 +44,9 @@ class GroqTranscriptionProvider:
     Groq offers extremely fast transcription with a generous free tier.
     """
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, api_base: str | None = None):
         self.api_key = api_key or os.environ.get("GROQ_API_KEY")
-        self.api_url = "https://api.groq.com/openai/v1/audio/transcriptions"
+        self.api_url = api_base or os.environ.get("GROQ_BASE_URL") or "https://api.groq.com/openai/v1/audio/transcriptions"
 
     async def transcribe(self, file_path: str | Path) -> str:
         """

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -175,7 +175,7 @@ async def test_manager_loads_plugin_from_dict_config():
         channels=ChannelsConfig.model_validate({
             "fakeplugin": {"enabled": True, "allowFrom": ["*"]},
         }),
-        providers=SimpleNamespace(groq=SimpleNamespace(api_key="")),
+        providers=SimpleNamespace(groq=SimpleNamespace(api_key="", api_base="")),
     )
 
     with patch(
@@ -191,6 +191,38 @@ async def test_manager_loads_plugin_from_dict_config():
 
     assert "fakeplugin" in mgr.channels
     assert isinstance(mgr.channels["fakeplugin"], _FakePlugin)
+
+
+@pytest.mark.asyncio
+async def test_manager_propagates_groq_transcription_api_base_to_channels():
+    from nanobot.channels.manager import ChannelManager
+
+    fake_config = SimpleNamespace(
+        channels=ChannelsConfig.model_validate({
+            "fakeplugin": {"enabled": True, "allowFrom": ["*"]},
+        }),
+        transcription_provider="groq",
+        providers=SimpleNamespace(
+            groq=SimpleNamespace(api_key="groq-key", api_base="http://proxy.local/v1/audio/transcriptions"),
+            openai=SimpleNamespace(api_key="openai-key", api_base="https://api.openai.com/v1/audio/transcriptions"),
+        ),
+    )
+
+    with patch(
+        "nanobot.channels.registry.discover_all",
+        return_value={"fakeplugin": _FakePlugin},
+    ):
+        mgr = ChannelManager.__new__(ChannelManager)
+        mgr.config = fake_config
+        mgr.bus = MessageBus()
+        mgr.channels = {}
+        mgr._dispatch_task = None
+        mgr._init_channels()
+
+    channel = mgr.channels["fakeplugin"]
+    assert channel.transcription_provider == "groq"
+    assert channel.transcription_api_key == "groq-key"
+    assert channel.transcription_api_base == "http://proxy.local/v1/audio/transcriptions"
 
 
 def test_channels_login_uses_discovered_plugin_class(monkeypatch):

--- a/tests/channels/test_channel_plugins.py
+++ b/tests/channels/test_channel_plugins.py
@@ -225,6 +225,81 @@ async def test_manager_propagates_groq_transcription_api_base_to_channels():
     assert channel.transcription_api_base == "http://proxy.local/v1/audio/transcriptions"
 
 
+@pytest.mark.asyncio
+async def test_manager_propagates_openai_transcription_api_base_to_channels():
+    from nanobot.channels.manager import ChannelManager
+
+    fake_config = SimpleNamespace(
+        channels=ChannelsConfig.model_validate({
+            "fakeplugin": {"enabled": True, "allowFrom": ["*"]},
+            "transcriptionProvider": "openai",
+        }),
+        providers=SimpleNamespace(
+            openai=SimpleNamespace(
+                api_key="openai-key",
+                api_base="http://proxy.local/v1/audio/transcriptions",
+            ),
+            groq=SimpleNamespace(api_key="groq-key", api_base=""),
+        ),
+    )
+
+    with patch(
+        "nanobot.channels.registry.discover_all",
+        return_value={"fakeplugin": _FakePlugin},
+    ):
+        mgr = ChannelManager.__new__(ChannelManager)
+        mgr.config = fake_config
+        mgr.bus = MessageBus()
+        mgr.channels = {}
+        mgr._dispatch_task = None
+        mgr._init_channels()
+
+    channel = mgr.channels["fakeplugin"]
+    assert channel.transcription_provider == "openai"
+    assert channel.transcription_api_key == "openai-key"
+    assert channel.transcription_api_base == "http://proxy.local/v1/audio/transcriptions"
+
+
+@pytest.mark.asyncio
+async def test_base_channel_passes_api_base_to_openai_transcription_provider():
+    """BaseChannel.transcribe_audio must forward transcription_api_base to OpenAI."""
+    from nanobot.providers import transcription as transcription_mod
+
+    channel = _FakePlugin({"enabled": True, "allowFrom": ["*"]}, MessageBus())
+    channel.transcription_provider = "openai"
+    channel.transcription_api_key = "k"
+    channel.transcription_api_base = "http://override/v1/audio/transcriptions"
+
+    captured: dict[str, object] = {}
+
+    class _StubOpenAI:
+        def __init__(self, api_key=None, api_base=None):
+            captured["api_key"] = api_key
+            captured["api_base"] = api_base
+
+        async def transcribe(self, file_path):
+            return "ok"
+
+    with patch.object(transcription_mod, "OpenAITranscriptionProvider", _StubOpenAI):
+        result = await channel.transcribe_audio("/tmp/does-not-matter.wav")
+
+    assert result == "ok"
+    assert captured["api_key"] == "k"
+    assert captured["api_base"] == "http://override/v1/audio/transcriptions"
+
+
+def test_openai_transcription_provider_honors_api_base_argument():
+    from nanobot.providers.transcription import OpenAITranscriptionProvider
+
+    default = OpenAITranscriptionProvider(api_key="k")
+    assert default.api_url == "https://api.openai.com/v1/audio/transcriptions"
+
+    custom = OpenAITranscriptionProvider(
+        api_key="k", api_base="http://override/v1/audio/transcriptions"
+    )
+    assert custom.api_url == "http://override/v1/audio/transcriptions"
+
+
 def test_channels_login_uses_discovered_plugin_class(monkeypatch):
     from nanobot.cli.commands import app
     from nanobot.config.schema import Config


### PR DESCRIPTION
## Summary

Wire `apiBase` from `config.json` to both Groq and OpenAI transcription providers, enabling self-hosted or proxied Whisper endpoints to be configured without relying solely on environment variables.

### Transcription (Groq)

- **fix: pass apiBase from config to GroqTranscriptionProvider** — `GroqTranscriptionProvider` now accepts `api_base` with `GROQ_BASE_URL` env fallback, and `ChannelManager` propagates the resolved base URL to each channel. (#3214)
- **test(channels): cover groq transcription api base propagation** — Adds tests verifying manager propagation, channel-to-provider forwarding, and default vs explicit `api_base`. (#3214)

### Transcription (OpenAI)

- **fix(transcription): honor api_base for OpenAI transcription provider** — `OpenAITranscriptionProvider` now accepts `api_base` with `OPENAI_TRANSCRIPTION_BASE_URL` env fallback, matching the Groq pattern. `BaseChannel.transcribe_audio` forwards `transcription_api_base` to the OpenAI provider. Adds three mirroring tests. (#3226)

@flobo3 @mohamed-elkholy95 thanks for your contribution