### PR TITLE
fix(discord): allow bot-to-bot messaging, only drop self-loops (#3217)

### DIFF
--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -433,8 +433,15 @@ class DiscordChannel(BaseChannel):
             raise
 
     async def _handle_discord_message(self, message: discord.Message) -> None:
-        """Handle incoming Discord messages from discord.py."""
-        if message.author.bot:
+        """Handle incoming Discord messages from discord.py.
+
+        Self-loop guard: only drop messages from this bot's own account. Messages
+        from other bots are allowed through so multi-agent setups (one bot asking
+        another for help, a bot mentioning another by @name, etc.) can work.
+        Bot-from-bot loops are still prevented per-instance because each bot
+        still ignores its own outbound messages. (#3217)
+        """
+        if self._bot_user_id is not None and str(message.author.id) == self._bot_user_id:
             return
 
         sender_id = str(message.author.id)

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -273,17 +273,41 @@ async def test_stop_is_safe_after_partial_start(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_on_message_ignores_bot_messages() -> None:
-    # Incoming bot-authored messages must be ignored to prevent feedback loops.
+async def test_on_message_ignores_self_messages() -> None:
+    # Self-loop guard: messages from this bot's own account must be dropped (#3217).
     channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), MessageBus())
+    channel._bot_user_id = "999"  # simulate bot identity populated in on_ready()
     handled: list[dict] = []
     channel._handle_message = lambda **kwargs: handled.append(kwargs)  # type: ignore[method-assign]
 
-    await channel._on_message(_make_message(author_bot=True))
+    await channel._on_message(_make_message(author_id=999, author_bot=True))
 
     assert handled == []
 
+
+@pytest.mark.asyncio
+async def test_on_message_accepts_messages_from_other_bots() -> None:
+    # Multi-agent setups: messages from OTHER bots must be processed, not dropped (#3217).
+    channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), MessageBus())
+    channel._bot_user_id = "999"
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle  # type: ignore[method-assign]
+
+    await channel._on_message(_make_message(author_id=123, author_bot=True))
+
+    assert len(handled) == 1
+    assert handled[0]["sender_id"] == "123"
+
+
+@pytest.mark.asyncio
+async def test_on_message_stops_typing_on_handle_exception() -> None:
     # If inbound handling raises, typing should be stopped for that channel.
+    channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), MessageBus())
+
     async def fail_handle(**kwargs) -> None:
         raise RuntimeError("boom")
 


### PR DESCRIPTION
Previously the Discord channel dropped every message from any bot account via `if message.author.bot`, which prevented legitimate multi-agent setups (one bot asking another for help, bot-to-bot @mentions, etc.) from working.

Narrow the guard to only drop messages from this bot's own account by comparing against self._bot_user_id (already populated in on_ready). Self-loop protection is preserved — each bot instance still ignores its own outbound messages.

Co-authored with Claude Opus 4.7