### PR TITLE
feat(dream): optional kill switch + custom Phase 1/2 template paths (#3282)

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from loguru import logger
 
-from nanobot.utils.prompt_templates import render_template
+from nanobot.utils.prompt_templates import render_template, render_template_from_path
 from nanobot.utils.helpers import ensure_dir, estimate_message_tokens, estimate_prompt_tokens_chain, strip_think
 
 from nanobot.agent.runner import AgentRunSpec, AgentRunner
@@ -561,6 +561,21 @@ class Consolidator:
 _STALE_THRESHOLD_DAYS = 14
 
 
+def _resolve_dream_template_path(raw: str | None, workspace: Path) -> Path | None:
+    """Resolve a user-supplied Dream template path (#3282).
+
+    Rules: ``~`` is expanded; absolute paths are used as-is; relative paths
+    resolve against *workspace*. Returns ``None`` when ``raw`` is ``None`` so
+    callers can fall back to the builtin template.
+    """
+    if raw is None:
+        return None
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = workspace / candidate
+    return candidate
+
+
 class Dream:
     """Two-phase memory processor: analyze history.jsonl, then edit files via AgentRunner.
 
@@ -589,8 +604,50 @@ class Dream:
         # Default True keeps the #3212 behavior; set False to feed MEMORY.md raw
         # (e.g. if a specific LLM reacts poorly to the `← Nd` suffix).
         self.annotate_line_ages = annotate_line_ages
+        # Dream scope controls (#3282). Set post-construction from DreamConfig
+        # by ``cli.commands.gateway`` (mirroring the pattern used for
+        # ``model``/``max_batch_size``/``max_iterations``). When
+        # ``enabled=False``, the cron job is never registered; the template
+        # paths are only validated when enabled is True.
+        self.enabled: bool = True
+        self.phase1_template_path: Path | None = None
+        self.phase2_template_path: Path | None = None
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
+
+    def validate_templates(self) -> None:
+        """Raise ``FileNotFoundError`` if a configured custom template is missing.
+
+        Called from gateway startup so misconfiguration fails fast instead of
+        at the next Dream tick. No-op when ``enabled=False`` — users can stage
+        in-progress templates without being forced to keep them runnable.
+        """
+        if not self.enabled:
+            return
+        for key, path in (
+            ("phase1_template", self.phase1_template_path),
+            ("phase2_template", self.phase2_template_path),
+        ):
+            if path is None:
+                continue
+            if not path.is_file():
+                raise FileNotFoundError(
+                    f"Dream {key} path does not exist: {path}"
+                )
+
+    def _render_phase1_prompt(self, **kwargs: Any) -> str:
+        if self.phase1_template_path is not None:
+            return render_template_from_path(
+                self.phase1_template_path, strip=True, **kwargs,
+            )
+        return render_template("agent/dream_phase1.md", strip=True, **kwargs)
+
+    def _render_phase2_prompt(self, **kwargs: Any) -> str:
+        if self.phase2_template_path is not None:
+            return render_template_from_path(
+                self.phase2_template_path, strip=True, **kwargs,
+            )
+        return render_template("agent/dream_phase2.md", strip=True, **kwargs)
 
     # -- tool registry -------------------------------------------------------
 
@@ -741,9 +798,7 @@ class Dream:
                 messages=[
                     {
                         "role": "system",
-                        "content": render_template(
-                            "agent/dream_phase1.md",
-                            strip=True,
+                        "content": self._render_phase1_prompt(
                             stale_threshold_days=_STALE_THRESHOLD_DAYS,
                         ),
                     },
@@ -773,9 +828,7 @@ class Dream:
         messages: list[dict[str, Any]] = [
             {
                 "role": "system",
-                "content": render_template(
-                    "agent/dream_phase2.md",
-                    strip=True,
+                "content": self._render_phase2_prompt(
                     skill_creator_path=str(skill_creator_path),
                 ),
             },

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -865,21 +865,34 @@ def gateway(
         console.print(f"[green]✓[/green] Health endpoint: http://{host}:{health_port}/health")
         async with server:
             await server.serve_forever()
-    # Register Dream system job (always-on, idempotent on restart)
+    # Register Dream system job (idempotent on restart). Skipped entirely when
+    # dream.enabled is False — the user has opted out (#3282).
     dream_cfg = config.agents.defaults.dream
     if dream_cfg.model_override:
         agent.dream.model = dream_cfg.model_override
     agent.dream.max_batch_size = dream_cfg.max_batch_size
     agent.dream.max_iterations = dream_cfg.max_iterations
     agent.dream.annotate_line_ages = dream_cfg.annotate_line_ages
+    agent.dream.enabled = dream_cfg.enabled
+    from nanobot.agent.memory import _resolve_dream_template_path
+    agent.dream.phase1_template_path = _resolve_dream_template_path(
+        dream_cfg.phase1_template, config.workspace_path,
+    )
+    agent.dream.phase2_template_path = _resolve_dream_template_path(
+        dream_cfg.phase2_template, config.workspace_path,
+    )
+    agent.dream.validate_templates()
     from nanobot.cron.types import CronJob, CronPayload
-    cron.register_system_job(CronJob(
-        id="dream",
-        name="dream",
-        schedule=dream_cfg.build_schedule(config.agents.defaults.timezone),
-        payload=CronPayload(kind="system_event"),
-    ))
-    console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
+    if dream_cfg.enabled:
+        cron.register_system_job(CronJob(
+            id="dream",
+            name="dream",
+            schedule=dream_cfg.build_schedule(config.agents.defaults.timezone),
+            payload=CronPayload(kind="system_event"),
+        ))
+        console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
+    else:
+        console.print("[yellow]Dream: disabled (dream.enabled=false)[/yellow]")
 
     async def run():
         try:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -36,6 +36,7 @@ class DreamConfig(Base):
 
     _HOUR_MS = 3_600_000
 
+    enabled: bool = True  # Kill switch; when False, no Dream cron job is registered (#3282)
     interval_h: int = Field(default=2, ge=1)  # Every 2 hours by default
     cron: str | None = Field(default=None, exclude=True)  # Legacy compatibility override
     model_override: str | None = Field(
@@ -49,6 +50,12 @@ class DreamConfig(Base):
     # on — set to False to feed MEMORY.md raw if a specific LLM reacts poorly
     # to the `← Nd` suffix or you want deterministic, git-independent prompts.
     annotate_line_ages: bool = True
+    # Custom Dream prompt paths (#3282). If set, used instead of the builtin
+    # templates. Absolute paths are used as-is; relative paths resolve against
+    # the workspace; ~ is expanded. Missing files raise at startup when Dream
+    # is enabled; ignored when enabled=False.
+    phase1_template: str | None = None
+    phase2_template: str | None = None
 
     def build_schedule(self, timezone: str) -> CronSchedule:
         """Build the runtime schedule, preferring the legacy cron override if present."""

--- a/nanobot/utils/prompt_templates.py
+++ b/nanobot/utils/prompt_templates.py
@@ -33,3 +33,15 @@ def render_template(name: str, *, strip: bool = False, **kwargs: Any) -> str:
     """
     text = _environment().get_template(name).render(**kwargs)
     return text.rstrip() if strip else text
+
+
+def render_template_from_path(path: Path, *, strip: bool = False, **kwargs: Any) -> str:
+    """Render a Jinja template at an arbitrary absolute path.
+
+    Used for user-supplied prompt overrides (e.g. Dream custom templates from
+    ``DreamConfig.phase1_template``). Reuses the shared Jinja ``Environment``
+    so ``{% include %}`` of builtin snippets continues to work.
+    """
+    source = path.read_text(encoding="utf-8")
+    text = _environment().from_string(source).render(**kwargs)
+    return text.rstrip() if strip else text

--- a/tests/agent/test_dream_templates.py
+++ b/tests/agent/test_dream_templates.py
@@ -83,6 +83,7 @@ def test_resolve_template_path_resolves_relative_against_workspace(tmp_path: Pat
 
 def test_resolve_template_path_expands_tilde(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Windows expanduser uses USERPROFILE, not HOME
     (tmp_path / "custom.md").write_text("x")
 
     resolved = _resolve_dream_template_path("~/custom.md", Path("/other-ws"))

--- a/tests/agent/test_dream_templates.py
+++ b/tests/agent/test_dream_templates.py
@@ -1,0 +1,198 @@
+"""Tests for Dream enabled flag + custom template paths (#3282)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.memory import Dream, MemoryStore, _resolve_dream_template_path
+from nanobot.config.schema import DreamConfig
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_dream_config_enabled_defaults_true() -> None:
+    cfg = DreamConfig()
+
+    assert cfg.enabled is True
+
+
+def test_dream_config_enabled_accepts_false_via_alias() -> None:
+    cfg = DreamConfig.model_validate({"enabled": False})
+
+    assert cfg.enabled is False
+
+
+def test_dream_config_template_paths_default_none() -> None:
+    cfg = DreamConfig()
+
+    assert cfg.phase1_template is None
+    assert cfg.phase2_template is None
+
+
+def test_dream_config_template_paths_accept_strings_via_camel_case() -> None:
+    cfg = DreamConfig.model_validate({
+        "phase1Template": "templates/dream_a.md",
+        "phase2Template": "/abs/dream_b.md",
+    })
+
+    assert cfg.phase1_template == "templates/dream_a.md"
+    assert cfg.phase2_template == "/abs/dream_b.md"
+
+
+def test_dream_config_dumps_template_paths_with_camel_case_aliases() -> None:
+    cfg = DreamConfig(phase1_template="a.md", phase2_template="b.md")
+
+    dumped = cfg.model_dump(by_alias=True)
+
+    assert dumped["phase1Template"] == "a.md"
+    assert dumped["phase2Template"] == "b.md"
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_template_path_returns_none_for_none() -> None:
+    assert _resolve_dream_template_path(None, Path("/ws")) is None
+
+
+def test_resolve_template_path_accepts_absolute(tmp_path: Path) -> None:
+    abs_template = tmp_path / "mine.md"
+    abs_template.write_text("x")
+
+    resolved = _resolve_dream_template_path(str(abs_template), Path("/ws"))
+
+    assert resolved == abs_template
+
+
+def test_resolve_template_path_resolves_relative_against_workspace(tmp_path: Path) -> None:
+    (tmp_path / "templates").mkdir()
+    rel_template = tmp_path / "templates" / "p1.md"
+    rel_template.write_text("x")
+
+    resolved = _resolve_dream_template_path("templates/p1.md", tmp_path)
+
+    assert resolved == rel_template
+
+
+def test_resolve_template_path_expands_tilde(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "custom.md").write_text("x")
+
+    resolved = _resolve_dream_template_path("~/custom.md", Path("/other-ws"))
+
+    assert resolved == tmp_path / "custom.md"
+
+
+# ---------------------------------------------------------------------------
+# Dream validation (conditional on enabled)
+# ---------------------------------------------------------------------------
+
+
+def _make_dream(store: MemoryStore) -> Dream:
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock()
+    return Dream(store=store, provider=provider, model="test-model")
+
+
+def test_validate_templates_raises_when_enabled_and_path_missing(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    dream = _make_dream(store)
+    dream.enabled = True
+    dream.phase1_template_path = tmp_path / "does-not-exist.md"
+
+    with pytest.raises(FileNotFoundError) as exc:
+        dream.validate_templates()
+
+    assert "phase1_template" in str(exc.value)
+
+
+def test_validate_templates_noop_when_disabled_even_with_bad_path(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    dream = _make_dream(store)
+    dream.enabled = False
+    dream.phase1_template_path = tmp_path / "still-missing.md"
+    dream.phase2_template_path = tmp_path / "also-missing.md"
+
+    # Should not raise — Dream is disabled, template paths are irrelevant.
+    dream.validate_templates()
+
+
+def test_validate_templates_passes_when_enabled_and_paths_exist(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    dream = _make_dream(store)
+    dream.enabled = True
+    good = tmp_path / "ok.md"
+    good.write_text("content")
+    dream.phase1_template_path = good
+    dream.phase2_template_path = good
+
+    dream.validate_templates()
+
+
+def test_validate_templates_noop_when_paths_are_none(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    dream = _make_dream(store)
+    dream.enabled = True
+    dream.phase1_template_path = None
+    dream.phase2_template_path = None
+
+    dream.validate_templates()
+
+
+# ---------------------------------------------------------------------------
+# Render source
+# ---------------------------------------------------------------------------
+
+
+def test_render_phase1_uses_custom_template_when_path_set(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    dream = _make_dream(store)
+    custom = tmp_path / "my_phase1.md"
+    custom.write_text("CUSTOM_PHASE1 {{ stale_threshold_days }}")
+    dream.phase1_template_path = custom
+
+    rendered = dream._render_phase1_prompt(stale_threshold_days=14)
+
+    assert rendered.startswith("CUSTOM_PHASE1 14")
+
+
+def test_render_phase1_uses_builtin_when_path_none(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    dream = _make_dream(store)
+    dream.phase1_template_path = None
+
+    rendered = dream._render_phase1_prompt(stale_threshold_days=14)
+
+    # Builtin prompt is long and references MEMORY.md consolidation — sanity checks.
+    assert len(rendered) > 100
+    assert "CUSTOM_PHASE1" not in rendered
+
+
+def test_render_phase2_uses_custom_template_when_path_set(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    dream = _make_dream(store)
+    custom = tmp_path / "my_phase2.md"
+    custom.write_text("CUSTOM_PHASE2 {{ skill_creator_path }}")
+    dream.phase2_template_path = custom
+
+    rendered = dream._render_phase2_prompt(skill_creator_path="/path/skill-creator/SKILL.md")
+
+    assert rendered.startswith("CUSTOM_PHASE2 /path/skill-creator/SKILL.md")
+
+
+def test_render_phase2_uses_builtin_when_path_none(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path)
+    dream = _make_dream(store)
+    dream.phase2_template_path = None
+
+    rendered = dream._render_phase2_prompt(skill_creator_path="/x/y/SKILL.md")
+
+    assert len(rendered) > 100
+    assert "CUSTOM_PHASE2" not in rendered

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1193,6 +1193,12 @@ def test_gateway_health_endpoint_binds_and_serves_expected_responses(
         model = None
         max_batch_size = 0
         max_iterations = 0
+        enabled = True
+        phase1_template_path = None
+        phase2_template_path = None
+
+        def validate_templates(self) -> None:
+            return None
 
         async def run(self) -> None:
             return None


### PR DESCRIPTION
Adds two opt-in DreamConfig fields so users can customize the self-learning loop without forking templates each upgrade:

- `enabled: bool = True` — kill switch. When False, no Dream cron job is registered at gateway startup. Existing users are unaffected.
- `phase1_template`, `phase2_template: str | None` — absolute or workspace-relative paths (with `~` expanded) to user-supplied Jinja templates. When set, the Dream process renders those instead of the builtin `templates/agent/dream_phaseN.md`. When None, behavior is unchanged.

Custom paths are validated at startup (fail fast, not at the next Dream tick) — except when `enabled=False`, so users can stage in-progress templates without being forced to keep them runnable.

The path resolution helper `_resolve_dream_template_path()` lives in `nanobot/agent/memory.py` alongside Dream itself; `cli/commands.py` only reads the string out of config and passes it through.

Why not a `scope` enum (none/memory/memory_context/full): considered but rejected. Prompt-level enforcement is soft — a rebellious LLM could still touch files outside the declared scope, producing probabilistic bugs. A config that promises "won't touch skills" and occasionally does is worse than no config at all. The reporter's own workaround (overwriting template files manually) is evidence that template-level control is what they actually want; we formalize that workflow instead of reinventing it with weaker guarantees.

Co-authored with Claude Opus 4.7 — strategy and review via Claude Desktop, implementation via Claude Code.