### PR TITLE
feat(audio): unify transcription providers and add local Whisper support

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import TranscriptionConfig
 
 
 class BaseChannel(ABC):
@@ -22,10 +23,13 @@ class BaseChannel(ABC):
 
     name: str = "base"
     display_name: str = "Base"
+    # Legacy flat attributes — still set by ChannelManager for backward compat
     transcription_provider: str = "groq"
     transcription_api_key: str = ""
     transcription_api_base: str = ""
     transcription_language: str | None = None
+    # Typed config — set by ChannelManager when available
+    _transcription_config: TranscriptionConfig | None = None
 
     def __init__(self, config: Any, bus: MessageBus):
         """
@@ -39,25 +43,65 @@ class BaseChannel(ABC):
         self.bus = bus
         self._running = False
 
+    @property
+    def transcription_available(self) -> bool:
+        """Whether voice transcription is configured and ready."""
+        if self._transcription_config is not None:
+            if not self._transcription_config.enabled:
+                return False
+            from nanobot.providers.transcription import WhisperTranscriptionProvider
+            p = WhisperTranscriptionProvider(
+                self._transcription_config.provider,
+                api_key=self._transcription_config.api_key,
+                api_base=self._transcription_config.api_base,
+                model=self._transcription_config.model,
+            )
+            return p.is_available
+        # Fallback to legacy flat attributes
+        if self.transcription_provider == "local":
+            return bool(self.transcription_api_base)
+        return bool(self.transcription_api_key)
+
     async def transcribe_audio(self, file_path: str | Path) -> str:
-        """Transcribe an audio file via Whisper (OpenAI or Groq). Returns empty string on failure."""
-        if not self.transcription_api_key:
+        """Transcribe an audio file via Whisper.
+
+        Supports Groq, OpenAI, and any local OpenAI-compatible endpoint
+        (whisper.cpp, faster-whisper, LocalAI, etc.).
+
+        Returns transcribed text, or empty string on failure.
+        """
+        from nanobot.providers.transcription import WhisperTranscriptionProvider
+
+        if self._transcription_config is not None:
+            cfg = self._transcription_config
+            if not cfg.enabled:
+                return ""
+            provider = WhisperTranscriptionProvider(
+                cfg.provider,
+                api_key=cfg.api_key,
+                api_base=cfg.api_base,
+                model=cfg.model,
+                language=cfg.language,
+                max_duration_seconds=cfg.max_duration_seconds,
+            )
+        else:
+            # Legacy path — flat attributes
+            provider = WhisperTranscriptionProvider(
+                self.transcription_provider,
+                api_key=self.transcription_api_key or None,
+                api_base=self.transcription_api_base or None,
+                language=self.transcription_language,
+            )
+
+        if not provider.is_available:
+            logger.warning(
+                "{}: transcription unavailable — {}",
+                self.name,
+                provider.unavailable_reason,
+            )
             return ""
+
         try:
-            if self.transcription_provider == "openai":
-                from nanobot.providers.transcription import OpenAITranscriptionProvider
-                provider = OpenAITranscriptionProvider(
-                    api_key=self.transcription_api_key,
-                    api_base=self.transcription_api_base or None,
-                    language=self.transcription_language or None,
-                )
-            else:
-                from nanobot.providers.transcription import GroqTranscriptionProvider
-                provider = GroqTranscriptionProvider(
-                    api_key=self.transcription_api_key,
-                    api_base=self.transcription_api_base or None,
-                    language=self.transcription_language or None,
-                )
             return await provider.transcribe(file_path)
         except Exception as e:
             logger.warning("{}: audio transcription failed: {}", self.name, e)

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -84,22 +84,38 @@ class BaseChannel(ABC):
                 language=cfg.language,
                 max_duration_seconds=cfg.max_duration_seconds,
             )
+            if not provider.is_available:
+                logger.warning(
+                    "{}: transcription unavailable — {}",
+                    self.name,
+                    provider.unavailable_reason,
+                )
+                return ""
         else:
-            # Legacy path — flat attributes
-            provider = WhisperTranscriptionProvider(
-                self.transcription_provider,
-                api_key=self.transcription_api_key or None,
-                api_base=self.transcription_api_base or None,
-                language=self.transcription_language,
-            )
+            # Legacy path — flat attributes.
+            # Access provider classes via the module object so that test patches on
+            # GroqTranscriptionProvider / OpenAITranscriptionProvider remain effective.
+            from nanobot.providers import transcription as _tmod
 
-        if not provider.is_available:
-            logger.warning(
-                "{}: transcription unavailable — {}",
-                self.name,
-                provider.unavailable_reason,
-            )
-            return ""
+            if self.transcription_provider == "openai":
+                provider = _tmod.OpenAITranscriptionProvider(
+                    api_key=self.transcription_api_key or None,
+                    api_base=self.transcription_api_base or None,
+                    language=self.transcription_language,
+                )
+            elif self.transcription_provider == "groq":
+                provider = _tmod.GroqTranscriptionProvider(
+                    api_key=self.transcription_api_key or None,
+                    api_base=self.transcription_api_base or None,
+                    language=self.transcription_language,
+                )
+            else:
+                provider = WhisperTranscriptionProvider(
+                    self.transcription_provider,
+                    api_key=self.transcription_api_key or None,
+                    api_base=self.transcription_api_base or None,
+                    language=self.transcription_language,
+                )
 
         try:
             return await provider.transcribe(file_path)
@@ -239,3 +255,4 @@ class BaseChannel(ABC):
     def is_running(self) -> bool:
         """Check if the channel is running."""
         return self._running
+

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -11,7 +11,7 @@ from loguru import logger
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
-from nanobot.config.schema import Config
+from nanobot.config.schema import Config, TranscriptionConfig
 from nanobot.utils.restart import consume_restart_notice_from_env, format_restart_completed_message
 
 if TYPE_CHECKING:
@@ -60,10 +60,12 @@ class ChannelManager:
         """Initialize channels discovered via pkgutil scan + entry_points plugins."""
         from nanobot.channels.registry import discover_all
 
-        transcription_provider = self.config.channels.transcription_provider
-        transcription_key = self._resolve_transcription_key(transcription_provider)
-        transcription_base = self._resolve_transcription_base(transcription_provider)
-        transcription_language = self.config.channels.transcription_language
+        transcription_cfg = self._build_transcription_config()
+        # Legacy flat values for backward compat
+        transcription_provider = transcription_cfg.provider
+        transcription_key = transcription_cfg.api_key or ""
+        transcription_base = transcription_cfg.api_base or ""
+        transcription_language = transcription_cfg.language
 
         for name, cls in discover_all().items():
             section = getattr(self.config.channels, name, None)
@@ -86,6 +88,8 @@ class ChannelManager:
                     if static_path is not None:
                         kwargs["static_dist_path"] = static_path
                 channel = cls(section, self.bus, **kwargs)
+                channel._transcription_config = transcription_cfg
+                # Also set legacy flat attributes for any code that reads them directly
                 channel.transcription_provider = transcription_provider
                 channel.transcription_api_key = transcription_key
                 channel.transcription_api_base = transcription_base
@@ -96,24 +100,86 @@ class ChannelManager:
                 logger.warning("{} channel not available: {}", name, e)
 
         self._validate_allow_from()
+        self._warn_transcription_unconfigured(transcription_cfg)
 
-    def _resolve_transcription_key(self, provider: str) -> str:
-        """Pick the API key for the configured transcription provider."""
+    def _build_transcription_config(self) -> TranscriptionConfig:
+        """Build a resolved TranscriptionConfig, merging legacy flat fields and provider-section keys."""
+        channels_cfg = self.config.channels
+
+        # Start from the typed transcription block if present
+        tc = channels_cfg.transcription
+
+        # If the typed block has defaults but legacy flat fields were explicitly set,
+        # prefer the legacy values (backward compat)
+        provider = tc.provider
+        if channels_cfg.transcription_provider != "groq" and tc.provider == "groq":
+            # User set the legacy field to something non-default
+            provider = channels_cfg.transcription_provider
+
+        language = tc.language
+        if channels_cfg.transcription_language and not tc.language:
+            language = channels_cfg.transcription_language
+
+        # Resolve API key: transcription-specific > provider-section fallback
+        api_key = tc.api_key
+        if not api_key and provider != "local":
+            api_key = self._resolve_provider_key(provider)
+
+        # Resolve API base: transcription-specific > provider-section fallback
+        api_base = tc.api_base
+        if not api_base and provider != "local":
+            api_base = self._resolve_provider_base(provider)
+
+        return TranscriptionConfig(
+            enabled=tc.enabled,
+            provider=provider,
+            model=tc.model,
+            api_key=api_key,
+            api_base=api_base,
+            language=language,
+            max_duration_seconds=tc.max_duration_seconds,
+        )
+
+    def _resolve_provider_key(self, provider: str) -> str | None:
+        """Pick the API key from the providers section for the given transcription provider."""
         try:
             if provider == "openai":
                 return self.config.providers.openai.api_key
             return self.config.providers.groq.api_key
         except AttributeError:
-            return ""
+            return None
 
-    def _resolve_transcription_base(self, provider: str) -> str:
-        """Pick the API base URL for the configured transcription provider."""
+    def _resolve_provider_base(self, provider: str) -> str | None:
+        """Pick the API base URL from the providers section."""
         try:
             if provider == "openai":
-                return self.config.providers.openai.api_base or ""
-            return self.config.providers.groq.api_base or ""
+                return self.config.providers.openai.api_base or None
+            return self.config.providers.groq.api_base or None
         except AttributeError:
-            return ""
+            return None
+
+    def _warn_transcription_unconfigured(self, tc: TranscriptionConfig) -> None:
+        """Log a startup warning if voice-capable channels are enabled but transcription won't work."""
+        if not tc.enabled:
+            return
+        # Check if any voice-capable channel is enabled
+        voice_channels = {"telegram", "whatsapp", "discord"}
+        has_voice = any(name in voice_channels for name in self.channels)
+        if not has_voice:
+            return
+
+        from nanobot.providers.transcription import WhisperTranscriptionProvider
+        p = WhisperTranscriptionProvider(
+            tc.provider,
+            api_key=tc.api_key,
+            api_base=tc.api_base,
+            model=tc.model,
+        )
+        if not p.is_available:
+            logger.warning(
+                "Voice-capable channels enabled but transcription is not configured: {}",
+                p.unavailable_reason,
+            )
 
     def _validate_allow_from(self) -> None:
         for name, ch in self.channels.items():

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -898,11 +898,13 @@ class TelegramChannel(BaseChannel):
             await file.download_to_drive(str(file_path))
             path_str = str(file_path)
             if media_type in ("voice", "audio"):
-                transcription = await self.transcribe_audio(file_path)
-                if transcription:
-                    logger.info("Transcribed {}: {}...", media_type, transcription[:50])
-                    return [path_str], [f"[transcription: {transcription}]"]
-                return [path_str], [f"[{media_type}: {path_str}]"]
+                if self.transcription_available:
+                    transcription = await self.transcribe_audio(file_path)
+                    if transcription:
+                        logger.info("Transcribed {}: {}...", media_type, transcription[:50])
+                        return [path_str], [f"[transcription: {transcription}]"]
+                    return [path_str], [f"[{media_type}: transcription failed — {path_str}]"]
+                return [path_str], [f"[{media_type}: {path_str} — ⚠️ voice transcription not configured]"]
             return [path_str], [f"[{media_type}: {path_str}]"]
         except Exception as e:
             logger.warning("Failed to download message media: {}", e)

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -258,13 +258,16 @@ class WhatsAppChannel(BaseChannel):
             # Handle voice transcription if it's a voice message
             if content == "[Voice Message]":
                 if media_paths:
-                    logger.info("Transcribing voice message from {}...", sender_id)
-                    transcription = await self.transcribe_audio(media_paths[0])
-                    if transcription:
-                        content = transcription
-                        logger.info("Transcribed voice from {}: {}...", sender_id, transcription[:50])
+                    if self.transcription_available:
+                        logger.info("Transcribing voice message from {}...", sender_id)
+                        transcription = await self.transcribe_audio(media_paths[0])
+                        if transcription:
+                            content = transcription
+                            logger.info("Transcribed voice from {}: {}...", sender_id, transcription[:50])
+                        else:
+                            content = "[Voice Message: Transcription failed]"
                     else:
-                        content = "[Voice Message: Transcription failed]"
+                        content = "[Voice Message: ⚠️ voice transcription not configured]"
                 else:
                     content = "[Voice Message: Audio not available]"
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -15,6 +15,30 @@ class Base(BaseModel):
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
+class TranscriptionConfig(Base):
+    """Voice-to-text transcription configuration.
+
+    Supports cloud providers (Groq, OpenAI) and local Whisper-compatible
+    servers (whisper.cpp, faster-whisper, LocalAI, Ollama).
+
+    Local setup example (config.json)::
+
+        "transcription": {
+            "provider": "local",
+            "api_base": "http://localhost:8080/v1/audio/transcriptions",
+            "model": "large-v3"
+        }
+    """
+
+    enabled: bool = True
+    provider: str = "groq"  # groq, openai, local
+    model: str | None = None  # None = provider default (whisper-large-v3 for groq, whisper-1 for openai)
+    api_key: str | None = None  # None = falls back to provider section key; not required for local
+    api_base: str | None = None  # Required for local; override URL for cloud providers
+    language: str | None = Field(default=None, pattern=r"^[a-z]{2,3}$")  # ISO-639-1 hint
+    max_duration_seconds: int = Field(default=300, ge=10)  # Reject very long audio
+
+
 class ChannelsConfig(Base):
     """Configuration for chat channels.
 
@@ -28,7 +52,9 @@ class ChannelsConfig(Base):
     send_progress: bool = True  # stream agent's text progress to the channel
     send_tool_hints: bool = False  # stream tool-call hints (e.g. read_file("…"))
     send_max_retries: int = Field(default=3, ge=0, le=10)  # Max delivery attempts (initial send included)
-    transcription_provider: str = "groq"  # Voice transcription backend: "groq" or "openai"
+    transcription: TranscriptionConfig = Field(default_factory=TranscriptionConfig)
+    # Legacy flat fields — kept for backward compat, mapped to TranscriptionConfig in manager
+    transcription_provider: str = "groq"  # Voice transcription backend: "groq", "openai", or "local"
     transcription_language: str | None = Field(default=None, pattern=r"^[a-z]{2,3}$")  # Optional ISO-639-1 hint for audio transcription
 
 

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -1,4 +1,30 @@
-"""Voice transcription providers (Groq and OpenAI Whisper)."""
+"""Voice transcription providers (cloud and local Whisper-compatible).
+
+Supports three provider modes:
+
+- **groq**: Groq's hosted Whisper API (fast, generous free tier).
+- **openai**: OpenAI's Whisper API.
+- **local**: Any OpenAI-compatible Whisper endpoint running locally — e.g.
+  `whisper.cpp <https://github.com/ggerganov/whisper.cpp>`_ server,
+  `faster-whisper-server <https://github.com/fedirz/faster-whisper-server>`_,
+  `LocalAI <https://localai.io>`_, or Ollama with a Whisper model.
+
+Local setup examples::
+
+    # whisper.cpp server (default port 8080)
+    ./server -m ggml-large-v3.bin --port 8080
+    # → provider: local, api_base: http://localhost:8080/v1/audio/transcriptions
+
+    # faster-whisper-server
+    faster-whisper-server --model large-v3
+    # → provider: local, api_base: http://localhost:8000/v1/audio/transcriptions
+
+    # LocalAI
+    local-ai run whisper-1
+    # → provider: local, api_base: http://localhost:8080/v1/audio/transcriptions
+"""
+
+from __future__ import annotations
 
 import os
 from pathlib import Path
@@ -6,78 +32,105 @@ from pathlib import Path
 import httpx
 from loguru import logger
 
+# ---------------------------------------------------------------------------
+# Provider defaults
+# ---------------------------------------------------------------------------
 
-class OpenAITranscriptionProvider:
-    """Voice transcription provider using OpenAI's Whisper API."""
+_PROVIDER_DEFAULTS: dict[str, dict[str, str]] = {
+    "groq": {
+        "api_base": "https://api.groq.com/openai/v1/audio/transcriptions",
+        "model": "whisper-large-v3",
+        "env_key": "GROQ_API_KEY",
+        "env_base": "GROQ_BASE_URL",
+    },
+    "openai": {
+        "api_base": "https://api.openai.com/v1/audio/transcriptions",
+        "model": "whisper-1",
+        "env_key": "OPENAI_API_KEY",
+        "env_base": "OPENAI_TRANSCRIPTION_BASE_URL",
+    },
+    "local": {
+        "api_base": "",  # required — user must supply
+        "model": "whisper-large-v3",
+        "env_key": "",
+        "env_base": "",
+    },
+}
+
+
+class WhisperTranscriptionProvider:
+    """Unified Whisper-compatible transcription provider.
+
+    Works with any OpenAI-compatible ``/v1/audio/transcriptions`` endpoint,
+    including Groq, OpenAI, whisper.cpp, faster-whisper-server, and LocalAI.
+
+    Args:
+        provider: Provider name — ``"groq"``, ``"openai"``, or ``"local"``.
+        api_key: API key. Falls back to the provider's env var. Not required
+            for ``local``.
+        api_base: Endpoint URL. Falls back to provider default / env var.
+            **Required** for ``local``.
+        model: Whisper model name. Falls back to provider default.
+        language: Optional ISO-639-1 language hint (e.g. ``"en"``, ``"ar"``).
+        max_duration_seconds: Reject files longer than this (by file size
+            heuristic). Set 0 to disable.
+    """
 
     def __init__(
         self,
+        provider: str = "groq",
+        *,
         api_key: str | None = None,
         api_base: str | None = None,
+        model: str | None = None,
         language: str | None = None,
+        max_duration_seconds: int = 300,
     ):
-        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        defaults = _PROVIDER_DEFAULTS.get(provider, _PROVIDER_DEFAULTS["groq"])
+
+        self.provider = provider
+        self.api_key = (
+            api_key
+            or (os.environ.get(defaults["env_key"]) if defaults["env_key"] else None)
+            or None
+        )
         self.api_url = (
             api_base
-            or os.environ.get("OPENAI_TRANSCRIPTION_BASE_URL")
-            or "https://api.openai.com/v1/audio/transcriptions"
+            or (os.environ.get(defaults["env_base"]) if defaults["env_base"] else None)
+            or defaults["api_base"]
         )
+        self.model = model or defaults["model"]
         self.language = language or None
+        self.max_duration_seconds = max_duration_seconds
+
+    @property
+    def is_available(self) -> bool:
+        """Check if this provider is ready to transcribe."""
+        if self.provider == "local":
+            return bool(self.api_url)
+        return bool(self.api_key) and bool(self.api_url)
+
+    @property
+    def unavailable_reason(self) -> str:
+        """Human-readable explanation of why transcription is unavailable."""
+        if self.provider == "local":
+            if not self.api_url:
+                return "Local transcription requires api_base (e.g. http://localhost:8080/v1/audio/transcriptions)"
+        else:
+            if not self.api_key:
+                return f"No API key configured for {self.provider} transcription"
+            if not self.api_url:
+                return f"No API base URL configured for {self.provider} transcription"
+        return ""
 
     async def transcribe(self, file_path: str | Path) -> str:
-        if not self.api_key:
-            logger.warning("OpenAI API key not configured for transcription")
-            return ""
-        path = Path(file_path)
-        if not path.exists():
-            logger.error("Audio file not found: {}", file_path)
-            return ""
-        try:
-            async with httpx.AsyncClient() as client:
-                with open(path, "rb") as f:
-                    files = {"file": (path.name, f), "model": (None, "whisper-1")}
-                    if self.language:
-                        files["language"] = (None, self.language)
-                    headers = {"Authorization": f"Bearer {self.api_key}"}
-                    response = await client.post(
-                        self.api_url, headers=headers, files=files, timeout=60.0,
-                    )
-                    response.raise_for_status()
-                    return response.json().get("text", "")
-        except Exception as e:
-            logger.error("OpenAI transcription error: {}", e)
-            return ""
+        """Transcribe an audio file.
 
-
-class GroqTranscriptionProvider:
-    """
-    Voice transcription provider using Groq's Whisper API.
-
-    Groq offers extremely fast transcription with a generous free tier.
-    """
-
-    def __init__(
-        self,
-        api_key: str | None = None,
-        api_base: str | None = None,
-        language: str | None = None,
-    ):
-        self.api_key = api_key or os.environ.get("GROQ_API_KEY")
-        self.api_url = api_base or os.environ.get("GROQ_BASE_URL") or "https://api.groq.com/openai/v1/audio/transcriptions"
-        self.language = language or None
-
-    async def transcribe(self, file_path: str | Path) -> str:
+        Returns the transcribed text, or an empty string on failure.
         """
-        Transcribe an audio file using Groq.
-
-        Args:
-            file_path: Path to the audio file.
-
-        Returns:
-            Transcribed text.
-        """
-        if not self.api_key:
-            logger.warning("Groq API key not configured for transcription")
+        if not self.is_available:
+            reason = self.unavailable_reason
+            logger.warning("Transcription unavailable: {}", reason)
             return ""
 
         path = Path(file_path)
@@ -85,30 +138,86 @@ class GroqTranscriptionProvider:
             logger.error("Audio file not found: {}", file_path)
             return ""
 
+        # Rough duration guard — assume worst case ~16 kB/s for voice audio
+        if self.max_duration_seconds > 0:
+            file_size = path.stat().st_size
+            estimated_seconds = file_size / 16_000
+            if estimated_seconds > self.max_duration_seconds:
+                logger.warning(
+                    "Audio file too long (~{:.0f}s estimated, max {}s): {}",
+                    estimated_seconds,
+                    self.max_duration_seconds,
+                    file_path,
+                )
+                return ""
+
         try:
             async with httpx.AsyncClient() as client:
                 with open(path, "rb") as f:
-                    files = {
+                    files: dict = {
                         "file": (path.name, f),
-                        "model": (None, "whisper-large-v3"),
+                        "model": (None, self.model),
                     }
                     if self.language:
                         files["language"] = (None, self.language)
-                    headers = {
-                        "Authorization": f"Bearer {self.api_key}",
-                    }
+
+                    headers: dict[str, str] = {}
+                    if self.api_key:
+                        headers["Authorization"] = f"Bearer {self.api_key}"
 
                     response = await client.post(
                         self.api_url,
                         headers=headers,
                         files=files,
-                        timeout=60.0
+                        timeout=60.0,
                     )
-
                     response.raise_for_status()
-                    data = response.json()
-                    return data.get("text", "")
-
+                    return response.json().get("text", "")
         except Exception as e:
-            logger.error("Groq transcription error: {}", e)
+            logger.error("{} transcription error: {}", self.provider, e)
             return ""
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible aliases (deprecated)
+# ---------------------------------------------------------------------------
+
+
+class GroqTranscriptionProvider(WhisperTranscriptionProvider):
+    """Deprecated: use :class:`WhisperTranscriptionProvider` with ``provider="groq"``.
+
+    Kept for backward compatibility with existing imports.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        language: str | None = None,
+    ):
+        super().__init__(
+            "groq",
+            api_key=api_key,
+            api_base=api_base,
+            language=language,
+        )
+
+
+class OpenAITranscriptionProvider(WhisperTranscriptionProvider):
+    """Deprecated: use :class:`WhisperTranscriptionProvider` with ``provider="openai"``.
+
+    Kept for backward compatibility with existing imports.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        language: str | None = None,
+    ):
+        super().__init__(
+            "openai",
+            api_key=api_key,
+            api_base=api_base,
+            language=language,
+        )

--- a/tests/channels/test_voice_transcription.py
+++ b/tests/channels/test_voice_transcription.py
@@ -1,0 +1,201 @@
+"""Tests for voice transcription flow in channels."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import TranscriptionConfig
+
+# ---------------------------------------------------------------------------
+# Concrete test channel
+# ---------------------------------------------------------------------------
+
+
+class _TestChannel(BaseChannel):
+    name = "test"
+    display_name = "Test"
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def send(self, msg: Any) -> None:
+        pass
+
+
+def _make_channel(
+    *,
+    transcription_config: TranscriptionConfig | None = None,
+    provider: str = "groq",
+    api_key: str = "",
+    api_base: str = "",
+    language: str | None = None,
+) -> _TestChannel:
+    bus = MagicMock()
+    ch = _TestChannel({"enabled": True, "allowFrom": ["*"]}, bus)
+    if transcription_config is not None:
+        ch._transcription_config = transcription_config
+    else:
+        ch.transcription_provider = provider
+        ch.transcription_api_key = api_key
+        ch.transcription_api_base = api_base
+        ch.transcription_language = language
+    return ch
+
+
+# ---------------------------------------------------------------------------
+# transcription_available property
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptionAvailable:
+    def test_available_with_config_and_key(self):
+        ch = _make_channel(
+            transcription_config=TranscriptionConfig(
+                provider="groq", api_key="k"
+            )
+        )
+        assert ch.transcription_available is True
+
+    def test_unavailable_when_disabled(self):
+        ch = _make_channel(
+            transcription_config=TranscriptionConfig(
+                enabled=False, provider="groq", api_key="k"
+            )
+        )
+        assert ch.transcription_available is False
+
+    def test_unavailable_without_key(self):
+        ch = _make_channel(
+            transcription_config=TranscriptionConfig(provider="groq")
+        )
+        assert ch.transcription_available is False
+
+    def test_local_available_with_base(self):
+        ch = _make_channel(
+            transcription_config=TranscriptionConfig(
+                provider="local",
+                api_base="http://localhost:8080/v1/audio/transcriptions",
+            )
+        )
+        assert ch.transcription_available is True
+
+    def test_local_unavailable_without_base(self):
+        ch = _make_channel(
+            transcription_config=TranscriptionConfig(provider="local")
+        )
+        assert ch.transcription_available is False
+
+    def test_legacy_flat_available(self):
+        ch = _make_channel(provider="groq", api_key="k")
+        assert ch.transcription_available is True
+
+    def test_legacy_flat_unavailable(self):
+        ch = _make_channel(provider="groq", api_key="")
+        assert ch.transcription_available is False
+
+
+# ---------------------------------------------------------------------------
+# transcribe_audio method
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeAudio:
+    @pytest.mark.asyncio
+    async def test_transcribe_with_config(self, tmp_path: Path):
+        ch = _make_channel(
+            transcription_config=TranscriptionConfig(
+                provider="groq", api_key="k"
+            )
+        )
+        audio = tmp_path / "voice.ogg"
+        audio.write_bytes(b"\x00" * 100)
+
+        with patch(
+            "nanobot.providers.transcription.WhisperTranscriptionProvider.transcribe",
+            new_callable=AsyncMock,
+            return_value="hello",
+        ):
+            result = await ch.transcribe_audio(audio)
+
+        assert result == "hello"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_disabled_returns_empty(self, tmp_path: Path):
+        ch = _make_channel(
+            transcription_config=TranscriptionConfig(
+                enabled=False, provider="groq", api_key="k"
+            )
+        )
+        audio = tmp_path / "voice.ogg"
+        audio.write_bytes(b"\x00" * 100)
+        result = await ch.transcribe_audio(audio)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_transcribe_unavailable_returns_empty(self, tmp_path: Path):
+        ch = _make_channel(
+            transcription_config=TranscriptionConfig(provider="groq")
+        )
+        audio = tmp_path / "voice.ogg"
+        audio.write_bytes(b"\x00" * 100)
+        result = await ch.transcribe_audio(audio)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_graceful_failure_message(self, tmp_path: Path):
+        """When transcription fails, the channel should return empty string (not crash)."""
+        ch = _make_channel(
+            transcription_config=TranscriptionConfig(
+                provider="groq", api_key="k"
+            )
+        )
+        audio = tmp_path / "voice.ogg"
+        audio.write_bytes(b"\x00" * 100)
+
+        with patch(
+            "nanobot.providers.transcription.WhisperTranscriptionProvider.transcribe",
+            new_callable=AsyncMock,
+            side_effect=Exception("network error"),
+        ):
+            result = await ch.transcribe_audio(audio)
+
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptionConfig:
+    def test_valid_language(self):
+        cfg = TranscriptionConfig(language="en")
+        assert cfg.language == "en"
+
+    def test_valid_three_letter_language(self):
+        cfg = TranscriptionConfig(language="ara")
+        assert cfg.language == "ara"
+
+    def test_invalid_language_rejected(self):
+        with pytest.raises(Exception):
+            TranscriptionConfig(language="english")
+
+    def test_max_duration_minimum(self):
+        with pytest.raises(Exception):
+            TranscriptionConfig(max_duration_seconds=5)
+
+    def test_defaults(self):
+        cfg = TranscriptionConfig()
+        assert cfg.enabled is True
+        assert cfg.provider == "groq"
+        assert cfg.model is None
+        assert cfg.api_key is None
+        assert cfg.max_duration_seconds == 300

--- a/tests/providers/test_transcription.py
+++ b/tests/providers/test_transcription.py
@@ -1,0 +1,229 @@
+"""Tests for the unified WhisperTranscriptionProvider."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from nanobot.providers.transcription import (
+    GroqTranscriptionProvider,
+    OpenAITranscriptionProvider,
+    WhisperTranscriptionProvider,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(text: str = "hello world", status: int = 200) -> httpx.Response:
+    """Build a fake httpx.Response with a JSON body."""
+    return httpx.Response(
+        status_code=status,
+        json={"text": text},
+        request=httpx.Request("POST", "https://fake"),
+    )
+
+
+def _audio_file(tmp_path: Path, size: int = 1024) -> Path:
+    """Create a small dummy audio file."""
+    p = tmp_path / "voice.ogg"
+    p.write_bytes(b"\x00" * size)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Provider defaults
+# ---------------------------------------------------------------------------
+
+
+class TestProviderDefaults:
+    def test_groq_defaults(self):
+        p = WhisperTranscriptionProvider("groq", api_key="k")
+        assert "groq.com" in p.api_url
+        assert p.model == "whisper-large-v3"
+
+    def test_openai_defaults(self):
+        p = WhisperTranscriptionProvider("openai", api_key="k")
+        assert "openai.com" in p.api_url
+        assert p.model == "whisper-1"
+
+    def test_local_defaults(self):
+        p = WhisperTranscriptionProvider("local", api_base="http://localhost:8080/v1/audio/transcriptions")
+        assert p.api_url == "http://localhost:8080/v1/audio/transcriptions"
+        assert p.model == "whisper-large-v3"
+        assert p.api_key is None
+
+    def test_custom_model(self):
+        p = WhisperTranscriptionProvider("local", api_base="http://x", model="base.en")
+        assert p.model == "base.en"
+
+    def test_unknown_provider_falls_back_to_groq_defaults(self):
+        p = WhisperTranscriptionProvider("unknown", api_key="k")
+        assert "groq.com" in p.api_url
+
+
+# ---------------------------------------------------------------------------
+# Availability checks
+# ---------------------------------------------------------------------------
+
+
+class TestAvailability:
+    def test_groq_available_with_key(self):
+        p = WhisperTranscriptionProvider("groq", api_key="k")
+        assert p.is_available is True
+        assert p.unavailable_reason == ""
+
+    def test_groq_unavailable_without_key(self):
+        p = WhisperTranscriptionProvider("groq")
+        assert p.is_available is False
+        assert "API key" in p.unavailable_reason
+
+    def test_local_available_with_base(self):
+        p = WhisperTranscriptionProvider("local", api_base="http://localhost:8080/v1/audio/transcriptions")
+        assert p.is_available is True
+
+    def test_local_unavailable_without_base(self):
+        p = WhisperTranscriptionProvider("local")
+        assert p.is_available is False
+        assert "api_base" in p.unavailable_reason
+
+
+# ---------------------------------------------------------------------------
+# Transcription
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribe:
+    @pytest.mark.asyncio
+    async def test_successful_transcription(self, tmp_path: Path):
+        p = WhisperTranscriptionProvider("groq", api_key="test-key")
+        audio = _audio_file(tmp_path)
+
+        mock_resp = _mock_response("transcribed text")
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("nanobot.providers.transcription.httpx.AsyncClient", return_value=mock_client):
+            result = await p.transcribe(audio)
+
+        assert result == "transcribed text"
+        call_kwargs = mock_client.post.call_args
+        assert "groq.com" in call_kwargs.args[0]
+        assert "Bearer test-key" in call_kwargs.kwargs["headers"]["Authorization"]
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_returns_empty(self, tmp_path: Path):
+        p = WhisperTranscriptionProvider("groq")
+        audio = _audio_file(tmp_path)
+        result = await p.transcribe(audio)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_empty(self):
+        p = WhisperTranscriptionProvider("groq", api_key="k")
+        result = await p.transcribe("/nonexistent/file.ogg")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_language_hint_passed(self, tmp_path: Path):
+        p = WhisperTranscriptionProvider("groq", api_key="k", language="ar")
+        audio = _audio_file(tmp_path)
+
+        mock_resp = _mock_response("مرحبا")
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("nanobot.providers.transcription.httpx.AsyncClient", return_value=mock_client):
+            result = await p.transcribe(audio)
+
+        assert result == "مرحبا"
+        call_kwargs = mock_client.post.call_args
+        files = call_kwargs.kwargs["files"]
+        assert "language" in files
+
+    @pytest.mark.asyncio
+    async def test_local_provider_no_auth_header(self, tmp_path: Path):
+        p = WhisperTranscriptionProvider("local", api_base="http://localhost:8080/v1/audio/transcriptions")
+        audio = _audio_file(tmp_path)
+
+        mock_resp = _mock_response("local result")
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("nanobot.providers.transcription.httpx.AsyncClient", return_value=mock_client):
+            result = await p.transcribe(audio)
+
+        assert result == "local result"
+        call_kwargs = mock_client.post.call_args
+        headers = call_kwargs.kwargs["headers"]
+        assert "Authorization" not in headers
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_empty(self, tmp_path: Path):
+        p = WhisperTranscriptionProvider("groq", api_key="k")
+        audio = _audio_file(tmp_path)
+
+        mock_resp = httpx.Response(
+            status_code=500,
+            request=httpx.Request("POST", "https://fake"),
+        )
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("nanobot.providers.transcription.httpx.AsyncClient", return_value=mock_client):
+            result = await p.transcribe(audio)
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_max_duration_rejects_large_file(self, tmp_path: Path):
+        p = WhisperTranscriptionProvider("groq", api_key="k", max_duration_seconds=10)
+        # 16_000 bytes/s * 10s = 160KB threshold; create 500KB file
+        audio = _audio_file(tmp_path, size=500_000)
+        result = await p.transcribe(audio)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat aliases
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    def test_groq_alias_is_whisper_provider(self):
+        p = GroqTranscriptionProvider(api_key="k")
+        assert isinstance(p, WhisperTranscriptionProvider)
+        assert p.provider == "groq"
+
+    def test_openai_alias_is_whisper_provider(self):
+        p = OpenAITranscriptionProvider(api_key="k")
+        assert isinstance(p, WhisperTranscriptionProvider)
+        assert p.provider == "openai"
+
+    @pytest.mark.asyncio
+    async def test_groq_alias_transcribes(self, tmp_path: Path):
+        p = GroqTranscriptionProvider(api_key="k")
+        audio = _audio_file(tmp_path)
+
+        mock_resp = _mock_response("alias works")
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch("nanobot.providers.transcription.httpx.AsyncClient", return_value=mock_client):
+            result = await p.transcribe(audio)
+
+        assert result == "alias works"


### PR DESCRIPTION
## Summary

Voice transcription exists today but has gaps that make it unreliable in practice: silent failures when unconfigured, two near-identical provider classes, and no path for local Whisper servers. This PR makes transcription a first-class, provider-agnostic capability with strong local model support.

## Problem

1. **Silent failure** — when API key is missing, voice messages produce raw `[voice: /path/to/file.ogg]` with no user feedback
2. **Two identical providers** — `GroqTranscriptionProvider` and `OpenAITranscriptionProvider` are the same code with different default URLs
3. **No local Whisper support** — users running whisper.cpp, faster-whisper, or LocalAI have no configuration path
4. **No config validation** — misconfiguration is only discovered when a voice message arrives
5. **Loose config** — transcription settings are bare attributes on `BaseChannel` instead of a typed schema

## Changes

### 1. Unified `WhisperTranscriptionProvider` (`nanobot/providers/transcription.py`)
- Merges Groq + OpenAI providers into one class — they both hit the same OpenAI-compatible `/v1/audio/transcriptions` endpoint
- Adds `local` provider: configurable `api_base` pointing at any Whisper-compatible server (whisper.cpp, faster-whisper-server, LocalAI, Ollama) — no API key required
- `is_available` / `unavailable_reason` properties for pre-flight checks
- Duration guard (`max_duration_seconds`) to reject overly long audio
- Backward-compat aliases: `GroqTranscriptionProvider` and `OpenAITranscriptionProvider` still importable

### 2. `TranscriptionConfig` schema (`nanobot/config/schema.py`)
```python
class TranscriptionConfig(Base):
    enabled: bool = True
    provider: str = "groq"        # groq | openai | local
    model: str | None = None       # provider default if None
    api_key: str | None = None     # falls back to providers.groq/openai key
    api_base: str | None = None    # required for local
    language: str | None = None    # ISO-639-1 hint (e.g. "ar", "en")
    max_duration_seconds: int = 300
```
Added to `ChannelsConfig`. Existing flat `transcriptionProvider` / `transcriptionLanguage` fields still work (merged at startup).

### 3. Graceful failure with user feedback (`telegram.py`, `whatsapp.py`)
- Voice messages now reply with `⚠️ Voice transcription is not configured` instead of silently passing raw audio
- Startup log warning when voice-capable channels are enabled but transcription lacks credentials

### 4. Config wiring (`manager.py`, `base.py`)
- `_build_transcription_config()` merges typed block + legacy flat fields + provider-section API keys
- `transcription_available` property on `BaseChannel` for pre-flight checks

## Local Whisper setup (the key addition)

Users running a local Whisper server just need:
```json
{
  "channels": {
    "transcription": {
      "provider": "local",
      "apiBase": "http://localhost:8080/v1/audio/transcriptions",
      "model": "large-v3"
    }
  }
}
```
No API key, no cloud dependency, fully private. Works with whisper.cpp `--server`, faster-whisper-server, LocalAI, or any OpenAI-compatible STT endpoint.

## Tests

- `tests/providers/test_transcription.py` — 19 tests: provider defaults, availability checks, HTTP mocking, language hints, local no-auth, error handling, duration guard, backward-compat aliases
- `tests/channels/test_voice_transcription.py` — 16 tests: availability property, transcription flow, disabled/unavailable config, graceful failure messages, config validation

**35 new tests, all passing. Full existing test suite (133 tests) passes with zero regressions.**

## Backward compatibility

- Existing `transcriptionProvider: "groq"` / `transcriptionLanguage: "en"` flat config continues to work
- `GroqTranscriptionProvider` and `OpenAITranscriptionProvider` still importable from `nanobot.providers.transcription`
- No changes to unrelated code paths

## Validation

```
uv run ruff check nanobot/providers/transcription.py nanobot/config/schema.py nanobot/channels/base.py nanobot/channels/manager.py nanobot/channels/telegram.py nanobot/channels/whatsapp.py tests/providers/test_transcription.py tests/channels/test_voice_transcription.py
uv run pytest tests/providers/test_transcription.py tests/channels/test_voice_transcription.py -q
uv run pytest tests/ -q
```