### PR TITLE
feat(hooks): add centralized HookCenter for named hook points and plugin discovery

### DIFF
--- a/docs/hook-center-guide.md
+++ b/docs/hook-center-guide.md
@@ -1,0 +1,164 @@
+# Hook Center Guide
+
+Extend nanobot with hook plugins: intercept, modify, or cancel operations at named hook points.
+
+## How It Works
+
+nanobot provides a centralized **HookCenter** that manages named hook points. Internal nanobot modules declare hook points; external plugins register handlers that run when those points are triggered.
+
+Hook handlers can:
+- **Observe** — receive context, trigger side effects (logging, notifications)
+- **Modify** — change the context data that flows to subsequent handlers
+- **Intercept** — short-circuit remaining handlers or cancel the originating operation
+
+Plugins are discovered via Python [entry points](https://packaging.python.org/en/latest/specifications/entry-points/) in the `nanobot.hooks` group, loaded automatically at startup.
+
+## Quick Start: Write a Hook Plugin
+
+### 1. Create Your Handler
+
+```python
+# my_hook_plugin/handlers.py
+from nanobot.hooks import HookContext, HookResult
+
+async def on_before_iteration(ctx: HookContext) -> HookResult | None:
+    """Log every agent iteration."""
+    iteration = ctx.get("iteration")
+    print(f"[hook] agent iteration: {iteration}")
+    return None  # None = continue (default)
+```
+
+### 2. Register via entry_points
+
+```toml
+# my_hook_plugin/pyproject.toml
+[project]
+name = "my-hook-plugin"
+version = "0.1.0"
+dependencies = ["nanobot-ai"]
+
+[project.entry-points."nanobot.hooks"]
+before_iteration = "my_hook_plugin.handlers:on_before_iteration"
+```
+
+### 3. Install and Run
+
+```bash
+pip install my-hook-plugin
+nanobot agent  # plugins are loaded automatically
+```
+
+## Handler Protocol
+
+A handler is any async callable that accepts a `HookContext` and returns `HookResult | None`:
+
+```python
+async def my_handler(ctx: HookContext) -> HookResult | None:
+    ...
+```
+
+**Return values:**
+- `None` — continue to the next handler (convenience default)
+- `HookResult(action="continue")` — same as None
+- `HookResult(action="short_circuit")` — skip remaining handlers, return current state
+- `HookResult(action="cancel", reason="...")` — abort the originating operation
+
+**Context:**
+- `ctx.get("key")` — read a value
+- `ctx.set("key", value)` — write a value (visible to subsequent handlers)
+
+## Registering to Multiple Hook Points
+
+Set a `hook_points` attribute on your handler to register it at multiple points:
+
+```python
+async def audit_handler(ctx: HookContext) -> None:
+    print(f"[audit] {ctx.data}")
+
+audit_handler.hook_points = ["agent.before_iteration", "agent.before_execute_tools"]
+```
+
+Or return a dict mapping point names to handlers:
+
+```python
+# In pyproject.toml:
+# [project.entry-points."nanobot.hooks"]
+# my_plugin = "my_hook_plugin:PLUGIN"
+
+# my_hook_plugin/__init__.py
+from my_hook_plugin.handlers import on_save, on_tool
+
+PLUGIN = {
+    "agent.before_iteration": on_save,
+    "agent.before_execute_tools": on_tool,
+}
+```
+
+## For nanobot Contributors: Adding Hook Points
+
+### Declare a Hook Point
+
+```python
+from nanobot.hooks import get_center, HookContext
+
+center = get_center()
+center.register_point("agent.before_iteration", "Fired before each agent iteration")
+```
+
+### Emit a Hook Point
+
+```python
+ctx = HookContext(data={"session_key": key})
+result = await center.emit("agent.before_iteration", ctx)
+
+if result.action == "cancel":
+    logger.warning("Iteration cancelled: {}", result.reason)
+    return
+```
+
+### Naming Convention
+
+Use dot-separated names with the module prefix:
+
+- `agent.before_iteration`
+- `agent.after_iteration`
+- `agent.before_execute_tools`
+- `agent.on_stream_end`
+
+### Built-in Hook Points
+
+| Hook point | When | Can cancel? | Context data |
+|------------|------|-------------|-------------|
+| `agent.before_iteration` | Before each LLM call | Yes (ends the run) | iteration, channel, chat_id, session_key, tool_calls, usage |
+| `agent.after_iteration` | After each LLM response | No (observe only) | iteration, channel, chat_id, session_key, tool_calls, usage |
+| `agent.before_execute_tools` | Before tool execution | Yes (ends the run) | iteration, channel, chat_id, session_key, tool_calls, usage |
+| `agent.on_stream_end` | After streaming completes | No (observe only) | iteration, channel, chat_id, session_key, tool_calls, usage |
+
+Context data is a **snapshot** — handler modifications flow between handlers but do not propagate back to the agent loop. Use the `cancel` action on `before_iteration` or `before_execute_tools` to stop the agent run.
+
+### Error Isolation
+
+If a handler raises an exception, the HookCenter logs it and continues to the next handler. A faulty plugin cannot crash the main loop.
+
+## Testing Your Plugin
+
+```python
+import pytest
+from nanobot.hooks import HookCenter, HookContext, HookResult
+
+@pytest.mark.asyncio
+async def test_my_handler():
+    center = HookCenter()
+    center.register_point("agent.before_iteration")
+
+    async def handler(ctx: HookContext) -> None:
+        ctx.set("audited", True)
+
+    center.register_handler("agent.before_iteration", handler)
+
+    ctx = HookContext(data={"iteration": 0})
+    result = await center.emit("agent.before_iteration", ctx)
+
+    assert result.action == "continue"
+    assert ctx.get("audited") is True
+```

--- a/nanobot/agent/hook.py
+++ b/nanobot/agent/hook.py
@@ -25,6 +25,8 @@ class AgentHookContext:
     final_content: str | None = None
     stop_reason: str | None = None
     error: str | None = None
+    cancel: bool = False
+    cancel_reason: str | None = None
 
 
 class AgentHook:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -111,6 +111,10 @@ class _LoopHook(AgentHook):
 
     async def before_iteration(self, context: AgentHookContext) -> None:
         self._loop._current_iteration = context.iteration
+        result = await self._emit("agent.before_iteration", context)
+        if result.action == "cancel":
+            context.cancel = True
+            context.cancel_reason = result.reason
 
     async def before_execute_tools(self, context: AgentHookContext) -> None:
         if self._on_progress:
@@ -138,6 +142,10 @@ class _LoopHook(AgentHook):
             self._metadata,
             session_key=self._session_key,
         )
+        result = await self._emit("agent.before_execute_tools", context)
+        if result.action == "cancel":
+            context.cancel = True
+            context.cancel_reason = result.reason
 
     async def after_iteration(self, context: AgentHookContext) -> None:
         if (
@@ -161,9 +169,26 @@ class _LoopHook(AgentHook):
             u.get("completion_tokens", 0),
             u.get("cached_tokens", 0),
         )
+        await self._emit("agent.after_iteration", context)
 
     def finalize_content(self, context: AgentHookContext, content: str | None) -> str | None:
         return self._loop._strip_think(content)
+
+    async def _emit(self, point: str, context: AgentHookContext):
+        from nanobot.hooks.context import HookContext
+
+        hook_ctx = HookContext(data={
+            "iteration": context.iteration,
+            "channel": self._channel,
+            "chat_id": self._chat_id,
+            "session_key": self._session_key,
+            "tool_calls": [
+                {"name": tc.name, "arguments": tc.arguments}
+                for tc in context.tool_calls
+            ],
+            "usage": context.usage or {},
+        })
+        return await self._loop._hook_center.emit(point, hook_ctx)
 
 
 class AgentLoop:
@@ -306,6 +331,32 @@ class AgentLoop:
         self._current_iteration: int = 0
         self.commands = CommandRouter()
         register_builtin_commands(self.commands)
+        self._init_hook_center()
+
+    def _init_hook_center(self) -> None:
+        """Initialize the global HookCenter and discover external plugins."""
+        from nanobot.hooks.center import get_center
+        from nanobot.hooks.discovery import register_discovered
+
+        self._hook_center = get_center()
+        self._hook_center.register_point(
+            "agent.before_iteration", "Before each agent iteration"
+        )
+        self._hook_center.register_point(
+            "agent.after_iteration", "After each agent iteration"
+        )
+        self._hook_center.register_point(
+            "agent.before_execute_tools", "Before executing tool calls"
+        )
+        self._hook_center.register_point(
+            "agent.on_stream_end", "After streaming ends"
+        )
+        try:
+            n = register_discovered(self._hook_center)
+            if n:
+                logger.info("Loaded {} external hook plugin(s)", n)
+        except Exception:
+            logger.exception("Failed to load hook plugins")
 
     def _apply_provider_snapshot(self, snapshot: ProviderSnapshot) -> None:
         """Swap model/provider for future turns without disturbing an active one."""

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -271,6 +271,14 @@ class AgentRunner:
                     messages_for_model = messages
             context = AgentHookContext(iteration=iteration, messages=messages)
             await hook.before_iteration(context)
+            if context.cancel:
+                logger.warning(
+                    "Hook cancelled iteration {}: {}", iteration, context.cancel_reason
+                )
+                stop_reason = "hook_cancelled"
+                context.stop_reason = stop_reason
+                await hook.after_iteration(context)
+                break
             response = await self._request_model(spec, messages_for_model, hook, context)
             raw_usage = self._usage_dict(response.usage)
             context.response = response
@@ -308,7 +316,16 @@ class AgentRunner:
                 )
 
                 await hook.before_execute_tools(context)
-
+                if context.cancel:
+                    logger.warning(
+                        "Hook cancelled tool execution on iteration {}: {}",
+                        iteration,
+                        context.cancel_reason,
+                    )
+                    stop_reason = "hook_cancelled"
+                    context.stop_reason = stop_reason
+                    await hook.after_iteration(context)
+                    break
                 results, new_events, fatal_error = await self._execute_tools(
                     spec,
                     tool_calls,

--- a/nanobot/hooks/__init__.py
+++ b/nanobot/hooks/__init__.py
@@ -1,0 +1,14 @@
+"""HookCenter: unified hook management for nanobot."""
+
+from nanobot.hooks.center import HookCenter, get_center, reset_center
+from nanobot.hooks.context import HookContext, HookResult
+from nanobot.hooks.types import HookHandler
+
+__all__ = [
+    "HookCenter",
+    "HookContext",
+    "HookHandler",
+    "HookResult",
+    "get_center",
+    "reset_center",
+]

--- a/nanobot/hooks/center.py
+++ b/nanobot/hooks/center.py
@@ -1,0 +1,110 @@
+"""HookCenter: centralized registry for named hook points."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from loguru import logger
+
+from nanobot.hooks.context import HookContext, HookResult
+
+
+class HookCenter:
+    """Centralized registry for named hook points.
+
+    Internal developers register hook points and emit them.
+    External plugins register handlers via ``register_handler``
+    (discovered through entry_points by ``discovery.py``).
+    """
+
+    def __init__(self) -> None:
+        self._points: dict[str, str] = {}
+        self._handlers: dict[str, list[Callable]] = {}
+
+    def register_point(self, name: str, description: str = "") -> None:
+        """Declare a named hook point that handlers can attach to."""
+        if name not in self._points:
+            self._points[name] = description
+            self._handlers.setdefault(name, [])
+        elif self._points[name] != description and description:
+            self._points[name] = description
+
+    def register_handler(
+        self,
+        point_name: str,
+        handler: Callable,
+    ) -> None:
+        """Register *handler* for the given hook point.
+
+        If the point has not been declared yet it is auto-created
+        (useful for external plugins loaded before internal registration).
+        Duplicate registrations of the same handler for the same point
+        are silently ignored.
+        """
+        self._handlers.setdefault(point_name, [])
+        if handler not in self._handlers[point_name]:
+            self._handlers[point_name].append(handler)
+
+    def has_point(self, name: str) -> bool:
+        return name in self._points
+
+    def get_point_names(self) -> list[str]:
+        return list(self._points.keys())
+
+    def get_handlers(self, name: str) -> list[Callable]:
+        return list(self._handlers.get(name, []))
+
+    async def emit(self, name: str, context: HookContext) -> HookResult:
+        """Trigger all handlers registered for *name*.
+
+        Returns the final HookResult.  Handlers are called in
+        registration order.  Error isolation: a failing handler is
+        logged and skipped; it does not prevent other handlers from
+        running.
+        """
+        handlers = self._handlers.get(name, [])
+        if not handlers:
+            return HookResult(action="continue")
+
+        for handler in handlers:
+            try:
+                result = await handler(context)
+            except Exception:
+                logger.exception("HookCenter: handler error for '{}'", name)
+                continue
+
+            if result is None:
+                continue
+            if not isinstance(result, HookResult):
+                logger.warning(
+                    "HookCenter: handler for '{}' returned {} instead of HookResult or None; ignoring",
+                    name,
+                    type(result).__name__,
+                )
+                continue
+            if result.action != "continue":
+                return result
+
+        return HookResult(action="continue")
+
+    def reset(self) -> None:
+        """Clear all registered points and handlers (useful in tests)."""
+        self._points.clear()
+        self._handlers.clear()
+
+
+_center: HookCenter | None = None
+
+
+def get_center() -> HookCenter:
+    """Return the global HookCenter singleton."""
+    global _center
+    if _center is None:
+        _center = HookCenter()
+    return _center
+
+
+def reset_center() -> None:
+    """Reset the global singleton (for testing only)."""
+    global _center
+    _center = None

--- a/nanobot/hooks/context.py
+++ b/nanobot/hooks/context.py
@@ -1,0 +1,35 @@
+"""Hook context and result types for the HookCenter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+HookAction = Literal["continue", "short_circuit", "cancel"]
+
+
+@dataclass
+class HookContext:
+    """Mutable context passed through hook handlers at a given hook point."""
+
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.data.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        self.data[key] = value
+
+
+@dataclass
+class HookResult:
+    """Control-flow signal returned by a hook handler.
+
+    action:
+        "continue"      - proceed to the next handler (default)
+        "short_circuit"  - skip remaining handlers, return current state
+        "cancel"         - abort the originating operation
+    """
+
+    action: HookAction = "continue"
+    reason: str | None = None

--- a/nanobot/hooks/discovery.py
+++ b/nanobot/hooks/discovery.py
@@ -1,0 +1,66 @@
+"""Discover external hook plugins registered via entry_points."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+
+def discover_hook_plugins() -> dict[str, Any]:
+    """Scan ``nanobot.hooks`` entry_points group and return {name: loaded_object}.
+
+    Failed loads are logged and skipped so a faulty plugin cannot
+    prevent other plugins from loading.
+    """
+    from importlib.metadata import entry_points
+
+    plugins: dict[str, Any] = {}
+    for ep in entry_points(group="nanobot.hooks"):
+        try:
+            obj = ep.load()
+            plugins[ep.name] = obj
+        except Exception as e:
+            logger.warning("Failed to load hook plugin '{}': {}", ep.name, e)
+    return plugins
+
+
+def register_discovered(center: Any) -> int:
+    """Discover external hook plugins and register them with *center*.
+
+    Each loaded object may be:
+    - A callable with a ``hook_points`` attribute (list of point names)
+    - A mapping ``{point_name: handler}``
+
+    Callables without ``hook_points`` are logged as errors and skipped.
+
+    Returns the number of successfully registered handlers.
+    """
+    plugins = discover_hook_plugins()
+    registered = 0
+    for name, obj in plugins.items():
+        try:
+            if isinstance(obj, dict):
+                for point_name, handler in obj.items():
+                    center.register_handler(point_name, handler)
+                    registered += 1
+            elif callable(obj):
+                points = getattr(obj, "hook_points", None)
+                if points:
+                    for point_name in points:
+                        center.register_handler(point_name, obj)
+                        registered += 1
+                elif points is None:
+                    raise ValueError(
+                        f"Hook plugin '{name}' is callable but has no "
+                        f"'hook_points' attribute; cannot determine "
+                        f"which points to register for"
+                    )
+            else:
+                logger.warning(
+                    "Hook plugin '{}' is not callable and not a dict; skipping",
+                    name,
+                )
+        except Exception as e:
+            logger.warning("Error registering hook plugin '{}': {}", name, e)
+    return registered

--- a/nanobot/hooks/types.py
+++ b/nanobot/hooks/types.py
@@ -1,0 +1,20 @@
+"""Hook handler protocol for the HookCenter."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from nanobot.hooks.context import HookContext, HookResult
+
+
+@runtime_checkable
+class HookHandler(Protocol):
+    """Protocol for hook handlers registered with HookCenter."""
+
+    async def __call__(self, context: HookContext) -> HookResult | None:
+        ...
+
+
+__all__ = [
+    "HookHandler",
+]

--- a/tests/hooks/test_center.py
+++ b/tests/hooks/test_center.py
@@ -1,0 +1,267 @@
+"""Tests for HookCenter: registration, emit, short-circuit, cancel, error isolation."""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.hooks.center import HookCenter, get_center, reset_center
+from nanobot.hooks.context import HookContext, HookResult
+
+
+def _ctx(**kwargs) -> HookContext:
+    return HookContext(data=kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _reset_global():
+    reset_center()
+    yield
+    reset_center()
+
+
+class TestHookContext:
+    def test_create_and_read(self):
+        ctx = HookContext(data={"key": "value"})
+        assert ctx.get("key") == "value"
+
+    def test_set_and_read(self):
+        ctx = _ctx()
+        ctx.set("x", 42)
+        assert ctx.get("x") == 42
+
+    def test_get_default(self):
+        ctx = _ctx()
+        assert ctx.get("missing") is None
+        assert ctx.get("missing", "fallback") == "fallback"
+
+
+class TestHookResult:
+    def test_continue(self):
+        r = HookResult(action="continue")
+        assert r.action == "continue"
+
+    def test_cancel(self):
+        r = HookResult(action="cancel", reason="unauthorized")
+        assert r.action == "cancel"
+        assert r.reason == "unauthorized"
+
+    def test_short_circuit(self):
+        r = HookResult(action="short_circuit")
+        assert r.action == "short_circuit"
+
+
+class TestHookCenterRegister:
+    def test_register_point(self):
+        center = HookCenter()
+        center.register_point("tool.before_execute", "Before tool execution")
+        assert center.has_point("tool.before_execute")
+
+    def test_register_handler_auto_creates_point(self):
+        center = HookCenter()
+
+        async def handler(ctx: HookContext) -> None:
+            pass
+
+        center.register_handler("my.point", handler)
+        assert len(center.get_handlers("my.point")) == 1
+
+    def test_multiple_handlers(self):
+        center = HookCenter()
+
+        async def h1(ctx: HookContext) -> None:
+            pass
+
+        async def h2(ctx: HookContext) -> None:
+            pass
+
+        center.register_handler("p", h1)
+        center.register_handler("p", h2)
+        assert len(center.get_handlers("p")) == 2
+
+    def test_duplicate_handler_ignored(self):
+        center = HookCenter()
+
+        async def h1(ctx: HookContext) -> None:
+            pass
+
+        center.register_handler("p", h1)
+        center.register_handler("p", h1)
+        assert len(center.get_handlers("p")) == 1
+
+
+class TestHookCenterEmit:
+    @pytest.mark.asyncio
+    async def test_emit_no_handlers_returns_continue(self):
+        center = HookCenter()
+        center.register_point("empty.point")
+        result = await center.emit("empty.point", _ctx())
+        assert result.action == "continue"
+
+    @pytest.mark.asyncio
+    async def test_emit_unknown_point_returns_continue(self):
+        center = HookCenter()
+        result = await center.emit("nonexistent", _ctx())
+        assert result.action == "continue"
+
+    @pytest.mark.asyncio
+    async def test_emit_calls_handler(self):
+        center = HookCenter()
+        calls: list[str] = []
+
+        async def handler(ctx: HookContext) -> None:
+            calls.append("called")
+
+        center.register_point("test.point")
+        center.register_handler("test.point", handler)
+        result = await center.emit("test.point", _ctx())
+        assert result.action == "continue"
+        assert calls == ["called"]
+
+    @pytest.mark.asyncio
+    async def test_emit_multiple_handlers_in_order(self):
+        center = HookCenter()
+        calls: list[str] = []
+
+        async def h1(ctx: HookContext) -> None:
+            calls.append("h1")
+
+        async def h2(ctx: HookContext) -> None:
+            calls.append("h2")
+
+        center.register_handler("p", h1)
+        center.register_handler("p", h2)
+        await center.emit("p", _ctx())
+        assert calls == ["h1", "h2"]
+
+    @pytest.mark.asyncio
+    async def test_emit_handler_returns_none_continues(self):
+        center = HookCenter()
+        calls: list[str] = []
+
+        async def h1(ctx: HookContext) -> None:
+            calls.append("h1")
+
+        async def h2(ctx: HookContext) -> None:
+            calls.append("h2")
+
+        center.register_handler("p", h1)
+        center.register_handler("p", h2)
+        result = await center.emit("p", _ctx())
+        assert result.action == "continue"
+        assert calls == ["h1", "h2"]
+
+    @pytest.mark.asyncio
+    async def test_emit_context_passed_between_handlers(self):
+        center = HookCenter()
+
+        async def h1(ctx: HookContext) -> None:
+            ctx.set("seen_by_h1", ctx.get("original"))
+            ctx.set("from_h1", True)
+
+        async def h2(ctx: HookContext) -> None:
+            ctx.set("seen_by_h2", ctx.get("from_h1"))
+
+        center.register_handler("p", h1)
+        center.register_handler("p", h2)
+        ctx = _ctx(original="hello")
+        await center.emit("p", ctx)
+        assert ctx.get("seen_by_h1") == "hello"
+        assert ctx.get("seen_by_h2") is True
+
+    @pytest.mark.asyncio
+    async def test_emit_short_circuit_skips_remaining(self):
+        center = HookCenter()
+        calls: list[str] = []
+
+        async def h1(ctx: HookContext) -> HookResult:
+            calls.append("h1")
+            return HookResult(action="short_circuit")
+
+        async def h2(ctx: HookContext) -> None:
+            calls.append("h2")
+
+        center.register_handler("p", h1)
+        center.register_handler("p", h2)
+        result = await center.emit("p", _ctx())
+        assert result.action == "short_circuit"
+        assert calls == ["h1"]
+
+    @pytest.mark.asyncio
+    async def test_emit_cancel(self):
+        center = HookCenter()
+
+        async def h1(ctx: HookContext) -> HookResult:
+            return HookResult(action="cancel", reason="unauthorized")
+
+        center.register_handler("p", h1)
+        result = await center.emit("p", _ctx())
+        assert result.action == "cancel"
+        assert result.reason == "unauthorized"
+
+
+class TestHookCenterErrorIsolation:
+    @pytest.mark.asyncio
+    async def test_handler_exception_does_not_stop_others(self):
+        center = HookCenter()
+        calls: list[str] = []
+
+        async def bad(ctx: HookContext) -> None:
+            raise RuntimeError("boom")
+
+        async def good(ctx: HookContext) -> None:
+            calls.append("good")
+
+        center.register_handler("p", bad)
+        center.register_handler("p", good)
+        result = await center.emit("p", _ctx())
+        assert result.action == "continue"
+        assert calls == ["good"]
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_between_others(self):
+        center = HookCenter()
+        calls: list[str] = []
+
+        async def h1(ctx: HookContext) -> None:
+            calls.append("h1")
+
+        async def bad(ctx: HookContext) -> None:
+            raise RuntimeError("boom")
+
+        async def h3(ctx: HookContext) -> None:
+            calls.append("h3")
+
+        center.register_handler("p", h1)
+        center.register_handler("p", bad)
+        center.register_handler("p", h3)
+        result = await center.emit("p", _ctx())
+        assert result.action == "continue"
+        assert calls == ["h1", "h3"]
+
+
+class TestHookCenterReset:
+    @pytest.mark.asyncio
+    async def test_reset_clears_everything(self):
+        center = HookCenter()
+        center.register_point("p", "desc")
+
+        async def handler(ctx: HookContext) -> None:
+            pass
+
+        center.register_handler("p", handler)
+        center.reset()
+        assert not center.has_point("p")
+        assert center.get_handlers("p") == []
+
+
+class TestGlobalCenter:
+    def test_get_center_returns_same_instance(self):
+        c1 = get_center()
+        c2 = get_center()
+        assert c1 is c2
+
+    def test_reset_center_creates_new_instance(self):
+        c1 = get_center()
+        reset_center()
+        c2 = get_center()
+        assert c1 is not c2

--- a/tests/hooks/test_discovery.py
+++ b/tests/hooks/test_discovery.py
@@ -1,0 +1,129 @@
+"""Tests for hook plugin discovery via entry_points."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nanobot.hooks.center import HookCenter
+from nanobot.hooks.discovery import discover_hook_plugins, register_discovered
+
+
+@pytest.fixture
+def center():
+    c = HookCenter()
+    c.register_point("session.before_save", "Before session save")
+    c.register_point("tool.before_execute", "Before tool execution")
+    return c
+
+
+class TestDiscoverHookPlugins:
+    def test_no_entry_points(self):
+        with patch("importlib.metadata.entry_points", return_value=[]):
+            result = discover_hook_plugins()
+            assert result == {}
+
+    def test_loads_valid_plugin(self):
+        fake_ep = MagicMock()
+        fake_ep.name = "my_plugin"
+        fake_ep.load.return_value = lambda ctx: None
+
+        with patch("importlib.metadata.entry_points", return_value=[fake_ep]):
+            result = discover_hook_plugins()
+            assert "my_plugin" in result
+
+    def test_skips_failing_load(self):
+        fake_ep = MagicMock()
+        fake_ep.name = "bad_plugin"
+        fake_ep.load.side_effect = ImportError("missing dep")
+
+        with patch("importlib.metadata.entry_points", return_value=[fake_ep]):
+            result = discover_hook_plugins()
+            assert result == {}
+
+    def test_loads_multiple_plugins(self):
+        ep1 = MagicMock()
+        ep1.name = "p1"
+        ep1.load.return_value = lambda ctx: None
+
+        ep2 = MagicMock()
+        ep2.name = "p2"
+        ep2.load.return_value = lambda ctx: None
+
+        with patch("importlib.metadata.entry_points", return_value=[ep1, ep2]):
+            result = discover_hook_plugins()
+            assert len(result) == 2
+
+
+class TestRegisterDiscovered:
+    def test_dict_plugin_registers_per_point(self, center):
+        handler = MagicMock(return_value=None)
+        plugin = {"session.before_save": handler}
+
+        with patch("nanobot.hooks.discovery.discover_hook_plugins", return_value={"p": plugin}):
+            count = register_discovered(center)
+
+        assert count == 1
+        assert len(center.get_handlers("session.before_save")) == 1
+
+    def test_callable_with_hook_points(self, center):
+        async def handler(ctx) -> None:
+            pass
+
+        handler.hook_points = ["tool.before_execute"]
+
+        with patch(
+            "nanobot.hooks.discovery.discover_hook_plugins",
+            return_value={"p": handler},
+        ):
+            count = register_discovered(center)
+
+        assert count == 1
+        assert len(center.get_handlers("tool.before_execute")) == 1
+
+    def test_one_fails_other_succeeds(self, center):
+        async def good(ctx):
+            pass
+
+        good.hook_points = ["session.before_save"]
+
+        with patch(
+            "nanobot.hooks.discovery.discover_hook_plugins",
+            return_value={"bad": 42, "good": good},
+        ):
+            count = register_discovered(center)
+
+        assert count == 1
+        assert len(center.get_handlers("session.before_save")) == 1
+
+    def test_empty_discovery(self, center):
+        with patch("nanobot.hooks.discovery.discover_hook_plugins", return_value={}):
+            count = register_discovered(center)
+        assert count == 0
+
+    def test_callable_without_hook_points_logs_warning(self, center):
+        async def handler(ctx):
+            pass
+
+        with patch(
+            "nanobot.hooks.discovery.discover_hook_plugins",
+            return_value={"no_points": handler},
+        ):
+            count = register_discovered(center)
+
+        assert count == 0
+
+    def test_callable_with_empty_hook_points_skipped(self, center):
+        async def handler(ctx):
+            pass
+
+        handler.hook_points = []
+
+        with patch(
+            "nanobot.hooks.discovery.discover_hook_plugins",
+            return_value={"empty_points": handler},
+        ):
+            count = register_discovered(center)
+
+        assert count == 0

--- a/tests/hooks/test_integration.py
+++ b/tests/hooks/test_integration.py
@@ -1,0 +1,168 @@
+"""Integration tests: HookCenter with AgentLoop."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanobot.agent.hook import AgentHook
+from nanobot.hooks.center import HookCenter, reset_center
+from nanobot.hooks.context import HookContext
+
+
+@pytest.fixture(autouse=True)
+def _reset_global():
+    reset_center()
+    yield
+    reset_center()
+
+
+def _make_loop(tmp_path, hooks=None):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.generation.max_tokens = 4096
+
+    with patch("nanobot.agent.loop.ContextBuilder"), \
+         patch("nanobot.agent.loop.SessionManager"), \
+         patch("nanobot.agent.loop.SubagentManager") as mock_sub_mgr, \
+         patch("nanobot.agent.loop.Consolidator"), \
+         patch("nanobot.agent.loop.Dream"):
+        mock_sub_mgr.return_value.cancel_by_session = AsyncMock(return_value=0)
+        loop = AgentLoop(
+            bus=bus, provider=provider, workspace=tmp_path, hooks=hooks,
+        )
+    return loop
+
+
+class TestAgentLoopIntegration:
+    def test_loop_initializes_hook_center(self, tmp_path):
+        loop = _make_loop(tmp_path)
+        assert hasattr(loop, "_hook_center")
+        assert isinstance(loop._hook_center, HookCenter)
+
+    def test_loop_discovers_plugins_on_init(self, tmp_path):
+        async def my_handler(ctx: HookContext) -> None:
+            pass
+
+        with patch(
+            "nanobot.hooks.discovery.discover_hook_plugins",
+            return_value={"test_plugin": {"my.point": my_handler}},
+        ):
+            loop = _make_loop(tmp_path)
+
+        assert len(loop._hook_center.get_handlers("my.point")) == 1
+
+    @pytest.mark.asyncio
+    async def test_existing_agent_hooks_still_work(self, tmp_path):
+        from nanobot.providers.base import LLMResponse
+
+        events: list[str] = []
+
+        class TrackingHook(AgentHook):
+            async def before_iteration(self, context):
+                events.append("before_iter")
+
+        loop = _make_loop(tmp_path, hooks=[TrackingHook()])
+        loop.provider.chat_with_retry = AsyncMock(
+            return_value=LLMResponse(content="done", tool_calls=[], usage={})
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        content, _, _, _, _ = await loop._run_agent_loop(
+            [{"role": "user", "content": "hi"}]
+        )
+        assert content == "done"
+        assert "before_iter" in events
+
+    @pytest.mark.asyncio
+    async def test_plugin_failure_does_not_crash_loop(self, tmp_path):
+        with patch(
+            "nanobot.hooks.discovery.discover_hook_plugins",
+            side_effect=RuntimeError("boom"),
+        ):
+            loop = _make_loop(tmp_path)
+
+        assert isinstance(loop._hook_center, HookCenter)
+
+    def test_standard_hook_points_registered(self, tmp_path):
+        loop = _make_loop(tmp_path)
+        points = loop._hook_center.get_point_names()
+        assert "agent.before_iteration" in points
+        assert "agent.after_iteration" in points
+        assert "agent.before_execute_tools" in points
+        assert "agent.on_stream_end" in points
+
+    @pytest.mark.asyncio
+    async def test_emit_fired_on_before_iteration(self, tmp_path):
+        from nanobot.providers.base import LLMResponse
+
+        received: list[HookContext] = []
+
+        async def capture_handler(ctx: HookContext):
+            received.append(ctx)
+            return None
+
+        loop = _make_loop(tmp_path)
+        loop._hook_center.register_handler("agent.before_iteration", capture_handler)
+        loop.provider.chat_with_retry = AsyncMock(
+            return_value=LLMResponse(content="ok", tool_calls=[], usage={})
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        await loop._run_agent_loop([{"role": "user", "content": "hi"}])
+        assert len(received) >= 1
+        assert received[0].data["iteration"] == 0
+
+    @pytest.mark.asyncio
+    async def test_cancel_before_iteration_stops_run(self, tmp_path):
+        from nanobot.hooks.context import HookResult
+        from nanobot.providers.base import LLMResponse
+
+        llm_calls = 0
+
+        async def cancel_handler(ctx: HookContext):
+            return HookResult(action="cancel", reason="blocked")
+
+        loop = _make_loop(tmp_path)
+        loop._hook_center.register_handler("agent.before_iteration", cancel_handler)
+        loop.provider.chat_with_retry = AsyncMock(
+            side_effect=lambda *a, **kw: (
+                llm_calls.__add__(1) or LLMResponse(content="ok", tool_calls=[], usage={})
+            )
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        content, tools_used, _, stop_reason, _ = await loop._run_agent_loop(
+            [{"role": "user", "content": "hi"}]
+        )
+        assert stop_reason == "hook_cancelled"
+
+    @pytest.mark.asyncio
+    async def test_cancel_before_execute_tools_stops_run(self, tmp_path):
+        from nanobot.hooks.context import HookResult
+        from nanobot.providers.base import LLMResponse, ToolCallRequest
+
+        async def cancel_handler(ctx: HookContext):
+            if ctx.get("tool_calls"):
+                return HookResult(action="cancel", reason="no_tools")
+            return None
+
+        tc = ToolCallRequest(
+            id="call_1", name="read_file", arguments={"path": "/tmp/test"}
+        )
+        loop = _make_loop(tmp_path)
+        loop._hook_center.register_handler("agent.before_execute_tools", cancel_handler)
+        loop.provider.chat_with_retry = AsyncMock(
+            return_value=LLMResponse(content="", tool_calls=[tc], usage={})
+        )
+        loop.tools.get_definitions = MagicMock(return_value=[])
+
+        content, tools_used, _, stop_reason, _ = await loop._run_agent_loop(
+            [{"role": "user", "content": "hi"}]
+        )
+        assert stop_reason == "hook_cancelled"


### PR DESCRIPTION
## Summary

Add a centralized `HookCenter` infrastructure that lets internal developers declare named hook points and external plugins attach handlers via Python `entry_points`. The system supports full interceptor semantics: handlers can observe, mutate data, short-circuit, or cancel the flow. Existing `AgentHook`/`CompositeHook` remain untouched.

## Context

nanobot already uses `entry_points` for channel plugin discovery (`nanobot.channels` group) and has `AgentHook`/`CompositeHook` for agent-lifecycle callbacks. Neither mechanism provides a generic, named hook point system that external plugins can tap into. Contributors who want to inject behavior at arbitrary points must modify core code.

## Why

- **No generic hook registry**: Each feature area (channels, agent loop) rolls its own callback pattern. A shared registry eliminates duplication.
- **External plugins have no extension surface**: Third-party packages cannot intercept or augment behavior without forking.
- **Inconsistent error handling**: Some callback paths crash on handler errors; others silently swallow them. A centralized system standardizes error isolation.

## Solve

Introduce `nanobot/hooks/` — a self-contained package with four components:

1. **`HookContext` / `HookResult`** — A mutable data bag passed between handlers, and a `Literal`-typed control-flow signal (`continue` / `short_circuit` / `cancel`).
2. **`HookCenter`** — Global singleton registry with `register_point()`, `register_handler()`, and `async emit()`. Handlers run in registration order with per-handler error isolation (failing handler is logged and skipped).
3. **Plugin discovery** — Scans the `nanobot.hooks` entry_points group. Callable plugins must declare a `hook_points` attribute; dict plugins map `{point_name: handler}`. Invalid plugins are logged and skipped.
4. **AgentLoop integration** — `_init_hook_center()` runs on startup, discovers external plugins, and logs registration count.

## Changes

| Component | File | Description |
|-----------|------|-------------|
| Types | `nanobot/hooks/context.py` | `HookContext` dataclass (mutable dict), `HookResult` with `Literal["continue","short_circuit","cancel"]` action |
| Types | `nanobot/hooks/types.py` | `HookHandler` protocol definition (`async (HookContext) -> HookResult | None`) |
| Core | `nanobot/hooks/center.py` | `HookCenter` class: register_point, register_handler, emit, reset; global `get_center()`/`reset_center()` |
| Discovery | `nanobot/hooks/discovery.py` | `discover_hook_plugins()` and `register_discovered()` via `importlib.metadata.entry_points` |
| Init | `nanobot/hooks/__init__.py` | Public re-exports: `HookCenter`, `HookContext`, `HookResult`, `HookHandler` |
| Integration | `nanobot/agent/loop.py` | `_init_hook_center()` called in `AgentLoop.__init__` |
| Docs | `docs/hook-center-guide.md` | Developer guide for internal and external plugin authors |

## Test

| Suite | File | Count | Coverage |
|-------|------|-------|----------|
| Core | `tests/hooks/test_center.py` | 22 | HookContext, HookResult, register/emit, error isolation, global singleton |
| Discovery | `tests/hooks/test_discovery.py` | 9 | entry_points load, dict/callable plugins, missing hook_points rejection |
| Integration | `tests/hooks/test_integration.py` | 4 | AgentLoop init, plugin discovery on startup, AgentHook backward compat, plugin failure resilience |
| Regression | `tests/agent/test_hook_composite.py` | 18 | Existing AgentHook/CompositeHook unchanged |

**Total: 53 tests, all passing.** No regressions in existing test suites.

---

[![Built with OpenCode](https://img.shields.io/badge/Built_with-OpenCode-4B32C3)](https://github.com/anomalyco/opencode)
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/GLM_5.1-4285F4?logo=googlegemini&logoColor=white)