### PR TITLE
fix: normalize DashScope reasoning_effort (minimal vs minimum)

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -387,16 +387,9 @@ class OpenAICompatProvider(LLMProvider):
                     kwargs.update(overrides)
                     break
 
-        # Semantic vs. wire distinction for reasoning_effort.
-        # - semantic_effort is nanobot's internal canonical form (OpenAI's
-        #   vocabulary: "minimal" / "low" / "medium" / "high"). It drives
-        #   decisions like whether to disable provider thinking modes.
-        # - wire_effort is what we actually serialize to the provider; some
-        #   providers (notably DashScope) reject "minimal" and require
-        #   "minimum" instead. We accept either spelling on input and
-        #   always compare on the semantic form so a user who configured
-        #   "minimum" (DashScope's native spelling) still gets thinking
-        #   disabled instead of accidentally enabled.
+        # Normalize reasoning_effort into a semantic form (OpenAI vocab)
+        # used for internal decisions, and a wire form actually sent out.
+        # "minimum" is accepted as a DashScope-native alias for "minimal".
         semantic_effort: str | None = None
         if isinstance(reasoning_effort, str):
             semantic_effort = reasoning_effort.lower()
@@ -405,9 +398,7 @@ class OpenAICompatProvider(LLMProvider):
 
         wire_effort = reasoning_effort
         if spec and spec.name == "dashscope" and semantic_effort == "minimal":
-            # DashScope's reasoning_effort.effort enum accepts: none /
-            # minimum / low / medium / high / xhigh. Literal "minimal"
-            # returns 400 invalid_value; translate on the outbound side.
+            # DashScope accepts none/minimum/low/medium/high/xhigh; "minimal" 400s.
             wire_effort = "minimum"
 
         if wire_effort:

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -387,14 +387,37 @@ class OpenAICompatProvider(LLMProvider):
                     kwargs.update(overrides)
                     break
 
-        if reasoning_effort:
-            kwargs["reasoning_effort"] = reasoning_effort
+        # Semantic vs. wire distinction for reasoning_effort.
+        # - semantic_effort is nanobot's internal canonical form (OpenAI's
+        #   vocabulary: "minimal" / "low" / "medium" / "high"). It drives
+        #   decisions like whether to disable provider thinking modes.
+        # - wire_effort is what we actually serialize to the provider; some
+        #   providers (notably DashScope) reject "minimal" and require
+        #   "minimum" instead. We accept either spelling on input and
+        #   always compare on the semantic form so a user who configured
+        #   "minimum" (DashScope's native spelling) still gets thinking
+        #   disabled instead of accidentally enabled.
+        semantic_effort: str | None = None
+        if isinstance(reasoning_effort, str):
+            semantic_effort = reasoning_effort.lower()
+            if semantic_effort == "minimum":
+                semantic_effort = "minimal"
+
+        wire_effort = reasoning_effort
+        if spec and spec.name == "dashscope" and semantic_effort == "minimal":
+            # DashScope's reasoning_effort.effort enum accepts: none /
+            # minimum / low / medium / high / xhigh. Literal "minimal"
+            # returns 400 invalid_value; translate on the outbound side.
+            wire_effort = "minimum"
+
+        if wire_effort:
+            kwargs["reasoning_effort"] = wire_effort
 
         # Provider-specific thinking parameters.
         # Only sent when reasoning_effort is explicitly configured so that
         # the provider default is preserved otherwise.
         if spec and reasoning_effort is not None:
-            thinking_enabled = reasoning_effort.lower() != "minimal"
+            thinking_enabled = semantic_effort != "minimal"
             extra: dict[str, Any] | None = None
             if spec.name == "dashscope":
                 extra = {"enable_thinking": thinking_enabled}
@@ -415,7 +438,7 @@ class OpenAICompatProvider(LLMProvider):
         # so that OpenRouter-style names like "moonshotai/kimi-k2.5" are handled
         # identically to bare names like "kimi-k2.5".
         if reasoning_effort is not None and _is_kimi_thinking_model(model_name):
-            thinking_enabled = reasoning_effort.lower() != "minimal"
+            thinking_enabled = semantic_effort != "minimal"
             kwargs.setdefault("extra_body", {}).update(
                 {"thinking": {"type": "enabled" if thinking_enabled else "disabled"}}
             )

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -731,28 +731,21 @@ def test_dashscope_thinking_enabled_with_reasoning_effort() -> None:
 
 
 def test_dashscope_thinking_disabled_for_minimal() -> None:
-    """OpenAI-style 'minimal' → DashScope wire value 'minimum' + thinking off.
-    DashScope rejects the literal string 'minimal' (invalid_value), so we
-    must translate on the outbound side while still honouring the 'no
-    thinking' intent via extra_body."""
+    """'minimal' → wire 'minimum' + thinking off on DashScope."""
     kw = _build_kwargs_for("dashscope", "qwen3-plus", reasoning_effort="minimal")
     assert kw["reasoning_effort"] == "minimum"
     assert kw["extra_body"] == {"enable_thinking": False}
 
 
 def test_dashscope_thinking_disabled_for_minimum_alias() -> None:
-    """Users who read DashScope docs may configure the native 'minimum'
-    spelling. Internally it's the same semantic as 'minimal' → thinking
-    must still be disabled (not enabled just because the string isn't
-    literally 'minimal')."""
+    """Native 'minimum' spelling must also disable thinking, not enable it."""
     kw = _build_kwargs_for("dashscope", "qwen3-plus", reasoning_effort="minimum")
     assert kw["reasoning_effort"] == "minimum"
     assert kw["extra_body"] == {"enable_thinking": False}
 
 
 def test_non_dashscope_minimal_not_retranslated() -> None:
-    """The DashScope-specific translation must not leak to other providers;
-    OpenAI / Anthropic / etc. speak 'minimal' natively."""
+    """DashScope-specific translation must not leak to other providers."""
     kw = _build_kwargs_for("openai", "gpt-5", reasoning_effort="minimal")
     assert kw["reasoning_effort"] == "minimal"
 

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -731,8 +731,30 @@ def test_dashscope_thinking_enabled_with_reasoning_effort() -> None:
 
 
 def test_dashscope_thinking_disabled_for_minimal() -> None:
+    """OpenAI-style 'minimal' → DashScope wire value 'minimum' + thinking off.
+    DashScope rejects the literal string 'minimal' (invalid_value), so we
+    must translate on the outbound side while still honouring the 'no
+    thinking' intent via extra_body."""
     kw = _build_kwargs_for("dashscope", "qwen3-plus", reasoning_effort="minimal")
+    assert kw["reasoning_effort"] == "minimum"
     assert kw["extra_body"] == {"enable_thinking": False}
+
+
+def test_dashscope_thinking_disabled_for_minimum_alias() -> None:
+    """Users who read DashScope docs may configure the native 'minimum'
+    spelling. Internally it's the same semantic as 'minimal' → thinking
+    must still be disabled (not enabled just because the string isn't
+    literally 'minimal')."""
+    kw = _build_kwargs_for("dashscope", "qwen3-plus", reasoning_effort="minimum")
+    assert kw["reasoning_effort"] == "minimum"
+    assert kw["extra_body"] == {"enable_thinking": False}
+
+
+def test_non_dashscope_minimal_not_retranslated() -> None:
+    """The DashScope-specific translation must not leak to other providers;
+    OpenAI / Anthropic / etc. speak 'minimal' natively."""
+    kw = _build_kwargs_for("openai", "gpt-5", reasoning_effort="minimal")
+    assert kw["reasoning_effort"] == "minimal"
 
 
 def test_dashscope_no_extra_body_when_reasoning_effort_none() -> None:


### PR DESCRIPTION
## Summary

DashScope rejects the OpenAI-style `reasoning_effort="minimal"` with:

```
'reasoning_effort.effort' must be one of:
  'none', 'minimum', 'low', 'medium', 'high', 'xhigh'
```

nanobot currently passes the string through verbatim in
`openai_compat_provider._build_kwargs`, so:

| User configures `reasoningEffort` | DashScope response | `enable_thinking` nanobot sends | Effective |
|---|---|---|---|
| `null` | accepts | (not sent, provider default) | thinking **on** for qwen3-plus family |
| `"minimal"` | **400 invalid_value** | would have been `false` | request fails |
| `"minimum"` | accepts | `true` (string != "minimal") | thinking **on** |
| `"low"` / `"none"` | accepts | `true` | thinking **on** |

There is no valid combination that disables thinking on DashScope today.

## Fix

Introduce a semantic/wire split so the `minimal` / `minimum` spelling
difference doesn't collide with the thinking-toggle logic:

- `semantic_effort` — nanobot's canonical internal form (OpenAI
  vocabulary). `"minimum"` on input is normalized to `"minimal"` so
  both spellings share one meaning.
- `wire_effort` — what we serialize. For DashScope with
  `semantic_effort == "minimal"` we translate to `"minimum"` outbound.
  Other providers unchanged.
- `thinking_enabled` (DashScope / MiniMax / ByteDance / Kimi branches)
  now compares on `semantic_effort`, so either spelling correctly
  disables provider-side thinking.

## Test plan

- [x] Strengthened `test_dashscope_thinking_disabled_for_minimal` —
      now asserts the outbound `reasoning_effort == "minimum"` in
      addition to `extra_body.enable_thinking == False`. The original
      only checked `extra_body`, which is how the 400 slipped past CI.
- [x] Added `test_dashscope_thinking_disabled_for_minimum_alias` —
      users who read the DashScope docs and configure `"minimum"` get
      thinking off, not on.
- [x] Added `test_non_dashscope_minimal_not_retranslated` — OpenAI
      and other providers still see `"minimal"` unchanged.
- [x] Full `tests/providers/` suite: 202 → 204 passed (the 57
      pre-existing failures are all `pytest-asyncio`-env related and
      unrelated to this change).

## Context

Observed against `qwen3.6-plus` via DashScope. With the patch in place
and `reasoningEffort: "minimal"` in `~/.nanobot/config.json`, tool-call
latency on a simple list query drops from ~94s (iter1 ~70s of hidden
thinking) to ~5-7s end-to-end.