### PR TITLE
fix(provider): gate reasoning-to-content fallback behind spec flag

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -709,8 +709,8 @@ class OpenAICompatProvider(LLMProvider):
             finish_reason = str(choice0.get("finish_reason") or "stop")
 
             raw_tool_calls: list[Any] = []
-            # StepFun Plan: fallback to reasoning field when content is empty
-            if not content and msg0.get("reasoning"):
+            # StepFun: fallback to reasoning field when content is empty
+            if not content and msg0.get("reasoning") and self._spec and self._spec.reasoning_as_content:
                 content = self._extract_text_content(msg0.get("reasoning"))
             reasoning_content = msg0.get("reasoning_content")
             if not reasoning_content and msg0.get("reasoning"):
@@ -770,7 +770,7 @@ class OpenAICompatProvider(LLMProvider):
                     finish_reason = ch.finish_reason
             if not content and m.content:
                 content = m.content
-            if not content and getattr(m, "reasoning", None):
+            if not content and getattr(m, "reasoning", None) and self._spec and self._spec.reasoning_as_content:
                 content = m.reasoning
 
         tool_calls = []

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -71,6 +71,11 @@ class ProviderSpec:
     # "reasoning_split" — {"reasoning_split": true/false}  (MiniMax)
     thinking_style: str = ""
 
+    # When True, treat the "reasoning" response field as formal content
+    # when "content" is empty.  Only set this for providers (e.g. StepFun)
+    # whose API returns the actual answer in "reasoning" instead of "content".
+    reasoning_as_content: bool = False
+
     @property
     def label(self) -> str:
         return self.display_name or self.name.title()
@@ -325,6 +330,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="Step Fun",
         backend="openai_compat",
         default_api_base="https://api.stepfun.com/v1",
+        reasoning_as_content=True,
     ),
     # Xiaomi MIMO (小米): OpenAI-compatible API
     ProviderSpec(

--- a/tests/providers/test_stepfun_reasoning.py
+++ b/tests/providers/test_stepfun_reasoning.py
@@ -9,6 +9,17 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.providers.registry import ProviderSpec
+
+_STEPFUN_SPEC = ProviderSpec(
+    name="stepfun",
+    keywords=("stepfun", "step"),
+    env_key="STEPFUN_API_KEY",
+    display_name="Step Fun",
+    backend="openai_compat",
+    default_api_base="https://api.stepfun.com/v1",
+    reasoning_as_content=True,
+)
 
 
 # ── _parse: dict branch ─────────────────────────────────────────────────────
@@ -17,7 +28,7 @@ from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 def test_parse_dict_stepfun_reasoning_fallback() -> None:
     """When content is None and reasoning exists, content falls back to reasoning."""
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
-        provider = OpenAICompatProvider()
+        provider = OpenAICompatProvider(spec=_STEPFUN_SPEC)
 
     response = {
         "choices": [{
@@ -39,7 +50,7 @@ def test_parse_dict_stepfun_reasoning_fallback() -> None:
 def test_parse_dict_stepfun_reasoning_priority() -> None:
     """reasoning_content field takes priority over reasoning when both present."""
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
-        provider = OpenAICompatProvider()
+        provider = OpenAICompatProvider(spec=_STEPFUN_SPEC)
 
     response = {
         "choices": [{
@@ -75,7 +86,7 @@ def _make_sdk_message(content, reasoning=None, reasoning_content=None):
 def test_parse_sdk_stepfun_reasoning_fallback() -> None:
     """SDK branch: content falls back to msg.reasoning when content is None."""
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
-        provider = OpenAICompatProvider()
+        provider = OpenAICompatProvider(spec=_STEPFUN_SPEC)
 
     msg = _make_sdk_message(content=None, reasoning="After analysis: result is 4.")
     choice = SimpleNamespace(finish_reason="stop", message=msg)
@@ -90,7 +101,7 @@ def test_parse_sdk_stepfun_reasoning_fallback() -> None:
 def test_parse_sdk_stepfun_reasoning_priority() -> None:
     """reasoning_content field takes priority over reasoning in SDK branch."""
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
-        provider = OpenAICompatProvider()
+        provider = OpenAICompatProvider(spec=_STEPFUN_SPEC)
 
     msg = _make_sdk_message(
         content=None,
@@ -244,3 +255,44 @@ def test_parse_chunks_sdk_reasoning_precedence() -> None:
     result = OpenAICompatProvider._parse_chunks(chunks)
 
     assert result.reasoning_content == "formal: "
+
+
+# ── Regression: non-StepFun providers must NOT promote reasoning to content ─
+
+
+def test_parse_dict_non_stepfun_no_reasoning_as_content() -> None:
+    """Providers without reasoning_as_content flag must not treat reasoning as content."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    response = {
+        "choices": [{
+            "message": {
+                "content": None,
+                "reasoning": "internal thought process that should NOT be shown to user",
+            },
+            "finish_reason": "stop",
+        }],
+    }
+
+    result = provider._parse(response)
+
+    # content stays None — reasoning is NOT promoted
+    assert result.content is None
+    # reasoning still goes to reasoning_content for display as thinking
+    assert result.reasoning_content == "internal thought process that should NOT be shown to user"
+
+
+def test_parse_sdk_non_stepfun_no_reasoning_as_content() -> None:
+    """SDK branch: providers without flag must not treat reasoning as content."""
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider()
+
+    msg = _make_sdk_message(content=None, reasoning="internal monologue")
+    choice = SimpleNamespace(finish_reason="stop", message=msg)
+    response = SimpleNamespace(choices=[choice], usage=None)
+
+    result = provider._parse(response)
+
+    assert result.content is None
+    assert result.reasoning_content == "internal monologue"


### PR DESCRIPTION
## Summary

- Non-streaming parse path (`_parse`) unconditionally promoted `reasoning` field to `content` when content was empty — intended for StepFun but applied to all providers
- Adds `reasoning_as_content: bool` to `ProviderSpec` (default `False`), set to `True` only for StepFun
- The fallback now requires this spec flag, preventing internal thinking chains from models like Xiaomi MIMO from being leaked as formal replies

## Comparison with #3445

This PR takes a different (and more robust) approach than #3445:
- **Ours**: Explicit provider-level flag — no guessing based on field presence
- **#3445**: Heuristic based on whether `reasoning_content` exists — still a global assumption that can break for future providers

Fixes #3443

## Test plan

- [x] All 12 existing StepFun reasoning tests pass (updated to pass StepFun spec)
- [x] 2 new regression tests verify non-StepFun providers do NOT promote reasoning to content
- [x] Full test suite passes (1714 passed)