### PR TITLE
fix(matrix): skip empty stream deltas before processing

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -551,14 +551,14 @@ class MatrixChannel(BaseChannel):
             await self._send_room_content(chat_id, content)
             return
 
+        if not delta.strip():
+            return
+
         buf = self._stream_bufs.get(chat_id)
         if buf is None:
             buf = _StreamBuf()
             self._stream_bufs[chat_id] = buf
         buf.text += delta
-    
-        if not buf.text.strip():
-            return
 
         now = self.monotonic_time()
 


### PR DESCRIPTION
## Problem

When providers like DeepSeek send empty `reasoning_content` chunks (e.g. `{"delta": {"reasoning_content": ""}}`), the Matrix channel appends them to the stream buffer. The subsequent `if not buf.text.strip(): return` check then triggers an empty message send because the buffer is non-empty (whitespace-only).

This causes empty messages to appear in Matrix rooms.

## Fix

Move the empty-delta guard to the top of `send_delta`, before any buffer manipulation. If `delta.strip()` is empty, we bail out immediately — no buffer touch, no message send.