### PR TITLE
refactor(templates): separate identity and SOUL responsibilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       run: uv run ruff check nanobot --select F401,F841
 
     - name: Run tests
-      run: uv run pytest tests/ --ignore=tests/channels/test_matrix_channel.py
+      run: uv run pytest tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -24,14 +25,15 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v4
 
-    - name: Install system dependencies
+    - name: Install system dependencies (Linux)
+      if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y libolm-dev build-essential
 
-    - name: Install all dependencies
+    - name: Install dependencies
       run: uv sync --all-extras
 
     - name: Lint with ruff
       run: uv run ruff check nanobot --select F401,F841
 
     - name: Run tests
-      run: uv run pytest tests/
+      run: uv run pytest tests/ --ignore=tests/channels/test_matrix_channel.py

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@
 .web
 .orion
 
+# webui (monorepo frontend)
+webui/node_modules/
+webui/dist/
+webui/coverage/
+webui/.vite/
+
 # Python bytecode & caches
 *.pyc
 *.pyo

--- a/README.md
+++ b/README.md
@@ -442,6 +442,13 @@ Install Matrix dependencies first:
 pip install nanobot-ai[matrix]
 ```
 
+> [!NOTE]
+> Matrix is not supported on Windows. `matrix-nio[e2e]` depends on
+> `python-olm`, which has no pre-built Windows wheel and is skipped by the
+> `matrix` extra on `sys_platform == 'win32'`. The command above will still
+> succeed on Windows but without `matrix-nio` installed, so enabling the
+> Matrix channel will fail at startup. Use macOS, Linux, or WSL2.
+
 **1. Create/choose a Matrix account**
 
 - Create or reuse a Matrix account on your homeserver (for example `matrix.org`).

--- a/docs/CHANNEL_PLUGIN_GUIDE.md
+++ b/docs/CHANNEL_PLUGIN_GUIDE.md
@@ -141,8 +141,11 @@ dependencies = ["nanobot", "aiohttp"]
 webhook = "nanobot_channel_webhook:WebhookChannel"
 
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.backends._legacy:_Backend"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["nanobot_channel_webhook"]
 ```
 
 The key (`webhook`) becomes the config section name. The value points to your `BaseChannel` subclass.

--- a/docs/CHANNEL_PLUGIN_GUIDE.md
+++ b/docs/CHANNEL_PLUGIN_GUIDE.md
@@ -135,7 +135,7 @@ class WebhookChannel(BaseChannel):
 [project]
 name = "nanobot-channel-webhook"
 version = "0.1.0"
-dependencies = ["nanobot", "aiohttp"]
+dependencies = ["nanobot-ai", "aiohttp"]
 
 [project.entry-points."nanobot.channels"]
 webhook = "nanobot_channel_webhook:WebhookChannel"

--- a/docs/WEBSOCKET.md
+++ b/docs/WEBSOCKET.md
@@ -7,7 +7,7 @@ Nanobot can act as a WebSocket server, allowing external clients (web apps, CLIs
 - Bidirectional real-time communication over WebSocket
 - Streaming support — receive agent responses token by token
 - Token-based authentication (static tokens and short-lived issued tokens)
-- Per-connection sessions — each connection gets a unique `chat_id`
+- Multi-chat multiplexing — one connection can run many concurrent `chat_id`s
 - TLS/SSL support (WSS) with enforced TLSv1.2 minimum
 - Client allow-list via `allowFrom`
 - Auto-cleanup of dead connections
@@ -98,6 +98,7 @@ All frames are JSON text. Each message has an `event` field.
 ```json
 {
   "event": "message",
+  "chat_id": "uuid-v4",
   "text": "Hello! How can I help?",
   "media": ["/tmp/image.png"],
   "reply_to": "msg-id"
@@ -111,6 +112,7 @@ All frames are JSON text. Each message has an `event` field.
 ```json
 {
   "event": "delta",
+  "chat_id": "uuid-v4",
   "text": "Hello",
   "stream_id": "s1"
 }
@@ -121,25 +123,46 @@ All frames are JSON text. Each message has an `event` field.
 ```json
 {
   "event": "stream_end",
+  "chat_id": "uuid-v4",
   "stream_id": "s1"
 }
 ```
 
+**`attached`** — confirmation for `new_chat` / `attach` inbound envelopes (see [Multi-chat multiplexing](#multi-chat-multiplexing)):
+
+```json
+{"event": "attached", "chat_id": "uuid-v4"}
+```
+
+**`error`** — soft error for malformed inbound envelopes. The connection stays open:
+
+```json
+{"event": "error", "detail": "invalid chat_id"}
+```
+
 ### Client → Server
 
-Send plain text:
+**Legacy (default chat):** send a plain string, or a JSON object with a recognized text field:
 
 ```json
 "Hello nanobot!"
 ```
 
-Or send a JSON object with a recognized text field:
-
 ```json
 {"content": "Hello nanobot!"}
 ```
 
-Recognized fields: `content`, `text`, `message` (checked in that order). Invalid JSON is treated as plain text.
+Recognized fields: `content`, `text`, `message` (checked in that order). Invalid JSON is treated as plain text. These frames route to the connection's default `chat_id` (the one announced in `ready`).
+
+**Typed envelopes (multi-chat):** any JSON object with a string `type` field is a typed envelope:
+
+| `type` | Fields | Effect |
+|--------|--------|--------|
+| `new_chat` | — | Server mints a new `chat_id`, subscribes this connection, replies with `attached`. |
+| `attach` | `chat_id` | Subscribe to an existing `chat_id` (e.g. after a page reload). Replies with `attached`. |
+| `message` | `chat_id`, `content` | Send `content` on `chat_id`. First use auto-attaches; no explicit `attach` needed. |
+
+See [Multi-chat multiplexing](#multi-chat-multiplexing) for the full flow.
 
 ## Configuration Reference
 
@@ -243,11 +266,53 @@ websocat "ws://127.0.0.1:8765/ws?client_id=alice&token=nbwt_aBcDeFg..."
 - Outstanding tokens are capped at 10,000. Requests beyond this return HTTP 429.
 - Expired tokens are purged lazily on each issue or validation request.
 
+## Multi-chat multiplexing
+
+A single WebSocket can carry many concurrent chats. The server tracks `chat_id -> {connections}` as a fan-out set, so the same chat can also be mirrored across multiple connections (e.g. two browser tabs).
+
+### Typical flow (web UI with a sidebar)
+
+```text
+client                                server
+  | --- connect -------------------->  |
+  | <-- {"event":"ready",              |
+  |      "chat_id":"d3..."}   (default)|
+  |                                     |
+  | --- {"type":"new_chat"} --------->  |
+  | <-- {"event":"attached",            |
+  |      "chat_id":"a1..."}             |
+  |                                     |
+  | --- {"type":"message",              |
+  |      "chat_id":"a1...",             |
+  |      "content":"hi"} ------------>  |
+  | <-- {"event":"delta", ...}          |
+  | <-- {"event":"stream_end", ...}     |
+  |                                     |
+  | --- {"type":"attach",               |  # after page reload
+  |      "chat_id":"a1..."} --------->  |
+  | <-- {"event":"attached", ...}       |
+```
+
+### Rules
+
+- Every outbound event carries `chat_id`. Clients must dispatch by that field.
+- `chat_id` format: `^[A-Za-z0-9_:-]{1,64}$`. Non-matching values return `error`.
+- `message` auto-attaches on first use — no separate `attach` is required for chats the server minted (`new_chat`) on the same connection.
+- Errors (invalid envelope, unknown `type`, bad `chat_id`) are soft: the server replies with `{"event":"error","detail":"..."}` and keeps the connection open.
+
+### Backward compatibility
+
+Legacy clients that only send plain text or `{"content": ...}` keep working unchanged: those frames route to the connection's default `chat_id` (the one from `ready`). No config flag is needed.
+
+### Security boundary
+
+`chat_id` is a *capability*: anyone holding a valid WebSocket auth credential and the chat_id can attach to that conversation and see its output. This is safe for nanobot's local, single-user model. Multi-tenant deployments should namespace chat_ids per user (or introduce a per-tenant auth gate) — nanobot does not do this today.
+
 ## Security Notes
 
 - **Timing-safe comparison**: Static token validation uses `hmac.compare_digest` to prevent timing attacks.
 - **Defense in depth**: `allowFrom` is checked at both the HTTP handshake level and the message level.
-- **Token isolation**: Each WebSocket connection gets a unique `chat_id`. Clients cannot access other sessions.
+- **chat_id as capability**: see [Multi-chat multiplexing](#multi-chat-multiplexing). Auth on the WebSocket handshake is the single line of defense; callers who pass it can attach to any chat_id they know.
 - **TLS enforcement**: When SSL is enabled, TLSv1.2 is the minimum allowed version.
 - **Default-secure**: `websocketRequiresToken` defaults to `true`. Explicitly set it to `false` only on trusted networks.
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -647,15 +647,23 @@ class AgentLoop:
             session, pending = self.auto_compact.prepare_session(session, key)
 
             await self.consolidator.maybe_consolidate_by_tokens(session)
-            if msg.sender_id == "subagent" and self._persist_subagent_followup(session, msg):
+            # Persist subagent follow-ups into durable history BEFORE prompt
+            # assembly. ContextBuilder merges adjacent same-role messages for
+            # provider compatibility, which previously caused the follow-up to
+            # disappear from session.messages while still being visible to the
+            # LLM via the merged prompt. See _persist_subagent_followup.
+            is_subagent = msg.sender_id == "subagent"
+            if is_subagent and self._persist_subagent_followup(session, msg):
                 self.sessions.save(session)
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
             history = session.get_history(max_messages=0)
-            current_role = "assistant" if msg.sender_id == "subagent" else "user"
+            current_role = "assistant" if is_subagent else "user"
 
+            # Subagent content is already in `history` above; passing it again
+            # as current_message would double-project it into the prompt.
             messages = self.context.build_messages(
                 history=history,
-                current_message="" if msg.sender_id == "subagent" else msg.content,
+                current_message="" if is_subagent else msg.content,
                 channel=channel,
                 chat_id=chat_id,
                 session_summary=pending,
@@ -875,7 +883,14 @@ class AgentLoop:
         session.updated_at = datetime.now()
 
     def _persist_subagent_followup(self, session: Session, msg: InboundMessage) -> bool:
-        """Persist subagent follow-ups before prompt assembly so history stays durable."""
+        """Persist subagent follow-ups before prompt assembly so history stays durable.
+
+        Returns True if a new entry was appended; False if the follow-up was
+        deduped (same ``subagent_task_id`` already in session) or carries no
+        content worth persisting.
+        """
+        if not msg.content:
+            return False
         task_id = msg.metadata.get("subagent_task_id") if isinstance(msg.metadata, dict) else None
         if task_id and any(
             m.get("injected_event") == "subagent_result" and m.get("subagent_task_id") == task_id

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -351,6 +351,7 @@ class AgentLoop:
         on_progress: Callable[..., Awaitable[None]] | None = None,
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
+        on_retry_wait: Callable[[str], Awaitable[None]] | None = None,
         *,
         session: Session | None = None,
         channel: str = "cli",
@@ -428,6 +429,7 @@ class AgentLoop:
             context_block_limit=self.context_block_limit,
             provider_retry_mode=self.provider_retry_mode,
             progress_callback=on_progress,
+            retry_wait_callback=on_retry_wait,
             checkpoint_callback=_checkpoint,
             injection_callback=_drain_pending,
         ))
@@ -738,6 +740,18 @@ class AgentLoop:
                 )
             )
 
+        async def _on_retry_wait(content: str) -> None:
+            meta = dict(msg.metadata or {})
+            meta["_retry_wait"] = True
+            await self.bus.publish_outbound(
+                OutboundMessage(
+                    channel=msg.channel,
+                    chat_id=msg.chat_id,
+                    content=content,
+                    metadata=meta,
+                )
+            )
+
         # Persist the triggering user message immediately, before running the
         # agent loop. If the process is killed mid-turn (OOM, SIGKILL, self-
         # restart, etc.), the existing runtime_checkpoint preserves the
@@ -756,6 +770,7 @@ class AgentLoop:
             on_progress=on_progress or _bus_progress,
             on_stream=on_stream,
             on_stream_end=on_stream_end,
+            on_retry_wait=_on_retry_wait,
             session=session,
             channel=msg.channel,
             chat_id=msg.chat_id,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -647,13 +647,17 @@ class AgentLoop:
             session, pending = self.auto_compact.prepare_session(session, key)
 
             await self.consolidator.maybe_consolidate_by_tokens(session)
+            if msg.sender_id == "subagent" and self._persist_subagent_followup(session, msg):
+                self.sessions.save(session)
             self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
             history = session.get_history(max_messages=0)
             current_role = "assistant" if msg.sender_id == "subagent" else "user"
 
             messages = self.context.build_messages(
                 history=history,
-                current_message=msg.content, channel=channel, chat_id=chat_id,
+                current_message="" if msg.sender_id == "subagent" else msg.content,
+                channel=channel,
+                chat_id=chat_id,
                 session_summary=pending,
                 current_role=current_role,
             )
@@ -869,6 +873,23 @@ class AgentLoop:
             entry.setdefault("timestamp", datetime.now().isoformat())
             session.messages.append(entry)
         session.updated_at = datetime.now()
+
+    def _persist_subagent_followup(self, session: Session, msg: InboundMessage) -> bool:
+        """Persist subagent follow-ups before prompt assembly so history stays durable."""
+        task_id = msg.metadata.get("subagent_task_id") if isinstance(msg.metadata, dict) else None
+        if task_id and any(
+            m.get("injected_event") == "subagent_result" and m.get("subagent_task_id") == task_id
+            for m in session.messages
+        ):
+            return False
+        session.add_message(
+            "assistant",
+            msg.content,
+            sender_id=msg.sender_id,
+            injected_event="subagent_result",
+            subagent_task_id=task_id,
+        )
+        return True
 
     def _set_runtime_checkpoint(self, session: Session, payload: dict[str, Any]) -> None:
         """Persist the latest in-flight turn state into session metadata."""

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -457,6 +457,8 @@ class Consolidator:
                 tools=None,
                 tool_choice=None,
             )
+            if response.finish_reason == "error":
+                raise RuntimeError(f"LLM returned error: {response.content}")
             summary = response.content or "[no summary]"
             self.store.append_history(summary)
             return summary

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -933,14 +933,15 @@ class AgentRunner:
                     kept = kept[i:]
                     break
             else:
-                # No user message in the kept window — walk backwards through
-                # non_system to find the nearest user message and keep it plus
-                # everything after it.  Providers like GLM reject requests
-                # where the first non-system message is not ``user`` (error 1214).
+                # Recover nearest user message from outside the kept window;
+                # GLM rejects system→assistant (error 1214).  Budget is
+                # intentionally exceeded — oversized beats invalid.
                 for idx in range(len(non_system) - 1, -1, -1):
                     if non_system[idx].get("role") == "user":
                         kept = non_system[idx:]
                         break
+                # If no user exists at all, _enforce_role_alternation
+                # will insert a synthetic one as a safety net.
             start = find_legal_message_start(kept)
             if start:
                 kept = kept[start:]

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -71,6 +71,7 @@ class AgentRunSpec:
     context_block_limit: int | None = None
     provider_retry_mode: str = "standard"
     progress_callback: Any | None = None
+    retry_wait_callback: Any | None = None
     checkpoint_callback: Any | None = None
     injection_callback: Any | None = None
 
@@ -552,7 +553,7 @@ class AgentRunner:
             "tools": tools,
             "model": spec.model,
             "retry_mode": spec.provider_retry_mode,
-            "on_retry_wait": spec.progress_callback,
+            "on_retry_wait": spec.retry_wait_callback,
         }
         if spec.temperature is not None:
             kwargs["temperature"] = spec.temperature

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -47,6 +47,7 @@ _COMPACTABLE_TOOLS = frozenset({
 _BACKFILL_CONTENT = "[Tool result unavailable — call was interrupted or lost]"
 
 
+
 @dataclass(slots=True)
 class AgentRunSpec:
     """Configuration for a single agent execution."""
@@ -119,7 +120,11 @@ class AgentRunner:
     ) -> None:
         """Append injected user messages while preserving role alternation."""
         for injection in injections:
-            if messages and injection.get("role") == "user" and messages[-1].get("role") == "user":
+            if (
+                messages
+                and injection.get("role") == "user"
+                and messages[-1].get("role") == "user"
+            ):
                 merged = dict(messages[-1])
                 merged["content"] = cls._merge_message_content(
                     merged.get("content"),
@@ -169,10 +174,7 @@ class AgentRunner:
         self._append_injected_messages(messages, injections)
         logger.info(
             "Injected {} follow-up message(s) {} ({}/{})",
-            len(injections),
-            phase,
-            injection_cycles,
-            _MAX_INJECTION_CYCLES,
+            len(injections), phase, injection_cycles, _MAX_INJECTION_CYCLES,
         )
         return True, injection_cycles
 
@@ -188,9 +190,12 @@ class AgentRunner:
             return []
         try:
             signature = inspect.signature(spec.injection_callback)
-            accepts_limit = "limit" in signature.parameters or any(
-                parameter.kind is inspect.Parameter.VAR_KEYWORD
-                for parameter in signature.parameters.values()
+            accepts_limit = (
+                "limit" in signature.parameters
+                or any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in signature.parameters.values()
+                )
             )
             if accepts_limit:
                 items = await spec.injection_callback(limit=_MAX_INJECTIONS_PER_TURN)
@@ -213,9 +218,7 @@ class AgentRunner:
             dropped = len(injected_messages) - _MAX_INJECTIONS_PER_TURN
             logger.warning(
                 "Injection callback returned {} messages, capping to {} ({} dropped)",
-                len(injected_messages),
-                _MAX_INJECTIONS_PER_TURN,
-                dropped,
+                len(injected_messages), _MAX_INJECTIONS_PER_TURN, dropped,
             )
             injected_messages = injected_messages[:_MAX_INJECTIONS_PER_TURN]
         return injected_messages
@@ -290,9 +293,7 @@ class AgentRunner:
                         "model": spec.model,
                         "assistant_message": assistant_message,
                         "completed_tool_results": [],
-                        "pending_tool_calls": [
-                            tc.to_openai_tool_call() for tc in response.tool_calls
-                        ],
+                        "pending_tool_calls": [tc.to_openai_tool_call() for tc in response.tool_calls],
                     },
                 )
 
@@ -331,10 +332,7 @@ class AgentRunner:
                     context.stop_reason = stop_reason
                     await hook.after_iteration(context)
                     should_continue, injection_cycles = await self._try_drain_injections(
-                        spec,
-                        messages,
-                        None,
-                        injection_cycles,
+                        spec, messages, None, injection_cycles,
                         phase="after tool error",
                     )
                     if should_continue:
@@ -356,10 +354,7 @@ class AgentRunner:
                 length_recovery_count = 0
                 # Checkpoint 1: drain injections after tools, before next LLM call
                 _drained, injection_cycles = await self._try_drain_injections(
-                    spec,
-                    messages,
-                    None,
-                    injection_cycles,
+                    spec, messages, None, injection_cycles,
                     phase="after tool execution",
                 )
                 if _drained:
@@ -367,9 +362,9 @@ class AgentRunner:
                 await hook.after_iteration(context)
                 continue
 
-            elif response.has_tool_calls:
+            if response.has_tool_calls:
                 logger.warning(
-                    "Ignoring tool calls under finish_reason='%s' for %s",
+                    "Ignoring tool calls under finish_reason='{}' for {}",
                     response.finish_reason,
                     spec.session_key or "default",
                 )
@@ -418,13 +413,11 @@ class AgentRunner:
                     )
                     if hook.wants_streaming():
                         await hook.on_stream_end(context, resuming=True)
-                    messages.append(
-                        build_assistant_message(
-                            clean,
-                            reasoning_content=response.reasoning_content,
-                            thinking_blocks=response.thinking_blocks,
-                        )
-                    )
+                    messages.append(build_assistant_message(
+                        clean,
+                        reasoning_content=response.reasoning_content,
+                        thinking_blocks=response.thinking_blocks,
+                    ))
                     messages.append(build_length_recovery_message())
                     await hook.after_iteration(context)
                     continue
@@ -441,10 +434,7 @@ class AgentRunner:
             # If injections are found we keep the stream alive (resuming=True)
             # so streaming channels don't prematurely finalize the card.
             should_continue, injection_cycles = await self._try_drain_injections(
-                spec,
-                messages,
-                assistant_message,
-                injection_cycles,
+                spec, messages, assistant_message, injection_cycles,
                 phase="after final response",
                 iteration=iteration,
             )
@@ -468,10 +458,7 @@ class AgentRunner:
                 context.stop_reason = stop_reason
                 await hook.after_iteration(context)
                 should_continue, injection_cycles = await self._try_drain_injections(
-                    spec,
-                    messages,
-                    None,
-                    injection_cycles,
+                    spec, messages, None, injection_cycles,
                     phase="after LLM error",
                 )
                 if should_continue:
@@ -488,10 +475,7 @@ class AgentRunner:
                 context.stop_reason = stop_reason
                 await hook.after_iteration(context)
                 should_continue, injection_cycles = await self._try_drain_injections(
-                    spec,
-                    messages,
-                    None,
-                    injection_cycles,
+                    spec, messages, None, injection_cycles,
                     phase="after empty response",
                 )
                 if should_continue:
@@ -499,14 +483,11 @@ class AgentRunner:
                     continue
                 break
 
-            messages.append(
-                assistant_message
-                or build_assistant_message(
-                    clean,
-                    reasoning_content=response.reasoning_content,
-                    thinking_blocks=response.thinking_blocks,
-                )
-            )
+            messages.append(assistant_message or build_assistant_message(
+                clean,
+                reasoning_content=response.reasoning_content,
+                thinking_blocks=response.thinking_blocks,
+            ))
             await self._emit_checkpoint(
                 spec,
                 {
@@ -542,10 +523,7 @@ class AgentRunner:
             # We ignore should_continue here because the for-loop has already
             # exhausted all iterations.
             drained_after_max_iterations, injection_cycles = await self._try_drain_injections(
-                spec,
-                messages,
-                None,
-                injection_cycles,
+                spec, messages, None, injection_cycles,
                 phase="after max_iterations",
             )
             if drained_after_max_iterations:
@@ -597,7 +575,6 @@ class AgentRunner:
             tools=spec.tools.get_definitions(),
         )
         if hook.wants_streaming():
-
             async def _stream(delta: str) -> None:
                 await hook.on_stream(context, delta)
 
@@ -651,19 +628,13 @@ class AgentRunner:
         tool_results: list[tuple[Any, dict[str, str], BaseException | None]] = []
         for batch in batches:
             if spec.concurrent_tools and len(batch) > 1:
-                tool_results.extend(
-                    await asyncio.gather(
-                        *(
-                            self._run_tool(spec, tool_call, external_lookup_counts)
-                            for tool_call in batch
-                        )
-                    )
-                )
+                tool_results.extend(await asyncio.gather(*(
+                    self._run_tool(spec, tool_call, external_lookup_counts)
+                    for tool_call in batch
+                )))
             else:
                 for tool_call in batch:
-                    tool_results.append(
-                        await self._run_tool(spec, tool_call, external_lookup_counts)
-                    )
+                    tool_results.append(await self._run_tool(spec, tool_call, external_lookup_counts))
 
         results: list[Any] = []
         events: list[dict[str, str]] = []
@@ -711,11 +682,7 @@ class AgentRunner:
                 "status": "error",
                 "detail": prep_error.split(": ", 1)[-1][:120],
             }
-            return (
-                prep_error + _HINT,
-                event,
-                RuntimeError(prep_error) if spec.fail_on_tool_error else None,
-            )
+            return prep_error + _HINT, event, RuntimeError(prep_error) if spec.fail_on_tool_error else None
         try:
             if tool is not None:
                 result = await tool.execute(**params)
@@ -777,11 +744,7 @@ class AgentRunner:
 
     @staticmethod
     def _append_model_error_placeholder(messages: list[dict[str, Any]]) -> None:
-        if (
-            messages
-            and messages[-1].get("role") == "assistant"
-            and not messages[-1].get("tool_calls")
-        ):
+        if messages and messages[-1].get("role") == "assistant" and not messages[-1].get("tool_calls"):
             return
         messages.append(build_assistant_message(_PERSISTED_MODEL_ERROR_PLACEHOLDER))
 
@@ -871,15 +834,12 @@ class AgentRunner:
             insert_at = assistant_idx + 1 + offset
             while insert_at < len(updated) and updated[insert_at].get("role") == "tool":
                 insert_at += 1
-            updated.insert(
-                insert_at,
-                {
-                    "role": "tool",
-                    "tool_call_id": call_id,
-                    "name": name,
-                    "content": _BACKFILL_CONTENT,
-                },
-            )
+            updated.insert(insert_at, {
+                "role": "tool",
+                "tool_call_id": call_id,
+                "name": name,
+                "content": _BACKFILL_CONTENT,
+            })
             offset += 1
         return updated
 
@@ -938,13 +898,9 @@ class AgentRunner:
         if not messages or not spec.context_window_tokens:
             return messages
 
-        provider_max_tokens = getattr(
-            getattr(self.provider, "generation", None), "max_tokens", 4096
-        )
-        max_output = (
-            spec.max_tokens
-            if isinstance(spec.max_tokens, int)
-            else (provider_max_tokens if isinstance(provider_max_tokens, int) else 4096)
+        provider_max_tokens = getattr(getattr(self.provider, "generation", None), "max_tokens", 4096)
+        max_output = spec.max_tokens if isinstance(spec.max_tokens, int) else (
+            provider_max_tokens if isinstance(provider_max_tokens, int) else 4096
         )
         budget = spec.context_block_limit or (
             spec.context_window_tokens - max_output - _SNIP_SAFETY_BUFFER
@@ -1027,3 +983,4 @@ class AgentRunner:
         if current:
             batches.append(current)
         return batches
+

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -40,12 +40,18 @@ _MAX_INJECTION_CYCLES = 5
 _SNIP_SAFETY_BUFFER = 1024
 _MICROCOMPACT_KEEP_RECENT = 10
 _MICROCOMPACT_MIN_CHARS = 500
-_COMPACTABLE_TOOLS = frozenset({
-    "read_file", "exec", "grep", "glob",
-    "web_search", "web_fetch", "list_dir",
-})
+_COMPACTABLE_TOOLS = frozenset(
+    {
+        "read_file",
+        "exec",
+        "grep",
+        "glob",
+        "web_search",
+        "web_fetch",
+        "list_dir",
+    }
+)
 _BACKFILL_CONTENT = "[Tool result unavailable — call was interrupted or lost]"
-
 
 
 @dataclass(slots=True)
@@ -120,11 +126,7 @@ class AgentRunner:
     ) -> None:
         """Append injected user messages while preserving role alternation."""
         for injection in injections:
-            if (
-                messages
-                and injection.get("role") == "user"
-                and messages[-1].get("role") == "user"
-            ):
+            if messages and injection.get("role") == "user" and messages[-1].get("role") == "user":
                 merged = dict(messages[-1])
                 merged["content"] = cls._merge_message_content(
                     merged.get("content"),
@@ -174,7 +176,10 @@ class AgentRunner:
         self._append_injected_messages(messages, injections)
         logger.info(
             "Injected {} follow-up message(s) {} ({}/{})",
-            len(injections), phase, injection_cycles, _MAX_INJECTION_CYCLES,
+            len(injections),
+            phase,
+            injection_cycles,
+            _MAX_INJECTION_CYCLES,
         )
         return True, injection_cycles
 
@@ -190,12 +195,9 @@ class AgentRunner:
             return []
         try:
             signature = inspect.signature(spec.injection_callback)
-            accepts_limit = (
-                "limit" in signature.parameters
-                or any(
-                    parameter.kind is inspect.Parameter.VAR_KEYWORD
-                    for parameter in signature.parameters.values()
-                )
+            accepts_limit = "limit" in signature.parameters or any(
+                parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in signature.parameters.values()
             )
             if accepts_limit:
                 items = await spec.injection_callback(limit=_MAX_INJECTIONS_PER_TURN)
@@ -218,7 +220,9 @@ class AgentRunner:
             dropped = len(injected_messages) - _MAX_INJECTIONS_PER_TURN
             logger.warning(
                 "Injection callback returned {} messages, capping to {} ({} dropped)",
-                len(injected_messages), _MAX_INJECTIONS_PER_TURN, dropped,
+                len(injected_messages),
+                _MAX_INJECTIONS_PER_TURN,
+                dropped,
             )
             injected_messages = injected_messages[:_MAX_INJECTIONS_PER_TURN]
         return injected_messages
@@ -273,7 +277,7 @@ class AgentRunner:
             context.tool_calls = list(response.tool_calls)
             self._accumulate_usage(usage, raw_usage)
 
-            if response.has_tool_calls:
+            if response.should_execute_tools:
                 if hook.wants_streaming():
                     await hook.on_stream_end(context, resuming=True)
 
@@ -293,7 +297,9 @@ class AgentRunner:
                         "model": spec.model,
                         "assistant_message": assistant_message,
                         "completed_tool_results": [],
-                        "pending_tool_calls": [tc.to_openai_tool_call() for tc in response.tool_calls],
+                        "pending_tool_calls": [
+                            tc.to_openai_tool_call() for tc in response.tool_calls
+                        ],
                     },
                 )
 
@@ -332,7 +338,10 @@ class AgentRunner:
                     context.stop_reason = stop_reason
                     await hook.after_iteration(context)
                     should_continue, injection_cycles = await self._try_drain_injections(
-                        spec, messages, None, injection_cycles,
+                        spec,
+                        messages,
+                        None,
+                        injection_cycles,
                         phase="after tool error",
                     )
                     if should_continue:
@@ -354,13 +363,23 @@ class AgentRunner:
                 length_recovery_count = 0
                 # Checkpoint 1: drain injections after tools, before next LLM call
                 _drained, injection_cycles = await self._try_drain_injections(
-                    spec, messages, None, injection_cycles,
+                    spec,
+                    messages,
+                    None,
+                    injection_cycles,
                     phase="after tool execution",
                 )
                 if _drained:
                     had_injections = True
                 await hook.after_iteration(context)
                 continue
+
+            elif response.has_tool_calls:
+                logger.warning(
+                    "Ignoring tool calls under finish_reason='%s' for %s",
+                    response.finish_reason,
+                    spec.session_key or "default",
+                )
 
             clean = hook.finalize_content(context, response.content)
             if response.finish_reason != "error" and is_blank_text(clean):
@@ -406,11 +425,13 @@ class AgentRunner:
                     )
                     if hook.wants_streaming():
                         await hook.on_stream_end(context, resuming=True)
-                    messages.append(build_assistant_message(
-                        clean,
-                        reasoning_content=response.reasoning_content,
-                        thinking_blocks=response.thinking_blocks,
-                    ))
+                    messages.append(
+                        build_assistant_message(
+                            clean,
+                            reasoning_content=response.reasoning_content,
+                            thinking_blocks=response.thinking_blocks,
+                        )
+                    )
                     messages.append(build_length_recovery_message())
                     await hook.after_iteration(context)
                     continue
@@ -427,7 +448,10 @@ class AgentRunner:
             # If injections are found we keep the stream alive (resuming=True)
             # so streaming channels don't prematurely finalize the card.
             should_continue, injection_cycles = await self._try_drain_injections(
-                spec, messages, assistant_message, injection_cycles,
+                spec,
+                messages,
+                assistant_message,
+                injection_cycles,
                 phase="after final response",
                 iteration=iteration,
             )
@@ -451,7 +475,10 @@ class AgentRunner:
                 context.stop_reason = stop_reason
                 await hook.after_iteration(context)
                 should_continue, injection_cycles = await self._try_drain_injections(
-                    spec, messages, None, injection_cycles,
+                    spec,
+                    messages,
+                    None,
+                    injection_cycles,
                     phase="after LLM error",
                 )
                 if should_continue:
@@ -468,7 +495,10 @@ class AgentRunner:
                 context.stop_reason = stop_reason
                 await hook.after_iteration(context)
                 should_continue, injection_cycles = await self._try_drain_injections(
-                    spec, messages, None, injection_cycles,
+                    spec,
+                    messages,
+                    None,
+                    injection_cycles,
                     phase="after empty response",
                 )
                 if should_continue:
@@ -476,11 +506,14 @@ class AgentRunner:
                     continue
                 break
 
-            messages.append(assistant_message or build_assistant_message(
-                clean,
-                reasoning_content=response.reasoning_content,
-                thinking_blocks=response.thinking_blocks,
-            ))
+            messages.append(
+                assistant_message
+                or build_assistant_message(
+                    clean,
+                    reasoning_content=response.reasoning_content,
+                    thinking_blocks=response.thinking_blocks,
+                )
+            )
             await self._emit_checkpoint(
                 spec,
                 {
@@ -516,7 +549,10 @@ class AgentRunner:
             # We ignore should_continue here because the for-loop has already
             # exhausted all iterations.
             drained_after_max_iterations, injection_cycles = await self._try_drain_injections(
-                spec, messages, None, injection_cycles,
+                spec,
+                messages,
+                None,
+                injection_cycles,
                 phase="after max_iterations",
             )
             if drained_after_max_iterations:
@@ -568,6 +604,7 @@ class AgentRunner:
             tools=spec.tools.get_definitions(),
         )
         if hook.wants_streaming():
+
             async def _stream(delta: str) -> None:
                 await hook.on_stream(context, delta)
 
@@ -621,13 +658,19 @@ class AgentRunner:
         tool_results: list[tuple[Any, dict[str, str], BaseException | None]] = []
         for batch in batches:
             if spec.concurrent_tools and len(batch) > 1:
-                tool_results.extend(await asyncio.gather(*(
-                    self._run_tool(spec, tool_call, external_lookup_counts)
-                    for tool_call in batch
-                )))
+                tool_results.extend(
+                    await asyncio.gather(
+                        *(
+                            self._run_tool(spec, tool_call, external_lookup_counts)
+                            for tool_call in batch
+                        )
+                    )
+                )
             else:
                 for tool_call in batch:
-                    tool_results.append(await self._run_tool(spec, tool_call, external_lookup_counts))
+                    tool_results.append(
+                        await self._run_tool(spec, tool_call, external_lookup_counts)
+                    )
 
         results: list[Any] = []
         events: list[dict[str, str]] = []
@@ -675,7 +718,11 @@ class AgentRunner:
                 "status": "error",
                 "detail": prep_error.split(": ", 1)[-1][:120],
             }
-            return prep_error + _HINT, event, RuntimeError(prep_error) if spec.fail_on_tool_error else None
+            return (
+                prep_error + _HINT,
+                event,
+                RuntimeError(prep_error) if spec.fail_on_tool_error else None,
+            )
         try:
             if tool is not None:
                 result = await tool.execute(**params)
@@ -737,7 +784,11 @@ class AgentRunner:
 
     @staticmethod
     def _append_model_error_placeholder(messages: list[dict[str, Any]]) -> None:
-        if messages and messages[-1].get("role") == "assistant" and not messages[-1].get("tool_calls"):
+        if (
+            messages
+            and messages[-1].get("role") == "assistant"
+            and not messages[-1].get("tool_calls")
+        ):
             return
         messages.append(build_assistant_message(_PERSISTED_MODEL_ERROR_PLACEHOLDER))
 
@@ -827,12 +878,15 @@ class AgentRunner:
             insert_at = assistant_idx + 1 + offset
             while insert_at < len(updated) and updated[insert_at].get("role") == "tool":
                 insert_at += 1
-            updated.insert(insert_at, {
-                "role": "tool",
-                "tool_call_id": call_id,
-                "name": name,
-                "content": _BACKFILL_CONTENT,
-            })
+            updated.insert(
+                insert_at,
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "name": name,
+                    "content": _BACKFILL_CONTENT,
+                },
+            )
             offset += 1
         return updated
 
@@ -891,9 +945,13 @@ class AgentRunner:
         if not messages or not spec.context_window_tokens:
             return messages
 
-        provider_max_tokens = getattr(getattr(self.provider, "generation", None), "max_tokens", 4096)
-        max_output = spec.max_tokens if isinstance(spec.max_tokens, int) else (
-            provider_max_tokens if isinstance(provider_max_tokens, int) else 4096
+        provider_max_tokens = getattr(
+            getattr(self.provider, "generation", None), "max_tokens", 4096
+        )
+        max_output = (
+            spec.max_tokens
+            if isinstance(spec.max_tokens, int)
+            else (provider_max_tokens if isinstance(provider_max_tokens, int) else 4096)
         )
         budget = spec.context_block_limit or (
             spec.context_window_tokens - max_output - _SNIP_SAFETY_BUFFER
@@ -976,4 +1034,3 @@ class AgentRunner:
         if current:
             batches.append(current)
         return batches
-

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -932,6 +932,15 @@ class AgentRunner:
                 if message.get("role") == "user":
                     kept = kept[i:]
                     break
+            else:
+                # No user message in the kept window — walk backwards through
+                # non_system to find the nearest user message and keep it plus
+                # everything after it.  Providers like GLM reject requests
+                # where the first non-system message is not ``user`` (error 1214).
+                for idx in range(len(non_system) - 1, -1, -1):
+                    if non_system[idx].get("role") == "user":
+                        kept = non_system[idx:]
+                        break
             start = find_legal_message_start(kept)
             if start:
                 kept = kept[start:]

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -40,17 +40,10 @@ _MAX_INJECTION_CYCLES = 5
 _SNIP_SAFETY_BUFFER = 1024
 _MICROCOMPACT_KEEP_RECENT = 10
 _MICROCOMPACT_MIN_CHARS = 500
-_COMPACTABLE_TOOLS = frozenset(
-    {
-        "read_file",
-        "exec",
-        "grep",
-        "glob",
-        "web_search",
-        "web_fetch",
-        "list_dir",
-    }
-)
+_COMPACTABLE_TOOLS = frozenset({
+    "read_file", "exec", "grep", "glob",
+    "web_search", "web_fetch", "list_dir",
+})
 _BACKFILL_CONTENT = "[Tool result unavailable — call was interrupted or lost]"
 
 

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -246,6 +246,10 @@ class SubagentManager:
             sender_id="subagent",
             chat_id=f"{origin['channel']}:{origin['chat_id']}",
             content=announce_content,
+            metadata={
+                "injected_event": "subagent_result",
+                "subagent_task_id": task_id,
+            },
         )
 
         await self.bus.publish_inbound(msg)

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -170,6 +170,7 @@ class SubagentManager:
                     restrict_to_workspace=self.restrict_to_workspace,
                     sandbox=self.exec_config.sandbox,
                     path_append=self.exec_config.path_append,
+                    allowed_env_keys=self.exec_config.allowed_env_keys,
                 ))
             if self.web_config.enable:
                 tools.register(WebSearchTool(config=self.web_config.search, proxy=self.web_config.proxy))

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -36,7 +36,7 @@ from nanobot.cron.types import CronJob, CronJobState, CronSchedule
             default=True,
         ),
         job_id=StringSchema("Job ID (for remove)"),
-        required=["action"],
+        required=["action", "message"],
     )
 )
 class CronTool(Tool):
@@ -128,7 +128,11 @@ class CronTool(Tool):
         deliver: bool = True,
     ) -> str:
         if not message:
-            return "Error: message is required for add"
+            return (
+                "Error: cron action='add' requires a non-empty 'message' "
+                "parameter describing what to do when the job triggers "
+                "(e.g. the reminder text). Retry including message=\"...\"."
+            )
         if not self._channel or not self._chat_id:
             return "Error: no session context (channel/chat_id)"
         if tz and not cron_expr:

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -18,8 +18,9 @@ from nanobot.cron.types import CronJob, CronJobState, CronSchedule
             "(e.g., 'weather-monitor', 'daily-standup'). Defaults to first 30 chars of message."
         ),
         message=StringSchema(
-            "Instruction for the agent to execute when the job triggers "
-            "(e.g., 'Send a reminder to WeChat: xxx' or 'Check system status and report')"
+            "REQUIRED when action='add'. Instruction for the agent to execute when the job triggers "
+            "(e.g., 'Send a reminder to WeChat: xxx' or 'Check system status and report'). "
+            "Not used for action='list' or action='remove'."
         ),
         every_seconds=IntegerSchema(0, description="Interval in seconds (for recurring tasks)"),
         cron_expr=StringSchema("Cron expression like '0 9 * * *' (for scheduled tasks)"),
@@ -35,8 +36,8 @@ from nanobot.cron.types import CronJob, CronJobState, CronSchedule
             description="Whether to deliver the execution result to the user channel (default true)",
             default=True,
         ),
-        job_id=StringSchema("Job ID (for remove)"),
-        required=["action", "message"],
+        job_id=StringSchema("REQUIRED when action='remove'. Job ID to remove (obtain via action='list')."),
+        required=["action"],
     )
 )
 class CronTool(Tool):

--- a/nanobot/agent/tools/file_state.py
+++ b/nanobot/agent/tools/file_state.py
@@ -80,11 +80,14 @@ def check_read(path: str | Path) -> str | None:
             entry.mtime = current_mtime
             return None
         return "Warning: file has been modified since last read. Re-read to verify content before editing."
+    # mtime unchanged - still check content hash to detect quick modifications
+    if entry.content_hash and _hash_file(p) != entry.content_hash:
+        return "Warning: file has been modified since last read. Re-read to verify content before editing."
     return None
 
 
 def is_unchanged(path: str | Path, offset: int = 1, limit: int | None = None) -> bool:
-    """Return True if file was previously read with same params and mtime is unchanged."""
+    """Return True if file was previously read with same params and content is unchanged."""
     p = str(Path(path).resolve())
     entry = _state.get(p)
     if entry is None:
@@ -97,7 +100,18 @@ def is_unchanged(path: str | Path, offset: int = 1, limit: int | None = None) ->
         current_mtime = os.path.getmtime(p)
     except OSError:
         return False
-    return current_mtime == entry.mtime
+    if current_mtime != entry.mtime:
+        # mtime changed - check if content also changed
+        current_hash = _hash_file(p)
+        if current_hash != entry.content_hash:
+            # Content actually changed - don't dedup
+            entry.can_dedup = False
+            return False
+        # Content identical despite mtime change (e.g. touch) - mark as not dedupable to force full read next time
+        entry.can_dedup = False
+        return True
+    # mtime unchanged - content must be identical
+    return True
 
 
 def clear() -> None:

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -2,6 +2,7 @@
 
 import difflib
 import mimetypes
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -178,7 +179,6 @@ class ReadFileTool(_FsTool):
 
             # Read dedup: same path + offset + limit + unchanged mtime → stub
             # Always check for external modifications before dedup
-            import os
             entry = file_state._state.get(str(fp.resolve()))
             try:
                 current_mtime = os.path.getmtime(fp)
@@ -218,6 +218,10 @@ class ReadFileTool(_FsTool):
                     return build_image_content_blocks(raw, mime, str(fp), f"(Image file: {path})")
                 return f"Error: Cannot read binary file {path} (MIME: {mime or 'unknown'}). Only UTF-8 text and images are supported."
 
+            # Normalize CRLF -> LF before line-splitting. Primarily a Windows
+            # concern (git checkouts with autocrlf, editors saving CRLF) but
+            # applied on all platforms so downstream StrReplace/Grep behavior
+            # is consistent regardless of where the file was written.
             text_content = text_content.replace("\r\n", "\n")
 
             all_lines = text_content.splitlines()

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -74,9 +74,22 @@ def _is_blocked_device(path: str | Path) -> bool:
     """Check if path is a blocked device that could hang or produce infinite output."""
     import re
     raw = str(path)
-    if raw in _BLOCKED_DEVICE_PATHS:
+
+    # Resolve symlinks to check the actual target
+    try:
+        resolved = str(Path(raw).resolve())
+    except (OSError, ValueError):
+        resolved = raw
+
+    if raw in _BLOCKED_DEVICE_PATHS or resolved in _BLOCKED_DEVICE_PATHS:
         return True
     if re.match(r"/proc/\d+/fd/[012]$", raw) or re.match(r"/proc/self/fd/[012]$", raw):
+        return True
+    if re.match(r"/proc/\d+/fd/[012]$", resolved) or re.match(r"/proc/self/fd/[012]$", resolved):
+        return True
+
+    # Check if resolved path starts with /dev/ (covers symlinks to devices)
+    if resolved.startswith("/dev/"):
         return True
     return False
 
@@ -164,13 +177,48 @@ class ReadFileTool(_FsTool):
                 return build_image_content_blocks(raw, mime, str(fp), f"(Image file: {path})")
 
             # Read dedup: same path + offset + limit + unchanged mtime → stub
-            if file_state.is_unchanged(fp, offset=offset, limit=limit):
-                return f"[File unchanged since last read: {path}]"
+            # Always check for external modifications before dedup
+            import os
+            entry = file_state._state.get(str(fp.resolve()))
+            try:
+                current_mtime = os.path.getmtime(fp)
+            except OSError:
+                current_mtime = 0.0
+            if entry and entry.can_dedup and entry.offset == offset and entry.limit == limit:
+                if current_mtime != entry.mtime:
+                    # File was modified externally - force full read and mark as not dedupable
+                    entry.can_dedup = False
+                    file_state.record_read(fp, offset=offset, limit=limit)  # Update state with new mtime
+                    # Continue to read full content (don't return dedup message)
+                else:
+                    # File unchanged - return dedup message
+                    # But only if content is actually unchanged (not just mtime)
+                    current_hash = file_state._hash_file(str(fp))
+                    if current_hash == entry.content_hash:
+                        return f"[File unchanged since last read: {path}]"
+                    else:
+                        # Content changed despite same mtime - force full read
+                        entry.can_dedup = False
+                        file_state.record_read(fp, offset=offset, limit=limit)
+            else:
+                # No previous state or marked as not dedupable - read full content
+                file_state.record_read(fp, offset=offset, limit=limit)
+                # Force full read by setting can_dedup to False for this read
+                if entry:
+                    entry.can_dedup = False
 
+            # Read the file content after dedup check
+            raw = fp.read_bytes()
             try:
                 text_content = raw.decode("utf-8")
             except UnicodeDecodeError:
+                # Binary file - return error message
+                mime = detect_image_mime(raw) or mimetypes.guess_type(path)[0]
+                if mime and mime.startswith("image/"):
+                    return build_image_content_blocks(raw, mime, str(fp), f"(Image file: {path})")
                 return f"Error: Cannot read binary file {path} (MIME: {mime or 'unknown'}). Only UTF-8 text and images are supported."
+
+            text_content = text_content.replace("\r\n", "\n")
 
             all_lines = text_content.splitlines()
             total = len(all_lines)

--- a/nanobot/agent/tools/self.py
+++ b/nanobot/agent/tools/self.py
@@ -67,6 +67,13 @@ class MyTool(Tool):
         "private_key", "access_token", "refresh_token", "auth",
     })
 
+    @classmethod
+    def _is_sensitive_field_name(cls, name: str) -> bool:
+        lowered = name.lower()
+        return lowered in cls._SENSITIVE_NAMES or any(
+            part in cls._SENSITIVE_NAMES for part in lowered.split("_")
+        )
+
     RESTRICTED: dict[str, dict[str, Any]] = {
         "max_iterations":        {"type": int, "min": 1,   "max": 100},
         "context_window_tokens": {"type": int, "min": 4096, "max": 1_000_000},
@@ -248,13 +255,16 @@ class MyTool(Tool):
             return f"{key}: {r}" if key else r
         # Complex object — small Pydantic models: show values; others: show field names for navigation
         cls_name = type(val).__name__
-        if hasattr(val, "model_fields"):
-            fields = list(val.model_fields.keys())
+        model_fields = getattr(type(val), "model_fields", None)
+        if model_fields:
+            fields = list(model_fields.keys())
             if len(fields) <= 8:
                 # Small config objects: show field=value pairs
                 pairs = []
                 for f in fields:
                     fv = getattr(val, f, "?")
+                    if MyTool._is_sensitive_field_name(f):
+                        continue
                     if isinstance(fv, (str, int, float, bool, type(None))):
                         pairs.append(f"{f}={fv!r}")
                     else:

--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -256,6 +256,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
 
         chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
         queue: asyncio.Queue[str | None] = asyncio.Queue()
+        stream_failed = False
 
         async def _on_stream(token: str) -> None:
             await queue.put(token)
@@ -264,6 +265,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
             await queue.put(None)
 
         async def _run() -> None:
+            nonlocal stream_failed
             try:
                 async with session_lock:
                     await asyncio.wait_for(
@@ -279,6 +281,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
                         timeout=timeout_s,
                     )
             except Exception:
+                stream_failed = True
                 logger.exception("Streaming error for session {}", session_key)
                 await queue.put(None)
 
@@ -292,8 +295,9 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
         finally:
             task.cancel()
 
-        await resp.write(_sse_chunk("", model_name, chunk_id, finish_reason="stop"))
-        await resp.write(_SSE_DONE)
+        if not stream_failed:
+            await resp.write(_sse_chunk("", model_name, chunk_id, finish_reason="stop"))
+            await resp.write(_SSE_DONE)
         return resp
 
     # -- non-streaming path (original logic) --

--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -118,6 +118,7 @@ class EmailChannel(BaseChannel):
             config = EmailConfig.model_validate(config)
         super().__init__(config, bus)
         self.config: EmailConfig = config
+        self._self_addresses = self._collect_self_addresses()
         self._last_subject_by_chat: dict[str, str] = {}
         self._last_message_id_by_chat: dict[str, str] = {}
         self._processed_uids: set[str] = set()  # Capped to prevent unbounded growth
@@ -379,6 +380,12 @@ class EmailChannel(BaseChannel):
                 sender = parseaddr(parsed.get("From", ""))[1].strip().lower()
                 if not sender:
                     continue
+                if self._is_self_address(sender):
+                    logger.info("Email from {} ignored: matches bot-owned address", sender)
+                    self._remember_processed_uid(uid, dedupe, cycle_uids)
+                    if mark_seen:
+                        client.store(imap_id, "+FLAGS", "\\Seen")
+                    continue
 
                 # --- Anti-spoofing: verify Authentication-Results ---
                 spf_pass, dkim_pass = self._check_authentication_results(parsed)
@@ -446,14 +453,7 @@ class EmailChannel(BaseChannel):
                     }
                 )
 
-                if uid:
-                    cycle_uids.add(uid)
-                if dedupe and uid:
-                    self._processed_uids.add(uid)
-                    # mark_seen is the primary dedup; this set is a safety net
-                    if len(self._processed_uids) > self._MAX_PROCESSED_UIDS:
-                        # Evict a random half to cap memory; mark_seen is the primary dedup
-                        self._processed_uids = set(list(self._processed_uids)[len(self._processed_uids) // 2:])
+                self._remember_processed_uid(uid, dedupe, cycle_uids)
 
                 if mark_seen:
                     client.store(imap_id, "+FLAGS", "\\Seen")
@@ -462,6 +462,50 @@ class EmailChannel(BaseChannel):
                 client.logout()
             except Exception:
                 pass
+
+    def _collect_self_addresses(self) -> set[str]:
+        """Return normalized email addresses owned by this channel instance."""
+        candidates = (
+            self.config.from_address,
+            self.config.smtp_username,
+            self.config.imap_username,
+        )
+        normalized = {
+            addr
+            for candidate in candidates
+            if (addr := self._normalize_address(candidate))
+        }
+        return normalized
+
+    @staticmethod
+    def _normalize_address(value: str) -> str:
+        """Normalize an address or mailbox-like identifier for comparisons."""
+        raw = (value or "").strip()
+        if not raw:
+            return ""
+        parsed = parseaddr(raw)[1].strip().lower()
+        if parsed:
+            return parsed
+        if "@" in raw:
+            return raw.lower()
+        return ""
+
+    def _is_self_address(self, sender: str) -> bool:
+        """Return True when an inbound sender belongs to the bot itself."""
+        normalized_sender = self._normalize_address(sender)
+        return bool(normalized_sender) and normalized_sender in self._self_addresses
+
+    def _remember_processed_uid(self, uid: str, dedupe: bool, cycle_uids: set[str]) -> None:
+        """Track a fetched UID so skipped messages are not reprocessed forever."""
+        if not uid:
+            return
+        cycle_uids.add(uid)
+        if dedupe:
+            self._processed_uids.add(uid)
+            # mark_seen is the primary dedup; this set is a safety net
+            if len(self._processed_uids) > self._MAX_PROCESSED_UIDS:
+                # Evict a random half to cap memory; mark_seen is the primary dedup
+                self._processed_uids = set(list(self._processed_uids)[len(self._processed_uids) // 2:])
 
     @classmethod
     def _is_stale_imap_error(cls, exc: Exception) -> bool:

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -189,6 +189,9 @@ class ChannelManager:
                     if not msg.metadata.get("_tool_hint") and not self.config.channels.send_progress:
                         continue
 
+                if msg.metadata.get("_retry_wait"):
+                    continue
+
                 # Coalesce consecutive _stream_delta messages for the same (channel, chat_id)
                 # to reduce API calls and improve streaming latency
                 if msg.metadata.get("_stream_delta") and not msg.metadata.get("_stream_end"):

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -7,6 +7,7 @@ import email.utils
 import hmac
 import http
 import json
+import re
 import secrets
 import ssl
 import time
@@ -19,7 +20,8 @@ from pydantic import Field, field_validator, model_validator
 from websockets.asyncio.server import ServerConnection, serve
 from websockets.datastructures import Headers
 from websockets.exceptions import ConnectionClosed
-from websockets.http11 import Request as WsRequest, Response
+from websockets.http11 import Request as WsRequest
+from websockets.http11 import Response
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -156,6 +158,37 @@ def _parse_inbound_payload(raw: str) -> str | None:
     return text
 
 
+# Accept UUIDs and short scoped keys like "unified:default". Keeps the capability
+# namespace small enough to rule out path traversal / quote injection tricks.
+_CHAT_ID_RE = re.compile(r"^[A-Za-z0-9_:-]{1,64}$")
+
+
+def _is_valid_chat_id(value: Any) -> bool:
+    return isinstance(value, str) and _CHAT_ID_RE.match(value) is not None
+
+
+def _parse_envelope(raw: str) -> dict[str, Any] | None:
+    """Return a typed envelope dict if the frame is a new-style JSON envelope, else None.
+
+    A frame qualifies when it parses as a JSON object with a string ``type`` field.
+    Legacy frames (plain text, or ``{"content": ...}`` without ``type``) return None;
+    callers should fall back to :func:`_parse_inbound_payload` for those.
+    """
+    text = raw.strip()
+    if not text.startswith("{"):
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    t = data.get("type")
+    if not isinstance(t, str):
+        return None
+    return data
+
+
 def _issue_route_secret_matches(headers: Any, configured_secret: str) -> bool:
     """Return True if the token-issue HTTP request carries credentials matching ``token_issue_secret``."""
     if not configured_secret:
@@ -181,10 +214,46 @@ class WebSocketChannel(BaseChannel):
             config = WebSocketConfig.model_validate(config)
         super().__init__(config, bus)
         self.config: WebSocketConfig = config
-        self._connections: dict[str, Any] = {}
+        # chat_id -> connections subscribed to it (fan-out target).
+        self._subs: dict[str, set[Any]] = {}
+        # connection -> chat_ids it is subscribed to (O(1) cleanup on disconnect).
+        self._conn_chats: dict[Any, set[str]] = {}
+        # connection -> default chat_id for legacy frames that omit routing.
+        self._conn_default: dict[Any, str] = {}
         self._issued_tokens: dict[str, float] = {}
         self._stop_event: asyncio.Event | None = None
         self._server_task: asyncio.Task[None] | None = None
+
+    # -- Subscription bookkeeping -------------------------------------------
+
+    def _attach(self, connection: Any, chat_id: str) -> None:
+        """Idempotently subscribe *connection* to *chat_id*."""
+        self._subs.setdefault(chat_id, set()).add(connection)
+        self._conn_chats.setdefault(connection, set()).add(chat_id)
+
+    def _cleanup_connection(self, connection: Any) -> None:
+        """Remove *connection* from every subscription set; safe to call multiple times."""
+        chat_ids = self._conn_chats.pop(connection, set())
+        for cid in chat_ids:
+            subs = self._subs.get(cid)
+            if subs is None:
+                continue
+            subs.discard(connection)
+            if not subs:
+                self._subs.pop(cid, None)
+        self._conn_default.pop(connection, None)
+
+    async def _send_event(self, connection: Any, event: str, **fields: Any) -> None:
+        """Send a control event (attached, error, ...) to a single connection."""
+        payload: dict[str, Any] = {"event": event}
+        payload.update(fields)
+        raw = json.dumps(payload, ensure_ascii=False)
+        try:
+            await connection.send(raw)
+        except ConnectionClosed:
+            self._cleanup_connection(connection)
+        except Exception as e:
+            logger.warning("websocket: failed to send {} event: {}", event, e)
 
     @classmethod
     def default_config(cls) -> dict[str, Any]:
@@ -353,21 +422,22 @@ class WebSocketChannel(BaseChannel):
             logger.warning("websocket: client_id too long ({} chars), truncating", len(client_id))
             client_id = client_id[:128]
 
-        chat_id = str(uuid.uuid4())
+        default_chat_id = str(uuid.uuid4())
 
         try:
             await connection.send(
                 json.dumps(
                     {
                         "event": "ready",
-                        "chat_id": chat_id,
+                        "chat_id": default_chat_id,
                         "client_id": client_id,
                     },
                     ensure_ascii=False,
                 )
             )
             # Register only after ready is successfully sent to avoid out-of-order sends
-            self._connections[chat_id] = connection
+            self._conn_default[connection] = default_chat_id
+            self._attach(connection, default_chat_id)
 
             async for raw in connection:
                 if isinstance(raw, bytes):
@@ -376,19 +446,66 @@ class WebSocketChannel(BaseChannel):
                     except UnicodeDecodeError:
                         logger.warning("websocket: ignoring non-utf8 binary frame")
                         continue
+
+                envelope = _parse_envelope(raw)
+                if envelope is not None:
+                    await self._dispatch_envelope(connection, client_id, envelope)
+                    continue
+
                 content = _parse_inbound_payload(raw)
                 if content is None:
                     continue
                 await self._handle_message(
                     sender_id=client_id,
-                    chat_id=chat_id,
+                    chat_id=default_chat_id,
                     content=content,
                     metadata={"remote": getattr(connection, "remote_address", None)},
                 )
         except Exception as e:
             logger.debug("websocket connection ended: {}", e)
         finally:
-            self._connections.pop(chat_id, None)
+            self._cleanup_connection(connection)
+
+    async def _dispatch_envelope(
+        self,
+        connection: Any,
+        client_id: str,
+        envelope: dict[str, Any],
+    ) -> None:
+        """Route one typed inbound envelope (``new_chat`` / ``attach`` / ``message``)."""
+        t = envelope.get("type")
+        if t == "new_chat":
+            new_id = str(uuid.uuid4())
+            self._attach(connection, new_id)
+            await self._send_event(connection, "attached", chat_id=new_id)
+            return
+        if t == "attach":
+            cid = envelope.get("chat_id")
+            if not _is_valid_chat_id(cid):
+                await self._send_event(connection, "error", detail="invalid chat_id")
+                return
+            self._attach(connection, cid)
+            await self._send_event(connection, "attached", chat_id=cid)
+            return
+        if t == "message":
+            cid = envelope.get("chat_id")
+            content = envelope.get("content")
+            if not _is_valid_chat_id(cid):
+                await self._send_event(connection, "error", detail="invalid chat_id")
+                return
+            if not isinstance(content, str) or not content.strip():
+                await self._send_event(connection, "error", detail="missing content")
+                return
+            # Auto-attach on first use so clients can one-shot without a separate attach.
+            self._attach(connection, cid)
+            await self._handle_message(
+                sender_id=client_id,
+                chat_id=cid,
+                content=content,
+                metadata={"remote": getattr(connection, "remote_address", None)},
+            )
+            return
+        await self._send_event(connection, "error", detail=f"unknown type: {t!r}")
 
     async def stop(self) -> None:
         if not self._running:
@@ -402,30 +519,31 @@ class WebSocketChannel(BaseChannel):
             except Exception as e:
                 logger.warning("websocket: server task error during shutdown: {}", e)
             self._server_task = None
-        self._connections.clear()
+        self._subs.clear()
+        self._conn_chats.clear()
+        self._conn_default.clear()
         self._issued_tokens.clear()
 
-    async def _safe_send(self, chat_id: str, raw: str, *, label: str = "") -> None:
-        """Send a raw frame, cleaning up dead connections on ConnectionClosed."""
-        connection = self._connections.get(chat_id)
-        if connection is None:
-            return
+    async def _safe_send_to(self, connection: Any, raw: str, *, label: str = "") -> None:
+        """Send a raw frame to one connection, cleaning up on ConnectionClosed."""
         try:
             await connection.send(raw)
         except ConnectionClosed:
-            self._connections.pop(chat_id, None)
-            logger.warning("websocket{}connection gone for chat_id={}", label, chat_id)
+            self._cleanup_connection(connection)
+            logger.warning("websocket{}connection gone", label)
         except Exception as e:
             logger.error("websocket{}send failed: {}", label, e)
             raise
 
     async def send(self, msg: OutboundMessage) -> None:
-        connection = self._connections.get(msg.chat_id)
-        if connection is None:
-            logger.warning("websocket: no active connection for chat_id={}", msg.chat_id)
+        # Snapshot the subscriber set so ConnectionClosed cleanups mid-iteration are safe.
+        conns = list(self._subs.get(msg.chat_id, ()))
+        if not conns:
+            logger.warning("websocket: no active subscribers for chat_id={}", msg.chat_id)
             return
         payload: dict[str, Any] = {
             "event": "message",
+            "chat_id": msg.chat_id,
             "text": msg.content,
         }
         if msg.media:
@@ -433,7 +551,8 @@ class WebSocketChannel(BaseChannel):
         if msg.reply_to:
             payload["reply_to"] = msg.reply_to
         raw = json.dumps(payload, ensure_ascii=False)
-        await self._safe_send(msg.chat_id, raw, label=" ")
+        for connection in conns:
+            await self._safe_send_to(connection, raw, label=" ")
 
     async def send_delta(
         self,
@@ -441,17 +560,20 @@ class WebSocketChannel(BaseChannel):
         delta: str,
         metadata: dict[str, Any] | None = None,
     ) -> None:
-        if self._connections.get(chat_id) is None:
+        conns = list(self._subs.get(chat_id, ()))
+        if not conns:
             return
         meta = metadata or {}
         if meta.get("_stream_end"):
-            body: dict[str, Any] = {"event": "stream_end"}
+            body: dict[str, Any] = {"event": "stream_end", "chat_id": chat_id}
         else:
             body = {
                 "event": "delta",
+                "chat_id": chat_id,
                 "text": delta,
             }
         if meta.get("_stream_id") is not None:
             body["stream_id"] = meta["_stream_id"]
         raw = json.dumps(body, ensure_ascii=False)
-        await self._safe_send(chat_id, raw, label=" stream ")
+        for connection in conns:
+            await self._safe_send_to(connection, raw, label=" stream ")

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -93,18 +93,12 @@ class HeartbeatService:
 
         response = await self.provider.chat_with_retry(
             messages=[
-                {
-                    "role": "system",
-                    "content": "You are a heartbeat agent. Call the heartbeat tool to report your decision.",
-                },
-                {
-                    "role": "user",
-                    "content": (
-                        f"Current Time: {current_time_str(self.timezone)}\n\n"
-                        "Review the following HEARTBEAT.md and decide whether there are active tasks.\n\n"
-                        f"{content}"
-                    ),
-                },
+                {"role": "system", "content": "You are a heartbeat agent. Call the heartbeat tool to report your decision."},
+                {"role": "user", "content": (
+                    f"Current Time: {current_time_str(self.timezone)}\n\n"
+                    "Review the following HEARTBEAT.md and decide whether there are active tasks.\n\n"
+                    f"{content}"
+                )},
             ],
             tools=_HEARTBEAT_TOOL,
             model=self.model,
@@ -113,7 +107,7 @@ class HeartbeatService:
         if not response.should_execute_tools:
             if response.has_tool_calls:
                 logger.warning(
-                    "Ignoring tool calls under finish_reason='%s' in heartbeat",
+                    "Ignoring heartbeat tool calls under finish_reason='{}'",
                     response.finish_reason,
                 )
             return "skip", ""
@@ -177,10 +171,7 @@ class HeartbeatService:
 
                 if response:
                     should_notify = await evaluate_response(
-                        response,
-                        tasks,
-                        self.provider,
-                        self.model,
+                        response, tasks, self.provider, self.model,
                     )
                     if should_notify and self.on_notify:
                         logger.info("Heartbeat: completed, delivering response")

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -93,18 +93,29 @@ class HeartbeatService:
 
         response = await self.provider.chat_with_retry(
             messages=[
-                {"role": "system", "content": "You are a heartbeat agent. Call the heartbeat tool to report your decision."},
-                {"role": "user", "content": (
-                    f"Current Time: {current_time_str(self.timezone)}\n\n"
-                    "Review the following HEARTBEAT.md and decide whether there are active tasks.\n\n"
-                    f"{content}"
-                )},
+                {
+                    "role": "system",
+                    "content": "You are a heartbeat agent. Call the heartbeat tool to report your decision.",
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        f"Current Time: {current_time_str(self.timezone)}\n\n"
+                        "Review the following HEARTBEAT.md and decide whether there are active tasks.\n\n"
+                        f"{content}"
+                    ),
+                },
             ],
             tools=_HEARTBEAT_TOOL,
             model=self.model,
         )
 
-        if not response.has_tool_calls:
+        if not response.should_execute_tools:
+            if response.has_tool_calls:
+                logger.warning(
+                    "Ignoring tool calls under finish_reason='%s' in heartbeat",
+                    response.finish_reason,
+                )
             return "skip", ""
 
         args = response.tool_calls[0].arguments
@@ -166,7 +177,10 @@ class HeartbeatService:
 
                 if response:
                     should_notify = await evaluate_response(
-                        response, tasks, self.provider, self.model,
+                        response,
+                        tasks,
+                        self.provider,
+                        self.model,
                     )
                     if should_notify and self.on_notify:
                         logger.info("Heartbeat: completed, delivering response")

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -77,6 +77,9 @@ class GenerationSettings:
     reasoning_effort: str | None = None
 
 
+_SYNTHETIC_USER_CONTENT = "(conversation continued)"
+
+
 class LLMProvider(ABC):
     """Base class for LLM providers."""
 
@@ -417,7 +420,7 @@ class LLMProvider(ABC):
         for i, msg in enumerate(merged):
             if msg.get("role") != "system":
                 if msg.get("role") == "assistant" and not msg.get("tool_calls"):
-                    merged.insert(i, {"role": "user", "content": "(conversation continued)"})
+                    merged.insert(i, {"role": "user", "content": _SYNTHETIC_USER_CONTENT})
                 break
 
         return merged

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -75,17 +75,18 @@ class LLMResponse:
     def should_execute_tools(self) -> bool:
         """Check if tool calls should be executed (guards against gateway injection).
 
-        Only execute when finish_reason explicitly signals tool intent.
-        Tool calls under any other finish_reason (refusal, content_filter, error, etc.)
-        are treated as anomalous and should not be executed.
+        Executes only when ``has_tool_calls`` is true and ``finish_reason`` is one of
+        the known-good signals: ``"tool_calls"`` (explicit intent) or ``"stop"`` (some
+        compliant providers emit ``stop`` for legitimate tool calls; existing paths in
+        ``openai_compat_provider`` already treat both as the tool-call terminal state).
+
+        Tool calls under any other ``finish_reason`` (e.g. ``refusal``, ``content_filter``,
+        ``error``) are treated as anomalous — typically injected by non-compliant API
+        gateways — and are skipped.
         """
         if not self.has_tool_calls:
             return False
-        if self.finish_reason == "tool_calls":
-            return True
-        if self.finish_reason == "stop":
-            return True
-        return False
+        return self.finish_reason in ("tool_calls", "stop")
 
 
 @dataclass(frozen=True)

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -18,7 +18,6 @@ from nanobot.utils.helpers import image_placeholder_text
 @dataclass
 class ToolCallRequest:
     """A tool call request from the LLM."""
-
     id: str
     name: str
     arguments: dict[str, Any]
@@ -41,16 +40,13 @@ class ToolCallRequest:
         if self.provider_specific_fields:
             tool_call["provider_specific_fields"] = self.provider_specific_fields
         if self.function_provider_specific_fields:
-            tool_call["function"]["provider_specific_fields"] = (
-                self.function_provider_specific_fields
-            )
+            tool_call["function"]["provider_specific_fields"] = self.function_provider_specific_fields
         return tool_call
 
 
 @dataclass
 class LLMResponse:
     """Response from an LLM provider."""
-
     content: str | None
     tool_calls: list[ToolCallRequest] = field(default_factory=list)
     finish_reason: str = "stop"
@@ -73,7 +69,8 @@ class LLMResponse:
 
     @property
     def should_execute_tools(self) -> bool:
-        """True only if tool_calls present AND finish_reason is a known-good signal (``tool_calls`` or ``stop``); blocks gateway-injected calls under ``refusal`` / ``content_filter`` / ``error``."""
+        """Tools execute only when has_tool_calls AND finish_reason is ``tool_calls`` / ``stop``.
+        Blocks gateway-injected calls under ``refusal`` / ``content_filter`` / ``error`` (#3220)."""
         if not self.has_tool_calls:
             return False
         return self.finish_reason in ("tool_calls", "stop")
@@ -114,28 +111,24 @@ class LLMProvider(ABC):
     )
     _RETRYABLE_STATUS_CODES = frozenset({408, 409, 429})
     _TRANSIENT_ERROR_KINDS = frozenset({"timeout", "connection"})
-    _NON_RETRYABLE_429_ERROR_TOKENS = frozenset(
-        {
-            "insufficient_quota",
-            "quota_exceeded",
-            "quota_exhausted",
-            "billing_hard_limit_reached",
-            "insufficient_balance",
-            "credit_balance_too_low",
-            "billing_not_active",
-            "payment_required",
-        }
-    )
-    _RETRYABLE_429_ERROR_TOKENS = frozenset(
-        {
-            "rate_limit_exceeded",
-            "rate_limit_error",
-            "too_many_requests",
-            "request_limit_exceeded",
-            "requests_limit_exceeded",
-            "overloaded_error",
-        }
-    )
+    _NON_RETRYABLE_429_ERROR_TOKENS = frozenset({
+        "insufficient_quota",
+        "quota_exceeded",
+        "quota_exhausted",
+        "billing_hard_limit_reached",
+        "insufficient_balance",
+        "credit_balance_too_low",
+        "billing_not_active",
+        "payment_required",
+    })
+    _RETRYABLE_429_ERROR_TOKENS = frozenset({
+        "rate_limit_exceeded",
+        "rate_limit_error",
+        "too_many_requests",
+        "request_limit_exceeded",
+        "requests_limit_exceeded",
+        "overloaded_error",
+    })
     _NON_RETRYABLE_429_TEXT_MARKERS = (
         "insufficient_quota",
         "insufficient quota",
@@ -179,11 +172,7 @@ class LLMProvider(ABC):
 
             if isinstance(content, str) and not content:
                 clean = dict(msg)
-                clean["content"] = (
-                    None
-                    if (msg.get("role") == "assistant" and msg.get("tool_calls"))
-                    else "(empty)"
-                )
+                clean["content"] = None if (msg.get("role") == "assistant" and msg.get("tool_calls")) else "(empty)"
                 result.append(clean)
                 continue
 
@@ -357,7 +346,10 @@ class LLMProvider(ABC):
     def _is_retryable_429_response(cls, response: LLMResponse) -> bool:
         type_token = cls._normalize_error_token(response.error_type)
         code_token = cls._normalize_error_token(response.error_code)
-        semantic_tokens = {token for token in (type_token, code_token) if token is not None}
+        semantic_tokens = {
+            token for token in (type_token, code_token)
+            if token is not None
+        }
         if any(token in cls._NON_RETRYABLE_429_ERROR_TOKENS for token in semantic_tokens):
             return False
 
@@ -511,13 +503,9 @@ class LLMProvider(ABC):
         streaming should override this method.
         """
         response = await self.chat(
-            messages=messages,
-            tools=tools,
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            reasoning_effort=reasoning_effort,
-            tool_choice=tool_choice,
+            messages=messages, tools=tools, model=model,
+            max_tokens=max_tokens, temperature=temperature,
+            reasoning_effort=reasoning_effort, tool_choice=tool_choice,
         )
         if on_content_delta and response.content:
             await on_content_delta(response.content)
@@ -554,13 +542,9 @@ class LLMProvider(ABC):
             reasoning_effort = self.generation.reasoning_effort
 
         kw: dict[str, Any] = dict(
-            messages=messages,
-            tools=tools,
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            reasoning_effort=reasoning_effort,
-            tool_choice=tool_choice,
+            messages=messages, tools=tools, model=model,
+            max_tokens=max_tokens, temperature=temperature,
+            reasoning_effort=reasoning_effort, tool_choice=tool_choice,
             on_content_delta=on_content_delta,
         )
         return await self._run_with_retry(
@@ -600,13 +584,9 @@ class LLMProvider(ABC):
             reasoning_effort = self.generation.reasoning_effort
 
         kw: dict[str, Any] = dict(
-            messages=messages,
-            tools=tools,
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            reasoning_effort=reasoning_effort,
-            tool_choice=tool_choice,
+            messages=messages, tools=tools, model=model,
+            max_tokens=max_tokens, temperature=temperature,
+            reasoning_effort=reasoning_effort, tool_choice=tool_choice,
         )
         return await self._run_with_retry(
             self._safe_chat,
@@ -734,7 +714,7 @@ class LLMProvider(ABC):
             if response.finish_reason != "error":
                 return response
             last_response = response
-            error_key = (response.content or "").strip().lower() or None
+            error_key = ((response.content or "").strip().lower() or None)
             if error_key and error_key == last_error_key:
                 identical_error_count += 1
             else:
@@ -776,7 +756,9 @@ class LLMProvider(ABC):
                     (response.content or "")[:120].lower(),
                 )
                 if on_retry_wait:
-                    await on_retry_wait(f"Model request failed after {attempt} retries, giving up.")
+                    await on_retry_wait(
+                        f"Model request failed after {attempt} retries, giving up."
+                    )
                 break
 
             base_delay = delays[min(attempt - 1, len(delays) - 1)]

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -18,6 +18,7 @@ from nanobot.utils.helpers import image_placeholder_text
 @dataclass
 class ToolCallRequest:
     """A tool call request from the LLM."""
+
     id: str
     name: str
     arguments: dict[str, Any]
@@ -40,13 +41,16 @@ class ToolCallRequest:
         if self.provider_specific_fields:
             tool_call["provider_specific_fields"] = self.provider_specific_fields
         if self.function_provider_specific_fields:
-            tool_call["function"]["provider_specific_fields"] = self.function_provider_specific_fields
+            tool_call["function"]["provider_specific_fields"] = (
+                self.function_provider_specific_fields
+            )
         return tool_call
 
 
 @dataclass
 class LLMResponse:
     """Response from an LLM provider."""
+
     content: str | None
     tool_calls: list[ToolCallRequest] = field(default_factory=list)
     finish_reason: str = "stop"
@@ -66,6 +70,18 @@ class LLMResponse:
     def has_tool_calls(self) -> bool:
         """Check if response contains tool calls."""
         return len(self.tool_calls) > 0
+
+    @property
+    def should_execute_tools(self) -> bool:
+        """Check if tool calls should be executed (guards against gateway injection).
+
+        Only execute when finish_reason explicitly signals tool intent.
+        Tool calls under any other finish_reason (refusal, content_filter, error, etc.)
+        are treated as anomalous and should not be executed.
+        """
+        if not self.has_tool_calls:
+            return False
+        return self.finish_reason == "tool_calls"
 
 
 @dataclass(frozen=True)
@@ -103,24 +119,28 @@ class LLMProvider(ABC):
     )
     _RETRYABLE_STATUS_CODES = frozenset({408, 409, 429})
     _TRANSIENT_ERROR_KINDS = frozenset({"timeout", "connection"})
-    _NON_RETRYABLE_429_ERROR_TOKENS = frozenset({
-        "insufficient_quota",
-        "quota_exceeded",
-        "quota_exhausted",
-        "billing_hard_limit_reached",
-        "insufficient_balance",
-        "credit_balance_too_low",
-        "billing_not_active",
-        "payment_required",
-    })
-    _RETRYABLE_429_ERROR_TOKENS = frozenset({
-        "rate_limit_exceeded",
-        "rate_limit_error",
-        "too_many_requests",
-        "request_limit_exceeded",
-        "requests_limit_exceeded",
-        "overloaded_error",
-    })
+    _NON_RETRYABLE_429_ERROR_TOKENS = frozenset(
+        {
+            "insufficient_quota",
+            "quota_exceeded",
+            "quota_exhausted",
+            "billing_hard_limit_reached",
+            "insufficient_balance",
+            "credit_balance_too_low",
+            "billing_not_active",
+            "payment_required",
+        }
+    )
+    _RETRYABLE_429_ERROR_TOKENS = frozenset(
+        {
+            "rate_limit_exceeded",
+            "rate_limit_error",
+            "too_many_requests",
+            "request_limit_exceeded",
+            "requests_limit_exceeded",
+            "overloaded_error",
+        }
+    )
     _NON_RETRYABLE_429_TEXT_MARKERS = (
         "insufficient_quota",
         "insufficient quota",
@@ -164,7 +184,11 @@ class LLMProvider(ABC):
 
             if isinstance(content, str) and not content:
                 clean = dict(msg)
-                clean["content"] = None if (msg.get("role") == "assistant" and msg.get("tool_calls")) else "(empty)"
+                clean["content"] = (
+                    None
+                    if (msg.get("role") == "assistant" and msg.get("tool_calls"))
+                    else "(empty)"
+                )
                 result.append(clean)
                 continue
 
@@ -338,10 +362,7 @@ class LLMProvider(ABC):
     def _is_retryable_429_response(cls, response: LLMResponse) -> bool:
         type_token = cls._normalize_error_token(response.error_type)
         code_token = cls._normalize_error_token(response.error_code)
-        semantic_tokens = {
-            token for token in (type_token, code_token)
-            if token is not None
-        }
+        semantic_tokens = {token for token in (type_token, code_token) if token is not None}
         if any(token in cls._NON_RETRYABLE_429_ERROR_TOKENS for token in semantic_tokens):
             return False
 
@@ -495,9 +516,13 @@ class LLMProvider(ABC):
         streaming should override this method.
         """
         response = await self.chat(
-            messages=messages, tools=tools, model=model,
-            max_tokens=max_tokens, temperature=temperature,
-            reasoning_effort=reasoning_effort, tool_choice=tool_choice,
+            messages=messages,
+            tools=tools,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
+            tool_choice=tool_choice,
         )
         if on_content_delta and response.content:
             await on_content_delta(response.content)
@@ -534,9 +559,13 @@ class LLMProvider(ABC):
             reasoning_effort = self.generation.reasoning_effort
 
         kw: dict[str, Any] = dict(
-            messages=messages, tools=tools, model=model,
-            max_tokens=max_tokens, temperature=temperature,
-            reasoning_effort=reasoning_effort, tool_choice=tool_choice,
+            messages=messages,
+            tools=tools,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
+            tool_choice=tool_choice,
             on_content_delta=on_content_delta,
         )
         return await self._run_with_retry(
@@ -576,9 +605,13 @@ class LLMProvider(ABC):
             reasoning_effort = self.generation.reasoning_effort
 
         kw: dict[str, Any] = dict(
-            messages=messages, tools=tools, model=model,
-            max_tokens=max_tokens, temperature=temperature,
-            reasoning_effort=reasoning_effort, tool_choice=tool_choice,
+            messages=messages,
+            tools=tools,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
+            tool_choice=tool_choice,
         )
         return await self._run_with_retry(
             self._safe_chat,
@@ -706,7 +739,7 @@ class LLMProvider(ABC):
             if response.finish_reason != "error":
                 return response
             last_response = response
-            error_key = ((response.content or "").strip().lower() or None)
+            error_key = (response.content or "").strip().lower() or None
             if error_key and error_key == last_error_key:
                 identical_error_count += 1
             else:
@@ -748,9 +781,7 @@ class LLMProvider(ABC):
                     (response.content or "")[:120].lower(),
                 )
                 if on_retry_wait:
-                    await on_retry_wait(
-                        f"Model request failed after {attempt} retries, giving up."
-                    )
+                    await on_retry_wait(f"Model request failed after {attempt} retries, giving up.")
                 break
 
             base_delay = delays[min(attempt - 1, len(delays) - 1)]

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -73,17 +73,7 @@ class LLMResponse:
 
     @property
     def should_execute_tools(self) -> bool:
-        """Check if tool calls should be executed (guards against gateway injection).
-
-        Executes only when ``has_tool_calls`` is true and ``finish_reason`` is one of
-        the known-good signals: ``"tool_calls"`` (explicit intent) or ``"stop"`` (some
-        compliant providers emit ``stop`` for legitimate tool calls; existing paths in
-        ``openai_compat_provider`` already treat both as the tool-call terminal state).
-
-        Tool calls under any other ``finish_reason`` (e.g. ``refusal``, ``content_filter``,
-        ``error``) are treated as anomalous — typically injected by non-compliant API
-        gateways — and are skipped.
-        """
+        """True only if tool_calls present AND finish_reason is a known-good signal (``tool_calls`` or ``stop``); blocks gateway-injected calls under ``refusal`` / ``content_filter`` / ``error``."""
         if not self.has_tool_calls:
             return False
         return self.finish_reason in ("tool_calls", "stop")

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -409,6 +409,17 @@ class LLMProvider(ABC):
             recovered["role"] = "user"
             merged.append(recovered)
 
+        # Safety net: ensure the first non-system message is not a bare
+        # ``assistant`` message.  Providers like GLM reject system→assistant
+        # with error 1214.  This can happen when upstream truncation (e.g.
+        # _snip_history) drops the only user message.  Insert a synthetic
+        # user message to keep the sequence valid.
+        for i, msg in enumerate(merged):
+            if msg.get("role") != "system":
+                if msg.get("role") == "assistant" and not msg.get("tool_calls"):
+                    merged.insert(i, {"role": "user", "content": "(conversation continued)"})
+                break
+
         return merged
 
     @staticmethod

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -81,7 +81,11 @@ class LLMResponse:
         """
         if not self.has_tool_calls:
             return False
-        return self.finish_reason == "tool_calls"
+        if self.finish_reason == "tool_calls":
+            return True
+        if self.finish_reason == "stop":
+            return True
+        return False
 
 
 @dataclass(frozen=True)

--- a/nanobot/templates/SOUL.md
+++ b/nanobot/templates/SOUL.md
@@ -2,8 +2,19 @@
 
 I am nanobot 🐈, a personal AI assistant.
 
-I solve problems by doing, not by describing what I would do.
-I keep responses short unless depth is asked for.
-I say what I know, flag what I don't, and never fake confidence.
-I stay friendly and curious — I'd rather ask a good question than guess wrong.
-I treat the user's time as the scarcest resource, and their trust as the most valuable.
+## Core Principles
+
+- Solve by doing, not by describing what I would do.
+- Keep responses short unless depth is asked for.
+- Say what I know, flag what I don't, and never fake confidence.
+- Stay friendly and curious — I'd rather ask a good question than guess wrong.
+- Treat the user's time as the scarcest resource, and their trust as the most valuable.
+
+## Execution Rules
+
+- Act immediately on single-step tasks — never end a turn with just a plan or promise.
+- For multi-step tasks, outline the plan first and wait for user confirmation before executing.
+- Read before you write — do not assume a file exists or contains what you expect.
+- If a tool call fails, diagnose the error and retry with a different approach before reporting failure.
+- When information is missing, look it up with tools first. Only ask the user when tools cannot answer.
+- After multi-step changes, verify the result (re-read the file, run the test, check the output).

--- a/nanobot/templates/agent/identity.md
+++ b/nanobot/templates/agent/identity.md
@@ -1,7 +1,3 @@
-# nanobot 🐈
-
-You are nanobot, a helpful AI assistant.
-
 ## Runtime
 {{ runtime }}
 
@@ -26,15 +22,7 @@ This conversation is via email. Structure with clear sections. Markdown may not 
 Output is rendered in a terminal. Avoid markdown headings and tables. Use plain text with minimal formatting.
 {% endif %}
 
-## Execution Rules
-
-- Act, don't narrate. If you can do it with a tool, do it now — never end a turn with just a plan or promise.
-- Read before you write. Do not assume a file exists or contains what you expect.
-- If a tool call fails, diagnose the error and retry with a different approach before reporting failure.
-- When information is missing, look it up with tools first. Only ask the user when tools cannot answer.
-- After multi-step changes, verify the result (re-read the file, run the test, check the output).
-
-## Search & Discovery
+## Tools
 
 - Prefer built-in `grep` / `glob` over `exec` for workspace search.
 - On broad searches, use `grep(output_mode="count")` to scope before requesting full content.

--- a/nanobot/templates/agent/identity.md
+++ b/nanobot/templates/agent/identity.md
@@ -22,7 +22,7 @@ This conversation is via email. Structure with clear sections. Markdown may not 
 Output is rendered in a terminal. Avoid markdown headings and tables. Use plain text with minimal formatting.
 {% endif %}
 
-## Tools
+## Search & Discovery
 
 - Prefer built-in `grep` / `glob` over `exec` for workspace search.
 - On broad searches, use `grep(output_mode="count")` to scope before requesting full content.

--- a/nanobot/utils/document.py
+++ b/nanobot/utils/document.py
@@ -159,14 +159,38 @@ def _extract_pptx(path: Path) -> str:
         for i, slide in enumerate(prs.slides, 1):
             slide_text: list[str] = []
             for shape in slide.shapes:
-                if hasattr(shape, "text") and shape.text:
-                    slide_text.append(shape.text)
+                _collect_pptx_shape_text(shape, slide_text)
             if slide_text:
                 slides.append(f"--- Slide {i} ---\n" + "\n".join(slide_text))
         return _truncate("\n\n".join(slides), _MAX_TEXT_LENGTH)
     except Exception as e:
         logger.error("Failed to extract PPTX {}: {}", path, e)
         return f"[error: failed to extract PPTX: {e!s}]"
+
+
+def _collect_pptx_shape_text(shape, out: list[str]) -> None:
+    """Collect text from a PPTX shape, recursing into groups and tables.
+
+    Groups have ``has_text_frame=False`` and must be walked via ``.shapes``;
+    tables are GraphicFrame objects whose cell text lives under ``.table``.
+    """
+    sub_shapes = getattr(shape, "shapes", None)
+    if sub_shapes is not None:
+        for sub in sub_shapes:
+            _collect_pptx_shape_text(sub, out)
+        return
+
+    if getattr(shape, "has_table", False):
+        for row in shape.table.rows:
+            cells = [cell.text.strip() for cell in row.cells]
+            line = "\t".join(cell for cell in cells if cell)
+            if line:
+                out.append(line)
+        return
+
+    text = getattr(shape, "text", "")
+    if text:
+        out.append(text)
 
 
 def _extract_text_file(path: Path) -> str:

--- a/nanobot/utils/evaluator.py
+++ b/nanobot/utils/evaluator.py
@@ -39,7 +39,6 @@ _EVALUATE_TOOL = [
     }
 ]
 
-
 async def evaluate_response(
     response: str,
     task_context: str,
@@ -56,15 +55,12 @@ async def evaluate_response(
         llm_response = await provider.chat_with_retry(
             messages=[
                 {"role": "system", "content": render_template("agent/evaluator.md", part="system")},
-                {
-                    "role": "user",
-                    "content": render_template(
-                        "agent/evaluator.md",
-                        part="user",
-                        task_context=task_context,
-                        response=response,
-                    ),
-                },
+                {"role": "user", "content": render_template(
+                    "agent/evaluator.md",
+                    part="user",
+                    task_context=task_context,
+                    response=response,
+                )},
             ],
             tools=_EVALUATE_TOOL,
             model=model,
@@ -75,7 +71,7 @@ async def evaluate_response(
         if not llm_response.should_execute_tools:
             if llm_response.has_tool_calls:
                 logger.warning(
-                    "evaluate_response: ignoring tool calls under finish_reason='%s', defaulting to notify",
+                    "evaluate_response: ignoring tool calls under finish_reason='{}', defaulting to notify",
                     llm_response.finish_reason,
                 )
             else:

--- a/nanobot/utils/evaluator.py
+++ b/nanobot/utils/evaluator.py
@@ -39,6 +39,7 @@ _EVALUATE_TOOL = [
     }
 ]
 
+
 async def evaluate_response(
     response: str,
     task_context: str,
@@ -55,12 +56,15 @@ async def evaluate_response(
         llm_response = await provider.chat_with_retry(
             messages=[
                 {"role": "system", "content": render_template("agent/evaluator.md", part="system")},
-                {"role": "user", "content": render_template(
-                    "agent/evaluator.md",
-                    part="user",
-                    task_context=task_context,
-                    response=response,
-                )},
+                {
+                    "role": "user",
+                    "content": render_template(
+                        "agent/evaluator.md",
+                        part="user",
+                        task_context=task_context,
+                        response=response,
+                    ),
+                },
             ],
             tools=_EVALUATE_TOOL,
             model=model,
@@ -68,8 +72,14 @@ async def evaluate_response(
             temperature=0.0,
         )
 
-        if not llm_response.has_tool_calls:
-            logger.warning("evaluate_response: no tool call returned, defaulting to notify")
+        if not llm_response.should_execute_tools:
+            if llm_response.has_tool_calls:
+                logger.warning(
+                    "evaluate_response: ignoring tool calls under finish_reason='%s', defaulting to notify",
+                    llm_response.finish_reason,
+                )
+            else:
+                logger.warning("evaluate_response: no tool call returned, defaulting to notify")
             return True
 
         args = llm_response.tool_calls[0].arguments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "slack-sdk>=3.39.0,<4.0.0",
     "slackify-markdown>=0.2.0,<1.0.0",
     "qq-botpy>=1.2.0,<2.0.0",
-    "python-socks[asyncio]>=2.8.0,<3.0.0",
+    "python-socks[asyncio]>=2.8.0,<3.0.0; sys_platform != 'win32'",
     "prompt-toolkit>=3.0.50,<4.0.0",
     "questionary>=2.0.0,<3.0.0",
     "mcp>=1.26.0,<2.0.0",
@@ -75,7 +75,7 @@ msteams = [
 ]
 
 matrix = [
-    "matrix-nio[e2e]>=0.25.2",
+    "matrix-nio[e2e]>=0.25.2; sys_platform != 'win32'",
     "mistune>=3.0.0,<4.0.0",
     "nh3>=0.2.17,<1.0.0",
 ]

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -65,6 +65,46 @@ class TestConsolidatorSummarize:
         assert result is None
 
 
+class TestConsolidatorArchiveErrorHandling:
+    """archive() must fall back to raw_archive when the LLM returns an error
+    response (finish_reason == 'error'), e.g. overloaded / quota exceeded.
+    See https://github.com/HKUDS/nanobot/issues/3244
+    """
+
+    async def test_archive_falls_back_on_error_finish_reason(self, consolidator, mock_provider, store):
+        """LLM returning finish_reason='error' should trigger raw_archive, not write error text."""
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Error: {'type': 'error', 'error': {'type': 'overloaded_error', 'message': 'overloaded_error (529)'}}",
+            finish_reason="error",
+        )
+        messages = [
+            {"role": "user", "content": "fix the auth bug"},
+            {"role": "assistant", "content": "Done, fixed the race condition."},
+        ]
+        result = await consolidator.archive(messages)
+        assert result is None
+        entries = store.read_unprocessed_history(since_cursor=0)
+        assert len(entries) == 1
+        assert "[RAW]" in entries[0]["content"]
+        assert "Error:" not in entries[0]["content"]
+
+    async def test_archive_preserves_summary_on_success(self, consolidator, mock_provider, store):
+        """Normal LLM response should still produce a proper summary entry."""
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="User fixed a bug in the auth module.",
+            finish_reason="stop",
+        )
+        messages = [
+            {"role": "user", "content": "fix the auth bug"},
+            {"role": "assistant", "content": "Done."},
+        ]
+        result = await consolidator.archive(messages)
+        assert result == "User fixed a bug in the auth module."
+        entries = store.read_unprocessed_history(since_cursor=0)
+        assert len(entries) == 1
+        assert "[RAW]" not in entries[0]["content"]
+
+
 class TestConsolidatorTokenBudget:
     async def test_prompt_below_threshold_does_not_consolidate(self, consolidator):
         """No consolidation when tokens are within budget."""

--- a/tests/agent/test_context_prompt_cache.py
+++ b/tests/agent/test_context_prompt_cache.py
@@ -149,14 +149,37 @@ def test_partial_dream_processing_shows_only_remainder(tmp_path) -> None:
 
 
 def test_execution_rules_in_system_prompt(tmp_path) -> None:
-    """New execution rules should appear in the system prompt."""
+    """Execution rules should appear in the system prompt via default SOUL.md."""
+    from nanobot.utils.helpers import sync_workspace_templates
+
     workspace = _make_workspace(tmp_path)
+    sync_workspace_templates(workspace, silent=True)
     builder = ContextBuilder(workspace)
 
     prompt = builder.build_system_prompt()
-    assert "Act, don't narrate" in prompt
+    assert "single-step tasks" in prompt
+    assert "multi-step tasks" in prompt
     assert "Read before you write" in prompt
     assert "verify the result" in prompt
+
+
+def test_identity_has_no_behavioral_instructions(tmp_path) -> None:
+    """Identity template should not contain behavioral rules or hardcoded name."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    identity = builder._get_identity(channel=None)
+    assert "You are nanobot" not in identity
+    assert "Act, don't narrate" not in identity
+    assert "Execution Rules" not in identity
+
+
+def test_default_soul_template_contains_execution_rules() -> None:
+    """Default SOUL.md template must contain execution rules with act/plan layering."""
+    soul = (pkg_files("nanobot") / "templates" / "SOUL.md").read_text(encoding="utf-8")
+    assert "## Execution Rules" in soul
+    assert "single-step tasks" in soul
+    assert "multi-step tasks" in soul
 
 
 def test_channel_format_hint_telegram(tmp_path) -> None:

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -561,3 +561,18 @@ def test_subagent_followup_dedupes_by_task_id() -> None:
     assert loop._persist_subagent_followup(session, msg) is True
     assert loop._persist_subagent_followup(session, msg) is False
     assert len(session.messages) == 1
+
+
+def test_subagent_followup_skips_empty_content() -> None:
+    loop = _mk_loop()
+    session = Session(key="cli:empty")
+    msg = InboundMessage(
+        channel="system",
+        sender_id="subagent",
+        chat_id="cli:empty",
+        content="",
+        metadata={"subagent_task_id": "sub-empty"},
+    )
+
+    assert loop._persist_subagent_followup(session, msg) is False
+    assert session.messages == []

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -417,3 +417,147 @@ async def test_stop_preserves_runtime_checkpoint_for_next_turn(tmp_path: Path) -
     ]
     assert AgentLoop._PENDING_USER_TURN_KEY not in session.metadata
     assert AgentLoop._RUNTIME_CHECKPOINT_KEY not in session.metadata
+
+
+@pytest.mark.asyncio
+async def test_system_subagent_followup_is_persisted_before_prompt_assembly(tmp_path: Path) -> None:
+    loop = _make_full_loop(tmp_path)
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    session = loop.sessions.get_or_create("cli:test")
+    session.add_message("user", "question")
+    session.add_message("assistant", "working")
+    loop.sessions.save(session)
+
+    seen: dict[str, list[dict]] = {}
+
+    async def fake_run_agent_loop(initial_messages, **_kwargs):
+        seen["initial_messages"] = initial_messages
+        return (
+            "done",
+            [],
+            [*initial_messages, {"role": "assistant", "content": "done"}],
+            "stop",
+            False,
+        )
+
+    loop._run_agent_loop = fake_run_agent_loop  # type: ignore[method-assign]
+
+    await loop._process_message(
+        InboundMessage(
+            channel="system",
+            sender_id="subagent",
+            chat_id="cli:test",
+            content="subagent result",
+            metadata={"subagent_task_id": "sub-1"},
+        )
+    )
+
+    non_system = [m for m in seen["initial_messages"] if m.get("role") != "system"]
+    assert [m["content"] for m in non_system[:2]] == ["question", "working"]
+    assert non_system[2]["content"].count("subagent result") == 1
+    assert "Current Time:" in non_system[2]["content"]
+
+    loop.sessions.invalidate("cli:test")
+    persisted = loop.sessions.get_or_create("cli:test")
+    assert [
+        {k: v for k, v in m.items() if k in {"role", "content", "injected_event", "subagent_task_id"}}
+        for m in persisted.messages
+    ] == [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "working"},
+        {
+            "role": "assistant",
+            "content": "subagent result",
+            "injected_event": "subagent_result",
+            "subagent_task_id": "sub-1",
+        },
+        {"role": "assistant", "content": "done"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multiple_subagent_followups_all_persist_as_standalone_history(tmp_path: Path) -> None:
+    loop = _make_full_loop(tmp_path)
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    async def fake_run_agent_loop(initial_messages, **_kwargs):
+        return (
+            "ack",
+            [],
+            [*initial_messages, {"role": "assistant", "content": "ack"}],
+            "stop",
+            False,
+        )
+
+    loop._run_agent_loop = fake_run_agent_loop  # type: ignore[method-assign]
+
+    for idx in range(3):
+        await loop._process_message(
+            InboundMessage(
+                channel="system",
+                sender_id="subagent",
+                chat_id="cli:multi",
+                content=f"subagent result {idx}",
+                metadata={"subagent_task_id": f"sub-{idx}"},
+            )
+        )
+
+    loop.sessions.invalidate("cli:multi")
+    persisted = loop.sessions.get_or_create("cli:multi")
+    followups = [m for m in persisted.messages if m.get("injected_event") == "subagent_result"]
+    assert [m["content"] for m in followups] == [
+        "subagent result 0",
+        "subagent result 1",
+        "subagent result 2",
+    ]
+
+
+def test_prompt_merge_does_not_replace_standalone_subagent_history_entry(tmp_path: Path) -> None:
+    loop = _mk_loop()
+    session = Session(key="cli:merge")
+    session.add_message("assistant", "previous assistant")
+
+    inserted = loop._persist_subagent_followup(
+        session,
+        InboundMessage(
+            channel="system",
+            sender_id="subagent",
+            chat_id="cli:merge",
+            content="subagent result",
+            metadata={"subagent_task_id": "sub-1"},
+        ),
+    )
+
+    assert inserted is True
+
+    builder = ContextBuilder(tmp_path)
+    projected = builder.build_messages(
+        history=session.get_history(max_messages=0),
+        current_message="",
+        current_role="assistant",
+        channel="cli",
+        chat_id="merge",
+    )
+
+    non_system = [m for m in projected if m.get("role") != "system"]
+    assert len(non_system) == 2
+    assert "subagent result" in non_system[-1]["content"]
+    assert session.messages[-1]["content"] == "subagent result"
+    assert session.messages[-1]["injected_event"] == "subagent_result"
+
+
+def test_subagent_followup_dedupes_by_task_id() -> None:
+    loop = _mk_loop()
+    session = Session(key="cli:dedupe")
+    msg = InboundMessage(
+        channel="system",
+        sender_id="subagent",
+        chat_id="cli:dedupe",
+        content="subagent result",
+        metadata={"subagent_task_id": "sub-1"},
+    )
+
+    assert loop._persist_subagent_followup(session, msg) is True
+    assert loop._persist_subagent_followup(session, msg) is False
+    assert len(session.messages) == 1

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -2909,3 +2909,12 @@ def test_snip_history_no_user_at_all_falls_back_gracefully(monkeypatch):
     assert isinstance(trimmed, list)
     # Must have at least system.
     assert any(m.get("role") == "system" for m in trimmed)
+    # The _enforce_role_alternation safety net must be able to fix whatever
+    # _snip_history returns here — verify it produces a valid sequence.
+    from nanobot.providers.base import LLMProvider
+    fixed = LLMProvider._enforce_role_alternation(trimmed)
+    non_system = [m for m in fixed if m["role"] != "system"]
+    if non_system:
+        assert non_system[0]["role"] in ("user", "tool"), (
+            f"Safety net should ensure first non-system is user/tool, got {non_system[0]['role']}"
+        )

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -2918,3 +2918,45 @@ def test_snip_history_no_user_at_all_falls_back_gracefully(monkeypatch):
         assert non_system[0]["role"] in ("user", "tool"), (
             f"Safety net should ensure first non-system is user/tool, got {non_system[0]['role']}"
         )
+
+
+@pytest.mark.asyncio
+async def test_runner_binds_on_retry_wait_to_retry_callback_not_progress():
+    """Regression: provider retry heartbeats must route through
+    ``retry_wait_callback``, not ``progress_callback``. Binding them to
+    the progress callback (as an earlier runtime refactor did) caused
+    internal retry diagnostics like "Model request failed, retry in 1s"
+    to leak to end-user channels as normal progress updates.
+    """
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    captured: dict = {}
+
+    async def chat_with_retry(**kwargs):
+        captured.update(kwargs)
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider = MagicMock()
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    progress_cb = AsyncMock()
+    retry_wait_cb = AsyncMock()
+
+    runner = AgentRunner(provider)
+    await runner.run(AgentRunSpec(
+        initial_messages=[
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "hi"},
+        ],
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        progress_callback=progress_cb,
+        retry_wait_callback=retry_wait_cb,
+    ))
+
+    assert captured["on_retry_wait"] is retry_wait_cb
+    assert captured["on_retry_wait"] is not progress_cb

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -643,10 +643,11 @@ def test_snip_history_drops_orphaned_tool_results_from_trimmed_slice(monkeypatch
 
     trimmed = runner._snip_history(spec, messages)
 
-    assert trimmed == [
-        {"role": "system", "content": "system"},
-        {"role": "assistant", "content": "after tool"},
-    ]
+    # After the fix, the user message is recovered so the sequence is valid
+    # for providers that require system → user (e.g. GLM error 1214).
+    assert trimmed[0]["role"] == "system"
+    non_system = [m for m in trimmed if m["role"] != "system"]
+    assert non_system[0]["role"] == "user", f"Expected user after system, got {non_system[0]['role']}"
 
 
 @pytest.mark.asyncio
@@ -2787,4 +2788,124 @@ async def test_injection_cycle_cap_on_error_path():
     assert result.had_injections is True
     # Should cap: _MAX_INJECTION_CYCLES drained rounds + 1 final round that breaks
     assert call_count["n"] == _MAX_INJECTION_CYCLES + 1
-    assert drain_count["n"] == _MAX_INJECTION_CYCLES
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for GLM-1214: _snip_history must preserve a user message
+# ---------------------------------------------------------------------------
+
+
+def test_snip_history_preserves_user_message_after_truncation(monkeypatch):
+    """When _snip_history truncates messages and the only user message ends up
+    outside the kept window, the method must recover the nearest user message
+    so the resulting sequence is valid for providers like GLM (which reject
+    system→assistant with error 1214).
+
+    This reproduces the exact scenario from the bug report:
+    - Normal interaction: user asks, assistant calls tool, tool returns,
+      assistant replies.
+    - Injection adds a phantom user message, triggering more tool calls.
+    - _snip_history activates, keeping only recent assistant/tool pairs.
+    - The injected user message is in the truncated prefix and gets lost.
+    """
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    runner = AgentRunner(provider)
+
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "assistant", "content": "previous reply"},
+        {"role": "user", "content": ".nanobot的同目录"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "tc_1", "type": "function", "function": {"name": "exec", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "tc_1", "content": "tool output 1"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "tc_2", "type": "function", "function": {"name": "exec", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "tc_2", "content": "tool output 2"},
+    ]
+
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=2000,
+        context_block_limit=100,
+    )
+
+    # Make estimate_prompt_tokens_chain report above budget so _snip_history activates.
+    monkeypatch.setattr("nanobot.agent.runner.estimate_prompt_tokens_chain", lambda *_a, **_kw: (500, None))
+    # Make kept window small: only the last 2 messages fit the budget.
+    token_sizes = {
+        "system": 0,
+        "previous reply": 200,
+        ".nanobot的同目录": 80,
+        "tool output 1": 80,
+        "tool output 2": 80,
+    }
+    monkeypatch.setattr(
+        "nanobot.agent.runner.estimate_message_tokens",
+        lambda msg: token_sizes.get(str(msg.get("content")), 100),
+    )
+
+    trimmed = runner._snip_history(spec, messages)
+
+    # The first non-system message MUST be user (not assistant).
+    non_system = [m for m in trimmed if m.get("role") != "system"]
+    assert non_system, "trimmed should contain at least one non-system message"
+    assert non_system[0]["role"] == "user", (
+        f"First non-system message must be 'user', got '{non_system[0]['role']}'. "
+        f"Roles: {[m['role'] for m in trimmed]}"
+    )
+
+
+def test_snip_history_no_user_at_all_falls_back_gracefully(monkeypatch):
+    """Edge case: if non_system has zero user messages, _snip_history should
+    still return a valid sequence (not crash or produce system→assistant)."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    runner = AgentRunner(provider)
+
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "assistant", "content": "reply"},
+        {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+        {"role": "assistant", "content": "reply 2"},
+        {"role": "tool", "tool_call_id": "tc_2", "content": "result 2"},
+    ]
+
+    spec = AgentRunSpec(
+        initial_messages=messages,
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        context_window_tokens=2000,
+        context_block_limit=100,
+    )
+
+    monkeypatch.setattr("nanobot.agent.runner.estimate_prompt_tokens_chain", lambda *_a, **_kw: (500, None))
+    monkeypatch.setattr(
+        "nanobot.agent.runner.estimate_message_tokens",
+        lambda msg: 100,
+    )
+
+    trimmed = runner._snip_history(spec, messages)
+
+    # Should not crash.  The result should still be a valid list.
+    assert isinstance(trimmed, list)
+    # Must have at least system.
+    assert any(m.get("role") == "system" for m in trimmed)

--- a/tests/agent/tools/test_self_tool.py
+++ b/tests/agent/tools/test_self_tool.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import BaseModel
 
 from nanobot.agent.tools.self import MyTool
 
@@ -167,6 +168,25 @@ class TestInspectPathNavigation:
         tool = _make_tool()
         result = await tool.execute(action="check", key="tools")
         assert "not accessible" in result
+
+    @pytest.mark.asyncio
+    async def test_inspect_nested_config_redacts_sensitive_scalar_fields(self):
+        class SearchConfig(BaseModel):
+            provider: str = "tavily"
+            api_key: str = "sk-test-secret"
+            base_url: str = ""
+            max_results: int = 5
+
+        loop = _make_mock_loop()
+        loop.web_config = MagicMock()
+        loop.web_config.search = SearchConfig()
+        tool = _make_tool(loop)
+
+        result = await tool.execute(action="check", key="web_config.search")
+
+        assert "provider='tavily'" in result
+        assert "sk-test-secret" not in result
+        assert "api_key" not in result.lower()
 
 
 

--- a/tests/agent/tools/test_subagent_tools.py
+++ b/tests/agent/tools/test_subagent_tools.py
@@ -1,0 +1,53 @@
+"""Tests for subagent tool registration and wiring."""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.config.schema import AgentDefaults
+
+_MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
+
+
+@pytest.mark.asyncio
+async def test_subagent_exec_tool_receives_allowed_env_keys(tmp_path):
+    """allowed_env_keys from ExecToolConfig must be forwarded to the subagent's ExecTool."""
+    from nanobot.agent.subagent import SubagentManager, SubagentStatus
+    from nanobot.bus.queue import MessageBus
+    from nanobot.config.schema import ExecToolConfig
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    mgr = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=bus,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        exec_config=ExecToolConfig(allowed_env_keys=["GOPATH", "JAVA_HOME"]),
+    )
+    mgr._announce_result = AsyncMock()
+
+    async def fake_run(spec):
+        exec_tool = spec.tools.get("exec")
+        assert exec_tool is not None
+        assert exec_tool.allowed_env_keys == ["GOPATH", "JAVA_HOME"]
+        return SimpleNamespace(
+            stop_reason="done",
+            final_content="done",
+            error=None,
+            tool_events=[],
+        )
+
+    mgr.runner.run = AsyncMock(side_effect=fake_run)
+
+    status = SubagentStatus(
+        task_id="sub-1", label="label", task_description="do task", started_at=time.monotonic()
+    )
+    await mgr._run_subagent(
+        "sub-1", "do task", "label", {"channel": "test", "chat_id": "c1"}, status
+    )
+
+    mgr.runner.run.assert_awaited_once()

--- a/tests/channels/test_channel_manager_delta_coalescing.py
+++ b/tests/channels/test_channel_manager_delta_coalescing.py
@@ -296,3 +296,50 @@ class TestDispatchOutboundWithCoalescing:
         # Should have pending regular message
         assert len(pending) == 1
         assert pending[0].content == "Final"
+
+
+class TestRetryWaitFiltering:
+    """Internal provider retry heartbeats must never reach channels."""
+
+    @pytest.mark.asyncio
+    async def test_retry_wait_message_dropped(self, manager, bus):
+        """A ``_retry_wait`` message must be filtered before channel dispatch.
+
+        Regression: provider retry diagnostics like
+        ``Model request failed, retry in 1s (attempt 1).`` were being
+        delivered to end-user channels because the runner bound
+        ``on_retry_wait`` to the progress callback.
+        """
+        retry_msg = OutboundMessage(
+            channel="mock",
+            chat_id="chat1",
+            content="Model request failed, retry in 1s (attempt 1).",
+            metadata={"_retry_wait": True},
+        )
+        real_msg = OutboundMessage(
+            channel="mock",
+            chat_id="chat1",
+            content="final answer",
+            metadata={},
+        )
+        await bus.publish_outbound(retry_msg)
+        await bus.publish_outbound(real_msg)
+
+        task = asyncio.create_task(manager._dispatch_outbound())
+        try:
+            for _ in range(30):
+                if manager.channels["mock"]._send_mock.await_count >= 1:
+                    break
+                await asyncio.sleep(0.05)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        send_mock = manager.channels["mock"]._send_mock
+        assert send_mock.await_count == 1
+        sent = send_mock.await_args_list[0].args[0]
+        assert sent.content == "final answer"
+        assert not sent.metadata.get("_retry_wait")

--- a/tests/channels/test_email_channel.py
+++ b/tests/channels/test_email_channel.py
@@ -92,6 +92,46 @@ def test_fetch_new_messages_parses_unseen_and_marks_seen(monkeypatch) -> None:
     assert items_again == []
 
 
+def test_fetch_new_messages_skips_self_sent_email_and_marks_seen(monkeypatch) -> None:
+    raw = _make_raw_email(from_addr="Nanobot <bot@example.com>", subject="Loop test")
+
+    class FakeIMAP:
+        def __init__(self) -> None:
+            self.store_calls: list[tuple[bytes, str, str]] = []
+
+        def login(self, _user: str, _pw: str):
+            return "OK", [b"logged in"]
+
+        def select(self, _mailbox: str):
+            return "OK", [b"1"]
+
+        def search(self, *_args):
+            return "OK", [b"1"]
+
+        def fetch(self, _imap_id: bytes, _parts: str):
+            return "OK", [(b"1 (UID 123 BODY[] {200})", raw), b")"]
+
+        def store(self, imap_id: bytes, op: str, flags: str):
+            self.store_calls.append((imap_id, op, flags))
+            return "OK", [b""]
+
+        def logout(self):
+            return "BYE", [b""]
+
+    fake = FakeIMAP()
+    monkeypatch.setattr("nanobot.channels.email.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    channel = EmailChannel(_make_config(from_address="bot@example.com"), MessageBus())
+    items = channel._fetch_new_messages()
+
+    assert items == []
+    assert fake.store_calls == [(b"1", "+FLAGS", "\\Seen")]
+
+    # Same UID should still be deduped after being ignored.
+    items_again = channel._fetch_new_messages()
+    assert items_again == []
+
+
 def test_fetch_new_messages_retries_once_when_imap_connection_goes_stale(monkeypatch) -> None:
     raw = _make_raw_email(subject="Invoice", body="Please pay")
     fail_once = {"pending": True}

--- a/tests/channels/test_email_channel.py
+++ b/tests/channels/test_email_channel.py
@@ -132,6 +132,69 @@ def test_fetch_new_messages_skips_self_sent_email_and_marks_seen(monkeypatch) ->
     assert items_again == []
 
 
+@pytest.mark.parametrize(
+    "config_override,from_header",
+    [
+        # Only smtp_username matches — simulates an SMTP relay where
+        # outbound From gets rewritten to the SMTP login identity.
+        (
+            {"from_address": "", "smtp_username": "bot@example.com", "imap_username": "other@imap.com"},
+            "bot@example.com",
+        ),
+        # Only imap_username matches — simulates mailbox-based identity
+        # with no explicit from_address set.
+        (
+            {"from_address": "", "smtp_username": "other@smtp.com", "imap_username": "bot@example.com"},
+            "bot@example.com",
+        ),
+        # Case-insensitive: inbound From arrives upper-cased.
+        (
+            {"from_address": "bot@example.com", "smtp_username": "other@smtp.com", "imap_username": "other@imap.com"},
+            "BOT@EXAMPLE.COM",
+        ),
+    ],
+    ids=["smtp_username_only", "imap_username_only", "case_insensitive"],
+)
+def test_fetch_new_messages_skips_self_sent_across_identity_sources(
+    monkeypatch, config_override, from_header
+) -> None:
+    """Self-address detection must fire when any of from_address / smtp_username /
+    imap_username matches, and must be case-insensitive."""
+    raw = _make_raw_email(from_addr=from_header, subject="Loop test")
+
+    class FakeIMAP:
+        def __init__(self) -> None:
+            self.store_calls: list[tuple[bytes, str, str]] = []
+
+        def login(self, _user: str, _pw: str):
+            return "OK", [b"logged in"]
+
+        def select(self, _mailbox: str):
+            return "OK", [b"1"]
+
+        def search(self, *_args):
+            return "OK", [b"1"]
+
+        def fetch(self, _imap_id: bytes, _parts: str):
+            return "OK", [(b"1 (UID 123 BODY[] {200})", raw), b")"]
+
+        def store(self, imap_id: bytes, op: str, flags: str):
+            self.store_calls.append((imap_id, op, flags))
+            return "OK", [b""]
+
+        def logout(self):
+            return "BYE", [b""]
+
+    fake = FakeIMAP()
+    monkeypatch.setattr("nanobot.channels.email.imaplib.IMAP4_SSL", lambda _h, _p: fake)
+
+    channel = EmailChannel(_make_config(**config_override), MessageBus())
+    items = channel._fetch_new_messages()
+
+    assert items == []
+    assert fake.store_calls == [(b"1", "+FLAGS", "\\Seen")]
+
+
 def test_fetch_new_messages_retries_once_when_imap_connection_goes_stale(monkeypatch) -> None:
     raw = _make_raw_email(subject="Invoice", body="Please pay")
     fail_once = {"pending": True}

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -17,9 +17,11 @@ from nanobot.bus.events import OutboundMessage
 from nanobot.channels.websocket import (
     WebSocketChannel,
     WebSocketConfig,
+    _is_valid_chat_id,
     _issue_route_secret_matches,
     _normalize_config_path,
     _normalize_http_path,
+    _parse_envelope,
     _parse_inbound_payload,
     _parse_query,
     _parse_request_path,
@@ -168,7 +170,7 @@ async def test_send_delivers_json_message_with_media_and_reply() -> None:
     bus = MagicMock()
     channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"]}, bus)
     mock_ws = AsyncMock()
-    channel._connections["chat-1"] = mock_ws
+    channel._attach(mock_ws, "chat-1")
 
     msg = OutboundMessage(
         channel="websocket",
@@ -182,6 +184,7 @@ async def test_send_delivers_json_message_with_media_and_reply() -> None:
     mock_ws.send.assert_awaited_once()
     payload = json.loads(mock_ws.send.call_args[0][0])
     assert payload["event"] == "message"
+    assert payload["chat_id"] == "chat-1"
     assert payload["text"] == "hello"
     assert payload["reply_to"] == "m1"
     assert payload["media"] == ["/tmp/a.png"]
@@ -201,12 +204,13 @@ async def test_send_removes_connection_on_connection_closed() -> None:
     channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"]}, bus)
     mock_ws = AsyncMock()
     mock_ws.send.side_effect = ConnectionClosed(Close(1006, ""), Close(1006, ""), True)
-    channel._connections["chat-1"] = mock_ws
+    channel._attach(mock_ws, "chat-1")
 
     msg = OutboundMessage(channel="websocket", chat_id="chat-1", content="hello")
     await channel.send(msg)
 
-    assert "chat-1" not in channel._connections
+    assert "chat-1" not in channel._subs
+    assert mock_ws not in channel._conn_chats
 
 
 @pytest.mark.asyncio
@@ -215,11 +219,12 @@ async def test_send_delta_removes_connection_on_connection_closed() -> None:
     channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"], "streaming": True}, bus)
     mock_ws = AsyncMock()
     mock_ws.send.side_effect = ConnectionClosed(Close(1006, ""), Close(1006, ""), True)
-    channel._connections["chat-1"] = mock_ws
+    channel._attach(mock_ws, "chat-1")
 
     await channel.send_delta("chat-1", "chunk", {"_stream_delta": True, "_stream_id": "s1"})
 
-    assert "chat-1" not in channel._connections
+    assert "chat-1" not in channel._subs
+    assert mock_ws not in channel._conn_chats
 
 
 @pytest.mark.asyncio
@@ -227,7 +232,7 @@ async def test_send_delta_emits_delta_and_stream_end() -> None:
     bus = MagicMock()
     channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"], "streaming": True}, bus)
     mock_ws = AsyncMock()
-    channel._connections["chat-1"] = mock_ws
+    channel._attach(mock_ws, "chat-1")
 
     await channel.send_delta("chat-1", "part", {"_stream_delta": True, "_stream_id": "sid"})
     await channel.send_delta("chat-1", "", {"_stream_end": True, "_stream_id": "sid"})
@@ -236,9 +241,11 @@ async def test_send_delta_emits_delta_and_stream_end() -> None:
     first = json.loads(mock_ws.send.call_args_list[0][0][0])
     second = json.loads(mock_ws.send.call_args_list[1][0][0])
     assert first["event"] == "delta"
+    assert first["chat_id"] == "chat-1"
     assert first["text"] == "part"
     assert first["stream_id"] == "sid"
     assert second["event"] == "stream_end"
+    assert second["chat_id"] == "chat-1"
     assert second["stream_id"] == "sid"
 
 
@@ -248,7 +255,7 @@ async def test_send_non_connection_closed_exception_is_raised() -> None:
     channel = WebSocketChannel({"enabled": True, "allowFrom": ["*"]}, bus)
     mock_ws = AsyncMock()
     mock_ws.send.side_effect = RuntimeError("unexpected")
-    channel._connections["chat-1"] = mock_ws
+    channel._attach(mock_ws, "chat-1")
 
     msg = OutboundMessage(channel="websocket", chat_id="chat-1", content="hello")
     with pytest.raises(RuntimeError, match="unexpected"):
@@ -596,3 +603,223 @@ async def test_websocket_requires_token_without_issue_path(bus: MagicMock) -> No
     finally:
         await channel.stop()
         await server_task
+
+
+# -- Multi-chat multiplexing -------------------------------------------------
+#
+# The multiplex protocol lets one WS connection route N logical chats over
+# typed envelopes (`new_chat` / `attach` / `message`). Legacy frames must keep
+# working on the connection's default chat_id.
+
+
+@pytest.mark.asyncio
+async def test_multiplex_legacy_still_works(bus: MagicMock) -> None:
+    port = 29930
+    channel = _ch(bus, port=port)
+    server_task = asyncio.create_task(channel.start())
+    await asyncio.sleep(0.3)
+
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}/ws?client_id=legacy") as client:
+            ready = json.loads(await client.recv())
+            default_chat = ready["chat_id"]
+
+            # Plain text frame routes to default chat_id
+            await client.send("hello from legacy")
+            await asyncio.sleep(0.1)
+            inbound = bus.publish_inbound.call_args[0][0]
+            assert inbound.chat_id == default_chat
+            assert inbound.content == "hello from legacy"
+
+            # {"content": ...} frame routes to default chat_id
+            await client.send(json.dumps({"content": "structured legacy"}))
+            await asyncio.sleep(0.1)
+            assert bus.publish_inbound.call_args[0][0].chat_id == default_chat
+            assert bus.publish_inbound.call_args[0][0].content == "structured legacy"
+
+            # Outbound still reaches the legacy client, with chat_id annotated
+            await channel.send(
+                OutboundMessage(channel="websocket", chat_id=default_chat, content="reply")
+            )
+            reply = json.loads(await client.recv())
+            assert reply["event"] == "message"
+            assert reply["chat_id"] == default_chat
+            assert reply["text"] == "reply"
+    finally:
+        await channel.stop()
+        await server_task
+
+
+@pytest.mark.asyncio
+async def test_multiplex_new_chat_roundtrip(bus: MagicMock) -> None:
+    port = 29931
+    channel = _ch(bus, port=port)
+    server_task = asyncio.create_task(channel.start())
+    await asyncio.sleep(0.3)
+
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}/ws?client_id=mp") as client:
+            ready = json.loads(await client.recv())
+            default_chat = ready["chat_id"]
+
+            await client.send(json.dumps({"type": "new_chat"}))
+            attached = json.loads(await client.recv())
+            assert attached["event"] == "attached"
+            new_chat = attached["chat_id"]
+            assert new_chat and new_chat != default_chat
+
+            # Send on the new chat via typed envelope
+            await client.send(
+                json.dumps({"type": "message", "chat_id": new_chat, "content": "hi on new"})
+            )
+            await asyncio.sleep(0.1)
+            inbound = bus.publish_inbound.call_args[0][0]
+            assert inbound.chat_id == new_chat
+            assert inbound.content == "hi on new"
+
+            # Server pushes a message back; chat_id must match
+            await channel.send(
+                OutboundMessage(channel="websocket", chat_id=new_chat, content="ok")
+            )
+            reply = json.loads(await client.recv())
+            assert reply["event"] == "message"
+            assert reply["chat_id"] == new_chat
+            assert reply["text"] == "ok"
+    finally:
+        await channel.stop()
+        await server_task
+
+
+@pytest.mark.asyncio
+async def test_multiplex_two_chats_isolated(bus: MagicMock) -> None:
+    port = 29932
+    channel = _ch(bus, port=port)
+    server_task = asyncio.create_task(channel.start())
+    await asyncio.sleep(0.3)
+
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}/ws?client_id=two") as client:
+            await client.recv()  # ready
+
+            await client.send(json.dumps({"type": "new_chat"}))
+            chat_a = json.loads(await client.recv())["chat_id"]
+            await client.send(json.dumps({"type": "new_chat"}))
+            chat_b = json.loads(await client.recv())["chat_id"]
+            assert chat_a != chat_b
+
+            # Push A → client sees A only (FIFO over the single WS).
+            await channel.send(
+                OutboundMessage(channel="websocket", chat_id=chat_a, content="for-A")
+            )
+            msg_a = json.loads(await client.recv())
+            assert msg_a["chat_id"] == chat_a
+            assert msg_a["text"] == "for-A"
+
+            # Push B → client sees B only.
+            await channel.send(
+                OutboundMessage(channel="websocket", chat_id=chat_b, content="for-B")
+            )
+            msg_b = json.loads(await client.recv())
+            assert msg_b["chat_id"] == chat_b
+            assert msg_b["text"] == "for-B"
+    finally:
+        await channel.stop()
+        await server_task
+
+
+@pytest.mark.asyncio
+async def test_multiplex_invalid_frames_return_error(bus: MagicMock) -> None:
+    port = 29933
+    channel = _ch(bus, port=port)
+    server_task = asyncio.create_task(channel.start())
+    await asyncio.sleep(0.3)
+
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}/ws?client_id=bad") as client:
+            await client.recv()  # ready
+
+            # attach with bad chat_id
+            await client.send(json.dumps({"type": "attach", "chat_id": "has space"}))
+            err1 = json.loads(await client.recv())
+            assert err1["event"] == "error"
+
+            # message with missing content
+            await client.send(json.dumps({"type": "message", "chat_id": "abc", "content": ""}))
+            err2 = json.loads(await client.recv())
+            assert err2["event"] == "error"
+
+            # unknown type
+            await client.send(json.dumps({"type": "nope"}))
+            err3 = json.loads(await client.recv())
+            assert err3["event"] == "error"
+
+            # Connection survives: legacy frame still works.
+            await client.send("still-alive")
+            await asyncio.sleep(0.1)
+            bus.publish_inbound.assert_awaited()
+            assert bus.publish_inbound.call_args[0][0].content == "still-alive"
+    finally:
+        await channel.stop()
+        await server_task
+
+
+@pytest.mark.asyncio
+async def test_multiplex_cleanup_on_disconnect(bus: MagicMock) -> None:
+    port = 29934
+    channel = _ch(bus, port=port)
+    server_task = asyncio.create_task(channel.start())
+    await asyncio.sleep(0.3)
+
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}/ws?client_id=dc") as client:
+            ready = json.loads(await client.recv())
+            default_chat = ready["chat_id"]
+            await client.send(json.dumps({"type": "new_chat"}))
+            extra_chat = json.loads(await client.recv())["chat_id"]
+            assert default_chat in channel._subs
+            assert extra_chat in channel._subs
+        # Client gone. Server-side tracking must be empty.
+        await asyncio.sleep(0.2)
+        assert default_chat not in channel._subs
+        assert extra_chat not in channel._subs
+        assert not channel._conn_chats
+        assert not channel._conn_default
+    finally:
+        await channel.stop()
+        await server_task
+
+
+def test_parse_envelope_detects_typed_frames() -> None:
+    assert _parse_envelope('{"type":"new_chat"}') == {"type": "new_chat"}
+    env = _parse_envelope('{"type":"message","chat_id":"abc","content":"hi"}')
+    assert env == {"type": "message", "chat_id": "abc", "content": "hi"}
+
+
+def test_parse_envelope_rejects_legacy_and_garbage() -> None:
+    # No `type` field → legacy, caller falls back to _parse_inbound_payload.
+    assert _parse_envelope('{"content":"hi"}') is None
+    assert _parse_envelope("plain text") is None
+    assert _parse_envelope("{broken") is None
+    assert _parse_envelope("[1,2,3]") is None
+    # Non-string `type` is not a valid envelope.
+    assert _parse_envelope('{"type":123}') is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("abc", True),
+        ("a1b2_c:d-e", True),
+        ("x" * 64, True),
+        ("unified:default", True),
+        ("", False),
+        ("x" * 65, False),
+        ("has space", False),
+        ("a/b", False),
+        ("a.b", False),
+        (None, False),
+        (123, False),
+    ],
+)
+def test_is_valid_chat_id(value: Any, expected: bool) -> None:
+    assert _is_valid_chat_id(value) is expected

--- a/tests/channels/test_websocket_integration.py
+++ b/tests/channels/test_websocket_integration.py
@@ -290,10 +290,11 @@ async def test_disconnected_client_cleanup(bus: MagicMock) -> None:
         async with WsTestClient("ws://127.0.0.1:29914/", client_id="tmp") as c:
             chat_id = (await c.recv_ready()).chat_id
         # disconnected
+        await asyncio.sleep(0.1)
         await ch.send(OutboundMessage(
             channel="websocket", chat_id=chat_id, content="orphan",
         ))
-        assert chat_id not in ch._connections
+        assert chat_id not in ch._subs
     finally:
         await ch.stop(); await t
 

--- a/tests/cron/test_cron_tool_schema_contract.py
+++ b/tests/cron/test_cron_tool_schema_contract.py
@@ -1,0 +1,99 @@
+"""Regression tests for the cron tool's JSON-schema / runtime contract (#3113).
+
+The schema advertised ``required=["action"]`` while ``_add_job`` rejected empty
+``message``; LLMs rationally omitted ``message`` and looped on the runtime
+error. The fix keeps ``required=["action"]`` (so ``list``/``remove`` stay
+callable) but states the per-action requirement in each field's description
+and tightens the runtime error for ``add`` without ``message``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.agent.tools.cron import CronTool
+from nanobot.agent.tools.registry import ToolRegistry
+
+
+class _SvcStub:
+    """Minimal CronService stand-in; we only exercise schema/dispatch paths."""
+
+    def list_jobs(self):
+        return []
+
+    def get_job(self, _job_id):
+        return None
+
+    def remove_job(self, _job_id):
+        return "not-found"
+
+    def add_job(self, **kwargs):
+        class _J:
+            pass
+
+        j = _J()
+        j.id = "id1"
+        j.name = kwargs.get("name", "x")
+        return j
+
+
+@pytest.fixture
+def registry() -> ToolRegistry:
+    tool = CronTool(_SvcStub(), default_timezone="UTC")
+    tool.set_context("channel", "chat-id")
+    reg = ToolRegistry()
+    reg.register(tool)
+    return reg
+
+
+class TestSchemaContract:
+    def test_list_accepted_without_message(self, registry: ToolRegistry) -> None:
+        # action='list' must pass schema validation with nothing but 'action'.
+        _, _, err = registry.prepare_call("cron", {"action": "list"})
+        assert err is None
+
+    def test_remove_accepted_without_message(self, registry: ToolRegistry) -> None:
+        # action='remove' must pass schema validation with just 'action' + 'job_id'.
+        _, _, err = registry.prepare_call("cron", {"action": "remove", "job_id": "abc"})
+        assert err is None
+
+    def test_add_with_message_accepted(self, registry: ToolRegistry) -> None:
+        _, _, err = registry.prepare_call(
+            "cron", {"action": "add", "message": "ping", "at": "2030-01-01T00:00:00"}
+        )
+        assert err is None
+
+    def test_add_without_message_surfaces_actionable_runtime_error(
+        self, registry: ToolRegistry
+    ) -> None:
+        # Schema permits omitting message; the runtime must return a message
+        # that tells the LLM exactly what's missing and how to retry, so it
+        # doesn't loop like #3113 reports.
+        import asyncio
+
+        tool = registry._tools["cron"]  # type: ignore[attr-defined]
+        out = asyncio.run(tool.execute(action="add", at="2030-01-01T00:00:00"))
+        assert "message" in out
+        assert "add" in out
+        assert "Retry" in out or "retry" in out
+
+
+class TestSchemaSelfDescribesRequirements:
+    def test_message_description_flags_add_requirement(self) -> None:
+        # LLMs rely on field descriptions to infer when something is actually
+        # needed. Without this hint, #3113's loop returns.
+        tool = CronTool(_SvcStub())
+        desc = tool.parameters["properties"]["message"]["description"]
+        assert "REQUIRED" in desc and "action='add'" in desc
+
+    def test_job_id_description_flags_remove_requirement(self) -> None:
+        tool = CronTool(_SvcStub())
+        desc = tool.parameters["properties"]["job_id"]["description"]
+        assert "REQUIRED" in desc and "action='remove'" in desc
+
+    def test_top_level_required_stays_narrow(self) -> None:
+        # If 'message' or 'job_id' ever creep back into top-level required,
+        # list/remove start failing schema validation (the bug PR #3163 v1
+        # accidentally introduced).
+        tool = CronTool(_SvcStub())
+        assert tool.parameters["required"] == ["action"]

--- a/tests/providers/test_enforce_role_alternation.py
+++ b/tests/providers/test_enforce_role_alternation.py
@@ -1,6 +1,6 @@
 """Tests for LLMProvider._enforce_role_alternation."""
 
-from nanobot.providers.base import LLMProvider
+from nanobot.providers.base import LLMProvider, _SYNTHETIC_USER_CONTENT
 
 
 class TestEnforceRoleAlternation:
@@ -208,7 +208,7 @@ class TestEnforceRoleAlternation:
         result = LLMProvider._enforce_role_alternation(msgs)
         non_system = [m for m in result if m["role"] != "system"]
         assert non_system[0]["role"] == "user"
-        assert non_system[0]["content"] == "(conversation continued)"
+        assert non_system[0]["content"] == _SYNTHETIC_USER_CONTENT
         # The original assistant should follow.
         assert non_system[1]["role"] == "assistant"
 

--- a/tests/providers/test_enforce_role_alternation.py
+++ b/tests/providers/test_enforce_role_alternation.py
@@ -195,3 +195,46 @@ class TestEnforceRoleAlternation:
         assert result[3]["role"] == "user"
         assert "And 3+3?" in result[3]["content"]
         assert "(please be quick)" in result[3]["content"]
+
+    def test_leading_assistant_after_system_inserts_synthetic_user(self):
+        """When the first non-system message is assistant (no tool_calls), a
+        synthetic user message is inserted to prevent GLM error 1214."""
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "previous reply"},
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+            {"role": "assistant", "content": "after tool"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        non_system = [m for m in result if m["role"] != "system"]
+        assert non_system[0]["role"] == "user"
+        assert non_system[0]["content"] == "(conversation continued)"
+        # The original assistant should follow.
+        assert non_system[1]["role"] == "assistant"
+
+    def test_leading_assistant_with_tool_calls_not_patched(self):
+        """An assistant message with tool_calls at the start is left as-is
+        because tool messages will follow and some providers accept this."""
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc_1", "type": "function", "function": {"name": "ls", "arguments": "{}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        non_system = [m for m in result if m["role"] != "system"]
+        # The assistant has tool_calls so it should NOT be patched.
+        assert non_system[0]["role"] == "assistant"
+        assert non_system[0].get("tool_calls") is not None
+
+    def test_user_after_system_not_patched(self):
+        """Normal system→user sequence is not modified."""
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert result[1]["role"] == "user"
+        assert result[1]["content"] == "hello"

--- a/tests/providers/test_llm_response.py
+++ b/tests/providers/test_llm_response.py
@@ -1,0 +1,57 @@
+"""Regression tests for ``LLMResponse.should_execute_tools`` (#3220).
+
+The agent used to execute tool calls whenever ``has_tool_calls`` was true, regardless
+of ``finish_reason``. Non-compliant API gateways that inject empty / bogus tool calls
+under ``refusal`` / ``content_filter`` / ``error`` pushed the agent into a tight loop
+until ``max_iterations`` fired. ``should_execute_tools`` is the single guard that
+every tool-execution site now funnels through.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.providers.base import LLMResponse, ToolCallRequest
+
+
+def _response(finish_reason: str, *, with_tool_call: bool = True) -> LLMResponse:
+    tool_calls = (
+        [ToolCallRequest(id="call_1", name="list_dir", arguments={"path": "."})]
+        if with_tool_call
+        else []
+    )
+    return LLMResponse(content=None, tool_calls=tool_calls, finish_reason=finish_reason)
+
+
+class TestShouldExecuteTools:
+    def test_no_tool_calls_never_executes(self) -> None:
+        # No tool calls present -> guard must reject regardless of finish_reason.
+        for reason in ("tool_calls", "stop", "length", "error", "refusal", "content_filter"):
+            resp = _response(reason, with_tool_call=False)
+            assert resp.should_execute_tools is False, f"rejected for finish_reason={reason!r}"
+
+    def test_tool_calls_with_tool_calls_reason_executes(self) -> None:
+        # The canonical case: provider explicitly signals tool intent.
+        resp = _response("tool_calls")
+        assert resp.has_tool_calls is True
+        assert resp.should_execute_tools is True
+
+    def test_tool_calls_with_stop_reason_executes(self) -> None:
+        # Some compliant providers emit "stop" together with tool_calls; the
+        # guard must accept this to avoid breaking real tool-calling flows.
+        # See openai_compat_provider.py:~633,678 where ("tool_calls", "stop")
+        # are both treated as terminal tool-call states.
+        resp = _response("stop")
+        assert resp.should_execute_tools is True
+
+    @pytest.mark.parametrize(
+        "anomalous_reason",
+        ["refusal", "content_filter", "error", "length", "function_call", ""],
+    )
+    def test_tool_calls_under_anomalous_reason_blocked(self, anomalous_reason: str) -> None:
+        # This is the #3220 bug: gateways injecting tool_calls under any of these
+        # finish_reasons must not cause execution. Blocking here is what prevents
+        # the infinite empty tool-call loop.
+        resp = _response(anomalous_reason)
+        assert resp.has_tool_calls is True
+        assert resp.should_execute_tools is False

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -251,3 +251,30 @@ async def test_stream_with_session_id(aiohttp_client) -> None:
     )
     assert resp.status == 200
     assert captured_key == "api:my-session"
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_streaming_backend_failure_does_not_emit_success_terminator(aiohttp_client) -> None:
+    """Backend exceptions should not surface as a normal stop+[DONE] stream."""
+    agent = MagicMock()
+
+    async def boom(**kwargs):
+        raise RuntimeError("backend blew up")
+
+    agent.process_direct = boom
+    agent._connect_mcp = AsyncMock()
+    agent.close_mcp = AsyncMock()
+
+    app = create_app(agent, model_name="m")
+    client = await aiohttp_client(app)
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hi"}], "stream": True},
+    )
+
+    assert resp.status == 200
+    body = await resp.text()
+    assert '"finish_reason": "stop"' not in body
+    assert "[DONE]" not in body

--- a/tests/test_document_parsing.py
+++ b/tests/test_document_parsing.py
@@ -209,6 +209,49 @@ class TestExtractText:
         # Text content may vary depending on PowerPoint layout defaults
         assert len(result) > 0
 
+    def test_extract_text_pptx_table(self, tmp_path: Path):
+        """Table cells should be extracted, not silently dropped."""
+        from pptx import Presentation
+        from pptx.util import Inches
+
+        pptx_file = tmp_path / "table.pptx"
+        prs = Presentation()
+        slide = prs.slides.add_slide(prs.slide_layouts[5])
+        table = slide.shapes.add_table(
+            2, 2, Inches(1), Inches(1), Inches(4), Inches(1)
+        ).table
+        table.cell(0, 0).text = "Header A"
+        table.cell(0, 1).text = "Header B"
+        table.cell(1, 0).text = "Alice"
+        table.cell(1, 1).text = "Bob"
+        prs.save(pptx_file)
+
+        result = extract_text(pptx_file)
+        assert result is not None
+        assert "Header A" in result
+        assert "Header B" in result
+        assert "Alice" in result
+        assert "Bob" in result
+
+    def test_extract_text_pptx_grouped_shapes(self, tmp_path: Path):
+        """Text inside grouped shapes must be extracted recursively."""
+        from pptx import Presentation
+        from pptx.util import Inches
+
+        pptx_file = tmp_path / "grouped.pptx"
+        prs = Presentation()
+        slide = prs.slides.add_slide(prs.slide_layouts[5])
+        group = slide.shapes.add_group_shape()
+        inner = group.shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(1)
+        )
+        inner.text_frame.text = "Inside group"
+        prs.save(pptx_file)
+
+        result = extract_text(pptx_file)
+        assert result is not None
+        assert "Inside group" in result
+
     def test_extract_text_pdf_not_found(self, tmp_path: Path):
         """Test that missing PDF files return error string."""
         missing_pdf = tmp_path / "nonexistent.pdf"

--- a/tests/tools/test_read_enhancements.py
+++ b/tests/tools/test_read_enhancements.py
@@ -1,5 +1,6 @@
 """Tests for ReadFileTool enhancements: description fix, read dedup, PDF support, device blacklist."""
 
+import os
 import sys
 
 import pytest
@@ -181,3 +182,67 @@ class TestReadDeviceBlacklist:
         result = await tool.execute(path=str(link))
         assert "Error" in result
         assert "blocked" in result.lower() or "device" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# file_state: mtime-unchanged / content-changed fallback
+# ---------------------------------------------------------------------------
+# On filesystems with coarse mtime resolution (NTFS ~100ms, FAT 2s) a fast
+# write-after-read can leave mtime unchanged. The content-hash fallback is
+# what protects against stale-read warnings being false-negative on those
+# platforms. Lock that behavior down here so nobody reverts it silently.
+
+class TestFileStateHashFallback:
+
+    def test_check_read_warns_when_content_changed_but_mtime_same(self, tmp_path):
+        f = tmp_path / "data.txt"
+        f.write_text("original", encoding="utf-8")
+        file_state.record_read(f)
+        original_mtime = os.path.getmtime(f)
+
+        f.write_text("modified", encoding="utf-8")
+        os.utime(f, (original_mtime, original_mtime))
+        assert os.path.getmtime(f) == original_mtime
+
+        warning = file_state.check_read(f)
+        assert warning is not None
+        assert "modified" in warning.lower()
+
+    def test_check_read_passes_when_content_and_mtime_unchanged(self, tmp_path):
+        f = tmp_path / "data.txt"
+        f.write_text("stable", encoding="utf-8")
+        file_state.record_read(f)
+
+        assert file_state.check_read(f) is None
+
+
+# ---------------------------------------------------------------------------
+# Line-ending normalization
+# ---------------------------------------------------------------------------
+# ReadFileTool normalizes CRLF -> LF before line-splitting. This primarily
+# helps Windows users whose checkouts carry CRLF line endings and whose
+# subsequent StrReplace edits would otherwise miss on `\r` boundaries. The
+# normalization applies on all platforms; these tests lock that in so the
+# behavior is intentional and discoverable, not accidental.
+
+class TestReadFileLineEndingNormalization:
+
+    @pytest.fixture()
+    def tool(self, tmp_path):
+        return ReadFileTool(workspace=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_crlf_is_normalized_to_lf(self, tool, tmp_path):
+        f = tmp_path / "crlf.txt"
+        f.write_bytes(b"alpha\r\nbeta\r\ngamma\r\n")
+        result = await tool.execute(path=str(f))
+        assert "\r" not in result
+        assert "alpha" in result and "beta" in result and "gamma" in result
+
+    @pytest.mark.asyncio
+    async def test_lf_only_is_preserved(self, tool, tmp_path):
+        f = tmp_path / "lf.txt"
+        f.write_bytes(b"alpha\nbeta\ngamma\n")
+        result = await tool.execute(path=str(f))
+        assert "\r" not in result
+        assert "alpha" in result and "beta" in result and "gamma" in result

--- a/tests/tools/test_read_enhancements.py
+++ b/tests/tools/test_read_enhancements.py
@@ -1,5 +1,7 @@
 """Tests for ReadFileTool enhancements: description fix, read dedup, PDF support, device blacklist."""
 
+import sys
+
 import pytest
 
 from nanobot.agent.tools.filesystem import ReadFileTool, WriteFileTool
@@ -143,6 +145,7 @@ class TestReadPdf:
 # Device path blacklist
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(sys.platform == "win32", reason="/dev directory doesn't exist on Windows")
 class TestReadDeviceBlacklist:
 
     @pytest.fixture()

--- a/tests/tools/test_search_tools.py
+++ b/tests/tools/test_search_tools.py
@@ -180,9 +180,13 @@ async def test_grep_files_with_matches_supports_head_limit_and_offset(tmp_path: 
         offset=1,
     )
 
-    lines = result.splitlines()
-    assert lines[0] == "src/b.py"
+    # Filesystem order is not deterministic across platforms, so just verify:
+    # 1. Only one file path is returned (head_limit=1 after offset=1)
+    # 2. The pagination info is correct
     assert "pagination: limit=1, offset=1" in result
+    # Count non-empty lines that start with src/ (file paths)
+    file_lines = [l for l in result.splitlines() if l.startswith("src/")]
+    assert len(file_lines) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -1,3 +1,4 @@
+import shlex
 import subprocess
 import sys
 from typing import Any
@@ -547,13 +548,20 @@ async def test_exec_always_returns_exit_code() -> None:
 async def test_exec_head_tail_truncation(tmp_path) -> None:
     """Long output should preserve both head and tail."""
     tool = ExecTool()
-    # Generate output that exceeds _MAX_OUTPUT (10_000 chars)
-    # Use a temp script file to avoid Windows command line quote parsing issues
+    # Generate output that exceeds _MAX_OUTPUT (10_000 chars).
+    # Use a temp script file so the output-generating logic lives in a file
+    # (Windows cmd.exe has finicky rules for quoting `-c` payloads with
+    # embedded newlines). ExecTool runs via create_subprocess_shell, so we
+    # must quote *both* the interpreter path and the script path — tmp_path
+    # on some CI runners and on many local Windows installs contains spaces
+    # (e.g. C:\Users\John Doe\AppData\...) which would otherwise break the
+    # shell's argv split.
     script_file = tmp_path / "gen_output.py"
     script_file.write_text("print('A' * 6000 + chr(10) + 'B' * 6000)", encoding="utf-8")
-    # On Windows, cmd.exe handles quotes differently. Use the path directly
-    # without additional quotes since the temp path shouldn't have spaces.
-    command = f"{sys.executable} {script_file}"
+    if sys.platform == "win32":
+        command = subprocess.list2cmdline([sys.executable, str(script_file)])
+    else:
+        command = f"{shlex.quote(sys.executable)} {shlex.quote(str(script_file))}"
     result = await tool.execute(command=command)
     assert "chars truncated" in result
     # Head portion should start with As

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -1,4 +1,3 @@
-import shlex
 import subprocess
 import sys
 from typing import Any
@@ -545,18 +544,16 @@ async def test_exec_always_returns_exit_code() -> None:
     assert "hello" in result
 
 
-async def test_exec_head_tail_truncation() -> None:
+async def test_exec_head_tail_truncation(tmp_path) -> None:
     """Long output should preserve both head and tail."""
     tool = ExecTool()
     # Generate output that exceeds _MAX_OUTPUT (10_000 chars)
-    # Use current interpreter (PATH may not have `python`). ExecTool uses
-    # create_subprocess_shell: POSIX needs shlex.quote; Windows uses cmd.exe
-    # rules, so list2cmdline is appropriate there.
-    script = "print('A' * 6000 + '\\n' + 'B' * 6000)"
-    if sys.platform == "win32":
-        command = subprocess.list2cmdline([sys.executable, "-c", script])
-    else:
-        command = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+    # Use a temp script file to avoid Windows command line quote parsing issues
+    script_file = tmp_path / "gen_output.py"
+    script_file.write_text("print('A' * 6000 + chr(10) + 'B' * 6000)", encoding="utf-8")
+    # On Windows, cmd.exe handles quotes differently. Use the path directly
+    # without additional quotes since the temp path shouldn't have spaces.
+    command = f"{sys.executable} {script_file}"
     result = await tool.execute(command=command)
     assert "chars truncated" in result
     # Head portion should start with As


### PR DESCRIPTION
Nightly tracking PR for #3275

## Summary

- Move all behavioral instructions out of `identity.md` into `SOUL.md`, giving each file a single clear purpose
- `identity.md`: capability facts only (runtime, workspace, format hints, tool guidance)
- `SOUL.md`: behavioral rules (name, personality, execution rules)
- Refine "Act, don't narrate" into layered behavior: act immediately on single-step tasks, plan first for multi-step tasks
- Eliminates the contradiction where identity said "never end with a plan" but user SOUL.md could say "always plan first"

## Test plan

- [x] All 572 agent tests pass