### PR TITLE
feat(metrics): opt-in per-turn latency metrics for voice/LLM pipeline…

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -36,6 +36,7 @@ from nanobot.command import CommandContext, CommandRouter, register_builtin_comm
 from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import LLMProvider
 from nanobot.session.manager import Session, SessionManager
+from nanobot.utils import metrics as turn_metrics
 from nanobot.utils.document import extract_documents
 from nanobot.utils.helpers import image_placeholder_text
 from nanobot.utils.helpers import truncate_text as truncate_text_fn
@@ -79,6 +80,7 @@ class _LoopHook(AgentHook):
     async def on_stream(self, context: AgentHookContext, delta: str) -> None:
         from nanobot.utils.helpers import strip_think
 
+        turn_metrics.mark_first_token()
         prev_clean = strip_think(self._stream_buf)
         self._stream_buf += delta
         new_clean = strip_think(self._stream_buf)
@@ -161,6 +163,7 @@ class AgentLoop:
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
         tools_config: ToolsConfig | None = None,
+        metrics_enabled: bool = False,
     ):
         from nanobot.config.schema import ExecToolConfig, ToolsConfig, WebToolsConfig
 
@@ -193,6 +196,7 @@ class AgentLoop:
         self._start_time = time.time()
         self._last_usage: dict[str, int] = {}
         self._extra_hooks: list[AgentHook] = hooks or []
+        self._metrics_enabled = metrics_enabled
 
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
         self.sessions = session_manager or SessionManager(workspace)
@@ -414,25 +418,26 @@ class AgentLoop:
                 items.append({"role": "user", "content": merged})
             return items
 
-        result = await self.runner.run(AgentRunSpec(
-            initial_messages=initial_messages,
-            tools=self.tools,
-            model=self.model,
-            max_iterations=self.max_iterations,
-            max_tool_result_chars=self.max_tool_result_chars,
-            hook=hook,
-            error_message="Sorry, I encountered an error calling the AI model.",
-            concurrent_tools=True,
-            workspace=self.workspace,
-            session_key=session.key if session else None,
-            context_window_tokens=self.context_window_tokens,
-            context_block_limit=self.context_block_limit,
-            provider_retry_mode=self.provider_retry_mode,
-            progress_callback=on_progress,
-            retry_wait_callback=on_retry_wait,
-            checkpoint_callback=_checkpoint,
-            injection_callback=_drain_pending,
-        ))
+        with turn_metrics.llm_timer():
+            result = await self.runner.run(AgentRunSpec(
+                initial_messages=initial_messages,
+                tools=self.tools,
+                model=self.model,
+                max_iterations=self.max_iterations,
+                max_tool_result_chars=self.max_tool_result_chars,
+                hook=hook,
+                error_message="Sorry, I encountered an error calling the AI model.",
+                concurrent_tools=True,
+                workspace=self.workspace,
+                session_key=session.key if session else None,
+                context_window_tokens=self.context_window_tokens,
+                context_block_limit=self.context_block_limit,
+                provider_retry_mode=self.provider_retry_mode,
+                progress_callback=on_progress,
+                retry_wait_callback=on_retry_wait,
+                checkpoint_callback=_checkpoint,
+                injection_callback=_drain_pending,
+            ))
         self._last_usage = result.usage
         if result.stop_reason == "max_iterations":
             logger.warning("Max iterations ({}) reached", self.max_iterations)
@@ -525,6 +530,10 @@ class AgentLoop:
         pending = asyncio.Queue(maxsize=20)
         self._pending_queues[session_key] = pending
 
+        metrics, metrics_token = turn_metrics.activate(
+            channel=msg.channel, enabled=self._metrics_enabled,
+        )
+
         try:
             async with lock, gate:
                 try:
@@ -581,6 +590,8 @@ class AgentLoop:
                         content="Sorry, I encountered an error.",
                     ))
         finally:
+            metrics.flush()
+            turn_metrics.deactivate(metrics_token)
             # Drain any messages still in the pending queue and re-publish
             # them to the bus so they are processed as fresh inbound messages
             # rather than silently lost.
@@ -663,14 +674,15 @@ class AgentLoop:
 
             # Subagent content is already in `history` above; passing it again
             # as current_message would double-project it into the prompt.
-            messages = self.context.build_messages(
-                history=history,
-                current_message="" if is_subagent else msg.content,
-                channel=channel,
-                chat_id=chat_id,
-                session_summary=pending,
-                current_role=current_role,
-            )
+            with turn_metrics.stage_timer("context_build"):
+                messages = self.context.build_messages(
+                    history=history,
+                    current_message="" if is_subagent else msg.content,
+                    channel=channel,
+                    chat_id=chat_id,
+                    session_summary=pending,
+                    current_role=current_role,
+                )
             final_content, _, all_msgs, _, _ = await self._run_agent_loop(
                 messages, session=session, channel=channel, chat_id=chat_id,
                 message_id=msg.metadata.get("message_id"),
@@ -718,14 +730,15 @@ class AgentLoop:
 
         history = session.get_history(max_messages=0)
 
-        initial_messages = self.context.build_messages(
-            history=history,
-            current_message=msg.content,
-            session_summary=pending,
-            media=msg.media if msg.media else None,
-            channel=msg.channel,
-            chat_id=msg.chat_id,
-        )
+        with turn_metrics.stage_timer("context_build"):
+            initial_messages = self.context.build_messages(
+                history=history,
+                current_message=msg.content,
+                session_summary=pending,
+                media=msg.media if msg.media else None,
+                channel=msg.channel,
+                chat_id=msg.chat_id,
+            )
 
         async def _bus_progress(content: str, *, tool_hint: bool = False) -> None:
             meta = dict(msg.metadata or {})

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -11,6 +11,7 @@ from typing import Any
 from loguru import logger
 
 from nanobot.agent.hook import AgentHook, AgentHookContext
+from nanobot.utils import metrics as turn_metrics
 from nanobot.utils.prompt_templates import render_template
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.providers.base import LLMProvider, ToolCallRequest
@@ -685,10 +686,11 @@ class AgentRunner:
             }
             return prep_error + _HINT, event, RuntimeError(prep_error) if spec.fail_on_tool_error else None
         try:
-            if tool is not None:
-                result = await tool.execute(**params)
-            else:
-                result = await spec.tools.execute(tool_call.name, params)
+            with turn_metrics.tool_timer(tool_call.name):
+                if tool is not None:
+                    result = await tool.execute(**params)
+                else:
+                    result = await spec.tools.execute(tool_call.name, params)
         except asyncio.CancelledError:
             raise
         except BaseException as exc:

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.utils import metrics as turn_metrics
 
 
 class BaseChannel(ABC):
@@ -55,7 +56,8 @@ class BaseChannel(ABC):
                     api_key=self.transcription_api_key,
                     api_base=self.transcription_api_base or None,
                 )
-            return await provider.transcribe(file_path)
+            with turn_metrics.stage_timer("stt"):
+                return await provider.transcribe(file_path)
         except Exception as e:
             logger.warning("{}: audio transcription failed: {}", self.name, e)
             return ""

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -689,6 +689,7 @@ def gateway(
         disabled_skills=config.agents.defaults.disabled_skills,
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
         tools_config=config.tools,
+        metrics_enabled=config.gateway.metrics_enabled,
     )
 
     # Set cron callback (needs agent)

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -162,6 +162,7 @@ class GatewayConfig(Base):
     host: str = "127.0.0.1"  # Safer default: local-only bind.
     port: int = 18790
     heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
+    metrics_enabled: bool = False  # Emit per-turn latency metrics as structured log lines (#3257)
 
 
 class WebSearchConfig(Base):

--- a/nanobot/utils/metrics.py
+++ b/nanobot/utils/metrics.py
@@ -1,0 +1,160 @@
+"""Per-turn latency metrics for voice/text pipelines (issue #3257).
+
+Opt-in via ``gateway.metrics_enabled``. When disabled, ``flush()`` is a no-op
+and the only per-turn cost is creating the ``TurnMetrics`` object and setting
+a ContextVar — both negligible.
+
+Design choices worth knowing for future readers:
+
+* **TTFT is only observable when the provider streams deltas.** Non-streaming
+  responses return the full completion atomically, so ``llm_ttft`` is reported
+  as ``None`` for those turns. The field is always present in the payload so
+  consumers (jq, Datadog, etc.) don't have to handle optionally-missing keys.
+* **``stage_timer`` / ``tool_timer`` are no-ops without an active turn.** This
+  lets the same instrumentation run from tests, cli paths, or any call-site
+  that doesn't go through ``AgentLoop._dispatch`` without guarding every use.
+* **The structured payload is emitted via ``logger.bind(metric="turn")``.**
+  We don't install our own sink. Operators who want the metric stream in its
+  own file/tool can add a filtered sink on ``record["extra"]["metric"]``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+
+from loguru import logger
+
+_current: ContextVar["TurnMetrics | None"] = ContextVar("turn_metrics", default=None)
+
+
+@dataclass
+class ToolTiming:
+    name: str
+    duration_ms: int
+
+
+@dataclass
+class TurnMetrics:
+    """Mutable per-turn metrics record. Not thread-safe (single asyncio task per turn)."""
+
+    turn_id: str
+    channel: str
+    enabled: bool
+    stages: dict[str, int] = field(default_factory=dict)
+    tool_timings: list[ToolTiming] = field(default_factory=list)
+    llm_ttft: int | None = None
+    _llm_started_ns: int | None = None
+    _activated_at_ns: int = field(default_factory=time.perf_counter_ns)
+
+    @classmethod
+    def current(cls) -> "TurnMetrics | None":
+        return _current.get()
+
+    def record_stage(self, name: str, duration_ms: int) -> None:
+        self.stages[name] = duration_ms
+
+    def record_tool(self, name: str, duration_ms: int) -> None:
+        self.tool_timings.append(ToolTiming(name=name, duration_ms=duration_ms))
+
+    def flush(self) -> None:
+        if not self.enabled:
+            return
+        total_ms = (time.perf_counter_ns() - self._activated_at_ns) // 1_000_000
+        payload: dict[str, Any] = {
+            "turn_id": self.turn_id,
+            "channel": self.channel,
+            "timings_ms": {
+                **self.stages,
+                "llm_ttft": self.llm_ttft,
+                "tool_calls": [
+                    {"name": t.name, "duration_ms": t.duration_ms}
+                    for t in self.tool_timings
+                ],
+                "total": total_ms,
+            },
+        }
+        logger.bind(metric="turn").info(json.dumps(payload))
+
+
+def activate(channel: str, enabled: bool) -> tuple[TurnMetrics, Any]:
+    """Create a TurnMetrics and install it on the current context."""
+    metrics = TurnMetrics(
+        turn_id=uuid.uuid4().hex[:12],
+        channel=channel,
+        enabled=enabled,
+    )
+    token = _current.set(metrics)
+    return metrics, token
+
+
+def deactivate(token: Any) -> None:
+    """Reset the current TurnMetrics to what it was before activate()."""
+    _current.reset(token)
+
+
+@contextmanager
+def stage_timer(name: str) -> Iterator[None]:
+    """Measure a stage and record its duration on the active turn metrics.
+
+    No-op if no turn metrics is active (e.g. CLI-only paths).
+    """
+    m = TurnMetrics.current()
+    if m is None:
+        yield
+        return
+    start = time.perf_counter_ns()
+    try:
+        yield
+    finally:
+        m.record_stage(name, (time.perf_counter_ns() - start) // 1_000_000)
+
+
+@contextmanager
+def tool_timer(name: str) -> Iterator[None]:
+    """Measure one tool invocation and append it to the active turn metrics."""
+    m = TurnMetrics.current()
+    if m is None:
+        yield
+        return
+    start = time.perf_counter_ns()
+    try:
+        yield
+    finally:
+        m.record_tool(name, (time.perf_counter_ns() - start) // 1_000_000)
+
+
+@contextmanager
+def llm_timer() -> Iterator[None]:
+    """Measure the whole LLM agent-loop and anchor the TTFT origin.
+
+    ``mark_first_token()`` within this block records ``llm_ttft`` relative to
+    the block start; outside of it, ``mark_first_token()`` is a no-op.
+    """
+    m = TurnMetrics.current()
+    if m is None:
+        yield
+        return
+    start = time.perf_counter_ns()
+    m._llm_started_ns = start
+    try:
+        yield
+    finally:
+        m.record_stage("llm_total", (time.perf_counter_ns() - start) // 1_000_000)
+        m._llm_started_ns = None
+
+
+def mark_first_token() -> None:
+    """Record ``llm_ttft`` the first time this is called inside ``llm_timer()``.
+
+    Safe to call on every stream delta — subsequent calls are ignored.
+    """
+    m = TurnMetrics.current()
+    if m is None or m.llm_ttft is not None or m._llm_started_ns is None:
+        return
+    m.llm_ttft = (time.perf_counter_ns() - m._llm_started_ns) // 1_000_000

--- a/tests/config/test_metrics_config.py
+++ b/tests/config/test_metrics_config.py
@@ -1,0 +1,21 @@
+from nanobot.config.schema import GatewayConfig
+
+
+def test_gateway_metrics_enabled_defaults_to_false() -> None:
+    cfg = GatewayConfig()
+
+    assert cfg.metrics_enabled is False
+
+
+def test_gateway_metrics_enabled_accepts_camel_case_alias() -> None:
+    cfg = GatewayConfig.model_validate({"metricsEnabled": True})
+
+    assert cfg.metrics_enabled is True
+
+
+def test_gateway_metrics_enabled_dumps_with_camel_case_alias() -> None:
+    cfg = GatewayConfig(metrics_enabled=True)
+
+    dumped = cfg.model_dump(by_alias=True)
+
+    assert dumped["metricsEnabled"] is True

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -1,0 +1,160 @@
+"""Tests for the turn latency metrics module (#3257)."""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from loguru import logger
+
+from nanobot.utils.metrics import (
+    TurnMetrics,
+    activate,
+    deactivate,
+    llm_timer,
+    mark_first_token,
+    stage_timer,
+    tool_timer,
+)
+
+
+@pytest.fixture
+def captured_metric_logs():
+    """Capture records tagged metric='turn' emitted during the test.
+
+    Other tests call ``logger.disable('nanobot')`` (see ``cli.commands.agent``)
+    and may leave loguru silenced for nanobot-namespaced modules. Re-enable
+    here so metric emissions from ``nanobot.utils.metrics`` are observable.
+    """
+    logger.enable("nanobot")
+    captured: list[dict] = []
+
+    def sink(message):
+        record = message.record
+        if record["extra"].get("metric") == "turn":
+            captured.append({"message": record["message"], "extra": dict(record["extra"])})
+
+    sink_id = logger.add(sink, level="INFO")
+    try:
+        yield captured
+    finally:
+        logger.remove(sink_id)
+
+
+def test_turn_metrics_disabled_emits_nothing(captured_metric_logs):
+    metrics, token = activate(channel="telegram", enabled=False)
+    try:
+        with stage_timer("stt"):
+            time.sleep(0.001)
+        metrics.flush()
+    finally:
+        deactivate(token)
+
+    assert captured_metric_logs == []
+
+
+def test_turn_metrics_enabled_emits_single_json_line(captured_metric_logs):
+    metrics, token = activate(channel="telegram", enabled=True)
+    try:
+        with stage_timer("stt"):
+            time.sleep(0.001)
+        metrics.flush()
+    finally:
+        deactivate(token)
+
+    assert len(captured_metric_logs) == 1
+    payload = json.loads(captured_metric_logs[0]["message"])
+    assert payload["channel"] == "telegram"
+    assert "turn_id" in payload
+    assert "stt" in payload["timings_ms"]
+    assert payload["timings_ms"]["llm_ttft"] is None
+    assert payload["timings_ms"]["tool_calls"] == []
+
+
+def test_stage_timer_records_duration():
+    metrics, token = activate(channel="cli", enabled=True)
+    try:
+        with stage_timer("context_build"):
+            time.sleep(0.005)
+    finally:
+        deactivate(token)
+
+    assert "context_build" in metrics.stages
+    assert metrics.stages["context_build"] >= 5
+
+
+def test_tool_timings_accumulate():
+    metrics, token = activate(channel="cli", enabled=True)
+    try:
+        with tool_timer("memory_search"):
+            time.sleep(0.001)
+        with tool_timer("web_fetch"):
+            time.sleep(0.001)
+    finally:
+        deactivate(token)
+
+    names = [t.name for t in metrics.tool_timings]
+    assert names == ["memory_search", "web_fetch"]
+    assert all(t.duration_ms >= 1 for t in metrics.tool_timings)
+
+
+def test_turn_id_unique_per_turn():
+    m1, t1 = activate(channel="cli", enabled=True)
+    deactivate(t1)
+    m2, t2 = activate(channel="cli", enabled=True)
+    deactivate(t2)
+
+    assert m1.turn_id != m2.turn_id
+
+
+def test_llm_ttft_recorded_only_when_streaming(captured_metric_logs):
+    metrics, token = activate(channel="telegram", enabled=True)
+    try:
+        with llm_timer():
+            time.sleep(0.002)
+            mark_first_token()
+            time.sleep(0.003)
+        metrics.flush()
+    finally:
+        deactivate(token)
+
+    payload = json.loads(captured_metric_logs[0]["message"])
+    assert payload["timings_ms"]["llm_ttft"] is not None
+    assert payload["timings_ms"]["llm_ttft"] >= 2
+    assert payload["timings_ms"]["llm_total"] >= 5
+
+
+def test_llm_ttft_null_when_no_first_token_marked(captured_metric_logs):
+    metrics, token = activate(channel="telegram", enabled=True)
+    try:
+        with llm_timer():
+            time.sleep(0.002)
+        metrics.flush()
+    finally:
+        deactivate(token)
+
+    payload = json.loads(captured_metric_logs[0]["message"])
+    assert payload["timings_ms"]["llm_ttft"] is None
+    assert payload["timings_ms"]["llm_total"] >= 2
+
+
+def test_total_measures_activate_to_flush(captured_metric_logs):
+    metrics, token = activate(channel="telegram", enabled=True)
+    try:
+        time.sleep(0.010)
+        metrics.flush()
+    finally:
+        deactivate(token)
+
+    payload = json.loads(captured_metric_logs[0]["message"])
+    assert payload["timings_ms"]["total"] >= 10
+
+
+def test_stage_timer_noop_without_active_metrics():
+    assert TurnMetrics.current() is None
+    with stage_timer("stt"):
+        pass
+    with tool_timer("x"):
+        pass
+    mark_first_token()
+    assert TurnMetrics.current() is None


### PR DESCRIPTION
## Summary

Adds opt-in per-turn latency metrics for voice/LLM pipelines (#3257), so users debugging slow voice interactions can see which stage (STT, context build, LLM, tool calls) is the bottleneck instead of guessing from end-to-end stopwatch numbers.

Closes #3257.

## Why

The reporter's voice setup was running at 35–60 s end-to-end with no way to attribute the latency. `ExecStartPost` / journal timestamps only mark process boundaries; everything inside the gateway was invisible.

## What changed

**New module `nanobot/utils/metrics.py`** — `TurnMetrics` dataclass, ContextVar anchor, and three context managers (`stage_timer`, `tool_timer`, `llm_timer`) plus `mark_first_token()`. No-op when no turn is active, so the instrumentation is safe in non-gateway paths.

**Instrumented boundaries:**

| Stage | File | Where |
|---|---|---|
| `stt` | `nanobot/channels/base.py` | `BaseChannel.transcribe_audio` around `provider.transcribe(file_path)` |
| `context_build` | `nanobot/agent/loop.py` | `_process_message` around the two `ContextBuilder.build_messages` call sites |
| `llm_total` | `nanobot/agent/loop.py` | `_run_agent_loop` around `self.runner.run(...)` |
| `llm_ttft` | `nanobot/agent/loop.py` | `_LoopHook.on_stream` first delta — streaming only (see Notes) |
| `tool_calls[].duration_ms` | `nanobot/agent/runner.py` | `_run_tool` around `tool.execute(...)` |
| `total` | `nanobot/utils/metrics.py` | anchored at `activate()`, computed at `flush()` — inbound-arrival → outbound-publish |

**Config opt-in:** `gateway.metrics_enabled: bool = False` added to `GatewayConfig`. When `False`, `flush()` is a no-op and only the ContextVar set/reset runs per turn.

**Payload shape (emitted via `logger.bind(metric="turn").info(json.dumps(...))`):**

```json
{
  "turn_id": "a1b2c3d4e5f6",
  "channel": "telegram",
  "timings_ms": {
    "stt": 980,
    "context_build": 12,
    "llm_total": 3450,
    "llm_ttft": 1500,
    "tool_calls": [{"name": "memory_search", "duration_ms": 320}],
    "total": 4782
  }
}
```

Operators who want the metric stream in its own sink can add a filtered loguru handler on `record["extra"]["metric"] == "turn"`.

## Tests

12 new tests, all green:

- `tests/utils/test_metrics.py` (9): disabled → no emit · enabled → single JSON line · `stage_timer` / `tool_timer` record durations · `turn_id` uniqueness · TTFT present when streaming / null when not · `total` spans `activate → flush` · no-op without active metrics.
- `tests/config/test_metrics_config.py` (3): default `False` · accepts `metricsEnabled` camelCase alias · dumps with camelCase alias.

Full regression suite: **1978 passed, 0 failed** (3 pre-existing skips).

## Out of scope (informed in issue thread)

- **TTS timing** — nanobot doesn't synthesize speech inside the framework; the reporter's Cartesia pipeline runs outside the process.
- **Outbound audio transport** — same reason.
- **Metrics sink hook** — a pluggable callback so external pipelines can inject their own timings is a clean follow-up if this PR lands and demand surfaces. Deliberately kept out of this PR to avoid the "framework of hooks" scope creep (~300 LOC) when the issue can be resolved with ~160 LOC of in-framework instrumentation.

## Notes for reviewer

- **`loop.py` diff looks bigger than it is.** The stat shows ~83 lines touched, but most of it is re-indentation from wrapping existing blocks in `with turn_metrics.stage_timer(...)` / `with turn_metrics.llm_timer(...)`. Net logical change: `+imports`, `+metrics_enabled` kwarg, `+activate/flush` in `_dispatch`, `+mark_first_token()` in `on_stream`, and the three `with ...:` wrappers.

- **`llm_ttft` streaming-only decision.** TTFT is only observable when the provider streams deltas. Non-streaming responses return the full completion atomically, so `llm_ttft` is reported as `null` for those turns. The field stays in the payload (never omitted) so downstream tooling has a stable schema — see `test_llm_ttft_null_when_no_first_token_marked`.

- **Logging test fixture note.** `logger.disable("nanobot")` is called elsewhere in the test suite (in `cli.commands.agent` code path that some CLI tests exercise) and can leak across tests. The metrics test fixture calls `logger.enable("nanobot")` locally to observe emissions — this is scoped to the fixture in `tests/utils/test_metrics.py`, not in `conftest.py`, so other tests' expectations about the global logger state are untouched.

- **Backward compatibility.** `metrics_enabled` defaults to `False`, and all `*_timer()` helpers are no-ops when no `TurnMetrics` is active, so nothing changes for existing users or callers outside the `gateway()` path.

## Checklist

- [x] Opt-in (disabled by default)
- [x] Payload schema stable between streaming and non-streaming turns (`llm_ttft: null` explicit)
- [x] No changes to `ChannelManager` or the runner's public API
- [x] Tests added for every new code path
- [x] Pydantic camelCase aliasing preserved (`metricsEnabled`)
- [x] 1978 pre-existing tests still pass

Co-authored with Claude Code @Opus 4.7