### PR TITLE
fix: strip partial think tags in streaming output

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -63,8 +63,8 @@ def strip_think(text: str) -> str:
     # Stream chunks may end in the middle of a control tag. Strip only known
     # control-token prefixes at the very end.
     partial_control_tag = (
-        r"</?(?:t|th|thi|thin|think|tho|thou|thoug|though|thought)"
-        r"|<\|?(?:c|ch|cha|chan|chann|channe|channel|channel\|?)"
+        r"</?(?:t|th|thi|thin|think|tho|thou|thoug|though|thought)>?"
+        r"|<\|?(?:c|ch|cha|chan|chann|channe|channel)(?:\|?>?)?"
     )
     text = re.sub(rf"(?:{partial_control_tag})$", "", text)
     text = re.sub(r"^\s*<\|?$", "", text)

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -31,6 +31,8 @@ def strip_think(text: str) -> str:
          explanatory prose that mentions these tokens.
       5. Orphan closing tags `</think>` / `</thought>` **at the very start
          or end of the text** only, for the same reason.
+      6. Trailing partial control tags split across stream chunks, such as
+         `<thi`, `<thin`, or `<tho`.
 
     Since this is also applied before persisting to history (memory.py),
     the edge-only stripping of (4) and (5) is deliberate: stripping those
@@ -57,6 +59,14 @@ def strip_think(text: str) -> str:
     text = re.sub(r"\s*</thought>\s*$", "", text)
     # Edge-only channel markers (harmony / Gemma 4 variant leaks).
     text = re.sub(r"^\s*<\|?channel\|?>\s*", "", text)
+    # Stream chunks may end in the middle of a control tag. Strip only known
+    # control-token prefixes at the very end.
+    partial_control_tag = (
+        r"</?(?:t|th|thi|thin|think|tho|thou|thoug|though|thought)"
+        r"|<\|?(?:c|ch|cha|chan|chann|channe|channel|channel\|?)"
+    )
+    text = re.sub(rf"(?:{partial_control_tag})$", "", text)
+    text = re.sub(r"^\s*<\|?$", "", text)
     return text.strip()
 
 

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -994,6 +994,27 @@ async def test_loop_stream_filter_hides_partial_trailing_think_prefix(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_loop_stream_filter_hides_complete_trailing_think_tag(tmp_path):
+    loop = _make_loop(tmp_path)
+    deltas: list[str] = []
+
+    async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+        await on_content_delta("Hello <think>")
+        await on_content_delta("hidden</think>World")
+        return LLMResponse(content="Hello <think>hidden</think>World", tool_calls=[], usage={})
+
+    loop.provider.chat_stream_with_retry = chat_stream_with_retry
+
+    async def on_stream(delta: str) -> None:
+        deltas.append(delta)
+
+    final_content, _, _, _, _ = await loop._run_agent_loop([], on_stream=on_stream)
+
+    assert final_content == "Hello World"
+    assert deltas == ["Hello", " World"]
+
+
+@pytest.mark.asyncio
 async def test_loop_retries_think_only_final_response(tmp_path):
     loop = _make_loop(tmp_path)
     call_count = {"n": 0}

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -973,6 +973,27 @@ async def test_loop_stream_filter_handles_think_only_prefix_without_crashing(tmp
 
 
 @pytest.mark.asyncio
+async def test_loop_stream_filter_hides_partial_trailing_think_prefix(tmp_path):
+    loop = _make_loop(tmp_path)
+    deltas: list[str] = []
+
+    async def chat_stream_with_retry(*, on_content_delta, **kwargs):
+        await on_content_delta("Hello <thin")
+        await on_content_delta("k>hidden</think>World")
+        return LLMResponse(content="Hello <think>hidden</think>World", tool_calls=[], usage={})
+
+    loop.provider.chat_stream_with_retry = chat_stream_with_retry
+
+    async def on_stream(delta: str) -> None:
+        deltas.append(delta)
+
+    final_content, _, _, _, _ = await loop._run_agent_loop([], on_stream=on_stream)
+
+    assert final_content == "Hello World"
+    assert deltas == ["Hello", " World"]
+
+
+@pytest.mark.asyncio
 async def test_loop_retries_think_only_final_response(tmp_path):
     loop = _make_loop(tmp_path)
     call_count = {"n": 0}

--- a/tests/test_tool_contextvars.py
+++ b/tests/test_tool_contextvars.py
@@ -49,7 +49,16 @@ async def test_spawn_tool_keeps_task_local_context() -> None:
     release = asyncio.Event()
 
     class _Manager:
-        async def spawn(self, *, task: str, label: str | None, origin_channel: str, origin_chat_id: str, session_key: str) -> str:
+        async def spawn(
+            self,
+            *,
+            task: str,
+            label: str | None,
+            origin_channel: str,
+            origin_chat_id: str,
+            session_key: str,
+            origin_message_id: str | None = None,
+        ) -> str:
             seen.append((origin_channel, origin_chat_id, session_key))
             return f"{origin_channel}:{origin_chat_id}:{task}"
 
@@ -147,7 +156,16 @@ async def test_spawn_tool_basic_set_context_and_execute() -> None:
     seen: list[tuple[str, str, str]] = []
 
     class _Manager:
-        async def spawn(self, *, task, label, origin_channel, origin_chat_id, session_key):
+        async def spawn(
+            self,
+            *,
+            task,
+            label,
+            origin_channel,
+            origin_chat_id,
+            session_key,
+            origin_message_id=None,
+        ):
             seen.append((origin_channel, origin_chat_id, session_key))
             return f"ok: {task}"
 
@@ -165,7 +183,16 @@ async def test_spawn_tool_default_values_without_set_context() -> None:
     seen: list[tuple[str, str, str]] = []
 
     class _Manager:
-        async def spawn(self, *, task, label, origin_channel, origin_chat_id, session_key):
+        async def spawn(
+            self,
+            *,
+            task,
+            label,
+            origin_channel,
+            origin_chat_id,
+            session_key,
+            origin_message_id=None,
+        ):
             seen.append((origin_channel, origin_chat_id, session_key))
             return "ok"
 

--- a/tests/utils/test_strip_think.py
+++ b/tests/utils/test_strip_think.py
@@ -102,6 +102,14 @@ class TestStripThinkMalformedLeaks:
         assert strip_think("<channel|>喷泉策略：09:00 开启") == ("喷泉策略：09:00 开启")
         assert strip_think("<|channel|>answer") == "answer"
 
+    def test_partial_trailing_think_tag_after_visible_text(self):
+        assert strip_think("喷泉策略说明 <thin") == "喷泉策略说明"
+        assert strip_think("answer <thought") == "answer"
+
+    def test_partial_trailing_channel_marker_after_visible_text(self):
+        assert strip_think("喷泉策略说明 <|chan") == "喷泉策略说明"
+        assert strip_think("answer <channel") == "answer"
+
 
 class TestStripThinkConservativePreserve:
     """Regression: the malformed-tag / orphan cleanup must NOT touch

--- a/tests/utils/test_strip_think.py
+++ b/tests/utils/test_strip_think.py
@@ -105,10 +105,12 @@ class TestStripThinkMalformedLeaks:
     def test_partial_trailing_think_tag_after_visible_text(self):
         assert strip_think("喷泉策略说明 <thin") == "喷泉策略说明"
         assert strip_think("answer <thought") == "answer"
+        assert strip_think("answer <think>") == "answer"
 
     def test_partial_trailing_channel_marker_after_visible_text(self):
         assert strip_think("喷泉策略说明 <|chan") == "喷泉策略说明"
         assert strip_think("answer <channel") == "answer"
+        assert strip_think("answer <|channel|>") == "answer"
 
 
 class TestStripThinkConservativePreserve:


### PR DESCRIPTION
## Summary

This PR prevents partial thinking/control tags from leaking to users during streaming responses.

In some cases, the model output could end a chunk with an incomplete tag fragment such as `<thi`, `<thin`, or `<tho`, which would be forwarded to the user before the full tag was available.

## Changes

- extend `strip_think` to remove trailing partial control-tag prefixes at the end of streamed text
- document the new streaming edge case in the helper docstring
- add unit tests for trailing partial `<think>` / `<thought>` and channel-marker fragments after visible text
- add a streaming integration test to verify incomplete tag fragments are not emitted through `on_stream`

## Validation

- ran: `uv run --extra dev pytest tests/utils/test_strip_think.py tests/agent/test_memory_store.py tests/agent/test_runner.py`
- result: 142 passed
