### PR TITLE
fix(anthropic): omit temperature for opus-4-7 (#3417)

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -436,6 +436,10 @@ class AnthropicProvider(LLMProvider):
         max_tokens = max(1, max_tokens)
         thinking_enabled = bool(reasoning_effort)
 
+        # claude-opus-4-7 deprecated the `temperature` parameter entirely — the
+        # API returns 400 if it is present, on any code path.
+        omit_temperature = "opus-4-7" in model_name
+
         kwargs: dict[str, Any] = {
             "model": model_name,
             "messages": anthropic_msgs,
@@ -450,14 +454,16 @@ class AnthropicProvider(LLMProvider):
             # Supported on claude-sonnet-4-6 and claude-opus-4-6.
             # Also auto-enables interleaved thinking between tool calls.
             kwargs["thinking"] = {"type": "adaptive"}
-            kwargs["temperature"] = 1.0
+            if not omit_temperature:
+                kwargs["temperature"] = 1.0
         elif thinking_enabled:
             budget_map = {"low": 1024, "medium": 4096, "high": max(8192, max_tokens)}
             budget = budget_map.get(reasoning_effort.lower(), 4096)
             kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
             kwargs["max_tokens"] = max(max_tokens, budget + 4096)
-            kwargs["temperature"] = 1.0
-        else:
+            if not omit_temperature:
+                kwargs["temperature"] = 1.0
+        elif not omit_temperature:
             kwargs["temperature"] = temperature
 
         if anthropic_tools:

--- a/tests/providers/test_anthropic_thinking.py
+++ b/tests/providers/test_anthropic_thinking.py
@@ -63,3 +63,9 @@ def test_none_does_not_enable_thinking() -> None:
     kw = _build(_make_provider(), None)
     assert "thinking" not in kw
     assert kw["temperature"] == 0.7
+
+
+def test_opus_4_7_omits_temperature() -> None:
+    kw = _build(_make_provider("claude-opus-4-7"), "adaptive")
+    assert "temperature" not in kw
+    assert kw["thinking"] == {"type": "adaptive"}

--- a/tests/providers/test_anthropic_thinking.py
+++ b/tests/providers/test_anthropic_thinking.py
@@ -65,7 +65,21 @@ def test_none_does_not_enable_thinking() -> None:
     assert kw["temperature"] == 0.7
 
 
-def test_opus_4_7_omits_temperature() -> None:
+def test_opus_4_7_omits_temperature_adaptive() -> None:
     kw = _build(_make_provider("claude-opus-4-7"), "adaptive")
     assert "temperature" not in kw
     assert kw["thinking"] == {"type": "adaptive"}
+
+
+def test_opus_4_7_omits_temperature_enabled() -> None:
+    """Enabled thinking (high) must also omit temperature for opus-4-7."""
+    kw = _build(_make_provider("claude-opus-4-7"), "high", max_tokens=4096)
+    assert "temperature" not in kw
+    assert kw["thinking"]["type"] == "enabled"
+
+
+def test_opus_4_7_omits_temperature_none() -> None:
+    """Without thinking, opus-4-7 must still omit temperature (API rejects it)."""
+    kw = _build(_make_provider("claude-opus-4-7"), None)
+    assert "temperature" not in kw
+    assert "thinking" not in kw


### PR DESCRIPTION
Closes #3417

`claude-opus-4-7` deprecated `temperature` — the API returns 400 whenever it is present. `_build_kwargs` set it on all three paths; now gated behind a `"opus-4-7" in model_name` check.