### PR TITLE
fix(matrix): don't send empty room messages from blank progress callbacks

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -523,7 +523,7 @@ class MatrixChannel(BaseChannel):
                         failures.append(fail)
             if failures:
                 text = f"{text.rstrip()}\n{chr(10).join(failures)}" if text.strip() else "\n".join(failures)
-            if text or not candidates:
+            if text.strip():
                 content = _build_matrix_text_content(text)
                 if relates_to:
                     content["m.relates_to"] = relates_to

--- a/tests/channels/test_matrix_channel.py
+++ b/tests/channels/test_matrix_channel.py
@@ -1191,6 +1191,44 @@ async def test_send_progress_keeps_typing_keepalive_running() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_empty_content_does_not_call_room_send() -> None:
+    """Progress messages with empty content must not produce an empty body: '' event."""
+    channel = MatrixChannel(_make_config(), MessageBus())
+    client = _FakeAsyncClient("", "", "", None)
+    channel.client = client
+
+    await channel.send(
+        OutboundMessage(
+            channel="matrix",
+            chat_id="!room:matrix.org",
+            content="",
+            metadata={"_progress": True},
+        )
+    )
+
+    assert client.room_send_calls == []
+
+
+@pytest.mark.asyncio
+async def test_send_whitespace_only_content_does_not_call_room_send() -> None:
+    """Progress messages with whitespace-only content must not produce an empty message."""
+    channel = MatrixChannel(_make_config(), MessageBus())
+    client = _FakeAsyncClient("", "", "", None)
+    channel.client = client
+
+    await channel.send(
+        OutboundMessage(
+            channel="matrix",
+            chat_id="!room:matrix.org",
+            content="   \n\n  ",
+            metadata={"_progress": True},
+        )
+    )
+
+    assert client.room_send_calls == []
+
+
+@pytest.mark.asyncio
 async def test_send_clears_typing_when_send_fails() -> None:
     channel = MatrixChannel(_make_config(), MessageBus())
     client = _FakeAsyncClient("", "", "", None)


### PR DESCRIPTION
Matrix was receiving events with `body: ""` whenever the agent loop fired a progress callback with empty content (e.g. tool-completion `_tool_events` payloads). Telegram was unaffected because its `send()` gates on `if msg.content`.

## Root cause

`MatrixChannel.send()` used:

```python
if text or not candidates:
    await self._send_room_content(chat_id, _build_matrix_text_content(text))
```

When `text = ""` and `candidates = []`, `not candidates` is `True`, so an `m.text` event with `body: ""` was unconditionally sent.

## Changes

- **`nanobot/channels/matrix.py`** — tighten the guard to `if text.strip():`, matching Telegram's existing behaviour; no text event is emitted when content is empty or whitespace-only.
- **`tests/channels/test_matrix_channel.py`** — two regression tests: `send()` with `content=""` and `content="   \n\n  "` must not call `room_send`.