### PR TITLE
feat(command): add /ping command for liveness health check

### DIFF
--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -306,6 +306,22 @@ async def cmd_dream_restore(ctx: CommandContext) -> OutboundMessage:
     )
 
 
+async def cmd_ping(ctx: CommandContext) -> OutboundMessage:
+    """Reply with Pong and bot uptime — a quick liveness health check."""
+    import time
+
+    elapsed = int(time.time() - ctx.loop._start_time)
+    hours, rem = divmod(elapsed, 3600)
+    minutes, seconds = divmod(rem, 60)
+    uptime = f"{hours}h {minutes}m {seconds}s" if hours else f"{minutes}m {seconds}s"
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=f"🏓 Pong! Uptime: {uptime}",
+        metadata=dict(ctx.msg.metadata or {}),
+    )
+
+
 async def cmd_help(ctx: CommandContext) -> OutboundMessage:
     """Return available slash commands."""
     return OutboundMessage(
@@ -324,6 +340,7 @@ def build_help_text() -> str:
         "/stop — Stop the current task",
         "/restart — Restart the bot",
         "/status — Show bot status",
+        "/ping — Check if the bot is alive",
         "/dream — Manually trigger Dream consolidation",
         "/dream-log — Show what the last Dream changed",
         "/dream-restore — Revert memory to a previous state",
@@ -339,6 +356,7 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.priority("/status", cmd_status)
     router.exact("/new", cmd_new)
     router.exact("/status", cmd_status)
+    router.exact("/ping", cmd_ping)
     router.exact("/dream", cmd_dream)
     router.exact("/dream-log", cmd_dream_log)
     router.prefix("/dream-log ", cmd_dream_log)

--- a/tests/cli/test_restart_command.py
+++ b/tests/cli/test_restart_command.py
@@ -157,6 +157,18 @@ class TestRestartCommand:
         assert response.metadata == {"render_as": "text"}
 
     @pytest.mark.asyncio
+    async def test_ping_returns_pong_with_uptime(self):
+        loop, _bus = _make_loop()
+        loop._start_time = time.time() - 90  # 1m 30s uptime
+
+        msg = InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="/ping")
+        response = await loop._process_message(msg)
+
+        assert response is not None
+        assert "Pong" in response.content
+        assert "1m 30s" in response.content
+
+    @pytest.mark.asyncio
     async def test_status_reports_runtime_info(self):
         loop, _bus = _make_loop()
         session = MagicMock()


### PR DESCRIPTION
## Summary

Adds a  slash command as a quick liveness health check.

Sending  replies with:


## Motivation

Currently the only way to check if the bot is alive is , which returns a full multi-line report.  gives a single-line instant confirmation — useful when you just want to know the bot is running, especially after a network hiccup or restart.

All other major bot frameworks (Discord.py bots, Telegram bots, Slack bots) conventionally include a  command for exactly this reason.

## Changes

- : add  handler (~13 lines) + register in  + add to 
- : add 

## Test plan
- [x] Unit test:  returns content containing "Pong" and correct uptime string
- [ ] Manual: send  to a running bot — should reply with 