### PR TITLE
fix(feishu): Fix done emoji addition and on-it emoji removal before task actually ends

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -1361,7 +1361,12 @@ class FeishuChannel(BaseChannel):
         # --- stream end: final update or fallback ---
         if meta.get("_stream_end"):
             message_id = meta.get("message_id")
-            if message_id:
+            # Only finalize the OnIt -> DONE reaction transition on the truly
+            # final stream end. _resuming=True means the agent will keep
+            # working (more tool-call rounds), so leave the reaction state
+            # in place — otherwise the OnIt indicator disappears prematurely
+            # and the DONE reaction fires after every tool call.
+            if message_id and not meta.get("_resuming"):
                 reaction_id = self._reaction_ids.pop(message_id, None)
                 if reaction_id:
                     await self._remove_reaction(message_id, reaction_id)

--- a/tests/channels/test_feishu_reaction.py
+++ b/tests/channels/test_feishu_reaction.py
@@ -255,3 +255,61 @@ class TestStreamEndReactionCleanup:
         )
 
         ch._remove_reaction.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_removal_when_resuming(self):
+        """_resuming=True means more tool-call rounds follow; reaction must persist."""
+        ch = _make_channel()
+        ch.config.done_emoji = "DONE"
+        ch._stream_bufs["oc_chat1"] = _FeishuStreamBuf(
+            text="partial", card_id="card_1", sequence=3, last_edit=0.0,
+        )
+        ch._reaction_ids["om_001"] = "rx_42"
+        ch._client.cardkit.v1.card_element.content.return_value = MagicMock(success=MagicMock(return_value=True))
+        ch._client.cardkit.v1.card.settings.return_value = MagicMock(success=MagicMock(return_value=True))
+        ch._remove_reaction = AsyncMock()
+        ch._add_reaction = AsyncMock()
+
+        await ch.send_delta(
+            "oc_chat1", "",
+            metadata={"_stream_end": True, "_resuming": True, "message_id": "om_001"},
+        )
+
+        ch._remove_reaction.assert_not_called()
+        ch._add_reaction.assert_not_called()
+        # OnIt reaction id is still tracked for the eventual final stream end
+        assert ch._reaction_ids.get("om_001") == "rx_42"
+
+    @pytest.mark.asyncio
+    async def test_done_emoji_only_on_final_stream_end(self):
+        """Across resuming rounds, done_emoji is added only on the final round."""
+        ch = _make_channel()
+        ch.config.done_emoji = "DONE"
+        ch._stream_bufs["oc_chat1"] = _FeishuStreamBuf(
+            text="t", card_id="card_1", sequence=3, last_edit=0.0,
+        )
+        ch._reaction_ids["om_001"] = "rx_42"
+        ch._client.cardkit.v1.card_element.content.return_value = MagicMock(success=MagicMock(return_value=True))
+        ch._client.cardkit.v1.card.settings.return_value = MagicMock(success=MagicMock(return_value=True))
+        ch._remove_reaction = AsyncMock()
+        ch._add_reaction = AsyncMock()
+
+        # Intermediate stream end (more tool calls coming).
+        await ch.send_delta(
+            "oc_chat1", "",
+            metadata={"_stream_end": True, "_resuming": True, "message_id": "om_001"},
+        )
+        ch._remove_reaction.assert_not_called()
+        ch._add_reaction.assert_not_called()
+
+        # Re-prime the stream buffer for the final round (the previous _stream_end popped it).
+        ch._stream_bufs["oc_chat1"] = _FeishuStreamBuf(
+            text="t", card_id="card_1", sequence=5, last_edit=0.0,
+        )
+        # Final stream end (resuming=False): OnIt removed, done_emoji added.
+        await ch.send_delta(
+            "oc_chat1", "",
+            metadata={"_stream_end": True, "_resuming": False, "message_id": "om_001"},
+        )
+        ch._remove_reaction.assert_called_once_with("om_001", "rx_42")
+        ch._add_reaction.assert_called_once_with("om_001", "DONE")


### PR DESCRIPTION
## Summary

The `done_emoji` reaction (and the OnIt removal) currently fires on every stream end, including intermediate stream ends between tool-call rounds. Two visible symptoms:

- The OnIt reaction disappears after the *first* tool call instead of staying for the duration of the task.
- The DONE reaction is added repeatedly during multi-tool-call sessions instead of once at completion.

`_resuming` is already stamped onto outbound metadata at `nanobot/agent/loop.py:747` (`meta["_resuming"] = resuming`) and is consumed by the CLI renderer at `nanobot/cli/commands.py:1132`, but the Feishu channel ignored it after #3133 removed the previous resuming-aware path.

This change wraps the OnIt-remove + `done_emoji`-add block in `if message_id and not meta.get("_resuming"):` inside `FeishuChannel.send_delta`. Result:

- Intermediate `_stream_end` (resuming=True) → reaction state untouched, OnIt persists, done_emoji not fired.
- Final `_stream_end` (resuming=False) → OnIt removed, `done_emoji` added once.

`_resuming` survives the manager's coalescer because `_coalesce_stream_deltas` only merges messages with `_stream_delta` set; a pure `_stream_end` (no `_stream_delta`) hits the non-matching branch and is delivered to `send_delta` with metadata intact.

The streaming card behavior, fallback path, and `_reaction_ids` lifecycle (cap at 500, pop-on-end) are unchanged.

## Test plan

- [x] `tests/channels/test_feishu_reaction.py::TestStreamEndReactionCleanup::test_no_removal_when_resuming` — `_resuming=True` does not call `_remove_reaction` or `_add_reaction`, and the tracked reaction id remains in `_reaction_ids` for the eventual final stream end.
- [x] `tests/channels/test_feishu_reaction.py::TestStreamEndReactionCleanup::test_done_emoji_only_on_final_stream_end` — across a resuming round followed by a final round, OnIt is removed and `done_emoji` is added exactly once on the final round.
- [x] All 52 tests in `test_feishu_reaction.py` + `test_feishu_streaming.py` pass.