### PR TITLE
fix: guard tool execution with finish_reason check

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -273,7 +273,7 @@ class AgentRunner:
             context.tool_calls = list(response.tool_calls)
             self._accumulate_usage(usage, raw_usage)
 
-            if response.has_tool_calls:
+            if response.finish_reason == "tool_calls" and response.has_tool_calls:
                 if hook.wants_streaming():
                     await hook.on_stream_end(context, resuming=True)
 
@@ -298,6 +298,11 @@ class AgentRunner:
                 )
 
                 await hook.before_execute_tools(context)
+            elif response.has_tool_calls:
+                logger.warning(
+                    "Ignoring unexpected tool calls under finish_reason='%s' (API gateway may have injected them)",
+                    response.finish_reason,
+                )
 
                 results, new_events, fatal_error = await self._execute_tools(
                     spec,


### PR DESCRIPTION
## Fix: Guard tool execution with finish_reason check to prevent infinite loops

**Problem:** The agent executes tool calls whenever  is true, regardless of . Some API gateways inject  under non-standard  values (refusal, content_filter, etc.), causing an infinite loop until  is hit.

**Solution:** Guard every tool-execution site so tools run only when . When  is true but , log a warning and skip execution.

**Issue:** #3220