### PR TITLE
feat:  Add module-level profiler API and integrate span tracing into nightly agent flow 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,7 @@ IMAP_PASSWORD=your-password-here
 |----------|---------|-------------|
 | `custom` | Any OpenAI-compatible endpoint | — |
 | `openrouter` | LLM (recommended, access to all models) | [openrouter.ai](https://openrouter.ai) |
+| `huggingface` | LLM (Hugging Face Inference Providers) | [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) |
 | `volcengine` | LLM (VolcEngine, pay-per-use) | [Coding Plan](https://www.volcengine.com/activity/codingplan?utm_campaign=nanobot&utm_content=nanobot&utm_medium=devrel&utm_source=OWO&utm_term=nanobot) · [volcengine.com](https://www.volcengine.com) |
 | `byteplus` | LLM (VolcEngine international, pay-per-use) | [Coding Plan](https://www.byteplus.com/en/activity/codingplan?utm_campaign=nanobot&utm_content=nanobot&utm_medium=devrel&utm_source=OWO&utm_term=nanobot) · [byteplus.com](https://www.byteplus.com) |
 | `anthropic` | LLM (Claude direct) | [console.anthropic.com](https://console.anthropic.com) |

--- a/nanobot/__init__.py
+++ b/nanobot/__init__.py
@@ -28,5 +28,6 @@ __version__ = _resolve_version()
 __logo__ = "🐈"
 
 from nanobot.nanobot import Nanobot, RunResult
+from nanobot.utils.profiler import ProfilerTrace, profiler
 
-__all__ = ["Nanobot", "RunResult"]
+__all__ = ["Nanobot", "RunResult", "ProfilerTrace", "profiler"]

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -46,6 +46,7 @@ from nanobot.session.manager import Session, SessionManager
 from nanobot.utils.document import extract_documents
 from nanobot.utils.helpers import image_placeholder_text
 from nanobot.utils.helpers import truncate_text as truncate_text_fn
+from nanobot.utils.profiler import profiler
 from nanobot.utils.progress_events import (
     build_tool_event_finish_payloads,
     build_tool_event_start_payload,
@@ -770,6 +771,7 @@ class AgentLoop:
         """Process a single inbound message and return the response."""
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
+            profiler.push("prepare_before_agent_loop", category="mainloop")
             channel, chat_id = (
                 msg.chat_id.split(":", 1) if ":" in msg.chat_id else ("cli", msg.chat_id)
             )
@@ -809,11 +811,15 @@ class AgentLoop:
                 session_summary=pending,
                 current_role=current_role,
             )
+            profiler.pop()
+            profiler.push("agent_loop", category="mainloop")
             final_content, _, all_msgs, stop_reason, _ = await self._run_agent_loop(
                 messages, session=session, channel=channel, chat_id=chat_id,
                 message_id=msg.metadata.get("message_id"),
                 pending_queue=pending_queue,
             )
+            profiler.pop()
+            profiler.push("session_end", category="mainloop")
             self._save_turn(session, all_msgs, 1 + len(history))
             self._clear_runtime_checkpoint(session)
             self.sessions.save(session)
@@ -824,12 +830,25 @@ class AgentLoop:
                 options,
                 channel,
             )
-            return OutboundMessage(
+            # Reconstruct channel-specific metadata from session.key so the
+            # outbound reply lands in the originating thread (not the channel
+            # top-level). The announce InboundMessage carries only
+            # injected_event metadata; we recover thread_ts from the session
+            # key, which slack writes as "slack:<chat_id>:<thread_ts>".
+            outbound_metadata: dict[str, Any] = {}
+            if channel == "slack" and key.startswith("slack:") and key.count(":") >= 2:
+                outbound_metadata["slack"] = {"thread_ts": key.split(":", 2)[2]}
+            outbound = OutboundMessage(
                 channel=channel,
                 chat_id=chat_id,
                 content=content,
                 buttons=buttons,
+                metadata=outbound_metadata,
             )
+            profiler.pop()
+            return outbound
+
+        profiler.push("prepare_before_agent_loop")
 
         # Extract document text from media at the processing boundary so all
         # channels benefit without format-specific logic in ContextBuilder.
@@ -932,6 +951,8 @@ class AgentLoop:
             self.sessions.save(session)
             user_persisted_early = True
 
+        profiler.pop()
+        profiler.push("agent_loop")
         final_content, _, all_msgs, stop_reason, had_injections = await self._run_agent_loop(
             initial_messages,
             on_progress=on_progress or _bus_progress,
@@ -944,6 +965,9 @@ class AgentLoop:
             message_id=msg.metadata.get("message_id"),
             pending_queue=pending_queue,
         )
+
+        profiler.pop()
+        profiler.push("session_end")
 
         if final_content is None or not final_content.strip():
             final_content = EMPTY_FINAL_RESPONSE_MESSAGE
@@ -977,13 +1001,15 @@ class AgentLoop:
         )
         if on_stream is not None and stop_reason not in {"ask_user", "error"}:
             meta["_streamed"] = True
-        return OutboundMessage(
+        outbound = OutboundMessage(
             channel=msg.channel,
             chat_id=msg.chat_id,
             content=final_content,
             metadata=meta,
             buttons=buttons,
         )
+        profiler.pop()
+        return outbound
 
     def _sanitize_persisted_blocks(
         self,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -838,15 +838,14 @@ class AgentLoop:
             outbound_metadata: dict[str, Any] = {}
             if channel == "slack" and key.startswith("slack:") and key.count(":") >= 2:
                 outbound_metadata["slack"] = {"thread_ts": key.split(":", 2)[2]}
-            outbound = OutboundMessage(
+            profiler.pop()
+            return OutboundMessage(
                 channel=channel,
                 chat_id=chat_id,
                 content=content,
                 buttons=buttons,
                 metadata=outbound_metadata,
             )
-            profiler.pop()
-            return outbound
 
         profiler.push("prepare_before_agent_loop")
 
@@ -988,6 +987,7 @@ class AgentLoop:
         # came from MessageTool.
         if (mt := self.tools.get("message")) and isinstance(mt, MessageTool) and mt._sent_in_turn:
             if not had_injections or stop_reason == "empty_final_response":
+                profiler.pop()
                 return None
 
         preview = final_content[:120] + "..." if len(final_content) > 120 else final_content
@@ -1001,15 +1001,14 @@ class AgentLoop:
         )
         if on_stream is not None and stop_reason not in {"ask_user", "error"}:
             meta["_streamed"] = True
-        outbound = OutboundMessage(
+        profiler.pop()
+        return OutboundMessage(
             channel=msg.channel,
             chat_id=msg.chat_id,
             content=final_content,
             metadata=meta,
             buttons=buttons,
         )
-        profiler.pop()
-        return outbound
 
     def _sanitize_persisted_blocks(
         self,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -830,21 +830,12 @@ class AgentLoop:
                 options,
                 channel,
             )
-            # Reconstruct channel-specific metadata from session.key so the
-            # outbound reply lands in the originating thread (not the channel
-            # top-level). The announce InboundMessage carries only
-            # injected_event metadata; we recover thread_ts from the session
-            # key, which slack writes as "slack:<chat_id>:<thread_ts>".
-            outbound_metadata: dict[str, Any] = {}
-            if channel == "slack" and key.startswith("slack:") and key.count(":") >= 2:
-                outbound_metadata["slack"] = {"thread_ts": key.split(":", 2)[2]}
             profiler.pop()
             return OutboundMessage(
                 channel=channel,
                 chat_id=chat_id,
                 content=content,
                 buttons=buttons,
-                metadata=outbound_metadata,
             )
 
         profiler.push("prepare_before_agent_loop")

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -447,8 +447,8 @@ class AgentRunner:
                         reasoning_content=response.reasoning_content,
                         thinking_blocks=response.thinking_blocks,
                     ))
-                    await hook.after_iteration(context)
                     messages.append(build_length_recovery_message())
+                    await hook.after_iteration(context)
                     profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": "length_recovery"})
                     continue
 

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -15,6 +15,7 @@ from nanobot.agent.hook import AgentHook, AgentHookContext
 from nanobot.agent.tools.ask import AskUserInterrupt
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.utils.profiler import ProfilerTrace, profiler
 from nanobot.utils.helpers import (
     build_assistant_message,
     estimate_message_tokens,
@@ -91,6 +92,7 @@ class AgentRunResult:
     error: str | None = None
     tool_events: list[dict[str, str]] = field(default_factory=list)
     had_injections: bool = False
+    profiler: ProfilerTrace | None = None
 
 
 class AgentRunner:
@@ -243,6 +245,7 @@ class AgentRunner:
         injection_cycles = 0
 
         for iteration in range(spec.max_iterations):
+            profiler.push("iteration_start")
             try:
                 # Keep the persisted conversation untouched. Context governance
                 # may repair or compact historical messages for the model, but
@@ -270,7 +273,9 @@ class AgentRunner:
                     messages_for_model = messages
             context = AgentHookContext(iteration=iteration, messages=messages)
             await hook.before_iteration(context)
+            profiler.push("llm_request")
             response = await self._request_model(spec, messages_for_model, hook, context)
+            profiler.pop()
             raw_usage = self._usage_dict(response.usage)
             context.response = response
             context.usage = dict(raw_usage)
@@ -307,12 +312,13 @@ class AgentRunner:
                 )
 
                 await hook.before_execute_tools(context)
-
+                profiler.push("tool_calls")
                 results, new_events, fatal_error = await self._execute_tools(
                     spec,
                     tool_calls,
                     external_lookup_counts,
                 )
+                profiler.pop()
                 tool_events.extend(new_events)
                 context.tool_results = list(results)
                 context.tool_events = list(new_events)
@@ -342,6 +348,7 @@ class AgentRunner:
                         if hook.wants_streaming():
                             await hook.on_stream_end(context, resuming=False)
                         await hook.after_iteration(context)
+                        profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": stop_reason})
                         break
                     error = f"Error: {type(fatal_error).__name__}: {fatal_error}"
                     final_content = error
@@ -357,7 +364,9 @@ class AgentRunner:
                     )
                     if should_continue:
                         had_injections = True
+                        profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": stop_reason})
                         continue
+                    profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": stop_reason})
                     break
                 await self._emit_checkpoint(
                     spec,
@@ -380,6 +389,7 @@ class AgentRunner:
                 if _drained:
                     had_injections = True
                 await hook.after_iteration(context)
+                profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": "tool_calls"})
                 continue
 
             if response.has_tool_calls:
@@ -403,6 +413,7 @@ class AgentRunner:
                     if hook.wants_streaming():
                         await hook.on_stream_end(context, resuming=False)
                     await hook.after_iteration(context)
+                    profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": "retry_empty_response"})
                     continue
                 logger.warning(
                     "Empty response on turn {} for {} after {} retries; attempting finalization",
@@ -438,8 +449,9 @@ class AgentRunner:
                         reasoning_content=response.reasoning_content,
                         thinking_blocks=response.thinking_blocks,
                     ))
-                    messages.append(build_length_recovery_message())
                     await hook.after_iteration(context)
+                    messages.append(build_length_recovery_message())
+                    profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": "length_recovery"})
                     continue
 
             assistant_message: dict[str, Any] | None = None
@@ -466,6 +478,7 @@ class AgentRunner:
 
             if should_continue:
                 await hook.after_iteration(context)
+                profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": "injected_continue"})
                 continue
 
             if response.finish_reason == "error":
@@ -483,7 +496,9 @@ class AgentRunner:
                 )
                 if should_continue:
                     had_injections = True
+                    profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": stop_reason})
                     continue
+                profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": stop_reason})
                 break
             if is_blank_text(clean):
                 final_content = EMPTY_FINAL_RESPONSE_MESSAGE
@@ -500,7 +515,9 @@ class AgentRunner:
                 )
                 if should_continue:
                     had_injections = True
+                    profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": stop_reason})
                     continue
+                profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": stop_reason})
                 break
 
             messages.append(assistant_message or build_assistant_message(
@@ -523,6 +540,7 @@ class AgentRunner:
             context.final_content = final_content
             context.stop_reason = stop_reason
             await hook.after_iteration(context)
+            profiler.pop(args={"finish_reason": response.finish_reason, "stop_reason": stop_reason})
             break
         else:
             stop_reason = "max_iterations"
@@ -558,6 +576,7 @@ class AgentRunner:
             error=error,
             tool_events=tool_events,
             had_injections=had_injections,
+            profiler=profiler.current(),
         )
 
     def _build_request_kwargs(
@@ -618,16 +637,24 @@ class AgentRunner:
         else:
             coro = self.provider.chat_with_retry(**kwargs)
 
+        profiler.push("llm_call", category="model")
         if timeout_s is None:
-            return await coro
-        try:
-            return await asyncio.wait_for(coro, timeout=timeout_s)
-        except asyncio.TimeoutError:
-            return LLMResponse(
-                content=f"Error calling LLM: timed out after {timeout_s:g}s",
-                finish_reason="error",
-                error_kind="timeout",
-            )
+            response = await coro
+        else:
+            try:
+                response = await asyncio.wait_for(coro, timeout=timeout_s)
+            except asyncio.TimeoutError:
+                response = LLMResponse(
+                    content=f"Error calling LLM: timed out after {timeout_s:g}s",
+                    finish_reason="error",
+                    error_kind="timeout",
+                )
+        profiler.pop(args={
+            "model": spec.model,
+            "messages": messages,
+            "response": response,
+        })
+        return response
 
     async def _request_finalization_retry(
         self,
@@ -669,6 +696,7 @@ class AgentRunner:
         tool_calls: list[ToolCallRequest],
         external_lookup_counts: dict[str, int],
     ) -> tuple[list[Any], list[dict[str, str]], BaseException | None]:
+        profiler.push("execute_tools", category="tool")
         batches = self._partition_tool_batches(spec, tool_calls)
         tool_results: list[tuple[Any, dict[str, str], BaseException | None]] = []
         for batch in batches:
@@ -697,6 +725,7 @@ class AgentRunner:
             events.append(event)
             if error is not None and fatal_error is None:
                 fatal_error = error
+        profiler.pop(args={"tool_count": len(tool_calls), "concurrent": spec.concurrent_tools})
         return results, events, fatal_error
 
     async def _run_tool(
@@ -705,6 +734,7 @@ class AgentRunner:
         tool_call: ToolCallRequest,
         external_lookup_counts: dict[str, int],
     ) -> tuple[Any, dict[str, str], BaseException | None]:
+        profiler.push(tool_call.name, category="tool")
         hint = "\n\n[Analyze the error above and try a different approach.]"
         lookup_error = repeated_external_lookup_error(
             tool_call.name,
@@ -717,6 +747,7 @@ class AgentRunner:
                 "status": "error",
                 "detail": "repeated external lookup blocked",
             }
+            profiler.pop(status="error", args={"tool_call": tool_call, "error": lookup_error})
             if spec.fail_on_tool_error:
                 return lookup_error + hint, event, RuntimeError(lookup_error)
             return lookup_error + hint, event, None
@@ -735,6 +766,7 @@ class AgentRunner:
                 "status": "error",
                 "detail": prep_error.split(": ", 1)[-1][:120],
             }
+            profiler.pop(status="error", args={"tool_call": tool_call, "error": prep_error})
             return prep_error + hint, event, RuntimeError(prep_error) if spec.fail_on_tool_error else None
         try:
             if tool is not None:
@@ -751,7 +783,9 @@ class AgentRunner:
             }
             if isinstance(exc, AskUserInterrupt):
                 event["status"] = "waiting"
+                profiler.pop(status="waiting", args={"tool_call": tool_call, "error": exc})
                 return "", event, exc
+            profiler.pop(status="error", args={"tool_call": tool_call, "error": exc})
             if spec.fail_on_tool_error:
                 return f"Error: {type(exc).__name__}: {exc}", event, exc
             return f"Error: {type(exc).__name__}: {exc}", event, None
@@ -762,6 +796,7 @@ class AgentRunner:
                 "status": "error",
                 "detail": result.replace("\n", " ").strip()[:120],
             }
+            profiler.pop(status="error", args={"tool_call": tool_call, "result": result})
             if spec.fail_on_tool_error:
                 return result + hint, event, RuntimeError(result)
             return result + hint, event, None
@@ -772,6 +807,7 @@ class AgentRunner:
             detail = "(empty)"
         elif len(detail) > 120:
             detail = detail[:120] + "..."
+        profiler.pop(status="ok", args={"tool_call": tool_call, "result": result})
         return result, {"name": tool_call.name, "status": "ok", "detail": detail}, None
 
     async def _emit_checkpoint(

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -273,9 +273,7 @@ class AgentRunner:
                     messages_for_model = messages
             context = AgentHookContext(iteration=iteration, messages=messages)
             await hook.before_iteration(context)
-            profiler.push("llm_request")
             response = await self._request_model(spec, messages_for_model, hook, context)
-            profiler.pop()
             raw_usage = self._usage_dict(response.usage)
             context.response = response
             context.usage = dict(raw_usage)

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -122,6 +122,7 @@ class ProvidersConfig(Base):
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
+    huggingface: ProviderConfig = Field(default_factory=ProviderConfig)
     deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
     groq: ProviderConfig = Field(default_factory=ProviderConfig)
     zhipu: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/nanobot.py
+++ b/nanobot/nanobot.py
@@ -9,6 +9,7 @@ from typing import Any
 from nanobot.agent.hook import AgentHook
 from nanobot.agent.loop import AgentLoop
 from nanobot.bus.queue import MessageBus
+from nanobot.utils.profiler import ProfilerTrace, profiler
 
 
 @dataclass(slots=True)
@@ -18,6 +19,7 @@ class RunResult:
     content: str
     tools_used: list[str]
     messages: list[dict[str, Any]]
+    profiler: ProfilerTrace | None = None
 
 
 class Nanobot:
@@ -105,6 +107,7 @@ class Nanobot:
             hooks: Optional lifecycle hooks for this run.
         """
         prev = self._loop._extra_hooks
+        prof = profiler.start(session_key=session_key)
         if hooks is not None:
             self._loop._extra_hooks = list(hooks)
         try:
@@ -113,9 +116,10 @@ class Nanobot:
             )
         finally:
             self._loop._extra_hooks = prev
+            profiler.finish()
 
         content = (response.content if response else None) or ""
-        return RunResult(content=content, tools_used=[], messages=[])
+        return RunResult(content=content, tools_used=[], messages=[], profiler=prof)
 
 
 def _make_provider(config: Any) -> Any:

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -120,6 +120,18 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://openrouter.ai/api/v1",
         supports_prompt_caching=True,
     ),
+    # Hugging Face Inference Providers: OpenAI-compatible router for chat models.
+    ProviderSpec(
+        name="huggingface",
+        keywords=("huggingface", "hugging-face"),
+        env_key="HF_TOKEN",
+        display_name="Hugging Face",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_key_prefix="hf_",
+        detect_by_base_keyword="huggingface",
+        default_api_base="https://router.huggingface.co/v1",
+    ),
     # AiHubMix: global gateway, OpenAI-compatible interface.
     # strip_model_prefix=True: doesn't understand "anthropic/claude-3",
     # strips to bare "claude-3".

--- a/nanobot/skills/create-instance/SKILL.md
+++ b/nanobot/skills/create-instance/SKILL.md
@@ -1,50 +1,64 @@
 ---
 name: create-instance
-description: "Create a new nanobot instance with separate config and workspace. Use when the user wants to set up a new bot for a different channel, persona, or purpose."
+description: "Create a new nanobot instance with separate config and workspace. Use when the user wants to set up a new bot, create a new instance for a different channel, persona, or purpose. Triggers on: create instance, new bot, set up bot, add bot, create telegram/discord/feishu/slack/wechat/wecom/dingtalk/qq/email/matrix/msteams/whatsapp bot, multi-instance setup."
 ---
 
 # Create Instance
 
 Set up a new nanobot instance with its own config and workspace.
 
-## When to Use
-
-When the user wants to create a new bot instance — typically for a different channel (Telegram, Discord, WeChat, etc.) or with different settings.
-
 ## Steps
 
-1. **Collect information from the user** (ask one at a time if not already provided):
-   - **Instance name** (required): a short identifier like `telegram-bot`, `discord-bot`
-   - **Channel type** (required): e.g. `telegram`, `discord`, `weixin`, `feishu`, `slack`
-   - **Model** (optional): LLM model to use. Defaults to the same model as the current instance.
+1. **Collect information** (ask one at a time if not already provided):
+   - **Instance name** (required): short identifier, e.g. `telegram-bot`, `work-slack`
+   - **Channel type** (required): see table below
+   - **Model** (optional): LLM model, defaults to current instance
 
-2. **Do NOT collect sensitive information** in the chat (API keys, bot tokens, secrets). API keys are automatically copied from the current instance. Channel-specific tokens (e.g. `telegram.token`) still need to be filled in manually.
+2. **Do NOT collect secrets** in the chat (API keys, bot tokens). API keys are automatically inherited from the current instance via `--inherit-config`. Channel-specific tokens must be filled in manually after creation.
 
-3. **Run the creation script** using the exec tool — always pass `--inherit-config` with the current instance's config path so API keys are copied:
+3. **Run the creation script**:
 
 ```bash
-python D:/path/to/nanobot/skills/create-instance/scripts/create_instance.py --name <name> --channel <channel> --inherit-config ~/.nanobot/config.json [--model <model>] [--config-dir <path>]
+python <skill-dir>/scripts/create_instance.py --name <name> --channel <channel> --inherit-config <current-config>
 ```
 
-**Path rules (critical on Windows):**
-- Use **forward-slash absolute paths** to the script, e.g. `D:/path/to/create_instance.py`
-- Do **NOT** wrap paths in quotes — the exec tool will mangle them
-- Do **NOT** use `cd` — the exec tool ignores it; working directory stays as workspace
-- Do **NOT** use backslash paths like `D:\path` — they will fail
+- `<skill-dir>` — the directory containing this SKILL.md
+- `<current-config>` — current instance's config path, typically `~/.nanobot/config.json`
+- Optional: `--model <model>`, `--config-dir <path>`
 
-Use `~/.nanobot/config.json` as the `--inherit-config` path unless the current instance uses a custom config location.
+**Exec tool constraints:**
+- Use forward-slash paths (works on all platforms)
+- Do not wrap paths in quotes
+- Do not use `cd`; pass the full script path directly
 
-4. **Report results to the user**:
-   - Where the config and workspace were created
-   - Which fields they need to fill in (the script will list them)
-   - The command to start the instance: `nanobot gateway --config <config-path>`
+4. **Report results** to the user:
+   - Config and workspace paths (script outputs them)
+   - Required fields to fill in (script lists them)
+   - Start command: `nanobot gateway --config <config-path>`
 
-## Examples
+## Available Channels
 
-User: "help me create a Telegram bot" (or similar request)
+| Channel | Key | Required Fields |
+|---------|-----|-----------------|
+| Telegram | `telegram` | token |
+| Discord | `discord` | token |
+| Feishu / Lark | `feishu` | app_id, app_secret |
+| DingTalk | `dingtalk` | client_id, client_secret |
+| Slack | `slack` | bot_token, app_token |
+| WeCom | `wecom` | bot_id, secret |
+| WeChat OA | `weixin` | token |
+| WhatsApp | `whatsapp` | bridge_token |
+| QQ | `qq` | app_id, secret |
+| Email | `email` | imap_host, imap_username, imap_password, smtp_host, smtp_username, smtp_password, from_address |
+| Matrix | `matrix` | user_id, password or access_token |
+| MS Teams | `msteams` | app_id, app_password, tenant_id |
+| MoChat | `mochat` | claw_token |
+| WebSocket | `websocket` | token |
 
-→ Ask for an instance name if not obvious from context
-→ Ask which model to use (optional, can skip if user doesn't care)
-→ Run: `python D:/path/to/nanobot/skills/create-instance/scripts/create_instance.py --name telegram-bot --channel telegram --inherit-config ~/.nanobot/config.json`
-  (Replace `D:/path/to/nanobot` with the actual nanobot source directory)
-→ Tell user: config created at `~/.nanobot-telegram/config.json`, fill in `channels.telegram.token`, then start with `nanobot gateway --config ~/.nanobot-telegram/config.json`
+For detailed channel configuration including optional fields, see `references/channels.md`.
+
+## Troubleshooting
+
+- **"Unknown channel"**: Channel name must match the Key column exactly. Run the script without arguments to see usage.
+- **"Config already exists"**: Use a different `--name` or `--config-dir` to create in a new location.
+- **Port conflicts**: The script auto-assigns free ports for gateway and API if defaults are in use.

--- a/nanobot/skills/create-instance/SKILL.md
+++ b/nanobot/skills/create-instance/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: create-instance
+description: "Create a new nanobot instance with separate config and workspace. Use when the user wants to set up a new bot for a different channel, persona, or purpose."
+---
+
+# Create Instance
+
+Set up a new nanobot instance with its own config and workspace.
+
+## When to Use
+
+When the user wants to create a new bot instance — typically for a different channel (Telegram, Discord, WeChat, etc.) or with different settings.
+
+## Steps
+
+1. **Collect information from the user** (ask one at a time if not already provided):
+   - **Instance name** (required): a short identifier like `telegram-bot`, `discord-bot`
+   - **Channel type** (required): e.g. `telegram`, `discord`, `weixin`, `feishu`, `slack`
+   - **Model** (optional): LLM model to use. Defaults to the same model as the current instance.
+
+2. **Do NOT collect sensitive information** in the chat (API keys, bot tokens, secrets). API keys are automatically copied from the current instance. Channel-specific tokens (e.g. `telegram.token`) still need to be filled in manually.
+
+3. **Run the creation script** using the exec tool — always pass `--inherit-config` with the current instance's config path so API keys are copied:
+
+```bash
+python D:/path/to/nanobot/skills/create-instance/scripts/create_instance.py --name <name> --channel <channel> --inherit-config ~/.nanobot/config.json [--model <model>] [--config-dir <path>]
+```
+
+**Path rules (critical on Windows):**
+- Use **forward-slash absolute paths** to the script, e.g. `D:/path/to/create_instance.py`
+- Do **NOT** wrap paths in quotes — the exec tool will mangle them
+- Do **NOT** use `cd` — the exec tool ignores it; working directory stays as workspace
+- Do **NOT** use backslash paths like `D:\path` — they will fail
+
+Use `~/.nanobot/config.json` as the `--inherit-config` path unless the current instance uses a custom config location.
+
+4. **Report results to the user**:
+   - Where the config and workspace were created
+   - Which fields they need to fill in (the script will list them)
+   - The command to start the instance: `nanobot gateway --config <config-path>`
+
+## Examples
+
+User: "help me create a Telegram bot" (or similar request)
+
+→ Ask for an instance name if not obvious from context
+→ Ask which model to use (optional, can skip if user doesn't care)
+→ Run: `python D:/path/to/nanobot/skills/create-instance/scripts/create_instance.py --name telegram-bot --channel telegram --inherit-config ~/.nanobot/config.json`
+  (Replace `D:/path/to/nanobot` with the actual nanobot source directory)
+→ Tell user: config created at `~/.nanobot-telegram/config.json`, fill in `channels.telegram.token`, then start with `nanobot gateway --config ~/.nanobot-telegram/config.json`

--- a/nanobot/skills/create-instance/references/channels.md
+++ b/nanobot/skills/create-instance/references/channels.md
@@ -1,0 +1,194 @@
+# Channel Configuration Reference
+
+Detailed configuration for each supported channel.
+
+## Field Types
+
+- **Required**: defaults to empty string `""`, must be filled in before the instance can start
+- **Optional**: has a sensible default, can be customized
+
+---
+
+## telegram
+
+**Required:**
+- `token` — Bot token from @BotFather
+
+**Notable optional:**
+- `proxy` — HTTP proxy URL
+- `group_policy` — `"open"` (all messages) or `"mention"` (default, only when @mentioned)
+- `streaming` — Enable streaming responses (default: true)
+- `reply_to_message` — Reply to the triggering message (default: false)
+- `react_emoji` — Emoji for "thinking" reaction (default: `"eyes"`)
+- `inline_keyboards` — Enable inline keyboard buttons (default: false)
+
+## discord
+
+**Required:**
+- `token` — Bot token from Discord Developer Portal
+
+**Notable optional:**
+- `allow_channels` — Restrict to specific channel IDs
+- `group_policy` — `"mention"` (default) or `"open"`
+- `streaming` — Enable streaming (default: true)
+- `proxy` — HTTP proxy URL
+- `intents` — Discord gateway intents (default: 37377)
+- `read_receipt_emoji` — Emoji for read receipt
+- `working_emoji` — Emoji for "working" indicator
+
+## feishu
+
+**Required:**
+- `app_id` — Feishu app ID
+- `app_secret` — Feishu app secret
+
+**Notable optional:**
+- `encrypt_key` — Event encryption key
+- `verification_token` — Event verification token
+- `domain` — `"feishu"` (default) or `"lark"`
+- `group_policy` — `"mention"` (default) or `"open"`
+- `streaming` — Enable streaming (default: true)
+
+## dingtalk
+
+**Required:**
+- `client_id` — DingTalk app client ID
+- `client_secret` — DingTalk app client secret
+
+**Notable optional:**
+- `allow_from` — Allowed user IDs
+
+## slack
+
+**Required:**
+- `bot_token` — Bot OAuth token (`xoxb-...`)
+- `app_token` — App-level token (`xapp-...`)
+
+**Notable optional:**
+- `mode` — `"socket"` (default, Socket Mode) or `"webhook"`
+- `reply_in_thread` — Reply in thread (default: true)
+- `react_emoji` — "thinking" emoji (default: `"eyes"`)
+- `done_emoji` — "done" emoji (default: `"white_check_mark"`)
+- `group_policy` — `"mention"` (default) or `"open"`
+- `dm.enabled` — Enable DM support
+- `dm.policy` — DM policy
+- `dm.allow_from` — Allowed DM users
+
+## wecom
+
+**Required:**
+- `bot_id` — WeCom bot ID
+- `secret` — WeCom bot secret
+
+**Notable optional:**
+- `allow_from` — Allowed users
+- `welcome_message` — Welcome message for new chats
+
+## weixin
+
+**Required:**
+- `token` — WeChat Official Account token
+
+**Notable optional:**
+- `base_url` — API base URL
+- `cdn_base_url` — CDN base URL
+- `state_dir` — State persistence directory
+- `poll_timeout` — Long polling timeout
+
+## whatsapp
+
+**Required:**
+- `bridge_token` — WhatsApp bridge token (auto-generated if absent)
+
+**Notable optional:**
+- `bridge_url` — Bridge WebSocket URL (default: `"ws://localhost:3001"`)
+- `group_policy` — `"open"` (default) or `"mention"`
+
+## qq
+
+**Required:**
+- `app_id` — QQ bot app ID
+- `secret` — QQ bot secret
+
+**Notable optional:**
+- `msg_format` — `"plain"` or `"markdown"`
+- `ack_message` — Acknowledgment message text
+- `media_dir` — Media file directory
+
+## email
+
+**Required:**
+- `imap_host` — IMAP server hostname
+- `imap_username` — IMAP login username
+- `imap_password` — IMAP login password
+- `smtp_host` — SMTP server hostname
+- `smtp_username` — SMTP login username
+- `smtp_password` — SMTP login password
+- `from_address` — Sender email address
+
+**Notable optional:**
+- `imap_port` — IMAP port (default: 993)
+- `smtp_port` — SMTP port (default: 587)
+- `imap_use_ssl` — Use SSL for IMAP (default: true)
+- `smtp_use_tls` — Use TLS for SMTP (default: true)
+- `poll_interval_seconds` — Polling interval (default: 30)
+- `mark_seen` — Mark emails as read (default: true)
+- `max_body_chars` — Max email body length (default: 12000)
+- `subject_prefix` — Reply subject prefix (default: `"Re: "`)
+- `verify_dkim` — Verify DKIM signatures (default: true)
+- `verify_spf` — Verify SPF records (default: true)
+- `allowed_attachment_types` — Allowed file extensions
+- `max_attachment_size` — Max attachment size in bytes
+- `consent_granted` — Must be set to `true` for the channel to start (default: false)
+- `auto_reply_enabled` — Enable auto-reply (default: true)
+
+## matrix
+
+**Required:**
+- `user_id` — Matrix user ID (e.g. `@bot:matrix.org`)
+- `password` or `access_token` — Login password OR access token
+
+**Notable optional:**
+- `homeserver` — Homeserver URL (default: `"https://matrix.org"`)
+- `device_id` — Device ID
+- `e2eeEnabled` — Enable end-to-end encryption (default: true)
+- `group_policy` — `"open"`, `"mention"`, or `"allowlist"`
+- `streaming` — Enable streaming (default: false)
+- `max_media_bytes` — Max media file size (default: 20MB)
+
+## msteams
+
+**Required:**
+- `app_id` — Azure AD app ID
+- `app_password` — Azure AD app password/secret
+- `tenant_id` — Azure AD tenant ID
+
+**Notable optional:**
+- `host` — Listen host (default: `"0.0.0.0"`)
+- `port` — Listen port (default: 3978)
+- `reply_in_thread` — Reply in thread (default: true)
+- `validate_inbound_auth` — Validate incoming auth (default: true)
+
+## mochat
+
+**Required:**
+- `claw_token` — MoChat Claw token
+
+**Notable optional:**
+- `base_url` — API base URL
+- `socket_url` — WebSocket URL
+- `refresh_interval_ms` — Refresh interval in ms
+- `watch_timeout_ms` — Watch timeout in ms
+
+## websocket
+
+Built-in WebSocket channel for programmatic access.
+
+**Required:**
+- `token` — Authentication token (enabled by default; set `websocket_requires_token: false` to disable)
+
+**Notable optional:**
+- `host` — Listen host (default: `"127.0.0.1"`)
+- `port` — Listen port (default: 8765)
+- `allow_from` — Allowed origins (default: `["*"]`)
+- `streaming` — Enable streaming (default: true)

--- a/nanobot/skills/create-instance/scripts/create_instance.py
+++ b/nanobot/skills/create-instance/scripts/create_instance.py
@@ -73,18 +73,27 @@ def _patch_config(
     """Patch the generated config: enable channel, set workspace, optionally set model."""
     data = json.loads(config_path.read_text(encoding="utf-8"))
 
-    # Inherit providers (API keys, api_base, etc.) from current instance
+    # Inherit providers and model from current instance
     if inherit_config_path and inherit_config_path.exists():
         try:
             src = json.loads(inherit_config_path.read_text(encoding="utf-8"))
+
+            # Inherit providers (API keys, api_base, etc.)
             src_providers = src.get("providers", {})
             if src_providers:
                 data.setdefault("providers", {})
                 for key, val in src_providers.items():
                     if isinstance(val, dict) and val.get("apiKey"):
                         data["providers"][key] = val
+
+            # Inherit model if not explicitly overridden
+            if not model:
+                parent_model = src.get("agents", {}).get("defaults", {}).get("model")
+                if parent_model:
+                    model = parent_model
+
         except Exception as exc:
-            print(f"[WARN] Could not inherit providers from {inherit_config_path}: {exc}", file=sys.stderr)
+            print(f"[WARN] Could not inherit from {inherit_config_path}: {exc}", file=sys.stderr)
 
     # Set workspace and model
     data.setdefault("agents", {}).setdefault("defaults", {})

--- a/nanobot/skills/create-instance/scripts/create_instance.py
+++ b/nanobot/skills/create-instance/scripts/create_instance.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Create a new nanobot instance with a dedicated config and workspace.
+
+Usage:
+    create_instance.py --name <name> --channel <channel> [--model <model>] [--config-dir <dir>]
+
+Examples:
+    create_instance.py --name telegram-bot --channel telegram
+    create_instance.py --name discord-bot --channel discord --model deepseek/deepseek-chat
+    create_instance.py --name my-bot --channel telegram --config-dir ~/.nanobot-custom
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import socket
+import sys
+from pathlib import Path
+
+
+def _validate_name(name: str) -> str:
+    """Normalize and validate instance name."""
+    name = name.strip().lower()
+    name = re.sub(r"[^a-z0-9-]", "-", name)
+    name = re.sub(r"-{2,}", "-", name)
+    name = name.strip("-")
+    if not name:
+        print("[ERROR] Instance name must contain at least one letter or digit.", file=sys.stderr)
+        sys.exit(1)
+    if len(name) > 64:
+        print(f"[ERROR] Instance name too long ({len(name)} chars, max 64).", file=sys.stderr)
+        sys.exit(1)
+    return name
+
+
+def _get_available_channels() -> list[str]:
+    """Get list of available channel names without importing channel classes."""
+    from nanobot.channels.registry import discover_channel_names
+
+    return discover_channel_names()
+
+
+def _run_onboard(config_path: Path, workspace: Path) -> None:
+    """Create skeleton config + workspace using nanobot's programmatic API."""
+    from nanobot.cli.commands import _onboard_plugins
+    from nanobot.config.loader import save_config, set_config_path
+    from nanobot.config.paths import get_workspace_path
+    from nanobot.config.schema import Config
+    from nanobot.utils.helpers import sync_workspace_templates
+
+    config = Config()
+    config.agents.defaults.workspace = str(workspace)
+    set_config_path(config_path)
+    save_config(config, config_path)
+    _onboard_plugins(config_path)
+
+    workspace_path = get_workspace_path(config.workspace_path)
+    if not workspace_path.exists():
+        workspace_path.mkdir(parents=True, exist_ok=True)
+    sync_workspace_templates(workspace_path)
+
+
+def _patch_config(
+    config_path: Path,
+    *,
+    channel: str,
+    workspace: Path,
+    model: str | None,
+    inherit_config_path: Path | None = None,
+) -> dict:
+    """Patch the generated config: enable channel, set workspace, optionally set model."""
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+
+    # Inherit providers (API keys, api_base, etc.) from current instance
+    if inherit_config_path and inherit_config_path.exists():
+        try:
+            src = json.loads(inherit_config_path.read_text(encoding="utf-8"))
+            src_providers = src.get("providers", {})
+            if src_providers:
+                data.setdefault("providers", {})
+                for key, val in src_providers.items():
+                    if isinstance(val, dict) and val.get("apiKey"):
+                        data["providers"][key] = val
+        except Exception as exc:
+            print(f"[WARN] Could not inherit providers from {inherit_config_path}: {exc}", file=sys.stderr)
+
+    # Set workspace and model
+    data.setdefault("agents", {}).setdefault("defaults", {})
+    data["agents"]["defaults"]["workspace"] = str(workspace)
+    if model:
+        data["agents"]["defaults"]["model"] = model
+
+    # Enable the target channel
+    channels = data.setdefault("channels", {})
+    if channel in channels and isinstance(channels[channel], dict):
+        channels[channel]["enabled"] = True
+    else:
+        channels[channel] = {"enabled": True}
+
+    # Auto-assign ports if defaults are already in use
+    _assign_free_ports(data)
+
+    # Validate with Pydantic, then save
+    from nanobot.config.schema import Config
+
+    Config.model_validate(data)
+    config_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    return data
+
+
+def _is_port_in_use(port: int, host: str = "127.0.0.1") -> bool:
+    """Check if a port is already in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((host, port))
+            return False
+        except OSError:
+            return True
+
+
+def _find_free_port(start: int, host: str = "127.0.0.1", max_tries: int = 100) -> int:
+    """Find the first free port starting from `start`."""
+    for port in range(start, start + max_tries):
+        if not _is_port_in_use(port, host):
+            return port
+    # OS-level fallback: ask the kernel for an ephemeral port
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return s.getsockname()[1]
+
+
+def _assign_free_ports(data: dict) -> None:
+    """If default gateway or API ports are in use, assign free ones."""
+    from nanobot.config.schema import ApiConfig, GatewayConfig
+
+    defaults = [
+        ("gateway", GatewayConfig()),
+        ("api", ApiConfig()),
+    ]
+    for key, default_cfg in defaults:
+        section = data.setdefault(key, {})
+        port = section.get("port", default_cfg.port)
+        host = section.get("host", default_cfg.host)
+        if _is_port_in_use(port, host):
+            section["port"] = _find_free_port(port + 1, host)
+
+
+def _get_channel_required_fields(channel: str) -> list[str]:
+    """Inspect a channel's default config and list fields that are empty strings."""
+    try:
+        from nanobot.channels.registry import load_channel_class
+
+        cls = load_channel_class(channel)
+        default = cls.default_config()
+        return sorted(k for k, v in default.items() if isinstance(v, str) and v == "" and k != "enabled")
+    except Exception as exc:
+        print(f"[WARN] Could not inspect channel '{channel}' defaults: {exc}", file=sys.stderr)
+        return []
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create a new nanobot instance.",
+    )
+    parser.add_argument("--name", required=True, help="Instance name (e.g. telegram-bot)")
+    parser.add_argument("--channel", required=True, help="Channel type (e.g. telegram, discord)")
+    parser.add_argument("--model", default=None, help="LLM model (default: same as current instance)")
+    parser.add_argument(
+        "--config-dir",
+        default=None,
+        help="Config directory (default: ~/.nanobot-{name})",
+    )
+    parser.add_argument(
+        "--inherit-config",
+        default=None,
+        help="Path to current instance's config.json to copy API keys from",
+    )
+    args = parser.parse_args()
+
+    # Validate name
+    name = _validate_name(args.name)
+
+    # Validate channel
+    available = _get_available_channels()
+    if args.channel not in available:
+        print(f"[ERROR] Unknown channel: {args.channel}", file=sys.stderr)
+        print(f"Available channels: {', '.join(sorted(available))}", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve paths
+    home = Path.home()
+    config_dir = Path(args.config_dir).expanduser().resolve() if args.config_dir else home / f".nanobot-{name}"
+    config_path = config_dir / "config.json"
+    workspace = config_dir / "workspace"
+
+    # Check for duplicate
+    if config_path.exists():
+        print(f"[ERROR] Config already exists at {config_path}", file=sys.stderr)
+        print("Delete it first or use a different --config-dir.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Creating instance '{name}'...")
+    print(f"  Config dir: {config_dir}")
+    print(f"  Workspace:  {workspace}")
+    print(f"  Channel:    {args.channel}")
+    if args.model:
+        print(f"  Model:      {args.model}")
+
+    # Run onboard
+    _run_onboard(config_path, workspace)
+
+    # Patch config
+    inherit_path = Path(args.inherit_config).expanduser().resolve() if args.inherit_config else None
+    _patch_config(
+        config_path,
+        channel=args.channel,
+        workspace=workspace,
+        model=args.model,
+        inherit_config_path=inherit_path,
+    )
+
+    # Report
+    print(f"\n[OK] Instance '{name}' created successfully.")
+    print(f"  Config: {config_path}")
+    print(f"  Workspace: {workspace}")
+
+    # List fields the user needs to fill in
+    required_fields = _get_channel_required_fields(args.channel)
+    if required_fields:
+        print(f"\n[IMPORTANT] Edit {config_path} and fill in these fields:")
+        for field in required_fields:
+            print(f"  - channels.{args.channel}.{field}")
+
+    print(f"\nTo start the instance:")
+    print(f"  nanobot gateway --config {config_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/nanobot/utils/profiler.py
+++ b/nanobot/utils/profiler.py
@@ -1,0 +1,541 @@
+"""Profiler instrumentation for nanobot runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from contextvars import ContextVar
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+_LANE_MAP = {
+    "mainloop": (1, 1),
+    "model": (1, 2),
+    "tool": (1, 3),
+}
+
+
+def _safe_json_dumps(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False, indent=2)
+    except TypeError:
+        return json.dumps(str(value), ensure_ascii=False, indent=2)
+
+
+def _span_sort_key(span: SpanRecord | ActiveBucket) -> tuple[float, float, str]:
+    return (span.start_ms, getattr(span, "end_ms", 0.0), getattr(span, "display_path", None) or span.name)
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    if hasattr(value, "to_openai_tool_call"):
+        try:
+            return _json_safe(value.to_openai_tool_call())
+        except Exception:
+            return str(value)
+    if hasattr(value, "arguments") and hasattr(value, "name"):
+        return {
+            "name": getattr(value, "name", None),
+            "arguments": _json_safe(getattr(value, "arguments", None)),
+            "id": getattr(value, "id", None),
+        }
+    return str(value)
+
+
+@dataclass(slots=True)
+class SpanRecord:
+    name: str
+    category: str
+    start_ms: float
+    end_ms: float
+    duration_ms: float
+    pid: int = 1
+    tid: int = 1
+    sibling_index: int = 0
+    status: str | None = None
+    path: str | None = None
+    display_path: str | None = None
+    parent_path: str | None = None
+    display_parent_path: str | None = None
+    depth: int | None = None
+    args: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ActiveBucket:
+    name: str
+    start_ms: float
+    category: str = "mainloop"
+    sibling_index: int = 0
+    status: str | None = None
+    path: str | None = None
+    parent_path: str | None = None
+    display_path: str | None = None
+    display_parent_path: str | None = None
+    child_counts: dict[str, int] = field(default_factory=dict)
+    args: dict[str, Any] = field(default_factory=dict)
+
+
+class ProfilerTrace:
+    """Concrete trace object that stores one profiling run's spans and exports.
+
+    This class is the underlying data container for one profiling session.
+    Normal callers are expected to use the module-level ``profiler`` proxy
+    instead of instantiating ``ProfilerTrace`` directly.
+    """
+
+    def __init__(self, enabled: bool | None = None) -> None:
+        if enabled is None:
+            enabled = profiler_enabled()
+        self.enabled = enabled
+        self.session_key: str | None = None
+        self.started_at: float = 0.0
+        self.ended_at: float = 0.0
+        self.total_duration_ms: float = 0.0
+        self.spans: list[SpanRecord] = []
+        self._stack: list[ActiveBucket] = []
+        self._root_child_counts: dict[str, int] = {}
+
+    def start(self, session_key: str | None = None) -> "ProfilerTrace":
+        """Start a new profiling session.
+
+        Args:
+            session_key: Optional stable identifier for the current run. This is
+                included in exported trace metadata and summaries.
+
+        Returns:
+            The profiler instance itself so callers can chain setup calls.
+        """
+        if not self.enabled:
+            return self
+        self.session_key = session_key
+        self.started_at = time.perf_counter()
+        return self
+
+    def finish(self) -> "ProfilerTrace":
+        """Finalize the profiling session and write trace outputs.
+
+        Any spans still left on the stack are closed automatically with the
+        status ``"auto_closed"``. The final summary JSON and Perfetto trace are
+        then written to the configured profiler output paths.
+
+        Returns:
+            The profiler instance itself.
+        """
+        if not self.enabled:
+            return self
+        while self._stack:
+            self.pop(status="auto_closed")
+        self.ended_at = time.perf_counter()
+        self.total_duration_ms = self._r((self.ended_at - self.started_at) * 1000)
+        self.write_json()
+        self.write_perfetto_json()
+        return self
+
+    def now_ms(self) -> float:
+        return 0.0 if not self.enabled else self._r((time.perf_counter() - self.started_at) * 1000)
+
+    def push(self, name: str, *, category: str = "mainloop", status: str | None = None) -> "ProfilerTrace":
+        """Open a new profiling span.
+
+        The new span becomes the current active span and is nested under the
+        current stack top, if any. Repeated sibling spans with the same name are
+        assigned a local ``sibling_index`` for display and export purposes.
+
+        ``push()`` is intentionally minimal: it only opens the span and records
+        its structural metadata. End-of-span payloads should be attached in
+        ``pop()``.
+
+        Args:
+            name: Logical span name, such as ``"agent_loop"`` or ``"llm_call"``.
+            category: High-level lane used for reporting and Perfetto export.
+                Expected values are typically ``"mainloop"``, ``"model"``, or
+                ``"tool"``.
+            status: Optional initial status attached to the span.
+
+        Returns:
+            The profiler instance itself.
+        """
+        if not self.enabled:
+            return self
+        parent = self._stack[-1] if self._stack else None
+        parent_path = parent.path or "" if parent else ""
+        display_parent_path = parent.display_path or "" if parent else ""
+        sibling_index = self._next_sibling_index(parent=parent, name=name)
+        self._stack.append(ActiveBucket(
+            name=name,
+            start_ms=self.now_ms(),
+            category=category,
+            sibling_index=sibling_index,
+            status=status,
+            path=self._join_path(parent_path, name),
+            parent_path=parent_path,
+            display_path=self._join_path(display_parent_path, f"{name}[{sibling_index}]"),
+            display_parent_path=display_parent_path,
+            args={},
+        ))
+        return self
+
+    def pop(self, *, status: str | None = None, args: dict[str, Any] | None = None) -> "ProfilerTrace":
+        """Close the most recently opened active span.
+
+        This method updates the active span with any final status or metadata,
+        computes its duration, normalizes category-specific payloads, and stores
+        the completed span in the exported trace list.
+
+        Args:
+            status: Optional final status for the span.
+            args: Optional metadata merged into the span before it is finalized.
+                This is the preferred place to attach end-of-span data such as
+                model responses, tool results, or errors.
+
+        Returns:
+            The profiler instance itself. If profiling is disabled or the stack
+            is empty, this is a no-op.
+        """
+        if not self.enabled or not self._stack:
+            return self
+        active = self._stack.pop()
+        if status is not None:
+            active.status = status
+        if args:
+            active.args.update(args)
+        end_ms = self.now_ms()
+        duration_ms = self._r(max(0.0, end_ms - active.start_ms))
+        self._apply_pop_updates(active, duration_ms)
+        pid, tid = self._lane_for_category(active.category)
+        self.spans.append(SpanRecord(
+            name=(active.display_path or active.name).rsplit("/", 1)[-1],
+            category=active.category,
+            start_ms=self._r(active.start_ms),
+            end_ms=self._r(end_ms),
+            duration_ms=duration_ms,
+            pid=pid,
+            tid=tid,
+            sibling_index=active.sibling_index,
+            status=active.status,
+            path=active.path,
+            display_path=active.display_path,
+            parent_path=active.parent_path or "",
+            display_parent_path=active.display_parent_path,
+            depth=len(self._stack) + 1,
+            args=dict(active.args),
+        ))
+        return self
+
+    def _next_sibling_index(self, *, parent: ActiveBucket | None, name: str) -> int:
+        counts = parent.child_counts if parent is not None else self._root_child_counts
+        index = counts.get(name, 0)
+        counts[name] = index + 1
+        return index
+
+    @staticmethod
+    def _join_path(parent: str, name: str) -> str:
+        return f"{parent}/{name}" if parent else name
+
+    def _apply_pop_updates(self, active: ActiveBucket, duration_ms: float) -> None:
+        if active.category == "model" and ("messages" in active.args or "response" in active.args):
+            self._apply_llm_pop_updates(active, duration_ms)
+        elif active.category == "tool" and any(key in active.args for key in ("tool_call", "result", "error")):
+            self._apply_tool_pop_updates(active, duration_ms)
+        active.args = _json_safe(active.args)
+
+    def _apply_llm_pop_updates(self, active: ActiveBucket, duration_ms: float) -> None:
+        del duration_ms
+        messages = active.args.get("messages") or []
+        response = active.args.get("response")
+        input_messages = [dict(message) for message in messages]
+        output_tool_calls = [tc.to_openai_tool_call() for tc in getattr(response, "tool_calls", [])]
+        llm_input_text = _safe_json_dumps(input_messages)
+        llm_output_content = getattr(response, "content", None)
+        llm_output_reasoning_content = getattr(response, "reasoning_content", None)
+        llm_output_finish_reason = getattr(response, "finish_reason", None)
+        llm_output_text = _safe_json_dumps({
+            "content": llm_output_content,
+            "reasoning_content": llm_output_reasoning_content,
+            "tool_calls": output_tool_calls,
+            "finish_reason": llm_output_finish_reason,
+        })
+        active.args = {
+            "model": active.args.get("model"),
+            "llm_input_messages": input_messages,
+            "llm_input_text": llm_input_text,
+            "llm_output_content": llm_output_content,
+            "llm_output_reasoning_content": llm_output_reasoning_content,
+            "llm_output_tool_calls": output_tool_calls,
+            "llm_output_finish_reason": llm_output_finish_reason,
+            "llm_output_text": llm_output_text,
+        }
+
+    def _apply_tool_pop_updates(self, active: ActiveBucket, duration_ms: float) -> None:
+        tool_call = active.args.get("tool_call")
+        result = active.args.get("result")
+        error = active.args.get("error")
+        arguments = dict(getattr(tool_call, "arguments", {}) or {})
+        detail = self._tool_detail(result=result, error=error)
+        error_type = type(error).__name__ if error is not None else None
+        error_text = str(error) if error is not None else None
+        active.args = {
+            "tool_name": getattr(tool_call, "name", active.name),
+            "arguments": arguments,
+            "detail": detail,
+            "error_type": error_type,
+            "error": error_text,
+        }
+
+    def _tool_detail(self, *, result: Any = None, error: BaseException | None = None) -> str:
+        detail = (str(error) if error is not None else "" if result is None else str(result)).replace("\n", " ").strip()
+        if not detail:
+            return "(empty)"
+        if len(detail) > 120:
+            return detail[:120] + "..."
+        return detail
+
+    @property
+    def llm_total_duration_ms(self) -> float:
+        """Sum of all model span durations across the full run."""
+        return self._r(sum(span.duration_ms for span in self.spans if span.category == "model"))
+
+    @property
+    def tools_total_duration_ms(self) -> float:
+        """Sum of individual tool call span durations across the full run.
+
+        This counts leaf tool work such as concrete tool invocations. If multiple
+        tool calls overlap inside the same outer tool phase, their durations are
+        all included in this total.
+        """
+        return self._r(sum(
+            span.duration_ms
+            for span in self.spans
+            if span.category == "tool" and not self._is_tool_batch_span(span)
+        ))
+
+    @property
+    def tools_walltime_duration_ms(self) -> float:
+        """Sum of outer tool-phase durations across the full run.
+
+        This measures the total duration of tool execution phases such as
+        ``execute_tools``. Unlike ``tools_total_duration_ms``, overlapping inner
+        tool calls are not double-counted here because only the outer batch spans
+        are included.
+        """
+        return self._r(sum(
+            span.duration_ms
+            for span in self.spans
+            if self._is_tool_batch_span(span)
+        ))
+
+    def summary_dict(self) -> dict[str, Any]:
+        """Build the exported run summary.
+
+        Time fields use a consistent scope:
+        - ``total_duration_ms``: full run duration from ``start()`` to ``finish()``
+        - ``llm_total_duration_ms``: sum of all model span durations in the run
+        - ``tools_total_duration_ms``: sum of all individual tool call durations in the run
+        - ``tools_walltime_duration_ms``: sum of outer tool-phase durations in the run
+
+        The first three are additive sums over matching spans. The tool
+        walltime field is intentionally different: it tracks the duration of the
+        outer tool phases so callers can distinguish tool work volume from the
+        total run duration occupied by tool execution.
+        """
+        llm_input_char_total = 0
+        llm_output_char_total = 0
+        for span in self.spans:
+            if span.category != "model":
+                continue
+            llm_input_char_total += len(str(span.args.get("llm_input_text") or ""))
+            llm_output_char_total += len(str(span.args.get("llm_output_text") or ""))
+        return {
+            "session_key": self.session_key,
+            "total_duration_ms": self._r(self.total_duration_ms),
+            "tool_call_count": sum(1 for span in self.spans if span.category == "tool" and not self._is_tool_batch_span(span)),
+            "span_count": len(self.spans),
+            "llm_total_duration_ms": self.llm_total_duration_ms,
+            "tools_total_duration_ms": self.tools_total_duration_ms,
+            "tools_walltime_duration_ms": self.tools_walltime_duration_ms,
+            "llm_input_char_total": llm_input_char_total,
+            "llm_output_char_total": llm_output_char_total,
+        }
+
+    def summary_text(self) -> str:
+        data = self.summary_dict()
+        return (
+            "profiler summary: "
+            f"run_duration_ms={data['total_duration_ms']:.3f}, "
+            f"llm_total_duration_ms={data['llm_total_duration_ms']:.3f}, "
+            f"tools_total_duration_ms={data['tools_total_duration_ms']:.3f}, "
+            f"tools_walltime_duration_ms={data['tools_walltime_duration_ms']:.3f}, "
+            f"tool_count={data['tool_call_count']}, "
+            f"spans={data['span_count']}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "session_key": self.session_key,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "total_duration_ms": self._r(self.total_duration_ms),
+            "summary": self.summary_dict(),
+            "spans": [asdict(item) for item in sorted(self.spans, key=lambda x: (x.start_ms, x.tid, x.display_path or x.name))],
+        }
+
+    def to_perfetto_dict(self) -> dict[str, Any]:
+        events: list[dict[str, Any]] = []
+        lane_names: dict[int, str] = {
+            1: "mainloop",
+            2: "model",
+            3: "tool",
+        }
+        events.append({"name": "process_name", "ph": "M", "pid": 1, "tid": 1, "args": {"name": "nanobot"}})
+        for tid, name in lane_names.items():
+            events.append({"name": "thread_name", "ph": "M", "pid": 1, "tid": tid, "args": {"name": name}})
+        for span in sorted(self.spans, key=lambda x: (x.start_ms, x.tid, x.display_path or x.name)):
+            args = dict(span.args)
+            args.setdefault("sibling_index", span.sibling_index)
+            if span.status is not None:
+                args.setdefault("status", span.status)
+            if span.path is not None:
+                args.setdefault("path", span.path)
+            if span.display_path is not None:
+                args.setdefault("display_path", span.display_path)
+            if span.parent_path is not None:
+                args.setdefault("parent_path", span.parent_path)
+            if span.display_parent_path is not None:
+                args.setdefault("display_parent_path", span.display_parent_path)
+            args.setdefault("duration_ms", span.duration_ms)
+            events.append({"name": span.display_path or span.name, "cat": span.category, "ph": "X", "ts": self._us_from_ms(span.start_ms), "dur": self._us_from_ms(span.duration_ms), "pid": span.pid, "tid": span.tid, "args": args})
+        return {"traceEvents": events, "displayTimeUnit": "ms", "metadata": {"session_key": self.session_key, "summary": self.summary_dict()}}
+
+    def write_json(self, path: str | Path=None) -> Path:
+        if path is None:
+            path = profiler_trace_path()
+        target = Path(path).expanduser().resolve()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(self.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+        return target
+
+    def write_perfetto_json(self, path: str | Path=None) -> Path:
+        if path is None:
+            path = profiler_perfetto_trace_path()
+        target = Path(path).expanduser().resolve()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(self.to_perfetto_dict(), ensure_ascii=False), encoding="utf-8")
+        return target
+
+    @staticmethod
+    def _r(value: float) -> float:
+        return round(value, 3)
+
+    @staticmethod
+    def _us_from_ms(value_ms: float) -> int:
+        return int(round(value_ms * 1000.0))
+
+    @staticmethod
+    def _is_tool_batch_span(span: SpanRecord) -> bool:
+        path = span.path or ""
+        return span.category == "tool" and path.split("/")[-1] == "execute_tools"
+
+    @staticmethod
+    def _lane_for_category(category: str) -> tuple[int, int]:
+        return _LANE_MAP.get(category, (1, 1))
+
+
+def profiler_enabled() -> bool:
+    value = os.environ.get("NANOBOT_PROFILER", "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _env_path(name: str, default: str) -> str | None:
+    value = os.environ.get(name, default).strip()
+    return value or None
+
+
+def profiler_trace_path() -> str | None:
+    return _env_path("NANOBOT_PROFILER_TRACE", "nanobot_trace.json")
+
+
+def profiler_perfetto_trace_path() -> str | None:
+    return _env_path("NANOBOT_PROFILER_PERFETTO_TRACE", "nanobot_trace_perfetto.json")
+
+
+
+
+_current_trace: ContextVar[ProfilerTrace | None] = ContextVar("nanobot_profiler_current_trace", default=None)
+
+
+class NanobotProfiler:
+    """Caller-facing profiler entrypoint backed by the current active trace.
+
+    Typical usage is:
+
+        from nanobot.utils.profiler import profiler
+
+        profiler.start(session_key)
+        profiler.push("run")
+        ...
+        profiler.pop()
+        trace = profiler.finish()
+
+    The active ``ProfilerTrace`` is stored in a context-local slot, so code can
+    call ``profiler.push()`` / ``profiler.pop()`` anywhere in the current run
+    without passing profiler objects through function parameters.
+    """
+
+    def current(self) -> ProfilerTrace | None:
+        """Return the active trace for the current context, if any."""
+        return _current_trace.get()
+
+    def set(self, trace: ProfilerTrace | None) -> ProfilerTrace | None:
+        """Bind a trace to the current context and return it."""
+        _current_trace.set(trace)
+        return trace
+
+    def clear(self) -> None:
+        """Remove the active trace from the current context."""
+        _current_trace.set(None)
+
+    def start(self, session_key: str | None = None, *, enabled: bool | None = None) -> ProfilerTrace:
+        """Create, start, and bind a new trace for the current context."""
+        trace = ProfilerTrace(enabled=enabled).start(session_key=session_key)
+        self.set(trace)
+        return trace
+
+    def finish(self) -> ProfilerTrace | None:
+        """Finish and clear the active trace for the current context."""
+        trace = self.current()
+        if trace is None:
+            return None
+        try:
+            trace.finish()
+            return trace
+        finally:
+            self.clear()
+
+    def push(self, name: str, *, category: str = "mainloop", status: str | None = None) -> ProfilerTrace | None:
+        """Open a span on the active trace. No-op when no trace is active."""
+        trace = self.current()
+        if trace is None:
+            return None
+        trace.push(name, category=category, status=status)
+        return trace
+
+    def pop(self, *, status: str | None = None, args: dict[str, Any] | None = None) -> ProfilerTrace | None:
+        """Close the latest span on the active trace. No-op when inactive."""
+        trace = self.current()
+        if trace is None:
+            return None
+        trace.pop(status=status, args=args)
+        return trace
+
+
+profiler = NanobotProfiler()

--- a/tests/skills/test_create_instance.py
+++ b/tests/skills/test_create_instance.py
@@ -1,0 +1,168 @@
+"""Tests for nanobot/skills/create-instance/scripts/create_instance.py."""
+
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).parent.parent.parent / "nanobot" / "skills" / "create-instance" / "scripts" / "create_instance.py"
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point HOME at a temp dir so nanobot writes configs there."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("NANOBOT_CONFIG", raising=False)
+    return tmp_path
+
+
+def _run_script(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Run create_instance.py as a subprocess."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=cwd,
+    )
+
+
+class TestValidation:
+    """Argument validation tests."""
+
+    def test_missing_required_args_exits_with_error(self) -> None:
+        result = _run_script()
+        assert result.returncode != 0
+
+    def test_invalid_channel_exits_with_error(self, tmp_home: Path) -> None:
+        result = _run_script("--name", "test", "--channel", "nonexistent_channel")
+        assert result.returncode != 0
+        assert "nonexistent_channel" in result.stderr or "nonexistent_channel" in result.stdout
+
+
+class TestCreateInstance:
+    """End-to-end instance creation tests."""
+
+    def test_creates_config_and_workspace(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result.returncode == 0, result.stderr
+
+        config_path = config_dir / "config.json"
+        assert config_path.exists(), f"Config not created at {config_path}"
+
+        workspace = config_dir / "workspace"
+        assert workspace.exists(), f"Workspace not created at {workspace}"
+
+    def test_config_has_channel_enabled(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        assert data["channels"]["telegram"]["enabled"] is True
+
+    def test_config_workspace_path_set(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        ws = data["agents"]["defaults"]["workspace"]
+        assert str(config_dir / "workspace") in ws or "workspace" in ws
+
+    def test_model_override(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--model", "deepseek/deepseek-chat",
+            "--config-dir", str(config_dir),
+        )
+        assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        assert data["agents"]["defaults"]["model"] == "deepseek/deepseek-chat"
+
+    def test_rejects_duplicate_instance(self, tmp_home: Path) -> None:
+        config_dir = tmp_home / ".nanobot-test"
+        result1 = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result1.returncode == 0
+
+        result2 = _run_script(
+            "--name", "test-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+        )
+        assert result2.returncode != 0
+
+    def test_port_reassigned_when_default_in_use(self, tmp_home: Path) -> None:
+        """When default gateway port is occupied, script should pick a different one."""
+        config_dir = tmp_home / ".nanobot-test"
+
+        # Bind to the default gateway port to simulate a running instance
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as blocker:
+            blocker.bind(("127.0.0.1", 18790))
+            blocker.listen(1)
+
+            result = _run_script(
+                "--name", "test-bot",
+                "--channel", "telegram",
+                "--config-dir", str(config_dir),
+            )
+            assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        assert data["gateway"]["port"] != 18790
+
+    def test_inherits_api_key_from_current_instance(self, tmp_home: Path) -> None:
+        """API keys from --inherit-config should be copied to new instance."""
+        # Create a fake "current instance" config with an API key
+        src_dir = tmp_home / ".nanobot-current"
+        src_dir.mkdir()
+        src_config = src_dir / "config.json"
+        src_config.write_text(json.dumps({
+            "providers": {
+                "anthropic": {"apiKey": "sk-test-key-12345"},
+                "deepseek": {"apiKey": "dsk-another-key"},
+                "openai": {},  # no key, should not be copied
+            },
+        }), encoding="utf-8")
+
+        config_dir = tmp_home / ".nanobot-new"
+        result = _run_script(
+            "--name", "new-bot",
+            "--channel", "telegram",
+            "--config-dir", str(config_dir),
+            "--inherit-config", str(src_config),
+        )
+        assert result.returncode == 0, result.stderr
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        providers = data.get("providers", {})
+        assert providers.get("anthropic", {}).get("apiKey") == "sk-test-key-12345"
+        assert providers.get("deepseek", {}).get("apiKey") == "dsk-another-key"
+        # openai had no key, so it should not be in the new config's providers
+        assert providers.get("openai", {}).get("apiKey") is None


### PR DESCRIPTION
## PR Title                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                          
 Add module-level profiler API and integrate span tracing into agent flow                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                          
 ## PR Description                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                          
 This PR adds a module-level profiler API and integrates span tracing into the main agent flow on top of `nightly`.                                                                                                                                                                       
                                                                                                                                                                                                                                                                                          
 ### What changed                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                          
 - add `nanobot.utils.profiler` with:                                                                                                                                                                                                                                                     
   - a module-level `profiler` entrypoint                                                                                                                                                                                                                                                 
   - `ProfilerTrace` as the underlying trace object                                                                                                                                                                                                                                       
 - export profiler APIs from `nanobot.__init__`                                                                                                                                                                                                                                           
 - integrate minimal profiler span instrumentation into:                                                                                                                                                                                                                                  
   - `nanobot/nanobot.py`                                                                                                                                                                                                                                                                 
   - `nanobot/agent/loop.py`                                                                                                                                                                                                                                                              
   - `nanobot/agent/runner.py`                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                          
 ### Design notes                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                          
 - the profiler uses a simple lifecycle:                                                                                                                                                                                                                                                  
   - `profiler.start(...)`                                                                                                                                                                                                                                                                
   - `profiler.push(...)`                                                                                                                                                                                                                                                                 
   - `profiler.pop(...)`                                                                                                                                                                                                                                                                  
   - `profiler.finish()`                                                                                                                                                                                                                                                                  
 - instrumentation is kept intentionally small and localized                                                                                                                                                                                                                              
 - existing business logic is preserved as much as possible                                                                                                                                                                                                                               
 - hook-related profiler exposure was not added, to avoid expanding unrelated API surface                                                                                                                                                                                                 
 - exported trace data is span-oriented, so callers can consume a generic nested trace structure                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                
 ### Notes on scope                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                          
 - this PR is intentionally limited to profiler integration                                                                                                                                                                                                                               
 - follow-up fixes removed instrumentation changes that drifted from current `nightly` behavior                                                                                                                                                                                           
 - the current diff keeps the integration aligned with current `nightly` control flow     