### PR TITLE
fix(cron): drop top-level oneOf so OpenAI Codex/Responses accept tool schema

### DIFF
--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -43,30 +43,12 @@ _CRON_PARAMETERS = tool_parameters_schema(
     required=["action"],
     description=(
         "Action-specific parameters: add requires a non-empty message plus one schedule "
-        "(every_seconds, cron_expr, or at); remove requires job_id; list only needs action."
+        "(every_seconds, cron_expr, or at); remove requires job_id; list only needs action. "
+        "Per-action requirements are enforced at runtime (see field descriptions) so the "
+        "top-level schema stays compatible with providers (e.g. OpenAI Codex/Responses) that "
+        "reject oneOf/anyOf/allOf/enum/not at the root of function parameters."
     ),
 )
-_CRON_PARAMETERS["oneOf"] = [
-    {
-        "properties": {
-            "action": {"enum": ["add"]},
-            "message": {"type": "string", "minLength": 1},
-        },
-        "required": ["action", "message"],
-    },
-    {
-        "properties": {
-            "action": {"enum": ["list"]},
-        },
-        "required": ["action"],
-    },
-    {
-        "properties": {
-            "action": {"enum": ["remove"]},
-        },
-        "required": ["action", "job_id"],
-    },
-]
 
 
 @tool_parameters(_CRON_PARAMETERS)

--- a/tests/cron/test_cron_tool_list.py
+++ b/tests/cron/test_cron_tool_list.py
@@ -348,24 +348,20 @@ def test_add_job_can_disable_delivery(tmp_path) -> None:
 def test_cron_schema_advertises_action_specific_requirements(tmp_path) -> None:
     tool = _make_tool(tmp_path)
 
+    # Only ``action`` is required at the schema root — per-action requirements
+    # are enforced at runtime via ``validate_params`` and surfaced to the LLM
+    # through field descriptions. We intentionally do NOT set top-level
+    # ``oneOf``/``anyOf``/``allOf``/``enum``/``not``: OpenAI Codex/Responses
+    # reject those at the root of function parameters (#3265 regression).
     assert tool.parameters["required"] == ["action"]
-    assert tool.parameters["oneOf"] == [
-        {
-            "properties": {
-                "action": {"enum": ["add"]},
-                "message": {"type": "string", "minLength": 1},
-            },
-            "required": ["action", "message"],
-        },
-        {
-            "properties": {"action": {"enum": ["list"]}},
-            "required": ["action"],
-        },
-        {
-            "properties": {"action": {"enum": ["remove"]}},
-            "required": ["action", "job_id"],
-        },
-    ]
+    for disallowed in ("oneOf", "anyOf", "allOf", "not"):
+        assert disallowed not in tool.parameters, (
+            f"Top-level '{disallowed}' is rejected by OpenAI Codex/Responses tool schemas"
+        )
+    message_desc = tool.parameters["properties"]["message"]["description"]
+    assert "REQUIRED" in message_desc and "action='add'" in message_desc
+    job_id_desc = tool.parameters["properties"]["job_id"]["description"]
+    assert "REQUIRED" in job_id_desc and "action='remove'" in job_id_desc
 
 
 def test_validate_params_requires_message_only_for_add(tmp_path) -> None:


### PR DESCRIPTION
## Summary

PR #3125 added a top-level `oneOf` branch to `_CRON_PARAMETERS` so that the cron tool schema could advertise per-action required fields. However, the OpenAI Codex / Responses API rejects `oneOf` / `anyOf` / `allOf` / `enum` / `not` at the root of a function's `parameters`. Since that merge landed on `main`, any agent that registers the cron tool fails to start when talking to Codex:

```
Error calling Codex: HTTP 400: {
  "error": {
    "message": "Invalid schema for function 'cron': schema must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top level.",
    "type": "invalid_request_error",
    "param": "tools[0].parameters",
    "code": "invalid_function_parameters"
  }
}
```

This PR removes the top-level `oneOf` so the schema is accepted by Codex (and stays interoperable with every other provider). **No behavior change**: the original goal of #3125 — stop LLMs from looping on the #3113 contract mismatch — is already carried by:

- `validate_params` — runtime-enforces `message` for `action='add'` and `job_id` for `action='remove'`.
- Field descriptions — each of `message` and `job_id` already says `REQUIRED when action='...'`, which is the signal LLMs actually rely on.

## Repro

1. Configure any agent that registers the cron tool.
2. Select an OpenAI Codex / Responses provider (e.g. `openai-codex/gpt-5.1-codex`).
3. Start the agent — it fails on the first model call with `HTTP 400 invalid_function_parameters`.

After this PR: the agent starts normally and `cron` tool calls succeed.

## Changes

- `nanobot/agent/tools/cron.py`: drop the `_CRON_PARAMETERS["oneOf"] = [...]` block; expand the root-level description to explain why the per-action contract lives in `validate_params` + field descriptions instead of a root-level `oneOf`.
- `tests/cron/test_cron_tool_list.py`: the regression test previously asserted the exact `oneOf` payload — that assertion is inverted to lock the new invariant (root-level `oneOf` / `anyOf` / `allOf` / `not` must never come back), while still asserting the `REQUIRED` hints remain on `message` and `job_id`.

## Why this is safe

- No provider besides Codex/Responses was exercising the top-level `oneOf`; OpenAI Chat Completions, Anthropic, and Copilot all ignore it.
- `validate_params` already returns the same `"message is required when action='add'"` / `"job_id is required when action='remove'"` errors the `oneOf` was trying to surface.
- The field descriptions already say `REQUIRED when action='add'` / `REQUIRED when action='remove'`, which is what LLMs actually use to avoid the #3113 loop.
- A new test locks in the "no top-level `oneOf`/`anyOf`/`allOf`/`not`" invariant so this cannot silently regress.

## Test plan

```
.venv/bin/python -m pytest tests/cron/                                       # 70 passed
.venv/bin/python -m pytest tests/agent/test_loop_cron_timezone.py tests/providers/   # 232 passed
```

## Target branch

`main` — this is a bug fix with no behavior change (per `CONTRIBUTING.md`).

## Related

- Introduced by: #3125 (Merge `3218307`) — *fix: harden cron tool contract*
- Original contract issue the `oneOf` was meant to address: #3113
