### PR TITLE
feat(mgp): opt-in MGP sidecar for governed cross-session memory

### DIFF
--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -85,7 +85,7 @@ class AutoCompact:
             last_active = session.updated_at
             summary = ""
             if archive_msgs:
-                summary = await self.consolidator.archive(archive_msgs) or ""
+                summary = await self.consolidator.archive(archive_msgs, session=session) or ""
             if summary and summary != "(nothing)":
                 self._summaries[key] = (summary, last_active)
                 session.metadata["_last_summary"] = {"text": summary, "last_active": last_active.isoformat()}

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -268,8 +268,9 @@ class AgentLoop:
         register_builtin_commands(self.commands)
 
         # MGP sidecar (opt-in, default disabled). When enabled we register the
-        # `recall_memory` tool and inject the sidecar reference into the
-        # Consolidator/Dream so their LLM-extracted facts also flow to MGP.
+        # `recall_memory` tool and install hooks on Consolidator/Dream so their
+        # LLM-extracted facts also flow to MGP. The Consolidator/Dream classes
+        # themselves stay MGP-unaware — see _wire_mgp_hooks below.
         # When disabled we suppress the `mgp-memory` skill so the LLM is not
         # told about a tool that does not exist in this loop.
         self.mgp_sidecar: AsyncMGPSidecar | None = None
@@ -281,8 +282,7 @@ class AgentLoop:
                 mgp_config,
                 workspace_id=str(workspace.expanduser().resolve()),
             )
-            self.consolidator.mgp_sidecar = self.mgp_sidecar
-            self.dream.mgp_sidecar = self.mgp_sidecar
+            self._wire_mgp_hooks(self.mgp_sidecar)
             self.tools.register(MGPRecallTool(
                 sidecar=self.mgp_sidecar,
                 default_scope=mgp_config.recall_default_scope,
@@ -292,6 +292,43 @@ class AgentLoop:
             # Hide the always-on mgp-memory skill so the LLM doesn't see a
             # phantom recall_memory tool when MGP isn't enabled.
             self.context.skills.disabled_skills.add("mgp-memory")
+
+    def _wire_mgp_hooks(self, sidecar: "AsyncMGPSidecar") -> None:
+        """Wire Consolidator/Dream MGP commits via their post-processing hooks.
+
+        Keeps memory.py free of any MGP imports; all sidecar interaction is
+        owned here by AgentLoop.
+        """
+
+        def _runtime_for_session(session: Any) -> Any:
+            if session.key and ":" in session.key:
+                channel, chat_id = session.key.split(":", 1)
+            else:
+                channel, chat_id = "cli", session.key or "direct"
+            return sidecar.build_runtime(
+                channel=channel,
+                chat_id=chat_id,
+                session_key=session.key,
+            )
+
+        def _on_archive(session: Any, summary: str) -> None:
+            if not sidecar.config.enable_consolidator_commit:
+                return
+            runtime = _runtime_for_session(session)
+            asyncio.create_task(sidecar.commit_bullets(runtime, summary))
+
+        def _on_phase1_analysis(analysis: str) -> None:
+            if not sidecar.config.enable_dream_commit:
+                return
+            runtime = sidecar.build_runtime(
+                channel="system",
+                chat_id="dream",
+                session_key="system:dream",
+            )
+            asyncio.create_task(sidecar.commit_dream_tags(runtime, analysis))
+
+        self.consolidator.on_archive = _on_archive
+        self.dream.on_phase1_analysis = _on_phase1_analysis
 
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -69,6 +69,7 @@ class _LoopHook(AgentHook):
         channel: str = "cli",
         chat_id: str = "direct",
         message_id: str | None = None,
+        sender_id: str | None = None,
     ) -> None:
         super().__init__(reraise=True)
         self._loop = agent_loop
@@ -78,6 +79,7 @@ class _LoopHook(AgentHook):
         self._channel = channel
         self._chat_id = chat_id
         self._message_id = message_id
+        self._sender_id = sender_id
         self._stream_buf = ""
 
     def wants_streaming(self) -> bool:
@@ -114,7 +116,9 @@ class _LoopHook(AgentHook):
         for tc in context.tool_calls:
             args_str = json.dumps(tc.arguments, ensure_ascii=False)
             logger.info("Tool call: {}({})", tc.name, args_str[:200])
-        self._loop._set_tool_context(self._channel, self._chat_id, self._message_id)
+        self._loop._set_tool_context(
+            self._channel, self._chat_id, self._message_id, sender_id=self._sender_id,
+        )
 
     async def after_iteration(self, context: AgentHookContext) -> None:
         u = context.usage or {}
@@ -350,18 +354,35 @@ class AgentLoop:
         finally:
             self._mcp_connecting = False
 
-    def _set_tool_context(self, channel: str, chat_id: str, message_id: str | None = None) -> None:
-        """Update context for all tools that need routing info."""
+    def _set_tool_context(
+        self,
+        channel: str,
+        chat_id: str,
+        message_id: str | None = None,
+        *,
+        sender_id: str | None = None,
+    ) -> None:
+        """Update context for all tools that need routing info.
+
+        ``sender_id`` is plumbed only into tools that accept it (currently
+        just ``recall_memory``); other tools keep their existing signatures.
+        Without this, group-chat MGP recalls would mis-attribute every
+        member to the same ``chat_id`` instead of their real sender id.
+        """
         # Compute the effective session key (accounts for unified sessions)
         # so that subagent results route to the correct pending queue.
         effective_key = UNIFIED_SESSION_KEY if self._unified_session else f"{channel}:{chat_id}"
         # `recall_memory` joins the spawn branch because its `set_context`
-        # signature is `(channel, chat_id, effective_key=None)`, identical to
-        # SpawnTool — so it inherits unified-session-aware key derivation.
+        # signature is `(channel, chat_id, effective_key=None, sender_id=None)`
+        # — a strict superset of SpawnTool's, so the existing dispatch works.
         for name in ("message", "spawn", "cron", "my", "recall_memory"):
             if tool := self.tools.get(name):
                 if hasattr(tool, "set_context"):
-                    if name in ("spawn", "recall_memory"):
+                    if name == "recall_memory":
+                        tool.set_context(
+                            channel, chat_id, effective_key=effective_key, sender_id=sender_id,
+                        )
+                    elif name == "spawn":
                         tool.set_context(channel, chat_id, effective_key=effective_key)
                     else:
                         tool.set_context(channel, chat_id, *([message_id] if name == "message" else []))
@@ -430,6 +451,7 @@ class AgentLoop:
         channel: str = "cli",
         chat_id: str = "direct",
         message_id: str | None = None,
+        sender_id: str | None = None,
         pending_queue: asyncio.Queue | None = None,
     ) -> tuple[str | None, list[str], list[dict], str, bool]:
         """Run the agent iteration loop.
@@ -449,6 +471,7 @@ class AgentLoop:
             channel=channel,
             chat_id=chat_id,
             message_id=message_id,
+            sender_id=sender_id,
         )
         hook: AgentHook = (
             CompositeHook([loop_hook] + self._extra_hooks) if self._extra_hooks else loop_hook
@@ -796,7 +819,9 @@ class AgentLoop:
             is_subagent = msg.sender_id == "subagent"
             if is_subagent and self._persist_subagent_followup(session, msg):
                 self.sessions.save(session)
-            self._set_tool_context(channel, chat_id, msg.metadata.get("message_id"))
+            self._set_tool_context(
+                channel, chat_id, msg.metadata.get("message_id"), sender_id=msg.sender_id,
+            )
             history = session.get_history(max_messages=0)
             current_role = "assistant" if is_subagent else "user"
 
@@ -814,6 +839,7 @@ class AgentLoop:
                 messages, session=session, channel=channel, chat_id=chat_id,
                 message_id=msg.metadata.get("message_id"),
                 pending_queue=pending_queue,
+                sender_id=msg.sender_id,
             )
             self._save_turn(session, all_msgs, 1 + len(history))
             self._clear_runtime_checkpoint(session)
@@ -854,7 +880,9 @@ class AgentLoop:
             session_summary=pending,
         )
 
-        self._set_tool_context(msg.channel, msg.chat_id, msg.metadata.get("message_id"))
+        self._set_tool_context(
+            msg.channel, msg.chat_id, msg.metadata.get("message_id"), sender_id=msg.sender_id,
+        )
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()
@@ -920,6 +948,7 @@ class AgentLoop:
             channel=msg.channel,
             chat_id=msg.chat_id,
             message_id=msg.metadata.get("message_id"),
+            sender_id=msg.sender_id,
             pending_queue=pending_queue,
         )
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -42,7 +42,14 @@ from nanobot.utils.helpers import truncate_text as truncate_text_fn
 from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
 
 if TYPE_CHECKING:
-    from nanobot.config.schema import ChannelsConfig, ExecToolConfig, ToolsConfig, WebToolsConfig
+    from nanobot.agent.mgp.sidecar import AsyncMGPSidecar
+    from nanobot.config.schema import (
+        ChannelsConfig,
+        ExecToolConfig,
+        MGPConfig,
+        ToolsConfig,
+        WebToolsConfig,
+    )
     from nanobot.cron.service import CronService
 
 
@@ -161,6 +168,7 @@ class AgentLoop:
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
         tools_config: ToolsConfig | None = None,
+        mgp_config: "MGPConfig | None" = None,
     ):
         from nanobot.config.schema import ExecToolConfig, ToolsConfig, WebToolsConfig
 
@@ -255,6 +263,32 @@ class AgentLoop:
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
 
+        # MGP sidecar (opt-in, default disabled). When enabled we register the
+        # `recall_memory` tool and inject the sidecar reference into the
+        # Consolidator/Dream so their LLM-extracted facts also flow to MGP.
+        # When disabled we suppress the `mgp-memory` skill so the LLM is not
+        # told about a tool that does not exist in this loop.
+        self.mgp_sidecar: AsyncMGPSidecar | None = None
+        if mgp_config is not None and mgp_config.enabled:
+            from nanobot.agent.mgp import build_sidecar
+            from nanobot.agent.tools.mgp_recall import MGPRecallTool
+
+            self.mgp_sidecar = build_sidecar(
+                mgp_config,
+                workspace_id=str(workspace.expanduser().resolve()),
+            )
+            self.consolidator.mgp_sidecar = self.mgp_sidecar
+            self.dream.mgp_sidecar = self.mgp_sidecar
+            self.tools.register(MGPRecallTool(
+                sidecar=self.mgp_sidecar,
+                default_scope=mgp_config.recall_default_scope,
+                default_limit=mgp_config.recall_default_limit,
+            ))
+        else:
+            # Hide the always-on mgp-memory skill so the LLM doesn't see a
+            # phantom recall_memory tool when MGP isn't enabled.
+            self.context.skills.disabled_skills.add("mgp-memory")
+
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
         allowed_dir = (
@@ -321,10 +355,13 @@ class AgentLoop:
         # Compute the effective session key (accounts for unified sessions)
         # so that subagent results route to the correct pending queue.
         effective_key = UNIFIED_SESSION_KEY if self._unified_session else f"{channel}:{chat_id}"
-        for name in ("message", "spawn", "cron", "my"):
+        # `recall_memory` joins the spawn branch because its `set_context`
+        # signature is `(channel, chat_id, effective_key=None)`, identical to
+        # SpawnTool — so it inherits unified-session-aware key derivation.
+        for name in ("message", "spawn", "cron", "my", "recall_memory"):
             if tool := self.tools.get(name):
                 if hasattr(tool, "set_context"):
-                    if name == "spawn":
+                    if name in ("spawn", "recall_memory"):
                         tool.set_context(channel, chat_id, effective_key=effective_key)
                     else:
                         tool.set_context(channel, chat_id, *([message_id] if name == "message" else []))

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -20,7 +20,6 @@ from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.utils.gitstore import GitStore
 
 if TYPE_CHECKING:
-    from nanobot.agent.mgp.sidecar import AsyncMGPSidecar
     from nanobot.providers.base import LLMProvider
     from nanobot.session.manager import Session, SessionManager
 
@@ -421,31 +420,15 @@ class Consolidator:
         self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
         )
-        # Optional MGP sidecar; injected by AgentLoop when mgp.enabled=true.
-        # When None (default) the commit hook in archive() is a no-op.
-        self.mgp_sidecar: AsyncMGPSidecar | None = None
+        # Post-archive hook (opt-in). Wired by AgentLoop when MGP is enabled
+        # so the produced summary can be mirrored to the MGP gateway. Stays
+        # None by default — Consolidator itself never imports mgp_client.
+        # Signature: (session, summary) -> None. Exceptions are caught here.
+        self.on_archive: Callable[[Session, str], None] | None = None
 
     def get_lock(self, session_key: str) -> asyncio.Lock:
         """Return the shared consolidation lock for one session."""
         return self._locks.setdefault(session_key, asyncio.Lock())
-
-    def _runtime_for_session(self, session: Session) -> Any:
-        """Build a runtime state for an MGP commit triggered by *session*.
-
-        Parses the conventional ``channel:chat_id`` shape of session keys.
-        Returns ``Any`` because :class:`RuntimeState` lives in the optional
-        mgp module — only callable when ``self.mgp_sidecar`` is set.
-        """
-        assert self.mgp_sidecar is not None
-        if session.key and ":" in session.key:
-            channel, chat_id = session.key.split(":", 1)
-        else:
-            channel, chat_id = "cli", session.key or "direct"
-        return self.mgp_sidecar.build_runtime(
-            channel=channel,
-            chat_id=chat_id,
-            session_key=session.key,
-        )
 
     def pick_consolidation_boundary(
         self,
@@ -515,11 +498,10 @@ class Consolidator:
     ) -> str | None:
         """Summarize messages via LLM and append to history.jsonl.
 
-        When ``session`` is provided AND an MGP sidecar is wired in AND
-        ``mgp.enable_consolidator_commit`` is true, the produced bullet
-        summary is also forwarded to the MGP gateway as a background task
-        (commit channel B). The MGP write is fire-and-forget — its outcome
-        does not affect the return value or the session's local archive.
+        When ``session`` is provided and ``self.on_archive`` is wired, the
+        produced summary is handed off to the hook (typically forwarded to
+        an MGP gateway by AgentLoop). The hook runs synchronously inline —
+        keep it cheap, or have it dispatch its own background task.
 
         Returns the summary text on success, None if nothing to archive.
         """
@@ -546,29 +528,16 @@ class Consolidator:
                 raise RuntimeError(f"LLM returned error: {response.content}")
             summary = response.content or "[no summary]"
             self.store.append_history(summary)
-            self._maybe_commit_to_mgp(session, summary)
+            if session is not None and self.on_archive is not None:
+                try:
+                    self.on_archive(session, summary)
+                except Exception:
+                    logger.exception("Consolidator on_archive hook failed (ignored)")
             return summary
         except Exception:
             logger.warning("Consolidation LLM call failed, raw-dumping to history")
             self.store.raw_archive(messages)
             return None
-
-    def _maybe_commit_to_mgp(self, session: Session | None, summary: str) -> None:
-        """Best-effort fan-out of a Consolidator summary to MGP.
-
-        Uses ``asyncio.create_task`` because we never want a slow MGP gateway
-        to block the consolidation path. ``self.mgp_sidecar`` is opt-in; when
-        absent (the default) this is a one-attribute lookup and returns.
-        """
-        if self.mgp_sidecar is None or session is None:
-            return
-        if not self.mgp_sidecar.config.enable_consolidator_commit:
-            return
-        try:
-            runtime = self._runtime_for_session(session)
-            asyncio.create_task(self.mgp_sidecar.commit_bullets(runtime, summary))
-        except Exception:
-            logger.exception("MGP consolidator commit dispatch failed (ignored)")
 
     async def maybe_consolidate_by_tokens(
         self,
@@ -719,23 +688,12 @@ class Dream:
         self.annotate_line_ages = annotate_line_ages
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
-        # Optional MGP sidecar; injected by AgentLoop when mgp.enabled=true.
-        # Used in run() to mirror Phase-1 [USER]/[MEMORY]/[SOUL] tags into MGP.
-        self.mgp_sidecar: AsyncMGPSidecar | None = None
-
-    def _workspace_runtime(self) -> Any:
-        """Build a runtime state for an MGP commit triggered by Dream.
-
-        Dream operates at workspace scope (cron-driven, no per-user channel),
-        so we synthesize a synthetic "system:dream" routing key. The sidecar
-        derives ``user_id`` / ``tenant_id`` per its standard rules.
-        """
-        assert self.mgp_sidecar is not None
-        return self.mgp_sidecar.build_runtime(
-            channel="system",
-            chat_id="dream",
-            session_key="system:dream",
-        )
+        # Post Phase-1 hook (opt-in). Wired by AgentLoop when MGP is enabled
+        # so the LLM-extracted [USER]/[MEMORY]/[SOUL] analysis can be mirrored
+        # to the MGP gateway. Stays None by default — Dream itself never
+        # imports mgp_client.
+        # Signature: (analysis: str) -> None. Exceptions are caught here.
+        self.on_phase1_analysis: Callable[[str], None] | None = None
 
     # -- tool registry -------------------------------------------------------
 
@@ -903,20 +861,11 @@ class Dream:
             logger.exception("Dream Phase 1 failed")
             return False
 
-        # Commit channel C: mirror Phase-1 [USER]/[MEMORY]/[SOUL] tags into MGP.
-        # Fire-and-forget — never block the local Dream pipeline on MGP.
-        if (
-            self.mgp_sidecar is not None
-            and self.mgp_sidecar.config.enable_dream_commit
-            and analysis
-        ):
+        if analysis and self.on_phase1_analysis is not None:
             try:
-                runtime = self._workspace_runtime()
-                asyncio.create_task(
-                    self.mgp_sidecar.commit_dream_tags(runtime, analysis)
-                )
+                self.on_phase1_analysis(analysis)
             except Exception:
-                logger.exception("MGP dream commit dispatch failed (ignored)")
+                logger.exception("Dream on_phase1_analysis hook failed (ignored)")
 
         # Phase 2: Delegate to AgentRunner with read_file / edit_file
         existing_skills = self._list_existing_skills()

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -20,6 +20,7 @@ from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.utils.gitstore import GitStore
 
 if TYPE_CHECKING:
+    from nanobot.agent.mgp.sidecar import AsyncMGPSidecar
     from nanobot.providers.base import LLMProvider
     from nanobot.session.manager import Session, SessionManager
 
@@ -420,10 +421,31 @@ class Consolidator:
         self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
         )
+        # Optional MGP sidecar; injected by AgentLoop when mgp.enabled=true.
+        # When None (default) the commit hook in archive() is a no-op.
+        self.mgp_sidecar: AsyncMGPSidecar | None = None
 
     def get_lock(self, session_key: str) -> asyncio.Lock:
         """Return the shared consolidation lock for one session."""
         return self._locks.setdefault(session_key, asyncio.Lock())
+
+    def _runtime_for_session(self, session: Session) -> Any:
+        """Build a runtime state for an MGP commit triggered by *session*.
+
+        Parses the conventional ``channel:chat_id`` shape of session keys.
+        Returns ``Any`` because :class:`RuntimeState` lives in the optional
+        mgp module — only callable when ``self.mgp_sidecar`` is set.
+        """
+        assert self.mgp_sidecar is not None
+        if session.key and ":" in session.key:
+            channel, chat_id = session.key.split(":", 1)
+        else:
+            channel, chat_id = "cli", session.key or "direct"
+        return self.mgp_sidecar.build_runtime(
+            channel=channel,
+            chat_id=chat_id,
+            session_key=session.key,
+        )
 
     def pick_consolidation_boundary(
         self,
@@ -486,8 +508,18 @@ class Consolidator:
             self._get_tool_definitions(),
         )
 
-    async def archive(self, messages: list[dict]) -> str | None:
+    async def archive(
+        self,
+        messages: list[dict],
+        session: Session | None = None,
+    ) -> str | None:
         """Summarize messages via LLM and append to history.jsonl.
+
+        When ``session`` is provided AND an MGP sidecar is wired in AND
+        ``mgp.enable_consolidator_commit`` is true, the produced bullet
+        summary is also forwarded to the MGP gateway as a background task
+        (commit channel B). The MGP write is fire-and-forget — its outcome
+        does not affect the return value or the session's local archive.
 
         Returns the summary text on success, None if nothing to archive.
         """
@@ -514,11 +546,29 @@ class Consolidator:
                 raise RuntimeError(f"LLM returned error: {response.content}")
             summary = response.content or "[no summary]"
             self.store.append_history(summary)
+            self._maybe_commit_to_mgp(session, summary)
             return summary
         except Exception:
             logger.warning("Consolidation LLM call failed, raw-dumping to history")
             self.store.raw_archive(messages)
             return None
+
+    def _maybe_commit_to_mgp(self, session: Session | None, summary: str) -> None:
+        """Best-effort fan-out of a Consolidator summary to MGP.
+
+        Uses ``asyncio.create_task`` because we never want a slow MGP gateway
+        to block the consolidation path. ``self.mgp_sidecar`` is opt-in; when
+        absent (the default) this is a one-attribute lookup and returns.
+        """
+        if self.mgp_sidecar is None or session is None:
+            return
+        if not self.mgp_sidecar.config.enable_consolidator_commit:
+            return
+        try:
+            runtime = self._runtime_for_session(session)
+            asyncio.create_task(self.mgp_sidecar.commit_bullets(runtime, summary))
+        except Exception:
+            logger.exception("MGP consolidator commit dispatch failed (ignored)")
 
     async def maybe_consolidate_by_tokens(
         self,
@@ -597,7 +647,7 @@ class Consolidator:
                     source,
                     len(chunk),
                 )
-                summary = await self.archive(chunk)
+                summary = await self.archive(chunk, session=session)
                 if summary:
                     last_summary = summary
                 else:
@@ -669,6 +719,23 @@ class Dream:
         self.annotate_line_ages = annotate_line_ages
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
+        # Optional MGP sidecar; injected by AgentLoop when mgp.enabled=true.
+        # Used in run() to mirror Phase-1 [USER]/[MEMORY]/[SOUL] tags into MGP.
+        self.mgp_sidecar: AsyncMGPSidecar | None = None
+
+    def _workspace_runtime(self) -> Any:
+        """Build a runtime state for an MGP commit triggered by Dream.
+
+        Dream operates at workspace scope (cron-driven, no per-user channel),
+        so we synthesize a synthetic "system:dream" routing key. The sidecar
+        derives ``user_id`` / ``tenant_id`` per its standard rules.
+        """
+        assert self.mgp_sidecar is not None
+        return self.mgp_sidecar.build_runtime(
+            channel="system",
+            chat_id="dream",
+            session_key="system:dream",
+        )
 
     # -- tool registry -------------------------------------------------------
 
@@ -835,6 +902,21 @@ class Dream:
         except Exception:
             logger.exception("Dream Phase 1 failed")
             return False
+
+        # Commit channel C: mirror Phase-1 [USER]/[MEMORY]/[SOUL] tags into MGP.
+        # Fire-and-forget — never block the local Dream pipeline on MGP.
+        if (
+            self.mgp_sidecar is not None
+            and self.mgp_sidecar.config.enable_dream_commit
+            and analysis
+        ):
+            try:
+                runtime = self._workspace_runtime()
+                asyncio.create_task(
+                    self.mgp_sidecar.commit_dream_tags(runtime, analysis)
+                )
+            except Exception:
+                logger.exception("MGP dream commit dispatch failed (ignored)")
 
         # Phase 2: Delegate to AgentRunner with read_file / edit_file
         existing_skills = self._list_existing_skills()

--- a/nanobot/agent/mgp/README.md
+++ b/nanobot/agent/mgp/README.md
@@ -1,56 +1,31 @@
 # MGP Sidecar for nanobot
 
-Optional integration that connects nanobot to a [Memory Governance Protocol
-(MGP)](https://github.com/hkuds/MGP) gateway. When enabled, the agent can
-explicitly recall cross-session, governed long-term memory via the
-`recall_memory` tool, and the LLM-extracted facts produced by nanobot's
-existing Consolidator and Dream pipelines are mirrored to MGP automatically.
+Optional integration that connects nanobot to a [Memory Governance Protocol (MGP)](https://github.com/HKUDS/MGP) gateway. When enabled, the agent can explicitly recall cross-session, governed long-term memory via the `recall_memory` tool, and the LLM-extracted facts produced by nanobot's existing Consolidator and Dream pipelines are mirrored to MGP automatically.
 
-> **TL;DR** — disabled by default; opt in with `agents.defaults.mgp.enabled: true`.
-> Recall is **agent-driven** (a tool, not a system-prompt injection).
-> Commit is **automatic** (rides on Consolidator + Dream output, zero added LLM cost).
+> **TL;DR** — disabled by default; opt in with `agents.defaults.mgp.enabled: true`. Recall is **agent-driven** (a tool, not a system-prompt injection). Commit is **automatic** (rides on Consolidator + Dream output, zero added LLM cost).
+
+> Gateway-side configuration (adapter selection, embedding models, authentication, troubleshooting) lives in the MGP repo: see [`integrations/nanobot/README.md`](https://github.com/HKUDS/MGP/blob/main/integrations/nanobot/README.md). This page only covers the runtime-side wiring.
 
 ---
 
 ## 1. Why MGP (vs nanobot's native bulk-injection memory)
 
-nanobot's native memory pipeline already does excellent work for stable,
-single-instance deployments:
+nanobot's native memory pipeline already does excellent work for stable, single-instance deployments:
 
-- `MEMORY.md` / `SOUL.md` / `USER.md` are **bulk-injected** into every system
-  prompt — the agent never has to "ask" for them.
+- `MEMORY.md` / `SOUL.md` / `USER.md` are **bulk-injected** into every system prompt — the agent never has to "ask" for them.
 - `Dream` periodically condenses raw history into curated long-term knowledge.
-- `Consolidator` summarizes evicted messages into `history.jsonl` so the agent
-  can `grep` them on demand.
+- `Consolidator` summarizes evicted messages into `history.jsonl` so the agent can `grep` them on demand.
 
 MGP is a **complementary** layer, not a replacement:
 
-| Dimension     | nanobot native                       | MGP sidecar (this package)        |
-| ------------- | ------------------------------------ | --------------------------------- |
-| Trigger       | Every LLM request, automatic         | Only when the agent calls a tool  |
-| Method        | Bulk inject curated full files       | Query-based recall via tool call  |
-| Query         | None (everything is always present)  | Agent-constructed search topic    |
-| Frequency     | 100% of turns                        | Typically <20% of turns           |
-| Best at       | "What the agent always should know"  | "What is relevant to this turn"   |
+| Dimension | nanobot native                      | MGP sidecar (this package)       |
+| --------- | ----------------------------------- | -------------------------------- |
+| Trigger   | Every LLM request, automatic        | Only when the agent calls a tool |
+| Method    | Bulk inject curated full files      | Query-based recall via tool call |
+| Frequency | 100% of turns                       | Typically <20% of turns          |
+| Best at   | "What the agent always should know" | "What is relevant to this turn"  |
 
-**The two stack**:
-
-```
-SOUL.md / MEMORY.md / USER.md   ← native bulk injection (always-on)
-                                +
-recall_memory tool (when needed) ← agent-driven targeted recall
-```
-
-Add MGP when you have at least one of:
-
-- Multi-device / multi-channel sync (agent should remember preferences across CLI ↔ Telegram ↔ web)
-- Multiple users sharing the same bot (group chats, customer-support style)
-- Long history where `grep` over `history.jsonl` becomes too slow
-- Cross-language / synonym-tolerant recall (requires a vector backend)
-- Compliance / audit logging requirements
-
-Skip MGP when you're a single-user, single-language, single-channel deployment
-— native memory is already enough.
+Add MGP when you have at least one of: multi-device sync, multi-user sharing the same bot, large history, cross-language recall (vector backend), or compliance/audit needs. Skip MGP for a single-user, single-channel deployment — native memory is already enough.
 
 ---
 
@@ -60,19 +35,17 @@ Skip MGP when you're a single-user, single-language, single-channel deployment
 
 ```mermaid
 flowchart TD
-  UserMsg["InboundMessage"] --> ProcessMessage["AgentLoop._process_message (unchanged)"]
-  ProcessMessage --> BuildMsgs["context.build_messages (unchanged)"]
+  UserMsg["InboundMessage"] --> ProcessMessage["AgentLoop._process_message"]
+  ProcessMessage --> BuildMsgs["context.build_messages"]
   BuildMsgs --> SystemPrompt["system prompt includes mgp-memory SKILL.md"]
   SystemPrompt --> LLMCall["LLM reasoning"]
   LLMCall --> Decide{"Need to recall?"}
-  Decide -->|"no (~80% of turns)"| Answer["Direct answer"]
-  Decide -->|"yes"| ToolCall["tool_call: recall_memory(query, scope?, limit?, types?)"]
-  ToolCall --> ToolExec["MGPRecallTool.execute"]
-  ToolExec --> Sidecar["sidecar.recall(runtime, intent)"]
+  Decide -->|"no, ~80% of turns"| Answer["Direct answer"]
+  Decide -->|"yes"| ToolCall["tool_call: recall_memory"]
+  ToolCall --> Sidecar["sidecar.recall(runtime, intent)"]
   Sidecar --> Gateway["MGP /search"]
-  Gateway --> Result["top-K results"]
-  Result --> ToolReturn["Formatted string back to LLM"]
-  ToolReturn --> LLMCall
+  Gateway --> Result["top-K results back to LLM"]
+  Result --> LLMCall
 ```
 
 ### Commit path (automatic, agent does not participate)
@@ -80,18 +53,12 @@ flowchart TD
 ```mermaid
 flowchart TD
   AgentRun["AgentLoop._run_agent_loop"] --> SaveTurn["session.save"]
-  SaveTurn --> ConsolBg["Consolidator.maybe_consolidate_by_tokens (background)"]
-  ConsolBg --> Archive["Consolidator.archive(messages, session=...)"]
-  Archive --> AppendHistory["store.append_history(summary)"]
-  AppendHistory --> CommitB{"sidecar enabled?"}
-  CommitB -->|"yes"| ParseBullets["parse_consolidator_bullets"]
-  ParseBullets --> WriteMGP1["asyncio.create_task: sidecar.commit_bullets(...)"]
+  SaveTurn --> Consol["Consolidator.archive (background, on token-budget trigger)"]
+  Consol --> CommitB["asyncio.create_task: sidecar.commit_bullets"]
 
-  CronTick["Cron 2h"] --> DreamRun["Dream.run"]
-  DreamRun --> Phase1["LLM Phase-1 [USER]/[MEMORY]/[SOUL] tags"]
-  Phase1 --> CommitC{"sidecar enabled?"}
-  CommitC -->|"yes"| ParseTags["parse_dream_phase1_tags"]
-  ParseTags --> WriteMGP2["asyncio.create_task: sidecar.commit_dream_tags(...)"]
+  CronTick["Cron 2h or /dream"] --> DreamRun["Dream.run"]
+  DreamRun --> Phase1["Phase-1 LLM produces [USER]/[MEMORY]/[SOUL] tags"]
+  Phase1 --> CommitC["asyncio.create_task: sidecar.commit_dream_tags"]
   Phase1 --> Phase2["Dream Phase 2 file edits (unchanged)"]
 ```
 
@@ -101,65 +68,43 @@ flowchart TD
 
 Two — and only two — channels write to MGP:
 
-| Channel                  | Trigger                                            | Content written                                                                                | Toggle                              |
-| ------------------------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------- |
-| B — Consolidator bullets | Token budget exceeded / autocompact / `/new`       | LLM-extracted bullets from `consolidator_archive.md` — one `MemoryCandidate` per bullet        | `mgp.enable_consolidator_commit`    |
-| C — Dream Phase-1 tags   | Cron every 2h / `/dream`                           | LLM-extracted `[USER]` / `[MEMORY]` / `[SOUL]` lines from `dream_phase1.md`                    | `mgp.enable_dream_commit`           |
+| Channel                  | Trigger                                       | Content written                                                                                     | Toggle                              |
+| ------------------------ | --------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| Consolidator bullets     | Token budget exceeded / autocompact / `/new`  | LLM-extracted bullets from `consolidator_archive.md` — one `MemoryCandidate` per bullet             | `mgp.enable_consolidator_commit`    |
+| Dream Phase-1 tags       | Cron every 2h / `/dream`                      | LLM-extracted `[USER]` / `[MEMORY]` / `[SOUL]` lines from `dream_phase1.md`                         | `mgp.enable_dream_commit`           |
 
-**Tag → MGP `(scope, type)` mapping for Dream Phase-1 commits**:
+**Tag → MGP `(scope, type)` mapping** for Dream Phase-1 commits:
 
-| Dream tag  | MGP scope | MGP memory type   | Rationale                                                                                              |
-| ---------- | --------- | ----------------- | ------------------------------------------------------------------------------------------------------ |
-| `[USER]`   | `user`    | `preference`      | User-specific facts (location, language, taste)                                                        |
-| `[MEMORY]` | `agent`   | `semantic_fact`   | Stable shared knowledge surfaced by Dream                                                              |
-| `[SOUL]`   | `agent`   | `profile`         | Agent identity / persona facts. Note: MGP has no `identity` type — `profile` is the canonical mapping. |
+| Dream tag  | MGP scope | MGP memory type | Note                                           |
+| ---------- | --------- | --------------- | ---------------------------------------------- |
+| `[USER]`   | `user`    | `preference`    | User-specific facts                            |
+| `[MEMORY]` | `agent`   | `semantic_fact` | Stable shared knowledge surfaced by Dream      |
+| `[SOUL]`   | `agent`   | `profile`       | Agent identity / persona — `identity` is not a valid MGP type |
 
-Memory types align with the MGP spec's `supported_memory_types` set
-(`profile / preference / episodic_event / semantic_fact / procedural_rule
-/ relationship / checkpoint_pointer / artifact_summary`) — the gateway
-will reject any other type with `MGP_INVALID_OBJECT`.
+Memory types align with the MGP spec's `supported_memory_types` set; the gateway rejects any other type with `MGP_INVALID_OBJECT`.
 
-**Never written to MGP**: raw user messages, raw assistant replies, tool call
-results, LLM `<thinking>`, `history.jsonl` entries themselves, the contents of
-`MEMORY.md` / `SOUL.md` / `USER.md`, media attachments, API keys, secrets.
-
-**Outbound during recall**: when the agent calls `recall_memory`, the **agent-
-constructed `query` string** (a concise topic, per the SKILL.md guidance) is
-sent to the gateway. This is not the user's raw message — see
-[Privacy Notes](#12-privacy-notes).
+**Never written to MGP**: raw user messages, raw assistant replies, tool call results, LLM `<thinking>`, `history.jsonl` entries themselves, the contents of `MEMORY.md` / `SOUL.md` / `USER.md`, media attachments, API keys, secrets.
 
 ---
 
 ## 4. What Doesn't Change
 
-When MGP is enabled, **all native memory behaviors stay exactly as-is**:
+When MGP is enabled, **all native memory behaviors stay exactly as-is**: `MEMORY.md` / `SOUL.md` / `USER.md` are still bulk-injected each turn, `history.jsonl` still serves `grep` lookups, Dream still edits local files and commits via git, autocompact still compresses idle sessions, and every existing slash command (`/dream`, `/dream-log`, `/dream-restore`, …) works unchanged.
 
-- `MEMORY.md`, `SOUL.md`, `USER.md` continue to be bulk-injected into the
-  system prompt every turn.
-- `history.jsonl` continues to be the source of truth for `grep`-based
-  history lookups by the agent.
-- `Dream` continues to edit local files and commit via git.
-- `autocompact` continues to compress idle sessions.
-- All slash commands (`/dream`, `/dream-log`, `/dream-restore`, ...) work
-  unchanged.
-
-If MGP is disabled (the default) or unreachable at runtime, the agent behaves
-**byte-identically** to a build without MGP.
+If MGP is disabled (the default) or unreachable at runtime, the agent behaves **byte-identically** to a build without MGP.
 
 ---
 
-## 5. Quickstart (PostgreSQL backend)
-
-Four steps, all PyPI:
+## 5. Quickstart
 
 ```bash
 # 1. Install nanobot's MGP client extra (~one extra dep)
 pip install "nanobot[mgp]"
 
-# 2. Install the MGP gateway with the postgres adapter extra
+# 2. Install the MGP gateway with your chosen adapter
 pip install "mgp-gateway[postgres]>=0.1.1"
 
-# 3. Run a Postgres for the gateway to use
+# 3. Run a Postgres for the gateway
 docker run -d --name mgp-pg \
   -e POSTGRES_USER=mgp -e POSTGRES_PASSWORD=mgp -e POSTGRES_DB=mgp \
   -p 5432:5432 postgres:16
@@ -170,421 +115,85 @@ MGP_POSTGRES_DSN='postgresql://mgp:mgp@127.0.0.1:5432/mgp' \
 mgp-gateway
 ```
 
-Then enable MGP in your nanobot config:
+Enable MGP in your nanobot config:
 
 ```yaml
 agents:
   defaults:
     mgp:
       enabled: true
-      # Recommended: pin a stable subject id so Dream-extracted [USER] facts
-      # land where CLI/channel sessions can find them. Without this the
-      # subject defaults to getpass.getuser() (the OS login).
+      gateway_url: "http://127.0.0.1:8080"
+      # Recommended for SDK / CLI use: pin a stable subject id so Dream
+      # `[USER]` facts land where CLI sessions can find them.
       default_user_id: "alice"
 ```
 
-Restart nanobot. Use `/mgp-status` to verify the connection. Ask the agent
-something that references past context (e.g. "what's my preferred indentation?")
-to see it call `recall_memory`.
+Restart nanobot and run `/mgp-status` to verify. Other adapters (`oceanbase`, `lancedb`, `mem0`, `zep`) and embedding configuration: see the [MGP nanobot integration guide](https://github.com/HKUDS/MGP/blob/main/integrations/nanobot/README.md#gateway-side-configuration-applies-to-both-paths).
 
 ---
 
 ## 6. Configuration Reference (nanobot side)
 
-All fields live under `agents.defaults.mgp` in nanobot config.
+All fields live under `agents.defaults.mgp`.
 
-| Field                          | Default                       | Purpose                                                              |
-| ------------------------------ | ----------------------------- | -------------------------------------------------------------------- |
-| `enabled`                      | `false`                       | Master switch. Off = no MGP code path runs at all.                   |
-| `gateway_url`                  | `http://127.0.0.1:8080`       | MGP gateway HTTP base URL.                                           |
-| `timeout`                      | `5.0`                         | Per-request timeout (seconds).                                       |
-| `fail_open`                    | `true`                        | Swallow MGP errors so a degraded gateway never breaks a turn.         |
-| `workspace_as_tenant`          | `true`                        | Use the workspace path as `tenant_id` when `tenant_id` is unset.     |
-| `tenant_id`                    | `null`                        | Explicit tenant id. Wins over `workspace_as_tenant`.                 |
-| `actor_agent`                  | `nanobot/main`                | Identity recorded in MGP's audit log.                                |
-| `api_key`                      | `null`                        | Bearer token (for gateways with `auth_mode=api_key`).                |
-| `enable_consolidator_commit`   | `true`                        | Mirror Consolidator bullets to MGP.                                  |
-| `enable_dream_commit`          | `true`                        | Mirror Dream Phase-1 tags to MGP.                                    |
-| `recall_default_scope`         | `"user"`                      | Default `scope` when the agent omits it in `recall_memory(...)`.     |
-| `recall_default_limit`         | `5`                           | Default `limit` when the agent omits it. Capped at 20.               |
-| `default_user_id`              | `null`                        | Stable subject id used by Dream commits and CLI direct sessions when no real per-user identifier exists. Falls back to `getpass.getuser()` when null. **Set this in SDK / multi-tenant deployments** so Dream-extracted `[USER]` facts land under a discoverable subject. |
+| Field                          | Default                  | Purpose                                                                                                            |
+| ------------------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `enabled`                      | `false`                  | Master switch. Off = no MGP code path runs at all.                                                                 |
+| `gateway_url`                  | `http://127.0.0.1:8080`  | MGP gateway HTTP base URL.                                                                                         |
+| `timeout`                      | `5.0`                    | Per-request timeout (seconds).                                                                                     |
+| `fail_open`                    | `true`                   | Swallow MGP errors so a degraded gateway never breaks a turn.                                                      |
+| `workspace_as_tenant`          | `true`                   | Use the workspace path as `tenant_id` when `tenant_id` is unset.                                                   |
+| `tenant_id`                    | `null`                   | Explicit tenant id. Wins over `workspace_as_tenant`.                                                               |
+| `actor_agent`                  | `nanobot/main`           | Identity recorded in MGP's audit log.                                                                              |
+| `api_key`                      | `null`                   | Bearer token (for gateways with `auth_mode=api_key`).                                                              |
+| `enable_consolidator_commit`   | `true`                   | Mirror Consolidator bullets to MGP.                                                                                |
+| `enable_dream_commit`          | `true`                   | Mirror Dream Phase-1 tags to MGP.                                                                                  |
+| `recall_default_scope`         | `"user"`                 | Default `scope` when the agent omits it in `recall_memory(...)`.                                                   |
+| `recall_default_limit`         | `5`                      | Default `limit` when the agent omits it. Capped at 20.                                                             |
+| `default_user_id`              | `null`                   | Stable subject id used by Dream commits and CLI direct sessions when no real per-user identifier exists. Falls back to `getpass.getuser()` when null. **Set this in SDK / multi-tenant deployments.** |
 
-There is **no `mode` / `shadow` field** — recall is agent-driven, so there is
-no auto-injection vs no-injection toggle. Granular control is through the
-two `enable_*_commit` flags.
+There is **no `mode` / `shadow` field** here — recall is agent-driven, so there is no auto-injection vs no-injection toggle. Granular control is through the two `enable_*_commit` flags.
 
 ### Subject (`user_id`) derivation
 
-The MGP subject under which a memory is written / searched is resolved
-per-call from routing context with the following priority:
+Per-call priority:
 
-1. `sender_id` from the inbound message (e.g. group-chat member id from
-   Telegram / Discord / WhatsApp / Slack — a real per-person identifier).
+1. `sender_id` from the inbound message (e.g. group-chat member id from Telegram / Discord / Slack).
 2. `chat_id` if it is not a synthetic placeholder (`direct`, `dream`, `user`).
-3. `session_key` tail when present and not synthetic.
-4. `mgp.default_user_id` from your config.
-5. `getpass.getuser()` (the OS login).
+3. `mgp.default_user_id` from your config.
+4. `getpass.getuser()` (the OS login).
 
-**Why this matters**: Dream runs at workspace scope and uses the synthetic
-`chat_id="dream"`. Without a configured `default_user_id`, every Dream
-`[USER]` fact would land under subject `"dream"` (or `getpass.getuser()`),
-not under the subject your CLI/channel session uses for recall — making
-those facts effectively unreachable. Always set `default_user_id` for
-SDK-only deployments and any setup where multiple bot instances should
-share one subject.
+**Why this matters**: Dream runs at workspace scope and uses the synthetic `chat_id="dream"`. Without a configured `default_user_id`, every Dream `[USER]` fact would land under subject `"dream"` (or `getpass.getuser()`) — not under the subject your CLI/channel session uses for recall, making those facts effectively unreachable. Always set `default_user_id` for SDK deployments.
 
-For group chats, the inbound `sender_id` is plumbed all the way down to
-`build_runtime` (see `_set_tool_context` in `agent/loop.py`), so each
-member gets their own user-scoped memory island even though the `chat_id`
-is shared.
+For group chats, the inbound `sender_id` is plumbed through `_set_tool_context` in `agent/loop.py`, so each member gets their own user-scoped memory island even though the `chat_id` is shared.
 
 ---
 
-## 7. Configuration Reference (gateway side)
+## 7. `recall_memory` Tool
 
-Adapter selection lives **on the MGP gateway side**, not in `nanobot.yaml`.
-nanobot only needs to know `gateway_url` (and optionally `api_key`).
-
-Production-grade adapters and required environment:
-
-| Adapter      | Install                                            | Required env                                                                                                                                   |
-| ------------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `postgres`   | `pip install "mgp-gateway[postgres]>=0.1.1"`       | `MGP_ADAPTER=postgres`, `MGP_POSTGRES_DSN=...`                                                                                                  |
-| `oceanbase`  | `pip install "mgp-gateway[oceanbase]>=0.1.1"`      | `MGP_ADAPTER=oceanbase`, **either** `MGP_OCEANBASE_DSN=...` **or** the discrete tuple `MGP_OCEANBASE_URI` + `MGP_OCEANBASE_USER` + `MGP_OCEANBASE_PASSWORD` + `MGP_OCEANBASE_DATABASE` (+ optional `MGP_OCEANBASE_TENANT`) |
-| `lancedb`    | `pip install "mgp-gateway[lancedb]>=0.1.1"`        | `MGP_ADAPTER=lancedb`, `MGP_LANCEDB_DIR=...`, `MGP_LANCEDB_EMBEDDING_PROVIDER`, `MGP_LANCEDB_EMBEDDING_MODEL`, `MGP_LANCEDB_EMBEDDING_API_KEY` (+ optional `MGP_LANCEDB_EMBEDDING_BASE_URL`, `MGP_LANCEDB_EMBEDDING_DIM`, `MGP_LANCEDB_TABLE`, `MGP_LANCEDB_ENABLE_HYBRID`) |
-| `mem0`       | `pip install mem0ai`                               | `MGP_ADAPTER=mem0`, `MGP_MEM0_API_KEY=...` (+ optional `MGP_MEM0_ORG_ID`, `MGP_MEM0_PROJECT_ID`, `MGP_MEM0_APP_ID`, `MGP_MEM0_ENABLE_GRAPH=true\|false`)                                                                                                  |
-| `zep`        | `pip install zep-cloud`                            | `MGP_ADAPTER=zep`, `MGP_ZEP_API_KEY=...` (+ optional `MGP_ZEP_BASE_URL`, `MGP_ZEP_GRAPH_USER_ID`, `MGP_ZEP_RERANKER`, `MGP_ZEP_RETURN_CONTEXT`, `MGP_ZEP_IGNORE_ROLES`)                                                                                                                                  |
-
-Reference adapters (`memory`, `file`, `graph`) are for protocol verification —
-do not use in production.
-
-Authentication on the gateway side:
-
-```bash
-export MGP_GATEWAY_AUTH_MODE=api_key   # off / api_key / bearer
-export MGP_GATEWAY_API_KEY=secret-...  # for api_key mode
-# export MGP_GATEWAY_BEARER_TOKEN=...  # for bearer mode
-mgp-gateway
-```
-
-The `MGP_GATEWAY_API_KEY` (or `MGP_GATEWAY_BEARER_TOKEN`) on the gateway side
-**must match** `agents.defaults.mgp.api_key` on the nanobot side.
-
-See the [MGP repository](https://github.com/hkuds/MGP) for the full set of
-gateway environment variables.
-
-### Do I need to configure an embedding model?
-
-**Only `lancedb` needs it.** All other adapters either run lexical search
-(`memory` / `file` / `graph` / `postgres` / `oceanbase`) or handle embeddings
-on the vendor side (`mem0` / `zep`). Configuration lives entirely on the
-**gateway** side; nanobot never touches an embedding model.
-
-#### LanceDB embedding env vars
-
-| Env var                          | Required           | Purpose                                                           |
-| -------------------------------- | ------------------ | ----------------------------------------------------------------- |
-| `MGP_LANCEDB_DIR`                | Yes                | Storage path                                                      |
-| `MGP_LANCEDB_EMBEDDING_PROVIDER` | Yes                | One of LanceDB's [registry](https://docs.lancedb.com/embedding/) entries (`openai`, `gemini`, `sentence-transformers`, `ollama`, `cohere`, …) plus the MGP alias `openrouter`, or `fake` for tests |
-| `MGP_LANCEDB_EMBEDDING_MODEL`    | Yes                | Model name as that provider expects it                            |
-| `MGP_LANCEDB_EMBEDDING_API_KEY`  | Cloud providers    | API key                                                           |
-| `MGP_LANCEDB_EMBEDDING_BASE_URL` | Optional           | Override endpoint — required for OpenAI-compatible relays         |
-| `MGP_LANCEDB_EMBEDDING_DIM`      | Optional           | Pin output dimension (must match table)                           |
-
-#### Three common setups
-
-```bash
-# A. OpenAI direct — cheap, strong English
-export MGP_LANCEDB_EMBEDDING_PROVIDER=openai
-export MGP_LANCEDB_EMBEDDING_MODEL=text-embedding-3-small
-export MGP_LANCEDB_EMBEDDING_API_KEY=sk-...
-
-# B. Local, free, air-gapped (model auto-downloaded on first use)
-export MGP_LANCEDB_EMBEDDING_PROVIDER=sentence-transformers
-export MGP_LANCEDB_EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
-
-# C. OpenRouter (built-in alias; aggregates many vendors behind one key)
-export MGP_LANCEDB_EMBEDDING_PROVIDER=openrouter
-export MGP_LANCEDB_EMBEDDING_API_KEY=sk-or-v1-...
-export MGP_LANCEDB_EMBEDDING_MODEL=openai/text-embedding-3-small  # vendor/model slug
-```
-
-#### Any other OpenAI-compatible relay
-
-Use `provider=openai` plus a custom `BASE_URL` — works for SiliconFlow,
-DeepInfra, Together, Fireworks, OneAPI/NewAPI, vLLM/Xinference/LocalAI, etc.
-
-```bash
-export MGP_LANCEDB_EMBEDDING_PROVIDER=openai
-export MGP_LANCEDB_EMBEDDING_BASE_URL=https://api.siliconflow.cn/v1
-export MGP_LANCEDB_EMBEDDING_API_KEY=sk-...
-export MGP_LANCEDB_EMBEDDING_MODEL=BAAI/bge-large-zh-v1.5
-```
-
-Verify any relay before pointing the gateway at it:
-
-```bash
-curl -s -X POST $MGP_LANCEDB_EMBEDDING_BASE_URL/embeddings \
-  -H "Authorization: Bearer $MGP_LANCEDB_EMBEDDING_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"model":"<model>","input":"hello"}' | jq '.data[0].embedding | length'
-```
-
-> Azure OpenAI uses a different URL scheme and won't work with this path —
-> wrap it with LiteLLM/OneAPI first, or wait for a dedicated provider.
-
-#### Notes
-
-- **Switching provider/model invalidates existing vectors.** Either
-  `rm -rf $MGP_LANCEDB_DIR` and rewrite, or use `/mgp/export` → `/mgp/import`
-  to recompute on the new model.
-- `mem0` / `zep` ignore all `MGP_LANCEDB_EMBEDDING_*` vars — model and
-  pricing are controlled on the vendor dashboard.
-- `provider=fake` produces deterministic hash vectors. CI only.
-
-### Switching adapters
-
-The nanobot side never needs to know which backend the gateway uses — it only
-needs `gateway_url`. To change backends:
-
-1. **Stop** the running gateway (`pkill mgp-gateway` or Ctrl-C).
-2. **Install** the new adapter's extras / SDK (table above) and **export** the
-   new env vars. Unset the old adapter's vars to avoid surprises.
-3. **Restart** `mgp-gateway`. Existing data does **not** migrate
-   automatically — each adapter has its own storage. Use `/mgp/export` →
-   `/mgp/import` (see `gateway.routes.memory`) if you need to carry data over.
-
-Nanobot itself does not need a restart unless `gateway_url` changes. Verify
-with `curl http://127.0.0.1:8080/healthz` (lightweight) or
-`curl http://127.0.0.1:8080/mgp/capabilities` (also reports
-`adapter_name` so you can confirm the swap took effect).
-
-### Vendor-specific notes for SaaS adapters
-
-**mem0** — sign up at [app.mem0.ai](https://app.mem0.ai) for `MGP_MEM0_API_KEY`.
-The adapter falls back to the env name `MEM0_API_KEY` if `MGP_MEM0_API_KEY`
-is unset, so existing mem0 users can reuse their key. `MGP_MEM0_ENABLE_GRAPH`
-defaults to `true`; turn it off if your mem0 plan does not include the graph
-feature.
-
-**zep** — sign up at [www.getzep.com](https://www.getzep.com) for
-`MGP_ZEP_API_KEY`. The adapter also accepts `ZEP_API_KEY` as a fallback. For
-self-hosted Zep, set `MGP_ZEP_BASE_URL=http://your-zep:8000`. Zep stores
-episodes under a single graph user (`MGP_ZEP_GRAPH_USER_ID`, default
-`mgp-global`); MGP subject isolation is layered **on top** via metadata
-filters, so you typically do not need to change this.
-
----
-
-## 8. Adapter Selection Guide
-
-### By user profile
-
-| Your situation                                              | Should you enable MGP? | Recommended backend           |
-| ----------------------------------------------------------- | ---------------------- | ----------------------------- |
-| Single-user, single-language, single-channel                | No                     | —                             |
-| Multi-device sync, agent should remember me everywhere      | Yes                    | `postgres`                    |
-| One bot serving multiple users (groups, support)            | Yes                    | `postgres` (subject-isolated) |
-| Frequent cross-language / synonym recall                    | Yes                    | `lancedb` or `mem0`           |
-| Large history (thousands of entries), `grep` is slow        | Yes                    | `lancedb`                     |
-| Compliance / audit / GDPR-style data governance             | Yes                    | `postgres` + audit log        |
-| High-scale CN deployment, already on OceanBase / OB Cloud   | Yes                    | `oceanbase`                   |
-| Already using mem0 or zep                                   | Yes                    | `mem0` / `zep`                |
-| Cannot tolerate >1s first-token latency                     | Avoid SaaS backends    | `postgres` / local `lancedb`  |
-
-For most setups `postgres` is the right default — it gives subject isolation,
-audit log, JSONB GIN search, and ~50–100 ms recall with a single Docker
-container. Switch to `oceanbase` only when you already operate an OB cluster
-or hit Postgres scaling limits; the bring-up cost is materially higher
-(8 GB+ RAM for a minimal `oceanbase-ce` Docker, longer startup, more env
-vars). Switch to `lancedb` when lexical match is not enough (cross-language,
-synonyms) and you can afford an embedding API. Switch to `mem0`/`zep` only
-when you're already invested in those products.
-
-### Retrieval behavior comparison (same data set)
-
-| Dimension                | nanobot native              | MGP postgres            | MGP oceanbase           | MGP lancedb               | MGP mem0       | MGP zep                |
-| ------------------------ | --------------------------- | ----------------------- | ----------------------- | ------------------------- | -------------- | ---------------------- |
-| Search method            | None (full bulk inject)     | SQL ILIKE / JSONB GIN   | SQL `LOWER(...) LIKE`   | Vector ANN (+ FTS hybrid) | Vector + graph | Vector + episode graph |
-| Ranks by relevance       | No                          | Yes (lexical score)     | Yes (lexical score)     | Yes (cosine)              | Yes            | Yes                    |
-| Cross-language matching  | Only after Dream normalizes | No                      | No                      | Yes                       | Yes            | Yes                    |
-| Synonym recall           | Only after Dream normalizes | No                      | No                      | Yes                       | Yes            | Yes                    |
-| Embedding model needed   | No                          | No                      | No                      | **Yes** (gateway-side)    | No (mem0 handles it) | No (zep handles it) |
-| Multi-user isolation     | No (single MEMORY.md)       | Yes (subject filter)    | Yes (subject filter)    | Yes                       | Yes            | Yes                    |
-| Cross-session sharing    | No (per-workspace)          | Yes (within tenant)     | Yes (within tenant)     | Yes                       | Yes            | Yes                    |
-| Recall latency           | 0 (no recall step)          | ~50–100 ms              | ~50–150 ms              | ~50–200 ms                | ~8–15 s        | ~1–2 s                 |
-| Min infra cost           | 0                           | 1 Postgres container    | OB cluster (8 GB+ RAM)  | Local dir + embedding API | SaaS account   | SaaS account           |
-| Curation quality         | Dream LLM (best)            | Raw bullets             | Raw bullets             | Raw bullets               | Light dedupe   | Light dedupe           |
-
-> **Note on OceanBase**: although `pyobvector` is the SDK used, the current
-> `oceanbase` adapter performs purely lexical search — the vector index is
-> not yet wired through the MGP gateway. Retrieval characteristics are
-> therefore close to `postgres`. Track upstream for vector search support
-> if cross-language / synonym matching is a hard requirement.
-
----
-
-## 9. `recall_memory` Tool Usage
-
-The agent sees the [`mgp-memory` skill](../../skills/mgp-memory/SKILL.md)
-in every system prompt. That skill teaches it when to call the tool. From
-the agent's perspective:
+The agent sees the [`mgp-memory` skill](../../skills/mgp-memory/SKILL.md) in every system prompt; that skill teaches it when to call the tool. From the agent's perspective:
 
 ```python
 recall_memory(
-    query="indentation preference",       # required: concise topic, NOT a full question
-    scope="user",                          # optional: "user" / "agent" / "session"
-    limit=5,                               # optional: 1..20
-    types=["preference"],                  # optional: filter by memory types
+    query="indentation preference",   # required: concise topic, NOT a full question
+    scope="user",                     # optional: "user" / "agent" / "session"
+    limit=5,                          # optional: 1..20
+    types=["preference"],             # optional: filter by memory types
 )
 ```
 
-Returns a string like:
+Returns formatted bullet lines, `(no memories found)`, or `[recall_memory degraded: <code>]` when the gateway failed (fail-open path).
 
-```
-- [preference] User prefers 4-space indentation for Python.
-- [preference] User prefers concise replies, no preamble.
-```
-
-…or `(no memories found)` when the search is empty, or
-`[recall_memory degraded: <code>]` when the gateway failed (fail-open path).
-
-When NOT to call:
-
-- Information is already in your system prompt (`MEMORY.md` / `SOUL.md` / `USER.md` / Recent History)
-- General knowledge questions
-- Pure code/tool tasks with no user-specific context
-- You already called `recall_memory` this turn and got results
-
-Full guidance lives in
-[`nanobot/skills/mgp-memory/SKILL.md`](../../skills/mgp-memory/SKILL.md).
+Full guidance lives in [`nanobot/skills/mgp-memory/SKILL.md`](../../skills/mgp-memory/SKILL.md).
 
 ---
 
-## 10. Slash Commands
+## 8. Slash Commands and Reliability
 
-`/mgp-status` shows:
+`/mgp-status` reports `enabled`, `gateway_url`, last recall (query, latency, hit count, error if any), and the last 32 commit outcomes. When MGP is disabled, it returns a one-liner pointing here.
 
-- `enabled` flag and gateway URL
-- whether the `recall_memory` tool is registered
-- which commit channels are on
-- the most recent recall outcome (query, latency, hit count, error if any)
-- the most recent commits (last 32 kept, with success/failure breakdown)
+**Fail-open by default.** Any MGP error (HTTP timeout, gateway 500, schema validation failure) is swallowed and surfaced to the agent as `[recall_memory degraded: <code>]`. The conversation never dies because of an MGP problem. Set `mgp.fail_open: false` only if you want hard failures.
 
-When MGP is disabled, `/mgp-status` returns a one-liner pointing here.
+**Privacy.** When `mgp.enabled: false` (default) nanobot does not import `mgp_client` and does not contact any gateway — full air-gap. When enabled, the **agent-constructed `query`** (a topic, not the user's raw message) is sent to the gateway during recall; only LLM-extracted bullets / tags are sent during commit. Raw conversation text is never sent.
 
----
-
-## 11. Trade-offs
-
-### Latency
-
-| Backend           | Recall round-trip  | Notes                                          |
-| ----------------- | ------------------ | ---------------------------------------------- |
-| `postgres` local  | ~50–100 ms         | Dominated by SQL plan + JSON parse             |
-| `oceanbase` local | ~50–150 ms         | Similar to Postgres + optional vector ANN      |
-| `lancedb` local   | ~50–200 ms         | Vector ANN + (optional) FTS hybrid             |
-| `mem0` SaaS       | ~8–15 s            | Through MGP HTTP → SaaS round-trip             |
-| `zep` SaaS        | ~1–2 s             | Same path; Zep is faster on the wire           |
-
-A recall call adds at most one extra LLM round-trip (the agent decides → tool
-runs → agent reasons again). The agent only pays this cost when it judges
-recall to be useful — typically ~20% of turns.
-
-### Reliability
-
-The sidecar is **fail-open** by default: any MGP error (HTTP timeout, gateway
-500, schema validation failure) is swallowed and surfaced to the agent as
-`[recall_memory degraded: <code>]`. The conversation never dies because of an
-MGP problem.
-
-### Misses
-
-The agent might forget to call `recall_memory` when it would have helped. The
-SKILL.md trigger word list ("remember", "I told you", "我之前说过", "还记得") is
-designed to minimize this, but it's not zero. If you observe specific topics
-that the agent should always check on, extend the SKILL.md examples.
-
-### Duplication
-
-The same fact may live both in `MEMORY.md` (Dream-curated, locally stored) and
-in MGP (raw bullets). This is intentional — local files stay the source of
-truth for the bulk-injected context, and MGP stays the source of truth for
-on-demand cross-session recall. Stage 2 may add `[FILE-REMOVE] →
-expire_memory` propagation to keep them in sync.
-
----
-
-## 12. Privacy Notes
-
-When the agent calls `recall_memory`, the **agent-constructed `query` string**
-(per the SKILL.md guidance — a topic, not a full user question) is sent to the
-configured gateway over HTTP.
-
-- **Local backends (`postgres`, `lancedb`, `oceanbase`)**: query stays on your
-  network — never leaves the gateway process.
-- **SaaS backends (`mem0`, `zep`)**: the gateway forwards the query to the
-  vendor's API, where it is processed under that vendor's privacy policy.
-
-For the **commit** path, only LLM-extracted bullets / tags are written. Raw
-conversation text is never sent. See [§3](#3-what-gets-written-who-controls-it)
-for the exhaustive list of what can and cannot be written.
-
-When `mgp.enabled=false` (default), nanobot does not import `mgp_client` and
-does not contact any gateway — full air-gap.
-
----
-
-## 13. Troubleshooting
-
-### `/mgp-status` says "MGP sidecar not enabled"
-
-Check that:
-- `mgp.enabled: true` is set in your config under `agents.defaults`.
-- You restarted nanobot after editing the config.
-
-### Tool exists but every call shows `[recall_memory degraded: ...]`
-
-- Confirm the gateway is running: `curl http://127.0.0.1:8080/healthz`
-  (returns `{"status":"ok",...}`). For more detail including the active
-  adapter name, hit `curl http://127.0.0.1:8080/mgp/capabilities`.
-- Confirm `mgp.gateway_url` matches the gateway's bind address.
-- If the gateway requires auth, set `mgp.api_key` AND
-  `MGP_GATEWAY_API_KEY` to the same value, with `MGP_GATEWAY_AUTH_MODE=api_key`.
-- For SaaS adapters, confirm the vendor key is valid:
-  `MGP_MEM0_API_KEY` for mem0, `MGP_ZEP_API_KEY` for zep. The adapter raises
-  `RuntimeError` on startup if the key is missing — check the gateway log.
-
-### Agent never calls `recall_memory` even when relevant
-
-- Confirm the `mgp-memory` skill is loaded (it should appear in the system
-  prompt — check via debug logs or `/status`).
-- Strengthen SKILL.md trigger words for your specific use case (the file is at
-  `nanobot/skills/mgp-memory/SKILL.md` — extending it is the canonical fix).
-- Test by saying something with a strong trigger: "remember when I said I
-  prefer X?" — this should reliably elicit a recall.
-
-### `ModuleNotFoundError: mgp_client`
-
-You enabled `mgp.enabled` without installing the optional dependency. Run:
-
-```bash
-pip install "nanobot[mgp]"
-```
-
-The error message from `build_sidecar` includes this exact hint.
-
-### Group chat shows the same memory across users
-
-Make sure your channel implementation populates `InboundMessage.sender_id`
-with the real per-person id (not the chat/room id). The loop now plumbs
-`sender_id` through `_set_tool_context` → `recall_memory.set_context`
-→ `sidecar.build_runtime`, but only if the channel actually sets it. If a
-custom channel leaves it empty, recall will fall back to `chat_id` and
-collapse all group members onto one subject again.
-
-### Latency spike after enabling MGP with a SaaS backend
-
-`mem0` and `zep` round-trips through the gateway are 8–15 s and 1–2 s
-respectively. If first-token latency matters, switch to `postgres` (~100 ms)
-or local `lancedb` (~200 ms). Use `/mgp-status` to monitor `last_recall.latency`.
+For gateway-side adapter selection, embedding configuration, authentication, and troubleshooting (`MGP_INVALID_OBJECT`, `PolicyDeniedError`, `401`, …): see the [MGP nanobot integration guide](https://github.com/HKUDS/MGP/blob/main/integrations/nanobot/README.md).

--- a/nanobot/agent/mgp/README.md
+++ b/nanobot/agent/mgp/README.md
@@ -245,15 +245,15 @@ is shared.
 Adapter selection lives **on the MGP gateway side**, not in `nanobot.yaml`.
 nanobot only needs to know `gateway_url` (and optionally `api_key`).
 
-Production-grade adapters:
+Production-grade adapters and required environment:
 
-| Adapter      | Install                                            | Required env                                                                                                         |
-| ------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `postgres`   | `pip install "mgp-gateway[postgres]>=0.1.1"`       | `MGP_ADAPTER=postgres`, `MGP_POSTGRES_DSN=...`                                                                        |
-| `oceanbase`  | `pip install "mgp-gateway[oceanbase]>=0.1.1"`      | `MGP_ADAPTER=oceanbase`, `MGP_OCEANBASE_DSN=...`                                                                      |
-| `lancedb`    | `pip install "mgp-gateway[lancedb]>=0.1.1"`        | `MGP_ADAPTER=lancedb`, `MGP_LANCEDB_DIR=...`, `MGP_LANCEDB_EMBEDDING_PROVIDER`, `MGP_LANCEDB_EMBEDDING_MODEL`, `MGP_LANCEDB_EMBEDDING_API_KEY` |
-| `mem0`       | `pip install mem0ai`                               | `MGP_ADAPTER=mem0`, `MGP_MEM0_API_KEY=...`                                                                           |
-| `zep`        | `pip install zep-cloud`                            | `MGP_ADAPTER=zep`, `MGP_ZEP_API_KEY=...`                                                                             |
+| Adapter      | Install                                            | Required env                                                                                                                                   |
+| ------------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `postgres`   | `pip install "mgp-gateway[postgres]>=0.1.1"`       | `MGP_ADAPTER=postgres`, `MGP_POSTGRES_DSN=...`                                                                                                  |
+| `oceanbase`  | `pip install "mgp-gateway[oceanbase]>=0.1.1"`      | `MGP_ADAPTER=oceanbase`, **either** `MGP_OCEANBASE_DSN=...` **or** the discrete tuple `MGP_OCEANBASE_URI` + `MGP_OCEANBASE_USER` + `MGP_OCEANBASE_PASSWORD` + `MGP_OCEANBASE_DATABASE` (+ optional `MGP_OCEANBASE_TENANT`) |
+| `lancedb`    | `pip install "mgp-gateway[lancedb]>=0.1.1"`        | `MGP_ADAPTER=lancedb`, `MGP_LANCEDB_DIR=...`, `MGP_LANCEDB_EMBEDDING_PROVIDER`, `MGP_LANCEDB_EMBEDDING_MODEL`, `MGP_LANCEDB_EMBEDDING_API_KEY` (+ optional `MGP_LANCEDB_EMBEDDING_BASE_URL`, `MGP_LANCEDB_EMBEDDING_DIM`, `MGP_LANCEDB_TABLE`, `MGP_LANCEDB_ENABLE_HYBRID`) |
+| `mem0`       | `pip install mem0ai`                               | `MGP_ADAPTER=mem0`, `MGP_MEM0_API_KEY=...` (+ optional `MGP_MEM0_ORG_ID`, `MGP_MEM0_PROJECT_ID`, `MGP_MEM0_APP_ID`, `MGP_MEM0_ENABLE_GRAPH=true\|false`)                                                                                                  |
+| `zep`        | `pip install zep-cloud`                            | `MGP_ADAPTER=zep`, `MGP_ZEP_API_KEY=...` (+ optional `MGP_ZEP_BASE_URL`, `MGP_ZEP_GRAPH_USER_ID`, `MGP_ZEP_RERANKER`, `MGP_ZEP_RETURN_CONTEXT`, `MGP_ZEP_IGNORE_ROLES`)                                                                                                                                  |
 
 Reference adapters (`memory`, `file`, `graph`) are for protocol verification —
 do not use in production.
@@ -262,12 +262,117 @@ Authentication on the gateway side:
 
 ```bash
 export MGP_GATEWAY_AUTH_MODE=api_key   # off / api_key / bearer
-export MGP_GATEWAY_API_KEY=secret-...  # set the same value as nanobot.yaml mgp.api_key
+export MGP_GATEWAY_API_KEY=secret-...  # for api_key mode
+# export MGP_GATEWAY_BEARER_TOKEN=...  # for bearer mode
 mgp-gateway
 ```
 
+The `MGP_GATEWAY_API_KEY` (or `MGP_GATEWAY_BEARER_TOKEN`) on the gateway side
+**must match** `agents.defaults.mgp.api_key` on the nanobot side.
+
 See the [MGP repository](https://github.com/hkuds/MGP) for the full set of
 gateway environment variables.
+
+### Do I need to configure an embedding model?
+
+**Only `lancedb` needs it.** All other adapters either run lexical search
+(`memory` / `file` / `graph` / `postgres` / `oceanbase`) or handle embeddings
+on the vendor side (`mem0` / `zep`). Configuration lives entirely on the
+**gateway** side; nanobot never touches an embedding model.
+
+#### LanceDB embedding env vars
+
+| Env var                          | Required           | Purpose                                                           |
+| -------------------------------- | ------------------ | ----------------------------------------------------------------- |
+| `MGP_LANCEDB_DIR`                | Yes                | Storage path                                                      |
+| `MGP_LANCEDB_EMBEDDING_PROVIDER` | Yes                | One of LanceDB's [registry](https://docs.lancedb.com/embedding/) entries (`openai`, `gemini`, `sentence-transformers`, `ollama`, `cohere`, …) plus the MGP alias `openrouter`, or `fake` for tests |
+| `MGP_LANCEDB_EMBEDDING_MODEL`    | Yes                | Model name as that provider expects it                            |
+| `MGP_LANCEDB_EMBEDDING_API_KEY`  | Cloud providers    | API key                                                           |
+| `MGP_LANCEDB_EMBEDDING_BASE_URL` | Optional           | Override endpoint — required for OpenAI-compatible relays         |
+| `MGP_LANCEDB_EMBEDDING_DIM`      | Optional           | Pin output dimension (must match table)                           |
+
+#### Three common setups
+
+```bash
+# A. OpenAI direct — cheap, strong English
+export MGP_LANCEDB_EMBEDDING_PROVIDER=openai
+export MGP_LANCEDB_EMBEDDING_MODEL=text-embedding-3-small
+export MGP_LANCEDB_EMBEDDING_API_KEY=sk-...
+
+# B. Local, free, air-gapped (model auto-downloaded on first use)
+export MGP_LANCEDB_EMBEDDING_PROVIDER=sentence-transformers
+export MGP_LANCEDB_EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
+
+# C. OpenRouter (built-in alias; aggregates many vendors behind one key)
+export MGP_LANCEDB_EMBEDDING_PROVIDER=openrouter
+export MGP_LANCEDB_EMBEDDING_API_KEY=sk-or-v1-...
+export MGP_LANCEDB_EMBEDDING_MODEL=openai/text-embedding-3-small  # vendor/model slug
+```
+
+#### Any other OpenAI-compatible relay
+
+Use `provider=openai` plus a custom `BASE_URL` — works for SiliconFlow,
+DeepInfra, Together, Fireworks, OneAPI/NewAPI, vLLM/Xinference/LocalAI, etc.
+
+```bash
+export MGP_LANCEDB_EMBEDDING_PROVIDER=openai
+export MGP_LANCEDB_EMBEDDING_BASE_URL=https://api.siliconflow.cn/v1
+export MGP_LANCEDB_EMBEDDING_API_KEY=sk-...
+export MGP_LANCEDB_EMBEDDING_MODEL=BAAI/bge-large-zh-v1.5
+```
+
+Verify any relay before pointing the gateway at it:
+
+```bash
+curl -s -X POST $MGP_LANCEDB_EMBEDDING_BASE_URL/embeddings \
+  -H "Authorization: Bearer $MGP_LANCEDB_EMBEDDING_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<model>","input":"hello"}' | jq '.data[0].embedding | length'
+```
+
+> Azure OpenAI uses a different URL scheme and won't work with this path —
+> wrap it with LiteLLM/OneAPI first, or wait for a dedicated provider.
+
+#### Notes
+
+- **Switching provider/model invalidates existing vectors.** Either
+  `rm -rf $MGP_LANCEDB_DIR` and rewrite, or use `/mgp/export` → `/mgp/import`
+  to recompute on the new model.
+- `mem0` / `zep` ignore all `MGP_LANCEDB_EMBEDDING_*` vars — model and
+  pricing are controlled on the vendor dashboard.
+- `provider=fake` produces deterministic hash vectors. CI only.
+
+### Switching adapters
+
+The nanobot side never needs to know which backend the gateway uses — it only
+needs `gateway_url`. To change backends:
+
+1. **Stop** the running gateway (`pkill mgp-gateway` or Ctrl-C).
+2. **Install** the new adapter's extras / SDK (table above) and **export** the
+   new env vars. Unset the old adapter's vars to avoid surprises.
+3. **Restart** `mgp-gateway`. Existing data does **not** migrate
+   automatically — each adapter has its own storage. Use `/mgp/export` →
+   `/mgp/import` (see `gateway.routes.memory`) if you need to carry data over.
+
+Nanobot itself does not need a restart unless `gateway_url` changes. Verify
+with `curl http://127.0.0.1:8080/healthz` (lightweight) or
+`curl http://127.0.0.1:8080/mgp/capabilities` (also reports
+`adapter_name` so you can confirm the swap took effect).
+
+### Vendor-specific notes for SaaS adapters
+
+**mem0** — sign up at [app.mem0.ai](https://app.mem0.ai) for `MGP_MEM0_API_KEY`.
+The adapter falls back to the env name `MEM0_API_KEY` if `MGP_MEM0_API_KEY`
+is unset, so existing mem0 users can reuse their key. `MGP_MEM0_ENABLE_GRAPH`
+defaults to `true`; turn it off if your mem0 plan does not include the graph
+feature.
+
+**zep** — sign up at [www.getzep.com](https://www.getzep.com) for
+`MGP_ZEP_API_KEY`. The adapter also accepts `ZEP_API_KEY` as a fallback. For
+self-hosted Zep, set `MGP_ZEP_BASE_URL=http://your-zep:8000`. Zep stores
+episodes under a single graph user (`MGP_ZEP_GRAPH_USER_ID`, default
+`mgp-global`); MGP subject isolation is layered **on top** via metadata
+filters, so you typically do not need to change this.
 
 ---
 
@@ -275,29 +380,47 @@ gateway environment variables.
 
 ### By user profile
 
-| Your situation                                          | Should you enable MGP? | Recommended backend       |
-| ------------------------------------------------------- | ---------------------- | ------------------------- |
-| Single-user, single-language, single-channel            | No                     | —                         |
-| Multi-device sync, agent should remember me everywhere  | Yes                    | `postgres`                |
-| One bot serving multiple users (groups, support)        | Yes                    | `postgres` (subject-isolated) |
-| Frequent cross-language / synonym recall                | Yes                    | `lancedb` or `mem0`       |
-| Large history (thousands of entries), `grep` is slow    | Yes                    | `lancedb`                 |
-| Compliance / audit / GDPR-style data governance         | Yes                    | `postgres` + audit log    |
-| Already using mem0 or zep                               | Yes                    | `mem0` / `zep`            |
-| Cannot tolerate >1s first-token latency                 | Avoid SaaS backends    | `postgres` / local `lancedb` |
+| Your situation                                              | Should you enable MGP? | Recommended backend           |
+| ----------------------------------------------------------- | ---------------------- | ----------------------------- |
+| Single-user, single-language, single-channel                | No                     | —                             |
+| Multi-device sync, agent should remember me everywhere      | Yes                    | `postgres`                    |
+| One bot serving multiple users (groups, support)            | Yes                    | `postgres` (subject-isolated) |
+| Frequent cross-language / synonym recall                    | Yes                    | `lancedb` or `mem0`           |
+| Large history (thousands of entries), `grep` is slow        | Yes                    | `lancedb`                     |
+| Compliance / audit / GDPR-style data governance             | Yes                    | `postgres` + audit log        |
+| High-scale CN deployment, already on OceanBase / OB Cloud   | Yes                    | `oceanbase`                   |
+| Already using mem0 or zep                                   | Yes                    | `mem0` / `zep`                |
+| Cannot tolerate >1s first-token latency                     | Avoid SaaS backends    | `postgres` / local `lancedb`  |
+
+For most setups `postgres` is the right default — it gives subject isolation,
+audit log, JSONB GIN search, and ~50–100 ms recall with a single Docker
+container. Switch to `oceanbase` only when you already operate an OB cluster
+or hit Postgres scaling limits; the bring-up cost is materially higher
+(8 GB+ RAM for a minimal `oceanbase-ce` Docker, longer startup, more env
+vars). Switch to `lancedb` when lexical match is not enough (cross-language,
+synonyms) and you can afford an embedding API. Switch to `mem0`/`zep` only
+when you're already invested in those products.
 
 ### Retrieval behavior comparison (same data set)
 
-| Dimension                | nanobot native             | MGP postgres            | MGP lancedb               | MGP mem0    | MGP zep              |
-| ------------------------ | -------------------------- | ----------------------- | ------------------------- | ----------- | -------------------- |
-| Search method            | None (full bulk inject)    | SQL ILIKE / JSONB GIN   | Vector ANN (+ FTS hybrid) | Vector + graph | Vector + episode graph |
-| Ranks by relevance       | No                         | Yes (lexical score)     | Yes (cosine)              | Yes         | Yes                  |
-| Cross-language matching  | Only after Dream normalizes | No                      | Yes                       | Yes         | Yes                  |
-| Synonym recall           | Only after Dream normalizes | No                      | Yes                       | Yes         | Yes                  |
-| Multi-user isolation     | No (single MEMORY.md)      | Yes (subject filter)    | Yes                       | Yes         | Yes                  |
-| Cross-session sharing    | No (per-workspace)         | Yes (within tenant)     | Yes                       | Yes         | Yes                  |
-| Recall latency           | 0 (no recall step)         | ~50–100 ms              | ~50–200 ms                | ~8–15 s     | ~1–2 s               |
-| Curation quality         | Dream LLM (best)           | Raw bullets             | Raw bullets               | Light dedupe | Light dedupe         |
+| Dimension                | nanobot native              | MGP postgres            | MGP oceanbase           | MGP lancedb               | MGP mem0       | MGP zep                |
+| ------------------------ | --------------------------- | ----------------------- | ----------------------- | ------------------------- | -------------- | ---------------------- |
+| Search method            | None (full bulk inject)     | SQL ILIKE / JSONB GIN   | SQL `LOWER(...) LIKE`   | Vector ANN (+ FTS hybrid) | Vector + graph | Vector + episode graph |
+| Ranks by relevance       | No                          | Yes (lexical score)     | Yes (lexical score)     | Yes (cosine)              | Yes            | Yes                    |
+| Cross-language matching  | Only after Dream normalizes | No                      | No                      | Yes                       | Yes            | Yes                    |
+| Synonym recall           | Only after Dream normalizes | No                      | No                      | Yes                       | Yes            | Yes                    |
+| Embedding model needed   | No                          | No                      | No                      | **Yes** (gateway-side)    | No (mem0 handles it) | No (zep handles it) |
+| Multi-user isolation     | No (single MEMORY.md)       | Yes (subject filter)    | Yes (subject filter)    | Yes                       | Yes            | Yes                    |
+| Cross-session sharing    | No (per-workspace)          | Yes (within tenant)     | Yes (within tenant)     | Yes                       | Yes            | Yes                    |
+| Recall latency           | 0 (no recall step)          | ~50–100 ms              | ~50–150 ms              | ~50–200 ms                | ~8–15 s        | ~1–2 s                 |
+| Min infra cost           | 0                           | 1 Postgres container    | OB cluster (8 GB+ RAM)  | Local dir + embedding API | SaaS account   | SaaS account           |
+| Curation quality         | Dream LLM (best)            | Raw bullets             | Raw bullets             | Raw bullets               | Light dedupe   | Light dedupe           |
+
+> **Note on OceanBase**: although `pyobvector` is the SDK used, the current
+> `oceanbase` adapter performs purely lexical search — the vector index is
+> not yet wired through the MGP gateway. Retrieval characteristics are
+> therefore close to `postgres`. Track upstream for vector search support
+> if cross-language / synonym matching is a hard requirement.
 
 ---
 
@@ -356,12 +479,13 @@ When MGP is disabled, `/mgp-status` returns a one-liner pointing here.
 
 ### Latency
 
-| Backend          | Recall round-trip   | Notes                                    |
-| ---------------- | ------------------- | ---------------------------------------- |
-| `postgres` local | ~50–100 ms          | Dominated by SQL plan + JSON parse       |
-| `lancedb` local  | ~50–200 ms          | Vector ANN + (optional) FTS hybrid       |
-| `mem0` SaaS      | ~8–15 s             | Through MGP HTTP → SaaS round-trip       |
-| `zep` SaaS       | ~1–2 s              | Same path; Zep is faster on the wire     |
+| Backend           | Recall round-trip  | Notes                                          |
+| ----------------- | ------------------ | ---------------------------------------------- |
+| `postgres` local  | ~50–100 ms         | Dominated by SQL plan + JSON parse             |
+| `oceanbase` local | ~50–150 ms         | Similar to Postgres + optional vector ANN      |
+| `lancedb` local   | ~50–200 ms         | Vector ANN + (optional) FTS hybrid             |
+| `mem0` SaaS       | ~8–15 s            | Through MGP HTTP → SaaS round-trip             |
+| `zep` SaaS        | ~1–2 s             | Same path; Zep is faster on the wire           |
 
 A recall call adds at most one extra LLM round-trip (the agent decides → tool
 runs → agent reasons again). The agent only pays this cost when it judges
@@ -421,10 +545,15 @@ Check that:
 
 ### Tool exists but every call shows `[recall_memory degraded: ...]`
 
-- Confirm the gateway is running: `curl http://127.0.0.1:8080/mgp/capabilities`
+- Confirm the gateway is running: `curl http://127.0.0.1:8080/healthz`
+  (returns `{"status":"ok",...}`). For more detail including the active
+  adapter name, hit `curl http://127.0.0.1:8080/mgp/capabilities`.
 - Confirm `mgp.gateway_url` matches the gateway's bind address.
 - If the gateway requires auth, set `mgp.api_key` AND
   `MGP_GATEWAY_API_KEY` to the same value, with `MGP_GATEWAY_AUTH_MODE=api_key`.
+- For SaaS adapters, confirm the vendor key is valid:
+  `MGP_MEM0_API_KEY` for mem0, `MGP_ZEP_API_KEY` for zep. The adapter raises
+  `RuntimeError` on startup if the key is missing — check the gateway log.
 
 ### Agent never calls `recall_memory` even when relevant
 

--- a/nanobot/agent/mgp/README.md
+++ b/nanobot/agent/mgp/README.md
@@ -106,6 +106,19 @@ Two — and only two — channels write to MGP:
 | B — Consolidator bullets | Token budget exceeded / autocompact / `/new`       | LLM-extracted bullets from `consolidator_archive.md` — one `MemoryCandidate` per bullet        | `mgp.enable_consolidator_commit`    |
 | C — Dream Phase-1 tags   | Cron every 2h / `/dream`                           | LLM-extracted `[USER]` / `[MEMORY]` / `[SOUL]` lines from `dream_phase1.md`                    | `mgp.enable_dream_commit`           |
 
+**Tag → MGP `(scope, type)` mapping for Dream Phase-1 commits**:
+
+| Dream tag  | MGP scope | MGP memory type   | Rationale                                                                                              |
+| ---------- | --------- | ----------------- | ------------------------------------------------------------------------------------------------------ |
+| `[USER]`   | `user`    | `preference`      | User-specific facts (location, language, taste)                                                        |
+| `[MEMORY]` | `agent`   | `semantic_fact`   | Stable shared knowledge surfaced by Dream                                                              |
+| `[SOUL]`   | `agent`   | `profile`         | Agent identity / persona facts. Note: MGP has no `identity` type — `profile` is the canonical mapping. |
+
+Memory types align with the MGP spec's `supported_memory_types` set
+(`profile / preference / episodic_event / semantic_fact / procedural_rule
+/ relationship / checkpoint_pointer / artifact_summary`) — the gateway
+will reject any other type with `MGP_INVALID_OBJECT`.
+
 **Never written to MGP**: raw user messages, raw assistant replies, tool call
 results, LLM `<thinking>`, `history.jsonl` entries themselves, the contents of
 `MEMORY.md` / `SOUL.md` / `USER.md`, media attachments, API keys, secrets.
@@ -164,6 +177,10 @@ agents:
   defaults:
     mgp:
       enabled: true
+      # Recommended: pin a stable subject id so Dream-extracted [USER] facts
+      # land where CLI/channel sessions can find them. Without this the
+      # subject defaults to getpass.getuser() (the OS login).
+      default_user_id: "alice"
 ```
 
 Restart nanobot. Use `/mgp-status` to verify the connection. Ask the agent
@@ -190,10 +207,36 @@ All fields live under `agents.defaults.mgp` in nanobot config.
 | `enable_dream_commit`          | `true`                        | Mirror Dream Phase-1 tags to MGP.                                    |
 | `recall_default_scope`         | `"user"`                      | Default `scope` when the agent omits it in `recall_memory(...)`.     |
 | `recall_default_limit`         | `5`                           | Default `limit` when the agent omits it. Capped at 20.               |
+| `default_user_id`              | `null`                        | Stable subject id used by Dream commits and CLI direct sessions when no real per-user identifier exists. Falls back to `getpass.getuser()` when null. **Set this in SDK / multi-tenant deployments** so Dream-extracted `[USER]` facts land under a discoverable subject. |
 
 There is **no `mode` / `shadow` field** — recall is agent-driven, so there is
 no auto-injection vs no-injection toggle. Granular control is through the
 two `enable_*_commit` flags.
+
+### Subject (`user_id`) derivation
+
+The MGP subject under which a memory is written / searched is resolved
+per-call from routing context with the following priority:
+
+1. `sender_id` from the inbound message (e.g. group-chat member id from
+   Telegram / Discord / WhatsApp / Slack — a real per-person identifier).
+2. `chat_id` if it is not a synthetic placeholder (`direct`, `dream`, `user`).
+3. `session_key` tail when present and not synthetic.
+4. `mgp.default_user_id` from your config.
+5. `getpass.getuser()` (the OS login).
+
+**Why this matters**: Dream runs at workspace scope and uses the synthetic
+`chat_id="dream"`. Without a configured `default_user_id`, every Dream
+`[USER]` fact would land under subject `"dream"` (or `getpass.getuser()`),
+not under the subject your CLI/channel session uses for recall — making
+those facts effectively unreachable. Always set `default_user_id` for
+SDK-only deployments and any setup where multiple bot instances should
+share one subject.
+
+For group chats, the inbound `sender_id` is plumbed all the way down to
+`build_runtime` (see `_set_tool_context` in `agent/loop.py`), so each
+member gets their own user-scoped memory island even though the `chat_id`
+is shared.
 
 ---
 
@@ -404,11 +447,12 @@ The error message from `build_sidecar` includes this exact hint.
 
 ### Group chat shows the same memory across users
 
-Known limitation: routing context (`_set_tool_context`) does not currently
-include `sender_id`, so all members of a group chat share the same `chat_id`
-as their `user_id`. 1:1 channels (CLI, Telegram DM, Discord DM) are isolated
-correctly. Tracking a future upstream change to expose `sender_id` to tools
-would close this gap.
+Make sure your channel implementation populates `InboundMessage.sender_id`
+with the real per-person id (not the chat/room id). The loop now plumbs
+`sender_id` through `_set_tool_context` → `recall_memory.set_context`
+→ `sidecar.build_runtime`, but only if the channel actually sets it. If a
+custom channel leaves it empty, recall will fall back to `chat_id` and
+collapse all group members onto one subject again.
 
 ### Latency spike after enabling MGP with a SaaS backend
 

--- a/nanobot/agent/mgp/README.md
+++ b/nanobot/agent/mgp/README.md
@@ -1,0 +1,417 @@
+# MGP Sidecar for nanobot
+
+Optional integration that connects nanobot to a [Memory Governance Protocol
+(MGP)](https://github.com/hkuds/MGP) gateway. When enabled, the agent can
+explicitly recall cross-session, governed long-term memory via the
+`recall_memory` tool, and the LLM-extracted facts produced by nanobot's
+existing Consolidator and Dream pipelines are mirrored to MGP automatically.
+
+> **TL;DR** — disabled by default; opt in with `agents.defaults.mgp.enabled: true`.
+> Recall is **agent-driven** (a tool, not a system-prompt injection).
+> Commit is **automatic** (rides on Consolidator + Dream output, zero added LLM cost).
+
+---
+
+## 1. Why MGP (vs nanobot's native bulk-injection memory)
+
+nanobot's native memory pipeline already does excellent work for stable,
+single-instance deployments:
+
+- `MEMORY.md` / `SOUL.md` / `USER.md` are **bulk-injected** into every system
+  prompt — the agent never has to "ask" for them.
+- `Dream` periodically condenses raw history into curated long-term knowledge.
+- `Consolidator` summarizes evicted messages into `history.jsonl` so the agent
+  can `grep` them on demand.
+
+MGP is a **complementary** layer, not a replacement:
+
+| Dimension     | nanobot native                       | MGP sidecar (this package)        |
+| ------------- | ------------------------------------ | --------------------------------- |
+| Trigger       | Every LLM request, automatic         | Only when the agent calls a tool  |
+| Method        | Bulk inject curated full files       | Query-based recall via tool call  |
+| Query         | None (everything is always present)  | Agent-constructed search topic    |
+| Frequency     | 100% of turns                        | Typically <20% of turns           |
+| Best at       | "What the agent always should know"  | "What is relevant to this turn"   |
+
+**The two stack**:
+
+```
+SOUL.md / MEMORY.md / USER.md   ← native bulk injection (always-on)
+                                +
+recall_memory tool (when needed) ← agent-driven targeted recall
+```
+
+Add MGP when you have at least one of:
+
+- Multi-device / multi-channel sync (agent should remember preferences across CLI ↔ Telegram ↔ web)
+- Multiple users sharing the same bot (group chats, customer-support style)
+- Long history where `grep` over `history.jsonl` becomes too slow
+- Cross-language / synonym-tolerant recall (requires a vector backend)
+- Compliance / audit logging requirements
+
+Skip MGP when you're a single-user, single-language, single-channel deployment
+— native memory is already enough.
+
+---
+
+## 2. How It Works
+
+### Recall path (agent decides)
+
+```mermaid
+flowchart TD
+  UserMsg["InboundMessage"] --> ProcessMessage["AgentLoop._process_message (unchanged)"]
+  ProcessMessage --> BuildMsgs["context.build_messages (unchanged)"]
+  BuildMsgs --> SystemPrompt["system prompt includes mgp-memory SKILL.md"]
+  SystemPrompt --> LLMCall["LLM reasoning"]
+  LLMCall --> Decide{"Need to recall?"}
+  Decide -->|"no (~80% of turns)"| Answer["Direct answer"]
+  Decide -->|"yes"| ToolCall["tool_call: recall_memory(query, scope?, limit?, types?)"]
+  ToolCall --> ToolExec["MGPRecallTool.execute"]
+  ToolExec --> Sidecar["sidecar.recall(runtime, intent)"]
+  Sidecar --> Gateway["MGP /search"]
+  Gateway --> Result["top-K results"]
+  Result --> ToolReturn["Formatted string back to LLM"]
+  ToolReturn --> LLMCall
+```
+
+### Commit path (automatic, agent does not participate)
+
+```mermaid
+flowchart TD
+  AgentRun["AgentLoop._run_agent_loop"] --> SaveTurn["session.save"]
+  SaveTurn --> ConsolBg["Consolidator.maybe_consolidate_by_tokens (background)"]
+  ConsolBg --> Archive["Consolidator.archive(messages, session=...)"]
+  Archive --> AppendHistory["store.append_history(summary)"]
+  AppendHistory --> CommitB{"sidecar enabled?"}
+  CommitB -->|"yes"| ParseBullets["parse_consolidator_bullets"]
+  ParseBullets --> WriteMGP1["asyncio.create_task: sidecar.commit_bullets(...)"]
+
+  CronTick["Cron 2h"] --> DreamRun["Dream.run"]
+  DreamRun --> Phase1["LLM Phase-1 [USER]/[MEMORY]/[SOUL] tags"]
+  Phase1 --> CommitC{"sidecar enabled?"}
+  CommitC -->|"yes"| ParseTags["parse_dream_phase1_tags"]
+  ParseTags --> WriteMGP2["asyncio.create_task: sidecar.commit_dream_tags(...)"]
+  Phase1 --> Phase2["Dream Phase 2 file edits (unchanged)"]
+```
+
+---
+
+## 3. What Gets Written, Who Controls It
+
+Two — and only two — channels write to MGP:
+
+| Channel                  | Trigger                                            | Content written                                                                                | Toggle                              |
+| ------------------------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------- |
+| B — Consolidator bullets | Token budget exceeded / autocompact / `/new`       | LLM-extracted bullets from `consolidator_archive.md` — one `MemoryCandidate` per bullet        | `mgp.enable_consolidator_commit`    |
+| C — Dream Phase-1 tags   | Cron every 2h / `/dream`                           | LLM-extracted `[USER]` / `[MEMORY]` / `[SOUL]` lines from `dream_phase1.md`                    | `mgp.enable_dream_commit`           |
+
+**Never written to MGP**: raw user messages, raw assistant replies, tool call
+results, LLM `<thinking>`, `history.jsonl` entries themselves, the contents of
+`MEMORY.md` / `SOUL.md` / `USER.md`, media attachments, API keys, secrets.
+
+**Outbound during recall**: when the agent calls `recall_memory`, the **agent-
+constructed `query` string** (a concise topic, per the SKILL.md guidance) is
+sent to the gateway. This is not the user's raw message — see
+[Privacy Notes](#12-privacy-notes).
+
+---
+
+## 4. What Doesn't Change
+
+When MGP is enabled, **all native memory behaviors stay exactly as-is**:
+
+- `MEMORY.md`, `SOUL.md`, `USER.md` continue to be bulk-injected into the
+  system prompt every turn.
+- `history.jsonl` continues to be the source of truth for `grep`-based
+  history lookups by the agent.
+- `Dream` continues to edit local files and commit via git.
+- `autocompact` continues to compress idle sessions.
+- All slash commands (`/dream`, `/dream-log`, `/dream-restore`, ...) work
+  unchanged.
+
+If MGP is disabled (the default) or unreachable at runtime, the agent behaves
+**byte-identically** to a build without MGP.
+
+---
+
+## 5. Quickstart (PostgreSQL backend)
+
+Four steps, all PyPI:
+
+```bash
+# 1. Install nanobot's MGP client extra (~one extra dep)
+pip install "nanobot[mgp]"
+
+# 2. Install the MGP gateway with the postgres adapter extra
+pip install "mgp-gateway[postgres]>=0.1.1"
+
+# 3. Run a Postgres for the gateway to use
+docker run -d --name mgp-pg \
+  -e POSTGRES_USER=mgp -e POSTGRES_PASSWORD=mgp -e POSTGRES_DB=mgp \
+  -p 5432:5432 postgres:16
+
+# 4. Start the gateway
+MGP_ADAPTER=postgres \
+MGP_POSTGRES_DSN='postgresql://mgp:mgp@127.0.0.1:5432/mgp' \
+mgp-gateway
+```
+
+Then enable MGP in your nanobot config:
+
+```yaml
+agents:
+  defaults:
+    mgp:
+      enabled: true
+```
+
+Restart nanobot. Use `/mgp-status` to verify the connection. Ask the agent
+something that references past context (e.g. "what's my preferred indentation?")
+to see it call `recall_memory`.
+
+---
+
+## 6. Configuration Reference (nanobot side)
+
+All fields live under `agents.defaults.mgp` in nanobot config.
+
+| Field                          | Default                       | Purpose                                                              |
+| ------------------------------ | ----------------------------- | -------------------------------------------------------------------- |
+| `enabled`                      | `false`                       | Master switch. Off = no MGP code path runs at all.                   |
+| `gateway_url`                  | `http://127.0.0.1:8080`       | MGP gateway HTTP base URL.                                           |
+| `timeout`                      | `5.0`                         | Per-request timeout (seconds).                                       |
+| `fail_open`                    | `true`                        | Swallow MGP errors so a degraded gateway never breaks a turn.         |
+| `workspace_as_tenant`          | `true`                        | Use the workspace path as `tenant_id` when `tenant_id` is unset.     |
+| `tenant_id`                    | `null`                        | Explicit tenant id. Wins over `workspace_as_tenant`.                 |
+| `actor_agent`                  | `nanobot/main`                | Identity recorded in MGP's audit log.                                |
+| `api_key`                      | `null`                        | Bearer token (for gateways with `auth_mode=api_key`).                |
+| `enable_consolidator_commit`   | `true`                        | Mirror Consolidator bullets to MGP.                                  |
+| `enable_dream_commit`          | `true`                        | Mirror Dream Phase-1 tags to MGP.                                    |
+| `recall_default_scope`         | `"user"`                      | Default `scope` when the agent omits it in `recall_memory(...)`.     |
+| `recall_default_limit`         | `5`                           | Default `limit` when the agent omits it. Capped at 20.               |
+
+There is **no `mode` / `shadow` field** — recall is agent-driven, so there is
+no auto-injection vs no-injection toggle. Granular control is through the
+two `enable_*_commit` flags.
+
+---
+
+## 7. Configuration Reference (gateway side)
+
+Adapter selection lives **on the MGP gateway side**, not in `nanobot.yaml`.
+nanobot only needs to know `gateway_url` (and optionally `api_key`).
+
+Production-grade adapters:
+
+| Adapter      | Install                                            | Required env                                                                                                         |
+| ------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `postgres`   | `pip install "mgp-gateway[postgres]>=0.1.1"`       | `MGP_ADAPTER=postgres`, `MGP_POSTGRES_DSN=...`                                                                        |
+| `oceanbase`  | `pip install "mgp-gateway[oceanbase]>=0.1.1"`      | `MGP_ADAPTER=oceanbase`, `MGP_OCEANBASE_DSN=...`                                                                      |
+| `lancedb`    | `pip install "mgp-gateway[lancedb]>=0.1.1"`        | `MGP_ADAPTER=lancedb`, `MGP_LANCEDB_DIR=...`, `MGP_LANCEDB_EMBEDDING_PROVIDER`, `MGP_LANCEDB_EMBEDDING_MODEL`, `MGP_LANCEDB_EMBEDDING_API_KEY` |
+| `mem0`       | `pip install mem0ai`                               | `MGP_ADAPTER=mem0`, `MGP_MEM0_API_KEY=...`                                                                           |
+| `zep`        | `pip install zep-cloud`                            | `MGP_ADAPTER=zep`, `MGP_ZEP_API_KEY=...`                                                                             |
+
+Reference adapters (`memory`, `file`, `graph`) are for protocol verification —
+do not use in production.
+
+Authentication on the gateway side:
+
+```bash
+export MGP_GATEWAY_AUTH_MODE=api_key   # off / api_key / bearer
+export MGP_GATEWAY_API_KEY=secret-...  # set the same value as nanobot.yaml mgp.api_key
+mgp-gateway
+```
+
+See the [MGP repository](https://github.com/hkuds/MGP) for the full set of
+gateway environment variables.
+
+---
+
+## 8. Adapter Selection Guide
+
+### By user profile
+
+| Your situation                                          | Should you enable MGP? | Recommended backend       |
+| ------------------------------------------------------- | ---------------------- | ------------------------- |
+| Single-user, single-language, single-channel            | No                     | —                         |
+| Multi-device sync, agent should remember me everywhere  | Yes                    | `postgres`                |
+| One bot serving multiple users (groups, support)        | Yes                    | `postgres` (subject-isolated) |
+| Frequent cross-language / synonym recall                | Yes                    | `lancedb` or `mem0`       |
+| Large history (thousands of entries), `grep` is slow    | Yes                    | `lancedb`                 |
+| Compliance / audit / GDPR-style data governance         | Yes                    | `postgres` + audit log    |
+| Already using mem0 or zep                               | Yes                    | `mem0` / `zep`            |
+| Cannot tolerate >1s first-token latency                 | Avoid SaaS backends    | `postgres` / local `lancedb` |
+
+### Retrieval behavior comparison (same data set)
+
+| Dimension                | nanobot native             | MGP postgres            | MGP lancedb               | MGP mem0    | MGP zep              |
+| ------------------------ | -------------------------- | ----------------------- | ------------------------- | ----------- | -------------------- |
+| Search method            | None (full bulk inject)    | SQL ILIKE / JSONB GIN   | Vector ANN (+ FTS hybrid) | Vector + graph | Vector + episode graph |
+| Ranks by relevance       | No                         | Yes (lexical score)     | Yes (cosine)              | Yes         | Yes                  |
+| Cross-language matching  | Only after Dream normalizes | No                      | Yes                       | Yes         | Yes                  |
+| Synonym recall           | Only after Dream normalizes | No                      | Yes                       | Yes         | Yes                  |
+| Multi-user isolation     | No (single MEMORY.md)      | Yes (subject filter)    | Yes                       | Yes         | Yes                  |
+| Cross-session sharing    | No (per-workspace)         | Yes (within tenant)     | Yes                       | Yes         | Yes                  |
+| Recall latency           | 0 (no recall step)         | ~50–100 ms              | ~50–200 ms                | ~8–15 s     | ~1–2 s               |
+| Curation quality         | Dream LLM (best)           | Raw bullets             | Raw bullets               | Light dedupe | Light dedupe         |
+
+---
+
+## 9. `recall_memory` Tool Usage
+
+The agent sees the [`mgp-memory` skill](../../skills/mgp-memory/SKILL.md)
+in every system prompt. That skill teaches it when to call the tool. From
+the agent's perspective:
+
+```python
+recall_memory(
+    query="indentation preference",       # required: concise topic, NOT a full question
+    scope="user",                          # optional: "user" / "agent" / "session"
+    limit=5,                               # optional: 1..20
+    types=["preference"],                  # optional: filter by memory types
+)
+```
+
+Returns a string like:
+
+```
+- [preference] User prefers 4-space indentation for Python.
+- [preference] User prefers concise replies, no preamble.
+```
+
+…or `(no memories found)` when the search is empty, or
+`[recall_memory degraded: <code>]` when the gateway failed (fail-open path).
+
+When NOT to call:
+
+- Information is already in your system prompt (`MEMORY.md` / `SOUL.md` / `USER.md` / Recent History)
+- General knowledge questions
+- Pure code/tool tasks with no user-specific context
+- You already called `recall_memory` this turn and got results
+
+Full guidance lives in
+[`nanobot/skills/mgp-memory/SKILL.md`](../../skills/mgp-memory/SKILL.md).
+
+---
+
+## 10. Slash Commands
+
+`/mgp-status` shows:
+
+- `enabled` flag and gateway URL
+- whether the `recall_memory` tool is registered
+- which commit channels are on
+- the most recent recall outcome (query, latency, hit count, error if any)
+- the most recent commits (last 32 kept, with success/failure breakdown)
+
+When MGP is disabled, `/mgp-status` returns a one-liner pointing here.
+
+---
+
+## 11. Trade-offs
+
+### Latency
+
+| Backend          | Recall round-trip   | Notes                                    |
+| ---------------- | ------------------- | ---------------------------------------- |
+| `postgres` local | ~50–100 ms          | Dominated by SQL plan + JSON parse       |
+| `lancedb` local  | ~50–200 ms          | Vector ANN + (optional) FTS hybrid       |
+| `mem0` SaaS      | ~8–15 s             | Through MGP HTTP → SaaS round-trip       |
+| `zep` SaaS       | ~1–2 s              | Same path; Zep is faster on the wire     |
+
+A recall call adds at most one extra LLM round-trip (the agent decides → tool
+runs → agent reasons again). The agent only pays this cost when it judges
+recall to be useful — typically ~20% of turns.
+
+### Reliability
+
+The sidecar is **fail-open** by default: any MGP error (HTTP timeout, gateway
+500, schema validation failure) is swallowed and surfaced to the agent as
+`[recall_memory degraded: <code>]`. The conversation never dies because of an
+MGP problem.
+
+### Misses
+
+The agent might forget to call `recall_memory` when it would have helped. The
+SKILL.md trigger word list ("remember", "I told you", "我之前说过", "还记得") is
+designed to minimize this, but it's not zero. If you observe specific topics
+that the agent should always check on, extend the SKILL.md examples.
+
+### Duplication
+
+The same fact may live both in `MEMORY.md` (Dream-curated, locally stored) and
+in MGP (raw bullets). This is intentional — local files stay the source of
+truth for the bulk-injected context, and MGP stays the source of truth for
+on-demand cross-session recall. Stage 2 may add `[FILE-REMOVE] →
+expire_memory` propagation to keep them in sync.
+
+---
+
+## 12. Privacy Notes
+
+When the agent calls `recall_memory`, the **agent-constructed `query` string**
+(per the SKILL.md guidance — a topic, not a full user question) is sent to the
+configured gateway over HTTP.
+
+- **Local backends (`postgres`, `lancedb`, `oceanbase`)**: query stays on your
+  network — never leaves the gateway process.
+- **SaaS backends (`mem0`, `zep`)**: the gateway forwards the query to the
+  vendor's API, where it is processed under that vendor's privacy policy.
+
+For the **commit** path, only LLM-extracted bullets / tags are written. Raw
+conversation text is never sent. See [§3](#3-what-gets-written-who-controls-it)
+for the exhaustive list of what can and cannot be written.
+
+When `mgp.enabled=false` (default), nanobot does not import `mgp_client` and
+does not contact any gateway — full air-gap.
+
+---
+
+## 13. Troubleshooting
+
+### `/mgp-status` says "MGP sidecar not enabled"
+
+Check that:
+- `mgp.enabled: true` is set in your config under `agents.defaults`.
+- You restarted nanobot after editing the config.
+
+### Tool exists but every call shows `[recall_memory degraded: ...]`
+
+- Confirm the gateway is running: `curl http://127.0.0.1:8080/mgp/capabilities`
+- Confirm `mgp.gateway_url` matches the gateway's bind address.
+- If the gateway requires auth, set `mgp.api_key` AND
+  `MGP_GATEWAY_API_KEY` to the same value, with `MGP_GATEWAY_AUTH_MODE=api_key`.
+
+### Agent never calls `recall_memory` even when relevant
+
+- Confirm the `mgp-memory` skill is loaded (it should appear in the system
+  prompt — check via debug logs or `/status`).
+- Strengthen SKILL.md trigger words for your specific use case (the file is at
+  `nanobot/skills/mgp-memory/SKILL.md` — extending it is the canonical fix).
+- Test by saying something with a strong trigger: "remember when I said I
+  prefer X?" — this should reliably elicit a recall.
+
+### `ModuleNotFoundError: mgp_client`
+
+You enabled `mgp.enabled` without installing the optional dependency. Run:
+
+```bash
+pip install "nanobot[mgp]"
+```
+
+The error message from `build_sidecar` includes this exact hint.
+
+### Group chat shows the same memory across users
+
+Known limitation: routing context (`_set_tool_context`) does not currently
+include `sender_id`, so all members of a group chat share the same `chat_id`
+as their `user_id`. 1:1 channels (CLI, Telegram DM, Discord DM) are isolated
+correctly. Tracking a future upstream change to expose `sender_id` to tools
+would close this gap.
+
+### Latency spike after enabling MGP with a SaaS backend
+
+`mem0` and `zep` round-trips through the gateway are 8–15 s and 1–2 s
+respectively. If first-token latency matters, switch to `postgres` (~100 ms)
+or local `lancedb` (~200 ms). Use `/mgp-status` to monitor `last_recall.latency`.

--- a/nanobot/agent/mgp/__init__.py
+++ b/nanobot/agent/mgp/__init__.py
@@ -1,0 +1,72 @@
+"""MGP sidecar package for nanobot.
+
+This subpackage is **opt-in**: it is only imported when ``mgp.enabled = true``
+in the agent config. Importing this top-level module is cheap and does NOT
+trigger an ``import mgp_client`` — the optional dependency is checked lazily
+in :func:`build_sidecar`.
+
+Public surface (intentionally tiny):
+
+* :func:`build_sidecar` — factory that returns an ``AsyncMGPSidecar``,
+  raising a clear install hint when ``mgp-client`` is missing.
+* :class:`MGPSidecarUnavailable` — raised when the optional dep is absent.
+
+Concrete dataclasses (``RecallOutcome``, ``CommitOutcome``, etc.) are also
+re-exported because they are safe to import without ``mgp_client``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .models import (
+    CommitOutcome,
+    ParsedFact,
+    RecallIntent,
+    RecallItem,
+    RecallOutcome,
+    RuntimeState,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only
+    from nanobot.config.schema import MGPConfig
+
+    from .sidecar import AsyncMGPSidecar
+
+
+class MGPSidecarUnavailable(RuntimeError):
+    """Raised when MGP sidecar is requested but ``mgp-client`` is not installed."""
+
+
+def build_sidecar(config: "MGPConfig", *, workspace_id: str | None = None) -> "AsyncMGPSidecar":
+    """Construct an :class:`AsyncMGPSidecar`. Imports ``mgp_client`` lazily.
+
+    Raises :class:`MGPSidecarUnavailable` with an actionable hint when the
+    optional dependency is missing — callers in ``AgentLoop.__init__`` are
+    expected to guard with ``if mgp_config.enabled`` before invoking this.
+    """
+    try:
+        import mgp_client  # noqa: F401  (probe import only)
+    except ImportError as exc:
+        raise MGPSidecarUnavailable(
+            "mgp-client is not installed. Install with: pip install 'nanobot[mgp]'"
+        ) from exc
+
+    # Defer the heavy import until after the dependency check so a missing
+    # mgp-client surfaces as a clear MGPSidecarUnavailable rather than a
+    # generic ImportError raised deep inside the package import chain.
+    from .sidecar import AsyncMGPSidecar
+
+    return AsyncMGPSidecar(config, workspace_id=workspace_id)
+
+
+__all__ = [
+    "CommitOutcome",
+    "MGPSidecarUnavailable",
+    "ParsedFact",
+    "RecallIntent",
+    "RecallItem",
+    "RecallOutcome",
+    "RuntimeState",
+    "build_sidecar",
+]

--- a/nanobot/agent/mgp/__init__.py
+++ b/nanobot/agent/mgp/__init__.py
@@ -1,18 +1,8 @@
-"""MGP sidecar package for nanobot.
+"""MGP sidecar package for nanobot. Opt-in; only imported when ``mgp.enabled = true``.
 
-This subpackage is **opt-in**: it is only imported when ``mgp.enabled = true``
-in the agent config. Importing this top-level module is cheap and does NOT
-trigger an ``import mgp_client`` — the optional dependency is checked lazily
-in :func:`build_sidecar`.
-
-Public surface (intentionally tiny):
-
-* :func:`build_sidecar` — factory that returns an ``AsyncMGPSidecar``,
-  raising a clear install hint when ``mgp-client`` is missing.
-* :class:`MGPSidecarUnavailable` — raised when the optional dep is absent.
-
-Concrete dataclasses (``RecallOutcome``, ``CommitOutcome``, etc.) are also
-re-exported because they are safe to import without ``mgp_client``.
+Importing this module is cheap: the optional ``mgp-client`` dependency is
+checked lazily inside :func:`build_sidecar`. The dataclasses re-exported
+below are safe to import without ``mgp-client``.
 """
 
 from __future__ import annotations
@@ -35,16 +25,11 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only
 
 
 class MGPSidecarUnavailable(RuntimeError):
-    """Raised when MGP sidecar is requested but ``mgp-client`` is not installed."""
+    """Raised when the MGP sidecar is requested but ``mgp-client`` is not installed."""
 
 
 def build_sidecar(config: "MGPConfig", *, workspace_id: str | None = None) -> "AsyncMGPSidecar":
-    """Construct an :class:`AsyncMGPSidecar`. Imports ``mgp_client`` lazily.
-
-    Raises :class:`MGPSidecarUnavailable` with an actionable hint when the
-    optional dependency is missing — callers in ``AgentLoop.__init__`` are
-    expected to guard with ``if mgp_config.enabled`` before invoking this.
-    """
+    """Build an :class:`AsyncMGPSidecar`, importing ``mgp_client`` lazily."""
     try:
         import mgp_client  # noqa: F401  (probe import only)
     except ImportError as exc:
@@ -52,9 +37,6 @@ def build_sidecar(config: "MGPConfig", *, workspace_id: str | None = None) -> "A
             "mgp-client is not installed. Install with: pip install 'nanobot[mgp]'"
         ) from exc
 
-    # Defer the heavy import until after the dependency check so a missing
-    # mgp-client surfaces as a clear MGPSidecarUnavailable rather than a
-    # generic ImportError raised deep inside the package import chain.
     from .sidecar import AsyncMGPSidecar
 
     return AsyncMGPSidecar(config, workspace_id=workspace_id)

--- a/nanobot/agent/mgp/mappers.py
+++ b/nanobot/agent/mgp/mappers.py
@@ -1,0 +1,166 @@
+"""Adapters between nanobot dataclasses and ``mgp_client`` protocol objects.
+
+``mgp_client`` is an *optional* dependency. This module imports it eagerly,
+so it must only be imported lazily (after ``build_sidecar`` has confirmed
+the package is available). See :mod:`nanobot.agent.mgp.__init__` for the
+gate.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from mgp_client import MemoryCandidate, PolicyContextBuilder, SearchQuery
+from mgp_client.models import PolicyContext
+
+from .models import ParsedFact, RecallIntent, RecallItem, RuntimeState
+
+
+# --- policy context -------------------------------------------------------
+
+
+def build_policy_context(runtime: RuntimeState, requested_action: str) -> PolicyContext:
+    """Map a :class:`RuntimeState` into an MGP ``PolicyContext``.
+
+    ``requested_action`` is one of MGP's verbs (``"search"`` / ``"write"`` /
+    ``"read"`` / ...). The same runtime state is reused across recall and
+    commit; only the action verb differs per call.
+    """
+    builder = PolicyContextBuilder(
+        actor_agent=runtime.actor_agent,
+        subject_kind=runtime.subject_kind,
+        subject_id=runtime.user_id,
+        tenant_id=runtime.tenant_id,
+        task_id=runtime.session_key,
+        session_id=runtime.session_key,
+        task_type=f"nanobot:{runtime.channel}",
+        channel=runtime.channel,
+        chat_id=runtime.chat_id,
+        runtime_id="nanobot",
+        correlation_id=runtime.correlation_id,
+    )
+    return builder.build(requested_action)
+
+
+# --- search query ---------------------------------------------------------
+
+
+# Query-shaping patterns: strip natural-language envelopes that the agent
+# might wrap a search topic in. These are conservative — agent SHOULD send a
+# concise topic per the SKILL.md guidance, but we sanitize just in case.
+_QUERY_ENVELOPES = (
+    r"^\s*what did i say about\s+",
+    r"^\s*what do you remember about\s+",
+    r"^\s*do you remember\s+",
+    r"^\s*what is my\s+",
+    r"^\s*remind me about\s+",
+    r"^\s*can you recall\s+",
+    r"^\s*tell me about my\s+",
+)
+_QUERY_TRAIL = re.compile(r"[\?\.\!]+$")
+
+
+def _normalize_query(query: str) -> str:
+    """Trim conversational scaffolding so the search hits the topic itself."""
+    text = re.sub(r"\s+", " ", query).strip()
+    lowered = text.lower()
+    for pattern in _QUERY_ENVELOPES:
+        m = re.match(pattern, lowered)
+        if m:
+            text = text[m.end():].strip()
+            break
+    text = _QUERY_TRAIL.sub("", text).strip()
+    return text or query.strip()
+
+
+def build_search_query(runtime: RuntimeState, intent: RecallIntent) -> SearchQuery:
+    """Build a typed ``SearchQuery`` payload for ``client.search_memory``."""
+    normalized = _normalize_query(intent.query)
+    keywords = [
+        token
+        for token in re.findall(r"[a-zA-Z0-9\u4e00-\u9fa5][a-zA-Z0-9_\-\u4e00-\u9fa5]*", normalized.lower())
+        if len(token) > 1
+    ][:8]
+    intent_type = "preference_lookup" if intent.types and "preference" in intent.types else "free_text"
+    return SearchQuery(
+        query=normalized,
+        query_text=normalized,
+        intent_type=intent_type,
+        keywords=keywords or None,
+        subject={"kind": runtime.subject_kind, "id": runtime.user_id},
+        scope=intent.scope,
+        target_memory_types=intent.types,
+        types=intent.types,
+        top_k=intent.limit,
+        limit=intent.limit,
+    )
+
+
+# --- write candidate ------------------------------------------------------
+
+
+def build_memory_candidate(runtime: RuntimeState, fact: ParsedFact) -> MemoryCandidate:
+    """Map a :class:`ParsedFact` into a typed ``MemoryCandidate``.
+
+    A ``merge_hint`` is attached so retries — and any future near-duplicate
+    suppression at the gateway — collapse onto the same canonical memory.
+    """
+    statement = fact.statement
+    content: dict[str, Any] = {"statement": statement}
+    if fact.preference_value:
+        content["preference"] = fact.preference_value
+
+    source_ref = fact.source_ref or f"nanobot:{runtime.channel}:{runtime.session_key}"
+    extensions: dict[str, Any] = {
+        "nanobot:channel": runtime.channel,
+        "nanobot:workspace": runtime.workspace_id,
+        "nanobot:session_key": runtime.session_key,
+    }
+    if runtime.chat_id:
+        extensions["nanobot:chat_id"] = runtime.chat_id
+    if runtime.correlation_id:
+        extensions["nanobot:correlation_id"] = runtime.correlation_id
+
+    dedupe_key = f"{runtime.user_id}:{fact.type}:{statement.strip().lower()}"
+
+    return MemoryCandidate(
+        candidate_kind="assertion",
+        subject={"kind": runtime.subject_kind, "id": runtime.user_id},
+        scope=fact.scope,
+        proposed_type=fact.type,
+        statement=statement,
+        source={"kind": "chat", "ref": source_ref},
+        content=content,
+        source_evidence=[
+            {"kind": "chat_message", "ref": source_ref, "excerpt": statement}
+        ],
+        merge_hint={"strategy": "dedupe", "dedupe_key": dedupe_key},
+        extensions=extensions,
+    )
+
+
+# --- search response normalization ---------------------------------------
+
+
+def normalize_search_results(data: dict[str, Any] | None) -> list[RecallItem]:
+    """Flatten a search response payload into a uniform list of items."""
+    if not data:
+        return []
+    items: list[RecallItem] = []
+    for entry in data.get("results", []):
+        items.append(
+            RecallItem(
+                memory=entry.get("memory") or {},
+                score=entry.get("score"),
+                score_kind=entry.get("score_kind"),
+                retrieval_mode=entry.get("retrieval_mode"),
+                return_mode=entry.get("return_mode") or "raw",
+                redaction_info=entry.get("redaction_info"),
+                backend_origin=entry.get("backend_origin"),
+                consumable_text=entry.get("consumable_text"),
+                matched_terms=entry.get("matched_terms"),
+                explanation=entry.get("explanation"),
+            )
+        )
+    return items

--- a/nanobot/agent/mgp/models.py
+++ b/nanobot/agent/mgp/models.py
@@ -96,7 +96,7 @@ class ParsedFact:
     """
 
     scope: str          # "user" / "agent" / "session"
-    type: str           # "preference" / "semantic_fact" / "identity" / "episodic_event"
+    type: str           # "preference" / "semantic_fact" / "profile" / "episodic_event"
     statement: str
     preference_value: str | None = None
     source_ref: str | None = None

--- a/nanobot/agent/mgp/models.py
+++ b/nanobot/agent/mgp/models.py
@@ -1,0 +1,102 @@
+"""Lightweight dataclasses for the MGP sidecar.
+
+These models intentionally have **no** dependency on ``mgp_client``. They can
+be imported even when the optional ``mgp-client`` package is not installed,
+which keeps tooling such as ``/mgp-status`` and tests cheap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class RuntimeState:
+    """Per-call runtime context fed into MGP policy and recall payloads.
+
+    The fields mirror what the MGP ``PolicyContextBuilder`` consumes; we keep
+    them in a plain dataclass so callers (sidecar / tool / consolidator hook)
+    can build it without importing ``mgp_client``.
+    """
+
+    actor_agent: str
+    user_id: str
+    session_key: str
+    workspace_id: str
+    channel: str
+    chat_id: str | None = None
+    subject_kind: str = "user"
+    tenant_id: str | None = None
+    correlation_id: str | None = None
+
+
+@dataclass
+class RecallIntent:
+    """A recall request constructed from agent tool-call params."""
+
+    query: str
+    limit: int = 5
+    scope: str = "user"
+    types: list[str] | None = None
+
+
+@dataclass
+class RecallItem:
+    """One normalized hit from MGP search response."""
+
+    memory: dict[str, Any]
+    score: float | None = None
+    score_kind: str | None = None
+    retrieval_mode: str | None = None
+    return_mode: str = "raw"
+    redaction_info: dict[str, Any] | None = None
+    backend_origin: str | None = None
+    consumable_text: str | None = None
+    matched_terms: list[str] | None = None
+    explanation: str | None = None
+
+
+@dataclass
+class RecallOutcome:
+    """Result of a single ``sidecar.recall(...)`` call.
+
+    ``executed`` flips to ``False`` when the sidecar shorted out (e.g. fail-open
+    swallowed a transport error). ``degraded`` indicates the call was attempted
+    but failed. The tool layer is expected to handle ``degraded`` gracefully.
+    """
+
+    executed: bool
+    degraded: bool
+    results: list[RecallItem] = field(default_factory=list)
+    request_id: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+
+@dataclass
+class CommitOutcome:
+    """Result of a single ``write_candidate`` attempt."""
+
+    executed: bool
+    written: bool
+    memory_id: str | None = None
+    request_id: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+
+@dataclass
+class ParsedFact:
+    """Intermediate structure produced by parsers.
+
+    Both ``parse_consolidator_bullets`` and ``parse_dream_phase1_tags``
+    normalize their inputs into a list of these so the sidecar can issue
+    uniform ``write_candidate`` calls regardless of source.
+    """
+
+    scope: str          # "user" / "agent" / "session"
+    type: str           # "preference" / "semantic_fact" / "identity" / "episodic_event"
+    statement: str
+    preference_value: str | None = None
+    source_ref: str | None = None

--- a/nanobot/agent/mgp/parsers.py
+++ b/nanobot/agent/mgp/parsers.py
@@ -19,10 +19,17 @@ from .models import ParsedFact
 
 
 # Tag → (scope, type) mapping for Dream Phase 1 output.
+#
+# NOTE: ``SOUL`` maps to ``profile`` (not ``identity``) because the MGP
+# spec's ``supported_memory_types`` set is ``profile / preference /
+# episodic_event / semantic_fact / procedural_rule / relationship /
+# checkpoint_pointer / artifact_summary`` — there is no ``identity``
+# type. ``profile`` is the closest semantic match for SOUL.md content
+# (stable agent persona / identity facts).
 DREAM_TAG_TO_MGP: dict[str, tuple[str, str]] = {
     "USER": ("user", "preference"),
     "MEMORY": ("agent", "semantic_fact"),
-    "SOUL": ("agent", "identity"),
+    "SOUL": ("agent", "profile"),
 }
 
 

--- a/nanobot/agent/mgp/parsers.py
+++ b/nanobot/agent/mgp/parsers.py
@@ -1,0 +1,164 @@
+"""Parsers that turn nanobot's existing LLM extraction outputs into MemoryCandidates.
+
+Two channels are supported:
+
+* :func:`parse_consolidator_bullets` — input is the raw bullet-list summary
+  produced by :file:`nanobot/templates/agent/consolidator_archive.md`.
+* :func:`parse_dream_phase1_tags` — input is the ``[USER]/[MEMORY]/[SOUL]``
+  tagged analysis produced by :file:`nanobot/templates/agent/dream_phase1.md`.
+
+Both intentionally have **no** dependency on ``mgp_client`` so they remain
+unit-testable without the optional package.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .models import ParsedFact
+
+
+# Tag → (scope, type) mapping for Dream Phase 1 output.
+DREAM_TAG_TO_MGP: dict[str, tuple[str, str]] = {
+    "USER": ("user", "preference"),
+    "MEMORY": ("agent", "semantic_fact"),
+    "SOUL": ("agent", "identity"),
+}
+
+
+_DREAM_TAG_RE = re.compile(r"^\[(USER|MEMORY|SOUL)\]\s+(.+?)\s*$")
+# Lines we deliberately skip when parsing Dream phase-1 output.
+_DREAM_IGNORED_TAGS = ("FILE-REMOVE", "SKILL", "SKIP")
+
+
+# Heuristic keyword → (scope, type) buckets for consolidator bullet
+# classification. The buckets follow the prompt's category labels in
+# ``consolidator_archive.md``: User facts / Decisions / Solutions / Events /
+# Preferences. Match order matters — preference wins over semantic_fact.
+_PREFERENCE_HINTS = (
+    "prefer",
+    "preference",
+    "favor",
+    "favourite",
+    "favorite",
+    "likes",
+    "dislikes",
+    "always use",
+    "always answer",
+    "always reply",
+    "communication style",
+    "tone",
+)
+_EVENT_HINTS = (
+    "deadline",
+    "scheduled",
+    "meeting",
+    "occurred",
+    "happened",
+    "tomorrow",
+    "next week",
+    "planned",
+)
+
+
+def _classify_bullet(text: str) -> tuple[str, str, str | None]:
+    """Return (scope, type, preference_value) for one bullet line.
+
+    Default classification is ``("user", "semantic_fact", None)`` because
+    nanobot's consolidator prompt explicitly targets *user-relevant* facts.
+    Bullets that look like preferences or events are remapped accordingly.
+    """
+    lower = text.lower()
+    if any(hint in lower for hint in _PREFERENCE_HINTS):
+        # Try to extract the preference value after a "prefers ..." or
+        # "always use ..." phrase. Fall back to the whole statement.
+        m = re.search(
+            r"(?:prefers|prefer|favors|favor|likes|always use|always answer|always reply)\s+(.+?)[\.;]?$",
+            text,
+            re.IGNORECASE,
+        )
+        value = m.group(1).strip() if m else text
+        return "user", "preference", value
+    if any(hint in lower for hint in _EVENT_HINTS):
+        return "user", "episodic_event", None
+    return "user", "semantic_fact", None
+
+
+def parse_consolidator_bullets(summary: str, *, source_ref: str | None = None) -> list[ParsedFact]:
+    """Split a consolidator summary into one ``ParsedFact`` per bullet.
+
+    Empty input or the explicit ``(nothing)`` sentinel returns ``[]``.
+    Lines that look like Markdown headers, ``[RAW]`` raw-archive markers,
+    or "User said:" raw archive bodies are filtered out so we never write
+    raw conversation transcripts to MGP.
+    """
+    if not summary:
+        return []
+    stripped = summary.strip()
+    if not stripped or stripped.lower() == "(nothing)":
+        return []
+    # Don't write raw-archived turns; that's tail-end fallback content.
+    if stripped.startswith("[RAW]"):
+        return []
+
+    facts: list[ParsedFact] = []
+    for raw_line in stripped.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        # Strip common bullet leaders: "- foo", "* foo", "1. foo".
+        m = re.match(r"^(?:[-*+]|\d+[.)])\s+(.+)$", line)
+        if m:
+            line = m.group(1).strip()
+        # Drop section-style headings that the LLM occasionally emits.
+        if line.startswith("#"):
+            continue
+        if not line:
+            continue
+        scope, mtype, pref_value = _classify_bullet(line)
+        facts.append(
+            ParsedFact(
+                scope=scope,
+                type=mtype,
+                statement=line,
+                preference_value=pref_value,
+                source_ref=source_ref,
+            )
+        )
+    return facts
+
+
+def parse_dream_phase1_tags(analysis: str, *, source_ref: str | None = None) -> list[ParsedFact]:
+    """Split Dream Phase-1 tagged output into one ``ParsedFact`` per relevant line.
+
+    Recognized tags map via :data:`DREAM_TAG_TO_MGP`. Lines tagged
+    ``[FILE-REMOVE]`` and ``[SKILL]`` are intentionally ignored in the MVP
+    (Stage 2 may turn ``[FILE-REMOVE]`` into ``expire_memory`` calls).
+    The ``[SKIP]`` sentinel from the prompt is also ignored.
+    """
+    if not analysis:
+        return []
+    facts: list[ParsedFact] = []
+    for raw_line in analysis.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        # Quick reject for ignored / sentinel tags before regex.
+        if any(line.startswith(f"[{t}") for t in _DREAM_IGNORED_TAGS):
+            continue
+        m = _DREAM_TAG_RE.match(line)
+        if not m:
+            continue
+        tag, statement = m.group(1), m.group(2).strip()
+        if not statement:
+            continue
+        scope, mtype = DREAM_TAG_TO_MGP[tag]
+        facts.append(
+            ParsedFact(
+                scope=scope,
+                type=mtype,
+                statement=statement,
+                source_ref=source_ref,
+            )
+        )
+    return facts

--- a/nanobot/agent/mgp/sidecar.py
+++ b/nanobot/agent/mgp/sidecar.py
@@ -104,9 +104,8 @@ class AsyncMGPSidecar:
                like ``"user"``)
             2. ``chat_id`` (when not a synthetic placeholder like ``"direct"``
                or ``"dream"``)
-            3. ``session_key.split(":", 1)[1]`` (parses ``channel:chat_id``)
-            4. ``config.default_user_id`` (configured fallback)
-            5. ``getpass.getuser()`` (OS login — keeps separate workstations /
+            3. ``config.default_user_id`` (configured fallback)
+            4. ``getpass.getuser()`` (OS login — keeps separate workstations /
                accounts isolated even when nothing is configured)
 
         Treating ``"direct"``/``"dream"`` as synthetic is critical for the
@@ -130,11 +129,7 @@ class AsyncMGPSidecar:
         elif resolved_chat_id and resolved_chat_id not in _SYNTHETIC_USER_IDS:
             user_id = resolved_chat_id
         else:
-            tail = resolved_session_key.split(":", 1)[1] if ":" in resolved_session_key else ""
-            if tail and tail not in _SYNTHETIC_USER_IDS:
-                user_id = tail
-            else:
-                user_id = self._default_user_id()
+            user_id = self._default_user_id()
 
         if self.config.tenant_id:
             tenant_id = self.config.tenant_id

--- a/nanobot/agent/mgp/sidecar.py
+++ b/nanobot/agent/mgp/sidecar.py
@@ -1,0 +1,275 @@
+"""Async MGP sidecar for nanobot.
+
+The sidecar is a thin wrapper over ``mgp_client.AsyncMGPClient`` that:
+
+* builds canonical :class:`RuntimeState` objects from per-call channel/session info,
+* fans the tool's ``recall`` requests into ``client.search_memory``,
+* fans Consolidator/Dream extracted facts into ``client.write_candidate`` calls,
+* swallows transport errors when ``fail_open=True`` (default) so MGP outages
+  never break the host nanobot loop,
+* records ``_last_recall`` / ``_last_commits`` for the ``/mgp-status`` command.
+
+``mgp_client`` is imported lazily here — this module is only imported by
+``build_sidecar`` after the optional dependency check succeeds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from loguru import logger
+from mgp_client import AsyncMGPClient
+from mgp_client.errors import MGPError
+
+from .mappers import (
+    build_memory_candidate,
+    build_policy_context,
+    build_search_query,
+    normalize_search_results,
+)
+from .models import (
+    CommitOutcome,
+    ParsedFact,
+    RecallIntent,
+    RecallOutcome,
+    RuntimeState,
+)
+from .parsers import parse_consolidator_bullets, parse_dream_phase1_tags
+
+if TYPE_CHECKING:
+    from nanobot.config.schema import MGPConfig
+
+
+# Cap how many CommitOutcome objects we keep for /mgp-status display.
+_LAST_COMMITS_KEEP = 32
+
+
+class AsyncMGPSidecar:
+    """Async wrapper around ``mgp_client.AsyncMGPClient`` tailored for nanobot.
+
+    One instance per :class:`AgentLoop`. The underlying httpx client is created
+    lazily on first use and reused thereafter; call :meth:`close` on shutdown.
+    """
+
+    def __init__(self, config: "MGPConfig", *, workspace_id: str | None = None) -> None:
+        self.config = config
+        # workspace_id is optional but recommended — used both as tenant
+        # fallback (workspace_as_tenant) and as the stable subject for
+        # agent-scoped Dream commits.
+        self._workspace_id = workspace_id or "nanobot-workspace"
+        self._client: AsyncMGPClient | None = None
+        self._client_lock = asyncio.Lock()
+        self._last_recall: RecallOutcome | None = None
+        self._last_recall_query: str | None = None
+        self._last_recall_latency_ms: float | None = None
+        self._last_recall_at: float | None = None
+        self._last_commits: list[CommitOutcome] = []
+
+    # -- runtime construction ----------------------------------------------
+
+    def build_runtime(
+        self,
+        *,
+        channel: str | None,
+        chat_id: str | None,
+        session_key: str | None = None,
+        sender_id: str | None = None,
+    ) -> RuntimeState:
+        """Construct a :class:`RuntimeState` from per-call routing context.
+
+        ``user_id`` derivation priority:
+            1. ``sender_id`` (when provided and not the literal ``"user"``)
+            2. ``chat_id`` (when not the synthetic ``"direct"`` placeholder)
+            3. ``session_key.split(":", 1)[1]`` (parses ``channel:chat_id``)
+            4. ``"user"`` fallback
+
+        ``tenant_id`` derivation:
+            1. ``config.tenant_id`` if set,
+            2. else ``self._workspace_id`` when ``workspace_as_tenant=True``,
+            3. else ``None``.
+        """
+        resolved_channel = channel or "cli"
+        resolved_chat_id = chat_id
+        resolved_session_key = session_key or (
+            f"{resolved_channel}:{resolved_chat_id}" if resolved_chat_id else f"{resolved_channel}:direct"
+        )
+
+        if sender_id and sender_id != "user":
+            user_id = sender_id
+        elif resolved_chat_id and resolved_chat_id != "direct":
+            user_id = resolved_chat_id
+        else:
+            # Last resort: try to recover something from session_key, but
+            # treat the synthetic "direct" sentinel as "no user" — otherwise
+            # CLI sessions would be mis-attributed to a literal user "direct".
+            tail = resolved_session_key.split(":", 1)[1] if ":" in resolved_session_key else ""
+            user_id = tail if tail and tail != "direct" else "user"
+
+        if self.config.tenant_id:
+            tenant_id = self.config.tenant_id
+        elif self.config.workspace_as_tenant:
+            tenant_id = self._workspace_id
+        else:
+            tenant_id = None
+
+        return RuntimeState(
+            actor_agent=self.config.actor_agent,
+            user_id=user_id,
+            session_key=resolved_session_key,
+            workspace_id=self._workspace_id,
+            channel=resolved_channel,
+            chat_id=resolved_chat_id,
+            tenant_id=tenant_id,
+        )
+
+    # -- client lifecycle --------------------------------------------------
+
+    async def _get_client(self) -> AsyncMGPClient:
+        if self._client is not None:
+            return self._client
+        async with self._client_lock:
+            if self._client is None:
+                headers: dict[str, str] = {}
+                if self.config.api_key:
+                    headers["Authorization"] = f"Bearer {self.config.api_key}"
+                self._client = AsyncMGPClient(
+                    self.config.gateway_url,
+                    timeout=self.config.timeout,
+                    headers=headers or None,
+                )
+        return self._client
+
+    async def close(self) -> None:
+        """Close the underlying httpx client. Idempotent."""
+        if self._client is None:
+            return
+        try:
+            await self._client.close()
+        except Exception:  # noqa: BLE001 - shutdown best-effort
+            logger.debug("MGP sidecar: error during client close (ignored)")
+        finally:
+            self._client = None
+
+    # -- recall ------------------------------------------------------------
+
+    async def recall(self, runtime: RuntimeState, intent: RecallIntent) -> RecallOutcome:
+        """Run a single ``search_memory`` call. ``fail_open`` swallows errors."""
+        started = time.monotonic()
+        self._last_recall_query = intent.query
+        try:
+            client = await self._get_client()
+            policy_context = build_policy_context(runtime, "search")
+            query = build_search_query(runtime, intent)
+            response = await client.search_memory(policy_context, query)
+            items = normalize_search_results(response.data)
+            outcome = RecallOutcome(
+                executed=True,
+                degraded=False,
+                results=items,
+                request_id=response.request_id,
+            )
+        except (MGPError, httpx.HTTPError, ValueError) as exc:
+            if not self.config.fail_open:
+                raise
+            outcome = RecallOutcome(
+                executed=False,
+                degraded=True,
+                error_code=getattr(exc, "code", type(exc).__name__),
+                error_message=str(exc),
+            )
+            logger.warning("MGP recall degraded ({}): {}", outcome.error_code, outcome.error_message)
+        finally:
+            self._last_recall_latency_ms = (time.monotonic() - started) * 1000.0
+            self._last_recall_at = time.time()
+
+        self._last_recall = outcome
+        return outcome
+
+    # -- commit ------------------------------------------------------------
+
+    async def commit_bullets(self, runtime: RuntimeState, summary: str) -> list[CommitOutcome]:
+        """Parse a Consolidator summary into facts and fan out write_candidate."""
+        if not self.config.enable_consolidator_commit:
+            return []
+        facts = parse_consolidator_bullets(
+            summary,
+            source_ref=f"nanobot:{runtime.channel}:{runtime.session_key}:consolidator",
+        )
+        return await self._commit_facts(runtime, facts)
+
+    async def commit_dream_tags(self, runtime: RuntimeState, analysis: str) -> list[CommitOutcome]:
+        """Parse a Dream Phase-1 analysis into facts and fan out write_candidate."""
+        if not self.config.enable_dream_commit:
+            return []
+        facts = parse_dream_phase1_tags(
+            analysis,
+            source_ref=f"nanobot:{runtime.workspace_id}:dream",
+        )
+        return await self._commit_facts(runtime, facts)
+
+    async def _commit_facts(self, runtime: RuntimeState, facts: list[ParsedFact]) -> list[CommitOutcome]:
+        if not facts:
+            return []
+        client = await self._get_client()
+        policy_context = build_policy_context(runtime, "write")
+        candidates = [build_memory_candidate(runtime, f) for f in facts]
+
+        async def _one(candidate: Any) -> CommitOutcome:
+            try:
+                response = await client.write_candidate(
+                    policy_context,
+                    candidate,
+                    merge_hint=candidate.merge_hint,
+                )
+                returned_memory = (response.data or {}).get("memory") or {}
+                return CommitOutcome(
+                    executed=True,
+                    written=True,
+                    memory_id=returned_memory.get("memory_id"),
+                    request_id=response.request_id,
+                )
+            except (MGPError, httpx.HTTPError, ValueError) as exc:
+                if not self.config.fail_open:
+                    raise
+                outcome = CommitOutcome(
+                    executed=False,
+                    written=False,
+                    error_code=getattr(exc, "code", type(exc).__name__),
+                    error_message=str(exc),
+                )
+                logger.warning(
+                    "MGP commit degraded ({}): {}", outcome.error_code, outcome.error_message,
+                )
+                return outcome
+
+        outcomes = await asyncio.gather(*[_one(c) for c in candidates], return_exceptions=False)
+        # Track recent commits for /mgp-status (bounded ring).
+        self._last_commits.extend(outcomes)
+        if len(self._last_commits) > _LAST_COMMITS_KEEP:
+            self._last_commits = self._last_commits[-_LAST_COMMITS_KEEP:]
+        return list(outcomes)
+
+    # -- /mgp-status helpers ----------------------------------------------
+
+    @property
+    def last_recall(self) -> RecallOutcome | None:
+        return self._last_recall
+
+    @property
+    def last_recall_query(self) -> str | None:
+        return self._last_recall_query
+
+    @property
+    def last_recall_latency_ms(self) -> float | None:
+        return self._last_recall_latency_ms
+
+    @property
+    def last_recall_at(self) -> float | None:
+        return self._last_recall_at
+
+    @property
+    def last_commits(self) -> list[CommitOutcome]:
+        return list(self._last_commits)

--- a/nanobot/agent/mgp/sidecar.py
+++ b/nanobot/agent/mgp/sidecar.py
@@ -16,8 +16,13 @@ The sidecar is a thin wrapper over ``mgp_client.AsyncMGPClient`` that:
 from __future__ import annotations
 
 import asyncio
+import getpass
 import time
 from typing import TYPE_CHECKING, Any
+
+# Synthetic chat_id / sender_id placeholders that should NOT be treated as a
+# real user identity. Anything matching falls through to ``default_user_id``.
+_SYNTHETIC_USER_IDS = frozenset({"user", "direct", "dream"})
 
 import httpx
 from loguru import logger
@@ -68,6 +73,20 @@ class AsyncMGPSidecar:
         self._last_recall_at: float | None = None
         self._last_commits: list[CommitOutcome] = []
 
+    def _default_user_id(self) -> str:
+        """Resolve the fallback subject for synthetic-channel runtimes.
+
+        Priority: ``config.default_user_id`` (explicit) → ``getpass.getuser()``
+        (OS login) → ``"user"`` (last-resort literal, only hit on exotic OSes
+        where ``getpass`` raises).
+        """
+        if self.config.default_user_id:
+            return self.config.default_user_id
+        try:
+            return getpass.getuser() or "user"
+        except Exception:  # noqa: BLE001 - getpass can raise on misconfigured envs
+            return "user"
+
     # -- runtime construction ----------------------------------------------
 
     def build_runtime(
@@ -81,10 +100,19 @@ class AsyncMGPSidecar:
         """Construct a :class:`RuntimeState` from per-call routing context.
 
         ``user_id`` derivation priority:
-            1. ``sender_id`` (when provided and not the literal ``"user"``)
-            2. ``chat_id`` (when not the synthetic ``"direct"`` placeholder)
+            1. ``sender_id`` (when provided and not a synthetic placeholder
+               like ``"user"``)
+            2. ``chat_id`` (when not a synthetic placeholder like ``"direct"``
+               or ``"dream"``)
             3. ``session_key.split(":", 1)[1]`` (parses ``channel:chat_id``)
-            4. ``"user"`` fallback
+            4. ``config.default_user_id`` (configured fallback)
+            5. ``getpass.getuser()`` (OS login — keeps separate workstations /
+               accounts isolated even when nothing is configured)
+
+        Treating ``"direct"``/``"dream"`` as synthetic is critical for the
+        Dream commit path: Dream operates at workspace scope but its
+        ``[USER]`` tags MUST land under the real subject the CLI uses, or
+        ``recall_memory(scope="user")`` will never find them.
 
         ``tenant_id`` derivation:
             1. ``config.tenant_id`` if set,
@@ -97,16 +125,16 @@ class AsyncMGPSidecar:
             f"{resolved_channel}:{resolved_chat_id}" if resolved_chat_id else f"{resolved_channel}:direct"
         )
 
-        if sender_id and sender_id != "user":
+        if sender_id and sender_id not in _SYNTHETIC_USER_IDS:
             user_id = sender_id
-        elif resolved_chat_id and resolved_chat_id != "direct":
+        elif resolved_chat_id and resolved_chat_id not in _SYNTHETIC_USER_IDS:
             user_id = resolved_chat_id
         else:
-            # Last resort: try to recover something from session_key, but
-            # treat the synthetic "direct" sentinel as "no user" — otherwise
-            # CLI sessions would be mis-attributed to a literal user "direct".
             tail = resolved_session_key.split(":", 1)[1] if ":" in resolved_session_key else ""
-            user_id = tail if tail and tail != "direct" else "user"
+            if tail and tail not in _SYNTHETIC_USER_IDS:
+                user_id = tail
+            else:
+                user_id = self._default_user_id()
 
         if self.config.tenant_id:
             tenant_id = self.config.tenant_id

--- a/nanobot/agent/tools/mgp_recall.py
+++ b/nanobot/agent/tools/mgp_recall.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only
         maximum=20,
     ),
     types=ArraySchema(
-        items=StringSchema(enum=["preference", "semantic_fact", "identity", "episodic_event"]),
+        items=StringSchema(enum=["preference", "semantic_fact", "profile", "episodic_event"]),
         description="Optional filter by memory types.",
     ),
     required=["query"],

--- a/nanobot/agent/tools/mgp_recall.py
+++ b/nanobot/agent/tools/mgp_recall.py
@@ -94,18 +94,27 @@ class MGPRecallTool(Tool):
         self._channel: ContextVar[str | None] = ContextVar("mgp_recall_channel", default=None)
         self._chat_id: ContextVar[str | None] = ContextVar("mgp_recall_chat_id", default=None)
         self._session_key: ContextVar[str | None] = ContextVar("mgp_recall_session_key", default=None)
+        self._sender_id: ContextVar[str | None] = ContextVar("mgp_recall_sender_id", default=None)
 
     def set_context(
         self,
         channel: str | None,
         chat_id: str | None,
         effective_key: str | None = None,
+        *,
+        sender_id: str | None = None,
     ) -> None:
-        """Per-task routing context. Signature mirrors :class:`SpawnTool` so
-        the loop's existing spawn-branch dispatch handles us with no new code.
+        """Per-task routing context. Signature is a superset of :class:`SpawnTool`
+        so the loop's existing spawn-branch dispatch handles us with no new code.
+
+        ``sender_id`` is the per-message sender (e.g. group-chat member id).
+        Without it, group-chat recalls all attribute to the same ``chat_id``
+        — meaning every group member shares one MGP subject. Threading
+        ``sender_id`` through gives each member their own user-scoped memory.
         """
         self._channel.set(channel)
         self._chat_id.set(chat_id)
+        self._sender_id.set(sender_id)
         self._session_key.set(
             effective_key
             or (f"{channel}:{chat_id}" if channel and chat_id else None)
@@ -126,6 +135,7 @@ class MGPRecallTool(Tool):
             channel=self._channel.get(),
             chat_id=self._chat_id.get(),
             session_key=self._session_key.get(),
+            sender_id=self._sender_id.get(),
         )
         intent = RecallIntent(
             query=query,

--- a/nanobot/agent/tools/mgp_recall.py
+++ b/nanobot/agent/tools/mgp_recall.py
@@ -1,0 +1,157 @@
+"""``recall_memory`` tool: agent-driven MGP recall.
+
+The tool gives the agent explicit access to the governed long-term memory
+store via ``mgp_client``. It is **only** registered when ``mgp.enabled=true``
+(see ``AgentLoop.__init__``); when disabled the tool is absent from the
+schema and the ``mgp-memory`` skill is suppressed so the LLM never sees a
+phantom capability.
+
+Routing context (channel / chat_id / session_key) is stored in
+``ContextVar`` instances per the convention introduced in upstream
+``ff8c28d``, so concurrent turns in unified-session mode don't leak state.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any
+
+from nanobot.agent.tools.base import Tool, tool_parameters
+from nanobot.agent.tools.schema import (
+    ArraySchema,
+    IntegerSchema,
+    StringSchema,
+    tool_parameters_schema,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only
+    from nanobot.agent.mgp.models import RecallOutcome
+    from nanobot.agent.mgp.sidecar import AsyncMGPSidecar
+
+
+@tool_parameters(tool_parameters_schema(
+    query=StringSchema(
+        "Concise topic to recall about the current user. Use a topic, not a "
+        "full question. Good: 'indentation preference'. Bad: 'what indentation "
+        "do I prefer?'.",
+    ),
+    scope=StringSchema(
+        "Memory scope. 'user' = user-specific facts (preferences, decisions); "
+        "'agent' = stable facts about the bot itself; 'session' = current-session events.",
+        enum=["user", "agent", "session"],
+    ),
+    limit=IntegerSchema(
+        description="Maximum number of memories to return (1-20). Defaults to "
+                    "the configured `recall_default_limit`.",
+        minimum=1,
+        maximum=20,
+    ),
+    types=ArraySchema(
+        items=StringSchema(enum=["preference", "semantic_fact", "identity", "episodic_event"]),
+        description="Optional filter by memory types.",
+    ),
+    required=["query"],
+))
+class MGPRecallTool(Tool):
+    """Agent-callable tool that searches the MGP gateway for relevant memories."""
+
+    @property
+    def name(self) -> str:  # type: ignore[override]
+        return "recall_memory"
+
+    @property
+    def description(self) -> str:  # type: ignore[override]
+        return (
+            "Search governed long-term memory for facts about the current user, "
+            "learned across previous sessions and channels.\n\n"
+            "Use this when:\n"
+            "- User refers to past preferences/decisions (\"remember my...\", \"what did I say about...\")\n"
+            "- You need cross-session context (something user told you before but not in current conversation)\n"
+            "- User asks about something that should be in long-term memory but is missing from your system prompt\n\n"
+            "Don't use this when:\n"
+            "- Information is already in your system prompt (MEMORY.md / SOUL.md / USER.md / Recent History)\n"
+            "- Question is about general world knowledge\n"
+            "- Question concerns only the current conversation\n\n"
+            "Returns a list of recalled memories as bullet points; each item includes its type and content."
+        )
+
+    @property
+    def read_only(self) -> bool:  # type: ignore[override]
+        return True
+
+    def __init__(
+        self,
+        sidecar: "AsyncMGPSidecar",
+        *,
+        default_scope: str = "user",
+        default_limit: int = 5,
+    ) -> None:
+        self.sidecar = sidecar
+        self._default_scope = default_scope
+        self._default_limit = default_limit
+        # ContextVar matches the new tool-routing convention (upstream ff8c28d)
+        # so concurrent turns (e.g. unified-session multi-channel) don't leak.
+        self._channel: ContextVar[str | None] = ContextVar("mgp_recall_channel", default=None)
+        self._chat_id: ContextVar[str | None] = ContextVar("mgp_recall_chat_id", default=None)
+        self._session_key: ContextVar[str | None] = ContextVar("mgp_recall_session_key", default=None)
+
+    def set_context(
+        self,
+        channel: str | None,
+        chat_id: str | None,
+        effective_key: str | None = None,
+    ) -> None:
+        """Per-task routing context. Signature mirrors :class:`SpawnTool` so
+        the loop's existing spawn-branch dispatch handles us with no new code.
+        """
+        self._channel.set(channel)
+        self._chat_id.set(chat_id)
+        self._session_key.set(
+            effective_key
+            or (f"{channel}:{chat_id}" if channel and chat_id else None)
+        )
+
+    async def execute(  # type: ignore[override]
+        self,
+        query: str,
+        scope: str | None = None,
+        limit: int | None = None,
+        types: list[str] | None = None,
+        **kwargs: Any,
+    ) -> str:
+        # Defer the import: AsyncMGPSidecar pulls mgp_client which is optional.
+        from nanobot.agent.mgp.models import RecallIntent
+
+        runtime = self.sidecar.build_runtime(
+            channel=self._channel.get(),
+            chat_id=self._chat_id.get(),
+            session_key=self._session_key.get(),
+        )
+        intent = RecallIntent(
+            query=query,
+            scope=scope or self._default_scope,
+            limit=limit if limit is not None else self._default_limit,
+            types=types,
+        )
+        outcome = await self.sidecar.recall(runtime, intent)
+        return self._format(outcome)
+
+    @staticmethod
+    def _format(outcome: "RecallOutcome") -> str:
+        """Render a :class:`RecallOutcome` for LLM consumption."""
+        if outcome.degraded:
+            return f"[recall_memory degraded: {outcome.error_code}]"
+        if not outcome.results:
+            return "(no memories found)"
+        lines: list[str] = []
+        for item in outcome.results:
+            mem_type = item.memory.get("type", "memory")
+            text = item.consumable_text
+            if not text:
+                content = item.memory.get("content")
+                if isinstance(content, dict):
+                    text = content.get("statement") or content.get("preference") or str(content)
+                else:
+                    text = str(content) if content is not None else ""
+            lines.append(f"- [{mem_type}] {text}")
+        return "\n".join(lines)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -594,6 +594,7 @@ def serve(
         disabled_skills=runtime_config.agents.defaults.disabled_skills,
         session_ttl_minutes=runtime_config.agents.defaults.session_ttl_minutes,
         tools_config=runtime_config.tools,
+        mgp_config=runtime_config.agents.defaults.mgp,
     )
 
     model_name = runtime_config.agents.defaults.model
@@ -698,6 +699,7 @@ def _run_gateway(
         disabled_skills=config.agents.defaults.disabled_skills,
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
         tools_config=config.tools,
+        mgp_config=config.agents.defaults.mgp,
     )
 
     # Set cron callback (needs agent)
@@ -1017,6 +1019,7 @@ def agent(
         disabled_skills=config.agents.defaults.disabled_skills,
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
         tools_config=config.tools,
+        mgp_config=config.agents.defaults.mgp,
     )
     restart_notice = consume_restart_notice_from_env()
     if restart_notice and should_show_cli_restart_notice(restart_notice, session_id):

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -101,7 +101,7 @@ async def cmd_new(ctx: CommandContext) -> OutboundMessage:
     loop.sessions.save(session)
     loop.sessions.invalidate(session.key)
     if snapshot:
-        loop._schedule_background(loop.consolidator.archive(snapshot))
+        loop._schedule_background(loop.consolidator.archive(snapshot, session=session))
     return OutboundMessage(
         channel=ctx.msg.channel, chat_id=ctx.msg.chat_id,
         content="New session started.",
@@ -316,6 +316,76 @@ async def cmd_help(ctx: CommandContext) -> OutboundMessage:
     )
 
 
+async def cmd_mgp_status(ctx: CommandContext) -> OutboundMessage:
+    """Show MGP sidecar status: connection, last recall, last commits."""
+    loop = ctx.loop
+    msg = ctx.msg
+    sidecar = getattr(loop, "mgp_sidecar", None)
+
+    if sidecar is None:
+        content = (
+            "MGP sidecar not enabled.\n\n"
+            "To enable: install the optional dependency, run an MGP gateway, "
+            "and set `agents.defaults.mgp.enabled: true` in your config. "
+            "See `nanobot/agent/mgp/README.md` for the full quickstart."
+        )
+        return OutboundMessage(
+            channel=msg.channel, chat_id=msg.chat_id,
+            content=content, metadata={**dict(msg.metadata or {}), "render_as": "text"},
+        )
+
+    cfg = sidecar.config
+    tool_present = bool(loop.tools.get("recall_memory"))
+    lines: list[str] = ["## MGP Sidecar Status", ""]
+    lines.append(f"- enabled: `{cfg.enabled}`")
+    lines.append(f"- gateway: `{cfg.gateway_url}`")
+    lines.append(f"- recall_memory tool: {'registered' if tool_present else 'NOT registered'}")
+    lines.append(f"- consolidator commit: {'on' if cfg.enable_consolidator_commit else 'off'}")
+    lines.append(f"- dream commit: {'on' if cfg.enable_dream_commit else 'off'}")
+    lines.append(f"- fail_open: `{cfg.fail_open}`")
+    if cfg.tenant_id:
+        lines.append(f"- tenant_id: `{cfg.tenant_id}`")
+    elif cfg.workspace_as_tenant:
+        lines.append("- tenant_id: workspace (auto)")
+
+    last_recall = sidecar.last_recall
+    lines.append("")
+    lines.append("### Last recall")
+    if last_recall is None:
+        lines.append("(no recall yet this run)")
+    else:
+        latency = sidecar.last_recall_latency_ms
+        lines.append(f"- query: `{sidecar.last_recall_query}`")
+        lines.append(f"- executed: `{last_recall.executed}`, degraded: `{last_recall.degraded}`")
+        lines.append(f"- hits: {len(last_recall.results)}")
+        if latency is not None:
+            lines.append(f"- latency: {latency:.0f} ms")
+        if last_recall.degraded:
+            lines.append(f"- error: `{last_recall.error_code}` — {last_recall.error_message}")
+
+    last_commits = sidecar.last_commits
+    lines.append("")
+    lines.append("### Recent commits")
+    if not last_commits:
+        lines.append("(no commits recorded yet this run)")
+    else:
+        written = sum(1 for c in last_commits if c.written)
+        failed = sum(1 for c in last_commits if not c.executed)
+        lines.append(f"- recorded: {len(last_commits)} (kept up to 32)")
+        lines.append(f"- written: {written}")
+        lines.append(f"- failed: {failed}")
+        if failed:
+            err_sample = next((c for c in reversed(last_commits) if not c.executed), None)
+            if err_sample is not None:
+                lines.append(f"- last error: `{err_sample.error_code}` — {err_sample.error_message}")
+
+    return OutboundMessage(
+        channel=msg.channel, chat_id=msg.chat_id,
+        content="\n".join(lines),
+        metadata={**dict(msg.metadata or {}), "render_as": "text"},
+    )
+
+
 def build_help_text() -> str:
     """Build canonical help text shared across channels."""
     lines = [
@@ -327,6 +397,7 @@ def build_help_text() -> str:
         "/dream — Manually trigger Dream consolidation",
         "/dream-log — Show what the last Dream changed",
         "/dream-restore — Revert memory to a previous state",
+        "/mgp-status — Show MGP sidecar status (when enabled)",
         "/help — Show available commands",
     ]
     return "\n".join(lines)
@@ -344,4 +415,5 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.prefix("/dream-log ", cmd_dream_log)
     router.exact("/dream-restore", cmd_dream_restore)
     router.prefix("/dream-restore ", cmd_dream_restore)
+    router.exact("/mgp-status", cmd_mgp_status)
     router.exact("/help", cmd_help)

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -317,72 +317,60 @@ async def cmd_help(ctx: CommandContext) -> OutboundMessage:
 
 
 async def cmd_mgp_status(ctx: CommandContext) -> OutboundMessage:
-    """Show MGP sidecar status: connection, last recall, last commits."""
+    """Show MGP sidecar status: gateway, toggles, last recall, last 32 commits."""
     loop = ctx.loop
     msg = ctx.msg
     sidecar = getattr(loop, "mgp_sidecar", None)
+    md = {**dict(msg.metadata or {}), "render_as": "text"}
 
     if sidecar is None:
-        content = (
-            "MGP sidecar not enabled.\n\n"
-            "To enable: install the optional dependency, run an MGP gateway, "
-            "and set `agents.defaults.mgp.enabled: true` in your config. "
-            "See `nanobot/agent/mgp/README.md` for the full quickstart."
-        )
         return OutboundMessage(
-            channel=msg.channel, chat_id=msg.chat_id,
-            content=content, metadata={**dict(msg.metadata or {}), "render_as": "text"},
+            channel=msg.channel, chat_id=msg.chat_id, metadata=md,
+            content=(
+                "MGP sidecar disabled. Set `agents.defaults.mgp.enabled: true` and run "
+                "an `mgp-gateway`. See `nanobot/agent/mgp/README.md`."
+            ),
         )
 
     cfg = sidecar.config
-    tool_present = bool(loop.tools.get("recall_memory"))
-    lines: list[str] = ["## MGP Sidecar Status", ""]
-    lines.append(f"- enabled: `{cfg.enabled}`")
-    lines.append(f"- gateway: `{cfg.gateway_url}`")
-    lines.append(f"- recall_memory tool: {'registered' if tool_present else 'NOT registered'}")
-    lines.append(f"- consolidator commit: {'on' if cfg.enable_consolidator_commit else 'off'}")
-    lines.append(f"- dream commit: {'on' if cfg.enable_dream_commit else 'off'}")
-    lines.append(f"- fail_open: `{cfg.fail_open}`")
-    if cfg.tenant_id:
-        lines.append(f"- tenant_id: `{cfg.tenant_id}`")
-    elif cfg.workspace_as_tenant:
-        lines.append("- tenant_id: workspace (auto)")
+    commit_flags = (
+        f"consolidator={'on' if cfg.enable_consolidator_commit else 'off'}, "
+        f"dream={'on' if cfg.enable_dream_commit else 'off'}"
+    )
+    lines = [
+        "## MGP Sidecar",
+        f"- gateway: `{cfg.gateway_url}` (fail_open=`{cfg.fail_open}`)",
+        f"- commits: {commit_flags}",
+    ]
 
-    last_recall = sidecar.last_recall
-    lines.append("")
-    lines.append("### Last recall")
-    if last_recall is None:
-        lines.append("(no recall yet this run)")
+    r = sidecar.last_recall
+    if r is None:
+        lines.append("- last recall: (none)")
+    elif r.degraded:
+        lines.append(
+            f"- last recall: `{sidecar.last_recall_query}` "
+            f"degraded `{r.error_code}` — {r.error_message}"
+        )
     else:
         latency = sidecar.last_recall_latency_ms
-        lines.append(f"- query: `{sidecar.last_recall_query}`")
-        lines.append(f"- executed: `{last_recall.executed}`, degraded: `{last_recall.degraded}`")
-        lines.append(f"- hits: {len(last_recall.results)}")
-        if latency is not None:
-            lines.append(f"- latency: {latency:.0f} ms")
-        if last_recall.degraded:
-            lines.append(f"- error: `{last_recall.error_code}` — {last_recall.error_message}")
+        lat = f", {latency:.0f}ms" if latency is not None else ""
+        lines.append(
+            f"- last recall: `{sidecar.last_recall_query}` "
+            f"hits={len(r.results)}{lat}"
+        )
 
-    last_commits = sidecar.last_commits
-    lines.append("")
-    lines.append("### Recent commits")
-    if not last_commits:
-        lines.append("(no commits recorded yet this run)")
+    commits = sidecar.last_commits
+    if not commits:
+        lines.append("- last commits: (none)")
     else:
-        written = sum(1 for c in last_commits if c.written)
-        failed = sum(1 for c in last_commits if not c.executed)
-        lines.append(f"- recorded: {len(last_commits)} (kept up to 32)")
-        lines.append(f"- written: {written}")
-        lines.append(f"- failed: {failed}")
-        if failed:
-            err_sample = next((c for c in reversed(last_commits) if not c.executed), None)
-            if err_sample is not None:
-                lines.append(f"- last error: `{err_sample.error_code}` — {err_sample.error_message}")
+        written = sum(1 for c in commits if c.written)
+        failed = sum(1 for c in commits if not c.executed)
+        tail = f"; last error `{commits[-1].error_code}`" if failed and not commits[-1].executed else ""
+        lines.append(f"- last commits: {len(commits)} (written={written}, failed={failed}){tail}")
 
     return OutboundMessage(
-        channel=msg.channel, chat_id=msg.chat_id,
+        channel=msg.channel, chat_id=msg.chat_id, metadata=md,
         content="\n".join(lines),
-        metadata={**dict(msg.metadata or {}), "render_as": "text"},
     )
 
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -65,6 +65,28 @@ class DreamConfig(Base):
         return f"every {hours}h"
 
 
+class MGPConfig(Base):
+    """MGP sidecar configuration for governed memory recall/commit.
+
+    Default ``enabled=false`` keeps nanobot's behavior byte-identical when MGP
+    is not configured: no ``mgp_client`` import, no ``recall_memory`` tool, no
+    ``mgp-memory`` skill in the system prompt. Flip ``enabled=true`` to opt in.
+    """
+
+    enabled: bool = False                                      # master switch
+    gateway_url: str = "http://127.0.0.1:8080"                 # MGP gateway HTTP base URL
+    timeout: float = 5.0                                       # per-request timeout in seconds
+    fail_open: bool = True                                     # swallow MGP errors so recall failures never break a turn
+    workspace_as_tenant: bool = True                           # use workspace path as tenant_id when tenant_id is unset
+    tenant_id: str | None = None                               # explicit tenant_id; overrides workspace_as_tenant
+    actor_agent: str = "nanobot/main"                          # identity recorded in audit logs
+    api_key: str | None = None                                 # bearer token when gateway auth_mode=api_key
+    enable_consolidator_commit: bool = True                    # write Consolidator bullets to MGP
+    enable_dream_commit: bool = True                           # write Dream Phase-1 tags to MGP
+    recall_default_scope: str = "user"                         # default scope when agent omits it
+    recall_default_limit: int = Field(default=5, ge=1, le=20)  # default top-K when agent omits it
+
+
 class AgentDefaults(Base):
     """Default agent configuration."""
 
@@ -91,6 +113,7 @@ class AgentDefaults(Base):
         serialization_alias="idleCompactAfterMinutes",
     )  # Auto-compact idle threshold in minutes (0 = disabled)
     dream: DreamConfig = Field(default_factory=DreamConfig)
+    mgp: MGPConfig = Field(default_factory=MGPConfig)  # opt-in MGP sidecar (default disabled)
 
 
 class AgentsConfig(Base):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -85,6 +85,12 @@ class MGPConfig(Base):
     enable_dream_commit: bool = True                           # write Dream Phase-1 tags to MGP
     recall_default_scope: str = "user"                         # default scope when agent omits it
     recall_default_limit: int = Field(default=5, ge=1, le=20)  # default top-K when agent omits it
+    # Stable subject id for routes that don't carry a real per-user identifier
+    # (CLI direct sessions, Dream workspace runs). Defaults to None — at runtime
+    # we then fall back to the OS login (``getpass.getuser()``). Setting this
+    # explicitly is recommended for SDK / multi-user-but-single-tenant deployments
+    # so that Dream-extracted ``[USER]`` facts land under a discoverable subject.
+    default_user_id: str | None = None
 
 
 class AgentDefaults(Base):

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -85,6 +85,7 @@ class Nanobot:
             disabled_skills=defaults.disabled_skills,
             session_ttl_minutes=defaults.session_ttl_minutes,
             tools_config=config.tools,
+            mgp_config=defaults.mgp,
         )
         return cls(loop)
 

--- a/nanobot/skills/mgp-memory/SKILL.md
+++ b/nanobot/skills/mgp-memory/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: mgp-memory
+description: Cross-session long-term memory via MGP. Call recall_memory when you need user-specific past context.
+always: true
+---
+
+# Long-term Memory (MGP)
+
+You have access to a governed long-term memory store via the `recall_memory` tool.
+It contains facts about the current user that were learned across previous sessions
+and channels (e.g. preferences, decisions, project context). The store is
+maintained automatically — your job is only to **read** from it when relevant.
+
+## When to call `recall_memory`
+
+Call it when ALL of these are true:
+
+- The current question would benefit from past context not visible in your system prompt
+- The likely-relevant fact is user-specific (preferences, decisions, history)
+- You can express the relevant fact as a short search query
+
+Strong triggers (call without hesitation):
+
+- User says "remember", "I told you", "as I mentioned before", "我之前说过", "还记得吗"
+- User asks "what is my X", "what did I say about Y"
+- User references a project / setting / preference by name without context
+
+Weak triggers (consider but don't always call):
+
+- A new request might benefit from prior preferences ("write me an email" → maybe recall communication style)
+- Cross-channel continuation (user just switched from one channel to another)
+
+## When NOT to call
+
+- The information is already in your system prompt (`MEMORY.md` / `SOUL.md` / `USER.md` / Recent History)
+- The question is general knowledge ("what is python")
+- Pure code/tool task with no user-specific context needed
+- You already called `recall_memory` this turn and got results — don't loop
+
+## Calling pattern
+
+`recall_memory(query="<concise topic>", scope="user", limit=5)`
+
+- `query`: write the **topic**, NOT a full question.
+  - Good: `"indentation preference"`, `"project codename"`, `"deployment style"`
+  - Bad: `"what indentation do I prefer?"`, `"can you tell me my project name?"`
+- `scope`: usually `"user"`. Use `"agent"` only for stable facts about the bot itself.
+- `limit`: defaults to 5; ask for more (up to 20) only when the topic is broad.
+- `types`: optional filter (`preference` / `semantic_fact` / `identity` / `episodic_event`)
+
+Cite recalled facts naturally in your reply; do NOT quote tool output verbatim.
+
+## Examples
+
+User: `Help me write a deployment script`
+Action: skip recall (no clear past-context need)
+
+User: `Use my usual deployment style`
+Action: `recall_memory(query="deployment style preferences")`
+
+User: `我之前说过的项目代号是什么？`
+Action: `recall_memory(query="project codename")`
+
+User: `Why did we pick postgres again?`
+Action: `recall_memory(query="postgres decision rationale")`
+
+User: `What's my favorite IDE?`
+Action: `recall_memory(query="IDE preference", types=["preference"])`
+
+## Notes
+
+- Recall is fail-open: if the MGP gateway is unreachable the tool returns
+  `[recall_memory degraded: ...]`. Treat that as "no extra context available"
+  and answer based on what you do know.
+- Recall is read-only. Memories are written automatically by background
+  consolidation — you do not need (and cannot) call any "remember" tool.
+- `/mgp-status` shows the latest recall outcome and connection state for
+  troubleshooting.

--- a/nanobot/skills/mgp-memory/SKILL.md
+++ b/nanobot/skills/mgp-memory/SKILL.md
@@ -46,7 +46,7 @@ Weak triggers (consider but don't always call):
   - Bad: `"what indentation do I prefer?"`, `"can you tell me my project name?"`
 - `scope`: usually `"user"`. Use `"agent"` only for stable facts about the bot itself.
 - `limit`: defaults to 5; ask for more (up to 20) only when the topic is broad.
-- `types`: optional filter (`preference` / `semantic_fact` / `identity` / `episodic_event`)
+- `types`: optional filter (`preference` / `semantic_fact` / `profile` / `episodic_event`)
 
 Cite recalled facts naturally in your reply; do NOT quote tool output verbatim.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ langsmith = [
 pdf = [
     "pymupdf>=1.25.0",
 ]
+mgp = [
+    "mgp-client>=0.1.1,<1.0.0",
+]
 dev = [
     "pytest>=9.0.0,<10.0.0",
     "pytest-asyncio>=1.3.0,<2.0.0",

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -124,7 +124,7 @@ class TestAutoCompact:
         s2.add_message("user", "recent")
         loop.sessions.save(s2)
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             return "Summary."
 
         loop.consolidator.archive = _fake_archive
@@ -146,7 +146,7 @@ class TestAutoCompact:
 
         archived_messages = []
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             archived_messages.extend(messages)
             return "Summary."
 
@@ -169,7 +169,7 @@ class TestAutoCompact:
         _add_turns(session, 6, prefix="hello")
         loop.sessions.save(session)
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             return "User said hello."
 
         loop.consolidator.archive = _fake_archive
@@ -191,7 +191,7 @@ class TestAutoCompact:
 
         archive_called = False
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             nonlocal archive_called
             archive_called = True
             return "Summary."
@@ -216,7 +216,7 @@ class TestAutoCompact:
 
         archived_count = 0
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             nonlocal archived_count
             archived_count = len(messages)
             return "Summary."
@@ -259,7 +259,7 @@ class TestAutoCompactIdleDetection:
 
         archived_messages = []
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             archived_messages.extend(messages)
             return "Summary."
 
@@ -326,7 +326,7 @@ class TestAutoCompactIdleDetection:
         session.updated_at = datetime.now() - timedelta(minutes=20)
         loop.sessions.save(session)
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             return "Summary."
 
         loop.consolidator.archive = _fake_archive
@@ -355,7 +355,7 @@ class TestAutoCompactSystemMessages:
         session.updated_at = datetime.now() - timedelta(minutes=20)
         loop.sessions.save(session)
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             return "Summary."
 
         loop.consolidator.archive = _fake_archive
@@ -437,7 +437,7 @@ class TestAutoCompactEdgeCases:
 
         archived_messages = []
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             archived_messages.extend(messages)
             return "Summary."
 
@@ -533,7 +533,7 @@ class TestAutoCompactIntegration:
         session.updated_at = datetime.now() - timedelta(minutes=20)
         loop.sessions.save(session)
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             return "Summary."
 
         loop.consolidator.archive = _fake_archive
@@ -594,7 +594,7 @@ class TestProactiveAutoCompact:
 
         archived_messages = []
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             archived_messages.extend(messages)
             return "User chatted about old things."
 
@@ -637,7 +637,7 @@ class TestProactiveAutoCompact:
         started = asyncio.Event()
         block_forever = asyncio.Event()
 
-        async def _slow_archive(messages):
+        async def _slow_archive(messages, session=None):
             nonlocal archive_count
             archive_count += 1
             started.set()
@@ -670,7 +670,7 @@ class TestProactiveAutoCompact:
         session.updated_at = datetime.now() - timedelta(minutes=20)
         loop.sessions.save(session)
 
-        async def _failing_archive(messages):
+        async def _failing_archive(messages, session=None):
             raise RuntimeError("LLM down")
 
         loop.consolidator.archive = _failing_archive
@@ -692,7 +692,7 @@ class TestProactiveAutoCompact:
 
         archive_called = False
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             nonlocal archive_called
             archive_called = True
             return "Summary."
@@ -715,7 +715,7 @@ class TestProactiveAutoCompact:
 
         archive_count = 0
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             nonlocal archive_count
             archive_count += 1
             return "Summary."
@@ -742,7 +742,7 @@ class TestProactiveAutoCompact:
 
         archive_count = 0
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             nonlocal archive_count
             archive_count += 1
             return "Summary."
@@ -779,7 +779,7 @@ class TestProactiveAutoCompact:
 
         archive_count = 0
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             nonlocal archive_count
             archive_count += 1
             return "Summary."
@@ -808,7 +808,7 @@ class TestProactiveAutoCompact:
 
         archive_count = 0
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             nonlocal archive_count
             archive_count += 1
             return "Summary."
@@ -834,7 +834,7 @@ class TestProactiveAutoCompact:
 
         archive_count = 0
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             nonlocal archive_count
             archive_count += 1
             return "Summary."
@@ -861,7 +861,7 @@ class TestProactiveAutoCompact:
 
         archive_count = 0
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             nonlocal archive_count
             archive_count += 1
             return "Summary."
@@ -900,7 +900,7 @@ class TestSummaryPersistence:
         session.updated_at = datetime.now() - timedelta(minutes=20)
         loop.sessions.save(session)
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             return "User said hello."
 
         loop.consolidator.archive = _fake_archive
@@ -925,7 +925,7 @@ class TestSummaryPersistence:
         session.updated_at = last_active
         loop.sessions.save(session)
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             return "User said hello."
 
         loop.consolidator.archive = _fake_archive
@@ -958,7 +958,7 @@ class TestSummaryPersistence:
         session.updated_at = datetime.now() - timedelta(minutes=20)
         loop.sessions.save(session)
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             return "Summary."
 
         loop.consolidator.archive = _fake_archive
@@ -989,7 +989,7 @@ class TestSummaryPersistence:
         session.updated_at = datetime.now() - timedelta(minutes=20)
         loop.sessions.save(session)
 
-        async def _fake_archive(messages):
+        async def _fake_archive(messages, session=None):
             return "Summary."
 
         loop.consolidator.archive = _fake_archive

--- a/tests/agent/test_consolidate_offset.py
+++ b/tests/agent/test_consolidate_offset.py
@@ -518,7 +518,7 @@ class TestNewCommandArchival:
 
         call_count = 0
 
-        async def _failing_summarize(_messages) -> bool:
+        async def _failing_summarize(_messages, session=None) -> bool:
             nonlocal call_count
             call_count += 1
             return False
@@ -551,7 +551,7 @@ class TestNewCommandArchival:
 
         archived_count = -1
 
-        async def _fake_summarize(messages) -> bool:
+        async def _fake_summarize(messages, session=None) -> bool:
             nonlocal archived_count
             archived_count = len(messages)
             return True
@@ -578,7 +578,7 @@ class TestNewCommandArchival:
             session.add_message("assistant", f"resp{i}")
         loop.sessions.save(session)
 
-        async def _ok_summarize(_messages) -> bool:
+        async def _ok_summarize(_messages, session=None) -> bool:
             return True
 
         loop.consolidator.archive = _ok_summarize  # type: ignore[method-assign]
@@ -604,7 +604,7 @@ class TestNewCommandArchival:
 
         archived = asyncio.Event()
 
-        async def _slow_summarize(_messages) -> bool:
+        async def _slow_summarize(_messages, session=None) -> bool:
             await asyncio.sleep(0.1)
             archived.set()
             return True

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -218,7 +218,7 @@ async def test_preflight_consolidation_before_llm_call(tmp_path, monkeypatch) ->
 
     loop = _make_loop(tmp_path, estimated_tokens=0, context_window_tokens=200)
 
-    async def track_consolidate(messages):
+    async def track_consolidate(messages, session=None):
         order.append("consolidate")
         return True
     loop.consolidator.archive = track_consolidate  # type: ignore[method-assign]

--- a/tests/manual/e2e_mgp_scenarios.py
+++ b/tests/manual/e2e_mgp_scenarios.py
@@ -1,0 +1,263 @@
+"""End-to-end MGP integration scenarios.
+
+Drives a real ``mgp-gateway`` (in-memory adapter) over real HTTP and exercises
+the full sidecar -> gateway -> adapter stack. The LLM provider is mocked so
+the run is deterministic and free; the goal is to validate **wiring**, not
+LLM behavior.
+
+Run from the repo root:
+
+    uv run --extra dev --extra mgp python tests/manual/e2e_mgp_scenarios.py
+
+The script returns exit code 0 if all scenarios pass, 1 otherwise. It is
+deliberately not a pytest test: spinning up the gateway subprocess for every
+test session would be too slow for the regular CI loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from nanobot.agent.loop import AgentLoop  # noqa: E402
+from nanobot.agent.mgp import build_sidecar  # noqa: E402
+from nanobot.agent.tools.mgp_recall import MGPRecallTool  # noqa: E402
+from nanobot.bus.queue import MessageBus  # noqa: E402
+from nanobot.config.schema import MGPConfig  # noqa: E402
+from nanobot.providers.base import GenerationSettings, LLMResponse  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Tiny pretty-print helpers
+# ---------------------------------------------------------------------------
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+INFO = "\033[36m••\033[0m"
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Gateway lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _start_gateway(port: int) -> subprocess.Popen[bytes]:
+    env = {**os.environ, "MGP_ADAPTER": "memory"}
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "gateway", "--host", "127.0.0.1", "--port", str(port)],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/healthz", timeout=0.5):
+                return proc
+        except Exception:
+            time.sleep(0.2)
+    proc.terminate()
+    raise RuntimeError(f"mgp-gateway did not become healthy on :{port}")
+
+
+# ---------------------------------------------------------------------------
+# Loop builder
+# ---------------------------------------------------------------------------
+
+
+def _make_loop(*, gateway_url: str, default_user_id: str | None, tmp_path: Path) -> AgentLoop:
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings(max_tokens=0)
+    provider.estimate_prompt_tokens.return_value = (0, "test-counter")
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+    provider.chat_stream_with_retry = AsyncMock(
+        return_value=LLMResponse(content="ok", tool_calls=[])
+    )
+
+    cfg = MGPConfig(
+        enabled=True,
+        gateway_url=gateway_url,
+        default_user_id=default_user_id,
+        # keep both commit channels on so we can exercise them
+        enable_consolidator_commit=True,
+        enable_dream_commit=True,
+    )
+    return AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        mgp_config=cfg,
+    )
+
+
+async def _drain_background_tasks() -> None:
+    """Let asyncio.create_task fan-outs run to completion."""
+    pending = [
+        t for t in asyncio.all_tasks() if not t.done() and t is not asyncio.current_task()
+    ]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+
+async def _call_recall(loop: AgentLoop, **kwargs: Any) -> str:
+    tool: MGPRecallTool = loop.tools.get("recall_memory")  # type: ignore[assignment]
+    return await tool.execute(**kwargs)
+
+
+async def scenario_1_recall_when_empty(loop: AgentLoop) -> tuple[bool, str]:
+    loop._set_tool_context(channel="cli", chat_id="alice", message_id="m1")
+    text = await _call_recall(loop, query="anything")
+    ok = "no memories found" in text.lower()
+    return ok, f"recall returned: {text!r}"
+
+
+async def scenario_2_consolidator_commit(loop: AgentLoop) -> tuple[bool, str]:
+    loop.provider.chat_with_retry = AsyncMock(
+        return_value=LLMResponse(content="- User has a cat named Luna", tool_calls=[])
+    )
+    session = loop.sessions.get_or_create("cli:alice")
+    session.messages = [{"role": "user", "content": "I love cats", "timestamp": "2026-01-01T00:00:00"}]
+    summary = await loop.consolidator.archive(session.messages, session=session)
+    await _drain_background_tasks()
+    ok = summary == "- User has a cat named Luna"
+    return ok, f"archive returned: {summary!r}"
+
+
+async def scenario_3_dream_phase1_commit(loop: AgentLoop) -> tuple[bool, str]:
+    analysis = (
+        "[USER] prefers replies in 中文\n"
+        "[MEMORY] runs nanobot on macOS\n"
+        "[SOUL] friendly, terse"
+    )
+    loop.dream.on_phase1_analysis(analysis)
+    await _drain_background_tasks()
+    last = loop.mgp_sidecar.last_commits
+    return bool(last), f"recorded {len(last)} commit outcome(s); last written={last[-1].written if last else None}"
+
+
+async def scenario_4_recall_finds_prior_commit(loop: AgentLoop) -> tuple[bool, str]:
+    """Closes the loop: write -> wait for adapter -> search returns the bullet."""
+    loop._set_tool_context(channel="cli", chat_id="alice", message_id="m4")
+    text = await _call_recall(loop, query="cat", scope="user", limit=5)
+    ok = "luna" in text.lower() or "cat" in text.lower()
+    return ok, f"recall returned: {text!r}"
+
+
+async def scenario_5_subject_chat_id_wins(loop: AgentLoop) -> tuple[bool, str]:
+    """Telegram-style chat with a real chat_id should write under that id."""
+    runtime = loop.mgp_sidecar.build_runtime(
+        channel="telegram", chat_id="user_999", session_key="telegram:user_999"
+    )
+    return runtime.user_id == "user_999", f"derived user_id={runtime.user_id!r}"
+
+
+async def scenario_6_dream_subject_falls_back_to_default(loop: AgentLoop) -> tuple[bool, str]:
+    """Dream uses chat_id='dream' (synthetic) — must hit default_user_id."""
+    runtime = loop.mgp_sidecar.build_runtime(
+        channel="system", chat_id="dream", session_key="system:dream"
+    )
+    return runtime.user_id == "alice", f"derived user_id={runtime.user_id!r}"
+
+
+async def scenario_7_fail_open_when_gateway_down(tmp_path: Path) -> tuple[bool, str]:
+    """Point the sidecar at a black-hole port: recall_memory must degrade, not crash."""
+    bad_loop = _make_loop(
+        gateway_url="http://127.0.0.1:1",  # nothing listens here
+        default_user_id="alice",
+        tmp_path=tmp_path / "fail_open",
+    )
+    bad_loop._set_tool_context(channel="cli", chat_id="alice", message_id="m7")
+    try:
+        text = await _call_recall(bad_loop, query="ping")
+    except Exception as e:
+        return False, f"raised {type(e).__name__}: {e}"
+    ok = "degraded" in text.lower() or "no memories" in text.lower()
+    return ok, f"got: {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+async def _run_all(tmp_path: Path, gateway_url: str) -> int:
+    loop = _make_loop(gateway_url=gateway_url, default_user_id="alice", tmp_path=tmp_path)
+
+    scenarios = [
+        ("1. recall returns 'no memories' when MGP is empty", scenario_1_recall_when_empty(loop)),
+        ("2. Consolidator archive commits bullet to MGP",      scenario_2_consolidator_commit(loop)),
+        ("3. Dream Phase-1 hook commits tagged analysis",      scenario_3_dream_phase1_commit(loop)),
+        ("4. Recall finds the prior commit (write→search)",    scenario_4_recall_finds_prior_commit(loop)),
+        ("5. Subject derivation: real chat_id wins",           scenario_5_subject_chat_id_wins(loop)),
+        ("6. Subject derivation: Dream → default_user_id",     scenario_6_dream_subject_falls_back_to_default(loop)),
+        ("7. Fail-open when gateway is unreachable",           scenario_7_fail_open_when_gateway_down(tmp_path)),
+    ]
+
+    failures = 0
+    for label, coro in scenarios:
+        try:
+            ok, detail = await coro
+        except Exception as e:
+            ok, detail = False, f"raised {type(e).__name__}: {e}"
+        marker = PASS if ok else FAIL
+        print(f"  {marker}  {label}")
+        print(f"        {detail}")
+        if not ok:
+            failures += 1
+    return failures
+
+
+def main() -> int:
+    import tempfile
+
+    port = _free_port()
+    gateway_url = f"http://127.0.0.1:{port}"
+    print(f"{INFO} starting mgp-gateway (memory adapter) on :{port}")
+    proc = _start_gateway(port)
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            tmp_path = Path(td)
+            print(f"{INFO} workspace: {tmp_path}")
+            print(f"{INFO} running 7 scenarios")
+            print()
+            failures = asyncio.run(_run_all(tmp_path, gateway_url))
+        print()
+        if failures == 0:
+            print(f"{PASS}  all 7 scenarios passed")
+            return 0
+        print(f"{FAIL}  {failures}/7 scenario(s) failed")
+        return 1
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_mgp_loop_integration.py
+++ b/tests/test_mgp_loop_integration.py
@@ -1,0 +1,209 @@
+"""AgentLoop ↔ MGP sidecar integration tests.
+
+Confirms the wiring contract between :class:`AgentLoop` and the optional
+sidecar:
+
+- when ``mgp.enabled=false`` the sidecar is never built, the recall_memory
+  tool is never registered, and the ``mgp-memory`` skill is suppressed
+- when ``mgp.enabled=true`` the sidecar is built once, the tool is
+  registered, and the Consolidator + Dream both receive the sidecar reference
+- ``recall_memory`` joins the spawn branch of ``_set_tool_context``
+
+We monkeypatch :func:`build_sidecar` so these tests don't require a real MGP
+gateway to be reachable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import MGPConfig
+from nanobot.providers.base import GenerationSettings, LLMResponse
+
+
+def _make_loop(tmp_path, *, mgp_config: MGPConfig | None, monkeypatch) -> AgentLoop:
+    """Build a minimal AgentLoop with a stubbed provider and a fake sidecar.
+
+    The fake sidecar is installed via monkeypatch on ``build_sidecar`` so the
+    enabled/disabled branch can be exercised without contacting any gateway.
+    """
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings(max_tokens=0)
+    provider.estimate_prompt_tokens.return_value = (0, "test-counter")
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+    provider.chat_stream_with_retry = AsyncMock(
+        return_value=LLMResponse(content="ok", tool_calls=[])
+    )
+
+    fake_sidecar = MagicMock(name="AsyncMGPSidecar")
+    # Mirror real attributes that AgentLoop touches via injection / status.
+    fake_sidecar.config = mgp_config
+
+    def _fake_build_sidecar(cfg, *, workspace_id=None):
+        return fake_sidecar
+
+    # build_sidecar is imported lazily inside AgentLoop.__init__, so patch
+    # at the package origin to intercept that import.
+    monkeypatch.setattr("nanobot.agent.mgp.build_sidecar", _fake_build_sidecar)
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        mgp_config=mgp_config,
+    )
+    # Stash the fake on the loop so tests can inspect it.
+    loop._fake_sidecar = fake_sidecar  # type: ignore[attr-defined]
+    return loop
+
+
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_mgp_does_not_build_sidecar(tmp_path, monkeypatch) -> None:
+    cfg = MGPConfig(enabled=False)
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+
+    assert loop.mgp_sidecar is None
+    assert loop.tools.get("recall_memory") is None
+    # Consolidator and Dream stay vanilla.
+    assert loop.consolidator.mgp_sidecar is None
+    assert loop.dream.mgp_sidecar is None
+
+
+def test_disabled_mgp_suppresses_mgp_memory_skill(tmp_path, monkeypatch) -> None:
+    cfg = MGPConfig(enabled=False)
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+    # The mgp-memory skill must be invisible to the LLM when MGP is off.
+    assert "mgp-memory" in loop.context.skills.disabled_skills
+
+
+def test_enabled_mgp_builds_sidecar_and_registers_tool(tmp_path, monkeypatch) -> None:
+    cfg = MGPConfig(enabled=True, gateway_url="http://test/")
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+
+    assert loop.mgp_sidecar is loop._fake_sidecar
+    tool = loop.tools.get("recall_memory")
+    assert tool is not None
+    # The tool reads its defaults from MGPConfig.
+    assert tool._default_scope == cfg.recall_default_scope
+    assert tool._default_limit == cfg.recall_default_limit
+    # And the skill is NOT disabled — agent should see it.
+    assert "mgp-memory" not in loop.context.skills.disabled_skills
+
+
+def test_enabled_mgp_injects_sidecar_into_consolidator_and_dream(tmp_path, monkeypatch) -> None:
+    cfg = MGPConfig(enabled=True)
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+    assert loop.consolidator.mgp_sidecar is loop._fake_sidecar
+    assert loop.dream.mgp_sidecar is loop._fake_sidecar
+
+
+def test_set_tool_context_routes_recall_memory_via_spawn_branch(tmp_path, monkeypatch) -> None:
+    cfg = MGPConfig(enabled=True)
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+    tool = loop.tools.get("recall_memory")
+    assert tool is not None
+
+    loop._set_tool_context(channel="telegram", chat_id="alice", message_id="m-1")
+
+    # The ContextVars should carry the channel / chat_id and an
+    # auto-derived effective_key (channel:chat_id when not unified-session).
+    assert tool._channel.get() == "telegram"
+    assert tool._chat_id.get() == "alice"
+    assert tool._session_key.get() == "telegram:alice"
+
+
+def test_set_tool_context_uses_unified_session_key(tmp_path, monkeypatch) -> None:
+    cfg = MGPConfig(enabled=True)
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation = GenerationSettings(max_tokens=0)
+    provider.estimate_prompt_tokens.return_value = (0, "test-counter")
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+    provider.chat_stream_with_retry = AsyncMock(
+        return_value=LLMResponse(content="ok", tool_calls=[])
+    )
+
+    fake_sidecar = MagicMock()
+    fake_sidecar.config = cfg
+    monkeypatch.setattr("nanobot.agent.mgp.build_sidecar", lambda c, *, workspace_id=None: fake_sidecar)
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        unified_session=True,
+        mgp_config=cfg,
+    )
+    loop._set_tool_context(channel="telegram", chat_id="alice", message_id="m-1")
+    tool = loop.tools.get("recall_memory")
+    assert tool._session_key.get() == "unified:default"
+
+
+@pytest.mark.asyncio
+async def test_consolidator_archive_dispatches_commit_when_enabled(tmp_path, monkeypatch) -> None:
+    """archive() must hand off the LLM summary to sidecar.commit_bullets."""
+    cfg = MGPConfig(enabled=True)
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+
+    # Make commit_bullets an awaitable that records its args.
+    loop._fake_sidecar.commit_bullets = AsyncMock(return_value=[])
+
+    # Patch the consolidator's LLM call to return a deterministic summary.
+    summary = "- User has a cat named Luna"
+    loop.provider.chat_with_retry = AsyncMock(
+        return_value=LLMResponse(content=summary, tool_calls=[])
+    )
+    session = loop.sessions.get_or_create("telegram:alice")
+    session.messages = [{"role": "user", "content": "hi", "timestamp": "2026-01-01T00:00:00"}]
+
+    # Drive a single archive() — fire-and-forget MGP commit dispatched.
+    result = await loop.consolidator.archive(session.messages, session=session)
+    assert result == summary
+
+    # Drain background tasks so commit_bullets actually runs.
+    pending = [t for t in __import__("asyncio").all_tasks() if not t.done() and t is not __import__("asyncio").current_task()]
+    if pending:
+        await __import__("asyncio").gather(*pending, return_exceptions=True)
+
+    loop._fake_sidecar.commit_bullets.assert_awaited()
+    # First positional arg is the runtime, second is the summary string.
+    call_args = loop._fake_sidecar.commit_bullets.await_args.args
+    assert call_args[1] == summary
+
+
+@pytest.mark.asyncio
+async def test_consolidator_archive_skips_commit_when_disabled(tmp_path, monkeypatch) -> None:
+    cfg = MGPConfig(enabled=True, enable_consolidator_commit=False)
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+    loop._fake_sidecar.commit_bullets = AsyncMock(return_value=[])
+    loop.provider.chat_with_retry = AsyncMock(
+        return_value=LLMResponse(content="- a fact", tool_calls=[])
+    )
+    session = loop.sessions.get_or_create("cli:direct")
+    session.messages = [{"role": "user", "content": "hi", "timestamp": "2026-01-01T00:00:00"}]
+    await loop.consolidator.archive(session.messages, session=session)
+    loop._fake_sidecar.commit_bullets.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_consolidator_archive_skips_commit_without_session(tmp_path, monkeypatch) -> None:
+    """Legacy callers that omit `session=` must still work without crashing."""
+    cfg = MGPConfig(enabled=True)
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+    loop._fake_sidecar.commit_bullets = AsyncMock(return_value=[])
+    loop.provider.chat_with_retry = AsyncMock(
+        return_value=LLMResponse(content="- a fact", tool_calls=[])
+    )
+    msgs = [{"role": "user", "content": "hi", "timestamp": "2026-01-01T00:00:00"}]
+    summary = await loop.consolidator.archive(msgs)  # no session=
+    assert summary == "- a fact"
+    loop._fake_sidecar.commit_bullets.assert_not_called()

--- a/tests/test_mgp_loop_integration.py
+++ b/tests/test_mgp_loop_integration.py
@@ -4,9 +4,12 @@ Confirms the wiring contract between :class:`AgentLoop` and the optional
 sidecar:
 
 - when ``mgp.enabled=false`` the sidecar is never built, the recall_memory
-  tool is never registered, and the ``mgp-memory`` skill is suppressed
+  tool is never registered, the Consolidator/Dream hooks stay None, and the
+  ``mgp-memory`` skill is suppressed
 - when ``mgp.enabled=true`` the sidecar is built once, the tool is
-  registered, and the Consolidator + Dream both receive the sidecar reference
+  registered, and AgentLoop installs the ``on_archive`` /
+  ``on_phase1_analysis`` hooks so Consolidator + Dream output flows to MGP
+  without those classes ever importing ``mgp_client`` themselves
 - ``recall_memory`` joins the spawn branch of ``_set_tool_context``
 
 We monkeypatch :func:`build_sidecar` so these tests don't require a real MGP
@@ -72,9 +75,9 @@ def test_disabled_mgp_does_not_build_sidecar(tmp_path, monkeypatch) -> None:
 
     assert loop.mgp_sidecar is None
     assert loop.tools.get("recall_memory") is None
-    # Consolidator and Dream stay vanilla.
-    assert loop.consolidator.mgp_sidecar is None
-    assert loop.dream.mgp_sidecar is None
+    # Consolidator and Dream stay MGP-unaware: their hooks are uninstalled.
+    assert loop.consolidator.on_archive is None
+    assert loop.dream.on_phase1_analysis is None
 
 
 def test_disabled_mgp_suppresses_mgp_memory_skill(tmp_path, monkeypatch) -> None:
@@ -98,11 +101,12 @@ def test_enabled_mgp_builds_sidecar_and_registers_tool(tmp_path, monkeypatch) ->
     assert "mgp-memory" not in loop.context.skills.disabled_skills
 
 
-def test_enabled_mgp_injects_sidecar_into_consolidator_and_dream(tmp_path, monkeypatch) -> None:
+def test_enabled_mgp_installs_hooks_on_consolidator_and_dream(tmp_path, monkeypatch) -> None:
+    """AgentLoop owns the MGP-side wiring: Consolidator/Dream just expose hooks."""
     cfg = MGPConfig(enabled=True)
     loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
-    assert loop.consolidator.mgp_sidecar is loop._fake_sidecar
-    assert loop.dream.mgp_sidecar is loop._fake_sidecar
+    assert callable(loop.consolidator.on_archive)
+    assert callable(loop.dream.on_phase1_analysis)
 
 
 def test_set_tool_context_routes_recall_memory_via_spawn_branch(tmp_path, monkeypatch) -> None:
@@ -207,3 +211,37 @@ async def test_consolidator_archive_skips_commit_without_session(tmp_path, monke
     summary = await loop.consolidator.archive(msgs)  # no session=
     assert summary == "- a fact"
     loop._fake_sidecar.commit_bullets.assert_not_called()
+
+
+# -- Dream → MGP wiring (post-decouple regression) --------------------------
+
+
+@pytest.mark.asyncio
+async def test_dream_phase1_hook_dispatches_commit_when_enabled(tmp_path, monkeypatch) -> None:
+    """Dream.on_phase1_analysis must hand the analysis to commit_dream_tags."""
+    import asyncio as _aio
+
+    cfg = MGPConfig(enabled=True)
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+    loop._fake_sidecar.commit_dream_tags = AsyncMock(return_value=[])
+
+    analysis = "[USER] prefers concise replies\n[MEMORY] uses python 3.11"
+    loop.dream.on_phase1_analysis(analysis)
+
+    pending = [t for t in _aio.all_tasks() if not t.done() and t is not _aio.current_task()]
+    if pending:
+        await _aio.gather(*pending, return_exceptions=True)
+
+    loop._fake_sidecar.commit_dream_tags.assert_awaited()
+    call_args = loop._fake_sidecar.commit_dream_tags.await_args.args
+    assert call_args[1] == analysis
+
+
+@pytest.mark.asyncio
+async def test_dream_phase1_hook_skips_commit_when_disabled(tmp_path, monkeypatch) -> None:
+    cfg = MGPConfig(enabled=True, enable_dream_commit=False)
+    loop = _make_loop(tmp_path, mgp_config=cfg, monkeypatch=monkeypatch)
+    loop._fake_sidecar.commit_dream_tags = AsyncMock(return_value=[])
+
+    loop.dream.on_phase1_analysis("[USER] foo")
+    loop._fake_sidecar.commit_dream_tags.assert_not_called()

--- a/tests/test_mgp_parsers.py
+++ b/tests/test_mgp_parsers.py
@@ -111,8 +111,10 @@ class TestParseDreamPhase1Tags:
         assert by_type["preference"].statement == "location is Tokyo"
         assert by_type["semantic_fact"].scope == "agent"
         assert by_type["semantic_fact"].statement == "project Atlas uses pgvector"
-        assert by_type["identity"].scope == "agent"
-        assert by_type["identity"].statement.startswith("respond in Chinese")
+        # SOUL maps to "profile" (the closest type in MGP's
+        # supported_memory_types — there is no "identity" type).
+        assert by_type["profile"].scope == "agent"
+        assert by_type["profile"].statement.startswith("respond in Chinese")
 
     def test_file_remove_lines_ignored(self) -> None:
         # FILE-REMOVE may be supported in a future stage; for MVP we ignore.
@@ -154,4 +156,4 @@ class TestParseDreamPhase1Tags:
         # surface in the diff.
         assert DREAM_TAG_TO_MGP["USER"] == ("user", "preference")
         assert DREAM_TAG_TO_MGP["MEMORY"] == ("agent", "semantic_fact")
-        assert DREAM_TAG_TO_MGP["SOUL"] == ("agent", "identity")
+        assert DREAM_TAG_TO_MGP["SOUL"] == ("agent", "profile")

--- a/tests/test_mgp_parsers.py
+++ b/tests/test_mgp_parsers.py
@@ -1,0 +1,157 @@
+"""Tests for nanobot.agent.mgp.parsers — bullet and dream-tag parsing.
+
+These tests have no MGP dependency: parsers operate on plain strings and
+return plain dataclasses. They cover the prompt-shape contracts encoded in
+nanobot's existing ``consolidator_archive.md`` and ``dream_phase1.md`` so a
+prompt change that breaks these tests is a deliberate signal, not a regression.
+"""
+
+from __future__ import annotations
+
+from nanobot.agent.mgp.parsers import (
+    DREAM_TAG_TO_MGP,
+    parse_consolidator_bullets,
+    parse_dream_phase1_tags,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_consolidator_bullets
+# ---------------------------------------------------------------------------
+
+
+class TestParseConsolidatorBullets:
+    def test_empty_input_returns_empty(self) -> None:
+        assert parse_consolidator_bullets("") == []
+        assert parse_consolidator_bullets("   \n\n  ") == []
+
+    def test_nothing_sentinel_returns_empty(self) -> None:
+        assert parse_consolidator_bullets("(nothing)") == []
+        # Whitespace + casing tolerated.
+        assert parse_consolidator_bullets("  (Nothing)  \n") == []
+
+    def test_raw_archive_marker_returns_empty(self) -> None:
+        # raw_archive() output should NOT be propagated to MGP.
+        raw = "[RAW] 12 messages\n[2026-04-21 10:00] USER: hello"
+        assert parse_consolidator_bullets(raw) == []
+
+    def test_dash_bullets_become_facts(self) -> None:
+        summary = "- User has a cat named Luna\n- Project codename is Atlas"
+        facts = parse_consolidator_bullets(summary)
+        assert len(facts) == 2
+        assert facts[0].statement == "User has a cat named Luna"
+        assert facts[1].statement == "Project codename is Atlas"
+        # Default classification: user / semantic_fact.
+        assert all(f.scope == "user" for f in facts)
+        assert all(f.type == "semantic_fact" for f in facts)
+
+    def test_other_bullet_styles_supported(self) -> None:
+        summary = "* one\n+ two\n1. three\n2) four"
+        facts = parse_consolidator_bullets(summary)
+        statements = [f.statement for f in facts]
+        assert statements == ["one", "two", "three", "four"]
+
+    def test_preference_classification(self) -> None:
+        summary = "- User prefers concise replies"
+        [fact] = parse_consolidator_bullets(summary)
+        assert fact.type == "preference"
+        assert fact.preference_value is not None
+        assert "concise replies" in fact.preference_value.lower()
+
+    def test_event_classification(self) -> None:
+        summary = "- Meeting scheduled for tomorrow morning"
+        [fact] = parse_consolidator_bullets(summary)
+        assert fact.type == "episodic_event"
+
+    def test_markdown_headers_dropped(self) -> None:
+        summary = "## User facts\n- Alice lives in Tokyo\n# Decisions\n- Switched to postgres"
+        facts = parse_consolidator_bullets(summary)
+        statements = [f.statement for f in facts]
+        assert statements == ["Alice lives in Tokyo", "Switched to postgres"]
+
+    def test_blank_lines_ignored(self) -> None:
+        summary = "- one\n\n\n- two\n\n"
+        assert len(parse_consolidator_bullets(summary)) == 2
+
+    def test_source_ref_propagated(self) -> None:
+        [fact] = parse_consolidator_bullets("- foo", source_ref="cli:direct:test")
+        assert fact.source_ref == "cli:direct:test"
+
+    def test_unbulleted_lines_still_treated_as_facts(self) -> None:
+        # Some LLMs forget the leading dash. We accept the line as-is rather
+        # than silently dropping it.
+        summary = "User likes dark mode"
+        [fact] = parse_consolidator_bullets(summary)
+        assert fact.statement == "User likes dark mode"
+        # "likes" matches the preference hint set.
+        assert fact.type == "preference"
+
+
+# ---------------------------------------------------------------------------
+# parse_dream_phase1_tags
+# ---------------------------------------------------------------------------
+
+
+class TestParseDreamPhase1Tags:
+    def test_empty_input_returns_empty(self) -> None:
+        assert parse_dream_phase1_tags("") == []
+
+    def test_skip_sentinel_returns_empty(self) -> None:
+        assert parse_dream_phase1_tags("[SKIP]") == []
+
+    def test_three_tag_classes_map_correctly(self) -> None:
+        analysis = (
+            "[USER] location is Tokyo\n"
+            "[MEMORY] project Atlas uses pgvector\n"
+            "[SOUL] respond in Chinese unless asked otherwise"
+        )
+        facts = parse_dream_phase1_tags(analysis)
+        by_type = {f.type: f for f in facts}
+        assert by_type["preference"].scope == "user"
+        assert by_type["preference"].statement == "location is Tokyo"
+        assert by_type["semantic_fact"].scope == "agent"
+        assert by_type["semantic_fact"].statement == "project Atlas uses pgvector"
+        assert by_type["identity"].scope == "agent"
+        assert by_type["identity"].statement.startswith("respond in Chinese")
+
+    def test_file_remove_lines_ignored(self) -> None:
+        # FILE-REMOVE may be supported in a future stage; for MVP we ignore.
+        analysis = "[FILE-REMOVE] outdated note\n[USER] real fact"
+        facts = parse_dream_phase1_tags(analysis)
+        assert [f.statement for f in facts] == ["real fact"]
+
+    def test_skill_lines_ignored(self) -> None:
+        # SKILL output goes to local skill files only, not MGP.
+        analysis = "[SKILL] foo: bar\n[MEMORY] real"
+        facts = parse_dream_phase1_tags(analysis)
+        assert [f.statement for f in facts] == ["real"]
+
+    def test_unknown_tags_ignored(self) -> None:
+        # Tags outside the mapping are silently dropped (defensive).
+        analysis = "[FOO] bar\n[USER] real fact"
+        facts = parse_dream_phase1_tags(analysis)
+        assert len(facts) == 1
+        assert facts[0].statement == "real fact"
+
+    def test_blank_lines_and_garbage_skipped(self) -> None:
+        analysis = "\nrandom prose\n[USER] fact one\n   \n[MEMORY] fact two\n"
+        facts = parse_dream_phase1_tags(analysis)
+        assert len(facts) == 2
+        assert {f.statement for f in facts} == {"fact one", "fact two"}
+
+    def test_empty_statement_after_tag_dropped(self) -> None:
+        # `[USER]   ` with no payload should not produce a fact.
+        analysis = "[USER]   \n[USER] real"
+        facts = parse_dream_phase1_tags(analysis)
+        assert [f.statement for f in facts] == ["real"]
+
+    def test_source_ref_propagated(self) -> None:
+        [fact] = parse_dream_phase1_tags("[USER] foo", source_ref="dream:wks-1")
+        assert fact.source_ref == "dream:wks-1"
+
+    def test_mapping_table_is_authoritative(self) -> None:
+        # Smoke-test against the public mapping table so future renames
+        # surface in the diff.
+        assert DREAM_TAG_TO_MGP["USER"] == ("user", "preference")
+        assert DREAM_TAG_TO_MGP["MEMORY"] == ("agent", "semantic_fact")
+        assert DREAM_TAG_TO_MGP["SOUL"] == ("agent", "identity")

--- a/tests/test_mgp_recall_tool.py
+++ b/tests/test_mgp_recall_tool.py
@@ -124,7 +124,12 @@ class TestSetContext:
         tool.set_context("telegram", "u-99", effective_key="telegram:u-99")
         await tool.execute(query="topic")
         kwargs = mock_sidecar.build_runtime.call_args.kwargs
-        assert kwargs == {"channel": "telegram", "chat_id": "u-99", "session_key": "telegram:u-99"}
+        assert kwargs == {
+            "channel": "telegram",
+            "chat_id": "u-99",
+            "session_key": "telegram:u-99",
+            "sender_id": None,
+        }
 
     @pytest.mark.asyncio
     async def test_set_context_synthesizes_session_key_when_missing(
@@ -146,7 +151,30 @@ class TestSetContext:
         tool.set_context(None, None)
         await tool.execute(query="x")
         kwargs = mock_sidecar.build_runtime.call_args.kwargs
-        assert kwargs == {"channel": None, "chat_id": None, "session_key": None}
+        assert kwargs == {
+            "channel": None,
+            "chat_id": None,
+            "session_key": None,
+            "sender_id": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_set_context_propagates_sender_id_for_group_chats(
+        self,
+        tool: MGPRecallTool,
+        mock_sidecar: MagicMock,
+    ) -> None:
+        # Regression: in group chats, every member shares one ``chat_id``.
+        # Without per-member ``sender_id`` plumbing the sidecar would
+        # collapse all of them into the same MGP subject. The tool MUST
+        # forward sender_id so user-scoped recall works correctly.
+        tool.set_context(
+            "telegram", "group-77", effective_key="telegram:group-77", sender_id="alice",
+        )
+        await tool.execute(query="topic")
+        kwargs = mock_sidecar.build_runtime.call_args.kwargs
+        assert kwargs["sender_id"] == "alice"
+        assert kwargs["chat_id"] == "group-77"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mgp_recall_tool.py
+++ b/tests/test_mgp_recall_tool.py
@@ -1,0 +1,209 @@
+"""Tests for nanobot.agent.tools.mgp_recall.MGPRecallTool.
+
+We mock the sidecar entirely (the sidecar itself is exercised in
+``test_mgp_sidecar.py``) so these tests focus on:
+
+- JSON Schema validation (required ``query``, enum / bound enforcement)
+- default scope/limit fall-throughs
+- ContextVar plumbing of channel/chat_id/effective_key
+- ``_format`` rendering for empty / normal / degraded outcomes
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.mgp.models import RecallOutcome, RecallItem
+from nanobot.agent.tools.mgp_recall import MGPRecallTool
+
+
+def _runtime_stub() -> SimpleNamespace:
+    """A trivial RuntimeState stand-in; the tool only forwards it."""
+    return SimpleNamespace(channel="cli", chat_id="alice", user_id="alice")
+
+
+@pytest.fixture
+def mock_sidecar() -> MagicMock:
+    sc = MagicMock()
+    sc.build_runtime = MagicMock(return_value=_runtime_stub())
+    sc.recall = AsyncMock(return_value=RecallOutcome(executed=True, degraded=False, results=[]))
+    return sc
+
+
+@pytest.fixture
+def tool(mock_sidecar: MagicMock) -> MGPRecallTool:
+    return MGPRecallTool(sidecar=mock_sidecar, default_scope="user", default_limit=5)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_schema_marks_query_required(self, tool: MGPRecallTool) -> None:
+        params = tool.parameters
+        assert params["type"] == "object"
+        assert "query" in params["properties"]
+        assert "query" in params["required"]
+
+    def test_validate_missing_query_fails(self, tool: MGPRecallTool) -> None:
+        errors = tool.validate_params({})
+        assert errors, "missing query should produce an error"
+
+    def test_validate_with_only_query_passes(self, tool: MGPRecallTool) -> None:
+        assert tool.validate_params({"query": "indentation preference"}) == []
+
+    def test_validate_scope_enum_enforced(self, tool: MGPRecallTool) -> None:
+        ok = tool.validate_params({"query": "x", "scope": "user"})
+        assert ok == []
+        bad = tool.validate_params({"query": "x", "scope": "WORLD"})
+        assert bad, "non-enum scope should fail validation"
+
+    def test_validate_limit_bounds_enforced(self, tool: MGPRecallTool) -> None:
+        assert tool.validate_params({"query": "x", "limit": 1}) == []
+        assert tool.validate_params({"query": "x", "limit": 20}) == []
+        assert tool.validate_params({"query": "x", "limit": 0})
+        assert tool.validate_params({"query": "x", "limit": 21})
+
+    def test_to_schema_includes_function_name(self, tool: MGPRecallTool) -> None:
+        schema = tool.to_schema()
+        assert schema["function"]["name"] == "recall_memory"
+        assert schema["function"]["description"]
+        # read_only flag flows through (used by concurrency planning).
+        assert tool.read_only is True
+
+
+# ---------------------------------------------------------------------------
+# execute → defaults
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDefaults:
+    @pytest.mark.asyncio
+    async def test_uses_default_scope_and_limit(
+        self,
+        tool: MGPRecallTool,
+        mock_sidecar: MagicMock,
+    ) -> None:
+        await tool.execute(query="indentation preference")
+        assert mock_sidecar.recall.await_count == 1
+        intent = mock_sidecar.recall.await_args.args[1]
+        assert intent.scope == "user"
+        assert intent.limit == 5
+        assert intent.types is None
+
+    @pytest.mark.asyncio
+    async def test_per_call_overrides_take_precedence(
+        self,
+        tool: MGPRecallTool,
+        mock_sidecar: MagicMock,
+    ) -> None:
+        await tool.execute(query="x", scope="agent", limit=12, types=["preference"])
+        intent = mock_sidecar.recall.await_args.args[1]
+        assert intent.scope == "agent"
+        assert intent.limit == 12
+        assert intent.types == ["preference"]
+
+
+# ---------------------------------------------------------------------------
+# set_context → ContextVar plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestSetContext:
+    @pytest.mark.asyncio
+    async def test_set_context_threads_runtime_via_contextvar(
+        self,
+        tool: MGPRecallTool,
+        mock_sidecar: MagicMock,
+    ) -> None:
+        tool.set_context("telegram", "u-99", effective_key="telegram:u-99")
+        await tool.execute(query="topic")
+        kwargs = mock_sidecar.build_runtime.call_args.kwargs
+        assert kwargs == {"channel": "telegram", "chat_id": "u-99", "session_key": "telegram:u-99"}
+
+    @pytest.mark.asyncio
+    async def test_set_context_synthesizes_session_key_when_missing(
+        self,
+        tool: MGPRecallTool,
+        mock_sidecar: MagicMock,
+    ) -> None:
+        tool.set_context("cli", "direct")
+        await tool.execute(query="x")
+        kwargs = mock_sidecar.build_runtime.call_args.kwargs
+        assert kwargs["session_key"] == "cli:direct"
+
+    @pytest.mark.asyncio
+    async def test_set_context_handles_none_safely(
+        self,
+        tool: MGPRecallTool,
+        mock_sidecar: MagicMock,
+    ) -> None:
+        tool.set_context(None, None)
+        await tool.execute(query="x")
+        kwargs = mock_sidecar.build_runtime.call_args.kwargs
+        assert kwargs == {"channel": None, "chat_id": None, "session_key": None}
+
+
+# ---------------------------------------------------------------------------
+# _format
+# ---------------------------------------------------------------------------
+
+
+class TestFormat:
+    def test_format_empty_results(self) -> None:
+        out = MGPRecallTool._format(RecallOutcome(executed=True, degraded=False, results=[]))
+        assert out == "(no memories found)"
+
+    def test_format_normal_results(self) -> None:
+        results = [
+            RecallItem(
+                memory={"type": "preference"},
+                consumable_text="User prefers dark mode.",
+            ),
+            RecallItem(
+                memory={"type": "semantic_fact"},
+                consumable_text="Project Atlas uses pgvector.",
+            ),
+        ]
+        out = MGPRecallTool._format(RecallOutcome(executed=True, degraded=False, results=results))
+        lines = out.splitlines()
+        assert lines == [
+            "- [preference] User prefers dark mode.",
+            "- [semantic_fact] Project Atlas uses pgvector.",
+        ]
+
+    def test_format_falls_back_to_content_dict(self) -> None:
+        # When consumable_text is absent we should still render something useful.
+        item = RecallItem(
+            memory={"type": "preference", "content": {"statement": "Dark mode."}},
+            consumable_text=None,
+        )
+        out = MGPRecallTool._format(RecallOutcome(executed=True, degraded=False, results=[item]))
+        assert out == "- [preference] Dark mode."
+
+    def test_format_degraded_outcome(self) -> None:
+        outcome = RecallOutcome(
+            executed=False, degraded=True,
+            error_code="ConnectError", error_message="refused",
+        )
+        out = MGPRecallTool._format(outcome)
+        assert "degraded" in out
+        assert "ConnectError" in out
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_format_output(
+        self,
+        tool: MGPRecallTool,
+        mock_sidecar: MagicMock,
+    ) -> None:
+        mock_sidecar.recall.return_value = RecallOutcome(
+            executed=True, degraded=False,
+            results=[RecallItem(memory={"type": "preference"}, consumable_text="A.")],
+        )
+        out = await tool.execute(query="x")
+        assert out == "- [preference] A."

--- a/tests/test_mgp_sidecar.py
+++ b/tests/test_mgp_sidecar.py
@@ -1,0 +1,344 @@
+"""Tests for nanobot.agent.mgp.sidecar.AsyncMGPSidecar.
+
+The real ``mgp_client.AsyncMGPClient`` is replaced by a small fake so these
+tests run without contacting any gateway. We exercise:
+
+- ``build_runtime`` derivation rules (user_id / tenant_id priority)
+- recall: success path normalization, fail-open, fail-closed
+- commit: bullet → write_candidate fan-out, commit-disabled toggle
+- ``/mgp-status`` accessor population (last_recall, last_commits)
+- the lazy-import error message in :func:`build_sidecar`
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from mgp_client.errors import BackendError
+
+from nanobot.agent.mgp import build_sidecar
+from nanobot.agent.mgp.models import RecallIntent
+from nanobot.agent.mgp.sidecar import AsyncMGPSidecar
+from nanobot.config.schema import MGPConfig
+
+
+def _config(**overrides: Any) -> MGPConfig:
+    """Build an MGPConfig with sane test defaults."""
+    base = dict(
+        enabled=True,
+        gateway_url="http://test-gw:8080",
+        timeout=2.0,
+        fail_open=True,
+        workspace_as_tenant=True,
+        tenant_id=None,
+        actor_agent="nanobot/test",
+        api_key=None,
+        enable_consolidator_commit=True,
+        enable_dream_commit=True,
+        recall_default_scope="user",
+        recall_default_limit=5,
+    )
+    base.update(overrides)
+    return MGPConfig(**base)
+
+
+def _mgp_response(data: dict[str, Any], request_id: str = "req_1") -> SimpleNamespace:
+    """Stand-in for mgp_client MGPResponse — we only touch .data and .request_id."""
+    return SimpleNamespace(data=data, request_id=request_id, status="ok", error=None)
+
+
+@pytest.fixture
+def fake_client() -> AsyncMock:
+    """A fake AsyncMGPClient with the methods the sidecar invokes."""
+    client = AsyncMock()
+    client.search_memory = AsyncMock()
+    client.write_candidate = AsyncMock()
+    client.close = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def sidecar(fake_client: AsyncMock) -> AsyncMGPSidecar:
+    sc = AsyncMGPSidecar(_config(), workspace_id="/tmp/wks-xyz")
+    # Bypass the lazy client factory so search/write hit our fake.
+    sc._client = fake_client
+    return sc
+
+
+# ---------------------------------------------------------------------------
+# build_runtime
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRuntime:
+    def test_user_id_falls_back_to_user(self) -> None:
+        sc = AsyncMGPSidecar(_config(), workspace_id="/tmp/wks")
+        rt = sc.build_runtime(channel="cli", chat_id="direct")
+        assert rt.user_id == "user"
+        assert rt.session_key == "cli:direct"
+
+    def test_user_id_uses_chat_id_when_not_direct(self) -> None:
+        sc = AsyncMGPSidecar(_config(), workspace_id="/tmp/wks")
+        rt = sc.build_runtime(channel="telegram", chat_id="u123")
+        assert rt.user_id == "u123"
+
+    def test_user_id_prefers_sender_id(self) -> None:
+        sc = AsyncMGPSidecar(_config(), workspace_id="/tmp/wks")
+        rt = sc.build_runtime(channel="telegram", chat_id="group42", sender_id="alice")
+        assert rt.user_id == "alice"
+
+    def test_user_id_ignores_literal_user_sender(self) -> None:
+        sc = AsyncMGPSidecar(_config(), workspace_id="/tmp/wks")
+        rt = sc.build_runtime(channel="cli", chat_id="bob", sender_id="user")
+        # "user" is the synthetic literal, not a real id; chat_id wins.
+        assert rt.user_id == "bob"
+
+    def test_tenant_explicit_overrides_workspace(self) -> None:
+        sc = AsyncMGPSidecar(_config(tenant_id="explicit-t"), workspace_id="/tmp/wks")
+        rt = sc.build_runtime(channel="cli", chat_id="direct")
+        assert rt.tenant_id == "explicit-t"
+
+    def test_tenant_falls_back_to_workspace(self) -> None:
+        sc = AsyncMGPSidecar(_config(tenant_id=None, workspace_as_tenant=True), workspace_id="/tmp/wks")
+        rt = sc.build_runtime(channel="cli", chat_id="direct")
+        assert rt.tenant_id == "/tmp/wks"
+
+    def test_tenant_none_when_both_disabled(self) -> None:
+        sc = AsyncMGPSidecar(_config(tenant_id=None, workspace_as_tenant=False), workspace_id="/tmp/wks")
+        rt = sc.build_runtime(channel="cli", chat_id="direct")
+        assert rt.tenant_id is None
+
+
+# ---------------------------------------------------------------------------
+# recall
+# ---------------------------------------------------------------------------
+
+
+class TestRecall:
+    @pytest.mark.asyncio
+    async def test_recall_normalizes_results(
+        self,
+        sidecar: AsyncMGPSidecar,
+        fake_client: AsyncMock,
+    ) -> None:
+        fake_client.search_memory.return_value = _mgp_response({
+            "results": [
+                {
+                    "memory": {"type": "preference", "memory_id": "m1"},
+                    "score": 0.9,
+                    "consumable_text": "User prefers dark mode.",
+                    "return_mode": "raw",
+                }
+            ],
+        })
+        runtime = sidecar.build_runtime(channel="cli", chat_id="alice")
+        outcome = await sidecar.recall(runtime, RecallIntent(query="theme preference"))
+        assert outcome.executed is True
+        assert outcome.degraded is False
+        assert len(outcome.results) == 1
+        assert outcome.results[0].consumable_text == "User prefers dark mode."
+        assert outcome.results[0].score == 0.9
+        # Status accessors populated for /mgp-status.
+        assert sidecar.last_recall is outcome
+        assert sidecar.last_recall_query == "theme preference"
+        assert sidecar.last_recall_latency_ms is not None
+
+    @pytest.mark.asyncio
+    async def test_recall_fail_open_returns_degraded(
+        self,
+        sidecar: AsyncMGPSidecar,
+        fake_client: AsyncMock,
+    ) -> None:
+        fake_client.search_memory.side_effect = httpx.ConnectError("refused")
+        runtime = sidecar.build_runtime(channel="cli", chat_id="alice")
+        outcome = await sidecar.recall(runtime, RecallIntent(query="x"))
+        assert outcome.executed is False
+        assert outcome.degraded is True
+        assert outcome.error_code == "ConnectError"
+        assert outcome.results == []
+
+    @pytest.mark.asyncio
+    async def test_recall_fail_closed_raises(self, fake_client: AsyncMock) -> None:
+        sc = AsyncMGPSidecar(_config(fail_open=False), workspace_id="/tmp/wks")
+        sc._client = fake_client
+        fake_client.search_memory.side_effect = BackendError(
+            code="MGP_BACKEND_ERROR", message="boom",
+        )
+        runtime = sc.build_runtime(channel="cli", chat_id="alice")
+        with pytest.raises(BackendError):
+            await sc.recall(runtime, RecallIntent(query="x"))
+
+    @pytest.mark.asyncio
+    async def test_recall_records_status_even_on_failure(
+        self,
+        sidecar: AsyncMGPSidecar,
+        fake_client: AsyncMock,
+    ) -> None:
+        fake_client.search_memory.side_effect = ValueError("bad payload")
+        runtime = sidecar.build_runtime(channel="cli", chat_id="alice")
+        outcome = await sidecar.recall(runtime, RecallIntent(query="probe"))
+        # last_recall_query is set BEFORE the call so /mgp-status can show it
+        # even if the underlying request blew up.
+        assert sidecar.last_recall_query == "probe"
+        assert sidecar.last_recall is outcome
+
+
+# ---------------------------------------------------------------------------
+# commit_bullets
+# ---------------------------------------------------------------------------
+
+
+class TestCommitBullets:
+    @pytest.mark.asyncio
+    async def test_commit_bullets_writes_one_per_bullet(
+        self,
+        sidecar: AsyncMGPSidecar,
+        fake_client: AsyncMock,
+    ) -> None:
+        fake_client.write_candidate.return_value = _mgp_response({"memory": {"memory_id": "mid"}})
+        runtime = sidecar.build_runtime(channel="cli", chat_id="alice")
+        outcomes = await sidecar.commit_bullets(
+            runtime,
+            "- User has a cat named Luna\n- Project codename is Atlas",
+        )
+        assert len(outcomes) == 2
+        assert all(o.written for o in outcomes)
+        assert fake_client.write_candidate.await_count == 2
+        # last_commits ring updated.
+        assert len(sidecar.last_commits) == 2
+
+    @pytest.mark.asyncio
+    async def test_commit_bullets_skips_nothing(
+        self,
+        sidecar: AsyncMGPSidecar,
+        fake_client: AsyncMock,
+    ) -> None:
+        outcomes = await sidecar.commit_bullets(sidecar.build_runtime(channel="cli", chat_id="x"), "(nothing)")
+        assert outcomes == []
+        fake_client.write_candidate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_commit_bullets_disabled_via_flag(self, fake_client: AsyncMock) -> None:
+        sc = AsyncMGPSidecar(_config(enable_consolidator_commit=False), workspace_id="/tmp/wks")
+        sc._client = fake_client
+        outcomes = await sc.commit_bullets(sc.build_runtime(channel="cli", chat_id="x"), "- one fact")
+        assert outcomes == []
+        fake_client.write_candidate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_commit_bullets_fail_open_per_candidate(
+        self,
+        sidecar: AsyncMGPSidecar,
+        fake_client: AsyncMock,
+    ) -> None:
+        # First call succeeds, second raises — both should resolve to outcomes
+        # under fail_open, the second flagged as failed.
+        fake_client.write_candidate.side_effect = [
+            _mgp_response({"memory": {"memory_id": "ok"}}),
+            httpx.ConnectError("nope"),
+        ]
+        outcomes = await sidecar.commit_bullets(
+            sidecar.build_runtime(channel="cli", chat_id="alice"),
+            "- one\n- two",
+        )
+        assert outcomes[0].written is True
+        assert outcomes[1].written is False
+        assert outcomes[1].error_code == "ConnectError"
+
+
+# ---------------------------------------------------------------------------
+# commit_dream_tags
+# ---------------------------------------------------------------------------
+
+
+class TestCommitDreamTags:
+    @pytest.mark.asyncio
+    async def test_commit_dream_tags_maps_correctly(
+        self,
+        sidecar: AsyncMGPSidecar,
+        fake_client: AsyncMock,
+    ) -> None:
+        fake_client.write_candidate.return_value = _mgp_response({"memory": {"memory_id": "mid"}})
+        runtime = sidecar.build_runtime(channel="system", chat_id="dream")
+        outcomes = await sidecar.commit_dream_tags(
+            runtime,
+            "[USER] location is Tokyo\n[MEMORY] uses pgvector\n[SOUL] respond in Chinese",
+        )
+        assert len(outcomes) == 3
+        # Inspect the candidates we sent — verify scope/type plumbing.
+        sent_candidates = [call.args[1] for call in fake_client.write_candidate.await_args_list]
+        scopes_types = sorted((c.scope, c.proposed_type) for c in sent_candidates)
+        assert scopes_types == [
+            ("agent", "identity"),
+            ("agent", "semantic_fact"),
+            ("user", "preference"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_commit_dream_tags_disabled_via_flag(self, fake_client: AsyncMock) -> None:
+        sc = AsyncMGPSidecar(_config(enable_dream_commit=False), workspace_id="/tmp/wks")
+        sc._client = fake_client
+        outcomes = await sc.commit_dream_tags(
+            sc.build_runtime(channel="system", chat_id="dream"),
+            "[USER] foo",
+        )
+        assert outcomes == []
+        fake_client.write_candidate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# build_sidecar lazy import
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSidecar:
+    def test_build_sidecar_returns_instance_when_dep_available(self) -> None:
+        # mgp_client is installed in this test env, so this must succeed.
+        sc = build_sidecar(_config(), workspace_id="/tmp/wks")
+        assert isinstance(sc, AsyncMGPSidecar)
+
+    def test_build_sidecar_error_message_when_missing(self, monkeypatch) -> None:
+        # Simulate the `pip install nanobot[mgp]` path by replacing the lazy
+        # import probe with one that raises.
+        import builtins
+
+        from nanobot.agent.mgp import MGPSidecarUnavailable
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "mgp_client":
+                raise ImportError("simulated missing dep")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        with pytest.raises(MGPSidecarUnavailable) as exc:
+            build_sidecar(_config())
+        assert "pip install" in str(exc.value)
+        assert "nanobot[mgp]" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# /mgp-status surface
+# ---------------------------------------------------------------------------
+
+
+class TestStatusAccessors:
+    @pytest.mark.asyncio
+    async def test_last_commits_kept_bounded(
+        self,
+        sidecar: AsyncMGPSidecar,
+        fake_client: AsyncMock,
+    ) -> None:
+        fake_client.write_candidate.return_value = _mgp_response({"memory": {"memory_id": "x"}})
+        # Push more than the keep-bound by issuing many small commits.
+        runtime = sidecar.build_runtime(channel="cli", chat_id="alice")
+        for _ in range(40):
+            await sidecar.commit_bullets(runtime, "- fact")
+        # Sidecar caps last_commits at 32 (ring buffer for /mgp-status).
+        assert len(sidecar.last_commits) == 32

--- a/tests/test_mgp_sidecar.py
+++ b/tests/test_mgp_sidecar.py
@@ -75,11 +75,19 @@ def sidecar(fake_client: AsyncMock) -> AsyncMGPSidecar:
 
 
 class TestBuildRuntime:
-    def test_user_id_falls_back_to_user(self) -> None:
+    def test_user_id_falls_back_to_default_user_id(self) -> None:
+        sc = AsyncMGPSidecar(_config(default_user_id="alice"), workspace_id="/tmp/wks")
+        rt = sc.build_runtime(channel="cli", chat_id="direct")
+        assert rt.user_id == "alice"
+        assert rt.session_key == "cli:direct"
+
+    def test_user_id_falls_back_to_os_login_when_unconfigured(self, monkeypatch) -> None:
+        # When no default_user_id is set we should pick up the OS login so
+        # different workstations / accounts don't collide on a literal "user".
+        monkeypatch.setattr("nanobot.agent.mgp.sidecar.getpass.getuser", lambda: "carol")
         sc = AsyncMGPSidecar(_config(), workspace_id="/tmp/wks")
         rt = sc.build_runtime(channel="cli", chat_id="direct")
-        assert rt.user_id == "user"
-        assert rt.session_key == "cli:direct"
+        assert rt.user_id == "carol"
 
     def test_user_id_uses_chat_id_when_not_direct(self) -> None:
         sc = AsyncMGPSidecar(_config(), workspace_id="/tmp/wks")
@@ -96,6 +104,14 @@ class TestBuildRuntime:
         rt = sc.build_runtime(channel="cli", chat_id="bob", sender_id="user")
         # "user" is the synthetic literal, not a real id; chat_id wins.
         assert rt.user_id == "bob"
+
+    def test_dream_workspace_runtime_resolves_to_default_user(self) -> None:
+        # Dream uses chat_id="dream" — that synthetic id MUST fall through
+        # to default_user_id, otherwise [USER] facts written by Dream would
+        # land under subject "dream" and never match a CLI user's recall.
+        sc = AsyncMGPSidecar(_config(default_user_id="dave"), workspace_id="/tmp/wks")
+        rt = sc.build_runtime(channel="system", chat_id="dream", session_key="system:dream")
+        assert rt.user_id == "dave"
 
     def test_tenant_explicit_overrides_workspace(self) -> None:
         sc = AsyncMGPSidecar(_config(tenant_id="explicit-t"), workspace_id="/tmp/wks")

--- a/tests/test_mgp_sidecar.py
+++ b/tests/test_mgp_sidecar.py
@@ -273,7 +273,7 @@ class TestCommitDreamTags:
         sent_candidates = [call.args[1] for call in fake_client.write_candidate.await_args_list]
         scopes_types = sorted((c.scope, c.proposed_type) for c in sent_candidates)
         assert scopes_types == [
-            ("agent", "identity"),
+            ("agent", "profile"),
             ("agent", "semantic_fact"),
             ("user", "preference"),
         ]

--- a/tests/test_nanobot_facade.py
+++ b/tests/test_nanobot_facade.py
@@ -166,3 +166,32 @@ def test_import_from_top_level():
     from nanobot import Nanobot as N, RunResult as R
     assert N is Nanobot
     assert R is RunResult
+
+
+def test_from_config_propagates_mgp_config(tmp_path):
+    """Regression: SDK facade must hand defaults.mgp to AgentLoop, otherwise
+    programmatic users silently lose the MGP sidecar even when the config
+    file enables it. See nanobot/nanobot.py: previous versions omitted
+    ``mgp_config=`` so the agent loop fell back to the default-disabled MGPConfig."""
+    config_path = _write_config(
+        tmp_path,
+        overrides={
+            "agents": {
+                "defaults": {
+                    "model": "openai/gpt-4.1",
+                    "mgp": {
+                        "enabled": True,
+                        "gatewayUrl": "http://gw.test:8080",
+                        "tenantId": "t-sdk",
+                        "actorAgent": "nanobot/sdk-test",
+                    },
+                }
+            },
+        },
+    )
+    bot = Nanobot.from_config(config_path, workspace=tmp_path)
+    sidecar = bot._loop.mgp_sidecar
+    assert sidecar is not None, "SDK facade should build the MGP sidecar when mgp.enabled=true"
+    assert sidecar.config.gateway_url == "http://gw.test:8080"
+    assert sidecar.config.tenant_id == "t-sdk"
+    assert sidecar.config.actor_agent == "nanobot/sdk-test"


### PR DESCRIPTION
## Summary

Add an **opt-in** integration with the [Memory Governance Protocol](https://github.com/HKUDS/MGP) (MGP) so nanobot agents can recall and commit cross-session, governed long-term memories without changing existing behavior when MGP is disabled.

The integration is a sidecar plus a single agent-facing `recall_memory` tool, wired into the existing Dream / Consolidator pipelines so users get persistent memory **without paying any extra LLM tokens** — we mirror outputs Dream/Consolidator already produce.

> **What changed since the first round of review.** The original diff was too invasive. The current branch:
> - **Decouples** Consolidator and Dream from the sidecar — they expose two callbacks (`on_archive`, `on_phase1_analysis`) and import nothing from MGP. AgentLoop owns all wiring in one place (`_wire_mgp_hooks`).
> - **Migrates** all gateway-side documentation (adapter selection, embedding for LanceDB, auth, troubleshooting, mapping) into the MGP repo — see merged [HKUDS/MGP #18](https://github.com/HKUDS/MGP/pull/18). The nanobot-side README shrinks **591 → 199 lines** and now focuses purely on runtime concerns.
> - **Trims** the package surface: `__init__.py` halved, `/mgp-status` rewritten as a 6-line summary, `build_runtime` user_id chain simplified from 5 steps to 4 (the dropped step never produced a different result in practice).
> - Net runtime-side delta this round: **+508 / −647 lines**.

## What lands

### MGP sidecar (`nanobot/agent/mgp/`)
- `sidecar.py` — async wrapper around `mgp-client.AsyncMGPClient` with **fail-open** semantics; any gateway error becomes a `[recall_memory degraded: <code>]` string, never crashes the conversation.
- `parsers.py` — converts Consolidator bullets and Dream Phase-1 tags (`[USER]` / `[MEMORY]` / `[SOUL]`) into MGP write candidates. `[SOUL]` maps to `agent/profile` (the only valid MGP type for self-identity facts).
- `mappers.py`, `models.py` — plumbing for runtime context, recall intents, commit candidates.
- `README.md` (199 lines) — runtime-side wiring reference. Gateway-side configuration links out to [`HKUDS/MGP/integrations/nanobot/README.md`](https://github.com/HKUDS/MGP/blob/main/integrations/nanobot/README.md).

### Agent tool (`nanobot/agent/tools/mgp_recall.py`)
- New `recall_memory` tool with `query` / `scope` / `limit` / `types`, registered only when MGP is enabled.
- Per-call routing context (channel / chat_id / session_key / **sender_id**) propagated via `ContextVar`.

### Skill (`nanobot/skills/mgp-memory/SKILL.md`)
- Always-on skill that teaches the agent **when** to call `recall_memory` and **when not to** (info already in MEMORY.md / SOUL.md / system prompt).

### Loop integration (`nanobot/agent/loop.py`, `memory.py`, `autocompact.py`)
- `AgentLoop.__init__` accepts an `mgp_config`. When enabled it builds a sidecar, registers the tool, and wires the Consolidator/Dream commit hooks via `_wire_mgp_hooks` — Consolidator/Dream classes themselves stay MGP-unaware.
- Threads `sender_id` from inbound messages through `_set_tool_context` → `recall_memory` so group chats isolate per-user memories instead of collapsing onto a shared `chat_id`.

### Subject (`user_id`) derivation
- New `MGPConfig.default_user_id` field providing a stable fallback for synthetic contexts (CLI direct sessions, Dream runs).
- 4-level priority: `sender_id` → `chat_id` → `default_user_id` → `getpass.getuser()`.

### SDK facade (`nanobot/nanobot.py`)
- `Nanobot.from_config()` passes `mgp_config=defaults.mgp` to `AgentLoop` so SDK consumers (not just CLI) get the sidecar wired in.

### Slash command (`nanobot/command/builtin.py`)
- `/mgp-status` reports gateway URL, commit toggles, last recall outcome, last 32 commit outcomes. Falls back to a one-liner pointing to the README when MGP is disabled.

### Config (`nanobot/config/schema.py`, `pyproject.toml`)
- New `MGPConfig` Pydantic model. All defaults keep MGP **off**.
- `mgp-client>=0.1.1` added as an optional dependency (only installed via `pip install "nanobot[mgp]"`).

### Tests
- 4 MGP test modules: `test_mgp_sidecar.py`, `test_mgp_parsers.py`, `test_mgp_recall_tool.py`, `test_mgp_loop_integration.py`. The latter now verifies the **hook** contract (`on_archive` / `on_phase1_analysis`) instead of the old attribute injection, plus a Dream Phase-1 commit regression.
- New `tests/manual/e2e_mgp_scenarios.py` — opt-in E2E driver against a real `mgp-gateway` (in-memory adapter) covering 7 scenarios. Not run by CI.
- Full suite: **2294 passed / 3 skipped.**

## Design rationale

- **Opt-in by default.** With `agents.defaults.mgp.enabled = false` (the default) nothing about the agent loop changes — the tool is not registered, no sidecar starts, no `mgp-client` import.
- **Zero LLM-cost commit.** Writes to MGP mirror Dream/Consolidator outputs nanobot already produces; no extra prompts, no extra tokens.
- **Fail-open.** Any MGP error (gateway 5xx, timeout, schema error) becomes a `[recall_memory degraded: <code>]` string. The conversation continues normally.
- **MGP-unaware core.** Consolidator and Dream don't import anything from `nanobot/agent/mgp/`; they expose two optional callbacks. AgentLoop is the only place that knows about both halves.
- **Backend-agnostic.** All adapter knowledge (`postgres` / `oceanbase` / `lancedb` / `mem0` / `zep`) lives on the MGP gateway side. Nanobot only knows `gateway_url`.

## Out of scope

- No new gateway / database. Users bring their own MGP gateway.
- No automatic data migration between adapters.
- No UI surface in webui. CLI / SDK only for now.

## Test plan

- [x] `pytest` — **2294 passed / 3 skipped**
- [x] `tests/manual/e2e_mgp_scenarios.py` — **7/7 PASS** against a real `mgp-gateway` (memory adapter) over real HTTP:
  - empty recall returns `(no memories found)`
  - Consolidator archive commits a bullet
  - Dream Phase-1 hook commits the tagged analysis
  - full write→search loop closes
  - subject derivation: real `chat_id` wins
  - subject derivation: Dream falls back to `default_user_id`
  - fail-open when the gateway is unreachable
- [x] LanceDB + OpenRouter embeddings — semantic recall validated previously (`"running outdoors as a hobby"` matches stored `"jogging in the park"` despite zero word overlap)
- [x] Disabled-mode parity: with `enabled=false`, all tests pass byte-identically

## Companion PR (merged)

[HKUDS/MGP #18](https://github.com/HKUDS/MGP/pull/18) — restructures `integrations/nanobot/README.md` around the two integration paths and hosts the gateway-side reference (adapters, embedding, mapping, subject derivation, troubleshooting) that no longer needs to live downstream.

## Compatibility

- **Python**: 3.11+ (matches nanobot main).
- **Dependencies**: only adds `mgp-client>=0.1.1` as **optional**. Existing installs see no impact.
- **Behavior**: byte-identical to current `main` when MGP is off. No public API removed or renamed.