### PR TITLE
fix(helpers): restore tiktoken fallback in estimate_prompt_tokens_chain

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -431,6 +431,7 @@ def estimate_prompt_tokens_chain(
             tokens, source = provider_counter(messages, tools, model)
             if isinstance(tokens, (int, float)) and tokens > 0:
                 return int(tokens), str(source or "provider_counter")
+    estimated = estimate_prompt_tokens(messages, tools)
     if estimated > 0:
         return int(estimated), "tiktoken"
     return 0, "none"


### PR DESCRIPTION
## Related Issue
Closes HKUDS/nanobot#3581

## Problem
`estimate_prompt_tokens_chain()` crashes with `NameError: name 'estimated' is not defined` when the provider counter is unavailable or raises an exception.

The crash occurs in `memory.py` during token-based memory consolidation.

## Root Cause
Commit `d9800ec` ("refactor: replace try-except blocks with contextlib.suppress") accidentally deleted the tiktoken fallback line when converting try/except to `with suppress()`.

## Solution
Restore the `estimated = estimate_prompt_tokens(messages, tools)` line that was accidentally deleted.

## Changes
1 file changed, 1 insertion(+):
- `nanobot/utils/helpers.py:434` - Add back the tiktoken fallback

## Testing
- All `tests/agent/test_consolidator.py` tests pass (17/17)
- The fix restores the original behavior where it falls back to tiktoken when the provider counter fails

