### PR TITLE
fix(codex): stream progress deltas to channels

### DIFF
--- a/nanobot/agent/hook.py
+++ b/nanobot/agent/hook.py
@@ -21,6 +21,7 @@ class AgentHookContext:
     tool_calls: list[ToolCallRequest] = field(default_factory=list)
     tool_results: list[Any] = field(default_factory=list)
     tool_events: list[dict[str, str]] = field(default_factory=list)
+    streamed_content: bool = False
     final_content: str | None = None
     stop_reason: str | None = None
     error: str | None = None

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -114,7 +114,7 @@ class _LoopHook(AgentHook):
 
     async def before_execute_tools(self, context: AgentHookContext) -> None:
         if self._on_progress:
-            if not self._on_stream:
+            if not self._on_stream and not context.streamed_content:
                 thought = self._loop._strip_think(
                     context.response.content if context.response else None
                 )

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -21,6 +21,7 @@ from nanobot.utils.helpers import (
     estimate_prompt_tokens_chain,
     find_legal_message_start,
     maybe_persist_tool_result,
+    strip_think,
     truncate_text,
 )
 from nanobot.utils.prompt_templates import render_template
@@ -607,13 +608,41 @@ class AgentRunner:
             messages,
             tools=spec.tools.get_definitions(),
         )
-        if hook.wants_streaming():
+        wants_streaming = hook.wants_streaming()
+        wants_progress_streaming = (
+            not wants_streaming
+            and spec.progress_callback is not None
+            and getattr(self.provider, "stream_progress_via_chat_stream", False) is True
+        )
+
+        if wants_streaming:
             async def _stream(delta: str) -> None:
+                if delta:
+                    context.streamed_content = True
                 await hook.on_stream(context, delta)
 
             coro = self.provider.chat_stream_with_retry(
                 **kwargs,
                 on_content_delta=_stream,
+            )
+        elif wants_progress_streaming:
+            stream_buf = ""
+
+            async def _stream_progress(delta: str) -> None:
+                nonlocal stream_buf
+                if not delta:
+                    return
+                prev_clean = strip_think(stream_buf)
+                stream_buf += delta
+                new_clean = strip_think(stream_buf)
+                incremental = new_clean[len(prev_clean):]
+                if incremental:
+                    context.streamed_content = True
+                    await spec.progress_callback(incremental)
+
+            coro = self.provider.chat_stream_with_retry(
+                **kwargs,
+                on_content_delta=_stream_progress,
             )
         else:
             coro = self.provider.chat_with_retry(**kwargs)

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -91,6 +91,8 @@ _SYNTHETIC_USER_CONTENT = "(conversation continued)"
 class LLMProvider(ABC):
     """Base class for LLM providers."""
 
+    stream_progress_via_chat_stream = False
+
     _CHAT_RETRY_DELAYS = (1, 2, 4)
     _PERSISTENT_MAX_DELAY = 60
     _PERSISTENT_IDENTICAL_ERROR_LIMIT = 10

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -26,6 +26,8 @@ DEFAULT_ORIGINATOR = "nanobot"
 class OpenAICodexProvider(LLMProvider):
     """Use Codex OAuth to call the Responses API."""
 
+    stream_progress_via_chat_stream = True
+
     def __init__(self, default_model: str = "openai-codex/gpt-5.1-codex"):
         super().__init__(api_key=None, api_base=None)
         self.default_model = default_model

--- a/tests/agent/test_loop_progress.py
+++ b/tests/agent/test_loop_progress.py
@@ -128,3 +128,89 @@ class TestToolEventProgress:
         finish = finish_msgs[0].metadata["_tool_events"][0]
         assert finish["phase"] == "end"
         assert finish["result"] == "file.txt"
+
+    @pytest.mark.asyncio
+    async def test_bus_progress_streams_provider_deltas_for_codex_style_provider(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Providers that opt in can stream content deltas through _progress messages."""
+        bus = MessageBus()
+        provider = MagicMock()
+        provider.stream_progress_via_chat_stream = True
+        provider.get_default_model.return_value = "openai-codex/gpt-5.5"
+
+        async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+            await on_content_delta("Hel")
+            await on_content_delta("lo")
+            return LLMResponse(content="Hello", tool_calls=[])
+
+        provider.chat_stream_with_retry = chat_stream_with_retry
+        provider.chat_with_retry = AsyncMock()
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="openai-codex/gpt-5.5")
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        await loop._dispatch(InboundMessage(
+            channel="websocket",
+            sender_id="u1",
+            chat_id="chat1",
+            content="say hello",
+        ))
+
+        outbound = []
+        while bus.outbound_size > 0:
+            outbound.append(await bus.consume_outbound())
+
+        progress = [m for m in outbound if m.metadata.get("_progress")]
+        final = [m for m in outbound if not m.metadata.get("_progress")]
+
+        assert [m.content for m in progress] == ["Hel", "lo"]
+        assert final[-1].content == "Hello"
+        provider.chat_with_retry.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_streamed_progress_is_not_repeated_before_tool_execution(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """If content was already streamed as progress, tool setup should not repeat it."""
+        loop = _make_loop(tmp_path)
+        loop.provider.stream_progress_via_chat_stream = True
+        tool_call = ToolCallRequest(id="call1", name="custom_tool", arguments={"path": "foo.txt"})
+        calls = iter([
+            LLMResponse(content="I will inspect it.", tool_calls=[tool_call]),
+            LLMResponse(content="Done", tool_calls=[]),
+        ])
+
+        async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+            response = next(calls)
+            if response.tool_calls:
+                await on_content_delta("I will ")
+                await on_content_delta("inspect it.")
+            return response
+
+        loop.provider.chat_stream_with_retry = chat_stream_with_retry
+        loop.provider.chat_with_retry = AsyncMock()
+        loop.tools.get_definitions = MagicMock(return_value=[])
+        loop.tools.prepare_call = MagicMock(return_value=(None, {"path": "foo.txt"}, None))
+        loop.tools.execute = AsyncMock(return_value="ok")
+
+        progress: list[tuple[str, bool, list[dict] | None]] = []
+
+        async def on_progress(
+            content: str,
+            *,
+            tool_hint: bool = False,
+            tool_events: list[dict] | None = None,
+        ) -> None:
+            progress.append((content, tool_hint, tool_events))
+
+        final_content, _, _, _, _ = await loop._run_agent_loop([], on_progress=on_progress)
+
+        assert final_content == "Done"
+        assert [item[0] for item in progress[:3]] == [
+            "I will",
+            " inspect it.",
+            'custom_tool("foo.txt")',
+        ]
+        assert all(item[0] != "I will inspect it." for item in progress)

--- a/tests/providers/test_providers_init.py
+++ b/tests/providers/test_providers_init.py
@@ -41,3 +41,9 @@ def test_explicit_provider_import_still_works(monkeypatch) -> None:
 
     assert namespace["AnthropicProvider"].__name__ == "AnthropicProvider"
     assert "nanobot.providers.anthropic_provider" in sys.modules
+
+
+def test_openai_codex_opts_into_progress_streaming() -> None:
+    from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+
+    assert OpenAICodexProvider.stream_progress_via_chat_stream is True


### PR DESCRIPTION
## Summary

Fixes #3426 by restoring intermediate channel progress for the OpenAI Codex provider.

Codex already consumes the Responses API as an SSE stream internally, but the normal channel progress path had no delta callback. As a result, channels received only the final response instead of `_progress=True` chunks during generation. This PR lets Codex opt into using the existing `chat_stream_with_retry` path for progress callbacks when a channel has `sendProgress` enabled.

## Source

- Related upstream issue/discussion: HKUDS/nanobot#3426
- Fork-only context, if any: none

## Boundary

- Files/modules intentionally changed: runner progress selection, loop progress de-duplication, provider capability declaration, Codex provider opt-in, focused tests.
- Files/modules intentionally left untouched: channel manager delivery rules, channel implementations, Codex SSE parser, provider retry policy, OpenAI-compatible provider behavior.
- User-visible behavior change: yes, Codex now emits intermediate `_progress=True` channel messages again.
- Config/API/storage/logging/network behavior change: no new config, API, storage, logging, network behavior, or permission change.

## Explanation

- Root cause or motivation: `OpenAICodexProvider.chat()` consumes Responses SSE internally but does not receive an `on_content_delta` callback, so normal channel progress delivery only sees the final accumulated response. The existing `_stream_delta` path works only for streaming-capable channels that request native streaming.
- Fix or design approach: add a provider capability, `stream_progress_via_chat_stream`, defaulting to `False` on `LLMProvider`. Codex sets it to `True`. When a progress callback exists and no native stream hook is active, the runner uses `chat_stream_with_retry` and forwards sanitized content deltas into the existing `_progress` path.
- Why this scope is sufficient: Codex already uses the same request logic for `chat()` and `chat_stream()`, so this exposes existing Responses API deltas without changing channel contracts, retry policy, or other providers.

## Notes

- No secrets, tokens, cookies, production logs, or personal data are included.
- Defaults do not expand permissions or network/file access.
- Logs and errors do not expose sensitive values.
- Security-sensitive behavior is documented or explicitly marked not applicable.

Notes: This is not security-sensitive; it changes progress delivery only.

## Verification

Commands run:

```bash
uv run --extra dev ruff check nanobot/providers/base.py nanobot/agent/hook.py nanobot/agent/runner.py nanobot/agent/loop.py nanobot/providers/openai_codex_provider.py tests/agent/test_loop_progress.py tests/providers/test_providers_init.py
uv run --extra dev pytest tests/agent/test_loop_progress.py tests/agent/test_runner.py::test_runner_streaming_hook_receives_deltas_and_end_signal tests/agent/test_runner.py::test_loop_stream_filter_handles_think_only_prefix_without_crashing
uv run --extra dev pytest tests/agent/test_runner.py tests/agent/test_loop_progress.py tests/providers/test_openai_responses.py tests/cli/test_commands.py::test_openai_codex_strip_prefix_supports_hyphen_and_underscore tests/providers/test_providers_init.py
git diff --check
```

Tests added or updated:

- Added coverage that a Codex-style provider streams content deltas into `_progress` outbound messages.
- Added coverage that already-streamed progress content is not repeated before tool execution.
- Added coverage that OpenAI Codex explicitly opts into the provider progress-streaming capability.

Manual verification:

- Inspected the final diff to confirm no channel implementations, retry policy, or SSE parser behavior changed.