### PR TITLE
fix(web_fetch): sanitize URL to strip markdown backticks and quotes before validation

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -388,9 +388,7 @@ class WebFetchTool(Tool):
         max_chars: int | None = None,
         **kwargs: Any,
     ) -> Any:
-        url = url.strip().strip("`").strip('"').strip("'")
-        if not (url.startswith("http://") or url.startswith("https://")):
-            return json.dumps({"error": "Invalid URL after cleaning", "url": url}, ensure_ascii=False)
+        url = url.strip(" \t\r\n`\"'")
         extract_mode = kwargs.pop("extractMode", extract_mode)
         max_chars = kwargs.pop("maxChars", max_chars) or self.max_chars
         is_valid, error_msg = _validate_url_safe(url)

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -388,6 +388,9 @@ class WebFetchTool(Tool):
         max_chars: int | None = None,
         **kwargs: Any,
     ) -> Any:
+        url = url.strip().strip("`").strip('"').strip("'")
+        if not (url.startswith("http://") or url.startswith("https://")):
+            return json.dumps({"error": "Invalid URL after cleaning", "url": url}, ensure_ascii=False)
         extract_mode = kwargs.pop("extractMode", extract_mode)
         max_chars = kwargs.pop("maxChars", max_chars) or self.max_chars
         is_valid, error_msg = _validate_url_safe(url)

--- a/tests/tools/test_web_fetch_url_sanitization.py
+++ b/tests/tools/test_web_fetch_url_sanitization.py
@@ -110,6 +110,24 @@ async def test_execute_strips_space_and_backticks():
     assert "error" not in data, f"unexpected error: {data}"
 
 
+@pytest.mark.asyncio
+async def test_execute_strips_mixed_markdown_and_quotes():
+    tool = WebFetchTool()
+    with _patch_env()[0], _patch_env()[1]:
+        result = await tool.execute(url='"`https://example.com/page`"')
+    data = json.loads(result)
+    assert "error" not in data, f"unexpected error: {data}"
+
+
+@pytest.mark.asyncio
+async def test_execute_keeps_case_insensitive_http_scheme():
+    tool = WebFetchTool()
+    with _patch_env()[0], _patch_env()[1]:
+        result = await tool.execute(url="HTTPS://example.com/page")
+    data = json.loads(result)
+    assert "error" not in data, f"unexpected error: {data}"
+
+
 # --- startswith guard tests ---
 
 @pytest.mark.asyncio
@@ -118,7 +136,7 @@ async def test_execute_rejects_non_http_url_after_cleaning():
     result = await tool.execute(url="ftp://example.com/file")
     data = json.loads(result)
     assert "error" in data
-    assert "Invalid URL" in data["error"]
+    assert "URL validation failed" in data["error"]
 
 
 @pytest.mark.asyncio
@@ -127,7 +145,7 @@ async def test_execute_rejects_garbage_after_cleaning():
     result = await tool.execute(url="`not a url at all`")
     data = json.loads(result)
     assert "error" in data
-    assert "Invalid URL" in data["error"]
+    assert "URL validation failed" in data["error"]
 
 
 @pytest.mark.asyncio
@@ -136,4 +154,4 @@ async def test_execute_rejects_bare_domain_after_cleaning():
     result = await tool.execute(url="`example.com/page`")
     data = json.loads(result)
     assert "error" in data
-    assert "Invalid URL" in data["error"]
+    assert "URL validation failed" in data["error"]

--- a/tests/tools/test_web_fetch_url_sanitization.py
+++ b/tests/tools/test_web_fetch_url_sanitization.py
@@ -1,0 +1,139 @@
+"""Tests for web_fetch URL sanitization (backtick/quote stripping)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from nanobot.agent.tools.web import WebFetchTool, _validate_url
+
+
+def _fake_resolve_public(hostname, port, family=0, type_=0):
+    import socket
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+
+class FakeResponse:
+    status_code = 200
+    url = "https://example.com/page"
+    text = "<html><head><title>T</title></head><body><p>ok</p></body></html>"
+    headers = {"content-type": "text/html"}
+    def raise_for_status(self): pass
+    def json(self): return {}
+
+
+class FakeStreamResponse:
+    headers = {"content-type": "text/html"}
+    url = "https://example.com/page"
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): return False
+
+
+class FakeClient:
+    def __init__(self, *a, **kw): pass
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): return False
+    def stream(self, method, url, **kw):
+        return FakeStreamResponse()
+    async def get(self, url, **kw):
+        return FakeResponse()
+
+
+def _patch_env():
+    return patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public), \
+           patch("nanobot.agent.tools.web.httpx.AsyncClient", FakeClient)
+
+
+# --- urlparse / _validate_url level tests ---
+
+@pytest.mark.parametrize("dirty_url", [
+    "`https://example.com/page`",
+    " `https://example.com/page` ",
+    '"https://example.com/page"',
+    "'https://example.com/page'",
+    '  "https://example.com/page"  ',
+])
+def test_dirty_urls_fail_validation(dirty_url):
+    is_valid, msg = _validate_url(dirty_url)
+    assert not is_valid
+
+
+def test_clean_url_passes_validation():
+    is_valid, msg = _validate_url("https://example.com/page")
+    assert is_valid
+
+
+def test_backtick_url_produces_empty_scheme_in_urlparse():
+    from urllib.parse import urlparse
+    p = urlparse("`https://example.com/page`")
+    assert p.scheme == ""
+    assert p.netloc == ""
+
+
+# --- WebFetchTool.execute integration tests ---
+
+@pytest.mark.asyncio
+async def test_execute_strips_backticks_and_succeeds():
+    tool = WebFetchTool()
+    with _patch_env()[0], _patch_env()[1]:
+        result = await tool.execute(url="`https://example.com/page`")
+    data = json.loads(result)
+    assert "error" not in data, f"unexpected error: {data}"
+
+
+@pytest.mark.asyncio
+async def test_execute_strips_double_quotes_and_succeeds():
+    tool = WebFetchTool()
+    with _patch_env()[0], _patch_env()[1]:
+        result = await tool.execute(url='"https://example.com/page"')
+    data = json.loads(result)
+    assert "error" not in data, f"unexpected error: {data}"
+
+
+@pytest.mark.asyncio
+async def test_execute_strips_single_quotes_and_succeeds():
+    tool = WebFetchTool()
+    with _patch_env()[0], _patch_env()[1]:
+        result = await tool.execute(url="'https://example.com/page'")
+    data = json.loads(result)
+    assert "error" not in data, f"unexpected error: {data}"
+
+
+@pytest.mark.asyncio
+async def test_execute_strips_space_and_backticks():
+    tool = WebFetchTool()
+    with _patch_env()[0], _patch_env()[1]:
+        result = await tool.execute(url="  `https://example.com/page`  ")
+    data = json.loads(result)
+    assert "error" not in data, f"unexpected error: {data}"
+
+
+# --- startswith guard tests ---
+
+@pytest.mark.asyncio
+async def test_execute_rejects_non_http_url_after_cleaning():
+    tool = WebFetchTool()
+    result = await tool.execute(url="ftp://example.com/file")
+    data = json.loads(result)
+    assert "error" in data
+    assert "Invalid URL" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_garbage_after_cleaning():
+    tool = WebFetchTool()
+    result = await tool.execute(url="`not a url at all`")
+    data = json.loads(result)
+    assert "error" in data
+    assert "Invalid URL" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_bare_domain_after_cleaning():
+    tool = WebFetchTool()
+    result = await tool.execute(url="`example.com/page`")
+    data = json.loads(result)
+    assert "error" in data
+    assert "Invalid URL" in data["error"]


### PR DESCRIPTION
## Summary

Sanitize the `url` parameter in `WebFetchTool.execute` to strip markdown formatting characters (backticks, quotes) that LLMs may inadvertently include in tool call arguments.

## Problem

When the LLM generates a `web_fetch` tool call, it may wrap the URL in markdown backticks:

```json
{"url": "`https://wttr.in/Beijing?m&lang=zh`"}
```

This causes `urlparse` to produce an empty `scheme` and `netloc`:

```
scheme='', netloc='', path='`https://wttr.in/Beijing?m&lang=zh'
```

As a result, `_validate_url` rejects the URL, and all fetch attempts (Jina Reader, readability fallback) fail. The LLM then retries with different URLs, wasting multiple tool-call iterations before giving up or falling back to `web_search`.

Example from production logs — 4 consecutive `web_fetch` calls all failed due to backtick-wrapped URLs:

```
web_fetch({"url": "`https://wttr.in/Beijing?m&lang=zh`"})       → Server disconnected
web_fetch({"url": "`https://wttr.in/Beijing?m&lang=zh`"})       → Server disconnected
web_fetch({"url": "`https://wttr.in/Beijing?format=j1`"})       → Server disconnected
web_fetch({"url": "`https://api.open-meteo.com/v1/forecast?..."}) → Server disconnected
```

## Root Cause

`WebFetchTool.execute` passed the `url` parameter directly to `_validate_url_safe` without any sanitization. LLM-generated tool arguments may contain surrounding whitespace, markdown backticks (`` ` ``), double quotes (`"`), or single quotes (`'`).

## Fix

Add URL cleaning at the top of `WebFetchTool.execute`:

1. Strip whitespace, backticks, double quotes, and single quotes from the URL
2. Early-reject if the cleaned URL does not start with `http://` or `https://`

```python
url = url.strip().strip("`").strip('"').strip("'")
if not (url.startswith("http://") or url.startswith("https://")):
    return json.dumps({"error": "Invalid URL after cleaning", "url": url}, ensure_ascii=False)
```

## Changes

- `nanobot/agent/tools/web.py` — Add URL sanitization and scheme guard in `WebFetchTool.execute`
- `tests/tools/test_web_fetch_url_sanitization.py` — New test file with 14 test cases

## Testing

14 tests covering:

| Category | Tests |
|---|---|
| Dirty URL validation | 5 parametrized cases (backticks, quotes, spaces) all fail `_validate_url` |
| Clean URL | Passes validation |
| urlparse behavior | Backtick URL produces empty scheme/netloc |
| Integration (execute) | Backticks, double quotes, single quotes, spaces — all cleaned and fetch succeeds |
| Guard (startswith) | `ftp://`, garbage strings, bare domains — all rejected with clear error |

All 14 tests pass.