### PR TITLE
feat(skills): add create-instance built-in skill + webui remote backend

### DIFF
--- a/.github/workflows/deploy-webui.yml
+++ b/.github/workflows/deploy-webui.yml
@@ -1,0 +1,55 @@
+name: Deploy WebUI to GitHub Pages
+
+on:
+  push:
+    branches: [webui]
+    paths:
+      - "webui/**"
+      - ".github/workflows/deploy-webui.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: webui
+        run: bun install --frozen-lockfile
+
+      - name: Build for GitHub Pages
+        working-directory: webui
+        env:
+          VITE_BASE: /nanobot/
+          VITE_BUILD_OUTDIR: dist
+        run: bun run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: webui/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -18,6 +18,7 @@ from nanobot.agent.context import ContextBuilder
 from nanobot.agent.hook import AgentHook, AgentHookContext, CompositeHook
 from nanobot.agent.memory import Consolidator, Dream
 from nanobot.agent.runner import _MAX_INJECTIONS_PER_TURN, AgentRunner, AgentRunSpec
+from nanobot.agent.runtime import AgentRuntime
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.ask import (
@@ -194,6 +195,8 @@ class AgentLoop:
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
         tools_config: ToolsConfig | None = None,
+        runtime_loader: Callable[[], AgentRuntime] | None = None,
+        runtime_signature: tuple[object, ...] | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, ToolsConfig, WebToolsConfig
 
@@ -202,6 +205,8 @@ class AgentLoop:
         self.bus = bus
         self.channels_config = channels_config
         self.provider = provider
+        self._runtime_loader = runtime_loader
+        self._runtime_signature = runtime_signature
         self.workspace = workspace
         self.model = model or provider.get_default_model()
         self.max_iterations = (
@@ -287,6 +292,43 @@ class AgentLoop:
         self._current_iteration: int = 0
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
+
+    def _apply_runtime(self, runtime: AgentRuntime) -> None:
+        """Swap model/provider for future turns without disturbing an active one."""
+        provider = runtime.provider
+        model = runtime.model
+        context_window_tokens = runtime.context_window_tokens
+        if self.provider is provider and self.model == model:
+            return
+        old_model = self.model
+        self.provider = provider
+        self.model = model
+        self.context_window_tokens = context_window_tokens
+        self.runner.provider = provider
+        self.subagents.provider = provider
+        self.subagents.model = model
+        self.subagents.runner.provider = provider
+        self.consolidator.provider = provider
+        self.consolidator.model = model
+        self.consolidator.context_window_tokens = context_window_tokens
+        self.consolidator.max_completion_tokens = provider.generation.max_tokens
+        self.dream.provider = provider
+        self.dream.model = model
+        self.dream._runner.provider = provider
+        self._runtime_signature = runtime.signature
+        logger.info("Runtime model switched for next turn: {} -> {}", old_model, model)
+
+    def _refresh_runtime(self) -> None:
+        if self._runtime_loader is None:
+            return
+        try:
+            runtime = self._runtime_loader()
+        except Exception:
+            logger.exception("Failed to refresh runtime config")
+            return
+        if runtime.signature == self._runtime_signature:
+            return
+        self._apply_runtime(runtime)
 
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
@@ -766,6 +808,7 @@ class AgentLoop:
         pending_queue: asyncio.Queue | None = None,
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
+        self._refresh_runtime()
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
             channel, chat_id = (

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -18,7 +18,6 @@ from nanobot.agent.context import ContextBuilder
 from nanobot.agent.hook import AgentHook, AgentHookContext, CompositeHook
 from nanobot.agent.memory import Consolidator, Dream
 from nanobot.agent.runner import _MAX_INJECTIONS_PER_TURN, AgentRunner, AgentRunSpec
-from nanobot.agent.runtime import AgentRuntime
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.subagent import SubagentManager
 from nanobot.agent.tools.ask import (
@@ -43,6 +42,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.command import CommandContext, CommandRouter, register_builtin_commands
 from nanobot.config.schema import AgentDefaults
 from nanobot.providers.base import LLMProvider
+from nanobot.providers.factory import ProviderSnapshot
 from nanobot.session.manager import Session, SessionManager
 from nanobot.utils.document import extract_documents
 from nanobot.utils.helpers import image_placeholder_text
@@ -196,8 +196,8 @@ class AgentLoop:
         unified_session: bool = False,
         disabled_skills: list[str] | None = None,
         tools_config: ToolsConfig | None = None,
-        runtime_loader: Callable[[], AgentRuntime] | None = None,
-        runtime_signature: tuple[object, ...] | None = None,
+        provider_snapshot_loader: Callable[[], ProviderSnapshot] | None = None,
+        provider_signature: tuple[object, ...] | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, ToolsConfig, WebToolsConfig
 
@@ -206,8 +206,8 @@ class AgentLoop:
         self.bus = bus
         self.channels_config = channels_config
         self.provider = provider
-        self._runtime_loader = runtime_loader
-        self._runtime_signature = runtime_signature
+        self._provider_snapshot_loader = provider_snapshot_loader
+        self._provider_signature = provider_signature
         self.workspace = workspace
         self.model = model or provider.get_default_model()
         self.max_iterations = (
@@ -295,11 +295,11 @@ class AgentLoop:
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
 
-    def _apply_runtime(self, runtime: AgentRuntime) -> None:
+    def _apply_provider_snapshot(self, snapshot: ProviderSnapshot) -> None:
         """Swap model/provider for future turns without disturbing an active one."""
-        provider = runtime.provider
-        model = runtime.model
-        context_window_tokens = runtime.context_window_tokens
+        provider = snapshot.provider
+        model = snapshot.model
+        context_window_tokens = snapshot.context_window_tokens
         if self.provider is provider and self.model == model:
             return
         old_model = self.model
@@ -317,20 +317,20 @@ class AgentLoop:
         self.dream.provider = provider
         self.dream.model = model
         self.dream._runner.provider = provider
-        self._runtime_signature = runtime.signature
+        self._provider_signature = snapshot.signature
         logger.info("Runtime model switched for next turn: {} -> {}", old_model, model)
 
-    def _refresh_runtime(self) -> None:
-        if self._runtime_loader is None:
+    def _refresh_provider_snapshot(self) -> None:
+        if self._provider_snapshot_loader is None:
             return
         try:
-            runtime = self._runtime_loader()
+            snapshot = self._provider_snapshot_loader()
         except Exception:
-            logger.exception("Failed to refresh runtime config")
+            logger.exception("Failed to refresh provider config")
             return
-        if runtime.signature == self._runtime_signature:
+        if snapshot.signature == self._provider_signature:
             return
-        self._apply_runtime(runtime)
+        self._apply_provider_snapshot(snapshot)
 
     def _register_default_tools(self) -> None:
         """Register the default set of tools."""
@@ -810,7 +810,7 @@ class AgentLoop:
         pending_queue: asyncio.Queue | None = None,
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
-        self._refresh_runtime()
+        self._refresh_provider_snapshot()
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
             channel, chat_id = (

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -307,16 +307,9 @@ class AgentLoop:
         self.model = model
         self.context_window_tokens = context_window_tokens
         self.runner.provider = provider
-        self.subagents.provider = provider
-        self.subagents.model = model
-        self.subagents.runner.provider = provider
-        self.consolidator.provider = provider
-        self.consolidator.model = model
-        self.consolidator.context_window_tokens = context_window_tokens
-        self.consolidator.max_completion_tokens = provider.generation.max_tokens
-        self.dream.provider = provider
-        self.dream.model = model
-        self.dream._runner.provider = provider
+        self.subagents.set_provider(provider, model)
+        self.consolidator.set_provider(provider, model, context_window_tokens)
+        self.dream.set_provider(provider, model)
         self._provider_signature = snapshot.signature
         logger.info("Runtime model switched for next turn: {} -> {}", old_model, model)
 

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -450,6 +450,17 @@ class Consolidator:
             weakref.WeakValueDictionary()
         )
 
+    def set_provider(
+        self,
+        provider: LLMProvider,
+        model: str,
+        context_window_tokens: int,
+    ) -> None:
+        self.provider = provider
+        self.model = model
+        self.context_window_tokens = context_window_tokens
+        self.max_completion_tokens = provider.generation.max_tokens
+
     def get_lock(self, session_key: str) -> asyncio.Lock:
         """Return the shared consolidation lock for one session."""
         return self._locks.setdefault(session_key, asyncio.Lock())
@@ -709,6 +720,11 @@ class Dream:
         self.annotate_line_ages = annotate_line_ages
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
+
+    def set_provider(self, provider: LLMProvider, model: str) -> None:
+        self.provider = provider
+        self.model = model
+        self._runner.provider = provider
 
     # -- tool registry -------------------------------------------------------
 

--- a/nanobot/agent/runtime.py
+++ b/nanobot/agent/runtime.py
@@ -1,0 +1,112 @@
+"""Runtime model/provider resolution for agent turns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from nanobot.config.schema import Config
+from nanobot.providers.base import GenerationSettings, LLMProvider
+from nanobot.providers.registry import find_by_name
+
+
+@dataclass(frozen=True)
+class AgentRuntime:
+    provider: LLMProvider
+    model: str
+    context_window_tokens: int
+    signature: tuple[object, ...]
+
+
+def make_provider(config: Config) -> LLMProvider:
+    """Create the LLM provider implied by config."""
+    model = config.agents.defaults.model
+    provider_name = config.get_provider_name(model)
+    p = config.get_provider(model)
+    spec = find_by_name(provider_name) if provider_name else None
+    backend = spec.backend if spec else "openai_compat"
+
+    if backend == "azure_openai":
+        if not p or not p.api_key or not p.api_base:
+            raise ValueError("Azure OpenAI requires api_key and api_base in config.")
+    elif backend == "openai_compat" and not model.startswith("bedrock/"):
+        needs_key = not (p and p.api_key)
+        exempt = spec and (spec.is_oauth or spec.is_local or spec.is_direct)
+        if needs_key and not exempt:
+            raise ValueError(f"No API key configured for provider '{provider_name}'.")
+
+    if backend == "openai_codex":
+        from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+
+        provider = OpenAICodexProvider(default_model=model)
+    elif backend == "azure_openai":
+        from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
+
+        provider = AzureOpenAIProvider(
+            api_key=p.api_key,
+            api_base=p.api_base,
+            default_model=model,
+        )
+    elif backend == "github_copilot":
+        from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
+
+        provider = GitHubCopilotProvider(default_model=model)
+    elif backend == "anthropic":
+        from nanobot.providers.anthropic_provider import AnthropicProvider
+
+        provider = AnthropicProvider(
+            api_key=p.api_key if p else None,
+            api_base=config.get_api_base(model),
+            default_model=model,
+            extra_headers=p.extra_headers if p else None,
+        )
+    else:
+        from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+        provider = OpenAICompatProvider(
+            api_key=p.api_key if p else None,
+            api_base=config.get_api_base(model),
+            default_model=model,
+            extra_headers=p.extra_headers if p else None,
+            spec=spec,
+        )
+
+    defaults = config.agents.defaults
+    provider.generation = GenerationSettings(
+        temperature=defaults.temperature,
+        max_tokens=defaults.max_tokens,
+        reasoning_effort=defaults.reasoning_effort,
+    )
+    return provider
+
+
+def runtime_signature(config: Config) -> tuple[object, ...]:
+    """Return the config fields that affect the primary LLM runtime."""
+    model = config.agents.defaults.model
+    defaults = config.agents.defaults
+    return (
+        model,
+        defaults.provider,
+        config.get_provider_name(model),
+        config.get_api_key(model),
+        config.get_api_base(model),
+        defaults.max_tokens,
+        defaults.temperature,
+        defaults.reasoning_effort,
+        defaults.context_window_tokens,
+    )
+
+
+def build_agent_runtime(config: Config) -> AgentRuntime:
+    return AgentRuntime(
+        provider=make_provider(config),
+        model=config.agents.defaults.model,
+        context_window_tokens=config.agents.defaults.context_window_tokens,
+        signature=runtime_signature(config),
+    )
+
+
+def load_agent_runtime(config_path: Path | None = None) -> AgentRuntime:
+    from nanobot.config.loader import load_config, resolve_config_env_vars
+
+    return build_agent_runtime(resolve_config_env_vars(load_config(config_path)))

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -96,6 +96,11 @@ class SubagentManager:
         self._task_statuses: dict[str, SubagentStatus] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
 
+    def set_provider(self, provider: LLMProvider, model: str) -> None:
+        self.provider = provider
+        self.model = model
+        self.runner.provider = provider
+
     async def spawn(
         self,
         task: str,

--- a/nanobot/agent/tools/ask.py
+++ b/nanobot/agent/tools/ask.py
@@ -6,7 +6,7 @@ from typing import Any
 from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.schema import ArraySchema, StringSchema, tool_parameters_schema
 
-BUTTON_CHANNELS = frozenset({"telegram"})
+STRUCTURED_BUTTON_CHANNELS = frozenset({"telegram", "websocket"})
 
 
 class AskUserInterrupt(BaseException):
@@ -130,7 +130,7 @@ def ask_user_outbound(
 ) -> tuple[str | None, list[list[str]]]:
     if not options:
         return content, []
-    if channel in BUTTON_CHANNELS:
+    if channel in STRUCTURED_BUTTON_CHANNELS:
         return content, [options]
     option_text = "\n".join(f"{index}. {option}" for index, option in enumerate(options, 1))
     return f"{content}\n\n{option_text}" if content else option_text, []

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -539,6 +539,12 @@ class WebSocketChannel(BaseChannel):
         if got == "/api/sessions":
             return self._handle_sessions_list(request)
 
+        if got == "/api/settings":
+            return self._handle_settings(request)
+
+        if got == "/api/settings/update":
+            return self._handle_settings_update(request)
+
         m = re.match(r"^/api/sessions/([^/]+)/messages$", got)
         if m:
             return self._handle_session_messages(request, m.group(1))
@@ -646,6 +652,75 @@ class WebSocketChannel(BaseChannel):
             if isinstance(s.get("key"), str) and s["key"].startswith("websocket:")
         ]
         return _http_json_response({"sessions": cleaned})
+
+    def _settings_payload(self, *, requires_restart: bool = False) -> dict[str, Any]:
+        from nanobot.config.loader import get_config_path, load_config
+        from nanobot.providers.registry import PROVIDERS, find_by_name
+
+        config = load_config()
+        defaults = config.agents.defaults
+        provider_name = config.get_provider_name(defaults.model) or defaults.provider
+        provider = config.get_provider(defaults.model)
+        selected_provider = provider_name
+        if defaults.provider != "auto":
+            spec = find_by_name(defaults.provider)
+            selected_provider = spec.name if spec else provider_name
+        return {
+            "agent": {
+                "model": defaults.model,
+                "provider": selected_provider,
+                "resolved_provider": provider_name,
+                "has_api_key": bool(provider and provider.api_key),
+            },
+            "providers": [
+                {"name": "auto", "label": "Auto"}
+            ] + [
+                {"name": spec.name, "label": spec.label}
+                for spec in PROVIDERS
+            ],
+            "runtime": {
+                "config_path": str(get_config_path().expanduser()),
+            },
+            "requires_restart": requires_restart,
+        }
+
+    def _handle_settings(self, request: WsRequest) -> Response:
+        if not self._check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        return _http_json_response(self._settings_payload())
+
+    def _handle_settings_update(self, request: WsRequest) -> Response:
+        if not self._check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        from nanobot.config.loader import load_config, save_config
+        from nanobot.providers.registry import find_by_name
+
+        query = _parse_query(request.path)
+        config = load_config()
+        defaults = config.agents.defaults
+        changed = False
+
+        model = _query_first(query, "model")
+        if model is not None:
+            model = model.strip()
+            if not model:
+                return _http_error(400, "model is required")
+            if defaults.model != model:
+                defaults.model = model
+                changed = True
+
+        provider = _query_first(query, "provider")
+        if provider is not None:
+            provider = provider.strip() or "auto"
+            if provider != "auto" and find_by_name(provider) is None:
+                return _http_error(400, "unknown provider")
+            if defaults.provider != provider:
+                defaults.provider = provider
+                changed = True
+
+        if changed:
+            save_config(config)
+        return _http_json_response(self._settings_payload(requires_restart=changed))
 
     @staticmethod
     def _is_webui_session_key(key: str) -> bool:

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -54,6 +54,14 @@ def _normalize_config_path(path: str) -> str:
     return _strip_trailing_slash(path)
 
 
+def _append_buttons_as_text(text: str, buttons: list[list[str]]) -> str:
+    labels = [label for row in buttons for label in row if label]
+    if not labels:
+        return text
+    fallback = "\n".join(f"{index}. {label}" for index, label in enumerate(labels, 1))
+    return f"{text}\n\n{fallback}" if text else fallback
+
+
 class WebSocketConfig(Base):
     """WebSocket server channel configuration.
 
@@ -1146,11 +1154,17 @@ class WebSocketChannel(BaseChannel):
         if not conns:
             logger.warning("websocket: no active subscribers for chat_id={}", msg.chat_id)
             return
+        text = msg.content
+        if msg.buttons:
+            text = _append_buttons_as_text(text, msg.buttons)
         payload: dict[str, Any] = {
             "event": "message",
             "chat_id": msg.chat_id,
-            "text": msg.content,
+            "text": text,
         }
+        if msg.buttons:
+            payload["buttons"] = msg.buttons
+            payload["button_prompt"] = msg.content
         if msg.media:
             payload["media"] = msg.media
             urls: list[dict[str, str]] = []

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -531,9 +531,9 @@ class WebSocketChannel(BaseChannel):
             if got == issue_expected:
                 return self._handle_token_issue_http(connection, request)
 
-        # 2. WebUI bootstrap: localhost-only, mints tokens for the embedded UI.
+        # 2. WebUI bootstrap: mints tokens for the embedded UI.
         if got == "/webui/bootstrap":
-            return self._handle_webui_bootstrap(connection)
+            return self._handle_webui_bootstrap(connection, request)
 
         # 3. REST surface for the embedded UI.
         if got == "/api/sessions":
@@ -606,8 +606,16 @@ class WebSocketChannel(BaseChannel):
             if now > expiry:
                 self._api_tokens.pop(token_key, None)
 
-    def _handle_webui_bootstrap(self, connection: Any) -> Response:
-        if not _is_localhost(connection):
+    def _handle_webui_bootstrap(self, connection: Any, request: WsRequest) -> Response:
+        # When token_issue_secret is configured, validate it regardless of
+        # source IP.  This secures deployments behind a reverse proxy (nginx)
+        # where all connections appear as localhost.
+        secret = self.config.token_issue_secret.strip()
+        if secret:
+            if not _issue_route_secret_matches(request.headers, secret):
+                return _http_error(401, "Unauthorized")
+        elif not _is_localhost(connection):
+            # No secret configured: only allow localhost (local dev mode).
             return _http_error(403, "webui bootstrap is localhost-only")
         # Cap outstanding tokens to avoid runaway growth from a misbehaving client.
         self._purge_expired_issued_tokens()

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -412,73 +412,13 @@ def _make_provider(config: Config):
 
     Routing is driven by ``ProviderSpec.backend`` in the registry.
     """
-    from nanobot.providers.base import GenerationSettings
-    from nanobot.providers.registry import find_by_name
+    from nanobot.agent.runtime import make_provider
 
-    model = config.agents.defaults.model
-    provider_name = config.get_provider_name(model)
-    p = config.get_provider(model)
-    spec = find_by_name(provider_name) if provider_name else None
-    backend = spec.backend if spec else "openai_compat"
-
-    # --- validation ---
-    if backend == "azure_openai":
-        if not p or not p.api_key or not p.api_base:
-            console.print("[red]Error: Azure OpenAI requires api_key and api_base.[/red]")
-            console.print("Set them in ~/.nanobot/config.json under providers.azure_openai section")
-            console.print("Use the model field to specify the deployment name.")
-            raise typer.Exit(1)
-    elif backend == "openai_compat" and not model.startswith("bedrock/"):
-        needs_key = not (p and p.api_key)
-        exempt = spec and (spec.is_oauth or spec.is_local or spec.is_direct)
-        if needs_key and not exempt:
-            console.print("[red]Error: No API key configured.[/red]")
-            console.print("Set one in ~/.nanobot/config.json under providers section")
-            raise typer.Exit(1)
-
-    # --- instantiation by backend ---
-    if backend == "openai_codex":
-        from nanobot.providers.openai_codex_provider import OpenAICodexProvider
-
-        provider = OpenAICodexProvider(default_model=model)
-    elif backend == "azure_openai":
-        from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
-
-        provider = AzureOpenAIProvider(
-            api_key=p.api_key,
-            api_base=p.api_base,
-            default_model=model,
-        )
-    elif backend == "github_copilot":
-        from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
-        provider = GitHubCopilotProvider(default_model=model)
-    elif backend == "anthropic":
-        from nanobot.providers.anthropic_provider import AnthropicProvider
-
-        provider = AnthropicProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-        )
-    else:
-        from nanobot.providers.openai_compat_provider import OpenAICompatProvider
-
-        provider = OpenAICompatProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-            spec=spec,
-        )
-
-    defaults = config.agents.defaults
-    provider.generation = GenerationSettings(
-        temperature=defaults.temperature,
-        max_tokens=defaults.max_tokens,
-        reasoning_effort=defaults.reasoning_effort,
-    )
-    return provider
+    try:
+        return make_provider(config)
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(1) from exc
 
 
 def _load_runtime_config(config: str | None = None, workspace: str | None = None) -> Config:
@@ -656,6 +596,7 @@ def _run_gateway(
 ) -> None:
     """Shared gateway runtime; ``open_browser_url`` opens a tab once channels are up."""
     from nanobot.agent.loop import AgentLoop
+    from nanobot.agent.runtime import build_agent_runtime, load_agent_runtime
     from nanobot.bus.queue import MessageBus
     from nanobot.channels.manager import ChannelManager
     from nanobot.cron.service import CronService
@@ -668,7 +609,12 @@ def _run_gateway(
     console.print(f"{__logo__} Starting nanobot gateway version {__version__} on port {port}...")
     sync_workspace_templates(config.workspace_path)
     bus = MessageBus()
-    provider = _make_provider(config)
+    try:
+        runtime = build_agent_runtime(config)
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(1) from exc
+    provider = runtime.provider
     session_manager = SessionManager(config.workspace_path)
 
     # Preserve existing single-workspace installs, but keep custom workspaces clean.
@@ -684,9 +630,9 @@ def _run_gateway(
         bus=bus,
         provider=provider,
         workspace=config.workspace_path,
-        model=config.agents.defaults.model,
+        model=runtime.model,
         max_iterations=config.agents.defaults.max_tool_iterations,
-        context_window_tokens=config.agents.defaults.context_window_tokens,
+        context_window_tokens=runtime.context_window_tokens,
         web_config=config.tools.web,
         context_block_limit=config.agents.defaults.context_block_limit,
         max_tool_result_chars=config.agents.defaults.max_tool_result_chars,
@@ -702,6 +648,8 @@ def _run_gateway(
         disabled_skills=config.agents.defaults.disabled_skills,
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
         tools_config=config.tools,
+        runtime_loader=load_agent_runtime,
+        runtime_signature=runtime.signature,
     )
 
     # Set cron callback (needs agent)

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -412,7 +412,7 @@ def _make_provider(config: Config):
 
     Routing is driven by ``ProviderSpec.backend`` in the registry.
     """
-    from nanobot.agent.runtime import make_provider
+    from nanobot.providers.factory import make_provider
 
     try:
         return make_provider(config)
@@ -597,7 +597,6 @@ def _run_gateway(
 ) -> None:
     """Shared gateway runtime; ``open_browser_url`` opens a tab once channels are up."""
     from nanobot.agent.loop import AgentLoop
-    from nanobot.agent.runtime import build_agent_runtime, load_agent_runtime
     from nanobot.agent.tools.cron import CronTool
     from nanobot.agent.tools.message import MessageTool
     from nanobot.bus.queue import MessageBus
@@ -605,6 +604,7 @@ def _run_gateway(
     from nanobot.cron.service import CronService
     from nanobot.cron.types import CronJob
     from nanobot.heartbeat.service import HeartbeatService
+    from nanobot.providers.factory import build_provider_snapshot, load_provider_snapshot
     from nanobot.session.manager import SessionManager
 
     port = port if port is not None else config.gateway.port
@@ -613,11 +613,11 @@ def _run_gateway(
     sync_workspace_templates(config.workspace_path)
     bus = MessageBus()
     try:
-        runtime = build_agent_runtime(config)
+        provider_snapshot = build_provider_snapshot(config)
     except ValueError as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(1) from exc
-    provider = runtime.provider
+    provider = provider_snapshot.provider
     session_manager = SessionManager(config.workspace_path)
 
     # Preserve existing single-workspace installs, but keep custom workspaces clean.
@@ -633,9 +633,9 @@ def _run_gateway(
         bus=bus,
         provider=provider,
         workspace=config.workspace_path,
-        model=runtime.model,
+        model=provider_snapshot.model,
         max_iterations=config.agents.defaults.max_tool_iterations,
-        context_window_tokens=runtime.context_window_tokens,
+        context_window_tokens=provider_snapshot.context_window_tokens,
         web_config=config.tools.web,
         context_block_limit=config.agents.defaults.context_block_limit,
         max_tool_result_chars=config.agents.defaults.max_tool_result_chars,
@@ -652,8 +652,8 @@ def _run_gateway(
         session_ttl_minutes=config.agents.defaults.session_ttl_minutes,
         consolidation_ratio=config.agents.defaults.consolidation_ratio,
         tools_config=config.tools,
-        runtime_loader=load_agent_runtime,
-        runtime_signature=runtime.signature,
+        provider_snapshot_loader=load_provider_snapshot,
+        provider_signature=provider_snapshot.signature,
     )
 
     from nanobot.agent.loop import UNIFIED_SESSION_KEY

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -119,62 +119,6 @@ class Nanobot:
 
 def _make_provider(config: Any) -> Any:
     """Create the LLM provider from config (extracted from CLI)."""
-    from nanobot.providers.base import GenerationSettings
-    from nanobot.providers.registry import find_by_name
+    from nanobot.agent.runtime import make_provider
 
-    model = config.agents.defaults.model
-    provider_name = config.get_provider_name(model)
-    p = config.get_provider(model)
-    spec = find_by_name(provider_name) if provider_name else None
-    backend = spec.backend if spec else "openai_compat"
-
-    if backend == "azure_openai":
-        if not p or not p.api_key or not p.api_base:
-            raise ValueError("Azure OpenAI requires api_key and api_base in config.")
-    elif backend == "openai_compat" and not model.startswith("bedrock/"):
-        needs_key = not (p and p.api_key)
-        exempt = spec and (spec.is_oauth or spec.is_local or spec.is_direct)
-        if needs_key and not exempt:
-            raise ValueError(f"No API key configured for provider '{provider_name}'.")
-
-    if backend == "openai_codex":
-        from nanobot.providers.openai_codex_provider import OpenAICodexProvider
-
-        provider = OpenAICodexProvider(default_model=model)
-    elif backend == "github_copilot":
-        from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
-
-        provider = GitHubCopilotProvider(default_model=model)
-    elif backend == "azure_openai":
-        from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
-
-        provider = AzureOpenAIProvider(
-            api_key=p.api_key, api_base=p.api_base, default_model=model
-        )
-    elif backend == "anthropic":
-        from nanobot.providers.anthropic_provider import AnthropicProvider
-
-        provider = AnthropicProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-        )
-    else:
-        from nanobot.providers.openai_compat_provider import OpenAICompatProvider
-
-        provider = OpenAICompatProvider(
-            api_key=p.api_key if p else None,
-            api_base=config.get_api_base(model),
-            default_model=model,
-            extra_headers=p.extra_headers if p else None,
-            spec=spec,
-        )
-
-    defaults = config.agents.defaults
-    provider.generation = GenerationSettings(
-        temperature=defaults.temperature,
-        max_tokens=defaults.max_tokens,
-        reasoning_effort=defaults.reasoning_effort,
-    )
-    return provider
+    return make_provider(config)

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -120,6 +120,6 @@ class Nanobot:
 
 def _make_provider(config: Any) -> Any:
     """Create the LLM provider from config (extracted from CLI)."""
-    from nanobot.agent.runtime import make_provider
+    from nanobot.providers.factory import make_provider
 
     return make_provider(config)

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -1,4 +1,4 @@
-"""Runtime model/provider resolution for agent turns."""
+"""Create LLM providers from config."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from nanobot.providers.registry import find_by_name
 
 
 @dataclass(frozen=True)
-class AgentRuntime:
+class ProviderSnapshot:
     provider: LLMProvider
     model: str
     context_window_tokens: int
@@ -80,8 +80,8 @@ def make_provider(config: Config) -> LLMProvider:
     return provider
 
 
-def runtime_signature(config: Config) -> tuple[object, ...]:
-    """Return the config fields that affect the primary LLM runtime."""
+def provider_signature(config: Config) -> tuple[object, ...]:
+    """Return the config fields that affect the primary LLM provider."""
     model = config.agents.defaults.model
     defaults = config.agents.defaults
     return (
@@ -97,16 +97,16 @@ def runtime_signature(config: Config) -> tuple[object, ...]:
     )
 
 
-def build_agent_runtime(config: Config) -> AgentRuntime:
-    return AgentRuntime(
+def build_provider_snapshot(config: Config) -> ProviderSnapshot:
+    return ProviderSnapshot(
         provider=make_provider(config),
         model=config.agents.defaults.model,
         context_window_tokens=config.agents.defaults.context_window_tokens,
-        signature=runtime_signature(config),
+        signature=provider_signature(config),
     )
 
 
-def load_agent_runtime(config_path: Path | None = None) -> AgentRuntime:
+def load_provider_snapshot(config_path: Path | None = None) -> ProviderSnapshot:
     from nanobot.config.loader import load_config, resolve_config_env_vars
 
-    return build_agent_runtime(resolve_config_env_vars(load_config(config_path)))
+    return build_provider_snapshot(resolve_config_env_vars(load_config(config_path)))

--- a/nanobot/skills/create-instance/SKILL.md
+++ b/nanobot/skills/create-instance/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: create-instance
+description: "Create a new nanobot instance with separate config and workspace. Use when the user wants to set up a new bot for a different channel, persona, or purpose. Triggers on phrases like: 'create a new instance', 'create a new bot', 'set up a new bot', 'add a new channel', '创建新实例', '创建新bot', '帮我创建一个新agent'."
+---
+
+# Create Instance
+
+Set up a new nanobot instance with its own config and workspace.
+
+## When to Use
+
+When the user wants to create a new bot instance — typically for a different channel (Telegram, Discord, WeChat, etc.) or with different settings.
+
+## Steps
+
+1. **Collect information from the user** (ask one at a time if not already provided):
+   - **Instance name** (required): a short identifier like `telegram-bot`, `discord-bot`
+   - **Channel type** (required): e.g. `telegram`, `discord`, `weixin`, `feishu`, `slack`
+   - **Model** (optional): LLM model to use. Defaults to the same model as the current instance.
+
+2. **Do NOT collect sensitive information** in the chat (API keys, bot tokens, secrets). API keys are automatically copied from the current instance. Channel-specific tokens (e.g. `telegram.token`) still need to be filled in manually.
+
+3. **Run the creation script** using the exec tool — always pass `--inherit-config` with the current instance's config path so API keys are copied:
+
+```bash
+python nanobot/skills/create-instance/scripts/create_instance.py --name <name> --channel <channel> --inherit-config <current-config-path> [--model <model>] [--config-dir <path>]
+```
+
+You can find the current config path from the environment or by reading the running config. If unsure, check the `NANOBOT_CONFIG` env var or use `~/.nanobot/config.json` as default.
+
+4. **Report results to the user**:
+   - Where the config and workspace were created
+   - Which fields they need to fill in (the script will list them)
+   - The command to start the instance: `nanobot gateway --config <config-path>`
+
+## Examples
+
+User: "帮我创建一个 Telegram bot"
+
+→ Ask: "给这个实例取个名字？" (if not obvious from context)
+→ Ask: "用什么模型？还是用当前的模型？" (optional, can skip if user doesn't care)
+→ Run: `python nanobot/skills/create-instance/scripts/create_instance.py --name telegram-bot --channel telegram --inherit-config ~/.nanobot/config.json`
+→ Tell user: config created at `~/.nanobot-telegram/config.json`, please fill in `channels.telegram.token`, then start with `nanobot gateway --config ~/.nanobot-telegram/config.json`

--- a/nanobot/skills/create-instance/scripts/create_instance.py
+++ b/nanobot/skills/create-instance/scripts/create_instance.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Create a new nanobot instance with a dedicated config and workspace.
+
+Usage:
+    create_instance.py --name <name> --channel <channel> [--model <model>] [--config-dir <dir>]
+
+Examples:
+    create_instance.py --name telegram-bot --channel telegram
+    create_instance.py --name discord-bot --channel discord --model deepseek/deepseek-chat
+    create_instance.py --name my-bot --channel telegram --config-dir ~/.nanobot-custom
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import socket
+import sys
+from pathlib import Path
+
+
+def _validate_name(name: str) -> str:
+    """Normalize and validate instance name."""
+    name = name.strip().lower()
+    name = re.sub(r"[^a-z0-9-]", "-", name)
+    name = re.sub(r"-{2,}", "-", name)
+    name = name.strip("-")
+    if not name:
+        print("[ERROR] Instance name must contain at least one letter or digit.", file=sys.stderr)
+        sys.exit(1)
+    if len(name) > 64:
+        print(f"[ERROR] Instance name too long ({len(name)} chars, max 64).", file=sys.stderr)
+        sys.exit(1)
+    return name
+
+
+def _get_available_channels() -> list[str]:
+    """Get list of available channel names without importing channel classes."""
+    from nanobot.channels.registry import discover_channel_names
+
+    return discover_channel_names()
+
+
+def _run_onboard(config_path: Path, workspace: Path) -> None:
+    """Create skeleton config + workspace using nanobot's programmatic API."""
+    from nanobot.cli.commands import _onboard_plugins
+    from nanobot.config.loader import save_config, set_config_path
+    from nanobot.config.paths import get_workspace_path
+    from nanobot.config.schema import Config
+    from nanobot.utils.helpers import sync_workspace_templates
+
+    config = Config()
+    config.agents.defaults.workspace = str(workspace)
+    set_config_path(config_path)
+    save_config(config, config_path)
+    _onboard_plugins(config_path)
+
+    workspace_path = get_workspace_path(config.workspace_path)
+    if not workspace_path.exists():
+        workspace_path.mkdir(parents=True, exist_ok=True)
+    sync_workspace_templates(workspace_path)
+
+
+def _patch_config(
+    config_path: Path,
+    *,
+    channel: str,
+    workspace: Path,
+    model: str | None,
+    inherit_config_path: Path | None = None,
+) -> dict:
+    """Patch the generated config: enable channel, set workspace, optionally set model."""
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+
+    # Inherit providers (API keys, api_base, etc.) from current instance
+    if inherit_config_path and inherit_config_path.exists():
+        try:
+            src = json.loads(inherit_config_path.read_text(encoding="utf-8"))
+            src_providers = src.get("providers", {})
+            if src_providers:
+                data.setdefault("providers", {})
+                for key, val in src_providers.items():
+                    if isinstance(val, dict) and val.get("apiKey"):
+                        data["providers"][key] = val
+        except Exception as exc:
+            print(f"[WARN] Could not inherit providers from {inherit_config_path}: {exc}", file=sys.stderr)
+
+    # Set workspace and model
+    data.setdefault("agents", {}).setdefault("defaults", {})
+    data["agents"]["defaults"]["workspace"] = str(workspace)
+    if model:
+        data["agents"]["defaults"]["model"] = model
+
+    # Enable the target channel
+    channels = data.setdefault("channels", {})
+    if channel in channels and isinstance(channels[channel], dict):
+        channels[channel]["enabled"] = True
+    else:
+        channels[channel] = {"enabled": True}
+
+    # Auto-assign ports if defaults are already in use
+    _assign_free_ports(data)
+
+    # Validate with Pydantic, then save
+    from nanobot.config.schema import Config
+
+    Config.model_validate(data)
+    config_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    return data
+
+
+def _is_port_in_use(port: int, host: str = "127.0.0.1") -> bool:
+    """Check if a port is already in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((host, port))
+            return False
+        except OSError:
+            return True
+
+
+def _find_free_port(start: int, host: str = "127.0.0.1", max_tries: int = 100) -> int:
+    """Find the first free port starting from `start`."""
+    for port in range(start, start + max_tries):
+        if not _is_port_in_use(port, host):
+            return port
+    # OS-level fallback: ask the kernel for an ephemeral port
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return s.getsockname()[1]
+
+
+def _assign_free_ports(data: dict) -> None:
+    """If default gateway or API ports are in use, assign free ones."""
+    from nanobot.config.schema import ApiConfig, GatewayConfig
+
+    defaults = [
+        ("gateway", GatewayConfig()),
+        ("api", ApiConfig()),
+    ]
+    for key, default_cfg in defaults:
+        section = data.setdefault(key, {})
+        port = section.get("port", default_cfg.port)
+        host = section.get("host", default_cfg.host)
+        if _is_port_in_use(port, host):
+            section["port"] = _find_free_port(port + 1, host)
+
+
+def _get_channel_required_fields(channel: str) -> list[str]:
+    """Inspect a channel's default config and list fields that are empty strings."""
+    try:
+        from nanobot.channels.registry import load_channel_class
+
+        cls = load_channel_class(channel)
+        default = cls.default_config()
+        return sorted(k for k, v in default.items() if isinstance(v, str) and v == "" and k != "enabled")
+    except Exception as exc:
+        print(f"[WARN] Could not inspect channel '{channel}' defaults: {exc}", file=sys.stderr)
+        return []
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create a new nanobot instance.",
+    )
+    parser.add_argument("--name", required=True, help="Instance name (e.g. telegram-bot)")
+    parser.add_argument("--channel", required=True, help="Channel type (e.g. telegram, discord)")
+    parser.add_argument("--model", default=None, help="LLM model (default: same as current instance)")
+    parser.add_argument(
+        "--config-dir",
+        default=None,
+        help="Config directory (default: ~/.nanobot-{name})",
+    )
+    parser.add_argument(
+        "--inherit-config",
+        default=None,
+        help="Path to current instance's config.json to copy API keys from",
+    )
+    args = parser.parse_args()
+
+    # Validate name
+    name = _validate_name(args.name)
+
+    # Validate channel
+    available = _get_available_channels()
+    if args.channel not in available:
+        print(f"[ERROR] Unknown channel: {args.channel}", file=sys.stderr)
+        print(f"Available channels: {', '.join(sorted(available))}", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve paths
+    home = Path.home()
+    config_dir = Path(args.config_dir).expanduser().resolve() if args.config_dir else home / f".nanobot-{name}"
+    config_path = config_dir / "config.json"
+    workspace = config_dir / "workspace"
+
+    # Check for duplicate
+    if config_path.exists():
+        print(f"[ERROR] Config already exists at {config_path}", file=sys.stderr)
+        print("Delete it first or use a different --config-dir.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Creating instance '{name}'...")
+    print(f"  Config dir: {config_dir}")
+    print(f"  Workspace:  {workspace}")
+    print(f"  Channel:    {args.channel}")
+    if args.model:
+        print(f"  Model:      {args.model}")
+
+    # Run onboard
+    _run_onboard(config_path, workspace)
+
+    # Patch config
+    inherit_path = Path(args.inherit_config).expanduser().resolve() if args.inherit_config else None
+    data = _patch_config(
+        config_path,
+        channel=args.channel,
+        workspace=workspace,
+        model=args.model,
+        inherit_config_path=inherit_path,
+    )
+
+    # Report
+    print(f"\n[OK] Instance '{name}' created successfully.")
+    print(f"  Config: {config_path}")
+    print(f"  Workspace: {workspace}")
+
+    # List fields the user needs to fill in
+    required_fields = _get_channel_required_fields(args.channel)
+    if required_fields:
+        print(f"\n[IMPORTANT] Edit {config_path} and fill in these fields:")
+        for field in required_fields:
+            print(f"  - channels.{args.channel}.{field}")
+
+    print(f"\nTo start the instance:")
+    print(f"  nanobot gateway --config {config_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_ask_user.py
+++ b/tests/agent/test_ask_user.py
@@ -205,3 +205,37 @@ async def test_ask_user_keeps_buttons_for_telegram(tmp_path):
     assert response is not None
     assert response.content == "Install the optional package?"
     assert response.buttons == [["Install", "Skip"]]
+
+
+@pytest.mark.asyncio
+async def test_ask_user_keeps_buttons_for_websocket(tmp_path):
+    async def chat_with_retry(**kwargs):
+        return LLMResponse(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCallRequest(
+                    id="call_ask",
+                    name="ask_user",
+                    arguments={
+                        "question": "Install the optional package?",
+                        "options": ["Install", "Skip"],
+                    },
+                )
+            ],
+        )
+
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=_make_provider(chat_with_retry),
+        workspace=tmp_path,
+        model="test-model",
+    )
+
+    response = await loop._process_message(
+        InboundMessage(channel="websocket", sender_id="user", chat_id="123", content="set it up")
+    )
+
+    assert response is not None
+    assert response.content == "Install the optional package?"
+    assert response.buttons == [["Install", "Skip"]]

--- a/tests/agent/test_runtime_refresh.py
+++ b/tests/agent/test_runtime_refresh.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.runtime import AgentRuntime
+from nanobot.bus.queue import MessageBus
+
+
+def _provider(default_model: str, max_tokens: int = 123) -> MagicMock:
+    provider = MagicMock()
+    provider.get_default_model.return_value = default_model
+    provider.generation = SimpleNamespace(max_tokens=max_tokens)
+    return provider
+
+
+def test_runtime_refresh_updates_loop_dependents(tmp_path: Path) -> None:
+    old_provider = _provider("old-model")
+    new_provider = _provider("new-model", max_tokens=456)
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=old_provider,
+        workspace=tmp_path,
+        model="old-model",
+        context_window_tokens=1000,
+        runtime_loader=lambda: AgentRuntime(
+            provider=new_provider,
+            model="new-model",
+            context_window_tokens=2000,
+            signature=("new-model",),
+        ),
+    )
+
+    loop._refresh_runtime()
+
+    assert loop.provider is new_provider
+    assert loop.model == "new-model"
+    assert loop.context_window_tokens == 2000
+    assert loop.runner.provider is new_provider
+    assert loop.subagents.provider is new_provider
+    assert loop.subagents.model == "new-model"
+    assert loop.subagents.runner.provider is new_provider
+    assert loop.consolidator.provider is new_provider
+    assert loop.consolidator.model == "new-model"
+    assert loop.consolidator.context_window_tokens == 2000
+    assert loop.consolidator.max_completion_tokens == 456
+    assert loop.dream.provider is new_provider
+    assert loop.dream.model == "new-model"
+    assert loop.dream._runner.provider is new_provider

--- a/tests/agent/test_runtime_refresh.py
+++ b/tests/agent/test_runtime_refresh.py
@@ -3,8 +3,8 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from nanobot.agent.loop import AgentLoop
-from nanobot.agent.runtime import AgentRuntime
 from nanobot.bus.queue import MessageBus
+from nanobot.providers.factory import ProviderSnapshot
 
 
 def _provider(default_model: str, max_tokens: int = 123) -> MagicMock:
@@ -23,7 +23,7 @@ def test_runtime_refresh_updates_loop_dependents(tmp_path: Path) -> None:
         workspace=tmp_path,
         model="old-model",
         context_window_tokens=1000,
-        runtime_loader=lambda: AgentRuntime(
+        provider_snapshot_loader=lambda: ProviderSnapshot(
             provider=new_provider,
             model="new-model",
             context_window_tokens=2000,
@@ -31,7 +31,7 @@ def test_runtime_refresh_updates_loop_dependents(tmp_path: Path) -> None:
         ),
     )
 
-    loop._refresh_runtime()
+    loop._refresh_provider_snapshot()
 
     assert loop.provider is new_provider
     assert loop.model == "new-model"

--- a/tests/agent/test_runtime_refresh.py
+++ b/tests/agent/test_runtime_refresh.py
@@ -14,7 +14,7 @@ def _provider(default_model: str, max_tokens: int = 123) -> MagicMock:
     return provider
 
 
-def test_runtime_refresh_updates_loop_dependents(tmp_path: Path) -> None:
+def test_provider_refresh_updates_all_model_dependents(tmp_path: Path) -> None:
     old_provider = _provider("old-model")
     new_provider = _provider("new-model", max_tokens=456)
     loop = AgentLoop(

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -178,6 +178,7 @@ async def test_send_delivers_json_message_with_media_and_reply() -> None:
         content="hello",
         reply_to="m1",
         media=["/tmp/a.png"],
+        buttons=[["Yes", "No"]],
     )
     await channel.send(msg)
 
@@ -185,9 +186,11 @@ async def test_send_delivers_json_message_with_media_and_reply() -> None:
     payload = json.loads(mock_ws.send.call_args[0][0])
     assert payload["event"] == "message"
     assert payload["chat_id"] == "chat-1"
-    assert payload["text"] == "hello"
+    assert payload["text"] == "hello\n\n1. Yes\n2. No"
+    assert payload["button_prompt"] == "hello"
     assert payload["reply_to"] == "m1"
     assert payload["media"] == ["/tmp/a.png"]
+    assert payload["buttons"] == [["Yes", "No"]]
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -26,6 +26,8 @@ from nanobot.channels.websocket import (
     _parse_query,
     _parse_request_path,
 )
+from nanobot.config.loader import load_config, save_config
+from nanobot.config.schema import Config
 
 # -- Shared helpers (aligned with test_websocket_integration.py) ---------------
 
@@ -437,6 +439,72 @@ async def test_http_route_issues_token_then_websocket_requires_it(bus: MagicMock
     finally:
         await channel.stop()
         await server_task
+
+
+@pytest.mark.asyncio
+async def test_settings_api_returns_safe_subset_and_updates_whitelist(
+    bus: MagicMock,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    port = 29891
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.agents.defaults.model = "openai/gpt-4o"
+    config.providers.openai.api_key = "secret-key"
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    channel = _ch(bus, port=port)
+    channel._api_tokens["tok"] = time.monotonic() + 300
+
+    server_task = asyncio.create_task(channel.start())
+    await asyncio.sleep(0.3)
+
+    try:
+        settings = await _http_get(
+            f"http://127.0.0.1:{port}/api/settings",
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert settings.status_code == 200
+        body = settings.json()
+        assert body["agent"]["model"] == "openai/gpt-4o"
+        assert body["agent"]["provider"] == "openai"
+        assert {"name": "auto", "label": "Auto"} in body["providers"]
+        assert body["agent"]["has_api_key"] is True
+        assert "secret-key" not in settings.text
+
+        updated = await _http_get(
+            "http://127.0.0.1:"
+            f"{port}/api/settings/update?model=openrouter/test"
+            "&provider=openrouter",
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert updated.status_code == 200
+        assert updated.json()["requires_restart"] is True
+
+        saved = load_config(config_path)
+        assert saved.agents.defaults.model == "openrouter/test"
+        assert saved.agents.defaults.provider == "openrouter"
+    finally:
+        await channel.stop()
+        await server_task
+
+
+def test_settings_payload_normalizes_camel_case_provider(
+    bus: MagicMock,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.agents.defaults.provider = "minimaxAnthropic"
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    body = _ch(bus)._settings_payload()
+
+    assert body["agent"]["provider"] == "minimax_anthropic"
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -8,11 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
-from nanobot.agent.runtime import AgentRuntime
 from nanobot.bus.events import OutboundMessage
 from nanobot.cli.commands import _make_provider, app
 from nanobot.config.schema import Config
 from nanobot.cron.types import CronJob, CronPayload
+from nanobot.providers.factory import ProviderSnapshot
 from nanobot.providers.openai_codex_provider import _strip_model_prefix
 from nanobot.providers.registry import find_by_name
 
@@ -777,8 +777,8 @@ def _stop_gateway_provider(_config) -> object:
     raise _StopGatewayError("stop")
 
 
-def _test_agent_runtime(provider: object, config: Config) -> AgentRuntime:
-    return AgentRuntime(
+def _test_provider_snapshot(provider: object, config: Config) -> ProviderSnapshot:
+    return ProviderSnapshot(
         provider=provider,
         model=config.agents.defaults.model,
         context_window_tokens=config.agents.defaults.context_window_tokens,
@@ -815,12 +815,12 @@ def _patch_cli_command_runtime(
         provider_factory,
     )
     monkeypatch.setattr(
-        "nanobot.agent.runtime.build_agent_runtime",
-        lambda _config: _test_agent_runtime(provider_factory(_config), _config),
+        "nanobot.providers.factory.build_provider_snapshot",
+        lambda _config: _test_provider_snapshot(provider_factory(_config), _config),
     )
     monkeypatch.setattr(
-        "nanobot.agent.runtime.load_agent_runtime",
-        lambda _config_path=None: _test_agent_runtime(provider_factory(config), config),
+        "nanobot.providers.factory.load_provider_snapshot",
+        lambda _config_path=None: _test_provider_snapshot(provider_factory(config), config),
     )
 
     if message_bus is not None:
@@ -962,12 +962,12 @@ def test_gateway_cron_evaluator_receives_scheduled_reminder_context(
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
     monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: provider)
     monkeypatch.setattr(
-        "nanobot.agent.runtime.build_agent_runtime",
-        lambda _config: _test_agent_runtime(provider, _config),
+        "nanobot.providers.factory.build_provider_snapshot",
+        lambda _config: _test_provider_snapshot(provider, _config),
     )
     monkeypatch.setattr(
-        "nanobot.agent.runtime.load_agent_runtime",
-        lambda _config_path=None: _test_agent_runtime(provider, config),
+        "nanobot.providers.factory.load_provider_snapshot",
+        lambda _config_path=None: _test_provider_snapshot(provider, config),
     )
     monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: bus)
 
@@ -1111,12 +1111,12 @@ def test_gateway_cron_job_suppresses_intermediate_progress(
     monkeypatch.setattr("nanobot.cli.commands.sync_workspace_templates", lambda _path: None)
     monkeypatch.setattr("nanobot.cli.commands._make_provider", lambda _config: object())
     monkeypatch.setattr(
-        "nanobot.agent.runtime.build_agent_runtime",
-        lambda _config: _test_agent_runtime(object(), _config),
+        "nanobot.providers.factory.build_provider_snapshot",
+        lambda _config: _test_provider_snapshot(object(), _config),
     )
     monkeypatch.setattr(
-        "nanobot.agent.runtime.load_agent_runtime",
-        lambda _config_path=None: _test_agent_runtime(object(), config),
+        "nanobot.providers.factory.load_provider_snapshot",
+        lambda _config_path=None: _test_provider_snapshot(object(), config),
     )
     monkeypatch.setattr("nanobot.bus.queue.MessageBus", lambda: bus)
     monkeypatch.setattr("nanobot.session.manager.SessionManager", lambda _workspace: object())

--- a/tests/skills/test_create_instance.py
+++ b/tests/skills/test_create_instance.py
@@ -1,0 +1,168 @@
+"""Tests for nanobot/skills/create-instance/scripts/create_instance.py."""
+
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parent.parent.parent / "nanobot" / "skills" / "create-instance" / "scripts" / "create_instance.py"
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point HOME at a temp dir so nanobot writes configs there."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("NANOBOT_CONFIG", raising=False)
+    return tmp_path
+
+
+def _run_script(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Run create_instance.py as a subprocess."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=cwd,
+    )
+
+
+class TestValidation:
+    """Argument validation tests."""
+
+    def test_missing_required_args_exits_with_error(self) -> None:
+        result = _run_script()
+        assert result.returncode != 0
+
+    def test_invalid_channel_exits_with_error(self, tmp_home: Path) -> None:
+        result = _run_script("--name", "test", "--channel", "nonexistent_channel")
+        assert result.returncode != 0
+        assert "nonexistent_channel" in result.stderr or "nonexistent_channel" in result.stdout
+
+
+class TestCreateInstance:
+    """End-to-end instance creation tests."""
+
+    def test_creates_config_and_workspace(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result.returncode == 0, result.stderr
+
+        config_path = config_dir / "config.json"
+        assert config_path.exists(), f"Config not created at {config_path}"
+
+        workspace = config_dir / "workspace"
+        assert workspace.exists(), f"Workspace not created at {workspace}"
+
+    def test_config_has_channel_enabled(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        assert data["channels"]["telegram"]["enabled"] is True
+
+    def test_config_workspace_path_set(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        ws = data["agents"]["defaults"]["workspace"]
+        assert str(config_dir / "workspace") in ws or "workspace" in ws
+
+    def test_model_override(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--model", "deepseek/deepseek-chat",
+            "--config-dir", str(config_dir),
+        )
+        assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        assert data["agents"]["defaults"]["model"] == "deepseek/deepseek-chat"
+
+    def test_rejects_duplicate_instance(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result1 = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result1.returncode == 0
+
+        result2 = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result2.returncode != 0
+
+    def test_port_reassigned_when_default_in_use(self, tmp_home: Path) -> None:
+        """When default gateway port is occupied, script should pick a different one."""
+        config_dir = tmp_home / ".nanobot-test"
+
+        # Bind to the default gateway port to simulate a running instance
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+            blocker.bind(("127.0.0.1", 18790))
+            blocker.listen(1)
+
+            result = _run_script(
+                "--name", "test-bot",
+                "--channel", "telegram",
+                "--config-dir", str(config_dir),
+            )
+            assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        assert data["gateway"]["port"] != 18790
+
+    def test_inherits_api_key_from_current_instance(self, tmp_home: Path) -> None:
+        """API keys from --inherit-config should be copied to new instance."""
+        # Create a fake "current instance" config with an API key
+        src_dir = tmp_home / ".nanobot-current"
+        src_dir.mkdir()
+        src_config = src_dir / "config.json"
+        src_config.write_text(json.dumps({
+            "providers": {
+                "anthropic": {"apiKey": "sk-test-key-12345"},
+                "deepseek": {"apiKey": "dsk-another-key"},
+                "openai": {},  # no key, should not be copied
+            },
+        }), encoding="utf-8")
+
+        config_dir = tmp_home / ".nanobot-new"
+        result = _run_script(
+            "--name", "new-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+            "--inherit-config", str(src_config),
+        )
+        assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        providers = data.get("providers", {})
+        assert providers.get("anthropic", {}).get("apiKey") == "sk-test-key-12345"
+        assert providers.get("deepseek", {}).get("apiKey") == "dsk-another-key"
+        # openai had no key, so it should not be in the new config's providers
+        assert providers.get("openai", {}).get("apiKey") is None

--- a/webui/README.md
+++ b/webui/README.md
@@ -85,6 +85,197 @@ directory served by `nanobot gateway` and bundled into the Python wheel.
 If you are cutting a release, run the build before packaging so the published
 wheel contains the current WebUI assets.
 
+## Deploy to GitHub Pages
+
+The WebUI can be deployed as a static site on GitHub Pages, connecting to a
+remote nanobot gateway over HTTPS + WebSocket. A GitHub Actions workflow
+(`.github/workflows/deploy-webui.yml`) is included for automatic deployment on
+pushes to the `webui` branch.
+
+### Ask Nanobot to Configure Itself
+
+Send this message to your Nanobot (via your existing channel, e.g. Feishu, terminal, etc.):
+
+```
+Please configure my nanobot gateway for GitHub Pages deployment. Here's what I need:
+
+1. My domain is: (your domain, e.g. nanobot.example.com)
+2. My GitHub Pages URL is: (e.g. https://your-username.github.io)
+3. My SSL certificate is at: (path to fullchain.pem)
+4. My SSL key is at: (path to privkey.pem)
+
+Do the following:
+
+1. Update the websocket channel in my config.json:
+   - Set `host` to `127.0.0.1` and `port` to `18765` (nginx will proxy to this)
+   - Set `token_issue_secret` to a strong random string
+   - Leave `sslCertfile` and `sslKeyfile` empty
+2. Generate an nginx config at `/etc/nginx/sites-available/nanobot-proxy.conf` that:
+   - Listens on port 8765 with SSL using my cert
+   - Handles CORS preflight (OPTIONS) for my GitHub Pages origin
+   - Adds CORS headers to all proxied responses
+   - Proxies everything (including WebSocket upgrade) to 127.0.0.1:18765
+3. Show me the sudo commands to enable the nginx site and reload nginx
+4. Give me the Server URL and the `token_issue_secret` value to enter in the WebUI
+
+Reference: https://github.com/HKUDS/nanobot/blob/main/docs/WEBSOCKET.md
+```
+
+After Nanobot updates the config and generates the nginx config, run the
+sudo commands it shows you, then restart the gateway with `/restart`.
+Open `https://<username>.github.io/nanobot/` and enter the Server URL and Secret.
+
+### Manual Configuration (Optional)
+
+If you prefer to configure everything manually, follow the steps below.
+
+### Prerequisites
+
+1. A fork of the nanobot repository on GitHub
+2. A domain name with an SSL certificate (e.g. Let's Encrypt)
+3. nginx installed on the server hosting the nanobot gateway
+4. The gateway accessible from the public internet
+
+### 1. Configure the nanobot gateway
+
+In `~/.nanobot/config.json`, set the websocket channel to listen on localhost
+only (nginx will handle TLS):
+
+```json
+{
+  "channels": {
+    "websocket": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 18765,
+      "token_issue_secret": "your-secret-here",
+      "sslCertfile": "",
+      "sslKeyfile": ""
+    }
+  }
+}
+```
+
+- **`host`** — Bind to `127.0.0.1` so only nginx can reach the gateway.
+- **`token_issue_secret`** — Set a secret to require authentication for WebUI
+  access. When configured, the WebUI must provide this secret to connect.
+  **Important:** when deploying behind nginx, you MUST set this — nginx makes all
+  connections appear as localhost, so the default localhost-only check is
+  effectively bypassed. Leave empty only for local development without nginx.
+- **`sslCertfile`/`sslKeyfile`** — Leave empty. nginx handles TLS.
+
+### 2. Restart the gateway
+
+Config changes take effect after a restart:
+
+```bash
+nanobot gateway
+# or if already running, use /restart in any channel
+```
+
+### 3. Configure nginx reverse proxy
+
+Create `/etc/nginx/sites-available/nanobot-proxy.conf`:
+
+```nginx
+server {
+    listen 8765 ssl;
+    server_name your-domain.example.com;
+
+    ssl_certificate     /path/to/fullchain.pem;
+    ssl_certificate_key /path/to/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    location / {
+        # CORS preflight — handled by nginx because the websockets library
+        # rejects OPTIONS requests before they reach process_request.
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin  https://<username>.github.io always;
+            add_header Access-Control-Allow-Methods  "GET, OPTIONS" always;
+            add_header Access-Control-Allow-Headers  "Authorization, X-Nanobot-Auth, Content-Type" always;
+            add_header Access-Control-Allow-Credentials true always;
+            return 204;
+        }
+
+        proxy_pass http://127.0.0.1:18765;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+
+        # CORS headers on proxied responses
+        add_header Access-Control-Allow-Origin  https://<username>.github.io always;
+        add_header Access-Control-Allow-Methods  "GET, OPTIONS" always;
+        add_header Access-Control-Allow-Headers  "Authorization, X-Nanobot-Auth, Content-Type" always;
+        add_header Access-Control-Allow-Credentials true always;
+    }
+}
+```
+
+Replace:
+- `your-domain.example.com` — your domain matching the SSL certificate
+- `/path/to/fullchain.pem`, `/path/to/privkey.pem` — your SSL cert paths
+- `https://<username>.github.io` — your GitHub Pages origin
+
+Then enable the site and reload nginx:
+
+```bash
+sudo ln -s /etc/nginx/sites-available/nanobot-proxy.conf /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+### 4. Enable GitHub Pages
+
+1. Go to your fork's **Settings > Pages**
+2. Set **Source** to "GitHub Actions"
+3. Push to the `webui` branch — the `deploy-webui.yml` workflow will build and deploy
+
+### 5. Connect from the WebUI
+
+Open `https://<username>.github.io/nanobot/` and enter:
+
+- **Server URL**: `https://your-domain.example.com:8765`
+- **Secret**: The `token_issue_secret` value from your config (required)
+
+### How it works
+
+```
+Browser (GitHub Pages, HTTPS)
+  │
+  │  fetch /webui/bootstrap  (GET)
+  │  WebSocket /ws?token=...
+  │
+  ▼
+nginx (TLS termination + CORS)
+  │
+  │  proxy_pass (plain HTTP)
+  │
+  ▼
+nanobot gateway (127.0.0.1:18765)
+```
+
+- **nginx** terminates TLS, handles CORS preflight (OPTIONS), and adds CORS
+  headers to all responses. It also proxies WebSocket upgrade requests.
+- **nanobot** listens on localhost only. When `token_issue_secret` is set in
+  config, the WebUI must authenticate with the secret; otherwise only
+  localhost connections are allowed.
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `401 Unauthorized` on bootstrap | `token_issue_secret` is set but the WebUI didn't provide the correct secret | Enter the secret in the WebUI connection form |
+| `ERR_CERT_COMMON_NAME_INVALID` | SSL cert domain doesn't match the URL | Use the domain that matches your cert, not the raw IP |
+| `Mixed Content` error | Accessing `http://` from `https://` page | Always use `https://` for the Server URL |
+| Duplicate `Access-Control-Allow-Origin` | nginx adding CORS headers in multiple location blocks | Check nginx config for duplicate `add_header` directives |
+| `net::ERR_EMPTY_RESPONSE` on OPTIONS | nanobot's websockets library rejects OPTIONS | Ensure nginx is proxying (not connecting directly to nanobot) |
+
 ## Test
 
 ```bash

--- a/webui/bun.lock
+++ b/webui/bun.lock
@@ -15,9 +15,11 @@
         "@radix-ui/react-tooltip": "^1.1.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "i18next": "^26.0.6",
         "lucide-react": "^0.469.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-i18next": "^17.0.4",
         "react-markdown": "^9.0.1",
         "react-syntax-highlighter": "^15.6.1",
         "rehype-katex": "^7.0.1",
@@ -506,7 +508,11 @@
 
     "highlightjs-vue": ["highlightjs-vue@1.0.0", "", {}, "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="],
 
+    "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
+
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "i18next": ["i18next@26.0.7", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-f7tL/iw0VQsx4nC5oNxBM2RjM8alNys5KzyiQTU6A9TI5TI89py4/Ez1cKFvHiLWsvzOXvuGUES+Kk/A2WiANQ=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
@@ -718,6 +724,8 @@
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
+    "react-i18next": ["react-i18next@17.0.4", "", { "dependencies": { "@babel/runtime": "^7.29.2", "html-parse-stringify": "^3.0.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "i18next": ">= 26.0.1", "react": ">= 16.8.0", "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g=="],
+
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-markdown": ["react-markdown@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw=="],
@@ -859,6 +867,8 @@
     "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
 
     "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DeleteConfirm } from "@/components/DeleteConfirm";
 import { Sidebar } from "@/components/Sidebar";
+import { SettingsView } from "@/components/settings/SettingsView";
 import { ThreadShell } from "@/components/thread/ThreadShell";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { preloadMarkdownText } from "@/components/MarkdownText";
@@ -25,6 +26,7 @@ type BootState =
 
 const SIDEBAR_STORAGE_KEY = "nanobot-webui.sidebar";
 const SIDEBAR_WIDTH = 279;
+type ShellView = "chat" | "settings";
 
 function readSidebarOpen(): boolean {
   if (typeof window === "undefined") return true;
@@ -136,22 +138,29 @@ export default function App() {
     );
   }
 
+  const handleModelNameChange = (modelName: string | null) => {
+    setState((current) =>
+      current.status === "ready" ? { ...current, modelName } : current,
+    );
+  };
+
   return (
     <ClientProvider
       client={state.client}
       token={state.token}
       modelName={state.modelName}
     >
-      <Shell />
+      <Shell onModelNameChange={handleModelNameChange} />
     </ClientProvider>
   );
 }
 
-function Shell() {
+function Shell({ onModelNameChange }: { onModelNameChange: (modelName: string | null) => void }) {
   const { t, i18n } = useTranslation();
   const { theme, toggle } = useTheme();
   const { sessions, loading, refresh, createChat, deleteChat } = useSessions();
   const [activeKey, setActiveKey] = useState<string | null>(null);
+  const [view, setView] = useState<ShellView>("chat");
   const [desktopSidebarOpen, setDesktopSidebarOpen] =
     useState<boolean>(readSidebarOpen);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
@@ -208,6 +217,7 @@ function Shell() {
     try {
       const chatId = await createChat();
       setActiveKey(`websocket:${chatId}`);
+      setView("chat");
       setMobileSidebarOpen(false);
       return chatId;
     } catch (e) {
@@ -219,6 +229,7 @@ function Shell() {
   const onSelectChat = useCallback(
     (key: string) => {
       setActiveKey(key);
+      setView("chat");
       setMobileSidebarOpen(false);
     },
     [],
@@ -266,6 +277,11 @@ function Shell() {
     onRefresh: () => void refresh(),
     onRequestDelete: (key: string, label: string) =>
       setPendingDelete({ key, label }),
+    activeView: view,
+    onOpenSettings: () => {
+      setView("settings" as const);
+      setMobileSidebarOpen(false);
+    },
   };
 
   return (
@@ -303,14 +319,23 @@ function Shell() {
       </Sheet>
 
       <main className="flex h-full min-w-0 flex-1 flex-col">
-        <ThreadShell
-          session={activeSession}
-          title={headerTitle}
-          onToggleSidebar={toggleSidebar}
-          onGoHome={() => setActiveKey(null)}
-          onNewChat={onNewChat}
-          hideSidebarToggleOnDesktop={desktopSidebarOpen}
-        />
+        {view === "settings" ? (
+          <SettingsView
+            theme={theme}
+            onToggleTheme={toggle}
+            onBackToChat={() => setView("chat")}
+            onModelNameChange={onModelNameChange}
+          />
+        ) : (
+          <ThreadShell
+            session={activeSession}
+            title={headerTitle}
+            onToggleSidebar={toggleSidebar}
+            onGoHome={() => setActiveKey(null)}
+            onNewChat={onNewChat}
+            hideSidebarToggleOnDesktop={desktopSidebarOpen}
+          />
+        )}
       </main>
 
       <DeleteConfirm

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -8,20 +8,29 @@ import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { preloadMarkdownText } from "@/components/MarkdownText";
 import { useSessions } from "@/hooks/useSessions";
 import { useTheme } from "@/hooks/useTheme";
-import { cn } from "@/lib/utils";
-import { deriveWsUrl, fetchBootstrap } from "@/lib/bootstrap";
+import { cn, asset } from "@/lib/utils";
+import {
+  deriveWsUrl,
+  fetchBootstrap,
+  loadConnectionSettings,
+  saveConnectionSettings,
+  clearConnectionSettings,
+  isSameOrigin,
+} from "@/lib/bootstrap";
 import { NanobotClient } from "@/lib/nanobot-client";
 import { ClientProvider } from "@/providers/ClientProvider";
 import type { ChatSummary } from "@/lib/types";
 
 type BootState =
   | { status: "loading" }
+  | { status: "setup" }
   | { status: "error"; message: string }
   | {
       status: "ready";
       client: NanobotClient;
       token: string;
       modelName: string | null;
+      baseUrl: string;
     };
 
 const SIDEBAR_STORAGE_KEY = "nanobot-webui.sidebar";
@@ -39,40 +48,87 @@ function readSidebarOpen(): boolean {
   }
 }
 
+/** Attempt bootstrap with the given server URL. Returns a ready BootState on success. */
+async function doBootstrap(
+  baseUrl: string,
+  secret: string = "",
+): Promise<{
+  client: NanobotClient;
+  token: string;
+  modelName: string | null;
+}> {
+  const boot = await fetchBootstrap(baseUrl, secret);
+  const url = deriveWsUrl(boot.ws_path, boot.token, baseUrl);
+  const client = new NanobotClient({
+    url,
+    onReauth: async () => {
+      try {
+        const refreshed = await fetchBootstrap(baseUrl, secret);
+        return deriveWsUrl(refreshed.ws_path, refreshed.token, baseUrl);
+      } catch {
+        return null;
+      }
+    },
+  });
+  client.connect();
+  return {
+    client,
+    token: boot.token,
+    modelName: boot.model_name ?? null,
+  };
+}
+
 export default function App() {
   const { t } = useTranslation();
   const [state, setState] = useState<BootState>({ status: "loading" });
+  const [setupServer, setSetupServer] = useState("");
+  const [setupSecret, setSetupSecret] = useState("");
+  const [setupError, setSetupError] = useState("");
+  const [setupSubmitting, setSetupSubmitting] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
+
     (async () => {
-      try {
-        const boot = await fetchBootstrap();
-        if (cancelled) return;
-        const url = deriveWsUrl(boot.ws_path, boot.token);
-        const client = new NanobotClient({
-          url,
-          onReauth: async () => {
-            try {
-              const refreshed = await fetchBootstrap();
-              return deriveWsUrl(refreshed.ws_path, refreshed.token);
-            } catch {
-              return null;
-            }
-          },
-        });
-        client.connect();
-        setState({
-          status: "ready",
-          client,
-          token: boot.token,
-          modelName: boot.model_name ?? null,
-        });
-      } catch (e) {
-        if (cancelled) return;
-        setState({ status: "error", message: (e as Error).message });
+      // 1. Try same-origin (gateway-served) mode first.
+      if (isSameOrigin()) {
+        try {
+          const result = await doBootstrap("");
+          if (cancelled) {
+            result.client.close();
+            return;
+          }
+          setState({ status: "ready", ...result, baseUrl: "" });
+          return;
+        } catch {
+          // Same-origin failed, fall through to remote mode.
+        }
+      }
+
+      // 2. Try cached remote settings.
+      const cached = loadConnectionSettings();
+      if (cached) {
+        setSetupServer(cached.server);
+        setSetupSecret(cached.secret);
+        try {
+          const result = await doBootstrap(cached.server, cached.secret);
+          if (cancelled) {
+            result.client.close();
+            return;
+          }
+          setState({ status: "ready", ...result, baseUrl: cached.server });
+          return;
+        } catch {
+          // Cached settings invalid, show setup form with pre-filled values.
+        }
+      }
+
+      // 3. Show connection setup form.
+      if (!cancelled) {
+        setState({ status: "setup" });
       }
     })();
+
     return () => {
       cancelled = true;
     };
@@ -95,12 +151,47 @@ export default function App() {
     return () => globalThis.clearTimeout(id);
   }, []);
 
+  const handleSetupSubmit = useCallback(async () => {
+    setSetupError("");
+    const server = setupServer.replace(/\/+$/, "");
+    if (!server) {
+      setSetupError(t("setup.error.emptyServer"));
+      return;
+    }
+    const isLocal =
+      server.includes("localhost") ||
+      server.includes("127.0.0.1") ||
+      server.includes("[::1]");
+    if (!isLocal && !setupSecret.trim()) {
+      setSetupError(t("setup.error.emptySecret"));
+      return;
+    }
+    setSetupSubmitting(true);
+    try {
+      const result = await doBootstrap(server, setupSecret);
+      saveConnectionSettings({ server, secret: setupSecret });
+      setState({ status: "ready", ...result, baseUrl: server });
+    } catch (e) {
+      setSetupError((e as Error).message);
+    } finally {
+      setSetupSubmitting(false);
+    }
+  }, [setupServer, setupSecret, t]);
+
+  const handleDisconnect = useCallback(() => {
+    if (state.status === "ready") {
+      state.client.close();
+    }
+    clearConnectionSettings();
+    setState({ status: "setup" });
+  }, [state]);
+
   if (state.status === "loading") {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <div className="flex flex-col items-center gap-3 animate-in fade-in-0 duration-300">
           <img
-            src="/brand/nanobot_icon.png"
+            src={asset("brand/nanobot_icon.png")}
             alt=""
             className="h-10 w-10 animate-pulse select-none"
             aria-hidden
@@ -117,12 +208,71 @@ export default function App() {
       </div>
     );
   }
+
+  if (state.status === "setup") {
+    return (
+      <div className="flex h-full w-full items-center justify-center px-4">
+        <div className="flex w-full max-w-sm flex-col items-center gap-6">
+          <img
+            src={asset("brand/nanobot_icon.png")}
+            alt=""
+            className="h-12 w-12 select-none"
+            aria-hidden
+            draggable={false}
+          />
+          <div className="flex flex-col gap-1 text-center">
+            <p className="text-lg font-semibold">{t("setup.title")}</p>
+            <p className="text-sm text-muted-foreground">
+              {t("setup.description")}
+            </p>
+          </div>
+          <form
+            className="flex w-full flex-col gap-3"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleSetupSubmit();
+            }}
+          >
+            <input
+              type="url"
+              value={setupServer}
+              onChange={(e) => setSetupServer(e.target.value)}
+              placeholder={t("setup.serverPlaceholder")}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              autoFocus
+            />
+            <input
+              type="password"
+              value={setupSecret}
+              onChange={(e) => setSetupSecret(e.target.value)}
+              placeholder={t("setup.secretPlaceholder")}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            {setupError && (
+              <p className="text-sm text-destructive">{setupError}</p>
+            )}
+            <button
+              type="submit"
+              disabled={setupSubmitting}
+              className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none"
+            >
+              {setupSubmitting ? t("setup.connecting") : t("setup.connect")}
+            </button>
+          </form>
+          <p className="text-xs text-muted-foreground text-center">
+            {t("setup.hint")}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   if (state.status === "error") {
     return (
       <div className="flex h-full w-full items-center justify-center px-4 text-center">
         <div className="flex max-w-md flex-col items-center gap-3">
           <img
-            src="/brand/nanobot_icon.png"
+            src={asset("brand/nanobot_icon.png")}
             alt=""
             className="h-10 w-10 opacity-60 grayscale select-none"
             aria-hidden
@@ -133,6 +283,12 @@ export default function App() {
           <p className="text-xs text-muted-foreground">
             {t("app.error.gatewayHint")}
           </p>
+          <button
+            onClick={() => setState({ status: "setup" })}
+            className="mt-2 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            {t("setup.title")}
+          </button>
         </div>
       </div>
     );
@@ -149,6 +305,8 @@ export default function App() {
       client={state.client}
       token={state.token}
       modelName={state.modelName}
+      baseUrl={state.baseUrl}
+      onDisconnect={handleDisconnect}
     >
       <Shell onModelNameChange={handleModelNameChange} />
     </ClientProvider>

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -1,9 +1,8 @@
-import { Moon, PanelLeftClose, Plus, RefreshCcw, Sun } from "lucide-react";
+import { Moon, PanelLeftClose, RefreshCcw, Settings, SquarePen, Sun } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { ChatList } from "@/components/ChatList";
 import { ConnectionBadge } from "@/components/ConnectionBadge";
-import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import type { ChatSummary } from "@/lib/types";
@@ -19,48 +18,60 @@ interface SidebarProps {
   onRefresh: () => void;
   onRequestDelete: (key: string, label: string) => void;
   onCollapse: () => void;
+  activeView?: "chat" | "settings";
+  onOpenSettings: () => void;
 }
 
 export function Sidebar(props: SidebarProps) {
   const { t } = useTranslation();
   return (
     <aside className="flex h-full w-full flex-col border-r border-sidebar-border/70 bg-sidebar text-sidebar-foreground">
-      <div className="flex items-center justify-between px-2 py-2">
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label={t("sidebar.collapse")}
-          onClick={props.onCollapse}
-          className="h-7 w-7 rounded-lg text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
-        >
-          <PanelLeftClose className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label={t("sidebar.toggleTheme")}
-          onClick={props.onToggleTheme}
-          className="h-7 w-7 rounded-lg text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
-        >
-          {props.theme === "dark" ? (
-            <Sun className="h-3.5 w-3.5" />
-          ) : (
-            <Moon className="h-3.5 w-3.5" />
-          )}
-        </Button>
+      <div className="flex items-center justify-between px-3 pb-2 pt-3">
+        <picture className="block min-w-0">
+          <source srcSet="/brand/nanobot_logo.webp" type="image/webp" />
+          <img
+            src="/brand/nanobot_logo.png"
+            alt="nanobot"
+            className="h-7 w-auto select-none object-contain"
+            draggable={false}
+          />
+        </picture>
+        <div className="flex items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={t("sidebar.toggleTheme")}
+            onClick={props.onToggleTheme}
+            className="h-7 w-7 rounded-lg text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          >
+            {props.theme === "dark" ? (
+              <Sun className="h-3.5 w-3.5" />
+            ) : (
+              <Moon className="h-3.5 w-3.5" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={t("sidebar.collapse")}
+            onClick={props.onCollapse}
+            className="h-7 w-7 rounded-lg text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          >
+            <PanelLeftClose className="h-3.5 w-3.5" />
+          </Button>
+        </div>
       </div>
-      <div className="px-2 pb-2.5">
+      <div className="px-2 pb-2">
         <Button
           onClick={props.onNewChat}
-          className="h-8.5 w-full justify-start gap-2 rounded-lg border border-sidebar-border/80 bg-card/25 px-3 text-[13px] font-medium text-sidebar-foreground shadow-none hover:bg-sidebar-accent/80"
-          variant="outline"
+          className="h-9 w-full justify-start gap-2 rounded-full px-3 text-[13px] font-medium text-sidebar-foreground/90 hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          variant="ghost"
         >
-          <Plus className="h-3.5 w-3.5" />
+          <SquarePen className="h-3.5 w-3.5" />
           {t("sidebar.newChat")}
         </Button>
       </div>
-      <Separator className="bg-sidebar-border/70" />
-      <div className="flex items-center justify-between px-2.5 py-2 text-[11px] font-medium text-muted-foreground">
+      <div className="flex items-center justify-between px-3 pb-1.5 pt-2.5 text-[11px] font-medium text-muted-foreground">
         <span>{t("sidebar.recent")}</span>
         <Button
           variant="ghost"
@@ -81,10 +92,17 @@ export function Sidebar(props: SidebarProps) {
           onRequestDelete={props.onRequestDelete}
         />
       </div>
-      <Separator className="bg-sidebar-border/70" />
+      <Separator className="bg-sidebar-border/50" />
       <div className="flex items-center justify-between gap-2 px-2.5 py-2 text-xs">
         <ConnectionBadge />
-        <LanguageSwitcher />
+        <Button
+          onClick={props.onOpenSettings}
+          className="h-7 gap-1.5 rounded-md px-2 text-[11px] text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          variant={props.activeView === "settings" ? "secondary" : "ghost"}
+        >
+          <Settings className="h-3.5 w-3.5" />
+          Settings
+        </Button>
       </div>
     </aside>
   );

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronLeft, Loader2 } from "lucide-react";
+
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { fetchSettings, updateSettings } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { useClient } from "@/providers/ClientProvider";
+import type { SettingsPayload } from "@/lib/types";
+
+interface SettingsViewProps {
+  theme: "light" | "dark";
+  onToggleTheme: () => void;
+  onBackToChat: () => void;
+  onModelNameChange: (modelName: string | null) => void;
+}
+
+export function SettingsView({
+  onBackToChat,
+  onModelNameChange,
+}: SettingsViewProps) {
+  const { token } = useClient();
+  const [settings, setSettings] = useState<SettingsPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    model: "",
+    provider: "auto",
+  });
+
+  const applyPayload = useCallback((payload: SettingsPayload) => {
+    setSettings(payload);
+    setForm({
+      model: payload.agent.model,
+      provider: payload.agent.provider,
+    });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchSettings(token)
+      .then((payload) => {
+        if (!cancelled) {
+          applyPayload(payload);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [applyPayload, token]);
+
+  const dirty = useMemo(() => {
+    if (!settings) return false;
+    return (
+      form.model !== settings.agent.model ||
+      form.provider !== settings.agent.provider
+    );
+  }, [form, settings]);
+
+  const save = async () => {
+    if (!dirty || saving) return;
+    setSaving(true);
+    try {
+      const payload = await updateSettings(token, form);
+      applyPayload(payload);
+      onModelNameChange(payload.agent.model || null);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto bg-background">
+      <main className="mx-auto w-full max-w-[1000px] px-6 py-6">
+        <button
+          type="button"
+          onClick={onBackToChat}
+          className="mb-4 inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+          Back to chat
+        </button>
+
+        <h1 className="mb-6 text-base font-semibold tracking-tight">General</h1>
+
+        {loading ? (
+          <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Loading settings...
+          </div>
+        ) : error ? (
+          <SettingsGroup>
+            <SettingsRow title="Could not load settings">
+              <span className="max-w-[520px] text-sm text-muted-foreground">{error}</span>
+            </SettingsRow>
+          </SettingsGroup>
+        ) : settings ? (
+          <SettingsSection
+            form={form}
+            setForm={setForm}
+            settings={settings}
+            dirty={dirty}
+            saving={saving}
+            onSave={save}
+          />
+        ) : null}
+      </main>
+    </div>
+  );
+}
+
+function SettingsSection({
+  form,
+  setForm,
+  settings,
+  dirty,
+  saving,
+  onSave,
+}: {
+  form: {
+    model: string;
+    provider: string;
+  };
+  setForm: React.Dispatch<React.SetStateAction<{
+    model: string;
+    provider: string;
+  }>>;
+  settings: SettingsPayload;
+  dirty: boolean;
+  saving: boolean;
+  onSave: () => void;
+}) {
+  return (
+    <div className="space-y-7">
+      <section>
+        <h2 className="mb-2 px-2 text-xs font-medium text-muted-foreground">AI</h2>
+        <SettingsGroup>
+          <SettingsRow title="Provider">
+            <select
+              value={form.provider}
+              onChange={(event) => setForm((prev) => ({ ...prev, provider: event.target.value }))}
+              className={cn(
+                "h-8 w-[210px] rounded-md border border-input bg-background px-2 text-sm",
+                "outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+            >
+              {settings.providers.map((provider) => (
+                <option key={provider.name} value={provider.name}>
+                  {provider.label}
+                </option>
+              ))}
+            </select>
+          </SettingsRow>
+
+          <SettingsRow title="Model">
+            <Input
+              value={form.model}
+              onChange={(event) => setForm((prev) => ({ ...prev, model: event.target.value }))}
+              className="h-8 w-[280px]"
+            />
+          </SettingsRow>
+
+          {(dirty || saving || settings.requires_restart) ? (
+            <SettingsFooter
+              dirty={dirty}
+              saving={saving}
+              saved={settings.requires_restart && !dirty}
+              onSave={onSave}
+            />
+          ) : null}
+        </SettingsGroup>
+      </section>
+
+      <section>
+        <h2 className="mb-2 px-2 text-xs font-medium text-muted-foreground">Interface</h2>
+        <SettingsGroup>
+          <SettingsRow title="Language">
+            <LanguageSwitcher />
+          </SettingsRow>
+        </SettingsGroup>
+      </section>
+    </div>
+  );
+}
+
+function SettingsGroup({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border/60 bg-card/80">
+      <div className="divide-y divide-border/50">{children}</div>
+    </div>
+  );
+}
+
+function SettingsRow({
+  title,
+  children,
+}: {
+  title: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-[52px] flex-col gap-3 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <div className="text-sm font-medium leading-5">{title}</div>
+      </div>
+      {children ? <div className="shrink-0 sm:ml-6">{children}</div> : null}
+    </div>
+  );
+}
+
+function SettingsFooter({
+  dirty,
+  saving,
+  saved,
+  onSave,
+}: {
+  dirty: boolean;
+  saving: boolean;
+  saved: boolean;
+  onSave: () => void;
+}) {
+  return (
+    <div className="flex min-h-[52px] items-center justify-between gap-4 px-3 py-2.5">
+      <div className="text-sm text-muted-foreground">
+        {saved ? "Saved. Restart nanobot to apply." : "Unsaved changes."}
+      </div>
+      <Button size="sm" variant="outline" onClick={onSave} disabled={!dirty || saving}>
+        {saving ? "Saving" : "Save"}
+      </Button>
+    </div>
+  );
+}

--- a/webui/src/components/thread/AskUserPrompt.tsx
+++ b/webui/src/components/thread/AskUserPrompt.tsx
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MessageSquareText } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface AskUserPromptProps {
+  question: string;
+  buttons: string[][];
+  onAnswer: (answer: string) => void;
+}
+
+export function AskUserPrompt({
+  question,
+  buttons,
+  onAnswer,
+}: AskUserPromptProps) {
+  const [customOpen, setCustomOpen] = useState(false);
+  const [custom, setCustom] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const options = buttons.flat().filter(Boolean);
+
+  useEffect(() => {
+    if (customOpen) {
+      inputRef.current?.focus();
+    }
+  }, [customOpen]);
+
+  const submitCustom = useCallback(() => {
+    const answer = custom.trim();
+    if (!answer) return;
+    onAnswer(answer);
+    setCustom("");
+    setCustomOpen(false);
+  }, [custom, onAnswer]);
+
+  if (options.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "mx-auto mb-2 w-full max-w-[49.5rem] rounded-[16px] border border-primary/30",
+        "bg-card/95 p-3 shadow-sm backdrop-blur",
+      )}
+      role="group"
+      aria-label="Question"
+    >
+      <div className="mb-2 flex items-start gap-2">
+        <div className="mt-0.5 rounded-full bg-primary/10 p-1.5 text-primary">
+          <MessageSquareText className="h-3.5 w-3.5" aria-hidden />
+        </div>
+        <p className="min-w-0 flex-1 text-sm font-medium leading-5 text-foreground">
+          {question}
+        </p>
+      </div>
+
+      <div className="grid gap-1.5 sm:grid-cols-2">
+        {options.map((option) => (
+          <Button
+            key={option}
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onAnswer(option)}
+            className="justify-start rounded-[10px] px-3 text-left"
+          >
+            <span className="truncate">{option}</span>
+          </Button>
+        ))}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setCustomOpen((open) => !open)}
+          className="justify-start rounded-[10px] px-3 text-muted-foreground"
+        >
+          Other...
+        </Button>
+      </div>
+
+      {customOpen ? (
+        <div className="mt-2 flex gap-2">
+          <textarea
+            ref={inputRef}
+            value={custom}
+            onChange={(event) => setCustom(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+                event.preventDefault();
+                submitCustom();
+              }
+            }}
+            rows={1}
+            placeholder="Type your own answer..."
+            className={cn(
+              "min-h-9 flex-1 resize-none rounded-[10px] border border-border/70 bg-background",
+              "px-3 py-2 text-sm leading-5 outline-none placeholder:text-muted-foreground",
+              "focus-visible:ring-1 focus-visible:ring-primary/40",
+            )}
+          />
+          <Button type="button" size="sm" onClick={submitCustom} disabled={!custom.trim()}>
+            Send
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webui/src/components/thread/ThreadHeader.tsx
+++ b/webui/src/components/thread/ThreadHeader.tsx
@@ -2,7 +2,7 @@ import { PanelLeftOpen } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { cn, asset } from "@/lib/utils";
 
 interface ThreadHeaderProps {
   title: string;
@@ -39,7 +39,7 @@ export function ThreadHeader({
           className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-accent/35 hover:text-foreground"
         >
           <img
-            src="/brand/nanobot_icon.png"
+            src={asset("brand/nanobot_icon.png")}
             alt=""
             className="h-4 w-4 rounded-[5px] opacity-85"
             aria-hidden

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { AskUserPrompt } from "@/components/thread/AskUserPrompt";
 import { ThreadComposer } from "@/components/thread/ThreadComposer";
 import { ThreadHeader } from "@/components/thread/ThreadHeader";
 import { StreamErrorNotice } from "@/components/thread/StreamErrorNotice";
@@ -57,6 +58,21 @@ export function ThreadShell({
     dismissStreamError,
   } = useNanobotStream(chatId, initial);
   const showHeroComposer = messages.length === 0 && !loading;
+  const pendingAsk = useMemo(() => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (message.kind === "trace") continue;
+      if (message.role === "user") return null;
+      if (message.role === "assistant" && message.buttons?.some((row) => row.length > 0)) {
+        return {
+          question: message.content,
+          buttons: message.buttons,
+        };
+      }
+      if (message.role === "assistant") return null;
+    }
+    return null;
+  }, [messages]);
 
   useEffect(() => {
     if (!chatId || loading) return;
@@ -150,6 +166,13 @@ export function ThreadShell({
               <StreamErrorNotice
                 error={streamError}
                 onDismiss={dismissStreamError}
+              />
+            ) : null}
+            {pendingAsk ? (
+              <AskUserPrompt
+                question={pendingAsk.question}
+                buttons={pendingAsk.buttons}
+                onAnswer={send}
               />
             ) : null}
             {session ? (

--- a/webui/src/components/thread/ThreadShell.tsx
+++ b/webui/src/components/thread/ThreadShell.tsx
@@ -9,6 +9,7 @@ import { ThreadViewport } from "@/components/thread/ThreadViewport";
 import { useNanobotStream } from "@/hooks/useNanobotStream";
 import { useSessionHistory } from "@/hooks/useSessions";
 import type { ChatSummary, UIMessage } from "@/lib/types";
+import { asset } from "@/lib/utils";
 import { useClient } from "@/providers/ClientProvider";
 
 interface ThreadShellProps {
@@ -134,7 +135,7 @@ export function ThreadShell({
     <div className="flex w-full max-w-[40rem] flex-col gap-2 text-left animate-in fade-in-0 slide-in-from-bottom-2 duration-500">
       <div className="inline-flex items-center gap-2 text-[11px] font-medium text-muted-foreground">
         <img
-          src="/brand/nanobot_icon.png"
+          src={asset("brand/nanobot_icon.png")}
           alt=""
           aria-hidden
           draggable={false}

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -160,13 +160,15 @@ export function useNanobotStream(
         setIsStreaming(false);
         setMessages((prev) => {
           const filtered = activeId ? prev.filter((m) => m.id !== activeId) : prev;
+          const content = ev.buttons?.length ? (ev.button_prompt ?? ev.text) : ev.text;
           return [
             ...filtered,
             {
               id: crypto.randomUUID(),
               role: "assistant",
-              content: ev.text,
+              content,
               createdAt: Date.now(),
+              ...(ev.buttons && ev.buttons.length > 0 ? { buttons: ev.buttons } : {}),
               ...(media && media.length > 0 ? { media } : {}),
             },
           ];

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -23,17 +23,19 @@ export function useSessions(): {
   createChat: () => Promise<string>;
   deleteChat: (key: string) => Promise<void>;
 } {
-  const { client, token } = useClient();
+  const { client, token, baseUrl } = useClient();
   const [sessions, setSessions] = useState<ChatSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const tokenRef = useRef(token);
   tokenRef.current = token;
+  const baseUrlRef = useRef(baseUrl);
+  baseUrlRef.current = baseUrl;
 
   const refresh = useCallback(async () => {
     try {
       setLoading(true);
-      const rows = await listSessions(tokenRef.current);
+      const rows = await listSessions(tokenRef.current, baseUrlRef.current);
       setSessions(rows);
       setError(null);
     } catch (e) {
@@ -70,7 +72,7 @@ export function useSessions(): {
 
   const deleteChat = useCallback(
     async (key: string) => {
-      await apiDeleteSession(tokenRef.current, key);
+      await apiDeleteSession(tokenRef.current, key, baseUrlRef.current);
       setSessions((prev) => prev.filter((s) => s.key !== key));
     },
     [],
@@ -85,7 +87,7 @@ export function useSessionHistory(key: string | null): {
   loading: boolean;
   error: string | null;
 } {
-  const { token } = useClient();
+  const { token, baseUrl } = useClient();
   const [state, setState] = useState<{
     key: string | null;
     messages: UIMessage[];
@@ -119,7 +121,7 @@ export function useSessionHistory(key: string | null): {
     });
     (async () => {
       try {
-        const body = await fetchSessionMessages(token, key);
+        const body = await fetchSessionMessages(token, key, baseUrl);
         if (cancelled) return;
         const ui: UIMessage[] = body.messages.flatMap((m, idx) => {
           if (m.role !== "user" && m.role !== "assistant") return [];

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -103,6 +103,19 @@
   "common": {
     "dismiss": "Dismiss"
   },
+  "setup": {
+    "title": "Connect to nanobot",
+    "description": "Enter your nanobot gateway address to get started.",
+    "serverPlaceholder": "http://192.168.1.100:8765",
+    "secretPlaceholder": "Secret",
+    "connect": "Connect",
+    "connecting": "Connecting…",
+    "hint": "Start the gateway with `nanobot gateway` and enter its address above.",
+    "error": {
+      "emptyServer": "Server address is required.",
+      "emptySecret": "Secret is required for remote connections."
+    }
+  },
   "errors": {
     "messageTooBig": {
       "title": "Message too large",

--- a/webui/src/i18n/locales/zh-CN/common.json
+++ b/webui/src/i18n/locales/zh-CN/common.json
@@ -103,6 +103,19 @@
   "common": {
     "dismiss": "关闭"
   },
+  "setup": {
+    "title": "连接到 nanobot",
+    "description": "输入你的 nanobot 网关地址即可开始使用。",
+    "serverPlaceholder": "http://192.168.1.100:8765",
+    "secretPlaceholder": "Secret",
+    "connect": "连接",
+    "connecting": "连接中…",
+    "hint": "启动网关：`nanobot gateway`，然后在上方输入地址。",
+    "error": {
+      "emptyServer": "请输入服务器地址。",
+      "emptySecret": "远程连接需要填写 Secret。"
+    }
+  },
   "errors": {
     "messageTooBig": {
       "title": "消息过大",

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { ChatSummary } from "./types";
+import type { ChatSummary, SettingsPayload, SettingsUpdate } from "./types";
 
 export class ApiError extends Error {
   status: number;
@@ -103,4 +103,22 @@ export async function deleteSession(
     token,
   );
   return body.deleted;
+}
+
+export async function fetchSettings(
+  token: string,
+  base: string = "",
+): Promise<SettingsPayload> {
+  return request<SettingsPayload>(`${base}/api/settings`, token);
+}
+
+export async function updateSettings(
+  token: string,
+  update: SettingsUpdate,
+  base: string = "",
+): Promise<SettingsPayload> {
+  const query = new URLSearchParams();
+  if (update.model !== undefined) query.set("model", update.model);
+  if (update.provider !== undefined) query.set("provider", update.provider);
+  return request<SettingsPayload>(`${base}/api/settings/update?${query}`, token);
 }

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -20,7 +20,6 @@ async function request<T>(
       ...(init?.headers ?? {}),
       Authorization: `Bearer ${token}`,
     },
-    credentials: "same-origin",
   });
   if (!res.ok) {
     throw new ApiError(res.status, `HTTP ${res.status}`);

--- a/webui/src/lib/bootstrap.ts
+++ b/webui/src/lib/bootstrap.ts
@@ -1,18 +1,87 @@
 import type { BootstrapResponse } from "./types";
 
+const STORAGE_KEY_SERVER = "nanobot.server";
+
+export interface ConnectionSettings {
+  server: string;
+  secret: string;
+}
+
+const STORAGE_KEY_SECRET = "nanobot.secret";
+
+/** Read cached connection settings from localStorage. */
+export function loadConnectionSettings(): ConnectionSettings | null {
+  try {
+    const server = window.localStorage.getItem(STORAGE_KEY_SERVER);
+    const secret = window.sessionStorage.getItem(STORAGE_KEY_SECRET) ?? "";
+    if (server) return { server, secret };
+  } catch {
+    // ignore storage errors
+  }
+  return null;
+}
+
+/** Persist connection settings to localStorage. */
+export function saveConnectionSettings(settings: ConnectionSettings): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY_SERVER, settings.server);
+    // Secret goes to sessionStorage so it doesn't persist across browser sessions.
+    if (settings.secret) {
+      window.sessionStorage.setItem(STORAGE_KEY_SECRET, settings.secret);
+    } else {
+      window.sessionStorage.removeItem(STORAGE_KEY_SECRET);
+    }
+  } catch {
+    // ignore storage errors
+  }
+}
+
+/** Clear cached connection settings. */
+export function clearConnectionSettings(): void {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY_SERVER);
+    window.sessionStorage.removeItem(STORAGE_KEY_SECRET);
+  } catch {
+    // ignore storage errors
+  }
+}
+
+/** Detect if the page is likely served by the nanobot gateway (same-origin). */
+export function isSameOrigin(): boolean {
+  try {
+    return (
+      window.location.hostname === "localhost" ||
+      window.location.hostname === "127.0.0.1" ||
+      window.location.hostname === "[::1]"
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Fetch a short-lived token + the WebSocket path from the gateway's
- * ``/webui/bootstrap`` endpoint. Localhost-only on the server side.
+ * ``/webui/bootstrap`` endpoint.
+ *
+ * CORS and TLS are handled by an nginx reverse proxy in front of the gateway.
+ * When no baseUrl is given, the request goes to the current origin.
  */
 export async function fetchBootstrap(
   baseUrl: string = "",
+  secret: string = "",
 ): Promise<BootstrapResponse> {
+  const headers: Record<string, string> = {};
+  if (secret) {
+    headers["Authorization"] = `Bearer ${secret}`;
+  }
   const res = await fetch(`${baseUrl}/webui/bootstrap`, {
     method: "GET",
     credentials: "same-origin",
+    headers,
   });
   if (!res.ok) {
-    throw new Error(`bootstrap failed: HTTP ${res.status}`);
+    const text = await res.text().catch(() => "");
+    throw new Error(text || `bootstrap failed: HTTP ${res.status}`);
   }
   const body = (await res.json()) as BootstrapResponse;
   if (!body.token || !body.ws_path) {
@@ -21,16 +90,26 @@ export async function fetchBootstrap(
   return body;
 }
 
-/** Derive a WebSocket URL from the current window location and the server-provided path.
+/**
+ * Build a WebSocket URL.
  *
- * Keeps the path segment exactly as the server registered it: the root ``/``
- * stays ``/`` and non-root paths are not given an extra trailing slash. This
- * matters because some WS servers dispatch handshakes based on the literal
- * path, not a normalised form.
+ * If baseUrl is provided (remote mode), derive scheme and host from it.
+ * Otherwise fall back to window.location (same-origin / gateway-served mode).
  */
-export function deriveWsUrl(wsPath: string, token: string): string {
+export function deriveWsUrl(
+  wsPath: string,
+  token: string,
+  baseUrl: string = "",
+): string {
   const path = wsPath && wsPath.startsWith("/") ? wsPath : `/${wsPath || ""}`;
   const query = `?token=${encodeURIComponent(token)}`;
+
+  if (baseUrl) {
+    const url = new URL(baseUrl);
+    const scheme = url.protocol === "https:" ? "wss" : "ws";
+    return `${scheme}://${url.host}${path}${query}`;
+  }
+
   if (typeof window === "undefined") {
     return `ws://127.0.0.1:8765${path}${query}`;
   }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -66,6 +66,28 @@ export interface BootstrapResponse {
   model_name?: string | null;
 }
 
+export interface SettingsPayload {
+  agent: {
+    model: string;
+    provider: string;
+    resolved_provider: string | null;
+    has_api_key: boolean;
+  };
+  providers: Array<{
+    name: string;
+    label: string;
+  }>;
+  runtime: {
+    config_path: string;
+  };
+  requires_restart: boolean;
+}
+
+export interface SettingsUpdate {
+  model?: string;
+  provider?: string;
+}
+
 export type ConnectionStatus =
   | "idle"
   | "connecting"

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -44,6 +44,8 @@ export interface UIMessage {
   images?: UIImage[];
   /** Signed or local UI-renderable media attachments. */
   media?: UIMediaAttachment[];
+  /** Optional answer choices for a pending ask_user question. */
+  buttons?: string[][];
 }
 
 export interface ChatSummary {
@@ -82,6 +84,9 @@ export type InboundEvent =
       reply_to?: string;
       media?: string[];
       media_urls?: Array<{ url: string; name?: string }>;
+      buttons?: string[][];
+      /** Original prompt before the websocket text fallback appends buttons. */
+      button_prompt?: string;
       /** Present when the frame is an agent breadcrumb (e.g. tool hint,
        * generic progress line) rather than a conversational reply. */
       kind?: "tool_hint" | "progress";

--- a/webui/src/lib/utils.ts
+++ b/webui/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
+
+/** Resolve a public asset path against Vite's base URL. */
+export function asset(assetPath: string): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const base = (import.meta as any).env?.BASE_URL ?? "/";
+  const joined = `${base}${assetPath}`;
+  // Collapse repeated slashes, but preserve the protocol "://".
+  return joined.replace(/(^https?:\/\/)|(\/+)/g, (_, proto: string | undefined) =>
+    proto ?? "/",
+  );
+}

--- a/webui/src/providers/ClientProvider.tsx
+++ b/webui/src/providers/ClientProvider.tsx
@@ -6,6 +6,8 @@ interface ClientContextValue {
   client: NanobotClient;
   token: string;
   modelName: string | null;
+  baseUrl: string;
+  onDisconnect: () => void;
 }
 
 const ClientContext = createContext<ClientContextValue | null>(null);
@@ -14,15 +16,19 @@ export function ClientProvider({
   client,
   token,
   modelName = null,
+  baseUrl = "",
+  onDisconnect,
   children,
 }: {
   client: NanobotClient;
   token: string;
   modelName?: string | null;
+  baseUrl?: string;
+  onDisconnect: () => void;
   children: ReactNode;
 }) {
   return (
-    <ClientContext.Provider value={{ client, token, modelName }}>
+    <ClientContext.Provider value={{ client, token, modelName, baseUrl, onDisconnect }}>
       {children}
     </ClientContext.Provider>
   );

--- a/webui/src/tests/api.test.ts
+++ b/webui/src/tests/api.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { deleteSession, fetchSessionMessages } from "@/lib/api";
+import { deleteSession, fetchSessionMessages, updateSettings } from "@/lib/api";
 
 describe("webui API helpers", () => {
   beforeEach(() => {
@@ -29,6 +29,20 @@ describe("webui API helpers", () => {
 
     expect(fetch).toHaveBeenCalledWith(
       "/api/sessions/websocket%3Achat-1/delete",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer tok" },
+      }),
+    );
+  });
+
+  it("serializes settings updates as a narrow query string", async () => {
+    await updateSettings("tok", {
+      model: "openrouter/test",
+      provider: "openrouter",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/settings/update?model=openrouter%2Ftest&provider=openrouter",
       expect.objectContaining({
         headers: { Authorization: "Bearer tok" },
       }),

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -146,4 +146,44 @@ describe("App layout", () => {
     expect(screen.queryByText('Delete “First chat”?')).not.toBeInTheDocument();
     expect(document.body.style.pointerEvents).not.toBe("none");
   }, 15_000);
+
+  it("opens the Cursor-style settings view from the sidebar", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes("/api/settings")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              agent: {
+                model: "openai/gpt-4o",
+                provider: "auto",
+                resolved_provider: "openai",
+                has_api_key: true,
+              },
+              providers: [
+                { name: "auto", label: "Auto" },
+                { name: "openai", label: "OpenAI" },
+              ],
+              runtime: {
+                config_path: "/tmp/config.json",
+              },
+              requires_restart: false,
+            }),
+          };
+        }
+        return { ok: false, status: 404, json: async () => ({}) };
+      }),
+    );
+
+    render(<App />);
+
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(await screen.findByRole("heading", { name: "General" })).toBeInTheDocument();
+    expect(screen.getByText("AI")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("openai/gpt-4o")).toBeInTheDocument();
+  });
 });

--- a/webui/src/tests/thread-shell.test.tsx
+++ b/webui/src/tests/thread-shell.test.tsx
@@ -7,11 +7,22 @@ import { ClientProvider } from "@/providers/ClientProvider";
 
 function makeClient() {
   const errorHandlers = new Set<(err: { kind: string }) => void>();
+  const chatHandlers = new Map<string, Set<(ev: import("@/lib/types").InboundEvent) => void>>();
   return {
     status: "open" as const,
     defaultChatId: null as string | null,
     onStatus: () => () => {},
-    onChat: () => () => {},
+    onChat: (chatId: string, handler: (ev: import("@/lib/types").InboundEvent) => void) => {
+      let handlers = chatHandlers.get(chatId);
+      if (!handlers) {
+        handlers = new Set();
+        chatHandlers.set(chatId, handlers);
+      }
+      handlers.add(handler);
+      return () => {
+        handlers?.delete(handler);
+      };
+    },
     onError: (handler: (err: { kind: string }) => void) => {
       errorHandlers.add(handler);
       return () => {
@@ -20,6 +31,9 @@ function makeClient() {
     },
     _emitError(err: { kind: string }) {
       for (const h of errorHandlers) h(err);
+    },
+    _emitChat(chatId: string, ev: import("@/lib/types").InboundEvent) {
+      for (const h of chatHandlers.get(chatId) ?? []) h(ev);
     },
     sendMessage: vi.fn(),
     newChat: vi.fn(),
@@ -410,5 +424,47 @@ describe("ThreadShell", () => {
 
     await waitFor(() => expect(screen.getByText("from chat b")).toBeInTheDocument());
     expect(screen.queryByText("from chat a")).not.toBeInTheDocument();
+  });
+
+  it("renders ask_user options above the composer and sends selected answers", async () => {
+    const client = makeClient();
+    const onNewChat = vi.fn().mockResolvedValue("chat-a");
+
+    render(
+      wrap(
+        client,
+        <ThreadShell
+          session={session("chat-a")}
+          title="Chat chat-a"
+          onToggleSidebar={() => {}}
+          onGoHome={() => {}}
+          onNewChat={onNewChat}
+        />,
+      ),
+    );
+
+    await act(async () => {
+      client._emitChat("chat-a", {
+        event: "message",
+        chat_id: "chat-a",
+        text: "How should I continue?",
+        buttons: [["Short answer", "Detailed answer"]],
+      });
+    });
+
+    expect(screen.getByRole("group", { name: "Question" })).toHaveTextContent(
+      "How should I continue?",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Short answer" }));
+
+    expect(client.sendMessage).toHaveBeenCalledWith(
+      "chat-a",
+      "Short answer",
+      undefined,
+    );
+    await waitFor(() => {
+      expect(screen.queryByRole("group", { name: "Question" })).not.toBeInTheDocument();
+    });
   });
 });

--- a/webui/src/tests/useNanobotStream.test.tsx
+++ b/webui/src/tests/useNanobotStream.test.tsx
@@ -113,4 +113,27 @@ describe("useNanobotStream", () => {
       { kind: "video", url: "/api/media/sig/payload", name: "demo.mp4" },
     ]);
   });
+
+  it("keeps assistant buttons on complete messages", () => {
+    const fake = fakeClient();
+    const { result } = renderHook(() => useNanobotStream("chat-q", []), {
+      wrapper: wrap(fake.client),
+    });
+
+    act(() => {
+      fake.emit("chat-q", {
+        event: "message",
+        chat_id: "chat-q",
+        text: "How should I continue?\n\n1. Short answer\n2. Detailed answer",
+        button_prompt: "How should I continue?",
+        buttons: [["Short answer", "Detailed answer"]],
+      });
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].content).toBe("How should I continue?");
+    expect(result.current.messages[0].buttons).toEqual([
+      ["Short answer", "Detailed answer"],
+    ]);
+  });
 });

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -6,9 +6,12 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const target = env.NANOBOT_API_URL ?? "http://127.0.0.1:8765";
   const wsTarget = target.replace(/^http/, "ws");
+  // GitHub Pages base: repo name for project sites, "/" for user sites or local dev.
+  const base = env.VITE_BASE ?? "/";
 
   return {
     plugins: [react()],
+    base,
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),
@@ -22,7 +25,7 @@ export default defineConfig(({ mode }) => {
       exclude: ["@radix-ui/react-dialog"],
     },
     build: {
-      outDir: path.resolve(__dirname, "../nanobot/web/dist"),
+      outDir: path.resolve(__dirname, env.VITE_BUILD_OUTDIR ?? "../nanobot/web/dist"),
       emptyOutDir: true,
       sourcemap: false,
     },


### PR DESCRIPTION
## Summary

- Add `create-instance` built-in skill that lets a running nanobot agent create new bot instances through a helper script
- Support GitHub Pages deployment for WebUI with remote backend (bootstrap + secret-based auth)

### create-instance skill

The agent can now create new nanobot instances via conversation:

1. User says "帮我创建一个 Telegram bot"
2. Agent collects instance name, channel type, and optional model
3. Agent runs `create_instance.py` which:
   - Creates config.json + workspace via nanobot's programmatic API
   - Enables the target channel
   - Inherits API keys from the current instance (`--inherit-config`)
   - Auto-assigns gateway/API ports if defaults are occupied
   - Reports required fields user needs to fill in (e.g. bot token)
4. User fills in channel-specific tokens and starts the instance

### WebUI remote backend

- Add `token_issue_secret` config for secret-based WebUI bootstrap
- Allow non-localhost origins to connect with shared secret
- Add GitHub Pages deployment workflow

## Test plan

- [x] 9/9 unit tests pass (`tests/skills/test_create_instance.py`)
- [x] Port auto-assignment verified with port conflict test
- [x] API key inheritance verified with `--inherit-config` test
- [x] Smoke test: created instance config passes Pydantic validation
- [x] Existing `~/.nanobot` untouched during testing
- [x] Existing test suite (`tests/agent/test_skills_loader.py`) passes without regression