### PR TITLE
fix(matrix): skip events received before bot startup

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -251,11 +251,13 @@ class MatrixChannel(BaseChannel):
         self._server_upload_limit_bytes: int | None = None
         self._server_upload_limit_checked = False
         self._stream_bufs: dict[str, _StreamBuf] = {}
+        self._started_at_ms: int = 0
 
 
     async def start(self) -> None:
         """Start Matrix client and begin sync loop."""
         self._running = True
+        self._started_at_ms = int(time.time() * 1000)
         _configure_nio_logging_bridge()
 
         self.store_path = get_data_dir() / "matrix-store"
@@ -674,6 +676,16 @@ class MatrixChannel(BaseChannel):
             return True
         return bool(self.config.allow_room_mentions and mentions.get("room") is True)
 
+    def _is_pre_startup_event(self, event: RoomMessage) -> bool:
+        """Skip events that landed in the timeline before this process started.
+
+        Matrix sync replays the room timeline on each startup/restart; without
+        this filter old messages would be re-handled as if they were fresh
+        (#3553).
+        """
+        ts = getattr(event, "server_timestamp", None)
+        return isinstance(ts, int) and ts < self._started_at_ms
+
     def _should_process_message(self, room: MatrixRoom, event: RoomMessage) -> bool:
         """Apply sender and room policy checks."""
         if not self.is_allowed(event.sender):
@@ -858,7 +870,11 @@ class MatrixChannel(BaseChannel):
         return meta
 
     async def _on_message(self, room: MatrixRoom, event: RoomMessageText) -> None:
-        if event.sender == self.config.user_id or not self._should_process_message(room, event):
+        if (
+            event.sender == self.config.user_id
+            or self._is_pre_startup_event(event)
+            or not self._should_process_message(room, event)
+        ):
             return
         await self._start_typing_keepalive(room.room_id)
         try:
@@ -871,7 +887,11 @@ class MatrixChannel(BaseChannel):
             raise
 
     async def _on_media_message(self, room: MatrixRoom, event: MatrixMediaEvent) -> None:
-        if event.sender == self.config.user_id or not self._should_process_message(room, event):
+        if (
+            event.sender == self.config.user_id
+            or self._is_pre_startup_event(event)
+            or not self._should_process_message(room, event)
+        ):
             return
         attachment, marker = await self._fetch_media_attachment(room, event)
         parts: list[str] = []

--- a/tests/channels/test_matrix_channel.py
+++ b/tests/channels/test_matrix_channel.py
@@ -381,6 +381,62 @@ async def test_on_message_skips_typing_for_self_message() -> None:
 
 
 @pytest.mark.asyncio
+async def test_on_message_skips_pre_startup_event() -> None:
+    channel = MatrixChannel(_make_config(), MessageBus())
+    client = _FakeAsyncClient("", "", "", None)
+    channel.client = client
+    channel._started_at_ms = 1_000_000
+
+    handled: list[str] = []
+
+    async def _fake_handle_message(**kwargs) -> None:
+        handled.append(kwargs["sender_id"])
+
+    channel._handle_message = _fake_handle_message  # type: ignore[method-assign]
+
+    room = SimpleNamespace(room_id="!room:matrix.org", display_name="Test room")
+    old_event = SimpleNamespace(
+        sender="@alice:matrix.org", body="old", source={}, server_timestamp=999_999
+    )
+    fresh_event = SimpleNamespace(
+        sender="@alice:matrix.org", body="fresh", source={}, server_timestamp=1_000_001
+    )
+
+    await channel._on_message(room, old_event)
+    await channel._on_message(room, fresh_event)
+
+    assert handled == ["@alice:matrix.org"]
+    assert client.typing_calls == [
+        ("!room:matrix.org", True, TYPING_NOTICE_TIMEOUT_MS),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_on_media_message_skips_pre_startup_event() -> None:
+    channel = MatrixChannel(_make_config(), MessageBus())
+    client = _FakeAsyncClient("", "", "", None)
+    channel.client = client
+    channel._started_at_ms = 1_000_000
+
+    handled: list[str] = []
+
+    async def _fake_handle_message(**kwargs) -> None:
+        handled.append(kwargs["sender_id"])
+
+    channel._handle_message = _fake_handle_message  # type: ignore[method-assign]
+
+    room = SimpleNamespace(room_id="!room:matrix.org", display_name="Test room")
+    old_event = SimpleNamespace(
+        sender="@alice:matrix.org", body="old", source={}, server_timestamp=999_999
+    )
+
+    await channel._on_media_message(room, old_event)
+
+    assert handled == []
+    assert client.typing_calls == []
+
+
+@pytest.mark.asyncio
 async def test_on_message_skips_typing_for_denied_sender() -> None:
     channel = MatrixChannel(_make_config(allow_from=["@bob:matrix.org"]), MessageBus())
     client = _FakeAsyncClient("", "", "", None)


### PR DESCRIPTION
## Summary

Closes #3553 — Matrix channel reads old messages on startup / `/restart`.

- Record `self._started_at_ms` when `start()` runs.
- Drop events whose `server_timestamp < _started_at_ms` at the entry of `_on_message` and `_on_media_message`.
- Add the same guard via a small `_is_pre_startup_event(event)` helper to keep the policy in one place.

## Why

Matrix sync replays the room timeline on each startup. Even with `store_sync_tokens=True` the sync token is not reliably re-injected when a session is restored via `access_token` + `load_store()` (vs full login), so the client re-reads recent timeline entries and `_on_message` fires for already-handled messages — exactly the symptom reported in #3553.

A timestamp guard is independent of sync-token state and matches the standard pattern used by matrix-nio bot examples. Trade-off: messages received while the bot is down won't be processed, which is what the issue reporter expects ("already read messages should not be interpreted again").

## Test plan

- [x] `pytest tests/channels/test_matrix_channel.py` — 64 passed
- [x] New `test_on_message_skips_pre_startup_event` covers text path
- [x] New `test_on_media_message_skips_pre_startup_event` covers media path
- [x] Existing tests still pass (events without `server_timestamp` continue to be processed because `_started_at_ms` defaults to `0` and `getattr` returns `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)