### PR TITLE
perf(document): lazy-import heavy document parsers

### DIFF
--- a/nanobot/utils/document.py
+++ b/nanobot/utils/document.py
@@ -7,26 +7,6 @@ from loguru import logger
 
 from nanobot.utils.helpers import detect_image_mime
 
-try:
-    from pypdf import PdfReader
-except ImportError:
-    PdfReader = None  # type: ignore
-
-try:
-    from docx import Document as DocxDocument
-except ImportError:
-    DocxDocument = None  # type: ignore
-
-try:
-    from openpyxl import load_workbook
-except ImportError:
-    load_workbook = None  # type: ignore
-
-try:
-    from pptx import Presentation as PptxPresentation
-except ImportError:
-    PptxPresentation = None  # type: ignore
-
 
 # Supported file extensions for text extraction
 SUPPORTED_EXTENSIONS: set[str] = {
@@ -78,22 +58,16 @@ def extract_text(path: Path) -> str | None:
 
     ext = path.suffix.lower()
 
-    # Document formats
+    # Document formats -- each branch lazily imports its parser so that
+    # startup does not pay the ~25 MB cost of loading openpyxl /
+    # python-docx / python-pptx / pypdf up front (see issue #3422).
     if ext == ".pdf":
-        if PdfReader is None:
-            return "[error: pypdf not installed]"
         return _extract_pdf(path)
     elif ext == ".docx":
-        if DocxDocument is None:
-            return "[error: python-docx not installed]"
         return _extract_docx(path)
     elif ext == ".xlsx":
-        if load_workbook is None:
-            return "[error: openpyxl not installed]"
         return _extract_xlsx(path)
     elif ext == ".pptx":
-        if PptxPresentation is None:
-            return "[error: python-pptx not installed]"
         return _extract_pptx(path)
     elif _is_text_extension(ext):
         return _extract_text_file(path)
@@ -107,6 +81,10 @@ def extract_text(path: Path) -> str | None:
 
 def _extract_pdf(path: Path) -> str:
     """Extract text from PDF using pypdf."""
+    try:
+        from pypdf import PdfReader
+    except ImportError:
+        return "[error: pypdf not installed]"
     try:
         reader = PdfReader(path)
         pages: list[str] = []
@@ -122,6 +100,10 @@ def _extract_pdf(path: Path) -> str:
 def _extract_docx(path: Path) -> str:
     """Extract text from DOCX using python-docx."""
     try:
+        from docx import Document as DocxDocument
+    except ImportError:
+        return "[error: python-docx not installed]"
+    try:
         doc = DocxDocument(path)
         paragraphs: list[str] = [p.text for p in doc.paragraphs if p.text.strip()]
         return _truncate("\n\n".join(paragraphs), _MAX_TEXT_LENGTH)
@@ -132,6 +114,10 @@ def _extract_docx(path: Path) -> str:
 
 def _extract_xlsx(path: Path) -> str:
     """Extract text from XLSX using openpyxl."""
+    try:
+        from openpyxl import load_workbook
+    except ImportError:
+        return "[error: openpyxl not installed]"
     try:
         wb = load_workbook(path, read_only=True, data_only=True)
         try:
@@ -155,6 +141,10 @@ def _extract_xlsx(path: Path) -> str:
 
 def _extract_pptx(path: Path) -> str:
     """Extract text from PPTX using python-pptx."""
+    try:
+        from pptx import Presentation as PptxPresentation
+    except ImportError:
+        return "[error: python-pptx not installed]"
     try:
         prs = PptxPresentation(path)
         slides: list[str] = []


### PR DESCRIPTION
## Summary

Moves `pypdf`, `python-docx`, `openpyxl`, and `python-pptx` imports from module level into the four `_extract_*` functions in `nanobot/utils/document.py`, so nanobot no longer pays the ~25 MB import cost on startup when no document parsing is actually needed for the session.

Fixes #3422.

## Why this matters

The issue traces it to `nanobot/utils/document.py` eagerly importing all four parsers inside `try/except ImportError` blocks at module load time. Since v0.1.5.post2 these are core dependencies, so the `ImportError` branch never fires in practice — each import adds its full cost to every startup, even sessions that never touch a PDF/DOCX/XLSX/PPTX file.

Moving the imports inside their extractor functions is a standard lazy-import pattern. First call to `_extract_pdf()` imports `pypdf` then; subsequent calls hit Python's module cache and are free. Sessions that don't open any of those file types never import the library at all.

## Changes

`nanobot/utils/document.py`:

- Deleted the four module-level `try/except ImportError` blocks (lines 11-26 in the old file).
- Inside each `_extract_pdf` / `_extract_docx` / `_extract_xlsx` / `_extract_pptx` function, moved the corresponding import into a `try/except ImportError` block at the top. On `ImportError` the function returns the same `"[error: <lib> not installed]"` string the module-level sentinel used to produce (so agents relying on that error payload are unaffected).
- Removed the now-redundant `if PdfReader is None:` / `if DocxDocument is None:` / `if load_workbook is None:` / `if PptxPresentation is None:` guards from the `extract_text()` dispatch — the extractor functions own the "not installed" branch now.
- Added a one-liner comment under `extract_text()` pointing at issue #3422 so the pattern is discoverable from the dispatch site.

No changes to:
- `SUPPORTED_EXTENSIONS` (still module-level — it's a plain set of strings with zero cost).
- `extract_text()` public API.
- `extract_documents()`.
- Error message shape.

## Testing

```
pytest tests/test_document_parsing.py -xvs
# 20 passed in 2.30s
```

All 20 existing tests in `test_document_parsing.py` pass without modification: dispatch behavior, XLSX / DOCX / PPTX / PDF extraction, empty-file / missing-file / unsupported-extension branches, case-sensitivity check, and grouped-shape / table-aware PPTX walking.

## AI disclosure

This contribution was developed with AI assistance (Claude Code).
