### PR TITLE
fix(exec): harden #2989 protections against shell-expansion bypass

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -17,6 +17,11 @@ from nanobot.config.paths import get_media_dir
 
 _IS_WINDOWS = sys.platform == "win32"
 
+# Match shell expansion forms: $(...), `...`, ${...}.
+_EXPANSION_RE = re.compile(r"\$\(|`|\$\{")
+# Match references to nanobot internal-state files (#2989). Lower-cased.
+_PROTECTED_TARGET_RE = re.compile(r"\.jsonl\b|\.dream_cursor\b|dream_cursor")
+
 
 @tool_parameters(
     tool_parameters_schema(
@@ -268,13 +273,29 @@ class ExecTool(Tool):
         return env
 
     def _guard_command(self, command: str, cwd: str) -> str | None:
-        """Best-effort safety guard for potentially destructive commands."""
+        """Best-effort safety guard for potentially destructive commands.
+
+        These checks run on the raw command string before bash sees it. They
+        cannot catch every shell-expansion trick (``${IFS}``, ``$(...)``,
+        backticks). For hard isolation set ``tools.exec.sandbox = "bwrap"``
+        so writes outside the workspace are blocked at the kernel level.
+        """
         cmd = command.strip()
         lower = cmd.lower()
 
         for pattern in self.deny_patterns:
             if re.search(pattern, lower):
                 return "Error: Command blocked by safety guard (dangerous pattern detected)"
+
+        # Defense-in-depth for the #2989 protections. The literal-substring
+        # patterns above are bypassed when both the command and the protected
+        # filename are split via expansion, e.g. ``$(echo tee) hist$(printf
+        # ory).jsonl``. If the raw command contains any expansion AND still
+        # mentions a .jsonl path or .dream_cursor, refuse it. Legitimate uses
+        # of $() rarely target .jsonl files; targeting one alongside expansion
+        # is treated as suspicious.
+        if _EXPANSION_RE.search(cmd) and _PROTECTED_TARGET_RE.search(lower):
+            return "Error: Command blocked by safety guard (dangerous pattern detected)"
 
         if self.allow_patterns:
             if not any(re.search(p, lower) for p in self.allow_patterns):

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -116,6 +116,56 @@ def test_exec_allows_reads_of_history_jsonl(command):
     assert result is None
 
 
+# --- Hardening: shell expansion must not defeat #2989 protections --------
+#
+# The literal-substring deny patterns above were bypassable by splitting both
+# the command and the protected filename via expansion, e.g.
+# `$(echo tee) /tmp/h/hist$(printf ory).jsonl`. The new defense-in-depth
+# check refuses any command that combines shell expansion with a reference
+# to a .jsonl path or .dream_cursor.
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Verified-live bypasses against the original patterns.
+        "$(echo tee) /tmp/h/hist$(printf ory).jsonl <<< PWNED",
+        "`printf tee` /tmp/h/hist`printf ory`.jsonl <<< PWNED",
+        "${EDITOR:-tee} /tmp/h/history.jsonl <<< PWNED",
+        # Variants that target the cursor file via expansion.
+        "$(echo cp) src /tmp/.dream_cursor",
+        "echo x > /tmp/$(echo .dream_cursor)",
+    ],
+)
+def test_exec_blocks_expansion_targeting_protected_files(command):
+    """Hardens #2989: expansion + .jsonl/.dream_cursor target must be blocked."""
+    tool = ExecTool()
+    result = tool._guard_command(command, "/tmp")
+    assert result is not None
+    assert "dangerous pattern" in result.lower()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Normal $() use that does not target nanobot state files.
+        "echo $(date)",
+        "cp src/$(basename dst).txt /tmp/",
+        "tar czf backup-$(date +%s).tar.gz src/",
+        "ls /tmp/$(whoami)",
+        "echo ${HOME}/notes.md",
+        "git log --since=$(date -d '1 week ago' +%Y-%m-%d)",
+        # .log / .txt with expansion is fine — only .jsonl is protected.
+        "tee /tmp/build-$(date +%s).log",
+    ],
+)
+def test_exec_allows_legitimate_command_substitution(command):
+    """Regression: innocent uses of $() / backticks / ${} must still execute."""
+    tool = ExecTool()
+    result = tool._guard_command(command, "/tmp")
+    assert result is None, f"unexpectedly blocked: {command!r} → {result!r}"
+
+
 # --- #2826: working_dir must not escape the configured workspace ---------
 
 


### PR DESCRIPTION
## Summary

- The `_guard_command` regex deny patterns for `history.jsonl` and `.dream_cursor` (added in #2989) match the literal substring in the raw command. They are bypassed when both the command verb and the protected filename are split via shell expansion, e.g. `\$(echo tee) /home/nanobot/.nanobot/memory/hist\$(printf ory).jsonl <<< PWNED`.
- Adds a defense-in-depth check: any command that combines shell expansion (`\$(...)`, backticks, `\${...}`) with a reference to a `.jsonl` path or `.dream_cursor` is now refused.
- Updates the `_guard_command` docstring to flag the guard as heuristic and point users at `tools.exec.sandbox = "bwrap"` for kernel-level isolation, matching the SECURITY.md §10 acknowledgement that shell-side filtering is intrinsically limited.

## Threat model

A prompt-injection-compromised LLM (poisoned web page returned by `web_fetch`, malicious email body, hostile MCP server output) emits a write-to-`history.jsonl` command using shell expansion to defeat the literal-substring deny patterns. Result: `history.jsonl` corrupted; Dream memory cursor breaks; nanobot's memory pipeline is unrecoverable without manual intervention.

Under the official Docker deployment, `~/.nanobot` is volume-mounted, so writes propagate to the host filesystem.

## Changes

- `nanobot/agent/tools/shell.py` — module-level `_EXPANSION_RE` and `_PROTECTED_TARGET_RE` constants; new check inserted in `_guard_command` after the existing deny-pattern loop; docstring updated to flag heuristic nature.
- `tests/tools/test_exec_security.py` — two new parametrized test classes:
  - `test_exec_blocks_expansion_targeting_protected_files` — five verified bypass vectors must now block.
  - `test_exec_allows_legitimate_command_substitution` — seven innocent uses of `\$(...)` / backticks / `\${...}` must still execute (regression guard against false positives).

## Backward compatibility

- All existing `#2989` literal-pattern blocks continue to fire unchanged.
- Innocent command-substitution patterns that don't target nanobot state files (`echo \$(date)`, `tar czf backup-\$(date +%s).tar.gz src/`, `tee /tmp/build-\$(date +%s).log`, etc.) still execute.
- The new check only fires when shell expansion AND a `.jsonl` / `.dream_cursor` reference are both present in the raw command. The conservative trade-off is that a command which *intentionally* uses expansion to construct a `.jsonl` path will be blocked; in practice no nanobot internal code does this.

## Honest scope

The check is defense-in-depth. It does NOT defend against:
- Generic destructive commands via expansion targeting paths other than `.jsonl` / `.dream_cursor` (e.g. `\${IFS}rm\${IFS}-rf <arbitrary-path>`). For that class, `tools.exec.sandbox = "bwrap"` is the kernel-level answer, as SECURITY.md §3 already recommends.
- A hypothetical bypass that splits the protected filename's extension itself (e.g. `hist\$(printf ory).jso\$(echo nl)`). This is the same class as the cases SECURITY.md §10 acknowledges as intrinsically limited.

The docstring and SECURITY.md framing make this scope explicit so future readers don't interpret the heuristic as a complete defense.

## Test plan

- [x] `uv run pytest tests/tools/test_exec_security.py` — 41/41 pass (12 new + 29 existing).
- [x] `uv run pytest tests/tools/` — 286 passed, 2 skipped, no regressions.
- [x] `uv run ruff check nanobot/agent/tools/shell.py tests/tools/test_exec_security.py` — clean on changed lines (pre-existing W291 in untouched lines left alone per the "minimal diff" rule).
- [x] End-to-end live verification inside the rebuilt `nanobot-api` container: 4 verified bypass variants now block; all 4 protected files survive; 4 legitimate `\$(...)` use cases still execute.

## Refs

- Hardens #2989