### PR TITLE
fix(config): preserve excluded fields in resolve_config_env_vars

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -4,9 +4,11 @@ import json
 import os
 import re
 from pathlib import Path
+from typing import Any
 
 import pydantic
 from loguru import logger
+from pydantic import BaseModel
 
 from nanobot.config.schema import Config
 
@@ -82,32 +84,50 @@ _ENV_REF_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
 
 def resolve_config_env_vars(config: Config) -> Config:
-    """Return a copy of *config* with ``${VAR}`` env-var references resolved.
+    """Return *config* with ``${VAR}`` env-var references resolved.
 
-    Only string values are affected; other types pass through unchanged.
-    Raises :class:`ValueError` if a referenced variable is not set.
+    Walks in place so fields declared with ``exclude=True`` (e.g.
+    ``DreamConfig.cron``) survive; returns the same instance when no
+    references are present. Raises ``ValueError`` if a referenced
+    variable is not set.
     """
-    data = config.model_dump(mode="json", by_alias=True)
-    if not _has_env_refs(data):
-        # Skip the dump→revalidate roundtrip so fields with ``exclude=True`` survive.
-        return config
-    data = _resolve_env_vars(data)
-    return Config.model_validate(data)
+    return _resolve_in_place(config)
 
 
-def _has_env_refs(obj: object) -> bool:
-    """Return True if any string value contains a ``${VAR}`` reference."""
+def _resolve_in_place(obj: Any) -> Any:
     if isinstance(obj, str):
-        return bool(_ENV_REF_PATTERN.search(obj))
+        new = _ENV_REF_PATTERN.sub(_env_replace, obj)
+        return new if new != obj else obj
+    if isinstance(obj, BaseModel):
+        updates: dict[str, Any] = {}
+        for name in type(obj).model_fields:
+            old = getattr(obj, name)
+            new = _resolve_in_place(old)
+            if new is not old:
+                updates[name] = new
+        extras = obj.__pydantic_extra__
+        new_extras: dict[str, Any] | None = None
+        if extras:
+            resolved = {k: _resolve_in_place(v) for k, v in extras.items()}
+            if any(resolved[k] is not extras[k] for k in extras):
+                new_extras = resolved
+        if not updates and new_extras is None:
+            return obj
+        copy = obj.model_copy(update=updates) if updates else obj.model_copy()
+        if new_extras is not None:
+            copy.__pydantic_extra__ = new_extras
+        return copy
     if isinstance(obj, dict):
-        return any(_has_env_refs(v) for v in obj.values())
+        resolved = {k: _resolve_in_place(v) for k, v in obj.items()}
+        return resolved if any(resolved[k] is not obj[k] for k in obj) else obj
     if isinstance(obj, list):
-        return any(_has_env_refs(v) for v in obj)
-    return False
+        resolved = [_resolve_in_place(v) for v in obj]
+        return resolved if any(nv is not ov for nv, ov in zip(resolved, obj)) else obj
+    return obj
 
 
 def _resolve_env_vars(obj: object) -> object:
-    """Recursively resolve ``${VAR}`` patterns in string values."""
+    """Recursively resolve ``${VAR}`` patterns in plain strings/dicts/lists."""
     if isinstance(obj, str):
         return _ENV_REF_PATTERN.sub(_env_replace, obj)
     if isinstance(obj, dict):

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -78,6 +78,9 @@ def save_config(config: Config, config_path: Path | None = None) -> None:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
+_ENV_REF_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
 def resolve_config_env_vars(config: Config) -> Config:
     """Return a copy of *config* with ``${VAR}`` env-var references resolved.
 
@@ -85,14 +88,28 @@ def resolve_config_env_vars(config: Config) -> Config:
     Raises :class:`ValueError` if a referenced variable is not set.
     """
     data = config.model_dump(mode="json", by_alias=True)
+    if not _has_env_refs(data):
+        # Skip the dump→revalidate roundtrip so fields with ``exclude=True`` survive.
+        return config
     data = _resolve_env_vars(data)
     return Config.model_validate(data)
+
+
+def _has_env_refs(obj: object) -> bool:
+    """Return True if any string value contains a ``${VAR}`` reference."""
+    if isinstance(obj, str):
+        return bool(_ENV_REF_PATTERN.search(obj))
+    if isinstance(obj, dict):
+        return any(_has_env_refs(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_has_env_refs(v) for v in obj)
+    return False
 
 
 def _resolve_env_vars(obj: object) -> object:
     """Recursively resolve ``${VAR}`` patterns in string values."""
     if isinstance(obj, str):
-        return re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", _env_replace, obj)
+        return _ENV_REF_PATTERN.sub(_env_replace, obj)
     if isinstance(obj, dict):
         return {k: _resolve_env_vars(v) for k, v in obj.items()}
     if isinstance(obj, list):

--- a/tests/config/test_env_interpolation.py
+++ b/tests/config/test_env_interpolation.py
@@ -102,3 +102,28 @@ class TestResolveConfig:
         assert resolved.agents.defaults.dream.describe_schedule() == (
             "cron 5 11 * * * (legacy)"
         )
+
+    def test_preserves_excluded_fields_with_env_refs(self, tmp_path, monkeypatch):
+        """Excluded fields must also survive when the config contains
+        ``${VAR}`` refs elsewhere. An in-place walk preserves the legacy
+        ``cron`` override even as unrelated string fields are substituted."""
+        monkeypatch.setenv("TEST_API_KEY", "resolved-key")
+        config_path = tmp_path / "config.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "agents": {"defaults": {"dream": {"cron": "5 11 * * *"}}},
+                    "providers": {"groq": {"apiKey": "${TEST_API_KEY}"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        raw = load_config(config_path)
+        resolved = resolve_config_env_vars(raw)
+
+        assert resolved.providers.groq.api_key == "resolved-key"
+        assert resolved.agents.defaults.dream.cron == "5 11 * * *"
+        assert resolved.agents.defaults.dream.describe_schedule() == (
+            "cron 5 11 * * * (legacy)"
+        )

--- a/tests/config/test_env_interpolation.py
+++ b/tests/config/test_env_interpolation.py
@@ -80,3 +80,25 @@ class TestResolveConfig:
 
         saved = json.loads(config_path.read_text(encoding="utf-8"))
         assert saved["channels"]["telegram"]["token"] == "${MY_TOKEN}"
+
+    def test_preserves_excluded_fields_when_no_env_refs(self, tmp_path):
+        """Regression: fields with ``exclude=True`` (e.g. DreamConfig.cron)
+        must survive ``resolve_config_env_vars`` when the config has no
+        ``${VAR}`` references. Previously the unconditional dump→revalidate
+        roundtrip silently dropped them."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text(
+            json.dumps(
+                {"agents": {"defaults": {"dream": {"cron": "5 11 * * *"}}}}
+            ),
+            encoding="utf-8",
+        )
+
+        raw = load_config(config_path)
+        assert raw.agents.defaults.dream.cron == "5 11 * * *"
+
+        resolved = resolve_config_env_vars(raw)
+        assert resolved.agents.defaults.dream.cron == "5 11 * * *"
+        assert resolved.agents.defaults.dream.describe_schedule() == (
+            "cron 5 11 * * * (legacy)"
+        )


### PR DESCRIPTION
## Summary

`resolve_config_env_vars` unconditionally dumped the config via `model_dump(mode="json")` and revalidated it, which silently dropped any field declared with `exclude=True`. The concrete victim is `DreamConfig.cron` (the legacy schedule override introduced by the Dream rename refactor in #2717): even when set in `config.json`, it was stripped at load time and the gateway always fell back to the default `every 2h` schedule.

This is an unintentional interaction between two recent, individually-sensible PRs:

- #2717 / `0a3a60a` introduced `cron: str | None = Field(default=None, exclude=True)` to keep the legacy override out of persisted dumps (tested by `test_dream_config_dump_uses_interval_h_and_hides_legacy_cron`).
- #2830 introduced `resolve_config_env_vars()`, which does a `model_dump(mode="json") → model_validate` roundtrip. That roundtrip honors `exclude=True` during the dump, so the field is lost.

## Fix

Skip the roundtrip entirely when the config has no `${VAR}` references. Env-var interpolation still works unchanged when refs exist; the legacy `cron` override (and any future `exclude=True` fields) now survive the common case of a fully-resolved config.

For the rarer case of `cron` + env ref in the same config, the field would still be dropped — but that's a pre-existing edge case and is easier to address separately (by reimplementing resolve as an in-place walk) if anyone hits it.

## Reproduce (before fix)

```python
from nanobot.config.loader import load_config, resolve_config_env_vars
# config.json has: {"agents": {"defaults": {"dream": {"cron": "5 11 * * *"}}}}
raw = load_config()
print(raw.agents.defaults.dream.describe_schedule())       # cron 5 11 * * * (legacy)
print(resolve_config_env_vars(raw).agents.defaults.dream.describe_schedule())  # every 2h  ← bug
```

Gateway startup log (pre-fix, relevant line): `✓ Dream: every 2h` regardless of config.

## Test plan

- [x] New regression test `test_preserves_excluded_fields_when_no_env_refs` covers the bug path
- [x] Existing `test_dream_config_dump_uses_interval_h_and_hides_legacy_cron` still passes (dump behavior unchanged)
- [x] Existing `test_resolves_env_vars_in_config` and `test_save_preserves_templates` still pass (resolve behavior unchanged when refs exist)
- [x] All tests in `tests/config/test_env_interpolation.py` and `tests/config/test_dream_config.py` green (16/16)