### PR TITLE
chore: define repository line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,30 @@
-# Ensure shell scripts always use LF line endings (Docker/Linux compat)
+# Normalize text files to LF across platforms.
+* text=auto eol=lf
+
+# Source, config, and documentation files.
+*.css text eol=lf
+*.html text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.jsx text eol=lf
+*.md text eol=lf
+*.mjs text eol=lf
+*.py text eol=lf
 *.sh text eol=lf
+*.toml text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.txt text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Binary assets.
+*.gif binary
+*.ico binary
+*.jpeg binary
+*.jpg binary
+*.png binary
+*.ttf binary
+*.webp binary
+*.woff binary
+*.woff2 binary


### PR DESCRIPTION
## Summary
Add a `.gitattributes` policy that pins text files to LF and marks common
binaries explicitly, so Windows checkouts don't introduce CRLF churn or
accidentally text-normalize binary assets.

## Why
Without an explicit policy, Git's default `core.autocrlf` behavior varies
across platforms and per-user configuration, producing whitespace-only
diffs and cross-OS contributor friction.

## Scope
- Single commit, cherry-picked from a downstream hardening fork.
- Adds `.gitattributes`; does not retroactively renormalize existing
  tracked files in this PR (kept minimal for reviewability).

## Test plan
- [ ] Maintainer CI passes on this branch.
- [ ] `git check-attr -a <any tracked text file>` reports `eol: lf`.