### PR TITLE
feat(weixin): multi-account support for personal WeChat channel

### DIFF
--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -112,6 +112,18 @@ def _has_downloadable_media_locator(media: dict[str, Any] | None) -> bool:
     return bool(str(media.get("encrypt_query_param", "") or "") or str(media.get("full_url", "") or "").strip())
 
 
+class WeixinAccountConfig(Base):
+    """Per-account WeChat configuration (used in multi-account mode)."""
+
+    token: str = ""
+    bot_id: str = ""  # Bot's iLinkai ID (e.g. xxxxxxxxxxxx@im.bot); changes on each QR scan
+    user_id: str = ""  # Stable WeChat user ID of the linked account; used as state filename
+    base_url: str = "https://ilinkai.weixin.qq.com"
+    cdn_base_url: str = "https://novac2c.cdn.weixin.qq.com/c2c"
+    route_tag: str | int | None = None
+    poll_timeout: int = DEFAULT_LONG_POLL_TIMEOUT_S
+
+
 class WeixinConfig(Base):
     """Personal WeChat channel configuration."""
 
@@ -121,68 +133,94 @@ class WeixinConfig(Base):
     cdn_base_url: str = "https://novac2c.cdn.weixin.qq.com/c2c"
     route_tag: str | int | None = None
     token: str = ""  # Manually set token, or obtained via QR login
-    state_dir: str = ""  # Default: ~/.nanobot/weixin/
+    state_dir: str = ""  # Override state directory (default: ~/.nanobot/weixin/)
     poll_timeout: int = DEFAULT_LONG_POLL_TIMEOUT_S  # seconds for long-poll
+    accounts: list[WeixinAccountConfig] = Field(default_factory=list)  # Optional per-account overrides
 
 
-class WeixinChannel(BaseChannel):
+class _WeixinAccountRunner:
+    """Per-account HTTP client, state, and polling loop for WeixinChannel.
+
+    One runner is created per ``{user_id}.json`` file discovered in the weixin
+    state directory, or per entry in ``WeixinConfig.accounts`` when explicit
+    per-account settings are needed.
     """
-    Personal WeChat channel using HTTP long-poll.
 
-    Connects to ilinkai.weixin.qq.com API to receive and send personal
-    WeChat messages. Authentication is via QR code login which produces
-    a bot token.
-    """
+    def __init__(
+        self,
+        idx: int,
+        cfg: WeixinAccountConfig,
+        channel: "WeixinChannel",
+        *,
+        multi: bool,
+    ) -> None:
+        self._idx = idx
+        self._cfg = cfg
+        self._channel = channel
+        self._multi = multi  # True => prefix chat_ids with "{bot_id}:{from_user_id}"
 
-    name = "weixin"
-    display_name = "WeChat"
-
-    @classmethod
-    def default_config(cls) -> dict[str, Any]:
-        return WeixinConfig().model_dump(by_alias=True)
-
-    def __init__(self, config: Any, bus: MessageBus):
-        if isinstance(config, dict):
-            config = WeixinConfig.model_validate(config)
-        super().__init__(config, bus)
-        self.config: WeixinConfig = config
-
-        # State
+        # Per-account state
         self._client: httpx.AsyncClient | None = None
         self._get_updates_buf: str = ""
-        self._context_tokens: dict[str, str] = {}  # from_user_id -> context_token
+        self._context_tokens: dict[str, str] = {}  # from_user_id (@im.wechat) -> context_token
         self._processed_ids: OrderedDict[str, None] = OrderedDict()
-        self._state_dir: Path | None = None
+        self._bot_id: str = cfg.bot_id  # Bot's iLinkai ID (e.g. xxxxxxxxxxxx@im.bot); changes each QR scan
+        self._user_id: str = cfg.user_id  # Stable WeChat user ID of the linked account (ilink_user_id from QR response)
         self._token: str = ""
-        self._poll_task: asyncio.Task | None = None
         self._next_poll_timeout_s: int = DEFAULT_LONG_POLL_TIMEOUT_S
         self._session_pause_until: float = 0.0
         self._typing_tasks: dict[str, asyncio.Task] = {}
         self._typing_tickets: dict[str, dict[str, Any]] = {}
+        self._running: bool = False
+
+    # ------------------------------------------------------------------
+    # chat_id helpers
+    # ------------------------------------------------------------------
+
+    def _make_chat_id(self, from_user_id: str) -> str:
+        """Build the chat_id seen by the bus (prefixed when multi-account)."""
+        if self._multi:
+            prefix = self._user_id or self._bot_id or str(self._idx)
+            return f"{prefix}:{from_user_id}"
+        return from_user_id
 
     # ------------------------------------------------------------------
     # State persistence
     # ------------------------------------------------------------------
 
-    def _get_state_dir(self) -> Path:
-        if self._state_dir:
-            return self._state_dir
-        if self.config.state_dir:
-            d = Path(self.config.state_dir).expanduser()
-        else:
-            d = get_runtime_subdir("weixin")
-        d.mkdir(parents=True, exist_ok=True)
-        self._state_dir = d
-        return d
+    def _get_state_file(self) -> Path | None:
+        """Return state file path: prefer stable user_id, fallback to bot_id."""
+        stem = self._user_id or self._bot_id
+        if stem:
+            return self._weixin_dir() / f"{stem}.json"
+        return None
+
+    def _get_legacy_state_file(self) -> Path:
+        """Legacy single-account state file path (fallback when user_id unknown)."""
+        return self._weixin_dir() / "account.json"
+
+    def _weixin_dir(self) -> Path:
+        """Resolve the weixin state directory, honouring config.state_dir override."""
+        sd = self._channel.config.state_dir
+        if sd:
+            p = Path(sd).expanduser()
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+        return get_runtime_subdir("weixin")
 
     def _load_state(self) -> bool:
         """Load saved account state. Returns True if a valid token was found."""
-        state_file = self._get_state_dir() / "account.json"
+        state_file = self._get_state_file() or self._get_legacy_state_file()
         if not state_file.exists():
             return False
         try:
             data = json.loads(state_file.read_text())
             self._token = data.get("token", "")
+            # Recover identifiers from state file if not already known
+            if not self._bot_id:
+                self._bot_id = data.get("bot_id", "")
+            if not self._user_id:
+                self._user_id = data.get("user_id", "")
             self._get_updates_buf = data.get("get_updates_buf", "")
             context_tokens = data.get("context_tokens", {})
             if isinstance(context_tokens, dict):
@@ -204,22 +242,24 @@ class WeixinChannel(BaseChannel):
                 self._typing_tickets = {}
             base_url = data.get("base_url", "")
             if base_url:
-                self.config.base_url = base_url
+                self._cfg.base_url = base_url
             return bool(self._token)
         except Exception:
             return False
 
     def _save_state(self) -> None:
-        state_file = self._get_state_dir() / "account.json"
+        state_file = self._get_state_file() or self._get_legacy_state_file()
         try:
             data = {
+                "bot_id": self._bot_id,
+                "user_id": self._user_id,
                 "token": self._token,
                 "get_updates_buf": self._get_updates_buf,
                 "context_tokens": self._context_tokens,
                 "typing_tickets": self._typing_tickets,
-                "base_url": self.config.base_url,
+                "base_url": self._cfg.base_url,
             }
-            state_file.write_text(json.dumps(data, ensure_ascii=False))
+            state_file.write_text(json.dumps(data, ensure_ascii=False, indent=2))
         except Exception:
             pass
 
@@ -248,8 +288,8 @@ class WeixinChannel(BaseChannel):
         }
         if auth and self._token:
             headers["Authorization"] = f"Bearer {self._token}"
-        if self.config.route_tag is not None and str(self.config.route_tag).strip():
-            headers["SKRouteTag"] = str(self.config.route_tag).strip()
+        if self._cfg.route_tag is not None and str(self._cfg.route_tag).strip():
+            headers["SKRouteTag"] = str(self._cfg.route_tag).strip()
         return headers
 
     @staticmethod
@@ -270,7 +310,7 @@ class WeixinChannel(BaseChannel):
         extra_headers: dict[str, str] | None = None,
     ) -> dict:
         assert self._client is not None
-        url = f"{self.config.base_url}/{endpoint}"
+        url = f"{self._cfg.base_url}/{endpoint}"
         hdrs = self._make_headers(auth=auth)
         if extra_headers:
             hdrs.update(extra_headers)
@@ -305,7 +345,7 @@ class WeixinChannel(BaseChannel):
         auth: bool = True,
     ) -> dict:
         assert self._client is not None
-        url = f"{self.config.base_url}/{endpoint}"
+        url = f"{self._cfg.base_url}/{endpoint}"
         payload = body or {}
         if "base_info" not in payload:
             payload["base_info"] = BASE_INFO
@@ -335,8 +375,10 @@ class WeixinChannel(BaseChannel):
         try:
             refresh_count = 0
             qrcode_id, scan_url = await self._fetch_qr_code()
+            if self._multi:
+                print(f"\n[Account {self._idx}] Scan QR code to login:")
             self._print_qr_code(scan_url)
-            current_poll_base_url = self.config.base_url
+            current_poll_base_url = self._cfg.base_url
 
             while self._running:
                 try:
@@ -360,21 +402,26 @@ class WeixinChannel(BaseChannel):
                 if status == "confirmed":
                     token = status_data.get("bot_token", "")
                     bot_id = status_data.get("ilink_bot_id", "")
-                    base_url = status_data.get("baseurl", "")
                     user_id = status_data.get("ilink_user_id", "")
+                    base_url = status_data.get("baseurl", "")
                     if token:
                         self._token = token
+                        if bot_id:
+                            self._bot_id = bot_id
+                        if user_id:
+                            self._user_id = user_id
                         if base_url:
-                            self.config.base_url = base_url
+                            self._cfg.base_url = base_url
                         self._save_state()
                         logger.info(
-                            "WeChat login successful! bot_id={} user_id={}",
+                            "WeChat account {} login successful! bot_id={} user_id={}",
+                            self._idx,
                             bot_id,
                             user_id,
                         )
                         return True
                     else:
-                        logger.error("Login confirmed but no bot_token in response")
+                        logger.error("WeChat account {} login confirmed but no bot_token", self._idx)
                         return False
                 elif status == "scaned_but_redirect":
                     redirect_host = str(status_data.get("redirect_host", "") or "").strip()
@@ -389,13 +436,14 @@ class WeixinChannel(BaseChannel):
                     refresh_count += 1
                     if refresh_count > MAX_QR_REFRESH_COUNT:
                         logger.warning(
-                            "QR code expired too many times ({}/{}), giving up.",
+                            "WeChat account {} QR code expired too many times ({}/{}), giving up.",
+                            self._idx,
                             refresh_count - 1,
                             MAX_QR_REFRESH_COUNT,
                         )
                         return False
                     qrcode_id, scan_url = await self._fetch_qr_code()
-                    current_poll_base_url = self.config.base_url
+                    current_poll_base_url = self._cfg.base_url
                     self._print_qr_code(scan_url)
                     continue
                 # status == "wait" — keep polling
@@ -403,7 +451,7 @@ class WeixinChannel(BaseChannel):
                 await asyncio.sleep(1)
 
         except Exception as e:
-            logger.error("WeChat QR login failed: {}", e)
+            logger.error("WeChat account {} QR login failed: {}", self._idx, e)
 
         return False
 
@@ -430,7 +478,7 @@ class WeixinChannel(BaseChannel):
             print(f"\nLogin URL: {url}\n")
 
     # ------------------------------------------------------------------
-    # Channel lifecycle
+    # Account lifecycle
     # ------------------------------------------------------------------
 
     async def login(self, force: bool = False) -> bool:
@@ -438,18 +486,19 @@ class WeixinChannel(BaseChannel):
         if force:
             self._token = ""
             self._get_updates_buf = ""
-            state_file = self._get_state_dir() / "account.json"
-            if state_file.exists():
-                state_file.unlink()
+            self._bot_id = self._cfg.bot_id
+            self._user_id = self._cfg.user_id
+            for sf in [self._get_state_file(), self._get_legacy_state_file()]:
+                if sf and sf.exists():
+                    sf.unlink()
         if self._token or self._load_state():
             return True
 
-        # Initialize HTTP client for the login flow
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(60, connect=30),
             follow_redirects=True,
         )
-        self._running = True  # Enable polling loop in _qr_login()
+        self._running = True
         try:
             return await self._qr_login()
         finally:
@@ -458,23 +507,27 @@ class WeixinChannel(BaseChannel):
                 await self._client.aclose()
                 self._client = None
 
-    async def start(self) -> None:
+    async def run(self) -> None:
+        """Main poll loop. Runs until stop() is called."""
         self._running = True
-        self._next_poll_timeout_s = self.config.poll_timeout
+        self._next_poll_timeout_s = self._cfg.poll_timeout
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(self._next_poll_timeout_s + 10, connect=30),
             follow_redirects=True,
         )
 
-        if self.config.token:
-            self._token = self.config.token
+        if self._cfg.token:
+            self._token = self._cfg.token
         elif not self._load_state():
             if not await self._qr_login():
-                logger.error("WeChat login failed. Run 'nanobot channels login weixin' to authenticate.")
+                logger.error(
+                    "WeChat account {} login failed. Run 'nanobot channels login weixin' to authenticate.",
+                    self._idx,
+                )
                 self._running = False
                 return
 
-        logger.info("WeChat channel starting with long-poll...")
+        logger.info("WeChat account {} starting with long-poll...", self._idx)
 
         consecutive_failures = 0
         while self._running:
@@ -496,14 +549,13 @@ class WeixinChannel(BaseChannel):
 
     async def stop(self) -> None:
         self._running = False
-        if self._poll_task and not self._poll_task.done():
-            self._poll_task.cancel()
         for chat_id in list(self._typing_tasks):
             await self._stop_typing(chat_id, clear_remote=False)
         if self._client:
             await self._client.aclose()
             self._client = None
         self._save_state()
+
     # ------------------------------------------------------------------
     # Polling  (matches monitor.ts monitorWeixinProvider)
     # ------------------------------------------------------------------
@@ -553,7 +605,8 @@ class WeixinChannel(BaseChannel):
                 self._pause_session()
                 remaining = self._session_pause_remaining_s()
                 logger.warning(
-                    "WeChat session expired (errcode {}). Pausing {} min.",
+                    "WeChat account {} session expired (errcode {}). Pausing {} min.",
+                    self._idx,
                     errcode,
                     max((remaining + 59) // 60, 1),
                 )
@@ -597,6 +650,7 @@ class WeixinChannel(BaseChannel):
             msg_id = f"{msg.get('from_user_id', '')}_{msg.get('create_time_ms', '')}"
         if msg_id in self._processed_ids:
             return
+        logger.debug(msg)
         self._processed_ids[msg_id] = None
         while len(self._processed_ids) > 1000:
             self._processed_ids.popitem(last=False)
@@ -672,7 +726,7 @@ class WeixinChannel(BaseChannel):
                         has_top_level_downloadable_media = True
                     file_path = await self._download_media_item(voice_item, "voice")
                     if file_path:
-                        transcription = await self.transcribe_audio(file_path)
+                        transcription = await self._channel.transcribe_audio(file_path)
                         if transcription:
                             content_parts.append(f"[voice] {transcription}")
                         else:
@@ -734,7 +788,7 @@ class WeixinChannel(BaseChannel):
                     voice_item = ref_media_item.get("voice_item") or {}
                     file_path = await self._download_media_item(voice_item, "voice")
                     if file_path:
-                        transcription = await self.transcribe_audio(file_path)
+                        transcription = await self._channel.transcribe_audio(file_path)
                         if transcription:
                             content_parts.append(f"[voice] {transcription}")
                         else:
@@ -759,7 +813,8 @@ class WeixinChannel(BaseChannel):
             return
 
         logger.info(
-            "WeChat inbound: from={} items={} bodyLen={}",
+            "WeChat account {} inbound: from={} items={} bodyLen={}",
+            self._idx,
             from_user_id,
             ",".join(str(i.get("type", 0)) for i in item_list),
             len(content),
@@ -767,9 +822,9 @@ class WeixinChannel(BaseChannel):
 
         await self._start_typing(from_user_id, ctx_token)
 
-        await self._handle_message(
+        await self._channel._handle_message(
             sender_id=from_user_id,
-            chat_id=from_user_id,
+            chat_id=self._make_chat_id(from_user_id),
             content=content,
             media=media_paths or None,
             metadata={"message_id": msg_id},
@@ -817,7 +872,7 @@ class WeixinChannel(BaseChannel):
             fallback_url = ""
             if encrypt_query_param:
                 fallback_url = (
-                    f"{self.config.cdn_base_url}/download"
+                    f"{self._cfg.cdn_base_url}/download"
                     f"?encrypted_query_param={quote(encrypt_query_param)}"
                 )
 
@@ -939,9 +994,10 @@ class WeixinChannel(BaseChannel):
         finally:
             pass
 
-    async def send(self, msg: OutboundMessage) -> None:
+    async def send(self, user_id: str, msg: OutboundMessage) -> None:
+        """Send an outbound message to user_id via this account."""
         if not self._client or not self._token:
-            logger.warning("WeChat client not initialized or not authenticated")
+            logger.warning("WeChat account {} client not initialized or not authenticated", self._idx)
             return
         try:
             self._assert_session_active()
@@ -950,26 +1006,27 @@ class WeixinChannel(BaseChannel):
 
         is_progress = bool((msg.metadata or {}).get("_progress", False))
         if not is_progress:
-            await self._stop_typing(msg.chat_id, clear_remote=True)
+            await self._stop_typing(user_id, clear_remote=True)
 
         content = msg.content.strip()
-        ctx_token = self._context_tokens.get(msg.chat_id, "")
+        ctx_token = self._context_tokens.get(user_id, "")
         if not ctx_token:
             logger.warning(
-                "WeChat: no context_token for chat_id={}, cannot send",
-                msg.chat_id,
+                "WeChat account {}: no context_token for user_id={}, cannot send",
+                self._idx,
+                user_id,
             )
             return
 
         typing_ticket = ""
         try:
-            typing_ticket = await self._get_typing_ticket(msg.chat_id, ctx_token)
+            typing_ticket = await self._get_typing_ticket(user_id, ctx_token)
         except Exception:
             typing_ticket = ""
 
         if typing_ticket:
             try:
-                await self._send_typing(msg.chat_id, typing_ticket, TYPING_STATUS_TYPING)
+                await self._send_typing(user_id, typing_ticket, TYPING_STATUS_TYPING)
             except Exception:
                 pass
 
@@ -977,14 +1034,14 @@ class WeixinChannel(BaseChannel):
         typing_keepalive_task: asyncio.Task | None = None
         if typing_ticket:
             typing_keepalive_task = asyncio.create_task(
-                self._typing_keepalive_loop(msg.chat_id, typing_ticket, typing_keepalive_stop)
+                self._typing_keepalive_loop(user_id, typing_ticket, typing_keepalive_stop)
             )
 
         try:
             # --- Send media files first (following Telegram channel pattern) ---
             for media_path in (msg.media or []):
                 try:
-                    await self._send_media_file(msg.chat_id, media_path, ctx_token)
+                    await self._send_media_file(user_id, media_path, ctx_token)
                 except (httpx.TimeoutException, httpx.TransportError) as net_err:
                     # Network/transport errors: do NOT fall back to text —
                     # the text send would also likely fail, and the outer
@@ -1017,16 +1074,15 @@ class WeixinChannel(BaseChannel):
                     filename = Path(media_path).name
                     logger.error("Failed to send WeChat media {}: {}", media_path, http_err)
                     await self._send_text(
-                        msg.chat_id, f"[Failed to send: {filename}]", ctx_token,
+                        user_id, f"[Failed to send: {filename}]", ctx_token,
                     )
                 except Exception as e:
                     # Non-network errors (format, file-not-found, etc.):
                     # notify the user via text fallback.
                     filename = Path(media_path).name
                     logger.error("Failed to send WeChat media {}: {}", media_path, e)
-                    # Notify user about failure via text
                     await self._send_text(
-                        msg.chat_id, f"[Failed to send: {filename}]", ctx_token,
+                        user_id, f"[Failed to send: {filename}]", ctx_token,
                     )
 
             # --- Send text content ---
@@ -1035,7 +1091,7 @@ class WeixinChannel(BaseChannel):
 
             chunks = split_message(content, WEIXIN_MAX_MESSAGE_LEN)
             for chunk in chunks:
-                await self._send_text(msg.chat_id, chunk, ctx_token)
+                await self._send_text(user_id, chunk, ctx_token)
         except Exception as e:
             logger.error("Error sending WeChat message: {}", e)
             raise
@@ -1050,7 +1106,7 @@ class WeixinChannel(BaseChannel):
 
             if typing_ticket and not is_progress:
                 try:
-                    await self._send_typing(msg.chat_id, typing_ticket, TYPING_STATUS_CANCEL)
+                    await self._send_typing(user_id, typing_ticket, TYPING_STATUS_CANCEL)
                 except Exception:
                     pass
 
@@ -1149,155 +1205,171 @@ class WeixinChannel(BaseChannel):
                 data.get("errmsg", ""),
             )
 
-    async def _send_media_file(
-        self,
-        to_user_id: str,
-        media_path: str,
-        context_token: str,
-    ) -> None:
-        """Upload a local file to WeChat CDN and send it as a media message.
 
-        Follows the exact protocol from ``@tencent-weixin/openclaw-weixin`` v1.0.3:
-        1. Generate a random 16-byte AES key (client-side).
-        2. Call ``getuploadurl`` with file metadata + hex-encoded AES key.
-        3. AES-128-ECB encrypt the file and POST to CDN (``{cdnBaseUrl}/upload``).
-        4. Read ``x-encrypted-param`` header from CDN response as the download param.
-        5. Send a ``sendmessage`` with the appropriate media item referencing the upload.
+
+class WeixinChannel(BaseChannel):
+    """
+    Personal WeChat channel using HTTP long-poll.
+
+    Supports multiple simultaneous WeChat accounts via the ``accounts`` list in
+    WeixinConfig. Each account runs its own independent poll loop and state file.
+    For single-account use the top-level ``token``/``state_dir``/etc. fields still work
+    unchanged — no migration needed.
+    """
+
+    name = "weixin"
+    display_name = "WeChat"
+
+    @classmethod
+    def default_config(cls) -> dict[str, Any]:
+        return WeixinConfig().model_dump(by_alias=True)
+
+    def __init__(self, config: Any, bus: MessageBus):
+        if isinstance(config, dict):
+            config = WeixinConfig.model_validate(config)
+        super().__init__(config, bus)
+        self.config: WeixinConfig = config
+
+        acct_cfgs = self._build_account_configs(config)
+        self._runners: list[_WeixinAccountRunner] = [
+            _WeixinAccountRunner(idx, acct_cfg, self, multi=True)
+            for idx, acct_cfg in enumerate(acct_cfgs)
+        ]
+
+    @staticmethod
+    def _build_account_configs(config: WeixinConfig) -> list[WeixinAccountConfig]:
+        """Build the normalized per-account config list.
+
+        Priority:
+        1. Explicit ``accounts`` list in config (allows per-account overrides).
+        2. Auto-discover ``{user_id}.json`` files in the weixin state directory.
+        3. Fresh install: single empty runner (will trigger QR login on startup).
         """
-        p = Path(media_path)
-        if not p.is_file():
-            raise FileNotFoundError(f"Media file not found: {media_path}")
+        if config.accounts:
+            return list(config.accounts)
 
-        raw_data = p.read_bytes()
-        raw_size = len(raw_data)
-        raw_md5 = hashlib.md5(raw_data).hexdigest()
-
-        # Determine upload media type from extension
-        ext = p.suffix.lower()
-        if ext in _IMAGE_EXTS:
-            upload_type = UPLOAD_MEDIA_IMAGE
-            item_type = ITEM_IMAGE
-            item_key = "image_item"
-        elif ext in _VIDEO_EXTS:
-            upload_type = UPLOAD_MEDIA_VIDEO
-            item_type = ITEM_VIDEO
-            item_key = "video_item"
-        elif ext in _VOICE_EXTS:
-            upload_type = UPLOAD_MEDIA_VOICE
-            item_type = ITEM_VOICE
-            item_key = "voice_item"
-        else:
-            upload_type = UPLOAD_MEDIA_FILE
-            item_type = ITEM_FILE
-            item_key = "file_item"
-
-        # Generate client-side AES-128 key (16 random bytes)
-        aes_key_raw = os.urandom(16)
-        aes_key_hex = aes_key_raw.hex()
-
-        # Compute encrypted size: PKCS7 padding to 16-byte boundary
-        # Matches aesEcbPaddedSize: Math.ceil((size + 1) / 16) * 16
-        padded_size = ((raw_size + 1 + 15) // 16) * 16
-
-        # Step 1: Get upload URL from server (prefer upload_full_url, fallback to upload_param)
-        file_key = os.urandom(16).hex()
-        upload_body: dict[str, Any] = {
-            "filekey": file_key,
-            "media_type": upload_type,
-            "to_user_id": to_user_id,
-            "rawsize": raw_size,
-            "rawfilemd5": raw_md5,
-            "filesize": padded_size,
-            "no_need_thumb": True,
-            "aeskey": aes_key_hex,
-        }
-
-        assert self._client is not None
-        upload_resp = await self._api_post("ilink/bot/getuploadurl", upload_body)
-
-        upload_full_url = str(upload_resp.get("upload_full_url", "") or "").strip()
-        upload_param = str(upload_resp.get("upload_param", "") or "")
-        if not upload_full_url and not upload_param:
-            raise RuntimeError(
-                "getuploadurl returned no upload URL "
-                f"(need upload_full_url or upload_param): {upload_resp}"
+        # Auto-discover: each {user_id}.json in the weixin dir = one account
+        sd = config.state_dir
+        weixin_dir = (Path(sd).expanduser() if sd else get_runtime_subdir("weixin"))
+        discovered = [
+            WeixinAccountConfig(
+                user_id=p.stem,
+                base_url=config.base_url,
+                cdn_base_url=config.cdn_base_url,
+                route_tag=config.route_tag,
+                poll_timeout=config.poll_timeout,
             )
+            for p in sorted(weixin_dir.glob("*.json"))
+            if p.stem != "account"  # exclude legacy single-account fallback file
+        ]
+        if discovered:
+            return discovered
 
-        # Step 2: AES-128-ECB encrypt and POST to CDN
-        aes_key_b64 = base64.b64encode(aes_key_raw).decode()
-        encrypted_data = _encrypt_aes_ecb(raw_data, aes_key_b64)
-
-        if upload_full_url:
-            cdn_upload_url = upload_full_url
-        else:
-            cdn_upload_url = (
-                f"{self.config.cdn_base_url}/upload"
-                f"?encrypted_query_param={quote(upload_param)}"
-                f"&filekey={quote(file_key)}"
+        # Fresh install or legacy single-account: one runner (QR login on first run)
+        return [
+            WeixinAccountConfig(
+                token=config.token,
+                base_url=config.base_url,
+                cdn_base_url=config.cdn_base_url,
+                route_tag=config.route_tag,
+                poll_timeout=config.poll_timeout,
             )
+        ]
 
-        cdn_resp = await self._client.post(
-            cdn_upload_url,
-            content=encrypted_data,
-            headers={"Content-Type": "application/octet-stream"},
+    async def login(self, force: bool = False) -> bool:
+        """Login all configured accounts sequentially (interactive QR code)."""
+        all_ok = True
+        for runner in self._runners:
+            ok = await runner.login(force=force)
+            if not ok:
+                all_ok = False
+        return all_ok
+
+    async def add_account(self) -> tuple[str, bool]:
+        """Run a fresh QR scan, save the result, and start polling immediately.
+
+        Returns ``(user_id, is_new)`` where ``is_new`` is True if this is a
+        brand-new account, False if an existing account's token was refreshed.
+        Returns ``("", False)`` on failure.
+
+        If the channel is already running the new runner's poll loop is started
+        as a background task so messages are received without a restart.
+        """
+        weixin_dir = get_runtime_subdir("weixin") if not self.config.state_dir else Path(self.config.state_dir).expanduser()
+        existing = {p.stem for p in weixin_dir.glob("*.json") if p.stem != "account"}
+
+        runner = _WeixinAccountRunner(
+            len(self._runners),
+            WeixinAccountConfig(
+                base_url=self.config.base_url,
+                cdn_base_url=self.config.cdn_base_url,
+                route_tag=self.config.route_tag,
+                poll_timeout=self.config.poll_timeout,
+            ),
+            self,
+            multi=True,
         )
-        cdn_resp.raise_for_status()
+        ok = await runner.login(force=True)
+        if not ok:
+            return ("", False)
 
-        # The download encrypted_query_param comes from CDN response header
-        download_param = cdn_resp.headers.get("x-encrypted-param", "")
-        if not download_param:
-            raise RuntimeError(
-                "CDN upload response missing x-encrypted-param header; "
-                f"status={cdn_resp.status_code} headers={dict(cdn_resp.headers)}"
-            )
+        is_new = runner._user_id not in existing
 
-        # Step 3: Send message with the media item
-        # aes_key for CDNMedia is the hex key encoded as base64
-        # (matches: Buffer.from(uploaded.aeskey).toString("base64"))
-        cdn_aes_key_b64 = base64.b64encode(aes_key_hex.encode()).decode()
+        # If this WeChat account already has a running runner (same user_id),
+        # update it in-place — bot_id may have changed on re-login.
+        for existing_runner in self._runners:
+            if runner._user_id and existing_runner._user_id == runner._user_id:
+                old_bot_id = existing_runner._bot_id
+                existing_runner._bot_id = runner._bot_id
+                existing_runner._user_id = runner._user_id
+                existing_runner._token = runner._token
+                existing_runner._get_updates_buf = runner._get_updates_buf
+                existing_runner._cfg.base_url = runner._cfg.base_url
+                if old_bot_id != runner._bot_id:
+                    logger.info(
+                        "WeChat account re-logged in: old bot_id={} → new bot_id={} (user_id={})",
+                        old_bot_id,
+                        runner._bot_id,
+                        runner._user_id,
+                    )
+                return (runner._bot_id, False)
 
-        media_item: dict[str, Any] = {
-            "media": {
-                "encrypt_query_param": download_param,
-                "aes_key": cdn_aes_key_b64,
-                "encrypt_type": 1,
-            },
-        }
+        # New account — register the runner.
+        self._runners.append(runner)
 
-        if item_type == ITEM_IMAGE:
-            media_item["mid_size"] = padded_size
-        elif item_type == ITEM_VIDEO:
-            media_item["video_size"] = padded_size
-        elif item_type == ITEM_FILE:
-            media_item["file_name"] = p.name
-            media_item["len"] = str(raw_size)
+        # Start polling immediately if the channel is already running.
+        if getattr(self, "_running", False):
+            asyncio.create_task(runner.run())
 
-        # Send each media item as its own message (matching reference plugin)
-        client_id = f"nanobot-{uuid.uuid4().hex[:12]}"
-        item_list: list[dict] = [{"type": item_type, item_key: media_item}]
+        return (runner._bot_id, is_new)
 
-        weixin_msg: dict[str, Any] = {
-            "from_user_id": "",
-            "to_user_id": to_user_id,
-            "client_id": client_id,
-            "message_type": MESSAGE_TYPE_BOT,
-            "message_state": MESSAGE_STATE_FINISH,
-            "item_list": item_list,
-        }
-        if context_token:
-            weixin_msg["context_token"] = context_token
+    async def start(self) -> None:
+        self._running = True
+        runner_tasks = [asyncio.create_task(runner.run()) for runner in self._runners]
+        await asyncio.gather(*runner_tasks, return_exceptions=True)
 
-        body: dict[str, Any] = {
-            "msg": weixin_msg,
-            "base_info": BASE_INFO,
-        }
+    async def stop(self) -> None:
+        self._running = False
+        for runner in self._runners:
+            await runner.stop()
 
-        data = await self._api_post("ilink/bot/sendmessage", body)
-        errcode = data.get("errcode", 0)
-        if errcode and errcode != 0:
-            raise RuntimeError(
-                f"WeChat send media error (code {errcode}): {data.get('errmsg', '')}"
-            )
+    def _resolve_runner(self, chat_id: str) -> tuple[_WeixinAccountRunner, str]:
+        """Return (runner, from_user_id) for an outbound chat_id.
+
+        chat_id format: ``{user_id}:{from_user_id}``  (user_id = stable WeChat
+        identity of the bot account; from_user_id = sender's WeChat ID).
+        """
+        if ":" in chat_id:
+            account_id, from_user_id = chat_id.split(":", 1)
+            for runner in self._runners:
+                if runner._user_id == account_id:
+                    return runner, from_user_id
+        # Fallback to first runner
+        return self._runners[0], chat_id
+
+    async def send(self, msg: OutboundMessage) -> None:
+        runner, user_id = self._resolve_runner(msg.chat_id)
+        await runner.send(user_id, msg)
 
 
 # ---------------------------------------------------------------------------

--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -221,6 +221,21 @@ class _WeixinAccountRunner:
                 self._bot_id = data.get("bot_id", "")
             if not self._user_id:
                 self._user_id = data.get("user_id", "")
+            # If we just loaded from account.json (legacy fallback) but a
+            # per-user state file now exists (written by a previous run after
+            # upgrade), prefer the newer per-user file — it has the latest token.
+            if state_file == self._get_legacy_state_file():
+                newer = self._get_state_file()
+                if newer and newer.exists():
+                    try:
+                        data = json.loads(newer.read_text())
+                        self._token = data.get("token", self._token)
+                        if not self._bot_id:
+                            self._bot_id = data.get("bot_id", "")
+                        if not self._user_id:
+                            self._user_id = data.get("user_id", "")
+                    except Exception:
+                        pass
             self._get_updates_buf = data.get("get_updates_buf", "")
             context_tokens = data.get("context_tokens", {})
             if isinstance(context_tokens, dict):
@@ -376,7 +391,7 @@ class _WeixinAccountRunner:
             refresh_count = 0
             qrcode_id, scan_url = await self._fetch_qr_code()
             if self._multi:
-                print(f"\n[Account {self._idx}] Scan QR code to login:")
+                print(f"\nScan QR code to add a new account or refresh token for an existing one:")
             self._print_qr_code(scan_url)
             current_poll_base_url = self._cfg.base_url
 
@@ -1166,6 +1181,136 @@ class _WeixinAccountRunner:
         except Exception as e:
             logger.debug("WeChat typing clear failed for {}: {}", chat_id, e)
 
+    async def _send_media_file(
+        self,
+        to_user_id: str,
+        media_path: str,
+        context_token: str,
+    ) -> None:
+        """Upload a local file to WeChat CDN and send it as a media message."""
+        p = Path(media_path)
+        if not p.is_file():
+            raise FileNotFoundError(f"Media file not found: {media_path}")
+
+        raw_data = p.read_bytes()
+        raw_size = len(raw_data)
+        raw_md5 = hashlib.md5(raw_data).hexdigest()
+
+        ext = p.suffix.lower()
+        if ext in _IMAGE_EXTS:
+            upload_type = UPLOAD_MEDIA_IMAGE
+            item_type = ITEM_IMAGE
+            item_key = "image_item"
+        elif ext in _VIDEO_EXTS:
+            upload_type = UPLOAD_MEDIA_VIDEO
+            item_type = ITEM_VIDEO
+            item_key = "video_item"
+        elif ext in _VOICE_EXTS:
+            upload_type = UPLOAD_MEDIA_VOICE
+            item_type = ITEM_VOICE
+            item_key = "voice_item"
+        else:
+            upload_type = UPLOAD_MEDIA_FILE
+            item_type = ITEM_FILE
+            item_key = "file_item"
+
+        aes_key_raw = os.urandom(16)
+        aes_key_hex = aes_key_raw.hex()
+        padded_size = ((raw_size + 1 + 15) // 16) * 16
+        file_key = os.urandom(16).hex()
+
+        upload_body: dict[str, Any] = {
+            "filekey": file_key,
+            "media_type": upload_type,
+            "to_user_id": to_user_id,
+            "rawsize": raw_size,
+            "rawfilemd5": raw_md5,
+            "filesize": padded_size,
+            "no_need_thumb": True,
+            "aeskey": aes_key_hex,
+        }
+
+        assert self._client is not None
+        upload_resp = await self._api_post("ilink/bot/getuploadurl", upload_body)
+
+        upload_full_url = str(upload_resp.get("upload_full_url", "") or "").strip()
+        upload_param = str(upload_resp.get("upload_param", "") or "")
+        if not upload_full_url and not upload_param:
+            raise RuntimeError(
+                "getuploadurl returned no upload URL "
+                f"(need upload_full_url or upload_param): {upload_resp}"
+            )
+
+        aes_key_b64 = base64.b64encode(aes_key_raw).decode()
+        encrypted_data = _encrypt_aes_ecb(raw_data, aes_key_b64)
+
+        if upload_full_url:
+            cdn_upload_url = upload_full_url
+        else:
+            cdn_upload_url = (
+                f"{self._channel.config.cdn_base_url}/upload"
+                f"?encrypted_query_param={quote(upload_param)}"
+                f"&filekey={quote(file_key)}"
+            )
+
+        cdn_resp = await self._client.post(
+            cdn_upload_url,
+            content=encrypted_data,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        cdn_resp.raise_for_status()
+
+        download_param = cdn_resp.headers.get("x-encrypted-param", "")
+        if not download_param:
+            raise RuntimeError(
+                "CDN upload response missing x-encrypted-param header; "
+                f"status={cdn_resp.status_code} headers={dict(cdn_resp.headers)}"
+            )
+
+        cdn_aes_key_b64 = base64.b64encode(aes_key_hex.encode()).decode()
+
+        media_item: dict[str, Any] = {
+            "media": {
+                "encrypt_query_param": download_param,
+                "aes_key": cdn_aes_key_b64,
+                "encrypt_type": 1,
+            },
+        }
+
+        if item_type == ITEM_IMAGE:
+            media_item["mid_size"] = padded_size
+        elif item_type == ITEM_VIDEO:
+            media_item["video_size"] = padded_size
+        elif item_type == ITEM_FILE:
+            media_item["file_name"] = p.name
+            media_item["len"] = str(raw_size)
+
+        client_id = f"nanobot-{uuid.uuid4().hex[:12]}"
+        item_list: list[dict] = [{"type": item_type, item_key: media_item}]
+
+        weixin_msg: dict[str, Any] = {
+            "from_user_id": "",
+            "to_user_id": to_user_id,
+            "client_id": client_id,
+            "message_type": MESSAGE_TYPE_BOT,
+            "message_state": MESSAGE_STATE_FINISH,
+            "item_list": item_list,
+        }
+        if context_token:
+            weixin_msg["context_token"] = context_token
+
+        body: dict[str, Any] = {
+            "msg": weixin_msg,
+            "base_info": BASE_INFO,
+        }
+
+        data = await self._api_post("ilink/bot/sendmessage", body)
+        errcode = data.get("errcode", 0)
+        if errcode and errcode != 0:
+            raise RuntimeError(
+                f"WeChat send media error (code {errcode}): {data.get('errmsg', '')}"
+            )
+
     async def _send_text(
         self,
         to_user_id: str,
@@ -1231,8 +1376,9 @@ class WeixinChannel(BaseChannel):
         self.config: WeixinConfig = config
 
         acct_cfgs = self._build_account_configs(config)
+        multi = len(acct_cfgs) > 1
         self._runners: list[_WeixinAccountRunner] = [
-            _WeixinAccountRunner(idx, acct_cfg, self, multi=True)
+            _WeixinAccountRunner(idx, acct_cfg, self, multi=multi)
             for idx, acct_cfg in enumerate(acct_cfgs)
         ]
 
@@ -1307,7 +1453,7 @@ class WeixinChannel(BaseChannel):
                 poll_timeout=self.config.poll_timeout,
             ),
             self,
-            multi=True,
+            multi=True,  # adding a second account always means multi mode
         )
         ok = await runner.login(force=True)
         if not ok:
@@ -1334,8 +1480,11 @@ class WeixinChannel(BaseChannel):
                     )
                 return (runner._bot_id, False)
 
-        # New account — register the runner.
+        # New account — register the runner, and switch ALL runners to multi mode
+        # now that there are genuinely multiple accounts.
         self._runners.append(runner)
+        for r in self._runners:
+            r._multi = True
 
         # Start polling immediately if the channel is already running.
         if getattr(self, "_running", False):

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1369,6 +1369,7 @@ def channels_login(
             console.print(f"[green]New account added:[/green] {user_id}")
         else:
             console.print(f"[green]Account token refreshed:[/green] {user_id}")
+        console.print("[dim]Restart nanobot for changes to take effect.[/dim]")
         return
 
     success = asyncio.run(channel.login(force=force))

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1359,6 +1359,18 @@ def channels_login(
     channel_cls = all_channels[channel_name]
     channel = channel_cls(channel_cfg, bus=None)
 
+    # If the channel supports add_account(), always run a fresh QR scan.
+    # After scanning, report whether it was a new account or a token refresh.
+    if hasattr(channel, "add_account"):
+        user_id, is_new = asyncio.run(channel.add_account())
+        if not user_id:
+            raise typer.Exit(1)
+        if is_new:
+            console.print(f"[green]New account added:[/green] {user_id}")
+        else:
+            console.print(f"[green]Account token refreshed:[/green] {user_id}")
+        return
+
     success = asyncio.run(channel.login(force=force))
 
     if not success:

--- a/tests/channels/test_weixin_channel.py
+++ b/tests/channels/test_weixin_channel.py
@@ -35,15 +35,20 @@ def _make_channel() -> tuple[WeixinChannel, MessageBus]:
     return channel, bus
 
 
+def _runner(channel: WeixinChannel):
+    """Return the first (and usually only) account runner for test assertions."""
+    return channel._runners[0]
+
+
 def test_make_headers_includes_route_tag_when_configured() -> None:
     bus = MessageBus()
     channel = WeixinChannel(
         WeixinConfig(enabled=True, allow_from=["*"], route_tag=123),
         bus,
     )
-    channel._token = "token"
+    _runner(channel)._token = "token"
 
-    headers = channel._make_headers()
+    headers = _runner(channel)._make_headers()
 
     assert headers["Authorization"] == "Bearer token"
     assert headers["SKRouteTag"] == "123"
@@ -61,11 +66,11 @@ def test_save_and_load_state_persists_context_tokens(tmp_path) -> None:
         WeixinConfig(enabled=True, allow_from=["*"], state_dir=str(tmp_path)),
         bus,
     )
-    channel._token = "token"
-    channel._get_updates_buf = "cursor"
-    channel._context_tokens = {"wx-user": "ctx-1"}
+    _runner(channel)._token = "token"
+    _runner(channel)._get_updates_buf = "cursor"
+    _runner(channel)._context_tokens = {"wx-user": "ctx-1"}
 
-    channel._save_state()
+    _runner(channel)._save_state()
 
     saved = json.loads((tmp_path / "account.json").read_text())
     assert saved["context_tokens"] == {"wx-user": "ctx-1"}
@@ -75,8 +80,8 @@ def test_save_and_load_state_persists_context_tokens(tmp_path) -> None:
         bus,
     )
 
-    assert restored._load_state() is True
-    assert restored._context_tokens == {"wx-user": "ctx-1"}
+    assert _runner(restored)._load_state() is True
+    assert _runner(restored)._context_tokens == {"wx-user": "ctx-1"}
 
 
 @pytest.mark.asyncio
@@ -92,9 +97,9 @@ async def test_process_message_deduplicates_inbound_ids() -> None:
         ],
     }
 
-    await channel._process_message(msg)
+    await _runner(channel)._process_message(msg)
     first = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
-    await channel._process_message(msg)
+    await _runner(channel)._process_message(msg)
 
     assert first.sender_id == "wx-user"
     assert first.chat_id == "wx-user"
@@ -105,11 +110,11 @@ async def test_process_message_deduplicates_inbound_ids() -> None:
 @pytest.mark.asyncio
 async def test_process_message_caches_context_token_and_send_uses_it() -> None:
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._send_text = AsyncMock()
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._send_text = AsyncMock()
 
-    await channel._process_message(
+    await _runner(channel)._process_message(
         {
             "message_type": 1,
             "message_id": "m2",
@@ -122,10 +127,10 @@ async def test_process_message_caches_context_token_and_send_uses_it() -> None:
     )
 
     await channel.send(
-        type("Msg", (), {"chat_id": "wx-user", "content": "pong", "media": [], "metadata": {}})()
+        type("Msg", (), {"chat_id": "wx-user", "content": "pong", "media": [], "metadata": {}})(),
     )
 
-    channel._send_text.assert_awaited_once_with("wx-user", "pong", "ctx-2")
+    _runner(channel)._send_text.assert_awaited_once_with("wx-user", "pong", "ctx-2")
 
 
 @pytest.mark.asyncio
@@ -136,7 +141,7 @@ async def test_process_message_persists_context_token_to_state_file(tmp_path) ->
         bus,
     )
 
-    await channel._process_message(
+    await _runner(channel)._process_message(
         {
             "message_type": 1,
             "message_id": "m2b",
@@ -155,9 +160,9 @@ async def test_process_message_persists_context_token_to_state_file(tmp_path) ->
 @pytest.mark.asyncio
 async def test_process_message_extracts_media_and_preserves_paths() -> None:
     channel, bus = _make_channel()
-    channel._download_media_item = AsyncMock(return_value="/tmp/test.jpg")
+    _runner(channel)._download_media_item = AsyncMock(return_value="/tmp/test.jpg")
 
-    await channel._process_message(
+    await _runner(channel)._process_message(
         {
             "message_type": 1,
             "message_id": "m3",
@@ -179,9 +184,9 @@ async def test_process_message_extracts_media_and_preserves_paths() -> None:
 @pytest.mark.asyncio
 async def test_process_message_falls_back_to_referenced_media_when_no_top_level_media() -> None:
     channel, bus = _make_channel()
-    channel._download_media_item = AsyncMock(return_value="/tmp/ref.jpg")
+    _runner(channel)._download_media_item = AsyncMock(return_value="/tmp/ref.jpg")
 
-    await channel._process_message(
+    await _runner(channel)._process_message(
         {
             "message_type": 1,
             "message_id": "m3-ref-fallback",
@@ -204,7 +209,7 @@ async def test_process_message_falls_back_to_referenced_media_when_no_top_level_
 
     inbound = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
 
-    channel._download_media_item.assert_awaited_once_with(
+    _runner(channel)._download_media_item.assert_awaited_once_with(
         {"media": {"encrypt_query_param": "ref-enc"}},
         "image",
     )
@@ -216,9 +221,9 @@ async def test_process_message_falls_back_to_referenced_media_when_no_top_level_
 @pytest.mark.asyncio
 async def test_process_message_does_not_use_referenced_fallback_when_top_level_media_exists() -> None:
     channel, bus = _make_channel()
-    channel._download_media_item = AsyncMock(side_effect=["/tmp/top.jpg", "/tmp/ref.jpg"])
+    _runner(channel)._download_media_item = AsyncMock(side_effect=["/tmp/top.jpg", "/tmp/ref.jpg"])
 
-    await channel._process_message(
+    await _runner(channel)._process_message(
         {
             "message_type": 1,
             "message_id": "m3-ref-no-fallback",
@@ -242,7 +247,7 @@ async def test_process_message_does_not_use_referenced_fallback_when_top_level_m
 
     inbound = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
 
-    channel._download_media_item.assert_awaited_once_with(
+    _runner(channel)._download_media_item.assert_awaited_once_with(
         {"media": {"encrypt_query_param": "top-enc"}},
         "image",
     )
@@ -254,9 +259,9 @@ async def test_process_message_does_not_use_referenced_fallback_when_top_level_m
 async def test_process_message_does_not_fallback_when_top_level_media_exists_but_download_fails() -> None:
     channel, bus = _make_channel()
     # Top-level image download fails (None), referenced image would succeed if fallback were triggered.
-    channel._download_media_item = AsyncMock(side_effect=[None, "/tmp/ref.jpg"])
+    _runner(channel)._download_media_item = AsyncMock(side_effect=[None, "/tmp/ref.jpg"])
 
-    await channel._process_message(
+    await _runner(channel)._process_message(
         {
             "message_type": 1,
             "message_id": "m3-ref-no-fallback-on-failure",
@@ -281,7 +286,7 @@ async def test_process_message_does_not_fallback_when_top_level_media_exists_but
     inbound = await asyncio.wait_for(bus.consume_inbound(), timeout=1.0)
 
     # Should only attempt top-level media item; reference fallback must not activate.
-    channel._download_media_item.assert_awaited_once_with(
+    _runner(channel)._download_media_item.assert_awaited_once_with(
         {"media": {"encrypt_query_param": "top-enc"}},
         "image",
     )
@@ -293,46 +298,46 @@ async def test_process_message_does_not_fallback_when_top_level_media_exists_but
 @pytest.mark.asyncio
 async def test_send_without_context_token_does_not_send_text() -> None:
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._send_text = AsyncMock()
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._send_text = AsyncMock()
 
     await channel.send(
         type("Msg", (), {"chat_id": "unknown-user", "content": "pong", "media": [], "metadata": {}})()
     )
 
-    channel._send_text.assert_not_awaited()
+    _runner(channel)._send_text.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_send_does_not_send_when_session_is_paused() -> None:
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-2"
-    channel._pause_session(60)
-    channel._send_text = AsyncMock()
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-2"
+    _runner(channel)._pause_session(60)
+    _runner(channel)._send_text = AsyncMock()
 
     await channel.send(
         type("Msg", (), {"chat_id": "wx-user", "content": "pong", "media": [], "metadata": {}})()
     )
 
-    channel._send_text.assert_not_awaited()
+    _runner(channel)._send_text.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_get_typing_ticket_fetches_and_caches_per_user() -> None:
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._api_post = AsyncMock(return_value={"ret": 0, "typing_ticket": "ticket-1"})
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._api_post = AsyncMock(return_value={"ret": 0, "typing_ticket": "ticket-1"})
 
-    first = await channel._get_typing_ticket("wx-user", "ctx-1")
-    second = await channel._get_typing_ticket("wx-user", "ctx-2")
+    first = await _runner(channel)._get_typing_ticket("wx-user", "ctx-1")
+    second = await _runner(channel)._get_typing_ticket("wx-user", "ctx-2")
 
     assert first == "ticket-1"
     assert second == "ticket-1"
-    channel._api_post.assert_awaited_once_with(
+    _runner(channel)._api_post.assert_awaited_once_with(
         "ilink/bot/getconfig",
         {"ilink_user_id": "wx-user", "context_token": "ctx-1", "base_info": weixin_mod.BASE_INFO},
     )
@@ -341,11 +346,11 @@ async def test_get_typing_ticket_fetches_and_caches_per_user() -> None:
 @pytest.mark.asyncio
 async def test_send_uses_typing_start_and_cancel_when_ticket_available() -> None:
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-typing"
-    channel._send_text = AsyncMock()
-    channel._api_post = AsyncMock(
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-typing"
+    _runner(channel)._send_text = AsyncMock()
+    _runner(channel)._api_post = AsyncMock(
         side_effect=[
             {"ret": 0, "typing_ticket": "ticket-typing"},
             {"ret": 0},
@@ -357,58 +362,58 @@ async def test_send_uses_typing_start_and_cancel_when_ticket_available() -> None
         type("Msg", (), {"chat_id": "wx-user", "content": "pong", "media": [], "metadata": {}})()
     )
 
-    channel._send_text.assert_awaited_once_with("wx-user", "pong", "ctx-typing")
-    assert channel._api_post.await_count == 3
-    assert channel._api_post.await_args_list[0].args[0] == "ilink/bot/getconfig"
-    assert channel._api_post.await_args_list[1].args[0] == "ilink/bot/sendtyping"
-    assert channel._api_post.await_args_list[1].args[1]["status"] == 1
-    assert channel._api_post.await_args_list[2].args[0] == "ilink/bot/sendtyping"
-    assert channel._api_post.await_args_list[2].args[1]["status"] == 2
+    _runner(channel)._send_text.assert_awaited_once_with("wx-user", "pong", "ctx-typing")
+    assert _runner(channel)._api_post.await_count == 3
+    assert _runner(channel)._api_post.await_args_list[0].args[0] == "ilink/bot/getconfig"
+    assert _runner(channel)._api_post.await_args_list[1].args[0] == "ilink/bot/sendtyping"
+    assert _runner(channel)._api_post.await_args_list[1].args[1]["status"] == 1
+    assert _runner(channel)._api_post.await_args_list[2].args[0] == "ilink/bot/sendtyping"
+    assert _runner(channel)._api_post.await_args_list[2].args[1]["status"] == 2
 
 
 @pytest.mark.asyncio
 async def test_send_still_sends_text_when_typing_ticket_missing() -> None:
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-no-ticket"
-    channel._send_text = AsyncMock()
-    channel._api_post = AsyncMock(return_value={"ret": 1, "errmsg": "no config"})
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-no-ticket"
+    _runner(channel)._send_text = AsyncMock()
+    _runner(channel)._api_post = AsyncMock(return_value={"ret": 1, "errmsg": "no config"})
 
     await channel.send(
         type("Msg", (), {"chat_id": "wx-user", "content": "pong", "media": [], "metadata": {}})()
     )
 
-    channel._send_text.assert_awaited_once_with("wx-user", "pong", "ctx-no-ticket")
-    channel._api_post.assert_awaited_once()
-    assert channel._api_post.await_args_list[0].args[0] == "ilink/bot/getconfig"
+    _runner(channel)._send_text.assert_awaited_once_with("wx-user", "pong", "ctx-no-ticket")
+    _runner(channel)._api_post.assert_awaited_once()
+    assert _runner(channel)._api_post.await_args_list[0].args[0] == "ilink/bot/getconfig"
 
 
 @pytest.mark.asyncio
 async def test_poll_once_pauses_session_on_expired_errcode() -> None:
     channel, _bus = _make_channel()
-    channel._client = SimpleNamespace(timeout=None)
-    channel._token = "token"
-    channel._api_post = AsyncMock(return_value={"ret": 0, "errcode": -14, "errmsg": "expired"})
+    _runner(channel)._client = SimpleNamespace(timeout=None)
+    _runner(channel)._token = "token"
+    _runner(channel)._api_post = AsyncMock(return_value={"ret": 0, "errcode": -14, "errmsg": "expired"})
 
-    await channel._poll_once()
+    await _runner(channel)._poll_once()
 
-    assert channel._session_pause_remaining_s() > 0
+    assert _runner(channel)._session_pause_remaining_s() > 0
 
 
 @pytest.mark.asyncio
 async def test_qr_login_refreshes_expired_qr_and_then_succeeds() -> None:
     channel, _bus = _make_channel()
-    channel._running = True
-    channel._save_state = lambda: None
-    channel._print_qr_code = lambda url: None
-    channel._api_get = AsyncMock(
+    _runner(channel)._running = True
+    _runner(channel)._save_state = lambda: None
+    _runner(channel)._print_qr_code = lambda url: None
+    _runner(channel)._api_get = AsyncMock(
         side_effect=[
             {"qrcode": "qr-1", "qrcode_img_content": "url-1"},
             {"qrcode": "qr-2", "qrcode_img_content": "url-2"},
         ]
     )
-    channel._api_get_with_base = AsyncMock(
+    _runner(channel)._api_get_with_base = AsyncMock(
         side_effect=[
             {"status": "expired"},
             {
@@ -421,19 +426,19 @@ async def test_qr_login_refreshes_expired_qr_and_then_succeeds() -> None:
         ]
     )
 
-    ok = await channel._qr_login()
+    ok = await _runner(channel)._qr_login()
 
     assert ok is True
-    assert channel._token == "token-2"
-    assert channel.config.base_url == "https://example.test"
+    assert _runner(channel)._token == "token-2"
+    assert _runner(channel)._cfg.base_url == "https://example.test"
 
 
 @pytest.mark.asyncio
 async def test_qr_login_returns_false_after_too_many_expired_qr_codes() -> None:
     channel, _bus = _make_channel()
-    channel._running = True
-    channel._print_qr_code = lambda url: None
-    channel._api_get = AsyncMock(
+    _runner(channel)._running = True
+    _runner(channel)._print_qr_code = lambda url: None
+    _runner(channel)._api_get = AsyncMock(
         side_effect=[
             {"qrcode": "qr-1", "qrcode_img_content": "url-1"},
             {"qrcode": "qr-2", "qrcode_img_content": "url-2"},
@@ -441,7 +446,7 @@ async def test_qr_login_returns_false_after_too_many_expired_qr_codes() -> None:
             {"qrcode": "qr-4", "qrcode_img_content": "url-4"},
         ]
     )
-    channel._api_get_with_base = AsyncMock(
+    _runner(channel)._api_get_with_base = AsyncMock(
         side_effect=[
             {"status": "expired"},
             {"status": "expired"},
@@ -450,7 +455,7 @@ async def test_qr_login_returns_false_after_too_many_expired_qr_codes() -> None:
         ]
     )
 
-    ok = await channel._qr_login()
+    ok = await _runner(channel)._qr_login()
 
     assert ok is False
 
@@ -458,10 +463,10 @@ async def test_qr_login_returns_false_after_too_many_expired_qr_codes() -> None:
 @pytest.mark.asyncio
 async def test_qr_login_switches_polling_base_url_on_redirect_status() -> None:
     channel, _bus = _make_channel()
-    channel._running = True
-    channel._save_state = lambda: None
-    channel._print_qr_code = lambda url: None
-    channel._fetch_qr_code = AsyncMock(return_value=("qr-1", "url-1"))
+    _runner(channel)._running = True
+    _runner(channel)._save_state = lambda: None
+    _runner(channel)._print_qr_code = lambda url: None
+    _runner(channel)._fetch_qr_code = AsyncMock(return_value=("qr-1", "url-1"))
 
     status_side_effect = [
         {"status": "scaned_but_redirect", "redirect_host": "idc.redirect.test"},
@@ -473,16 +478,16 @@ async def test_qr_login_switches_polling_base_url_on_redirect_status() -> None:
             "ilink_user_id": "wx-user",
         },
     ]
-    channel._api_get = AsyncMock(side_effect=list(status_side_effect))
-    channel._api_get_with_base = AsyncMock(side_effect=list(status_side_effect))
+    _runner(channel)._api_get = AsyncMock(side_effect=list(status_side_effect))
+    _runner(channel)._api_get_with_base = AsyncMock(side_effect=list(status_side_effect))
 
-    ok = await channel._qr_login()
+    ok = await _runner(channel)._qr_login()
 
     assert ok is True
-    assert channel._token == "token-3"
-    assert channel._api_get_with_base.await_count == 2
-    first_call = channel._api_get_with_base.await_args_list[0]
-    second_call = channel._api_get_with_base.await_args_list[1]
+    assert _runner(channel)._token == "token-3"
+    assert _runner(channel)._api_get_with_base.await_count == 2
+    first_call = _runner(channel)._api_get_with_base.await_args_list[0]
+    second_call = _runner(channel)._api_get_with_base.await_args_list[1]
     assert first_call.kwargs["base_url"] == "https://ilinkai.weixin.qq.com"
     assert second_call.kwargs["base_url"] == "https://idc.redirect.test"
 
@@ -490,10 +495,10 @@ async def test_qr_login_switches_polling_base_url_on_redirect_status() -> None:
 @pytest.mark.asyncio
 async def test_qr_login_redirect_without_host_keeps_current_polling_base_url() -> None:
     channel, _bus = _make_channel()
-    channel._running = True
-    channel._save_state = lambda: None
-    channel._print_qr_code = lambda url: None
-    channel._fetch_qr_code = AsyncMock(return_value=("qr-1", "url-1"))
+    _runner(channel)._running = True
+    _runner(channel)._save_state = lambda: None
+    _runner(channel)._print_qr_code = lambda url: None
+    _runner(channel)._fetch_qr_code = AsyncMock(return_value=("qr-1", "url-1"))
 
     status_side_effect = [
         {"status": "scaned_but_redirect"},
@@ -505,16 +510,16 @@ async def test_qr_login_redirect_without_host_keeps_current_polling_base_url() -
             "ilink_user_id": "wx-user",
         },
     ]
-    channel._api_get = AsyncMock(side_effect=list(status_side_effect))
-    channel._api_get_with_base = AsyncMock(side_effect=list(status_side_effect))
+    _runner(channel)._api_get = AsyncMock(side_effect=list(status_side_effect))
+    _runner(channel)._api_get_with_base = AsyncMock(side_effect=list(status_side_effect))
 
-    ok = await channel._qr_login()
+    ok = await _runner(channel)._qr_login()
 
     assert ok is True
-    assert channel._token == "token-4"
-    assert channel._api_get_with_base.await_count == 2
-    first_call = channel._api_get_with_base.await_args_list[0]
-    second_call = channel._api_get_with_base.await_args_list[1]
+    assert _runner(channel)._token == "token-4"
+    assert _runner(channel)._api_get_with_base.await_count == 2
+    first_call = _runner(channel)._api_get_with_base.await_args_list[0]
+    second_call = _runner(channel)._api_get_with_base.await_args_list[1]
     assert first_call.kwargs["base_url"] == "https://ilinkai.weixin.qq.com"
     assert second_call.kwargs["base_url"] == "https://ilinkai.weixin.qq.com"
 
@@ -522,12 +527,12 @@ async def test_qr_login_redirect_without_host_keeps_current_polling_base_url() -
 @pytest.mark.asyncio
 async def test_qr_login_resets_redirect_base_url_after_qr_refresh() -> None:
     channel, _bus = _make_channel()
-    channel._running = True
-    channel._save_state = lambda: None
-    channel._print_qr_code = lambda url: None
-    channel._fetch_qr_code = AsyncMock(side_effect=[("qr-1", "url-1"), ("qr-2", "url-2")])
+    _runner(channel)._running = True
+    _runner(channel)._save_state = lambda: None
+    _runner(channel)._print_qr_code = lambda url: None
+    _runner(channel)._fetch_qr_code = AsyncMock(side_effect=[("qr-1", "url-1"), ("qr-2", "url-2")])
 
-    channel._api_get_with_base = AsyncMock(
+    _runner(channel)._api_get_with_base = AsyncMock(
         side_effect=[
             {"status": "scaned_but_redirect", "redirect_host": "idc.redirect.test"},
             {"status": "expired"},
@@ -541,14 +546,14 @@ async def test_qr_login_resets_redirect_base_url_after_qr_refresh() -> None:
         ]
     )
 
-    ok = await channel._qr_login()
+    ok = await _runner(channel)._qr_login()
 
     assert ok is True
-    assert channel._token == "token-5"
-    assert channel._api_get_with_base.await_count == 3
-    first_call = channel._api_get_with_base.await_args_list[0]
-    second_call = channel._api_get_with_base.await_args_list[1]
-    third_call = channel._api_get_with_base.await_args_list[2]
+    assert _runner(channel)._token == "token-5"
+    assert _runner(channel)._api_get_with_base.await_count == 3
+    first_call = _runner(channel)._api_get_with_base.await_args_list[0]
+    second_call = _runner(channel)._api_get_with_base.await_args_list[1]
+    third_call = _runner(channel)._api_get_with_base.await_args_list[2]
     assert first_call.kwargs["base_url"] == "https://ilinkai.weixin.qq.com"
     assert second_call.kwargs["base_url"] == "https://idc.redirect.test"
     assert third_call.kwargs["base_url"] == "https://ilinkai.weixin.qq.com"
@@ -558,7 +563,7 @@ async def test_qr_login_resets_redirect_base_url_after_qr_refresh() -> None:
 async def test_process_message_skips_bot_messages() -> None:
     channel, bus = _make_channel()
 
-    await channel._process_message(
+    await _runner(channel)._process_message(
         {
             "message_type": MESSAGE_TYPE_BOT,
             "message_id": "m4",
@@ -576,12 +581,12 @@ async def test_process_message_skips_bot_messages() -> None:
 async def test_process_message_starts_typing_on_inbound() -> None:
     """Typing indicator fires immediately when user message arrives."""
     channel, _bus = _make_channel()
-    channel._running = True
-    channel._client = object()
-    channel._token = "token"
-    channel._start_typing = AsyncMock()
+    _runner(channel)._running = True
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._start_typing = AsyncMock()
 
-    await channel._process_message(
+    await _runner(channel)._process_message(
         {
             "message_type": 1,
             "message_id": "m-typing",
@@ -593,27 +598,27 @@ async def test_process_message_starts_typing_on_inbound() -> None:
         }
     )
 
-    channel._start_typing.assert_awaited_once_with("wx-user", "ctx-typing")
+    _runner(channel)._start_typing.assert_awaited_once_with("wx-user", "ctx-typing")
 
 
 @pytest.mark.asyncio
 async def test_send_final_message_clears_typing_indicator() -> None:
     """Non-progress send should cancel typing status."""
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-2"
-    channel._typing_tickets["wx-user"] = {"ticket": "ticket-2", "next_fetch_at": 9999999999}
-    channel._send_text = AsyncMock()
-    channel._api_post = AsyncMock(return_value={"ret": 0})
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-2"
+    _runner(channel)._typing_tickets["wx-user"] = {"ticket": "ticket-2", "next_fetch_at": 9999999999}
+    _runner(channel)._send_text = AsyncMock()
+    _runner(channel)._api_post = AsyncMock(return_value={"ret": 0})
 
     await channel.send(
         type("Msg", (), {"chat_id": "wx-user", "content": "pong", "media": [], "metadata": {}})()
     )
 
-    channel._send_text.assert_awaited_once_with("wx-user", "pong", "ctx-2")
+    _runner(channel)._send_text.assert_awaited_once_with("wx-user", "pong", "ctx-2")
     typing_cancel_calls = [
-        c for c in channel._api_post.await_args_list
+        c for c in _runner(channel)._api_post.await_args_list
         if c.args[0] == "ilink/bot/sendtyping" and c.args[1]["status"] == 2
     ]
     assert len(typing_cancel_calls) >= 1
@@ -623,12 +628,12 @@ async def test_send_final_message_clears_typing_indicator() -> None:
 async def test_send_progress_message_keeps_typing_indicator() -> None:
     """Progress messages must not cancel typing status."""
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-2"
-    channel._typing_tickets["wx-user"] = {"ticket": "ticket-2", "next_fetch_at": 9999999999}
-    channel._send_text = AsyncMock()
-    channel._api_post = AsyncMock(return_value={"ret": 0})
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-2"
+    _runner(channel)._typing_tickets["wx-user"] = {"ticket": "ticket-2", "next_fetch_at": 9999999999}
+    _runner(channel)._send_text = AsyncMock()
+    _runner(channel)._api_post = AsyncMock(return_value={"ret": 0})
 
     await channel.send(
         type(
@@ -643,9 +648,9 @@ async def test_send_progress_message_keeps_typing_indicator() -> None:
         )()
     )
 
-    channel._send_text.assert_awaited_once_with("wx-user", "thinking", "ctx-2")
+    _runner(channel)._send_text.assert_awaited_once_with("wx-user", "thinking", "ctx-2")
     typing_cancel_calls = [
-        c for c in channel._api_post.await_args_list
+        c for c in _runner(channel)._api_post.await_args_list
         if c.args and c.args[0] == "ilink/bot/sendtyping" and c.args[1].get("status") == 2
     ]
     assert len(typing_cancel_calls) == 0
@@ -668,8 +673,8 @@ async def test_send_media_uses_upload_full_url_when_present(tmp_path) -> None:
     media_file.write_bytes(b"hello-weixin")
 
     cdn_post = AsyncMock(return_value=_DummyHttpResponse(headers={"x-encrypted-param": "dl-param"}))
-    channel._client = SimpleNamespace(post=cdn_post)
-    channel._api_post = AsyncMock(
+    _runner(channel)._client = SimpleNamespace(post=cdn_post)
+    _runner(channel)._api_post = AsyncMock(
         side_effect=[
             {
                 "upload_full_url": "https://upload-full.example.test/path?foo=bar",
@@ -679,7 +684,7 @@ async def test_send_media_uses_upload_full_url_when_present(tmp_path) -> None:
         ]
     )
 
-    await channel._send_media_file("wx-user", str(media_file), "ctx-1")
+    await _runner(channel)._send_media_file("wx-user", str(media_file), "ctx-1")
 
     # first POST call is CDN upload
     cdn_url = cdn_post.await_args_list[0].args[0]
@@ -694,15 +699,15 @@ async def test_send_media_falls_back_to_upload_param_url(tmp_path) -> None:
     media_file.write_bytes(b"hello-weixin")
 
     cdn_post = AsyncMock(return_value=_DummyHttpResponse(headers={"x-encrypted-param": "dl-param"}))
-    channel._client = SimpleNamespace(post=cdn_post)
-    channel._api_post = AsyncMock(
+    _runner(channel)._client = SimpleNamespace(post=cdn_post)
+    _runner(channel)._api_post = AsyncMock(
         side_effect=[
             {"upload_param": "enc-need-fallback"},
             {"ret": 0},
         ]
     )
 
-    await channel._send_media_file("wx-user", str(media_file), "ctx-1")
+    await _runner(channel)._send_media_file("wx-user", str(media_file), "ctx-1")
 
     cdn_url = cdn_post.await_args_list[0].args[0]
     assert cdn_url.startswith(f"{channel.config.cdn_base_url}/upload?encrypted_query_param=enc-need-fallback")
@@ -717,20 +722,20 @@ async def test_send_media_voice_file_uses_voice_item_and_voice_upload_type(tmp_p
     media_file.write_bytes(b"voice-bytes")
 
     cdn_post = AsyncMock(return_value=_DummyHttpResponse(headers={"x-encrypted-param": "voice-dl-param"}))
-    channel._client = SimpleNamespace(post=cdn_post)
-    channel._api_post = AsyncMock(
+    _runner(channel)._client = SimpleNamespace(post=cdn_post)
+    _runner(channel)._api_post = AsyncMock(
         side_effect=[
             {"upload_full_url": "https://upload-full.example.test/voice?foo=bar"},
             {"ret": 0},
         ]
     )
 
-    await channel._send_media_file("wx-user", str(media_file), "ctx-voice")
+    await _runner(channel)._send_media_file("wx-user", str(media_file), "ctx-voice")
 
-    getupload_body = channel._api_post.await_args_list[0].args[1]
+    getupload_body = _runner(channel)._api_post.await_args_list[0].args[1]
     assert getupload_body["media_type"] == 4
 
-    sendmessage_body = channel._api_post.await_args_list[1].args[1]
+    sendmessage_body = _runner(channel)._api_post.await_args_list[1].args[1]
     item = sendmessage_body["msg"]["item_list"][0]
     assert item["type"] == 3
     assert "voice_item" in item
@@ -741,20 +746,20 @@ async def test_send_media_voice_file_uses_voice_item_and_voice_upload_type(tmp_p
 @pytest.mark.asyncio
 async def test_send_typing_uses_keepalive_until_send_finishes() -> None:
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-typing-loop"
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-typing-loop"
     async def _api_post_side_effect(endpoint: str, _body: dict | None = None, *, auth: bool = True):
         if endpoint == "ilink/bot/getconfig":
             return {"ret": 0, "typing_ticket": "ticket-keepalive"}
         return {"ret": 0}
 
-    channel._api_post = AsyncMock(side_effect=_api_post_side_effect)
+    _runner(channel)._api_post = AsyncMock(side_effect=_api_post_side_effect)
 
     async def _slow_send_text(*_args, **_kwargs) -> None:
         await asyncio.sleep(0.03)
 
-    channel._send_text = AsyncMock(side_effect=_slow_send_text)
+    _runner(channel)._send_text = AsyncMock(side_effect=_slow_send_text)
 
     old_interval = weixin_mod.TYPING_KEEPALIVE_INTERVAL_S
     weixin_mod.TYPING_KEEPALIVE_INTERVAL_S = 0.01
@@ -767,7 +772,7 @@ async def test_send_typing_uses_keepalive_until_send_finishes() -> None:
 
     status_calls = [
         c.args[1]["status"]
-        for c in channel._api_post.await_args_list
+        for c in _runner(channel)._api_post.await_args_list
         if c.args and c.args[0] == "ilink/bot/sendtyping"
     ]
     assert status_calls.count(1) >= 2
@@ -777,43 +782,43 @@ async def test_send_typing_uses_keepalive_until_send_finishes() -> None:
 @pytest.mark.asyncio
 async def test_get_typing_ticket_failure_uses_backoff_and_cached_ticket(monkeypatch) -> None:
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
 
     now = {"value": 1000.0}
     monkeypatch.setattr(weixin_mod.time, "time", lambda: now["value"])
     monkeypatch.setattr(weixin_mod.random, "random", lambda: 0.5)
 
-    channel._api_post = AsyncMock(return_value={"ret": 0, "typing_ticket": "ticket-ok"})
-    first = await channel._get_typing_ticket("wx-user", "ctx-1")
+    _runner(channel)._api_post = AsyncMock(return_value={"ret": 0, "typing_ticket": "ticket-ok"})
+    first = await _runner(channel)._get_typing_ticket("wx-user", "ctx-1")
     assert first == "ticket-ok"
 
     # force refresh window reached
     now["value"] = now["value"] + (12 * 60 * 60) + 1
-    channel._api_post = AsyncMock(return_value={"ret": 1, "errmsg": "temporary failure"})
+    _runner(channel)._api_post = AsyncMock(return_value={"ret": 1, "errmsg": "temporary failure"})
 
     # On refresh failure, should still return cached ticket and apply backoff.
-    second = await channel._get_typing_ticket("wx-user", "ctx-2")
+    second = await _runner(channel)._get_typing_ticket("wx-user", "ctx-2")
     assert second == "ticket-ok"
-    assert channel._api_post.await_count == 1
+    assert _runner(channel)._api_post.await_count == 1
 
     # Before backoff expiry, no extra fetch should happen.
     now["value"] += 1
-    third = await channel._get_typing_ticket("wx-user", "ctx-3")
+    third = await _runner(channel)._get_typing_ticket("wx-user", "ctx-3")
     assert third == "ticket-ok"
-    assert channel._api_post.await_count == 1
+    assert _runner(channel)._api_post.await_count == 1
 
 
 @pytest.mark.asyncio
 async def test_qr_login_treats_temporary_connect_error_as_wait_and_recovers() -> None:
     channel, _bus = _make_channel()
-    channel._running = True
-    channel._save_state = lambda: None
-    channel._print_qr_code = lambda url: None
-    channel._fetch_qr_code = AsyncMock(return_value=("qr-1", "url-1"))
+    _runner(channel)._running = True
+    _runner(channel)._save_state = lambda: None
+    _runner(channel)._print_qr_code = lambda url: None
+    _runner(channel)._fetch_qr_code = AsyncMock(return_value=("qr-1", "url-1"))
 
     request = httpx.Request("GET", "https://ilinkai.weixin.qq.com/ilink/bot/get_qrcode_status")
-    channel._api_get_with_base = AsyncMock(
+    _runner(channel)._api_get_with_base = AsyncMock(
         side_effect=[
             httpx.ConnectError("temporary network", request=request),
             {
@@ -826,23 +831,23 @@ async def test_qr_login_treats_temporary_connect_error_as_wait_and_recovers() ->
         ]
     )
 
-    ok = await channel._qr_login()
+    ok = await _runner(channel)._qr_login()
 
     assert ok is True
-    assert channel._token == "token-net-ok"
+    assert _runner(channel)._token == "token-net-ok"
 
 
 @pytest.mark.asyncio
 async def test_qr_login_treats_5xx_gateway_response_error_as_wait_and_recovers() -> None:
     channel, _bus = _make_channel()
-    channel._running = True
-    channel._save_state = lambda: None
-    channel._print_qr_code = lambda url: None
-    channel._fetch_qr_code = AsyncMock(return_value=("qr-1", "url-1"))
+    _runner(channel)._running = True
+    _runner(channel)._save_state = lambda: None
+    _runner(channel)._print_qr_code = lambda url: None
+    _runner(channel)._fetch_qr_code = AsyncMock(return_value=("qr-1", "url-1"))
 
     request = httpx.Request("GET", "https://ilinkai.weixin.qq.com/ilink/bot/get_qrcode_status")
     response = httpx.Response(status_code=524, request=request)
-    channel._api_get_with_base = AsyncMock(
+    _runner(channel)._api_get_with_base = AsyncMock(
         side_effect=[
             httpx.HTTPStatusError("gateway timeout", request=request, response=response),
             {
@@ -855,10 +860,10 @@ async def test_qr_login_treats_5xx_gateway_response_error_as_wait_and_recovers()
         ]
     )
 
-    ok = await channel._qr_login()
+    ok = await _runner(channel)._qr_login()
 
     assert ok is True
-    assert channel._token == "token-5xx-ok"
+    assert _runner(channel)._token == "token-5xx-ok"
 
 
 def test_decrypt_aes_ecb_strips_valid_pkcs7_padding() -> None:
@@ -901,7 +906,7 @@ async def test_download_media_item_uses_full_url_when_present(tmp_path) -> None:
     weixin_mod.get_media_dir = lambda _name: tmp_path
 
     full_url = "https://cdn.example.test/download/full"
-    channel._client = SimpleNamespace(
+    _runner(channel)._client = SimpleNamespace(
         get=AsyncMock(return_value=_DummyDownloadResponse(content=b"raw-image-bytes"))
     )
 
@@ -911,11 +916,11 @@ async def test_download_media_item_uses_full_url_when_present(tmp_path) -> None:
             "encrypt_query_param": "enc-fallback-should-not-be-used",
         },
     }
-    saved_path = await channel._download_media_item(item, "image")
+    saved_path = await _runner(channel)._download_media_item(item, "image")
 
     assert saved_path is not None
     assert Path(saved_path).read_bytes() == b"raw-image-bytes"
-    channel._client.get.assert_awaited_once_with(full_url)
+    _runner(channel)._client.get.assert_awaited_once_with(full_url)
 
 
 @pytest.mark.asyncio
@@ -924,7 +929,7 @@ async def test_download_media_item_falls_back_when_full_url_returns_retryable_er
     weixin_mod.get_media_dir = lambda _name: tmp_path
 
     full_url = "https://cdn.example.test/download/full?taskid=123"
-    channel._client = SimpleNamespace(
+    _runner(channel)._client = SimpleNamespace(
         get=AsyncMock(
             side_effect=[
                 _DummyErrorDownloadResponse(full_url, 500),
@@ -939,13 +944,13 @@ async def test_download_media_item_falls_back_when_full_url_returns_retryable_er
             "encrypt_query_param": "enc-fallback",
         },
     }
-    saved_path = await channel._download_media_item(item, "image")
+    saved_path = await _runner(channel)._download_media_item(item, "image")
 
     assert saved_path is not None
     assert Path(saved_path).read_bytes() == b"fallback-bytes"
-    assert channel._client.get.await_count == 2
-    assert channel._client.get.await_args_list[0].args[0] == full_url
-    fallback_url = channel._client.get.await_args_list[1].args[0]
+    assert _runner(channel)._client.get.await_count == 2
+    assert _runner(channel)._client.get.await_args_list[0].args[0] == full_url
+    fallback_url = _runner(channel)._client.get.await_args_list[1].args[0]
     assert fallback_url.startswith(f"{channel.config.cdn_base_url}/download?encrypted_query_param=enc-fallback")
 
 
@@ -954,16 +959,16 @@ async def test_download_media_item_falls_back_to_encrypt_query_param(tmp_path) -
     channel, _bus = _make_channel()
     weixin_mod.get_media_dir = lambda _name: tmp_path
 
-    channel._client = SimpleNamespace(
+    _runner(channel)._client = SimpleNamespace(
         get=AsyncMock(return_value=_DummyDownloadResponse(content=b"fallback-bytes"))
     )
 
     item = {"media": {"encrypt_query_param": "enc-fallback"}}
-    saved_path = await channel._download_media_item(item, "image")
+    saved_path = await _runner(channel)._download_media_item(item, "image")
 
     assert saved_path is not None
     assert Path(saved_path).read_bytes() == b"fallback-bytes"
-    called_url = channel._client.get.await_args_list[0].args[0]
+    called_url = _runner(channel)._client.get.await_args_list[0].args[0]
     assert called_url.startswith(f"{channel.config.cdn_base_url}/download?encrypted_query_param=enc-fallback")
 
 
@@ -973,15 +978,15 @@ async def test_download_media_item_does_not_retry_when_full_url_fails_without_fa
     weixin_mod.get_media_dir = lambda _name: tmp_path
 
     full_url = "https://cdn.example.test/download/full"
-    channel._client = SimpleNamespace(
+    _runner(channel)._client = SimpleNamespace(
         get=AsyncMock(return_value=_DummyErrorDownloadResponse(full_url, 500))
     )
 
     item = {"media": {"full_url": full_url}}
-    saved_path = await channel._download_media_item(item, "image")
+    saved_path = await _runner(channel)._download_media_item(item, "image")
 
     assert saved_path is None
-    channel._client.get.assert_awaited_once_with(full_url)
+    _runner(channel)._client.get.assert_awaited_once_with(full_url)
 
 
 @pytest.mark.asyncio
@@ -990,7 +995,7 @@ async def test_download_media_item_non_image_requires_aes_key_even_with_full_url
     weixin_mod.get_media_dir = lambda _name: tmp_path
 
     full_url = "https://cdn.example.test/download/voice"
-    channel._client = SimpleNamespace(
+    _runner(channel)._client = SimpleNamespace(
         get=AsyncMock(return_value=_DummyDownloadResponse(content=b"ciphertext-or-unknown"))
     )
 
@@ -999,10 +1004,10 @@ async def test_download_media_item_non_image_requires_aes_key_even_with_full_url
             "full_url": full_url,
         },
     }
-    saved_path = await channel._download_media_item(item, "voice")
+    saved_path = await _runner(channel)._download_media_item(item, "voice")
 
     assert saved_path is None
-    channel._client.get.assert_not_awaited()
+    _runner(channel)._client.get.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -1028,11 +1033,11 @@ async def test_send_media_timeout_error_propagates_without_text_fallback() -> No
     """httpx.TimeoutException during media send must re-raise immediately,
     NOT fall back to _send_text (which would also fail during network issues)."""
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-1"
-    channel._send_media_file = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
-    channel._send_text = AsyncMock()
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-1"
+    _runner(channel)._send_media_file = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+    _runner(channel)._send_text = AsyncMock()
 
     msg = _make_outbound_msg(chat_id="wx-user", media=["/tmp/photo.jpg"])
 
@@ -1040,74 +1045,74 @@ async def test_send_media_timeout_error_propagates_without_text_fallback() -> No
         await channel.send(msg)
 
     # _send_text must NOT have been called as a fallback
-    channel._send_text.assert_not_awaited()
+    _runner(channel)._send_text.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_send_media_transport_error_propagates_without_text_fallback() -> None:
     """httpx.TransportError during media send must re-raise immediately."""
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-1"
-    channel._send_media_file = AsyncMock(
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-1"
+    _runner(channel)._send_media_file = AsyncMock(
         side_effect=httpx.TransportError("connection reset")
     )
-    channel._send_text = AsyncMock()
+    _runner(channel)._send_text = AsyncMock()
 
     msg = _make_outbound_msg(chat_id="wx-user", media=["/tmp/photo.jpg"])
 
     with pytest.raises(httpx.TransportError, match="connection reset"):
         await channel.send(msg)
 
-    channel._send_text.assert_not_awaited()
+    _runner(channel)._send_text.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_send_media_5xx_http_status_error_propagates_without_text_fallback() -> None:
     """httpx.HTTPStatusError with a 5xx status must re-raise immediately."""
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-1"
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-1"
 
     fake_response = httpx.Response(
         status_code=503,
         request=httpx.Request("POST", "https://example.test/upload"),
     )
-    channel._send_media_file = AsyncMock(
+    _runner(channel)._send_media_file = AsyncMock(
         side_effect=httpx.HTTPStatusError(
             "Service Unavailable", request=fake_response.request, response=fake_response
         )
     )
-    channel._send_text = AsyncMock()
+    _runner(channel)._send_text = AsyncMock()
 
     msg = _make_outbound_msg(chat_id="wx-user", media=["/tmp/photo.jpg"])
 
     with pytest.raises(httpx.HTTPStatusError, match="Service Unavailable"):
         await channel.send(msg)
 
-    channel._send_text.assert_not_awaited()
+    _runner(channel)._send_text.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_send_media_4xx_http_status_error_falls_back_to_text() -> None:
     """httpx.HTTPStatusError with a 4xx status should fall back to text, not re-raise."""
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-1"
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-1"
 
     fake_response = httpx.Response(
         status_code=400,
         request=httpx.Request("POST", "https://example.test/upload"),
     )
-    channel._send_media_file = AsyncMock(
+    _runner(channel)._send_media_file = AsyncMock(
         side_effect=httpx.HTTPStatusError(
             "Bad Request", request=fake_response.request, response=fake_response
         )
     )
-    channel._send_text = AsyncMock()
+    _runner(channel)._send_text = AsyncMock()
 
     msg = _make_outbound_msg(chat_id="wx-user", media=["/tmp/photo.jpg"])
 
@@ -1115,7 +1120,7 @@ async def test_send_media_4xx_http_status_error_falls_back_to_text() -> None:
     await channel.send(msg)
 
     # _send_text should have been called with the fallback message
-    channel._send_text.assert_awaited_once_with(
+    _runner(channel)._send_text.assert_awaited_once_with(
         "wx-user", "[Failed to send: photo.jpg]", "ctx-1"
     )
 
@@ -1124,20 +1129,20 @@ async def test_send_media_4xx_http_status_error_falls_back_to_text() -> None:
 async def test_send_media_file_not_found_falls_back_to_text() -> None:
     """FileNotFoundError (a non-network error) should fall back to text."""
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-1"
-    channel._send_media_file = AsyncMock(
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-1"
+    _runner(channel)._send_media_file = AsyncMock(
         side_effect=FileNotFoundError("Media file not found: /tmp/missing.jpg")
     )
-    channel._send_text = AsyncMock()
+    _runner(channel)._send_text = AsyncMock()
 
     msg = _make_outbound_msg(chat_id="wx-user", media=["/tmp/missing.jpg"])
 
     # Should NOT raise
     await channel.send(msg)
 
-    channel._send_text.assert_awaited_once_with(
+    _runner(channel)._send_text.assert_awaited_once_with(
         "wx-user", "[Failed to send: missing.jpg]", "ctx-1"
     )
 
@@ -1146,20 +1151,20 @@ async def test_send_media_file_not_found_falls_back_to_text() -> None:
 async def test_send_media_value_error_falls_back_to_text() -> None:
     """ValueError (e.g. unsupported format) should fall back to text."""
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-1"
-    channel._send_media_file = AsyncMock(
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-1"
+    _runner(channel)._send_media_file = AsyncMock(
         side_effect=ValueError("Unsupported media format")
     )
-    channel._send_text = AsyncMock()
+    _runner(channel)._send_text = AsyncMock()
 
     msg = _make_outbound_msg(chat_id="wx-user", media=["/tmp/file.xyz"])
 
     # Should NOT raise
     await channel.send(msg)
 
-    channel._send_text.assert_awaited_once_with(
+    _runner(channel)._send_text.assert_awaited_once_with(
         "wx-user", "[Failed to send: file.xyz]", "ctx-1"
     )
 
@@ -1169,13 +1174,13 @@ async def test_send_media_network_error_does_not_double_api_calls() -> None:
     """During network issues, media send should make exactly 1 API call attempt,
     not 2 (media + text fallback).  Verify total call count."""
     channel, _bus = _make_channel()
-    channel._client = object()
-    channel._token = "token"
-    channel._context_tokens["wx-user"] = "ctx-1"
-    channel._send_media_file = AsyncMock(
+    _runner(channel)._client = object()
+    _runner(channel)._token = "token"
+    _runner(channel)._context_tokens["wx-user"] = "ctx-1"
+    _runner(channel)._send_media_file = AsyncMock(
         side_effect=httpx.ConnectError("connection refused")
     )
-    channel._send_text = AsyncMock()
+    _runner(channel)._send_text = AsyncMock()
 
     msg = _make_outbound_msg(chat_id="wx-user", content="hello", media=["/tmp/img.png"])
 
@@ -1183,5 +1188,5 @@ async def test_send_media_network_error_does_not_double_api_calls() -> None:
         await channel.send(msg)
 
     # _send_media_file called once, _send_text never called
-    channel._send_media_file.assert_awaited_once()
-    channel._send_text.assert_not_awaited()
+    _runner(channel)._send_media_file.assert_awaited_once()
+    _runner(channel)._send_text.assert_not_awaited()


### PR DESCRIPTION

### Summary

Refactors the WeChat channel to support running multiple personal WeChat accounts simultaneously under a single nanobot instance, while preserving full backward compatibility for existing single-account deployments.

---

### New Features

**Multiple accounts**
- Add `WeixinAccountConfig` — a per-account config model with its own `token`, `bot_id`, `user_id`, `base_url`, `cdn_base_url`, `route_tag`, and `poll_timeout`.
- Add `accounts: list[WeixinAccountConfig]` field to `WeixinConfig` for explicit per-account overrides.
- Each account runs in its own `_WeixinAccountRunner` with an independent HTTP client, state file, poll loop, and typing state.

**Stable per-account state files**
- State is now saved to `{user_id}.json` (the stable WeChat identity) instead of the shared `account.json`.
- Both `bot_id` and `user_id` are persisted in the state file. `bot_id` changes on every QR scan; `user_id` is stable and used as the filename.

**`add_account()` on `WeixinChannel`**
- A new `add_account()` method triggers a fresh QR scan and registers the new account.
- If the scanned account already has a running runner (token refresh), the runner's credentials are updated in-place without interrupting the poll loop.
- When a second account is added, all existing runners are switched to multi-account mode automatically.

**`nanobot channels login weixin` enhancements**
- The CLI now calls `add_account()` when available, replacing the old single-account `login()` path.
- Reports whether a new account was added or an existing token was refreshed.
- Instructs the user to restart nanobot for changes to take effect.

---

### Backward Compatibility

- **Single-account users are unaffected.** `multi` mode (which prefixes `chat_id` as `{user_id}:{from_user_id}`) is only activated when two or more accounts are present. A single account continues to use the bare `from_user_id` as `chat_id`, preserving all existing sessions.
- **`account.json` migration is automatic.** On first startup after upgrade, `_load_state()` falls back to `account.json`. After reading it, it immediately checks whether a per-user `{user_id}.json` already exists (written by a previous run) and prefers that file if so. No manual migration is required; users will not be logged out.
- **`WeixinConfig.state_dir` is preserved** for users who override the default state directory.

---

### Internal Refactoring

- Extracted all per-account logic (HTTP client, state, polling, sending, QR login) from `WeixinChannel` into `_WeixinAccountRunner`. `WeixinChannel` becomes a thin coordinator that owns the runner list and delegates `send()` / `start()` / `stop()`.
- `_send_media_file` and `_send_text` moved to `_WeixinAccountRunner`; `cdn_base_url` now resolved via `self._channel.config` for CDN fallback URL construction.
- State JSON is now pretty-printed (`indent=2`) for easier manual inspection.

---

### Tests

- All 45 existing tests updated to access runner-level state via a `_runner(channel)` helper.
- Test coverage retained for: QR login flow, state persistence, media send/error classification, download, typing keepalive, and `chat_id` format.