### PR TITLE
feat(prompt):guide llm read session history

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -31,9 +31,10 @@ class ContextBuilder:
         self,
         skill_names: list[str] | None = None,
         channel: str | None = None,
+        chat_id: str | None = None,
     ) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
-        parts = [self._get_identity(channel=channel)]
+        parts = [self._get_identity(channel=channel, chat_id=chat_id)]
 
         bootstrap = self._load_bootstrap_files()
         if bootstrap:
@@ -62,7 +63,7 @@ class ContextBuilder:
 
         return "\n\n---\n\n".join(parts)
 
-    def _get_identity(self, channel: str | None = None) -> str:
+    def _get_identity(self, channel: str | None = None, chat_id: str | None = None) -> str:
         """Get the core identity section."""
         workspace_path = str(self.workspace.expanduser().resolve())
         system = platform.system()
@@ -74,6 +75,7 @@ class ContextBuilder:
             runtime=runtime,
             platform_policy=render_template("agent/platform_policy.md", system=system),
             channel=channel or "",
+            chat_id=chat_id or "",
         )
 
     @staticmethod
@@ -148,7 +150,7 @@ class ContextBuilder:
         else:
             merged = [{"type": "text", "text": runtime_ctx}] + user_content
         messages = [
-            {"role": "system", "content": self.build_system_prompt(skill_names, channel=channel)},
+            {"role": "system", "content": self.build_system_prompt(skill_names, channel=channel, chat_id=chat_id)},
             *history,
         ]
         if messages[-1].get("role") == current_role:

--- a/nanobot/templates/agent/identity.md
+++ b/nanobot/templates/agent/identity.md
@@ -9,6 +9,7 @@ You are nanobot, a helpful AI assistant.
 Your workspace is at: {{ workspace_path }}
 - Long-term memory: {{ workspace_path }}/memory/MEMORY.md (automatically managed by Dream — do not edit directly)
 - History log: {{ workspace_path }}/memory/history.jsonl (append-only JSONL; prefer built-in `grep` for search).
+- Session file: {{ workspace_path }}/sessions/{{ channel }}_{{ chat_id }}.jsonl (use `grep` with keywords to search past conversations beyond current context)
 - Custom skills: {{ workspace_path }}/skills/{% raw %}{skill-name}{% endraw %}/SKILL.md
 
 {{ platform_policy }}

--- a/tests/agent/test_context_prompt_cache.py
+++ b/tests/agent/test_context_prompt_cache.py
@@ -205,6 +205,38 @@ def test_build_messages_passes_channel_to_system_prompt(tmp_path) -> None:
     assert "messaging app" in system
 
 
+def test_session_file_path_rendered_with_channel_and_chat_id(tmp_path) -> None:
+    """Identity should include exact session file path using channel and chat_id."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    prompt = builder.build_system_prompt(channel="telegram", chat_id="123456")
+    assert "sessions/telegram_123456.jsonl" in prompt
+    assert "grep" in prompt
+
+
+def test_session_file_path_with_none_channel_and_chat_id(tmp_path) -> None:
+    """When channel/chat_id are None, session path should render with empty values."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    prompt = builder.build_system_prompt()
+    assert "sessions/_.jsonl" in prompt
+
+
+def test_build_messages_passes_chat_id_to_system_prompt(tmp_path) -> None:
+    """build_messages should pass chat_id through to build_system_prompt."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    messages = builder.build_messages(
+        history=[], current_message="hi",
+        channel="telegram", chat_id="999888",
+    )
+    system = messages[0]["content"]
+    assert "sessions/telegram_999888.jsonl" in system
+
+
 def test_subagent_result_does_not_create_consecutive_assistant_messages(tmp_path) -> None:
     workspace = _make_workspace(tmp_path)
     builder = ContextBuilder(workspace)


### PR DESCRIPTION
Summary

Enable the LLM to locate and read the full session history file on demand, mitigating context loss caused by prompt compression in multi-turn conversations.

Motivation

In long-running sessions, early messages are often compressed or dropped to fit within the context window. Once discarded, those details are irrecoverable from the LLM's perspective, leading to:
- Repeated user prompts ("I already told you...").
- Broken continuity across turns.
- Hallucinated reconstructions of prior context.

By surfacing the exact session file path in the system prompt, we give the LLM a way to pull the original, uncompressed history when it needs to recall something that no longer fits in the active context.

Changes

- context.py: Add `chat_id` parameter to `build_system_prompt()` and `_get_identity()`, thread it into the identity template.
- identity.md: Add one line — `Session file: {{ workspace_path }}/sessions/{{ channel }}_{{ chat_id }}.jsonl` — with a short grep usage hint.
- Tests: 3 new cases — exact path with channel+chat_id, None fallback (`sessions/_.jsonl`), and full `build_messages` integration.

Prompt Caching Impact

None. `channel` + `chat_id` are constant within a session, so the system prompt stays stable across turns.