### PR TITLE
feat(runtime): add explicit LLM fallback chain across providers/models

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -404,77 +404,23 @@ def _onboard_plugins(config_path: Path) -> None:
 
 
 def _make_provider(config: Config):
-    """Create the appropriate LLM provider from config.
+    """Create the appropriate LLM provider from config."""
+    from nanobot.providers.factory import build_provider
 
-    Routing is driven by ``ProviderSpec.backend`` in the registry.
-    """
-    from nanobot.providers.base import GenerationSettings
-    from nanobot.providers.registry import find_by_name
-
-    model = config.agents.defaults.model
-    provider_name = config.get_provider_name(model)
-    p = config.get_provider(model)
-    spec = find_by_name(provider_name) if provider_name else None
-    backend = spec.backend if spec else "openai_compat"
-
-    # --- validation ---
-    if backend == "azure_openai":
-        if not p or not p.api_key or not p.api_base:
+    try:
+        return build_provider(config)
+    except ValueError as exc:
+        message = str(exc)
+        if "Azure OpenAI requires api_key and api_base" in message:
             console.print("[red]Error: Azure OpenAI requires api_key and api_base.[/red]")
             console.print("Set them in ~/.nanobot/config.json under providers.azure_openai section")
             console.print("Use the model field to specify the deployment name.")
-            raise typer.Exit(1)
-    elif backend == "openai_compat" and not model.startswith("bedrock/"):
-        needs_key = not (p and p.api_key)
-        exempt = spec and (spec.is_oauth or spec.is_local or spec.is_direct)
-        if needs_key and not exempt:
+        elif "No API key configured for provider" in message:
             console.print("[red]Error: No API key configured.[/red]")
             console.print("Set one in ~/.nanobot/config.json under providers section")
-            raise typer.Exit(1)
-
-    # --- instantiation by backend ---
-    if backend == "openai_codex":
-        from nanobot.providers.openai_codex_provider import OpenAICodexProvider
-
-        provider = OpenAICodexProvider(default_model=model)
-    elif backend == "azure_openai":
-        from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
-
-        provider = AzureOpenAIProvider(
-            api_key=p.api_key,
-            api_base=p.api_base,
-            default_model=model,
-        )
-    elif backend == "github_copilot":
-        from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
-        provider = GitHubCopilotProvider(default_model=model)
-    elif backend == "anthropic":
-        from nanobot.providers.anthropic_provider import AnthropicProvider
-
-        provider = AnthropicProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-        )
-    else:
-        from nanobot.providers.openai_compat_provider import OpenAICompatProvider
-
-        provider = OpenAICompatProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-            spec=spec,
-        )
-
-    defaults = config.agents.defaults
-    provider.generation = GenerationSettings(
-        temperature=defaults.temperature,
-        max_tokens=defaults.max_tokens,
-        reasoning_effort=defaults.reasoning_effort,
-    )
-    return provider
+        else:
+            console.print(f"[red]Error: {message}[/red]")
+        raise typer.Exit(1) from exc
 
 
 def _load_runtime_config(config: str | None = None, workspace: str | None = None) -> Config:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -64,6 +64,13 @@ class DreamConfig(Base):
         return f"every {hours}h"
 
 
+class FallbackTarget(Base):
+    """Explicit fallback target for runtime provider/model failover."""
+
+    model: str
+    provider: str = "auto"
+
+
 class AgentDefaults(Base):
     """Default agent configuration."""
 
@@ -79,6 +86,7 @@ class AgentDefaults(Base):
     max_tool_iterations: int = 200
     max_tool_result_chars: int = 16_000
     provider_retry_mode: Literal["standard", "persistent"] = "standard"
+    fallbacks: list[FallbackTarget] = Field(default_factory=list)
     reasoning_effort: str | None = None  # low / medium / high / adaptive - enables LLM thinking mode
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
     unified_session: bool = False  # Share one session across all channels (single-user multi-device)

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -119,62 +119,6 @@ class Nanobot:
 
 def _make_provider(config: Any) -> Any:
     """Create the LLM provider from config (extracted from CLI)."""
-    from nanobot.providers.base import GenerationSettings
-    from nanobot.providers.registry import find_by_name
+    from nanobot.providers.factory import build_provider
 
-    model = config.agents.defaults.model
-    provider_name = config.get_provider_name(model)
-    p = config.get_provider(model)
-    spec = find_by_name(provider_name) if provider_name else None
-    backend = spec.backend if spec else "openai_compat"
-
-    if backend == "azure_openai":
-        if not p or not p.api_key or not p.api_base:
-            raise ValueError("Azure OpenAI requires api_key and api_base in config.")
-    elif backend == "openai_compat" and not model.startswith("bedrock/"):
-        needs_key = not (p and p.api_key)
-        exempt = spec and (spec.is_oauth or spec.is_local or spec.is_direct)
-        if needs_key and not exempt:
-            raise ValueError(f"No API key configured for provider '{provider_name}'.")
-
-    if backend == "openai_codex":
-        from nanobot.providers.openai_codex_provider import OpenAICodexProvider
-
-        provider = OpenAICodexProvider(default_model=model)
-    elif backend == "github_copilot":
-        from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
-
-        provider = GitHubCopilotProvider(default_model=model)
-    elif backend == "azure_openai":
-        from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
-
-        provider = AzureOpenAIProvider(
-            api_key=p.api_key, api_base=p.api_base, default_model=model
-        )
-    elif backend == "anthropic":
-        from nanobot.providers.anthropic_provider import AnthropicProvider
-
-        provider = AnthropicProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-        )
-    else:
-        from nanobot.providers.openai_compat_provider import OpenAICompatProvider
-
-        provider = OpenAICompatProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-            spec=spec,
-        )
-
-    defaults = config.agents.defaults
-    provider.generation = GenerationSettings(
-        temperature=defaults.temperature,
-        max_tokens=defaults.max_tokens,
-        reasoning_effort=defaults.reasoning_effort,
-    )
-    return provider
+    return build_provider(config)

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -1,0 +1,119 @@
+"""Provider construction helpers shared by CLI and runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nanobot.providers.base import GenerationSettings, LLMProvider
+from nanobot.providers.fallback_provider import FallbackCandidate, FallbackProvider
+from nanobot.providers.registry import find_by_name
+
+
+def _resolve_provider(config: Any, model: str, provider_override: str | None = None):
+    forced = provider_override or "auto"
+    if forced != "auto":
+        spec = find_by_name(forced)
+        if spec is None:
+            raise ValueError(f"Unknown provider '{forced}'.")
+        provider_config = getattr(config.providers, spec.name, None)
+        return provider_config, spec.name, spec
+
+    provider_name = config.get_provider_name(model)
+    provider_config = config.get_provider(model)
+    spec = find_by_name(provider_name) if provider_name else None
+    return provider_config, provider_name, spec
+
+
+def _resolve_api_base(provider_config: Any, spec: Any) -> str | None:
+    if provider_config and provider_config.api_base:
+        return provider_config.api_base
+    if spec and spec.default_api_base:
+        return spec.default_api_base
+    return None
+
+
+def build_single_provider(config: Any, model: str, provider_override: str | None = None) -> tuple[LLMProvider, str]:
+    provider_config, provider_name, spec = _resolve_provider(config, model, provider_override)
+    backend = spec.backend if spec else "openai_compat"
+
+    if backend == "azure_openai":
+        if not provider_config or not provider_config.api_key or not provider_config.api_base:
+            raise ValueError("Azure OpenAI requires api_key and api_base in config.")
+    elif backend == "openai_compat" and not model.startswith("bedrock/"):
+        needs_key = not (provider_config and provider_config.api_key)
+        exempt = spec and (spec.is_oauth or spec.is_local or spec.is_direct)
+        if needs_key and not exempt:
+            raise ValueError(f"No API key configured for provider '{provider_name}'.")
+
+    if backend == "openai_codex":
+        from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+
+        provider = OpenAICodexProvider(default_model=model)
+    elif backend == "github_copilot":
+        from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
+
+        provider = GitHubCopilotProvider(default_model=model)
+    elif backend == "azure_openai":
+        from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+
+        provider = AzureOpenAIProvider(
+            api_key=provider_config.api_key,
+            api_base=provider_config.api_base,
+            default_model=model,
+        )
+    elif backend == "anthropic":
+        from nanobot.providers.anthropic_provider import AnthropicProvider
+
+        provider = AnthropicProvider(
+            api_key=provider_config.api_key if provider_config else None,
+            api_base=_resolve_api_base(provider_config, spec),
+            default_model=model,
+            extra_headers=provider_config.extra_headers if provider_config else None,
+        )
+    else:
+        from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+        provider = OpenAICompatProvider(
+            api_key=provider_config.api_key if provider_config else None,
+            api_base=_resolve_api_base(provider_config, spec),
+            default_model=model,
+            extra_headers=provider_config.extra_headers if provider_config else None,
+            spec=spec,
+        )
+
+    defaults = config.agents.defaults
+    provider.generation = GenerationSettings(
+        temperature=defaults.temperature,
+        max_tokens=defaults.max_tokens,
+        reasoning_effort=defaults.reasoning_effort,
+    )
+    return provider, provider_name or "unknown"
+
+
+def build_provider(config: Any) -> LLMProvider:
+    defaults = config.agents.defaults
+    primary_provider, primary_name = build_single_provider(
+        config,
+        defaults.model,
+        defaults.provider,
+    )
+    if not defaults.fallbacks:
+        return primary_provider
+
+    candidates = [
+        FallbackCandidate(
+            provider=primary_provider,
+            model=defaults.model,
+            provider_name=primary_name,
+        )
+    ]
+    for target in defaults.fallbacks:
+        provider, provider_name = build_single_provider(config, target.model, target.provider)
+        candidates.append(
+            FallbackCandidate(
+                provider=provider,
+                model=target.model,
+                provider_name=provider_name,
+            )
+        )
+    return FallbackProvider(candidates)

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -25,6 +25,14 @@ def _resolve_provider(config: Any, model: str, provider_override: str | None = N
 
 
 def _resolve_api_base(provider_config: Any, spec: Any) -> str | None:
+    """Resolve API base URL from already-matched provider config and spec.
+
+    This mirrors the logic in ``Config.get_api_base()`` but operates on
+    pre-resolved objects.  We cannot call ``get_api_base(model)`` directly
+    because it re-resolves the provider via ``_match_provider(model)`` which
+    only reads ``agents.defaults.provider`` — that would return the wrong
+    provider config for fallback targets that override the provider.
+    """
     if provider_config and provider_config.api_base:
         return provider_config.api_base
     if spec and spec.default_api_base:

--- a/nanobot/providers/fallback_provider.py
+++ b/nanobot/providers/fallback_provider.py
@@ -1,0 +1,244 @@
+"""Runtime provider wrapper that adds explicit ordered fallback candidates."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+from typing import Any
+
+from loguru import logger
+
+from nanobot.providers.base import LLMProvider, LLMResponse
+
+
+@dataclass(frozen=True)
+class FallbackCandidate:
+    """One runtime provider/model candidate in the fallback chain."""
+
+    provider: LLMProvider
+    model: str
+    provider_name: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.provider_name}/{self.model}"
+
+
+class FallbackProvider(LLMProvider):
+    """Wrap ordered providers and fail over on transient terminal errors."""
+
+    def __init__(self, candidates: list[FallbackCandidate]):
+        if not candidates:
+            raise ValueError("FallbackProvider requires at least one candidate")
+        super().__init__()
+        self._candidates = list(candidates)
+        self.generation = candidates[0].provider.generation
+
+    def get_default_model(self) -> str:
+        return self._candidates[0].model
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+    ) -> LLMResponse:
+        candidate = self._candidates[0]
+        return await candidate.provider.chat(
+            messages=messages,
+            tools=tools,
+            model=model or candidate.model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
+            tool_choice=tool_choice,
+        )
+
+    async def chat_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        reasoning_effort: str | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        candidate = self._candidates[0]
+        return await candidate.provider.chat_stream(
+            messages=messages,
+            tools=tools,
+            model=model or candidate.model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
+            tool_choice=tool_choice,
+            on_content_delta=on_content_delta,
+        )
+
+    async def chat_with_retry(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: object = LLMProvider._SENTINEL,
+        temperature: object = LLMProvider._SENTINEL,
+        reasoning_effort: object = LLMProvider._SENTINEL,
+        tool_choice: str | dict[str, Any] | None = None,
+        retry_mode: str = "standard",
+        on_retry_wait: Callable[[str], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        return await self._call_with_fallback(
+            stream=False,
+            messages=messages,
+            tools=tools,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
+            tool_choice=tool_choice,
+            retry_mode=retry_mode,
+            on_retry_wait=on_retry_wait,
+        )
+
+    async def chat_stream_with_retry(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: object = LLMProvider._SENTINEL,
+        temperature: object = LLMProvider._SENTINEL,
+        reasoning_effort: object = LLMProvider._SENTINEL,
+        tool_choice: str | dict[str, Any] | None = None,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        retry_mode: str = "standard",
+        on_retry_wait: Callable[[str], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        return await self._call_with_fallback(
+            stream=True,
+            messages=messages,
+            tools=tools,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
+            tool_choice=tool_choice,
+            on_content_delta=on_content_delta,
+            retry_mode=retry_mode,
+            on_retry_wait=on_retry_wait,
+        )
+
+    async def _call_with_fallback(
+        self,
+        *,
+        stream: bool,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        model: str | None,
+        max_tokens: object,
+        temperature: object,
+        reasoning_effort: object,
+        tool_choice: str | dict[str, Any] | None,
+        retry_mode: str,
+        on_retry_wait: Callable[[str], Awaitable[None]] | None,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        last_response: LLMResponse | None = None
+        active_candidates = [
+            FallbackCandidate(candidate.provider, model or candidate.model, candidate.provider_name)
+            for candidate in self._candidates
+        ]
+
+        for index, candidate in enumerate(active_candidates, start=1):
+            emitted_delta = False
+
+            async def _wrapped_delta(delta: str) -> None:
+                nonlocal emitted_delta
+                if delta:
+                    emitted_delta = True
+                    if on_content_delta:
+                        await on_content_delta(delta)
+
+            resolved_max_tokens = (
+                candidate.provider.generation.max_tokens
+                if max_tokens is self._SENTINEL or max_tokens is None
+                else max_tokens
+            )
+            resolved_temperature = (
+                candidate.provider.generation.temperature
+                if temperature is self._SENTINEL or temperature is None
+                else temperature
+            )
+            resolved_reasoning_effort = (
+                candidate.provider.generation.reasoning_effort
+                if reasoning_effort is self._SENTINEL
+                else reasoning_effort
+            )
+
+            request_kwargs: dict[str, Any] = {
+                "messages": copy.deepcopy(messages),
+                "tools": tools,
+                "model": candidate.model,
+                "max_tokens": resolved_max_tokens,
+                "temperature": resolved_temperature,
+                "reasoning_effort": resolved_reasoning_effort,
+                "tool_choice": tool_choice,
+            }
+            if stream:
+                request_kwargs["on_content_delta"] = _wrapped_delta
+
+                async def _call_stream_once(**inner_kwargs: Any) -> LLMResponse:
+                    response = await candidate.provider._safe_chat_stream(**inner_kwargs)
+                    if emitted_delta and response.finish_reason == "error":
+                        response = replace(response, error_should_retry=False)
+                    return response
+
+                response = await candidate.provider._run_with_retry(
+                    _call_stream_once,
+                    request_kwargs,
+                    request_kwargs["messages"],
+                    retry_mode=retry_mode,
+                    on_retry_wait=on_retry_wait,
+                )
+            else:
+                response = await candidate.provider.chat_with_retry(
+                    **request_kwargs,
+                    retry_mode=retry_mode,
+                    on_retry_wait=on_retry_wait,
+                )
+
+            if response.finish_reason != "error":
+                return response
+
+            last_response = response
+            if stream and emitted_delta:
+                logger.warning(
+                    "LLM fallback disabled after partial streamed output from {}",
+                    candidate.label,
+                )
+                return response
+
+            if not candidate.provider._is_transient_response(response):
+                return response
+
+            if index >= len(active_candidates):
+                return response
+
+            next_candidate = active_candidates[index]
+            logger.warning(
+                "LLM fallback: {} -> {} after transient error: {}",
+                candidate.label,
+                next_candidate.label,
+                (response.content or "")[:160].lower(),
+            )
+
+        return last_response if last_response is not None else LLMResponse(
+            content="LLM fallback exhausted",
+            finish_reason="error",
+        )

--- a/tests/providers/test_provider_retry.py
+++ b/tests/providers/test_provider_retry.py
@@ -3,7 +3,10 @@ import copy
 
 import pytest
 
+from nanobot.config.schema import Config
+from nanobot.providers import factory
 from nanobot.providers.base import GenerationSettings, LLMProvider, LLMResponse
+from nanobot.providers.fallback_provider import FallbackProvider
 
 
 class ScriptedProvider(LLMProvider):
@@ -560,3 +563,140 @@ async def test_chat_stream_with_retry_normalizes_explicit_none_max_tokens() -> N
     assert response.content == "ok"
     assert provider.last_kwargs["max_tokens"] == 4096
     assert provider.last_kwargs["temperature"] == 0.7
+
+
+class StreamingErrorProvider(ScriptedProvider):
+    async def chat_stream(self, *args, **kwargs) -> LLMResponse:
+        self.calls += 1
+        self.last_kwargs = kwargs
+        on_content_delta = kwargs.get("on_content_delta")
+        if on_content_delta:
+            await on_content_delta("partial")
+        return LLMResponse(content="503 upstream reset", finish_reason="error")
+
+
+@pytest.mark.asyncio
+async def test_fallback_provider_advances_to_next_candidate_after_transient_error(monkeypatch) -> None:
+    primary = ScriptedProvider([
+        LLMResponse(content="429 rate limit a", finish_reason="error"),
+        LLMResponse(content="429 rate limit b", finish_reason="error"),
+        LLMResponse(content="429 rate limit c", finish_reason="error"),
+        LLMResponse(content="503 final server error", finish_reason="error"),
+    ])
+    fallback = ScriptedProvider([LLMResponse(content="ok from fallback")])
+    provider = FallbackProvider([
+        factory.FallbackCandidate(provider=primary, model="gpt-5.4", provider_name="openai"),
+        factory.FallbackCandidate(provider=fallback, model="claude-sonnet-4-6", provider_name="anthropic"),
+    ])
+
+    async def _fake_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", _fake_sleep)
+
+    response = await provider.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.content == "ok from fallback"
+    assert primary.calls == 4
+    assert fallback.calls == 1
+    assert primary.last_kwargs["model"] == "gpt-5.4"
+    assert fallback.last_kwargs["model"] == "claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
+async def test_fallback_provider_stops_on_non_transient_error() -> None:
+    primary = ScriptedProvider([LLMResponse(content="401 unauthorized", finish_reason="error")])
+    fallback = ScriptedProvider([LLMResponse(content="should not run")])
+    provider = FallbackProvider([
+        factory.FallbackCandidate(provider=primary, model="gpt-5.4", provider_name="openai"),
+        factory.FallbackCandidate(provider=fallback, model="claude-sonnet-4-6", provider_name="anthropic"),
+    ])
+
+    response = await provider.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.content == "401 unauthorized"
+    assert primary.calls == 1
+    assert fallback.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_fallback_provider_stream_does_not_fail_over_after_first_delta(monkeypatch) -> None:
+    fallback = ScriptedProvider([LLMResponse(content="should not run")])
+    provider = FallbackProvider([
+        factory.FallbackCandidate(provider=StreamingErrorProvider([]), model="gpt-5.4", provider_name="openai"),
+        factory.FallbackCandidate(provider=fallback, model="claude-sonnet-4-6", provider_name="anthropic"),
+    ])
+    deltas: list[str] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        return None
+
+    async def _on_delta(delta: str) -> None:
+        deltas.append(delta)
+
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", _fake_sleep)
+
+    response = await provider.chat_stream_with_retry(
+        messages=[{"role": "user", "content": "hello"}],
+        on_content_delta=_on_delta,
+    )
+
+    assert response.content == "503 upstream reset"
+    assert deltas == ["partial"]
+    assert fallback.calls == 0
+
+
+def test_config_parses_explicit_fallback_targets() -> None:
+    config = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "model": "gpt-5.4",
+                "fallbacks": [
+                    {"model": "claude-sonnet-4-6", "provider": "anthropic"},
+                    {"model": "gpt-4.1-mini"},
+                ],
+            },
+        },
+    })
+
+    assert [target.model for target in config.agents.defaults.fallbacks] == [
+        "claude-sonnet-4-6",
+        "gpt-4.1-mini",
+    ]
+    assert [target.provider for target in config.agents.defaults.fallbacks] == [
+        "anthropic",
+        "auto",
+    ]
+
+
+def test_build_provider_wraps_primary_and_configured_fallbacks(monkeypatch) -> None:
+    config = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "model": "gpt-5.4",
+                "provider": "openai",
+                "fallbacks": [
+                    {"model": "claude-sonnet-4-6", "provider": "anthropic"},
+                ],
+            },
+        },
+    })
+    created: list[tuple[str, str | None]] = []
+
+    def _fake_build_single_provider(cfg, model, provider_override=None):
+        created.append((model, provider_override))
+        return ScriptedProvider([LLMResponse(content=f"ok:{model}")]), (provider_override or "auto")
+
+    monkeypatch.setattr(factory, "build_single_provider", _fake_build_single_provider)
+
+    provider = factory.build_provider(config)
+
+    assert isinstance(provider, FallbackProvider)
+    assert created == [
+        ("gpt-5.4", "openai"),
+        ("claude-sonnet-4-6", "anthropic"),
+    ]
+    assert [candidate.model for candidate in provider._candidates] == [
+        "gpt-5.4",
+        "claude-sonnet-4-6",
+    ]


### PR DESCRIPTION
## Problem

nanobot can be configured with multiple LLM providers, but at runtime it only uses one provider/model pair.

Today, if the active provider/model hits a transient upstream failure, nanobot only retries that same provider via `provider_retry_mode`. Once those retries are exhausted, the turn fails even if another configured provider is healthy.

That leaves a real gap between configuration and runtime behavior:

- multiple providers can be configured
- only one provider/model is active for the turn
- transient provider failure still becomes a hard user-visible failure

Streaming has one extra constraint: once text has already started streaming, we cannot safely fail over to another model without duplicating or corrupting user-visible output.

## Root Cause

Provider selection currently happens once inside `_make_provider()`, which constructs a single provider instance and returns it.

After that:

- `provider_retry_mode` retries only the same provider
- there is no explicit ordered fallback chain in config
- there is no runtime wrapper that can move to another provider/model after terminal transient failure
- streaming has no guardrail for the "fallback after first delta" case

## Solution

This PR adds explicit runtime fallback chains across providers/models.

### Config

Adds `agents.defaults.fallbacks`, an ordered list of fallback targets:

```json
{
  "agents": {
    "defaults": {
      "model": "gpt-5.4",
      "provider": "openai",
      "fallbacks": [
        {"model": "claude-sonnet-4-6", "provider": "anthropic"},
        {"model": "gpt-4.1-mini"}
      ]
    }
  }
}
```

Each fallback entry supports:

- `model` (required)
- `provider` (optional, defaults to `auto`)

### Runtime

Extract provider construction into a shared factory used by both runtime and CLI.

Add `FallbackProvider`, which wraps the primary provider plus ordered fallback candidates and applies this policy:

1. Use the primary provider first.
2. Preserve the existing retry behavior within that provider.
3. If the provider still ends in a transient error, move to the next configured fallback.
4. Stop immediately on non-transient errors.
5. For streaming, never fail over after the first content delta has been emitted.
6. Keep behavior unchanged when no fallbacks are configured.

Implementation details:

- each candidate gets its own provider instance
- messages are deep-copied per candidate so provider-specific rewrites do not leak across fallback boundaries
- CLI and runtime now share the same provider-construction logic instead of maintaining two separate implementations

## Tests

Added coverage for:

- parsing explicit fallback targets from config
- falling through to the next candidate after transient terminal failure
- stopping on non-transient errors without failover
- disabling stream failover after the first emitted delta
- existing CLI `_make_provider()` behavior still working through the shared factory path

Commands run:

```bash
uv run --python 3.12 pytest -q tests/providers/test_provider_retry.py tests/cli/test_commands.py -k 'fallback or make_provider'
uv run --python 3.12 ruff check nanobot/config/schema.py nanobot/providers/fallback_provider.py nanobot/providers/factory.py tests/providers/test_provider_retry.py
```
