### PR TITLE
fix: allow_patterns take priority over deny_patterns in ExecTool

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -374,8 +374,8 @@ class AgentLoop:
                     sandbox=self.exec_config.sandbox,
                     path_append=self.exec_config.path_append,
                     allowed_env_keys=self.exec_config.allowed_env_keys,
-                    allow_patterns=self.exec_config.allow_patterns or None,
-                    deny_patterns=self.exec_config.deny_patterns or None,
+                    allow_patterns=self.exec_config.allow_patterns,
+                    deny_patterns=self.exec_config.deny_patterns,
                 )
             )
         if self.web_config.enable:

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -374,6 +374,8 @@ class AgentLoop:
                     sandbox=self.exec_config.sandbox,
                     path_append=self.exec_config.path_append,
                     allowed_env_keys=self.exec_config.allowed_env_keys,
+                    allow_patterns=self.exec_config.allow_patterns or None,
+                    deny_patterns=self.exec_config.deny_patterns or None,
                 )
             )
         if self.web_config.enable:

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -833,7 +833,6 @@ class AgentRunner:
 
     # Markers identifying tool results that represent a workspace / safety boundary rejection.
     _WORKSPACE_BLOCK_MARKERS: tuple[str, ...] = (
-        "blocked by safety guard",
         "outside the configured workspace",
         "outside allowed directory",
         "working_dir is outside",

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -839,6 +839,7 @@ class AgentRunner:
         "working_dir could not be resolved",
         "path traversal detected",
         "path outside working dir",
+        "internal/private url detected",
     )
 
     @classmethod

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -188,6 +188,8 @@ class SubagentManager:
                     sandbox=self.exec_config.sandbox,
                     path_append=self.exec_config.path_append,
                     allowed_env_keys=self.exec_config.allowed_env_keys,
+                    allow_patterns=self.exec_config.allow_patterns or None,
+                    deny_patterns=self.exec_config.deny_patterns or None,
                 ))
             if self.web_config.enable:
                 tools.register(

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -188,8 +188,8 @@ class SubagentManager:
                     sandbox=self.exec_config.sandbox,
                     path_append=self.exec_config.path_append,
                     allowed_env_keys=self.exec_config.allowed_env_keys,
-                    allow_patterns=self.exec_config.allow_patterns or None,
-                    deny_patterns=self.exec_config.deny_patterns or None,
+                    allow_patterns=self.exec_config.allow_patterns,
+                    deny_patterns=self.exec_config.deny_patterns,
                 ))
             if self.web_config.enable:
                 tools.register(

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -276,16 +276,16 @@ class ExecTool(Tool):
         # allow_patterns take priority over deny_patterns so that users can
         # exempt specific commands (e.g. "rm -rf" inside a build directory)
         # from the hardcoded deny list via configuration.
-        if self.allow_patterns and any(re.search(p, lower) for p in self.allow_patterns):
-            pass  # explicitly allowed – skip deny check
-        else:
+        explicitly_allowed = bool(self.allow_patterns) and any(
+            re.search(p, lower) for p in self.allow_patterns
+        )
+        if not explicitly_allowed:
             for pattern in self.deny_patterns:
                 if re.search(pattern, lower):
                     return "Error: Command blocked by deny pattern filter"
 
             if self.allow_patterns:
-                if not any(re.search(p, lower) for p in self.allow_patterns):
-                    return "Error: Command blocked by allowlist filter (not in allowlist)"
+                return "Error: Command blocked by allowlist filter (not in allowlist)"
 
         from nanobot.security.network import contains_internal_url
         if contains_internal_url(cmd):

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -52,7 +52,7 @@ class ExecTool(Tool):
         self.timeout = timeout
         self.working_dir = working_dir
         self.sandbox = sandbox
-        self.deny_patterns = deny_patterns or [
+        self.deny_patterns = (deny_patterns or []) + [
             r"\brm\s+-[rf]{1,2}\b",          # rm -r, rm -rf, rm -fr
             r"\bdel\s+/[fq]\b",              # del /f, del /q
             r"\brmdir\s+/s\b",               # rmdir /s
@@ -273,13 +273,19 @@ class ExecTool(Tool):
         cmd = command.strip()
         lower = cmd.lower()
 
-        for pattern in self.deny_patterns:
-            if re.search(pattern, lower):
-                return "Error: Command blocked by safety guard (dangerous pattern detected)"
+        # allow_patterns take priority over deny_patterns so that users can
+        # exempt specific commands (e.g. "rm -rf" inside a build directory)
+        # from the hardcoded deny list via configuration.
+        if self.allow_patterns and any(re.search(p, lower) for p in self.allow_patterns):
+            pass  # explicitly allowed – skip deny check
+        else:
+            for pattern in self.deny_patterns:
+                if re.search(pattern, lower):
+                    return "Error: Command blocked by safety guard (dangerous pattern detected)"
 
-        if self.allow_patterns:
-            if not any(re.search(p, lower) for p in self.allow_patterns):
-                return "Error: Command blocked by safety guard (not in allowlist)"
+            if self.allow_patterns:
+                if not any(re.search(p, lower) for p in self.allow_patterns):
+                    return "Error: Command blocked by safety guard (not in allowlist)"
 
         from nanobot.security.network import contains_internal_url
         if contains_internal_url(cmd):

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -281,11 +281,11 @@ class ExecTool(Tool):
         else:
             for pattern in self.deny_patterns:
                 if re.search(pattern, lower):
-                    return "Error: Command blocked by safety guard (dangerous pattern detected)"
+                    return "Error: Command blocked by deny pattern filter"
 
             if self.allow_patterns:
                 if not any(re.search(p, lower) for p in self.allow_patterns):
-                    return "Error: Command blocked by safety guard (not in allowlist)"
+                    return "Error: Command blocked by allowlist filter (not in allowlist)"
 
         from nanobot.security.network import contains_internal_url
         if contains_internal_url(cmd):

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -223,6 +223,8 @@ class ExecToolConfig(Base):
     path_append: str = ""
     sandbox: str = ""  # sandbox backend: "" (none) or "bwrap"
     allowed_env_keys: list[str] = Field(default_factory=list)  # Env var names to pass through to subprocess (e.g. ["GOPATH", "JAVA_HOME"])
+    allow_patterns: list[str] = Field(default_factory=list)  # Regex patterns that bypass deny_patterns (e.g. [r"rm\s+-rf\s+/tmp/"])
+    deny_patterns: list[str] = Field(default_factory=list)  # Extra regex patterns to block (appended to built-in list)
 
 class MCPServerConfig(Base):
     """MCP server connection configuration (stdio or HTTP)."""

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -352,6 +352,27 @@ async def test_runner_stops_on_workspace_violation_without_fail_on_tool_error():
     ]
 
 
+def test_is_workspace_violation_recognizes_ssrf_block():
+    """Internal/private URL block must be classified as a fatal workspace violation.
+
+    Regression guard: the deny/allowlist filter messages were intentionally split
+    out of `_WORKSPACE_BLOCK_MARKERS` so the LLM can retry, but SSRF rejections
+    are a hard security boundary and must remain fatal.
+    """
+    from nanobot.agent.runner import AgentRunner
+
+    ssrf_msg = "Error: Command blocked by safety guard (internal/private URL detected)"
+    assert AgentRunner._is_workspace_violation(ssrf_msg) is True
+
+    # Sanity: deny/allowlist filter messages are deliberately *not* fatal.
+    assert AgentRunner._is_workspace_violation(
+        "Error: Command blocked by deny pattern filter"
+    ) is False
+    assert AgentRunner._is_workspace_violation(
+        "Error: Command blocked by allowlist filter (not in allowlist)"
+    ) is False
+
+
 @pytest.mark.asyncio
 async def test_runner_persists_large_tool_results_for_follow_up_calls(tmp_path):
     from nanobot.agent.runner import AgentRunSpec, AgentRunner

--- a/tests/tools/test_exec_allow_patterns.py
+++ b/tests/tools/test_exec_allow_patterns.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from nanobot.agent.tools.shell import ExecTool
 
 

--- a/tests/tools/test_exec_allow_patterns.py
+++ b/tests/tools/test_exec_allow_patterns.py
@@ -1,0 +1,60 @@
+"""Tests for allow_patterns priority over deny_patterns."""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.agent.tools.shell import ExecTool
+
+
+def test_deny_patterns_block_rm_rf():
+    """Baseline: rm -rf is blocked by default deny list."""
+    tool = ExecTool()
+    result = tool._guard_command("rm -rf /tmp/build", "/tmp")
+    assert result is not None
+    assert "dangerous pattern" in result.lower()
+
+
+def test_allow_patterns_bypass_deny():
+    """allow_patterns take priority: matching command skips deny check."""
+    tool = ExecTool(allow_patterns=[r"rm\s+-rf\s+/tmp/"])
+    result = tool._guard_command("rm -rf /tmp/build", "/tmp")
+    assert result is None
+
+
+def test_allow_patterns_must_match_to_bypass():
+    """Non-matching allow_patterns do NOT bypass deny."""
+    tool = ExecTool(allow_patterns=[r"rm\s+-rf\s+/opt/"])
+    result = tool._guard_command("rm -rf /tmp/build", "/tmp")
+    assert result is not None
+    assert "dangerous pattern" in result.lower()
+
+
+def test_extra_deny_patterns_from_config():
+    """User-supplied deny patterns are appended to built-in list."""
+    tool = ExecTool(deny_patterns=[r"\bping\b"])
+    # ping is blocked by extra deny
+    assert tool._guard_command("ping example.com", "/tmp") is not None
+    # rm -rf still blocked by built-in deny
+    assert tool._guard_command("rm -rf /tmp/x", "/tmp") is not None
+
+
+def test_allow_patterns_bypass_extra_deny():
+    """allow_patterns also bypasses user-supplied deny patterns."""
+    tool = ExecTool(
+        deny_patterns=[r"\bping\b"],
+        allow_patterns=[r"\bping\s+example\.com\b"],
+    )
+    result = tool._guard_command("ping example.com", "/tmp")
+    assert result is None
+
+
+def test_allow_patterns_is_whitelist_only():
+    """When allow_patterns is set, non-matching non-denied commands are blocked."""
+    tool = ExecTool(allow_patterns=[r"\becho\b"])
+    # echo matches allow → ok
+    assert tool._guard_command("echo hello", "/tmp") is None
+    # ls does not match allow and is not in deny → blocked by allowlist
+    result = tool._guard_command("ls /tmp", "/tmp")
+    assert result is not None
+    assert "allowlist" in result.lower()

--- a/tests/tools/test_exec_allow_patterns.py
+++ b/tests/tools/test_exec_allow_patterns.py
@@ -12,7 +12,7 @@ def test_deny_patterns_block_rm_rf():
     tool = ExecTool()
     result = tool._guard_command("rm -rf /tmp/build", "/tmp")
     assert result is not None
-    assert "dangerous pattern" in result.lower()
+        assert "deny pattern filter" in result.lower()
 
 
 def test_allow_patterns_bypass_deny():
@@ -27,7 +27,7 @@ def test_allow_patterns_must_match_to_bypass():
     tool = ExecTool(allow_patterns=[r"rm\s+-rf\s+/opt/"])
     result = tool._guard_command("rm -rf /tmp/build", "/tmp")
     assert result is not None
-    assert "dangerous pattern" in result.lower()
+        assert "deny pattern filter" in result.lower()
 
 
 def test_extra_deny_patterns_from_config():

--- a/tests/tools/test_exec_allow_patterns.py
+++ b/tests/tools/test_exec_allow_patterns.py
@@ -12,7 +12,7 @@ def test_deny_patterns_block_rm_rf():
     tool = ExecTool()
     result = tool._guard_command("rm -rf /tmp/build", "/tmp")
     assert result is not None
-        assert "deny pattern filter" in result.lower()
+    assert "deny pattern filter" in result.lower()
 
 
 def test_allow_patterns_bypass_deny():
@@ -27,7 +27,7 @@ def test_allow_patterns_must_match_to_bypass():
     tool = ExecTool(allow_patterns=[r"rm\s+-rf\s+/opt/"])
     result = tool._guard_command("rm -rf /tmp/build", "/tmp")
     assert result is not None
-        assert "deny pattern filter" in result.lower()
+    assert "deny pattern filter" in result.lower()
 
 
 def test_extra_deny_patterns_from_config():

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -94,7 +94,7 @@ def test_exec_blocks_writes_to_history_jsonl(command):
     tool = ExecTool()
     result = tool._guard_command(command, "/tmp")
     assert result is not None
-    assert "dangerous pattern" in result.lower()
+    assert "deny pattern filter" in result.lower()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

1. **allow_patterns cannot override deny_patterns**: `ExecTool._guard_command()` checks deny_patterns before allow_patterns. When a command matches a deny pattern, it is immediately blocked with no way to exempt it via allow_patterns. The built-in deny list can never be whitelisted.

2. **user-supplied deny_patterns replace built-in list**: config `deny_patterns` uses `or [list]` which accidentally disables default safety patterns.

3. **deny pattern blocks silently abort turns**: deny pattern error message `"blocked by safety guard"` is included in `_WORKSPACE_BLOCK_MARKERS`, causing deny_pattern blocks to be misclassified as fatal workspace violations. LLMs have no chance to retry — the turn is aborted immediately, and if `MessageTool._sent_in_turn` is True, the error message is silently swallowed (returns `None`) with no notification sent to the user.

## Changes

| File | Change |
|------|--------|
| `nanobot/agent/tools/shell.py` | allow_patterns checked first; if matched, skip deny check. deny_patterns now **appends** to built-in list. Error messages use distinct phrasing to separate deny/allowlist blocks from workspace path errors. |
| `nanobot/agent/config/schema.py` | Add `allow_patterns` and `deny_patterns` fields to `ExecToolConfig` |
| `nanobot/agent/runner.py` | Remove `"blocked by safety guard"` from `_WORKSPACE_BLOCK_MARKERS` so deny_pattern errors are treated as normal tool errors (LLM can retry) instead of fatal violations |
| `nanobot/agent/loop.py` | Pass config allow/deny patterns to ExecTool |
| `nanobot/agent/subagent.py` | Pass config allow/deny patterns to ExecTool (same as loop.py) |
| `tests/tools/test_exec_allow_patterns.py` | Tests covering priority, whitelist-only, extra deny patterns, and updated assertions |

## Config Example

```json
{
  "exec": {
    "allowPatterns": ["rm\\s+-rf\\s+/tmp/"],
    "denyPatterns": ["\\bping\\b"]
  }
}
```

This allows destructive commands under `/tmp/` while still blocking other usage.