### PR TITLE
fix(transcription): convert non-WAV audio to 16kHz mono WAV before upload

### DIFF
--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -1,10 +1,66 @@
 """Voice transcription providers (Groq and OpenAI Whisper)."""
 
 import os
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 import httpx
 from loguru import logger
+
+
+def _ensure_whisper_compatible_audio(path: Path) -> tuple[Path, str | None]:
+    """Convert non-WAV input to 16 kHz mono WAV via ffmpeg.
+
+    Cloud Whisper backends (OpenAI, Groq) accept many audio formats, but
+    self-hosted ones — notably whisper.cpp's ``/inference`` endpoint —
+    accept only 16 kHz mono WAV and reject everything else with HTTP 400.
+    Telegram, WhatsApp and Feishu all deliver voice messages as OGG/Opus,
+    which makes any local-Whisper deployment unusable without a separate
+    pre-processing step.
+
+    The function is best-effort: if ffmpeg is missing or the conversion
+    fails, the original path is returned and the caller can still try the
+    upload (cloud backends will succeed; local backends will keep their
+    current 400 behaviour, which is no worse than today).
+
+    Returns:
+        ``(path_to_send, cleanup_path)``. ``cleanup_path`` is the absolute
+        path of a tempfile that the caller should ``os.unlink`` once done,
+        or ``None`` when no tempfile was created.
+    """
+    if path.suffix.lower() == ".wav":
+        return path, None
+    if not shutil.which("ffmpeg"):
+        logger.warning(
+            "ffmpeg not found on PATH; sending {} as-is. Local Whisper backends "
+            "(whisper.cpp, etc.) require 16 kHz mono WAV and may reject this.",
+            path.suffix,
+        )
+        return path, None
+    try:
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-loglevel", "error",
+                "-i", str(path),
+                "-ar", "16000", "-ac", "1", "-f", "wav",
+                tmp.name,
+            ],
+            check=True, capture_output=True,
+        )
+        return Path(tmp.name), tmp.name
+    except (subprocess.CalledProcessError, OSError) as e:
+        stderr = ""
+        if isinstance(e, subprocess.CalledProcessError) and e.stderr:
+            stderr = e.stderr.decode(errors="ignore")[:200]
+        logger.warning(
+            "ffmpeg conversion of {} failed ({}); sending original. {}",
+            path.name, type(e).__name__, stderr,
+        )
+        return path, None
 
 
 class OpenAITranscriptionProvider:
@@ -32,10 +88,11 @@ class OpenAITranscriptionProvider:
         if not path.exists():
             logger.error("Audio file not found: {}", file_path)
             return ""
+        upload_path, cleanup_path = _ensure_whisper_compatible_audio(path)
         try:
             async with httpx.AsyncClient() as client:
-                with open(path, "rb") as f:
-                    files = {"file": (path.name, f), "model": (None, "whisper-1")}
+                with open(upload_path, "rb") as f:
+                    files = {"file": (upload_path.name, f), "model": (None, "whisper-1")}
                     if self.language:
                         files["language"] = (None, self.language)
                     headers = {"Authorization": f"Bearer {self.api_key}"}
@@ -47,6 +104,12 @@ class OpenAITranscriptionProvider:
         except Exception as e:
             logger.error("OpenAI transcription error: {}", e)
             return ""
+        finally:
+            if cleanup_path:
+                try:
+                    os.unlink(cleanup_path)
+                except OSError:
+                    pass
 
 
 class GroqTranscriptionProvider:
@@ -85,11 +148,12 @@ class GroqTranscriptionProvider:
             logger.error("Audio file not found: {}", file_path)
             return ""
 
+        upload_path, cleanup_path = _ensure_whisper_compatible_audio(path)
         try:
             async with httpx.AsyncClient() as client:
-                with open(path, "rb") as f:
+                with open(upload_path, "rb") as f:
                     files = {
-                        "file": (path.name, f),
+                        "file": (upload_path.name, f),
                         "model": (None, "whisper-large-v3"),
                     }
                     if self.language:
@@ -112,3 +176,9 @@ class GroqTranscriptionProvider:
         except Exception as e:
             logger.error("Groq transcription error: {}", e)
             return ""
+        finally:
+            if cleanup_path:
+                try:
+                    os.unlink(cleanup_path)
+                except OSError:
+                    pass

--- a/tests/providers/test_transcription_format_convert.py
+++ b/tests/providers/test_transcription_format_convert.py
@@ -1,0 +1,79 @@
+"""Tests for the audio-format normalization helper used by transcription providers.
+
+The helper is best-effort: ffmpeg may be missing in the test environment, so we
+exercise three branches:
+  1. ``.wav`` input is passed through untouched.
+  2. ffmpeg-missing branch returns the original path with no tempfile.
+  3. ffmpeg-success branch returns a tempfile path and a cleanup pointer.
+"""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nanobot.providers.transcription import _ensure_whisper_compatible_audio
+
+
+def test_wav_input_passes_through(tmp_path: Path) -> None:
+    wav = tmp_path / "voice.wav"
+    wav.write_bytes(b"RIFF....WAVEfmt ")
+
+    upload, cleanup = _ensure_whisper_compatible_audio(wav)
+
+    assert upload == wav
+    assert cleanup is None
+
+
+def test_missing_ffmpeg_returns_original(tmp_path: Path) -> None:
+    ogg = tmp_path / "voice.ogg"
+    ogg.write_bytes(b"OggS\x00")
+
+    with patch("nanobot.providers.transcription.shutil.which", return_value=None):
+        upload, cleanup = _ensure_whisper_compatible_audio(ogg)
+
+    assert upload == ogg
+    assert cleanup is None
+
+
+def test_ffmpeg_failure_returns_original(tmp_path: Path) -> None:
+    import subprocess
+
+    ogg = tmp_path / "voice.ogg"
+    ogg.write_bytes(b"OggS\x00")
+
+    fake_error = subprocess.CalledProcessError(1, ["ffmpeg"], stderr=b"boom")
+    with patch("nanobot.providers.transcription.shutil.which", return_value="/usr/bin/ffmpeg"), \
+         patch("nanobot.providers.transcription.subprocess.run", side_effect=fake_error):
+        upload, cleanup = _ensure_whisper_compatible_audio(ogg)
+
+    assert upload == ogg
+    assert cleanup is None
+
+
+@pytest.mark.skipif(
+    not __import__("shutil").which("ffmpeg"),
+    reason="ffmpeg not installed in test environment",
+)
+def test_ffmpeg_real_conversion(tmp_path: Path) -> None:
+    """Round-trip test that runs only when a real ffmpeg is on PATH."""
+    import subprocess
+
+    src = tmp_path / "tone.opus"
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-loglevel", "error",
+            "-f", "lavfi", "-i", "sine=frequency=440:duration=0.2",
+            "-c:a", "libopus",
+            str(src),
+        ],
+        check=True, capture_output=True,
+    )
+
+    upload, cleanup = _ensure_whisper_compatible_audio(src)
+    try:
+        assert cleanup is not None
+        assert upload.suffix == ".wav"
+        assert upload.stat().st_size > 0
+    finally:
+        if cleanup:
+            Path(cleanup).unlink(missing_ok=True)


### PR DESCRIPTION
## Problem

`OpenAITranscriptionProvider` and `GroqTranscriptionProvider` upload the audio file verbatim. OpenAI Cloud and Groq accept any common format, but **self-hosted Whisper backends behind `OPENAI_TRANSCRIPTION_BASE_URL` (notably whisper.cpp's `/inference` endpoint) accept only 16 kHz mono WAV** and return HTTP 400 for everything else.

Voice messages from Telegram, WhatsApp and Feishu all arrive as OGG/Opus, so any local-Whisper deployment is effectively broken without an external pre-processing step.

### Reproduce

```bash
# Run any whisper.cpp server, e.g.
./whisper-server -m ggml-large-v3.bin --port 8200

# Configure nanobot to use it
export OPENAI_TRANSCRIPTION_BASE_URL=http://localhost:8200/inference
export OPENAI_API_KEY=anything

# Send a Telegram voice message → 400 Bad Request, transcription returns ""
```

## Fix

Add a module-level helper `_ensure_whisper_compatible_audio()` that calls `ffmpeg` to normalise non-WAV input to 16 kHz mono WAV:

- `.wav` input is passed through untouched (zero overhead for the common case).
- If `ffmpeg` is missing on `PATH`, the original path is returned with a warning log — cloud backends still work, local backends keep their current 400 behaviour (no regression).
- If `ffmpeg` returns non-zero, the same fall-back kicks in.

Both providers call the helper before opening the upload stream and unlink the tempfile in `finally`.

## Tests

`tests/providers/test_transcription_format_convert.py` covers:

- WAV passthrough (no tempfile created)
- Missing `ffmpeg` returns the original path
- `ffmpeg` non-zero exit returns the original path
- Real round-trip through libopus, gated on `ffmpeg` being installed

All four pass on Python 3.14.4 with the project's `pyproject.toml` install.

## Backwards compatibility

- Cloud backends (OpenAI, Groq): identical behaviour — they accept WAV just as well as OGG, and the conversion is silently bypassed for `.wav` input.
- Local backends without `ffmpeg`: identical behaviour — original path is uploaded with a warning log.
- Local backends with `ffmpeg`: previously broken (HTTP 400), now work.

`ffmpeg` is treated as a runtime dependency only when needed; it's already a hard dependency for several other channels (Feishu voice download, WhatsApp media handling) and ships in nearly every Linux base image.

## Relation to #3513

#3513 ("unify transcription providers and add local Whisper support") refactors this module to introduce a `local` provider and remove the duplication between `OpenAITranscriptionProvider` and `GroqTranscriptionProvider`. It does **not** address audio-format conversion — even after #3513 lands, whisper.cpp users will still hit the 400 problem.

This PR is therefore complementary. Once #3513 is merged, the `_ensure_whisper_compatible_audio()` helper can be moved into the unified `WhisperTranscriptionProvider` with a one-line refit.

---

Bug discovered and patch authored together with my AI assistant Ren (Claude Opus 4.7). I'm submitting; the analysis is hers.