### PR TITLE
Fix/minimax reasoning split

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -398,6 +398,8 @@ class OpenAICompatProvider(LLMProvider):
             extra: dict[str, Any] | None = None
             if spec.name == "dashscope":
                 extra = {"enable_thinking": thinking_enabled}
+            elif spec.name == "minimax":
+                extra = {"reasoning_split": thinking_enabled}
             elif spec.name in (
                 "volcengine", "volcengine_coding_plan",
                 "byteplus", "byteplus_coding_plan",

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -740,6 +740,21 @@ def test_dashscope_no_extra_body_when_reasoning_effort_none() -> None:
     assert "extra_body" not in kw
 
 
+def test_minimax_reasoning_split_enabled_with_reasoning_effort() -> None:
+    kw = _build_kwargs_for("minimax", "MiniMax-M2.7", reasoning_effort="medium")
+    assert kw["extra_body"] == {"reasoning_split": True}
+
+
+def test_minimax_reasoning_split_disabled_for_minimal() -> None:
+    kw = _build_kwargs_for("minimax", "MiniMax-M2.7", reasoning_effort="minimal")
+    assert kw["extra_body"] == {"reasoning_split": False}
+
+
+def test_minimax_no_extra_body_when_reasoning_effort_none() -> None:
+    kw = _build_kwargs_for("minimax", "MiniMax-M2.7", reasoning_effort=None)
+    assert "extra_body" not in kw
+
+
 def test_volcengine_thinking_enabled() -> None:
     kw = _build_kwargs_for("volcengine", "doubao-seed-2-0-pro", reasoning_effort="high")
     assert kw["extra_body"] == {"thinking": {"type": "enabled"}}


### PR DESCRIPTION
## Summary

Fix MiniMax reasoning support on the OpenAI-compatible backend by translating `reasoning_effort` into MiniMax's provider-specific `extra_body.reasoning_split` flag.

Closes #3068.

## What Changed

- add MiniMax-specific thinking translation in `OpenAICompatProvider._build_kwargs()`
- map `reasoning_effort != "minimal"` to `extra_body={"reasoning_split": true}`
- map `reasoning_effort == "minimal"` to `extra_body={"reasoning_split": false}`
- preserve current behavior when `reasoning_effort` is not set
- add regression tests for MiniMax provider kwargs

## Why

MiniMax's OpenAI-compatible endpoint does not honor the raw `reasoning_effort` field.  
It expects separated reasoning to be enabled through `extra_body.reasoning_split`, so nanobot was silently ignoring reasoning mode for the built-in `minimax` provider.

This patch keeps the existing OpenAI-compatible backend behavior intact while making `reasoningEffort` effective for MiniMax users.

## Testing

- `uv run --extra dev pytest tests/providers/test_litellm_kwargs.py -q`
