### PR TITLE
fix(agent): subagent announces from threaded callers route to channel session, not the originating thread

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -403,7 +403,16 @@ class AgentLoop:
         session_key: str | None = None,
     ) -> None:
         """Update context for all tools that need routing info."""
-        effective_key = UNIFIED_SESSION_KEY if self._unified_session else f"{channel}:{chat_id}"
+        # When the caller threads a thread-scoped session_key (e.g. slack with
+        # reply_in_thread: true), honor it so spawn announces route back to
+        # the originating thread session. Falls back to unified mode or
+        # channel:chat_id for callers that don't have a thread-scoped key.
+        if session_key is not None:
+            effective_key = session_key
+        elif self._unified_session:
+            effective_key = UNIFIED_SESSION_KEY
+        else:
+            effective_key = f"{channel}:{chat_id}"
         for name in ("message", "spawn", "cron", "my"):
             if tool := self.tools.get(name):
                 if hasattr(tool, "set_context"):
@@ -830,7 +839,10 @@ class AgentLoop:
                 msg.chat_id.split(":", 1) if ":" in msg.chat_id else ("cli", msg.chat_id)
             )
             logger.info("Processing system message from {}", msg.sender_id)
-            key = f"{channel}:{chat_id}"
+            # Honor session_key_override so subagent announces from threaded
+            # callers route to the originating thread session, not the
+            # channel-level session derived from chat_id.
+            key = msg.session_key_override or f"{channel}:{chat_id}"
             session = self.sessions.get_or_create(key)
             if self._restore_runtime_checkpoint(session):
                 self.sessions.save(session)
@@ -885,11 +897,20 @@ class AgentLoop:
                 options,
                 channel,
             )
+            # Reconstruct channel-specific metadata from session.key so the
+            # outbound reply lands in the originating thread (not the channel
+            # top-level). The announce InboundMessage carries only
+            # injected_event metadata; we recover thread_ts from the session
+            # key, which slack writes as "slack:<chat_id>:<thread_ts>".
+            outbound_metadata: dict[str, Any] = {}
+            if channel == "slack" and key.startswith("slack:") and key.count(":") >= 2:
+                outbound_metadata["slack"] = {"thread_ts": key.split(":", 2)[2]}
             return OutboundMessage(
                 channel=channel,
                 chat_id=chat_id,
                 content=content,
                 buttons=buttons,
+                metadata=outbound_metadata,
             )
 
         # Extract document text from media at the processing boundary so all

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -660,3 +660,63 @@ def test_subagent_followup_skips_empty_content() -> None:
 
     assert loop._persist_subagent_followup(session, msg) is False
     assert session.messages == []
+
+
+def test_set_tool_context_passes_thread_session_key_to_spawn(tmp_path: Path) -> None:
+    loop = _make_full_loop(tmp_path)
+
+    loop._set_tool_context(
+        "slack",
+        "C123",
+        metadata={"slack": {"thread_ts": "1700.42", "channel_type": "channel"}},
+        session_key="slack:C123:1700.42",
+    )
+
+    spawn_tool = loop.tools.get("spawn")
+    assert spawn_tool is not None
+    assert spawn_tool._session_key.get() == "slack:C123:1700.42"
+
+
+@pytest.mark.asyncio
+async def test_system_subagent_followup_uses_thread_session_and_slack_metadata(tmp_path: Path) -> None:
+    loop = _make_full_loop(tmp_path)
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    thread_session = loop.sessions.get_or_create("slack:C123:1700.42")
+    thread_session.add_message("user", "thread question")
+    loop.sessions.save(thread_session)
+
+    seen: dict[str, list[dict]] = {}
+
+    async def fake_run_agent_loop(initial_messages, **_kwargs):
+        seen["initial_messages"] = initial_messages
+        return (
+            "done",
+            [],
+            [*initial_messages, {"role": "assistant", "content": "done"}],
+            "stop",
+            False,
+        )
+
+    loop._run_agent_loop = fake_run_agent_loop  # type: ignore[method-assign]
+
+    outbound = await loop._process_message(
+        InboundMessage(
+            channel="system",
+            sender_id="subagent",
+            chat_id="slack:C123",
+            content="subagent result",
+            session_key_override="slack:C123:1700.42",
+            metadata={"subagent_task_id": "sub-1"},
+        )
+    )
+
+    assert outbound is not None
+    assert outbound.channel == "slack"
+    assert outbound.chat_id == "C123"
+    assert outbound.metadata == {"slack": {"thread_ts": "1700.42"}}
+    assert "thread question" in seen["initial_messages"][1]["content"]
+
+    loop.sessions.invalidate("slack:C123:1700.42")
+    persisted = loop.sessions.get_or_create("slack:C123:1700.42")
+    assert any(m.get("subagent_task_id") == "sub-1" for m in persisted.messages)


### PR DESCRIPTION
## Summary

Subagent completion announces from a threaded chat (e.g. slack with `reply_in_thread: true`) are routed back to the channel-level session rather than the originating thread session. The parent agent sitting in the thread never sees the announce in its context, so it confabulates "still running" indefinitely. Even after PR #3463 (commit `038a140`), which threaded `metadata` and `session_key` through `_LoopHook` and `_set_tool_context` for the cron and message tools, the spawn dispatch and the system-channel branch in `_process_message` still drop `thread_ts` at three distinct points.

## Reproduce

Slack config with `reply_in_thread: true`. From inside a slack thread:

> spawn a subagent that writes 'ok' to verify.txt and reports back when done

Observed:
- Subagent completes; `_announce_result` publishes correctly.
- Token consolidation log line after the announce targets `slack:<channel>` (channel session), not `slack:<channel>:<thread_ts>` (thread session).
- The thread session JSONL `slack_<channel>_<thread_ts>.jsonl` never receives the announce.
- A new channel session JSONL `slack_<channel>.jsonl` is created (or accumulates further) holding the announce template content.
- The LLM's reply to the announce posts to the channel top-level rather than the originating thread.
- Parent agent inside the thread keeps generating "still running" updates because no completion event ever appears in its context.

## Root cause (three layers)

`channels/slack.py:348` correctly constructs a thread-scoped `session_key` for inbound messages:

```python
session_key = f"slack:{chat_id}:{thread_ts}" if thread_ts and channel_type != "im" else None
```

The inbound `InboundMessage` carries this via `session_key_override`, and `_effective_session_key(msg)` returns the right thread-scoped key. PR #3463 plumbed `session_key` and `metadata` into `_LoopHook` and `_set_tool_context` so cron and message tools could honor the originating thread for proactive replies. But three downstream points still drop `thread_ts`:

**(a) `_set_tool_context` body still computes `effective_key` from `channel:chat_id`.** The signature was extended but the body is unchanged:

```python
def _set_tool_context(
    self, channel: str, chat_id: str,
    message_id: str | None = None, metadata: dict | None = None,
    session_key: str | None = None,
) -> None:
    effective_key = UNIFIED_SESSION_KEY if self._unified_session else f"{channel}:{chat_id}"
    for name in ("message", "spawn", "cron", "my"):
        if tool := self.tools.get(name):
            if hasattr(tool, "set_context"):
                if name == "spawn":
                    tool.set_context(channel, chat_id, effective_key=effective_key)  # <-- still channel-only
                elif name == "cron":
                    tool.set_context(channel, chat_id, metadata=metadata, session_key=session_key)
                elif name == "message":
                    tool.set_context(channel, chat_id, message_id, metadata=metadata)
                else:
                    tool.set_context(channel, chat_id)
```

The `session_key` parameter is used for cron and message but the spawn dispatch ignores it. So `SpawnTool`'s ContextVar receives the channel-only `effective_key`, and the announce InboundMessage ends up with a channel-only `session_key_override`.

**(b) `_process_message`'s system-channel branch ignores `session_key_override`** when loading the session:

```python
if msg.channel == "system":
    channel, chat_id = (msg.chat_id.split(":", 1) if ":" in msg.chat_id else ("cli", msg.chat_id))
    ...
    key = f"{channel}:{chat_id}"          # <-- ignores msg.session_key_override
    session = self.sessions.get_or_create(key)
```

So even if the announce InboundMessage carried the right thread-scoped override (after fix a), the consumer side discards it and routes to the channel-level session.

**(c) The OutboundMessage returned from the system-channel branch carries no metadata**, so slack's outbound dispatcher has no `thread_ts` to use:

```python
return OutboundMessage(
    channel=channel,
    chat_id=chat_id,
    content=content,
    buttons=buttons,
)
```

The slack outbound code reads `msg.metadata.get("slack", {}).get("thread_ts")`. With empty metadata, it falls through and posts to the channel top-level rather than the originating thread.

## Proposed fix

Three small edits in `nanobot/agent/loop.py`. See attached PR.

1. `_set_tool_context` body: when `session_key` is provided, use it as `effective_key`. Falls back to unified mode or `channel:chat_id` for callers without a thread-scoped key.
2. System-channel session loading: replace `key = f"{channel}:{chat_id}"` with `key = msg.session_key_override or f"{channel}:{chat_id}"`.
3. System-channel OutboundMessage: reconstruct `slack thread_ts` metadata from the loaded session key when `channel == "slack"` and the key is `slack:<chat_id>:<thread_ts>`.

Total: ~12 net lines changed.

## Test

No regression test included in the initial commit. Happy to extend `tests/agent/test_task_cancel.py` with one once the maintainer confirms preferred mocking style for `SubagentManager` / `_set_tool_context` (the existing patterns mock at slightly different layers).

## Related

- #2321 / #2322 (original Feishu report and partial fix; commit `2193a64`)
- #3321 / commit `68466b1` (effective-key plumbing through `SubagentManager`)
- #3463 / commit `038a140` (`metadata` and `session_key` plumbing through `_LoopHook` and `_set_tool_context` for cron and message tools; this PR is the natural completion for spawn dispatch and system-channel routing)
aerea-alpha@spark-2c37:~/dgx-stack/images/nanobot/upstream-pr$ cat /home/aerea-alpha/dgx-stack/images/nanobot/upstream-pr/PR_DESCRIPTION.md
# fix(agent): complete thread-session routing for spawn dispatch and system-channel branch

## Summary

Builds on PR #3463 (commit `038a140`), which threaded `metadata` and `session_key` through `_LoopHook` and `_set_tool_context` for the cron and message tools. Three downstream gaps remained where `thread_ts` is still dropped:

1. `_set_tool_context`'s body still computes `effective_key` from `channel:chat_id` and passes that to spawn, even when the caller provides a thread-scoped `session_key`. The new parameter is wired in for cron/message but spawn dispatch ignores it.
2. `_process_message`'s system-channel branch loads the session via `key = f"{channel}:{chat_id}"`, ignoring `msg.session_key_override`. So even when the announce InboundMessage carries the right override, the consumer side discards it.
3. The OutboundMessage returned from the system-channel branch has no metadata, so slack's outbound dispatcher has no `thread_ts` to use and posts the LLM's reply to the channel top-level rather than the originating thread.

This PR closes all three gaps with three small edits in `nanobot/agent/loop.py`.

Fixes #3464.

## Behavior change

- **Slack channels with `reply_in_thread: true`:** subagent announces and follow-up replies now arrive in the originating thread session instead of leaking into the channel-level session.
- **Other channels constructing thread-scoped session keys** (matrix threads, telegram thread mode, etc.): the session-loading and effective-key fixes apply identically since they're platform-agnostic. The outbound `thread_ts` reconstruction is slack-specific by virtue of the session-key format slack uses; other channels would benefit from the same pattern but are out of scope for this PR.
- **Unified session mode:** no change. Falls back to `UNIFIED_SESSION_KEY` when `session_key` is not provided.
- **CLI / non-channel callers:** no change. They don't pass `session_key` and the fallback to `f"{channel}:{chat_id}"` matches prior behavior.

## Implementation

Three edits in `nanobot/agent/loop.py`. ~12 net lines changed.

1. **`_set_tool_context` body**: when `session_key` is provided, use it as `effective_key`; otherwise fall back to existing unified-mode or `channel:chat_id` logic. Spawn now sees the same thread-scoped key the cron and message tools already receive.
2. **System-channel session loading**: `key = msg.session_key_override or f"{channel}:{chat_id}"` so threaded callers route to the originating thread session. Preserves prior behavior for callers without an override.
3. **System-channel OutboundMessage**: reconstruct slack `thread_ts` metadata from the session key (`slack:<chat_id>:<thread_ts>`) so the outbound dispatcher posts in the thread, not the channel top-level. No-op for non-slack channels and for slack DMs (which don't have threads).

No new abstractions; reuses `Session.key`, `InboundMessage.session_key_override`, and the slack channel's existing `metadata.slack.thread_ts` outbound contract.

## Reproduce

Slack config with `reply_in_thread: true`. From inside a slack thread:

> spawn a subagent that writes 'ok' to verify.txt and reports back when done

- Before: announce lands in `slack_<channel>.jsonl` (channel session), parent in the thread never sees the completion event, eventual reply (if any) posts to the channel top-level.
- After: announce lands in `slack_<channel>_<thread_ts>.jsonl` (thread session), parent in the thread responds within seconds, reply posts in the thread.

## Tests

No regression test included. Pre-merge happy to add one in `tests/agent/test_task_cancel.py` that asserts a thread-scoped `session_key_override` on the inbound message flows from `_set_tool_context` into the announce InboundMessage and that the system-channel `OutboundMessage` carries the recovered `thread_ts` metadata. Did not include here because local pytest setup was unavailable to verify; would prefer a green test in PR review than a guessed one.

The change has been validated end-to-end against current main in a slack workspace with `reply_in_thread: true`: subagent spawned from a thread → announce in the thread session JSONL → bot reply posts in the thread, not the channel.