### PR TITLE
feat: support multiple custom OpenAI-compatible providers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,6 +205,7 @@ Tracing covers the providers that go through nanobot's OpenAI-compatible client 
 > - **Step Fun (Mainland China)**: If your API key is from Step Fun's mainland China platform (stepfun.com), set `"apiBase": "https://api.stepfun.com/v1"` in your stepfun provider config.
 > - **Xiaomi MiMo thinking mode**: MiMo models (e.g. `mimo-v2.5-pro`) default to enabled thinking. Use `agents.defaults.reasoningEffort: "none"` to disable it, or `"low"` / `"medium"` / `"high"` to keep it on. Omitting the field preserves the provider's per-model default.
 > - **Xiaomi MiMo Token Plan**: If you're on MiMo's token plan, set `"apiBase": "https://token-plan-sgp.xiaomimimo.com/v1"` in your xiaomi_mimo provider config.
+> - **Custom OpenAI-compatible providers**: Besides the built-in `custom` provider, any extra key under `providers` can define its own OpenAI-compatible endpoint. For example, `providers.companyProxy.apiBase` plus `modelPresets.primary.provider: "companyProxy"` creates a separate custom provider. Set `apiBase`; set `apiKey` only when the endpoint requires it.
 
 | Provider | Purpose | Get API Key |
 |----------|---------|-------------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,7 +205,7 @@ Tracing covers the providers that go through nanobot's OpenAI-compatible client 
 > - **Step Fun (Mainland China)**: If your API key is from Step Fun's mainland China platform (stepfun.com), set `"apiBase": "https://api.stepfun.com/v1"` in your stepfun provider config.
 > - **Xiaomi MiMo thinking mode**: MiMo models (e.g. `mimo-v2.5-pro`) default to enabled thinking. Use `agents.defaults.reasoningEffort: "none"` to disable it, or `"low"` / `"medium"` / `"high"` to keep it on. Omitting the field preserves the provider's per-model default.
 > - **Xiaomi MiMo Token Plan**: If you're on MiMo's token plan, set `"apiBase": "https://token-plan-sgp.xiaomimimo.com/v1"` in your xiaomi_mimo provider config.
-> - **Custom OpenAI-compatible providers**: Besides the built-in `custom` provider, any extra key under `providers` can define its own OpenAI-compatible endpoint. For example, `providers.companyProxy.apiBase` plus `modelPresets.primary.provider: "companyProxy"` creates a separate custom provider. Set `apiBase`; set `apiKey` only when the endpoint requires it.
+> - **Custom OpenAI-compatible providers**: Besides the built-in `custom` provider, any extra key under `providers` can define its own OpenAI-compatible endpoint. For example, `providers.companyProxy.apiBase` plus `modelPresets.primary.provider: "companyProxy"` creates a separate custom provider. Set `apiBase`; set `apiKey` only when the endpoint requires it. This named-custom path uses the OpenAI-compatible request format only. For Anthropic-compatible proxies, use `providers.anthropic.apiBase` with `provider: "anthropic"`.
 
 | Provider | Purpose | Get API Key |
 |----------|---------|-------------|
@@ -859,7 +859,9 @@ Connects directly to any OpenAI-compatible endpoint — llama.cpp, Together AI, 
 > }
 > ```
 >
-> In short: **chat-completions-compatible endpoint → `custom`**; **Responses-compatible endpoint → `azure_openai`**.
+> Anthropic-compatible endpoints are separate: use `providers.anthropic.apiBase` and set the preset provider to `anthropic`. Arbitrary custom provider names do not use the Anthropic Messages API format.
+>
+> In short: **chat-completions-compatible endpoint → `custom` or a named custom provider**; **Responses-compatible endpoint → `azure_openai`**; **Anthropic-compatible endpoint → `anthropic` with `apiBase`**.
 
 Some OpenAI-compatible gateways expose request-body extensions such as vLLM guided decoding or local sampling controls. Put those under `extraBody`; nanobot merges them into the chat-completions request body after its provider defaults:
 

--- a/docs/provider-cookbook.md
+++ b/docs/provider-cookbook.md
@@ -168,6 +168,36 @@ ANTHROPIC_API_KEY="sk-ant-..." nanobot agent -m "Hello!"
 
 If you copied a model name such as `anthropic/claude-sonnet-4.5`, that is a gateway-style model path and belongs under `provider: "openrouter"`, not `provider: "anthropic"`.
 
+If you use an Anthropic-compatible proxy, keep the preset provider as `anthropic` and set `providers.anthropic.apiBase`:
+
+```json
+{
+  "providers": {
+    "anthropic": {
+      "apiKey": "${ANTHROPIC_API_KEY}",
+      "apiBase": "https://anthropic-proxy.example.com"
+    }
+  },
+  "modelPresets": {
+    "primary": {
+      "label": "Anthropic proxy",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5",
+      "maxTokens": 4096,
+      "contextWindowTokens": 200000,
+      "temperature": 0.1
+    }
+  },
+  "agents": {
+    "defaults": {
+      "modelPreset": "primary"
+    }
+  }
+}
+```
+
+Do not configure Anthropic-compatible endpoints as arbitrary custom provider names; named custom providers use the OpenAI-compatible request format.
+
 ## Recipe: Custom OpenAI-Compatible Provider
 
 This recipe applies to an OpenAI-compatible service that is not a named nanobot provider.
@@ -246,7 +276,7 @@ For multiple custom endpoints, do not overload the single `custom` block. Name e
 }
 ```
 
-These custom names behave like direct OpenAI-compatible providers: `apiBase` is required, `apiKey` is optional when the endpoint allows anonymous or placeholder credentials, and `apiType` should be left unset.
+These custom names behave like direct OpenAI-compatible providers: `apiBase` is required, `apiKey` is optional when the endpoint allows anonymous or placeholder credentials, and `apiType` should be left unset. They do not support Anthropic-compatible endpoints; use the `anthropic` provider with `apiBase` for that case.
 
 ## Recipe: Ollama Local Model
 

--- a/docs/provider-cookbook.md
+++ b/docs/provider-cookbook.md
@@ -207,6 +207,47 @@ nanobot agent -m "Hello!"
 
 `apiBase` is the HTTP base URL, not the model name. Include the version path when the service expects it, such as `/v1`. If the service requires a non-empty key but does not validate it, use a placeholder such as `"apiKey": "EMPTY"`.
 
+For multiple custom endpoints, do not overload the single `custom` block. Name each endpoint under `providers` and reference that same name from the preset:
+
+```json
+{
+  "providers": {
+    "workProxy": {
+      "apiKey": "${WORK_PROXY_API_KEY}",
+      "apiBase": "https://proxy.example.com/v1"
+    },
+    "lab-local": {
+      "apiBase": "http://127.0.0.1:8000/v1"
+    }
+  },
+  "modelPresets": {
+    "work": {
+      "label": "Work proxy",
+      "provider": "workProxy",
+      "model": "gpt-4o-mini",
+      "maxTokens": 4096,
+      "contextWindowTokens": 65536,
+      "temperature": 0.1
+    },
+    "lab": {
+      "label": "Lab local",
+      "provider": "lab-local",
+      "model": "served-model-name",
+      "maxTokens": 4096,
+      "contextWindowTokens": 65536,
+      "temperature": 0.1
+    }
+  },
+  "agents": {
+    "defaults": {
+      "modelPreset": "work"
+    }
+  }
+}
+```
+
+These custom names behave like direct OpenAI-compatible providers: `apiBase` is required, `apiKey` is optional when the endpoint allows anonymous or placeholder credentials, and `apiType` should be left unset.
+
 ## Recipe: Ollama Local Model
 
 This recipe applies when Ollama is already installed and the model has been pulled locally.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -377,6 +377,16 @@ Provider selection follows this practical rule:
 - Gateway providers such as OpenRouter and AiHubMix can route many model families, so the model name must be valid for that gateway.
 - Local providers should normally be explicit because generic local model names such as `llama3.2` do not always contain provider keywords.
 
+### Model Name Prefixes
+
+`family/model-name` does not always select provider `family`. Prefix-based provider inference only runs when the active provider is `"auto"`.
+
+- Explicit provider wins: `provider: "openrouter"` with `model: "anthropic/claude-sonnet-4.5"` calls OpenRouter, not Anthropic.
+- With `provider: "auto"`, a prefix matching a configured built-in or named custom provider can select that provider. Named custom prefixes are stripped before request, so `companyProxy/gpt-4o-mini` is sent upstream as `gpt-4o-mini`.
+- With an explicit named custom provider, the model is sent as written; `provider: "companyProxy"` with `model: "openai/gpt-4o-mini"` sends `openai/gpt-4o-mini` to `companyProxy`.
+
+Pin `provider` in presets when using gateway catalog IDs such as `anthropic/claude-sonnet-4.5`.
+
 ## Model Presets
 
 Model presets are the recommended model configuration surface. Use them when you want named model choices, runtime `/model` switching, or reusable fallback targets.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -150,7 +150,7 @@ Anthropic direct uses the native Anthropic provider. Do not use an OpenRouter mo
 
 ### Custom OpenAI-Compatible Endpoint
 
-The `custom` provider fits OpenAI-compatible endpoints that are not represented by a named provider.
+The `custom` provider fits one OpenAI-compatible endpoint that is not represented by a named provider.
 
 ```json
 {
@@ -177,6 +177,43 @@ The `custom` provider fits OpenAI-compatible endpoints that are not represented 
 ```
 
 `custom` does not infer a default base URL. Set `apiBase`.
+
+If you have more than one custom OpenAI-compatible endpoint, give each endpoint its own provider key under `providers` and use that same key in the model preset. The key can be a name that makes sense in your environment, such as `companyProxy`, `tenant-a`, or `dev-local`.
+
+```json
+{
+  "providers": {
+    "companyProxy": {
+      "apiKey": "${COMPANY_PROXY_API_KEY}",
+      "apiBase": "https://llm-proxy.example.com/v1"
+    },
+    "tenant-a": {
+      "apiBase": "https://tenant-a.example.com/v1"
+    }
+  },
+  "modelPresets": {
+    "company": {
+      "provider": "companyProxy",
+      "model": "gpt-4o-mini",
+      "maxTokens": 8192,
+      "contextWindowTokens": 65536
+    },
+    "tenantA": {
+      "provider": "tenant-a",
+      "model": "served-model-name",
+      "maxTokens": 8192,
+      "contextWindowTokens": 65536
+    }
+  },
+  "agents": {
+    "defaults": {
+      "modelPreset": "company"
+    }
+  }
+}
+```
+
+Custom provider keys are treated as direct OpenAI-compatible providers. `apiBase` is required because nanobot cannot know the endpoint URL. `apiKey` is optional for local servers or private proxies that do not require one. Do not set `apiType` on custom provider keys; `apiType` is only for `providers.openai`.
 
 ### Ollama
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -121,6 +121,27 @@ Use the model ID exactly as OpenRouter lists it.
 
 Anthropic direct uses the native Anthropic provider. Do not use an OpenRouter model ID unless the provider is OpenRouter.
 
+If you use an Anthropic-compatible proxy, keep the provider as `anthropic` and override `apiBase`:
+
+```json
+{
+  "providers": {
+    "anthropic": {
+      "apiKey": "${ANTHROPIC_API_KEY}",
+      "apiBase": "https://anthropic-proxy.example.com"
+    }
+  },
+  "modelPresets": {
+    "primary": {
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5"
+    }
+  }
+}
+```
+
+Arbitrary custom provider names are OpenAI-compatible only; they do not use the Anthropic Messages API request format.
+
 ### OpenAI Direct
 
 ```json
@@ -214,6 +235,8 @@ If you have more than one custom OpenAI-compatible endpoint, give each endpoint 
 ```
 
 Custom provider keys are treated as direct OpenAI-compatible providers. `apiBase` is required because nanobot cannot know the endpoint URL. `apiKey` is optional for local servers or private proxies that do not require one. Do not set `apiType` on custom provider keys; `apiType` is only for `providers.openai`.
+
+This named custom provider path is not for Anthropic-compatible endpoints. For Anthropic-compatible proxies, use `providers.anthropic.apiBase` and set the preset provider to `anthropic`.
 
 ### Ollama
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -234,7 +234,7 @@ If you have more than one custom OpenAI-compatible endpoint, give each endpoint 
 }
 ```
 
-Custom provider keys are treated as direct OpenAI-compatible providers. `apiBase` is required because nanobot cannot know the endpoint URL. `apiKey` is optional for local servers or private proxies that do not require one. Do not set `apiType` on custom provider keys; `apiType` is only for `providers.openai`.
+Custom provider keys are treated as direct OpenAI-compatible providers. `apiBase` is required because nanobot cannot know the endpoint URL. `apiKey` is optional for local servers or private proxies that do not require one. Choose a name that does not conflict with a built-in provider name or alias, such as `openai`, `openai-codex`, `github-copilot`, or `lm-studio`. Do not set `apiType` on custom provider keys; `apiType` is only for `providers.openai`.
 
 This named custom provider path is not for Anthropic-compatible endpoints. For Anthropic-compatible proxies, use `providers.anthropic.apiBase` and set the preset provider to `anthropic`.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,7 +102,7 @@ Common config mistakes:
 | Symptom | Check |
 |---|---|
 | JSON parse error | Validate commas, braces, and quotes. Most docs examples are partial snippets to merge. |
-| Unknown or missing provider | Use provider registry names such as `openrouter`, `anthropic`, `openai`, `ollama`, `vllm`, `lm_studio`. |
+| Unknown or missing provider | Use provider registry names such as `openrouter`, `anthropic`, `openai`, `ollama`, `vllm`, `lm_studio`, or define a custom OpenAI-compatible provider key under `providers` and reference that exact key from the active preset. |
 | snake_case vs camelCase confusion | Both are accepted, but docs use camelCase because nanobot writes config with aliases such as `apiKey`, `modelPresets`, `intervalS`. |
 | Environment variable error | `${VAR_NAME}` references are resolved at startup. Set the variable before running nanobot. |
 | Edited config but behavior did not change | Restart `nanobot gateway`; long-running processes read config at startup. |

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
 
@@ -96,13 +96,22 @@ class AgentsConfig(Base):
 class ProviderConfig(Base):
     """LLM provider configuration."""
 
+    # Re-declare model_config to ensure alias_generator is applied
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     api_key: str | None = None
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
 
 
 class ProvidersConfig(Base):
-    """Configuration for LLM providers."""
+    """Configuration for LLM providers.
+
+    Supports custom providers via extra fields — any additional field
+    becomes an OpenAI-compatible custom provider.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
     azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
@@ -133,6 +142,15 @@ class ProvidersConfig(Base):
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
+
+    @model_validator(mode="after")
+    def convert_extra_providers(self):
+        """Convert extra fields (custom providers) to ProviderConfig objects."""
+        if self.model_extra:
+            for key, value in self.model_extra.items():
+                if isinstance(value, dict):
+                    self.model_extra[key] = ProviderConfig.model_validate(value)
+        return self
 
 
 class HeartbeatConfig(Base):
@@ -229,7 +247,11 @@ class Config(BaseSettings):
         self, model: str | None = None
     ) -> tuple["ProviderConfig | None", str | None]:
         """Match provider config and its registry name. Returns (config, spec_name)."""
-        from nanobot.providers.registry import PROVIDERS, find_by_name
+        from nanobot.providers.registry import (
+            PROVIDERS,
+            create_dynamic_spec,
+            find_by_name,
+        )
 
         forced = self.agents.defaults.provider
         if forced != "auto":
@@ -237,6 +259,11 @@ class Config(BaseSettings):
             if spec:
                 p = getattr(self.providers, spec.name, None)
                 return (p, spec.name) if p else (None, None)
+            # Check for custom provider by name (try both original and normalized)
+            for name_to_try in (forced, forced.replace("-", "_")):
+                p = getattr(self.providers, name_to_try, None)
+                if p and isinstance(p, ProviderConfig):
+                    return p, name_to_try
             return None, None
 
         model_lower = (model or self.agents.defaults.model).lower()
@@ -254,6 +281,14 @@ class Config(BaseSettings):
             if p and model_prefix and normalized_prefix == spec.name:
                 if spec.is_oauth or spec.is_local or p.api_key:
                     return p, spec.name
+
+        # Check for custom provider by prefix (e.g., "myprovider/gpt-4")
+        # Try both original prefix and normalized (snake_case) prefix
+        if model_prefix:
+            for prefix_to_try in (model_prefix, normalized_prefix):
+                p = getattr(self.providers, prefix_to_try, None)
+                if p and isinstance(p, ProviderConfig) and p.api_base:
+                    return p, prefix_to_try
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
@@ -288,6 +323,15 @@ class Config(BaseSettings):
             p = getattr(self.providers, spec.name, None)
             if p and p.api_key:
                 return p, spec.name
+
+        # Final fallback: check for any configured custom provider
+        for attr_name in dir(self.providers):
+            if attr_name.startswith("_"):
+                continue
+            p = getattr(self.providers, attr_name, None)
+            if isinstance(p, ProviderConfig) and p.api_base:
+                return p, attr_name
+
         return None, None
 
     def get_provider(self, model: str | None = None) -> ProviderConfig | None:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -245,7 +245,14 @@ class ProvidersConfig(Base):
     def convert_extra_providers(self):
         """Convert extra fields (custom providers) to ProviderConfig objects."""
         if self.model_extra:
+            from nanobot.providers.registry import find_by_name
+
             for key, value in self.model_extra.items():
+                if spec := find_by_name(key):
+                    raise ValueError(
+                        f"providers.{key} conflicts with built-in provider {spec.name!r}; "
+                        "use the built-in provider key or choose a different custom provider name"
+                    )
                 if isinstance(value, dict):
                     self.model_extra[key] = ProviderConfig.model_validate(value)
         return self

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -194,7 +194,13 @@ class BedrockProviderConfig(ProviderConfig):
 
 
 class ProvidersConfig(Base):
-    """Configuration for LLM providers."""
+    """Configuration for LLM providers.
+
+    Supports custom providers via extra fields — any additional field
+    becomes an OpenAI-compatible custom provider.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
     azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
@@ -243,6 +249,15 @@ class ProvidersConfig(Base):
             provider = getattr(self, name, None)
             if isinstance(provider, ProviderConfig) and provider.api_type != "auto":
                 raise ValueError("providers.<name>.api_type is only supported for providers.openai")
+        return self
+
+    @model_validator(mode="after")
+    def convert_extra_providers(self):
+        """Convert extra fields (custom providers) to ProviderConfig objects."""
+        if self.model_extra:
+            for key, value in self.model_extra.items():
+                if isinstance(value, dict):
+                    self.model_extra[key] = ProviderConfig.model_validate(value)
         return self
 
 
@@ -381,7 +396,10 @@ class Config(BaseSettings):
         preset: ModelPresetConfig | None = None,
     ) -> tuple["ProviderConfig | None", str | None]:
         """Match provider config and its registry name. Returns (config, spec_name)."""
-        from nanobot.providers.registry import PROVIDERS, find_by_name
+        from nanobot.providers.registry import (
+            PROVIDERS,
+            find_by_name,
+        )
 
         resolved = preset or self.resolve_preset()
         forced = resolved.provider
@@ -390,6 +408,11 @@ class Config(BaseSettings):
             if spec:
                 p = getattr(self.providers, spec.name, None)
                 return (p, spec.name) if p else (None, None)
+            # Check for custom provider by name (try both original and normalized)
+            for name_to_try in (forced, forced.replace("-", "_")):
+                p = getattr(self.providers, name_to_try, None)
+                if p and isinstance(p, ProviderConfig):
+                    return p, name_to_try
             return None, None
 
         model_lower = (model or resolved.model).lower()
@@ -409,6 +432,14 @@ class Config(BaseSettings):
             if p and model_prefix and normalized_prefix == spec.name:
                 if spec.is_oauth or spec.is_local or spec.is_direct or p.api_key:
                     return p, spec.name
+
+        # Check for custom provider by prefix (e.g., "myprovider/gpt-4")
+        # Try both original prefix and normalized (snake_case) prefix
+        if model_prefix:
+            for prefix_to_try in (model_prefix, normalized_prefix):
+                p = getattr(self.providers, prefix_to_try, None)
+                if p and isinstance(p, ProviderConfig) and p.api_base:
+                    return p, prefix_to_try
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
@@ -445,6 +476,15 @@ class Config(BaseSettings):
             p = getattr(self.providers, spec.name, None)
             if p and p.api_key:
                 return p, spec.name
+
+        # Final fallback: check for any configured custom provider
+        for attr_name in dir(self.providers):
+            if attr_name.startswith("_"):
+                continue
+            p = getattr(self.providers, attr_name, None)
+            if isinstance(p, ProviderConfig) and p.api_base:
+                return p, attr_name
+
         return None, None
 
     def get_provider(

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -242,6 +242,15 @@ class ProvidersConfig(Base):
     nvidia: ProviderConfig = Field(default_factory=ProviderConfig)  # NVIDIA NIM (nvapi- keys)
 
     @model_validator(mode="after")
+    def convert_extra_providers(self):
+        """Convert extra fields (custom providers) to ProviderConfig objects."""
+        if self.model_extra:
+            for key, value in self.model_extra.items():
+                if isinstance(value, dict):
+                    self.model_extra[key] = ProviderConfig.model_validate(value)
+        return self
+
+    @model_validator(mode="after")
     def _validate_api_type_scope(self) -> "ProvidersConfig":
         for name in self.__class__.model_fields:
             if name == "openai":
@@ -249,15 +258,9 @@ class ProvidersConfig(Base):
             provider = getattr(self, name, None)
             if isinstance(provider, ProviderConfig) and provider.api_type != "auto":
                 raise ValueError("providers.<name>.api_type is only supported for providers.openai")
-        return self
-
-    @model_validator(mode="after")
-    def convert_extra_providers(self):
-        """Convert extra fields (custom providers) to ProviderConfig objects."""
-        if self.model_extra:
-            for key, value in self.model_extra.items():
-                if isinstance(value, dict):
-                    self.model_extra[key] = ProviderConfig.model_validate(value)
+        for provider in (self.model_extra or {}).values():
+            if isinstance(provider, ProviderConfig) and provider.api_type != "auto":
+                raise ValueError("providers.<name>.api_type is only supported for providers.openai")
         return self
 
 
@@ -478,10 +481,7 @@ class Config(BaseSettings):
                 return p, spec.name
 
         # Final fallback: check for any configured custom provider
-        for attr_name in dir(self.providers):
-            if attr_name.startswith("_"):
-                continue
-            p = getattr(self.providers, attr_name, None)
+        for attr_name, p in (self.providers.model_extra or {}).items():
             if isinstance(p, ProviderConfig) and p.api_base:
                 return p, attr_name
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -406,16 +406,24 @@ class Config(BaseSettings):
 
         resolved = preset or self.resolve_preset()
         forced = resolved.provider
+
+        def _custom_provider_by_name(name: str) -> tuple[ProviderConfig, str] | None:
+            normalized = name.replace("-", "_").lower()
+            for attr_name, provider in (self.providers.model_extra or {}).items():
+                if not isinstance(provider, ProviderConfig):
+                    continue
+                if attr_name.replace("-", "_").lower() == normalized:
+                    return provider, attr_name
+            return None
+
         if forced != "auto":
             spec = find_by_name(forced)
             if spec:
                 p = getattr(self.providers, spec.name, None)
                 return (p, spec.name) if p else (None, None)
-            # Check for custom provider by name (try both original and normalized)
-            for name_to_try in (forced, forced.replace("-", "_")):
-                p = getattr(self.providers, name_to_try, None)
-                if p and isinstance(p, ProviderConfig):
-                    return p, name_to_try
+            custom = _custom_provider_by_name(forced)
+            if custom is not None:
+                return custom
             return None, None
 
         model_lower = (model or resolved.model).lower()
@@ -436,13 +444,14 @@ class Config(BaseSettings):
                 if spec.is_oauth or spec.is_local or spec.is_direct or p.api_key:
                     return p, spec.name
 
-        # Check for custom provider by prefix (e.g., "myprovider/gpt-4")
-        # Try both original prefix and normalized (snake_case) prefix
+        # Check for custom provider by prefix (e.g., "companyProxy/gpt-4").
+        # Return the matching provider even when apiBase is missing, so a
+        # malformed explicit prefix fails instead of falling through to a
+        # different custom provider.
         if model_prefix:
-            for prefix_to_try in (model_prefix, normalized_prefix):
-                p = getattr(self.providers, prefix_to_try, None)
-                if p and isinstance(p, ProviderConfig) and p.api_base:
-                    return p, prefix_to_try
+            custom = _custom_provider_by_name(normalized_prefix)
+            if custom is not None:
+                return custom
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -42,6 +42,8 @@ def _make_provider_core(
     p = config.get_provider(model, preset=resolved)
     spec = find_by_name(provider_name) if provider_name else None
     if provider_name and not spec and p:
+        if not p.api_base:
+            raise ValueError(f"Provider '{provider_name}' requires api_base in config.")
         spec = create_dynamic_spec(provider_name)
     if spec and spec.is_transcription_only:
         raise ValueError(f"Provider '{provider_name}' only supports transcription.")
@@ -50,6 +52,14 @@ def _make_provider_core(
     if backend == "azure_openai":
         if not p or not p.api_base:
             raise ValueError("Azure OpenAI requires api_base in config.")
+    elif (
+        backend == "openai_compat"
+        and spec
+        and spec.is_direct
+        and not spec.default_api_base
+        and not (p and p.api_base)
+    ):
+        raise ValueError(f"Provider '{provider_name}' requires api_base in config.")
     elif backend == "openai_compat" and not model.startswith("bedrock/"):
         needs_key = not (p and p.api_key)
         exempt = spec and (spec.is_oauth or spec.is_local or spec.is_direct)

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from nanobot.config.schema import Config, InlineFallbackConfig, ModelPresetConfig
 from nanobot.providers.base import LLMProvider
 from nanobot.providers.fallback_provider import FallbackProvider
-from nanobot.providers.registry import find_by_name
+from nanobot.providers.registry import create_dynamic_spec, find_by_name
 
 
 @dataclass(frozen=True)
@@ -41,6 +41,8 @@ def _make_provider_core(
     provider_name = config.get_provider_name(model, preset=resolved)
     p = config.get_provider(model, preset=resolved)
     spec = find_by_name(provider_name) if provider_name else None
+    if provider_name and not spec and p:
+        spec = create_dynamic_spec(provider_name)
     if spec and spec.is_transcription_only:
         raise ValueError(f"Provider '{provider_name}' only supports transcription.")
     backend = spec.backend if spec else "openai_compat"

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from loguru import logger
+from pydantic.alias_generators import to_snake
 
 from nanobot.providers.base import (
     LLMProvider,
@@ -91,6 +92,10 @@ _MODEL_THINKING_STYLES: dict[str, str] = {
 
 def _model_slug(model_name: str) -> str:
     return model_name.lower().rsplit("/", 1)[-1]
+
+
+def _provider_prefix_key(name: str) -> str:
+    return to_snake(name.replace("-", "_")).lower()
 
 
 def _requires_max_completion_tokens(model_name: str) -> bool:
@@ -592,6 +597,22 @@ class OpenAICompatProvider(LLMProvider):
     # Build kwargs
     # ------------------------------------------------------------------
 
+    def _request_model_name(self, model_name: str) -> str:
+        spec = self._spec
+        if not spec or "/" not in model_name:
+            return model_name
+        if spec.strip_model_prefix:
+            return model_name.split("/")[-1]
+
+        route_prefixes = getattr(spec, "strip_model_prefixes", ())
+        if not isinstance(route_prefixes, tuple) or not route_prefixes:
+            return model_name
+        model_prefix, routed_model = model_name.split("/", 1)
+        model_prefix_key = _provider_prefix_key(model_prefix)
+        if any(_provider_prefix_key(prefix) == model_prefix_key for prefix in route_prefixes):
+            return routed_model
+        return model_name
+
     @staticmethod
     def _supports_temperature(
         model_name: str,
@@ -625,8 +646,7 @@ class OpenAICompatProvider(LLMProvider):
             if any(model_name.lower().startswith(k) for k in ("anthropic/", "claude")):
                 messages, tools = self._apply_cache_control(messages, tools)
 
-        if spec and spec.strip_model_prefix:
-            model_name = model_name.split("/")[-1]
+        model_name = self._request_model_name(model_name)
 
         kwargs: dict[str, Any] = {
             "model": model_name,
@@ -830,8 +850,7 @@ class OpenAICompatProvider(LLMProvider):
     ) -> dict[str, Any]:
         """Build a Responses API body for direct OpenAI requests."""
         model_name = model or self.default_model
-        if self._spec and self._spec.strip_model_prefix:
-            model_name = model_name.split("/")[-1]
+        model_name = self._request_model_name(model_name)
         sanitized_messages = self._sanitize_messages(self._sanitize_empty_content(messages))
         instructions, input_items = convert_messages(sanitized_messages)
 

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -393,3 +393,16 @@ def find_by_name(name: str) -> ProviderSpec | None:
         if spec.name == normalized:
             return spec
     return None
+
+
+def create_dynamic_spec(name: str) -> ProviderSpec:
+    """Create a dynamic ProviderSpec for custom user-defined providers."""
+    normalized = to_snake(name.replace("-", "_"))
+    return ProviderSpec(
+        name=normalized,
+        keywords=(),
+        env_key="",
+        display_name=name.title(),
+        backend="openai_compat",
+        is_direct=True,
+    )

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -545,3 +545,16 @@ def find_by_name(name: str) -> ProviderSpec | None:
         if spec.name == normalized:
             return spec
     return None
+
+
+def create_dynamic_spec(name: str) -> ProviderSpec:
+    """Create a dynamic ProviderSpec for custom user-defined providers."""
+    normalized = to_snake(name.replace("-", "_"))
+    return ProviderSpec(
+        name=normalized,
+        keywords=(),
+        env_key="",
+        display_name=name.title(),
+        backend="openai_compat",
+        is_direct=True,
+    )

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -49,6 +49,7 @@ class ProviderSpec:
 
     # gateway behavior
     strip_model_prefix: bool = False  # strip "provider/" before sending to gateway
+    strip_model_prefixes: tuple[str, ...] = ()  # strip only when the first model segment matches
     supports_max_completion_tokens: bool = False
 
     # per-model param overrides, e.g. (("kimi-k2.5", {"temperature": 1.0}),)
@@ -550,6 +551,7 @@ def find_by_name(name: str) -> ProviderSpec | None:
 def create_dynamic_spec(name: str) -> ProviderSpec:
     """Create a dynamic ProviderSpec for custom user-defined providers."""
     normalized = to_snake(name.replace("-", "_"))
+    strip_prefixes = tuple(dict.fromkeys((name, normalized)))
     return ProviderSpec(
         name=normalized,
         keywords=(),
@@ -557,4 +559,5 @@ def create_dynamic_spec(name: str) -> ProviderSpec:
         display_name=name.title(),
         backend="openai_compat",
         is_direct=True,
+        strip_model_prefixes=strip_prefixes,
     )

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -270,6 +270,12 @@ def _provider_requires_api_key(spec: Any) -> bool:
     return True
 
 
+def _provider_requires_api_base(spec: Any) -> bool:
+    if spec.name == "azure_openai":
+        return True
+    return bool(spec.backend == "openai_compat" and spec.is_direct and not spec.default_api_base)
+
+
 def _oauth_provider_status(spec: Any) -> dict[str, Any]:
     if not getattr(spec, "is_oauth", False):
         return {"configured": False, "account": None, "expires_at": None, "login_supported": False}
@@ -321,7 +327,7 @@ def _oauth_provider_status(spec: Any) -> dict[str, Any]:
 def _provider_configured_for_settings(spec: Any, provider_config: Any) -> bool:
     if spec.is_oauth:
         return bool(_oauth_provider_status(spec)["configured"])
-    if spec.name == "azure_openai":
+    if _provider_requires_api_base(spec):
         return bool(provider_config.api_base)
     if _provider_requires_api_key(spec):
         return bool(provider_config.api_key)

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -334,11 +334,11 @@ def _provider_configured_for_settings(spec: Any, provider_config: Any) -> bool:
 
 
 def _dynamic_provider_items(config: Any) -> list[tuple[str, ProviderConfig]]:
-    items: list[tuple[str, ProviderConfig]] = []
-    for name, provider_config in (config.providers.model_extra or {}).items():
-        if isinstance(provider_config, ProviderConfig):
-            items.append((name, provider_config))
-    return items
+    return [
+        (name, provider_config)
+        for name, provider_config in (config.providers.model_extra or {}).items()
+        if isinstance(provider_config, ProviderConfig)
+    ]
 
 
 def _resolve_settings_provider(

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -22,12 +22,12 @@ from nanobot.audio.transcription_registry import (
     transcription_provider_names,
 )
 from nanobot.config.loader import get_config_path, load_config, save_config
-from nanobot.config.schema import ModelPresetConfig
+from nanobot.config.schema import ModelPresetConfig, ProviderConfig
 from nanobot.providers.image_generation import (
     get_image_gen_provider,
     image_gen_provider_names,
 )
-from nanobot.providers.registry import PROVIDERS, find_by_name
+from nanobot.providers.registry import PROVIDERS, create_dynamic_spec, find_by_name
 from nanobot.security.workspace_access import workspace_sandbox_status
 from nanobot.webui.token_usage import token_usage_payload
 from nanobot.webui.workspaces import (
@@ -333,6 +333,62 @@ def _provider_configured_for_settings(spec: Any, provider_config: Any) -> bool:
     )
 
 
+def _dynamic_provider_items(config: Any) -> list[tuple[str, ProviderConfig]]:
+    items: list[tuple[str, ProviderConfig]] = []
+    for name, provider_config in (config.providers.model_extra or {}).items():
+        if isinstance(provider_config, ProviderConfig):
+            items.append((name, provider_config))
+    return items
+
+
+def _resolve_settings_provider(
+    config: Any,
+    provider_name: str,
+) -> tuple[Any, str, ProviderConfig] | None:
+    spec = find_by_name(provider_name)
+    if spec is not None:
+        provider_config = getattr(config.providers, spec.name, None)
+        if isinstance(provider_config, ProviderConfig):
+            return spec, spec.name, provider_config
+        return None
+
+    normalized = provider_name.replace("-", "_")
+    for extra_name, provider_config in _dynamic_provider_items(config):
+        if provider_name == extra_name or normalized == extra_name.replace("-", "_"):
+            return create_dynamic_spec(extra_name), extra_name, provider_config
+    return None
+
+
+def _provider_settings_row(
+    name: str,
+    spec: Any,
+    provider_config: ProviderConfig,
+) -> dict[str, Any]:
+    oauth_status = _oauth_provider_status(spec) if spec.is_oauth else None
+    row = {
+        "name": name,
+        "label": spec.label,
+        "configured": (
+            bool(oauth_status["configured"])
+            if oauth_status is not None
+            else _provider_configured_for_settings(spec, provider_config)
+        ),
+        "auth_type": "oauth" if spec.is_oauth else "api_key",
+        "api_key_required": _provider_requires_api_key(spec),
+        "api_key_hint": _mask_secret_hint(provider_config.api_key),
+        "api_base": provider_config.api_base,
+        "default_api_base": spec.default_api_base or None,
+        "model_selectable": not spec.is_transcription_only,
+    }
+    if oauth_status is not None:
+        row["oauth_account"] = oauth_status["account"]
+        row["oauth_expires_at"] = oauth_status["expires_at"]
+        row["oauth_login_supported"] = oauth_status["login_supported"]
+    if spec.name == "openai":
+        row["api_type"] = provider_config.api_type
+    return row
+
+
 def _model_catalog_kind(spec: Any) -> str:
     if spec.name in _MODEL_LIST_CATALOG_PROVIDERS:
         return "catalog"
@@ -423,12 +479,15 @@ def provider_models_payload(query: QueryParams) -> dict[str, Any]:
     provider_name = (_query_first(query, "provider") or "").strip()
     if not provider_name:
         raise WebUISettingsError("provider is required")
-    spec = find_by_name(provider_name)
-    if spec is None:
+
+    config = load_config()
+    resolved_provider = _resolve_settings_provider(config, provider_name)
+    if resolved_provider is None:
         raise WebUISettingsError("unknown provider")
+    spec, provider_key, provider_config = resolved_provider
 
     base_payload: dict[str, Any] = {
-        "provider": spec.name,
+        "provider": provider_key,
         "label": spec.label,
         "catalog_kind": _model_catalog_kind(spec),
         "models": [],
@@ -450,11 +509,6 @@ def provider_models_payload(query: QueryParams) -> dict[str, Any]:
             "catalog_kind": "unsupported",
             "message": "Model list is not available for this provider. Type a model ID manually.",
         }
-
-    config = load_config()
-    provider_config = getattr(config.providers, spec.name, None)
-    if provider_config is None:
-        raise WebUISettingsError("unknown provider")
 
     api_base = _resolve_env_placeholders(provider_config.api_base) or spec.default_api_base
     if spec.name == "openai" and not api_base:
@@ -556,16 +610,13 @@ def _model_configuration_slug(label: str) -> str:
 def _validate_configured_provider(config: Any, provider: str) -> None:
     if provider == "auto":
         return
-    spec = find_by_name(provider)
-    if spec is None:
+    resolved_provider = _resolve_settings_provider(config, provider)
+    if resolved_provider is None:
         raise WebUISettingsError("unknown provider")
+    spec, _, provider_config = resolved_provider
     if spec.is_transcription_only:
         raise WebUISettingsError("provider does not support chat models")
-    provider_config = getattr(config.providers, provider, None)
-    if (
-        provider_config is None
-        or not _provider_configured_for_settings(spec, provider_config)
-    ):
+    if not _provider_configured_for_settings(spec, provider_config):
         raise WebUISettingsError("provider is not configured")
 
 
@@ -645,29 +696,15 @@ def settings_payload(
         provider_config = getattr(config.providers, spec.name, None)
         if provider_config is None:
             continue
-        oauth_status = _oauth_provider_status(spec) if spec.is_oauth else None
-        row = {
-            "name": spec.name,
-            "label": spec.label,
-            "configured": (
-                bool(oauth_status["configured"])
-                if oauth_status is not None
-                else _provider_configured_for_settings(spec, provider_config)
-            ),
-            "auth_type": "oauth" if spec.is_oauth else "api_key",
-            "api_key_required": _provider_requires_api_key(spec),
-            "api_key_hint": _mask_secret_hint(provider_config.api_key),
-            "api_base": provider_config.api_base,
-            "default_api_base": spec.default_api_base or None,
-            "model_selectable": not spec.is_transcription_only,
-        }
-        if oauth_status is not None:
-            row["oauth_account"] = oauth_status["account"]
-            row["oauth_expires_at"] = oauth_status["expires_at"]
-            row["oauth_login_supported"] = oauth_status["login_supported"]
-        if spec.name == "openai":
-            row["api_type"] = provider_config.api_type
-        providers.append(row)
+        providers.append(_provider_settings_row(spec.name, spec, provider_config))
+    for provider_key, provider_config in _dynamic_provider_items(config):
+        providers.append(
+            _provider_settings_row(
+                provider_key,
+                create_dynamic_spec(provider_key),
+                provider_config,
+            )
+        )
 
     search_config = config.tools.web.search
     image_config = config.tools.image_generation
@@ -1024,13 +1061,13 @@ def update_provider_settings(query: QueryParams) -> dict[str, Any]:
     provider_name = (_query_first(query, "provider") or "").strip()
     if not provider_name:
         raise WebUISettingsError("provider is required")
-    spec = find_by_name(provider_name)
-    if spec is None or spec.is_oauth:
-        raise WebUISettingsError("unknown provider")
 
     config = load_config()
-    provider_config = getattr(config.providers, spec.name, None)
-    if provider_config is None:
+    resolved_provider = _resolve_settings_provider(config, provider_name)
+    if resolved_provider is None:
+        raise WebUISettingsError("unknown provider")
+    spec, provider_key, provider_config = resolved_provider
+    if spec.is_oauth:
         raise WebUISettingsError("unknown provider")
 
     changed = False
@@ -1065,8 +1102,8 @@ def update_provider_settings(query: QueryParams) -> dict[str, Any]:
     restart_required = (
         changed
         and image_config.enabled
-        and image_config.provider == spec.name
-        and get_image_gen_provider(spec.name) is not None
+        and image_config.provider == provider_key
+        and get_image_gen_provider(provider_key) is not None
     )
     return settings_payload(requires_restart=restart_required)
 

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -688,6 +688,41 @@ def test_make_provider_treats_dynamic_custom_provider_as_direct():
     assert kwargs["base_url"] == "https://example.com/v1"
 
 
+def test_make_provider_rejects_dynamic_custom_provider_without_api_base():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "my-company-api", "model": "gpt-4o-mini"}},
+            "providers": {
+                "my-company-api": {
+                    "apiKey": "sk-test",
+                }
+            },
+        }
+    )
+
+    with pytest.raises(ValueError, match="Provider 'my-company-api' requires api_base"):
+        make_provider(config)
+
+
+def test_make_provider_rejects_auto_dynamic_custom_prefix_without_api_base():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "companyProxy/gpt-4o"}},
+            "providers": {
+                "otherProxy": {
+                    "apiBase": "https://other.example.test/v1",
+                },
+                "companyProxy": {
+                    "apiKey": "sk-company",
+                },
+            },
+        }
+    )
+
+    with pytest.raises(ValueError, match="Provider 'companyProxy' requires api_base"):
+        make_provider(config)
+
+
 @pytest.fixture
 def mock_agent_runtime(tmp_path):
     """Mock agent command dependencies for focused CLI tests."""

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -664,6 +664,30 @@ def test_make_provider_passes_extra_headers_to_custom_provider():
     assert kwargs["default_headers"]["x-session-affinity"] == "sticky-session"
 
 
+def test_make_provider_treats_dynamic_custom_provider_as_direct():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "my-company-api", "model": "gpt-4o-mini"}},
+            "providers": {
+                "my-company-api": {
+                    "apiBase": "https://example.com/v1",
+                }
+            },
+        }
+    )
+
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as mock_async_openai:
+        provider = make_provider(config)
+        asyncio.run(provider._ensure_client())
+
+    assert provider.get_default_model() == "gpt-4o-mini"
+    assert provider._spec.name == "my_company_api"
+    assert provider._spec.is_direct is True
+    kwargs = mock_async_openai.call_args.kwargs
+    assert kwargs["api_key"] == "no-key"
+    assert kwargs["base_url"] == "https://example.com/v1"
+
+
 @pytest.fixture
 def mock_agent_runtime(tmp_path):
     """Mock agent command dependencies for focused CLI tests."""

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -688,6 +688,106 @@ def test_make_provider_treats_dynamic_custom_provider_as_direct():
     assert kwargs["base_url"] == "https://example.com/v1"
 
 
+def test_make_provider_strips_dynamic_custom_route_prefix_from_request_model():
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "my-company-api/gpt-4o-mini"}},
+            "providers": {
+                "my-company-api": {
+                    "apiBase": "https://example.com/v1",
+                }
+            },
+        }
+    )
+
+    provider = make_provider(config)
+
+    kwargs = provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model=None,
+        max_tokens=16,
+        temperature=0.1,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+    body = provider._build_responses_body(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model=None,
+        max_tokens=16,
+        temperature=0.1,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assert config.get_provider_name() == "my-company-api"
+    assert kwargs["model"] == "gpt-4o-mini"
+    assert body["model"] == "gpt-4o-mini"
+
+
+def test_make_provider_preserves_namespaced_model_for_forced_dynamic_provider():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "my-company-api",
+                    "model": "openai/gpt-4o-mini",
+                }
+            },
+            "providers": {
+                "my-company-api": {
+                    "apiBase": "https://example.com/v1",
+                }
+            },
+        }
+    )
+
+    provider = make_provider(config)
+    kwargs = provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model=None,
+        max_tokens=16,
+        temperature=0.1,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assert kwargs["model"] == "openai/gpt-4o-mini"
+
+
+def test_make_provider_strips_dynamic_custom_route_prefix_once():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "auto",
+                    "model": "my-company-api/openai/gpt-4o-mini",
+                }
+            },
+            "providers": {
+                "my-company-api": {
+                    "apiBase": "https://example.com/v1",
+                }
+            },
+        }
+    )
+
+    provider = make_provider(config)
+    kwargs = provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model=None,
+        max_tokens=16,
+        temperature=0.1,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assert kwargs["model"] == "openai/gpt-4o-mini"
+
+
 def test_make_provider_rejects_dynamic_custom_provider_without_api_base():
     config = Config.model_validate(
         {

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -79,6 +79,50 @@ def test_custom_provider_fallback_uses_model_extra_without_pydantic_warnings() -
         assert config.get_provider_name() == "my-company-api"
 
 
+def test_dynamic_custom_provider_prefix_matches_camel_case_key() -> None:
+    config = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "provider": "auto",
+                "model": "companyProxy/gpt-4o-mini",
+            }
+        },
+        "providers": {
+            "otherProxy": {
+                "apiBase": "https://other.example.test/v1",
+            },
+            "companyProxy": {
+                "apiBase": "https://company.example.test/v1",
+            },
+        },
+    })
+
+    assert config.get_provider_name() == "companyProxy"
+    assert config.get_api_base() == "https://company.example.test/v1"
+
+
+def test_dynamic_custom_provider_prefix_does_not_fall_through_when_base_missing() -> None:
+    config = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "provider": "auto",
+                "model": "companyProxy/gpt-4o-mini",
+            }
+        },
+        "providers": {
+            "otherProxy": {
+                "apiBase": "https://other.example.test/v1",
+            },
+            "companyProxy": {
+                "apiKey": "sk-company",
+            },
+        },
+    })
+
+    assert config.get_provider_name() == "companyProxy"
+    assert config.get_api_base() is None
+
+
 def test_legacy_defaults_config_without_presets_still_resolves() -> None:
     config = Config.model_validate({
         "agents": {

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -60,6 +60,18 @@ def test_provider_api_type_is_openai_only() -> None:
         })
 
 
+@pytest.mark.parametrize("provider_name", ["openai-codex", "github-copilot", "lm-studio"])
+def test_dynamic_custom_provider_rejects_builtin_provider_aliases(provider_name: str) -> None:
+    with pytest.raises(ValueError, match="conflicts with built-in provider"):
+        Config.model_validate({
+            "providers": {
+                provider_name: {
+                    "apiBase": "https://example.test/v1",
+                }
+            }
+        })
+
+
 def test_custom_provider_fallback_uses_model_extra_without_pydantic_warnings() -> None:
     config = Config.model_validate({
         "agents": {

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from nanobot.config.schema import Config
@@ -46,6 +48,35 @@ def test_provider_api_type_is_openai_only() -> None:
                 }
             }
         })
+
+    with pytest.raises(ValueError, match="only supported"):
+        Config.model_validate({
+            "providers": {
+                "my-company-api": {
+                    "apiBase": "https://example.test/v1",
+                    "apiType": "responses",
+                }
+            }
+        })
+
+
+def test_custom_provider_fallback_uses_model_extra_without_pydantic_warnings() -> None:
+    config = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "model": "unmatched-model",
+            }
+        },
+        "providers": {
+            "my-company-api": {
+                "apiBase": "https://example.test/v1",
+            }
+        },
+    })
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert config.get_provider_name() == "my-company-api"
 
 
 def test_legacy_defaults_config_without_presets_still_resolves() -> None:

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -18,6 +18,7 @@ from nanobot.webui.settings_api import (
     update_agent_settings,
     update_model_configuration,
     update_network_safety_settings,
+    update_provider_settings,
     update_transcription_settings,
 )
 
@@ -62,6 +63,38 @@ def test_create_model_configuration_writes_label_and_selects(
             }
         )
     assert duplicate.value.status == 409
+
+
+def test_create_model_configuration_accepts_dynamic_custom_provider(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "providers": {
+                "my-company-api": {
+                    "apiBase": "https://example.test/v1",
+                }
+            }
+        }
+    )
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = create_model_configuration(
+        {
+            "label": ["Tenant model"],
+            "provider": ["my-company-api"],
+            "model": ["gpt-4o-mini"],
+        }
+    )
+
+    assert payload["agent"]["model_preset"] == "tenant-model"
+    assert payload["agent"]["provider"] == "my-company-api"
+    saved = load_config(config_path)
+    assert saved.model_presets["tenant-model"].provider == "my-company-api"
+    assert saved.model_presets["tenant-model"].model == "gpt-4o-mini"
 
 
 def test_create_model_configuration_rejects_unconfigured_provider(
@@ -122,6 +155,40 @@ def test_update_model_configuration_edits_named_preset_and_selects(
     assert saved.model_presets["codex"].label == "Codex"
     assert saved.model_presets["codex"].provider == "openai_codex"
     assert saved.model_presets["codex"].model == "openai-codex/gpt-5.5"
+
+
+def test_update_provider_settings_updates_dynamic_custom_provider(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "providers": {
+                "my-company-api": {
+                    "apiBase": "https://old.example/v1",
+                }
+            }
+        }
+    )
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = update_provider_settings(
+        {
+            "provider": ["my-company-api"],
+            "apiBase": ["https://new.example/v1"],
+            "apiKey": ["sk-test"],
+        }
+    )
+
+    providers = {row["name"]: row for row in payload["providers"]}
+    assert providers["my-company-api"]["api_base"] == "https://new.example/v1"
+    assert providers["my-company-api"]["api_key_hint"] == "••••"
+    saved = load_config(config_path)
+    dynamic_provider = saved.providers.model_extra["my-company-api"]
+    assert dynamic_provider.api_base == "https://new.example/v1"
+    assert dynamic_provider.api_key == "sk-test"
 
 
 def test_update_agent_settings_accepts_context_window_options(
@@ -221,6 +288,39 @@ def test_settings_payload_includes_oauth_provider_status(
     assert providers["openai_codex"]["auth_type"] == "oauth"
     assert providers["openai_codex"]["configured"] is True
     assert providers["openai_codex"]["oauth_account"] == "acct-test"
+
+
+def test_settings_payload_includes_dynamic_custom_provider(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "my-company-api",
+                    "model": "gpt-4o-mini",
+                }
+            },
+            "providers": {
+                "my-company-api": {
+                    "apiBase": "https://example.test/v1",
+                }
+            },
+        }
+    )
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+    providers = {row["name"]: row for row in payload["providers"]}
+
+    assert payload["agent"]["provider"] == "my-company-api"
+    assert payload["agent"]["resolved_provider"] == "my-company-api"
+    assert providers["my-company-api"]["configured"] is True
+    assert providers["my-company-api"]["api_key_required"] is False
+    assert providers["my-company-api"]["api_base"] == "https://example.test/v1"
 
 
 def test_settings_payload_includes_network_safety_fields(
@@ -676,6 +776,42 @@ def test_provider_models_payload_fetches_openai_compatible_models(
     assert payload["model_count"] == 2
     assert payload["models"][0]["id"] == "deepseek-chat"
     assert payload["models"][1]["context_window"] == 65536
+
+
+def test_provider_models_payload_fetches_dynamic_custom_provider_models(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate(
+        {
+            "providers": {
+                "my-company-api": {
+                    "apiBase": "https://example.test/v1",
+                }
+            }
+        }
+    )
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    def fake_get(url: str, **kwargs):
+        assert url == "https://example.test/v1/models"
+        assert "Authorization" not in kwargs["headers"]
+        return httpx.Response(
+            200,
+            json={"data": [{"id": "custom-gpt", "owned_by": "example"}]},
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr("nanobot.webui.settings_api.httpx.get", fake_get)
+
+    payload = provider_models_payload({"provider": ["my-company-api"]})
+
+    assert payload["provider"] == "my-company-api"
+    assert payload["status"] == "available"
+    assert payload["catalog_kind"] == "custom"
+    assert payload["models"][0]["id"] == "custom-gpt"
 
 
 @pytest.mark.parametrize(

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -113,6 +113,31 @@ def test_create_model_configuration_accepts_dynamic_custom_provider(
     assert saved.model_presets["tenant-model"].model == "gpt-4o-mini"
 
 
+def test_create_model_configuration_rejects_dynamic_custom_provider_without_api_base(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate({
+        "providers": {
+            DYNAMIC_PROVIDER_NAME: {
+                "apiKey": "sk-test",
+            }
+        }
+    })
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    with pytest.raises(WebUISettingsError, match="provider is not configured"):
+        create_model_configuration(
+            {
+                "label": ["Tenant model"],
+                "provider": [DYNAMIC_PROVIDER_NAME],
+                "model": ["gpt-4o-mini"],
+            }
+        )
+
+
 def test_create_model_configuration_rejects_unconfigured_provider(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -313,6 +338,29 @@ def test_settings_payload_includes_dynamic_custom_provider(
     assert providers[DYNAMIC_PROVIDER_NAME]["configured"] is True
     assert providers[DYNAMIC_PROVIDER_NAME]["api_key_required"] is False
     assert providers[DYNAMIC_PROVIDER_NAME]["api_base"] == DYNAMIC_PROVIDER_API_BASE
+
+
+def test_settings_payload_marks_dynamic_custom_provider_without_api_base_unconfigured(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate({
+        "providers": {
+            DYNAMIC_PROVIDER_NAME: {
+                "apiKey": "sk-test",
+            }
+        }
+    })
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    payload = settings_payload()
+    providers = {row["name"]: row for row in payload["providers"]}
+
+    assert providers[DYNAMIC_PROVIDER_NAME]["configured"] is False
+    assert providers[DYNAMIC_PROVIDER_NAME]["api_key_hint"] == "••••"
+    assert providers[DYNAMIC_PROVIDER_NAME]["api_base"] is None
 
 
 def test_settings_payload_includes_network_safety_fields(

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -22,6 +22,31 @@ from nanobot.webui.settings_api import (
     update_transcription_settings,
 )
 
+DYNAMIC_PROVIDER_NAME = "my-company-api"
+DYNAMIC_PROVIDER_API_BASE = "https://example.test/v1"
+
+
+def _dynamic_provider_config(
+    *,
+    api_base: str = DYNAMIC_PROVIDER_API_BASE,
+    defaults: bool = False,
+) -> Config:
+    raw_config = {
+        "providers": {
+            DYNAMIC_PROVIDER_NAME: {
+                "apiBase": api_base,
+            }
+        }
+    }
+    if defaults:
+        raw_config["agents"] = {
+            "defaults": {
+                "provider": DYNAMIC_PROVIDER_NAME,
+                "model": "gpt-4o-mini",
+            }
+        }
+    return Config.model_validate(raw_config)
+
 
 def test_create_model_configuration_writes_label_and_selects(
     tmp_path,
@@ -70,30 +95,21 @@ def test_create_model_configuration_accepts_dynamic_custom_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     config_path = tmp_path / "config.json"
-    config = Config.model_validate(
-        {
-            "providers": {
-                "my-company-api": {
-                    "apiBase": "https://example.test/v1",
-                }
-            }
-        }
-    )
-    save_config(config, config_path)
+    save_config(_dynamic_provider_config(), config_path)
     monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
 
     payload = create_model_configuration(
         {
             "label": ["Tenant model"],
-            "provider": ["my-company-api"],
+            "provider": [DYNAMIC_PROVIDER_NAME],
             "model": ["gpt-4o-mini"],
         }
     )
 
     assert payload["agent"]["model_preset"] == "tenant-model"
-    assert payload["agent"]["provider"] == "my-company-api"
+    assert payload["agent"]["provider"] == DYNAMIC_PROVIDER_NAME
     saved = load_config(config_path)
-    assert saved.model_presets["tenant-model"].provider == "my-company-api"
+    assert saved.model_presets["tenant-model"].provider == DYNAMIC_PROVIDER_NAME
     assert saved.model_presets["tenant-model"].model == "gpt-4o-mini"
 
 
@@ -162,31 +178,22 @@ def test_update_provider_settings_updates_dynamic_custom_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     config_path = tmp_path / "config.json"
-    config = Config.model_validate(
-        {
-            "providers": {
-                "my-company-api": {
-                    "apiBase": "https://old.example/v1",
-                }
-            }
-        }
-    )
-    save_config(config, config_path)
+    save_config(_dynamic_provider_config(api_base="https://old.example/v1"), config_path)
     monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
 
     payload = update_provider_settings(
         {
-            "provider": ["my-company-api"],
+            "provider": [DYNAMIC_PROVIDER_NAME],
             "apiBase": ["https://new.example/v1"],
             "apiKey": ["sk-test"],
         }
     )
 
     providers = {row["name"]: row for row in payload["providers"]}
-    assert providers["my-company-api"]["api_base"] == "https://new.example/v1"
-    assert providers["my-company-api"]["api_key_hint"] == "••••"
+    assert providers[DYNAMIC_PROVIDER_NAME]["api_base"] == "https://new.example/v1"
+    assert providers[DYNAMIC_PROVIDER_NAME]["api_key_hint"] == "••••"
     saved = load_config(config_path)
-    dynamic_provider = saved.providers.model_extra["my-company-api"]
+    dynamic_provider = saved.providers.model_extra[DYNAMIC_PROVIDER_NAME]
     assert dynamic_provider.api_base == "https://new.example/v1"
     assert dynamic_provider.api_key == "sk-test"
 
@@ -295,32 +302,17 @@ def test_settings_payload_includes_dynamic_custom_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     config_path = tmp_path / "config.json"
-    config = Config.model_validate(
-        {
-            "agents": {
-                "defaults": {
-                    "provider": "my-company-api",
-                    "model": "gpt-4o-mini",
-                }
-            },
-            "providers": {
-                "my-company-api": {
-                    "apiBase": "https://example.test/v1",
-                }
-            },
-        }
-    )
-    save_config(config, config_path)
+    save_config(_dynamic_provider_config(defaults=True), config_path)
     monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
 
     payload = settings_payload()
     providers = {row["name"]: row for row in payload["providers"]}
 
-    assert payload["agent"]["provider"] == "my-company-api"
-    assert payload["agent"]["resolved_provider"] == "my-company-api"
-    assert providers["my-company-api"]["configured"] is True
-    assert providers["my-company-api"]["api_key_required"] is False
-    assert providers["my-company-api"]["api_base"] == "https://example.test/v1"
+    assert payload["agent"]["provider"] == DYNAMIC_PROVIDER_NAME
+    assert payload["agent"]["resolved_provider"] == DYNAMIC_PROVIDER_NAME
+    assert providers[DYNAMIC_PROVIDER_NAME]["configured"] is True
+    assert providers[DYNAMIC_PROVIDER_NAME]["api_key_required"] is False
+    assert providers[DYNAMIC_PROVIDER_NAME]["api_base"] == DYNAMIC_PROVIDER_API_BASE
 
 
 def test_settings_payload_includes_network_safety_fields(
@@ -783,20 +775,11 @@ def test_provider_models_payload_fetches_dynamic_custom_provider_models(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     config_path = tmp_path / "config.json"
-    config = Config.model_validate(
-        {
-            "providers": {
-                "my-company-api": {
-                    "apiBase": "https://example.test/v1",
-                }
-            }
-        }
-    )
-    save_config(config, config_path)
+    save_config(_dynamic_provider_config(), config_path)
     monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
 
     def fake_get(url: str, **kwargs):
-        assert url == "https://example.test/v1/models"
+        assert url == f"{DYNAMIC_PROVIDER_API_BASE}/models"
         assert "Authorization" not in kwargs["headers"]
         return httpx.Response(
             200,
@@ -806,9 +789,9 @@ def test_provider_models_payload_fetches_dynamic_custom_provider_models(
 
     monkeypatch.setattr("nanobot.webui.settings_api.httpx.get", fake_get)
 
-    payload = provider_models_payload({"provider": ["my-company-api"]})
+    payload = provider_models_payload({"provider": [DYNAMIC_PROVIDER_NAME]})
 
-    assert payload["provider"] == "my-company-api"
+    assert payload["provider"] == DYNAMIC_PROVIDER_NAME
     assert payload["status"] == "available"
     assert payload["catalog_kind"] == "custom"
     assert payload["models"][0]["id"] == "custom-gpt"

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -341,6 +341,13 @@ function settingsProviderConfigured(
 ): boolean {
   const row = settingsProviderRow(payload, provider);
   if (row) return row.configured;
+  if (provider === "auto") {
+    const resolvedRow = settingsProviderRow(
+      payload,
+      payload.agent.resolved_provider ?? payload.agent.provider,
+    );
+    if (resolvedRow) return resolvedRow.configured;
+  }
   return payload.agent.has_api_key;
 }
 

--- a/webui/src/tests/settings-view.test.tsx
+++ b/webui/src/tests/settings-view.test.tsx
@@ -100,6 +100,46 @@ function settingsPayload(): SettingsPayload {
   };
 }
 
+function autoDynamicProviderPayload(
+  options: {
+    configured: boolean;
+    hasApiKey: boolean;
+    apiBase: string | null;
+    apiKeyHint: string | null;
+  },
+): SettingsPayload {
+  const base = settingsPayload();
+  return {
+    ...base,
+    agent: {
+      ...base.agent,
+      model: "companyProxy/gpt-4o",
+      provider: "companyProxy",
+      resolved_provider: "companyProxy",
+      has_api_key: options.hasApiKey,
+    },
+    model_presets: [
+      {
+        ...base.model_presets[0],
+        model: "companyProxy/gpt-4o",
+        provider: "auto",
+      },
+    ],
+    providers: [
+      {
+        name: "companyProxy",
+        label: "Company Proxy",
+        configured: options.configured,
+        auth_type: "api_key",
+        api_key_required: false,
+        api_key_hint: options.apiKeyHint,
+        api_base: options.apiBase,
+        default_api_base: null,
+      },
+    ],
+  };
+}
+
 const installedAnyGen = {
   name: "anygen",
   display_name: "AnyGen",
@@ -334,6 +374,47 @@ describe("SettingsView Apps catalog", () => {
     expect(await screen.findByText("Context window")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "64K" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "256K" })).toBeInTheDocument();
+  });
+
+  it("uses the resolved provider row for auto dynamic providers without api keys", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>(() => {})));
+
+    renderSettingsView({
+      initialSection: "models",
+      initialSettings: autoDynamicProviderPayload({
+        configured: true,
+        hasApiKey: false,
+        apiBase: "https://proxy.example.test/v1",
+        apiKeyHint: null,
+      }),
+    });
+
+    const configurationButton = await screen.findByRole("button", {
+      name: "Current configuration",
+    });
+    expect(configurationButton).toHaveTextContent("companyProxy/gpt-4o");
+    expect(configurationButton).toHaveTextContent("Company Proxy");
+    expect(configurationButton).not.toHaveTextContent("Not configured");
+  });
+
+  it("does not treat auto dynamic provider api keys as configured without apiBase", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>(() => {})));
+
+    renderSettingsView({
+      initialSection: "models",
+      initialSettings: autoDynamicProviderPayload({
+        configured: false,
+        hasApiKey: true,
+        apiBase: null,
+        apiKeyHint: "sk-...",
+      }),
+    });
+
+    const configurationButton = await screen.findByRole("button", {
+      name: "Current configuration",
+    });
+    expect(configurationButton).toHaveTextContent("Not configured");
+    expect(configurationButton).toHaveTextContent("Company Proxy · companyProxy/gpt-4o");
   });
 
   it("marks the current model as unconfigured when its provider needs setup", async () => {


### PR DESCRIPTION
# Feature: Support Multiple Custom OpenAI-Compatible Providers

## Problem
Currently, nanobot only supports a single custom provider named `custom`. Users who need to connect to multiple custom OpenAI-compatible endpoints (e.g., different internal APIs, multiple cloud providers) have no clean way to do this.

## Solution
This PR allows users to define **arbitrary named custom providers** in their config with any identifier (including kebab-case like `my-provider`).

## Usage

### Config (`~/.nanobot/config.json`)
```json
{
  "providers": {
    "custom": {
      "apiKey": "sk-xxx",
      "apiBase": "https://api.example.com/v1"
    },
    "my-company-api": {
      "apiKey": "sk-internal",
      "apiBase": "https://internal-api.company.com/v1"
    },
    "another_provider": {
      "apiKey": "sk-other",
      "apiBase": "https://api.other.com/v1"
    }
  }
}
```

### CLI Usage
```bash
# Via model prefix (kebab-case supported)
nanobot /my-company-api/gpt-4 "hello"

# Via --provider flag
nanobot --provider my-company-api "hello"
nanobot --provider another_provider "hello"
```

## Changes

### `config/schema.py`
- `ProvidersConfig`: add `extra="allow"` to accept arbitrary provider fields
- `ProviderConfig`: ensure `alias_generator=to_camel` properly maps `apiKey`/`apiBase` to `api_key`/`api_base`
- Add `model_validator` to convert extra provider dicts to `ProviderConfig` objects
- `_match_provider()`: check for custom provider by prefix and by name (supports both kebab-case and snake_case)

### `providers/registry.py`
- Add `create_dynamic_spec()` helper for creating dynamic provider specs

## Backward Compatibility
- ✅ Existing `custom` provider continues to work exactly as before
- ✅ No breaking changes to config format
- ✅ All existing providers unchanged

## Testing
```bash
# Test with custom provider
nanobot /my-provider/gpt-4 "test message"
nanobot --provider my-provider "test message"
```
