### PR TITLE
feat: Implement provider failover routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .env
 .web
 .orion
+r0/
+r0-*/
 
 # webui (monorepo frontend)
 webui/node_modules/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,29 @@ IMAP_PASSWORD=your-password-here
 | `github_copilot` | LLM (GitHub Copilot, OAuth) | `nanobot provider login github-copilot` |
 | `qianfan` | LLM (Baidu Qianfan) | [cloud.baidu.com](https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26) |
 
+### Model Failover
+
+Set `agents.defaults.fallbackModels` to let nanobot try another model after the active provider has exhausted its own retry policy and returned a transient final error. nanobot does not perform preflight network checks, does not mutate the session model, and does not switch for schema/auth/context-length/content-policy errors. Quota, billing, and payment errors do not fail over unless `failoverOnQuota` is enabled.
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "anthropic/claude-opus-4-5",
+      "fallbackModels": ["openai/gpt-4.1-mini", "openrouter/anthropic/claude-sonnet-4-5"],
+      "failover": {
+        "enabled": true,
+        "cooldownSeconds": 120,
+        "maxSwitchesPerTurn": 0,
+        "failoverOnQuota": false
+      }
+    }
+  }
+}
+```
+
+Streaming responses are buffered until a candidate succeeds. If the primary model emits partial text and then fails, that partial text is discarded and only the successful fallback output is sent.
+
 
 <details>
 <summary><b>OpenAI Codex (OAuth)</b></summary>

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1427,6 +1427,8 @@ def status():
         from nanobot.providers.registry import PROVIDERS
 
         console.print(f"Model: {config.agents.defaults.model}")
+        if config.agents.defaults.fallback_models:
+            console.print(f"Fallbacks: {' -> '.join(config.agents.defaults.fallback_models)}")
 
         # Check API keys from registry
         for spec in PROVIDERS:

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -90,6 +90,11 @@ async def cmd_status(ctx: CommandContext) -> OutboundMessage:
             max_completion_tokens=getattr(
                 getattr(loop.provider, "generation", None), "max_tokens", 8192
             ),
+            fallback_models=(
+                loop.provider.fallback_chain()
+                if callable(getattr(loop.provider, "fallback_chain", None))
+                else ()
+            ),
         ),
         metadata={**dict(ctx.msg.metadata or {}), "render_as": "text"},
     )

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -65,6 +65,15 @@ class DreamConfig(Base):
         return f"every {hours}h"
 
 
+class FailoverConfig(Base):
+    """Cross-model failover behavior after provider-local retry is exhausted."""
+
+    enabled: bool = True
+    cooldown_seconds: float = Field(default=120.0, ge=0)
+    max_switches_per_turn: int = Field(default=0, ge=0)
+    failover_on_quota: bool = False
+
+
 class AgentDefaults(Base):
     """Default agent configuration."""
 
@@ -80,6 +89,8 @@ class AgentDefaults(Base):
     max_tool_iterations: int = 200
     max_tool_result_chars: int = 16_000
     provider_retry_mode: Literal["standard", "persistent"] = "standard"
+    fallback_models: list[str] = Field(default_factory=list)
+    failover: FailoverConfig = Field(default_factory=FailoverConfig)
     reasoning_effort: str | None = None  # low / medium / high / adaptive - enables LLM thinking mode
     timezone: str = "UTC"  # IANA timezone, e.g. "Asia/Shanghai", "America/New_York"
     unified_session: bool = False  # Share one session across all channels (single-user multi-device)

--- a/nanobot/providers/__init__.py
+++ b/nanobot/providers/__init__.py
@@ -25,16 +25,23 @@ _LAZY_IMPORTS = {
     "AzureOpenAIProvider": ".azure_openai_provider",
 }
 
+_LAZY_MODULES = {
+    "factory": ".factory",
+    "failover": ".failover",
+}
+
 if TYPE_CHECKING:
     from nanobot.providers.anthropic_provider import AnthropicProvider
     from nanobot.providers.azure_openai_provider import AzureOpenAIProvider
     from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
-    from nanobot.providers.openai_compat_provider import OpenAICompatProvider
     from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+    from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 
 
 def __getattr__(name: str):
     """Lazily expose provider implementations without importing all backends up front."""
+    if name in _LAZY_MODULES:
+        return import_module(_LAZY_MODULES[name], __name__)
     module_name = _LAZY_IMPORTS.get(name)
     if module_name is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from nanobot.config.schema import Config
 from nanobot.providers.base import GenerationSettings, LLMProvider
+from nanobot.providers.failover import ModelCandidate, ModelRouter
 from nanobot.providers.registry import find_by_name
 
 
@@ -16,11 +18,16 @@ class ProviderSnapshot:
     model: str
     context_window_tokens: int
     signature: tuple[object, ...]
+    fallback_models: tuple[str, ...] = ()
 
 
 def make_provider(config: Config) -> LLMProvider:
     """Create the LLM provider implied by config."""
-    model = config.agents.defaults.model
+    return make_provider_for_model(config, config.agents.defaults.model)
+
+
+def make_provider_for_model(config: Config, model: str) -> LLMProvider:
+    """Create the LLM provider candidate for a specific model string."""
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
     spec = find_by_name(provider_name) if provider_name else None
@@ -80,29 +87,82 @@ def make_provider(config: Config) -> LLMProvider:
     return provider
 
 
+def _provider_config_signature(config: Config, model: str) -> tuple[object, ...]:
+    provider_name = config.get_provider_name(model)
+    p = config.get_provider(model)
+    extra_headers: tuple[tuple[str, str], ...] = ()
+    if p and p.extra_headers:
+        extra_headers = tuple(sorted((str(k), str(v)) for k, v in p.extra_headers.items()))
+    return (
+        model,
+        provider_name,
+        config.get_api_key(model),
+        config.get_api_base(model),
+        extra_headers,
+    )
+
+
+def _failover_signature(config: Config) -> tuple[Any, ...]:
+    defaults = config.agents.defaults
+    failover = defaults.failover
+    return (
+        tuple(defaults.fallback_models),
+        failover.enabled,
+        failover.cooldown_seconds,
+        failover.max_switches_per_turn,
+        failover.failover_on_quota,
+    )
+
+
 def provider_signature(config: Config) -> tuple[object, ...]:
     """Return the config fields that affect the primary LLM provider."""
     model = config.agents.defaults.model
     defaults = config.agents.defaults
+    candidate_models = (model, *defaults.fallback_models)
     return (
-        model,
         defaults.provider,
-        config.get_provider_name(model),
-        config.get_api_key(model),
-        config.get_api_base(model),
+        tuple(_provider_config_signature(config, candidate) for candidate in candidate_models),
         defaults.max_tokens,
         defaults.temperature,
         defaults.reasoning_effort,
         defaults.context_window_tokens,
+        _failover_signature(config),
     )
 
 
+def _make_fallback_candidates(config: Config) -> list[ModelCandidate]:
+    candidates: list[ModelCandidate] = []
+    for model in config.agents.defaults.fallback_models:
+        provider_name = config.get_provider_name(model)
+        candidates.append(
+            ModelCandidate(
+                model=model,
+                provider_name=provider_name,
+                provider_factory=lambda m=model: make_provider_for_model(config, m),
+            )
+        )
+    return candidates
+
+
 def build_provider_snapshot(config: Config) -> ProviderSnapshot:
+    defaults = config.agents.defaults
+    primary = make_provider(config)
+    provider: LLMProvider = primary
+    fallback_models = tuple(defaults.fallback_models)
+    if defaults.failover.enabled and fallback_models:
+        provider = ModelRouter(
+            primary_provider=primary,
+            primary_model=defaults.model,
+            primary_provider_name=config.get_provider_name(defaults.model),
+            fallback_candidates=_make_fallback_candidates(config),
+            failover=defaults.failover,
+        )
     return ProviderSnapshot(
-        provider=make_provider(config),
-        model=config.agents.defaults.model,
-        context_window_tokens=config.agents.defaults.context_window_tokens,
+        provider=provider,
+        model=defaults.model,
+        context_window_tokens=defaults.context_window_tokens,
         signature=provider_signature(config),
+        fallback_models=fallback_models,
     )
 
 

--- a/nanobot/providers/failover.py
+++ b/nanobot/providers/failover.py
@@ -1,0 +1,353 @@
+"""Provider-like model router with bounded cross-model failover."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+
+from nanobot.config.schema import FailoverConfig
+from nanobot.providers.base import GenerationSettings, LLMProvider, LLMResponse
+
+
+@dataclass(frozen=True)
+class ModelCandidate:
+    """Lazy provider candidate used by ModelRouter."""
+
+    model: str
+    provider_name: str | None
+    provider_factory: Callable[[], LLMProvider]
+
+    @property
+    def key(self) -> tuple[str | None, str]:
+        return self.provider_name, self.model
+
+    @property
+    def label(self) -> str:
+        provider = self.provider_name or "unknown"
+        return f"{provider}/{self.model}"
+
+
+class ModelRouter(LLMProvider):
+    """Route to fallback models after a provider returns a final retry error."""
+
+    supports_progress_deltas = False
+
+    _BLOCKED_STATUS_CODES = frozenset({400, 401, 403, 404, 422})
+    _QUOTA_MARKERS = (
+        "insufficient_quota",
+        "insufficient quota",
+        "quota exceeded",
+        "quota_exceeded",
+        "quota exhausted",
+        "quota_exhausted",
+        "billing hard limit",
+        "billing_hard_limit_reached",
+        "billing not active",
+        "insufficient balance",
+        "insufficient_balance",
+        "credit balance too low",
+        "payment required",
+        "out of credits",
+        "out of quota",
+        "exceeded your current quota",
+    )
+    _NON_FAILOVER_MARKERS = (
+        "context length",
+        "context_length",
+        "maximum context",
+        "max context",
+        "token budget",
+        "too many tokens",
+        "schema",
+        "invalid request",
+        "invalid_request",
+        "invalid parameter",
+        "invalid_parameter",
+        "unsupported",
+        "unauthorized",
+        "authentication",
+        "permission",
+        "forbidden",
+        "refusal",
+        "content policy",
+        "content_filter",
+        "policy violation",
+        "safety",
+    )
+
+    def __init__(
+        self,
+        *,
+        primary_provider: LLMProvider,
+        primary_model: str,
+        primary_provider_name: str | None,
+        fallback_candidates: list[ModelCandidate],
+        failover: FailoverConfig,
+    ) -> None:
+        super().__init__(
+            api_key=getattr(primary_provider, "api_key", None),
+            api_base=getattr(primary_provider, "api_base", None),
+        )
+        self.primary_provider = primary_provider
+        self.primary_model = primary_model
+        self.primary_provider_name = primary_provider_name
+        self.fallback_candidates = list(fallback_candidates)
+        self.failover = failover
+        self.generation = getattr(primary_provider, "generation", GenerationSettings())
+        self._provider_cache: dict[tuple[str | None, str], LLMProvider] = {
+            (primary_provider_name, primary_model): primary_provider
+        }
+        self._cooldowns: dict[tuple[str | None, str], float] = {}
+
+    def get_default_model(self) -> str:
+        return self.primary_model
+
+    async def chat(self, **kwargs: Any) -> LLMResponse:
+        return await self.primary_provider.chat(**kwargs)
+
+    async def chat_stream(self, **kwargs: Any) -> LLMResponse:
+        return await self.primary_provider.chat_stream(**kwargs)
+
+    def fallback_chain(self) -> tuple[str, ...]:
+        return tuple(candidate.model for candidate in self.fallback_candidates)
+
+    def _candidate_chain(self) -> list[ModelCandidate]:
+        switch_limit = self.failover.max_switches_per_turn
+        fallbacks = (
+            self.fallback_candidates
+            if switch_limit == 0
+            else self.fallback_candidates[:switch_limit]
+        )
+        return [
+            ModelCandidate(
+                model=self.primary_model,
+                provider_name=self.primary_provider_name,
+                provider_factory=lambda: self.primary_provider,
+            ),
+            *fallbacks,
+        ]
+
+    def _is_in_cooldown(self, candidate: ModelCandidate, now: float) -> bool:
+        until = self._cooldowns.get(candidate.key)
+        return until is not None and until > now
+
+    def _mark_cooldown(self, candidate: ModelCandidate) -> None:
+        if self.failover.cooldown_seconds <= 0:
+            return
+        self._cooldowns[candidate.key] = time.monotonic() + self.failover.cooldown_seconds
+
+    def _get_provider(self, candidate: ModelCandidate) -> LLMProvider:
+        provider = self._provider_cache.get(candidate.key)
+        if provider is not None:
+            return provider
+        provider = candidate.provider_factory()
+        self._provider_cache[candidate.key] = provider
+        return provider
+
+    def _factory_error_response(self, candidate: ModelCandidate, exc: Exception) -> LLMResponse:
+        logger.warning(
+            "Failed to configure fallback candidate provider={} model={}: {}",
+            candidate.provider_name,
+            candidate.model,
+            exc,
+        )
+        return LLMResponse(
+            content=f"Error configuring fallback model {candidate.model}: {exc}",
+            finish_reason="error",
+            error_kind="configuration",
+            error_should_retry=False,
+        )
+
+    def _is_quota_error(self, response: LLMResponse) -> bool:
+        tokens = {
+            self._normalize_error_token(response.error_type),
+            self._normalize_error_token(response.error_code),
+        }
+        if any(token in self._NON_RETRYABLE_429_ERROR_TOKENS for token in tokens if token):
+            return True
+        content = (response.content or "").lower()
+        return any(marker in content for marker in self._QUOTA_MARKERS)
+
+    def _is_blocked_error(self, response: LLMResponse) -> bool:
+        status = response.error_status_code
+        if status is not None and int(status) in self._BLOCKED_STATUS_CODES:
+            return True
+        if response.finish_reason in {"refusal", "content_filter"}:
+            return True
+        content = (response.content or "").lower()
+        return any(marker in content for marker in self._NON_FAILOVER_MARKERS)
+
+    def _should_failover(self, response: LLMResponse) -> bool:
+        if response.finish_reason != "error":
+            return False
+        if self._is_blocked_error(response):
+            return False
+        if self._is_quota_error(response) and not self.failover.failover_on_quota:
+            return False
+        return self._is_transient_response(response)
+
+    def _log_failover(
+        self,
+        *,
+        candidate: ModelCandidate,
+        response: LLMResponse,
+        next_candidate: ModelCandidate | None,
+    ) -> None:
+        status = response.error_status_code
+        kind = response.error_kind or response.error_type or response.error_code or "unknown"
+        if next_candidate is None:
+            logger.warning(
+                "LLM failover exhausted provider={} model={} status={} kind={}",
+                candidate.provider_name,
+                candidate.model,
+                status,
+                kind,
+            )
+            return
+        logger.warning(
+            "LLM failover provider={} model={} status={} kind={} next_provider={} next_model={} cooldown={}",
+            candidate.provider_name,
+            candidate.model,
+            status,
+            kind,
+            next_candidate.provider_name,
+            next_candidate.model,
+            self.failover.cooldown_seconds > 0,
+        )
+
+    async def _route(
+        self,
+        call: Callable[[LLMProvider, str, Callable[[str], Awaitable[None]] | None], Awaitable[LLMResponse]],
+        *,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        if not self.failover.enabled or not self.fallback_candidates:
+            return await call(self.primary_provider, self.primary_model, on_content_delta)
+
+        chain = self._candidate_chain()
+        last_response: LLMResponse | None = None
+        now = time.monotonic()
+        for index, candidate in enumerate(chain):
+            if index > 0 and self._is_in_cooldown(candidate, now):
+                logger.info(
+                    "Skipping LLM fallback in cooldown provider={} model={}",
+                    candidate.provider_name,
+                    candidate.model,
+                )
+                continue
+            try:
+                provider = self._get_provider(candidate)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                response = self._factory_error_response(candidate, exc)
+            else:
+                response = await call(provider, candidate.model, on_content_delta)
+
+            if response.finish_reason != "error":
+                if index > 0:
+                    logger.info(
+                        "LLM failover selected provider={} model={}",
+                        candidate.provider_name,
+                        candidate.model,
+                    )
+                return response
+
+            last_response = response
+            if not self._should_failover(response):
+                return response
+
+            self._mark_cooldown(candidate)
+            next_candidate = next(
+                (
+                    item for item in chain[index + 1:]
+                    if not self._is_in_cooldown(item, time.monotonic())
+                ),
+                None,
+            )
+            self._log_failover(
+                candidate=candidate,
+                response=response,
+                next_candidate=next_candidate,
+            )
+
+        return last_response or LLMResponse(
+            content="No available fallback model candidate.",
+            finish_reason="error",
+            error_kind="configuration",
+            error_should_retry=False,
+        )
+
+    async def chat_with_retry(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: object = LLMProvider._SENTINEL,
+        temperature: object = LLMProvider._SENTINEL,
+        reasoning_effort: object = LLMProvider._SENTINEL,
+        tool_choice: str | dict[str, Any] | None = None,
+        retry_mode: str = "standard",
+        on_retry_wait: Callable[[str], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        async def call(provider: LLMProvider, candidate_model: str, _delta: Any) -> LLMResponse:
+            return await provider.chat_with_retry(
+                messages=messages,
+                tools=tools,
+                model=candidate_model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                reasoning_effort=reasoning_effort,
+                tool_choice=tool_choice,
+                retry_mode=retry_mode,
+                on_retry_wait=on_retry_wait,
+            )
+
+        return await self._route(call)
+
+    async def chat_stream_with_retry(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: object = LLMProvider._SENTINEL,
+        temperature: object = LLMProvider._SENTINEL,
+        reasoning_effort: object = LLMProvider._SENTINEL,
+        tool_choice: str | dict[str, Any] | None = None,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        retry_mode: str = "standard",
+        on_retry_wait: Callable[[str], Awaitable[None]] | None = None,
+    ) -> LLMResponse:
+        async def call(
+            provider: LLMProvider,
+            candidate_model: str,
+            external_delta: Callable[[str], Awaitable[None]] | None,
+        ) -> LLMResponse:
+            buffered: list[str] = []
+
+            async def buffer_delta(delta: str) -> None:
+                buffered.append(delta)
+
+            response = await provider.chat_stream_with_retry(
+                messages=messages,
+                tools=tools,
+                model=candidate_model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                reasoning_effort=reasoning_effort,
+                tool_choice=tool_choice,
+                on_content_delta=buffer_delta if external_delta else None,
+                retry_mode=retry_mode,
+                on_retry_wait=on_retry_wait,
+            )
+            if response.finish_reason != "error" and external_delta:
+                for delta in buffered:
+                    await external_delta(delta)
+            return response
+
+        return await self._route(call, on_content_delta=on_content_delta)

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -441,6 +441,7 @@ def build_status_content(
     search_usage_text: str | None = None,
     active_task_count: int = 0,
     max_completion_tokens: int = 8192,
+    fallback_models: list[str] | tuple[str, ...] = (),
 ) -> str:
     """Build a human-readable runtime status snapshot.
 
@@ -480,6 +481,8 @@ def build_status_content(
         f"\u23f1 Uptime: {uptime}",
         f"\u26a1 Tasks: {active_task_count} active",
     ]
+    if fallback_models:
+        lines.insert(2, f"\U0001f501 Fallbacks: {' -> '.join(fallback_models)}")
     if search_usage_text:
         lines.append(search_usage_text)
     return "\n".join(lines)

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -223,6 +223,50 @@ async def test_runner_streaming_hook_receives_deltas_and_end_signal():
 
 
 @pytest.mark.asyncio
+async def test_runner_accepts_provider_like_model_router():
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+    from nanobot.config.schema import FailoverConfig
+    from nanobot.providers.failover import ModelCandidate, ModelRouter
+
+    primary = MagicMock()
+    fallback = MagicMock()
+    primary.chat_with_retry = AsyncMock(return_value=LLMResponse(
+        content="primary timeout",
+        finish_reason="error",
+        error_kind="timeout",
+    ))
+    fallback.chat_with_retry = AsyncMock(return_value=LLMResponse(content="fallback done"))
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    router = ModelRouter(
+        primary_provider=primary,
+        primary_model="primary-model",
+        primary_provider_name="primary",
+        fallback_candidates=[
+            ModelCandidate(
+                model="fallback-model",
+                provider_name="fallback",
+                provider_factory=lambda: fallback,
+            )
+        ],
+        failover=FailoverConfig(cooldown_seconds=0),
+    )
+
+    result = await AgentRunner(router).run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "hello"}],
+        tools=tools,
+        model="primary-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "fallback done"
+    primary.chat_with_retry.assert_awaited_once()
+    fallback.chat_with_retry.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_runner_returns_max_iterations_fallback():
     from nanobot.agent.runner import AgentRunSpec, AgentRunner
 

--- a/tests/config/test_failover_config.py
+++ b/tests/config/test_failover_config.py
@@ -1,0 +1,60 @@
+import pytest
+from pydantic import ValidationError
+
+from nanobot.config.schema import AgentDefaults, Config
+
+
+def test_failover_defaults_are_disabled_until_fallback_models_configured() -> None:
+    defaults = AgentDefaults()
+
+    assert defaults.fallback_models == []
+    assert defaults.failover.enabled is True
+    assert defaults.failover.cooldown_seconds == 120.0
+    assert defaults.failover.max_switches_per_turn == 0
+    assert defaults.failover.failover_on_quota is False
+
+
+def test_fallback_models_and_failover_accept_camel_case_aliases() -> None:
+    config = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "fallbackModels": ["openai/gpt-4.1-mini", "anthropic/claude-sonnet-4-5"],
+                "failover": {
+                    "cooldownSeconds": 30,
+                    "maxSwitchesPerTurn": 1,
+                    "failoverOnQuota": True,
+                },
+            }
+        }
+    })
+
+    defaults = config.agents.defaults
+    assert defaults.fallback_models == [
+        "openai/gpt-4.1-mini",
+        "anthropic/claude-sonnet-4-5",
+    ]
+    assert defaults.failover.cooldown_seconds == 30
+    assert defaults.failover.max_switches_per_turn == 1
+    assert defaults.failover.failover_on_quota is True
+
+
+def test_invalid_failover_values_are_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Config.model_validate({
+            "agents": {
+                "defaults": {
+                    "fallbackModels": ["openai/gpt-4.1-mini"],
+                    "failover": {"cooldownSeconds": -1},
+                }
+            }
+        })
+
+    with pytest.raises(ValidationError):
+        Config.model_validate({
+            "agents": {
+                "defaults": {
+                    "fallbackModels": ["openai/gpt-4.1-mini"],
+                    "failover": {"maxSwitchesPerTurn": -1},
+                }
+            }
+        })

--- a/tests/providers/test_model_router.py
+++ b/tests/providers/test_model_router.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from nanobot.config.schema import FailoverConfig
+from nanobot.providers.base import LLMProvider, LLMResponse
+from nanobot.providers.failover import ModelCandidate, ModelRouter
+
+
+class ScriptedProvider(LLMProvider):
+    def __init__(
+        self,
+        model: str,
+        responses: list[LLMResponse],
+        *,
+        stream_chunks: list[list[str]] | None = None,
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self.responses = list(responses)
+        self.stream_chunks = list(stream_chunks or [])
+        self.calls: list[tuple[str | None, str]] = []
+
+    def get_default_model(self) -> str:
+        return self.model
+
+    async def chat(self, **kwargs) -> LLMResponse:
+        raise AssertionError("ModelRouter should use provider-local chat_with_retry")
+
+    async def chat_with_retry(self, *, model: str | None = None, **kwargs) -> LLMResponse:
+        self.calls.append((model, "chat"))
+        return self.responses.pop(0)
+
+    async def chat_stream_with_retry(
+        self,
+        *,
+        model: str | None = None,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+        **kwargs,
+    ) -> LLMResponse:
+        self.calls.append((model, "stream"))
+        chunks = self.stream_chunks.pop(0) if self.stream_chunks else []
+        if on_content_delta:
+            for chunk in chunks:
+                await on_content_delta(chunk)
+        return self.responses.pop(0)
+
+
+def _router(
+    primary: ScriptedProvider,
+    fallback: ScriptedProvider | None = None,
+    *,
+    failover: FailoverConfig | None = None,
+) -> ModelRouter:
+    fallback_candidates = []
+    if fallback is not None:
+        fallback_candidates.append(
+            ModelCandidate(
+                model=fallback.model,
+                provider_name="fallback",
+                provider_factory=lambda: fallback,
+            )
+        )
+    return ModelRouter(
+        primary_provider=primary,
+        primary_model=primary.model,
+        primary_provider_name="primary",
+        fallback_candidates=fallback_candidates,
+        failover=failover or FailoverConfig(cooldown_seconds=0),
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_delegates_exactly_once() -> None:
+    primary = ScriptedProvider("primary-model", [LLMResponse(content="ok")])
+    router = _router(primary)
+
+    response = await router.chat_with_retry(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.content == "ok"
+    assert primary.calls == [("primary-model", "chat")]
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_routes_to_fallback() -> None:
+    primary = ScriptedProvider(
+        "primary-model",
+        [LLMResponse(content="timeout", finish_reason="error", error_kind="timeout")],
+    )
+    fallback = ScriptedProvider("fallback-model", [LLMResponse(content="fallback ok")])
+    router = _router(primary, fallback)
+
+    response = await router.chat_with_retry(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.content == "fallback ok"
+    assert primary.calls == [("primary-model", "chat")]
+    assert fallback.calls == [("fallback-model", "chat")]
+
+
+@pytest.mark.asyncio
+async def test_non_transient_error_does_not_route() -> None:
+    primary = ScriptedProvider(
+        "primary-model",
+        [
+            LLMResponse(
+                content="401 unauthorized",
+                finish_reason="error",
+                error_status_code=401,
+            )
+        ],
+    )
+    fallback = ScriptedProvider("fallback-model", [LLMResponse(content="fallback ok")])
+    router = _router(primary, fallback)
+
+    response = await router.chat_with_retry(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.content == "401 unauthorized"
+    assert fallback.calls == []
+
+
+@pytest.mark.asyncio
+async def test_quota_error_does_not_route_by_default() -> None:
+    primary = ScriptedProvider(
+        "primary-model",
+        [
+            LLMResponse(
+                content="insufficient quota",
+                finish_reason="error",
+                error_status_code=429,
+                error_code="insufficient_quota",
+            )
+        ],
+    )
+    fallback = ScriptedProvider("fallback-model", [LLMResponse(content="fallback ok")])
+    router = _router(primary, fallback)
+
+    response = await router.chat_with_retry(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.content == "insufficient quota"
+    assert fallback.calls == []
+
+
+@pytest.mark.asyncio
+async def test_all_candidates_fail_returns_final_error() -> None:
+    primary = ScriptedProvider(
+        "primary-model",
+        [LLMResponse(content="primary down", finish_reason="error", error_status_code=503)],
+    )
+    fallback = ScriptedProvider(
+        "fallback-model",
+        [LLMResponse(content="fallback down", finish_reason="error", error_status_code=500)],
+    )
+    router = _router(primary, fallback)
+
+    response = await router.chat_with_retry(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.content == "fallback down"
+    assert fallback.calls == [("fallback-model", "chat")]
+
+
+@pytest.mark.asyncio
+async def test_cooldown_skips_failed_candidate_on_next_call() -> None:
+    primary = ScriptedProvider(
+        "primary-model",
+        [
+            LLMResponse(content="primary down", finish_reason="error", error_status_code=503),
+            LLMResponse(content="primary down again", finish_reason="error", error_status_code=503),
+        ],
+    )
+    fallback = ScriptedProvider(
+        "fallback-model",
+        [
+            LLMResponse(content="fallback down", finish_reason="error", error_status_code=500),
+        ],
+    )
+    router = _router(primary, fallback, failover=FailoverConfig(cooldown_seconds=60))
+
+    first = await router.chat_with_retry(messages=[{"role": "user", "content": "hi"}])
+    second = await router.chat_with_retry(messages=[{"role": "user", "content": "hi"}])
+
+    assert first.content == "fallback down"
+    assert second.content == "primary down again"
+    assert fallback.calls == [("fallback-model", "chat")]
+
+
+@pytest.mark.asyncio
+async def test_streaming_discards_failed_candidate_buffer_and_flushes_success() -> None:
+    primary = ScriptedProvider(
+        "primary-model",
+        [LLMResponse(content="primary failed", finish_reason="error", error_status_code=503)],
+        stream_chunks=[["bad ", "partial"]],
+    )
+    fallback = ScriptedProvider(
+        "fallback-model",
+        [LLMResponse(content="good final")],
+        stream_chunks=[["good ", "stream"]],
+    )
+    router = _router(primary, fallback)
+    deltas: list[str] = []
+
+    async def on_delta(delta: str) -> None:
+        deltas.append(delta)
+
+    response = await router.chat_stream_with_retry(
+        messages=[{"role": "user", "content": "hi"}],
+        on_content_delta=on_delta,
+    )
+
+    assert response.content == "good final"
+    assert deltas == ["good ", "stream"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_flushes_primary_success_buffer() -> None:
+    primary = ScriptedProvider(
+        "primary-model",
+        [LLMResponse(content="primary final")],
+        stream_chunks=[["hello", " world"]],
+    )
+    fallback = ScriptedProvider("fallback-model", [LLMResponse(content="fallback ok")])
+    router = _router(primary, fallback)
+    deltas: list[str] = []
+
+    async def on_delta(delta: str) -> None:
+        deltas.append(delta)
+
+    response = await router.chat_stream_with_retry(
+        messages=[{"role": "user", "content": "hi"}],
+        on_content_delta=on_delta,
+    )
+
+    assert response.content == "primary final"
+    assert deltas == ["hello", " world"]
+    assert fallback.calls == []

--- a/tests/providers/test_provider_factory_failover.py
+++ b/tests/providers/test_provider_factory_failover.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from nanobot.config.schema import Config
+from nanobot.providers.base import LLMProvider, LLMResponse
+from nanobot.providers.factory import build_provider_snapshot, provider_signature
+from nanobot.providers.failover import ModelRouter
+
+
+class DummyProvider(LLMProvider):
+    def __init__(self, model: str) -> None:
+        super().__init__()
+        self.model = model
+
+    async def chat(self, **kwargs) -> LLMResponse:
+        return LLMResponse(content=self.model)
+
+    def get_default_model(self) -> str:
+        return self.model
+
+
+def test_provider_signature_changes_when_fallback_config_changes() -> None:
+    base = Config.model_validate({
+        "agents": {"defaults": {"model": "anthropic/claude-opus-4-5"}}
+    })
+    with_fallback = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "model": "anthropic/claude-opus-4-5",
+                "fallbackModels": ["openai/gpt-4.1-mini"],
+            }
+        }
+    })
+    with_failover_policy = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "model": "anthropic/claude-opus-4-5",
+                "fallbackModels": ["openai/gpt-4.1-mini"],
+                "failover": {"cooldownSeconds": 5},
+            }
+        }
+    })
+
+    assert provider_signature(base) != provider_signature(with_fallback)
+    assert provider_signature(with_fallback) != provider_signature(with_failover_policy)
+
+
+def test_build_provider_snapshot_returns_plain_provider_without_fallback(monkeypatch) -> None:
+    config = Config.model_validate({
+        "agents": {"defaults": {"model": "anthropic/claude-opus-4-5"}}
+    })
+
+    monkeypatch.setattr(
+        "nanobot.providers.factory.make_provider_for_model",
+        lambda _config, model: DummyProvider(model),
+    )
+
+    snapshot = build_provider_snapshot(config)
+
+    assert isinstance(snapshot.provider, DummyProvider)
+    assert snapshot.fallback_models == ()
+
+
+def test_build_provider_snapshot_wraps_router_and_lazily_builds_fallback(monkeypatch) -> None:
+    config = Config.model_validate({
+        "agents": {
+            "defaults": {
+                "model": "anthropic/claude-opus-4-5",
+                "fallbackModels": ["openai/gpt-4.1-mini"],
+                "temperature": 0.3,
+                "maxTokens": 123,
+            }
+        }
+    })
+    built_models: list[str] = []
+
+    def make_dummy(_config: Config, model: str) -> DummyProvider:
+        built_models.append(model)
+        return DummyProvider(model)
+
+    monkeypatch.setattr("nanobot.providers.factory.make_provider_for_model", make_dummy)
+
+    snapshot = build_provider_snapshot(config)
+
+    assert isinstance(snapshot.provider, ModelRouter)
+    assert snapshot.fallback_models == ("openai/gpt-4.1-mini",)
+    assert built_models == ["anthropic/claude-opus-4-5"]
+
+    fallback_provider = snapshot.provider._get_provider(snapshot.provider.fallback_candidates[0])
+    assert fallback_provider.get_default_model() == "openai/gpt-4.1-mini"
+    assert built_models == ["anthropic/claude-opus-4-5", "openai/gpt-4.1-mini"]


### PR DESCRIPTION
# Implement provider/model failover routing

## Summary

Implements provider/model failover for #3376 after provider-local retry is exhausted.

This PR adds a provider-like `ModelRouter` layer between `AgentRunner` and concrete `LLMProvider` implementations. The runner still calls the same provider interface, while the router owns candidate selection, lazy fallback provider construction, cooldown, and safe streaming behavior.

The main goal is to make `fallbackModels` work without pushing provider-selection logic into `AgentRunner`, without mutating session state on fallback success, and without adding any preflight network IO.

## Background

Today, provider-local retry can recover from transient failures inside a single provider/model. When that retry is exhausted, the final error is returned to the agent loop even when another configured model could handle the same request.

This PR keeps the existing provider retry behavior intact and adds one bounded layer above it:

1. The selected provider gets the first request.
2. That provider performs its own local retry policy.
3. Only if it returns a final eligible error does `ModelRouter` try the next configured fallback candidate.
4. Non-transient errors return immediately so bugs, bad requests, auth failures, and policy/context issues are not hidden by fallback.

## Configuration

Adds `fallbackModels` under `agents.defaults`:

```json
{
  "agents": {
    "defaults": {
      "model": "anthropic/claude-opus-4-5",
      "fallbackModels": [
        "openai/gpt-4.1-mini",
        "openrouter/anthropic/claude-sonnet-4-5"
      ]
    }
  }
}
```

Adds minimal `failover` policy config:

```json
{
  "agents": {
    "defaults": {
      "failover": {
        "enabled": true,
        "cooldownSeconds": 120,
        "maxSwitchesPerTurn": 0,
        "failoverOnQuota": false
      }
    }
  }
}
```

Notes:

- `maxSwitchesPerTurn: 0` means all configured fallback models may be considered.
- `failoverOnQuota` defaults to `false`, so quota, billing, balance, and payment errors do not route by default.
- CamelCase config keys are supported by the existing schema alias behavior.

## Implementation Details

### Config schema

- Adds `FailoverConfig`.
- Adds `AgentDefaults.fallback_models`.
- Adds `AgentDefaults.failover`.

### Provider factory

- Refactors primary provider creation into `make_provider_for_model(config, model)`.
- Builds fallback candidates with the same model-string matching path as the primary model.
- Wraps the primary provider in `ModelRouter` only when failover is enabled and fallback models are configured.
- Keeps the no-fallback path returning the concrete provider directly.
- Extends `ProviderSnapshot.signature` so runtime refresh detects:
  - fallback model chain changes
  - failover policy changes
  - provider config changes for any candidate model

### ModelRouter

Adds `nanobot.providers.failover.ModelRouter` with provider-compatible methods:

- `chat_with_retry()`
- `chat_stream_with_retry()`
- `get_default_model()`

Router behavior:

- Candidate order is primary model followed by configured fallback models.
- Fallback providers are constructed lazily and cached.
- Candidate cooldown is process-local and in-memory.
- Provider-local retry remains owned by each concrete provider.
- Router only switches after the provider returns a final eligible error.
- Logs include provider/model, error category, cooldown state, and selected fallback model.
- Logs do not include API keys, headers, prompts, response tokens, or secret material.

### Streaming behavior

Streaming failover uses a buffer-before-switch policy:

1. Candidate deltas are buffered inside `ModelRouter`.
2. If the candidate succeeds, buffered deltas are flushed to the external callback, then the response returns.
3. If the candidate fails, buffered deltas are discarded and the router tries the next eligible fallback.

This avoids mixing partial output from a failed primary model with fallback output.

## Error Policy

Failover is allowed for transient final errors, including:

- timeout errors
- connection errors
- HTTP 408
- HTTP 409
- retryable HTTP 429
- HTTP 5xx
- provider responses marked `error_should_retry=True`

Failover is blocked for errors that should surface directly, including:

- HTTP 400 / 401 / 403 / 404 / 422
- auth and permission failures
- invalid request or invalid parameter errors
- schema errors
- unsupported feature/model errors
- context length and token budget errors
- content policy, refusal, and content filter errors
- quota, billing, balance, and payment errors by default

## User Impact

Users can now configure a fallback chain and get automatic recovery from transient provider/model outages without changing their active model setting or session state.

Example:

```json
{
  "agents": {
    "defaults": {
      "model": "anthropic/claude-opus-4-5",
      "fallbackModels": ["openai/gpt-4.1-mini"]
    }
  }
}
```

With that configuration, if the primary provider exhausts local retry on a transient final error, nanobot will try the fallback model for the same request.

## Observability

- `/status` shows the fallback chain when configured.
- CLI `nanobot status` shows configured fallbacks.
- Router logs show routing decisions without exposing secrets.

## Compatibility

- No fallback configured: existing behavior is preserved.
- `AgentRunner` remains provider-interface oriented and does not parse fallback models.
- `AgentLoop.model` and session state are not mutated when fallback succeeds.
- `provider_retry_mode="persistent"` is passed through to providers and is not rewritten by the router.

## Validation

Full requested regression suite:

```bash
uv run --extra dev pytest tests/providers tests/agent tests/config tests/cli/test_commands.py
```

Result:

```text
1134 passed, 3 warnings
```

Targeted new and critical tests:

```bash
uv run --extra dev pytest \
  tests/providers/test_model_router.py \
  tests/providers/test_provider_factory_failover.py \
  tests/config/test_failover_config.py \
  tests/providers/test_providers_init.py::test_importing_providers_package_is_lazy \
  tests/agent/test_runner.py::test_runner_accepts_provider_like_model_router
```

Result:

```text
16 passed
```

Targeted ruff checks:

```bash
uv run --extra dev ruff check \
  nanobot/config/schema.py \
  nanobot/providers/failover.py \
  nanobot/providers/factory.py \
  tests/providers/test_model_router.py \
  tests/providers/test_provider_factory_failover.py \
  tests/config/test_failover_config.py
```

```bash
uv run --extra dev ruff check \
  nanobot/providers/__init__.py \
  nanobot/command/builtin.py \
  nanobot/utils/helpers.py
```

Result:

```text
All checks passed
```

Additional check:

```bash
git diff --check
```

Result: passed.

Note: full-repo ruff still reports pre-existing unrelated lint issues in untouched files, so targeted ruff was used for touched clean files.

## Files of Interest

- `nanobot/providers/failover.py`
- `nanobot/providers/factory.py`
- `nanobot/config/schema.py`
- `tests/providers/test_model_router.py`
- `tests/providers/test_provider_factory_failover.py`
- `tests/config/test_failover_config.py`
- `docs/configuration.md`

## Follow-up

Phase 2 can integrate model presets once preset support lands, so fallback entries can evolve from raw model strings to preset names without coupling that work to this minimal failover core.
