### PR TITLE
feat(tools): add LRU cache for read-only tool results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1682,6 +1682,28 @@ How it works:
 >
 > This differs from the **token-driven soft consolidation** that fires when a prompt exceeds the context budget: that path only advances an internal `last_consolidated` cursor and leaves the session file untouched, so the raw tool-call trail stays on disk and can still be replayed or audited. If you rely on that trail for debugging or auditing, leave `idleCompactAfterMinutes` at the default `0` and let only the token-driven path run.
 
+### Tool Result Cache
+
+When an agent performs repeated lookups within a session — fetching the same file, re-running the same search query, re-reading a URL — nanobot can skip redundant round-trips by returning the previously-seen result from an in-memory cache.
+
+Only **read-only** tools are eligible for caching (`read_file`, `list_dir`, `glob`, `grep`, `web_search`, `web_fetch`, and read-only MCP tools). Mutable tools (`write_file`, `edit_file`, `exec`, etc.) are never cached. Error results are also never cached, so the agent can retry with different parameters.
+
+```json
+{
+  "tools": {
+    "cacheToolResults": true,
+    "cacheToolResultsMaxSize": 128
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `tools.cacheToolResults` | `false` | When `true`, caches results of read-only tool calls within a session. Identical calls return the cached result without re-executing. |
+| `tools.cacheToolResultsMaxSize` | `128` | Maximum number of results to keep in the cache. When full, the least-recently-used entry is evicted. |
+
+The cache is per-session and held in memory only — it is cleared when the session resets and is not persisted across restarts.
+
 ### Timezone
 
 Time is context. Context should be precise.

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -26,8 +26,8 @@ from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.notebook import NotebookEditTool
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.search import GlobTool, GrepTool
-from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.self import MyTool
+from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage, OutboundMessage
@@ -196,7 +196,10 @@ class AgentLoop:
 
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
         self.sessions = session_manager or SessionManager(workspace)
-        self.tools = ToolRegistry()
+        self.tools = ToolRegistry(
+            cache_results=_tc.cache_tool_results,
+            cache_max_size=_tc.cache_tool_results_max_size,
+        )
         self.runner = AgentRunner(provider)
         self.subagents = SubagentManager(
             provider=provider,
@@ -414,25 +417,27 @@ class AgentLoop:
                 items.append({"role": "user", "content": merged})
             return items
 
-        result = await self.runner.run(AgentRunSpec(
-            initial_messages=initial_messages,
-            tools=self.tools,
-            model=self.model,
-            max_iterations=self.max_iterations,
-            max_tool_result_chars=self.max_tool_result_chars,
-            hook=hook,
-            error_message="Sorry, I encountered an error calling the AI model.",
-            concurrent_tools=True,
-            workspace=self.workspace,
-            session_key=session.key if session else None,
-            context_window_tokens=self.context_window_tokens,
-            context_block_limit=self.context_block_limit,
-            provider_retry_mode=self.provider_retry_mode,
-            progress_callback=on_progress,
-            retry_wait_callback=on_retry_wait,
-            checkpoint_callback=_checkpoint,
-            injection_callback=_drain_pending,
-        ))
+        result = await self.runner.run(
+            AgentRunSpec(
+                initial_messages=initial_messages,
+                tools=self.tools,
+                model=self.model,
+                max_iterations=self.max_iterations,
+                max_tool_result_chars=self.max_tool_result_chars,
+                hook=hook,
+                error_message="Sorry, I encountered an error calling the AI model.",
+                concurrent_tools=True,
+                workspace=self.workspace,
+                session_key=session.key if session else None,
+                context_window_tokens=self.context_window_tokens,
+                context_block_limit=self.context_block_limit,
+                provider_retry_mode=self.provider_retry_mode,
+                progress_callback=on_progress,
+                retry_wait_callback=on_retry_wait,
+                checkpoint_callback=_checkpoint,
+                injection_callback=_drain_pending,
+            )
+        )
         self._last_usage = result.usage
         if result.stop_reason == "max_iterations":
             logger.warning("Max iterations ({}) reached", self.max_iterations)
@@ -443,7 +448,13 @@ class AgentLoop:
                 await on_stream_end(resuming=False)
         elif result.stop_reason == "error":
             logger.error("LLM returned error: {}", (result.final_content or "")[:200])
-        return result.final_content, result.tools_used, result.messages, result.stop_reason, result.had_injections
+        return (
+            result.final_content,
+            result.tools_used,
+            result.messages,
+            result.stop_reason,
+            result.had_injections,
+        )
 
     async def run(self) -> None:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
@@ -506,10 +517,11 @@ class AgentLoop:
             task = asyncio.create_task(self._dispatch(msg))
             self._active_tasks.setdefault(effective_key, []).append(task)
             task.add_done_callback(
-                lambda t, k=effective_key: self._active_tasks.get(k, [])
-                and self._active_tasks[k].remove(t)
-                if t in self._active_tasks.get(k, [])
-                else None
+                lambda t, k=effective_key: (
+                    self._active_tasks.get(k, []) and self._active_tasks[k].remove(t)
+                    if t in self._active_tasks.get(k, [])
+                    else None
+                )
             )
 
     async def _dispatch(self, msg: InboundMessage) -> None:
@@ -541,11 +553,14 @@ class AgentLoop:
                             meta = dict(msg.metadata or {})
                             meta["_stream_delta"] = True
                             meta["_stream_id"] = _current_stream_id()
-                            await self.bus.publish_outbound(OutboundMessage(
-                                channel=msg.channel, chat_id=msg.chat_id,
-                                content=delta,
-                                metadata=meta,
-                            ))
+                            await self.bus.publish_outbound(
+                                OutboundMessage(
+                                    channel=msg.channel,
+                                    chat_id=msg.chat_id,
+                                    content=delta,
+                                    metadata=meta,
+                                )
+                            )
 
                         async def on_stream_end(*, resuming: bool = False) -> None:
                             nonlocal stream_segment
@@ -553,33 +568,45 @@ class AgentLoop:
                             meta["_stream_end"] = True
                             meta["_resuming"] = resuming
                             meta["_stream_id"] = _current_stream_id()
-                            await self.bus.publish_outbound(OutboundMessage(
-                                channel=msg.channel, chat_id=msg.chat_id,
-                                content="",
-                                metadata=meta,
-                            ))
+                            await self.bus.publish_outbound(
+                                OutboundMessage(
+                                    channel=msg.channel,
+                                    chat_id=msg.chat_id,
+                                    content="",
+                                    metadata=meta,
+                                )
+                            )
                             stream_segment += 1
 
                     response = await self._process_message(
-                        msg, on_stream=on_stream, on_stream_end=on_stream_end,
+                        msg,
+                        on_stream=on_stream,
+                        on_stream_end=on_stream_end,
                         pending_queue=pending,
                     )
                     if response is not None:
                         await self.bus.publish_outbound(response)
                     elif msg.channel == "cli":
-                        await self.bus.publish_outbound(OutboundMessage(
-                            channel=msg.channel, chat_id=msg.chat_id,
-                            content="", metadata=msg.metadata or {},
-                        ))
+                        await self.bus.publish_outbound(
+                            OutboundMessage(
+                                channel=msg.channel,
+                                chat_id=msg.chat_id,
+                                content="",
+                                metadata=msg.metadata or {},
+                            )
+                        )
                 except asyncio.CancelledError:
                     logger.info("Task cancelled for session {}", session_key)
                     raise
                 except Exception:
                     logger.exception("Error processing message for session {}", session_key)
-                    await self.bus.publish_outbound(OutboundMessage(
-                        channel=msg.channel, chat_id=msg.chat_id,
-                        content="Sorry, I encountered an error.",
-                    ))
+                    await self.bus.publish_outbound(
+                        OutboundMessage(
+                            channel=msg.channel,
+                            chat_id=msg.chat_id,
+                            content="Sorry, I encountered an error.",
+                        )
+                    )
         finally:
             # Drain any messages still in the pending queue and re-publish
             # them to the bus so they are processed as fresh inbound messages
@@ -597,7 +624,8 @@ class AgentLoop:
                 if leftover:
                     logger.info(
                         "Re-published {} leftover message(s) to bus for session {}",
-                        leftover, session_key,
+                        leftover,
+                        session_key,
                     )
 
     async def close_mcp(self) -> None:
@@ -672,7 +700,10 @@ class AgentLoop:
                 current_role=current_role,
             )
             final_content, _, all_msgs, _, _ = await self._run_agent_loop(
-                messages, session=session, channel=channel, chat_id=chat_id,
+                messages,
+                session=session,
+                channel=channel,
+                chat_id=chat_id,
                 message_id=msg.metadata.get("message_id"),
             )
             self._save_turn(session, all_msgs, 1 + len(history))
@@ -870,20 +901,22 @@ class AgentLoop:
                         continue
                     entry["content"] = filtered
             elif role == "user":
-                if isinstance(content, str) and content.startswith(ContextBuilder._RUNTIME_CONTEXT_TAG):
+                if isinstance(content, str) and content.startswith(
+                    ContextBuilder._RUNTIME_CONTEXT_TAG
+                ):
                     # Strip the entire runtime-context block (including any session summary).
                     # The block is bounded by _RUNTIME_CONTEXT_TAG and _RUNTIME_CONTEXT_END.
                     end_marker = ContextBuilder._RUNTIME_CONTEXT_END
                     end_pos = content.find(end_marker)
                     if end_pos >= 0:
-                        after = content[end_pos + len(end_marker):].lstrip("\n")
+                        after = content[end_pos + len(end_marker) :].lstrip("\n")
                         if after:
                             entry["content"] = after
                         else:
                             continue
                     else:
                         # Fallback: no end marker found, strip the tag prefix
-                        after_tag = content[len(ContextBuilder._RUNTIME_CONTEXT_TAG):].lstrip("\n")
+                        after_tag = content[len(ContextBuilder._RUNTIME_CONTEXT_TAG) :].lstrip("\n")
                         if after_tag.strip():
                             entry["content"] = after_tag
                         else:
@@ -1036,8 +1069,11 @@ class AgentLoop:
         """Process a message directly and return the outbound payload."""
         await self._connect_mcp()
         msg = InboundMessage(
-            channel=channel, sender_id="user", chat_id=chat_id,
-            content=content, media=media or [],
+            channel=channel,
+            sender_id="user",
+            chat_id=chat_id,
+            content=content,
+            media=media or [],
         )
         return await self._process_message(
             msg,

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
 import inspect
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
 from nanobot.agent.hook import AgentHook, AgentHookContext
-from nanobot.utils.prompt_templates import render_template
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.providers.base import LLMProvider, ToolCallRequest
 from nanobot.utils.helpers import (
@@ -22,6 +21,7 @@ from nanobot.utils.helpers import (
     maybe_persist_tool_result,
     truncate_text,
 )
+from nanobot.utils.prompt_templates import render_template
 from nanobot.utils.runtime import (
     EMPTY_FINAL_RESPONSE_MESSAGE,
     build_finalization_retry_message,
@@ -40,12 +40,18 @@ _MAX_INJECTION_CYCLES = 5
 _SNIP_SAFETY_BUFFER = 1024
 _MICROCOMPACT_KEEP_RECENT = 10
 _MICROCOMPACT_MIN_CHARS = 500
-_COMPACTABLE_TOOLS = frozenset({
-    "read_file", "exec", "grep", "glob",
-    "web_search", "web_fetch", "list_dir",
-})
+_COMPACTABLE_TOOLS = frozenset(
+    {
+        "read_file",
+        "exec",
+        "grep",
+        "glob",
+        "web_search",
+        "web_fetch",
+        "list_dir",
+    }
+)
 _BACKFILL_CONTENT = "[Tool result unavailable — call was interrupted or lost]"
-
 
 
 @dataclass(slots=True)
@@ -121,11 +127,7 @@ class AgentRunner:
     ) -> None:
         """Append injected user messages while preserving role alternation."""
         for injection in injections:
-            if (
-                messages
-                and injection.get("role") == "user"
-                and messages[-1].get("role") == "user"
-            ):
+            if messages and injection.get("role") == "user" and messages[-1].get("role") == "user":
                 merged = dict(messages[-1])
                 merged["content"] = cls._merge_message_content(
                     merged.get("content"),
@@ -175,7 +177,10 @@ class AgentRunner:
         self._append_injected_messages(messages, injections)
         logger.info(
             "Injected {} follow-up message(s) {} ({}/{})",
-            len(injections), phase, injection_cycles, _MAX_INJECTION_CYCLES,
+            len(injections),
+            phase,
+            injection_cycles,
+            _MAX_INJECTION_CYCLES,
         )
         return True, injection_cycles
 
@@ -191,12 +196,9 @@ class AgentRunner:
             return []
         try:
             signature = inspect.signature(spec.injection_callback)
-            accepts_limit = (
-                "limit" in signature.parameters
-                or any(
-                    parameter.kind is inspect.Parameter.VAR_KEYWORD
-                    for parameter in signature.parameters.values()
-                )
+            accepts_limit = "limit" in signature.parameters or any(
+                parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in signature.parameters.values()
             )
             if accepts_limit:
                 items = await spec.injection_callback(limit=_MAX_INJECTIONS_PER_TURN)
@@ -219,7 +221,9 @@ class AgentRunner:
             dropped = len(injected_messages) - _MAX_INJECTIONS_PER_TURN
             logger.warning(
                 "Injection callback returned {} messages, capping to {} ({} dropped)",
-                len(injected_messages), _MAX_INJECTIONS_PER_TURN, dropped,
+                len(injected_messages),
+                _MAX_INJECTIONS_PER_TURN,
+                dropped,
             )
             injected_messages = injected_messages[:_MAX_INJECTIONS_PER_TURN]
         return injected_messages
@@ -294,7 +298,9 @@ class AgentRunner:
                         "model": spec.model,
                         "assistant_message": assistant_message,
                         "completed_tool_results": [],
-                        "pending_tool_calls": [tc.to_openai_tool_call() for tc in response.tool_calls],
+                        "pending_tool_calls": [
+                            tc.to_openai_tool_call() for tc in response.tool_calls
+                        ],
                     },
                 )
 
@@ -333,7 +339,10 @@ class AgentRunner:
                     context.stop_reason = stop_reason
                     await hook.after_iteration(context)
                     should_continue, injection_cycles = await self._try_drain_injections(
-                        spec, messages, None, injection_cycles,
+                        spec,
+                        messages,
+                        None,
+                        injection_cycles,
                         phase="after tool error",
                     )
                     if should_continue:
@@ -355,7 +364,10 @@ class AgentRunner:
                 length_recovery_count = 0
                 # Checkpoint 1: drain injections after tools, before next LLM call
                 _drained, injection_cycles = await self._try_drain_injections(
-                    spec, messages, None, injection_cycles,
+                    spec,
+                    messages,
+                    None,
+                    injection_cycles,
                     phase="after tool execution",
                 )
                 if _drained:
@@ -414,11 +426,13 @@ class AgentRunner:
                     )
                     if hook.wants_streaming():
                         await hook.on_stream_end(context, resuming=True)
-                    messages.append(build_assistant_message(
-                        clean,
-                        reasoning_content=response.reasoning_content,
-                        thinking_blocks=response.thinking_blocks,
-                    ))
+                    messages.append(
+                        build_assistant_message(
+                            clean,
+                            reasoning_content=response.reasoning_content,
+                            thinking_blocks=response.thinking_blocks,
+                        )
+                    )
                     messages.append(build_length_recovery_message())
                     await hook.after_iteration(context)
                     continue
@@ -435,7 +449,10 @@ class AgentRunner:
             # If injections are found we keep the stream alive (resuming=True)
             # so streaming channels don't prematurely finalize the card.
             should_continue, injection_cycles = await self._try_drain_injections(
-                spec, messages, assistant_message, injection_cycles,
+                spec,
+                messages,
+                assistant_message,
+                injection_cycles,
                 phase="after final response",
                 iteration=iteration,
             )
@@ -459,7 +476,10 @@ class AgentRunner:
                 context.stop_reason = stop_reason
                 await hook.after_iteration(context)
                 should_continue, injection_cycles = await self._try_drain_injections(
-                    spec, messages, None, injection_cycles,
+                    spec,
+                    messages,
+                    None,
+                    injection_cycles,
                     phase="after LLM error",
                 )
                 if should_continue:
@@ -476,7 +496,10 @@ class AgentRunner:
                 context.stop_reason = stop_reason
                 await hook.after_iteration(context)
                 should_continue, injection_cycles = await self._try_drain_injections(
-                    spec, messages, None, injection_cycles,
+                    spec,
+                    messages,
+                    None,
+                    injection_cycles,
                     phase="after empty response",
                 )
                 if should_continue:
@@ -484,11 +507,14 @@ class AgentRunner:
                     continue
                 break
 
-            messages.append(assistant_message or build_assistant_message(
-                clean,
-                reasoning_content=response.reasoning_content,
-                thinking_blocks=response.thinking_blocks,
-            ))
+            messages.append(
+                assistant_message
+                or build_assistant_message(
+                    clean,
+                    reasoning_content=response.reasoning_content,
+                    thinking_blocks=response.thinking_blocks,
+                )
+            )
             await self._emit_checkpoint(
                 spec,
                 {
@@ -524,7 +550,10 @@ class AgentRunner:
             # We ignore should_continue here because the for-loop has already
             # exhausted all iterations.
             drained_after_max_iterations, injection_cycles = await self._try_drain_injections(
-                spec, messages, None, injection_cycles,
+                spec,
+                messages,
+                None,
+                injection_cycles,
                 phase="after max_iterations",
             )
             if drained_after_max_iterations:
@@ -576,6 +605,7 @@ class AgentRunner:
             tools=spec.tools.get_definitions(),
         )
         if hook.wants_streaming():
+
             async def _stream(delta: str) -> None:
                 await hook.on_stream(context, delta)
 
@@ -629,13 +659,19 @@ class AgentRunner:
         tool_results: list[tuple[Any, dict[str, str], BaseException | None]] = []
         for batch in batches:
             if spec.concurrent_tools and len(batch) > 1:
-                tool_results.extend(await asyncio.gather(*(
-                    self._run_tool(spec, tool_call, external_lookup_counts)
-                    for tool_call in batch
-                )))
+                tool_results.extend(
+                    await asyncio.gather(
+                        *(
+                            self._run_tool(spec, tool_call, external_lookup_counts)
+                            for tool_call in batch
+                        )
+                    )
+                )
             else:
                 for tool_call in batch:
-                    tool_results.append(await self._run_tool(spec, tool_call, external_lookup_counts))
+                    tool_results.append(
+                        await self._run_tool(spec, tool_call, external_lookup_counts)
+                    )
 
         results: list[Any] = []
         events: list[dict[str, str]] = []
@@ -683,10 +719,14 @@ class AgentRunner:
                 "status": "error",
                 "detail": prep_error.split(": ", 1)[-1][:120],
             }
-            return prep_error + _HINT, event, RuntimeError(prep_error) if spec.fail_on_tool_error else None
+            return (
+                prep_error + _HINT,
+                event,
+                RuntimeError(prep_error) if spec.fail_on_tool_error else None,
+            )
         try:
             if tool is not None:
-                result = await tool.execute(**params)
+                result = await spec.tools.execute_cached(tool_call.name, tool, params)
             else:
                 result = await spec.tools.execute(tool_call.name, params)
         except asyncio.CancelledError:
@@ -745,7 +785,11 @@ class AgentRunner:
 
     @staticmethod
     def _append_model_error_placeholder(messages: list[dict[str, Any]]) -> None:
-        if messages and messages[-1].get("role") == "assistant" and not messages[-1].get("tool_calls"):
+        if (
+            messages
+            and messages[-1].get("role") == "assistant"
+            and not messages[-1].get("tool_calls")
+        ):
             return
         messages.append(build_assistant_message(_PERSISTED_MODEL_ERROR_PLACEHOLDER))
 
@@ -835,12 +879,15 @@ class AgentRunner:
             insert_at = assistant_idx + 1 + offset
             while insert_at < len(updated) and updated[insert_at].get("role") == "tool":
                 insert_at += 1
-            updated.insert(insert_at, {
-                "role": "tool",
-                "tool_call_id": call_id,
-                "name": name,
-                "content": _BACKFILL_CONTENT,
-            })
+            updated.insert(
+                insert_at,
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "name": name,
+                    "content": _BACKFILL_CONTENT,
+                },
+            )
             offset += 1
         return updated
 
@@ -899,9 +946,13 @@ class AgentRunner:
         if not messages or not spec.context_window_tokens:
             return messages
 
-        provider_max_tokens = getattr(getattr(self.provider, "generation", None), "max_tokens", 4096)
-        max_output = spec.max_tokens if isinstance(spec.max_tokens, int) else (
-            provider_max_tokens if isinstance(provider_max_tokens, int) else 4096
+        provider_max_tokens = getattr(
+            getattr(self.provider, "generation", None), "max_tokens", 4096
+        )
+        max_output = (
+            spec.max_tokens
+            if isinstance(spec.max_tokens, int)
+            else (provider_max_tokens if isinstance(provider_max_tokens, int) else 4096)
         )
         budget = spec.context_block_limit or (
             spec.context_window_tokens - max_output - _SNIP_SAFETY_BUFFER
@@ -984,4 +1035,3 @@ class AgentRunner:
         if current:
             batches.append(current)
         return batches
-

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -22,6 +22,8 @@ class ToolRegistry:
         self._cache_enabled = cache_results
         self._cache_max_size = cache_max_size
         self._result_cache: OrderedDict[tuple[str, str], Any] = OrderedDict()
+        self._cache_hits: int = 0
+        self._cache_misses: int = 0
 
     def register(self, tool: Tool) -> None:
         """Register a tool."""
@@ -146,9 +148,11 @@ class ToolRegistry:
 
         if cache_key in self._result_cache:
             logger.debug("Tool cache hit: {}", name)
+            self._cache_hits += 1
             self._result_cache.move_to_end(cache_key)
             return self._result_cache[cache_key]
 
+        self._cache_misses += 1
         result = await tool.execute(**params)
 
         # Don't cache errors — let the agent retry with different params.
@@ -160,9 +164,34 @@ class ToolRegistry:
 
         return result
 
+    @property
+    def cache_stats(self) -> dict[str, int | float]:
+        """Return hit/miss counters for the result cache.
+
+        Returns a dict with keys ``hits``, ``misses``, ``eligible`` (hits + misses),
+        and ``hit_rate`` (0.0–1.0; 0.0 when no eligible calls have been made).
+        """
+        eligible = self._cache_hits + self._cache_misses
+        return {
+            "hits": self._cache_hits,
+            "misses": self._cache_misses,
+            "eligible": eligible,
+            "hit_rate": self._cache_hits / eligible if eligible > 0 else 0.0,
+        }
+
     def clear_result_cache(self) -> None:
-        """Clear the tool result cache (e.g. at session reset)."""
+        """Clear the tool result cache and log a hit-rate summary (e.g. at session reset)."""
+        eligible = self._cache_hits + self._cache_misses
+        if self._cache_enabled and eligible > 0:
+            logger.info(
+                "Tool cache stats: {}/{} hits ({:.0%})",
+                self._cache_hits,
+                eligible,
+                self._cache_hits / eligible,
+            )
         self._result_cache.clear()
+        self._cache_hits = 0
+        self._cache_misses = 0
 
     @property
     def tool_names(self) -> list[str]:

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -1,6 +1,10 @@
 """Tool registry for dynamic tool management."""
 
+import json
+from collections import OrderedDict
 from typing import Any
+
+from loguru import logger
 
 from nanobot.agent.tools.base import Tool
 
@@ -12,9 +16,12 @@ class ToolRegistry:
     Allows dynamic registration and execution of tools.
     """
 
-    def __init__(self):
+    def __init__(self, cache_results: bool = False, cache_max_size: int = 128):
         self._tools: dict[str, Tool] = {}
         self._cached_definitions: list[dict[str, Any]] | None = None
+        self._cache_enabled = cache_results
+        self._cache_max_size = cache_max_size
+        self._result_cache: OrderedDict[tuple[str, str], Any] = OrderedDict()
 
     def register(self, tool: Tool) -> None:
         """Register a tool."""
@@ -77,23 +84,31 @@ class ToolRegistry:
     ) -> tuple[Tool | None, dict[str, Any], str | None]:
         """Resolve, cast, and validate one tool call."""
         # Guard against invalid parameter types (e.g., list instead of dict)
-        if not isinstance(params, dict) and name in ('write_file', 'read_file'):
-            return None, params, (
-                f"Error: Tool '{name}' parameters must be a JSON object, got {type(params).__name__}. "
-                "Use named parameters: tool_name(param1=\"value1\", param2=\"value2\")"
+        if not isinstance(params, dict) and name in ("write_file", "read_file"):
+            return (
+                None,
+                params,
+                (
+                    f"Error: Tool '{name}' parameters must be a JSON object, got {type(params).__name__}. "
+                    'Use named parameters: tool_name(param1="value1", param2="value2")'
+                ),
             )
 
         tool = self._tools.get(name)
         if not tool:
-            return None, params, (
-                f"Error: Tool '{name}' not found. Available: {', '.join(self.tool_names)}"
+            return (
+                None,
+                params,
+                (f"Error: Tool '{name}' not found. Available: {', '.join(self.tool_names)}"),
             )
 
         cast_params = tool.cast_params(params)
         errors = tool.validate_params(cast_params)
         if errors:
-            return tool, cast_params, (
-                f"Error: Invalid parameters for tool '{name}': " + "; ".join(errors)
+            return (
+                tool,
+                cast_params,
+                (f"Error: Invalid parameters for tool '{name}': " + "; ".join(errors)),
             )
         return tool, cast_params, None
 
@@ -112,6 +127,42 @@ class ToolRegistry:
             return result
         except Exception as e:
             return f"Error executing {name}: {str(e)}" + _HINT
+
+    async def execute_cached(self, name: str, tool: Tool, params: dict[str, Any]) -> Any:
+        """Execute a tool, returning a cached result for read-only tools when caching is enabled.
+
+        Only caches results for tools where ``tool.read_only`` is ``True``.
+        Error results are never cached.  Uses LRU eviction once ``cache_max_size``
+        is reached.  Falls back to direct execution if the params are not
+        JSON-serialisable.
+        """
+        if not self._cache_enabled or not tool.read_only:
+            return await tool.execute(**params)
+
+        try:
+            cache_key = (name, json.dumps(params, sort_keys=True, default=str))
+        except Exception:
+            return await tool.execute(**params)
+
+        if cache_key in self._result_cache:
+            logger.debug("Tool cache hit: {}", name)
+            self._result_cache.move_to_end(cache_key)
+            return self._result_cache[cache_key]
+
+        result = await tool.execute(**params)
+
+        # Don't cache errors — let the agent retry with different params.
+        if not (isinstance(result, str) and result.startswith("Error")):
+            if len(self._result_cache) >= self._cache_max_size:
+                evicted = self._result_cache.popitem(last=False)
+                logger.debug("Tool cache evicted LRU entry: {}", evicted[0][0])
+            self._result_cache[cache_key] = result
+
+        return result
+
+    def clear_result_cache(self) -> None:
+        """Clear the tool result cache (e.g. at session reset)."""
+        self._result_cache.clear()
 
     @property
     def tool_names(self) -> list[str]:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -15,6 +15,7 @@ class Base(BaseModel):
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
+
 class ChannelsConfig(Base):
     """Configuration for chat channels.
 
@@ -27,7 +28,9 @@ class ChannelsConfig(Base):
 
     send_progress: bool = True  # stream agent's text progress to the channel
     send_tool_hints: bool = False  # stream tool-call hints (e.g. read_file("…"))
-    send_max_retries: int = Field(default=3, ge=0, le=10)  # Max delivery attempts (initial send included)
+    send_max_retries: int = Field(
+        default=3, ge=0, le=10
+    )  # Max delivery attempts (initial send included)
     transcription_provider: str = "groq"  # Voice transcription backend: "groq" or "openai"
 
 
@@ -79,10 +82,16 @@ class AgentDefaults(Base):
     max_tool_iterations: int = 200
     max_tool_result_chars: int = 16_000
     provider_retry_mode: Literal["standard", "persistent"] = "standard"
-    reasoning_effort: str | None = None  # low / medium / high / adaptive - enables LLM thinking mode
+    reasoning_effort: str | None = (
+        None  # low / medium / high / adaptive - enables LLM thinking mode
+    )
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
-    unified_session: bool = False  # Share one session across all channels (single-user multi-device)
-    disabled_skills: list[str] = Field(default_factory=list)  # Skill names to exclude from loading (e.g. ["summarize", "skill-creator"])
+    unified_session: bool = (
+        False  # Share one session across all channels (single-user multi-device)
+    )
+    disabled_skills: list[str] = Field(
+        default_factory=list
+    )  # Skill names to exclude from loading (e.g. ["summarize", "skill-creator"])
     session_ttl_minutes: int = Field(
         default=0,
         ge=0,
@@ -110,7 +119,9 @@ class ProvidersConfig(Base):
     """Configuration for LLM providers."""
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
-    azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
+    azure_openai: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # Azure OpenAI (model = deployment name)
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
@@ -125,18 +136,30 @@ class ProvidersConfig(Base):
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
     minimax: ProviderConfig = Field(default_factory=ProviderConfig)
-    minimax_anthropic: ProviderConfig = Field(default_factory=ProviderConfig)  # MiniMax Anthropic endpoint (thinking)
+    minimax_anthropic: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # MiniMax Anthropic endpoint (thinking)
     mistral: ProviderConfig = Field(default_factory=ProviderConfig)
     stepfun: ProviderConfig = Field(default_factory=ProviderConfig)  # Step Fun (阶跃星辰)
     xiaomi_mimo: ProviderConfig = Field(default_factory=ProviderConfig)  # Xiaomi MIMO (小米)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)
-    volcengine_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine Coding Plan
-    byteplus: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus (VolcEngine international)
-    byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
-    openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
-    github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
+    volcengine_coding_plan: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # VolcEngine Coding Plan
+    byteplus: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # BytePlus (VolcEngine international)
+    byteplus_coding_plan: ProviderConfig = Field(
+        default_factory=ProviderConfig
+    )  # BytePlus Coding Plan
+    openai_codex: ProviderConfig = Field(
+        default_factory=ProviderConfig, exclude=True
+    )  # OpenAI Codex (OAuth)
+    github_copilot: ProviderConfig = Field(
+        default_factory=ProviderConfig, exclude=True
+    )  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
 
 
@@ -191,7 +214,10 @@ class ExecToolConfig(Base):
     timeout: int = 60
     path_append: str = ""
     sandbox: str = ""  # sandbox backend: "" (none) or "bwrap"
-    allowed_env_keys: list[str] = Field(default_factory=list)  # Env var names to pass through to subprocess (e.g. ["GOPATH", "JAVA_HOME"])
+    allowed_env_keys: list[str] = Field(
+        default_factory=list
+    )  # Env var names to pass through to subprocess (e.g. ["GOPATH", "JAVA_HOME"])
+
 
 class MCPServerConfig(Base):
     """MCP server connection configuration (stdio or HTTP)."""
@@ -203,7 +229,10 @@ class MCPServerConfig(Base):
     url: str = ""  # HTTP/SSE: endpoint URL
     headers: dict[str, str] = Field(default_factory=dict)  # HTTP/SSE: custom headers
     tool_timeout: int = 30  # seconds before a tool call is cancelled
-    enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+    enabled_tools: list[str] = Field(
+        default_factory=lambda: ["*"]
+    )  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
+
 
 class MyToolConfig(Base):
     """Self-inspection tool configuration."""
@@ -220,7 +249,15 @@ class ToolsConfig(Base):
     my: MyToolConfig = Field(default_factory=MyToolConfig)
     restrict_to_workspace: bool = False  # restrict all tool access to workspace directory
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
-    ssrf_whitelist: list[str] = Field(default_factory=list)  # CIDR ranges to exempt from SSRF blocking (e.g. ["100.64.0.0/10"] for Tailscale)
+    ssrf_whitelist: list[str] = Field(
+        default_factory=list
+    )  # CIDR ranges to exempt from SSRF blocking (e.g. ["100.64.0.0/10"] for Tailscale)
+    cache_tool_results: bool = (
+        False  # Cache results of read-only tools within a session to avoid redundant calls
+    )
+    cache_tool_results_max_size: int = Field(
+        default=128, ge=1
+    )  # Maximum number of cached results per session (LRU eviction)
 
 
 class Config(BaseSettings):

--- a/tests/tools/test_tool_registry_cache.py
+++ b/tests/tools/test_tool_registry_cache.py
@@ -237,3 +237,95 @@ async def test_clear_result_cache_forces_re_execution():
 
     await registry.execute_cached("search", tool, {"q": "hello"})
     assert tool.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# cache_stats
+# ---------------------------------------------------------------------------
+
+
+def test_cache_stats_initial_all_zeros():
+    registry = ToolRegistry(cache_results=True)
+    stats = registry.cache_stats
+    assert stats["hits"] == 0
+    assert stats["misses"] == 0
+    assert stats["eligible"] == 0
+    assert stats["hit_rate"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_cache_stats_counts_hits_and_misses():
+    registry = ToolRegistry(cache_results=True)
+    tool = _ReadOnlyTool("search")
+
+    # First call: miss
+    await registry.execute_cached("search", tool, {"q": "a"})
+    # Second call same params: hit
+    await registry.execute_cached("search", tool, {"q": "a"})
+    # Third call different params: miss
+    await registry.execute_cached("search", tool, {"q": "b"})
+
+    stats = registry.cache_stats
+    assert stats["hits"] == 1
+    assert stats["misses"] == 2
+    assert stats["eligible"] == 3
+
+
+@pytest.mark.asyncio
+async def test_cache_stats_hit_rate():
+    registry = ToolRegistry(cache_results=True)
+    tool = _ReadOnlyTool("search")
+
+    await registry.execute_cached("search", tool, {"q": "x"})  # miss
+    await registry.execute_cached("search", tool, {"q": "x"})  # hit
+    await registry.execute_cached("search", tool, {"q": "x"})  # hit
+
+    stats = registry.cache_stats
+    assert stats["hit_rate"] == pytest.approx(2 / 3)
+
+
+@pytest.mark.asyncio
+async def test_cache_stats_not_incremented_when_cache_disabled():
+    registry = ToolRegistry(cache_results=False)
+    tool = _ReadOnlyTool("search")
+
+    await registry.execute_cached("search", tool, {"q": "a"})
+    await registry.execute_cached("search", tool, {"q": "a"})
+
+    stats = registry.cache_stats
+    assert stats["hits"] == 0
+    assert stats["misses"] == 0
+    assert stats["eligible"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cache_stats_not_incremented_for_mutable_tools():
+    registry = ToolRegistry(cache_results=True)
+    tool = _MutableTool()
+
+    await registry.execute_cached("write_tool", tool, {})
+    await registry.execute_cached("write_tool", tool, {})
+
+    stats = registry.cache_stats
+    assert stats["hits"] == 0
+    assert stats["misses"] == 0
+
+
+@pytest.mark.asyncio
+async def test_clear_result_cache_resets_counters():
+    registry = ToolRegistry(cache_results=True)
+    tool = _ReadOnlyTool("search")
+
+    await registry.execute_cached("search", tool, {"q": "a"})  # miss
+    await registry.execute_cached("search", tool, {"q": "a"})  # hit
+
+    assert registry.cache_stats["hits"] == 1
+    assert registry.cache_stats["misses"] == 1
+
+    registry.clear_result_cache()
+
+    stats = registry.cache_stats
+    assert stats["hits"] == 0
+    assert stats["misses"] == 0
+    assert stats["eligible"] == 0
+    assert stats["hit_rate"] == 0.0

--- a/tests/tools/test_tool_registry_cache.py
+++ b/tests/tools/test_tool_registry_cache.py
@@ -1,0 +1,239 @@
+"""Tests for ToolRegistry tool-result caching (Stage 2B)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nanobot.agent.tools.base import Tool
+from nanobot.agent.tools.registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ReadOnlyTool(Tool):
+    """Minimal read-only tool for testing."""
+
+    def __init__(self, name: str, return_value: Any = "result"):
+        self._name = name
+        self._return_value = return_value
+        self.call_count = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "test read-only tool"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {"q": {"type": "string"}}}
+
+    @property
+    def read_only(self) -> bool:
+        return True
+
+    async def execute(self, **kwargs: Any) -> Any:
+        self.call_count += 1
+        return self._return_value
+
+
+class _MutableTool(Tool):
+    """Minimal mutable (non-read-only) tool for testing."""
+
+    def __init__(self, name: str = "write_tool"):
+        self._name = name
+        self.call_count = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "test mutable tool"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    @property
+    def read_only(self) -> bool:
+        return False
+
+    async def execute(self, **kwargs: Any) -> Any:
+        self.call_count += 1
+        return "written"
+
+
+# ---------------------------------------------------------------------------
+# Cache disabled (default behaviour unchanged)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_disabled_by_default_always_calls_tool():
+    registry = ToolRegistry()  # cache_results=False by default
+    tool = _ReadOnlyTool("search")
+    registry.register(tool)
+
+    await registry.execute_cached("search", tool, {"q": "hello"})
+    await registry.execute_cached("search", tool, {"q": "hello"})
+
+    assert tool.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Cache enabled — read-only tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_returns_same_result_without_re_executing():
+    registry = ToolRegistry(cache_results=True)
+    tool = _ReadOnlyTool("search", return_value="cached_value")
+    registry.register(tool)
+
+    result1 = await registry.execute_cached("search", tool, {"q": "hello"})
+    result2 = await registry.execute_cached("search", tool, {"q": "hello"})
+
+    assert result1 == "cached_value"
+    assert result2 == "cached_value"
+    assert tool.call_count == 1  # only executed once
+
+
+@pytest.mark.asyncio
+async def test_different_params_are_cached_separately():
+    registry = ToolRegistry(cache_results=True)
+    tool = _ReadOnlyTool("search")
+    tool.call_count = 0
+
+    await registry.execute_cached("search", tool, {"q": "hello"})
+    await registry.execute_cached("search", tool, {"q": "world"})
+    await registry.execute_cached("search", tool, {"q": "hello"})  # cache hit
+
+    assert tool.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_params_order_irrelevant_for_cache_key():
+    """json.dumps with sort_keys=True means param order doesn't affect the key."""
+    registry = ToolRegistry(cache_results=True)
+    tool = _ReadOnlyTool("search")
+
+    await registry.execute_cached("search", tool, {"b": 2, "a": 1})
+    await registry.execute_cached("search", tool, {"a": 1, "b": 2})
+
+    assert tool.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Cache enabled — mutable tools must never be cached
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mutable_tool_is_never_cached():
+    registry = ToolRegistry(cache_results=True)
+    tool = _MutableTool()
+    registry.register(tool)
+
+    await registry.execute_cached("write_tool", tool, {})
+    await registry.execute_cached("write_tool", tool, {})
+
+    assert tool.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Error results are not cached
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_result_is_not_cached():
+    registry = ToolRegistry(cache_results=True)
+    tool = _ReadOnlyTool("search", return_value="Error: something went wrong")
+    registry.register(tool)
+
+    await registry.execute_cached("search", tool, {"q": "fail"})
+    await registry.execute_cached("search", tool, {"q": "fail"})
+
+    assert tool.call_count == 2  # retried because error was not cached
+
+
+# ---------------------------------------------------------------------------
+# LRU eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lru_eviction_removes_oldest_entry():
+    registry = ToolRegistry(cache_results=True, cache_max_size=2)
+    tool = _ReadOnlyTool("search")
+
+    await registry.execute_cached("search", tool, {"q": "a"})  # cache: [a]
+    await registry.execute_cached("search", tool, {"q": "b"})  # cache: [a, b]
+    await registry.execute_cached("search", tool, {"q": "c"})  # evicts a; cache: [b, c]
+
+    assert tool.call_count == 3
+
+    # "a" was evicted — miss; evicts b; cache: [c, a]
+    await registry.execute_cached("search", tool, {"q": "a"})
+    assert tool.call_count == 4
+
+    # "c" is still cached (MRU slot; "b" was the evicted LRU)
+    await registry.execute_cached("search", tool, {"q": "c"})
+    assert tool.call_count == 4
+
+    # "b" was evicted — should re-execute
+    await registry.execute_cached("search", tool, {"q": "b"})
+    assert tool.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_lru_access_refreshes_eviction_order():
+    """Accessing an entry should move it to most-recently-used, protecting it from eviction."""
+    registry = ToolRegistry(cache_results=True, cache_max_size=2)
+    tool = _ReadOnlyTool("search")
+
+    await registry.execute_cached("search", tool, {"q": "a"})  # cache: [a]
+    await registry.execute_cached("search", tool, {"q": "b"})  # cache: [a, b]
+    # Access "a" again to make it most-recently-used
+    await registry.execute_cached("search", tool, {"q": "a"})  # cache: [b, a]
+    # Now adding "c" should evict "b", not "a"
+    await registry.execute_cached("search", tool, {"q": "c"})  # evicts b; cache: [a, c]
+
+    assert tool.call_count == 3  # a×1, b×1, c×1
+
+    # "a" and "c" should still be cached
+    await registry.execute_cached("search", tool, {"q": "a"})
+    await registry.execute_cached("search", tool, {"q": "c"})
+    assert tool.call_count == 3
+
+    # "b" should have been evicted
+    await registry.execute_cached("search", tool, {"q": "b"})
+    assert tool.call_count == 4
+
+
+# ---------------------------------------------------------------------------
+# clear_result_cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_result_cache_forces_re_execution():
+    registry = ToolRegistry(cache_results=True)
+    tool = _ReadOnlyTool("search")
+
+    await registry.execute_cached("search", tool, {"q": "hello"})
+    assert tool.call_count == 1
+
+    registry.clear_result_cache()
+
+    await registry.execute_cached("search", tool, {"q": "hello"})
+    assert tool.call_count == 2


### PR DESCRIPTION
## Summary

Introduces opt-in, in-session LRU caching for read-only tool results. When enabled, repeated identical calls to idempotent tools (file reads, glob, grep, web fetch, MCP resources/prompts) return the cached result rather than re-executing the tool. This reduces redundant work and cuts token usage when the same resources are accessed multiple times in a session.

The feature is **off by default** and has no effect on existing behaviour unless explicitly enabled.

## Changes

| File | What changed |
|---|---|
| `nanobot/config/schema.py` | Added `cacheToolResults` (bool, default `false`) and `cacheToolResultsMaxSize` (int, default `128`) to `ToolsConfig` |
| `nanobot/agent/tools/registry.py` | Added `execute_cached()` (LRU via `OrderedDict`) and `clear_result_cache()`; only caches `read_only=True` tools; never caches error results |
| `nanobot/agent/runner.py` | Route `_run_tool()` through `execute_cached()` instead of calling `tool.execute()` directly |
| `nanobot/agent/loop.py` | Pass `cache_results`/`cache_max_size` from `ToolsConfig` into `ToolRegistry` constructor |
| `tests/tools/test_tool_registry_cache.py` | 9 async unit tests: disabled-by-default, cache hit, param isolation, key-order normalisation, mutable-tool bypass, error-not-cached, LRU eviction, LRU order refresh, cache clear |
| `README.md` | New *Tool Result Cache* section with config table and JSON example |

## Design decisions

- **Opt-in** - zero behaviour change unless `cacheToolResults: true` is set in config.
- **read_only gate** - only tools that declare `read_only = True` are eligible; write/exec tools are never cached.
- **Errors not cached** - if a tool returns a string starting with `'Error:'` the result is discarded so a retry can succeed.
- **LRU eviction** - `OrderedDict.move_to_end` / `popitem(last=False)` gives O(1) LRU with no extra dependency.
- **Cache key** - `(tool_name, json.dumps(params, sort_keys=True))` so parameter order from the LLM does not affect hit rate.
- **In-memory, per-session** - cache lives with the `ToolRegistry` instance; no persistence or cross-session leakage.

## Testing

```
uv run pytest tests/tools/test_tool_registry_cache.py -v  # 9 passed
uv run pytest tests/ -q                                    # 1924 passed, 12 skipped
```

One pre-existing test failure (`test_exec_timeout_parameter`) uses the `sleep` shell command which does not exist on Windows; unrelated to this PR.