### PR TITLE
fix(provider): prevent reasoning field leaking into content

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -709,12 +709,11 @@ class OpenAICompatProvider(LLMProvider):
             finish_reason = str(choice0.get("finish_reason") or "stop")
 
             raw_tool_calls: list[Any] = []
-            # StepFun Plan: fallback to reasoning field when content is empty
-            if not content and msg0.get("reasoning"):
-                content = self._extract_text_content(msg0.get("reasoning"))
             reasoning_content = msg0.get("reasoning_content")
             if not reasoning_content and msg0.get("reasoning"):
                 reasoning_content = self._extract_text_content(msg0.get("reasoning"))
+                if not content:
+                    content = reasoning_content
             for ch in choices:
                 ch_map = self._maybe_mapping(ch) or {}
                 m = self._maybe_mapping(ch_map.get("message")) or {}
@@ -770,8 +769,6 @@ class OpenAICompatProvider(LLMProvider):
                     finish_reason = ch.finish_reason
             if not content and m.content:
                 content = m.content
-            if not content and getattr(m, "reasoning", None):
-                content = m.reasoning
 
         tool_calls = []
         for tc in raw_tool_calls:
@@ -791,6 +788,8 @@ class OpenAICompatProvider(LLMProvider):
         reasoning_content = getattr(msg, "reasoning_content", None) or None
         if not reasoning_content and getattr(msg, "reasoning", None):
             reasoning_content = msg.reasoning
+            if not content:
+                content = msg.reasoning
 
         return LLMResponse(
             content=content,

--- a/tests/providers/test_reasoning_content.py
+++ b/tests/providers/test_reasoning_content.py
@@ -52,7 +52,33 @@ def test_parse_dict_reasoning_content_none_when_absent() -> None:
     assert result.reasoning_content is None
 
 
-# ── _parse_chunks: streaming dict branch ─────────────────────────────────
+def test_parse_dict_content_not_fallback_to_reasoning_when_reasoning_content_exists() -> None:
+    """When reasoning_content exists, reasoning should NOT fall back to content.
+
+    Regression test for issue #3443: providers like MiMo that return
+    reasoning_content should NOT have reasoning leaked into content.
+    """
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response = {
+        "choices": [{
+            "message": {
+                "content": None,
+                "reasoning": "Let me think step by step... The answer is 42.",
+                "reasoning_content": "Let me think step by step... The answer is 42.",
+            },
+            "finish_reason": "stop",
+        }],
+    }
+
+    result = provider._parse(response)
+
+    assert result.content is None
+    assert result.reasoning_content == "Let me think step by step... The answer is 42."
+
+
+# ── _parse_chunks: streaming ──────────────────────────────────────────────
 
 
 def test_parse_chunks_dict_accumulates_reasoning_content() -> None:

--- a/tests/providers/test_stepfun_reasoning.py
+++ b/tests/providers/test_stepfun_reasoning.py
@@ -15,7 +15,10 @@ from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 
 
 def test_parse_dict_stepfun_reasoning_fallback() -> None:
-    """When content is None and reasoning exists, content falls back to reasoning."""
+    """When content is None and reasoning exists WITHOUT reasoning_content (StepFun case), content falls back to reasoning.
+
+    StepFun Plan API returns the actual response in 'reasoning' field without 'reasoning_content'.
+    """
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
         provider = OpenAICompatProvider()
 
@@ -32,12 +35,15 @@ def test_parse_dict_stepfun_reasoning_fallback() -> None:
     result = provider._parse(response)
 
     assert result.content == "Let me think... The answer is 42."
-    # reasoning_content should also be populated from reasoning
     assert result.reasoning_content == "Let me think... The answer is 42."
 
 
 def test_parse_dict_stepfun_reasoning_priority() -> None:
-    """reasoning_content field takes priority over reasoning when both present."""
+    """When reasoning_content exists, it takes priority - reasoning is NOT content (issue #3443 fix).
+
+    Providers like MiMo return both reasoning_content (chain-of-thought) and reasoning.
+    The reasoning field should NOT be used as content.
+    """
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
         provider = OpenAICompatProvider()
 
@@ -54,8 +60,7 @@ def test_parse_dict_stepfun_reasoning_priority() -> None:
 
     result = provider._parse(response)
 
-    assert result.content == "informal thinking"
-    # reasoning_content uses the dedicated field, not reasoning
+    assert result.content is None
     assert result.reasoning_content == "formal reasoning content"
 
 
@@ -73,7 +78,7 @@ def _make_sdk_message(content, reasoning=None, reasoning_content=None):
 
 
 def test_parse_sdk_stepfun_reasoning_fallback() -> None:
-    """SDK branch: content falls back to msg.reasoning when content is None."""
+    """SDK branch: content falls back to msg.reasoning when content is None and reasoning_content is absent."""
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
         provider = OpenAICompatProvider()
 
@@ -88,7 +93,7 @@ def test_parse_sdk_stepfun_reasoning_fallback() -> None:
 
 
 def test_parse_sdk_stepfun_reasoning_priority() -> None:
-    """reasoning_content field takes priority over reasoning in SDK branch."""
+    """SDK branch: when reasoning_content exists, reasoning is NOT content (issue #3443 fix)."""
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
         provider = OpenAICompatProvider()
 
@@ -102,7 +107,7 @@ def test_parse_sdk_stepfun_reasoning_priority() -> None:
 
     result = provider._parse(response)
 
-    assert result.content == "thinking process"
+    assert result.content is None
     assert result.reasoning_content == "formal reasoning"
 
 


### PR DESCRIPTION
Fixes #3443: When reasoning_content exists, the reasoning field should only populate reasoning_content, not content. This prevents chain-of-thought from being shown to users on non-streaming paths.

The fix adds a condition: content fallback to reasoning only happens when reasoning_content is absent (StepFun Plan scenario), not when it exists (MiMo/DeepSeek-R1 scenario).

Added regression test for the bug fix.