### PR TITLE
fix(matrix): skip empty stream deltas before processing

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -551,14 +551,14 @@ class MatrixChannel(BaseChannel):
             await self._send_room_content(chat_id, content)
             return
 
+        if not delta.strip():
+            return
+
         buf = self._stream_bufs.get(chat_id)
         if buf is None:
             buf = _StreamBuf()
             self._stream_bufs[chat_id] = buf
         buf.text += delta
-    
-        if not buf.text.strip():
-            return
 
         now = self.monotonic_time()
 


### PR DESCRIPTION
Empty `reasoning_content` chunks from providers like DeepSeek were being appended to the stream buffer and triggering empty message sends to Matrix rooms.

Move the empty-delta check to the top of `send_delta` so we bail out before touching the buffer at all.

Fixes the "empty message" spam in Matrix rooms when using DeepSeek models.