### PR TITLE
feat(webui): add file attachment support to WebSocket channel

### DIFF
--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import email.utils
 import hmac
 import http
@@ -28,7 +29,9 @@ from websockets.http11 import Response
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
+from nanobot.utils.helpers import safe_filename
 
 if TYPE_CHECKING:
     from nanobot.session.manager import SessionManager
@@ -207,6 +210,10 @@ def _parse_envelope(raw: str) -> dict[str, Any] | None:
 
 
 _LOCALHOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+_MAX_MEDIA_SIZE = 10 * 1024 * 1024  # 10 MB per file
+_MAX_MEDIA_COUNT = 20
+_MAX_TOTAL_MEDIA_SIZE = 25 * 1024 * 1024  # 25 MB per message
+_DATA_URL_RE = re.compile(r"^data:([^;]+);base64,(.+)$", re.DOTALL)
 
 # Matches the legacy chat-id pattern but allows file-system-safe stems too,
 # so the API can address sessions whose keys came from non-WebSocket channels.
@@ -500,6 +507,44 @@ class WebSocketChannel(BaseChannel):
             if now > expiry:
                 self._api_tokens.pop(token_key, None)
 
+    @staticmethod
+    def _save_media_data_urls(media: Any) -> list[str]:
+        """Convert base64 data-URL strings from a WS envelope to on-disk paths."""
+        if not isinstance(media, list):
+            return []
+        if len(media) > _MAX_MEDIA_COUNT:
+            logger.warning("websocket: media array exceeds {} items, truncating", _MAX_MEDIA_COUNT)
+            media = media[:_MAX_MEDIA_COUNT]
+        media_dir = get_media_dir("websocket")
+        media_dir.mkdir(parents=True, exist_ok=True)
+        saved: list[str] = []
+        total_size = 0
+        for item in media:
+            if not isinstance(item, str):
+                continue
+            m = _DATA_URL_RE.match(item)
+            if not m:
+                continue
+            mime_type, b64 = m.group(1), m.group(2)
+            try:
+                raw = base64.b64decode(b64)
+            except Exception as e:
+                logger.debug("websocket: failed to decode base64 media: {}", e)
+                continue
+            if len(raw) > _MAX_MEDIA_SIZE:
+                logger.warning("websocket: skipping media payload exceeding {}MB", _MAX_MEDIA_SIZE // (1024 * 1024))
+                continue
+            total_size += len(raw)
+            if total_size > _MAX_TOTAL_MEDIA_SIZE:
+                logger.warning("websocket: total media size exceeds {}MB, stopping", _MAX_TOTAL_MEDIA_SIZE // (1024 * 1024))
+                break
+            ext = mimetypes.guess_extension(mime_type) or ".bin"
+            filename = f"{uuid.uuid4().hex[:12]}{ext}"
+            dest = media_dir / safe_filename(filename)
+            dest.write_bytes(raw)
+            saved.append(str(dest))
+        return saved
+
     def _handle_webui_bootstrap(self, connection: Any) -> Response:
         if not _is_localhost(connection):
             return _http_error(403, "webui bootstrap is localhost-only")
@@ -783,14 +828,18 @@ class WebSocketChannel(BaseChannel):
                 await self._send_event(connection, "error", detail="invalid chat_id")
                 return
             if not isinstance(content, str) or not content.strip():
-                await self._send_event(connection, "error", detail="missing content")
-                return
+                if "media" not in envelope:
+                    await self._send_event(connection, "error", detail="missing content")
+                    return
+                content = ""
             # Auto-attach on first use so clients can one-shot without a separate attach.
             self._attach(connection, cid)
+            media = self._save_media_data_urls(envelope.get("media"))
             await self._handle_message(
                 sender_id=client_id,
                 chat_id=cid,
                 content=content,
+                media=media or None,
                 metadata={"remote": getattr(connection, "remote_address", None)},
             )
             return

--- a/webui/src/components/thread/ThreadComposer.tsx
+++ b/webui/src/components/thread/ThreadComposer.tsx
@@ -1,16 +1,33 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ArrowUp } from "lucide-react";
+import { ArrowUp, Paperclip, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
+interface PendingAttachment {
+  name: string;
+  dataUrl: string;
+}
+
 interface ThreadComposerProps {
-  onSend: (content: string) => void;
+  onSend: (content: string, media?: string[]) => void;
   disabled?: boolean;
   placeholder?: string;
   modelLabel?: string | null;
   variant?: "thread" | "hero";
+}
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB per file (matches backend _MAX_MEDIA_SIZE)
+const MAX_TOTAL_SIZE = 25 * 1024 * 1024; // 25 MB total per message
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
 }
 
 export function ThreadComposer({
@@ -22,7 +39,9 @@ export function ThreadComposer({
 }: ThreadComposerProps) {
   const { t } = useTranslation();
   const [value, setValue] = useState("");
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const isHero = variant === "hero";
   const resolvedPlaceholder =
     placeholder ?? t("thread.composer.placeholderThread");
@@ -37,9 +56,12 @@ export function ThreadComposer({
 
   const submit = useCallback(() => {
     const trimmed = value.trim();
-    if (!trimmed || disabled) return;
-    onSend(trimmed);
+    const hasMedia = attachments.length > 0;
+    if ((!trimmed && !hasMedia) || disabled) return;
+    const media = hasMedia ? attachments.map((a) => a.dataUrl) : undefined;
+    onSend(trimmed, media);
     setValue("");
+    setAttachments([]);
     requestAnimationFrame(() => {
       const el = textareaRef.current;
       if (el) {
@@ -47,7 +69,7 @@ export function ThreadComposer({
         el.focus();
       }
     });
-  }, [disabled, onSend, value]);
+  }, [disabled, onSend, value, attachments]);
 
   const onKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
@@ -61,6 +83,47 @@ export function ThreadComposer({
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, 260)}px`;
   };
+
+  const handleFileSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (!files?.length) return;
+      const currentTotal = attachments.reduce((sum, a) => sum + a.dataUrl.length, 0);
+      let totalSize = currentTotal;
+      const newAttachments: PendingAttachment[] = [];
+      const skipped: string[] = [];
+      for (const file of Array.from(files)) {
+        if (file.size > MAX_FILE_SIZE) {
+          skipped.push(file.name);
+          continue;
+        }
+        if (totalSize + file.size > MAX_TOTAL_SIZE) {
+          skipped.push(file.name);
+          break;
+        }
+        try {
+          const dataUrl = await readFileAsDataUrl(file);
+          newAttachments.push({ name: file.name, dataUrl });
+          totalSize += file.size;
+        } catch {
+          skipped.push(file.name);
+        }
+      }
+      if (skipped.length > 0) {
+        console.warn("Skipped files (size exceeded):", skipped.join(", "));
+      }
+      setAttachments((prev) => [...prev, ...newAttachments]);
+      // Reset so the same file can be re-selected
+      e.target.value = "";
+    },
+    [attachments],
+  );
+
+  const removeAttachment = useCallback((index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const canSend = (value.trim() || attachments.length > 0) && !disabled;
 
   return (
     <form
@@ -80,6 +143,27 @@ export function ThreadComposer({
           disabled && "opacity-60",
         )}
       >
+        {attachments.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 px-3 pt-2">
+            {attachments.map((att, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center gap-1 rounded-md bg-secondary/70 px-2 py-1 text-[11px] text-secondary-foreground"
+              >
+                <Paperclip className="h-3 w-3" />
+                <span className="max-w-[120px] truncate">{att.name}</span>
+                <button
+                  type="button"
+                  onClick={() => removeAttachment(i)}
+                  className="ml-0.5 rounded-full p-0.5 hover:bg-secondary-foreground/20"
+                  aria-label={t("thread.composer.removeAttachment")}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
         <textarea
           ref={textareaRef}
           value={value}
@@ -107,6 +191,28 @@ export function ThreadComposer({
           )}
         >
           <div className="flex min-w-0 items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={handleFileSelect}
+              accept="image/*,.pdf,.txt,.md,.csv,.json,.xml,.html,.css,.js,.ts,.py,.java,.c,.cpp,.h,.go,.rs,.rb,.php,.sql,.yaml,.yml,.toml,.ini,.cfg,.log,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.zip,.tar,.gz,.rar"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              disabled={disabled}
+              onClick={() => fileInputRef.current?.click()}
+              aria-label={t("thread.composer.attach")}
+              className={cn(
+                "rounded-full text-muted-foreground hover:text-foreground",
+                isHero ? "h-7 w-7" : "h-6.5 w-6.5",
+              )}
+            >
+              <Paperclip className={cn(isHero ? "h-4 w-4" : "h-3.5 w-3.5")} />
+            </Button>
             {modelLabel ? (
               <span
                 title={modelLabel}
@@ -131,12 +237,12 @@ export function ThreadComposer({
           <Button
             type="submit"
             size="icon"
-            disabled={disabled || !value.trim()}
+            disabled={!canSend}
             aria-label={t("thread.composer.send")}
             className={cn(
               "rounded-full border border-border/70 bg-secondary/85 text-secondary-foreground shadow-none transition-transform hover:bg-accent",
               isHero ? "h-8.5 w-8.5" : "h-7.5 w-7.5",
-              value.trim() && !disabled && "hover:scale-[1.03] active:scale-95",
+              canSend && "hover:scale-[1.03] active:scale-95",
             )}
           >
             <ArrowUp className={cn(isHero ? "h-4.5 w-4.5" : "h-4 w-4")} />

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -40,7 +40,7 @@ export function ThreadShell({
   const { messages: historical, loading } = useSessionHistory(historyKey);
   const { client, modelName } = useClient();
   const [booting, setBooting] = useState(false);
-  const pendingFirstRef = useRef<string | null>(null);
+  const pendingFirstRef = useRef<{ content: string; media?: string[] } | null>(null);
   const messageCacheRef = useRef<Map<string, UIMessage[]>>(new Map());
 
   const initial = useMemo(() => {
@@ -78,13 +78,13 @@ export function ThreadShell({
     const pending = pendingFirstRef.current;
     if (!pending) return;
     pendingFirstRef.current = null;
-    client.sendMessage(chatId, pending);
+    client.sendMessage(chatId, pending.content, pending.media);
     setMessages((prev) => [
       ...prev,
       {
         id: crypto.randomUUID(),
         role: "user",
-        content: pending,
+        content: pending.content,
         createdAt: Date.now(),
       },
     ]);
@@ -92,10 +92,10 @@ export function ThreadShell({
   }, [chatId, client, setMessages]);
 
   const handleWelcomeSend = useCallback(
-    async (content: string) => {
+    async (content: string, media?: string[]) => {
       if (booting) return;
       setBooting(true);
-      pendingFirstRef.current = content;
+      pendingFirstRef.current = { content, media };
       const newId = await onNewChat();
       if (!newId) {
         pendingFirstRef.current = null;

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -22,7 +22,7 @@ export function useNanobotStream(
 ): {
   messages: UIMessage[];
   isStreaming: boolean;
-  send: (content: string) => void;
+  send: (content: string, media?: string[]) => void;
   setMessages: React.Dispatch<React.SetStateAction<UIMessage[]>>;
 } {
   const { client } = useClient();
@@ -145,8 +145,8 @@ export function useNanobotStream(
   }, [chatId, client]);
 
   const send = useCallback(
-    (content: string) => {
-      if (!chatId || !content.trim()) return;
+    (content: string, media?: string[]) => {
+      if (!chatId || (!content.trim() && !media?.length)) return;
       setMessages((prev) => [
         ...prev,
         {
@@ -156,7 +156,7 @@ export function useNanobotStream(
           createdAt: Date.now(),
         },
       ]);
-      client.sendMessage(chatId, content);
+      client.sendMessage(chatId, content || " ", media);
     },
     [chatId, client],
   );

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -64,7 +64,9 @@
       "placeholderOpening": "Opening a new chat…",
       "inputAria": "Message input",
       "sendHint": "Enter to send · Shift+Enter for newline",
-      "send": "Send message"
+      "send": "Send message",
+      "attach": "Attach file",
+      "removeAttachment": "Remove attachment"
     },
     "scrollToBottom": "Scroll to bottom"
   },

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -64,7 +64,9 @@
       "placeholderOpening": "正在打开新对话…",
       "inputAria": "消息输入框",
       "sendHint": "Enter 发送 · Shift+Enter 换行",
-      "send": "发送消息"
+      "send": "发送消息",
+      "attach": "添加附件",
+      "removeAttachment": "移除附件"
     },
     "scrollToBottom": "滚动到底部"
   },

--- a/webui/src/lib/nanobot-client.ts
+++ b/webui/src/lib/nanobot-client.ts
@@ -151,9 +151,9 @@ export class NanobotClient {
     }
   }
 
-  sendMessage(chatId: string, content: string): void {
+  sendMessage(chatId: string, content: string, media?: string[]): void {
     this.knownChats.add(chatId);
-    this.queueSend({ type: "message", chat_id: chatId, content });
+    this.queueSend({ type: "message", chat_id: chatId, content, media });
   }
 
   // -- internals ---------------------------------------------------------

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -71,4 +71,4 @@ export type InboundEvent =
 export type Outbound =
   | { type: "new_chat" }
   | { type: "attach"; chat_id: string }
-  | { type: "message"; chat_id: string; content: string };
+  | { type: "message"; chat_id: string; content: string; media?: string[] };

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -88,6 +88,7 @@ describe("ThreadShell", () => {
       expect(client.sendMessage).toHaveBeenCalledWith(
         "chat-a",
         "persist me across tabs",
+        undefined,
       ),
     );
     expect(screen.getByText("persist me across tabs")).toBeInTheDocument();
@@ -151,6 +152,7 @@ describe("ThreadShell", () => {
       expect(client.sendMessage).toHaveBeenCalledWith(
         "chat-a",
         "delete me cleanly",
+        undefined,
       ),
     );
     expect(screen.getByText("delete me cleanly")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Add file attachment upload capability to the webui composer (paperclip button)
- Files are encoded as base64 data URLs in the WebSocket message envelope
- Backend decodes, saves to disk, and passes media paths to the agent loop
- Enforce per-file (10MB), per-message (25MB total), and count (20) limits

## Changes

**Backend** (`nanobot/channels/websocket.py`):
- Add `_save_media_data_urls()` static method: base64 data URLs → on-disk files
- Extend `_dispatch_envelope` to handle optional `media` field in message envelopes
- Allow empty content when media is present

**Frontend** (`webui/src/`):
- `ThreadComposer.tsx`: Add paperclip attachment button, file input, preview badges with remove
- `ThreadShell.tsx`: Support media in welcome (hero) send flow
- `useNanobotStream.ts`: Pass media through to NanobotClient
- `nanobot-client.ts`: Accept optional `media` parameter in `sendMessage`
- `types.ts`: Add `media?: string[]` to `Outbound` message type
- i18n keys added for en and zh-CN
- Tests updated for new `sendMessage` signature

## Test plan
- [x] All 25 existing tests pass
- [x] TypeScript compiles without errors
- [x] Manual test: attach file → send → agent receives and reads file
- [x] Attachment preview shows file name with remove button
- [x] Send button enables when only attachment (no text)
- [x] Both hero and thread composer modes support attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)