### PR TITLE
fix(utils/document): use try/finally in _extract_xlsx to ensure workbook is always closed

### DIFF
--- a/nanobot/utils/document.py
+++ b/nanobot/utils/document.py
@@ -133,7 +133,8 @@ def _extract_docx(path: Path) -> str:
 def _extract_xlsx(path: Path) -> str:
     """Extract text from XLSX using openpyxl."""
     try:
-        with load_workbook(path, read_only=True, data_only=True) as wb:
+        wb = load_workbook(path, read_only=True, data_only=True)
+        try:
             sheets: list[str] = []
             for sheet_name in wb.sheetnames:
                 ws = wb[sheet_name]
@@ -145,6 +146,8 @@ def _extract_xlsx(path: Path) -> str:
                 if rows:
                     sheets.append(f"--- Sheet: {sheet_name} ---\n" + "\n".join(rows))
             return _truncate("\n\n".join(sheets), _MAX_TEXT_LENGTH)
+        finally:
+            wb.close()
     except Exception as e:
         logger.error("Failed to extract XLSX {}: {}", path, e)
         return f"[error: failed to extract XLSX: {e!s}]"

--- a/nanobot/utils/document.py
+++ b/nanobot/utils/document.py
@@ -133,19 +133,18 @@ def _extract_docx(path: Path) -> str:
 def _extract_xlsx(path: Path) -> str:
     """Extract text from XLSX using openpyxl."""
     try:
-        wb = load_workbook(path, read_only=True, data_only=True)
-        sheets: list[str] = []
-        for sheet_name in wb.sheetnames:
-            ws = wb[sheet_name]
-            rows: list[str] = []
-            for row in ws.iter_rows(values_only=True):
-                row_text = "\t".join(str(cell) if cell is not None else "" for cell in row)
-                if row_text.strip():
-                    rows.append(row_text)
-            if rows:
-                sheets.append(f"--- Sheet: {sheet_name} ---\n" + "\n".join(rows))
-        wb.close()
-        return _truncate("\n\n".join(sheets), _MAX_TEXT_LENGTH)
+        with load_workbook(path, read_only=True, data_only=True) as wb:
+            sheets: list[str] = []
+            for sheet_name in wb.sheetnames:
+                ws = wb[sheet_name]
+                rows: list[str] = []
+                for row in ws.iter_rows(values_only=True):
+                    row_text = "\t".join(str(cell) if cell is not None else "" for cell in row)
+                    if row_text.strip():
+                        rows.append(row_text)
+                if rows:
+                    sheets.append(f"--- Sheet: {sheet_name} ---\n" + "\n".join(rows))
+            return _truncate("\n\n".join(sheets), _MAX_TEXT_LENGTH)
     except Exception as e:
         logger.error("Failed to extract XLSX {}: {}", path, e)
         return f"[error: failed to extract XLSX: {e!s}]"


### PR DESCRIPTION
## Description

Use a `try/finally` block in `_extract_xlsx()` to ensure the openpyxl workbook is always properly closed, even when exceptions occur during sheet iteration.

## Problem Solved

Previously, `wb.close()` was called outside a `finally` block. If an exception was raised during sheet iteration (e.g., corrupted worksheet), the workbook would not be closed, potentially leading to:

- File handle leaks
- Locked files that cannot be deleted or reopened
- Increased memory usage over time in long-running processes

The initial approach used a `with` context manager (`with load_workbook(...) as wb:`), but this caused a CI failure because `openpyxl`'s `Workbook` object does **not** implement the context manager protocol (`__enter__/__exit__`), resulting in:

```'Workbook' object does not support the context manager protocol```

The fix uses `try/finally` instead, which achieves the same resource-safety guarantee without relying on context manager support.

## Changes Made

- Replaced bare `wb = load_workbook(...)` + `wb.close()` with `wb = load_workbook(...)` wrapped in `try/finally` to guarantee `wb.close()` is always called

## Testing

- Existing tests `test_extract_text_xlsx` and `test_extract_text_xlsx_empty_sheet` now pass
- All other document parsing tests remain unaffected