### PR TITLE
feat(gateway): add on_start/on_stop lifecycle notifications (#3279)

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -628,6 +628,25 @@ def serve(
 # ============================================================================
 
 
+async def _notify_gateway_lifecycle(
+    bus,
+    pick_target,
+    content: str,
+) -> None:
+    """Publish a gateway lifecycle notification via the user's most-recent channel.
+
+    Routed through the outbound bus so the dispatcher's retry loop (see
+    ``ChannelManager._send_with_retry``) absorbs any transient race with a
+    channel that is still finishing its handshake. No-op for cli-only setups.
+    """
+    from nanobot.bus.events import OutboundMessage
+
+    channel, chat_id = pick_target()
+    if channel == "cli":
+        return
+    await bus.publish_outbound(OutboundMessage(channel=channel, chat_id=chat_id, content=content))
+
+
 @app.command()
 def gateway(
     port: int | None = typer.Option(None, "--port", "-p", help="Gateway port"),
@@ -885,6 +904,16 @@ def gateway(
         try:
             await cron.start()
             await heartbeat.start()
+            # Schedule the on_start lifecycle notification.
+            # Fixed 2s delay so the message posts after channel startup logs settle;
+            # a dedicated "channels ready" signal would require touching ChannelManager
+            # and is out of scope here. The dispatcher's retry loop covers residual
+            # races where a channel handshake is still in flight.
+            if config.gateway.on_start:
+                async def _send_on_start():
+                    await asyncio.sleep(2.0)
+                    await _notify_gateway_lifecycle(bus, _pick_heartbeat_target, config.gateway.on_start)
+                asyncio.create_task(_send_on_start())
             await asyncio.gather(
                 agent.run(),
                 channels.start_all(),
@@ -898,6 +927,13 @@ def gateway(
             console.print("\n[red]Error: Gateway crashed unexpectedly[/red]")
             console.print(traceback.format_exc())
         finally:
+            # Send on_stop before tearing channels down so the dispatcher can still flush it.
+            if config.gateway.on_stop:
+                try:
+                    await _notify_gateway_lifecycle(bus, _pick_heartbeat_target, config.gateway.on_stop)
+                    await asyncio.sleep(0.5)
+                except Exception:
+                    logger.exception("Gateway on_stop notification failed")
             await agent.close_mcp()
             heartbeat.stop()
             cron.stop()

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -162,6 +162,8 @@ class GatewayConfig(Base):
     host: str = "127.0.0.1"  # Safer default: local-only bind.
     port: int = 18790
     heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
+    on_start: str | None = None  # Message sent via the most recent user channel once the gateway is up
+    on_stop: str | None = None  # Message sent via the most recent user channel before shutdown
 
 
 class WebSearchConfig(Base):

--- a/tests/cli/test_gateway_lifecycle.py
+++ b/tests/cli/test_gateway_lifecycle.py
@@ -1,0 +1,21 @@
+from nanobot.bus.queue import MessageBus
+from nanobot.cli.commands import _notify_gateway_lifecycle
+
+
+async def test_notify_gateway_lifecycle_publishes_to_picked_target() -> None:
+    bus = MessageBus()
+
+    await _notify_gateway_lifecycle(bus, lambda: ("telegram", "1001"), "Gateway online 🟢")
+
+    msg = await bus.consume_outbound()
+    assert msg.channel == "telegram"
+    assert msg.chat_id == "1001"
+    assert msg.content == "Gateway online 🟢"
+
+
+async def test_notify_gateway_lifecycle_is_noop_for_cli_target() -> None:
+    bus = MessageBus()
+
+    await _notify_gateway_lifecycle(bus, lambda: ("cli", "direct"), "Gateway online")
+
+    assert bus.outbound_size == 0

--- a/tests/config/test_gateway_config.py
+++ b/tests/config/test_gateway_config.py
@@ -1,0 +1,27 @@
+from nanobot.config.schema import GatewayConfig
+
+
+def test_gateway_config_lifecycle_hooks_default_to_none() -> None:
+    cfg = GatewayConfig()
+
+    assert cfg.on_start is None
+    assert cfg.on_stop is None
+
+
+def test_gateway_config_accepts_lifecycle_hook_strings() -> None:
+    cfg = GatewayConfig.model_validate({
+        "onStart": "Gateway 已启动 🟢",
+        "onStop": "Gateway 已停止 🔴",
+    })
+
+    assert cfg.on_start == "Gateway 已启动 🟢"
+    assert cfg.on_stop == "Gateway 已停止 🔴"
+
+
+def test_gateway_config_dumps_lifecycle_hooks_with_camel_case_aliases() -> None:
+    cfg = GatewayConfig(on_start="ready", on_stop="bye")
+
+    dumped = cfg.model_dump(by_alias=True)
+
+    assert dumped["onStart"] == "ready"
+    assert dumped["onStop"] == "bye"


### PR DESCRIPTION
Adds optional `gateway.on_start` / `gateway.on_stop` config fields that post a fixed message via the user's most-recent channel when the gateway finishes startup and before it shuts down.

Rationale: systemd `ExecStartPost` fires before channel handshakes complete, so lifecycle-aware notifications need to live inside the gateway process. The helper reuses the existing `_pick_heartbeat_target` routing and the outbound dispatcher's retry loop, so no changes to `ChannelManager` are required.

A 2s post-startup delay is used as a workaround; a dedicated "channels ready" signal is left as a follow-up so the scope stays small.

Backward compatible: both fields default to `None` (disabled).

Co-authored with Claude Code @Opus 4.7