### PR TITLE
feat(read_file): add DOCX, XLSX, PPTX office document support

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -137,10 +137,11 @@ class ReadFileTool(_FsTool):
     @property
     def description(self) -> str:
         return (
-            "Read a file (text or image). Text output format: LINE_NUM|CONTENT. "
+            "Read a file (text, image, or document). "
+            "Text output format: LINE_NUM|CONTENT. "
             "Images return visual content for analysis. "
-            "Use offset and limit for large files. "
-            "Cannot read non-image binary files. "
+            "Supports PDF, DOCX, XLSX, PPTX documents. "
+            "Use offset and limit for large text files. "
             "Reads exceeding ~128K chars are truncated."
         )
 
@@ -168,6 +169,10 @@ class ReadFileTool(_FsTool):
             # PDF support
             if fp.suffix.lower() == ".pdf":
                 return self._read_pdf(fp, pages)
+
+            # Office document support
+            if fp.suffix.lower() in {".docx", ".xlsx", ".pptx"}:
+                return self._read_office_doc(fp)
 
             raw = fp.read_bytes()
             if not raw:
@@ -302,6 +307,25 @@ class ReadFileTool(_FsTool):
             result += f"\n\n(Showing pages {start + 1}-{end + 1} of {total_pages}. Use pages='{end + 2}-{min(end + 1 + self._MAX_PDF_PAGES, total_pages)}' to continue.)"
         if len(result) > self._MAX_CHARS:
             result = result[:self._MAX_CHARS] + "\n\n(PDF text truncated at ~128K chars)"
+        return result
+
+    def _read_office_doc(self, fp: Path) -> str:
+        from nanobot.utils.document import extract_text
+
+        result = extract_text(fp)
+
+        if result is None:
+            return f"Error: Unsupported file format: {fp.suffix}"
+
+        if result.startswith("[error:"):
+            return f"Error reading {fp.suffix.upper()} file: {result}"
+
+        if not result:
+            return f"({fp.suffix.upper().lstrip('.')} has no extractable text: {fp})"
+
+        if len(result) > self._MAX_CHARS:
+            result = result[:self._MAX_CHARS] + "\n\n(Document text truncated at ~128K chars)"
+
         return result
 
 

--- a/tests/tools/test_read_enhancements.py
+++ b/tests/tools/test_read_enhancements.py
@@ -1,7 +1,8 @@
-"""Tests for ReadFileTool enhancements: description fix, read dedup, PDF support, device blacklist."""
+"""Tests for ReadFileTool enhancements: description fix, read dedup, PDF support, device blacklist, office docs."""
 
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -246,3 +247,123 @@ class TestReadFileLineEndingNormalization:
         result = await tool.execute(path=str(f))
         assert "\r" not in result
         assert "alpha" in result and "beta" in result and "gamma" in result
+
+
+# ---------------------------------------------------------------------------
+# Office document support (DOCX, XLSX, PPTX)
+# ---------------------------------------------------------------------------
+
+class TestReadOfficeDocuments:
+
+    @pytest.fixture()
+    def tool(self, tmp_path):
+        return ReadFileTool(workspace=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_docx_returns_extracted_text(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value="Title\n\nParagraph 1"):
+            f = tmp_path / "test.docx"
+            f.write_bytes(b"PK")
+            result = await tool.execute(path=str(f))
+        assert "Title" in result
+        assert "Paragraph 1" in result
+        assert "Error" not in result
+
+    @pytest.mark.asyncio
+    async def test_xlsx_returns_extracted_text(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value="--- Sheet: Sheet1 ---\nName\tAge\nAlice\t30"):
+            f = tmp_path / "test.xlsx"
+            f.write_bytes(b"PK")
+            result = await tool.execute(path=str(f))
+        assert "Sheet1" in result
+        assert "Alice" in result
+
+    @pytest.mark.asyncio
+    async def test_pptx_returns_extracted_text(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value="--- Slide 1 ---\nWelcome\n--- Slide 2 ---\nContent"):
+            f = tmp_path / "test.pptx"
+            f.write_bytes(b"PK")
+            result = await tool.execute(path=str(f))
+        assert "Welcome" in result
+        assert "Content" in result
+
+    @pytest.mark.asyncio
+    async def test_docx_missing_library(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value="[error: python-docx not installed]"):
+            f = tmp_path / "test.docx"
+            f.write_bytes(b"PK")
+            result = await tool.execute(path=str(f))
+        assert "Error" in result
+        assert "python-docx not installed" in result
+
+    @pytest.mark.asyncio
+    async def test_docx_corrupt_file(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value="[error: failed to extract DOCX: bad zip]"):
+            f = tmp_path / "test.docx"
+            f.write_bytes(b"not-a-zip")
+            result = await tool.execute(path=str(f))
+        assert "Error" in result
+        assert "failed to extract DOCX" in result
+
+    @pytest.mark.asyncio
+    async def test_unsupported_extension(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value=None):
+            f = tmp_path / "test.docx"
+            f.write_bytes(b"PK")
+            result = await tool.execute(path=str(f))
+        assert "Error" in result
+        assert "Unsupported" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_document_returns_descriptive_message(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value=""):
+            f = tmp_path / "empty.docx"
+            f.write_bytes(b"PK")
+            result = await tool.execute(path=str(f))
+        assert "no extractable text" in result
+
+
+class TestOfficeDocTruncation:
+
+    @pytest.fixture()
+    def tool(self, tmp_path):
+        return ReadFileTool(workspace=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_large_document_truncated(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value="x" * 200_000):
+            f = tmp_path / "large.docx"
+            f.write_bytes(b"PK")
+            result = await tool.execute(path=str(f))
+        assert len(result) <= ReadFileTool._MAX_CHARS + 100
+        assert "truncated at ~128K chars" in result
+
+    @pytest.mark.asyncio
+    async def test_small_document_not_truncated(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value="Hello world"):
+            f = tmp_path / "small.docx"
+            f.write_bytes(b"PK")
+            result = await tool.execute(path=str(f))
+        assert "truncated" not in result
+        assert "Hello world" in result
+
+    @pytest.mark.asyncio
+    async def test_error_response_not_truncated(self, tool, tmp_path):
+        with patch("nanobot.utils.document.extract_text", return_value="[error: failed to extract DOCX: something went wrong]"):
+            f = tmp_path / "bad.docx"
+            f.write_bytes(b"PK")
+            result = await tool.execute(path=str(f))
+        assert "Error" in result
+        assert "truncated" not in result
+
+
+class TestReadDescriptionUpdate:
+
+    def test_description_mentions_documents(self):
+        tool = ReadFileTool()
+        desc = tool.description.lower()
+        assert "document" in desc or "docx" in desc or "xlsx" in desc or "pptx" in desc
+
+    def test_description_no_longer_says_cannot_read(self):
+        tool = ReadFileTool()
+        assert "cannot read" not in tool.description.lower()


### PR DESCRIPTION
## Summary

Extend `read_file` tool to support reading office documents (DOCX, XLSX, PPTX) by connecting to the existing `extract_text()` utility in `nanobot/utils/document.py`.

## Context

Wire up the existing office document extractors in document.py to
ReadFileTool by adding an extension guard and _read_office_doc() method
that follows the established PDF pattern. Handles missing libraries,
corrupt files, empty documents, and 128K truncation consistently.

Intentionally minimal: does not refactor document.py error protocol or
unify truncation footers to avoid behavioral changes in existing PDF path.


## Why

The `ReadFileTool` supported UTF-8 text, images, and PDFs, but rejected `.docx`, `.xlsx`, and `.pptx` files with `"Error: Cannot read binary file"`. Meanwhile, `nanobot/utils/document.py` already contained complete extraction logic (`_extract_docx()`, `_extract_xlsx()`, `_extract_pptx()`) with proper library guards, error handling, and truncation — it was simply not wired up to the tool layer.

## Solve

Connected the two layers by adding an extension guard in `execute()` (matching the existing PDF pattern) and a new `_read_office_doc()` method that delegates to `document.extract_text()`.

## Changes

| File | Change |
|------|--------|
| `nanobot/agent/tools/filesystem.py:173-175` | Add extension guard for `.docx/.xlsx/.pptx` after PDF check, before raw bytes read |
| `nanobot/agent/tools/filesystem.py:312-329` | Add `_read_office_doc()` — delegates to `extract_text()`, handles errors, empty docs, and 128K truncation |
| `nanobot/agent/tools/filesystem.py:139-146` | Update tool description to advertise document format support |
| `tests/tools/test_read_enhancements.py` | Add 12 new tests: happy paths (DOCX/XLSX/PPTX), errors (missing lib, corrupt, unsupported), truncation, empty doc, description |

## Tests

**Completed (29 passed, 2 skipped — pre-existing PDF skips):**

- [x] DOCX returns extracted text
- [x] XLSX returns extracted text with sheet headers
- [x] PPTX returns extracted text with slide headers
- [x] Missing library returns actionable error message
- [x] Corrupt file returns error (not unhandled exception)
- [x] Unsupported extension returns error
- [x] Empty document returns descriptive message (consistent with PDF)
- [x] Large document (>128K) is truncated with footer
- [x] Small document is not truncated
- [x] Error responses are not truncated
- [x] Tool description mentions document support
- [x] Tool description no longer says "cannot read"
- [x] All existing tests (text, PDF, image, dedup, device blacklist) continue to pass

**Not yet done:**

- [ ] Boundary test at exactly `_MAX_CHARS` (off-by-one guard)
- [ ] Error path tests for `.xlsx` and `.pptx` (currently only `.docx` tested)
- [ ] Integration test with real office document libraries (current tests mock `extract_text`)

## Enhancement Directions

1. **Pagination for office documents** — PDF has a `pages` parameter; office docs lack equivalent. Large XLSX with many sheets truncates at 128K with no way to continue. Consider adding sheet/slide-level pagination in a follow-up.

2. **Structured error protocol** — Error detection relies on `startswith("[error:")` string sniffing. A shared constant or discriminated return type from `extract_text()` would eliminate the fragile coupling between `filesystem.py` and `document.py`.

3. **Dead code cleanup** — The `result is None` guard in `_read_office_doc()` is unreachable because the extension gate already filters to `.docx/.xlsx/.pptx`. Harmless but misleading to future maintainers.

---

[![Built with OpenCode](https://img.shields.io/badge/Built_with-OpenCode-4B32C3)](https://github.com/anomalyco/opencode)
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/GLM_5.1-4285F4?logo=googlegemini&logoColor=white)