### PR TITLE
fix(provider): bound OpenAI-compatible request timeouts

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -60,6 +60,7 @@ _KIMI_THINKING_MODELS: frozenset[str] = frozenset({
     "kimi-k2.6",
     "k2.6-code-preview",
 })
+_OPENAI_COMPAT_REQUEST_TIMEOUT_S = 120.0
 
 # Maps ProviderSpec.thinking_style → extra_body builder.
 # Each builder takes a bool (thinking_enabled) and returns the dict to
@@ -88,6 +89,26 @@ def _is_kimi_thinking_model(model_name: str) -> bool:
     if "/" in name and name.rsplit("/", 1)[1] in _KIMI_THINKING_MODELS:
         return True
     return False
+
+
+def _openai_compat_timeout_s() -> float:
+    """Return the bounded request timeout used for OpenAI-compatible providers."""
+    return _float_env("NANOBOT_OPENAI_COMPAT_TIMEOUT_S", _OPENAI_COMPAT_REQUEST_TIMEOUT_S)
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid {}={!r}; using {}", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Ignoring non-positive {}={!r}; using {}", name, raw, default)
+        return default
+    return value
 
 
 def _short_tool_id() -> str:
@@ -251,10 +272,12 @@ class OpenAICompatProvider(LLMProvider):
         # opening a fresh connection for each request, which is cheap on a
         # LAN.  Cloud providers benefit from keepalive, so we leave the
         # default pool settings for them.
+        timeout_s = _openai_compat_timeout_s()
         http_client: httpx.AsyncClient | None = None
         if _is_local_endpoint(spec, effective_base):
             http_client = httpx.AsyncClient(
                 limits=httpx.Limits(keepalive_expiry=0),
+                timeout=timeout_s,
             )
 
         self._client = AsyncOpenAI(
@@ -262,6 +285,7 @@ class OpenAICompatProvider(LLMProvider):
             base_url=effective_base,
             default_headers=default_headers,
             max_retries=0,
+            timeout=timeout_s,
             http_client=http_client,
         )
 

--- a/tests/providers/test_openai_compat_timeout.py
+++ b/tests/providers/test_openai_compat_timeout.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch, sentinel
+
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.providers.registry import ProviderSpec
+
+
+def _assert_openai_compat_timeout(timeout) -> None:
+    assert timeout == 120.0
+
+
+def test_openai_compat_provider_sets_sdk_timeout() -> None:
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as mock_async_openai:
+        OpenAICompatProvider(api_key="test-key", api_base="https://example.com/v1")
+
+    kwargs = mock_async_openai.call_args.kwargs
+    _assert_openai_compat_timeout(kwargs["timeout"])
+    assert kwargs["http_client"] is None
+
+
+def test_openai_compat_provider_sets_timeout_on_local_http_client() -> None:
+    spec = ProviderSpec(
+        name="local",
+        keywords=(),
+        env_key="",
+        is_local=True,
+        default_api_base="http://127.0.0.1:11434/v1",
+    )
+
+    with (
+        patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as mock_async_openai,
+        patch(
+            "nanobot.providers.openai_compat_provider.httpx.AsyncClient",
+            return_value=sentinel.http_client,
+        ) as mock_http_client,
+    ):
+        OpenAICompatProvider(spec=spec)
+
+    client_kwargs = mock_http_client.call_args.kwargs
+    _assert_openai_compat_timeout(client_kwargs["timeout"])
+    assert client_kwargs["limits"].keepalive_expiry == 0
+
+    openai_kwargs = mock_async_openai.call_args.kwargs
+    _assert_openai_compat_timeout(openai_kwargs["timeout"])
+    assert openai_kwargs["http_client"] is sentinel.http_client
+
+
+def test_openai_compat_provider_timeout_can_be_overridden_by_env(monkeypatch) -> None:
+    monkeypatch.setenv("NANOBOT_OPENAI_COMPAT_TIMEOUT_S", "45")
+
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as mock_async_openai:
+        OpenAICompatProvider(api_key="test-key", api_base="https://example.com/v1")
+
+    assert mock_async_openai.call_args.kwargs["timeout"] == 45.0


### PR DESCRIPTION
## Summary

This PR adds an explicit request timeout to `OpenAICompatProvider` so OpenAI-compatible providers do not inherit the OpenAI Python SDK's long default read/write timeout behavior.

The change follows the existing OpenAI Codex provider pattern: apply a bounded request-layer timeout, let provider failures be converted into structured `LLMResponse` errors, and rely on the existing provider retry policy for transient timeout recovery.

## Problem

`OpenAICompatProvider` currently creates `AsyncOpenAI` without passing a timeout.

The OpenAI Python SDK can wait up to 600 seconds for read/write operations. When an OpenAI-compatible gateway stalls, this can leave a nanobot session unresponsive for several minutes before the failure is surfaced.

There is already an outer agent-runner guard via `NANOBOT_LLM_TIMEOUT_S` (default 300s), but that guard operates above the provider call. It prevents indefinite session lock starvation, but it does not set a bounded timeout on the underlying OpenAI SDK/httpx request itself.

That means a stalled provider request can still hold the underlying HTTP operation much longer than desired.

## Motivation

Fixes #3455.

The intended behavior is for provider-level request stalls to fail early enough that the existing provider retry path can handle them as transient failures.


## Changes

- Adds a default OpenAI-compatible request timeout of `120s`.
- Adds `NANOBOT_OPENAI_COMPAT_TIMEOUT_S` so deployments can tune the timeout without code changes.
- Passes the timeout to `AsyncOpenAI(...)`.
- Applies the same timeout to the local-endpoint `httpx.AsyncClient(...)`.
- Preserves the existing local-endpoint `keepalive_expiry=0` behavior.
- Adds focused regression tests for:
  - SDK timeout initialization
  - local custom HTTP client timeout initialization
  - environment override behavior

## Retry / Recovery Behavior

This PR does not introduce a separate retry mechanism.

Timeout exceptions from the OpenAI-compatible provider continue to be handled by the provider error path and classified as structured transient errors (`error_kind="timeout"`). The existing provider retry policy already knows how to retry transient timeout errors.

So the behavior is:

1. Provider request stalls.
2. Provider-layer timeout fires.
3. The failure is converted into an `LLMResponse(..., finish_reason="error", error_kind="timeout")`.
4. Existing provider retry logic handles it according to the configured retry mode.

This keeps the fix narrowly scoped and avoids duplicating retry logic.

## Why 120 seconds?

The default `120s` provider timeout is intentionally below the agent runner's default outer timeout (`NANOBOT_LLM_TIMEOUT_S=300`).

That gives the provider layer enough time for large-context requests while still allowing it to surface a structured timeout before the runner-level guard cancels the entire model call.

Deployments with slower gateways can override this with:

```bash
NANOBOT_OPENAI_COMPAT_TIMEOUT_S=180

```

## Non-Goals

This PR does not change:

- provider retry counts
- provider retry backoff behavior
- provider routing
- model failover
- streaming idle timeout behavior
- generation settings

## Validation

- .venv/bin/python -m ruff check nanobot/providers/openai_compat_provider.py tests/providers/test_openai_compat_timeout.py tests/providers/test_provider_retry.py
- .venv/bin/python -m pytest tests/providers/test_openai_compat_timeout.py tests/providers/test_provider_retry.py
- .venv/bin/python -m pytest tests/providers

Smoke-tested provider construction with the real OpenAI SDK client constructor without sending network requests.

