### PR TITLE
fix: deduplicate SPF/DKIM-rejected emails to stop log spam

### DIFF
--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -395,10 +395,7 @@ class EmailChannel(BaseChannel):
                         "(no 'spf=pass' in Authentication-Results header)",
                         sender,
                     )
-                    if uid:
-                        cycle_uids.add(uid)
-                        if dedupe:
-                            self._processed_uids.add(uid)
+                    self._remember_processed_uid(uid, dedupe, cycle_uids)
                     continue
                 if self.config.verify_dkim and not dkim_pass:
                     logger.warning(
@@ -406,10 +403,7 @@ class EmailChannel(BaseChannel):
                         "(no 'dkim=pass' in Authentication-Results header)",
                         sender,
                     )
-                    if uid:
-                        cycle_uids.add(uid)
-                        if dedupe:
-                            self._processed_uids.add(uid)
+                    self._remember_processed_uid(uid, dedupe, cycle_uids)
                     continue
 
                 subject = self._decode_header_value(parsed.get("Subject", ""))

--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -395,6 +395,10 @@ class EmailChannel(BaseChannel):
                         "(no 'spf=pass' in Authentication-Results header)",
                         sender,
                     )
+                    if uid:
+                        cycle_uids.add(uid)
+                        if dedupe:
+                            self._processed_uids.add(uid)
                     continue
                 if self.config.verify_dkim and not dkim_pass:
                     logger.warning(
@@ -402,6 +406,10 @@ class EmailChannel(BaseChannel):
                         "(no 'dkim=pass' in Authentication-Results header)",
                         sender,
                     )
+                    if uid:
+                        cycle_uids.add(uid)
+                        if dedupe:
+                            self._processed_uids.add(uid)
                     continue
 
                 subject = self._decode_header_value(parsed.get("Subject", ""))


### PR DESCRIPTION
## Problem

When an email is rejected by SPF/DKIM verification, the warning is logged every poll cycle (~60s) for the same message because the UID is never added to the dedup sets (`cycle_uids`, `_processed_uids`).

Example log spam:
```
2026-04-17 08:06:44 | WARNING | Email from support@scrapecreators.com rejected: SPF verification failed
2026-04-17 08:07:45 | WARNING | Email from support@scrapecreators.com rejected: SPF verification failed
...repeats every ~60s
```

## Fix

Add rejected email UIDs to `cycle_uids` and `_processed_uids` before `continue`, so the warning fires once per message instead of once per poll.

## Files changed

- `nanobot/channels/email.py` — dedup UIDs on SPF and DKIM reject paths