### PR TITLE
feat(skills): mark skills unavailable when required env vars aren't accessible to exec

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -21,11 +21,21 @@ class ContextBuilder:
     _MAX_RECENT_HISTORY = 50
     _RUNTIME_CONTEXT_END = "[/Runtime Context]"
 
-    def __init__(self, workspace: Path, timezone: str | None = None, disabled_skills: list[str] | None = None):
+    def __init__(
+        self,
+        workspace: Path,
+        timezone: str | None = None,
+        disabled_skills: list[str] | None = None,
+        exec_env_keys: list[str] | None = None,
+    ):
         self.workspace = workspace
         self.timezone = timezone
         self.memory = MemoryStore(workspace)
-        self.skills = SkillsLoader(workspace, disabled_skills=set(disabled_skills) if disabled_skills else None)
+        self.skills = SkillsLoader(
+            workspace,
+            disabled_skills=set(disabled_skills) if disabled_skills else None,
+            exec_env_keys=set(exec_env_keys) if exec_env_keys is not None else None,
+        )
 
     def build_system_prompt(
         self,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -26,7 +26,7 @@ from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.notebook import NotebookEditTool
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.search import GlobTool, GrepTool
-from nanobot.agent.tools.shell import ExecTool
+from nanobot.agent.tools.shell import ExecTool, get_default_exec_env_keys
 from nanobot.agent.tools.self import MyTool
 from nanobot.agent.tools.spawn import SpawnTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
@@ -194,7 +194,8 @@ class AgentLoop:
         self._last_usage: dict[str, int] = {}
         self._extra_hooks: list[AgentHook] = hooks or []
 
-        self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
+        exec_env_keys = list(get_default_exec_env_keys() | set(self.exec_config.allowed_env_keys))
+        self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills, exec_env_keys=exec_env_keys)
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
         self.runner = AgentRunner(provider)

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -26,11 +26,18 @@ class SkillsLoader:
     specific tools or perform certain tasks.
     """
 
-    def __init__(self, workspace: Path, builtin_skills_dir: Path | None = None, disabled_skills: set[str] | None = None):
+    def __init__(
+        self,
+        workspace: Path,
+        builtin_skills_dir: Path | None = None,
+        disabled_skills: set[str] | None = None,
+        exec_env_keys: set[str] | None = None,
+    ):
         self.workspace = workspace
         self.workspace_skills = workspace / "skills"
         self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR
         self.disabled_skills = disabled_skills or set()
+        self.exec_env_keys = exec_env_keys
 
     def _skill_entries_from_dir(self, base: Path, source: str, *, skip_names: set[str] | None = None) -> list[dict[str, str]]:
         if not base.exists():
@@ -141,6 +148,14 @@ class SkillsLoader:
                 lines.append(f"- **{skill_name}** — {desc}{suffix}  `{entry['path']}`")
         return "\n".join(lines)
 
+    def _env_var_available(self, var: str) -> bool:
+        """Check if an env var is set and accessible to exec subprocesses."""
+        if not os.environ.get(var):
+            return False
+        if self.exec_env_keys is not None:
+            return var in self.exec_env_keys
+        return True
+
     def _get_missing_requirements(self, skill_meta: dict) -> str:
         """Get a description of missing requirements."""
         requires = skill_meta.get("requires", {})
@@ -148,7 +163,7 @@ class SkillsLoader:
         required_env_vars = requires.get("env", [])
         return ", ".join(
             [f"CLI: {command_name}" for command_name in required_bins if not shutil.which(command_name)]
-            + [f"ENV: {env_name}" for env_name in required_env_vars if not os.environ.get(env_name)]
+            + [f"ENV: {env_name}" for env_name in required_env_vars if not self._env_var_available(env_name)]
         )
 
     def _get_skill_description(self, name: str) -> str:
@@ -192,7 +207,7 @@ class SkillsLoader:
         required_bins = requires.get("bins", [])
         required_env_vars = requires.get("env", [])
         return all(shutil.which(cmd) for cmd in required_bins) and all(
-            os.environ.get(var) for var in required_env_vars
+            self._env_var_available(var) for var in required_env_vars
         )
 
     def _get_skill_meta(self, name: str) -> dict:

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -286,11 +286,14 @@ class SubagentManager:
         """Build a focused system prompt for the subagent."""
         from nanobot.agent.context import ContextBuilder
         from nanobot.agent.skills import SkillsLoader
+        from nanobot.agent.tools.shell import get_default_exec_env_keys
 
         time_ctx = ContextBuilder._build_runtime_context(None, None)
+        exec_env_keys = get_default_exec_env_keys() | set(self.exec_config.allowed_env_keys)
         skills_summary = SkillsLoader(
             self.workspace,
             disabled_skills=self.disabled_skills,
+            exec_env_keys=exec_env_keys,
         ).build_skills_summary()
         return render_template(
             "agent/subagent_system.md",

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -17,6 +17,18 @@ from nanobot.config.paths import get_media_dir
 
 _IS_WINDOWS = sys.platform == "win32"
 
+_UNIX_DEFAULT_ENV_KEYS = frozenset({"HOME", "LANG", "TERM"})
+_WINDOWS_DEFAULT_ENV_KEYS = frozenset({
+    "SYSTEMROOT", "COMSPEC", "USERPROFILE", "HOMEDRIVE", "HOMEPATH",
+    "TEMP", "TMP", "PATHEXT", "PATH", "APPDATA", "LOCALAPPDATA",
+    "ProgramData", "ProgramFiles", "ProgramFiles(x86)", "ProgramW6432",
+})
+
+
+def get_default_exec_env_keys() -> frozenset[str]:
+    """Return env var names always forwarded to exec subprocesses."""
+    return _WINDOWS_DEFAULT_ENV_KEYS if _IS_WINDOWS else _UNIX_DEFAULT_ENV_KEYS
+
 
 @tool_parameters(
     tool_parameters_schema(

--- a/tests/agent/test_skills_loader.py
+++ b/tests/agent/test_skills_loader.py
@@ -220,6 +220,92 @@ def test_list_skills_filter_unavailable_excludes_unmet_env_requirement(
     assert loader.list_skills(filter_unavailable=True) == []
 
 
+def test_skill_unavailable_when_env_var_not_in_exec_env_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skill requires MY_VAR which is set in os.environ but not in exec_env_keys."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True)
+    _write_skill(
+        skills_root,
+        "needs_env",
+        metadata_json={"requires": {"env": ["MY_VAR"]}},
+    )
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    monkeypatch.setenv("MY_VAR", "present")
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin, exec_env_keys={"HOME", "LANG"})
+    assert loader.list_skills(filter_unavailable=True) == []
+
+
+def test_skill_available_when_env_var_in_exec_env_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skill requires MY_VAR which is set and included in exec_env_keys."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True)
+    skill_path = _write_skill(
+        skills_root,
+        "needs_env",
+        metadata_json={"requires": {"env": ["MY_VAR"]}},
+    )
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    monkeypatch.setenv("MY_VAR", "present")
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin, exec_env_keys={"HOME", "MY_VAR"})
+    entries = loader.list_skills(filter_unavailable=True)
+    assert entries == [{"name": "needs_env", "path": str(skill_path), "source": "workspace"}]
+
+
+def test_skill_unavailable_when_env_var_in_exec_env_keys_but_not_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skill requires MY_VAR which is in exec_env_keys but not set in os.environ."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True)
+    _write_skill(
+        skills_root,
+        "needs_env",
+        metadata_json={"requires": {"env": ["MY_VAR"]}},
+    )
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    monkeypatch.delenv("MY_VAR", raising=False)
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin, exec_env_keys={"HOME", "MY_VAR"})
+    assert loader.list_skills(filter_unavailable=True) == []
+
+
+def test_exec_env_keys_none_falls_back_to_os_environ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When exec_env_keys is None, env check uses os.environ only (backward compat)."""
+    workspace = tmp_path / "ws"
+    skills_root = workspace / "skills"
+    skills_root.mkdir(parents=True)
+    skill_path = _write_skill(
+        skills_root,
+        "needs_env",
+        metadata_json={"requires": {"env": ["MY_VAR"]}},
+    )
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+
+    monkeypatch.setenv("MY_VAR", "present")
+
+    loader = SkillsLoader(workspace, builtin_skills_dir=builtin, exec_env_keys=None)
+    entries = loader.list_skills(filter_unavailable=True)
+    assert entries == [{"name": "needs_env", "path": str(skill_path), "source": "workspace"}]
+
+
 def test_list_skills_openclaw_metadata_parsed_for_requirements(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/tools/test_exec_env.py
+++ b/tests/tools/test_exec_env.py
@@ -74,3 +74,15 @@ async def test_exec_allowed_env_keys_missing_var_ignored(monkeypatch):
     tool = ExecTool(allowed_env_keys=["NONEXISTENT_VAR_12345"])
     result = await tool.execute(command="printenv NONEXISTENT_VAR_12345")
     assert "Exit code: 1" in result
+
+
+def test_get_default_exec_env_keys_returns_expected_keys():
+    """get_default_exec_env_keys should return the platform-appropriate default keys."""
+    from nanobot.agent.tools.shell import get_default_exec_env_keys
+
+    keys = get_default_exec_env_keys()
+    if sys.platform == "win32":
+        assert "SYSTEMROOT" in keys
+        assert "PATH" in keys
+    else:
+        assert keys == {"HOME", "LANG", "TERM"}


### PR DESCRIPTION
Skills declaring requires.env in their frontmatter were only checked against os.environ. A skill could appear available even though the exec tool wouldn't forward its required env var to subprocesses (which use a minimal, isolated environment).

Now SkillsLoader checks required env vars against the actual set of keys the exec tool will forward: platform defaults
(HOME, LANG, TERM on Unix) plus allowed_env_keys from config.