### PR TITLE
[codex] fix(cron): persist claim before await

### DIFF
--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -318,6 +318,7 @@ class CronService:
         """Execute a single job."""
         start_ms = _now_ms()
         logger.info("Cron: executing job '{}' ({})", job.name, job.id)
+        self._claim_job(job, start_ms)
 
         try:
             if self.on_job:
@@ -333,7 +334,6 @@ class CronService:
             logger.error("Cron: job '{}' failed: {}", job.name, e)
 
         end_ms = _now_ms()
-        job.state.last_run_at_ms = start_ms
         job.updated_at_ms = end_ms
 
         job.state.run_history.append(CronRunRecord(
@@ -351,9 +351,20 @@ class CronService:
             else:
                 job.enabled = False
                 job.state.next_run_at_ms = None
+        elif job.state.next_run_at_ms is None:
+            job.state.next_run_at_ms = _compute_next_run(job.schedule, start_ms)
+
+    def _claim_job(self, job: CronJob, start_ms: int) -> None:
+        """Persist a running claim before awaiting the job callback."""
+        job.state.last_status = "running"
+        job.state.last_error = None
+        job.state.last_run_at_ms = start_ms
+        job.updated_at_ms = start_ms
+        if job.schedule.kind == "at":
+            job.state.next_run_at_ms = None
         else:
-            # Compute next run
-            job.state.next_run_at_ms = _compute_next_run(job.schedule, _now_ms())
+            job.state.next_run_at_ms = _compute_next_run(job.schedule, start_ms)
+        self._save_store()
 
     def _append_action(self, action: Literal["add", "del", "update"], params: dict):
         self.store_path.parent.mkdir(parents=True, exist_ok=True)

--- a/nanobot/cron/types.py
+++ b/nanobot/cron/types.py
@@ -33,7 +33,7 @@ class CronPayload:
 class CronRunRecord:
     """A single execution record for a cron job."""
     run_at_ms: int
-    status: Literal["ok", "error", "skipped"]
+    status: Literal["ok", "error", "skipped", "running"]
     duration_ms: int = 0
     error: str | None = None
 
@@ -43,7 +43,7 @@ class CronJobState:
     """Runtime state of a job."""
     next_run_at_ms: int | None = None
     last_run_at_ms: int | None = None
-    last_status: Literal["ok", "error", "skipped"] | None = None
+    last_status: Literal["ok", "error", "skipped", "running"] | None = None
     last_error: str | None = None
     run_history: list[CronRunRecord] = field(default_factory=list)
 

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -55,6 +55,51 @@ async def test_execute_job_records_run_history(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_job_persists_running_claim_before_callback_returns(tmp_path) -> None:
+    store_path = tmp_path / "cron" / "jobs.json"
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def on_job(_job) -> None:
+        started.set()
+        await release.wait()
+
+    service = CronService(store_path, on_job=on_job)
+    job = service.add_job(
+        name="claim",
+        schedule=CronSchedule(kind="every", every_ms=60_000),
+        message="hello",
+    )
+
+    task = asyncio.create_task(service.run_job(job.id))
+    await started.wait()
+
+    raw = json.loads(store_path.read_text())
+    state = raw["jobs"][0]["state"]
+    assert state["lastStatus"] == "running"
+    assert state["lastRunAtMs"] is not None
+    assert state["nextRunAtMs"] is not None
+    assert state["nextRunAtMs"] > state["lastRunAtMs"]
+
+    observer = CronService(store_path)
+    in_flight = observer.get_job(job.id)
+    assert in_flight is not None
+    assert in_flight.state.last_status == "running"
+    assert in_flight.state.last_run_at_ms is not None
+    assert in_flight.state.next_run_at_ms is not None
+    assert in_flight.state.next_run_at_ms > in_flight.state.last_run_at_ms
+
+    release.set()
+    assert await task is True
+
+    completed = service.get_job(job.id)
+    assert completed is not None
+    assert completed.state.last_status == "ok"
+    assert len(completed.state.run_history) == 1
+    assert completed.state.run_history[0].status == "ok"
+
+
+@pytest.mark.asyncio
 async def test_run_history_records_errors(tmp_path) -> None:
     store_path = tmp_path / "cron" / "jobs.json"
 


### PR DESCRIPTION
## What changed

- persist a running cron claim before awaiting the job callback
- extend cron status typing to allow the transient `running` state
- add a regression test that reads `jobs.json` during callback suspension and verifies the claim is already on disk

## Why

`CronService` previously only wrote `lastRunAtMs` and the next schedule after the callback returned. That left a duplicate-execution window: another instance could reload the same due job from disk and run it again before the first callback finished.

## Impact

- recurring jobs now advance their next trigger as soon as execution is claimed
- one-shot jobs clear `nextRunAtMs` immediately when claimed
- concurrent observers can see `lastStatus="running"` while the callback is still in flight

## Validation

- `uv run pytest tests/cron/test_cron_service.py -q -k 'execute_job_records_run_history or execute_job_persists_running_claim_before_callback_returns or run_history_records_errors or run_history_trimmed_to_max or run_history_persisted_to_disk'`
- `git diff --check`

## Notes

- `tests/cron/test_cron_service.py` still has unrelated pre-existing failures in this checkout around `max_sleep_ms` and `update_job`; this PR does not change those areas.
