### PR TITLE
fix(agent): respect configured max iterations for subagents

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -258,6 +258,7 @@ class AgentLoop:
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
             disabled_skills=disabled_skills,
+            max_iterations=self.max_iterations,
         )
         self._unified_session = unified_session
         self._max_messages = max_messages if max_messages > 0 else 120
@@ -306,6 +307,10 @@ class AgentLoop:
         self._current_iteration: int = 0
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
+
+    def _sync_subagent_runtime_limits(self) -> None:
+        """Keep subagent runtime limits aligned with mutable loop settings."""
+        self.subagents.max_iterations = self.max_iterations
 
     def _apply_provider_snapshot(self, snapshot: ProviderSnapshot) -> None:
         """Swap model/provider for future turns without disturbing an active one."""
@@ -531,6 +536,8 @@ class AgentLoop:
 
         Returns (final_content, tools_used, messages, stop_reason, had_injections).
         """
+        self._sync_subagent_runtime_limits()
+
         loop_hook = _LoopHook(
             self,
             on_progress=on_progress,

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -20,7 +20,7 @@ from nanobot.agent.tools.shell import ExecTool
 from nanobot.agent.tools.web import WebFetchTool, WebSearchTool
 from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
-from nanobot.config.schema import ExecToolConfig, WebToolsConfig
+from nanobot.config.schema import AgentDefaults, ExecToolConfig, WebToolsConfig
 from nanobot.providers.base import LLMProvider
 from nanobot.utils.prompt_templates import render_template
 
@@ -81,6 +81,7 @@ class SubagentManager:
         exec_config: "ExecToolConfig | None" = None,
         restrict_to_workspace: bool = False,
         disabled_skills: list[str] | None = None,
+        max_iterations: int | None = None,
     ):
         self.provider = provider
         self.workspace = workspace
@@ -91,6 +92,11 @@ class SubagentManager:
         self.exec_config = exec_config or ExecToolConfig()
         self.restrict_to_workspace = restrict_to_workspace
         self.disabled_skills = set(disabled_skills or [])
+        self.max_iterations = (
+            max_iterations
+            if max_iterations is not None
+            else AgentDefaults().max_tool_iterations
+        )
         self.runner = AgentRunner(provider)
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._task_statuses: dict[str, SubagentStatus] = {}
@@ -202,7 +208,7 @@ class SubagentManager:
                 initial_messages=messages,
                 tools=tools,
                 model=self.model,
-                max_iterations=15,
+                max_iterations=self.max_iterations,
                 max_tool_result_chars=self.max_tool_result_chars,
                 hook=_SubagentHook(task_id, status),
                 max_iterations_message="Task completed but no final response was generated.",

--- a/nanobot/agent/tools/self.py
+++ b/nanobot/agent/tools/self.py
@@ -394,6 +394,8 @@ class MyTool(Tool):
         if "min_len" in spec and len(str(value)) < spec["min_len"]:
             return f"Error: '{key}' must be at least {spec['min_len']} characters"
         setattr(self._loop, key, value)
+        if key == "max_iterations" and hasattr(self._loop, "_sync_subagent_runtime_limits"):
+            self._loop._sync_subagent_runtime_limits()
         self._audit("modify", f"{key}: {old!r} -> {value!r}")
         return f"Set {key} = {value!r} (was {old!r})"
 

--- a/tests/agent/tools/test_self_tool_runtime_sync.py
+++ b/tests/agent/tools/test_self_tool_runtime_sync.py
@@ -1,0 +1,29 @@
+"""Focused tests for MyTool runtime sync side effects."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.agent.tools.self import MyTool
+
+
+@pytest.mark.asyncio
+async def test_my_tool_max_iterations_syncs_subagent_limit() -> None:
+    loop = MagicMock()
+    loop.max_iterations = 40
+    loop._runtime_vars = {}
+    loop.subagents = MagicMock()
+    loop.subagents.max_iterations = loop.max_iterations
+
+    def _sync_subagent_runtime_limits() -> None:
+        loop.subagents.max_iterations = loop.max_iterations
+
+    loop._sync_subagent_runtime_limits = _sync_subagent_runtime_limits
+
+    tool = MyTool(loop=loop)
+
+    result = await tool.execute(action="set", key="max_iterations", value=80)
+
+    assert "Set max_iterations = 80" in result
+    assert loop.max_iterations == 80
+    assert loop.subagents.max_iterations == 80

--- a/tests/agent/tools/test_subagent_tools.py
+++ b/tests/agent/tools/test_subagent_tools.py
@@ -55,10 +55,128 @@ async def test_subagent_exec_tool_receives_allowed_env_keys(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_subagent_uses_configured_max_iterations(tmp_path):
+    """Subagents should honor the configured tool-iteration limit."""
+    from nanobot.agent.subagent import SubagentManager, SubagentStatus
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    mgr = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=bus,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        max_iterations=37,
+    )
+    mgr._announce_result = AsyncMock()
+
+    async def fake_run(spec):
+        assert spec.max_iterations == 37
+        return SimpleNamespace(
+            stop_reason="done",
+            final_content="done",
+            error=None,
+            tool_events=[],
+        )
+
+    mgr.runner.run = AsyncMock(side_effect=fake_run)
+
+    status = SubagentStatus(
+        task_id="sub-1", label="label", task_description="do task", started_at=time.monotonic()
+    )
+    await mgr._run_subagent(
+        "sub-1", "do task", "label", {"channel": "test", "chat_id": "c1"}, status
+    )
+
+    mgr.runner.run.assert_awaited_once()
+
+
+def test_subagent_default_max_iterations_matches_agent_defaults(tmp_path):
+    """Direct SubagentManager construction should use the agent default limit."""
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    mgr = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=bus,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    )
+
+    assert mgr.max_iterations == AgentDefaults().max_tool_iterations
+
+
+def test_agent_loop_passes_max_iterations_to_subagents(tmp_path):
+    """AgentLoop's configured limit should be shared with spawned subagents."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        max_iterations=42,
+    )
+
+    assert loop.subagents.max_iterations == 42
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_syncs_updated_max_iterations_before_run(tmp_path):
+    """Runtime max_iterations changes should be reflected before tool execution."""
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+
+    loop = AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        max_iterations=42,
+    )
+    loop.tools.get_definitions = MagicMock(return_value=[])
+
+    async def fake_run(spec):
+        assert spec.max_iterations == 55
+        assert loop.subagents.max_iterations == 55
+        return SimpleNamespace(
+            stop_reason="done",
+            final_content="done",
+            error=None,
+            tool_events=[],
+            messages=[],
+            usage={},
+            had_injections=False,
+            tools_used=[],
+        )
+
+    loop.runner.run = AsyncMock(side_effect=fake_run)
+    loop.max_iterations = 55
+
+    await loop._run_agent_loop([])
+
+    loop.runner.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_drain_pending_blocks_while_subagents_running(tmp_path):
     """_drain_pending should block when no messages are available but sub-agents are still running."""
     from nanobot.agent.loop import AgentLoop
-    from nanobot.agent.subagent import SubagentManager
     from nanobot.bus.events import InboundMessage
     from nanobot.bus.queue import MessageBus
     from nanobot.session.manager import Session
@@ -74,8 +192,6 @@ async def test_drain_pending_blocks_while_subagents_running(tmp_path):
     injection_callback = None
 
     # Capture the injection_callback that _run_agent_loop creates
-    original_run = loop.runner.run
-
     async def fake_runner_run(spec):
         nonlocal injection_callback
         injection_callback = spec.injection_callback


### PR DESCRIPTION
## Summary

- Pass the parent agent's configured `max_iterations` into `SubagentManager`
- Use that value for subagent `AgentRunSpec` instead of the old hardcoded `15`
- Default directly constructed `SubagentManager` instances to `AgentDefaults().max_tool_iterations`
- Keep subagent limits synchronized when `AgentLoop.max_iterations` changes at runtime, including updates made through `my(action="set", key="max_iterations", ...)`
- Add regression tests for direct construction, `AgentLoop` wiring, runtime synchronization, and `MyTool` updates

## Root Cause

The main agent loop already reads `agents.defaults.maxToolIterations` and stores it as `self.max_iterations`, but subagents did not use that setting. `SubagentManager._run_subagent()` always passed `max_iterations=15` to `AgentRunSpec`, so long-running subagent work could stop early even when users configured a higher iteration budget.

## Fix

This changes subagent iteration budgeting to follow the same runtime limit as the parent agent:

- `AgentLoop` passes its configured `max_iterations` into `SubagentManager`
- `SubagentManager` stores the value and passes it through to `AgentRunSpec`
- direct `SubagentManager` construction falls back to `AgentDefaults().max_tool_iterations`
- `AgentLoop._sync_subagent_runtime_limits()` keeps the subagent manager aligned before each agent loop run
- `MyTool` calls the same sync helper after changing `max_iterations`

## Impact

Users who increase `maxToolIterations` now get the same budget for spawned subagents. This avoids premature subagent termination for longer research, polling, or multi-step background tasks while keeping the change scoped to the existing runtime limit.

Fixes #970.

## Validation

- `uv run --extra dev pytest tests/agent/tools/test_subagent_tools.py tests/agent/tools/test_self_tool_runtime_sync.py tests/agent/test_runner.py::test_subagent_max_iterations_announces_existing_fallback -q`
- `uv run --extra dev ruff check nanobot/agent/subagent.py nanobot/agent/loop.py nanobot/agent/tools/self.py tests/agent/tools/test_subagent_tools.py tests/agent/tools/test_self_tool_runtime_sync.py`

Note: the targeted pytest run passes with one existing async queue warning from `tests/agent/test_runner.py::test_subagent_max_iterations_announces_existing_fallback`.
