### PR TITLE
feat(heartbeat): add model override for heartbeat phases

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -394,6 +394,7 @@ class AgentLoop:
         chat_id: str = "direct",
         message_id: str | None = None,
         pending_queue: asyncio.Queue | None = None,
+        model_override: str | None = None,
     ) -> tuple[str | None, list[str], list[dict], str, bool]:
         """Run the agent iteration loop.
 
@@ -453,7 +454,7 @@ class AgentLoop:
         result = await self.runner.run(AgentRunSpec(
             initial_messages=initial_messages,
             tools=self.tools,
-            model=self.model,
+            model=model_override or self.model,
             max_iterations=self.max_iterations,
             max_tool_result_chars=self.max_tool_result_chars,
             hook=hook,
@@ -698,6 +699,7 @@ class AgentLoop:
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
         pending_queue: asyncio.Queue | None = None,
+        model_override: str | None = None,
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
         # System messages: parse origin from chat_id ("channel:chat_id")
@@ -744,6 +746,7 @@ class AgentLoop:
             final_content, _, all_msgs, _, _ = await self._run_agent_loop(
                 messages, session=session, channel=channel, chat_id=chat_id,
                 message_id=msg.metadata.get("message_id"),
+                model_override=model_override,
             )
             self._save_turn(session, all_msgs, 1 + len(history))
             self._clear_runtime_checkpoint(session)
@@ -849,6 +852,7 @@ class AgentLoop:
             chat_id=msg.chat_id,
             message_id=msg.metadata.get("message_id"),
             pending_queue=pending_queue,
+            model_override=model_override,
         )
 
         if final_content is None or not final_content.strip():
@@ -1105,8 +1109,14 @@ class AgentLoop:
         on_progress: Callable[[str], Awaitable[None]] | None = None,
         on_stream: Callable[[str], Awaitable[None]] | None = None,
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
+        model_override: str | None = None,
     ) -> OutboundMessage | None:
-        """Process a message directly and return the outbound payload."""
+        """Process a message directly and return the outbound payload.
+
+        When *model_override* is set, the LLM calls for this request use
+        the given model instead of the agent's default.  The override is
+        scoped to this call and does not mutate shared agent state.
+        """
         await self._connect_mcp()
         msg = InboundMessage(
             channel=channel, sender_id="user", chat_id=chat_id,
@@ -1118,4 +1128,5 @@ class AgentLoop:
             on_progress=on_progress,
             on_stream=on_stream,
             on_stream_end=on_stream_end,
+            model_override=model_override,
         )

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -797,6 +797,7 @@ def _run_gateway(
             channel=channel,
             chat_id=chat_id,
             on_progress=_silent,
+            model_override=hb_cfg.model,
         )
 
         # Keep a small tail of heartbeat history so the loop stays bounded
@@ -825,6 +826,7 @@ def _run_gateway(
         interval_s=hb_cfg.interval_s,
         enabled=hb_cfg.enabled,
         timezone=config.agents.defaults.timezone,
+        heartbeat_model=hb_cfg.model,
     )
 
     if channels.enabled_channels:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -146,6 +146,7 @@ class HeartbeatConfig(Base):
     enabled: bool = True
     interval_s: int = 30 * 60  # 30 minutes
     keep_recent_messages: int = 8
+    model: str | None = None  # Override model for heartbeat (Phase 1 + Phase 2)
 
 
 class ApiConfig(Base):

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -60,10 +60,11 @@ class HeartbeatService:
         interval_s: int = 30 * 60,
         enabled: bool = True,
         timezone: str | None = None,
+        heartbeat_model: str | None = None,
     ):
         self.workspace = workspace
         self.provider = provider
-        self.model = model
+        self.model = heartbeat_model or model
         self.on_execute = on_execute
         self.on_notify = on_notify
         self.interval_s = interval_s

--- a/tests/heartbeat/test_heartbeat_model_override.py
+++ b/tests/heartbeat/test_heartbeat_model_override.py
@@ -1,0 +1,113 @@
+"""Tests for heartbeat model override feature."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.config.schema import HeartbeatConfig
+from nanobot.heartbeat.service import HeartbeatService
+
+
+@pytest.fixture
+def mock_provider():
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock()
+    return provider
+
+
+@pytest.fixture
+def tmp_workspace(tmp_path: Path) -> Path:
+    hb_file = tmp_path / "HEARTBEAT.md"
+    hb_file.write_text("Check email.\n")
+    return tmp_path
+
+
+class TestHeartbeatModelOverride:
+    """Verify that heartbeat.model overrides the agent model for both phases."""
+
+    def test_config_default_model_is_none(self):
+        cfg = HeartbeatConfig()
+        assert cfg.model is None
+
+    def test_config_accepts_model_string(self):
+        cfg = HeartbeatConfig(model="anthropic/claude-haiku-3.5")
+        assert cfg.model == "anthropic/claude-haiku-3.5"
+
+    def test_service_uses_agent_model_when_no_override(self, mock_provider, tmp_workspace):
+        svc = HeartbeatService(
+            workspace=tmp_workspace,
+            provider=mock_provider,
+            model="anthropic/claude-opus-4",
+        )
+        assert svc.model == "anthropic/claude-opus-4"
+
+    def test_service_uses_heartbeat_model_when_set(self, mock_provider, tmp_workspace):
+        svc = HeartbeatService(
+            workspace=tmp_workspace,
+            provider=mock_provider,
+            model="anthropic/claude-opus-4",
+            heartbeat_model="anthropic/claude-haiku-3.5",
+        )
+        assert svc.model == "anthropic/claude-haiku-3.5"
+
+    @pytest.mark.asyncio
+    async def test_phase1_decide_uses_heartbeat_model(self, mock_provider, tmp_workspace):
+        """Phase 1 LLM call should use the heartbeat model, not agent model."""
+        response = MagicMock()
+        response.should_execute_tools = True
+        response.has_tool_calls = True
+        response.tool_calls = [MagicMock(arguments={"action": "skip", "tasks": ""})]
+        mock_provider.chat_with_retry.return_value = response
+
+        svc = HeartbeatService(
+            workspace=tmp_workspace,
+            provider=mock_provider,
+            model="anthropic/claude-opus-4",
+            heartbeat_model="anthropic/claude-haiku-3.5",
+        )
+
+        action, tasks = await svc._decide("Check email.")
+
+        call_kwargs = mock_provider.chat_with_retry.call_args
+        assert call_kwargs.kwargs.get("model") == "anthropic/claude-haiku-3.5"
+        assert action == "skip"
+
+    @pytest.mark.asyncio
+    async def test_phase1_decide_uses_agent_model_without_override(
+        self, mock_provider, tmp_workspace
+    ):
+        """Without override, Phase 1 should use the agent model."""
+        response = MagicMock()
+        response.should_execute_tools = True
+        response.has_tool_calls = True
+        response.tool_calls = [MagicMock(arguments={"action": "skip", "tasks": ""})]
+        mock_provider.chat_with_retry.return_value = response
+
+        svc = HeartbeatService(
+            workspace=tmp_workspace,
+            provider=mock_provider,
+            model="anthropic/claude-opus-4",
+        )
+
+        await svc._decide("Check email.")
+
+        call_kwargs = mock_provider.chat_with_retry.call_args
+        assert call_kwargs.kwargs.get("model") == "anthropic/claude-opus-4"
+
+
+class TestProcessDirectModelOverride:
+    """Verify that process_direct passes model_override without mutating agent state."""
+
+    def test_process_direct_signature_accepts_model_override(self):
+        """process_direct should accept model_override as a keyword argument."""
+        import inspect  # noqa: E402
+
+        from nanobot.agent.loop import AgentLoop
+
+        sig = inspect.signature(AgentLoop.process_direct)
+        assert "model_override" in sig.parameters
+        param = sig.parameters["model_override"]
+        assert param.default is None

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -409,7 +409,7 @@ async def test_process_direct_accepts_media() -> None:
 
     captured_msg = None
 
-    async def fake_process(msg, *, session_key="", on_progress=None, on_stream=None, on_stream_end=None):
+    async def fake_process(msg, *, session_key="", on_progress=None, on_stream=None, on_stream_end=None, model_override=None):
         nonlocal captured_msg
         captured_msg = msg
         return None


### PR DESCRIPTION
## Summary

Add `gateway.heartbeat.model` config option that lets operators run heartbeat on a different (typically cheaper) model than the agent's primary model. First-class implementation — no shared state mutation.

## Motivation

Heartbeat runs are periodic background checks (email, calendar, signals) that don't need the full reasoning power of a flagship model. Currently, heartbeat always uses the agent's primary model — so if you run `gpt-5.4` for chat, heartbeat also burns those tokens on routine checks.

This PR lets you decouple the two:

```json
{
  "gateway": {
    "heartbeat": {
      "model": "anthropic/claude-haiku-3.5"
    }
  }
}
```

Chat stays on the primary model, heartbeat runs on a cheaper one.

## Architecture

The model override flows cleanly through the call chain without mutating shared agent state:

```
process_direct(model_override=...)
  → _process_message(model_override=...)
    → _run_agent_loop(model_override=...)
      → AgentRunSpec(model=override or self.model)
```

This is request-scoped: `agent.model` is never touched, so concurrent message processing remains safe. Compare to the naive approach of temporarily swapping `agent.model` in a try/finally — that mutates shared state and creates a race window.

**Phase 1 (decision):** `HeartbeatService` stores the override as `self.model` and passes it to `provider.chat_with_retry()` directly.

**Phase 2 (execution):** The override passes through `process_direct → _process_message → _run_agent_loop → AgentRunSpec` without touching the agent's model field.

## Changes

- **`nanobot/config/schema.py`** — Add optional `model: str | None` to `HeartbeatConfig` (default: `None`)
- **`nanobot/agent/loop.py`** — Add `model_override: str | None = None` parameter to `process_direct`, `_process_message`, and `_run_agent_loop`. `AgentRunSpec` receives `model_override or self.model`.
- **`nanobot/heartbeat/service.py`** — Accept `heartbeat_model` param; use it for Phase 1 LLM calls
- **`nanobot/cli/commands.py`** — Pass `hb_cfg.model` as `model_override` to `process_direct` (clean, no try/finally mutation)
- **`tests/heartbeat/test_heartbeat_model_override.py`** — 7 tests: config defaults, service model selection, Phase 1 routing, `process_direct` signature validation

## Behavior

| Config | Phase 1 (decide) | Phase 2 (execute) | agent.model |
|---|---|---|---|
| `model` not set | Agent model | Agent model | Unchanged |
| `model: "haiku"` | Haiku | Haiku | Unchanged ✅ |

## Tests

```
$ python3.12 -m pytest tests/heartbeat/test_heartbeat_model_override.py -q
.......                                                                  [100%]
7 passed

$ python3.12 -m pytest tests/cli/test_commands.py tests/agent/test_unified_session.py -q
60 passed

$ ruff check nanobot/config/schema.py nanobot/heartbeat/service.py tests/heartbeat/
All checks passed!
```