### PR TITLE
fix(email): deduplicate SPF/DKIM-rejected emails to stop log spam

### DIFF
--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -395,10 +395,7 @@ class EmailChannel(BaseChannel):
                         "(no 'spf=pass' in Authentication-Results header)",
                         sender,
                     )
-                    if uid:
-                        cycle_uids.add(uid)
-                        if dedupe:
-                            self._processed_uids.add(uid)
+                    self._remember_processed_uid(uid, dedupe, cycle_uids)
                     continue
                 if self.config.verify_dkim and not dkim_pass:
                     logger.warning(
@@ -406,10 +403,7 @@ class EmailChannel(BaseChannel):
                         "(no 'dkim=pass' in Authentication-Results header)",
                         sender,
                     )
-                    if uid:
-                        cycle_uids.add(uid)
-                        if dedupe:
-                            self._processed_uids.add(uid)
+                    self._remember_processed_uid(uid, dedupe, cycle_uids)
                     continue
 
                 subject = self._decode_header_value(parsed.get("Subject", ""))

--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -395,6 +395,10 @@ class EmailChannel(BaseChannel):
                         "(no 'spf=pass' in Authentication-Results header)",
                         sender,
                     )
+                    if uid:
+                        cycle_uids.add(uid)
+                        if dedupe:
+                            self._processed_uids.add(uid)
                     continue
                 if self.config.verify_dkim and not dkim_pass:
                     logger.warning(
@@ -402,6 +406,10 @@ class EmailChannel(BaseChannel):
                         "(no 'dkim=pass' in Authentication-Results header)",
                         sender,
                     )
+                    if uid:
+                        cycle_uids.add(uid)
+                        if dedupe:
+                            self._processed_uids.add(uid)
                     continue
 
                 subject = self._decode_header_value(parsed.get("Subject", ""))


### PR DESCRIPTION
## Summary

Cherry-pick #3243 from nightly. When SPF/DKIM verification rejects an email, the UID was not tracked in dedup sets, causing the same warning to be logged every ~60s poll cycle.

### Email channel

- **fix: deduplicate SPF/DKIM-rejected emails to stop log spam** — Add rejected email UIDs to `cycle_uids` and `_processed_uids` before `continue`, so the warning fires once per message instead of once per poll. (#3243)
- **refactor(email): use _remember_processed_uid in SPF/DKIM reject paths** — Replaces inline dedup logic with the existing helper to match the style of other reject branches and keep the `_processed_uids` eviction logic in one place. (#3243)

@flobo3 thanks for your contribution