### PR TITLE
feat: per-provider generation config

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,34 @@
+# Fix: WeCom WebSocket client initialization and event handlers
+
+## Problem
+
+The WeCom channel fails to start due to three issues in `nanobot/channels/wecom.py`:
+
+1. **WSClient initialization**: The SDK's `WSClient` expects keyword arguments, but nanobot passes a dict, causing `TypeError: __init__() takes 1 positional argument`
+
+2. **connect_async vs connect**: The code uses `connect_async()` but the SDK only provides `connect()`
+
+3. **Event handler signature mismatch**: All event handlers define `frame: Any` as required, but some SDK events (like `connected`, `authenticated`) don't pass a frame argument, causing `TypeError`
+
+## Solution
+
+1. Change `WSClient({...})` to `WSClient(bot_id=..., secret=..., ...)`
+
+2. Change `connect_async()` to `connect()`
+
+3. Make all event handler `frame` parameters optional: `frame: Any = None`
+
+## Changes
+
+- `nanobot/channels/wecom.py`:
+  - Line ~120: WSClient instantiation (dict → keyword args)
+  - Line ~144: connect_async() → connect()
+  - Lines ~157-194: All `_on_*` methods: `frame: Any` → `frame: Any = None`
+
+## Testing
+
+After this fix, WeCom channel connects successfully:
+```
+WeCom WebSocket connected
+WeCom authenticated successfully
+```

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,116 @@
+# Feature: Per-Provider Generation Config
+
+## Summary
+
+Support `maxTokens`, `contextWindowTokens`, `temperature`, and `reasoningEffort` at the provider level, so that switching providers/models automatically applies the correct generation parameters without manually updating global `agents.defaults`.
+
+## Motivation
+
+Currently, generation parameters (`maxTokens`, `contextWindowTokens`, `temperature`, `reasoningEffort`) are only configurable under `agents.defaults` — a single global setting shared by all providers. This creates several problems:
+
+1. **Manual parameter lookup on every model switch** — When switching from a 200K-context model (e.g., Claude) to a 32K model (e.g., some DeepSeek variants), users must manually look up and update `contextWindowTokens` and `maxTokens` in `agents.defaults`.
+2. **No per-provider optimization** — Different providers/models have different optimal settings. A one-size-fits-all approach means either under-utilizing capable models or risking API errors from exceeding limits.
+3. **Fallback mismatch** — When provider fallback occurs, the global generation settings may be inappropriate for the fallback provider's model.
+
+## Proposed Design
+
+### 1. Extend `ProviderConfig` with optional generation fields
+
+```python
+# schema.py
+
+class ProviderGenerationConfig(Base):
+    """Per-provider generation settings (all optional, override agents.defaults)."""
+    max_tokens: int | None = None
+    context_window_tokens: int | None = None
+    temperature: float | None = None
+    reasoning_effort: str | None = None
+
+
+class ProviderConfig(Base):
+    """LLM provider configuration."""
+    api_key: str | None = None
+    api_base: str | None = None
+    extra_headers: dict[str, str] | None = None
+    generation: ProviderGenerationConfig | None = None  # NEW
+```
+
+### 2. Merge logic: provider-level overrides global defaults
+
+When creating a provider, merge generation settings with priority: **provider > agents.defaults**
+
+```python
+# nanobot.py / cli/commands.py
+
+defaults = config.agents.defaults
+pg = provider_config.generation if provider_config and provider_config.generation else None
+
+provider.generation = GenerationSettings(
+    temperature=pg.temperature if pg and pg.temperature is not None else defaults.temperature,
+    max_tokens=pg.max_tokens if pg and pg.max_tokens is not None else defaults.max_tokens,
+    reasoning_effort=pg.reasoning_effort if pg and pg.reasoning_effort is not None else defaults.reasoning_effort,
+)
+```
+
+For `context_window_tokens`, same merge logic applies wherever it's consumed (memory compaction, etc.).
+
+### 3. Example config
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": "minimax-m2.5",
+      "provider": "tencent-coding-plan",
+      "maxTokens": 8192,
+      "contextWindowTokens": 65536
+    }
+  },
+  "providers": {
+    "anthropic": {
+      "apiKey": "sk-xxx",
+      "apiBase": "http://localhost:8080/v1",
+      "generation": {
+        "maxTokens": 16384,
+        "contextWindowTokens": 200000,
+        "temperature": 0.2
+      }
+    },
+    "tencent-coding-plan": {
+      "apiKey": "xxx",
+      "apiBase": "https://api.lkeap.cloud.tencent.com/coding/v3",
+      "generation": {
+        "maxTokens": 8192,
+        "contextWindowTokens": 65536
+      }
+    },
+    "openrouter": {
+      "apiKey": "sk-or-xxx",
+      "generation": {
+        "maxTokens": 32768,
+        "contextWindowTokens": 128000
+      }
+    }
+  }
+}
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `nanobot/config/schema.py` | Add `ProviderGenerationConfig` class; add `generation` field to `ProviderConfig` |
+| `nanobot/nanobot.py` | Merge provider-level generation config when creating provider |
+| `nanobot/cli/commands.py` | Same merge logic for CLI path |
+| `nanobot/agent/memory.py` | Use merged `context_window_tokens` for compaction decisions |
+
+## Backward Compatibility
+
+- Fully backward compatible — all new fields are optional with `None` defaults
+- If no `generation` is set on a provider, behavior is identical to current version (falls back to `agents.defaults`)
+- No config migration needed
+
+## Open Questions
+
+- Should `context_window_tokens` also be part of `ProviderGenerationConfig`, or should it live separately since it's not a generation parameter per se (it's used for memory compaction, not sent to the API)?
+- Should we also support per-model overrides (e.g., different settings for `claude-opus` vs `claude-sonnet` under the same provider)?

--- a/nanobot/channels/wecom.py
+++ b/nanobot/channels/wecom.py
@@ -117,13 +117,13 @@ class WecomChannel(BaseChannel):
         self._generate_req_id = generate_req_id
 
         # Create WebSocket client
-        self._client = WSClient({
-            "bot_id": self.config.bot_id,
-            "secret": self.config.secret,
-            "reconnect_interval": 1000,
-            "max_reconnect_attempts": -1,  # Infinite reconnect
-            "heartbeat_interval": 30000,
-        })
+        self._client = WSClient(
+            bot_id=self.config.bot_id,
+            secret=self.config.secret,
+            reconnect_interval=1000,
+            max_reconnect_attempts=-1,  # Infinite reconnect
+            heartbeat_interval=30000,
+        )
 
         # Register event handlers
         self._client.on("connected", self._on_connected)
@@ -141,7 +141,7 @@ class WecomChannel(BaseChannel):
         logger.info("No public IP required - using WebSocket to receive events")
 
         # Connect
-        await self._client.connect_async()
+        await self._client.connect()
 
         # Keep running until stopped
         while self._running:
@@ -154,44 +154,44 @@ class WecomChannel(BaseChannel):
             await self._client.disconnect()
         logger.info("WeCom bot stopped")
 
-    async def _on_connected(self, frame: Any) -> None:
+    async def _on_connected(self, frame: Any = None) -> None:
         """Handle WebSocket connected event."""
         logger.info("WeCom WebSocket connected")
 
-    async def _on_authenticated(self, frame: Any) -> None:
+    async def _on_authenticated(self, frame: Any = None) -> None:
         """Handle authentication success event."""
         logger.info("WeCom authenticated successfully")
 
-    async def _on_disconnected(self, frame: Any) -> None:
+    async def _on_disconnected(self, frame: Any = None) -> None:
         """Handle WebSocket disconnected event."""
         reason = frame.body if hasattr(frame, 'body') else str(frame)
         logger.warning("WeCom WebSocket disconnected: {}", reason)
 
-    async def _on_error(self, frame: Any) -> None:
+    async def _on_error(self, frame: Any = None) -> None:
         """Handle error event."""
         logger.error("WeCom error: {}", frame)
 
-    async def _on_text_message(self, frame: Any) -> None:
+    async def _on_text_message(self, frame: Any = None) -> None:
         """Handle text message."""
         await self._process_message(frame, "text")
 
-    async def _on_image_message(self, frame: Any) -> None:
+    async def _on_image_message(self, frame: Any = None) -> None:
         """Handle image message."""
         await self._process_message(frame, "image")
 
-    async def _on_voice_message(self, frame: Any) -> None:
+    async def _on_voice_message(self, frame: Any = None) -> None:
         """Handle voice message."""
         await self._process_message(frame, "voice")
 
-    async def _on_file_message(self, frame: Any) -> None:
+    async def _on_file_message(self, frame: Any = None) -> None:
         """Handle file message."""
         await self._process_message(frame, "file")
 
-    async def _on_mixed_message(self, frame: Any) -> None:
+    async def _on_mixed_message(self, frame: Any = None) -> None:
         """Handle mixed content message."""
         await self._process_message(frame, "mixed")
 
-    async def _on_enter_chat(self, frame: Any) -> None:
+    async def _on_enter_chat(self, frame: Any = None) -> None:
         """Handle enter_chat event (user opens chat with bot)."""
         try:
             # Extract body from WsFrame dataclass or dict

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
 
@@ -96,13 +96,22 @@ class AgentsConfig(Base):
 class ProviderConfig(Base):
     """LLM provider configuration."""
 
+    # Re-declare model_config to ensure alias_generator is applied
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     api_key: str | None = None
     api_base: str | None = None
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
 
 
 class ProvidersConfig(Base):
-    """Configuration for LLM providers."""
+    """Configuration for LLM providers.
+
+    Supports custom providers via extra fields — any additional field
+    becomes an OpenAI-compatible custom provider.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     custom: ProviderConfig = Field(default_factory=ProviderConfig)  # Any OpenAI-compatible endpoint
     azure_openai: ProviderConfig = Field(default_factory=ProviderConfig)  # Azure OpenAI (model = deployment name)
@@ -133,6 +142,15 @@ class ProvidersConfig(Base):
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
+
+    @model_validator(mode="after")
+    def convert_extra_providers(self):
+        """Convert extra fields (custom providers) to ProviderConfig objects."""
+        if self.model_extra:
+            for key, value in self.model_extra.items():
+                if isinstance(value, dict):
+                    self.model_extra[key] = ProviderConfig.model_validate(value)
+        return self
 
 
 class HeartbeatConfig(Base):
@@ -229,7 +247,11 @@ class Config(BaseSettings):
         self, model: str | None = None
     ) -> tuple["ProviderConfig | None", str | None]:
         """Match provider config and its registry name. Returns (config, spec_name)."""
-        from nanobot.providers.registry import PROVIDERS, find_by_name
+        from nanobot.providers.registry import (
+            PROVIDERS,
+            create_dynamic_spec,
+            find_by_name,
+        )
 
         forced = self.agents.defaults.provider
         if forced != "auto":
@@ -237,6 +259,11 @@ class Config(BaseSettings):
             if spec:
                 p = getattr(self.providers, spec.name, None)
                 return (p, spec.name) if p else (None, None)
+            # Check for custom provider by name (try both original and normalized)
+            for name_to_try in (forced, forced.replace("-", "_")):
+                p = getattr(self.providers, name_to_try, None)
+                if p and isinstance(p, ProviderConfig):
+                    return p, name_to_try
             return None, None
 
         model_lower = (model or self.agents.defaults.model).lower()
@@ -254,6 +281,14 @@ class Config(BaseSettings):
             if p and model_prefix and normalized_prefix == spec.name:
                 if spec.is_oauth or spec.is_local or p.api_key:
                     return p, spec.name
+
+        # Check for custom provider by prefix (e.g., "myprovider/gpt-4")
+        # Try both original prefix and normalized (snake_case) prefix
+        if model_prefix:
+            for prefix_to_try in (model_prefix, normalized_prefix):
+                p = getattr(self.providers, prefix_to_try, None)
+                if p and isinstance(p, ProviderConfig) and p.api_base:
+                    return p, prefix_to_try
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
@@ -288,6 +323,15 @@ class Config(BaseSettings):
             p = getattr(self.providers, spec.name, None)
             if p and p.api_key:
                 return p, spec.name
+
+        # Final fallback: check for any configured custom provider
+        for attr_name in dir(self.providers):
+            if attr_name.startswith("_"):
+                continue
+            p = getattr(self.providers, attr_name, None)
+            if isinstance(p, ProviderConfig) and p.api_base:
+                return p, attr_name
+
         return None, None
 
     def get_provider(self, model: str | None = None) -> ProviderConfig | None:

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -393,3 +393,16 @@ def find_by_name(name: str) -> ProviderSpec | None:
         if spec.name == normalized:
             return spec
     return None
+
+
+def create_dynamic_spec(name: str) -> ProviderSpec:
+    """Create a dynamic ProviderSpec for custom user-defined providers."""
+    normalized = to_snake(name.replace("-", "_"))
+    return ProviderSpec(
+        name=normalized,
+        keywords=(),
+        env_key="",
+        display_name=name.title(),
+        backend="openai_compat",
+        is_direct=True,
+    )


### PR DESCRIPTION
# Feature: Per-Provider Generation Config

## Summary

Support `maxTokens`, `contextWindowTokens`, `temperature`, and `reasoningEffort` at the provider level, so that switching providers/models automatically applies the correct generation parameters without manually updating global `agents.defaults`.

## Motivation

Currently, generation parameters (`maxTokens`, `contextWindowTokens`, `temperature`, `reasoningEffort`) are only configurable under `agents.defaults` — a single global setting shared by all providers. This creates several problems:

1. **Manual parameter lookup on every model switch** — When switching from a 200K-context model (e.g., Claude) to a 32K model (e.g., some DeepSeek variants), users must manually look up and update `contextWindowTokens` and `maxTokens` in `agents.defaults`.
2. **No per-provider optimization** — Different providers/models have different optimal settings. A one-size-fits-all approach means either under-utilizing capable models or risking API errors from exceeding limits.
3. **Fallback mismatch** — When provider fallback occurs, the global generation settings may be inappropriate for the fallback provider's model.

## Proposed Design

### 1. Extend `ProviderConfig` with optional generation fields

```python
# schema.py

class ProviderGenerationConfig(Base):
    """Per-provider generation settings (all optional, override agents.defaults)."""
    max_tokens: int | None = None
    context_window_tokens: int | None = None
    temperature: float | None = None
    reasoning_effort: str | None = None


class ProviderConfig(Base):
    """LLM provider configuration."""
    api_key: str | None = None
    api_base: str | None = None
    extra_headers: dict[str, str] | None = None
    generation: ProviderGenerationConfig | None = None  # NEW
```

### 2. Merge logic: provider-level overrides global defaults

When creating a provider, merge generation settings with priority: **provider > agents.defaults**

```python
# nanobot.py / cli/commands.py

defaults = config.agents.defaults
pg = provider_config.generation if provider_config and provider_config.generation else None

provider.generation = GenerationSettings(
    temperature=pg.temperature if pg and pg.temperature is not None else defaults.temperature,
    max_tokens=pg.max_tokens if pg and pg.max_tokens is not None else defaults.max_tokens,
    reasoning_effort=pg.reasoning_effort if pg and pg.reasoning_effort is not None else defaults.reasoning_effort,
)
```

For `context_window_tokens`, same merge logic applies wherever it's consumed (memory compaction, etc.).

### 3. Example config

```json
{
  "agents": {
    "defaults": {
      "model": "minimax-m2.5",
      "provider": "tencent-coding-plan",
      "maxTokens": 8192,
      "contextWindowTokens": 65536
    }
  },
  "providers": {
    "anthropic": {
      "apiKey": "sk-xxx",
      "apiBase": "http://localhost:8080/v1",
      "generation": {
        "maxTokens": 16384,
        "contextWindowTokens": 200000,
        "temperature": 0.2
      }
    },
    "tencent-coding-plan": {
      "apiKey": "xxx",
      "apiBase": "https://api.lkeap.cloud.tencent.com/coding/v3",
      "generation": {
        "maxTokens": 8192,
        "contextWindowTokens": 65536
      }
    },
    "openrouter": {
      "apiKey": "sk-or-xxx",
      "generation": {
        "maxTokens": 32768,
        "contextWindowTokens": 128000
      }
    }
  }
}
```

## Files to Modify

| File | Change |
|------|--------|
| `nanobot/config/schema.py` | Add `ProviderGenerationConfig` class; add `generation` field to `ProviderConfig` |
| `nanobot/nanobot.py` | Merge provider-level generation config when creating provider |
| `nanobot/cli/commands.py` | Same merge logic for CLI path |
| `nanobot/agent/memory.py` | Use merged `context_window_tokens` for compaction decisions |

## Backward Compatibility

- Fully backward compatible — all new fields are optional with `None` defaults
- If no `generation` is set on a provider, behavior is identical to current version (falls back to `agents.defaults`)
- No config migration needed

## Open Questions

- Should `context_window_tokens` also be part of `ProviderGenerationConfig`, or should it live separately since it's not a generation parameter per se (it's used for memory compaction, not sent to the API)?
- Should we also support per-model overrides (e.g., different settings for `claude-opus` vs `claude-sonnet` under the same provider)?
