### PR TITLE
fix(memory): fall back to raw_archive on LLM error response

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -457,6 +457,8 @@ class Consolidator:
                 tools=None,
                 tool_choice=None,
             )
+            if response.finish_reason == "error":
+                raise RuntimeError(f"LLM returned error: {response.content}")
             summary = response.content or "[no summary]"
             self.store.append_history(summary)
             return summary

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -65,6 +65,46 @@ class TestConsolidatorSummarize:
         assert result is None
 
 
+class TestConsolidatorArchiveErrorHandling:
+    """archive() must fall back to raw_archive when the LLM returns an error
+    response (finish_reason == 'error'), e.g. overloaded / quota exceeded.
+    See https://github.com/HKUDS/nanobot/issues/3244
+    """
+
+    async def test_archive_falls_back_on_error_finish_reason(self, consolidator, mock_provider, store):
+        """LLM returning finish_reason='error' should trigger raw_archive, not write error text."""
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Error: {'type': 'error', 'error': {'type': 'overloaded_error', 'message': 'overloaded_error (529)'}}",
+            finish_reason="error",
+        )
+        messages = [
+            {"role": "user", "content": "fix the auth bug"},
+            {"role": "assistant", "content": "Done, fixed the race condition."},
+        ]
+        result = await consolidator.archive(messages)
+        assert result is None
+        entries = store.read_unprocessed_history(since_cursor=0)
+        assert len(entries) == 1
+        assert "[RAW]" in entries[0]["content"]
+        assert "Error:" not in entries[0]["content"]
+
+    async def test_archive_preserves_summary_on_success(self, consolidator, mock_provider, store):
+        """Normal LLM response should still produce a proper summary entry."""
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="User fixed a bug in the auth module.",
+            finish_reason="stop",
+        )
+        messages = [
+            {"role": "user", "content": "fix the auth bug"},
+            {"role": "assistant", "content": "Done."},
+        ]
+        result = await consolidator.archive(messages)
+        assert result == "User fixed a bug in the auth module."
+        entries = store.read_unprocessed_history(since_cursor=0)
+        assert len(entries) == 1
+        assert "[RAW]" not in entries[0]["content"]
+
+
 class TestConsolidatorTokenBudget:
     async def test_prompt_below_threshold_does_not_consolidate(self, consolidator):
         """No consolidation when tokens are within budget."""


### PR DESCRIPTION
## Summary

When `/new` is executed, the session JSONL is cleared **before** the background `archive()` task runs. If the LLM call fails (e.g. minimax2.7 returns 529 overloaded), `chat_with_retry` returns an `LLMResponse` with `finish_reason="error"` instead of raising an exception. The current code treats this error message as a valid summary and writes it to `history.jsonl`, resulting in **irreversible data loss** — the session is empty and history only contains the error text.

## Root Cause

`archive()` in `agent/memory.py` only catches `Exception` for the `raw_archive` fallback. An error LLM response does not raise, so the fallback is never triggered.

## Fix

Check `response.finish_reason` after the LLM call. If it equals `"error"`, raise `RuntimeError` to fall through to the existing `except` branch, which calls `raw_archive(messages)` — preserving the original messages in `history.jsonl`.

```diff
+            if response.finish_reason == "error":
+                raise RuntimeError(f"LLM returned error: {response.content}")
             summary = response.content or "[no summary]"
```

## Tests

Added `TestConsolidatorArchiveErrorHandling` with two cases (TDD):
- `test_archive_falls_back_on_error_finish_reason` — verifies raw_archive is called when `finish_reason="error"`
- `test_preserves_summary_on_success` — verifies normal flow is unaffected

All 8 tests in `test_consolidator.py` pass.

Fixes #3244