### PR TITLE
fix(provider): bound OpenAI-compatible request timeouts

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -60,6 +60,10 @@ _KIMI_THINKING_MODELS: frozenset[str] = frozenset({
     "kimi-k2.6",
     "k2.6-code-preview",
 })
+_OPENAI_COMPAT_CONNECT_TIMEOUT_S = 10.0
+_OPENAI_COMPAT_READ_TIMEOUT_S = 120.0
+_OPENAI_COMPAT_WRITE_TIMEOUT_S = 120.0
+_OPENAI_COMPAT_POOL_TIMEOUT_S = 10.0
 
 # Maps ProviderSpec.thinking_style → extra_body builder.
 # Each builder takes a bool (thinking_enabled) and returns the dict to
@@ -88,6 +92,16 @@ def _is_kimi_thinking_model(model_name: str) -> bool:
     if "/" in name and name.rsplit("/", 1)[1] in _KIMI_THINKING_MODELS:
         return True
     return False
+
+
+def _openai_compat_timeout() -> httpx.Timeout:
+    """Return the bounded HTTP timeout used for OpenAI-compatible providers."""
+    return httpx.Timeout(
+        connect=_OPENAI_COMPAT_CONNECT_TIMEOUT_S,
+        read=_OPENAI_COMPAT_READ_TIMEOUT_S,
+        write=_OPENAI_COMPAT_WRITE_TIMEOUT_S,
+        pool=_OPENAI_COMPAT_POOL_TIMEOUT_S,
+    )
 
 
 def _short_tool_id() -> str:
@@ -251,10 +265,12 @@ class OpenAICompatProvider(LLMProvider):
         # opening a fresh connection for each request, which is cheap on a
         # LAN.  Cloud providers benefit from keepalive, so we leave the
         # default pool settings for them.
+        timeout = _openai_compat_timeout()
         http_client: httpx.AsyncClient | None = None
         if _is_local_endpoint(spec, effective_base):
             http_client = httpx.AsyncClient(
                 limits=httpx.Limits(keepalive_expiry=0),
+                timeout=timeout,
             )
 
         self._client = AsyncOpenAI(
@@ -262,6 +278,7 @@ class OpenAICompatProvider(LLMProvider):
             base_url=effective_base,
             default_headers=default_headers,
             max_retries=0,
+            timeout=timeout,
             http_client=http_client,
         )
 

--- a/tests/providers/test_openai_compat_timeout.py
+++ b/tests/providers/test_openai_compat_timeout.py
@@ -1,0 +1,47 @@
+from unittest.mock import patch, sentinel
+
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.providers.registry import ProviderSpec
+
+
+def _assert_openai_compat_timeout(timeout) -> None:
+    assert timeout.connect == 10.0
+    assert timeout.read == 120.0
+    assert timeout.write == 120.0
+    assert timeout.pool == 10.0
+
+
+def test_openai_compat_provider_sets_sdk_timeout() -> None:
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as mock_async_openai:
+        OpenAICompatProvider(api_key="test-key", api_base="https://example.com/v1")
+
+    kwargs = mock_async_openai.call_args.kwargs
+    _assert_openai_compat_timeout(kwargs["timeout"])
+    assert kwargs["http_client"] is None
+
+
+def test_openai_compat_provider_sets_timeout_on_local_http_client() -> None:
+    spec = ProviderSpec(
+        name="local",
+        keywords=(),
+        env_key="",
+        is_local=True,
+        default_api_base="http://127.0.0.1:11434/v1",
+    )
+
+    with (
+        patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as mock_async_openai,
+        patch(
+            "nanobot.providers.openai_compat_provider.httpx.AsyncClient",
+            return_value=sentinel.http_client,
+        ) as mock_http_client,
+    ):
+        OpenAICompatProvider(spec=spec)
+
+    client_kwargs = mock_http_client.call_args.kwargs
+    _assert_openai_compat_timeout(client_kwargs["timeout"])
+    assert client_kwargs["limits"].keepalive_expiry == 0
+
+    openai_kwargs = mock_async_openai.call_args.kwargs
+    _assert_openai_compat_timeout(openai_kwargs["timeout"])
+    assert openai_kwargs["http_client"] is sentinel.http_client


### PR DESCRIPTION
## Summary

- Add an explicit bounded HTTP timeout for OpenAI-compatible providers.
- Apply the timeout to the `AsyncOpenAI` client so cloud OpenAI-compatible providers no longer inherit the SDK's long 600s read/write defaults.
- Apply the same timeout to the local-endpoint `httpx.AsyncClient` while preserving the existing `keepalive_expiry=0` behavior for local model servers.
- Add focused tests covering both normal SDK initialization and local custom HTTP client initialization.

## Motivation

Fixes #3455.

`OpenAICompatProvider` previously constructed `AsyncOpenAI` without an explicit timeout. The OpenAI Python SDK defaults can allow read/write operations to hang for up to 600 seconds before surfacing a timeout. In practice, a slow or stalled OpenAI-compatible gateway can keep the agent loop unresponsive for several minutes before retry/error handling has a chance to run.

## Implementation Notes

This PR introduces a small module-level timeout helper with the following bounds:

- connect: 10s
- read: 120s
- write: 120s
- pool: 10s

The change is intentionally scoped to OpenAI-compatible provider client construction. It does not alter retry policy, streaming idle timeout behavior, provider routing, or generation settings.

## Validation

- `.venv/bin/python -m ruff check nanobot/providers/openai_compat_provider.py tests/providers/test_openai_compat_timeout.py`
- `.venv/bin/python -m pytest tests/providers/test_openai_compat_timeout.py tests/cli/test_commands.py::test_make_provider_passes_extra_headers_to_custom_provider tests/cli/test_commands.py::test_openai_compat_provider_passes_model_through`
- `.venv/bin/python -m pytest tests/providers`
- Smoke-tested provider construction with the real OpenAI SDK client constructor without sending network requests.
