### PR TITLE
docs: add WebSocket channel configuration guide for WebUI development

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -35,7 +35,27 @@ From the repository root:
 pip install -e .
 ```
 
-### 2. Start the gateway
+### 2. Enable WebSocket channel
+
+Make sure the WebSocket channel is enabled in your nanobot configuration. If not already configured, add the following to your `~/.nanobot/config.json` file:
+
+```json
+{
+  "channels": {
+    "websocket": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 8765,
+      "path": "/",
+      "websocketRequiresToken": false,
+      "allowFrom": ["*"],
+      "streaming": true
+    }
+  }
+}
+```
+
+### 3. Start the gateway
 
 In one terminal:
 
@@ -43,7 +63,7 @@ In one terminal:
 nanobot gateway
 ```
 
-### 3. Start the WebUI dev server
+### 4. Start the WebUI dev server
 
 In another terminal:
 


### PR DESCRIPTION
## Description

Added missing WebSocket channel configuration instructions to the WebUI development documentation, helping developers properly configure the nanobot gateway when working locally.

## Problem Solved

When following the original documentation, new developers encounter a "bootstrap failed: HTTP 500" error because they don't know they need to enable the WebSocket channel in the configuration file.

## Changes Made

- Added a new "Enable WebSocket channel" step in the "Develop from source" section
- Provided a complete configuration example with all necessary parameters
- Renumbered subsequent steps for proper sequence