### PR TITLE
feat(agent): tool-loop guardrails to break runaway tool calls

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,7 +1,43 @@
 # Third-Party Notices
 
 The following third-party components are redistributed as part of the packaged
-nanobot Python distribution (`pip install nanobot-ai`).
+nanobot Python distribution (`pip install nanobot-ai`), or have been ported
+into nanobot's own source tree under their original license terms.
+
+---
+
+## hermes-agent — tool-call loop guardrails (MIT)
+
+- **Source**: https://github.com/NousResearch/hermes-agent
+- **Used in**: `nanobot/agent/tool_guardrails.py`
+
+The per-turn tool-call guardrail controller is a port of hermes-agent's
+`agent/tool_guardrails.py`, adapted to nanobot's tool inventory and runner
+integration.
+
+```
+MIT License
+
+Copyright (c) 2025 Nous Research
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
 
 ---
 

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -13,6 +13,13 @@ from typing import Any
 from loguru import logger
 
 from nanobot.agent.hook import AgentHook, AgentHookContext
+from nanobot.agent.tool_guardrails import (
+    ToolCallGuardrailController,
+    ToolGuardrailConfig,
+    ToolGuardrailDecision,
+    append_guidance,
+    synthetic_block_result,
+)
 from nanobot.agent.tools.ask import AskUserInterrupt
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
@@ -79,6 +86,7 @@ class AgentRunSpec:
     checkpoint_callback: Any | None = None
     injection_callback: Any | None = None
     llm_timeout_s: float | None = None
+    tool_guardrail_config: ToolGuardrailConfig | None = None
 
 
 @dataclass(slots=True)
@@ -239,6 +247,7 @@ class AgentRunner:
         stop_reason = "completed"
         tool_events: list[dict[str, str]] = []
         external_lookup_counts: dict[str, int] = {}
+        guardrail_controller = ToolCallGuardrailController(spec.tool_guardrail_config)
         empty_content_retries = 0
         length_recovery_count = 0
         had_injections = False
@@ -314,6 +323,7 @@ class AgentRunner:
                     spec,
                     tool_calls,
                     external_lookup_counts,
+                    guardrail_controller,
                 )
                 tool_events.extend(new_events)
                 context.tool_results = list(results)
@@ -698,20 +708,23 @@ class AgentRunner:
         spec: AgentRunSpec,
         tool_calls: list[ToolCallRequest],
         external_lookup_counts: dict[str, int],
+        guardrail_controller: ToolCallGuardrailController,
     ) -> tuple[list[Any], list[dict[str, str]], BaseException | None]:
         batches = self._partition_tool_batches(spec, tool_calls)
         tool_results: list[tuple[Any, dict[str, str], BaseException | None]] = []
         for batch in batches:
             if spec.concurrent_tools and len(batch) > 1:
                 batch_results = await asyncio.gather(*(
-                    self._run_tool(spec, tool_call, external_lookup_counts)
+                    self._run_tool(spec, tool_call, external_lookup_counts, guardrail_controller)
                     for tool_call in batch
                 ))
                 tool_results.extend(batch_results)
             else:
                 batch_results = []
                 for tool_call in batch:
-                    result = await self._run_tool(spec, tool_call, external_lookup_counts)
+                    result = await self._run_tool(
+                        spec, tool_call, external_lookup_counts, guardrail_controller,
+                    )
                     tool_results.append(result)
                     batch_results.append(result)
                     if isinstance(result[2], AskUserInterrupt):
@@ -734,8 +747,23 @@ class AgentRunner:
         spec: AgentRunSpec,
         tool_call: ToolCallRequest,
         external_lookup_counts: dict[str, int],
+        guardrail_controller: ToolCallGuardrailController,
     ) -> tuple[Any, dict[str, str], BaseException | None]:
         hint = "\n\n[Analyze the error above and try a different approach.]"
+
+        guardrail_pre = guardrail_controller.before_call(tool_call.name, tool_call.arguments)
+        if guardrail_pre.should_halt:
+            logger.warning(
+                "Tool guardrail blocked {}: {} (count={})",
+                tool_call.name, guardrail_pre.code, guardrail_pre.count,
+            )
+            event = {
+                "name": tool_call.name,
+                "status": "error",
+                "detail": f"guardrail:{guardrail_pre.code}",
+            }
+            return synthetic_block_result(guardrail_pre), event, RuntimeError(guardrail_pre.message)
+
         lookup_error = repeated_external_lookup_error(
             tool_call.name,
             tool_call.arguments,
@@ -789,6 +817,7 @@ class AgentRunner:
             if isinstance(exc, AskUserInterrupt):
                 event["status"] = "waiting"
                 return "", event, exc
+            err_text = f"Error: {type(exc).__name__}: {exc}"
             if self._is_workspace_violation(str(exc)):
                 logger.warning(
                     "Tool {} blocked by workspace/safety guard; aborting turn: {}",
@@ -797,10 +826,21 @@ class AgentRunner:
                 )
                 event["detail"] = ("workspace_violation: "
                                    + str(exc).replace("\n", " ").strip())[:160]
-                return f"Error: {type(exc).__name__}: {exc}", event, exc
-            if spec.fail_on_tool_error:
-                return f"Error: {type(exc).__name__}: {exc}", event, exc
-            return f"Error: {type(exc).__name__}: {exc}", event, None
+                # Workspace violations are terminal — record as failure but
+                # don't run guardrail logic (the loop is being aborted anyway).
+                guardrail_controller.after_call(
+                    tool_call.name, tool_call.arguments, err_text, failed=True,
+                )
+                return err_text, event, exc
+            decision = guardrail_controller.after_call(
+                tool_call.name, tool_call.arguments, err_text, failed=True,
+            )
+            err_text = append_guidance(err_text, decision)
+            fatal = exc if (spec.fail_on_tool_error or decision.action == "halt") else None
+            if decision.action == "halt":
+                event["detail"] = f"guardrail:{decision.code}"
+                return err_text, event, RuntimeError(decision.message)
+            return err_text, event, fatal
 
         if isinstance(result, str) and result.startswith("Error"):
             event = {
@@ -818,10 +858,31 @@ class AgentRunner:
                 )
                 event["detail"] = ("workspace_violation: "
                                    + result.replace("\n", " ").strip())[:160]
+                guardrail_controller.after_call(
+                    tool_call.name, tool_call.arguments, result, failed=True,
+                )
                 return result, event, RuntimeError(result)
+            decision = guardrail_controller.after_call(
+                tool_call.name, tool_call.arguments, result, failed=True,
+            )
+            annotated = append_guidance(result + hint, decision)
+            if decision.action == "halt":
+                event["detail"] = f"guardrail:{decision.code}"
+                return annotated, event, RuntimeError(decision.message)
             if spec.fail_on_tool_error:
-                return result + hint, event, RuntimeError(result)
-            return result + hint, event, None
+                return annotated, event, RuntimeError(result)
+            return annotated, event, None
+
+        # Success path: feed result to the guardrail tracker for idempotent-no-progress detection.
+        result_text = result if isinstance(result, str) else (
+            "" if result is None else str(result)
+        )
+        decision = guardrail_controller.after_call(
+            tool_call.name, tool_call.arguments, result_text, failed=False,
+        )
+        annotated_result = result
+        if decision.action == "warn" and isinstance(result, str):
+            annotated_result = append_guidance(result, decision)
 
         detail = "" if result is None else str(result)
         detail = detail.replace("\n", " ").strip()
@@ -829,7 +890,7 @@ class AgentRunner:
             detail = "(empty)"
         elif len(detail) > 120:
             detail = detail[:120] + "..."
-        return result, {"name": tool_call.name, "status": "ok", "detail": detail}, None
+        return annotated_result, {"name": tool_call.name, "status": "ok", "detail": detail}, None
 
     # Markers identifying tool results that represent a workspace / safety boundary rejection.
     _WORKSPACE_BLOCK_MARKERS: tuple[str, ...] = (

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -836,10 +836,10 @@ class AgentRunner:
                 tool_call.name, tool_call.arguments, err_text, failed=True,
             )
             err_text = append_guidance(err_text, decision)
-            fatal = exc if (spec.fail_on_tool_error or decision.action == "halt") else None
             if decision.action == "halt":
                 event["detail"] = f"guardrail:{decision.code}"
                 return err_text, event, RuntimeError(decision.message)
+            fatal = exc if spec.fail_on_tool_error else None
             return err_text, event, fatal
 
         if isinstance(result, str) and result.startswith("Error"):

--- a/nanobot/agent/tool_guardrails.py
+++ b/nanobot/agent/tool_guardrails.py
@@ -1,0 +1,400 @@
+"""Per-turn tool-call loop guardrails.
+
+A side-effect-free controller that observes ``(tool, args, result)`` tuples
+within a single agent turn and emits a decision: ``allow``, ``warn``,
+``block``, or ``halt``. The runner owns whether decisions become synthetic
+tool results, appended guidance, or hard turn termination.
+
+This addresses the "model retries the same failing call until iteration
+budget runs out" failure mode (#2298), which is especially common with
+small or local models.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+IDEMPOTENT_TOOL_NAMES = frozenset(
+    {
+        "read_file",
+        "list_dir",
+        "glob",
+        "grep",
+        "web_search",
+        "web_fetch",
+        "memory_search",
+        "ask_user",
+    }
+)
+
+MUTATING_TOOL_NAMES = frozenset(
+    {
+        "exec",
+        "write_file",
+        "edit_file",
+        "notebook_edit",
+        "cron",
+        "message",
+        "spawn",
+        "memory",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ToolGuardrailConfig:
+    """Per-turn guardrail thresholds."""
+
+    warnings_enabled: bool = True
+    hard_stop_enabled: bool = True
+    exact_failure_warn_after: int = 2
+    exact_failure_block_after: int = 5
+    same_tool_failure_warn_after: int = 3
+    same_tool_failure_halt_after: int = 8
+    no_progress_warn_after: int = 2
+    no_progress_block_after: int = 5
+    idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
+    mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "ToolGuardrailConfig":
+        if not isinstance(data, Mapping):
+            return cls()
+
+        warn_after = data.get("warn_after")
+        warn_after = warn_after if isinstance(warn_after, Mapping) else {}
+        hard_stop_after = data.get("hard_stop_after")
+        hard_stop_after = hard_stop_after if isinstance(hard_stop_after, Mapping) else {}
+
+        defaults = cls()
+        return cls(
+            warnings_enabled=_as_bool(data.get("warnings_enabled"), defaults.warnings_enabled),
+            hard_stop_enabled=_as_bool(data.get("hard_stop_enabled"), defaults.hard_stop_enabled),
+            exact_failure_warn_after=_positive_int(
+                warn_after.get("exact_failure"),
+                defaults.exact_failure_warn_after,
+            ),
+            same_tool_failure_warn_after=_positive_int(
+                warn_after.get("same_tool_failure"),
+                defaults.same_tool_failure_warn_after,
+            ),
+            no_progress_warn_after=_positive_int(
+                warn_after.get("idempotent_no_progress"),
+                defaults.no_progress_warn_after,
+            ),
+            exact_failure_block_after=_positive_int(
+                hard_stop_after.get("exact_failure"),
+                defaults.exact_failure_block_after,
+            ),
+            same_tool_failure_halt_after=_positive_int(
+                hard_stop_after.get("same_tool_failure"),
+                defaults.same_tool_failure_halt_after,
+            ),
+            no_progress_block_after=_positive_int(
+                hard_stop_after.get("idempotent_no_progress"),
+                defaults.no_progress_block_after,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ToolCallSignature:
+    tool_name: str
+    args_hash: str
+
+    @classmethod
+    def from_call(cls, tool_name: str, args: Mapping[str, Any] | None) -> "ToolCallSignature":
+        canonical = canonical_tool_args(args or {})
+        return cls(tool_name=tool_name, args_hash=_sha256(canonical))
+
+
+@dataclass(frozen=True)
+class ToolGuardrailDecision:
+    action: str = "allow"  # allow | warn | block | halt
+    code: str = "allow"
+    message: str = ""
+    tool_name: str = ""
+    count: int = 0
+    signature: ToolCallSignature | None = None
+
+    @property
+    def should_halt(self) -> bool:
+        return self.action in {"block", "halt"}
+
+
+def canonical_tool_args(args: Mapping[str, Any]) -> str:
+    """Sorted, compact JSON serialization of tool arguments."""
+    if not isinstance(args, Mapping):
+        raise TypeError(f"tool args must be a mapping, got {type(args).__name__}")
+    return json.dumps(
+        args,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+class ToolCallGuardrailController:
+    """Per-turn observer for repeated failed or non-progressing tool calls."""
+
+    def __init__(self, config: ToolGuardrailConfig | None = None):
+        self.config = config or ToolGuardrailConfig()
+        self.reset_for_turn()
+
+    def reset_for_turn(self) -> None:
+        self._exact_failure_counts: dict[ToolCallSignature, int] = {}
+        self._same_tool_failure_counts: dict[str, int] = {}
+        self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._halt_decision: ToolGuardrailDecision | None = None
+
+    @property
+    def halt_decision(self) -> ToolGuardrailDecision | None:
+        return self._halt_decision
+
+    def before_call(
+        self, tool_name: str, args: Mapping[str, Any] | None
+    ) -> ToolGuardrailDecision:
+        signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+        if not self.config.hard_stop_enabled:
+            return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+
+        exact_count = self._exact_failure_counts.get(signature, 0)
+        if exact_count >= self.config.exact_failure_block_after:
+            decision = ToolGuardrailDecision(
+                action="block",
+                code="repeated_exact_failure_block",
+                message=(
+                    f"Blocked {tool_name}: the same call failed {exact_count} times "
+                    "with identical arguments. Stop retrying it unchanged; change "
+                    "approach or explain the blocker to the user."
+                ),
+                tool_name=tool_name,
+                count=exact_count,
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
+
+        if self._is_idempotent(tool_name):
+            record = self._no_progress.get(signature)
+            if record is not None:
+                _result_hash_unused, repeat_count = record
+                if repeat_count >= self.config.no_progress_block_after:
+                    decision = ToolGuardrailDecision(
+                        action="block",
+                        code="idempotent_no_progress_block",
+                        message=(
+                            f"Blocked {tool_name}: read-only call returned the same "
+                            f"result {repeat_count} times. Stop repeating it; use the "
+                            "result already provided or change the query."
+                        ),
+                        tool_name=tool_name,
+                        count=repeat_count,
+                        signature=signature,
+                    )
+                    self._halt_decision = decision
+                    return decision
+
+        return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+
+    def after_call(
+        self,
+        tool_name: str,
+        args: Mapping[str, Any] | None,
+        result: str | None,
+        *,
+        failed: bool,
+    ) -> ToolGuardrailDecision:
+        args = _coerce_args(args)
+        signature = ToolCallSignature.from_call(tool_name, args)
+
+        if failed:
+            exact_count = self._exact_failure_counts.get(signature, 0) + 1
+            self._exact_failure_counts[signature] = exact_count
+            self._no_progress.pop(signature, None)
+
+            same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
+            self._same_tool_failure_counts[tool_name] = same_count
+
+            if (
+                self.config.hard_stop_enabled
+                and same_count >= self.config.same_tool_failure_halt_after
+            ):
+                decision = ToolGuardrailDecision(
+                    action="halt",
+                    code="same_tool_failure_halt",
+                    message=(
+                        f"Stopped {tool_name}: it failed {same_count} times this turn. "
+                        "Stop retrying the same failing path; choose a different approach."
+                    ),
+                    tool_name=tool_name,
+                    count=same_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+
+            if (
+                self.config.warnings_enabled
+                and exact_count >= self.config.exact_failure_warn_after
+            ):
+                return ToolGuardrailDecision(
+                    action="warn",
+                    code="repeated_exact_failure_warning",
+                    message=(
+                        f"{tool_name} has failed {exact_count} times with identical "
+                        "arguments. This looks like a loop; inspect the error and "
+                        "change strategy instead of retrying it unchanged."
+                    ),
+                    tool_name=tool_name,
+                    count=exact_count,
+                    signature=signature,
+                )
+
+            if (
+                self.config.warnings_enabled
+                and same_count >= self.config.same_tool_failure_warn_after
+            ):
+                return ToolGuardrailDecision(
+                    action="warn",
+                    code="same_tool_failure_warning",
+                    message=(
+                        f"{tool_name} has failed {same_count} times this turn. "
+                        "This looks like a loop; change approach before retrying."
+                    ),
+                    tool_name=tool_name,
+                    count=same_count,
+                    signature=signature,
+                )
+
+            return ToolGuardrailDecision(
+                tool_name=tool_name, count=exact_count, signature=signature,
+            )
+
+        # Success path: clear failure counters; track repeat results for idempotent tools.
+        self._exact_failure_counts.pop(signature, None)
+        self._same_tool_failure_counts.pop(tool_name, None)
+
+        if not self._is_idempotent(tool_name):
+            self._no_progress.pop(signature, None)
+            return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+
+        result_hash = _hash_result(result)
+        previous = self._no_progress.get(signature)
+        repeat_count = 1
+        if previous is not None and previous[0] == result_hash:
+            repeat_count = previous[1] + 1
+        self._no_progress[signature] = (result_hash, repeat_count)
+
+        if (
+            self.config.warnings_enabled
+            and repeat_count >= self.config.no_progress_warn_after
+        ):
+            return ToolGuardrailDecision(
+                action="warn",
+                code="idempotent_no_progress_warning",
+                message=(
+                    f"{tool_name} returned the same result {repeat_count} times. "
+                    "Use the result already provided or change the query instead "
+                    "of repeating it unchanged."
+                ),
+                tool_name=tool_name,
+                count=repeat_count,
+                signature=signature,
+            )
+
+        return ToolGuardrailDecision(
+            tool_name=tool_name, count=repeat_count, signature=signature,
+        )
+
+    def _is_idempotent(self, tool_name: str) -> bool:
+        if tool_name in self.config.mutating_tools:
+            return False
+        return tool_name in self.config.idempotent_tools
+
+
+def synthetic_block_result(decision: ToolGuardrailDecision) -> str:
+    """Build a synthetic tool result body for a blocked call."""
+    payload: dict[str, Any] = {
+        "error": decision.message,
+        "guardrail": {
+            "action": decision.action,
+            "code": decision.code,
+            "tool_name": decision.tool_name,
+            "count": decision.count,
+        },
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def append_guidance(result: str | None, decision: ToolGuardrailDecision) -> str:
+    """Append a `[Tool loop ...]` annotation to the tool result content."""
+    if decision.action not in {"warn", "halt"} or not decision.message:
+        return result or ""
+    label = "Tool loop hard stop" if decision.action == "halt" else "Tool loop warning"
+    return (
+        f"{result or ''}\n\n[{label}: {decision.code}; "
+        f"count={decision.count}; {decision.message}]"
+    )
+
+
+def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    return args if isinstance(args, Mapping) else {}
+
+
+def _hash_result(result: str | None) -> str:
+    if result is None:
+        return _sha256("")
+    try:
+        parsed = json.loads(result)
+    except (TypeError, ValueError):
+        parsed = None
+    if parsed is not None:
+        try:
+            canonical = json.dumps(
+                parsed,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            )
+        except TypeError:
+            canonical = str(parsed)
+    else:
+        canonical = result
+    return _sha256(canonical)
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default
+
+
+def _positive_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 1 else default
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()

--- a/nanobot/agent/tool_guardrails.py
+++ b/nanobot/agent/tool_guardrails.py
@@ -8,6 +8,15 @@ tool results, appended guidance, or hard turn termination.
 This addresses the "model retries the same failing call until iteration
 budget runs out" failure mode (#2298), which is especially common with
 small or local models.
+
+Ported from hermes-agent's ``agent/tool_guardrails.py``
+(https://github.com/NousResearch/hermes-agent), adapted to nanobot's
+tool inventory and runner integration. Original work:
+
+    MIT License
+    Copyright (c) 2025 Nous Research
+
+The full MIT text is reproduced in this project's ``THIRD_PARTY_NOTICES.md``.
 """
 
 from __future__ import annotations

--- a/nanobot/agent/tool_guardrails.py
+++ b/nanobot/agent/tool_guardrails.py
@@ -117,7 +117,9 @@ class ToolCallSignature:
 
     @classmethod
     def from_call(cls, tool_name: str, args: Mapping[str, Any] | None) -> "ToolCallSignature":
-        canonical = canonical_tool_args(args or {})
+        # Coerce defensively — direct callers (third parties, tests) shouldn't
+        # be able to crash the controller by passing a list / non-Mapping.
+        canonical = canonical_tool_args(_coerce_args(args))
         return cls(tool_name=tool_name, args_hash=_sha256(canonical))
 
 

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -3091,3 +3091,94 @@ async def test_runner_binds_on_retry_wait_to_retry_callback_not_progress():
 
     assert captured["on_retry_wait"] is retry_wait_cb
     assert captured["on_retry_wait"] is not progress_cb
+
+
+# ---------------------------------------------------------------------------
+# Tool-loop guardrail integration (#2298 / PR #3580)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_guardrail_blocks_repeated_failing_call_in_runner():
+    """End-to-end: model keeps emitting the same failing write_file. Once the
+    block threshold is hit, the next call's tool result is the guardrail's
+    synthetic JSON body and the agent halts with stop_reason='tool_error'."""
+    import json as _json
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+    from nanobot.agent.tool_guardrails import ToolGuardrailConfig
+
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
+        content="retrying",
+        tool_calls=[ToolCallRequest(
+            id="call_x", name="write_file", arguments={"path": "/x", "content": "y"},
+        )],
+    ))
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="Error: permission denied")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[],
+        tools=tools,
+        model="test-model",
+        max_iterations=20,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        tool_guardrail_config=ToolGuardrailConfig(
+            exact_failure_warn_after=2,
+            exact_failure_block_after=3,
+        ),
+    ))
+
+    assert result.stop_reason == "tool_error"
+    tool_messages = [m for m in result.messages if m.get("role") == "tool"]
+    # First few calls hit the real tool then return the error result;
+    # the call that trips the block returns a synthetic JSON body.
+    last_tool = tool_messages[-1]
+    last_content = last_tool["content"]
+    if isinstance(last_content, list):
+        last_content = "".join(
+            part.get("text", "") for part in last_content if isinstance(part, dict)
+        )
+    parsed = _json.loads(last_content)
+    assert parsed["guardrail"]["code"] == "repeated_exact_failure_block"
+    assert parsed["guardrail"]["tool_name"] == "write_file"
+    # The runner should have stopped before max_iterations — guardrail kicked in early.
+    assert tools.execute.await_count <= 4
+
+
+@pytest.mark.asyncio
+async def test_guardrail_disabled_lets_loop_run_to_max_iterations():
+    """With hard_stop_enabled=False the controller is observation-only;
+    the loop terminates only when max_iterations runs out."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+    from nanobot.agent.tool_guardrails import ToolGuardrailConfig
+
+    provider = MagicMock()
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
+        content="retrying",
+        tool_calls=[ToolCallRequest(
+            id="call_x", name="write_file", arguments={"path": "/x"},
+        )],
+    ))
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="Error: permission denied")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[],
+        tools=tools,
+        model="test-model",
+        max_iterations=4,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        tool_guardrail_config=ToolGuardrailConfig(
+            warnings_enabled=False,
+            hard_stop_enabled=False,
+        ),
+    ))
+
+    assert result.stop_reason == "max_iterations"
+    # Tool was called every iteration — guardrail did not block anything.
+    assert tools.execute.await_count == 4

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -815,6 +815,7 @@ async def test_runner_batches_read_only_tools_before_exclusive_work():
     tools.register(write_a)
 
     runner = AgentRunner(MagicMock())
+    from nanobot.agent.tool_guardrails import ToolCallGuardrailController
     await runner._execute_tools(
         AgentRunSpec(
             initial_messages=[],
@@ -830,6 +831,7 @@ async def test_runner_batches_read_only_tools_before_exclusive_work():
             ToolCallRequest(id="rw1", name="write_a", arguments={}),
         ],
         {},
+        ToolCallGuardrailController(),
     )
 
     assert shared_events[0:2] == ["start:read_a", "start:read_b"]
@@ -859,6 +861,7 @@ async def test_runner_does_not_batch_exclusive_read_only_tools():
     tools.register(read_b)
 
     runner = AgentRunner(MagicMock())
+    from nanobot.agent.tool_guardrails import ToolCallGuardrailController
     await runner._execute_tools(
         AgentRunSpec(
             initial_messages=[],
@@ -874,6 +877,7 @@ async def test_runner_does_not_batch_exclusive_read_only_tools():
             ToolCallRequest(id="ro2", name="read_b", arguments={}),
         ],
         {},
+        ToolCallGuardrailController(),
     )
 
     assert shared_events[0] == "start:read_a"
@@ -1190,10 +1194,25 @@ async def test_subagent_max_iterations_announces_existing_fallback(tmp_path, mon
     bus = MessageBus()
     provider = MagicMock()
     provider.get_default_model.return_value = "test-model"
-    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(
-        content="working",
-        tool_calls=[ToolCallRequest(id="call_1", name="list_dir", arguments={"path": "."})],
-    ))
+    # Vary the tool call args so the per-turn idempotent-no-progress guardrail
+    # doesn't trip first — this test specifically exercises the max_iterations
+    # fallback path.
+    counter = {"n": 0}
+
+    async def _vary_chat(*_args, **_kwargs):
+        counter["n"] += 1
+        return LLMResponse(
+            content="working",
+            tool_calls=[
+                ToolCallRequest(
+                    id=f"call_{counter['n']}",
+                    name="list_dir",
+                    arguments={"path": f"./dir_{counter['n']}"},
+                ),
+            ],
+        )
+
+    provider.chat_with_retry = AsyncMock(side_effect=_vary_chat)
     mgr = SubagentManager(
         provider=provider,
         workspace=tmp_path,
@@ -1203,7 +1222,9 @@ async def test_subagent_max_iterations_announces_existing_fallback(tmp_path, mon
     mgr._announce_result = AsyncMock()
 
     async def fake_execute(self, **kwargs):
-        return "tool result"
+        # Return a unique result per call so the no-progress guardrail
+        # also doesn't fire on result-hash repetition.
+        return f"tool result {counter['n']}"
 
     monkeypatch.setattr("nanobot.agent.tools.filesystem.ListDirTool.execute", fake_execute)
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -1,0 +1,176 @@
+"""Unit tests for the tool-loop guardrail controller (#2298)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nanobot.agent.tool_guardrails import (
+    ToolCallGuardrailController,
+    ToolGuardrailConfig,
+    append_guidance,
+    canonical_tool_args,
+    synthetic_block_result,
+)
+
+
+def _make(**overrides) -> ToolCallGuardrailController:
+    return ToolCallGuardrailController(ToolGuardrailConfig(**overrides))
+
+
+def test_canonical_args_sorts_keys_for_stable_signature() -> None:
+    assert canonical_tool_args({"b": 1, "a": 2}) == canonical_tool_args({"a": 2, "b": 1})
+
+
+def test_first_failure_does_not_warn() -> None:
+    c = _make()
+    decision = c.after_call("read_file", {"path": "/x"}, "Error: nope", failed=True)
+    assert decision.action == "allow"
+
+
+def test_repeated_exact_failure_warns_after_threshold() -> None:
+    c = _make(exact_failure_warn_after=2)
+    args = {"path": "/x"}
+    c.after_call("read_file", args, "Error: nope", failed=True)
+    decision = c.after_call("read_file", args, "Error: nope", failed=True)
+    assert decision.action == "warn"
+    assert decision.code == "repeated_exact_failure_warning"
+    assert decision.count == 2
+
+
+def test_repeated_exact_failure_blocks_at_block_threshold() -> None:
+    c = _make(exact_failure_block_after=3)
+    args = {"path": "/x"}
+    for _ in range(3):
+        c.after_call("write_file", args, "Error: denied", failed=True)
+    pre = c.before_call("write_file", args)
+    assert pre.action == "block"
+    assert pre.code == "repeated_exact_failure_block"
+    assert c.halt_decision is not None
+
+
+def test_block_disabled_when_hard_stop_disabled() -> None:
+    c = _make(hard_stop_enabled=False, exact_failure_block_after=3)
+    args = {"path": "/x"}
+    for _ in range(5):
+        c.after_call("write_file", args, "Error: denied", failed=True)
+    pre = c.before_call("write_file", args)
+    assert pre.action == "allow"
+    assert c.halt_decision is None
+
+
+def test_same_tool_failure_halts_across_different_args() -> None:
+    c = _make(same_tool_failure_halt_after=3)
+    for i in range(3):
+        decision = c.after_call("exec", {"cmd": f"foo-{i}"}, "Error: fail", failed=True)
+    assert decision.action == "halt"
+    assert decision.code == "same_tool_failure_halt"
+    assert decision.count == 3
+
+
+def test_idempotent_no_progress_warns_when_same_result_repeats() -> None:
+    c = _make(no_progress_warn_after=2)
+    args = {"path": "/etc"}
+    c.after_call("read_file", args, "hello", failed=False)
+    decision = c.after_call("read_file", args, "hello", failed=False)
+    assert decision.action == "warn"
+    assert decision.code == "idempotent_no_progress_warning"
+    assert decision.count == 2
+
+
+def test_idempotent_no_progress_blocks_at_block_threshold() -> None:
+    c = _make(no_progress_block_after=3)
+    args = {"q": "foo"}
+    for _ in range(3):
+        c.after_call("web_search", args, '{"hits":[]}', failed=False)
+    pre = c.before_call("web_search", args)
+    assert pre.action == "block"
+    assert pre.code == "idempotent_no_progress_block"
+
+
+def test_mutating_tool_no_progress_does_not_warn() -> None:
+    """write_file is mutating — even repeated identical success should not warn."""
+    c = _make(no_progress_warn_after=2)
+    args = {"path": "/x", "content": "hi"}
+    decisions = [
+        c.after_call("write_file", args, "ok", failed=False) for _ in range(5)
+    ]
+    assert all(d.action == "allow" for d in decisions)
+
+
+def test_failure_then_success_resets_failure_counter() -> None:
+    c = _make(exact_failure_warn_after=2, exact_failure_block_after=3)
+    args = {"path": "/x"}
+    c.after_call("read_file", args, "Error: nope", failed=True)
+    c.after_call("read_file", args, "Error: nope", failed=True)  # would warn
+    c.after_call("read_file", args, "ok", failed=False)
+    pre = c.before_call("read_file", args)
+    assert pre.action == "allow"
+
+
+def test_reset_for_turn_clears_state() -> None:
+    c = _make()
+    c.after_call("exec", {"cmd": "x"}, "Error", failed=True)
+    c.after_call("exec", {"cmd": "y"}, "Error", failed=True)
+    c.reset_for_turn()
+    decision = c.after_call("exec", {"cmd": "z"}, "Error", failed=True)
+    assert decision.action == "allow"
+
+
+def test_synthetic_block_result_returns_json_with_error() -> None:
+    c = _make(exact_failure_block_after=1)
+    args = {"path": "/x"}
+    c.after_call("write_file", args, "Error", failed=True)
+    pre = c.before_call("write_file", args)
+    assert pre.should_halt
+    body = synthetic_block_result(pre)
+    parsed = json.loads(body)
+    assert parsed["error"] == pre.message
+    assert parsed["guardrail"]["code"] == "repeated_exact_failure_block"
+
+
+def test_append_guidance_adds_warning_suffix() -> None:
+    c = _make(exact_failure_warn_after=2)
+    args = {"path": "/x"}
+    c.after_call("read_file", args, "Error", failed=True)
+    decision = c.after_call("read_file", args, "Error", failed=True)
+    annotated = append_guidance("Error", decision)
+    assert "[Tool loop warning:" in annotated
+    assert "repeated_exact_failure_warning" in annotated
+
+
+def test_append_guidance_noop_for_allow() -> None:
+    c = _make()
+    decision = c.after_call("read_file", {"path": "/x"}, "ok", failed=False)
+    assert append_guidance("ok", decision) == "ok"
+
+
+def test_config_from_mapping_overrides_thresholds() -> None:
+    cfg = ToolGuardrailConfig.from_mapping({
+        "warnings_enabled": False,
+        "warn_after": {"exact_failure": 7},
+        "hard_stop_after": {"same_tool_failure": 99},
+    })
+    assert cfg.warnings_enabled is False
+    assert cfg.exact_failure_warn_after == 7
+    assert cfg.same_tool_failure_halt_after == 99
+
+
+def test_config_from_mapping_falls_back_to_defaults_for_invalid_values() -> None:
+    cfg = ToolGuardrailConfig.from_mapping({
+        "warn_after": {"exact_failure": -1},  # negative → ignored
+        "warnings_enabled": "maybe",  # not parseable → default
+    })
+    defaults = ToolGuardrailConfig()
+    assert cfg.exact_failure_warn_after == defaults.exact_failure_warn_after
+    assert cfg.warnings_enabled == defaults.warnings_enabled
+
+
+def test_loop_signature_unaffected_by_dict_key_order() -> None:
+    """A real-world loop where the model alternates arg key order shouldn't
+    bypass the no-progress detector."""
+    c = _make(no_progress_warn_after=2)
+    c.after_call("read_file", {"a": 1, "b": 2}, "data", failed=False)
+    decision = c.after_call("read_file", {"b": 2, "a": 1}, "data", failed=False)
+    assert decision.action == "warn"

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -174,3 +174,22 @@ def test_loop_signature_unaffected_by_dict_key_order() -> None:
     c.after_call("read_file", {"a": 1, "b": 2}, "data", failed=False)
     decision = c.after_call("read_file", {"b": 2, "a": 1}, "data", failed=False)
     assert decision.action == "warn"
+
+
+def test_controller_does_not_crash_on_non_mapping_args() -> None:
+    """Direct callers may pass list / None / scalars; controller must coerce
+    silently rather than raising and tearing down the agent loop."""
+    c = _make()
+    # before_call / after_call already coerce internally; just verify the
+    # public ``from_call`` path is also defensive (used by external callers).
+    from nanobot.agent.tool_guardrails import ToolCallSignature
+
+    sig_list = ToolCallSignature.from_call("read_file", ["not", "a", "mapping"])  # type: ignore[arg-type]
+    sig_none = ToolCallSignature.from_call("read_file", None)
+    sig_empty = ToolCallSignature.from_call("read_file", {})
+    # All non-mapping inputs collapse to the same empty-args signature.
+    assert sig_list.args_hash == sig_none.args_hash == sig_empty.args_hash
+
+    # And the live observation methods don't crash either.
+    assert c.before_call("read_file", "garbage").action == "allow"  # type: ignore[arg-type]
+    assert c.after_call("read_file", None, "ok", failed=False).action == "allow"


### PR DESCRIPTION
## Summary

Closes #2298 — small / local models routinely fall into "model retries the same failing tool 40 times until max_iterations" loops, burning tokens with no progress.

This PR adds a per-turn controller that observes `(tool, args, result)` tuples and returns one of `allow` / `warn` / `block` / `halt` when:

- the **same exact call** keeps failing (warn at 2, block at 5),
- the **same tool** fails repeatedly across different args (warn at 3, halt at 8),
- an **idempotent** call returns the same result repeatedly (warn at 2, block at 5).

## What changes

- New module `nanobot/agent/tool_guardrails.py` — pure-function controller, no I/O. Signature = `(tool_name, sha256(canonical_json(args)))`. Counters reset each turn.
- Tool classification reflecting nanobot's actual tool inventory:
  - **idempotent:** `read_file`, `list_dir`, `glob`, `grep`, `web_search`, `web_fetch`, `memory_search`, `ask_user`
  - **mutating:** `exec`, `write_file`, `edit_file`, `notebook_edit`, `cron`, `message`, `spawn`, `memory`
- `runner._run_tool` consults the controller before each call (synthetic JSON `{"error": ..., "guardrail": ...}` returned on block) and after each call (`[Tool loop warning: ...]` suffix appended to non-fatal results).
- `AgentRunSpec` gains an optional `tool_guardrail_config` field so config.yaml can tune thresholds in a follow-up.

## Why these defaults

Both warnings and hard stops are enabled by default. nanobot agents typically run **unattended** in chat-server contexts where silent runaway burns money — the user can't intervene mid-loop the way an interactive CLI user can. Thresholds are generous enough that legitimate retries (~3-5 attempts at solving a tricky problem) won't trip the halt. Hard stops can be disabled per-spec:

```python
spec.tool_guardrail_config = ToolGuardrailConfig(hard_stop_enabled=False)
```

## Prior art / attribution

The controller's signature/decision shape follows the pattern in [hermes-agent's `agent/tool_guardrails.py`](https://github.com/NousResearch/hermes-agent/blob/main/agent/tool_guardrails.py) (MIT, Nous Research). Source-file header and `THIRD_PARTY_NOTICES.md` carry the upstream copyright as required by MIT. Adapted to nanobot's tool inventory, runner integration, and unattended-agent default policy.

## Test plan

- [x] `pytest tests/agent/test_tool_guardrails.py` — 17 unit tests cover all decision paths and config parsing
- [x] `pytest tests/agent/test_runner.py` — 74 passed (2 existing tests updated to thread the controller; 1 test that exercised a "list_dir-forever" loop was tightened to vary args/results so it still tests the max_iterations fallback rather than the new guardrail-block path)
- [x] `pytest tests/agent/` — full suite, **771 passed**
- [x] No regressions in surrounding modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)