### PR TITLE
docs: add CLAUDE.md and .agent/ guides for AI contributors

### DIFF
--- a/.agent/design.md
+++ b/.agent/design.md
@@ -6,6 +6,10 @@ These rules govern architectural decisions. When adding a feature or fixing a bu
 
 New capabilities should be added via `channels/`, `tools/`, skills, or MCP servers. The files `agent/loop.py` and `agent/runner.py` form the critical core path; changes there should be minimal and justified. If a feature can live in a channel adapter, a tool, or an external MCP server, it should not be inlined into the agent loop.
 
+## Less structure, more intelligence
+
+Prefer simple, readable code over new framework layers and indirection. Add structure only when it removes real complexity, protects an important boundary, or matches an established local pattern. The best fix is often a smaller prompt, a tighter tool contract, a channel-local change, or one focused regression test.
+
 ## Prefer duplication over premature abstraction
 
 Channels and providers are allowed to repeat similar logic (send retries, media handling, message splitting). Do not introduce complex base classes or shared helpers just to eliminate duplication across channel files. Each channel file should remain self-contained and readable on its own. The same applies to provider implementations.
@@ -13,6 +17,10 @@ Channels and providers are allowed to repeat similar logic (send retries, media 
 ## Minimal change that solves the real problem
 
 Fix bugs by changing only what is necessary. Do not bundle unrelated refactors or clean-ups into a feature or bugfix PR. If a refactor is genuinely required, it should be a separate PR targeting `nightly`.
+
+## Keep PRs reviewable
+
+A bugfix should make the protected invariant clear, change the smallest surface that enforces it, and add only the closest regression test. If a diff starts changing ownership boundaries or mixing behavior changes with clean-up, split it before it becomes hard to review.
 
 ## Explicit over magical
 

--- a/.agent/design.md
+++ b/.agent/design.md
@@ -1,0 +1,19 @@
+# Design Constraints
+
+These rules govern architectural decisions. When adding a feature or fixing a bug, prefer paths that respect these boundaries.
+
+## Core stays small; extend at the edges
+
+New capabilities should be added via `channels/`, `tools/`, skills, or MCP servers. The files `agent/loop.py` and `agent/runner.py` form the critical core path; changes there should be minimal and justified. If a feature can live in a channel adapter, a tool, or an external MCP server, it should not be inlined into the agent loop.
+
+## Prefer duplication over premature abstraction
+
+Channels and providers are allowed to repeat similar logic (send retries, media handling, message splitting). Do not introduce complex base classes or shared helpers just to eliminate duplication across channel files. Each channel file should remain self-contained and readable on its own. The same applies to provider implementations.
+
+## Minimal change that solves the real problem
+
+Fix bugs by changing only what is necessary. Do not bundle unrelated refactors or clean-ups into a feature or bugfix PR. If a refactor is genuinely required, it should be a separate PR targeting `nightly`.
+
+## Explicit over magical
+
+Configuration must be declared explicitly in `config/schema.py` Pydantic models. Error handling should raise clear exceptions rather than silently correcting bad input. Provider auto-detection exists, but every resolution path must be traceable from the factory to the concrete provider class.

--- a/.agent/gotchas.md
+++ b/.agent/gotchas.md
@@ -25,6 +25,12 @@ nanobot explicitly supports Windows. Key differences to keep in mind:
 
 Agent system prompts and scenario-specific instructions live in `nanobot/templates/` as Jinja2 markdown files (`identity.md`, `platform_policy.md`, `HEARTBEAT.md`, `SOUL.md`, etc.). Changing these files alters agent behavior as directly as changing Python code. They are loaded by `utils/prompt_templates.py`.
 
+Tool descriptions, skills, and replayed session history also shape model behavior. Treat changes to those surfaces like runtime code: keep them narrow, add a focused regression test when possible, and avoid teaching the model to repeat internal markers, local paths, or tool-call text.
+
+## Context Pollution Persists
+
+Anything written into memory, session history, or prompt inputs can be replayed into future LLM calls. Metadata such as timestamps, local media paths, tool-call echoes, and raw fallback dumps must be bounded and sanitized before they become examples for the model to imitate.
+
 ## Heartbeat Virtual Tool Call
 
 The heartbeat service (`heartbeat/service.py`) does not parse free-text LLM output. Instead, it injects a virtual `heartbeat` tool with `action: skip | run` into the conversation. Phase 1 is a structured decision; Phase 2 executes only on `run`. When adding new periodic background checks, follow this virtual-tool-call pattern rather than string matching.

--- a/.agent/gotchas.md
+++ b/.agent/gotchas.md
@@ -1,0 +1,38 @@
+# Common Gotchas
+
+## Do not use `ruff format`
+
+`CONTRIBUTING.md` mentions `ruff format`, but **do not run it** — it destroys git blame history. Only `ruff check` should be used.
+
+## Config `${VAR}` References
+
+`config/loader.py` resolves `${VAR}` patterns in `config.json` at load time. This is **not** a shell-like default-value syntax. If the environment variable is missing, `load_config` raises `ValueError` and the agent falls back to default configuration.
+
+Example valid usage:
+```json
+{ "providers": { "openrouter": { "apiKey": "${OPENROUTER_KEY}" } } }
+```
+
+## Windows Compatibility
+
+nanobot explicitly supports Windows. Key differences to keep in mind:
+- `ExecTool` uses `cmd /c` on Windows instead of `sh -c` (`shell.py`).
+- `cli/commands.py` forces `sys.stdout`/`stderr` to UTF-8 on startup to handle emoji and multilingual input.
+- MCP stdio server commands are normalized for Windows path separators (`mcp.py`).
+- Always use `pathlib.Path` for path manipulation; do not assume `/` separators.
+
+## Prompt Templates
+
+Agent system prompts and scenario-specific instructions live in `nanobot/templates/` as Jinja2 markdown files (`identity.md`, `platform_policy.md`, `HEARTBEAT.md`, `SOUL.md`, etc.). Changing these files alters agent behavior as directly as changing Python code. They are loaded by `utils/prompt_templates.py`.
+
+## Heartbeat Virtual Tool Call
+
+The heartbeat service (`heartbeat/service.py`) does not parse free-text LLM output. Instead, it injects a virtual `heartbeat` tool with `action: skip | run` into the conversation. Phase 1 is a structured decision; Phase 2 executes only on `run`. When adding new periodic background checks, follow this virtual-tool-call pattern rather than string matching.
+
+## Skills as Extension Point
+
+Built-in skills live in `nanobot/skills/` (markdown + YAML frontmatter format). Agent capabilities that are "know-how" rather than code should be added as skills, not hardcoded into the agent loop. External skills can be published to and installed from ClawHub.
+
+## Atomic Session Writes
+
+`agent/memory.py` writes `history.jsonl` atomically (temp file + fsync + rename + directory fsync). This guarantees durability across crashes. Do not replace this with a plain `open(..., "w")` write.

--- a/.agent/security.md
+++ b/.agent/security.md
@@ -1,0 +1,25 @@
+# Security Boundaries
+
+The agent operates with significant power (file system, shell, web). The following guards must not be bypassed when modifying related code.
+
+## Workspace Restriction
+
+Filesystem tools (`read_file`, `write_file`, `edit_file`, `list_dir`) resolve paths through `_resolve_path` (`agent/tools/filesystem.py`), which enforces that the resolved path must lie under `allowed_dir` (typically the configured workspace), plus the media upload directory (`get_media_dir()`) and any `extra_allowed_dirs`.
+
+Shell execution (`ExecTool`, `agent/tools/shell.py`) also respects `restrict_to_workspace`: if enabled and `working_dir` is outside the workspace, the command is rejected before execution.
+
+**Rule**: Any new path-handling logic must go through `_resolve_path` or perform an equivalent `allowed_dir` check.
+
+## SSRF Protection
+
+All outbound HTTP requests from agent tools must pass through `validate_url_target` (`security/network.py`). By default it blocks RFC1918 private addresses, link-local ranges, and cloud metadata endpoints (including `169.254.169.254`).
+
+The only escape hatch is `configure_ssrf_whitelist(cidrs)`, which reads from `config.tools.ssrf_whitelist` at load time.
+
+**Rule**: Do not add direct `httpx.get` / `requests.get` calls in tools. Route through the existing web fetch utilities or replicate the `validate_url_target` check.
+
+## Shell Sandbox
+
+`tools/sandbox.py` provides optional command wrapping. The only backend currently shipped is `bwrap` (bubblewrap), intended for containerized deployments. On Windows and bare-metal Linux without `bwrap`, commands run in the native shell with workspace restriction as the only guard.
+
+**Rule**: If adding a new sandbox backend, implement `_wrap_<name>(command, workspace, cwd) -> str` and register it in `_BACKENDS`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+nanobot is a lightweight, open-source AI agent framework written in Python with a React/TypeScript WebUI. It centers around a small agent loop that receives messages from chat channels, invokes an LLM provider, executes tools, and manages session memory.
+
+## Development Commands
+
+```bash
+# Python: run single test / lint
+pytest tests/test_openai_api.py::test_function -v
+ruff check nanobot/
+
+# WebUI: dev server (proxies API/WS to gateway :8765), build, test
+# Build outputs to ../nanobot/web/dist (bundled into the Python wheel)
+cd webui && bun run dev      # or NANOBOT_API_URL=... bun run dev
+cd webui && bun run build
+cd webui && bun run test
+
+# Gateway
+nanobot gateway
+```
+
+## High-Level Architecture
+
+### Core Data Flow
+
+Messages flow through an async `MessageBus` (`nanobot/bus/queue.py`) that decouples chat channels from the agent core:
+
+1. **Channels** (`nanobot/channels/`) receive messages from external platforms and publish `InboundMessage` events to the bus.
+2. **`AgentLoop`** (`nanobot/agent/loop.py`) consumes inbound messages, builds context, and coordinates the turn.
+3. **`AgentRunner`** (`nanobot/agent/runner.py`) handles the actual LLM conversation loop: send messages to the provider, receive tool calls, execute tools, and stream responses.
+4. Responses are published as `OutboundMessage` events back to the appropriate channel.
+
+### Key Subsystems
+
+- **Agent Loop** (`nanobot/agent/loop.py`, `runner.py`): The core processing engine. `AgentLoop` manages session keys, hooks, and context building. `AgentRunner` executes the multi-turn LLM conversation with tool execution.
+- **LLM Providers** (`nanobot/providers/`): Provider implementations (Anthropic, OpenAI-compatible, Azure, GitHub Copilot, etc.) built on a common base (`base.py`). `factory.py` and `registry.py` handle instantiation and model discovery.
+- **Channels** (`nanobot/channels/`): Platform integrations (Telegram, Discord, Slack, Feishu, Matrix, WhatsApp, QQ, WeChat, WebSocket, etc.). `manager.py` discovers and coordinates them. Channels are auto-discovered via `pkgutil` scan + entry-point plugins.
+- **Tools** (`nanobot/agent/tools/`): Agent capabilities exposed to the LLM: filesystem (read/write/edit/list), shell execution, web search/fetch, MCP servers, cron, notebook editing, subagent spawning, and `MyTool` for self-modification.
+- **Memory** (`nanobot/agent/memory.py`): Session history persistence with Dream two-phase memory consolidation. Uses atomic writes with fsync for durability.
+- **Session Management** (`nanobot/session/manager.py`): Per-session history, context compaction, and TTL-based auto-compaction.
+- **Config** (`nanobot/config/schema.py`, `loader.py`): Pydantic-based configuration loaded from `~/.nanobot/config.json`. Supports camelCase aliases for JSON compatibility.
+- **Bridge** (`bridge/`): TypeScript services (e.g. WhatsApp bridge) bundled into the wheel via `pyproject.toml` `force-include`.
+- **WebUI** (`webui/`): Vite-based React SPA that talks to the gateway over a WebSocket multiplex protocol. The dev server proxies `/api`, `/webui`, `/auth`, and WebSocket traffic to the gateway.
+
+### Entry Points
+
+- **CLI**: `nanobot/cli/commands.py`
+- **Python SDK**: `nanobot/nanobot.py`
+
+## Project-Specific Notes
+
+- Architecture constraints: [`.agent/design.md`](.agent/design.md)
+- Security boundaries: [`.agent/security.md`](.agent/security.md)
+- Common gotchas: [`.agent/gotchas.md`](.agent/gotchas.md)
+
+## Branching Strategy
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full two-branch model (`main` vs `nightly`) and PR guidelines.
+
+## Code Style
+
+- Python 3.11+, asyncio throughout.
+- Line length: 100.
+- Linting: `ruff` with rules E, F, I, N, W (E501 ignored).
+- pytest with `asyncio_mode = "auto"`.
+
+## Common File Locations
+
+- Config schema: `nanobot/config/schema.py`
+- Provider base / new provider template: `nanobot/providers/base.py`
+- Channel base / new channel template: `nanobot/channels/base.py`
+- Tool registry: `nanobot/agent/tools/registry.py`
+- WebUI dev proxy config: `webui/vite.config.ts`
+- Tests mirror the `nanobot/` package structure.


### PR DESCRIPTION
This PR adds a `CLAUDE.md` file and an `.agent/` directory to help future Claude Code instances (and other AI coding assistants) work effectively in this repository.

**What is included**

- **`CLAUDE.md`** — a concise quick-reference covering:
  - Development commands (pytest, ruff, WebUI dev server)
  - High-level architecture (MessageBus → AgentLoop → Runner → Channels)
  - Key subsystems and entry points
  - Branching strategy (refs `CONTRIBUTING.md`)
  - Code style
  - Common file locations

- **`.agent/design.md`** — architectural constraints that govern code decisions:
  - Core stays small; extend at the edges
  - Prefer duplication over premature abstraction
  - Minimal change that solves the real problem
  - Explicit over magical

- **`.agent/security.md`** — security boundaries that must not be bypassed:
  - Workspace restriction (`_resolve_path`)
  - SSRF protection (`validate_url_target`)
  - Shell sandbox (`bwrap` backend)

- **`.agent/gotchas.md`** — project-specific gotchas:
  - Do not use `ruff format` (destroys git blame)
  - Config `${VAR}` syntax semantics
  - Windows compatibility notes
  - Prompt templates live in `nanobot/templates/`
  - Heartbeat virtual tool call pattern
  - Atomic session writes
  - Skills as extension point

**Status**: This is a **draft** — please feel free to suggest additions, removals, or rewording. I’d especially like @re-bin’s input on whether the design constraints and gotchas accurately reflect the project’s philosophy and whether anything critical is missing.