### PR TITLE
fix(telegram): split oversized stream buffer mid-flight

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -626,6 +626,10 @@ class TelegramChannel(BaseChannel):
                 logger.warning("Stream initial send failed: {}", e)
                 raise  # Let ChannelManager handle retry
         elif (now - buf.last_edit) >= self.config.stream_edit_interval:
+            if len(buf.text) > TELEGRAM_MAX_MESSAGE_LEN:
+                await self._flush_stream_overflow(int_chat_id, buf, thread_kwargs)
+                buf.last_edit = now
+                return
             try:
                 await self._call_with_retry(
                     self._app.bot.edit_message_text,
@@ -639,6 +643,44 @@ class TelegramChannel(BaseChannel):
                     return
                 logger.warning("Stream edit failed: {}", e)
                 raise  # Let ChannelManager handle retry
+
+    async def _flush_stream_overflow(
+        self,
+        chat_id: int,
+        buf: "_StreamBuf",
+        thread_kwargs: dict,
+    ) -> None:
+        """Split an oversized stream buffer mid-flight.
+
+        Edits the current stream message with the first chunk, sends any
+        intermediate chunks as standalone messages, then opens a new message
+        for the tail so subsequent deltas continue streaming into it.
+        """
+        chunks = split_message(buf.text, TELEGRAM_MAX_MESSAGE_LEN)
+        if len(chunks) <= 1:
+            return
+        try:
+            await self._call_with_retry(
+                self._app.bot.edit_message_text,
+                chat_id=chat_id, message_id=buf.message_id,
+                text=chunks[0],
+            )
+        except Exception as e:
+            if not self._is_not_modified_error(e):
+                logger.warning("Stream overflow edit failed: {}", e)
+                raise
+        for chunk in chunks[1:-1]:
+            await self._call_with_retry(
+                self._app.bot.send_message,
+                chat_id=chat_id, text=chunk, **thread_kwargs,
+            )
+        tail = chunks[-1]
+        sent = await self._call_with_retry(
+            self._app.bot.send_message,
+            chat_id=chat_id, text=tail, **thread_kwargs,
+        )
+        buf.message_id = sent.message_id
+        buf.text = tail
 
     async def _on_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /start command."""

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -531,6 +531,39 @@ async def test_send_delta_incremental_edit_treats_not_modified_as_success() -> N
 
 
 @pytest.mark.asyncio
+async def test_send_delta_incremental_edit_splits_oversized_buffer() -> None:
+    """Mid-stream overflow: once buf.text exceeds Telegram's limit, split into
+    chunks, edit the current message with the first chunk, and re-anchor the
+    buffer to a new message for the tail so further deltas keep streaming."""
+    from nanobot.channels.telegram import TELEGRAM_MAX_MESSAGE_LEN
+
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+    channel._app.bot.edit_message_text = AsyncMock()
+    channel._app.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=99))
+
+    oversized = "x" * (TELEGRAM_MAX_MESSAGE_LEN + 500)
+    channel._stream_bufs["123"] = _StreamBuf(
+        text=oversized, message_id=7, last_edit=0.0, stream_id="s:0"
+    )
+
+    await channel.send_delta("123", "y", {"_stream_delta": True, "_stream_id": "s:0"})
+
+    channel._app.bot.edit_message_text.assert_called_once()
+    edit_text = channel._app.bot.edit_message_text.call_args.kwargs.get("text", "")
+    assert len(edit_text) <= TELEGRAM_MAX_MESSAGE_LEN
+
+    channel._app.bot.send_message.assert_called_once()
+    buf = channel._stream_bufs["123"]
+    assert buf.message_id == 99
+    assert len(buf.text) <= TELEGRAM_MAX_MESSAGE_LEN
+    assert buf.last_edit > 0.0
+
+
+@pytest.mark.asyncio
 async def test_send_delta_initial_send_keeps_message_in_thread() -> None:
     channel = TelegramChannel(
         TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),


### PR DESCRIPTION
Streaming edits called edit_message_text(text=buf.text) without chunking, so once accumulated deltas crossed Telegram's 4096-char limit an ongoing stream would fail with BadRequest while _stream_end still had chunking. 
Now overflow is flushed by editing the first chunk in place, sending any middle chunks, and re-anchoring the buffer to a new message for the tail so subsequent deltas keep streaming.

## logs/gateway.err.log

```
2026-04-19 22:02:01.759 | ERROR    | nanobot.channels.manager:_send_with_retry:271 - Failed to send to telegram after 3 attempts: BadRequest - Text is too long
2026-04-19 22:02:01.989 | WARNING  | nanobot.channels.telegram:send_delta:640 - Stream edit failed: Text is too long
2026-04-19 22:02:01.989 | WARNING  | nanobot.channels.manager:_send_with_retry:277 - Send to telegram failed (attempt 1/3): BadRequest, retrying in 1s
2026-04-19 22:02:03.258 | WARNING  | nanobot.channels.telegram:send_delta:640 - Stream edit failed: Text is too long
2026-04-19 22:02:03.259 | WARNING  | nanobot.channels.manager:_send_with_retry:277 - Send to telegram failed (attempt 2/3): BadRequest, retrying in 2s
2026-04-19 22:02:06.093 | WARNING  | nanobot.channels.telegram:send_delta:640 - Stream edit failed: Text is too long
2026-04-19 22:02:06.093 | ERROR    | nanobot.channels.manager:_send_with_retry:271 - Failed to send to telegram after 3 attempts: BadRequest - Text is too long
2026-04-19 22:02:06.325 | WARNING  | nanobot.channels.telegram:send_delta:640 - Stream edit failed: Text is too long
2026-04-19 22:02:06.325 | WARNING  | nanobot.channels.manager:_send_with_retry:277 - Send to telegram failed (attempt 1/3): BadRequest, retrying in 1s
2026-04-19 22:02:07.552 | WARNING  | nanobot.channels.telegram:send_delta:640 - Stream edit failed: Text is too long
2026-04-19 22:02:07.553 | WARNING  | nanobot.channels.manager:_send_with_retry:277 - Send to telegram failed (attempt 2/3): BadRequest, retrying in 2s
2026-04-19 22:02:09.830 | WARNING  | nanobot.channels.telegram:send_delta:640 - Stream edit failed: Text is too long
2026-04-19 22:02:09.830 | ERROR    | nanobot.channels.manager:_send_with_retry:271 - Failed to send to telegram after 3 attempts: BadRequest - Text is too long
```