### PR TITLE
hook: expose latency_ms on AgentHookContext and measure LLM call time

### DIFF
--- a/nanobot/agent/hook.py
+++ b/nanobot/agent/hook.py
@@ -17,6 +17,7 @@ class AgentHookContext:
     iteration: int
     messages: list[dict[str, Any]]
     response: LLMResponse | None = None
+    latency_ms: float | None = None
     usage: dict[str, int] = field(default_factory=dict)
     tool_calls: list[ToolCallRequest] = field(default_factory=list)
     tool_results: list[Any] = field(default_factory=list)

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import dataclass, field
 import inspect
 from pathlib import Path
@@ -267,7 +268,9 @@ class AgentRunner:
                     messages_for_model = messages
             context = AgentHookContext(iteration=iteration, messages=messages)
             await hook.before_iteration(context)
+            _t0 = time.perf_counter()
             response = await self._request_model(spec, messages_for_model, hook, context)
+            context.latency_ms = (time.perf_counter() - _t0) * 1000
             raw_usage = self._usage_dict(response.usage)
             context.response = response
             context.usage = dict(raw_usage)


### PR DESCRIPTION
The AgentHook surface exposes `before_iteration` and `after_iteration` callbacks but does not give hook implementations the LLM call duration. Any hook that wants to record latency — for Prometheus histograms, audit logs, tracing — has to re-derive timing by wrapping the call externally, which requires patching framework internals. That's not a reasonable ask of downstream users.

This PR adds one optional field to `AgentHookContext`:

- `latency_ms: float | None` — wall time of the `_request_model` call in milliseconds

The `response` field was already present. This change adds only the missing timing field. Default is `None`; existing hook implementations that don't read it are unaffected and require no changes.

The change is minimal: two lines in `hook.py` (field declaration) and three lines in `runner.py` (`time.perf_counter()` bracket around `_request_model`, assignment before hooks fire). No new abstractions, no behavior change for existing callers.

This is a common need — any observability hook (Prometheus, OpenTelemetry, structured audit logs) needs latency. Keeping it upstream avoids everyone who wants this solving it the same ugly way independently.

Testing: syntax-parse verified locally. I don't have the full test suite wired, so I'd appreciate a maintainer run of `pytest` to confirm nothing is broken. The change is mechanical enough that I'd be surprised if it touched any test paths, but worth checking.