### PR TITLE
docs: add macOS LaunchAgent setup for gateway

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ Start here for setup, everyday usage, and deployment.
 | CLI reference | [`cli-reference.md`](./cli-reference.md) | Core CLI commands and common entrypoints |
 | In-chat commands | [`chat-commands.md`](./chat-commands.md) | Slash commands and periodic task behavior |
 | OpenAI-compatible API | [`openai-api.md`](./openai-api.md) | Local API endpoints, request format, and file uploads |
-| Deployment | [`deployment.md`](./deployment.md) | Docker and Linux service setup |
+| Deployment | [`deployment.md`](./deployment.md) | Docker, Linux service, and macOS LaunchAgent setup |
 
 ## Advanced Docs
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,11 +103,7 @@ On macOS, run the gateway as a `launchd` user agent so it starts automatically a
 which nanobot   # e.g. /Users/youruser/.local/bin/nanobot
 ```
 
-If you installed nanobot with `uv tool`, you may also want the Python path for `ProgramArguments`:
-
-```bash
-which python
-```
+Use this absolute `nanobot` path in `ProgramArguments` so the console script keeps the Python environment from your install method.
 
 **2. Create the LaunchAgent plist** at `~/Library/LaunchAgents/ai.nanobot.gateway.plist` (replace paths if needed):
 
@@ -121,7 +117,6 @@ which python
 
   <key>ProgramArguments</key>
   <array>
-    <string>/Users/youruser/.local/share/uv/tools/nanobot-ai/bin/python</string>
     <string>/Users/youruser/.local/bin/nanobot</string>
     <string>gateway</string>
     <string>--workspace</string>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -95,17 +95,17 @@ If you edit the `.service` file itself, run `systemctl --user daemon-reload` bef
 
 ## macOS LaunchAgent
 
-On macOS, run the gateway as a `launchd` user agent so it starts automatically after login and restarts if it exits unexpectedly.
+Use a LaunchAgent when you want `nanobot gateway` to stay online after you log in, without keeping a terminal open.
 
-**1. Find the nanobot binary path:**
+**1. Get the absolute `nanobot` path:**
 
 ```bash
 which nanobot   # e.g. /Users/youruser/.local/bin/nanobot
 ```
 
-Use this absolute `nanobot` path in `ProgramArguments` so the console script keeps the Python environment from your install method.
+Use that exact path in the plist. It keeps the Python environment from your install method.
 
-**2. Create the LaunchAgent plist** at `~/Library/LaunchAgents/ai.nanobot.gateway.plist` (replace paths if needed):
+**2. Create `~/Library/LaunchAgents/ai.nanobot.gateway.plist`:**
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -140,14 +140,6 @@ Use this absolute `nanobot` path in `ProgramArguments` so the console script kee
 
   <key>StandardErrorPath</key>
   <string>/Users/youruser/.nanobot/logs/gateway.error.log</string>
-
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>PATH</key>
-    <string>/Users/youruser/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    <key>PYTHONUNBUFFERED</key>
-    <string>1</string>
-  </dict>
 </dict>
 </plist>
 ```
@@ -155,7 +147,7 @@ Use this absolute `nanobot` path in `ProgramArguments` so the console script kee
 **3. Load and start it:**
 
 ```bash
-mkdir -p ~/.nanobot/logs
+mkdir -p ~/Library/LaunchAgents ~/.nanobot/logs
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.nanobot.gateway.plist
 launchctl enable gui/$(id -u)/ai.nanobot.gateway
 launchctl kickstart -k gui/$(id -u)/ai.nanobot.gateway
@@ -165,11 +157,10 @@ launchctl kickstart -k gui/$(id -u)/ai.nanobot.gateway
 
 ```bash
 launchctl list | grep ai.nanobot.gateway
-launchctl kickstart -k gui/$(id -u)/ai.nanobot.gateway
+launchctl kickstart -k gui/$(id -u)/ai.nanobot.gateway   # restart
 launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.nanobot.gateway.plist
-log stream --process nanobot
 ```
 
-If you edit the plist itself, run `launchctl bootout ...` and `launchctl bootstrap ...` again so `launchd` reloads the updated definition.
+After editing the plist, run `launchctl bootout ...` and `launchctl bootstrap ...` again.
 
-> **Note:** if `launchctl kickstart` fails with an "address already in use" error, you probably still have a manually started `nanobot gateway` process running on the same port. Stop the manual process first, then kickstart the LaunchAgent again.
+> **Note:** if startup fails with "address already in use", stop the manually started `nanobot gateway` process first.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -92,3 +92,89 @@ If you edit the `.service` file itself, run `systemctl --user daemon-reload` bef
 > ```bash
 > loginctl enable-linger $USER
 > ```
+
+## macOS LaunchAgent
+
+On macOS, run the gateway as a `launchd` user agent so it starts automatically after login and restarts if it exits unexpectedly.
+
+**1. Find the nanobot binary path:**
+
+```bash
+which nanobot   # e.g. /Users/youruser/.local/bin/nanobot
+```
+
+If you installed nanobot with `uv tool`, you may also want the Python path for `ProgramArguments`:
+
+```bash
+which python
+```
+
+**2. Create the LaunchAgent plist** at `~/Library/LaunchAgents/ai.nanobot.gateway.plist` (replace paths if needed):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.nanobot.gateway</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/youruser/.local/share/uv/tools/nanobot-ai/bin/python</string>
+    <string>/Users/youruser/.local/bin/nanobot</string>
+    <string>gateway</string>
+    <string>--workspace</string>
+    <string>/Users/youruser/.nanobot/workspace</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/youruser/.nanobot/workspace</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/Users/youruser/.nanobot/logs/gateway.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/youruser/.nanobot/logs/gateway.error.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/Users/youruser/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+</dict>
+</plist>
+```
+
+**3. Load and start it:**
+
+```bash
+mkdir -p ~/.nanobot/logs
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.nanobot.gateway.plist
+launchctl enable gui/$(id -u)/ai.nanobot.gateway
+launchctl kickstart -k gui/$(id -u)/ai.nanobot.gateway
+```
+
+**Common operations:**
+
+```bash
+launchctl list | grep ai.nanobot.gateway
+launchctl kickstart -k gui/$(id -u)/ai.nanobot.gateway
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.nanobot.gateway.plist
+log stream --process nanobot
+```
+
+If you edit the plist itself, run `launchctl bootout ...` and `launchctl bootstrap ...` again so `launchd` reloads the updated definition.
+
+> **Note:** if `launchctl kickstart` fails with an "address already in use" error, you probably still have a manually started `nanobot gateway` process running on the same port. Stop the manual process first, then kickstart the LaunchAgent again.


### PR DESCRIPTION
## Summary
- add a macOS LaunchAgent section to deployment docs
- document a launchd plist for running nanobot gateway at login
- include common launchctl operations and a note about port conflicts with manually started instances

## Why
Users running nanobot on macOS need a documented way to keep the gateway online after reboot/login, similar to the existing Linux systemd example.

## Testing
- verified the documented LaunchAgent pattern locally on macOS
- confirmed launchd starts nanobot gateway and reconnects Telegram after reboot/login
