### PR TITLE
fix(agent): resolve relative media paths in MessageTool

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -368,7 +368,7 @@ class AgentLoop:
                 WebSearchTool(config=self.web_config.search, proxy=self.web_config.proxy)
             )
             self.tools.register(WebFetchTool(proxy=self.web_config.proxy))
-        self.tools.register(MessageTool(send_callback=self.bus.publish_outbound))
+        self.tools.register(MessageTool(send_callback=self.bus.publish_outbound, workspace=self.workspace))
         self.tools.register(SpawnTool(manager=self.subagents))
         if self.cron_service:
             self.tools.register(

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -2,6 +2,7 @@
 
 import os
 from contextvars import ContextVar
+from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from nanobot.agent.tools.base import Tool, tool_parameters
@@ -35,8 +36,10 @@ class MessageTool(Tool):
         default_channel: str = "",
         default_chat_id: str = "",
         default_message_id: str | None = None,
+        workspace: str | Path | None = None,
     ):
         self._send_callback = send_callback
+        self._workspace = Path(workspace).expanduser() if workspace is not None else get_workspace_path()
         self._default_channel: ContextVar[str] = ContextVar("message_default_channel", default=default_channel)
         self._default_chat_id: ContextVar[str] = ContextVar("message_default_chat_id", default=default_chat_id)
         self._default_message_id: ContextVar[str | None] = ContextVar(
@@ -149,7 +152,7 @@ class MessageTool(Tool):
                 if p.startswith(("http://", "https://")) or os.path.isabs(p):
                     resolved.append(p)
                 else:
-                    resolved.append(str(get_workspace_path() / p))
+                    resolved.append(str(self._workspace / p))
             media = resolved
 
         metadata = dict(self._default_metadata.get()) if same_target else {}

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -1,11 +1,13 @@
 """Message tool for sending messages to users."""
 
+import os
 from contextvars import ContextVar
 from typing import Any, Awaitable, Callable
 
 from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.schema import ArraySchema, StringSchema, tool_parameters_schema
 from nanobot.bus.events import OutboundMessage
+from nanobot.config.paths import get_workspace_path
 
 
 @tool_parameters(
@@ -140,6 +142,15 @@ class MessageTool(Tool):
 
         if not self._send_callback:
             return "Error: Message sending not configured"
+
+        if media:
+            resolved = []
+            for p in media:
+                if p.startswith(("http://", "https://")) or os.path.isabs(p):
+                    resolved.append(p)
+                else:
+                    resolved.append(str(get_workspace_path() / p))
+            media = resolved
 
         metadata = dict(self._default_metadata.get()) if same_target else {}
         if message_id:

--- a/tests/tools/test_message_tool.py
+++ b/tests/tools/test_message_tool.py
@@ -111,6 +111,26 @@ async def test_message_tool_resolves_relative_media_paths() -> None:
 
 
 @pytest.mark.asyncio
+async def test_message_tool_resolves_relative_media_paths_from_active_workspace(tmp_path) -> None:
+    sent: list[OutboundMessage] = []
+
+    async def _send(msg: OutboundMessage) -> None:
+        sent.append(msg)
+
+    workspace = tmp_path / "workspace"
+    tool = MessageTool(send_callback=_send, workspace=workspace)
+
+    await tool.execute(
+        content="see attached",
+        channel="telegram",
+        chat_id="1",
+        media=["output/image.png"],
+    )
+
+    assert sent[0].media == [str(workspace / "output/image.png")]
+
+
+@pytest.mark.asyncio
 async def test_message_tool_passes_through_absolute_media_paths() -> None:
     sent: list[OutboundMessage] = []
 

--- a/tests/tools/test_message_tool.py
+++ b/tests/tools/test_message_tool.py
@@ -1,7 +1,10 @@
+import os
+
 import pytest
 
 from nanobot.agent.tools.message import MessageTool
 from nanobot.bus.events import OutboundMessage
+from nanobot.config.paths import get_workspace_path
 
 
 @pytest.mark.asyncio
@@ -85,3 +88,97 @@ async def test_message_tool_does_not_inherit_metadata_for_cross_target() -> None
     await tool.execute(content="channel reply", channel="slack", chat_id="C999")
 
     assert sent[0].metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_message_tool_resolves_relative_media_paths() -> None:
+    sent: list[OutboundMessage] = []
+
+    async def _send(msg: OutboundMessage) -> None:
+        sent.append(msg)
+
+    tool = MessageTool(send_callback=_send)
+
+    await tool.execute(
+        content="see attached",
+        channel="telegram",
+        chat_id="1",
+        media=["output/image.png"],
+    )
+
+    expected = str(get_workspace_path() / "output/image.png")
+    assert sent[0].media == [expected]
+
+
+@pytest.mark.asyncio
+async def test_message_tool_passes_through_absolute_media_paths() -> None:
+    sent: list[OutboundMessage] = []
+
+    async def _send(msg: OutboundMessage) -> None:
+        sent.append(msg)
+
+    tool = MessageTool(send_callback=_send)
+
+    abs_path = os.path.abspath(os.path.join(os.sep, "tmp", "abs_image.png"))
+
+    await tool.execute(
+        content="see attached",
+        channel="telegram",
+        chat_id="1",
+        media=[abs_path],
+    )
+
+    assert sent[0].media == [abs_path]
+
+
+@pytest.mark.asyncio
+async def test_message_tool_passes_through_url_media_paths() -> None:
+    sent: list[OutboundMessage] = []
+
+    async def _send(msg: OutboundMessage) -> None:
+        sent.append(msg)
+
+    tool = MessageTool(send_callback=_send)
+
+    url = "https://example.com/image.png"
+
+    await tool.execute(
+        content="see attached",
+        channel="telegram",
+        chat_id="1",
+        media=[url],
+    )
+
+    assert sent[0].media == [url]
+
+
+@pytest.mark.asyncio
+async def test_message_tool_resolves_mixed_media_paths() -> None:
+    sent: list[OutboundMessage] = []
+
+    async def _send(msg: OutboundMessage) -> None:
+        sent.append(msg)
+
+    tool = MessageTool(send_callback=_send)
+
+    abs_path = os.path.abspath(os.path.join(os.sep, "tmp", "absolute.png"))
+
+    await tool.execute(
+        content="see attached",
+        channel="telegram",
+        chat_id="1",
+        media=[
+            "output/relative.png",
+            abs_path,
+            "https://example.com/url.png",
+            "http://example.com/http.png",
+        ],
+    )
+
+    expected_relative = str(get_workspace_path() / "output/relative.png")
+    assert sent[0].media == [
+        expected_relative,
+        abs_path,
+        "https://example.com/url.png",
+        "http://example.com/http.png",
+    ]


### PR DESCRIPTION
## Summary

- Resolves relative media paths in `MessageTool.execute()` against `get_workspace_path()` before constructing `OutboundMessage`
- Fixes media file upload failures in Docker deployments where the process CWD differs from the workspace directory (closes #3435)
- URLs and absolute paths pass through unchanged; only relative paths are resolved

## Test plan

- [x] `tests/tools/test_message_tool.py` — 4 new tests covering relative path resolution, absolute path pass-through, URL pass-through, and mixed lists
- [x] `tests/channels/test_wecom_channel.py` — 29 regression tests all passing