### PR TITLE
fix(cli): respect sys.stdout.isatty() in stream renderer (#3265)

### DIFF
--- a/nanobot/cli/stream.py
+++ b/nanobot/cli/stream.py
@@ -18,7 +18,17 @@ from nanobot import __logo__
 
 
 def _make_console() -> Console:
-    return Console(file=sys.stdout, force_terminal=True)
+    """Create a Console that emits plain text when stdout is not a TTY.
+
+    Rich's spinner, Live render, and cursor-visibility escape codes all
+    key off ``Console.is_terminal``. Forcing ``force_terminal=True`` overrode
+    the ``isatty()`` check and caused control sequences (``\\x1b[?25l``,
+    braille spinner frames) to pollute programmatic consumers such as
+    ``docker exec -i`` or pipes, even with ``NO_COLOR`` or ``TERM=dumb``.
+    Deferring to ``isatty()`` keeps Rich output in interactive terminals
+    and plain text everywhere else (#3265).
+    """
+    return Console(file=sys.stdout, force_terminal=sys.stdout.isatty())
 
 
 class ThinkingSpinner:

--- a/tests/cli/test_cli_input.py
+++ b/tests/cli/test_cli_input.py
@@ -167,7 +167,19 @@ def test_stream_renderer_stop_for_input_stops_spinner():
         spinner.stop.assert_called_once()
 
 
-def test_make_console_uses_force_terminal():
-    """Console should be created with force_terminal=True for proper ANSI handling."""
-    console = stream_mod._make_console()
-    assert console._force_terminal is True
+def test_make_console_force_terminal_when_stdout_is_tty():
+    """Console should set force_terminal=True when stdout is a TTY (rich output)."""
+    import sys
+    with patch.object(sys.stdout, "isatty", return_value=True):
+        console = stream_mod._make_console()
+        assert console._force_terminal is True
+
+
+def test_make_console_force_terminal_false_when_stdout_is_not_tty():
+    """Console should set force_terminal=False when stdout is not a TTY so that
+    ANSI escape codes (cursor visibility, braille spinner frames) don't pollute
+    piped output such as `docker exec -i` (#3265)."""
+    import sys
+    with patch.object(sys.stdout, "isatty", return_value=False):
+        console = stream_mod._make_console()
+        assert console._force_terminal is False


### PR DESCRIPTION
When stdout is not a TTY (e.g. docker exec -i, pipes), nanobot emitted
cursor-visibility escape sequences and braille spinner frames mixed into
the response output. Forcing force_terminal=True overrode Rich's isatty()
detection. Deferring to sys.stdout.isatty() keeps rich output in real
terminals and plain text everywhere else.

Co-authored with Claude Opus 4.7