### PR TITLE
fix: sanitize Matrix user_id for Windows-safe store file names

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -262,10 +262,18 @@ class MatrixChannel(BaseChannel):
         self.store_path.mkdir(parents=True, exist_ok=True)
         self.session_path = self.store_path / "session.json"
 
+        # Replace ':' with '_' to produce a Windows-safe filename
+        safe_store_name = self.config.user_id.replace(":", "_") + f"_{self.config.device_id}.db"
+
         self.client = AsyncClient(
-            homeserver=self.config.homeserver, user=self.config.user_id,
+            homeserver=self.config.homeserver,
+            user=self.config.user_id,
             store_path=self.store_path,
-            config=AsyncClientConfig(store_sync_tokens=True, encryption_enabled=self.config.e2ee_enabled),
+            config=AsyncClientConfig(
+                store_sync_tokens=True,
+                encryption_enabled=self.config.e2ee_enabled,
+                store_name=safe_store_name,
+            ),
         )
 
         self._register_event_callbacks()


### PR DESCRIPTION
- Replace ':' with '_' in store_name to avoid WinError 123
- Pass sanitized store_name via AsyncClientConfig
- Fixes issue #3506 where Matrix channel fails on Windows due to colon in user_id causing invalid file paths in matrix-nio's DefaultStore