### PR TITLE
fix(heartbeat): skip empty active task checks

### DIFF
--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -84,6 +84,90 @@ class HeartbeatService:
                 return None
         return None
 
+    @staticmethod
+    def _has_active_tasks(content: str) -> bool:
+        """Return True when HEARTBEAT.md contains actionable task text."""
+        active_lines = HeartbeatService._active_task_section_lines(content)
+        if active_lines is None:
+            active_lines = content.splitlines()
+
+        in_html_comment = False
+        for line in active_lines:
+            line, in_html_comment = HeartbeatService._strip_html_comment(line, in_html_comment)
+            normalized = line.strip()
+            if not normalized:
+                continue
+            if HeartbeatService._is_heartbeat_template_line(normalized):
+                continue
+            return True
+        return False
+
+    @staticmethod
+    def _active_task_section_lines(content: str) -> list[str] | None:
+        lines = content.splitlines()
+        section_start: int | None = None
+        section_level: int | None = None
+
+        for index, line in enumerate(lines):
+            stripped = line.lstrip()
+            level = len(stripped) - len(stripped.lstrip("#"))
+            if level == 0 or level > 6 or not stripped[level:].startswith(" "):
+                continue
+            title = stripped[level:].strip().casefold()
+            if title == "active tasks":
+                section_start = index + 1
+                section_level = level
+                break
+
+        if section_start is None or section_level is None:
+            return None
+
+        section_end = len(lines)
+        for index in range(section_start, len(lines)):
+            stripped = lines[index].lstrip()
+            level = len(stripped) - len(stripped.lstrip("#"))
+            if 0 < level <= section_level and stripped[level:].startswith(" "):
+                section_end = index
+                break
+
+        return lines[section_start:section_end]
+
+    @staticmethod
+    def _strip_html_comment(line: str, in_comment: bool) -> tuple[str, bool]:
+        remaining = line
+        output = ""
+
+        while remaining:
+            if in_comment:
+                end = remaining.find("-->")
+                if end == -1:
+                    return output, True
+                remaining = remaining[end + 3:]
+                in_comment = False
+                continue
+
+            start = remaining.find("<!--")
+            if start == -1:
+                output += remaining
+                break
+            output += remaining[:start]
+            remaining = remaining[start + 4:]
+            end = remaining.find("-->")
+            if end == -1:
+                return output, True
+            remaining = remaining[end + 3:]
+
+        return output, in_comment
+
+    @staticmethod
+    def _is_heartbeat_template_line(line: str) -> bool:
+        lower = line.casefold()
+        if line.startswith("#"):
+            return True
+        if lower in {"---", "***", "___"}:
+            return True
+        return False
+
     async def _decide(self, content: str) -> tuple[str, str]:
         """Phase 1: ask LLM to decide skip/run via virtual tool call.
 
@@ -190,6 +274,10 @@ class HeartbeatService:
             logger.debug("Heartbeat: HEARTBEAT.md missing or empty")
             return
 
+        if not self._has_active_tasks(content):
+            logger.debug("Heartbeat: no active tasks, skipping LLM call")
+            return
+
         logger.info("Heartbeat: checking for tasks...")
 
         try:
@@ -229,6 +317,8 @@ class HeartbeatService:
         """Manually trigger a heartbeat."""
         content = self._read_heartbeat_file()
         if not content:
+            return None
+        if not self._has_active_tasks(content):
             return None
         action, tasks = await self._decide(content)
         if action != "run" or not self.on_execute:

--- a/tests/agent/test_heartbeat_service.py
+++ b/tests/agent/test_heartbeat_service.py
@@ -22,6 +22,61 @@ class DummyProvider(LLMProvider):
         return "test-model"
 
 
+def test_has_active_tasks_skips_empty_active_section() -> None:
+    content = """
+# HEARTBEAT
+
+## Active Tasks
+
+<!-- Add tasks here when heartbeat should run. -->
+
+## Notes
+- [ ] archived note outside the active section
+"""
+
+    assert not HeartbeatService._has_active_tasks(content)
+
+
+def test_has_active_tasks_detects_unchecked_task_in_active_section() -> None:
+    content = """
+# HEARTBEAT
+
+## Active Tasks
+
+- [ ] check production alerts
+
+## Notes
+- no active tasks
+"""
+
+    assert HeartbeatService._has_active_tasks(content)
+
+
+def test_has_active_tasks_keeps_ambiguous_content_for_llm_decision() -> None:
+    content = """
+## Active Tasks
+- [x] already handled
+No active tasks right now.
+"""
+
+    assert HeartbeatService._has_active_tasks(content)
+
+
+def test_has_active_tasks_supports_legacy_task_without_heading() -> None:
+    assert HeartbeatService._has_active_tasks("- [ ] check deployments")
+
+
+def test_has_active_tasks_skips_template_without_heading() -> None:
+    content = """
+# HEARTBEAT
+
+<!-- Nothing to do right now. -->
+## Notes
+"""
+
+    assert not HeartbeatService._has_active_tasks(content)
+
+
 @pytest.mark.asyncio
 async def test_start_is_idempotent(tmp_path) -> None:
     provider = DummyProvider([])
@@ -121,6 +176,84 @@ async def test_trigger_now_returns_none_when_decision_is_skip(tmp_path) -> None:
     )
 
     assert await service.trigger_now() is None
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_llm_when_active_tasks_section_is_empty(tmp_path) -> None:
+    (tmp_path / "HEARTBEAT.md").write_text(
+        """
+# HEARTBEAT
+
+## Active Tasks
+
+<!-- Add tasks here when heartbeat should run. -->
+""",
+        encoding="utf-8",
+    )
+
+    provider = DummyProvider([
+        LLMResponse(
+            content="",
+            tool_calls=[
+                ToolCallRequest(
+                    id="hb_1",
+                    name="heartbeat",
+                    arguments={"action": "run", "tasks": "should not run"},
+                )
+            ],
+        )
+    ])
+
+    executed: list[str] = []
+
+    async def _on_execute(tasks: str) -> str:
+        executed.append(tasks)
+        return "done"
+
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+        on_execute=_on_execute,
+    )
+
+    await service._tick()
+
+    assert provider.calls == 0
+    assert executed == []
+
+
+@pytest.mark.asyncio
+async def test_trigger_now_skips_llm_when_active_tasks_section_is_empty(tmp_path) -> None:
+    (tmp_path / "HEARTBEAT.md").write_text(
+        """
+## Active Tasks
+<!-- No active tasks. -->
+### Later
+""",
+        encoding="utf-8",
+    )
+
+    provider = DummyProvider([
+        LLMResponse(
+            content="",
+            tool_calls=[
+                ToolCallRequest(
+                    id="hb_1",
+                    name="heartbeat",
+                    arguments={"action": "run", "tasks": "should not run"},
+                )
+            ],
+        )
+    ])
+    service = HeartbeatService(
+        workspace=tmp_path,
+        provider=provider,
+        model="openai/gpt-4o-mini",
+    )
+
+    assert await service.trigger_now() is None
+    assert provider.calls == 0
 
 
 @pytest.mark.asyncio
@@ -286,4 +419,3 @@ async def test_decide_prompt_includes_current_time(tmp_path) -> None:
     user_msg = captured_messages[1]
     assert user_msg["role"] == "user"
     assert "Current Time:" in user_msg["content"]
-


### PR DESCRIPTION
## Summary

- Add a conservative local pre-check before heartbeat phase 1 calls the LLM.
- Parse the `Active Tasks` Markdown section when present, otherwise fall back to checking the whole `HEARTBEAT.md` content.
- Skip the LLM call only when the relevant content is empty or comment/template-only.
- Apply the same guard to manual `trigger_now()`.

## Why

When `HEARTBEAT.md` has no substantive task content, the heartbeat service still calls the LLM every interval to decide whether to skip. This wastes tokens for empty/template heartbeat files.

The pre-check stays conservative: any ambiguous natural-language text still goes through the existing LLM decision path.

Fixes #2406.

## Validation

- `uv run --extra dev pytest tests/agent/test_heartbeat_service.py tests/heartbeat/test_heartbeat_deliverability.py tests/cli/test_commands.py -k 'heartbeat' -q`
- `uv run --extra dev ruff check nanobot/heartbeat/service.py tests/agent/test_heartbeat_service.py tests/heartbeat/test_heartbeat_deliverability.py`
- `git diff --check`
