### PR TITLE
fix(slack): polish threaded replies and proactive delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ nanobot agent
 
 - Want different LLM providers, web search, MCP, security settings, or more config options? See [Configuration](./docs/configuration.md)
 - Want to run nanobot in chat apps like Telegram, Discord, WeChat or Feishu? See [Chat Apps](./docs/chat-apps.md)
-- Using Slack? Add `files:write` if you want nanobot to upload images, videos, or files.
 - Want Docker or Linux service deployment? See [Deployment](./docs/deployment.md)
 
 ## 🧪 WebUI (Development)

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ nanobot agent
 
 - Want different LLM providers, web search, MCP, security settings, or more config options? See [Configuration](./docs/configuration.md)
 - Want to run nanobot in chat apps like Telegram, Discord, WeChat or Feishu? See [Chat Apps](./docs/chat-apps.md)
+- Using Slack? Add `files:write` if you want nanobot to upload images, videos, or files.
 - Want Docker or Linux service deployment? See [Deployment](./docs/deployment.md)
 
 ## 🧪 WebUI (Development)

--- a/docs/chat-apps.md
+++ b/docs/chat-apps.md
@@ -434,10 +434,12 @@ Uses **Socket Mode** — no public URL required.
 
 **2. Configure the app**
 - **Socket Mode**: Toggle ON → Generate an **App-Level Token** with `connections:write` scope → copy it (`xapp-...`)
-- **OAuth & Permissions**: Add bot scopes: `chat:write`, `reactions:write`, `app_mentions:read`, `channels:history`, `groups:history`, `im:history`, `mpim:history`
+- **OAuth & Permissions**: Add bot scopes: `chat:write`, `reactions:write`, `app_mentions:read`, `files:write`, `channels:history`, `groups:history`, `im:history`, `mpim:history`
 - **Event Subscriptions**: Toggle ON → Subscribe to bot events: `message.im`, `message.channels`, `app_mention` → Save Changes
 - **App Home**: Scroll to **Show Tabs** → Enable **Messages Tab** → Check **"Allow users to send Slash commands and messages from the messages tab"**
 - **Install App**: Click **Install to Workspace** → Authorize → copy the **Bot Token** (`xoxb-...`)
+
+> `files:write` is required for images, videos, and other file uploads. If you add it later, reinstall the Slack app to the workspace and restart nanobot so it uses the updated bot token.
 
 **3. Configure nanobot**
 

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -172,6 +172,7 @@ class ChannelManager:
                 channel=notice.channel,
                 chat_id=notice.chat_id,
                 content=format_restart_completed_message(notice.started_at_raw),
+                metadata=dict(notice.metadata or {}),
             ),
         ))
 

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -16,6 +16,7 @@ from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.config.schema import Base
+from nanobot.utils.helpers import split_message
 
 
 class SlackDMConfig(Base):
@@ -46,6 +47,9 @@ class SlackConfig(Base):
     dm: SlackDMConfig = Field(default_factory=SlackDMConfig)
 
 
+SLACK_MAX_MESSAGE_LEN = 39_000  # Slack API allows ~40k; leave margin
+
+
 class SlackChannel(BaseChannel):
     """Slack channel using Socket Mode."""
 
@@ -58,6 +62,8 @@ class SlackChannel(BaseChannel):
     @classmethod
     def default_config(cls) -> dict[str, Any]:
         return SlackConfig().model_dump(by_alias=True)
+
+    _THREAD_CONTEXT_CACHE_LIMIT = 10_000
 
     def __init__(self, config: Any, bus: MessageBus):
         if isinstance(config, dict):
@@ -131,14 +137,17 @@ class SlackChannel(BaseChannel):
                 else None
             )
 
-            # Slack rejects empty text payloads. Keep media-only messages media-only,
-            # but send a single blank message when the bot has no text or files to send.
             if msg.content or not (msg.media or []):
-                await self._web_client.chat_postMessage(
-                    channel=target_chat_id,
-                    text=self._to_mrkdwn(msg.content) if msg.content else " ",
-                    thread_ts=thread_ts_param,
-                )
+                mrkdwn = self._to_mrkdwn(msg.content) if msg.content else " "
+                buttons = getattr(msg, "buttons", None) or []
+                chunks = split_message(mrkdwn, SLACK_MAX_MESSAGE_LEN)
+                for index, chunk in enumerate(chunks):
+                    kwargs: dict[str, Any] = dict(
+                        channel=target_chat_id, text=chunk, thread_ts=thread_ts_param,
+                    )
+                    if buttons and index == len(chunks) - 1:
+                        kwargs["blocks"] = self._build_button_blocks(chunk, buttons)
+                    await self._web_client.chat_postMessage(**kwargs)
 
             for media_path in msg.media or []:
                 try:
@@ -276,6 +285,9 @@ class SlackChannel(BaseChannel):
         req: SocketModeRequest,
     ) -> None:
         """Handle incoming Socket Mode requests."""
+        if req.type == "interactive":
+            await self._on_block_action(client, req)
+            return
         if req.type != "events_api":
             return
 
@@ -375,6 +387,37 @@ class SlackChannel(BaseChannel):
         except Exception:
             logger.exception("Error handling Slack message from {}", sender_id)
 
+    async def _on_block_action(self, client: SocketModeClient, req: SocketModeRequest) -> None:
+        """Handle button clicks from ask_user blocks."""
+        await client.send_socket_mode_response(SocketModeResponse(envelope_id=req.envelope_id))
+        payload = req.payload or {}
+        actions = payload.get("actions") or []
+        if not actions:
+            return
+        value = str(actions[0].get("value") or "")
+        user_info = payload.get("user") or {}
+        sender_id = str(user_info.get("id") or "")
+        channel_info = payload.get("channel") or {}
+        chat_id = str(channel_info.get("id") or "")
+        if not sender_id or not chat_id or not value:
+            return
+        message_info = payload.get("message") or {}
+        thread_ts = message_info.get("thread_ts") or message_info.get("ts")
+        channel_type = self._infer_channel_type(chat_id)
+        if not self._is_allowed(sender_id, chat_id, channel_type):
+            return
+        session_key = f"slack:{chat_id}:{thread_ts}" if thread_ts else None
+        try:
+            await self._handle_message(
+                sender_id=sender_id,
+                chat_id=chat_id,
+                content=value,
+                metadata={"slack": {"thread_ts": thread_ts, "channel_type": channel_type}},
+                session_key=session_key,
+            )
+        except Exception:
+            logger.exception("Error handling Slack button click from {}", sender_id)
+
     async def _with_thread_context(
         self,
         text: str,
@@ -399,6 +442,8 @@ class SlackChannel(BaseChannel):
         key = f"{chat_id}:{thread_ts}"
         if key in self._thread_context_attempted:
             return text
+        if len(self._thread_context_attempted) >= self._THREAD_CONTEXT_CACHE_LIMIT:
+            self._thread_context_attempted.clear()
         self._thread_context_attempted.add(key)
 
         try:
@@ -427,13 +472,35 @@ class SlackChannel(BaseChannel):
             if item.get("subtype"):
                 continue
             sender = str(item.get("user") or item.get("bot_id") or "unknown")
-            if self._bot_user_id and sender == self._bot_user_id:
-                continue
+            is_bot = self._bot_user_id is not None and sender == self._bot_user_id
+            label = "bot" if is_bot else f"<@{sender}>"
             text = str(item.get("text") or "").strip()
             if not text:
                 continue
-            lines.append(f"- <@{sender}>: {self._strip_bot_mention(text)}")
+            text = self._strip_bot_mention(text)
+            if len(text) > 500:
+                text = text[:500] + "…"
+            lines.append(f"- {label}: {text}")
         return lines
+
+    @staticmethod
+    def _build_button_blocks(text: str, buttons: list[list[str]]) -> list[dict[str, Any]]:
+        """Build Slack Block Kit blocks with action buttons for ask_user choices."""
+        blocks: list[dict[str, Any]] = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": text[:3000]}},
+        ]
+        elements = []
+        for row in buttons:
+            for label in row:
+                elements.append({
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": label[:75]},
+                    "value": label[:75],
+                    "action_id": f"ask_user_{label[:50]}",
+                })
+        if elements:
+            blocks.append({"type": "actions", "elements": elements[:25]})
+        return blocks
 
     async def _update_react_emoji(self, chat_id: str, ts: str | None) -> None:
         """Remove the in-progress reaction and optionally add a done reaction."""
@@ -480,6 +547,19 @@ class SlackChannel(BaseChannel):
         if self.config.group_policy == "allowlist":
             return chat_id in self.config.group_allow_from
         return False
+
+    def is_allowed(self, sender_id: str) -> bool:
+        # Slack needs channel-aware policy checks, so _on_socket_request and
+        # _on_block_action call _is_allowed before handing off to BaseChannel.
+        return True
+
+    @staticmethod
+    def _infer_channel_type(chat_id: str) -> str:
+        if chat_id.startswith("D"):
+            return "im"
+        if chat_id.startswith("G"):
+            return "group"
+        return "channel"
 
     def _strip_bot_mention(self, text: str) -> str:
         if not text or not self._bot_user_id:

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -348,7 +348,8 @@ class SlackChannel(BaseChannel):
 
         # Thread-scoped session key for channel/group messages
         session_key = f"slack:{chat_id}:{thread_ts}" if thread_ts and channel_type != "im" else None
-        content = await self._with_thread_context(
+        is_slash = text.strip().startswith("/")
+        content = text if is_slash else await self._with_thread_context(
             text,
             chat_id=chat_id,
             channel_type=channel_type,

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -714,9 +714,11 @@ def _run_gateway(
         from nanobot.utils.evaluator import evaluate_response
 
         reminder_note = (
-            "[Scheduled Task] Timer finished.\n\n"
-            f"Task '{job.name}' has been triggered.\n"
-            f"Scheduled instruction: {job.payload.message}"
+            "The scheduled time has arrived. Deliver this reminder to the user now, "
+            "as a brief and natural message in their language. Speak directly to them — "
+            "do not narrate progress, summarize, include user IDs, or add status reports "
+            "like 'Done' or 'Reminded'.\n\n"
+            f"Reminder: {job.payload.message}"
         )
 
         cron_tool = agent.tools.get("cron")

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -28,7 +28,11 @@ async def cmd_stop(ctx: CommandContext) -> OutboundMessage:
 async def cmd_restart(ctx: CommandContext) -> OutboundMessage:
     """Restart the process in-place via os.execv."""
     msg = ctx.msg
-    set_restart_notice_to_env(channel=msg.channel, chat_id=msg.chat_id)
+    set_restart_notice_to_env(
+        channel=msg.channel,
+        chat_id=msg.chat_id,
+        metadata=dict(msg.metadata or {}),
+    )
 
     async def _do_restart():
         await asyncio.sleep(1)

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -109,6 +109,12 @@ class CronService:
                             deliver=j["payload"].get("deliver", False),
                             channel=j["payload"].get("channel"),
                             to=j["payload"].get("to"),
+                            channel_meta=(
+                                j["payload"].get("channelMeta")
+                                or j["payload"].get("channel_meta")
+                                or {}
+                            ),
+                            session_key=j["payload"].get("sessionKey") or j["payload"].get("session_key"),
                         ),
                         state=CronJobState(
                             next_run_at_ms=j.get("state", {}).get("nextRunAtMs"),
@@ -210,6 +216,8 @@ class CronService:
                         "deliver": j.payload.deliver,
                         "channel": j.payload.channel,
                         "to": j.payload.to,
+                        "channelMeta": j.payload.channel_meta,
+                        "sessionKey": j.payload.session_key,
                     },
                     "state": {
                         "nextRunAtMs": j.state.next_run_at_ms,

--- a/nanobot/utils/restart.py
+++ b/nanobot/utils/restart.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 RESTART_NOTIFY_CHANNEL_ENV = "NANOBOT_RESTART_NOTIFY_CHANNEL"
 RESTART_NOTIFY_CHAT_ID_ENV = "NANOBOT_RESTART_NOTIFY_CHAT_ID"
+RESTART_NOTIFY_METADATA_ENV = "NANOBOT_RESTART_NOTIFY_METADATA"
 RESTART_STARTED_AT_ENV = "NANOBOT_RESTART_STARTED_AT"
 
 
@@ -16,6 +19,7 @@ class RestartNotice:
     channel: str
     chat_id: str
     started_at_raw: str
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 def format_restart_completed_message(started_at_raw: str) -> str:
@@ -30,11 +34,20 @@ def format_restart_completed_message(started_at_raw: str) -> str:
     return f"Restart completed{elapsed_suffix}."
 
 
-def set_restart_notice_to_env(*, channel: str, chat_id: str) -> None:
+def set_restart_notice_to_env(
+    *, channel: str, chat_id: str, metadata: dict[str, Any] | None = None,
+) -> None:
     """Write restart notice env values for the next process."""
     os.environ[RESTART_NOTIFY_CHANNEL_ENV] = channel
     os.environ[RESTART_NOTIFY_CHAT_ID_ENV] = chat_id
     os.environ[RESTART_STARTED_AT_ENV] = str(time.time())
+    if metadata:
+        try:
+            os.environ[RESTART_NOTIFY_METADATA_ENV] = json.dumps(metadata, default=str)
+        except (TypeError, ValueError):
+            os.environ.pop(RESTART_NOTIFY_METADATA_ENV, None)
+    else:
+        os.environ.pop(RESTART_NOTIFY_METADATA_ENV, None)
 
 
 def consume_restart_notice_from_env() -> RestartNotice | None:
@@ -42,9 +55,23 @@ def consume_restart_notice_from_env() -> RestartNotice | None:
     channel = os.environ.pop(RESTART_NOTIFY_CHANNEL_ENV, "").strip()
     chat_id = os.environ.pop(RESTART_NOTIFY_CHAT_ID_ENV, "").strip()
     started_at_raw = os.environ.pop(RESTART_STARTED_AT_ENV, "").strip()
+    metadata_raw = os.environ.pop(RESTART_NOTIFY_METADATA_ENV, "").strip()
     if not (channel and chat_id):
         return None
-    return RestartNotice(channel=channel, chat_id=chat_id, started_at_raw=started_at_raw)
+    metadata: dict[str, Any] = {}
+    if metadata_raw:
+        try:
+            parsed = json.loads(metadata_raw)
+        except (TypeError, ValueError):
+            parsed = None
+        if isinstance(parsed, dict):
+            metadata = parsed
+    return RestartNotice(
+        channel=channel,
+        chat_id=chat_id,
+        started_at_raw=started_at_raw,
+        metadata=metadata,
+    )
 
 
 def should_show_cli_restart_notice(notice: RestartNotice, session_id: str) -> bool:

--- a/tests/channels/test_slack_channel.py
+++ b/tests/channels/test_slack_channel.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 
 # Check optional Slack dependencies before running tests
@@ -10,7 +13,7 @@ except ImportError:
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
-from nanobot.channels.slack import SlackChannel, SlackConfig
+from nanobot.channels.slack import SLACK_MAX_MESSAGE_LEN, SlackChannel, SlackConfig
 
 
 class _FakeAsyncWebClient:
@@ -34,14 +37,16 @@ class _FakeAsyncWebClient:
         channel: str,
         text: str,
         thread_ts: str | None = None,
+        blocks: list[dict[str, object]] | None = None,
     ) -> None:
-        self.chat_post_calls.append(
-            {
-                "channel": channel,
-                "text": text,
-                "thread_ts": thread_ts,
-            }
-        )
+        call: dict[str, object | None] = {
+            "channel": channel,
+            "text": text,
+            "thread_ts": thread_ts,
+        }
+        if blocks is not None:
+            call["blocks"] = blocks
+        self.chat_post_calls.append(call)
 
     async def files_upload_v2(
         self,
@@ -153,6 +158,61 @@ async def test_send_omits_thread_for_dm_messages() -> None:
     assert fake_web.chat_post_calls[0]["thread_ts"] is None
     assert len(fake_web.file_upload_calls) == 1
     assert fake_web.file_upload_calls[0]["thread_ts"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_splits_long_messages() -> None:
+    channel = SlackChannel(SlackConfig(enabled=True), MessageBus())
+    fake_web = _FakeAsyncWebClient()
+    channel._web_client = fake_web
+
+    await channel.send(
+        OutboundMessage(
+            channel="slack",
+            chat_id="C123",
+            content="x" * (SLACK_MAX_MESSAGE_LEN + 10),
+        )
+    )
+
+    assert len(fake_web.chat_post_calls) == 2
+    assert all(len(str(call["text"])) <= SLACK_MAX_MESSAGE_LEN for call in fake_web.chat_post_calls)
+
+
+@pytest.mark.asyncio
+async def test_send_renders_buttons_on_last_message_chunk() -> None:
+    channel = SlackChannel(SlackConfig(enabled=True), MessageBus())
+    fake_web = _FakeAsyncWebClient()
+    channel._web_client = fake_web
+
+    await channel.send(
+        OutboundMessage(
+            channel="slack",
+            chat_id="C123",
+            content="Choose one",
+            buttons=[["Yes", "No"]],
+        )
+    )
+
+    assert len(fake_web.chat_post_calls) == 1
+    blocks = fake_web.chat_post_calls[0]["blocks"]
+    assert isinstance(blocks, list)
+    assert blocks[-1] == {
+        "type": "actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Yes"},
+                "value": "Yes",
+                "action_id": "ask_user_Yes",
+            },
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "No"},
+                "value": "No",
+                "action_id": "ask_user_No",
+            },
+        ],
+    }
 
 
 @pytest.mark.asyncio
@@ -333,6 +393,7 @@ async def test_with_thread_context_fetches_root_once() -> None:
         "messages": [
             {"ts": "111.000", "user": "UROOT", "text": "drink water"},
             {"ts": "112.000", "user": "U2", "text": "good idea"},
+            {"ts": "112.500", "user": "UBOT", "text": "I'll remind you."},
             {"ts": "113.000", "user": "U3", "text": "<@UBOT> what did you see?"},
         ]
     }
@@ -353,6 +414,7 @@ async def test_with_thread_context_fetches_root_once() -> None:
     assert "Slack thread context before this mention:" in content
     assert "- <@UROOT>: drink water" in content
     assert "- <@U2>: good idea" in content
+    assert "- bot: I'll remind you." in content
     assert "U3" not in content
     assert content.endswith("Current message:\nwhat did you see?")
 
@@ -366,3 +428,38 @@ async def test_with_thread_context_fetches_root_once() -> None:
     )
     assert second == "again"
     assert len(fake_web.conversations_replies_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_slack_slash_command_skips_thread_context() -> None:
+    channel = SlackChannel(SlackConfig(enabled=True, allow_from=[]), MessageBus())
+    channel._bot_user_id = "UBOT"
+    channel._with_thread_context = AsyncMock(return_value="wrapped")  # type: ignore[method-assign]
+    channel._handle_message = AsyncMock()  # type: ignore[method-assign]
+    client = SimpleNamespace(send_socket_mode_response=AsyncMock())
+    req = SimpleNamespace(
+        type="events_api",
+        envelope_id="env-1",
+        payload={
+            "event": {
+                "type": "app_mention",
+                "user": "U1",
+                "channel": "C123",
+                "text": "<@UBOT> /restart",
+                "thread_ts": "111.000",
+                "ts": "112.000",
+            }
+        },
+    )
+
+    await channel._on_socket_request(client, req)
+
+    channel._with_thread_context.assert_not_awaited()
+    channel._handle_message.assert_awaited_once()
+    assert channel._handle_message.await_args.kwargs["content"] == "/restart"
+
+
+def test_slack_channel_uses_channel_aware_allow_policy() -> None:
+    channel = SlackChannel(SlackConfig(enabled=True, allow_from=[]), MessageBus())
+    assert channel.is_allowed("U1") is True
+    assert channel._is_allowed("U1", "C123", "channel") is True

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1067,9 +1067,11 @@ def test_gateway_cron_evaluator_receives_scheduled_reminder_context(
     assert seen["provider"] is provider
     assert seen["model"] == "test-model"
     assert seen["task_context"] == (
-        "[Scheduled Task] Timer finished.\n\n"
-        "Task 'stretch' has been triggered.\n"
-        "Scheduled instruction: Remind me to stretch."
+        "The scheduled time has arrived. Deliver this reminder to the user now, "
+        "as a brief and natural message in their language. Speak directly to them — "
+        "do not narrate progress, summarize, include user IDs, or add status reports "
+        "like 'Done' or 'Reminded'.\n\n"
+        "Reminder: Remind me to stretch."
     )
     bus.publish_outbound.assert_awaited_once_with(
         OutboundMessage(

--- a/tests/cron/test_cron_service.py
+++ b/tests/cron/test_cron_service.py
@@ -66,6 +66,37 @@ def test_add_job_preserves_channel_meta_and_session_key(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_channel_meta_and_session_key_survive_store_reload(tmp_path) -> None:
+    store_path = tmp_path / "cron" / "jobs.json"
+    service = CronService(store_path)
+    await service.start()
+    meta = {"slack": {"thread_ts": "1234567890.123456", "channel_type": "channel"}}
+    try:
+        job = service.add_job(
+            name="thread test",
+            schedule=CronSchedule(kind="every", every_ms=60_000),
+            message="hello",
+            deliver=True,
+            channel="slack",
+            to="C123",
+            channel_meta=meta,
+            session_key="slack:C123:1234567890.123456",
+        )
+    finally:
+        service.stop()
+
+    raw = json.loads(store_path.read_text(encoding="utf-8"))
+    payload = raw["jobs"][0]["payload"]
+    assert payload["channelMeta"] == meta
+    assert payload["sessionKey"] == "slack:C123:1234567890.123456"
+
+    reloaded = CronService(store_path).get_job(job.id)
+    assert reloaded is not None
+    assert reloaded.payload.channel_meta == meta
+    assert reloaded.payload.session_key == "slack:C123:1234567890.123456"
+
+
+@pytest.mark.asyncio
 async def test_execute_job_records_run_history(tmp_path) -> None:
     store_path = tmp_path / "cron" / "jobs.json"
     service = CronService(store_path, on_job=lambda _: asyncio.sleep(0))

--- a/tests/utils/test_restart.py
+++ b/tests/utils/test_restart.py
@@ -16,6 +16,7 @@ from nanobot.utils.restart import (
 def test_set_and_consume_restart_notice_env_roundtrip(monkeypatch):
     monkeypatch.delenv("NANOBOT_RESTART_NOTIFY_CHANNEL", raising=False)
     monkeypatch.delenv("NANOBOT_RESTART_NOTIFY_CHAT_ID", raising=False)
+    monkeypatch.delenv("NANOBOT_RESTART_NOTIFY_METADATA", raising=False)
     monkeypatch.delenv("NANOBOT_RESTART_STARTED_AT", raising=False)
 
     set_restart_notice_to_env(channel="feishu", chat_id="oc_123")
@@ -25,12 +26,40 @@ def test_set_and_consume_restart_notice_env_roundtrip(monkeypatch):
     assert notice.channel == "feishu"
     assert notice.chat_id == "oc_123"
     assert notice.started_at_raw
+    assert notice.metadata == {}
 
     # Consumed values should be cleared from env.
     assert consume_restart_notice_from_env() is None
     assert "NANOBOT_RESTART_NOTIFY_CHANNEL" not in os.environ
     assert "NANOBOT_RESTART_NOTIFY_CHAT_ID" not in os.environ
+    assert "NANOBOT_RESTART_NOTIFY_METADATA" not in os.environ
     assert "NANOBOT_RESTART_STARTED_AT" not in os.environ
+
+
+def test_restart_notice_preserves_metadata_across_env(monkeypatch):
+    monkeypatch.delenv("NANOBOT_RESTART_NOTIFY_CHANNEL", raising=False)
+    monkeypatch.delenv("NANOBOT_RESTART_NOTIFY_CHAT_ID", raising=False)
+    monkeypatch.delenv("NANOBOT_RESTART_NOTIFY_METADATA", raising=False)
+    monkeypatch.delenv("NANOBOT_RESTART_STARTED_AT", raising=False)
+
+    set_restart_notice_to_env(
+        channel="slack",
+        chat_id="C123",
+        metadata={"slack": {"thread_ts": "1700.42", "channel_type": "channel"}},
+    )
+
+    notice = consume_restart_notice_from_env()
+    assert notice is not None
+    assert notice.metadata == {
+        "slack": {"thread_ts": "1700.42", "channel_type": "channel"}
+    }
+    assert "NANOBOT_RESTART_NOTIFY_METADATA" not in os.environ
+
+
+def test_restart_notice_clears_stale_metadata(monkeypatch):
+    monkeypatch.setenv("NANOBOT_RESTART_NOTIFY_METADATA", '{"stale": true}')
+    set_restart_notice_to_env(channel="cli", chat_id="direct")
+    assert "NANOBOT_RESTART_NOTIFY_METADATA" not in os.environ
 
 
 def test_format_restart_completed_message_with_elapsed(monkeypatch):


### PR DESCRIPTION
## Summary

This PR tightens Slack as a first-class chat surface instead of treating it like a plain message sink.

It fixes the thread context path for proactive replies, `/restart`, and slash commands, then adds a few Slack-specific UX improvements: long message splitting, Block Kit buttons for ask-user choices, safer thread-context hydration, and clearer docs for file upload permissions.

## What Changed

- Preserve Slack thread routing for proactive messages:
  - Cron jobs now persist `channelMeta` and `sessionKey` across store reloads.
  - Cron replies are recorded into the originating channel/thread session so the conversation can continue naturally.
  - `/restart` now carries channel metadata across `os.execv`, so `Restart completed` lands in the same Slack thread.

- Improve reminder quality:
  - Cron fire-time prompts now ask the agent to speak directly to the user.
  - This avoids status-report replies like `Done ✅ 已提醒 U0...`.

- Keep slash commands command-shaped:
  - Slack thread context is skipped for messages that start with `/`.
  - This prevents `/restart` from being wrapped inside thread history and routed to the LLM as normal chat.

- Improve Slack message rendering:
  - Split long Slack replies before hitting Slack’s message size limit.
  - Render `OutboundMessage.buttons` with Slack Block Kit.
  - Route button clicks back into the same Slack thread/session.
  - Keep prior bot replies in hydrated thread context so follow-up questions have the right local history.
  - Bound the thread-context cache to avoid unbounded growth in long-running gateways.

- Update docs:
  - Document `files:write` as required for Slack image/video/file uploads.
  - Add a short README reminder for Slack media uploads.

## Test Plan

- `python -m pytest tests/channels/test_slack_channel.py tests/utils/test_restart.py tests/cli/test_restart_command.py tests/tools/test_message_tool.py tests/agent/test_loop_tool_context.py -q`

Result: `37 passed`