### PR TITLE
feat: add ZenMux provider support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -152,6 +152,7 @@ class ProvidersConfig(Base):
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
+    zenmux: ProviderConfig = Field(default_factory=ProviderConfig)  # ZenMux API gateway
 
 
 class HeartbeatConfig(Base):

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -212,6 +212,18 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
     ),
 
 
+    # ZenMux: OpenAI-compatible gateway at zenmux.ai
+    ProviderSpec(
+        name="zenmux",
+        keywords=("zenmux",),
+        env_key="ZENMUX_API_KEY",
+        display_name="ZenMux",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_base_keyword="zenmux",
+        default_api_base="https://zenmux.ai/api/v1",
+    ),
+
     # === Standard providers (matched by model-name keywords) ===============
     # Anthropic: native Anthropic SDK
     ProviderSpec(


### PR DESCRIPTION
Add ZenMux (zenmux.ai) as an OpenAI-compatible gateway provider.

- Register ProviderSpec in providers/registry.py (gateway section)
- Add config field to ProvidersConfig in config/schema.py

Configuration example:

```json
{
  "providers": {
    "zenmux": {
      "apiKey": "sk-..."
    }
  },
  "agents": {
    "defaults": {
      "model": "zenmux/claude-opus-4-6"
    }
  }
}
```

ZenMux is an API gateway that provides a unified OpenAI-compatible interface for multiple LLM providers (Anthropic, OpenAI, etc.) with built-in load balancing and key management. In addition, ZenMux also supports personal subscription for API usage.