### PR TITLE
fix(provider): preserve reasoning_content when merging consecutive assistant messages

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -88,6 +88,31 @@ class GenerationSettings:
 _SYNTHETIC_USER_CONTENT = "(conversation continued)"
 
 
+def _carry_over_reasoning(
+    src: dict[str, Any],
+    dst: dict[str, Any],
+) -> None:
+    """Merge ``reasoning_content`` from *src* into *dst*.
+
+    When ``_enforce_role_alternation`` merges consecutive assistant
+    messages, the ``reasoning_content`` field (used by DeepSeek-R1 /
+    DeepSeek-V4 thinking mode and others) must be preserved.  If both
+    messages carry reasoning, the texts are joined; if only one does,
+    its value is kept.
+    """
+    src_rc = src.get("reasoning_content")
+    dst_rc = dst.get("reasoning_content")
+    # Guard: reasoning_content is always str | None in practice.
+    if not isinstance(src_rc, str):
+        src_rc = None
+    if not isinstance(dst_rc, str):
+        dst_rc = None
+    if src_rc and dst_rc:
+        dst["reasoning_content"] = (dst_rc + "\n\n" + src_rc).strip()
+    elif src_rc:
+        dst["reasoning_content"] = src_rc
+
+
 class LLMProvider(ABC):
     """Base class for LLM providers."""
 
@@ -392,16 +417,24 @@ class LLMProvider(ABC):
                     prev_has_tools = bool(prev.get("tool_calls"))
                     curr_has_tools = bool(msg.get("tool_calls"))
                     if curr_has_tools:
-                        merged[-1] = dict(msg)
+                        replacement = dict(msg)
+                        _carry_over_reasoning(prev, replacement)
+                        merged[-1] = replacement
                         continue
                     if prev_has_tools:
+                        _carry_over_reasoning(msg, prev)
                         continue
                 prev_content = prev.get("content") or ""
                 curr_content = msg.get("content") or ""
                 if isinstance(prev_content, str) and isinstance(curr_content, str):
                     prev["content"] = (prev_content + "\n\n" + curr_content).strip()
+                    if role == "assistant":
+                        _carry_over_reasoning(msg, prev)
                 else:
-                    merged[-1] = dict(msg)
+                    replacement = dict(msg)
+                    if role == "assistant":
+                        _carry_over_reasoning(prev, replacement)
+                    merged[-1] = replacement
             else:
                 merged.append(dict(msg))
 
@@ -420,6 +453,10 @@ class LLMProvider(ABC):
         ):
             recovered = dict(last_popped)
             recovered["role"] = "user"
+            # Strip assistant-only fields that have no meaning on a user message.
+            recovered.pop("reasoning_content", None)
+            recovered.pop("thinking_blocks", None)
+            recovered.pop("tool_calls", None)
             merged.append(recovered)
 
         # Safety net: ensure the first non-system message is not a bare

--- a/tests/providers/test_enforce_role_alternation.py
+++ b/tests/providers/test_enforce_role_alternation.py
@@ -238,3 +238,108 @@ class TestEnforceRoleAlternation:
         result = LLMProvider._enforce_role_alternation(msgs)
         assert result[1]["role"] == "user"
         assert result[1]["content"] == "hello"
+
+    # ---- reasoning_content preservation (DeepSeek-R1 / V4 thinking) ----
+
+    def test_merge_preserves_reasoning_content_from_earlier(self):
+        """When two plain assistant messages merge, earlier reasoning_content is kept."""
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "A", "reasoning_content": "think-A"},
+            {"role": "assistant", "content": "B"},
+            {"role": "user", "content": "Next"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert len(result) == 3
+        assert result[1]["reasoning_content"] == "think-A"
+
+    def test_merge_preserves_reasoning_content_from_later(self):
+        """When two plain assistant messages merge, later reasoning_content is carried over."""
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "A"},
+            {"role": "assistant", "content": "B", "reasoning_content": "think-B"},
+            {"role": "user", "content": "Next"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert len(result) == 3
+        assert result[1]["reasoning_content"] == "think-B"
+
+    def test_merge_concatenates_both_reasoning_contents(self):
+        """When both messages have reasoning_content, they are joined."""
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "A", "reasoning_content": "think-A"},
+            {"role": "assistant", "content": "B", "reasoning_content": "think-B"},
+            {"role": "user", "content": "Next"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert len(result) == 3
+        assert "think-A" in result[1]["reasoning_content"]
+        assert "think-B" in result[1]["reasoning_content"]
+
+    def test_tool_call_replacement_carries_over_reasoning(self):
+        """Earlier reasoning_content survives when the later message has tool_calls."""
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "A", "reasoning_content": "think-A"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "1"}], "reasoning_content": "think-B"},
+            {"role": "tool", "content": "result1", "tool_call_id": "1"},
+            {"role": "user", "content": "Next"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        asst = [m for m in result if m["role"] == "assistant"][0]
+        assert asst["tool_calls"] == [{"id": "1"}]
+        # Both reasoning contents should be preserved.
+        assert "think-A" in asst["reasoning_content"]
+        assert "think-B" in asst["reasoning_content"]
+
+    def test_prev_tool_call_skips_curr_but_carries_reasoning(self):
+        """When prev has tool_calls, curr is skipped but its reasoning_content is preserved."""
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "1"}]},
+            {"role": "assistant", "content": "B", "reasoning_content": "think-B"},
+            {"role": "tool", "content": "result1", "tool_call_id": "1"},
+            {"role": "user", "content": "Next"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        asst = [m for m in result if m["role"] == "assistant"][0]
+        assert asst["tool_calls"] == [{"id": "1"}]
+        assert asst["reasoning_content"] == "think-B"
+
+    def test_non_string_merge_carries_over_reasoning(self):
+        """When content is non-string, replacement carries earlier reasoning."""
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": [{"type": "text", "text": "A"}], "reasoning_content": "think-A"},
+            {"role": "assistant", "content": "B"},
+            {"role": "user", "content": "Next"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        asst = [m for m in result if m["role"] == "assistant"][0]
+        assert asst["reasoning_content"] == "think-A"
+
+    def test_empty_string_reasoning_does_not_overwrite_nonempty(self):
+        """Empty-string reasoning_content should not overwrite existing non-empty."""
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "A", "reasoning_content": "think-A"},
+            {"role": "assistant", "content": "B", "reasoning_content": ""},
+            {"role": "user", "content": "Next"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        asst = [m for m in result if m["role"] == "assistant"][0]
+        assert asst["reasoning_content"] == "think-A"
+
+    def test_trailing_assistant_recovery_strips_reasoning_content(self):
+        """Recovered user message should not carry reasoning_content or tool_calls."""
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "result", "reasoning_content": "secret"},
+        ]
+        result = LLMProvider._enforce_role_alternation(msgs)
+        assert len(result) == 2
+        assert result[1]["role"] == "user"
+        assert "reasoning_content" not in result[1]
+        assert "tool_calls" not in result[1]


### PR DESCRIPTION
## Summary

- Fix DeepSeek thinking mode 400 error caused by `_enforce_role_alternation()` silently dropping `reasoning_content` when merging consecutive assistant messages
- Add `_carry_over_reasoning()` helper to preserve and concatenate `reasoning_content` across all 4 merge branches in `_enforce_role_alternation()`
- Strip assistant-only fields (`reasoning_content`, `thinking_blocks`, `tool_calls`) when recovering trailing assistant messages as user role

## Root Cause

DeepSeek thinking mode requires `reasoning_content` to be passed back in all subsequent API requests when tool calls were involved. The `_enforce_role_alternation()` method merged consecutive assistant messages by concatenating `content` but silently discarded `reasoning_content`, triggering:

```
Error: The reasoning_content in the thinking mode must be passed back to the API.
```

This could occur after history truncation (`_snip_history`) or checkpoint restoration created consecutive assistant messages.

## Changes

- `nanobot/providers/base.py` — New `_carry_over_reasoning(src, dst)` helper + integration into all merge branches + recovery path cleanup
- `tests/providers/test_enforce_role_alternation.py` — 8 new test cases covering reasoning_content preservation

## Test plan

- [x] All 8 new tests pass (reasoning carry-over in all merge scenarios)
- [x] All 167 existing provider/agent tests pass with no regression
- [ ] Manual test with DeepSeek-R1/V4 thinking mode + tool calls in multi-turn conversation