### PR TITLE
fix(weixin): refresh context_token via getconfig on missing or stale token

### DIFF
--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -876,6 +876,60 @@ class WeixinChannel(BaseChannel):
     # Outbound  (matches send.ts buildTextMessageReq + sendMessageWeixin)
     # ------------------------------------------------------------------
 
+    async def _refresh_context_token(self, user_id: str, *, retries: int = 2) -> str:
+        """Obtain a fresh context_token via the getconfig API.
+
+        Called when the cached token is missing or stale (e.g. after a gateway
+        restart or before a proactive / cron-triggered message).  Retries up to
+        *retries* times on network / server errors.
+        """
+        body: dict[str, Any] = {
+            "ilink_user_id": user_id,
+            "context_token": None,
+            "base_info": BASE_INFO,
+        }
+        for attempt in range(1, retries + 1):
+            try:
+                data = await self._api_post("ilink/bot/getconfig", body)
+                logger.debug(
+                    "WeChat: getconfig response for chat_id={}: ret={} errcode={} fields={}",
+                    user_id,
+                    data.get("ret"),
+                    data.get("errcode"),
+                    [k for k in data if k not in ("base_info",)],
+                )
+                token = str(data.get("context_token", "") or "")
+                if token:
+                    self._context_tokens[user_id] = token
+                    self._save_state()
+                    logger.info(
+                        "WeChat: refreshed context_token for chat_id={}",
+                        user_id,
+                    )
+                    return token
+                logger.warning(
+                    "WeChat: getconfig returned no context_token for chat_id={}",
+                    user_id,
+                )
+                return ""
+            except Exception as exc:
+                logger.warning(
+                    "WeChat: getconfig attempt {}/{} failed for chat_id={}: {}",
+                    attempt,
+                    retries,
+                    user_id,
+                    exc,
+                )
+                if attempt < retries:
+                    await asyncio.sleep(1 * attempt)
+
+        logger.warning(
+            "WeChat: failed to refresh context_token for chat_id={} after {} attempts",
+            user_id,
+            retries,
+        )
+        return ""
+
     async def _get_typing_ticket(self, user_id: str, context_token: str = "") -> str:
         """Get typing ticket with per-user refresh + failure backoff cache."""
         now = time.time()
@@ -955,11 +1009,13 @@ class WeixinChannel(BaseChannel):
         content = msg.content.strip()
         ctx_token = self._context_tokens.get(msg.chat_id, "")
         if not ctx_token:
-            logger.warning(
-                "WeChat: no context_token for chat_id={}, cannot send",
-                msg.chat_id,
-            )
-            return
+            ctx_token = await self._refresh_context_token(msg.chat_id)
+            if not ctx_token:
+                logger.warning(
+                    "WeChat: no context_token for chat_id={}, cannot send",
+                    msg.chat_id,
+                )
+                return
 
         typing_ticket = ""
         try:

--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -79,6 +79,18 @@ BASE_INFO: dict[str, str] = {"channel_version": WEIXIN_CHANNEL_VERSION}
 ERRCODE_SESSION_EXPIRED = -14
 SESSION_PAUSE_DURATION_S = 60 * 60
 
+# sendmessage errcodes that indicate an expired / invalid context_token.
+_STALE_TOKEN_ERRCODES: frozenset[int] = frozenset({-6})
+
+
+class _ContextTokenExpiredError(Exception):
+    """sendmessage returned an error indicating the context_token is stale."""
+
+
+def _is_stale_context_token_error(data: dict) -> bool:
+    """Return True if a sendmessage response signals an expired context_token."""
+    return data.get("errcode", 0) in _STALE_TOKEN_ERRCODES
+
 # Retry constants (matching the reference plugin's monitor.ts)
 MAX_CONSECUTIVE_FAILURES = 3
 BACKOFF_DELAY_S = 30
@@ -1036,10 +1048,20 @@ class WeixinChannel(BaseChannel):
                 self._typing_keepalive_loop(msg.chat_id, typing_ticket, typing_keepalive_stop)
             )
 
+        _retried = False
+
         try:
             # --- Send media files first (following Telegram channel pattern) ---
             for media_path in (msg.media or []):
                 try:
+                    await self._send_media_file(msg.chat_id, media_path, ctx_token)
+                except _ContextTokenExpiredError:
+                    if _retried:
+                        raise
+                    ctx_token = await self._refresh_context_token(msg.chat_id)
+                    if not ctx_token:
+                        raise
+                    _retried = True
                     await self._send_media_file(msg.chat_id, media_path, ctx_token)
                 except (httpx.TimeoutException, httpx.TransportError) as net_err:
                     # Network/transport errors: do NOT fall back to text —
@@ -1091,7 +1113,21 @@ class WeixinChannel(BaseChannel):
 
             chunks = split_message(content, WEIXIN_MAX_MESSAGE_LEN)
             for chunk in chunks:
-                await self._send_text(msg.chat_id, chunk, ctx_token)
+                try:
+                    await self._send_text(msg.chat_id, chunk, ctx_token)
+                except _ContextTokenExpiredError:
+                    if _retried:
+                        raise
+                    ctx_token = await self._refresh_context_token(msg.chat_id)
+                    if not ctx_token:
+                        raise
+                    _retried = True
+                    await self._send_text(msg.chat_id, chunk, ctx_token)
+        except _ContextTokenExpiredError:
+            logger.warning(
+                "WeChat: context_token expired for chat_id={} after retry",
+                msg.chat_id,
+            )
         except Exception as e:
             logger.error("Error sending WeChat message: {}", e)
             raise
@@ -1199,6 +1235,10 @@ class WeixinChannel(BaseChannel):
         data = await self._api_post("ilink/bot/sendmessage", body)
         errcode = data.get("errcode", 0)
         if errcode and errcode != 0:
+            if _is_stale_context_token_error(data):
+                raise _ContextTokenExpiredError(
+                    f"context_token expired (code {errcode}): {data.get('errmsg', '')}"
+                )
             logger.warning(
                 "WeChat send error (code {}): {}",
                 errcode,
@@ -1351,6 +1391,10 @@ class WeixinChannel(BaseChannel):
         data = await self._api_post("ilink/bot/sendmessage", body)
         errcode = data.get("errcode", 0)
         if errcode and errcode != 0:
+            if _is_stale_context_token_error(data):
+                raise _ContextTokenExpiredError(
+                    f"context_token expired (code {errcode}): {data.get('errmsg', '')}"
+                )
             raise RuntimeError(
                 f"WeChat send media error (code {errcode}): {data.get('errmsg', '')}"
             )

--- a/tests/channels/test_weixin_channel.py
+++ b/tests/channels/test_weixin_channel.py
@@ -1185,3 +1185,41 @@ async def test_send_media_network_error_does_not_double_api_calls() -> None:
     # _send_media_file called once, _send_text never called
     channel._send_media_file.assert_awaited_once()
     channel._send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_without_context_token_still_delivers_message_via_getconfig_refresh() -> None:
+    """When context_token is missing (e.g. gateway restart or cron job),
+    send() should attempt to obtain a fresh context_token via the getconfig
+    API so the message is delivered instead of being silently dropped.
+
+    This is the cron-job regression: a scheduled task fires at 08:00 but the
+    user has not sent any message since yesterday, so the cached token is
+    gone / expired.  The bot must still be able to proactively send.
+    """
+    channel, _bus = _make_channel()
+    channel._client = object()
+    channel._token = "token"
+    channel._send_text = AsyncMock()
+
+    getconfig_calls: list[dict] = []
+
+    async def _mock_api_post(endpoint: str, body: dict | None = None) -> dict:
+        getconfig_calls.append({"endpoint": endpoint, "body": body})
+        if endpoint == "ilink/bot/getconfig":
+            return {
+                "ret": 0,
+                "typing_ticket": "ticket-refreshed",
+                "context_token": "ctx-refreshed",
+            }
+        return {"ret": 0}
+
+    channel._api_post = AsyncMock(side_effect=_mock_api_post)
+
+    msg = _make_outbound_msg(chat_id="wx-user", content="hello from cron")
+
+    await channel.send(msg)
+
+    channel._send_text.assert_awaited_once_with("wx-user", "hello from cron", "ctx-refreshed")
+    assert channel._context_tokens.get("wx-user") == "ctx-refreshed"
+    assert any(c["endpoint"] == "ilink/bot/getconfig" for c in getconfig_calls)

--- a/tests/channels/test_weixin_channel.py
+++ b/tests/channels/test_weixin_channel.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-import pytest
 import httpx
+import pytest
 
 import nanobot.channels.weixin as weixin_mod
 from nanobot.bus.queue import MessageBus
@@ -15,10 +15,10 @@ from nanobot.channels.weixin import (
     ITEM_TEXT,
     MESSAGE_TYPE_BOT,
     WEIXIN_CHANNEL_VERSION,
-    _decrypt_aes_ecb,
-    _encrypt_aes_ecb,
     WeixinChannel,
     WeixinConfig,
+    _decrypt_aes_ecb,
+    _encrypt_aes_ecb,
 )
 
 
@@ -1223,3 +1223,49 @@ async def test_send_without_context_token_still_delivers_message_via_getconfig_r
     channel._send_text.assert_awaited_once_with("wx-user", "hello from cron", "ctx-refreshed")
     assert channel._context_tokens.get("wx-user") == "ctx-refreshed"
     assert any(c["endpoint"] == "ilink/bot/getconfig" for c in getconfig_calls)
+
+
+@pytest.mark.asyncio
+async def test_send_retries_on_stale_context_token() -> None:
+    """When sendmessage rejects a stale context_token, send() should refresh
+    the token via getconfig and retry the sendmessage once.
+
+    Regression test: after a gateway restart or long idle period the cached
+    context_token may be present (persisted in account.json) but stale.
+    The first sendmessage returns a token-expired error; send() must refresh
+    the token and retry instead of silently dropping the message.
+    """
+    channel, _bus = _make_channel()
+    channel._client = object()
+    channel._token = "token"
+    channel._context_tokens["wx-user"] = "old-ctx"
+    channel._send_media_file = AsyncMock()
+
+    sendmessage_calls: list[dict] = []
+
+    async def _mock_api_post(
+        endpoint: str, body: dict | None = None, *, auth: bool = True,
+    ) -> dict:
+        if endpoint == "ilink/bot/sendmessage":
+            sendmessage_calls.append(body)
+            if len(sendmessage_calls) == 1:
+                return {"errcode": -6, "errmsg": "context_token expired"}
+            return {"ret": 0, "errcode": 0}
+        if endpoint == "ilink/bot/getconfig":
+            return {
+                "ret": 0,
+                "context_token": "ctx-refreshed",
+                "typing_ticket": "ticket-new",
+            }
+        return {"ret": 0}
+
+    channel._api_post = AsyncMock(side_effect=_mock_api_post)
+
+    msg = _make_outbound_msg(chat_id="wx-user", content="hello")
+    await channel.send(msg)
+
+    # sendmessage called twice: first with old token (failed), then with refreshed token
+    assert len(sendmessage_calls) == 2
+    assert sendmessage_calls[0]["msg"]["context_token"] == "old-ctx"
+    assert sendmessage_calls[1]["msg"]["context_token"] == "ctx-refreshed"
+    assert channel._context_tokens["wx-user"] == "ctx-refreshed"


### PR DESCRIPTION
## Summary

Fix a bug where WeChat messages sent by scheduled cron jobs (or after a gateway restart) are silently dropped due to a missing or **stale** `context_token`.

## Problem

When a cron job triggers a WeChat message, the `send()` method checks for a cached `context_token`. If the token is missing or expired, the message can be silently lost.

Two failure modes:
1. **Token missing** — never cached or cleared.
2. **Token stale** — present in `account.json` (reloaded on startup) but expired. `sendmessage` rejects it, but `_send_text()` only logged the error and did not retry.

## Fix

### Commit 1 (ba3263d) — Cache-miss refresh
Added `_refresh_context_token()` calling `ilink/bot/getconfig`; modified `send()` to refresh on cache miss.

### Commit 2 (fed7457) — Stale-token refresh + retry
- Added `_ContextTokenExpiredError` to detect expired token responses from `sendmessage`.
- `_send_text()` / `_send_media_file()` now raise on stale-token errors.
- `send()` catches the error, refreshes via `getconfig`, and retries once.
- Fixed `ruff` import sorting.

## Testing
- 47 tests pass (46 existing + 1 new stale-token regression test)
- `ruff check` — all checks passed
