### PR TITLE
Fix reasoning_effort="none" handling and add gemma to Gemini routing

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -434,7 +434,7 @@ class AnthropicProvider(LLMProvider):
             )
 
         max_tokens = max(1, max_tokens)
-        thinking_enabled = bool(reasoning_effort)
+        thinking_enabled = bool(reasoning_effort) and reasoning_effort.lower() != "none"
 
         # claude-opus-4-7 deprecated the `temperature` parameter entirely — the
         # API returns 400 if it is present, on any code path.

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -71,7 +71,7 @@ class AzureOpenAIProvider(LLMProvider):
         reasoning_effort: str | None = None,
     ) -> bool:
         """Return True when temperature is likely supported for this deployment."""
-        if reasoning_effort:
+        if reasoning_effort and reasoning_effort.lower() != "none":
             return False
         name = deployment_name.lower()
         return not any(token in name for token in ("gpt-5", "o1", "o3", "o4"))
@@ -102,7 +102,7 @@ class AzureOpenAIProvider(LLMProvider):
         if self._supports_temperature(deployment, reasoning_effort):
             body["temperature"] = temperature
 
-        if reasoning_effort:
+        if reasoning_effort and reasoning_effort.lower() != "none":
             body["reasoning"] = {"effort": reasoning_effort}
             body["include"] = ["reasoning.encrypted_content"]
 

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -60,7 +60,7 @@ class OpenAICodexProvider(LLMProvider):
             "tool_choice": tool_choice or "auto",
             "parallel_tool_calls": True,
         }
-        if reasoning_effort:
+        if reasoning_effort and reasoning_effort.lower() != "none":
             body["reasoning"] = {"effort": reasoning_effort}
         if tools:
             body["tools"] = convert_tools(tools)

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -570,7 +570,7 @@ class OpenAICompatProvider(LLMProvider):
             # DashScope accepts none/minimum/low/medium/high/xhigh; "minimal" 400s.
             wire_effort = "minimum"
 
-        if wire_effort:
+        if wire_effort and semantic_effort != "none":
             kwargs["reasoning_effort"] = wire_effort
 
         # Provider-specific thinking parameters.
@@ -579,7 +579,7 @@ class OpenAICompatProvider(LLMProvider):
         # The mapping is driven by ProviderSpec.thinking_style so that adding
         # a new provider never requires touching this function.
         if spec and spec.thinking_style and reasoning_effort is not None:
-            thinking_enabled = semantic_effort != "minimal"
+            thinking_enabled = semantic_effort not in ("none", "minimal")
             extra = _THINKING_STYLE_MAP.get(spec.thinking_style, lambda _: None)(thinking_enabled)
             if extra:
                 kwargs.setdefault("extra_body", {}).update(extra)
@@ -589,7 +589,7 @@ class OpenAICompatProvider(LLMProvider):
         # so that OpenRouter-style names like "moonshotai/kimi-k2.5" are handled
         # identically to bare names like "kimi-k2.5".
         if reasoning_effort is not None and _is_kimi_thinking_model(model_name):
-            thinking_enabled = semantic_effort != "minimal"
+            thinking_enabled = semantic_effort not in ("none", "minimal")
             kwargs.setdefault("extra_body", {}).update(
                 {"thinking": {"type": "enabled" if thinking_enabled else "disabled"}}
             )
@@ -609,9 +609,9 @@ class OpenAICompatProvider(LLMProvider):
         # thinking happened on that turn").
         thinking_active = (
             (spec and spec.thinking_style and reasoning_effort is not None
-             and semantic_effort != "minimal")
+             and semantic_effort not in ("none", "minimal"))
             or (reasoning_effort is not None and _is_kimi_thinking_model(model_name)
-                and semantic_effort != "minimal")
+                and semantic_effort not in ("none", "minimal"))
         )
         if thinking_active:
             for msg in kwargs["messages"]:

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -267,7 +267,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
     # Gemini: Google's OpenAI-compatible endpoint
     ProviderSpec(
         name="gemini",
-        keywords=("gemini",),
+        keywords=("gemini", "gemma"),
         env_key="GEMINI_API_KEY",
         display_name="Gemini",
         backend="openai_compat",

--- a/tests/providers/test_anthropic_thinking.py
+++ b/tests/providers/test_anthropic_thinking.py
@@ -83,3 +83,10 @@ def test_opus_4_7_omits_temperature_none() -> None:
     kw = _build(_make_provider("claude-opus-4-7"), None)
     assert "temperature" not in kw
     assert "thinking" not in kw
+
+
+def test_reasoning_effort_string_none_does_not_enable_thinking() -> None:
+    """reasoning_effort='none' must not enable thinking — treated same as disabled."""
+    kw = _build(_make_provider(), "none")
+    assert "thinking" not in kw
+    assert kw["temperature"] == 0.7

--- a/tests/providers/test_azure_openai_provider.py
+++ b/tests/providers/test_azure_openai_provider.py
@@ -78,6 +78,11 @@ def test_supports_temperature_with_reasoning_effort():
     assert AzureOpenAIProvider._supports_temperature("gpt-4o", reasoning_effort="medium") is False
 
 
+def test_supports_temperature_with_reasoning_effort_none_string():
+    """reasoning_effort='none' must NOT suppress temperature — it means thinking is off."""
+    assert AzureOpenAIProvider._supports_temperature("gpt-4o", reasoning_effort="none") is True
+
+
 # ---------------------------------------------------------------------------
 # _build_body — Responses API body construction
 # ---------------------------------------------------------------------------
@@ -129,6 +134,16 @@ def test_build_body_with_reasoning():
     assert "reasoning.encrypted_content" in body.get("include", [])
     # temperature omitted for reasoning models
     assert "temperature" not in body
+
+
+def test_build_body_reasoning_effort_none_string_omits_reasoning():
+    """reasoning_effort='none' must not inject a reasoning body and must allow temperature."""
+    provider = AzureOpenAIProvider(api_key="k", api_base="https://r.com", default_model="gpt-4o")
+    body = provider._build_body(
+        [{"role": "user", "content": "hi"}], None, "gpt-4o", 4096, 0.7, "none", None,
+    )
+    assert "reasoning" not in body
+    assert body["temperature"] == 0.7
 
 
 def test_build_body_image_conversion():

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -121,6 +121,14 @@ def test_openrouter_spec_is_gateway() -> None:
     assert spec.default_api_base == "https://openrouter.ai/api/v1"
 
 
+def test_gemma_routes_to_gemini_provider() -> None:
+    """gemma models (e.g. gemma-3-27b-it) must auto-route to Gemini when GEMINI_API_KEY is set.
+    Users running gemma via the Gemini API endpoint expect automatic provider detection."""
+    spec = find_by_name("gemini")
+    assert spec is not None
+    assert "gemma" in spec.keywords
+
+
 def test_openrouter_sets_default_attribution_headers() -> None:
     spec = find_by_name("openrouter")
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as MockClient:
@@ -1050,3 +1058,46 @@ def test_kimi_k2_thinking_series_no_thinking_injection() -> None:
     """kimi-k2-thinking series models must NOT receive extra_body.thinking."""
     kw = _build_kwargs_for("moonshot", "kimi-k2-thinking", reasoning_effort="high")
     assert "extra_body" not in kw
+
+
+# ---------------------------------------------------------------------------
+# reasoning_effort="none" — treated as thinking disabled 
+# ---------------------------------------------------------------------------
+
+def test_deepseek_thinking_disabled_for_none_string() -> None:
+    """reasoning_effort='none' must send thinking.type=disabled and skip reasoning_effort field."""
+    kw = _build_kwargs_for("deepseek", "deepseek-v4-pro", reasoning_effort="none")
+    assert kw.get("extra_body") == {"thinking": {"type": "disabled"}}
+    assert "reasoning_effort" not in kw
+
+
+def test_kimi_k25_thinking_disabled_for_none_string() -> None:
+    """reasoning_effort='none' maps to thinking disabled for kimi-k2.5."""
+    kw = _build_kwargs_for("moonshot", "kimi-k2.5", reasoning_effort="none")
+    assert kw.get("extra_body") == {"thinking": {"type": "disabled"}}
+
+
+def test_dashscope_thinking_disabled_for_none_string() -> None:
+    """reasoning_effort='none' disables thinking and must not emit reasoning_effort on DashScope."""
+    kw = _build_kwargs_for("dashscope", "qwen3.6-plus", reasoning_effort="none")
+    assert kw.get("extra_body") == {"enable_thinking": False}
+    assert "reasoning_effort" not in kw
+
+
+def test_deepseek_no_backfill_when_reasoning_effort_none_string() -> None:
+    """reasoning_effort='none' must NOT trigger reasoning_content backfill (thinking inactive)."""
+    spec = find_by_name("deepseek")
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        p = OpenAICompatProvider(api_key="k", default_model="deepseek-v4-pro", spec=spec)
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "continue"},
+    ]
+    kw = p._build_kwargs(
+        messages=list(messages), tools=None, model="deepseek-v4-pro",
+        max_tokens=1024, temperature=0.7,
+        reasoning_effort="none", tool_choice=None,
+    )
+    assistant = kw["messages"][1]
+    assert "reasoning_content" not in assistant


### PR DESCRIPTION
## Problem

Two issues when using `reasoning_effort: "none"`:

1. **API 400 errors on Gemini/gemma models**: The value `"none"` was sent as `reasoning_effort` to the API, but Gemini/gemma models reject it with "Thinking budget is not supported for this model".

2. **Inconsistent "none" handling across providers**: Some code paths treated `"none"` as enabling thinking mode, while others (4 existing checks at L461, L507, L646, L737) already treated it as disabled.

3. **gemma models not routed to Gemini provider**: In auto mode, models like `gemma-4-31b-it` were not matched to the Gemini provider because the keyword `"gemma"` was missing from the ProviderSpec.

## Solution

Unify `reasoning_effort="none"` to mean "thinking disabled" across all providers, consistent with the 4 existing checks already in the codebase.
Add `"gemma"` to the Gemini provider keywords.

## Changes

| File | Change |
|------|--------|
| `openai_compat_provider.py` | Don't send `reasoning_effort` when `"none"`; treat `"none"` as disabled in thinking_style, Kimi, and backfill paths (4 fixes) |
| `anthropic_provider.py` | Don't enable extended thinking when `"none"` |
| `openai_codex_provider.py` | Don't send reasoning body when `"none"` |
| `azure_openai_provider.py` | Don't suppress temperature or send reasoning body when `"none"` (2 fixes) |
| `registry.py` | Add `"gemma"` to Gemini ProviderSpec keywords |

## Testing

All existing tests pass (70 passed, 23 skipped — skipped tests are pre-existing async tests requiring pytest-asyncio).