### PR TITLE
fix(api): avoid success-style SSE termination after backend failure

### DIFF
--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -256,6 +256,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
 
         chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
         queue: asyncio.Queue[str | None] = asyncio.Queue()
+        stream_failed = False
 
         async def _on_stream(token: str) -> None:
             await queue.put(token)
@@ -264,6 +265,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
             await queue.put(None)
 
         async def _run() -> None:
+            nonlocal stream_failed
             try:
                 async with session_lock:
                     await asyncio.wait_for(
@@ -279,6 +281,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
                         timeout=timeout_s,
                     )
             except Exception:
+                stream_failed = True
                 logger.exception("Streaming error for session {}", session_key)
                 await queue.put(None)
 
@@ -292,8 +295,9 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
         finally:
             task.cancel()
 
-        await resp.write(_sse_chunk("", model_name, chunk_id, finish_reason="stop"))
-        await resp.write(_SSE_DONE)
+        if not stream_failed:
+            await resp.write(_sse_chunk("", model_name, chunk_id, finish_reason="stop"))
+            await resp.write(_SSE_DONE)
         return resp
 
     # -- non-streaming path (original logic) --

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -251,3 +251,30 @@ async def test_stream_with_session_id(aiohttp_client) -> None:
     )
     assert resp.status == 200
     assert captured_key == "api:my-session"
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_streaming_backend_failure_does_not_emit_success_terminator(aiohttp_client) -> None:
+    """Backend exceptions should not surface as a normal stop+[DONE] stream."""
+    agent = MagicMock()
+
+    async def boom(**kwargs):
+        raise RuntimeError("backend blew up")
+
+    agent.process_direct = boom
+    agent._connect_mcp = AsyncMock()
+    agent.close_mcp = AsyncMock()
+
+    app = create_app(agent, model_name="m")
+    client = await aiohttp_client(app)
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hi"}], "stream": True},
+    )
+
+    assert resp.status == 200
+    body = await resp.text()
+    assert '"finish_reason": "stop"' not in body
+    assert "[DONE]" not in body


### PR DESCRIPTION
## Summary
Follow up on the known limitation noted during #3222 review: a backend exception in the streaming path currently still produces the normal success-style SSE terminator (`finish_reason: "stop"` + `[DONE]`).

That makes a failed streamed request look successful to OpenAI-compatible clients.

Closes #3260.

## Root Cause
In `nanobot/api/server.py`, the streaming task catches backend exceptions, logs them, and pushes `None` into the queue. The outer path then unconditionally writes the same success terminator used for a successful stream.

## Fix
Keep the patch minimal:
- track whether the streaming backend failed
- suppress the success-style stop chunk and `[DONE]` marker when the backend raised
- add regression coverage for the failure path

Non-streaming behavior is unchanged.

## Test plan
```bash
PYTHONPATH=$PWD pytest -q tests/test_api_stream.py
```

Result locally: **10 passed**.

## Why this scope
Recent nanobot merges tend to favor small, reviewable fixes that:
- solve one concrete bug
- leave unaffected paths untouched
- explain root cause clearly
- add regression coverage

This patch intentionally stops at suppressing the false-success terminator. It does not introduce a new custom SSE error event shape in the same review.
