### PR TITLE
feat: spawn_status/spawn_cancel tools, domain loop detection, hardened cursor recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ logs/
 tmp/
 temp/
 *.tmp
+nanobot.env/

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -29,6 +29,8 @@ from nanobot.agent.tools.search import GlobTool, GrepTool
 from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.self import MyTool
 from nanobot.agent.tools.spawn import SpawnTool
+from nanobot.agent.tools.spawn_status import SpawnStatusTool
+from nanobot.agent.tools.spawn_cancel import SpawnCancelTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -315,6 +317,8 @@ class AgentLoop:
             self.tools.register(WebFetchTool(proxy=self.web_config.proxy))
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
         self.tools.register(SpawnTool(manager=self.subagents))
+        self.tools.register(SpawnStatusTool(subagent_manager=self.subagents))
+        self.tools.register(SpawnCancelTool(subagent_manager=self.subagents))
         if self.cron_service:
             self.tools.register(
                 CronTool(self.cron_service, default_timezone=self.context.timezone or "UTC")

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -317,8 +317,8 @@ class AgentLoop:
             self.tools.register(WebFetchTool(proxy=self.web_config.proxy))
         self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
         self.tools.register(SpawnTool(manager=self.subagents))
-        self.tools.register(SpawnStatusTool(subagent_manager=self.subagents))
-        self.tools.register(SpawnCancelTool(subagent_manager=self.subagents))
+        self.tools.register(SpawnStatusTool(manager=self.subagents))
+        self.tools.register(SpawnCancelTool(manager=self.subagents))
         if self.cron_service:
             self.tools.register(
                 CronTool(self.cron_service, default_timezone=self.context.timezone or "UTC")

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -226,6 +226,15 @@ class SubagentManager:
                 logger.info("Subagent [{}] completed successfully", task_id)
                 await self._announce_result(task_id, label, task, final_result, origin, "ok")
 
+        except asyncio.TimeoutError:
+            status.phase = "error"
+            status.error = f"Timed out after {timeout} seconds"
+            logger.error("Subagent [{}] timed out after {} seconds", task_id, timeout)
+            await self._announce_result(task_id, label, task, f"Error: {status.error}", origin, "error")
+        except asyncio.CancelledError:
+            status.phase = "error"
+            status.error = "Cancelled"
+            logger.info("Subagent [{}] cancelled", task_id)
         except Exception as e:
             status.phase = "error"
             status.error = str(e)

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -103,6 +103,8 @@ class SubagentManager:
         origin_channel: str = "cli",
         origin_chat_id: str = "direct",
         session_key: str | None = None,
+        max_iterations: int | None = None,
+        timeout_seconds: int | None = None,
     ) -> str:
         """Spawn a subagent to execute a task in the background."""
         task_id = str(uuid.uuid4())[:8]
@@ -118,7 +120,9 @@ class SubagentManager:
         self._task_statuses[task_id] = status
 
         bg_task = asyncio.create_task(
-            self._run_subagent(task_id, task, display_label, origin, status)
+            self._run_subagent(task_id, task, display_label, origin, status,
+                               max_iterations=max_iterations,
+                               timeout_seconds=timeout_seconds)
         )
         self._running_tasks[task_id] = bg_task
         if session_key:
@@ -144,6 +148,8 @@ class SubagentManager:
         label: str,
         origin: dict[str, str],
         status: SubagentStatus,
+        max_iterations: int | None = None,
+        timeout_seconds: int | None = None,
     ) -> None:
         """Execute the subagent task and announce the result."""
         logger.info("Subagent [{}] starting task: {}", task_id, label)
@@ -181,18 +187,24 @@ class SubagentManager:
                 {"role": "user", "content": task},
             ]
 
-            result = await self.runner.run(AgentRunSpec(
-                initial_messages=messages,
-                tools=tools,
-                model=self.model,
-                max_iterations=15,
-                max_tool_result_chars=self.max_tool_result_chars,
-                hook=_SubagentHook(task_id, status),
-                max_iterations_message="Task completed but no final response was generated.",
-                error_message=None,
-                fail_on_tool_error=True,
-                checkpoint_callback=_on_checkpoint,
-            ))
+            max_iter = max_iterations or 15
+            timeout = timeout_seconds or 300
+
+            result = await asyncio.wait_for(
+                self.runner.run(AgentRunSpec(
+                    initial_messages=messages,
+                    tools=tools,
+                    model=self.model,
+                    max_iterations=max_iter,
+                    max_tool_result_chars=self.max_tool_result_chars,
+                    hook=_SubagentHook(task_id, status),
+                    max_iterations_message="Task completed but no final response was generated.",
+                    error_message=None,
+                    fail_on_tool_error=True,
+                    checkpoint_callback=_on_checkpoint,
+                )),
+                timeout=timeout,
+            )
             status.phase = "done"
             status.stop_reason = result.stop_reason
 
@@ -308,6 +320,41 @@ class SubagentManager:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         return len(tasks)
+
+    async def cancel_by_id(self, task_id: str) -> int:
+        """Cancel a specific subagent by task ID. Returns count cancelled."""
+        task = self._running_tasks.get(task_id)
+        if task and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            return 1
+        return 0
+
+    def get_task_status(self, task_id: str) -> str:
+        """Return status info for a specific subagent."""
+        status = self._task_statuses.get(task_id)
+        if status is None:
+            return f"No subagent found with ID {task_id}."
+        return self._format_status(status)
+
+    def get_all_status(self) -> str:
+        """Return status of all tracked subagents (running and recent)."""
+        if not self._task_statuses and not self._running_tasks:
+            return "No subagent tasks tracked."
+        lines = []
+        for tid, status in self._task_statuses.items():
+            lines.append(self._format_status(status))
+        return "\n".join(lines) if lines else "No subagent tasks tracked."
+
+    def _format_status(self, status: SubagentStatus) -> str:
+        """Format a SubagentStatus into a human-readable string."""
+        elapsed = time.monotonic() - status.started_at
+        mins, secs = divmod(int(elapsed), 60)
+        running = "running" if status.phase not in ("done", "error") else status.phase
+        return (
+            f"Task ID: {status.task_id} | Label: {status.label} | "
+            f"Elapsed: {mins}m {secs}s | Status: {running}"
+        )
 
     def get_running_count(self) -> int:
         """Return the number of currently running subagents."""

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -235,6 +235,7 @@ class SubagentManager:
             status.phase = "error"
             status.error = "Cancelled"
             logger.info("Subagent [{}] cancelled", task_id)
+            raise
         except Exception as e:
             status.phase = "error"
             status.error = str(e)

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -4,7 +4,7 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 
 from nanobot.agent.tools.base import Tool, tool_parameters
-from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
+from nanobot.agent.tools.schema import IntegerSchema, StringSchema, tool_parameters_schema
 
 if TYPE_CHECKING:
     from nanobot.agent.subagent import SubagentManager
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
     tool_parameters_schema(
         task=StringSchema("The task for the subagent to complete"),
         label=StringSchema("Optional short label for the task (for display)"),
-        max_iterations=StringSchema("Optional maximum model iterations for the subagent (default 15)"),
-        timeout_seconds=StringSchema("Optional maximum wall-clock time in seconds before the subagent is cancelled (default 300)"),
+        max_iterations=IntegerSchema(0, description="Optional maximum model iterations for the subagent (default 15)", nullable=True),
+        timeout_seconds=IntegerSchema(0, description="Optional maximum wall-clock time in seconds before the subagent is cancelled (default 300)", nullable=True),
         required=["task"],
     )
 )
@@ -52,11 +52,6 @@ class SpawnTool(Tool):
                       max_iterations: int | None = None, timeout_seconds: int | None = None,
                       **kwargs: Any) -> str:
         """Spawn a subagent to execute the given task."""
-        # tool_parameters wraps everything as StringSchema — coerce to int
-        if max_iterations is not None:
-            max_iterations = int(max_iterations)
-        if timeout_seconds is not None:
-            timeout_seconds = int(timeout_seconds)
         return await self._manager.spawn(
             task=task,
             label=label,
@@ -64,5 +59,5 @@ class SpawnTool(Tool):
             origin_chat_id=self._origin_chat_id.get(),
             session_key=self._session_key.get(),
             max_iterations=max_iterations,
-            timeout_seconds=timeout_seconds, (fix(spawn): coerce max_iterations and timeout_seconds from string to int)
+            timeout_seconds=timeout_seconds,
         )

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     tool_parameters_schema(
         task=StringSchema("The task for the subagent to complete"),
         label=StringSchema("Optional short label for the task (for display)"),
+        max_iterations=StringSchema("Optional maximum model iterations for the subagent (default 15)"),
+        timeout_seconds=StringSchema("Optional maximum wall-clock time in seconds before the subagent is cancelled (default 300)"),
         required=["task"],
     )
 )
@@ -46,12 +48,21 @@ class SpawnTool(Tool):
             "and use a dedicated subdirectory when helpful."
         )
 
-    async def execute(self, task: str, label: str | None = None, **kwargs: Any) -> str:
+    async def execute(self, task: str, label: str | None = None,
+                      max_iterations: int | None = None, timeout_seconds: int | None = None,
+                      **kwargs: Any) -> str:
         """Spawn a subagent to execute the given task."""
+        # tool_parameters wraps everything as StringSchema — coerce to int
+        if max_iterations is not None:
+            max_iterations = int(max_iterations)
+        if timeout_seconds is not None:
+            timeout_seconds = int(timeout_seconds)
         return await self._manager.spawn(
             task=task,
             label=label,
             origin_channel=self._origin_channel.get(),
             origin_chat_id=self._origin_chat_id.get(),
             session_key=self._session_key.get(),
+            max_iterations=max_iterations,
+            timeout_seconds=timeout_seconds, (fix(spawn): coerce max_iterations and timeout_seconds from string to int)
         )

--- a/nanobot/agent/tools/spawn_cancel.py
+++ b/nanobot/agent/tools/spawn_cancel.py
@@ -1,0 +1,46 @@
+"""Spawn cancel tool — cancel a running subagent by task ID."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nanobot.agent.tools.base import Tool
+
+
+class SpawnCancelTool(Tool):
+    """Cancel a running subagent by its task ID."""
+
+    def __init__(self, subagent_manager) -> None:
+        self._manager = subagent_manager
+
+    @property
+    def name(self) -> str:
+        return "spawn_cancel"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Cancel a running subagent by its task ID. "
+            "Use spawn_status first to see running tasks and their IDs."
+        )
+
+    async def execute(self, task_id: str, **kwargs: Any) -> str:
+        if not task_id:
+            return "Error: task_id is required."
+        count = await self._manager.cancel_by_id(task_id)
+        if count > 0:
+            return f"Cancelled subagent {task_id}."
+        return f"No running subagent found with ID {task_id}."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Task ID of the subagent to cancel",
+                },
+            },
+            "required": ["task_id"],
+        }

--- a/nanobot/agent/tools/spawn_cancel.py
+++ b/nanobot/agent/tools/spawn_cancel.py
@@ -2,16 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.base import Tool, tool_parameters
+from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
+
+if TYPE_CHECKING:
+    from nanobot.agent.subagent import SubagentManager
 
 
+@tool_parameters(
+    tool_parameters_schema(
+        task_id=StringSchema("Task ID of the subagent to cancel"),
+        required=["task_id"],
+    )
+)
 class SpawnCancelTool(Tool):
     """Cancel a running subagent by its task ID."""
 
-    def __init__(self, subagent_manager) -> None:
-        self._manager = subagent_manager
+    def __init__(self, manager: "SubagentManager") -> None:
+        self._manager = manager
 
     @property
     def name(self) -> str:
@@ -31,16 +41,3 @@ class SpawnCancelTool(Tool):
         if count > 0:
             return f"Cancelled subagent {task_id}."
         return f"No running subagent found with ID {task_id}."
-
-    @property
-    def parameters(self) -> dict[str, Any]:
-        return {
-            "type": "object",
-            "properties": {
-                "task_id": {
-                    "type": "string",
-                    "description": "Task ID of the subagent to cancel",
-                },
-            },
-            "required": ["task_id"],
-        }

--- a/nanobot/agent/tools/spawn_status.py
+++ b/nanobot/agent/tools/spawn_status.py
@@ -1,0 +1,43 @@
+"""Spawn status tool — list running subagent tasks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nanobot.agent.tools.base import Tool
+
+
+class SpawnStatusTool(Tool):
+    """Check the status of spawned subagents."""
+
+    def __init__(self, subagent_manager) -> None:
+        self._manager = subagent_manager
+
+    @property
+    def name(self) -> str:
+        return "spawn_status"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Check the status of spawned subagents. "
+            "Returns task ID, label, elapsed time, and status (running/done/error). "
+            "Use without arguments to list all subagents, or pass a specific task_id."
+        )
+
+    async def execute(self, task_id: str | None = None, **kwargs: Any) -> str:
+        if task_id:
+            return self._manager.get_task_status(task_id)
+        return self._manager.get_all_status()
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Optional: task ID of a specific subagent to check",
+                },
+            },
+        }

--- a/nanobot/agent/tools/spawn_status.py
+++ b/nanobot/agent/tools/spawn_status.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.base import Tool, tool_parameters
+from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
+
+if TYPE_CHECKING:
+    from nanobot.agent.subagent import SubagentManager
 
 
+@tool_parameters(
+    tool_parameters_schema(
+        task_id=StringSchema("Optional: task ID of a specific subagent to check", nullable=True),
+    )
+)
 class SpawnStatusTool(Tool):
     """Check the status of spawned subagents."""
 
-    def __init__(self, subagent_manager) -> None:
-        self._manager = subagent_manager
+    def __init__(self, manager: "SubagentManager") -> None:
+        self._manager = manager
 
     @property
     def name(self) -> str:
@@ -29,15 +38,3 @@ class SpawnStatusTool(Tool):
         if task_id:
             return self._manager.get_task_status(task_id)
         return self._manager.get_all_status()
-
-    @property
-    def parameters(self) -> dict[str, Any]:
-        return {
-            "type": "object",
-            "properties": {
-                "task_id": {
-                    "type": "string",
-                    "description": "Optional: task ID of a specific subagent to check",
-                },
-            },
-        }

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -715,6 +715,40 @@ class TelegramChannel(BaseChannel):
                     text=preview,
                 )
                 buf.last_edit = now
+            except BadRequest as e:
+                if self._is_not_modified_error(e):
+                    buf.last_edit = now
+                    return
+                # If the accumulated stream text exceeded Telegram's 4096-char
+                # limit, finalize the current message with a truncated or chunked
+                # edit and spin up a new stream buffer for the overflow.
+                if "message is too long" in str(e).lower():
+                    logger.info(
+                        "Stream buffer exceeded Telegram limit for {}, splitting",
+                        chat_id,
+                    )
+                    chunks = split_message(buf.text, TELEGRAM_MAX_MESSAGE_LEN)
+                    # Edit the existing message down to the first chunk
+                    if chunks:
+                        try:
+                            await self._call_with_retry(
+                                self._app.bot.edit_message_text,
+                                chat_id=int_chat_id,
+                                message_id=buf.message_id,
+                                text=chunks[0],
+                            )
+                        except Exception:
+                            pass  # best-effort truncation
+                        # Send overflow chunks as new messages
+                        for extra in chunks[1:]:
+                            await self._send_text(int_chat_id, extra)
+                    # Reset buffer for continued streaming into a fresh message
+                    buf.text = ""
+                    buf.message_id = None
+                    buf.last_edit = now
+                    return
+                logger.warning("Stream edit failed: {}", e)
+                raise  # Let ChannelManager handle retry
             except Exception as e:
                 if self._is_not_modified_error(e):
                     buf.last_edit = now

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -9,8 +9,7 @@ from loguru import logger
 from nanobot.utils.helpers import stringify_text_blocks
 
 _MAX_REPEAT_EXTERNAL_LOOKUPS = 2
-_MAX_REPEAT_SAME_DOMAIN = 3
-_MAX_REPEAT_SAME_DOMAIN = 3
+_MAX_REPEAT_SAME_DOMAIN = 10
 
 EMPTY_FINAL_RESPONSE_MESSAGE = (
     "I completed the tool steps but couldn't produce a final answer. "

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -9,6 +9,8 @@ from loguru import logger
 from nanobot.utils.helpers import stringify_text_blocks
 
 _MAX_REPEAT_EXTERNAL_LOOKUPS = 2
+_MAX_REPEAT_SAME_DOMAIN = 3
+_MAX_REPEAT_SAME_DOMAIN = 3
 
 EMPTY_FINAL_RESPONSE_MESSAGE = (
     "I completed the tool steps but couldn't produce a final answer. "
@@ -73,25 +75,58 @@ def external_lookup_signature(tool_name: str, arguments: dict[str, Any]) -> str 
     return None
 
 
+def external_lookup_domain(tool_name: str, arguments: dict[str, Any]) -> str | None:
+    """Extract domain from web_fetch URLs for same-domain repeat detection."""
+    if tool_name == "web_fetch":
+        url = str(arguments.get("url") or "").strip()
+        if url:
+            try:
+                from urllib.parse import urlparse
+                domain = urlparse(url).netloc.lower()
+                if domain and domain not in ("localhost", "127.0.0.1"):
+                    return f"domain:{domain}"
+            except Exception:
+                pass
+    return None
+
+
 def repeated_external_lookup_error(
     tool_name: str,
     arguments: dict[str, Any],
     seen_counts: dict[str, int],
 ) -> str | None:
     """Block repeated external lookups after a small retry budget."""
+    # Check exact URL/query match first
     signature = external_lookup_signature(tool_name, arguments)
-    if signature is None:
-        return None
-    count = seen_counts.get(signature, 0) + 1
-    seen_counts[signature] = count
-    if count <= _MAX_REPEAT_EXTERNAL_LOOKUPS:
-        return None
-    logger.warning(
-        "Blocking repeated external lookup {} on attempt {}",
-        signature[:160],
-        count,
-    )
-    return (
-        "Error: repeated external lookup blocked. "
-        "Use the results you already have to answer, or try a meaningfully different source."
-    )
+    if signature is not None:
+        count = seen_counts.get(signature, 0) + 1
+        seen_counts[signature] = count
+        if count <= _MAX_REPEAT_EXTERNAL_LOOKUPS:
+            pass  # continue to domain check below
+        else:
+            logger.warning(
+                "Blocking repeated external lookup {} on attempt {}",
+                signature[:160],
+                count,
+            )
+            return (
+                "Error: repeated external lookup blocked. "
+                "Use the results you already have to answer, or try a meaningfully different source."
+            )
+
+    # Check same-domain repeats (catches different URLs from same site)
+    domain_sig = external_lookup_domain(tool_name, arguments)
+    if domain_sig is not None:
+        domain_count = seen_counts.get(domain_sig, 0) + 1
+        seen_counts[domain_sig] = domain_count
+        if domain_count > _MAX_REPEAT_SAME_DOMAIN:
+            logger.warning(
+                "Blocking repeated domain lookup {} on attempt {}",
+                domain_sig[:80],
+                domain_count,
+            )
+            return (
+                "Error: you have already fetched from this domain multiple times. "
+                "Use the results you already have to answer, or try a different source."
+            )
+    return None

--- a/tests/agent/tools/test_spawn_tools.py
+++ b/tests/agent/tools/test_spawn_tools.py
@@ -366,10 +366,11 @@ class TestTimeoutCleanup:
         with patch.object(mgr, "_build_subagent_prompt", return_value="test prompt"), \
              patch("nanobot.agent.subagent.ToolRegistry"), \
              patch("nanobot.agent.subagent.WebToolsConfig"):
-            await mgr._run_subagent(
-                "sub-1", "do thing", "cancelled-task",
-                {"channel": "test", "chat_id": "c1"}, status,
-            )
+            with pytest.raises(asyncio.CancelledError):
+                await mgr._run_subagent(
+                    "sub-1", "do thing", "cancelled-task",
+                    {"channel": "test", "chat_id": "c1"}, status,
+                )
 
         assert status.phase == "error"
         assert status.error == "Cancelled"

--- a/tests/agent/tools/test_spawn_tools.py
+++ b/tests/agent/tools/test_spawn_tools.py
@@ -1,0 +1,461 @@
+"""Tests for spawn_status, spawn_cancel, domain loop detection, and timeout cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.config.schema import AgentDefaults
+
+_MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
+
+
+# ---------------------------------------------------------------------------
+# Domain loop detection (runtime.py)
+# ---------------------------------------------------------------------------
+
+
+class TestDomainLoopDetection:
+    def test_same_domain_blocked_after_threshold(self):
+        from nanobot.utils.runtime import repeated_external_lookup_error
+
+        seen: dict[str, int] = {}
+        # 10 fetches from the same domain — should all pass
+        for i in range(10):
+            result = repeated_external_lookup_error(
+                "web_fetch",
+                {"url": f"https://docs.python.org/3/library?page={i}"},
+                seen,
+            )
+            assert result is None, f"fetch {i+1} should not be blocked"
+
+        # 11th should be blocked
+        result = repeated_external_lookup_error(
+            "web_fetch",
+            {"url": "https://docs.python.org/3/whatsnew"},
+            seen,
+        )
+        assert result is not None
+        assert "domain" in result.lower()
+
+    def test_different_domains_not_blocked(self):
+        from nanobot.utils.runtime import repeated_external_lookup_error
+
+        seen: dict[str, int] = {}
+        domains = ["example.com", "github.com", "docs.python.org", "arxiv.org", "wikipedia.org"]
+        for domain in domains:
+            result = repeated_external_lookup_error(
+                "web_fetch",
+                {"url": f"https://{domain}/page"},
+                seen,
+            )
+            assert result is None, f"domain {domain} should not be blocked"
+
+    def test_localhost_and_127_0_0_1_excluded(self):
+        from nanobot.utils.runtime import repeated_external_lookup_error
+
+        seen: dict[str, int] = {}
+        for url in ["http://localhost:8080/api", "http://127.0.0.1:5000/health"]:
+            result = repeated_external_lookup_error("web_fetch", {"url": url}, seen)
+            assert result is None
+
+    def test_web_search_not_affected_by_domain_check(self):
+        """Domain detection only applies to web_fetch, not web_search."""
+        from nanobot.utils.runtime import repeated_external_lookup_error
+
+        seen: dict[str, int] = {}
+        # web_search has its own exact-match throttling (2 retries max)
+        # First 2 should pass, 3rd blocked by exact query match
+        for i in range(2):
+            result = repeated_external_lookup_error(
+                "web_search",
+                {"query": "test query"},
+                seen,
+            )
+            assert result is None, f"web_search attempt {i+1} should pass"
+
+        # 3rd identical query blocked by exact match, not domain
+        result = repeated_external_lookup_error(
+            "web_search",
+            {"query": "test query"},
+            seen,
+        )
+        assert result is not None
+
+    def test_exact_url_still_throttled_independently(self):
+        """Exact URL throttle (2 retries) fires before domain throttle (10)."""
+        from nanobot.utils.runtime import repeated_external_lookup_error
+
+        seen: dict[str, int] = {}
+        # Same URL 3 times — blocked by exact match (threshold 2)
+        for i in range(2):
+            result = repeated_external_lookup_error(
+                "web_fetch",
+                {"url": "https://example.com/same-page"},
+                seen,
+            )
+            assert result is None, f"attempt {i+1} should pass"
+
+        # 3rd identical URL is blocked
+        result = repeated_external_lookup_error(
+            "web_fetch",
+            {"url": "https://example.com/same-page"},
+            seen,
+        )
+        assert result is not None
+        assert "repeated" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# spawn_status tool
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnStatusTool:
+    @pytest.mark.asyncio
+    async def test_status_returns_info_for_known_task(self):
+        from nanobot.agent.subagent import SubagentManager, SubagentStatus
+        from nanobot.agent.tools.spawn_status import SpawnStatusTool
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+        mgr._task_statuses["sub-1"] = SubagentStatus(
+            task_id="sub-1", label="test-task", task_description="do stuff", started_at=time.monotonic()
+        )
+
+        tool = SpawnStatusTool(mgr)
+        result = await tool.execute(task_id="sub-1")
+        assert "sub-1" in result
+        assert "test-task" in result
+
+    @pytest.mark.asyncio
+    async def test_status_returns_message_for_unknown_task(self):
+        from nanobot.agent.subagent import SubagentManager
+        from nanobot.agent.tools.spawn_status import SpawnStatusTool
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+
+        tool = SpawnStatusTool(mgr)
+        result = await tool.execute(task_id="nonexistent")
+        assert "No subagent" in result
+
+    @pytest.mark.asyncio
+    async def test_status_all_returns_empty_when_no_tasks(self):
+        from nanobot.agent.subagent import SubagentManager
+        from nanobot.agent.tools.spawn_status import SpawnStatusTool
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+
+        tool = SpawnStatusTool(mgr)
+        result = await tool.execute()
+        assert "No subagent tasks" in result
+
+    @pytest.mark.asyncio
+    async def test_status_all_lists_multiple_tasks(self):
+        from nanobot.agent.subagent import SubagentManager, SubagentStatus
+        from nanobot.agent.tools.spawn_status import SpawnStatusTool
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+        mgr._task_statuses["sub-1"] = SubagentStatus(
+            task_id="sub-1", label="alpha", task_description="task a", started_at=time.monotonic()
+        )
+        mgr._task_statuses["sub-2"] = SubagentStatus(
+            task_id="sub-2", label="beta", task_description="task b", started_at=time.monotonic()
+        )
+
+        tool = SpawnStatusTool(mgr)
+        result = await tool.execute()
+        assert "sub-1" in result
+        assert "sub-2" in result
+        assert "alpha" in result
+        assert "beta" in result
+
+
+# ---------------------------------------------------------------------------
+# spawn_cancel tool
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnCancelTool:
+    @pytest.mark.asyncio
+    async def test_cancel_running_task(self):
+        from nanobot.agent.subagent import SubagentManager
+        from nanobot.agent.tools.spawn_cancel import SpawnCancelTool
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+
+        cancelled = asyncio.Event()
+
+        async def slow():
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        task = asyncio.create_task(slow())
+        await asyncio.sleep(0)
+        mgr._running_tasks["sub-1"] = task
+
+        tool = SpawnCancelTool(mgr)
+        result = await tool.execute(task_id="sub-1")
+        assert "Cancelled" in result
+        assert cancelled.is_set()
+
+    @pytest.mark.asyncio
+    async def test_cancel_nonexistent_task(self):
+        from nanobot.agent.subagent import SubagentManager
+        from nanobot.agent.tools.spawn_cancel import SpawnCancelTool
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+
+        tool = SpawnCancelTool(mgr)
+        result = await tool.execute(task_id="ghost")
+        assert "No running" in result
+
+    @pytest.mark.asyncio
+    async def test_cancel_empty_task_id(self):
+        from nanobot.agent.subagent import SubagentManager
+        from nanobot.agent.tools.spawn_cancel import SpawnCancelTool
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+
+        tool = SpawnCancelTool(mgr)
+        result = await tool.execute(task_id="")
+        assert "Error" in result
+
+
+# ---------------------------------------------------------------------------
+# Timeout cleanup (subagent.py)
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutCleanup:
+    @pytest.mark.asyncio
+    async def test_timeout_error_sets_status_and_announces(self):
+        """asyncio.TimeoutError must set status.phase='error' and announce."""
+        from nanobot.agent.subagent import SubagentManager, SubagentStatus
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+        mgr._announce_result = AsyncMock()
+
+        status = SubagentStatus(
+            task_id="sub-1", label="slow-task", task_description="do slow thing", started_at=time.monotonic()
+        )
+
+        # Patch the inner await so TimeoutError fires from asyncio.wait_for
+        original_run = mgr.runner.run
+        async def fake_run(spec):
+            raise asyncio.TimeoutError()
+        mgr.runner.run = fake_run
+
+        # We need to bypass tool setup — mock _build_subagent_prompt and tool registry
+        with patch.object(mgr, "_build_subagent_prompt", return_value="test prompt"), \
+             patch("nanobot.agent.subagent.ToolRegistry"), \
+             patch("nanobot.agent.subagent.WebToolsConfig"):
+            await mgr._run_subagent(
+                "sub-1", "do slow thing", "slow-task",
+                {"channel": "test", "chat_id": "c1"}, status,
+                timeout_seconds=1,
+            )
+
+        assert status.phase == "error"
+        assert "Timed out" in status.error
+        mgr._announce_result.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_sets_status_no_announce(self):
+        """asyncio.CancelledError must set status.phase='error' but NOT announce."""
+        from nanobot.agent.subagent import SubagentManager, SubagentStatus
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+        mgr._announce_result = AsyncMock()
+
+        status = SubagentStatus(
+            task_id="sub-1", label="cancelled-task", task_description="do thing", started_at=time.monotonic()
+        )
+
+        async def fake_run(spec):
+            raise asyncio.CancelledError()
+
+        mgr.runner.run = fake_run
+
+        with patch.object(mgr, "_build_subagent_prompt", return_value="test prompt"), \
+             patch("nanobot.agent.subagent.ToolRegistry"), \
+             patch("nanobot.agent.subagent.WebToolsConfig"):
+            await mgr._run_subagent(
+                "sub-1", "do thing", "cancelled-task",
+                {"channel": "test", "chat_id": "c1"}, status,
+            )
+
+        assert status.phase == "error"
+        assert status.error == "Cancelled"
+        mgr._announce_result.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_leave_zombie_entries(self):
+        """After timeout, _cleanup callback removes task from tracking dicts."""
+        from nanobot.agent.subagent import SubagentManager, SubagentStatus
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+        mgr._announce_result = AsyncMock()
+
+        status = SubagentStatus(
+            task_id="sub-1", label="zombie-test", task_description="do thing", started_at=time.monotonic()
+        )
+
+        async def fake_run(spec):
+            raise asyncio.TimeoutError()
+
+        mgr.runner.run = AsyncMock(side_effect=fake_run)
+
+        # Simulate what spawn() does: create background task with _cleanup callback
+        async def run_with_cleanup():
+            await mgr._run_subagent(
+                "sub-1", "do thing", "zombie-test",
+                {"channel": "test", "chat_id": "c1"}, status,
+                timeout_seconds=1,
+            )
+
+        bg_task = asyncio.create_task(run_with_cleanup())
+
+        def _cleanup(_: asyncio.Task) -> None:
+            mgr._running_tasks.pop("sub-1", None)
+            mgr._task_statuses.pop("sub-1", None)
+
+        bg_task.add_done_callback(_cleanup)
+        mgr._running_tasks["sub-1"] = bg_task
+        mgr._task_statuses["sub-1"] = status
+
+        await asyncio.gather(bg_task, return_exceptions=True)
+
+        # After completion + cleanup, no zombie entries
+        assert "sub-1" not in mgr._running_tasks
+        assert "sub-1" not in mgr._task_statuses
+
+
+# ---------------------------------------------------------------------------
+# IntegerSchema for spawn params
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnToolIntegerParams:
+    def test_spawn_tool_uses_integer_schema(self):
+        """Verify spawn tool registers max_iterations and timeout_seconds as IntegerSchema."""
+        from nanobot.agent.tools.spawn import SpawnTool
+        import inspect
+
+        # Check that the module imports IntegerSchema
+        from nanobot.agent.tools import spawn as spawn_mod
+        assert hasattr(spawn_mod, 'IntegerSchema'), "spawn.py should import IntegerSchema"
+
+    def test_spawn_tool_name_and_description(self):
+        from nanobot.agent.subagent import SubagentManager
+        from nanobot.agent.tools.spawn import SpawnTool
+        from nanobot.bus.queue import MessageBus
+
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.get_default_model.return_value = "test-model"
+        mgr = SubagentManager(
+            provider=provider,
+            workspace=MagicMock(),
+            bus=bus,
+            max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        )
+
+        tool = SpawnTool(mgr)
+        assert tool.name == "spawn"
+        assert "subagent" in tool.description.lower()

--- a/tests/test_tool_contextvars.py
+++ b/tests/test_tool_contextvars.py
@@ -49,7 +49,7 @@ async def test_spawn_tool_keeps_task_local_context() -> None:
     release = asyncio.Event()
 
     class _Manager:
-        async def spawn(self, *, task: str, label: str | None, origin_channel: str, origin_chat_id: str, session_key: str) -> str:
+        async def spawn(self, *, task: str, label: str | None, origin_channel: str, origin_chat_id: str, session_key: str, max_iterations: int | None = None, timeout_seconds: int | None = None) -> str:
             seen.append((origin_channel, origin_chat_id, session_key))
             return f"{origin_channel}:{origin_chat_id}:{task}"
 
@@ -147,7 +147,7 @@ async def test_spawn_tool_basic_set_context_and_execute() -> None:
     seen: list[tuple[str, str, str]] = []
 
     class _Manager:
-        async def spawn(self, *, task, label, origin_channel, origin_chat_id, session_key):
+        async def spawn(self, *, task, label, origin_channel, origin_chat_id, session_key, max_iterations=None, timeout_seconds=None):
             seen.append((origin_channel, origin_chat_id, session_key))
             return f"ok: {task}"
 
@@ -165,7 +165,7 @@ async def test_spawn_tool_default_values_without_set_context() -> None:
     seen: list[tuple[str, str, str]] = []
 
     class _Manager:
-        async def spawn(self, *, task, label, origin_channel, origin_chat_id, session_key):
+        async def spawn(self, *, task, label, origin_channel, origin_chat_id, session_key, max_iterations=None, timeout_seconds=None):
             seen.append((origin_channel, origin_chat_id, session_key))
             return "ok"
 


### PR DESCRIPTION
## Summary

Adds spawn status/cancel tools, domain loop detection for web_fetch, and subagent timeout cleanup.

### What's new

**spawn_status tool** — `SpawnStatusTool` lets agents query running subagent tasks (task ID, label, elapsed time, status). Accepts optional `task_id` param or lists all tasks.

**spawn_cancel tool** — `SpawnCancelTool` cancels a running subagent by task ID. Uses `spawn_status` first to discover task IDs.

**spawn params** — `max_iterations` and `timeout_seconds` params on the spawn tool, using `IntegerSchema` with nullable defaults (0 = use framework defaults).

**Domain loop detection** — `repeated_external_lookup_error()` in `runtime.py` now tracks same-domain fetches in addition to exact-URL matching. Blocks `web_fetch` after 10 fetches to the same domain (configurable via `_MAX_REPEAT_SAME_DOMAIN`). Localhost/127.0.0.1 are excluded. Complements upstream's exact-URL throttle (`_MAX_REPEAT_EXTERNAL_LOOKUPS = 2`).

**Timeout cleanup** — Explicit `asyncio.TimeoutError` and `CancelledError` handlers in `subagent.py` prevent zombie entries in `_running_tasks` and `_task_statuses`.

**Telegram stream fix** — Catches `Message_too_long` during stream edits, splits buffer via `split_message()`, edits existing message to first chunk, sends overflow as new messages.

### Changes

| File | Type |
|------|------|
| `nanobot/agent/tools/spawn_status.py` | New — SpawnStatusTool with @tool_parameters |
| `nanobot/agent/tools/spawn_cancel.py` | New — SpawnCancelTool with @tool_parameters |
| `nanobot/agent/tools/spawn.py` | Modified — IntegerSchema params, removed runtime int() coerce |
| `nanobot/agent/subagent.py` | Modified — cancel_by_id, get_task_status, get_all_status, timeout/cancel handlers |
| `nanobot/agent/loop.py` | Modified — register spawn_status and spawn_cancel tools |
| `nanobot/utils/runtime.py` | Modified — domain loop detection (threshold 10) |
| `nanobot/channels/telegram.py` | Modified — Message_too_long stream split |
| `tests/agent/tools/test_spawn_tools.py` | New — 17 tests |

### Tests (17/17 passing)

- **Domain loop detection** (5): threshold blocking, multi-domain pass, localhost exempt, web_search unaffected, exact URL still throttled
- **spawn_status** (4): known task, unknown task, empty list, multiple tasks
- **spawn_cancel** (3): cancel running, cancel nonexistent, empty task_id
- **Timeout cleanup** (3): TimeoutError announces result, CancelledError silent, no zombie entries
- **IntegerSchema** (2): import check, tool instantiation

### Rebased on

Latest `upstream/main` (cursor recovery from PR #3340 already merged upstream — no duplication).