### PR TITLE
fix(security): recurse into sh -c / bash -c wrappers to close quote-bypass (MIT-164)

### DIFF
--- a/nanobot/agent/hook.py
+++ b/nanobot/agent/hook.py
@@ -17,6 +17,7 @@ class AgentHookContext:
     iteration: int
     messages: list[dict[str, Any]]
     response: LLMResponse | None = None
+    latency_ms: float | None = None
     usage: dict[str, int] = field(default_factory=dict)
     tool_calls: list[ToolCallRequest] = field(default_factory=list)
     tool_results: list[Any] = field(default_factory=list)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import dataclasses
 import json
 import os
@@ -47,6 +48,34 @@ if TYPE_CHECKING:
 
 
 UNIFIED_SESSION_KEY = "unified:default"
+
+# Only Mihai can modify system internals (architecture, skills, prompts, code)
+OWNER_USER_ID = "1476998117906845890"
+
+# Patterns that indicate system modification intent (checked against user messages)
+_SYSTEM_MOD_PATTERNS = [
+    # Architecture
+    r"update\s+architecture", r"modify\s+architecture", r"change\s+architecture",
+    # Skills / plugins
+    r"(add|install|create|remove|delete|uninstall)\s+(a\s+)?(skill|plugin|extension|tool)",
+    # System prompts / personality
+    r"(change|modify|update|edit|rewrite)\s+(your|the|ziggy.s?|nanobot.s?)?\s*(system\s+prompt|personality|soul|identity|instructions|behavior)",
+    r"(change|modify|update)\s+.*SOUL\.md",
+    r"(change|modify|update)\s+.*AGENTS\.md",
+    # Code changes to nanobot itself
+    r"(change|modify|edit|update|rewrite)\s+(your|the|ziggy.s?|nanobot.s?)?\s*(source\s+)?code",
+]
+
+_compiled_system_mod = [re.compile(p, re.IGNORECASE) for p in _SYSTEM_MOD_PATTERNS]
+
+
+def is_system_modification(content: str) -> bool:
+    """Check if message requests system-level changes (skills, prompts, code, config)."""
+    text = content.strip()
+    for pattern in _compiled_system_mod:
+        if pattern.search(text):
+            return True
+    return False
 
 
 class _LoopHook(AgentHook):
@@ -563,6 +592,17 @@ class AgentLoop:
             msg = dataclasses.replace(msg, session_key_override=session_key)
         lock = self._session_locks.setdefault(session_key, asyncio.Lock())
         gate = self._concurrency_gate or nullcontext()
+
+        # Ziggy: guard — only owner can request system modifications
+        if is_system_modification(msg.content):
+            if msg.sender_id != OWNER_USER_ID:
+                await self.bus.publish_outbound(OutboundMessage(
+                    channel=msg.channel, chat_id=msg.chat_id,
+                    content="I can't make changes to my own system, skills, or configuration. "
+                            "Only my owner can authorize that. Let me know if there's something "
+                            "else I can help you with!",
+                ))
+                return
 
         # Register a pending queue so follow-up messages for this session are
         # routed here (mid-turn injection) instead of spawning a new task.

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -22,6 +22,7 @@ from nanobot.agent.runner import _MAX_INJECTIONS_PER_TURN, AgentRunner, AgentRun
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.audit import AuditLogger
+from nanobot.agent.tools.recall import IngestTool, RecallTool
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.message import MessageTool
@@ -348,6 +349,12 @@ class AgentLoop:
             self.tools.register(
                 CronTool(self.cron_service, default_timezone=self.context.timezone or "UTC")
             )
+        # Ziggy: recall/ingest tools for ChromaDB vector memory
+        try:
+            self.tools.register(RecallTool(workspace=self.workspace))
+            self.tools.register(IngestTool(workspace=self.workspace, allowed_dir=None))
+        except Exception as _e:
+            logger.debug("RecallTool/IngestTool registration skipped: {}", _e)
 
     async def _connect_mcp(self) -> None:
         """Connect to configured MCP servers (one-time, lazy)."""

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -21,6 +21,7 @@ from nanobot.agent.memory import Consolidator, Dream
 from nanobot.agent.runner import _MAX_INJECTIONS_PER_TURN, AgentRunner, AgentRunSpec
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.subagent import SubagentManager
+from nanobot.agent.tools.audit import AuditLogger
 from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.message import MessageTool
@@ -146,6 +147,29 @@ class _LoopHook(AgentHook):
             u.get("completion_tokens", 0),
             u.get("cached_tokens", 0),
         )
+        # Ziggy: Prometheus metrics + audit log for each LLM call
+        response = context.response
+        latency_ms = context.latency_ms
+        if latency_ms is not None:
+            try:
+                from nanobot.dashboard.server import _PROM_AVAILABLE
+                if _PROM_AVAILABLE:
+                    from nanobot.dashboard.server import PROM_LLM_DURATION
+                    PROM_LLM_DURATION.observe(latency_ms)
+            except Exception:
+                pass
+        try:
+            self._loop._audit_logger.log_llm_call(
+                session_id=self._chat_id,
+                channel=self._channel,
+                model=self._loop.model,
+                tokens_in=u.get("prompt_tokens"),
+                tokens_out=u.get("completion_tokens"),
+                latency_ms=latency_ms,
+                ttft_ms=getattr(response, "ttft_ms", None) if response else None,
+            )
+        except Exception:
+            pass
 
     def finalize_content(self, context: AgentHookContext, content: str | None) -> str | None:
         return self._loop._strip_think(content)
@@ -226,6 +250,8 @@ class AgentLoop:
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
+        self._audit_logger = AuditLogger()
+        self.tools.set_audit_logger(self._audit_logger)
         self.runner = AgentRunner(provider)
         self.subagents = SubagentManager(
             provider=provider,

--- a/nanobot/agent/rag.py
+++ b/nanobot/agent/rag.py
@@ -1,0 +1,430 @@
+"""RAG (Retrieval-Augmented Generation) layer for semantic memory search.
+
+Augments the existing two-layer memory system (MEMORY.md + HISTORY.md) with
+ChromaDB-backed semantic search across conversations, documents, and facts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nanobot.utils.helpers import ensure_dir
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CHUNK_SIZE = 500        # target chars per document chunk
+_CHUNK_OVERLAP = 80      # overlap between consecutive chunks
+_MSG_WINDOW = 4          # messages per conversation window
+_MSG_STEP = 2            # step between windows (creates overlap)
+_SUPPORTED_SUFFIXES = {
+    ".md", ".txt", ".py", ".json",
+    ".pdf", ".docx", ".doc",
+    ".csv", ".html", ".htm", ".xml",
+    ".yaml", ".yml", ".rst", ".log",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now().isoformat()
+
+
+def _chunk_text(text: str, chunk_size: int = _CHUNK_SIZE, overlap: int = _CHUNK_OVERLAP) -> list[str]:
+    """Split text into overlapping chunks, preferring paragraph boundaries."""
+    if not text or not text.strip():
+        return []
+
+    # First try to split on double-newlines (paragraphs).
+    paragraphs = [p.strip() for p in re.split(r"\n\n+", text) if p.strip()]
+    chunks: list[str] = []
+    current = ""
+
+    for para in paragraphs:
+        if len(current) + len(para) + 2 <= chunk_size:
+            current = (current + "\n\n" + para).strip() if current else para
+        else:
+            if current:
+                chunks.append(current)
+            # Para itself may be larger than chunk_size — hard split it.
+            if len(para) > chunk_size:
+                for i in range(0, len(para), chunk_size - overlap):
+                    piece = para[i : i + chunk_size]
+                    if piece.strip():
+                        chunks.append(piece.strip())
+                current = ""
+            else:
+                current = para
+
+    if current:
+        chunks.append(current)
+
+    # If we only have one big block (no paragraph breaks) fall back to hard split.
+    if not chunks:
+        for i in range(0, len(text), chunk_size - overlap):
+            piece = text[i : i + chunk_size].strip()
+            if piece:
+                chunks.append(piece)
+
+    return chunks
+
+
+def _window_messages(messages: list[dict], window: int = _MSG_WINDOW, step: int = _MSG_STEP) -> list[str]:
+    """Produce overlapping windows of messages as text blocks."""
+    blocks: list[str] = []
+    for i in range(0, max(1, len(messages) - window + 1), step):
+        segment = messages[i : i + window]
+        lines = []
+        for m in segment:
+            if not m.get("content"):
+                continue
+            role = m.get("role", "?").upper()
+            ts = m.get("timestamp", "")[:16]
+            prefix = f"[{ts}] {role}: " if ts else f"{role}: "
+            content = m["content"]
+            if not isinstance(content, str):
+                content = str(content)
+            lines.append(prefix + content[:800])
+        text = "\n".join(lines).strip()
+        if text:
+            blocks.append(text)
+    return blocks
+
+
+def _extract_text(file_path: Path) -> str:
+    """Extract text content from a file, handling binary formats (PDF, DOCX)."""
+    suffix = file_path.suffix.lower()
+
+    if suffix == ".pdf":
+        try:
+            import pdfplumber
+        except ImportError:
+            logger.warning("pdfplumber not installed, skipping PDF: {}", file_path)
+            return ""
+        pages: list[str] = []
+        with pdfplumber.open(file_path) as pdf:
+            for page in pdf.pages:
+                page_text = page.extract_text()
+                if page_text:
+                    pages.append(page_text)
+        return "\n\n".join(pages)
+
+    if suffix in (".docx", ".doc"):
+        try:
+            import docx as python_docx
+        except ImportError:
+            logger.warning("python-docx not installed, skipping DOCX: {}", file_path)
+            return ""
+        doc = python_docx.Document(str(file_path))
+        return "\n\n".join(
+            para.text for para in doc.paragraphs if para.text.strip()
+        )
+
+    # All other supported types are text-based.
+    return file_path.read_text(encoding="utf-8", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# RAGStore
+# ---------------------------------------------------------------------------
+
+class RAGStore:
+    """ChromaDB-backed semantic store with three collections.
+
+    Collections
+    -----------
+    conversations  — windowed chunks from live/consolidated sessions
+    documents      — ingested files (markdown, text, code, JSON)
+    knowledge      — individual facts extracted from consolidation
+    """
+
+    COLLECTIONS = ("conversations", "documents", "knowledge")
+
+    def __init__(self, workspace: Path) -> None:
+        self.rag_dir = ensure_dir(workspace / "rag")
+        self._client = None
+        self._cols: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Lazy initialization
+    # ------------------------------------------------------------------
+
+    def _get_client(self):
+        """Return (and lazily create) the ChromaDB persistent client."""
+        if self._client is None:
+            try:
+                import chromadb
+            except ImportError as exc:
+                raise RuntimeError(
+                    "chromadb is not installed. Run: pip install chromadb"
+                ) from exc
+            self._client = chromadb.PersistentClient(path=str(self.rag_dir))
+            logger.debug("ChromaDB client initialised at {}", self.rag_dir)
+        return self._client
+
+    def _col(self, name: str):
+        """Return (and cache) a ChromaDB collection, creating it if absent."""
+        if name not in self._cols:
+            client = self._get_client()
+            # get_or_create uses the default embedding function
+            # (all-MiniLM-L6-v2 via sentence-transformers, auto-downloaded).
+            self._cols[name] = client.get_or_create_collection(name)
+            logger.debug("Collection '{}' ready", name)
+        return self._cols[name]
+
+    # ------------------------------------------------------------------
+    # Public write API
+    # ------------------------------------------------------------------
+
+    def add_conversation(
+        self,
+        session_id: str,
+        messages: list[dict],
+        timestamp: str | None = None,
+    ) -> None:
+        """Chunk a list of message dicts and embed them in the conversations collection."""
+        if not messages:
+            return
+        ts = timestamp or _now_iso()
+        blocks = _window_messages(messages)
+        if not blocks:
+            return
+
+        col = self._col("conversations")
+        ids, docs, metas = [], [], []
+        for idx, block in enumerate(blocks):
+            uid = f"{session_id}__{ts}__{idx}"
+            ids.append(uid)
+            docs.append(block)
+            metas.append({"session_id": session_id, "timestamp": ts, "chunk_index": idx})
+
+        try:
+            col.upsert(ids=ids, documents=docs, metadatas=metas)
+            logger.debug("RAG: upserted {} conversation chunk(s) for session {}", len(ids), session_id)
+        except Exception:
+            logger.exception("RAG: failed to upsert conversation chunks for session {}", session_id)
+
+    def add_document(
+        self,
+        path: str,
+        content: str,
+        metadata: dict | None = None,
+    ) -> None:
+        """Chunk a document and embed it in the documents collection."""
+        if not content or not content.strip():
+            logger.warning("RAG: skipping empty document {}", path)
+            return
+
+        chunks = _chunk_text(content)
+        if not chunks:
+            return
+
+        col = self._col("documents")
+        safe_path = path.replace("/", "_").replace("\\", "_").replace(":", "_")
+        ts = _now_iso()
+        base_meta = {"path": path, "timestamp": ts, **(metadata or {})}
+
+        ids, docs, metas = [], [], []
+        for idx, chunk in enumerate(chunks):
+            uid = f"doc__{safe_path}__{idx}"
+            ids.append(uid)
+            docs.append(chunk)
+            metas.append({**base_meta, "chunk_index": idx, "total_chunks": len(chunks)})
+
+        try:
+            col.upsert(ids=ids, documents=docs, metadatas=metas)
+            logger.debug("RAG: upserted {} chunk(s) for document {}", len(ids), path)
+        except Exception:
+            logger.exception("RAG: failed to upsert document {}", path)
+
+    def add_knowledge(
+        self,
+        fact: str,
+        source: str = "consolidation",
+        timestamp: str | None = None,
+    ) -> None:
+        """Store a single fact/entity in the knowledge collection."""
+        fact = fact.strip()
+        if not fact:
+            return
+
+        ts = timestamp or _now_iso()
+        col = self._col("knowledge")
+        # Stable ID based on content hash so duplicate facts are deduplicated.
+        uid = "fact__" + hashlib.sha1(fact.encode()).hexdigest()[:16]
+
+        try:
+            col.upsert(
+                ids=[uid],
+                documents=[fact],
+                metadatas=[{"source": source, "timestamp": ts}],
+            )
+            logger.debug("RAG: upserted knowledge fact ({}…)", fact[:60])
+        except Exception:
+            logger.exception("RAG: failed to upsert knowledge fact")
+
+    # ------------------------------------------------------------------
+    # Public read API
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        n_results: int = 5,
+        collection: str | None = None,
+    ) -> list[dict]:
+        """Semantic search across one or all collections.
+
+        Returns a flat list of dicts with keys:
+            content, metadata, distance, collection
+        sorted by distance (ascending = most similar first).
+        """
+        if not query or not query.strip():
+            return []
+
+        target_cols = [collection] if collection else list(self.COLLECTIONS)
+        results: list[dict] = []
+
+        for col_name in target_cols:
+            try:
+                col = self._col(col_name)
+                count = col.count()
+                if count == 0:
+                    continue
+                k = min(n_results, count)
+                raw = col.query(query_texts=[query], n_results=k)
+                docs = raw.get("documents", [[]])[0]
+                metas = raw.get("metadatas", [[]])[0]
+                dists = raw.get("distances", [[]])[0]
+                for doc, meta, dist in zip(docs, metas, dists):
+                    results.append(
+                        {
+                            "content": doc,
+                            "metadata": meta,
+                            "distance": dist,
+                            "collection": col_name,
+                        }
+                    )
+            except Exception:
+                logger.exception("RAG: search failed in collection '{}'", col_name)
+
+        results.sort(key=lambda r: r["distance"])
+        return results[:n_results]
+
+    # ------------------------------------------------------------------
+    # Migration / bulk ingestion
+    # ------------------------------------------------------------------
+
+    def ingest_history(self, history_file: Path) -> int:
+        """Parse HISTORY.md and embed each entry in the conversations collection.
+
+        Returns the number of entries ingested.
+        """
+        if not history_file.exists():
+            logger.info("RAG: history file not found, skipping ingest: {}", history_file)
+            return 0
+
+        text = history_file.read_text(encoding="utf-8")
+        # Each entry is separated by blank lines; entries start with a timestamp.
+        entries = [e.strip() for e in re.split(r"\n\n+", text) if e.strip()]
+        if not entries:
+            return 0
+
+        col = self._col("conversations")
+        ids, docs, metas = [], [], []
+
+        for idx, entry in enumerate(entries):
+            # Try to extract the timestamp from the entry header [YYYY-MM-DD HH:MM]
+            m = re.match(r"\[(\d{4}-\d{2}-\d{2}[^\]]*)\]", entry)
+            ts = m.group(1) if m else _now_iso()
+            uid = f"history__{idx}__{ts.replace(' ', 'T')[:19]}"
+            ids.append(uid)
+            docs.append(entry)
+            metas.append({"source": "HISTORY.md", "timestamp": ts, "entry_index": idx})
+
+        try:
+            col.upsert(ids=ids, documents=docs, metadatas=metas)
+            logger.info("RAG: ingested {} HISTORY.md entries", len(ids))
+        except Exception:
+            logger.exception("RAG: failed to ingest HISTORY.md")
+            return 0
+
+        return len(entries)
+
+    def ingest_directory(self, dir_path: Path, glob: str = "**/*.md") -> int:
+        """Bulk-ingest all matching files from a directory.
+
+        Returns the number of files successfully ingested.
+        """
+        if not dir_path.is_dir():
+            logger.warning("RAG: ingest_directory path is not a directory: {}", dir_path)
+            return 0
+
+        count = 0
+        for file_path in sorted(dir_path.glob(glob)):
+            if file_path.suffix not in _SUPPORTED_SUFFIXES:
+                continue
+            try:
+                content = _extract_text(file_path)
+                if not content or not content.strip():
+                    logger.debug("RAG: skipping empty file {}", file_path)
+                    continue
+                self.add_document(
+                    path=str(file_path),
+                    content=content,
+                    metadata={"source": "directory_ingest", "filename": file_path.name},
+                )
+                count += 1
+            except Exception:
+                logger.exception("RAG: failed to ingest file {}", file_path)
+
+        logger.info("RAG: ingest_directory ingested {} file(s) from {}", count, dir_path)
+        return count
+
+    # ------------------------------------------------------------------
+    # Helpers for consolidation integration
+    # ------------------------------------------------------------------
+
+    def extract_and_store_facts(
+        self,
+        history_entry: str,
+        memory_update: str,
+        timestamp: str | None = None,
+    ) -> None:
+        """Extract bullet-point facts from a memory update and store them individually.
+
+        Intended to be called right after consolidation so the knowledge
+        collection stays current without requiring a separate LLM call.
+        """
+        ts = timestamp or _now_iso()
+        # Collect lines that look like facts: bullet/numbered lists, or sentences.
+        candidates: list[str] = []
+
+        for line in memory_update.splitlines():
+            stripped = line.strip()
+            # Skip headings, empty lines, and very short lines.
+            if not stripped or stripped.startswith("#") or len(stripped) < 10:
+                continue
+            # Remove leading bullet/numbering markers.
+            cleaned = re.sub(r"^[-*+\d.)\s]+", "", stripped).strip()
+            if len(cleaned) >= 10:
+                candidates.append(cleaned)
+
+        # Also treat the full history entry as a single knowledge chunk.
+        if history_entry and history_entry.strip():
+            self.add_knowledge(history_entry.strip(), source="history_entry", timestamp=ts)
+
+        for fact in candidates:
+            self.add_knowledge(fact, source="memory_update", timestamp=ts)
+
+        logger.debug("RAG: stored {} facts from consolidation", len(candidates))

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import dataclass, field
 import inspect
 from pathlib import Path
@@ -267,7 +268,9 @@ class AgentRunner:
                     messages_for_model = messages
             context = AgentHookContext(iteration=iteration, messages=messages)
             await hook.before_iteration(context)
+            _t0 = time.perf_counter()
             response = await self._request_model(spec, messages_for_model, hook, context)
+            context.latency_ms = (time.perf_counter() - _t0) * 1000
             raw_usage = self._usage_dict(response.usage)
             context.response = response
             context.usage = dict(raw_usage)

--- a/nanobot/agent/tools/audit.py
+++ b/nanobot/agent/tools/audit.py
@@ -1,0 +1,306 @@
+"""Audit logging for tool executions.
+
+Appends one JSON line per tool call to ~/.nanobot/workspace/audit.jsonl.
+Each line records the timestamp, tool name, sanitised arguments, result
+status, session_id, and originating channel so that operators can review
+what the agent did and when.
+
+Usage
+-----
+    from nanobot.agent.tools.audit import AuditLogger
+
+    logger = AuditLogger()
+    await logger.log(
+        tool_name="exec",
+        arguments={"command": "ls /tmp"},
+        result_status="ok",
+        session_id="discord:123456",
+        channel="discord",
+    )
+
+    recent = logger.query(limit=20)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Argument-level secret redaction
+# ---------------------------------------------------------------------------
+
+# Field names whose values should be replaced with the placeholder below.
+_SECRET_FIELDS: frozenset[str] = frozenset(
+    {
+        "token",
+        "api_key",
+        "apikey",
+        "api_token",
+        "password",
+        "passwd",
+        "secret",
+        "bridge_token",
+        "access_token",
+        "app_token",
+        "bot_token",
+        "claw_token",
+        "imap_password",
+        "smtp_password",
+        "encrypt_key",
+        "verification_token",
+        "client_secret",
+    }
+)
+
+_REDACTED = "[REDACTED]"
+
+
+def _redact(value: Any, key: str | None = None) -> Any:
+    """Recursively redact known secret fields from a value.
+
+    Parameters
+    ----------
+    value:
+        The value to inspect (string, dict, list, or other).
+    key:
+        The dict key that produced this value; if it matches a known secret
+        field name, the entire value is replaced with ``[REDACTED]``.
+    """
+    if key is not None:
+        normalised = key.lower().replace("-", "_")
+        if normalised in _SECRET_FIELDS:
+            return _REDACTED
+
+    if isinstance(value, dict):
+        return {k: _redact(v, k) for k, v in value.items()}
+
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+
+    return value
+
+
+def _sanitise_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *arguments* with secret values replaced."""
+    return _redact(arguments)  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# AuditLogger
+# ---------------------------------------------------------------------------
+
+
+class AuditLogger:
+    """Append-only JSONL audit log for tool executions.
+
+    Parameters
+    ----------
+    log_path:
+        Path to the JSONL file.  Defaults to
+        ``~/.nanobot/workspace/audit.jsonl``.
+    """
+
+    def __init__(self, log_path: Path | None = None) -> None:
+        if log_path is None:
+            log_path = Path.home() / ".nanobot" / "workspace" / "audit.jsonl"
+        self._log_path = log_path
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def log(
+        self,
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        result_status: str,
+        session_id: str = "",
+        channel: str = "",
+        error: str | None = None,
+        duration_ms: float | None = None,
+    ) -> None:
+        """Append one audit entry to the log file (synchronous).
+
+        Parameters
+        ----------
+        tool_name:
+            Name of the tool that was called (e.g. ``"exec"``).
+        arguments:
+            Raw arguments dict passed to the tool.  Secret fields are
+            automatically redacted before writing.
+        result_status:
+            ``"ok"`` on success, ``"error"`` on failure, ``"blocked"`` when
+            the guard rejected the call.
+        session_id:
+            The session key (e.g. ``"discord:123456789"``).
+        channel:
+            The inbound channel name (e.g. ``"discord"``, ``"telegram"``).
+        error:
+            Optional error message when *result_status* is not ``"ok"``.
+        duration_ms:
+            Optional wall-clock duration of the tool execution in
+            milliseconds.
+        """
+        entry = self._build_entry(
+            tool_name=tool_name,
+            arguments=arguments,
+            result_status=result_status,
+            session_id=session_id,
+            channel=channel,
+            error=error,
+            duration_ms=duration_ms,
+        )
+        self._append(entry)
+
+    def log_llm_call(
+        self,
+        *,
+        session_id: str = "",
+        channel: str = "",
+        model: str = "",
+        tokens_in: int | None = None,
+        tokens_out: int | None = None,
+        latency_ms: float | None = None,
+        tool_calls_made: int = 0,
+        ttft_ms: float | None = None,
+    ) -> None:
+        """Append one llm_call event to the audit log.
+
+        Records per-iteration LLM usage so token counts and latency
+        are durable beyond journald rotation.
+        """
+        entry: dict[str, Any] = {
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "event_type": "llm_call",
+            "session_id": session_id,
+            "channel": channel,
+            "model": model,
+            "pid": os.getpid(),
+        }
+        if tokens_in is not None:
+            entry["tokens_in"] = tokens_in
+        if tokens_out is not None:
+            entry["tokens_out"] = tokens_out
+        if latency_ms is not None:
+            entry["latency_ms"] = round(latency_ms, 2)
+        if tool_calls_made:
+            entry["tool_calls_made"] = tool_calls_made
+        if ttft_ms is not None:
+            entry["ttft_ms"] = round(ttft_ms, 2)
+        self._append(entry)
+
+    def query(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Return the *limit* most-recent audit entries.
+
+        Parameters
+        ----------
+        limit:
+            Maximum number of entries to return.  Defaults to 50.
+
+        Returns
+        -------
+        list[dict]:
+            Entries in chronological order (oldest first), up to *limit*
+            entries.  Returns an empty list if the log file does not exist
+            or is unreadable.
+        """
+        if not self._log_path.exists():
+            return []
+
+        entries: list[dict[str, Any]] = []
+        try:
+            with open(self._log_path, encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        # Corrupt line — skip silently.
+                        continue
+        except OSError:
+            return []
+
+        return entries[-limit:]
+
+    def query_by_tool(self, tool_name: str, limit: int = 50) -> list[dict[str, Any]]:
+        """Return the *limit* most-recent entries for a specific tool.
+
+        Parameters
+        ----------
+        tool_name:
+            Name of the tool to filter by.
+        limit:
+            Maximum number of entries to return.
+        """
+        all_entries = self.query(limit=max(limit * 10, 500))
+        matching = [e for e in all_entries if e.get("tool_name") == tool_name]
+        return matching[-limit:]
+
+    def query_by_session(self, session_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        """Return the *limit* most-recent entries for a specific session.
+
+        Parameters
+        ----------
+        session_id:
+            Session key to filter by (e.g. ``"discord:123456789"``).
+        limit:
+            Maximum number of entries to return.
+        """
+        all_entries = self.query(limit=max(limit * 10, 500))
+        matching = [e for e in all_entries if e.get("session_id") == session_id]
+        return matching[-limit:]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_entry(
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        result_status: str,
+        session_id: str,
+        channel: str,
+        error: str | None,
+        duration_ms: float | None,
+    ) -> dict[str, Any]:
+        """Construct the dict that will be serialised to one JSONL line."""
+        entry: dict[str, Any] = {
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "tool_name": tool_name,
+            "arguments": _sanitise_arguments(arguments),
+            "result_status": result_status,
+            "session_id": session_id,
+            "channel": channel,
+            "pid": os.getpid(),
+        }
+        if error is not None:
+            entry["error"] = error
+        if duration_ms is not None:
+            entry["duration_ms"] = round(duration_ms, 2)
+        return entry
+
+    def _append(self, entry: dict[str, Any]) -> None:
+        """Write *entry* as a single JSON line to the log file.
+
+        Creates parent directories if they do not exist.  Errors are
+        printed to stderr rather than raised so that audit failures never
+        break tool execution.
+        """
+        try:
+            self._log_path.parent.mkdir(parents=True, exist_ok=True)
+            line = json.dumps(entry, ensure_ascii=False) + "\n"
+            with open(self._log_path, "a", encoding="utf-8") as fh:
+                fh.write(line)
+        except Exception as exc:  # pragma: no cover
+            # Audit must not crash the agent.
+            import sys
+            print(f"[AuditLogger] Failed to write audit entry: {exc}", file=sys.stderr)

--- a/nanobot/agent/tools/base.py
+++ b/nanobot/agent/tools/base.py
@@ -203,6 +203,13 @@ class Tool(ABC):
                 return val
 
         if t == "string":
+            # Don't stringify composite types — a malformed tool call like
+            # ``{"path": ["/tmp/x"]}`` should surface as a validation error,
+            # not be silently coerced to ``"['/tmp/x']"`` which bypasses
+            # validate_params and produces confusing runtime behavior.
+            # Pass composites through so validate_params rejects them cleanly.
+            if isinstance(val, (list, dict, set, tuple)):
+                return val
             return val if val is None else str(val)
 
         if t == "boolean" and isinstance(val, str):

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -160,14 +160,28 @@ class ReadFileTool(_FsTool):
                 return f"Error: Reading {path} is blocked (device path that could hang or produce infinite output)."
 
             # Sensitive-path blocklist (MIT-121): refuse to read private keys,
-            # credential caches, keyrings, etc. Catches both the raw input
-            # (e.g. '~/.ssh/id_rsa') and the resolved path (symlinks / ../ escapes).
+            # credential caches, keyrings, etc. Runs on the raw input AND on
+            # the resolved path so a symlink at an innocent name or a ".."
+            # traversal that terminates in a sensitive location is still caught.
+            #
+            # Policy: "better false positive than leak." is_sensitive_path()
+            # blocks broadly and deliberately:
+            #   - Private key material (id_rsa, *.pem, *.key, etc.)
+            #   - Credential caches (~/.aws/, ~/.config/gcloud/, ~/.docker/config.json)
+            #   - Environment files (.env*)
+            #   - Credential JSON (credentials.json, service_account_key.json)
+            # This includes a few files that are not strictly secret — public
+            # TLS certs shipped as *.pem and public SSH keys id_*.pub — on
+            # purpose. The cost of a blocked read is "use shell to copy it";
+            # the cost of a leaked private key is unbounded. MIT-140 tracks a
+            # narrowing for id_*.pub where the false positive is most painful.
             if is_sensitive_path(path):
                 return f"Error: Reading {path} is blocked (sensitive path — credentials or key material)."
 
             fp = self._resolve(path)
             if _is_blocked_device(fp):
                 return f"Error: Reading {fp} is blocked (device path that could hang or produce infinite output)."
+            # Post-resolve pass: defense-in-depth against symlink / traversal escapes.
             if is_sensitive_path(fp):
                 return f"Error: Reading {path} is blocked (sensitive path — credentials or key material)."
             if not fp.exists():
@@ -702,7 +716,10 @@ class EditFileTool(_FsTool):
                 return "Error: This is a Jupyter notebook. Use the notebook_edit tool instead of edit_file."
 
             # Sensitive-path blocklist (MIT-121): refuse to edit private keys,
-            # credential caches, keyrings, etc.
+            # credential caches, keyrings, etc. Same "better false positive
+            # than leak" policy as read_file — see the policy block there for
+            # the full list and rationale. Post-resolve pass guards against
+            # symlink / ".." traversal to a sensitive target.
             if is_sensitive_path(path):
                 return f"Error: Editing {path} is blocked (sensitive path — credentials or key material)."
 

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -14,6 +14,20 @@ from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
 from nanobot.config.paths import get_media_dir
 
 
+# ---------------------------------------------------------------------------
+# Module-level context set by ToolRegistry.set_context().
+#
+# `_current_sender_id` carries the identity of the message sender whose
+# request is currently being executed.  It is set by
+# `ToolRegistry.set_context(..., sender_id=...)` at the start of each turn
+# and is available to filesystem tools that need owner-only authorization
+# (e.g. owner-only write/edit guards on protected paths — see MIT-121-series
+# security work).  Defaults to empty string, meaning "no sender attributed"
+# (internal caller, subagent, or legacy path).
+# ---------------------------------------------------------------------------
+_current_sender_id: str = ""
+
+
 def _resolve_path(
     path: str,
     workspace: Path | None = None,

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -12,6 +12,7 @@ from nanobot.agent.tools.schema import BooleanSchema, IntegerSchema, StringSchem
 from nanobot.agent.tools import file_state
 from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
 from nanobot.config.paths import get_media_dir
+from nanobot.utils.sensitive import is_sensitive_path
 
 
 def _resolve_path(
@@ -158,9 +159,17 @@ class ReadFileTool(_FsTool):
             if _is_blocked_device(path):
                 return f"Error: Reading {path} is blocked (device path that could hang or produce infinite output)."
 
+            # Sensitive-path blocklist (MIT-121): refuse to read private keys,
+            # credential caches, keyrings, etc. Catches both the raw input
+            # (e.g. '~/.ssh/id_rsa') and the resolved path (symlinks / ../ escapes).
+            if is_sensitive_path(path):
+                return f"Error: Reading {path} is blocked (sensitive path — credentials or key material)."
+
             fp = self._resolve(path)
             if _is_blocked_device(fp):
                 return f"Error: Reading {fp} is blocked (device path that could hang or produce infinite output)."
+            if is_sensitive_path(fp):
+                return f"Error: Reading {path} is blocked (sensitive path — credentials or key material)."
             if not fp.exists():
                 return f"Error: File not found: {path}"
             if not fp.is_file():
@@ -692,7 +701,14 @@ class EditFileTool(_FsTool):
             if path.endswith(".ipynb"):
                 return "Error: This is a Jupyter notebook. Use the notebook_edit tool instead of edit_file."
 
+            # Sensitive-path blocklist (MIT-121): refuse to edit private keys,
+            # credential caches, keyrings, etc.
+            if is_sensitive_path(path):
+                return f"Error: Editing {path} is blocked (sensitive path — credentials or key material)."
+
             fp = self._resolve(path)
+            if is_sensitive_path(fp):
+                return f"Error: Editing {path} is blocked (sensitive path — credentials or key material)."
 
             # Create-file semantics: old_text='' + file doesn't exist → create
             if not fp.exists():

--- a/nanobot/agent/tools/recall.py
+++ b/nanobot/agent/tools/recall.py
@@ -1,0 +1,267 @@
+"""Recall and ingest tools backed by the RAG semantic store."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nanobot.agent.tools.base import Tool
+
+_SUPPORTED_SUFFIXES = {
+    ".md", ".txt", ".py", ".json",
+    ".pdf", ".docx", ".doc",
+    ".csv", ".html", ".htm", ".xml",
+    ".yaml", ".yml", ".rst", ".log",
+}
+
+
+class RecallTool(Tool):
+    """Semantic search across RAG collections (conversations, documents, knowledge)."""
+
+    def __init__(self, workspace: Path) -> None:
+        self._workspace = workspace
+        self._rag: Any = None  # lazy: nanobot.agent.rag.RAGStore
+
+    def _get_rag(self):
+        if self._rag is None:
+            from nanobot.agent.rag import RAGStore
+            self._rag = RAGStore(self._workspace)
+        return self._rag
+
+    @property
+    def name(self) -> str:
+        return "recall"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Semantic search over long-term memory: past conversations, ingested documents, "
+            "and extracted knowledge facts. Use this to find things like 'what did we discuss "
+            "about GPUs last week?' or 'find notes about deployment'. "
+            "Scope can be 'all', 'conversations', 'documents', or 'knowledge'."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Natural-language search query.",
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["all", "conversations", "documents", "knowledge"],
+                    "description": (
+                        "Which collection to search. "
+                        "'all' searches everywhere (default). "
+                        "'conversations' finds past chat segments. "
+                        "'documents' searches ingested files. "
+                        "'knowledge' searches extracted facts."
+                    ),
+                },
+                "n_results": {
+                    "type": "integer",
+                    "description": "Number of results to return (default 5, max 20).",
+                    "minimum": 1,
+                    "maximum": 20,
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def execute(
+        self,
+        query: str,
+        scope: str = "all",
+        n_results: int = 5,
+        **kwargs: Any,
+    ) -> str:
+        try:
+            rag = self._get_rag()
+        except RuntimeError as exc:
+            return f"Error: {exc}"
+
+        valid_scopes = {"all", "conversations", "documents", "knowledge"}
+        if scope not in valid_scopes:
+            return f"Error: invalid scope '{scope}'. Must be one of: {', '.join(sorted(valid_scopes))}"
+
+        collection = None if scope == "all" else scope
+        n = min(max(n_results, 1), 20)
+
+        try:
+            results = rag.search(query=query, n_results=n, collection=collection)
+        except Exception as exc:
+            logger.exception("recall tool: search failed")
+            return f"Error performing semantic search: {exc}"
+
+        if not results:
+            return f"No results found for: {query!r} (scope={scope})"
+
+        lines = [f"Semantic recall: {len(results)} result(s) for {query!r} (scope={scope})\n"]
+        for i, r in enumerate(results, 1):
+            meta = r.get("metadata", {})
+            coll = r.get("collection", "?")
+            dist = r.get("distance", 0.0)
+            content = r.get("content", "")
+
+            # Build a compact metadata summary for the agent.
+            meta_parts: list[str] = [f"collection={coll}"]
+            if ts := meta.get("timestamp", "")[:16]:
+                meta_parts.append(f"time={ts}")
+            if src := meta.get("source") or meta.get("path") or meta.get("session_id"):
+                meta_parts.append(f"source={src}")
+            meta_parts.append(f"similarity={1 - dist:.2f}")
+
+            lines.append(f"[{i}] {' | '.join(meta_parts)}")
+            # Indent content for readability.
+            for content_line in content.splitlines():
+                lines.append(f"    {content_line}")
+            lines.append("")
+
+        return "\n".join(lines).rstrip()
+
+
+class IngestTool(Tool):
+    """Ingest a file or directory into the RAG semantic store."""
+
+    def __init__(self, workspace: Path, allowed_dir: Path | None = None) -> None:
+        self._workspace = workspace
+        self._allowed_dir = allowed_dir
+        self._rag: Any = None  # lazy: nanobot.agent.rag.RAGStore
+
+    def _get_rag(self):
+        if self._rag is None:
+            from nanobot.agent.rag import RAGStore
+            self._rag = RAGStore(self._workspace)
+        return self._rag
+
+    @property
+    def name(self) -> str:
+        return "ingest"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Ingest a file or directory into the RAG semantic store so its contents "
+            "can be found later via the recall tool. "
+            f"Supported file types: {', '.join(sorted(_SUPPORTED_SUFFIXES))}. "
+            "For directories, all matching files are ingested recursively."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or workspace-relative path to a file or directory.",
+                },
+                "glob": {
+                    "type": "string",
+                    "description": (
+                        "Glob pattern for directory ingestion (default '**/*.md'). "
+                        "Only used when path is a directory."
+                    ),
+                },
+            },
+            "required": ["path"],
+        }
+
+    async def execute(self, path: str, glob: str = "**/*.md", **kwargs: Any) -> str:
+        try:
+            rag = self._get_rag()
+        except RuntimeError as exc:
+            return f"Error: {exc}"
+
+        target = Path(path).expanduser()
+        if not target.is_absolute():
+            target = self._workspace / target
+        target = target.resolve()
+
+        if self._allowed_dir is not None:
+            allowed = self._allowed_dir.resolve()
+            try:
+                target.relative_to(allowed)
+            except ValueError:
+                return f"Error: path {path} is outside the allowed directory ({allowed})"
+
+        if not target.exists():
+            return f"Error: path does not exist: {path}"
+
+        try:
+            if target.is_dir():
+                count = rag.ingest_directory(target, glob=glob)
+                return (
+                    f"Ingested {count} file(s) from {target} into the RAG store. "
+                    "Use recall to search the content."
+                )
+
+            # Single file.
+            if target.suffix not in _SUPPORTED_SUFFIXES:
+                return (
+                    f"Error: unsupported file type '{target.suffix}'. "
+                    f"Supported: {', '.join(sorted(_SUPPORTED_SUFFIXES))}"
+                )
+
+            # --- Extract text based on file type ---
+            suffix = target.suffix.lower()
+
+            if suffix == ".pdf":
+                try:
+                    import pdfplumber
+                except ImportError:
+                    return (
+                        "Error: pdfplumber is not installed. "
+                        "Run: pip install pdfplumber"
+                    )
+                pages_text: list[str] = []
+                with pdfplumber.open(target) as pdf:
+                    for page in pdf.pages:
+                        page_text = page.extract_text()
+                        if page_text:
+                            pages_text.append(page_text)
+                content = "\n\n".join(pages_text)
+
+            elif suffix in (".docx", ".doc"):
+                try:
+                    import docx as python_docx
+                except ImportError:
+                    return (
+                        "Error: python-docx is not installed. "
+                        "Run: pip install python-docx"
+                    )
+                doc = python_docx.Document(str(target))
+                content = "\n\n".join(
+                    para.text for para in doc.paragraphs if para.text.strip()
+                )
+
+            elif suffix == ".csv":
+                content = target.read_text(encoding="utf-8", errors="replace")
+
+            else:
+                # All other text-based formats (.md, .txt, .py, .json,
+                # .html, .htm, .xml, .yaml, .yml, .rst, .log)
+                content = target.read_text(encoding="utf-8", errors="replace")
+
+            if not content.strip():
+                return f"Warning: file {path} is empty, nothing ingested."
+
+            rag.add_document(
+                path=str(target),
+                content=content,
+                metadata={"source": "manual_ingest", "filename": target.name},
+            )
+            return (
+                f"Ingested {target.name} ({len(content)} chars, "
+                f"{len(content.split())} words) into the RAG store. "
+                "Use recall to search the content."
+            )
+        except Exception as exc:
+            logger.exception("ingest tool: failed for {}", path)
+            return f"Error ingesting {path}: {exc}"

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -1,5 +1,6 @@
 """Tool registry for dynamic tool management."""
 
+import time
 from typing import Any
 
 from nanobot.agent.tools.base import Tool
@@ -14,17 +15,34 @@ class ToolRegistry:
 
     def __init__(self):
         self._tools: dict[str, Tool] = {}
-        self._cached_definitions: list[dict[str, Any]] | None = None
+        self._definitions_cache: list[dict[str, Any]] | None = None
+        self._audit_logger = None
+        self._session_id: str = ""
+        self._channel: str = ""
+        self._sender_id: str = ""
 
     def register(self, tool: Tool) -> None:
         """Register a tool."""
         self._tools[tool.name] = tool
-        self._cached_definitions = None
+        self._definitions_cache = None
 
     def unregister(self, name: str) -> None:
         """Unregister a tool by name."""
         self._tools.pop(name, None)
-        self._cached_definitions = None
+        self._definitions_cache = None
+
+    def set_audit_logger(self, audit_logger) -> None:
+        """Attach an AuditLogger to record all tool executions."""
+        self._audit_logger = audit_logger
+
+    def set_context(self, session_id: str, channel: str, sender_id: str = "") -> None:
+        """Set session context for audit logging and access control."""
+        self._session_id = session_id
+        self._channel = channel
+        self._sender_id = sender_id
+        # Propagate sender to filesystem tools for protected-path checks
+        from nanobot.agent.tools import filesystem as _fs
+        _fs._current_sender_id = sender_id
 
     def get(self, name: str) -> Tool | None:
         """Get a tool by name."""
@@ -52,8 +70,8 @@ class ToolRegistry:
         sorted and appended.  The result is cached until the next
         register/unregister call.
         """
-        if self._cached_definitions is not None:
-            return self._cached_definitions
+        if self._definitions_cache is not None:
+            return self._definitions_cache
 
         definitions = [tool.to_schema() for tool in self._tools.values()]
         builtins: list[dict[str, Any]] = []
@@ -67,51 +85,95 @@ class ToolRegistry:
 
         builtins.sort(key=self._schema_name)
         mcp_tools.sort(key=self._schema_name)
-        self._cached_definitions = builtins + mcp_tools
-        return self._cached_definitions
+        self._definitions_cache = builtins + mcp_tools
+        return self._definitions_cache
 
-    def prepare_call(
+    async def execute(
         self,
         name: str,
         params: dict[str, Any],
-    ) -> tuple[Tool | None, dict[str, Any], str | None]:
-        """Resolve, cast, and validate one tool call."""
+        *,
+        session_id: str | None = None,
+        channel: str | None = None,
+    ) -> str:
+        """Execute a tool by name with given parameters.
+
+        *session_id* and *channel* are per-call overrides for audit logging,
+        avoiding shared mutable state across concurrent workers.
+        """
+        _HINT = "\n\n[Analyze the error above and try a different approach.]"
+
         # Guard against invalid parameter types (e.g., list instead of dict)
         if not isinstance(params, dict) and name in ('write_file', 'read_file'):
-            return None, params, (
+            return (
                 f"Error: Tool '{name}' parameters must be a JSON object, got {type(params).__name__}. "
-                "Use named parameters: tool_name(param1=\"value1\", param2=\"value2\")"
+                "Use named parameters: tool_name(param1=\"value1\", param2=\"value2\")" + _HINT
             )
 
         tool = self._tools.get(name)
         if not tool:
-            return None, params, (
-                f"Error: Tool '{name}' not found. Available: {', '.join(self.tool_names)}"
-            )
+            return f"Error: Tool '{name}' not found. Available: {', '.join(self.tool_names)}"
 
-        cast_params = tool.cast_params(params)
-        errors = tool.validate_params(cast_params)
-        if errors:
-            return tool, cast_params, (
-                f"Error: Invalid parameters for tool '{name}': " + "; ".join(errors)
-            )
-        return tool, cast_params, None
+        sid = session_id or self._session_id
+        ch = channel or self._channel
 
-    async def execute(self, name: str, params: dict[str, Any]) -> Any:
-        """Execute a tool by name with given parameters."""
-        _HINT = "\n\n[Analyze the error above and try a different approach.]"
-        tool, params, error = self.prepare_call(name, params)
-        if error:
-            return error + _HINT
-
+        t0 = time.monotonic()
         try:
-            assert tool is not None  # guarded by prepare_call()
+            errors = tool.validate_params(params)
+            if errors:
+                self._audit("error", name, params, t0, sid, ch, error="; ".join(errors))
+                return f"Error: Invalid parameters for tool '{name}': " + "; ".join(errors) + _HINT
             result = await tool.execute(**params)
-            if isinstance(result, str) and result.startswith("Error"):
+            duration_ms = (time.monotonic() - t0) * 1000
+            status = "error" if isinstance(result, str) and result.startswith("Error") else "ok"
+            self._audit(status, name, params, t0, sid, ch)
+            self._prom_observe(name, status, duration_ms)
+            if status == "error":
                 return result + _HINT
             return result
         except Exception as e:
+            duration_ms = (time.monotonic() - t0) * 1000
+            self._audit("error", name, params, t0, sid, ch, error=str(e))
+            self._prom_observe(name, "error", duration_ms)
             return f"Error executing {name}: {str(e)}" + _HINT
+
+    def _audit(
+        self,
+        status: str,
+        name: str,
+        params: dict,
+        t0: float,
+        session_id: str = "",
+        channel: str = "",
+        error: str | None = None,
+    ) -> None:
+        """Log a tool execution to the audit logger if attached."""
+        if self._audit_logger is None:
+            return
+        try:
+            self._audit_logger.log(
+                tool_name=name,
+                arguments=params,
+                result_status=status,
+                session_id=session_id,
+                channel=channel,
+                error=error,
+                duration_ms=(time.monotonic() - t0) * 1000,
+            )
+        except Exception:
+            pass  # Audit must never crash tool execution
+
+    @staticmethod
+    def _prom_observe(tool_name: str, status: str, duration_ms: float) -> None:
+        """Feed Prometheus metrics if available."""
+        try:
+            from nanobot.dashboard.server import _PROM_AVAILABLE
+            if _PROM_AVAILABLE:
+                from nanobot.dashboard.server import PROM_TOOL_CALLS, PROM_TOOL_DURATION
+                PROM_TOOL_CALLS.labels(tool_name=tool_name, status=status).inc()
+                PROM_TOOL_DURATION.labels(tool_name=tool_name).observe(duration_ms)
+        except Exception:
+            pass
 
     @property
     def tool_names(self) -> list[str]:

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -4,6 +4,7 @@ import time
 from typing import Any
 
 from nanobot.agent.tools.base import Tool
+from nanobot.utils.sensitive import redact_if_sensitive
 
 
 class ToolRegistry:
@@ -130,6 +131,13 @@ class ToolRegistry:
             self._prom_observe(name, status, duration_ms)
             if status == "error":
                 return result + _HINT
+            # Defence-in-depth: scrub embedded secrets (private keys, API tokens,
+            # AWS/GitHub/Slack creds, ...) from successful tool output before the
+            # model ever sees it. Non-string results (e.g. ReadFileTool's image
+            # content blocks -> list[dict]) bypass the scrubber and pass through
+            # untouched.
+            if isinstance(result, str):
+                result = redact_if_sensitive(result)
             return result
         except Exception as e:
             duration_ms = (time.monotonic() - t0) * 1000

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -120,6 +120,9 @@ class ToolRegistry:
 
         t0 = time.monotonic()
         try:
+            # Schema-driven cast (e.g. stringly-typed ints from LLM JSON) before
+            # validation — regression restored from pre-1d18d24 prepare_call().
+            params = tool.cast_params(params)
             errors = tool.validate_params(params)
             if errors:
                 self._audit("error", name, params, t0, sid, ch, error="; ".join(errors))

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -141,26 +141,45 @@ class ToolRegistry:
             # RSA PRIVATE KEY-----...". Before MIT-147, the error branch was a
             # short-circuit that bypassed the redactor entirely, so anything a
             # (possibly adversarial) tool stuffed into an `Error:` prefix would
-            # leak straight to the model. The fix routes both branches through
-            # the same scrubber; the `_HINT` suffix is appended *after* the
-            # redactor so the model still gets the "try something else" nudge
-            # on error even when the body got redacted.
+            # leak straight to the model.
+            #
+            # Error-prefix preservation: `AgentRunner._run_tool()` (and other
+            # downstream consumers) detect tool failures via
+            # `result.startswith("Error")`. The raw redaction notice does NOT
+            # start with "Error", so on the error branch we re-wrap the
+            # redacted result in an "Error: ..." shell to preserve the
+            # failure-detection contract. The `_HINT` suffix is appended after
+            # redaction so the model still gets the "try something else" nudge.
             #
             # Non-string results (e.g. ReadFileTool's image content blocks ->
             # list[dict]) bypass the scrubber and pass through untouched.
             if isinstance(result, str):
-                result = redact_if_sensitive(result)
+                redacted = redact_if_sensitive(result)
                 if status == "error":
-                    result = result + _HINT
+                    # Preserve the "Error:" prefix that downstream failure
+                    # detection relies on, even when the body was scrubbed.
+                    if not redacted.startswith("Error"):
+                        redacted = f"Error ({name}): {redacted}"
+                    result = redacted + _HINT
+                else:
+                    result = redacted
             return result
         except Exception as e:
             duration_ms = (time.monotonic() - t0) * 1000
             self._audit("error", name, params, t0, sid, ch, error=str(e))
             self._prom_observe(name, "error", duration_ms)
-            # Exception strings can also carry secrets — e.g. a ValueError raised
-            # while parsing a file embeds the line that failed. Run the redactor
-            # on the exception path too (MIT-147).
-            return redact_if_sensitive(f"Error executing {name}: {str(e)}") + _HINT
+            # Exception strings can also carry secrets — e.g. a ValueError
+            # raised while parsing a file embeds the line that failed. Run
+            # the redactor on the exception path too (MIT-147).
+            #
+            # Preserve the "Error executing ..." prefix so downstream failure
+            # detection keeps working when the exception message contained
+            # a secret and got fully replaced by the redaction notice.
+            raw = f"Error executing {name}: {str(e)}"
+            redacted = redact_if_sensitive(raw)
+            if not redacted.startswith("Error"):
+                redacted = f"Error executing {name}: {redacted}"
+            return redacted + _HINT
 
     def _audit(
         self,

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -132,21 +132,35 @@ class ToolRegistry:
             status = "error" if isinstance(result, str) and result.startswith("Error") else "ok"
             self._audit(status, name, params, t0, sid, ch)
             self._prom_observe(name, status, duration_ms)
-            if status == "error":
-                return result + _HINT
-            # Defence-in-depth: scrub embedded secrets (private keys, API tokens,
-            # AWS/GitHub/Slack creds, ...) from successful tool output before the
-            # model ever sees it. Non-string results (e.g. ReadFileTool's image
-            # content blocks -> list[dict]) bypass the scrubber and pass through
-            # untouched.
+            # Defence-in-depth: scrub embedded secrets from any string result,
+            # both success AND error paths (MIT-147).
+            #
+            # Tool authors can legitimately return error strings that embed the
+            # offending payload for the model to reason about — e.g. "Error:
+            # invalid AWS credentials: AKIA..." or "Error parsing PEM: -----BEGIN
+            # RSA PRIVATE KEY-----...". Before MIT-147, the error branch was a
+            # short-circuit that bypassed the redactor entirely, so anything a
+            # (possibly adversarial) tool stuffed into an `Error:` prefix would
+            # leak straight to the model. The fix routes both branches through
+            # the same scrubber; the `_HINT` suffix is appended *after* the
+            # redactor so the model still gets the "try something else" nudge
+            # on error even when the body got redacted.
+            #
+            # Non-string results (e.g. ReadFileTool's image content blocks ->
+            # list[dict]) bypass the scrubber and pass through untouched.
             if isinstance(result, str):
                 result = redact_if_sensitive(result)
+                if status == "error":
+                    result = result + _HINT
             return result
         except Exception as e:
             duration_ms = (time.monotonic() - t0) * 1000
             self._audit("error", name, params, t0, sid, ch, error=str(e))
             self._prom_observe(name, "error", duration_ms)
-            return f"Error executing {name}: {str(e)}" + _HINT
+            # Exception strings can also carry secrets — e.g. a ValueError raised
+            # while parsing a file embeds the line that failed. Run the redactor
+            # on the exception path too (MIT-147).
+            return redact_if_sensitive(f"Error executing {name}: {str(e)}") + _HINT
 
     def _audit(
         self,

--- a/nanobot/agent/tools/search.py
+++ b/nanobot/agent/tools/search.py
@@ -9,6 +9,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, TypeVar
 
 from nanobot.agent.tools.filesystem import ListDirTool, _FsTool
+from nanobot.utils.sensitive import is_sensitive_path
 
 _DEFAULT_HEAD_LIMIT = 250
 T = TypeVar("T")
@@ -400,6 +401,19 @@ class GrepTool(_SearchTool):
             if not (target.is_dir() or target.is_file()):
                 return f"Error: Unsupported path: {path}"
 
+            # MIT-136: refuse direct grep against a known-sensitive file.
+            # Recursive descent into a directory that *contains* sensitive
+            # files is handled later by skipping individual entries
+            # (see the per-file sensitivity check in the walk loop).
+            if target.is_file() and (
+                is_sensitive_path(path) or is_sensitive_path(target)
+            ):
+                return (
+                    f"Error: Path is protected by security policy: {path}. "
+                    "Grepping sensitive files (SSH keys, credentials, "
+                    ".env, PEM, etc.) is not permitted."
+                )
+
             flags = re.IGNORECASE if case_insensitive else 0
             try:
                 needle = re.escape(pattern) if fixed_strings else pattern
@@ -422,6 +436,7 @@ class GrepTool(_SearchTool):
             size_truncated = False
             skipped_binary = 0
             skipped_large = 0
+            skipped_sensitive = 0
             matching_files: list[str] = []
             counts: dict[str, int] = {}
             file_mtimes: dict[str, float] = {}
@@ -432,6 +447,12 @@ class GrepTool(_SearchTool):
                 if glob and not _match_glob(rel_path, file_path.name, glob):
                     continue
                 if not _matches_type(file_path.name, type):
+                    continue
+                # MIT-136: silently skip sensitive files during recursive
+                # grep so one stray key file cannot fail the whole call,
+                # while still preventing contents from reaching the model.
+                if is_sensitive_path(file_path):
+                    skipped_sensitive += 1
                     continue
 
                 raw = file_path.read_bytes()
@@ -542,6 +563,10 @@ class GrepTool(_SearchTool):
                 notes.append(f"(skipped {skipped_binary} binary/unreadable files)")
             if skipped_large:
                 notes.append(f"(skipped {skipped_large} large files)")
+            if skipped_sensitive:
+                notes.append(
+                    f"(skipped {skipped_sensitive} sensitive-path files)"
+                )
             if output_mode == "count" and counts:
                 notes.append(
                     f"(total matches: {sum(counts.values())} in {len(counts)} files)"

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -14,6 +14,7 @@ from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.sandbox import wrap_command
 from nanobot.agent.tools.schema import IntegerSchema, StringSchema, tool_parameters_schema
 from nanobot.config.paths import get_media_dir
+from nanobot.utils.sensitive import check_shell_command
 
 _IS_WINDOWS = sys.platform == "win32"
 
@@ -275,6 +276,14 @@ class ExecTool(Tool):
         for pattern in self.deny_patterns:
             if re.search(pattern, lower):
                 return "Error: Command blocked by safety guard (dangerous pattern detected)"
+
+        # Secret-dump / key-exfiltration pre-screen (MIT-123). Delegates to
+        # the shared sensitive-data denylist in nanobot.utils.sensitive so the
+        # same rules apply to shell as to filesystem tools. We translate the
+        # returned reason into this module's "safety guard" phrasing for
+        # consistency with the surrounding messages.
+        if check_shell_command(cmd) is not None:
+            return "Error: Command blocked by safety guard (sensitive data access detected)"
 
         if self.allow_patterns:
             if not any(re.search(p, lower) for p in self.allow_patterns):

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import re
 import shutil
+import signal
 import sys
 from pathlib import Path
 from typing import Any
@@ -141,6 +142,7 @@ class ExecTool(Tool):
             else:
                 command = f'export PATH="$PATH:{self.path_append}"; {command}'
 
+        process: asyncio.subprocess.Process | None = None
         try:
             process = await self._spawn(command, cwd, env)
 
@@ -183,12 +185,28 @@ class ExecTool(Tool):
 
         except Exception as e:
             return f"Error executing command: {str(e)}"
+        finally:
+            # MIT-162: guarantee the subprocess *group* is torn down on every
+            # exit path — success, exception, timeout, or task cancellation.
+            # Without this, commands like `sudo nmap ...` leave orphaned child
+            # trees reparented to the gateway, leaking PIDs and memory long
+            # after the tool call has returned. Commands that already exited
+            # cleanly are cheap: _kill_process becomes a no-op once the
+            # process group is gone.
+            if process is not None and process.returncode is None:
+                await self._kill_process(process)
 
     @staticmethod
     async def _spawn(
         command: str, cwd: str, env: dict[str, str],
     ) -> asyncio.subprocess.Process:
-        """Launch *command* in a platform-appropriate shell."""
+        """Launch *command* in a platform-appropriate shell.
+
+        On Unix the child is placed in its own session (``start_new_session=True``)
+        so we can signal the entire process group during cleanup — without this,
+        fork-happy commands (``sudo``, ``bash -c 'cmd1 | cmd2'``, nmap) leave
+        orphan descendants behind when the parent exits (MIT-162).
+        """
         if _IS_WINDOWS:
             comspec = env.get("COMSPEC", os.environ.get("COMSPEC", "cmd.exe"))
             return await asyncio.create_subprocess_exec(
@@ -205,12 +223,42 @@ class ExecTool(Tool):
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,
             env=env,
+            start_new_session=True,
         )
 
     @staticmethod
     async def _kill_process(process: asyncio.subprocess.Process) -> None:
-        """Kill a subprocess and reap it to prevent zombies."""
-        process.kill()
+        """Kill a subprocess *and its entire process group*, then reap it.
+
+        MIT-162: we intentionally skip SIGTERM and go straight to SIGKILL on
+        the process group. ``sudo`` and other privilege-escalation wrappers
+        routinely swallow SIGTERM, leaving their children as orphans. On Unix
+        the child was spawned with ``start_new_session=True``, so its PID is
+        also its PGID; ``killpg`` takes down the whole tree in one call.
+        Windows has no process-group primitive available here, so we fall back
+        to the single-process kill the Python stdlib provides.
+        """
+        if not _IS_WINDOWS:
+            try:
+                pgid = os.getpgid(process.pid)
+                os.killpg(pgid, signal.SIGKILL)
+            except ProcessLookupError:
+                # Group already exited — nothing to signal.
+                pass
+            except PermissionError as e:
+                # Shouldn't happen since we own the child, but don't let it
+                # abort cleanup; fall through to the per-process kill below.
+                logger.debug("killpg denied for pid {}: {}", process.pid, e)
+
+        # Always ask the stdlib to kill the proc it owns — on Unix this is
+        # redundant after a successful killpg but still a cheap safety net
+        # (e.g. if getpgid raced with the child exiting); on Windows it's
+        # the primary kill path.
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+
         try:
             await asyncio.wait_for(process.wait(), timeout=5.0)
         except asyncio.TimeoutError:
@@ -307,8 +355,8 @@ class ExecTool(Tool):
                     continue
 
                 media_path = get_media_dir().resolve()
-                if (p.is_absolute() 
-                    and cwd_path not in p.parents 
+                if (p.is_absolute()
+                    and cwd_path not in p.parents
                     and p != cwd_path
                     and media_path not in p.parents
                     and p != media_path

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -10,16 +10,17 @@ from loguru import logger
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.utils.security import sanitize_input
 
 
 class BaseChannel(ABC):
     """
     Abstract base class for chat channel implementations.
-
+    
     Each channel (Telegram, Discord, etc.) should implement this interface
     to integrate with the nanobot message bus.
     """
-
+    
     name: str = "base"
     display_name: str = "Base"
     transcription_provider: str = "groq"
@@ -29,7 +30,7 @@ class BaseChannel(ABC):
     def __init__(self, config: Any, bus: MessageBus):
         """
         Initialize the channel.
-
+        
         Args:
             config: Channel-specific configuration.
             bus: The message bus for communication.
@@ -76,24 +77,24 @@ class BaseChannel(ABC):
     async def start(self) -> None:
         """
         Start the channel and begin listening for messages.
-
+        
         This should be a long-running async task that:
         1. Connects to the chat platform
         2. Listens for incoming messages
         3. Forwards messages to the bus via _handle_message()
         """
         pass
-
+    
     @abstractmethod
     async def stop(self) -> None:
         """Stop the channel and clean up resources."""
         pass
-
+    
     @abstractmethod
     async def send(self, msg: OutboundMessage) -> None:
         """
         Send a message through this channel.
-
+        
         Args:
             msg: The message to send.
 
@@ -122,7 +123,16 @@ class BaseChannel(ABC):
         return bool(streaming) and type(self).send_delta is not BaseChannel.send_delta
 
     def is_allowed(self, sender_id: str) -> bool:
-        """Check if *sender_id* is permitted.  Empty list → deny all; ``"*"`` → allow all."""
+        """
+        Check if a sender is allowed to use this bot.
+        
+        Args:
+            sender_id: The sender's identifier.
+        
+        Returns:
+            True if allowed, False otherwise.
+        """
+        # Fail-closed: empty allow list = deny all; ["*"] = allow all
         if isinstance(self.config, dict):
             if "allow_from" in self.config:
                 allow_list = self.config.get("allow_from")
@@ -131,12 +141,19 @@ class BaseChannel(ABC):
         else:
             allow_list = getattr(self.config, "allow_from", [])
         if not allow_list:
-            logger.warning("{}: allow_from is empty — all access denied", self.name)
             return False
         if "*" in allow_list:
             return True
-        return str(sender_id) in allow_list
 
+        sender_str = str(sender_id)
+        if sender_str in allow_list:
+            return True
+        if "|" in sender_str:
+            for part in sender_str.split("|"):
+                if part and part in allow_list:
+                    return True
+        return False
+    
     async def _handle_message(
         self,
         sender_id: str,
@@ -148,9 +165,9 @@ class BaseChannel(ABC):
     ) -> None:
         """
         Handle an incoming message from the chat platform.
-
+        
         This method checks permissions and forwards to the bus.
-
+        
         Args:
             sender_id: The sender's identifier.
             chat_id: The chat/channel identifier.
@@ -166,6 +183,28 @@ class BaseChannel(ABC):
                 sender_id, self.name,
             )
             return
+        
+        # Sanitize input for prompt injection defense
+        sanitized_content, was_injection = sanitize_input(content)
+
+        # Block high-confidence injection attempts with user feedback
+        if was_injection:
+            logger.warning(
+                "Blocked prompt injection from sender {} on channel {}",
+                sender_id, self.name,
+            )
+            # Send user-visible feedback instead of silent drop
+            try:
+                await self.bus.publish_outbound(
+                    OutboundMessage(
+                        channel=self.name,
+                        chat_id=str(chat_id),
+                        content="Your message was blocked by the safety filter. If this is a mistake, try rephrasing.",
+                    )
+                )
+            except Exception:
+                pass  # Best effort
+            return
 
         meta = metadata or {}
         if self.supports_streaming:
@@ -175,12 +214,12 @@ class BaseChannel(ABC):
             channel=self.name,
             sender_id=str(sender_id),
             chat_id=str(chat_id),
-            content=content,
+            content=sanitized_content,
             media=media or [],
             metadata=meta,
             session_key_override=session_key,
         )
-
+        
         await self.bus.publish_inbound(msg)
 
     @classmethod

--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -199,7 +199,7 @@ class EmailChannel(BaseChannel):
             logger.info("Skip automatic email reply to {}: auto_reply_enabled is false", to_addr)
             return
 
-        base_subject = self._last_subject_by_chat.get(to_addr, "nanobot reply")
+        base_subject = self._last_subject_by_chat.get(to_addr, "Ziggy reply")
         subject = self._reply_subject(base_subject)
         if msg.metadata and isinstance(msg.metadata.get("subject"), str):
             override = msg.metadata["subject"].strip()
@@ -671,7 +671,7 @@ class EmailChannel(BaseChannel):
         return html.unescape(text)
 
     def _reply_subject(self, base_subject: str) -> str:
-        subject = (base_subject or "").strip() or "nanobot reply"
+        subject = (base_subject or "").strip() or "Ziggy reply"
         prefix = self.config.subject_prefix or "Re: "
         if subject.lower().startswith("re:"):
             return subject

--- a/nanobot/dashboard/README
+++ b/nanobot/dashboard/README
@@ -1,0 +1,100 @@
+Nanobot Status Dashboard
+========================
+
+Standalone usage
+----------------
+
+    python -m nanobot.dashboard.server
+    python -m nanobot.dashboard.server --port 18791
+    python -m nanobot.dashboard.server --host 127.0.0.1 --port 18791
+
+Then open http://localhost:18791 in a browser.
+
+The server uses only the Python standard library (http.server, socket,
+urllib.request) plus pathlib/json — no pip dependencies required.
+
+
+CLI integration (nanobot/nanobot/cli/commands.py)
+-------------------------------------------------
+
+Add the following command to commands.py so users can start the dashboard
+via `nanobot dashboard`:
+
+    @app.command()
+    def dashboard(
+        port: int = typer.Option(18791, "--port", "-p", help="Dashboard port"),
+        host: str = typer.Option("0.0.0.0", "--host", help="Bind address"),
+    ):
+        """Start the nanobot web status dashboard (port 18791 by default)."""
+        from nanobot.dashboard.server import run
+        console.print(f"{__logo__} Dashboard at http://localhost:{port}")
+        run(host=host, port=port)
+
+Paste it in the "Gateway / Server" section, after the existing `gateway`
+command, then users can run:
+
+    nanobot dashboard
+    nanobot dashboard --port 9000
+
+
+Running alongside the gateway
+------------------------------
+
+The dashboard and the gateway run independently on different ports (18790
+for the gateway, 18791 for the dashboard).  You can start them in
+separate terminals or add both to your systemd/supervisord unit files.
+
+Example systemd drop-in (~/.config/systemd/user/nanobot-dashboard.service):
+
+    [Unit]
+    Description=Nanobot status dashboard
+    After=network.target
+
+    [Service]
+    ExecStart=/usr/bin/python3 -m nanobot.dashboard.server --port 18791
+    Restart=on-failure
+    RestartSec=5
+
+    [Install]
+    WantedBy=default.target
+
+
+API endpoint
+------------
+
+GET /api/status  →  JSON
+
+    {
+      "uptime":            "1d 2h 3m 4s",
+      "uptime_seconds":    93784.0,
+      "server_time":       "2026-03-09 10:00:00 UTC",
+      "llama_server": {
+        "status":  "ok" | "error" | "unreachable",
+        "detail":  "..."
+      },
+      "gateway": {
+        "status":  "up" | "down",
+        "port":    18790
+      },
+      "sessions": {
+        "count":         12,
+        "last_modified": "2026-03-09 09:58:00 UTC",
+        "last_modified_ts": 1741514280.0
+      },
+      "last_message_time": "2026-03-09 09:58:00 UTC",
+      "last_message_ts":   1741514280.0,
+      "memory": {
+        "memory_bytes":   4096,
+        "history_bytes":  8192,
+        "memory_exists":  true,
+        "history_exists": true
+      },
+      "cron_jobs": {
+        "count": 3,
+        "path":  "/home/user/.nanobot/cron/jobs.json"
+      },
+      "disk_usage": {
+        "bytes": 10485760,
+        "human": "10.0 MB"
+      }
+    }

--- a/nanobot/dashboard/__main__.py
+++ b/nanobot/dashboard/__main__.py
@@ -1,0 +1,7 @@
+"""Allow `python -m nanobot.dashboard` as an alias for the server."""
+
+from nanobot.dashboard.server import _parse_args, run
+
+if __name__ == "__main__":
+    args = _parse_args()
+    run(host=args.host, port=args.port)

--- a/nanobot/dashboard/server.py
+++ b/nanobot/dashboard/server.py
@@ -1,0 +1,1147 @@
+"""
+Nanobot status dashboard server.
+
+Runs a lightweight HTTP server on port 18791 that serves a single-page
+status dashboard and a JSON /api/status endpoint.
+
+Usage:
+    python -m nanobot.dashboard.server
+    python -m nanobot.dashboard.server --port 18791
+    python -m nanobot.dashboard.server --host 127.0.0.1 --port 18791
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import socket
+import time
+import urllib.parse
+import urllib.request
+import urllib.error
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from threading import Thread
+from typing import Any
+
+try:
+    from prometheus_client import (
+        Counter, Histogram, Gauge, generate_latest,
+        CONTENT_TYPE_LATEST, CollectorRegistry, REGISTRY,
+    )
+    _PROM_AVAILABLE = True
+except ImportError:
+    _PROM_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+_NANOBOT_DIR = Path.home() / ".nanobot"
+_WORKSPACE_DIR = _NANOBOT_DIR / "workspace"
+_SESSIONS_DIR = _WORKSPACE_DIR / "sessions"
+_MEMORY_DIR = _WORKSPACE_DIR / "memory"
+_MEMORY_FILE = _MEMORY_DIR / "MEMORY.md"
+_HISTORY_FILE = _MEMORY_DIR / "HISTORY.md"
+_CRON_JOBS_FILE = _WORKSPACE_DIR / "cron_jobs.json"
+_SKILLS_DIR = _WORKSPACE_DIR / "skills"
+_AUDIT_FILE = _WORKSPACE_DIR / "audit.jsonl"
+_PENDING_MESSAGES_FILE = _WORKSPACE_DIR / "pending_messages.jsonl"
+_CONFIG_FILE = _NANOBOT_DIR / "config.json"
+_ARCHITECTURE_FILE = _WORKSPACE_DIR / "architecture.json"
+
+# Keys in config JSON whose values should be redacted
+_SENSITIVE_KEYS = re.compile(
+    r"(key|token|secret|password|credential|auth)", re.IGNORECASE
+)
+
+# Boot time for uptime tracking
+_START_TIME = time.monotonic()
+_START_WALL = time.time()
+
+# Optional bearer token for API authentication.
+# Set via NANOBOT_DASHBOARD_TOKEN env var to require auth on /api/* endpoints.
+_AUTH_TOKEN: str | None = os.environ.get("NANOBOT_DASHBOARD_TOKEN") or None
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics (lazily used by agent loop instrumentation)
+# ---------------------------------------------------------------------------
+if _PROM_AVAILABLE:
+    PROM_TOOL_CALLS = Counter(
+        'nanobot_tool_calls_total', 'Total tool calls', ['tool_name', 'status'],
+    )
+    PROM_TOOL_ERRORS = Counter(
+        'nanobot_tool_errors_total', 'Total tool call errors', ['tool_name'],
+    )
+    PROM_TOOL_DURATION = Histogram(
+        'nanobot_tool_duration_ms', 'Tool call duration in ms', ['tool_name'],
+        buckets=[5, 10, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000],
+    )
+    PROM_LLM_DURATION = Histogram(
+        'nanobot_llm_call_duration_ms', 'LLM inference duration in ms',
+        buckets=[500, 1000, 2500, 5000, 10000, 20000, 30000, 60000],
+    )
+    PROM_MESSAGES = Counter(
+        'nanobot_messages_total', 'Total messages processed', ['channel'],
+    )
+    PROM_ACTIVE_SESSIONS = Gauge(
+        'nanobot_active_sessions', 'Sessions active in last hour',
+    )
+    PROM_UPTIME = Gauge(
+        'nanobot_uptime_seconds', 'Process uptime in seconds',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audit -> Prometheus sync (cross-process bridge)
+# ---------------------------------------------------------------------------
+# The gateway process writes llm_call entries to audit.jsonl; this dashboard
+# process serves /prom/metrics.  Since prometheus_client histograms are
+# in-process-only, we replay new llm_call lines from the audit file into our
+# local PROM_LLM_DURATION histogram at every scrape, tracking a byte offset
+# so we only parse each line once.
+
+_audit_prom_offset: int = 0  # byte offset of last-read position in audit.jsonl
+
+
+def _sync_audit_to_prom() -> None:
+    """Replay unread audit.jsonl entries into Prometheus metrics.
+
+    Processes two event shapes:
+    - llm_call events (have event_type == "llm_call"): observed into PROM_LLM_DURATION.
+    - tool_call events (have tool_name, no event_type field): increment
+      PROM_TOOL_CALLS{tool_name, status} and PROM_TOOL_ERRORS{tool_name} on error.
+
+    A byte-offset watermark (_audit_prom_offset) ensures each line is processed
+    exactly once across scrapes.  On process startup the offset is 0, so the
+    first scrape performs a full backfill of all historical entries in the file.
+    """
+    global _audit_prom_offset
+    if not _PROM_AVAILABLE:
+        return
+    if not _AUDIT_FILE.exists():
+        return
+    try:
+        with open(_AUDIT_FILE, 'rb') as fh:
+            fh.seek(_audit_prom_offset)
+            new_bytes = fh.read()
+            new_offset = _audit_prom_offset + len(new_bytes)
+        for raw_line in new_bytes.split(b'\n'):
+            raw_line = raw_line.strip()
+            if not raw_line:
+                continue
+            try:
+                entry = json.loads(raw_line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            event_type = entry.get('event_type')
+            if event_type == 'llm_call':
+                # LLM call: observe latency histogram
+                latency = entry.get('latency_ms')
+                if isinstance(latency, (int, float)):
+                    PROM_LLM_DURATION.observe(float(latency))
+            elif 'tool_name' in entry:
+                # Tool call: increment per-tool counters
+                tool_name = entry.get('tool_name') or 'unknown'
+                result_status = entry.get('result_status') or 'unknown'
+                PROM_TOOL_CALLS.labels(tool_name=tool_name, status=result_status).inc()
+                if result_status != 'ok':
+                    PROM_TOOL_ERRORS.labels(tool_name=tool_name).inc()
+        _audit_prom_offset = new_offset
+    except OSError:
+        pass
+
+
+
+# ---------------------------------------------------------------------------
+# Data collection helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_port(host: str, port: int, timeout: float = 1.0) -> bool:
+    """Return True if a TCP connection to host:port succeeds."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _check_llama_server() -> dict[str, Any]:
+    """
+    Hit localhost:8001/health and return a small status dict.
+    Returns: {"status": "ok"|"error"|"unreachable", "detail": str}
+    """
+    url = "http://localhost:8001/health"
+    try:
+        with urllib.request.urlopen(url, timeout=2) as resp:
+            body = resp.read(4096).decode("utf-8", errors="replace")
+            try:
+                data = json.loads(body)
+            except json.JSONDecodeError:
+                data = {"raw": body}
+            # llama.cpp returns {"status": "ok"} when healthy
+            status_val = data.get("status", "")
+            if status_val == "ok" or resp.status == 200:
+                return {"status": "ok", "detail": status_val or "200 OK"}
+            return {"status": "error", "detail": status_val or f"HTTP {resp.status}"}
+    except urllib.error.URLError as exc:
+        return {"status": "unreachable", "detail": str(exc.reason)}
+    except Exception as exc:
+        return {"status": "error", "detail": str(exc)}
+
+
+def _check_gateway(port: int = 18790) -> dict[str, Any]:
+    """Check if the nanobot gateway TCP port is open."""
+    up = _check_port("localhost", port)
+    return {"status": "up" if up else "down", "port": port}
+
+
+def _collect_sessions() -> dict[str, Any]:
+    """Gather session file stats from the sessions directory."""
+    if not _SESSIONS_DIR.exists():
+        return {"count": 0, "last_modified": None, "last_modified_ts": None}
+
+    files = list(_SESSIONS_DIR.glob("*.jsonl"))
+    if not files:
+        return {"count": 0, "last_modified": None, "last_modified_ts": None}
+
+    newest = max(files, key=lambda p: p.stat().st_mtime)
+    mtime = newest.stat().st_mtime
+    dt = datetime.fromtimestamp(mtime, tz=timezone.utc)
+    return {
+        "count": len(files),
+        "last_modified": dt.strftime("%Y-%m-%d %H:%M:%S UTC"),
+        "last_modified_ts": mtime,
+    }
+
+
+def _collect_memory() -> dict[str, Any]:
+    """Return byte sizes of MEMORY.md and HISTORY.md."""
+    def _size(p: Path) -> int:
+        try:
+            return p.stat().st_size
+        except OSError:
+            return 0
+
+    return {
+        "memory_bytes": _size(_MEMORY_FILE),
+        "history_bytes": _size(_HISTORY_FILE),
+        "memory_exists": _MEMORY_FILE.exists(),
+        "history_exists": _HISTORY_FILE.exists(),
+    }
+
+
+def _collect_cron_jobs() -> dict[str, Any]:
+    """Count entries in cron_jobs.json (or the data-dir jobs.json)."""
+    # Try workspace-level file first, then the data-dir location used by CronService
+    candidates = [
+        _CRON_JOBS_FILE,
+        _NANOBOT_DIR / "cron" / "jobs.json",
+    ]
+    for path in candidates:
+        if path.exists():
+            try:
+                with open(path, encoding="utf-8") as f:
+                    data = json.load(f)
+                # CronService stores {"jobs": [...]} or a raw list
+                if isinstance(data, dict):
+                    jobs = data.get("jobs", [])
+                elif isinstance(data, list):
+                    jobs = data
+                else:
+                    jobs = []
+                return {"count": len(jobs), "path": str(path)}
+            except Exception:
+                return {"count": 0, "path": str(path), "error": "parse error"}
+    return {"count": 0, "path": None}
+
+
+def _collect_disk_usage() -> dict[str, Any]:
+    """Walk ~/.nanobot/ and return total bytes used."""
+    total = 0
+    if _NANOBOT_DIR.exists():
+        for dirpath, _dirs, filenames in os.walk(_NANOBOT_DIR):
+            for fname in filenames:
+                try:
+                    total += os.path.getsize(os.path.join(dirpath, fname))
+                except OSError:
+                    pass
+    return {"bytes": total, "human": _human_bytes(total)}
+
+
+def _human_bytes(n: int) -> str:
+    """Format bytes as a human-readable string."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} TB"
+
+
+def _format_uptime(seconds: float) -> str:
+    """Format elapsed seconds as d h m s string."""
+    s = int(seconds)
+    d, s = divmod(s, 86400)
+    h, s = divmod(s, 3600)
+    m, s = divmod(s, 60)
+    parts = []
+    if d:
+        parts.append(f"{d}d")
+    if h:
+        parts.append(f"{h}h")
+    if m:
+        parts.append(f"{m}m")
+    parts.append(f"{s}s")
+    return " ".join(parts)
+
+
+def _parse_query_params(full_path: str) -> dict[str, str]:
+    """Extract query parameters from the full request path."""
+    parsed = urllib.parse.urlparse(full_path)
+    params = urllib.parse.parse_qs(parsed.query)
+    # Flatten: take first value for each key
+    return {k: v[0] for k, v in params.items()}
+
+
+def _redact_sensitive(obj: Any) -> Any:
+    """
+    Recursively walk a JSON-compatible object and fully redact values whose
+    keys look like secrets/tokens/keys.  No partial reveal.
+    """
+    if isinstance(obj, dict):
+        result = {}
+        for k, v in obj.items():
+            if isinstance(v, str) and _SENSITIVE_KEYS.search(k):
+                result[k] = "***REDACTED***"
+            elif isinstance(v, str) and k.lower() in ("extra_headers", "headers"):
+                result[k] = "***REDACTED***"
+            else:
+                result[k] = _redact_sensitive(v)
+        return result
+    elif isinstance(obj, list):
+        return [_redact_sensitive(item) for item in obj]
+    return obj
+
+
+def _parse_yaml_frontmatter(text: str) -> dict[str, str]:
+    """
+    Parse simple YAML frontmatter between --- delimiters.
+    Only handles flat key: value pairs (strings).  Good enough for
+    name/description in SKILL.md files without pulling in PyYAML.
+    """
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return {}
+    result: dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        if ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            result[key] = value
+    return result
+
+
+def _read_file_safe(path: Path) -> str:
+    """Read a text file, returning empty string on any error."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# API status builder
+# ---------------------------------------------------------------------------
+
+
+def build_status() -> dict[str, Any]:
+    """Collect and return the full status payload."""
+    elapsed = time.monotonic() - _START_TIME
+    sessions = _collect_sessions()
+    return {
+        "uptime": _format_uptime(elapsed),
+        "uptime_seconds": round(elapsed, 1),
+        "server_time": datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+        "llama_server": _check_llama_server(),
+        "gateway": _check_gateway(),
+        "sessions": sessions,
+        "last_message_time": sessions.get("last_modified"),
+        "last_message_ts": sessions.get("last_modified_ts"),
+        "memory": _collect_memory(),
+        "cron_jobs": _collect_cron_jobs(),
+        "disk_usage": _collect_disk_usage(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# API endpoint handlers (return dicts or raise)
+# ---------------------------------------------------------------------------
+
+
+def _api_sessions_list() -> list[dict[str, Any]]:
+    """List all sessions with metadata and message counts."""
+    if not _SESSIONS_DIR.exists():
+        return []
+
+    sessions: list[dict[str, Any]] = []
+    for fpath in sorted(_SESSIONS_DIR.glob("*.jsonl")):
+        try:
+            with open(fpath, encoding="utf-8") as f:
+                lines = f.readlines()
+        except OSError:
+            continue
+
+        if not lines:
+            continue
+
+        # First line is metadata
+        metadata: dict[str, Any] = {}
+        try:
+            first = json.loads(lines[0])
+            if first.get("_type") == "metadata":
+                metadata = first
+        except (json.JSONDecodeError, IndexError):
+            pass
+
+        # Message count = total lines minus the metadata line
+        message_count = len(lines) - 1 if metadata else len(lines)
+
+        # Session key: use the key from metadata, or derive from filename
+        key = metadata.get("key", fpath.stem)
+
+        sessions.append({
+            "key": key,
+            "created_at": metadata.get("created_at"),
+            "updated_at": metadata.get("updated_at"),
+            "message_count": message_count,
+        })
+
+    return sessions
+
+
+def _api_session_detail(session_key: str, limit: int | None, offset: int) -> dict[str, Any]:
+    """
+    Get messages for a single session.
+
+    session_key uses underscores in the URL (e.g. discord_1234) which maps
+    to the filename discord_1234.jsonl on disk.
+    """
+    # Validate session key: no path traversal
+    if "/" in session_key or "\\" in session_key or ".." in session_key:
+        return {"error": "Invalid session key"}
+    fpath = _SESSIONS_DIR / f"{session_key}.jsonl"
+    if fpath.resolve().parent != _SESSIONS_DIR.resolve():
+        return {"error": "Invalid session key"}
+    if not fpath.exists():
+        return {"error": f"Session not found: {session_key}"}
+
+    try:
+        with open(fpath, encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError as exc:
+        return {"error": f"Failed to read session: {exc}"}
+
+    # Parse all lines, skip metadata
+    messages: list[dict[str, Any]] = []
+    metadata: dict[str, Any] = {}
+    for i, line in enumerate(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if i == 0 and obj.get("_type") == "metadata":
+            metadata = obj
+            continue
+        messages.append(obj)
+
+    total = len(messages)
+
+    # Apply pagination
+    messages = messages[offset:]
+    if limit is not None:
+        messages = messages[:limit]
+
+    return {
+        "key": metadata.get("key", session_key),
+        "created_at": metadata.get("created_at"),
+        "updated_at": metadata.get("updated_at"),
+        "total_messages": total,
+        "offset": offset,
+        "limit": limit,
+        "messages": messages,
+    }
+
+
+def _api_memory() -> dict[str, Any]:
+    """Return contents of MEMORY.md and HISTORY.md."""
+    return {
+        "memory": _read_file_safe(_MEMORY_FILE),
+        "history": _read_file_safe(_HISTORY_FILE),
+    }
+
+
+def _api_skills() -> list[dict[str, Any]]:
+    """List installed skills by scanning for SKILL.md with YAML frontmatter."""
+    if not _SKILLS_DIR.exists():
+        return []
+
+    skills: list[dict[str, Any]] = []
+    for skill_dir in sorted(_SKILLS_DIR.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.exists():
+            continue
+        content = _read_file_safe(skill_file)
+        if not content:
+            continue
+        frontmatter = _parse_yaml_frontmatter(content)
+        skills.append({
+            "name": frontmatter.get("name", skill_dir.name),
+            "description": frontmatter.get("description", ""),
+        })
+
+    return skills
+
+
+def _api_audit(limit: int) -> list[dict[str, Any]]:
+    """Return the last N audit log entries."""
+    if not _AUDIT_FILE.exists():
+        return []
+
+    try:
+        with open(_AUDIT_FILE, encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError:
+        return []
+
+    # Take the last `limit` lines
+    tail = lines[-limit:] if limit < len(lines) else lines
+
+    entries: list[dict[str, Any]] = []
+    for line in tail:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    return entries
+
+
+_MAX_MESSAGE_CONTENT_LENGTH = 4096
+
+# Simple rate limiter: tracks last N requests per IP
+_rate_limit_log: dict[str, list[float]] = {}
+_RATE_LIMIT_WINDOW = 60.0  # seconds
+_RATE_LIMIT_MAX = 10  # max requests per window
+
+
+def _check_rate_limit(client_ip: str) -> bool:
+    """Return True if the request is within rate limits."""
+    now = time.time()
+    entries = _rate_limit_log.get(client_ip, [])
+    entries = [t for t in entries if now - t < _RATE_LIMIT_WINDOW]
+    if len(entries) >= _RATE_LIMIT_MAX:
+        _rate_limit_log[client_ip] = entries
+        return False
+    entries.append(now)
+    _rate_limit_log[client_ip] = entries
+    return True
+
+
+def _api_post_message(body: dict[str, Any]) -> tuple[dict[str, Any], int]:
+    """
+    Queue a message for the bot by appending to pending_messages.jsonl.
+    Returns (response_dict, http_status).
+    """
+    channel = body.get("channel")
+    chat_id = body.get("chat_id")
+    content = body.get("content")
+
+    if not channel or not chat_id or not content:
+        return {
+            "error": "Missing required fields: channel, chat_id, content"
+        }, 400
+
+    # Validate channel name
+    _VALID_CHANNELS = {"discord", "telegram", "slack", "whatsapp", "feishu",
+                       "matrix", "email", "dingtalk", "qq", "mochat", "cli", "api"}
+    if channel not in _VALID_CHANNELS:
+        return {"error": f"Invalid channel: {channel}"}, 400
+
+    # Enforce content length limit
+    if len(content) > _MAX_MESSAGE_CONTENT_LENGTH:
+        return {"error": f"Content too long (max {_MAX_MESSAGE_CONTENT_LENGTH} chars)"}, 400
+
+    # Screen for prompt injection
+    from nanobot.utils.security import sanitize_input
+    content, was_injection = sanitize_input(content)
+    if was_injection:
+        return {"error": "Message blocked: potential prompt injection detected"}, 400
+
+    entry = {
+        "channel": channel,
+        "chat_id": chat_id,
+        "content": content,
+        "queued_at": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+    try:
+        # Ensure parent directory exists
+        _PENDING_MESSAGES_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(_PENDING_MESSAGES_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError as exc:
+        return {"error": f"Failed to queue message: {exc}"}, 500
+
+    return {"status": "queued"}, 200
+
+
+def _api_metrics() -> dict[str, Any]:
+    """
+    Compute tool-level and timeline metrics from the audit log.
+
+    Returns a dict with keys: tool_stats, timeline, session_stats, overall,
+    recent.
+    """
+    import statistics
+    from collections import defaultdict
+
+    now = time.time()
+    now_dt = datetime.now(tz=timezone.utc)
+    cutoff_24h = now - 86400
+
+    # -- read audit entries ------------------------------------------------
+    entries: list[dict[str, Any]] = []
+    if _AUDIT_FILE.exists():
+        try:
+            with open(_AUDIT_FILE, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            pass
+
+    # -- per-tool accumulators --------------------------------------------
+    tool_counts: dict[str, int] = defaultdict(int)
+    tool_durations: dict[str, list[float]] = defaultdict(list)
+    tool_errors: dict[str, int] = defaultdict(int)
+
+    # -- timeline accumulators (keyed by ISO hour string) ------------------
+    hour_counts: dict[str, int] = defaultdict(int)
+    hour_durations: dict[str, list[float]] = defaultdict(list)
+    hour_errors: dict[str, int] = defaultdict(int)
+
+    # -- session accumulators ---------------------------------------------
+    session_msg_counts: dict[str, int] = defaultdict(int)
+    session_last_seen: dict[str, float] = {}
+
+    # -- overall accumulators ---------------------------------------------
+    all_durations: list[float] = []
+    total_errors = 0
+
+    for entry in entries:
+        ts_str = entry.get("timestamp", "")
+        tool = entry.get("tool_name", "unknown")
+        duration = entry.get("duration_ms")
+        status = entry.get("result_status", "ok")
+        session = entry.get("session_id", "unknown")
+        # channel = entry.get("channel", "unknown")  # available if needed
+
+        # Parse timestamp
+        ts_epoch: float | None = None
+        try:
+            if ts_str:
+                dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                ts_epoch = dt.timestamp()
+        except (ValueError, TypeError):
+            ts_epoch = None
+
+        is_error = status not in ("ok", "success", "")
+
+        # Per-tool stats (all time)
+        tool_counts[tool] += 1
+        if duration is not None:
+            try:
+                dur_f = float(duration)
+                tool_durations[tool].append(dur_f)
+                all_durations.append(dur_f)
+            except (ValueError, TypeError):
+                pass
+        if is_error:
+            tool_errors[tool] += 1
+            total_errors += 1
+
+        # Session tracking
+        session_msg_counts[session] += 1
+        if ts_epoch is not None:
+            session_last_seen[session] = max(
+                session_last_seen.get(session, 0), ts_epoch,
+            )
+
+        # Timeline (last 24h only)
+        if ts_epoch is not None and ts_epoch >= cutoff_24h:
+            # Bucket by hour: "2026-03-16T14"
+            try:
+                hour_key = datetime.fromtimestamp(
+                    ts_epoch, tz=timezone.utc,
+                ).strftime("%Y-%m-%dT%H")
+            except (OSError, ValueError):
+                continue
+            hour_counts[hour_key] += 1
+            if duration is not None:
+                try:
+                    hour_durations[hour_key].append(float(duration))
+                except (ValueError, TypeError):
+                    pass
+            if is_error:
+                hour_errors[hour_key] += 1
+
+    # -- build tool_stats -------------------------------------------------
+    def _percentile(data: list[float], pct: float) -> float:
+        if not data:
+            return 0.0
+        s = sorted(data)
+        k = (len(s) - 1) * pct / 100.0
+        f = int(k)
+        c = f + 1
+        if c >= len(s):
+            return round(s[f], 2)
+        return round(s[f] + (k - f) * (s[c] - s[f]), 2)
+
+    tool_stats: list[dict[str, Any]] = []
+    all_tool_names = sorted(
+        tool_counts.keys() | tool_durations.keys() | tool_errors.keys()
+    )
+    for tool_name in all_tool_names:
+        durs = tool_durations.get(tool_name, [])
+        tool_stats.append({
+            "tool": tool_name,
+            "count": tool_counts.get(tool_name, 0),
+            "avg_ms": round(statistics.mean(durs), 2) if durs else 0,
+            "p50_ms": _percentile(durs, 50),
+            "p95_ms": _percentile(durs, 95),
+            "error_count": tool_errors.get(tool_name, 0),
+        })
+
+    # -- build timeline (24 hour buckets) ---------------------------------
+    timeline: list[dict[str, Any]] = []
+    for h in range(24):
+        dt_hour = now_dt.replace(minute=0, second=0, microsecond=0) - \
+                  timedelta(hours=23 - h)
+        hour_key = dt_hour.strftime("%Y-%m-%dT%H")
+        durs = hour_durations.get(hour_key, [])
+        timeline.append({
+            "hour": hour_key,
+            "count": hour_counts.get(hour_key, 0),
+            "avg_ms": round(statistics.mean(durs), 2) if durs else 0,
+            "errors": hour_errors.get(hour_key, 0),
+        })
+
+    # -- session stats ----------------------------------------------------
+    active_cutoff = now - 3600
+    active_sessions = sum(
+        1 for ts in session_last_seen.values() if ts >= active_cutoff
+    )
+    msg_per_session = list(session_msg_counts.values())
+    session_stats = {
+        "total_sessions": len(session_msg_counts),
+        "active_last_hour": active_sessions,
+        "avg_messages_per_session": round(
+            statistics.mean(msg_per_session), 1,
+        ) if msg_per_session else 0,
+        "max_messages_per_session": max(msg_per_session) if msg_per_session else 0,
+    }
+
+    # -- overall ----------------------------------------------------------
+    total_messages = len(entries)
+    elapsed = time.monotonic() - _START_TIME
+    overall = {
+        "total_messages": total_messages,
+        "avg_response_ms": round(
+            statistics.mean(all_durations), 2,
+        ) if all_durations else 0,
+        "error_rate": round(
+            total_errors / total_messages * 100, 2,
+        ) if total_messages else 0,
+        "uptime": _format_uptime(elapsed),
+        "uptime_seconds": round(elapsed, 1),
+    }
+
+    # -- recent (last 20 entries) -----------------------------------------
+    recent: list[dict[str, Any]] = []
+    for entry in entries[-20:]:
+        recent.append({
+            "timestamp": entry.get("timestamp"),
+            "tool_name": entry.get("tool_name"),
+            "duration_ms": entry.get("duration_ms"),
+            "result_status": entry.get("result_status"),
+            "session_id": entry.get("session_id"),
+            "channel": entry.get("channel"),
+        })
+
+    return {
+        "tool_stats": tool_stats,
+        "timeline": timeline,
+        "session_stats": session_stats,
+        "overall": overall,
+        "recent": recent,
+    }
+
+
+def _api_config() -> dict[str, Any]:
+    """Return sanitized config with secrets redacted."""
+    if not _CONFIG_FILE.exists():
+        return {"error": "Config file not found"}
+
+    try:
+        with open(_CONFIG_FILE, encoding="utf-8") as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"error": f"Failed to read config: {exc}"}
+
+    return _redact_sensitive(config)
+
+
+def _api_architecture() -> dict[str, Any]:
+    """Return system architecture documentation."""
+    if not _ARCHITECTURE_FILE.exists():
+        return {"error": "Architecture file not found"}
+
+    try:
+        with open(_ARCHITECTURE_FILE, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"error": f"Failed to read architecture: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# HTTP request handler
+# ---------------------------------------------------------------------------
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    """Minimal request handler: serves / and /api/* endpoints."""
+
+    # Silence default access log noise; override to log or suppress
+    def log_message(self, fmt: str, *args: Any) -> None:  # noqa: D102
+        pass  # suppress per-request stdout noise; errors still go to stderr
+
+    # ------------------------------------------------------------------
+    # CORS helpers
+    # ------------------------------------------------------------------
+
+    _ORIGIN_RE = re.compile(r'^https?://(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$')
+
+    def _add_cors_headers(self) -> None:
+        """Append CORS and security headers to the current response."""
+        origin = self.headers.get("Origin", "")
+        # Strict localhost-only origin matching (no startswith to prevent localhost.evil.com)
+        if origin and self._ORIGIN_RE.match(origin):
+            self.send_header("Access-Control-Allow-Origin", origin)
+        else:
+            self.send_header("Access-Control-Allow-Origin", "http://localhost:18791")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        # Security headers
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+        )
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+
+    def _check_auth(self, require: bool = False) -> bool:
+        """Check bearer token auth. Returns True if ok.
+
+        If *require* is True, the endpoint is always protected even when
+        no dashboard token has been configured.
+        """
+        if _AUTH_TOKEN is None and not require:
+            return True
+        if _AUTH_TOKEN is None and require:
+            self._send_json({"error": "Unauthorized — set NANOBOT_DASHBOARD_TOKEN to use this endpoint"}, 401)
+            return False
+        auth_header = self.headers.get("Authorization", "")
+        if auth_header == f"Bearer {_AUTH_TOKEN}":
+            return True
+        self._send_json({"error": "Unauthorized"}, 401)
+        return False
+
+    # ------------------------------------------------------------------
+    # Response helpers
+    # ------------------------------------------------------------------
+
+    def _send_json(self, data: Any, status: int = 200) -> None:
+        body = json.dumps(data, indent=2).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-cache")
+        self._add_cors_headers()
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_html(self, html: bytes, status: int = 200) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(html)))
+        self.send_header("Cache-Control", "no-cache")
+        self._add_cors_headers()
+        self.end_headers()
+        self.wfile.write(html)
+
+    def _send_404(self) -> None:
+        body = b"Not Found"
+        self.send_response(404)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self._add_cors_headers()
+        self.end_headers()
+        self.wfile.write(body)
+
+    # ------------------------------------------------------------------
+    # HTTP method handlers
+    # ------------------------------------------------------------------
+
+    def do_OPTIONS(self) -> None:  # noqa: N802
+        """Handle CORS preflight requests."""
+        self.send_response(204)
+        self._add_cors_headers()
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = self.path.split("?")[0].rstrip("/") or "/"
+        params = _parse_query_params(self.path)
+
+        # Require auth for API endpoints
+        if path.startswith("/api/") and not self._check_auth():
+            return
+
+        if path in ("/", "/index.html"):
+            tpl = _TEMPLATES_DIR / "index.html"
+            try:
+                html = tpl.read_bytes()
+                self._send_html(html)
+            except OSError:
+                self._send_html(b"<h1>Template not found</h1>", 500)
+
+        elif path == "/api/status":
+            try:
+                payload = build_status()
+                self._send_json(payload)
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        elif path == "/api/sessions":
+            if not self._check_auth(require=True):
+                return
+            try:
+                self._send_json(_api_sessions_list())
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        elif path.startswith("/api/sessions/"):
+            # Extract session key from /api/sessions/<key>
+            if not self._check_auth(require=True):
+                return
+            session_key = path[len("/api/sessions/"):]
+            if not session_key:
+                self._send_json({"error": "Session key required"}, 400)
+                return
+            try:
+                limit_str = params.get("limit")
+                offset_str = params.get("offset", "0")
+                limit = min(int(limit_str), 1000) if limit_str is not None else None
+                offset = max(int(offset_str), 0)
+            except (ValueError, TypeError):
+                self._send_json({"error": "Invalid limit/offset parameters"}, 400)
+                return
+            try:
+                result = _api_session_detail(session_key, limit, offset)
+                if "error" in result:
+                    is_invalid = result["error"] == "Invalid session key"
+                    self._send_json(result, 400 if is_invalid else 404)
+                    return
+                self._send_json(result)
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        elif path == "/api/memory":
+            if not self._check_auth(require=True):
+                return
+            try:
+                self._send_json(_api_memory())
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        elif path == "/api/skills":
+            try:
+                self._send_json(_api_skills())
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        elif path == "/api/audit":
+            if not self._check_auth(require=True):
+                return
+            try:
+                limit_str = params.get("limit", "50")
+                limit = min(max(int(limit_str), 1), 500)
+            except (ValueError, TypeError):
+                self._send_json({"error": "Invalid limit parameter"}, 400)
+                return
+            try:
+                self._send_json(_api_audit(limit))
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        elif path == "/api/config":
+            # Always require auth — config contains sensitive info
+            if not self._check_auth(require=True):
+                return
+            try:
+                self._send_json(_api_config())
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        elif path == "/api/metrics":
+            if not self._check_auth(require=True):
+                return
+            try:
+                self._send_json(_api_metrics())
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        elif path == "/api/architecture":
+            try:
+                self._send_json(_api_architecture())
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        elif path == "/metrics":
+            tpl = _TEMPLATES_DIR / "metrics.html"
+            try:
+                html = tpl.read_bytes()
+                self._send_html(html)
+            except OSError:
+                self._send_html(b"<h1>Template not found</h1>", 500)
+
+        elif path == "/prom/metrics":
+            if not _PROM_AVAILABLE:
+                self._send_json({"error": "prometheus-client not installed"}, 503)
+                return
+            # Update gauges before serving
+            PROM_UPTIME.set(time.monotonic() - _START_TIME)
+            # Replay new llm_call entries from audit.jsonl into the histogram
+            _sync_audit_to_prom()
+            try:
+                output = generate_latest()
+                self.send_response(200)
+                self.send_header("Content-Type", CONTENT_TYPE_LATEST)
+                self.send_header("Content-Length", str(len(output)))
+                self.end_headers()
+                self.wfile.write(output)
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+
+        else:
+            self._send_404()
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = self.path.split("?")[0].rstrip("/")
+
+        if path.startswith("/api/") and not self._check_auth():
+            return
+
+        if path == "/api/message":
+            # Always require auth for message injection (RCE vector)
+            if not self._check_auth(require=True):
+                return
+            # Rate limit
+            client_ip = self.client_address[0]
+            if not _check_rate_limit(client_ip):
+                self._send_json({"error": "Rate limit exceeded (max 10/min)"}, 429)
+                return
+            # Read and parse JSON body
+            content_length = int(self.headers.get("Content-Length", 0))
+            if content_length == 0:
+                self._send_json({"error": "Empty request body"}, 400)
+                return
+            try:
+                raw = self.rfile.read(content_length)
+                body = json.loads(raw.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                self._send_json({"error": f"Invalid JSON: {exc}"}, 400)
+                return
+
+            try:
+                result, status = _api_post_message(body)
+                self._send_json(result, status)
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, 500)
+        else:
+            self._send_404()
+
+
+# ---------------------------------------------------------------------------
+# Server entry point
+# ---------------------------------------------------------------------------
+
+
+def run(host: str = "127.0.0.1", port: int = 18791) -> None:
+    """Start the dashboard HTTP server (blocking)."""
+    server = HTTPServer((host, port), DashboardHandler)
+    addr = f"http://{host if host != '0.0.0.0' else 'localhost'}:{port}"
+    print(f"Nanobot dashboard running at {addr}")
+    print("Press Ctrl+C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down dashboard.")
+    finally:
+        server.server_close()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m nanobot.dashboard.server",
+        description="Nanobot status dashboard",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind address (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=18791,
+        help="Port to listen on (default: 18791)",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    run(host=args.host, port=args.port)

--- a/nanobot/dashboard/templates/index.html
+++ b/nanobot/dashboard/templates/index.html
@@ -1,0 +1,725 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>nanobot status</title>
+  <style>
+    /* ------------------------------------------------------------------ */
+    /* Reset & base                                                         */
+    /* ------------------------------------------------------------------ */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:          #0d1117;
+      --bg-card:     #161b22;
+      --bg-card-alt: #1c2128;
+      --border:      #30363d;
+      --border-dim:  #21262d;
+      --text:        #c9d1d9;
+      --text-dim:    #8b949e;
+      --text-bright: #f0f6fc;
+      --accent:      #58a6ff;
+      --green:       #3fb950;
+      --red:         #f85149;
+      --yellow:      #d29922;
+      --radius:      8px;
+      --mono:        'Cascadia Code', 'Fira Code', 'JetBrains Mono',
+                     ui-monospace, 'Courier New', monospace;
+    }
+
+    html { font-size: 15px; scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--mono);
+      min-height: 100vh;
+      padding: 0 0 3rem;
+    }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* ------------------------------------------------------------------ */
+    /* Header                                                               */
+    /* ------------------------------------------------------------------ */
+    header {
+      background: var(--bg-card);
+      border-bottom: 1px solid var(--border);
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .header-brand {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-size: 1.15rem;
+      font-weight: 700;
+      color: var(--text-bright);
+      letter-spacing: -0.02em;
+    }
+
+    .header-brand .cat { font-size: 1.4rem; }
+
+    .header-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.2rem;
+      font-size: 0.75rem;
+      color: var(--text-dim);
+    }
+
+    #server-time { color: var(--text); }
+
+    /* ------------------------------------------------------------------ */
+    /* Main layout                                                          */
+    /* ------------------------------------------------------------------ */
+    main {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 0;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Top summary bar                                                      */
+    /* ------------------------------------------------------------------ */
+    .summary-bar {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 0.85rem 1.4rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .summary-item {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+      font-size: 0.8rem;
+      color: var(--text-dim);
+    }
+
+    .summary-item .label { color: var(--text-dim); }
+    .summary-item .value { color: var(--text-bright); font-weight: 600; }
+
+    .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .dot-green  { background: var(--green); box-shadow: 0 0 6px var(--green); }
+    .dot-red    { background: var(--red);   box-shadow: 0 0 6px var(--red); }
+    .dot-yellow { background: var(--yellow); }
+    .dot-grey   { background: var(--text-dim); }
+
+    /* ------------------------------------------------------------------ */
+    /* Card grid                                                            */
+    /* ------------------------------------------------------------------ */
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 1rem;
+    }
+
+    .card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem 1.4rem 1.1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      transition: border-color 0.2s;
+    }
+
+    .card:hover { border-color: var(--accent); }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .card-title {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-dim);
+      font-weight: 600;
+    }
+
+    .badge {
+      font-size: 0.7rem;
+      font-weight: 700;
+      padding: 0.15em 0.55em;
+      border-radius: 4px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .badge-ok     { background: rgba(63,185,80,0.15);  color: var(--green);  border: 1px solid rgba(63,185,80,0.35); }
+    .badge-err    { background: rgba(248,81,73,0.15);  color: var(--red);    border: 1px solid rgba(248,81,73,0.35); }
+    .badge-warn   { background: rgba(210,153,34,0.15); color: var(--yellow); border: 1px solid rgba(210,153,34,0.35); }
+    .badge-grey   { background: rgba(139,148,158,0.15); color: var(--text-dim); border: 1px solid var(--border-dim); }
+
+    .card-value {
+      font-size: 2rem;
+      font-weight: 700;
+      color: var(--text-bright);
+      line-height: 1;
+      letter-spacing: -0.03em;
+    }
+
+    .card-value.small { font-size: 1.1rem; letter-spacing: -0.01em; }
+
+    .card-rows {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .card-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      font-size: 0.78rem;
+      border-top: 1px solid var(--border-dim);
+      padding-top: 0.35rem;
+    }
+
+    .card-row .rk { color: var(--text-dim); }
+    .card-row .rv { color: var(--text); font-weight: 500; }
+    .card-row .rv.ok  { color: var(--green); }
+    .card-row .rv.err { color: var(--red);   }
+
+    /* ------------------------------------------------------------------ */
+    /* Last message section                                                 */
+    /* ------------------------------------------------------------------ */
+    .last-msg-card {
+      grid-column: 1 / -1;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Refresh bar                                                          */
+    /* ------------------------------------------------------------------ */
+    .refresh-bar {
+      margin-bottom: 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 0.75rem;
+      font-size: 0.75rem;
+      color: var(--text-dim);
+    }
+
+    .refresh-bar button {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.75rem;
+      padding: 0.25em 0.75em;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .refresh-bar button:hover { background: var(--bg-card-alt); }
+
+    #refresh-status { opacity: 0.7; }
+
+    /* progress bar that animates toward next auto-refresh */
+    .progress-wrap {
+      width: 120px;
+      height: 3px;
+      background: var(--border);
+      border-radius: 2px;
+      overflow: hidden;
+    }
+
+    #refresh-progress {
+      height: 100%;
+      background: var(--accent);
+      width: 0%;
+      transition: width 1s linear;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Loading / error overlay                                             */
+    /* ------------------------------------------------------------------ */
+    #loading-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(13,17,23,0.85);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.9rem;
+      color: var(--text-dim);
+      z-index: 100;
+    }
+
+    #loading-overlay.hidden { display: none; }
+
+    .spinner {
+      display: inline-block;
+      width: 1em;
+      height: 1em;
+      border: 2px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin-right: 0.5em;
+    }
+
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ------------------------------------------------------------------ */
+    /* Footer                                                               */
+    /* ------------------------------------------------------------------ */
+    footer {
+      text-align: center;
+      font-size: 0.7rem;
+      color: var(--text-dim);
+      margin-top: 3rem;
+      padding: 0 1rem;
+      opacity: 0.6;
+    }
+  </style>
+</head>
+<body>
+
+<div id="loading-overlay">
+  <span class="spinner"></span> Loading status...
+</div>
+
+<header>
+  <div class="header-brand">
+    <span class="cat" aria-hidden="true">&#x1F408;</span>
+    nanobot <span style="color:var(--text-dim);font-weight:400">/ status</span>
+  </div>
+  <div class="header-meta">
+    <span id="server-time">&mdash;</span>
+    <span>auto-refresh every 30s</span>
+  </div>
+</header>
+
+<main>
+  <!-- summary strip -->
+  <div class="summary-bar" id="summary-bar">
+    <div class="summary-item">
+      <div class="dot dot-grey" id="dot-llm"></div>
+      <span class="label">LLM</span>
+      <span class="value" id="sum-llm">&mdash;</span>
+    </div>
+    <div class="summary-item">
+      <div class="dot dot-grey" id="dot-gw"></div>
+      <span class="label">Gateway</span>
+      <span class="value" id="sum-gw">&mdash;</span>
+    </div>
+    <div class="summary-item">
+      <span class="label">Uptime</span>
+      <span class="value" id="sum-uptime">&mdash;</span>
+    </div>
+    <div class="summary-item">
+      <span class="label">Sessions</span>
+      <span class="value" id="sum-sessions">&mdash;</span>
+    </div>
+    <div class="summary-item">
+      <span class="label">Cron jobs</span>
+      <span class="value" id="sum-cron">&mdash;</span>
+    </div>
+    <div class="summary-item">
+      <span class="label">Disk</span>
+      <span class="value" id="sum-disk">&mdash;</span>
+    </div>
+  </div>
+
+  <!-- refresh controls -->
+  <div class="refresh-bar">
+    <span id="refresh-status">last fetched &mdash;</span>
+    <div class="progress-wrap" title="next auto-refresh">
+      <div id="refresh-progress"></div>
+    </div>
+    <button id="btn-refresh" onclick="fetchAndRender()">refresh now</button>
+  </div>
+
+  <!-- card grid -->
+  <div class="grid" id="card-grid">
+
+    <!-- LLM Server card -->
+    <div class="card" id="card-llm">
+      <div class="card-header">
+        <span class="card-title">LLM Server</span>
+        <span class="badge badge-grey" id="badge-llm">...</span>
+      </div>
+      <div class="card-value small" id="val-llm">&mdash;</div>
+      <div class="card-rows">
+        <div class="card-row">
+          <span class="rk">endpoint</span>
+          <span class="rv">localhost:8001</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">health path</span>
+          <span class="rv">/health</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">detail</span>
+          <span class="rv" id="llm-detail">&mdash;</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Gateway card -->
+    <div class="card" id="card-gw">
+      <div class="card-header">
+        <span class="card-title">Gateway</span>
+        <span class="badge badge-grey" id="badge-gw">...</span>
+      </div>
+      <div class="card-value small" id="val-gw">&mdash;</div>
+      <div class="card-rows">
+        <div class="card-row">
+          <span class="rk">port</span>
+          <span class="rv" id="gw-port">&mdash;</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">check</span>
+          <span class="rv">TCP connect</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Uptime card -->
+    <div class="card">
+      <div class="card-header">
+        <span class="card-title">Dashboard Uptime</span>
+        <span class="badge badge-ok">live</span>
+      </div>
+      <div class="card-value" id="val-uptime">&mdash;</div>
+      <div class="card-rows">
+        <div class="card-row">
+          <span class="rk">dashboard port</span>
+          <span class="rv">18791</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">server time</span>
+          <span class="rv" id="row-server-time">&mdash;</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Sessions card -->
+    <div class="card">
+      <div class="card-header">
+        <span class="card-title">Sessions</span>
+        <span class="badge badge-grey" id="badge-sessions">...</span>
+      </div>
+      <div class="card-value" id="val-sessions">&mdash;</div>
+      <div class="card-rows">
+        <div class="card-row">
+          <span class="rk">path</span>
+          <span class="rv" style="font-size:0.68rem">~/.nanobot/workspace/sessions/</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">format</span>
+          <span class="rv">*.jsonl</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">most recent</span>
+          <span class="rv" id="session-mtime">&mdash;</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Memory card -->
+    <div class="card">
+      <div class="card-header">
+        <span class="card-title">Memory</span>
+        <span class="badge badge-grey" id="badge-memory">...</span>
+      </div>
+      <div class="card-value small" id="val-memory">&mdash;</div>
+      <div class="card-rows">
+        <div class="card-row">
+          <span class="rk">MEMORY.md</span>
+          <span class="rv" id="mem-memory">&mdash;</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">HISTORY.md</span>
+          <span class="rv" id="mem-history">&mdash;</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">path</span>
+          <span class="rv" style="font-size:0.68rem">~/.nanobot/workspace/memory/</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Cron card -->
+    <div class="card">
+      <div class="card-header">
+        <span class="card-title">Cron Jobs</span>
+        <span class="badge badge-grey" id="badge-cron">...</span>
+      </div>
+      <div class="card-value" id="val-cron">&mdash;</div>
+      <div class="card-rows">
+        <div class="card-row">
+          <span class="rk">store path</span>
+          <span class="rv" id="cron-path" style="font-size:0.68rem">&mdash;</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Disk Usage card -->
+    <div class="card">
+      <div class="card-header">
+        <span class="card-title">Disk Usage</span>
+        <span class="badge badge-grey" id="badge-disk">info</span>
+      </div>
+      <div class="card-value" id="val-disk">&mdash;</div>
+      <div class="card-rows">
+        <div class="card-row">
+          <span class="rk">root</span>
+          <span class="rv" style="font-size:0.68rem">~/.nanobot/</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">bytes</span>
+          <span class="rv" id="disk-bytes">&mdash;</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Last message card (full width) -->
+    <div class="card last-msg-card">
+      <div class="card-header">
+        <span class="card-title">Last Activity</span>
+        <span class="badge badge-grey" id="badge-activity">...</span>
+      </div>
+      <div class="card-value small" id="val-last-msg">&mdash;</div>
+      <div class="card-rows">
+        <div class="card-row">
+          <span class="rk">relative</span>
+          <span class="rv" id="last-msg-rel">&mdash;</span>
+        </div>
+        <div class="card-row">
+          <span class="rk">source</span>
+          <span class="rv">most recently modified session file</span>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- /.grid -->
+</main>
+
+<footer>
+  nanobot dashboard &mdash; port 18791 &mdash; no external dependencies
+</footer>
+
+<script>
+  /* ------------------------------------------------------------------ */
+  /* Helpers                                                               */
+  /* ------------------------------------------------------------------ */
+
+  function el(id) { return document.getElementById(id); }
+
+  function humanBytes(n) {
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let u = 0;
+    while (n >= 1024 && u < units.length - 1) { n /= 1024; u++; }
+    return n.toFixed(1) + ' ' + units[u];
+  }
+
+  function relativeTime(tsSeconds) {
+    if (!tsSeconds) return 'never';
+    const diff = Math.floor(Date.now() / 1000 - tsSeconds);
+    if (diff < 5)   return 'just now';
+    if (diff < 60)  return `${diff}s ago`;
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+    return `${Math.floor(diff / 86400)}d ago`;
+  }
+
+  /* badge helpers */
+  function setBadge(id, cls, text) {
+    const b = el(id);
+    b.className = 'badge ' + cls;
+    b.textContent = text;
+  }
+
+  /* coloured dot */
+  function setDot(id, cls) {
+    el(id).className = 'dot ' + cls;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Render                                                                */
+  /* ------------------------------------------------------------------ */
+
+  function render(data) {
+    /* Header / summary */
+    el('server-time').textContent  = data.server_time || '—';
+    el('row-server-time').textContent = data.server_time || '—';
+
+    /* Uptime */
+    el('val-uptime').textContent  = data.uptime || '—';
+    el('sum-uptime').textContent  = data.uptime || '—';
+
+    /* LLM Server */
+    const llm = data.llama_server || {};
+    const llmOk = llm.status === 'ok';
+    const llmDown = llm.status === 'unreachable';
+    el('val-llm').textContent = llmOk ? 'healthy' : (llmDown ? 'unreachable' : (llm.status || '—'));
+    el('llm-detail').textContent = llm.detail || '—';
+    setBadge('badge-llm', llmOk ? 'badge-ok' : (llmDown ? 'badge-err' : 'badge-warn'),
+             llmOk ? 'ok' : (llmDown ? 'down' : 'error'));
+    setDot('dot-llm', llmOk ? 'dot-green' : 'dot-red');
+    el('sum-llm').textContent = llmOk ? 'ok' : (llmDown ? 'down' : 'err');
+
+    /* Gateway */
+    const gw = data.gateway || {};
+    const gwUp = gw.status === 'up';
+    el('val-gw').textContent  = gwUp ? 'up' : 'down';
+    el('gw-port').textContent = gw.port || '18790';
+    setBadge('badge-gw', gwUp ? 'badge-ok' : 'badge-err', gwUp ? 'up' : 'down');
+    setDot('dot-gw', gwUp ? 'dot-green' : 'dot-red');
+    el('sum-gw').textContent = gwUp ? 'up' : 'down';
+
+    /* Sessions */
+    const sess = data.sessions || {};
+    const sessCount = sess.count ?? 0;
+    el('val-sessions').textContent     = sessCount;
+    el('session-mtime').textContent    = sess.last_modified || 'none';
+    el('sum-sessions').textContent     = sessCount;
+    setBadge('badge-sessions', sessCount > 0 ? 'badge-ok' : 'badge-grey',
+             sessCount > 0 ? sessCount + ' files' : 'empty');
+
+    /* Memory */
+    const mem = data.memory || {};
+    const memTotal = (mem.memory_bytes || 0) + (mem.history_bytes || 0);
+    el('val-memory').textContent  = humanBytes(memTotal);
+    el('mem-memory').textContent  = mem.memory_exists
+      ? humanBytes(mem.memory_bytes || 0) : 'not found';
+    el('mem-history').textContent = mem.history_exists
+      ? humanBytes(mem.history_bytes || 0) : 'not found';
+    const memOk = mem.memory_exists || mem.history_exists;
+    setBadge('badge-memory', memOk ? 'badge-ok' : 'badge-warn', memOk ? 'found' : 'missing');
+
+    /* Cron */
+    const cron = data.cron_jobs || {};
+    const cronCount = cron.count ?? 0;
+    el('val-cron').textContent  = cronCount;
+    el('sum-cron').textContent  = cronCount;
+    el('cron-path').textContent = cron.path || '—';
+    setBadge('badge-cron', cronCount > 0 ? 'badge-ok' : 'badge-grey',
+             cronCount > 0 ? cronCount + ' jobs' : 'none');
+
+    /* Disk */
+    const disk = data.disk_usage || {};
+    el('val-disk').textContent   = disk.human || humanBytes(disk.bytes || 0);
+    el('disk-bytes').textContent = (disk.bytes || 0).toLocaleString() + ' B';
+    el('sum-disk').textContent   = disk.human || '—';
+    setBadge('badge-disk', 'badge-grey', 'info');
+
+    /* Last activity */
+    const lmt = data.last_message_ts;
+    const lmtStr = data.last_message_time;
+    el('val-last-msg').textContent  = lmtStr || 'no sessions yet';
+    el('last-msg-rel').textContent  = relativeTime(lmt);
+    const actBadge = lmt
+      ? (Date.now() / 1000 - lmt < 3600 ? 'badge-ok' : 'badge-grey')
+      : 'badge-grey';
+    setBadge('badge-activity', actBadge, lmt ? 'recent' : 'idle');
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Fetch                                                                 */
+  /* ------------------------------------------------------------------ */
+
+  let _lastFetchTs = null;
+
+  async function fetchAndRender() {
+    el('btn-refresh').disabled = true;
+    try {
+      const resp = await fetch('/api/status');
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      const data = await resp.json();
+      render(data);
+      _lastFetchTs = Date.now();
+      el('refresh-status').textContent =
+        'last fetched ' + new Date(_lastFetchTs).toLocaleTimeString();
+      el('loading-overlay').classList.add('hidden');
+    } catch (err) {
+      el('refresh-status').textContent = 'fetch error: ' + err.message;
+    } finally {
+      el('btn-refresh').disabled = false;
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Auto-refresh with progress bar                                        */
+  /* ------------------------------------------------------------------ */
+
+  const REFRESH_INTERVAL_MS = 30_000;
+  let _refreshTimer  = null;
+  let _progressTimer = null;
+
+  function startRefreshCycle() {
+    /* animate progress bar from 0 -> 100% over REFRESH_INTERVAL_MS */
+    const bar = el('refresh-progress');
+    bar.style.transition = 'none';
+    bar.style.width = '0%';
+
+    /* tiny delay so the browser picks up the 0% reset before animating */
+    setTimeout(() => {
+      bar.style.transition = `width ${REFRESH_INTERVAL_MS / 1000}s linear`;
+      bar.style.width = '100%';
+    }, 50);
+
+    clearTimeout(_refreshTimer);
+    _refreshTimer = setTimeout(async () => {
+      await fetchAndRender();
+      startRefreshCycle();
+    }, REFRESH_INTERVAL_MS);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Relative-time ticker (updates every 10s without a full fetch)        */
+  /* ------------------------------------------------------------------ */
+
+  function tickRelativeTimes() {
+    /* We keep a module-level cache of last_message_ts from most recent fetch */
+    if (window._lastMsgTs !== undefined) {
+      el('last-msg-rel').textContent = relativeTime(window._lastMsgTs);
+    }
+  }
+
+  /* Patch render() to cache the ts */
+  const _origRender = render;
+  function render(data) {
+    window._lastMsgTs = data.last_message_ts || null;
+    _origRender(data);
+  }
+
+  setInterval(tickRelativeTimes, 10_000);
+
+  /* ------------------------------------------------------------------ */
+  /* Boot                                                                  */
+  /* ------------------------------------------------------------------ */
+
+  fetchAndRender().then(startRefreshCycle);
+</script>
+</body>
+</html>

--- a/nanobot/dashboard/templates/metrics.html
+++ b/nanobot/dashboard/templates/metrics.html
@@ -1,0 +1,751 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>nanobot metrics</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <style>
+    /* ------------------------------------------------------------------ */
+    /* Reset & base (matches index.html dark theme)                        */
+    /* ------------------------------------------------------------------ */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:          #0d1117;
+      --bg-card:     #161b22;
+      --bg-card-alt: #1c2128;
+      --border:      #30363d;
+      --border-dim:  #21262d;
+      --text:        #c9d1d9;
+      --text-dim:    #8b949e;
+      --text-bright: #f0f6fc;
+      --accent:      #58a6ff;
+      --green:       #3fb950;
+      --red:         #f85149;
+      --yellow:      #d29922;
+      --orange:      #db8b2f;
+      --purple:      #bc8cff;
+      --radius:      8px;
+      --mono:        'Cascadia Code', 'Fira Code', 'JetBrains Mono',
+                     ui-monospace, 'Courier New', monospace;
+    }
+
+    html { font-size: 15px; scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--mono);
+      min-height: 100vh;
+      padding: 0 0 3rem;
+    }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* ------------------------------------------------------------------ */
+    /* Header                                                               */
+    /* ------------------------------------------------------------------ */
+    header {
+      background: var(--bg-card);
+      border-bottom: 1px solid var(--border);
+      padding: 1rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .header-brand {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-size: 1.15rem;
+      font-weight: 700;
+      color: var(--text-bright);
+      letter-spacing: -0.02em;
+    }
+
+    .header-brand .cat { font-size: 1.4rem; }
+
+    .header-nav {
+      display: flex;
+      align-items: center;
+      gap: 1.2rem;
+      font-size: 0.8rem;
+    }
+
+    .header-nav a {
+      color: var(--text-dim);
+      transition: color 0.15s;
+    }
+
+    .header-nav a:hover,
+    .header-nav a.active {
+      color: var(--accent);
+      text-decoration: none;
+    }
+
+    .header-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.2rem;
+      font-size: 0.75rem;
+      color: var(--text-dim);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Main layout                                                          */
+    /* ------------------------------------------------------------------ */
+    main {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 0;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Summary cards row                                                    */
+    /* ------------------------------------------------------------------ */
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .summary-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.1rem 1.3rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.3rem;
+      transition: border-color 0.2s;
+    }
+
+    .summary-card:hover { border-color: var(--accent); }
+
+    .summary-card .label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-dim);
+      font-weight: 600;
+    }
+
+    .summary-card .value {
+      font-size: 1.8rem;
+      font-weight: 700;
+      color: var(--text-bright);
+      line-height: 1.1;
+      letter-spacing: -0.03em;
+    }
+
+    .summary-card .sub {
+      font-size: 0.72rem;
+      color: var(--text-dim);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Chart cards                                                          */
+    /* ------------------------------------------------------------------ */
+    .chart-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(540px, 1fr));
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .chart-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem 1.4rem 1rem;
+      transition: border-color 0.2s;
+    }
+
+    .chart-card:hover { border-color: var(--accent); }
+
+    .chart-card .chart-title {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-dim);
+      font-weight: 600;
+      margin-bottom: 0.8rem;
+    }
+
+    .chart-card canvas {
+      width: 100% !important;
+      max-height: 280px;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Recent table                                                         */
+    /* ------------------------------------------------------------------ */
+    .recent-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem 1.4rem 1rem;
+      margin-bottom: 1.5rem;
+      overflow-x: auto;
+    }
+
+    .recent-card .chart-title {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-dim);
+      font-weight: 600;
+      margin-bottom: 0.8rem;
+    }
+
+    .recent-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.78rem;
+    }
+
+    .recent-table th {
+      text-align: left;
+      color: var(--text-dim);
+      font-weight: 600;
+      padding: 0.4rem 0.6rem;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .recent-table td {
+      padding: 0.4rem 0.6rem;
+      border-bottom: 1px solid var(--border-dim);
+      color: var(--text);
+    }
+
+    .recent-table tr:hover td {
+      background: var(--bg-card-alt);
+    }
+
+    .status-ok { color: var(--green); }
+    .status-err { color: var(--red); }
+
+    /* ------------------------------------------------------------------ */
+    /* Refresh bar                                                          */
+    /* ------------------------------------------------------------------ */
+    .refresh-bar {
+      margin-bottom: 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 0.75rem;
+      font-size: 0.75rem;
+      color: var(--text-dim);
+    }
+
+    .refresh-bar button {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      color: var(--accent);
+      font-family: var(--mono);
+      font-size: 0.75rem;
+      padding: 0.25em 0.75em;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .refresh-bar button:hover { background: var(--bg-card-alt); }
+
+    .progress-wrap {
+      width: 120px;
+      height: 3px;
+      background: var(--border);
+      border-radius: 2px;
+      overflow: hidden;
+    }
+
+    #refresh-progress {
+      height: 100%;
+      background: var(--accent);
+      width: 0%;
+      transition: width 1s linear;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Loading overlay                                                      */
+    /* ------------------------------------------------------------------ */
+    #loading-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(13,17,23,0.85);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.9rem;
+      color: var(--text-dim);
+      z-index: 100;
+    }
+
+    #loading-overlay.hidden { display: none; }
+
+    .spinner {
+      display: inline-block;
+      width: 1em;
+      height: 1em;
+      border: 2px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin-right: 0.5em;
+    }
+
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ------------------------------------------------------------------ */
+    /* Footer                                                               */
+    /* ------------------------------------------------------------------ */
+    footer {
+      text-align: center;
+      font-size: 0.7rem;
+      color: var(--text-dim);
+      margin-top: 3rem;
+      padding: 0 1rem;
+      opacity: 0.6;
+    }
+
+    @media (max-width: 600px) {
+      .chart-grid { grid-template-columns: 1fr; }
+      .summary-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+  </style>
+</head>
+<body>
+
+<div id="loading-overlay">
+  <span class="spinner"></span> Loading metrics...
+</div>
+
+<header>
+  <div class="header-brand">
+    <span class="cat" aria-hidden="true">&#x1F408;</span>
+    nanobot <span style="color:var(--text-dim);font-weight:400">/ metrics</span>
+  </div>
+  <div class="header-nav">
+    <a href="/">status</a>
+    <a href="/metrics" class="active">metrics</a>
+  </div>
+  <div class="header-meta">
+    <span id="last-update">&mdash;</span>
+    <span>auto-refresh every 60s</span>
+  </div>
+</header>
+
+<main>
+  <!-- Summary cards -->
+  <div class="summary-grid">
+    <div class="summary-card">
+      <span class="label">Total Messages</span>
+      <span class="value" id="sum-total">--</span>
+      <span class="sub">all time</span>
+    </div>
+    <div class="summary-card">
+      <span class="label">Avg Response Time</span>
+      <span class="value" id="sum-avg-ms">--</span>
+      <span class="sub">milliseconds</span>
+    </div>
+    <div class="summary-card">
+      <span class="label">Error Rate</span>
+      <span class="value" id="sum-error-rate">--</span>
+      <span class="sub">percent</span>
+    </div>
+    <div class="summary-card">
+      <span class="label">Active Sessions</span>
+      <span class="value" id="sum-active">--</span>
+      <span class="sub">last hour</span>
+    </div>
+  </div>
+
+  <!-- Refresh controls -->
+  <div class="refresh-bar">
+    <span id="refresh-status">last fetched &mdash;</span>
+    <div class="progress-wrap" title="next auto-refresh">
+      <div id="refresh-progress"></div>
+    </div>
+    <button id="btn-refresh" onclick="fetchMetrics()">refresh now</button>
+  </div>
+
+  <!-- Chart grid -->
+  <div class="chart-grid">
+    <div class="chart-card">
+      <div class="chart-title">Response Latency Timeline (24h)</div>
+      <canvas id="chart-latency"></canvas>
+    </div>
+    <div class="chart-card">
+      <div class="chart-title">Error Rate (24h)</div>
+      <canvas id="chart-errors"></canvas>
+    </div>
+    <div class="chart-card">
+      <div class="chart-title">Tool Usage (call count)</div>
+      <canvas id="chart-tool-usage"></canvas>
+    </div>
+    <div class="chart-card">
+      <div class="chart-title">Tool Performance (avg ms)</div>
+      <canvas id="chart-tool-perf"></canvas>
+    </div>
+  </div>
+
+  <!-- Recent executions table -->
+  <div class="recent-card">
+    <div class="chart-title">Recent Tool Executions</div>
+    <table class="recent-table">
+      <thead>
+        <tr>
+          <th>Timestamp</th>
+          <th>Tool</th>
+          <th>Duration (ms)</th>
+          <th>Status</th>
+          <th>Session</th>
+          <th>Channel</th>
+        </tr>
+      </thead>
+      <tbody id="recent-tbody">
+        <tr><td colspan="6" style="color:var(--text-dim)">Loading...</td></tr>
+      </tbody>
+    </table>
+  </div>
+</main>
+
+<footer>
+  nanobot metrics dashboard &mdash; port 18791
+</footer>
+
+<script>
+  /* ------------------------------------------------------------------ */
+  /* Helpers                                                               */
+  /* ------------------------------------------------------------------ */
+  function el(id) { return document.getElementById(id); }
+
+  /* Chart.js global defaults for dark theme */
+  Chart.defaults.color = '#8b949e';
+  Chart.defaults.borderColor = '#21262d';
+  Chart.defaults.font.family = "'Cascadia Code', 'Fira Code', monospace";
+  Chart.defaults.font.size = 11;
+
+  /* Chart instances (so we can destroy + recreate on refresh) */
+  let chartLatency = null;
+  let chartErrors = null;
+  let chartToolUsage = null;
+  let chartToolPerf = null;
+
+  /* ------------------------------------------------------------------ */
+  /* Render summary cards                                                  */
+  /* ------------------------------------------------------------------ */
+  function renderSummary(data) {
+    const ov = data.overall || {};
+    const ss = data.session_stats || {};
+
+    el('sum-total').textContent = (ov.total_messages || 0).toLocaleString();
+    el('sum-avg-ms').textContent = (ov.avg_response_ms || 0).toFixed(1);
+    el('sum-error-rate').textContent = (ov.error_rate || 0).toFixed(2) + '%';
+    el('sum-active').textContent = ss.active_last_hour || 0;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Render charts                                                         */
+  /* ------------------------------------------------------------------ */
+  function formatHourLabel(isoHour) {
+    /* "2026-03-16T14" -> "14:00" */
+    const parts = isoHour.split('T');
+    if (parts.length === 2) return parts[1] + ':00';
+    return isoHour;
+  }
+
+  function renderLatencyChart(timeline) {
+    const labels = timeline.map(t => formatHourLabel(t.hour));
+    const values = timeline.map(t => t.avg_ms);
+
+    if (chartLatency) chartLatency.destroy();
+    chartLatency = new Chart(el('chart-latency'), {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Avg Latency (ms)',
+          data: values,
+          borderColor: '#58a6ff',
+          backgroundColor: 'rgba(88, 166, 255, 0.1)',
+          fill: true,
+          tension: 0.3,
+          pointRadius: 3,
+          pointBackgroundColor: '#58a6ff',
+          borderWidth: 2,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+        },
+        scales: {
+          x: {
+            grid: { color: '#21262d' },
+            ticks: { maxRotation: 45, maxTicksLimit: 12 },
+          },
+          y: {
+            grid: { color: '#21262d' },
+            beginAtZero: true,
+            title: { display: true, text: 'ms', color: '#8b949e' },
+          },
+        },
+      },
+    });
+  }
+
+  function renderErrorChart(timeline) {
+    const labels = timeline.map(t => formatHourLabel(t.hour));
+    const values = timeline.map(t => t.errors);
+
+    if (chartErrors) chartErrors.destroy();
+    chartErrors = new Chart(el('chart-errors'), {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Errors',
+          data: values,
+          borderColor: '#f85149',
+          backgroundColor: 'rgba(248, 81, 73, 0.1)',
+          fill: true,
+          tension: 0.3,
+          pointRadius: 3,
+          pointBackgroundColor: '#f85149',
+          borderWidth: 2,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+        },
+        scales: {
+          x: {
+            grid: { color: '#21262d' },
+            ticks: { maxRotation: 45, maxTicksLimit: 12 },
+          },
+          y: {
+            grid: { color: '#21262d' },
+            beginAtZero: true,
+            title: { display: true, text: 'errors', color: '#8b949e' },
+          },
+        },
+      },
+    });
+  }
+
+  function renderToolUsageChart(toolStats) {
+    /* Sort by count descending, take top 15 */
+    const sorted = [...toolStats].sort((a, b) => b.count - a.count).slice(0, 15);
+    const labels = sorted.map(t => t.tool);
+    const values = sorted.map(t => t.count);
+
+    /* Generate colours: accent-based gradient */
+    const colours = sorted.map((_, i) => {
+      const hue = 210 + (i * 17) % 60;
+      return `hsla(${hue}, 70%, 60%, 0.85)`;
+    });
+
+    if (chartToolUsage) chartToolUsage.destroy();
+    chartToolUsage = new Chart(el('chart-tool-usage'), {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Call Count',
+          data: values,
+          backgroundColor: colours,
+          borderColor: colours.map(c => c.replace('0.85', '1')),
+          borderWidth: 1,
+          borderRadius: 3,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        indexAxis: 'y',
+        plugins: {
+          legend: { display: false },
+        },
+        scales: {
+          x: {
+            grid: { color: '#21262d' },
+            beginAtZero: true,
+            title: { display: true, text: 'calls', color: '#8b949e' },
+          },
+          y: {
+            grid: { display: false },
+          },
+        },
+      },
+    });
+  }
+
+  function renderToolPerfChart(toolStats) {
+    /* Sort by avg_ms descending, take top 15 */
+    const sorted = [...toolStats]
+      .filter(t => t.avg_ms > 0)
+      .sort((a, b) => b.avg_ms - a.avg_ms)
+      .slice(0, 15);
+    const labels = sorted.map(t => t.tool);
+    const avgVals = sorted.map(t => t.avg_ms);
+    const p95Vals = sorted.map(t => t.p95_ms);
+
+    if (chartToolPerf) chartToolPerf.destroy();
+    chartToolPerf = new Chart(el('chart-tool-perf'), {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            label: 'Avg (ms)',
+            data: avgVals,
+            backgroundColor: 'rgba(88, 166, 255, 0.7)',
+            borderColor: 'rgba(88, 166, 255, 1)',
+            borderWidth: 1,
+            borderRadius: 3,
+          },
+          {
+            label: 'P95 (ms)',
+            data: p95Vals,
+            backgroundColor: 'rgba(210, 153, 34, 0.5)',
+            borderColor: 'rgba(210, 153, 34, 1)',
+            borderWidth: 1,
+            borderRadius: 3,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            labels: { boxWidth: 12, padding: 16 },
+          },
+        },
+        scales: {
+          x: {
+            grid: { display: false },
+            ticks: { maxRotation: 45 },
+          },
+          y: {
+            grid: { color: '#21262d' },
+            beginAtZero: true,
+            title: { display: true, text: 'ms', color: '#8b949e' },
+          },
+        },
+      },
+    });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Render recent executions table                                        */
+  /* ------------------------------------------------------------------ */
+  function renderRecent(recent) {
+    const tbody = el('recent-tbody');
+    if (!recent || recent.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="6" style="color:var(--text-dim)">No recent executions</td></tr>';
+      return;
+    }
+
+    /* Show newest first */
+    const rows = [...recent].reverse();
+    tbody.innerHTML = rows.map(r => {
+      const ts = r.timestamp || '--';
+      const tool = r.tool_name || '--';
+      const dur = r.duration_ms != null ? r.duration_ms.toFixed(1) : '--';
+      const status = r.result_status || 'ok';
+      const isErr = status !== 'ok' && status !== 'success' && status !== '';
+      const statusCls = isErr ? 'status-err' : 'status-ok';
+      const session = r.session_id || '--';
+      const channel = r.channel || '--';
+
+      /* Truncate long timestamps for readability */
+      let tsShort = ts;
+      if (ts.length > 19) tsShort = ts.substring(11, 19);
+
+      return `<tr>
+        <td>${tsShort}</td>
+        <td>${tool}</td>
+        <td>${dur}</td>
+        <td class="${statusCls}">${status}</td>
+        <td style="font-size:0.7rem;color:var(--text-dim)">${session.substring(0, 12)}</td>
+        <td>${channel}</td>
+      </tr>`;
+    }).join('');
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Fetch & render                                                        */
+  /* ------------------------------------------------------------------ */
+  async function fetchMetrics() {
+    el('btn-refresh').disabled = true;
+    try {
+      const resp = await fetch('/api/metrics');
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      const data = await resp.json();
+
+      renderSummary(data);
+      renderLatencyChart(data.timeline || []);
+      renderErrorChart(data.timeline || []);
+      renderToolUsageChart(data.tool_stats || []);
+      renderToolPerfChart(data.tool_stats || []);
+      renderRecent(data.recent || []);
+
+      el('last-update').textContent = new Date().toLocaleTimeString();
+      el('refresh-status').textContent = 'last fetched ' + new Date().toLocaleTimeString();
+      el('loading-overlay').classList.add('hidden');
+    } catch (err) {
+      el('refresh-status').textContent = 'fetch error: ' + err.message;
+      el('loading-overlay').classList.add('hidden');
+    } finally {
+      el('btn-refresh').disabled = false;
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Auto-refresh with progress bar                                        */
+  /* ------------------------------------------------------------------ */
+  const REFRESH_INTERVAL_MS = 60_000;
+  let _refreshTimer = null;
+
+  function startRefreshCycle() {
+    const bar = el('refresh-progress');
+    bar.style.transition = 'none';
+    bar.style.width = '0%';
+
+    setTimeout(() => {
+      bar.style.transition = `width ${REFRESH_INTERVAL_MS / 1000}s linear`;
+      bar.style.width = '100%';
+    }, 50);
+
+    clearTimeout(_refreshTimer);
+    _refreshTimer = setTimeout(async () => {
+      await fetchMetrics();
+      startRefreshCycle();
+    }, REFRESH_INTERVAL_MS);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Boot                                                                  */
+  /* ------------------------------------------------------------------ */
+  fetchMetrics().then(startRefreshCycle);
+</script>
+</body>
+</html>

--- a/nanobot/providers/__init__.py
+++ b/nanobot/providers/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "OpenAICodexProvider",
     "GitHubCopilotProvider",
     "AzureOpenAIProvider",
+    "CustomProvider",
 ]
 
 _LAZY_IMPORTS = {
@@ -23,11 +24,13 @@ _LAZY_IMPORTS = {
     "OpenAICodexProvider": ".openai_codex_provider",
     "GitHubCopilotProvider": ".github_copilot_provider",
     "AzureOpenAIProvider": ".azure_openai_provider",
+    "CustomProvider": ".custom_provider",
 }
 
 if TYPE_CHECKING:
     from nanobot.providers.anthropic_provider import AnthropicProvider
     from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+    from nanobot.providers.custom_provider import CustomProvider
     from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
     from nanobot.providers.openai_compat_provider import OpenAICompatProvider
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -54,6 +54,7 @@ class LLMResponse:
     retry_after: float | None = None  # Provider supplied retry wait in seconds.
     reasoning_content: str | None = None  # Kimi, DeepSeek-R1, MiMo etc.
     thinking_blocks: list[dict] | None = None  # Anthropic extended thinking
+    ttft_ms: float | None = None  # Time to first token (streaming only)
     # Structured error metadata used by retry policy when finish_reason == "error".
     error_status_code: int | None = None
     error_kind: str | None = None  # e.g. "timeout", "connection"
@@ -204,12 +205,6 @@ class LLMProvider(ABC):
                         clean["content"] = "(empty)"
                     result.append(clean)
                     continue
-
-            if isinstance(content, dict):
-                clean = dict(msg)
-                clean["content"] = [content]
-                result.append(clean)
-                continue
 
             result.append(msg)
         return result

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -1,0 +1,126 @@
+"""Direct OpenAI-compatible provider — bypasses LiteLLM."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import time as _time
+
+import json_repair
+from openai import AsyncOpenAI
+
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+
+
+class CustomProvider(LLMProvider):
+
+    def __init__(self, api_key: str = "no-key", api_base: str = "http://localhost:8000/v1", default_model: str = "default"):
+        super().__init__(api_key, api_base)
+        self.default_model = default_model
+        self._client = AsyncOpenAI(api_key=api_key, base_url=api_base)
+
+    async def chat(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
+                   model: str | None = None, max_tokens: int = 4096, temperature: float = 0.7) -> LLMResponse:
+        kwargs: dict[str, Any] = {
+            "model": model or self.default_model,
+            "messages": self._sanitize_empty_content(messages),
+            "max_tokens": max(1, max_tokens),
+            "temperature": temperature,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        if tools:
+            kwargs.update(tools=tools, tool_choice="auto")
+        try:
+            return await self._stream(kwargs)
+        except Exception as e:
+            return LLMResponse(content=f"Error: {e}", finish_reason="error")
+
+    async def _stream(self, kwargs: dict[str, Any]) -> LLMResponse:
+        """Stream a chat completion, recording TTFT at the first content chunk."""
+        content_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        finish_reason = "stop"
+        usage: dict[str, int] = {}
+        ttft_ms: float | None = None
+        # tool call accumulator: index -> {id, name, args}
+        tc_buf: dict[int, dict] = {}
+
+        _start = _time.perf_counter()
+        stream = await self._client.chat.completions.create(**kwargs)
+        async for chunk in stream:
+            # Usage appears in final chunk when stream_options include_usage=True
+            if getattr(chunk, "usage", None):
+                u = chunk.usage
+                usage = {
+                    "prompt_tokens": u.prompt_tokens or 0,
+                    "completion_tokens": u.completion_tokens or 0,
+                    "total_tokens": u.total_tokens or 0,
+                }
+            choices = chunk.choices
+            if not choices:
+                continue
+            delta = choices[0].delta
+            if choices[0].finish_reason:
+                finish_reason = choices[0].finish_reason
+
+            # TTFT: first chunk carrying any content or tool call delta
+            has_content = bool(getattr(delta, "content", None))
+            has_reasoning = bool(getattr(delta, "reasoning_content", None))
+            has_tool = bool(getattr(delta, "tool_calls", None))
+            if ttft_ms is None and (has_content or has_reasoning or has_tool):
+                ttft_ms = (_time.perf_counter() - _start) * 1000
+
+            if has_reasoning:
+                reasoning_parts.append(delta.reasoning_content)
+            if has_content:
+                content_parts.append(delta.content)
+            if has_tool:
+                for tc_delta in delta.tool_calls:
+                    idx = tc_delta.index
+                    if idx not in tc_buf:
+                        tc_buf[idx] = {"id": "", "name": "", "args": []}
+                    if tc_delta.id:
+                        tc_buf[idx]["id"] = tc_delta.id
+                    if tc_delta.function.name:
+                        tc_buf[idx]["name"] = tc_delta.function.name
+                    if tc_delta.function.arguments:
+                        tc_buf[idx]["args"].append(tc_delta.function.arguments)
+
+        content = "".join(content_parts) or None
+        reasoning = "".join(reasoning_parts) or None
+        tool_calls = [
+            ToolCallRequest(
+                id=buf["id"],
+                name=buf["name"],
+                arguments=json_repair.loads("".join(buf["args"])),
+            )
+            for buf in tc_buf.values()
+        ]
+        return LLMResponse(
+            content=content,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            usage=usage,
+            reasoning_content=reasoning,
+            ttft_ms=ttft_ms,
+        )
+
+    def _parse(self, response: Any) -> LLMResponse:
+        choice = response.choices[0]
+        msg = choice.message
+        tool_calls = [
+            ToolCallRequest(id=tc.id, name=tc.function.name,
+                            arguments=json_repair.loads(tc.function.arguments) if isinstance(tc.function.arguments, str) else tc.function.arguments)
+            for tc in (msg.tool_calls or [])
+        ]
+        u = response.usage
+        return LLMResponse(
+            content=msg.content, tool_calls=tool_calls, finish_reason=choice.finish_reason or "stop",
+            usage={"prompt_tokens": u.prompt_tokens, "completion_tokens": u.completion_tokens, "total_tokens": u.total_tokens} if u else {},
+            reasoning_content=getattr(msg, "reasoning_content", None) or None,
+        )
+
+    def get_default_model(self) -> str:
+        return self.default_model
+

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -275,6 +275,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         ),
     ),
     # MiniMax: OpenAI-compatible API
+    # M2.5 is trained at temp=1.0, top_p=0.95 per the model card.
     ProviderSpec(
         name="minimax",
         keywords=("minimax",),
@@ -282,6 +283,9 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="MiniMax",
         backend="openai_compat",
         default_api_base="https://api.minimax.io/v1",
+        model_overrides=(
+            ("minimax-m2.5", {"temperature": 1.0, "top_p": 0.95}),
+        ),
     ),
     # MiniMax Anthropic-compatible endpoint: supports thinking mode
     ProviderSpec(

--- a/nanobot/templates/AGENTS.md
+++ b/nanobot/templates/AGENTS.md
@@ -2,15 +2,17 @@
 
 ## Scheduled Reminders
 
-Before scheduling reminders, check available skills and follow skill guidance first.
-Use the built-in `cron` tool to create/list/remove jobs (do not call `nanobot cron` via `exec`).
+When user asks for a reminder at a specific time, use `exec` to run:
+```
+nanobot cron add --name "reminder" --message "Your message" --at "YYYY-MM-DDTHH:MM:SS" --deliver --to "USER_ID" --channel "CHANNEL"
+```
 Get USER_ID and CHANNEL from the current session (e.g., `8281248569` and `telegram` from `telegram:8281248569`).
 
 **Do NOT just write reminders to MEMORY.md** — that won't trigger actual notifications.
 
 ## Heartbeat Tasks
 
-`HEARTBEAT.md` is checked on the configured heartbeat interval. Use file tools to manage periodic tasks:
+`HEARTBEAT.md` is checked every 30 minutes. Use file tools to manage periodic tasks:
 
 - **Add**: `edit_file` to append new tasks
 - **Remove**: `edit_file` to delete completed tasks

--- a/nanobot/templates/SOUL.md
+++ b/nanobot/templates/SOUL.md
@@ -1,6 +1,6 @@
 # Soul
 
-I am nanobot 🐈, a personal AI assistant.
+I am Ziggy ⚡, a personal AI assistant.
 
 ## Core Principles
 

--- a/nanobot/utils/__init__.py
+++ b/nanobot/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility functions for nanobot."""
 
-from nanobot.utils.helpers import ensure_dir
+from nanobot.utils.helpers import ensure_dir, get_workspace_path, get_data_path
 from nanobot.utils.path import abbreviate_path
 
-__all__ = ["ensure_dir", "abbreviate_path"]
+__all__ = ["ensure_dir", "get_workspace_path", "get_data_path", "abbreviate_path"]

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -94,6 +94,17 @@ def ensure_dir(path: Path) -> Path:
     return path
 
 
+def get_data_path() -> Path:
+    """~/.nanobot data directory."""
+    return ensure_dir(Path.home() / ".nanobot")
+
+
+def get_workspace_path(workspace: str | None = None) -> Path:
+    """Resolve and ensure workspace path. Defaults to ~/.nanobot/workspace."""
+    path = Path(workspace).expanduser() if workspace else Path.home() / ".nanobot" / "workspace"
+    return ensure_dir(path)
+
+
 def timestamp() -> str:
     """Current ISO timestamp."""
     return datetime.now().isoformat()
@@ -533,5 +544,3 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
         gs.init()
     except Exception:
         logger.warning("Failed to initialize git store for {}", workspace)
-
-    return added

--- a/nanobot/utils/security.py
+++ b/nanobot/utils/security.py
@@ -1,0 +1,163 @@
+"""Input sanitization and prompt injection defense."""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class InjectionResult:
+    """Result of injection detection."""
+    is_injection: bool
+    confidence: float  # 0.0 to 1.0
+    detected_patterns: list[str]
+    sanitized_content: str
+
+
+class PromptInjectionDetector:
+    """
+    Regex-based prompt injection detection.
+    
+    Covers common patterns:
+    - Direct instruction override attempts
+    - Role manipulation
+    - Delimiter injection
+    - System prompt extraction attempts
+    """
+    
+    # Patterns that indicate injection attempts
+    PATTERNS = [
+        # Direct overrides
+        (r"(?i)(ignore\s+(all\s+)?(previous|above|prior)\s+(instructions?|prompts?|commands?))", "override_attempt", 0.9),
+        (r"(?i)(disregard\s+(all\s+)?(previous|above|prior)\s+(instructions?|prompts?|commands?))", "override_attempt", 0.9),
+        (r"(?i)(forget\s+(everything|all|your)\s+(instructions?|programming|training|guidelines?|rules?))", "override_attempt", 0.85),
+
+        # Role manipulation
+        (r"(?i)(you\s+are\s+(now|no\s+longer|instead\s+of|instead)\b)", "role_manipulation", 0.8),
+        (r"(?i)(act\s+as\s+(if\s+)?(a\s+)?(different|new|another|admin|root|system))", "role_manipulation", 0.8),
+        (r"(?i)(pretend\s+(to\s+)?(be|that\s+you\s+are)|imagine\s+(you\s+are|that))", "role_manipulation", 0.75),
+        (r"(?i)(roleplay\s+as|play\s+the\s+role\s+of)", "role_manipulation", 0.7),
+
+        # Delimiter injection
+        (r"(\x00|\x1b|\x04|\x05)", "control_char", 0.6),
+        (r"(\[\[|\]\]|\{\{|\}\}|<<<|>>>|---{3,})", "delimiter_injection", 0.5),
+
+        # System prompt extraction
+        (r"(?i)(show\s+(me\s+)?(your\s+)?(system\s+)?(instructions?|prompt|configuration|settings?|rules?))", "prompt_extraction", 0.85),
+        (r"(?i)(what\s+(are|were)\s+(your\s+)?(system\s+)?instructions?)", "prompt_extraction", 0.8),
+        (r"(?i)(repeat\s+(all\s+)?(your\s+)?(instructions?|system\s+prompt))", "prompt_extraction", 0.9),
+
+        # Jailbreak attempts
+        (r"(?i)\b(do\s+anything\s+now|developer\s+mode|bypass\s+(safety|restrictions?|filters?)|jailbreak)\b", "jailbreak", 0.95),
+        (r"(?i)(new\s+instructions?|override\s+system|system\s+override)", "jailbreak", 0.9),
+
+        # Code injection — only match at word boundaries to reduce false positives
+        (r"(?i)\b(exec\s*\(|eval\s*\(|__import__|subprocess\s*\(|os\.system\s*\(|shell_exec\s*\()", "code_injection", 0.95),
+        (r"(?i)^import\s+(os|sys|subprocess)\s*$", "code_injection", 0.8),
+
+        # Prompt leaking
+        (r"(?i)(tell\s+me\s+your\s+(system\s+)?prompt|reveal\s+(your\s+)?(system\s+)?instructions?)", "prompt_leaking", 0.85),
+        (r"(?i)(output\s+(your\s+)?(system\s+)?(instructions?|prompt)\b)", "prompt_leaking", 0.9),
+    ]
+    
+    # High-confidence threshold
+    CONFIDENCE_THRESHOLD = 0.7
+    
+    def __init__(self, threshold: float = 0.7):
+        self.threshold = threshold
+        self._compiled_patterns = [
+            (re.compile(pattern), name, confidence)
+            for pattern, name, confidence in self.PATTERNS
+        ]
+    
+    def detect(self, content: str) -> InjectionResult:
+        """
+        Analyze content for prompt injection attempts.
+        
+        Returns InjectionResult with:
+        - is_injection: bool - whether injection was detected
+        - confidence: float - confidence score (0-1)
+        - detected_patterns: list of detected pattern names
+        - sanitized_content: content with dangerous parts removed
+        """
+        if not content:
+            return InjectionResult(
+                is_injection=False,
+                confidence=0.0,
+                detected_patterns=[],
+                sanitized_content=content
+            )
+        
+        detected = []
+        max_confidence = 0.0
+        
+        for pattern, name, confidence in self._compiled_patterns:
+            if pattern.search(content):
+                detected.append(name)
+                max_confidence = max(max_confidence, confidence)
+        
+        # Sanitize: remove or escape detected patterns
+        sanitized = self._sanitize(content, detected)
+        
+        is_injection = max_confidence >= self.threshold
+        
+        return InjectionResult(
+            is_injection=is_injection,
+            confidence=max_confidence,
+            detected_patterns=detected,
+            sanitized_content=sanitized
+        )
+    
+    def _sanitize(self, content: str, detected: list[str]) -> str:
+        """Remove or escape detected injection patterns."""
+        if not detected:
+            return content
+        
+        sanitized = content
+        
+        # Remove control characters
+        sanitized = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', sanitized)
+        
+        # Escape common delimiters that might be used for injection
+        sanitized = re.sub(r'\[{2,}', '[', sanitized)
+        sanitized = re.sub(r'\]{2,}', ']', sanitized)
+        sanitized = re.sub(r'={3,}', '==', sanitized)
+        
+        return sanitized.strip()
+
+
+# Singleton instance
+_detector: Optional[PromptInjectionDetector] = None
+
+
+def get_detector() -> PromptInjectionDetector:
+    """Get or create the detector singleton."""
+    global _detector
+    if _detector is None:
+        _detector = PromptInjectionDetector()
+    return _detector
+
+
+def sanitize_input(content: str, log_detections: bool = True) -> tuple[str, bool]:
+    """
+    Sanitize user input for prompt injection.
+    
+    Args:
+        content: Raw user input
+        log_detections: Whether to log detected injections
+    
+    Returns:
+        Tuple of (sanitized_content, was_injection_detected)
+    """
+    detector = get_detector()
+    result = detector.detect(content)
+    
+    if result.is_injection and log_detections:
+        import loguru
+        logger = loguru.logger
+        logger.warning(
+            f"Prompt injection detected: {result.detected_patterns} "
+            f"(confidence: {result.confidence:.2f})"
+        )
+    
+    return result.sanitized_content, result.is_injection

--- a/nanobot/utils/sensitive.py
+++ b/nanobot/utils/sensitive.py
@@ -57,11 +57,20 @@ _SENSITIVE_PATH_PATTERNS: list[str] = [
 # names (e.g. `secrets/app.env`) should rely on path-based blocks (by adding
 # `/secrets/` to `_SENSITIVE_PATH_PATTERNS`) rather than a broad filename
 # catch-all.
+#
+# Note on SSH key filename scope (MIT-140): the `id_(rsa|dsa|ecdsa|ed25519)`
+# pattern intentionally excludes the `.pub` suffix. Public keys are, by
+# definition, safe to disclose — agent workflows legitimately need to read
+# `id_*.pub` to configure deployment targets, authorized_keys, CI runners,
+# etc. Private-key material is still blocked by this filename rule (for the
+# bare names) and, more importantly, by the `/.ssh/` path prefix in
+# `_SENSITIVE_PATH_PATTERNS` (which catches any file — public or private —
+# living under `~/.ssh/`).
 _SENSITIVE_FILENAME_PATTERNS: list[re.Pattern] = [
     re.compile(r"(^|/)\.env(\..+)?$", re.IGNORECASE),            # .env, .env.local, .env.production
     re.compile(r"(^|/)credentials\.json$", re.IGNORECASE),
     re.compile(r"(^|/)service[-_]?account[-_]?key\.json$", re.IGNORECASE),
-    re.compile(r"(^|/)id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$"),       # SSH key files by name
+    re.compile(r"(^|/)id_(rsa|dsa|ecdsa|ed25519)$"),               # SSH private key files by name (MIT-140: exclude .pub)
     re.compile(r"(^|/).*\.pem$", re.IGNORECASE),
     re.compile(r"(^|/).*\.key$", re.IGNORECASE),                   # TLS private keys
 ]

--- a/nanobot/utils/sensitive.py
+++ b/nanobot/utils/sensitive.py
@@ -48,6 +48,15 @@ _SENSITIVE_PATH_PATTERNS: list[str] = [
 ]
 
 # File name patterns that are sensitive regardless of directory
+#
+# Note on `.env` scope: the pattern below matches files whose basename begins
+# with `.env` (e.g. `.env`, `.env.local`, `.env.production`).  We intentionally
+# do NOT widen this to `*.env` — that would collide with legitimate filenames
+# like `example.env`, `template.env`, or documentation fixtures where
+# disclosure is safe.  Operators who place dotenv files under non-standard
+# names (e.g. `secrets/app.env`) should rely on path-based blocks (by adding
+# `/secrets/` to `_SENSITIVE_PATH_PATTERNS`) rather than a broad filename
+# catch-all.
 _SENSITIVE_FILENAME_PATTERNS: list[re.Pattern] = [
     re.compile(r"(^|/)\.env(\..+)?$", re.IGNORECASE),            # .env, .env.local, .env.production
     re.compile(r"(^|/)credentials\.json$", re.IGNORECASE),
@@ -144,6 +153,14 @@ def redact_if_sensitive(text: str) -> str:
 # 3. Shell command pre-screening
 # ---------------------------------------------------------------------------
 
+# Reusable fragment: optional path prefix ending in `/` that precedes `.ssh/`.
+# Matches `~/`, `./`, `/home/user/`, `/root/`, or empty (bare `.ssh/`).
+# Shape: `(?:~/|\S*/)?\.ssh/`
+#   - `~/`          — explicit home-relative
+#   - `\S*/`        — any non-space run ending in `/` (absolute, relative, etc.)
+#   - `?`           — or no prefix at all (just `.ssh/`)
+_SSH_PATH_PREFIX = r"(?:~/|\S*/)?\.ssh/"
+
 # Commands whose primary purpose is to dump environment / secrets.
 _BLOCKED_SHELL_COMMANDS: list[re.Pattern] = [
     # env-dumping commands (standalone or at start of pipe)
@@ -152,25 +169,25 @@ _BLOCKED_SHELL_COMMANDS: list[re.Pattern] = [
     re.compile(r"(?:^|\|)\s*\bexport\s+-p\b"),
     re.compile(r"(?:^|\|)\s*\bset\s*$"),                 # bare 'set' dumps shell vars
     re.compile(r"(?:^|\|)\s*\bdeclare\s+-x\b"),
-    # Direct reads of sensitive paths
-    re.compile(r"\bcat\s+[~]?/?\.ssh/", re.IGNORECASE),
+    # Direct reads of sensitive paths (absolute, ~, or relative)
+    re.compile(r"\bcat\s+" + _SSH_PATH_PREFIX, re.IGNORECASE),
     re.compile(r"\bcat\s+/etc/shadow\b", re.IGNORECASE),
     re.compile(r"\bcat\s+.*\.env\b", re.IGNORECASE),
     re.compile(r"\bcat\s+.*\.pem\b", re.IGNORECASE),
     re.compile(r"\bcat\s+.*\.key\b", re.IGNORECASE),
     re.compile(r"\bcat\s+.*/credentials\.json\b", re.IGNORECASE),
     # Reading sensitive dirs with other tools
-    re.compile(r"\b(?:less|more|head|tail|bat|nano|vim?|view)\s+[~]?/?\.ssh/", re.IGNORECASE),
+    re.compile(r"\b(?:less|more|head|tail|bat|nano|vim?|view)\s+" + _SSH_PATH_PREFIX, re.IGNORECASE),
     re.compile(r"\b(?:less|more|head|tail|bat|nano|vim?|view)\s+/etc/shadow\b", re.IGNORECASE),
     # Key scanning / dumping
     re.compile(r"\bssh-add\s+-[lL]\b"),
     re.compile(r"\bgpg\s+--export-secret", re.IGNORECASE),
     # Base64 encoding of key files (exfiltration attempt)
-    re.compile(r"\bbase64\s+[~]?/?\.ssh/", re.IGNORECASE),
+    re.compile(r"\bbase64\s+" + _SSH_PATH_PREFIX, re.IGNORECASE),
     re.compile(r"\bbase64\s+.*\.pem\b", re.IGNORECASE),
     re.compile(r"\bbase64\s+.*\.key\b", re.IGNORECASE),
-    # xxd / od on key files
-    re.compile(r"\b(?:xxd|od|hexdump)\s+[~]?/?\.ssh/", re.IGNORECASE),
+    # xxd / od / hexdump on key files
+    re.compile(r"\b(?:xxd|od|hexdump)\s+" + _SSH_PATH_PREFIX, re.IGNORECASE),
 ]
 
 

--- a/nanobot/utils/sensitive.py
+++ b/nanobot/utils/sensitive.py
@@ -124,11 +124,14 @@ _SECRET_CONTENT_PATTERNS: list[tuple[re.Pattern, str]] = [
     # *prefix* of the token (not a label followed by `=` or `:`). Added as a
     # parallel pattern rather than broadening the labeled regex above —
     # widening that one would catch far too much ordinary prose.
-    # Token charset covers JWT (base64url + dot), opaque tokens, hex, and
-    # provider-specific formats (dash, dot, underscore, alphanum). Minimum
-    # length of 20 filters out documentation-style placeholders like
-    # `Bearer token`, `Bearer xxx`, or `Bearer abc123`.
-    (re.compile(r"\bBearer\s+[A-Za-z0-9_\-\.]{20,}"), "bearer token"),
+    #
+    # Case-insensitive: RFC 7235 says auth-scheme names are case-insensitive,
+    # and middleware / log formatters freely normalize between `Bearer`,
+    # `bearer`, and `BEARER`. Charset matches the labeled-credential regex
+    # above (`[A-Za-z0-9_\-/.+]`) so opaque base64 tokens with `/` and `+`
+    # aren't missed. Minimum length of 20 filters documentation placeholders
+    # like `Bearer token`, `Bearer xxx`, or `Bearer YOUR_TOKEN_HERE`.
+    (re.compile(r"\bBearer\s+[A-Za-z0-9_\-/.+]{20,}", re.IGNORECASE), "bearer token"),
     # GitHub / GitLab / npm tokens
     (re.compile(r"(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}"), "GitHub token"),
     (re.compile(r"glpat-[A-Za-z0-9\-_]{20,}"), "GitLab token"),

--- a/nanobot/utils/sensitive.py
+++ b/nanobot/utils/sensitive.py
@@ -129,8 +129,11 @@ _SECRET_CONTENT_PATTERNS: list[tuple[re.Pattern, str]] = [
     # and middleware / log formatters freely normalize between `Bearer`,
     # `bearer`, and `BEARER`. Charset matches the labeled-credential regex
     # above (`[A-Za-z0-9_\-/.+]`) so opaque base64 tokens with `/` and `+`
-    # aren't missed. Minimum length of 20 filters documentation placeholders
-    # like `Bearer token`, `Bearer xxx`, or `Bearer YOUR_TOKEN_HERE`.
+    # aren't missed. Minimum length of 20 filters out short placeholders
+    # (`Bearer token`, `Bearer xxx`, `Bearer TODO`); longer token-shaped
+    # placeholders like `Bearer YOUR_DEVELOPMENT_ACCESS_TOKEN` may still
+    # match. Accepted false-positive cost — redacting a stray placeholder
+    # is cheaper than leaking a real token.
     (re.compile(r"\bBearer\s+[A-Za-z0-9_\-/.+]{20,}", re.IGNORECASE), "bearer token"),
     # GitHub / GitLab / npm tokens
     (re.compile(r"(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}"), "GitHub token"),

--- a/nanobot/utils/sensitive.py
+++ b/nanobot/utils/sensitive.py
@@ -1,0 +1,190 @@
+"""Sensitive data detection, path blocking, and content redaction.
+
+This module provides the shared security layer used by both the filesystem
+tools (read_file, edit_file) and the shell tool (exec) to prevent leakage
+of private keys, credentials, tokens, and other secrets.
+"""
+
+import os
+import re
+from pathlib import Path
+
+from loguru import logger
+
+# ---------------------------------------------------------------------------
+# 1. Sensitive path detection
+# ---------------------------------------------------------------------------
+
+# Directories / files that must never be read or targeted by commands.
+# Paths are checked after expanding ~ and resolving symlinks.
+_SENSITIVE_PATH_PATTERNS: list[str] = [
+    # SSH key material
+    "/.ssh/",
+    "/etc/ssh/ssh_host_",
+    # System credential stores
+    "/etc/shadow",
+    "/etc/gshadow",
+    "/etc/security/opasswd",
+    # GNOME / KDE keyrings
+    "/.local/share/keyrings/",
+    "/.kde/share/apps/kwallet/",
+    # GPG private keyring
+    "/.gnupg/private-keys-v1.d/",
+    "/.gnupg/secring.gpg",
+    # Cloud credential caches
+    "/.aws/credentials",
+    "/.aws/config",
+    "/.azure/",
+    "/.config/gcloud/credentials.db",
+    "/.config/gcloud/application_default_credentials.json",
+    # Docker config (may contain registry passwords)
+    "/.docker/config.json",
+    # Kubernetes
+    "/.kube/config",
+    # Password / secret files
+    "/.netrc",
+    "/.pgpass",
+    "/.my.cnf",
+]
+
+# File name patterns that are sensitive regardless of directory
+_SENSITIVE_FILENAME_PATTERNS: list[re.Pattern] = [
+    re.compile(r"(^|/)\.env(\..+)?$", re.IGNORECASE),            # .env, .env.local, .env.production
+    re.compile(r"(^|/)credentials\.json$", re.IGNORECASE),
+    re.compile(r"(^|/)service[-_]?account[-_]?key\.json$", re.IGNORECASE),
+    re.compile(r"(^|/)id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$"),       # SSH key files by name
+    re.compile(r"(^|/).*\.pem$", re.IGNORECASE),
+    re.compile(r"(^|/).*\.key$", re.IGNORECASE),                   # TLS private keys
+]
+
+
+def is_sensitive_path(path: str | Path) -> bool:
+    """Return True if *path* points to a known sensitive location or file.
+
+    The check is intentionally broad — it is better to block a false-positive
+    than to leak a private key.
+    """
+    try:
+        resolved = str(Path(path).expanduser().resolve())
+    except Exception:
+        resolved = str(path)
+
+    # Absolute directory / prefix checks
+    for pattern in _SENSITIVE_PATH_PATTERNS:
+        if pattern in resolved:
+            return True
+
+    # Basename / filename checks
+    for regex in _SENSITIVE_FILENAME_PATTERNS:
+        if regex.search(resolved):
+            return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# 2. Content-level secret detection & redaction
+# ---------------------------------------------------------------------------
+
+# Regex patterns that match secret material inside file / command output.
+_SECRET_CONTENT_PATTERNS: list[tuple[re.Pattern, str]] = [
+    # PEM-encoded private keys (RSA, EC, DSA, OPENSSH, PKCS8, etc.)
+    (re.compile(r"-----BEGIN\s+[\w\s]*PRIVATE\s+KEY-----", re.IGNORECASE), "private key"),
+    # Certificates (optional — certificates are less secret, but the request asked for them)
+    (re.compile(r"-----BEGIN\s+CERTIFICATE-----", re.IGNORECASE), "certificate"),
+    # AWS-style keys
+    (re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}", re.IGNORECASE), "AWS access key"),
+    # Generic long hex/base64 tokens preceded by common labels
+    (re.compile(
+        r"""(?:api[_-]?key|api[_-]?secret|secret[_-]?key|access[_-]?token|auth[_-]?token|"""
+        r"""password|passwd|bearer)\s*[:=]\s*['"]?[A-Za-z0-9_\-/.+]{20,}""",
+        re.IGNORECASE,
+    ), "credential/token"),
+    # GitHub / GitLab / npm tokens
+    (re.compile(r"(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}"), "GitHub token"),
+    (re.compile(r"glpat-[A-Za-z0-9\-_]{20,}"), "GitLab token"),
+    (re.compile(r"npm_[A-Za-z0-9]{36,}"), "npm token"),
+    # Slack tokens
+    (re.compile(r"xox[bpras]-[A-Za-z0-9\-]{10,}"), "Slack token"),
+    # Generic "PRIVATE KEY" blob (catches partial dumps)
+    (re.compile(r"-----BEGIN\s+RSA", re.IGNORECASE), "RSA key material"),
+    (re.compile(r"-----BEGIN\s+EC", re.IGNORECASE), "EC key material"),
+    (re.compile(r"-----BEGIN\s+DSA", re.IGNORECASE), "DSA key material"),
+    (re.compile(r"-----BEGIN\s+OPENSSH", re.IGNORECASE), "OpenSSH key material"),
+]
+
+_REDACTION_NOTICE = (
+    "[REDACTED — sensitive content detected ({detail}). "
+    "Displaying secrets is blocked by security policy.]"
+)
+
+
+def scan_content(text: str) -> str | None:
+    """Scan *text* for secret material.
+
+    Returns a human-readable description of the first match, or ``None``
+    if the content appears clean.
+    """
+    for pattern, label in _SECRET_CONTENT_PATTERNS:
+        if pattern.search(text):
+            return label
+    return None
+
+
+def redact_if_sensitive(text: str) -> str:
+    """Return *text* unchanged if clean, or a redacted message otherwise."""
+    match = scan_content(text)
+    if match:
+        logger.warning("Redacted output containing: {}", match)
+        return _REDACTION_NOTICE.format(detail=match)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# 3. Shell command pre-screening
+# ---------------------------------------------------------------------------
+
+# Commands whose primary purpose is to dump environment / secrets.
+_BLOCKED_SHELL_COMMANDS: list[re.Pattern] = [
+    # env-dumping commands (standalone or at start of pipe)
+    re.compile(r"(?:^|\|)\s*(?:printenv|/usr/bin/printenv)\b"),
+    re.compile(r"(?:^|\|)\s*\benv\b(?!\s+\S+\s*=)"),   # bare 'env' but not 'env VAR=val cmd'
+    re.compile(r"(?:^|\|)\s*\bexport\s+-p\b"),
+    re.compile(r"(?:^|\|)\s*\bset\s*$"),                 # bare 'set' dumps shell vars
+    re.compile(r"(?:^|\|)\s*\bdeclare\s+-x\b"),
+    # Direct reads of sensitive paths
+    re.compile(r"\bcat\s+[~]?/?\.ssh/", re.IGNORECASE),
+    re.compile(r"\bcat\s+/etc/shadow\b", re.IGNORECASE),
+    re.compile(r"\bcat\s+.*\.env\b", re.IGNORECASE),
+    re.compile(r"\bcat\s+.*\.pem\b", re.IGNORECASE),
+    re.compile(r"\bcat\s+.*\.key\b", re.IGNORECASE),
+    re.compile(r"\bcat\s+.*/credentials\.json\b", re.IGNORECASE),
+    # Reading sensitive dirs with other tools
+    re.compile(r"\b(?:less|more|head|tail|bat|nano|vim?|view)\s+[~]?/?\.ssh/", re.IGNORECASE),
+    re.compile(r"\b(?:less|more|head|tail|bat|nano|vim?|view)\s+/etc/shadow\b", re.IGNORECASE),
+    # Key scanning / dumping
+    re.compile(r"\bssh-add\s+-[lL]\b"),
+    re.compile(r"\bgpg\s+--export-secret", re.IGNORECASE),
+    # Base64 encoding of key files (exfiltration attempt)
+    re.compile(r"\bbase64\s+[~]?/?\.ssh/", re.IGNORECASE),
+    re.compile(r"\bbase64\s+.*\.pem\b", re.IGNORECASE),
+    re.compile(r"\bbase64\s+.*\.key\b", re.IGNORECASE),
+    # xxd / od on key files
+    re.compile(r"\b(?:xxd|od|hexdump)\s+[~]?/?\.ssh/", re.IGNORECASE),
+]
+
+
+def check_shell_command(command: str) -> str | None:
+    """Screen a shell command for attempts to access sensitive data.
+
+    Returns an error string if the command is blocked, or ``None`` if it
+    passes the check.
+    """
+    for pattern in _BLOCKED_SHELL_COMMANDS:
+        if pattern.search(command):
+            logger.warning("Blocked sensitive shell command: {}", command)
+            return (
+                "Error: Command blocked by security policy — "
+                "accessing sensitive data (keys, credentials, secrets) is not permitted."
+            )
+    return None

--- a/nanobot/utils/sensitive.py
+++ b/nanobot/utils/sensitive.py
@@ -7,6 +7,7 @@ of private keys, credentials, tokens, and other secrets.
 
 import os
 import re
+import shlex
 from pathlib import Path
 
 from loguru import logger
@@ -217,12 +218,92 @@ _BLOCKED_SHELL_COMMANDS: list[re.Pattern] = [
 ]
 
 
-def check_shell_command(command: str) -> str | None:
-    """Screen a shell command for attempts to access sensitive data.
+# Shell-wrapper names that take `-c <script>` and execute the script argument
+# as a new shell command. Basename match against the first token of the
+# command (after stripping any directory prefix like `/bin/` or `/usr/bin/`).
+#
+# MIT-164: `sh -c "printenv"` escaped the regex-based prescreen because the
+# denylisted command was wrapped inside a quoted argument the regexes never
+# saw. Detecting the wrapper shape and recursing into the extracted script
+# closes that bypass without reworking the regex layer.
+_SHELL_WRAPPER_BASENAMES: frozenset[str] = frozenset(
+    {"sh", "bash", "zsh", "dash", "ash", "ksh"}
+)
+
+# Recursion depth cap for nested wrappers (`sh -c "bash -c '...'"`).  Three
+# is well beyond anything seen in practice; the guard exists purely to bound
+# runtime on pathological input.
+_MAX_SHELL_WRAPPER_DEPTH = 3
+
+
+def _extract_shell_wrapper_inner(command: str) -> str | None:
+    """If *command* has the shape `<shell> -c <script>`, return the script.
+
+    Uses :func:`shlex.split` so all three quoting forms are handled uniformly:
+
+    * ``sh -c 'printenv'``        — single-quoted
+    * ``sh -c "printenv"``        — double-quoted
+    * ``sh -c printenv``          — unquoted (bash permits this for a single arg)
+
+    The shell binary may appear with or without a path prefix
+    (``sh``, ``/bin/sh``, ``/usr/bin/bash``, …). Any trailing tokens after
+    the ``-c`` script (POSIX ``sh -c <script> [argv0 [args...]]``) are
+    ignored — the script is always the third token and is the only thing
+    that gets executed as shell syntax.
+
+    Returns ``None`` when the command does not look like a recognized
+    wrapper, or when :mod:`shlex` cannot parse it (malformed quoting).
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        # Unclosed quotes, etc. — don't attempt inner extraction; the outer
+        # regex check has already run and is the authoritative result for
+        # malformed input.  Returning None here means the caller falls
+        # through to "clean" exactly as before this change — no regression.
+        return None
+
+    if len(tokens) < 3:
+        return None
+
+    # First token: the shell binary, possibly path-prefixed.
+    shell_basename = os.path.basename(tokens[0])
+    if shell_basename not in _SHELL_WRAPPER_BASENAMES:
+        return None
+
+    # Second token must be `-c` (POSIX contract for "run the next arg as
+    # a shell script").  Other `-` flags (`-l`, `-i`, `-s`) don't take a
+    # script argument the same way, so we only recurse on `-c`.
+    if tokens[1] != "-c":
+        return None
+
+    return tokens[2]
+
+
+def check_shell_command(command: str, _depth: int = 0) -> str | None:
+    r"""Screen a shell command for attempts to access sensitive data.
 
     Returns an error string if the command is blocked, or ``None`` if it
     passes the check.
+
+    MIT-164: if *command* is a shell-wrapper invocation of the form
+    ``sh -c "<inner>"`` (or ``bash``/``zsh``/``dash``/``ash``/``ksh``,
+    with or without a path prefix), the inner script is extracted via
+    :func:`shlex.split` and recursively screened.  This closes a whole-layer
+    bypass where any denylisted command could be run simply by wrapping it:
+    the outer regex layer never saw the denylisted command because it was
+    inside a quoted argument.
+
+    Known remaining gap (tracked separately — MIT-165 scope): the env-dumper
+    regexes (``printenv``/``env``/``export -p``/``set``/``declare -x``)
+    anchor at ``(?:^|\|)`` — start-of-string or after a pipe — so a command
+    like ``sh -c 'cd /tmp && printenv'`` unwraps to ``cd /tmp && printenv``
+    and passes the regex layer because the dumper is after ``&&``, not
+    after ``^`` or ``|``.  Widening the anchor set (``;``, ``&&``, ``||``,
+    subshell openers) is the MIT-165 fix; MIT-164 is scoped to closing the
+    quote-wrapper layer.
     """
+    # 1. Regex denylist on the literal command text.
     for pattern in _BLOCKED_SHELL_COMMANDS:
         if pattern.search(command):
             logger.warning("Blocked sensitive shell command: {}", command)
@@ -230,4 +311,15 @@ def check_shell_command(command: str) -> str | None:
                 "Error: Command blocked by security policy — "
                 "accessing sensitive data (keys, credentials, secrets) is not permitted."
             )
+
+    # 2. MIT-164: shell-wrapper unwrap + recurse.  `_depth` is an anti-loop
+    # guard for pathological nesting (`sh -c "bash -c 'sh -c ...'"`) — in
+    # practice depth > 1 is extremely rare, but a hard cap is cheap.
+    if _depth >= _MAX_SHELL_WRAPPER_DEPTH:
+        return None
+
+    inner = _extract_shell_wrapper_inner(command)
+    if inner is not None:
+        return check_shell_command(inner, _depth + 1)
+
     return None

--- a/nanobot/utils/sensitive.py
+++ b/nanobot/utils/sensitive.py
@@ -118,6 +118,17 @@ _SECRET_CONTENT_PATTERNS: list[tuple[re.Pattern, str]] = [
         r"""password|passwd|bearer)\s*[:=]\s*['"]?[A-Za-z0-9_\-/.+]{20,}""",
         re.IGNORECASE,
     ), "credential/token"),
+    # HTTP Authorization Bearer header (MIT-148).
+    # The labeled-credential regex above matches `bearer=xyz` / `bearer: xyz`
+    # forms, but NOT the actual HTTP header shape where `Bearer` is the
+    # *prefix* of the token (not a label followed by `=` or `:`). Added as a
+    # parallel pattern rather than broadening the labeled regex above —
+    # widening that one would catch far too much ordinary prose.
+    # Token charset covers JWT (base64url + dot), opaque tokens, hex, and
+    # provider-specific formats (dash, dot, underscore, alphanum). Minimum
+    # length of 20 filters out documentation-style placeholders like
+    # `Bearer token`, `Bearer xxx`, or `Bearer abc123`.
+    (re.compile(r"\bBearer\s+[A-Za-z0-9_\-\.]{20,}"), "bearer token"),
     # GitHub / GitLab / npm tokens
     (re.compile(r"(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}"), "GitHub token"),
     (re.compile(r"glpat-[A-Za-z0-9\-_]{20,}"), "GitLab token"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,10 @@ api = [
 wecom = [
     "wecom-aibot-sdk-python>=0.1.5",
 ]
+ziggy = [
+    "chromadb>=0.6.0,<1.0.0",
+    "prometheus-client>=0.20.0,<1.0.0",
+]
 weixin = [
     "qrcode[pil]>=8.0",
     "pycryptodome>=3.20.0",

--- a/tests/tools/test_exec_env.py
+++ b/tests/tools/test_exec_env.py
@@ -87,15 +87,24 @@ async def test_exec_allowed_env_keys_does_not_leak_others(monkeypatch):
 @_UNIX_ONLY
 @pytest.mark.asyncio
 async def test_exec_allowed_env_keys_missing_var_ignored(monkeypatch):
-    """If an allowed key is not set in the parent process, it should be silently skipped."""
+    """If an allowed key is not set in the parent process, it should be silently skipped.
+
+    The contract under test: when a key listed in `allowed_env_keys` is not
+    set in the parent, the subprocess env must not contain it at all — NOT
+    present-but-empty. This distinguishes a correct skip from a regression
+    that forwards missing keys as `VAR=""`.
+    """
     monkeypatch.delenv("NONEXISTENT_VAR_12345", raising=False)
     tool = ExecTool(allowed_env_keys=["NONEXISTENT_VAR_12345"])
-    # `[ -n "$VAR" ] || exit 1` exits with code 1 when VAR is empty or
-    # unset — equivalent to `printenv VAR`'s exit-1-on-missing behaviour
-    # pre-MIT-123. Confirms the child sees the allowed key as unset when
-    # the parent didn't export it, and that nothing in the passthrough
-    # layer errors or sets a default.
+    # `${VAR+set}` expands to "set" only when VAR is *defined* (even if
+    # empty); it's empty when VAR is unset.  `[ -z "${VAR+set}" ]` therefore
+    # succeeds (exit 0) iff the var is truly unset. We negate with `|| exit
+    # 1` so the test passes only when the child's env has NO entry for
+    # NONEXISTENT_VAR_12345 — this catches a hypothetical regression where
+    # the passthrough layer starts forwarding missing keys as empty strings,
+    # which the old `printenv` check (and a naive `-n` replacement) would
+    # have let slip through.
     result = await tool.execute(
-        command='sh -c \'[ -n "$NONEXISTENT_VAR_12345" ] || exit 1\''
+        command='sh -c \'[ -z "${NONEXISTENT_VAR_12345+set}" ] || exit 1\''
     )
-    assert "Exit code: 1" in result
+    assert "Exit code: 0" in result

--- a/tests/tools/test_exec_env.py
+++ b/tests/tools/test_exec_env.py
@@ -45,13 +45,31 @@ async def test_exec_path_append_preserves_system_path():
     assert "Exit code: 0" in result
 
 
+# ---------------------------------------------------------------------------
+# MIT-143: `printenv` at command-start is now blocked by the shell
+# pre-screen added in MIT-123 (it's classified as a secret-dump command).
+# These two tests were written before that guard landed and relied on
+# `printenv` to verify `allowed_env_keys` passthrough.
+#
+# Replace `printenv VAR` with `sh -c 'echo "$VAR"'` — the prescreen only
+# matches `printenv` at the start of the command line (or after a pipe),
+# not when it appears inside a quoted `sh -c` argument, so `echo` in a
+# sub-shell is a stable, non-denylisted alternative that still exercises
+# the env-var passthrough path. Production shell prescreen is not
+# touched; this is a pure test refactor.
+# ---------------------------------------------------------------------------
+
+
 @_UNIX_ONLY
 @pytest.mark.asyncio
 async def test_exec_allowed_env_keys_passthrough(monkeypatch):
     """Env vars listed in allowed_env_keys should be visible to commands."""
     monkeypatch.setenv("MY_CUSTOM_VAR", "hello-from-config")
     tool = ExecTool(allowed_env_keys=["MY_CUSTOM_VAR"])
-    result = await tool.execute(command="printenv MY_CUSTOM_VAR")
+    # `echo "$MY_CUSTOM_VAR"` inside `sh -c '...'` reads the single env var
+    # the child inherits via allowed_env_keys — equivalent to
+    # `printenv MY_CUSTOM_VAR` pre-MIT-123 but not caught by the prescreen.
+    result = await tool.execute(command='sh -c \'echo "$MY_CUSTOM_VAR"\'')
     assert "hello-from-config" in result
 
 
@@ -72,5 +90,12 @@ async def test_exec_allowed_env_keys_missing_var_ignored(monkeypatch):
     """If an allowed key is not set in the parent process, it should be silently skipped."""
     monkeypatch.delenv("NONEXISTENT_VAR_12345", raising=False)
     tool = ExecTool(allowed_env_keys=["NONEXISTENT_VAR_12345"])
-    result = await tool.execute(command="printenv NONEXISTENT_VAR_12345")
+    # `[ -n "$VAR" ] || exit 1` exits with code 1 when VAR is empty or
+    # unset — equivalent to `printenv VAR`'s exit-1-on-missing behaviour
+    # pre-MIT-123. Confirms the child sees the allowed key as unset when
+    # the parent didn't export it, and that nothing in the passthrough
+    # layer errors or sets a default.
+    result = await tool.execute(
+        command='sh -c \'[ -n "$NONEXISTENT_VAR_12345" ] || exit 1\''
+    )
     assert "Exit code: 1" in result

--- a/tests/tools/test_exec_process_group.py
+++ b/tests/tools/test_exec_process_group.py
@@ -1,0 +1,292 @@
+"""Subprocess-tree cleanup tests for ExecTool (MIT-162).
+
+The exec tool used to leak subprocess trees when a tool call ended: on
+timeout, cancel, or even success the Python-level ``proc.kill()`` only
+signalled the immediate child (``bash -l -c ...``), leaving grandchildren
+reparented to init/PID 1 and running until they felt like it. A real
+session watched a ``sudo nmap ... | head`` tree live 94 minutes past the
+tool call that spawned it.
+
+These tests exercise the fix:
+
+  1. ``start_new_session=True`` on Unix so the child gets its own PGID,
+  2. SIGKILL on the whole PGID (skipping SIGTERM, which ``sudo`` swallows),
+  3. cleanup runs in ``finally`` so it fires on every exit path.
+
+Each test tags the command it runs with a unique marker (``exec -a
+mit162_<uuid> sleep 30``) so scanning ``/proc`` can't be confused by
+leaks from previous test runs on the same host — we only care about the
+child we just launched. ``exec -a NAME`` rewrites ``argv[0]`` of the
+``sleep`` process, which shows up directly in ``/proc/<pid>/cmdline``.
+
+All tests are Unix-only; Windows doesn't have POSIX process groups and
+uses a different cleanup path.
+"""
+
+import asyncio
+import os
+import signal
+import sys
+import time
+import uuid
+
+import pytest
+
+from nanobot.agent.tools.shell import ExecTool
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Process-group cleanup is POSIX-only; Windows uses a different path.",
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_marker(tag: str) -> str:
+    # `exec -a` requires a token that's a valid argv[0] — no spaces, no
+    # hyphens that could trip up shell parsing, keep it identifier-safe.
+    return f"mit162_{tag}_{uuid.uuid4().hex}"
+
+
+def _sleep_cmd(marker: str, seconds: int = 30) -> str:
+    """A shell command that spawns `sleep` with ``argv[0]`` == *marker*.
+
+    This is how the test locates *its own* sleep grandchild: scan /proc for
+    the exact marker instead of the generic "sleep 30" string that other
+    tests (or leftover leaks) would also match.
+    """
+    return f"exec -a {marker} sleep {seconds}"
+
+
+def _find_pid_by_marker(marker: str) -> int | None:
+    """Return the PID of a process whose ``argv[0]`` equals *marker*, else None."""
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/cmdline", "rb") as f:
+                raw = f.read()
+        except (FileNotFoundError, PermissionError, ProcessLookupError):
+            continue
+        if not raw:
+            continue
+        argv0 = raw.split(b"\x00", 1)[0].decode(errors="replace")
+        if argv0 == marker:
+            return int(entry)
+    return None
+
+
+def _wait_for_pid_to_appear(marker: str, timeout: float) -> int | None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        pid = _find_pid_by_marker(marker)
+        if pid is not None:
+            return pid
+        time.sleep(0.02)
+    return None
+
+
+def _wait_for_pid_to_exit(pid: int, timeout: float) -> bool:
+    """True if *pid* is no longer alive within *timeout* seconds."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            # Process exists but we can't signal it — treat as still alive
+            # and keep polling; if it ever goes away we'll see ESRCH.
+            pass
+        time.sleep(0.02)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# spawn flag
+# ---------------------------------------------------------------------------
+
+class TestSpawnSessionFlag:
+    """``start_new_session=True`` is the foundation of the whole fix."""
+
+    @pytest.mark.asyncio
+    async def test_unix_spawn_uses_new_session(self):
+        """On Unix the child must be placed in its own session/PGID."""
+        from unittest.mock import AsyncMock, patch
+
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", False),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_exec.return_value = AsyncMock()
+            await ExecTool._spawn("echo hi", "/tmp", {"HOME": "/tmp"})
+
+        kwargs = mock_exec.call_args.kwargs
+        assert kwargs.get("start_new_session") is True, (
+            "spawn must request a new session so killpg can target the whole tree"
+        )
+
+
+# ---------------------------------------------------------------------------
+# real-subprocess cleanup tests
+# ---------------------------------------------------------------------------
+
+class TestTimeoutKillsTree:
+    """On timeout the entire subprocess tree must be gone."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_sleeping_child(self):
+        """A sleep that times out at 1s must not survive past the call."""
+        marker = _make_marker("timeout")
+        tool = ExecTool(timeout=1)
+
+        task = asyncio.create_task(tool.execute(command=_sleep_cmd(marker)))
+
+        pid = await asyncio.get_event_loop().run_in_executor(
+            None, _wait_for_pid_to_appear, marker, 2.0
+        )
+        assert pid is not None, (
+            f"could not locate the sleep child for marker {marker}; "
+            "test harness failed to observe the process before cleanup"
+        )
+
+        result = await task
+        assert "timed out" in result.lower()
+
+        gone = _wait_for_pid_to_exit(pid, timeout=3.0)
+        assert gone, f"sleep child (pid {pid}) outlived the timed-out exec call"
+
+
+class TestCancelKillsTree:
+    """When the enclosing task is cancelled mid-exec, cleanup still runs."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_kills_sleeping_child(self):
+        marker = _make_marker("cancel")
+        tool = ExecTool(timeout=30)
+        task = asyncio.create_task(tool.execute(command=_sleep_cmd(marker)))
+
+        # Wait for the grandchild to actually exist before we pull the rug.
+        pid = await asyncio.get_event_loop().run_in_executor(
+            None, _wait_for_pid_to_appear, marker, 2.0
+        )
+        assert pid is not None, (
+            "test harness failed to see the sleep child before cancellation"
+        )
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        gone = _wait_for_pid_to_exit(pid, timeout=3.0)
+        assert gone, f"sleep child (pid {pid}) outlived the cancelled exec call"
+
+
+class TestSigtermTrappedChildIsSigkilled:
+    """The sudo-style case: a child that ignores SIGTERM must still die."""
+
+    @pytest.mark.asyncio
+    async def test_sigterm_ignoring_child_is_killed(self, tmp_path):
+        marker = _make_marker("trap")
+        # A bash script that ignores SIGTERM/INT/HUP and holds a sleep child
+        # open via `wait`. The only way out is SIGKILL on the process group.
+        # The sleep is launched in a subshell so we can rewrite its argv[0]
+        # (the marker) — that's what lets the test locate it on /proc.
+        script = tmp_path / "stubborn.sh"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            # trap '' TERM INT HUP = install an empty handler for each
+            # signal (``trap -`` would *reset* to default and let them kill).
+            "trap '' TERM INT HUP\n"
+            f"(exec -a {marker} sleep 30) &\n"
+            "wait $!\n"
+        )
+        script.chmod(0o755)
+
+        tool = ExecTool(timeout=1)
+        task = asyncio.create_task(tool.execute(command=str(script)))
+
+        pid = await asyncio.get_event_loop().run_in_executor(
+            None, _wait_for_pid_to_appear, marker, 2.0
+        )
+        assert pid is not None, (
+            "test harness failed to see the sleep grandchild before cleanup"
+        )
+
+        start = time.monotonic()
+        result = await task
+        elapsed = time.monotonic() - start
+
+        assert "timed out" in result.lower()
+        # _kill_process has a 5s budget to reap; anything longer hints at a
+        # SIGTERM-only kill stuck waiting on a trap-ignoring process.
+        assert elapsed < 10, f"cleanup took {elapsed:.1f}s — SIGTERM likely used"
+
+        gone = _wait_for_pid_to_exit(pid, timeout=3.0)
+        assert gone, (
+            f"sleep grandchild (pid {pid}) beneath the SIGTERM-trapping "
+            f"parent survived cleanup"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _kill_process unit tests
+# ---------------------------------------------------------------------------
+
+class TestKillProcessHandlesMissingGroup:
+    """If the group already exited, killpg's ProcessLookupError must not bubble."""
+
+    @pytest.mark.asyncio
+    async def test_process_lookup_error_is_swallowed(self, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 999999  # almost certainly dead / unused
+        fake_proc.returncode = None
+        fake_proc.kill = MagicMock(side_effect=ProcessLookupError)
+        fake_proc.wait = AsyncMock(return_value=0)
+
+        def boom_getpgid(_pid):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(os, "getpgid", boom_getpgid)
+
+        # Must not raise — a dead group is a no-op, not an error.
+        await ExecTool._kill_process(fake_proc)
+
+    @pytest.mark.asyncio
+    async def test_killpg_is_sigkill_not_sigterm(self, monkeypatch):
+        """The fix skips SIGTERM; sudo/trap-installed children need SIGKILL."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        recorded = []
+
+        def fake_getpgid(pid):
+            return pid  # same-as-pid is fine for bookkeeping
+
+        def fake_killpg(pgid, sig):
+            recorded.append((pgid, sig))
+
+        monkeypatch.setattr(os, "getpgid", fake_getpgid)
+        monkeypatch.setattr(os, "killpg", fake_killpg)
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.returncode = None
+        fake_proc.kill = MagicMock()
+        fake_proc.wait = AsyncMock(return_value=0)
+
+        await ExecTool._kill_process(fake_proc)
+
+        assert recorded, "killpg must be invoked on the pgid"
+        (pgid, sig) = recorded[0]
+        assert sig == signal.SIGKILL, (
+            f"process-group kill must use SIGKILL (got {sig!r}); "
+            "SIGTERM is silently swallowed by sudo/trap-installed children"
+        )

--- a/tests/tools/test_exec_process_group.py
+++ b/tests/tools/test_exec_process_group.py
@@ -34,9 +34,19 @@ import pytest
 
 from nanobot.agent.tools.shell import ExecTool
 
+# Skip on Windows (no POSIX process groups) *and* on POSIX platforms without
+# a Linux-style /proc filesystem (macOS/BSD). The real-subprocess tests locate
+# their grandchildren by scanning /proc/<pid>/cmdline; there's no portable
+# equivalent we can rely on without shelling out to pgrep, which the exec
+# prescreen may itself filter. The production fix (start_new_session + killpg)
+# is exercised generically via the mocked _kill_process tests below, so the
+# /proc-dependent cases just add Linux-side defense in depth.
 pytestmark = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Process-group cleanup is POSIX-only; Windows uses a different path.",
+    sys.platform == "win32" or not os.path.isdir("/proc"),
+    reason=(
+        "Process-group cleanup tests require a Linux-style /proc filesystem; "
+        "Windows has no POSIX process groups and macOS/BSD lack /proc."
+    ),
 )
 
 

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -182,3 +182,78 @@ async def test_exec_ignores_workspace_check_when_not_restricted(tmp_path):
     result = await tool.execute(command="echo ok", working_dir=str(other))
     assert "ok" in result
     assert "outside the configured workspace" not in result
+
+
+# ---------------------------------------------------------------------------
+# MIT-123: shell command pre-screen against the secret-dump denylist.
+#
+# `_guard_command` is the single safety chokepoint for `ExecTool`. It must
+# reject commands whose purpose is to dump environment variables, read SSH /
+# GPG keys, cat credential files, base64 key material for exfil, etc.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # env-dumpers
+        "printenv",
+        "env",
+        "env | grep SECRET",
+        "export -p",
+        # SSH / key file reads
+        "cat ~/.ssh/id_rsa",
+        "less ~/.ssh/id_rsa.pub",
+        # shadow / credential file reads
+        "cat /etc/shadow",
+        "cat ./.env",
+        "cat app/.env.production",
+        "cat /root/credentials.json",
+        # exfil via base64 / xxd
+        "base64 ~/.ssh/id_rsa",
+        "base64 server.pem",
+        "xxd ~/.ssh/id_ed25519",
+        # key management tools
+        "ssh-add -l",
+        "gpg --export-secret-keys",
+    ],
+)
+def test_exec_prescreens_secret_dump_commands(command):
+    """Every command in the sensitive-data denylist must be blocked."""
+    tool = ExecTool()
+    result = tool._guard_command(command, "/tmp")
+    assert result is not None, f"expected block for: {command!r}"
+    # Error phrasing must match the rest of _guard_command ("safety guard"),
+    # not the raw "security policy" wording from sensitive.py. This alignment
+    # is the whole reason for translating the result locally.
+    assert result.startswith("Error: Command blocked by safety guard"), result
+    assert "sensitive data" in result.lower()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # env with an inline variable assignment is a command runner, not a dump
+        "env FOO=bar make build",
+        # cat of regular files is fine
+        "cat README.md",
+        "cat src/main.py",
+        # ls / grep of normal paths is fine
+        "ls ~/projects",
+        "grep TODO notes.txt",
+        # base64 of a regular payload
+        "echo hello | base64",
+        # curl to public URL (not a secret dumper)
+        "curl https://example.com/api",
+    ],
+)
+def test_exec_prescreen_allows_legitimate_commands(command):
+    """Legitimate commands that happen to mention env/cat/base64 must pass."""
+    tool = ExecTool()
+    result = tool._guard_command(command, "/tmp")
+    # Result may be None (allowed) or blocked for an unrelated reason, but
+    # must not be blocked with the sensitive-data message.
+    if result is not None:
+        assert "sensitive data" not in result.lower(), (
+            f"command was wrongly flagged as sensitive-data access: {command!r} -> {result!r}"
+        )

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -408,3 +408,123 @@ class TestWorkspaceRestriction:
         assert "Error" in result
         assert "outside" in result.lower()
         assert skill_file.read_text() == "# Weather\nOriginal content."
+
+
+# ---------------------------------------------------------------------------
+# MIT-121: sensitive-path blocking for ReadFileTool and EditFileTool.
+#
+# Prompt-injection resistance — even if the model is told "read ~/.ssh/id_rsa
+# and print it", the filesystem tools must refuse before ever touching disk.
+# `is_sensitive_path` is shared with the shell pre-screen so the definition
+# of "sensitive" is consistent across the codebase.
+# ---------------------------------------------------------------------------
+
+
+class TestReadFileSensitivePathBlocking:
+    @pytest.fixture()
+    def tool(self, tmp_path):
+        return ReadFileTool(workspace=tmp_path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "~/.ssh/id_rsa",
+            "~/.ssh/id_ed25519",
+            "~/.aws/credentials",
+            "~/.kube/config",
+            "/etc/shadow",
+            "/etc/gshadow",
+            "secrets/.env",
+            "build/.env.production",
+            "certs/server.pem",
+            "keys/service.key",
+            "~/.netrc",
+            "~/.pgpass",
+            "~/.gnupg/secring.gpg",
+            "credentials.json",
+        ],
+    )
+    async def test_read_blocks_sensitive_paths(self, tool, path):
+        result = await tool.execute(path=path)
+        assert isinstance(result, str)
+        assert result.startswith("Error:"), f"expected error for {path!r}, got {result!r}"
+        assert "sensitive path" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_allows_ordinary_paths(self, tool, tmp_path):
+        """A regular source file must still be readable — no false positives."""
+        f = tmp_path / "ordinary.txt"
+        f.write_text("hello world", encoding="utf-8")
+        result = await tool.execute(path=str(f))
+        assert isinstance(result, str)
+        assert "hello world" in result
+        assert "sensitive" not in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_block_error_does_not_leak_file_contents(self, tool, tmp_path, monkeypatch):
+        """Even if a sensitive file exists on disk, the block must pre-empt the read."""
+        # Seed a fake secret at a sensitive location inside tmp_path and trick
+        # the tool into treating it as `/.ssh/id_rsa` via an absolute path.
+        secret_dir = tmp_path / ".ssh"
+        secret_dir.mkdir()
+        secret_file = secret_dir / "id_rsa"
+        secret_file.write_text("SUPER_SECRET_KEY_MATERIAL", encoding="utf-8")
+
+        result = await tool.execute(path=str(secret_file))
+        assert isinstance(result, str)
+        assert "SUPER_SECRET_KEY_MATERIAL" not in result
+        assert result.startswith("Error:")
+        assert "sensitive path" in result.lower()
+
+
+class TestEditFileSensitivePathBlocking:
+    @pytest.fixture()
+    def tool(self, tmp_path):
+        return EditFileTool(workspace=tmp_path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "~/.ssh/id_rsa",
+            "~/.aws/credentials",
+            "~/.kube/config",
+            "/etc/shadow",
+            "secrets/.env",
+            "certs/server.pem",
+            "credentials.json",
+        ],
+    )
+    async def test_edit_blocks_sensitive_paths(self, tool, path):
+        result = await tool.execute(path=path, old_text="foo", new_text="bar")
+        assert isinstance(result, str)
+        assert result.startswith("Error:"), f"expected error for {path!r}, got {result!r}"
+        assert "sensitive path" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_edit_allows_ordinary_paths(self, tool, tmp_path):
+        """A regular file must still be editable — no false positives."""
+        f = tmp_path / "code.py"
+        f.write_text("x = 1\n", encoding="utf-8")
+        result = await tool.execute(path=str(f), old_text="x = 1", new_text="x = 2")
+        assert isinstance(result, str)
+        assert "Successfully edited" in result
+        assert f.read_text() == "x = 2\n"
+
+    @pytest.mark.asyncio
+    async def test_edit_sensitive_does_not_mutate_file(self, tool, tmp_path):
+        """Block must happen before any write hits disk."""
+        secret_dir = tmp_path / ".ssh"
+        secret_dir.mkdir()
+        secret_file = secret_dir / "id_rsa"
+        original = "ORIGINAL_KEY_CONTENT"
+        secret_file.write_text(original, encoding="utf-8")
+
+        result = await tool.execute(
+            path=str(secret_file), old_text=original, new_text="TAMPERED"
+        )
+        assert result.startswith("Error:")
+        assert "sensitive path" in result.lower()
+        # File must be untouched.
+        assert secret_file.read_text() == original

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -528,3 +528,128 @@ class TestEditFileSensitivePathBlocking:
         assert "sensitive path" in result.lower()
         # File must be untouched.
         assert secret_file.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# MIT-121 review follow-up: symlink and traversal regression tests.
+#
+# The sensitive-path check runs twice — once on the caller-provided path and
+# once on the post-`_resolve()` form. The second pass exists specifically to
+# catch indirection: a symlink at an innocent-looking path that terminates
+# inside a sensitive directory, or a `..` traversal that escapes a safe
+# prefix into one. Without a test the defense-in-depth claim is untested.
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkTraversalBlocking:
+    """Regression tests for symlink / `..` escapes to sensitive targets."""
+
+    def _make_sensitive_target(self, tmp_path):
+        """Materialise a sensitive file inside tmp_path and return its path."""
+        secret_dir = tmp_path / ".ssh"
+        secret_dir.mkdir(exist_ok=True)
+        secret = secret_dir / "id_rsa"
+        secret.write_text("SUPER_SECRET_KEY_MATERIAL", encoding="utf-8")
+        return secret
+
+    @pytest.mark.asyncio
+    async def test_read_blocks_symlink_to_sensitive_target(self, tmp_path):
+        """Symlink from innocent-looking path to a sensitive target must block."""
+        secret = self._make_sensitive_target(tmp_path)
+        link = tmp_path / "notes.txt"
+        link.symlink_to(secret)
+
+        tool = ReadFileTool(workspace=tmp_path)
+        try:
+            result = await tool.execute(path=str(link))
+        finally:
+            # Teardown: remove symlink, leave the target for other tests / tmp_path cleanup.
+            if link.is_symlink() or link.exists():
+                link.unlink()
+
+        assert isinstance(result, str)
+        assert result.startswith("Error:")
+        assert "sensitive path" in result.lower()
+        # Contents must never appear in the error response.
+        assert "SUPER_SECRET_KEY_MATERIAL" not in result
+
+    @pytest.mark.asyncio
+    async def test_read_blocks_symlink_chain_to_sensitive_target(self, tmp_path):
+        """Two-hop symlink chain to a sensitive target must still be blocked."""
+        secret = self._make_sensitive_target(tmp_path)
+        hop1 = tmp_path / "hop1.txt"
+        hop2 = tmp_path / "hop2.txt"
+        hop1.symlink_to(secret)
+        hop2.symlink_to(hop1)
+
+        tool = ReadFileTool(workspace=tmp_path)
+        try:
+            result = await tool.execute(path=str(hop2))
+        finally:
+            for link in (hop2, hop1):
+                if link.is_symlink() or link.exists():
+                    link.unlink()
+
+        assert result.startswith("Error:")
+        assert "sensitive path" in result.lower()
+        assert "SUPER_SECRET_KEY_MATERIAL" not in result
+
+    @pytest.mark.asyncio
+    async def test_read_blocks_traversal_to_sensitive_target(self, tmp_path):
+        """A `..` path that resolves into a sensitive directory must block."""
+        secret = self._make_sensitive_target(tmp_path)
+        safe_dir = tmp_path / "safe"
+        safe_dir.mkdir()
+        # safe/../.ssh/id_rsa → resolves to the sensitive file above.
+        traversal = f"{safe_dir}/../.ssh/{secret.name}"
+
+        tool = ReadFileTool(workspace=tmp_path)
+        result = await tool.execute(path=traversal)
+
+        assert result.startswith("Error:")
+        assert "sensitive path" in result.lower()
+        assert "SUPER_SECRET_KEY_MATERIAL" not in result
+
+    @pytest.mark.asyncio
+    async def test_edit_blocks_symlink_to_sensitive_target(self, tmp_path):
+        """edit_file must refuse to write through a symlink to a sensitive file."""
+        secret = self._make_sensitive_target(tmp_path)
+        original = secret.read_text()
+        link = tmp_path / "notes.txt"
+        link.symlink_to(secret)
+
+        tool = EditFileTool(workspace=tmp_path)
+        try:
+            result = await tool.execute(
+                path=str(link),
+                old_text="SUPER_SECRET_KEY_MATERIAL",
+                new_text="TAMPERED",
+            )
+        finally:
+            if link.is_symlink() or link.exists():
+                link.unlink()
+
+        assert result.startswith("Error:")
+        assert "sensitive path" in result.lower()
+        # The underlying target must not have been modified.
+        assert secret.read_text() == original
+
+    @pytest.mark.asyncio
+    async def test_edit_blocks_traversal_to_sensitive_target(self, tmp_path):
+        """edit_file must refuse a `..` path that resolves into a sensitive dir."""
+        secret = self._make_sensitive_target(tmp_path)
+        original = secret.read_text()
+        safe_dir = tmp_path / "safe"
+        safe_dir.mkdir()
+        traversal = f"{safe_dir}/../.ssh/{secret.name}"
+
+        tool = EditFileTool(workspace=tmp_path)
+        result = await tool.execute(
+            path=traversal,
+            old_text="SUPER_SECRET_KEY_MATERIAL",
+            new_text="TAMPERED",
+        )
+
+        assert result.startswith("Error:")
+        assert "sensitive path" in result.lower()
+        assert secret.read_text() == original

--- a/tests/tools/test_search_sensitive.py
+++ b/tests/tools/test_search_sensitive.py
@@ -1,0 +1,201 @@
+"""Tests for GrepTool sensitive-path blocking — MIT-136.
+
+Defence-in-depth: MIT-121 closes read_file/edit_file over sensitive paths;
+MIT-122 redacts secrets from tool output; MIT-136 stops GrepTool from
+reading file contents at sensitive paths in the first place so secret
+material never reaches the scanner.
+
+Design decisions:
+  * Direct hit on a sensitive file  ->  fail the whole call with an
+    explicit blocked-path error (no contents are read).
+  * Recursive descent that includes sensitive files  ->  silently skip
+    each sensitive entry, surface the count in the output notes, and
+    let the rest of the grep proceed.  Rationale: one stray ~/.ssh/
+    inside a large tree shouldn't fail an otherwise-legitimate search.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nanobot.agent.tools.search import GrepTool
+
+
+# ---------------------------------------------------------------------------
+# Direct hit: grep called with a sensitive file as the target
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grep_direct_sensitive_file_is_blocked(tmp_path: Path) -> None:
+    """Grepping straight into a sensitive file (e.g. .ssh/id_rsa) must be
+    refused before any bytes are read."""
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    key_path = ssh_dir / "id_rsa"
+    key_path.write_text(
+        "-----BEGIN RSA PRIVATE KEY-----\nsecret-material\n-----END RSA PRIVATE KEY-----\n",
+        encoding="utf-8",
+    )
+
+    tool = GrepTool(workspace=tmp_path, allowed_dir=tmp_path)
+    result = await tool.execute(pattern="BEGIN RSA", path=".ssh/id_rsa")
+
+    assert result.startswith("Error:"), result
+    assert "protected by security policy" in result
+    # Crucially, no key material leaked through the error.
+    assert "secret-material" not in result
+    assert "BEGIN RSA PRIVATE KEY" not in result
+
+
+@pytest.mark.asyncio
+async def test_grep_direct_env_file_is_blocked(tmp_path: Path) -> None:
+    """.env is in the sensitive-filename list; direct grep must refuse."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("API_KEY=s3cret\n", encoding="utf-8")
+
+    tool = GrepTool(workspace=tmp_path, allowed_dir=tmp_path)
+    result = await tool.execute(pattern="API_KEY", path=".env")
+
+    assert result.startswith("Error:"), result
+    assert "protected by security policy" in result
+    assert "s3cret" not in result
+
+
+@pytest.mark.asyncio
+async def test_grep_direct_pem_file_is_blocked(tmp_path: Path) -> None:
+    """*.pem matches the sensitive-filename regex; direct grep must refuse."""
+    pem_path = tmp_path / "server.pem"
+    pem_path.write_text("fake-pem-body\n", encoding="utf-8")
+
+    tool = GrepTool(workspace=tmp_path, allowed_dir=tmp_path)
+    result = await tool.execute(pattern="fake", path="server.pem")
+
+    assert result.startswith("Error:"), result
+    assert "protected by security policy" in result
+
+
+# ---------------------------------------------------------------------------
+# Recursive descent: sensitive files inside a scanned tree are skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grep_recursive_skips_ssh_silently(tmp_path: Path) -> None:
+    """Recursive grep over a tree containing .ssh/ must:
+      * Not fail the call
+      * Not surface any content from the .ssh/ file
+      * Return matches from the other (non-sensitive) files as normal
+      * Report a 'skipped N sensitive-path files' note
+    """
+    # Normal source tree
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text(
+        "TOKEN = 'BEGIN RSA MARKER in source'\n", encoding="utf-8"
+    )
+
+    # Sensitive material nested under the scan root
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "id_rsa").write_text(
+        "-----BEGIN RSA PRIVATE KEY-----\nreal-key\n-----END RSA PRIVATE KEY-----\n",
+        encoding="utf-8",
+    )
+
+    tool = GrepTool(workspace=tmp_path, allowed_dir=tmp_path)
+    result = await tool.execute(pattern="BEGIN RSA", path=".")
+
+    # Recursive call must succeed (not return an Error:)
+    assert not result.startswith("Error:"), result
+
+    # Non-sensitive source file was grepped as usual
+    assert "src/app.py" in result
+
+    # Sensitive file path must never appear in output
+    assert ".ssh/id_rsa" not in result
+    assert "real-key" not in result
+    # Key body never surfaced either
+    assert "real-key" not in result
+
+    # Skip count is reported
+    assert "sensitive-path files" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_recursive_skip_note_counts_multiple_files(tmp_path: Path) -> None:
+    """Multiple sensitive files in the tree are all skipped and counted."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "ok.py").write_text("pattern here\n", encoding="utf-8")
+
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "id_rsa").write_text("pattern here\n", encoding="utf-8")
+    (ssh_dir / "id_ed25519").write_text("pattern here\n", encoding="utf-8")
+
+    (tmp_path / "secret.pem").write_text("pattern here\n", encoding="utf-8")
+
+    tool = GrepTool(workspace=tmp_path, allowed_dir=tmp_path)
+    result = await tool.execute(pattern="pattern here", path=".")
+
+    assert "src/ok.py" in result
+    assert ".ssh" not in result
+    assert "secret.pem" not in result
+    # At least 3 sensitive files skipped — exact number may include .pub etc.
+    assert "sensitive-path files" in result
+
+
+# ---------------------------------------------------------------------------
+# Negative cases: ordinary paths still work
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grep_ordinary_file_is_allowed(tmp_path: Path) -> None:
+    """Non-sensitive targets keep working unchanged."""
+    path = tmp_path / "notes.txt"
+    path.write_text("hello world\n", encoding="utf-8")
+
+    tool = GrepTool(workspace=tmp_path, allowed_dir=tmp_path)
+    result = await tool.execute(pattern="hello", path="notes.txt")
+
+    assert not result.startswith("Error:"), result
+    assert "notes.txt" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_ordinary_directory_is_allowed(tmp_path: Path) -> None:
+    """Non-sensitive directory targets keep working unchanged and do not
+    spuriously emit a 'skipped sensitive' note."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "a.py").write_text("needle\n", encoding="utf-8")
+    (tmp_path / "src" / "b.py").write_text("needle\n", encoding="utf-8")
+
+    tool = GrepTool(workspace=tmp_path, allowed_dir=tmp_path)
+    result = await tool.execute(pattern="needle", path="src")
+
+    assert not result.startswith("Error:"), result
+    assert "a.py" in result
+    assert "b.py" in result
+    assert "sensitive-path files" not in result
+
+
+@pytest.mark.asyncio
+async def test_grep_no_matches_still_works_in_tree_with_sensitive_files(
+    tmp_path: Path,
+) -> None:
+    """If the pattern doesn't match anything, the standard no-matches message
+    is returned — the sensitive skip logic must not shadow it."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("unrelated content\n", encoding="utf-8")
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "id_rsa").write_text("PRIVATE\n", encoding="utf-8")
+
+    tool = GrepTool(workspace=tmp_path, allowed_dir=tmp_path)
+    result = await tool.execute(pattern="does-not-match", path=".")
+
+    # Either a no-matches message or at worst an empty result with notes
+    assert "does-not-match" in result or "No matches" in result
+    assert "PRIVATE" not in result

--- a/tests/tools/test_tool_registry.py
+++ b/tests/tools/test_tool_registry.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from nanobot.agent.tools.base import Tool
 from nanobot.agent.tools.registry import ToolRegistry
 
@@ -101,3 +103,150 @@ def test_unregister_invalidates_cache() -> None:
     second = registry.get_definitions()
     assert first is not second
     assert len(second) == 1
+
+
+# ---------------------------------------------------------------------------
+# Secret redaction (MIT-122)
+#
+# ToolRegistry.execute() must scrub embedded secrets from string results so
+# that, even if a misbehaving or adversarial tool pulls a private key or API
+# token into its output, the model never gets to see it. Non-string results
+# (e.g. ReadFileTool returning a list of multimodal image blocks) must pass
+# through untouched.
+# ---------------------------------------------------------------------------
+
+
+class _StringReturningTool(Tool):
+    """Fake tool that returns a caller-supplied string verbatim."""
+
+    def __init__(self, name: str, payload: str):
+        self._name = name
+        self._payload = payload
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"{self._name} tool"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs: Any) -> Any:
+        return self._payload
+
+
+class _ListReturningTool(Tool):
+    """Fake tool that returns a list result (mimics ReadFileTool for images)."""
+
+    def __init__(self, name: str, payload: list[dict[str, Any]]):
+        self._name = name
+        self._payload = payload
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"{self._name} tool"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs: Any) -> Any:
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_execute_redacts_private_key_in_output() -> None:
+    payload = (
+        "Here are some notes:\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEAy3... (truncated)\n"
+        "-----END RSA PRIVATE KEY-----\n"
+    )
+    registry = ToolRegistry()
+    registry.register(_StringReturningTool("leaky", payload))
+
+    result = await registry.execute("leaky", {})
+
+    assert "BEGIN RSA PRIVATE KEY" not in result
+    assert "REDACTED" in result
+    assert "security policy" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_redacts_aws_access_key() -> None:
+    payload = "export AWS_ACCESS_KEY_ID=AKIAABCDEFGHIJKLMNOP\n"
+    registry = ToolRegistry()
+    registry.register(_StringReturningTool("leaky", payload))
+
+    result = await registry.execute("leaky", {})
+
+    assert "AKIAABCDEFGHIJKLMNOP" not in result
+    assert "REDACTED" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_redacts_github_token() -> None:
+    payload = "Authorization: token ghp_0123456789abcdef0123456789abcdef0123\n"
+    registry = ToolRegistry()
+    registry.register(_StringReturningTool("leaky", payload))
+
+    result = await registry.execute("leaky", {})
+
+    assert "ghp_0123456789abcdef0123456789abcdef0123" not in result
+    assert "REDACTED" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_clean_output_unchanged() -> None:
+    payload = "hello, world — no secrets here"
+    registry = ToolRegistry()
+    registry.register(_StringReturningTool("clean", payload))
+
+    result = await registry.execute("clean", {})
+
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_touch_list_results() -> None:
+    """Non-string results (image blocks from ReadFileTool) must pass through."""
+    image_blocks: list[dict[str, Any]] = [
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+            "_meta": {"path": "/tmp/pixel.png"},
+        },
+        {"type": "text", "text": "(Image file: /tmp/pixel.png)"},
+    ]
+    registry = ToolRegistry()
+    registry.register(_ListReturningTool("read_file", image_blocks))
+
+    result = await registry.execute("read_file", {})
+
+    # Identity — the list must flow through untouched, not stringified.
+    assert result is image_blocks
+    assert isinstance(result, list)
+    assert result[0]["image_url"]["url"] == "data:image/png;base64,AAAA"
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_redact_error_output() -> None:
+    """Error outputs are short-circuited before the redactor runs.
+
+    Error strings are safe by construction (they come from our own error
+    builders) and we want them to reach the model verbatim so it can react.
+    """
+    registry = ToolRegistry()
+    registry.register(_StringReturningTool("boom", "Error: something bad"))
+
+    result = await registry.execute("boom", {})
+
+    assert result.startswith("Error: something bad")

--- a/tests/tools/test_tool_registry.py
+++ b/tests/tools/test_tool_registry.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from nanobot.agent.tools.base import Tool
 from nanobot.agent.tools.registry import ToolRegistry
 
@@ -49,37 +51,58 @@ def test_get_definitions_orders_builtins_then_mcp_tools() -> None:
     ]
 
 
-def test_prepare_call_read_file_rejects_non_object_params_with_actionable_hint() -> None:
+# ---------------------------------------------------------------------------
+# Parameter-type validation for read_file / write_file — originally covered
+# by `registry.prepare_call(...)` (removed in commit 1d18d24 when the
+# timing/audit wrapper in `execute()` absorbed `prepare_call`).  The
+# semantic contract still holds through `execute()`, so the tests are
+# re-targeted there to keep the coverage.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_read_file_rejects_non_object_params_with_actionable_hint() -> None:
     registry = ToolRegistry()
     registry.register(_FakeTool("read_file"))
 
-    tool, params, error = registry.prepare_call("read_file", ["foo.txt"])
+    result = await registry.execute("read_file", ["foo.txt"])
 
-    assert tool is None
-    assert params == ["foo.txt"]
-    assert error is not None
-    assert "must be a JSON object" in error
-    assert "Use named parameters" in error
+    assert "must be a JSON object" in result
+    assert "Use named parameters" in result
 
 
-def test_prepare_call_other_tools_keep_generic_object_validation() -> None:
+@pytest.mark.asyncio
+async def test_execute_other_tools_keep_generic_object_validation() -> None:
+    """Non read_file/write_file tools still flow through the generic
+    `validate_params` path and get the generic error message."""
     registry = ToolRegistry()
     registry.register(_FakeTool("grep"))
 
-    tool, params, error = registry.prepare_call("grep", ["TODO"])
+    result = await registry.execute("grep", ["TODO"])
 
-    assert tool is not None
-    assert params == ["TODO"]
-    assert error == "Error: Invalid parameters for tool 'grep': parameters must be an object, got list"
+    # The specific 'JSON object' hint is reserved for read_file/write_file.
+    assert "must be a JSON object" not in result
+    # And the generic validator's error surfaces instead.
+    assert "Invalid parameters for tool 'grep'" in result
 
 
-def test_get_definitions_returns_cached_result() -> None:
+# ---------------------------------------------------------------------------
+# Cache behaviour for get_definitions().  The internal attribute was
+# renamed `_cached_definitions` -> `_definitions_cache` in commit 1d18d24,
+# so the old test that poked at the attribute by its old name is removed.
+# The observable contract — same list instance across calls, fresh list
+# after mutation — is kept via the two invalidation tests below.
+# ---------------------------------------------------------------------------
+
+
+def test_get_definitions_is_cached_between_calls() -> None:
+    """Back-to-back calls return the same list instance (stable ordering
+    cache, no resorting)."""
     registry = ToolRegistry()
     registry.register(_FakeTool("read_file"))
     first = registry.get_definitions()
-    assert registry._cached_definitions is not None
     second = registry.get_definitions()
-    assert first == second
+    assert first is second
 
 
 def test_register_invalidates_cache() -> None:

--- a/tests/tools/test_tool_registry.py
+++ b/tests/tools/test_tool_registry.py
@@ -297,6 +297,12 @@ async def test_execute_does_not_touch_list_results() -> None:
 # `redact_if_sensitive()` call; the `_HINT` suffix is appended *after*
 # redaction on the error branch so the "try another approach" nudge still
 # reaches the model.
+#
+# Downstream contract: `AgentRunner._run_tool()` (and other consumers) use
+# `result.startswith("Error")` to detect failed tool calls. The bare
+# redaction notice does NOT begin with "Error", so the registry re-wraps
+# the redacted body in an "Error ..." shell on the error branches to
+# preserve that contract.
 # ---------------------------------------------------------------------------
 
 
@@ -313,6 +319,8 @@ async def test_execute_redacts_aws_key_in_error_output() -> None:
     assert "REDACTED" in result
     # The error-path hint still attaches so the model knows to try again.
     assert "Analyze the error above" in result
+    # Downstream-contract: failure detection via startswith("Error")
+    assert result.startswith("Error")
 
 
 @pytest.mark.asyncio
@@ -333,6 +341,7 @@ async def test_execute_redacts_pem_material_in_error_output() -> None:
     assert "MIIEowIBAAKCAQEAy3SECRETSECRETSECRET" not in result
     assert "REDACTED" in result
     assert "Analyze the error above" in result
+    assert result.startswith("Error")
 
 
 @pytest.mark.asyncio
@@ -350,6 +359,7 @@ async def test_execute_redacts_github_token_in_error_output() -> None:
     assert "ghp_0123456789abcdef0123456789abcdef0123" not in result
     assert "REDACTED" in result
     assert "Analyze the error above" in result
+    assert result.startswith("Error")
 
 
 @pytest.mark.asyncio
@@ -390,6 +400,7 @@ async def test_execute_redacts_secret_in_exception_message() -> None:
     assert "BEGIN OPENSSH PRIVATE KEY" not in result
     assert "REDACTED" in result
     assert "Analyze the error above" in result
+    assert result.startswith("Error")
 
 
 @pytest.mark.asyncio
@@ -405,6 +416,7 @@ async def test_execute_redacts_akia_in_exception_message() -> None:
     assert "AKIAABCDEFGHIJKLMNOP" not in result
     assert "REDACTED" in result
     assert "Analyze the error above" in result
+    assert result.startswith("Error")
 
 
 @pytest.mark.asyncio
@@ -419,6 +431,58 @@ async def test_execute_clean_exception_passes_through_with_hint() -> None:
     assert "disk full" in result
     assert "Analyze the error above" in result
     assert "REDACTED" not in result
+    assert result.startswith("Error")
+
+
+@pytest.mark.asyncio
+async def test_execute_preserves_error_prefix_when_whole_body_is_redacted() -> None:
+    """MIT-147 (codex review): `AgentRunner._run_tool()` relies on
+    `result.startswith("Error")` to classify tool calls as failed.
+
+    Before the codex fix, when a tool returned an error string consisting ONLY
+    of secret material (worst case), `redact_if_sensitive()` would replace the
+    whole body with `[REDACTED — ...]` — which does NOT start with "Error".
+    The runner would then mark the call as `ok` and skip `fail_on_tool_error`
+    handling. This test pins the fix: the registry re-wraps a scrubbed error
+    body in an `Error (...)` shell so the downstream detector keeps working.
+    """
+    # Pathological case: the entire error body is the secret. The redactor
+    # replaces the whole string, leaving no "Error:" prefix in the raw match.
+    secret_only = "AKIAABCDEFGHIJKLMNOP"
+    registry = ToolRegistry()
+    # The tool returns a pure-error string starting with "Error" (so the
+    # registry classifies status=error), but the payload after that is just
+    # the secret — redaction swallows everything downstream of the first match.
+    registry.register(
+        _StringReturningTool("pure_error", f"Error: {secret_only}")
+    )
+
+    result = await registry.execute("pure_error", {})
+
+    # Secret must be gone.
+    assert secret_only not in result
+    # Redaction notice must be present.
+    assert "REDACTED" in result
+    # CRITICAL: the runner uses startswith("Error") to detect failures.
+    # If this regresses, `fail_on_tool_error` paths stop firing.
+    assert result.startswith("Error")
+    # Hint is still appended.
+    assert "Analyze the error above" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_preserves_error_prefix_when_exception_body_is_redacted() -> None:
+    """Same downstream-contract guarantee on the exception branch."""
+    secret_only_exc = RuntimeError("AKIAABCDEFGHIJKLMNOP")
+    registry = ToolRegistry()
+    registry.register(_RaisingTool("bad_exc", secret_only_exc))
+
+    result = await registry.execute("bad_exc", {})
+
+    assert "AKIAABCDEFGHIJKLMNOP" not in result
+    assert "REDACTED" in result
+    assert result.startswith("Error")  # downstream failure detection contract
+    assert "Analyze the error above" in result
 
 
 class _AnyReturningTool(Tool):

--- a/tests/tools/test_tool_registry.py
+++ b/tests/tools/test_tool_registry.py
@@ -183,6 +183,32 @@ class _ListReturningTool(Tool):
         return self._payload
 
 
+class _RaisingTool(Tool):
+    """Fake tool that raises a caller-supplied exception when executed.
+
+    Used to exercise the `except Exception` branch of `ToolRegistry.execute()`.
+    """
+
+    def __init__(self, name: str, exc: BaseException):
+        self._name = name
+        self._exc = exc
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"{self._name} tool"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs: Any) -> Any:
+        raise self._exc
+
+
 @pytest.mark.asyncio
 async def test_execute_redacts_private_key_in_output() -> None:
     payload = (
@@ -258,19 +284,141 @@ async def test_execute_does_not_touch_list_results() -> None:
     assert result[0]["image_url"]["url"] == "data:image/png;base64,AAAA"
 
 
-@pytest.mark.asyncio
-async def test_execute_does_not_redact_error_output() -> None:
-    """Error outputs are short-circuited before the redactor runs.
+# ---------------------------------------------------------------------------
+# Error-path redaction (MIT-147)
+#
+# Before MIT-147, `ToolRegistry.execute()` short-circuited on
+# `isinstance(result, str) and result.startswith("Error")` and returned
+# `result + _HINT` without running the secret scrubber. A tool that produced
+# an error string carrying a secret — e.g. an auth module that echoes the
+# rejected AKIA key back in its error message, or a PEM parser that dumps
+# the offending blob — would therefore leak that secret straight to the
+# model.  MIT-147 routes both success and error branches through the same
+# `redact_if_sensitive()` call; the `_HINT` suffix is appended *after*
+# redaction on the error branch so the "try another approach" nudge still
+# reaches the model.
+# ---------------------------------------------------------------------------
 
-    Error strings are safe by construction (they come from our own error
-    builders) and we want them to reach the model verbatim so it can react.
-    """
+
+@pytest.mark.asyncio
+async def test_execute_redacts_aws_key_in_error_output() -> None:
+    """MIT-147: AKIA-style secrets embedded in Error: strings must be scrubbed."""
+    payload = "Error: invalid AWS credentials: AKIAABCDEFGHIJKLMNOP is not valid"
     registry = ToolRegistry()
-    registry.register(_StringReturningTool("boom", "Error: something bad"))
+    registry.register(_StringReturningTool("boom", payload))
 
     result = await registry.execute("boom", {})
 
-    assert result.startswith("Error: something bad")
+    assert "AKIAABCDEFGHIJKLMNOP" not in result
+    assert "REDACTED" in result
+    # The error-path hint still attaches so the model knows to try again.
+    assert "Analyze the error above" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_redacts_pem_material_in_error_output() -> None:
+    """MIT-147: a tool that dumps a PEM blob into its error message must have it scrubbed."""
+    payload = (
+        "Error parsing key file:\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEAy3SECRETSECRETSECRETSECRETSECRETSECRETSECRETSECRET==\n"
+        "-----END RSA PRIVATE KEY-----\n"
+    )
+    registry = ToolRegistry()
+    registry.register(_StringReturningTool("parser", payload))
+
+    result = await registry.execute("parser", {})
+
+    assert "BEGIN RSA PRIVATE KEY" not in result
+    assert "MIIEowIBAAKCAQEAy3SECRETSECRETSECRET" not in result
+    assert "REDACTED" in result
+    assert "Analyze the error above" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_redacts_github_token_in_error_output() -> None:
+    """MIT-147: a GitHub token exfiltration attempt via Error: string is scrubbed."""
+    payload = (
+        "Error: GitHub API rejected token "
+        "ghp_0123456789abcdef0123456789abcdef0123 (403 Forbidden)"
+    )
+    registry = ToolRegistry()
+    registry.register(_StringReturningTool("gh", payload))
+
+    result = await registry.execute("gh", {})
+
+    assert "ghp_0123456789abcdef0123456789abcdef0123" not in result
+    assert "REDACTED" in result
+    assert "Analyze the error above" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_clean_error_passes_through_with_hint() -> None:
+    """MIT-147: error strings with no secrets stay intact and still gain the HINT suffix.
+
+    This is the regression guard for the previous test_execute_does_not_redact_error_output
+    behavior — the hint is still there, the body is still readable; the only change is
+    that secret-bearing error bodies now get scrubbed.
+    """
+    registry = ToolRegistry()
+    registry.register(_StringReturningTool("boom", "Error: something bad happened"))
+
+    result = await registry.execute("boom", {})
+
+    assert result.startswith("Error: something bad happened")
+    assert "Analyze the error above" in result
+    # No REDACTED substitution for clean errors.
+    assert "REDACTED" not in result
+
+
+@pytest.mark.asyncio
+async def test_execute_redacts_secret_in_exception_message() -> None:
+    """MIT-147: secrets embedded in raised exceptions must also be scrubbed.
+
+    A tool that raises `ValueError(f"could not parse {pem_content}")` would previously
+    surface the PEM blob verbatim in the `Error executing {name}: {str(e)}` line.
+    """
+    pem_in_exc = (
+        "could not parse: -----BEGIN OPENSSH PRIVATE KEY----- "
+        "MIIEowIBAAKCAQEAy3 (truncated) -----END OPENSSH PRIVATE KEY-----"
+    )
+    registry = ToolRegistry()
+    registry.register(_RaisingTool("parser", ValueError(pem_in_exc)))
+
+    result = await registry.execute("parser", {})
+
+    assert "BEGIN OPENSSH PRIVATE KEY" not in result
+    assert "REDACTED" in result
+    assert "Analyze the error above" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_redacts_akia_in_exception_message() -> None:
+    """MIT-147: AKIA keys in exception messages are scrubbed on the except branch."""
+    registry = ToolRegistry()
+    registry.register(
+        _RaisingTool("aws", RuntimeError("connection failed for AKIAABCDEFGHIJKLMNOP"))
+    )
+
+    result = await registry.execute("aws", {})
+
+    assert "AKIAABCDEFGHIJKLMNOP" not in result
+    assert "REDACTED" in result
+    assert "Analyze the error above" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_clean_exception_passes_through_with_hint() -> None:
+    """Regression: clean exception messages surface intact with the HINT suffix."""
+    registry = ToolRegistry()
+    registry.register(_RaisingTool("boom", RuntimeError("disk full")))
+
+    result = await registry.execute("boom", {})
+
+    assert "Error executing boom" in result
+    assert "disk full" in result
+    assert "Analyze the error above" in result
+    assert "REDACTED" not in result
 
 
 class _AnyReturningTool(Tool):

--- a/tests/tools/test_tool_registry.py
+++ b/tests/tools/test_tool_registry.py
@@ -250,3 +250,71 @@ async def test_execute_does_not_redact_error_output() -> None:
     result = await registry.execute("boom", {})
 
     assert result.startswith("Error: something bad")
+
+
+class _AnyReturningTool(Tool):
+    """Fake tool that returns an arbitrary non-string payload verbatim."""
+
+    def __init__(self, name: str, payload: Any):
+        self._name = name
+        self._payload = payload
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"{self._name} tool"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs: Any) -> Any:
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_structured_payload_containing_secret_string_unchanged() -> None:
+    """Document string-only redaction scope: nested structured payloads pass through.
+
+    Current behavior is string-only redaction; `ToolRegistry.execute()` guards the
+    scrubber with `isinstance(result, str)`, so dict/list results flow through
+    untouched even when they embed secret-looking strings in nested fields. This
+    is intentional today (image blocks from ReadFileTool are list[dict]), but it
+    is a known scope limit: if a future tool returns user-facing text in a nested
+    field, consider recursive scanning (tracked separately, unticketed).
+
+    This test is a regression guard + scope-documentation test, not a fix.
+    """
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEAy3... (truncated)\n"
+        "-----END RSA PRIVATE KEY-----\n"
+    )
+    # Nested dict (simulating a future tool that returns structured output)
+    dict_payload: dict[str, Any] = {"content": pem, "meta": {"path": "/tmp/key.pem"}}
+    registry = ToolRegistry()
+    registry.register(_AnyReturningTool("structured_dict", dict_payload))
+
+    result = await registry.execute("structured_dict", {})
+
+    # Pass-through: the dict flows through untouched, secret string still present.
+    assert result is dict_payload
+    assert isinstance(result, dict)
+    assert "BEGIN RSA PRIVATE KEY" in result["content"]
+    assert "REDACTED" not in result["content"]
+
+    # Same contract for a list of dicts with a nested secret string.
+    list_payload: list[dict[str, Any]] = [
+        {"type": "text", "text": "Authorization: token ghp_0123456789abcdef0123456789abcdef0123"},
+    ]
+    registry2 = ToolRegistry()
+    registry2.register(_AnyReturningTool("structured_list", list_payload))
+
+    result2 = await registry2.execute("structured_list", {})
+
+    assert result2 is list_payload
+    assert isinstance(result2, list)
+    assert "ghp_0123456789abcdef0123456789abcdef0123" in result2[0]["text"]

--- a/tests/tools/test_tool_registry_set_context.py
+++ b/tests/tools/test_tool_registry_set_context.py
@@ -1,0 +1,65 @@
+"""Regression tests for ToolRegistry.set_context — MIT-138.
+
+Covers the sender-id propagation path from the registry into the filesystem
+tools module, which previously referenced a symbol (`_current_sender_id`)
+that was not defined in `filesystem.py`.
+"""
+
+from __future__ import annotations
+
+from nanobot.agent.tools import filesystem as _fs
+from nanobot.agent.tools.registry import ToolRegistry
+
+
+def test_set_context_does_not_raise() -> None:
+    """set_context must complete cleanly — no AttributeError from the
+    `_fs._current_sender_id = sender_id` assignment."""
+    registry = ToolRegistry()
+    # No exception should surface here.
+    registry.set_context(session_id="sess-1", channel="slack", sender_id="user-42")
+
+
+def test_set_context_propagates_sender_to_filesystem_module() -> None:
+    """After set_context, the filesystem module's sender-id mirror must match
+    the value the registry was given."""
+    registry = ToolRegistry()
+    registry.set_context(session_id="sess-2", channel="matrix", sender_id="alice")
+
+    assert _fs._current_sender_id == "alice"
+
+    # Subsequent calls overwrite, not append.
+    registry.set_context(session_id="sess-3", channel="matrix", sender_id="bob")
+    assert _fs._current_sender_id == "bob"
+
+
+def test_set_context_stores_fields_on_registry() -> None:
+    """set_context must persist the full triple on the registry too, so
+    per-call audit logging can fall back to them when no override is given."""
+    registry = ToolRegistry()
+    registry.set_context(session_id="sess-4", channel="teams", sender_id="carol")
+
+    assert registry._session_id == "sess-4"
+    assert registry._channel == "teams"
+    assert registry._sender_id == "carol"
+
+
+def test_set_context_default_sender_id_is_empty_string() -> None:
+    """sender_id is optional — calling set_context without it must not raise
+    and must normalise to an empty string in the filesystem module (matches
+    the module-level default)."""
+    registry = ToolRegistry()
+    registry.set_context(session_id="sess-5", channel="cli")
+
+    assert registry._sender_id == ""
+    assert _fs._current_sender_id == ""
+
+
+def test_filesystem_module_defines_current_sender_id_at_import() -> None:
+    """Guard the module-level attribute itself — importing the filesystem
+    module without first calling set_context must still leave the symbol
+    defined with its documented default value type."""
+    # Fresh import shouldn't be needed — we just assert the symbol exists
+    # and is a string.  The default value after set_context above may be
+    # anything (test ordering is not guaranteed), but the type must hold.
+    assert hasattr(_fs, "_current_sender_id")
+    assert isinstance(_fs._current_sender_id, str)

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -658,3 +658,164 @@ def test_cast_nullable_param_no_crash() -> None:
     assert result["name"] == "hello"
     result = tool.cast_params({"name": None})
     assert result["name"] is None
+
+
+# --- MIT-145: composite-to-string coercion guard ---
+
+
+def test_cast_params_list_not_stringified_for_string_type() -> None:
+    """Lists passed where a string is expected must not be stringified.
+
+    Regression: codex flagged during PR #8 review that ``str([...])`` silently
+    produced ``"['/tmp/x']"`` which passed ``validate_params`` (since the
+    result is a string) and reached the tool's execute() with garbage input.
+    """
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+    )
+    result = tool.cast_params({"path": ["/tmp/x"]})
+    # Composite value must pass through unchanged, not be stringified.
+    assert result["path"] == ["/tmp/x"]
+    assert isinstance(result["path"], list)
+    # validate_params must now reject it cleanly.
+    errors = tool.validate_params(result)
+    assert any("path should be string" in e for e in errors)
+
+
+def test_cast_params_dict_not_stringified_for_string_type() -> None:
+    """Dicts passed where a string is expected must not be stringified."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+    )
+    result = tool.cast_params({"path": {"k": "v"}})
+    assert result["path"] == {"k": "v"}
+    assert isinstance(result["path"], dict)
+    errors = tool.validate_params(result)
+    assert any("path should be string" in e for e in errors)
+
+
+def test_cast_params_tuple_not_stringified_for_string_type() -> None:
+    """Tuples must also skip stringification (same failure mode)."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+        }
+    )
+    result = tool.cast_params({"path": ("/tmp/x", "/tmp/y")})
+    assert result["path"] == ("/tmp/x", "/tmp/y")
+    errors = tool.validate_params(result)
+    assert any("path should be string" in e for e in errors)
+
+
+def test_cast_params_set_not_stringified_for_string_type() -> None:
+    """Sets must also skip stringification."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+        }
+    )
+    value = {"/tmp/x"}
+    result = tool.cast_params({"path": value})
+    assert result["path"] == value
+    assert isinstance(result["path"], set)
+    errors = tool.validate_params(result)
+    assert any("path should be string" in e for e in errors)
+
+
+def test_cast_params_nullable_string_list_not_stringified() -> None:
+    """Composite guard also applies for nullable string unions."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"path": {"type": ["string", "null"]}},
+        }
+    )
+    result = tool.cast_params({"path": ["/tmp/x"]})
+    assert result["path"] == ["/tmp/x"]
+    errors = tool.validate_params(result)
+    assert any("path should be string" in e for e in errors)
+
+
+def test_cast_params_primitive_casts_preserved_integer() -> None:
+    """Existing primitive casts must keep working (regression sentinel)."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"count": {"type": "integer"}},
+        }
+    )
+    result = tool.cast_params({"count": "3"})
+    assert result["count"] == 3
+    assert isinstance(result["count"], int)
+
+
+def test_cast_params_primitive_casts_preserved_boolean() -> None:
+    """Existing boolean string casts must keep working."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"enabled": {"type": "boolean"}},
+        }
+    )
+    assert tool.cast_params({"enabled": "true"})["enabled"] is True
+    assert tool.cast_params({"enabled": "false"})["enabled"] is False
+
+
+def test_cast_params_integer_stringification_still_works_for_string_type() -> None:
+    """Non-composite scalars (int, float, bool) should still stringify for string target."""
+    tool = CastTestTool(
+        {
+            "type": "object",
+            "properties": {"label": {"type": "string"}},
+        }
+    )
+    # Preserving pre-MIT-145 behavior: scalars get str()'d.
+    assert tool.cast_params({"label": 42})["label"] == "42"
+    assert tool.cast_params({"label": 3.14})["label"] == "3.14"
+    assert tool.cast_params({"label": True})["label"] == "True"
+
+
+async def test_registry_rejects_composite_string_coercion() -> None:
+    """End-to-end: ToolRegistry.execute with composite-for-string returns a
+    validation error instead of silently executing with stringified garbage.
+    """
+    from nanobot.agent.tools.registry import ToolRegistry
+
+    class _StringPathTool(Tool):
+        @property
+        def name(self) -> str:
+            return "string_path_tool"
+
+        @property
+        def description(self) -> str:
+            return "requires a string path"
+
+        @property
+        def parameters(self) -> dict[str, Any]:
+            return {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            }
+
+        async def execute(self, **kwargs: Any) -> str:
+            # If we reach here with a list, the bug is back.
+            return f"executed with path={kwargs['path']!r}"
+
+    reg = ToolRegistry()
+    reg.register(_StringPathTool())
+    result = await reg.execute("string_path_tool", {"path": ["/tmp/x"]})
+    assert "Invalid parameters" in result
+    assert "path should be string" in result
+    # And it must NOT have reached execute() with the stringified list.
+    assert "executed with path=" not in result

--- a/tests/utils/test_sensitive.py
+++ b/tests/utils/test_sensitive.py
@@ -238,6 +238,12 @@ def test_ssh_public_key_inside_ssh_dir_still_blocked_by_path_rule() -> None:
         "2026-04-21 http POST /api Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9xxxxxxx 200",
         # With surrounding structured-output quotes — generic synthetic token
         'headers = {"Authorization": "Bearer tkn_fakefakefakefakefakefake"}',
+        # Case variants — RFC 7235 says auth-scheme is case-insensitive
+        "authorization: bearer abcdefghijklmnopqrstuvwxyz",  # lowercase
+        "Authorization: BEARER ABCDEFGHIJKLMNOPQRSTUVWXYZ",  # uppercase
+        "Authorization: BeArEr MixedCaseTokenAbcdefghijklmn",  # mixed
+        # Base64 token with `/` and `+` characters (opaque tokens)
+        "Authorization: Bearer abc/def+ghi/jkl+mno/pqrstuvw",
     ],
 )
 def test_bearer_token_is_detected(text: str) -> None:
@@ -273,6 +279,34 @@ def test_bearer_redaction_output_shape() -> None:
     assert "eyJhbGciOiJIUzI1NiIs_abcdefghijklmnopqrst" not in result
     assert "REDACTED" in result
     assert "bearer token" in result
+
+
+def test_bearer_case_insensitive_redaction() -> None:
+    """Defence-in-depth regression: the redactor must scrub lowercase/UPPERCASE Bearer too."""
+    # Lowercase header — common when middleware normalizes headers
+    lower = "authorization: bearer opaque_token_abcdefghij1234567890\n"
+    out_lower = redact_if_sensitive(lower)
+    assert "opaque_token_abcdefghij1234567890" not in out_lower
+    assert "REDACTED" in out_lower
+
+    # All-caps
+    upper = "AUTHORIZATION: BEARER opaque_token_ABCDEFGHIJ1234567890\n"
+    out_upper = redact_if_sensitive(upper)
+    assert "opaque_token_ABCDEFGHIJ1234567890" not in out_upper
+    assert "REDACTED" in out_upper
+
+
+def test_bearer_base64_token_redaction() -> None:
+    """Regression: base64 tokens with `/` and `+` in the payload must be scrubbed.
+
+    Opaque/session bearer tokens are often raw base64 — the pattern must include
+    those characters (matching the labeled-credential regex charset) or real
+    Authorization headers will leak through.
+    """
+    payload = "Authorization: Bearer abc/def+ghi/jkl+mno/pqrstuvwxyz01\n"
+    result = redact_if_sensitive(payload)
+    assert "abc/def+ghi/jkl+mno/pqrstuvwxyz01" not in result
+    assert "REDACTED" in result
 
 
 def test_existing_credential_patterns_still_match() -> None:

--- a/tests/utils/test_sensitive.py
+++ b/tests/utils/test_sensitive.py
@@ -7,6 +7,8 @@ import pytest
 from nanobot.utils.sensitive import (
     check_shell_command,
     is_sensitive_path,
+    redact_if_sensitive,
+    scan_content,
 )
 
 
@@ -206,3 +208,91 @@ def test_ssh_public_key_inside_ssh_dir_still_blocked_by_path_rule() -> None:
     """
     assert is_sensitive_path("/home/mihai/.ssh/id_rsa.pub") is True
     assert is_sensitive_path("/root/.ssh/id_ed25519.pub") is True
+
+
+# ---------------------------------------------------------------------------
+# MIT-148: HTTP Authorization Bearer header detection
+#
+# The pre-MIT-148 labeled-credential regex matched `bearer=token` or
+# `bearer: token` shapes, but NOT the real-world HTTP header
+# `Authorization: Bearer <token>` — `Bearer` is the *prefix* of the token,
+# not a label followed by `=` / `:`.  The new parallel pattern fills that
+# gap without broadening the labeled regex (which, if widened, would catch
+# too much ordinary prose / logs).
+#
+# Note on test fixtures: all Bearer-token literals below are deliberately
+# synthetic and do NOT match any provider-specific secret shape (no
+# `sk_live_`, `pk_`, `ghp_`, etc.). This avoids tripping GitHub's push
+# protection secret scanner on what are clearly test-only strings.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Canonical HTTP header form with a JWT-shaped token
+        "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc.def",
+        # Header-less Bearer form (curl examples, middleware logs)
+        "Bearer kid_abcdefghij1234567890",
+        # Mid-line occurrence in a log line
+        "2026-04-21 http POST /api Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9xxxxxxx 200",
+        # With surrounding structured-output quotes — generic synthetic token
+        'headers = {"Authorization": "Bearer tkn_fakefakefakefakefakefake"}',
+    ],
+)
+def test_bearer_token_is_detected(text: str) -> None:
+    """MIT-148: real-world Bearer-prefix tokens (20+ chars) must be flagged."""
+    assert scan_content(text) == "bearer token", f"Expected bearer-token match for: {text!r}"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Documentation-style placeholders — too short to be a real token
+        "Bearer short",
+        "Bearer token",
+        "Bearer xxx",
+        "Bearer abc123",
+        "Authorization: Bearer YOUR_TOKEN_HERE",  # 16 chars, under the 20-char floor
+        # Prose usage of the word "bearer" unrelated to auth
+        "The bearer of this letter is authorized to...",
+        # Bearer followed by too-short token at end of string
+        "Try: Bearer foo",
+    ],
+)
+def test_bearer_placeholder_and_prose_not_flagged(text: str) -> None:
+    """MIT-148: short placeholders (< 20 chars) and non-auth prose must not match."""
+    # Either no match at all, or a match from a different pattern — just not "bearer token".
+    assert scan_content(text) != "bearer token", f"False positive bearer-token for: {text!r}"
+
+
+def test_bearer_redaction_output_shape() -> None:
+    """The full redact_if_sensitive pipeline must replace the token with the REDACTED notice."""
+    payload = "Authorization: Bearer eyJhbGciOiJIUzI1NiIs_abcdefghijklmnopqrst\n"
+    result = redact_if_sensitive(payload)
+    assert "eyJhbGciOiJIUzI1NiIs_abcdefghijklmnopqrst" not in result
+    assert "REDACTED" in result
+    assert "bearer token" in result
+
+
+def test_existing_credential_patterns_still_match() -> None:
+    """Regression: MIT-148 added a parallel pattern; existing detections must still fire."""
+    # The labeled form — `bearer=<token>` — should still match (via the
+    # pre-existing labeled-credential regex, now labeled "credential/token").
+    # We only assert a match occurred; the label may be "credential/token"
+    # OR "bearer token" depending on ordering, both are correct.
+    assert scan_content("bearer=abcdefghij1234567890xxxx") is not None
+
+    # AWS access key
+    assert scan_content("AKIAABCDEFGHIJKLMNOP") == "AWS access key"
+    # GitHub token
+    assert scan_content("ghp_0123456789abcdef0123456789abcdef0123") == "GitHub token"
+    # Private key blob
+    assert scan_content("-----BEGIN RSA PRIVATE KEY-----\n...") == "private key"
+
+
+def test_clean_text_not_flagged() -> None:
+    """No false positives on ordinary prose (no secrets at all)."""
+    assert scan_content("hello world") is None
+    assert scan_content("The quick brown fox.") is None
+    assert scan_content("Response headers: Content-Type: application/json") is None

--- a/tests/utils/test_sensitive.py
+++ b/tests/utils/test_sensitive.py
@@ -330,3 +330,143 @@ def test_clean_text_not_flagged() -> None:
     assert scan_content("hello world") is None
     assert scan_content("The quick brown fox.") is None
     assert scan_content("Response headers: Content-Type: application/json") is None
+
+
+# ---------------------------------------------------------------------------
+# MIT-164: `sh -c "..."` / `bash -c '...'` / `zsh -c ...` quote-bypass
+#
+# Before MIT-164 the shell pre-screen used regexes anchored at
+# `(?:^|\|)` (start-of-command or after-pipe), so any denylisted command
+# could be smuggled past the check by wrapping it in `sh -c "..."` — the
+# denylisted token lived inside a quoted argument the regex never saw.
+# The fix detects the `<shell> -c <script>` shape (for sh/bash/zsh/dash/
+# ash/ksh, with or without a `/bin/` or `/usr/bin/` path prefix), extracts
+# the inner script via shlex.split, and recursively screens it.  Depth is
+# capped to guard against pathological nesting.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Canonical bypass — single-quoted, inner command is a secret-dumper
+        "sh -c 'printenv'",
+        # Double-quoted wrapper
+        'sh -c "printenv"',
+        # Unquoted inner (bash accepts this for a single-token script)
+        "sh -c printenv",
+        # SSH-key read inside a wrapper
+        'sh -c "cat ~/.ssh/id_rsa"',
+        "sh -c 'cat /home/mihai/.ssh/id_rsa'",
+        "sh -c 'cat /etc/shadow'",
+        # bash / zsh wrappers
+        "bash -c 'base64 ~/.ssh/id_rsa'",
+        'zsh -c "ssh-add -l"',
+        "dash -c 'printenv'",
+        # Path-prefixed shell binaries
+        "/bin/sh -c 'export -p'",
+        '/usr/bin/bash -c "cat /etc/shadow"',
+        "/usr/local/bin/zsh -c 'printenv'",
+        # env dumper inside wrapper
+        'bash -c "env"',
+        # Nested wrappers — recursion handles this via _depth
+        "sh -c \"bash -c 'printenv'\"",
+        # gpg export inside wrapper
+        "sh -c 'gpg --export-secret-keys'",
+        # xxd / hexdump on SSH keys inside wrapper
+        "sh -c 'xxd ~/.ssh/id_ed25519'",
+    ],
+)
+def test_mit164_wrapper_bypass_is_blocked(command: str) -> None:
+    """MIT-164: `sh -c "<denylisted>"` and friends must recurse into the inner script."""
+    result = check_shell_command(command)
+    assert result is not None, f"Expected block for wrapped command: {command!r}"
+    assert "blocked by security policy" in result
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # MIT-143 replacement shape — the exact string used by
+        # tests/tools/test_exec_env.py::test_exec_allowed_env_keys_passthrough.
+        # If the MIT-164 wrapper detector falsely blocks this, the MIT-143
+        # battery regresses.
+        'sh -c \'echo "$MY_CUSTOM_VAR"\'',
+        # MIT-143 "missing var" shape — also pulled verbatim from
+        # tests/tools/test_exec_env.py::test_exec_allowed_env_keys_missing_var_ignored.
+        'sh -c \'[ -z "${NONEXISTENT_VAR_12345+set}" ] || exit 1\'',
+        # Ordinary `sh -c` usage — no denylisted command inside
+        "sh -c 'cd foo && make'",
+        "sh -c 'git status'",
+        'bash -c "npm install"',
+        "bash -c 'pytest tests/'",
+        "sh -c 'echo hello'",
+        "sh -c 'ls /tmp'",
+        # Shell invoked WITHOUT -c (not a wrapper) — must not be treated as
+        # a wrapper regardless of remaining args
+        "sh script.sh",
+        "bash --version",
+        # Shell invoked with -c but the script is a benign pipeline
+        "sh -c 'ls | wc -l'",
+        # Short invocation (len < 3 tokens) — must pass through silently
+        "sh",
+        "sh -c",
+        # `zsh -c "echo $VAR"` — env expansion, not env dump
+        'zsh -c "echo $HOME"',
+    ],
+)
+def test_mit164_legitimate_wrapper_usage_still_allowed(command: str) -> None:
+    """MIT-164: benign `sh -c` / `bash -c` usage must not be false-positived.
+
+    In particular, the two MIT-143 replacement shapes used by
+    ``tests/tools/test_exec_env.py`` must stay green — that test suite is the
+    canonical regression signal for "did we over-block the wrapper path?".
+    """
+    assert check_shell_command(command) is None, f"False positive for: {command!r}"
+
+
+def test_mit164_malformed_quoting_does_not_crash() -> None:
+    """Unclosed-quote command must not raise — shlex.split ValueError is caught.
+
+    Contract: malformed shell input falls through to the "clean" result
+    (same behaviour as before MIT-164).  The outer regex layer has already
+    run and is the authoritative result for input shlex can't parse.
+    Crucially, we must NOT raise — the shell tool treats exceptions from
+    the prescreen as unexpected errors.
+    """
+    # Unclosed single quote — shlex will raise ValueError internally.
+    result = check_shell_command("sh -c 'printenv")
+    # Either None (no regex match on the malformed outer string) or a
+    # block string; the important part is that no exception escapes.
+    assert result is None or "blocked by security policy" in result
+
+
+def test_mit164_recursion_depth_is_bounded() -> None:
+    """Deeply nested wrappers must not loop — the depth guard is load-bearing.
+
+    Crafted input:
+        sh -c "sh -c 'sh -c \"sh -c printenv\"'"
+
+    Each unwrap peels one layer; at depth == 3 the guard stops recursion
+    and returns None (for the innermost `printenv`, if reached; else the
+    match fires earlier).  The test asserts only that the call terminates
+    and produces a bool-ish result — it does not mandate block/allow at
+    the cap, because the cap is a runtime guard, not a security boundary.
+    """
+    deep = "sh -c \"sh -c 'sh -c \\\"sh -c \\\\\\\"printenv\\\\\\\"\\\"'\""
+    # Should not raise, should not hang.  Value itself is implementation-
+    # defined at the depth cap; "did we return in finite time" is the
+    # property under test.
+    result = check_shell_command(deep)
+    assert result is None or isinstance(result, str)
+
+
+def test_mit164_nested_wrapper_blocks_inner_denylist() -> None:
+    """Two-level nesting within the depth cap must still block.
+
+    `sh -c "bash -c 'printenv'"` → unwrap to `bash -c 'printenv'` (depth 1)
+    → unwrap to `printenv` (depth 2) → regex hits.
+    """
+    result = check_shell_command("sh -c \"bash -c 'printenv'\"")
+    assert result is not None
+    assert "blocked by security policy" in result

--- a/tests/utils/test_sensitive.py
+++ b/tests/utils/test_sensitive.py
@@ -146,3 +146,63 @@ def test_ordinary_paths_not_flagged() -> None:
     """No false positives on regular source files."""
     assert is_sensitive_path("/home/mihai/project/main.py") is False
     assert is_sensitive_path("/home/mihai/project/README.md") is False
+
+
+# ---------------------------------------------------------------------------
+# MIT-140: narrow id_*.pub exclusion from sensitive filename patterns
+#
+# Public SSH keys (id_*.pub) are, by definition, safe to disclose — agents
+# legitimately need to read them to deploy authorized_keys, configure CI
+# runners, etc.  The filename-only regex must block bare private-key names
+# while allowing `.pub` siblings.  Private keys *inside* `~/.ssh/` are still
+# blocked by the separate `/.ssh/` path-prefix rule, which catches public
+# AND private alike — callers who need to read `id_*.pub` should keep the
+# file outside `~/.ssh/`, or the block will (correctly) fire anyway.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "id_rsa",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+        "/tmp/keys/id_rsa",
+        "/tmp/keys/id_ed25519",
+    ],
+)
+def test_ssh_private_key_filenames_still_blocked(filename: str) -> None:
+    """MIT-140: bare SSH private-key filenames remain blocked regardless of directory."""
+    assert is_sensitive_path(filename) is True, f"Expected block for: {filename!r}"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "id_rsa.pub",
+        "id_dsa.pub",
+        "id_ecdsa.pub",
+        "id_ed25519.pub",
+        "/tmp/keys/id_rsa.pub",
+        "/tmp/keys/id_ed25519.pub",
+    ],
+)
+def test_ssh_public_key_filenames_allowed_outside_ssh_dir(filename: str) -> None:
+    """MIT-140: `.pub` siblings of SSH keys are public info — filename regex must allow them.
+
+    (Files under `~/.ssh/` are still caught by the `/.ssh/` path-prefix rule,
+    which is intentional — the filename regex itself should not block `.pub`.)
+    """
+    assert is_sensitive_path(filename) is False, f"Unexpected block for: {filename!r}"
+
+
+def test_ssh_public_key_inside_ssh_dir_still_blocked_by_path_rule() -> None:
+    """Regression: `.pub` files inside `~/.ssh/` stay blocked via the path-prefix rule.
+
+    The filename rule now permits `id_*.pub`, but the `/.ssh/` path prefix in
+    `_SENSITIVE_PATH_PATTERNS` catches anything under the SSH directory.  This
+    is the defence-in-depth split MIT-140 documents.
+    """
+    assert is_sensitive_path("/home/mihai/.ssh/id_rsa.pub") is True
+    assert is_sensitive_path("/root/.ssh/id_ed25519.pub") is True

--- a/tests/utils/test_sensitive.py
+++ b/tests/utils/test_sensitive.py
@@ -1,0 +1,148 @@
+"""Tests for nanobot.utils.sensitive — regex coverage for MIT-139 gaps."""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.utils.sensitive import (
+    check_shell_command,
+    is_sensitive_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shell command pre-screening — MIT-139 Gap A: absolute SSH paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Absolute paths (the bug MIT-139 fixes)
+        "cat /home/mihai/.ssh/id_rsa",
+        "cat /root/.ssh/id_rsa",
+        "cat /Users/alice/.ssh/id_ed25519",
+        # Home-relative
+        "cat ~/.ssh/id_rsa",
+        # Bare
+        "cat .ssh/id_rsa",
+        # Dot-relative
+        "cat ./.ssh/id_rsa",
+        # Case-insensitive command
+        "CAT /home/mihai/.ssh/id_rsa",
+        # Other reader tools — same gap, same fix
+        "less /home/mihai/.ssh/id_rsa",
+        "more /home/mihai/.ssh/config",
+        "head /home/mihai/.ssh/id_rsa",
+        "tail /root/.ssh/authorized_keys",
+        "bat /home/mihai/.ssh/id_ed25519",
+        "vim /home/mihai/.ssh/id_rsa",
+        "vi /home/mihai/.ssh/id_rsa",
+        "view /home/mihai/.ssh/id_rsa",
+        "nano /home/mihai/.ssh/id_rsa",
+        # Exfiltration variants
+        "base64 /home/mihai/.ssh/id_rsa",
+        "xxd /home/mihai/.ssh/id_rsa",
+        "od /home/mihai/.ssh/id_rsa",
+        "hexdump /home/mihai/.ssh/id_rsa",
+    ],
+)
+def test_check_shell_command_blocks_ssh_paths(command: str) -> None:
+    """All variants of reading .ssh/ — absolute, home, relative, bare — must be blocked."""
+    result = check_shell_command(command)
+    assert result is not None, f"Expected block for: {command!r}"
+    assert "blocked by security policy" in result
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Pre-MIT-139 cases must still block (regression guard)
+        "cat ~/.ssh/id_rsa",
+        "cat /etc/shadow",
+        "cat .env",
+        "cat /path/to/app.pem",
+        "cat secrets.key",
+        "cat /home/user/credentials.json",
+        "less ~/.ssh/config",
+        "less /etc/shadow",
+        "base64 ~/.ssh/id_rsa",
+        "base64 foo.pem",
+        "base64 app.key",
+        "xxd ~/.ssh/id_ed25519",
+        "printenv",
+        "env",
+        "export -p",
+        "declare -x",
+        "ssh-add -l",
+        "ssh-add -L",
+        "gpg --export-secret-keys",
+    ],
+)
+def test_check_shell_command_preserves_existing_blocks(command: str) -> None:
+    """Existing MIT-123-era denials must keep working after MIT-139 widening."""
+    assert check_shell_command(command) is not None, f"Regression: expected block for: {command!r}"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Ordinary commands must not be caught by the widened pattern
+        "cat README.md",
+        "cat /etc/hostname",
+        "ls /home/mihai/.ssh",  # listing is out of scope — only content reads are blocked
+        "echo hello",
+        "grep TODO src/",
+        "env VAR=value some_cmd",  # 'env' as prefix command, not dumper
+        "cat /home/mihai/notes.txt",
+        "less /var/log/syslog",
+        "head -n 10 data.csv",
+        # `.ssh` as a substring, not as a path segment, must not trigger
+        "cat foo.sshkey",  # no '/' boundary
+    ],
+)
+def test_check_shell_command_allows_benign_commands(command: str) -> None:
+    """Widened patterns must not regress into false positives."""
+    assert check_shell_command(command) is None, f"False positive for: {command!r}"
+
+
+# ---------------------------------------------------------------------------
+# Sensitive filename — MIT-139 Gap B: decision documented narrow
+# ---------------------------------------------------------------------------
+
+
+def test_dotenv_variants_blocked() -> None:
+    """Files whose basename begins with .env — the canonical cases — must block."""
+    assert is_sensitive_path(".env") is True
+    assert is_sensitive_path("/home/mihai/project/.env") is True
+    assert is_sensitive_path("/home/mihai/project/.env.local") is True
+    assert is_sensitive_path("/home/mihai/project/.env.production") is True
+
+
+def test_env_suffix_filenames_not_broadly_blocked() -> None:
+    """MIT-139 decision: keep the `.env` regex narrow to filename-starts-with-.env.
+
+    Widening to `*.env` would catch legitimate fixtures (`example.env`,
+    `template.env`, documentation samples).  Operators who need to block
+    custom-named dotenv files (e.g. `secrets/app.env`) should add the
+    containing directory to `_SENSITIVE_PATH_PATTERNS` rather than broaden
+    the filename regex.
+    """
+    # Not blocked by filename alone — documented as intentional
+    assert is_sensitive_path("/tmp/example.env") is False
+    assert is_sensitive_path("/tmp/template.env") is False
+
+
+def test_sensitive_paths_still_caught() -> None:
+    """Regression: unrelated sensitive paths must still be caught."""
+    assert is_sensitive_path("/home/mihai/.ssh/id_rsa") is True
+    assert is_sensitive_path("/etc/shadow") is True
+    assert is_sensitive_path("/home/mihai/.aws/credentials") is True
+    assert is_sensitive_path("/home/mihai/project/server.pem") is True
+    assert is_sensitive_path("/home/mihai/project/server.key") is True
+
+
+def test_ordinary_paths_not_flagged() -> None:
+    """No false positives on regular source files."""
+    assert is_sensitive_path("/home/mihai/project/main.py") is False
+    assert is_sensitive_path("/home/mihai/project/README.md") is False


### PR DESCRIPTION
## Summary

Closes a whole-layer bypass in the nanobot shell pre-screen: any denylisted command (`printenv`, `cat ~/.ssh/id_rsa`, `base64 ~/.ssh/id_rsa`, `ssh-add -l`, `export -p`, ...) could be smuggled past `check_shell_command()` by wrapping it in `sh -c "..."` / `bash -c '...'` / `zsh -c "..."`. The regex denylist uses `(?:^|\|)` anchors, so the denylisted token -- living inside a quoted argument -- was never visible to the regexes.

**Fix:** after the existing regex pass, detect the `<shell> -c <script>` shape via `shlex.split` and recursively screen the extracted script. Handles sh/bash/zsh/dash/ash/ksh with or without path prefixes (`/bin/sh`, `/usr/bin/bash`, ...); quote variants (single, double, unquoted single-token) are all normalised by shlex. A `_MAX_SHELL_WRAPPER_DEPTH = 3` cap bounds runtime on nested wrappers.

**MIT-143 regression guard:** the two `sh -c` shapes used by `tests/tools/test_exec_env.py` (`sh -c 'echo "$MY_CUSTOM_VAR"'` and the `${VAR+set}` missing-var probe) are explicitly in the new allow-list parametrize. Verified green locally.

**Scope:** MIT-164 closes the quote-wrapper layer only. The chained-command bypass inside the unwrapped script (`sh -c 'cd /tmp && printenv'` -- dumper regex anchors at `^`/`|`, not `&&`/`;`/`||`) is out of scope and called out as MIT-165 in the `check_shell_command` docstring.

## Test plan

- [x] `pytest tests/utils/test_sensitive.py` -- **119 passed** (30 new MIT-164 cases: 17 positive block, 13 negative allow, plus 3 edge-case tests for malformed quoting / recursion depth / two-level nesting)
- [x] `pytest tests/tools/test_exec_env.py` -- **7 passed** (MIT-143 battery stays green -- wrapper detector does not false-positive on benign `sh -c 'echo "$VAR"'`)
- [x] `pytest tests/tools/ tests/utils/ tests/security/` -- **618 passed, 2 skipped** (skips are pre-existing macOS/BSD `/proc` gates from MIT-162)
- [x] Manual spot-check: `sh -c 'printenv'`, `sh -c "cat ~/.ssh/id_rsa"`, nested `sh -c "bash -c 'printenv'"` all block; `sh -c 'echo hello'`, `bash -c 'npm install'`, `sh script.sh` (no `-c`) all allow
- [ ] After merge: run `shell_prescreen_v0.yaml` `quote_bypass` case on Spark -- should flip from `known_limitation_hit` to `known_limitation_resolved`

Fixes MIT-164