### PR TITLE
feat(providers): add Hugging Face inference provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,7 @@ IMAP_PASSWORD=your-password-here
 |----------|---------|-------------|
 | `custom` | Any OpenAI-compatible endpoint | — |
 | `openrouter` | LLM (recommended, access to all models) | [openrouter.ai](https://openrouter.ai) |
+| `huggingface` | LLM (Hugging Face Inference Providers) | [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) |
 | `volcengine` | LLM (VolcEngine, pay-per-use) | [Coding Plan](https://www.volcengine.com/activity/codingplan?utm_campaign=nanobot&utm_content=nanobot&utm_medium=devrel&utm_source=OWO&utm_term=nanobot) · [volcengine.com](https://www.volcengine.com) |
 | `byteplus` | LLM (VolcEngine international, pay-per-use) | [Coding Plan](https://www.byteplus.com/en/activity/codingplan?utm_campaign=nanobot&utm_content=nanobot&utm_medium=devrel&utm_source=OWO&utm_term=nanobot) · [byteplus.com](https://www.byteplus.com) |
 | `anthropic` | LLM (Claude direct) | [console.anthropic.com](https://console.anthropic.com) |

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -122,6 +122,7 @@ class ProvidersConfig(Base):
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
+    huggingface: ProviderConfig = Field(default_factory=ProviderConfig)
     deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
     groq: ProviderConfig = Field(default_factory=ProviderConfig)
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -120,6 +120,18 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://openrouter.ai/api/v1",
         supports_prompt_caching=True,
     ),
+    # Hugging Face Inference Providers: OpenAI-compatible router for chat models.
+    ProviderSpec(
+        name="huggingface",
+        keywords=("huggingface", "hugging-face"),
+        env_key="HF_TOKEN",
+        display_name="Hugging Face",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_key_prefix="hf_",
+        detect_by_base_keyword="huggingface",
+        default_api_base="https://router.huggingface.co/v1",
+    ),
     # AiHubMix: global gateway, OpenAI-compatible interface.
     # strip_model_prefix=True: doesn't understand "anthropic/claude-3",
     # strips to bare "claude-3".


### PR DESCRIPTION
Hi, I'm Célina from Hugging Face 🤗  This PR adds support for [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers/en/index) as a `nanobot` LLM provider.

Changes:
- Adds a `huggingface` provider entry to the provider registry.
- Uses the OpenAI-compatible Hugging Face router: `https://router.huggingface.co/v1`.
- Uses `HF_TOKEN` as the provider API key environment variable.
- Exposes `providers.huggingface` in the config schema.

I've tested the integration and it works as expected:

```console
$ export HF_TOKEN="hf_xxx"

$ cat > /tmp/nanobot-hf-config.json <<'JSON'
{
  "providers": {
    "huggingface": {
      "apiKey": "${HF_TOKEN}"
    }
  },
  "agents": {
    "defaults": {
      "provider": "huggingface",
      "model": "moonshotai/Kimi-K2.6",
      "workspace": "/tmp/nanobot-hf-workspace"
    }
  }
}
JSON

$ nanobot agent --config /tmp/nanobot-hf-config.json -m "Reply with exactly: hf-ok"
Using config: /private/tmp/nanobot-hf-config.json
  Created HEARTBEAT.md
  Created USER.md
  Created SOUL.md
  Created AGENTS.md
  Created TOOLS.md
  Created memory/MEMORY.md
  Created memory/history.jsonl
2026-04-27 18:41:20.121 | INFO     | nanobot.utils.gitstore:init:113 - Git store initialized at /tmp/nanobot-hf-workspace

🐈 nanobot
hf-ok
```