### PR TITLE
fix(matrix): correct allow_room_mentions default type

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -214,7 +214,7 @@ class MatrixConfig(Base):
     allow_from: list[str] = Field(default_factory=list)
     group_policy: Literal["open", "mention", "allowlist"] = "open"
     group_allow_from: list[str] = Field(default_factory=list)
-    allow_room_mentions: bool = False,
+    allow_room_mentions: bool = False
     streaming: bool = False
 
 


### PR DESCRIPTION
## Summary

Fixes a Pydantic serialization warning shown during `nanobot onboard`.

When running onboarding, the following warning appears:

```text
(.venv) liu@LAPTOP:~/myProject/nanobot$ nanobot onboard
✓ Created config at /home/liu/.nanobot/config.json
/home/liu/myProject/nanobot/.venv/lib/python3.13/site-packages/pydantic/main.py:475: UserWarning: Pydantic serializer warnings:
  PydanticSerializationUnexpectedValue(Expected `bool` - serialized value may not be as expected [field_name='allow_room_mentions', input_value=(False,), input_type=tuple])
  return self.__pydantic_serializer__.to_python(

🐈 nanobot is ready!

Next steps:
  1. Add your API key to /home/liu/.nanobot/config.json
     Get one at: https://openrouter.ai/keys
  2. Chat: nanobot agent -m "Hello!" --config /home/liu/.nanobot/config.json
