### PR TITLE
docs: avoid POSIX-only temp paths in examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ nanobot agent -m "Hello!"
 nanobot agent -c ~/.nanobot-telegram/config.json -m "Hello!"
 
 # One-off workspace override on top of that config
-nanobot agent -c ~/.nanobot-telegram/config.json -w /tmp/nanobot-telegram-test -m "Hello!"
+nanobot agent -c ~/.nanobot-telegram/config.json -w ./nanobot-telegram-test -m "Hello!"
 ```
 
 > Docker users: use `docker run -it` for interactive OAuth login.
@@ -154,7 +154,7 @@ nanobot agent -m "Hello!"
 nanobot agent -c ~/.nanobot-telegram/config.json -m "Hello!"
 
 # One-off workspace override on top of that config
-nanobot agent -c ~/.nanobot-telegram/config.json -w /tmp/nanobot-telegram-test -m "Hello!"
+nanobot agent -c ~/.nanobot-telegram/config.json -w ./nanobot-telegram-test -m "Hello!"
 ```
 
 > Docker users: use `docker run -it` for interactive OAuth login.

--- a/docs/multiple-instances.md
+++ b/docs/multiple-instances.md
@@ -43,7 +43,7 @@ nanobot agent -c ~/.nanobot-telegram/config.json -m "Hello from Telegram instanc
 nanobot agent -c ~/.nanobot-discord/config.json -m "Hello from Discord instance"
 
 # Optional one-off workspace override
-nanobot agent -c ~/.nanobot-telegram/config.json -w /tmp/nanobot-telegram-test
+nanobot agent -c ~/.nanobot-telegram/config.json -w ./nanobot-telegram-test
 ```
 
 > `nanobot agent` starts a local CLI agent using the selected workspace/config. It does not attach to or proxy through an already running `nanobot gateway` process.
@@ -108,7 +108,7 @@ public or LAN-facing address.
 Override workspace for one-off runs when needed:
 
 ```bash
-nanobot gateway --config ~/.nanobot-telegram/config.json --workspace /tmp/nanobot-telegram-test
+nanobot gateway --config ~/.nanobot-telegram/config.json --workspace ./nanobot-telegram-test
 ```
 
 ## Common Use Cases

--- a/docs/my-tool.md
+++ b/docs/my-tool.md
@@ -41,7 +41,7 @@ my(action="check")
 # → max_iterations: 40
 #   context_window_tokens: 65536
 #   model: 'anthropic/claude-sonnet-4-20250514'
-#   workspace: PosixPath('/tmp/workspace')
+#   workspace: Path('workspace')
 #   provider_retry_mode: 'standard'
 #   max_tool_result_chars: 16000
 #   _current_iteration: 3

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -100,7 +100,7 @@ All frames are JSON text. Each message has an `event` field.
   "event": "message",
   "chat_id": "uuid-v4",
   "text": "Hello! How can I help?",
-  "media": ["/tmp/image.png"],
+  "media": ["path/to/image.png"],
   "reply_to": "msg-id"
 }
 ```

--- a/nanobot/skills/tmux/SKILL.md
+++ b/nanobot/skills/tmux/SKILL.md
@@ -78,8 +78,8 @@ for i in 1 2 3 4 5; do
 done
 
 # Launch agents in different workdirs
-tmux -S "$SOCKET" send-keys -t agent-1 "cd /tmp/project1 && codex --yolo 'Fix bug X'" Enter
-tmux -S "$SOCKET" send-keys -t agent-2 "cd /tmp/project2 && codex --yolo 'Fix bug Y'" Enter
+tmux -S "$SOCKET" send-keys -t agent-1 "cd ~/project1 && codex --yolo 'Fix bug X'" Enter
+tmux -S "$SOCKET" send-keys -t agent-2 "cd ~/project2 && codex --yolo 'Fix bug Y'" Enter
 
 # Poll for completion (check if prompt returned)
 for sess in agent-1 agent-2; do

--- a/nanobot/skills/weather/SKILL.md
+++ b/nanobot/skills/weather/SKILL.md
@@ -35,7 +35,7 @@ Tips:
 - Airport codes: `wttr.in/JFK`
 - Units: `?m` (metric) `?u` (USCS)
 - Today only: `?1` · Current only: `?0`
-- PNG: `curl -s "wttr.in/Berlin.png" -o /tmp/weather.png`
+- PNG: `curl -s "wttr.in/Berlin.png" -o weather.png`
 
 ## Open-Meteo (fallback, JSON)
 


### PR DESCRIPTION
## Summary
Replace POSIX-only `/tmp/...` paths in documentation examples with portable
equivalents so Windows and macOS readers can copy-paste without edits.

## Why
Existing examples assume a POSIX filesystem. Cross-OS users have to
mentally translate before running the snippets, which causes friction in
setup-time docs.

## Scope
- Single commit, cherry-picked from a downstream hardening fork that runs
  a CI matrix on ubuntu / windows / macos.
- Documentation only — no code or behavior change.

## Test plan
- [ ] Maintainer CI passes on this branch.