### PR TITLE
feat(exec): add activity-aware timeout controls

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1003,6 +1003,8 @@ MCP tools are automatically discovered and registered on startup. The LLM can us
 | `tools.restrictToWorkspace` | `false` | When `true`, restricts **all** agent tools (shell, file read/write/edit, list) to the workspace directory. Prevents path traversal and out-of-scope access. |
 | `tools.exec.sandbox` | `""` | Sandbox backend for shell commands. Set to `"bwrap"` to wrap exec calls in a [bubblewrap](https://github.com/containers/bubblewrap) sandbox — the process can only see the workspace (read-write) and media directory (read-only); config files and API keys are hidden. Automatically enables `restrictToWorkspace` for file tools. **Linux only** — requires `bwrap` installed (`apt install bubblewrap`; pre-installed in the Docker image). Not available on macOS or Windows (bwrap depends on Linux kernel namespaces). |
 | `tools.exec.enable` | `true` | When `false`, the shell `exec` tool is not registered at all. Use this to completely disable shell command execution. |
+| `tools.exec.timeout` | `60` | Hard timeout in seconds for shell commands. Set to `0` to disable the config-level hard timeout for long-running trusted tasks. Per-call `exec(timeout=...)` values supplied by the model remain capped separately. |
+| `tools.exec.idleTimeout` | `300` | Activity-aware timeout in seconds. Commands that produce no stdout/stderr for this long are killed, while active long-running commands can continue until the hard timeout. Set to `0` to disable the idle guard. |
 | `tools.exec.pathAppend` | `""` | Extra directories to append to `PATH` when running shell commands (e.g. `/usr/sbin` for `ufw`). |
 | `channels.*.allowFrom` | `[]` (deny all) | Whitelist of user IDs. Empty denies all; use `["*"]` to allow everyone. |
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -370,6 +370,7 @@ class AgentLoop:
                 ExecTool(
                     working_dir=str(self.workspace),
                     timeout=self.exec_config.timeout,
+                    idle_timeout=self.exec_config.idle_timeout,
                     restrict_to_workspace=self.restrict_to_workspace,
                     sandbox=self.exec_config.sandbox,
                     path_append=self.exec_config.path_append,

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -184,6 +184,7 @@ class SubagentManager:
                 tools.register(ExecTool(
                     working_dir=str(self.workspace),
                     timeout=self.exec_config.timeout,
+                    idle_timeout=self.exec_config.idle_timeout,
                     restrict_to_workspace=self.restrict_to_workspace,
                     sandbox=self.exec_config.sandbox,
                     path_append=self.exec_config.path_append,

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -19,6 +19,14 @@ from nanobot.config.paths import get_media_dir
 _IS_WINDOWS = sys.platform == "win32"
 
 
+class _ExecHardTimeoutError(TimeoutError):
+    """Raised when a command exceeds its configured hard timeout."""
+
+
+class _ExecIdleTimeoutError(TimeoutError):
+    """Raised when a command stops producing output for too long."""
+
+
 @tool_parameters(
     tool_parameters_schema(
         command=StringSchema("The shell command to execute"),
@@ -26,8 +34,10 @@ _IS_WINDOWS = sys.platform == "win32"
         timeout=IntegerSchema(
             60,
             description=(
-                "Timeout in seconds. Increase for long-running commands "
-                "like compilation or installation (default 60, max 600)."
+                "Per-call timeout in seconds. Increase for long-running commands "
+                "like compilation or installation (default 60, max 600). Configure "
+                "tools.exec.timeout for longer default hard timeouts; tools.exec.idleTimeout "
+                "still kills commands that stop producing output."
             ),
             minimum=1,
             maximum=600,
@@ -41,6 +51,7 @@ class ExecTool(Tool):
     def __init__(
         self,
         timeout: int = 60,
+        idle_timeout: int = 300,
         working_dir: str | None = None,
         deny_patterns: list[str] | None = None,
         allow_patterns: list[str] | None = None,
@@ -50,6 +61,7 @@ class ExecTool(Tool):
         allowed_env_keys: list[str] | None = None,
     ):
         self.timeout = timeout
+        self.idle_timeout = idle_timeout
         self.working_dir = working_dir
         self.sandbox = sandbox
         self.deny_patterns = (deny_patterns or []) + [
@@ -80,8 +92,9 @@ class ExecTool(Tool):
     def name(self) -> str:
         return "exec"
 
-    _MAX_TIMEOUT = 600
+    _MAX_TOOL_TIMEOUT = 600
     _MAX_OUTPUT = 10_000
+    _STREAM_CHUNK_SIZE = 4096
 
     @property
     def description(self) -> str:
@@ -132,7 +145,7 @@ class ExecTool(Tool):
                 command = wrap_command(self.sandbox, command, workspace, cwd)
                 cwd = str(Path(workspace).resolve())
 
-        effective_timeout = min(timeout or self.timeout, self._MAX_TIMEOUT)
+        hard_timeout, idle_timeout = self._resolve_timeouts(timeout)
         env = self._build_env()
 
         if self.path_append:
@@ -146,13 +159,17 @@ class ExecTool(Tool):
             process = await self._spawn(command, cwd, env)
 
             try:
-                stdout, stderr = await asyncio.wait_for(
-                    process.communicate(),
-                    timeout=effective_timeout,
+                stdout, stderr = await self._communicate_with_timeouts(
+                    process,
+                    hard_timeout=hard_timeout,
+                    idle_timeout=idle_timeout,
                 )
-            except asyncio.TimeoutError:
+            except _ExecHardTimeoutError:
                 await self._kill_process(process)
-                return f"Error: Command timed out after {effective_timeout} seconds"
+                return f"Error: Command timed out after {hard_timeout} seconds"
+            except _ExecIdleTimeoutError:
+                await self._kill_process(process)
+                return f"Error: Command produced no output for {idle_timeout} seconds"
             except asyncio.CancelledError:
                 await self._kill_process(process)
                 raise
@@ -184,6 +201,157 @@ class ExecTool(Tool):
 
         except Exception as e:
             return f"Error executing command: {str(e)}"
+
+    def _resolve_timeouts(self, timeout: int | None) -> tuple[int | None, int | None]:
+        """Resolve configured and per-call timeouts.
+
+        The config-level timeout may be larger than the tool-call cap, and 0
+        disables timeout entirely.  Explicit per-call timeouts remain capped by
+        the tool schema/runtime guard and cannot disable the timeout.  The idle
+        timeout is config-only and guards silent commands without punishing
+        active long-running tasks.
+        """
+        if timeout is None:
+            if self.timeout <= 0:
+                hard_timeout = None
+            else:
+                hard_timeout = self.timeout
+        elif timeout <= 0:
+            hard_timeout = self._MAX_TOOL_TIMEOUT
+        else:
+            hard_timeout = min(timeout, self._MAX_TOOL_TIMEOUT)
+
+        idle_timeout = self.idle_timeout if self.idle_timeout > 0 else None
+        return hard_timeout, idle_timeout
+
+    async def _communicate_with_timeouts(
+        self,
+        process: asyncio.subprocess.Process,
+        *,
+        hard_timeout: int | None,
+        idle_timeout: int | None,
+    ) -> tuple[bytes, bytes]:
+        """Read process output while enforcing hard and idle deadlines."""
+        stdout_stream = getattr(process, "stdout", None)
+        stderr_stream = getattr(process, "stderr", None)
+        if (
+            not isinstance(stdout_stream, asyncio.StreamReader)
+            or not isinstance(stderr_stream, asyncio.StreamReader)
+        ):
+            if hard_timeout is None:
+                return await process.communicate()
+            try:
+                return await asyncio.wait_for(process.communicate(), timeout=hard_timeout)
+            except asyncio.TimeoutError as exc:
+                raise _ExecHardTimeoutError from exc
+
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        last_activity = started_at
+        hard_deadline = started_at + hard_timeout if hard_timeout is not None else None
+        stdout_chunks: list[bytes] = []
+        stderr_chunks: list[bytes] = []
+        queue: asyncio.Queue[tuple[str, bytes, BaseException | None]] = asyncio.Queue()
+        live_streams = {"stdout", "stderr"}
+
+        async def _read_stream(label: str, stream: asyncio.StreamReader) -> None:
+            try:
+                while True:
+                    data = await stream.read(self._STREAM_CHUNK_SIZE)
+                    await queue.put((label, data, None))
+                    if not data:
+                        break
+            except Exception as exc:
+                await queue.put((label, b"", exc))
+
+        readers = [
+            asyncio.create_task(_read_stream("stdout", stdout_stream)),
+            asyncio.create_task(_read_stream("stderr", stderr_stream)),
+        ]
+
+        try:
+            while live_streams:
+                now = loop.time()
+                wait_timeout: float | None = None
+
+                if hard_deadline is not None:
+                    hard_remaining = hard_deadline - now
+                    if hard_remaining <= 0:
+                        raise _ExecHardTimeoutError
+                    wait_timeout = hard_remaining
+
+                if idle_timeout is not None:
+                    idle_remaining = (last_activity + idle_timeout) - now
+                    if idle_remaining <= 0:
+                        raise _ExecIdleTimeoutError
+                    wait_timeout = (
+                        idle_remaining
+                        if wait_timeout is None
+                        else min(wait_timeout, idle_remaining)
+                    )
+
+                try:
+                    label, data, error = await asyncio.wait_for(
+                        queue.get(),
+                        timeout=wait_timeout,
+                    )
+                except asyncio.TimeoutError as exc:
+                    now = loop.time()
+                    if hard_deadline is not None and now >= hard_deadline:
+                        raise _ExecHardTimeoutError from exc
+                    raise _ExecIdleTimeoutError from exc
+
+                if error is not None:
+                    raise RuntimeError(f"Error reading process {label}: {error}") from error
+
+                if data:
+                    last_activity = loop.time()
+                    if label == "stdout":
+                        stdout_chunks.append(data)
+                    else:
+                        stderr_chunks.append(data)
+                else:
+                    live_streams.discard(label)
+
+            while process.returncode is None:
+                now = loop.time()
+                wait_timeout: float | None = None
+
+                if hard_deadline is not None:
+                    hard_remaining = hard_deadline - now
+                    if hard_remaining <= 0:
+                        raise _ExecHardTimeoutError
+                    wait_timeout = hard_remaining
+
+                if idle_timeout is not None:
+                    idle_remaining = (last_activity + idle_timeout) - now
+                    if idle_remaining <= 0:
+                        raise _ExecIdleTimeoutError
+                    wait_timeout = (
+                        idle_remaining
+                        if wait_timeout is None
+                        else min(wait_timeout, idle_remaining)
+                    )
+
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=wait_timeout)
+                except asyncio.TimeoutError as exc:
+                    now = loop.time()
+                    if hard_deadline is not None and now >= hard_deadline:
+                        raise _ExecHardTimeoutError from exc
+                    raise _ExecIdleTimeoutError from exc
+
+            return b"".join(stdout_chunks), b"".join(stderr_chunks)
+        finally:
+            for reader in readers:
+                if not reader.done():
+                    reader.cancel()
+            await asyncio.gather(*readers, return_exceptions=True)
+
+    def _resolve_timeout(self, timeout: int | None) -> int | None:
+        """Backward-compatible hard timeout resolver."""
+        hard_timeout, _ = self._resolve_timeouts(timeout)
+        return hard_timeout
 
     @staticmethod
     async def _spawn(

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -219,7 +219,8 @@ class ExecToolConfig(Base):
     """Shell exec tool configuration."""
 
     enable: bool = True
-    timeout: int = 60
+    timeout: int = Field(default=60, ge=0)  # Default exec timeout in seconds; 0 disables timeout
+    idle_timeout: int = Field(default=300, ge=0)  # Kill commands silent for this many seconds; 0 disables idle guard
     path_append: str = ""
     sandbox: str = ""  # sandbox backend: "" (none) or "bwrap"
     allowed_env_keys: list[str] = Field(default_factory=list)  # Env var names to pass through to subprocess (e.g. ["GOPATH", "JAVA_HOME"])

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -15,6 +15,7 @@ from nanobot.agent.tools import (
 from nanobot.agent.tools.base import Tool
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.agent.tools.shell import ExecTool
+from nanobot.config.schema import Config
 
 
 class SampleTool(Tool):
@@ -584,6 +585,92 @@ async def test_exec_timeout_capped_at_max() -> None:
     tool = ExecTool()
     # Should not raise — just clamp to 600
     result = await tool.execute(command="echo ok", timeout=9999)
+    assert "Exit code: 0" in result
+
+
+def test_exec_config_accepts_zero_timeout() -> None:
+    config = Config.model_validate({"tools": {"exec": {"timeout": 0}}})
+
+    assert config.tools.exec.timeout == 0
+
+
+def test_exec_config_accepts_timeout_above_per_call_cap() -> None:
+    config = Config.model_validate({"tools": {"exec": {"timeout": 3600}}})
+
+    assert config.tools.exec.timeout == 3600
+
+
+def test_exec_config_accepts_idle_timeout() -> None:
+    config = Config.model_validate({"tools": {"exec": {"idleTimeout": 120}}})
+
+    assert config.tools.exec.idle_timeout == 120
+
+
+def test_exec_config_timeout_above_per_call_cap_is_not_clamped() -> None:
+    tool = ExecTool(timeout=3600)
+
+    assert tool._resolve_timeouts(timeout=None) == (3600, 300)
+
+
+def test_exec_config_zero_disables_hard_timeout() -> None:
+    tool = ExecTool(timeout=0)
+
+    assert tool._resolve_timeouts(timeout=None) == (None, 300)
+
+
+def test_exec_idle_timeout_can_be_disabled() -> None:
+    tool = ExecTool(timeout=0, idle_timeout=0)
+
+    assert tool._resolve_timeouts(timeout=None) == (None, None)
+
+
+def test_exec_per_call_timeout_remains_capped() -> None:
+    tool = ExecTool(timeout=3600)
+
+    assert tool._resolve_timeouts(timeout=9999) == (600, 300)
+
+
+def test_exec_per_call_zero_does_not_disable_timeout() -> None:
+    tool = ExecTool(timeout=0)
+
+    assert tool._resolve_timeouts(timeout=0) == (600, 300)
+
+
+async def test_exec_idle_timeout_kills_silent_command(tmp_path) -> None:
+    script_file = tmp_path / "silent.py"
+    script_file.write_text("import time\ntime.sleep(2)\n", encoding="utf-8")
+    command = (
+        subprocess.list2cmdline([sys.executable, str(script_file)])
+        if sys.platform == "win32"
+        else f"{shlex.quote(sys.executable)} {shlex.quote(str(script_file))}"
+    )
+    tool = ExecTool(timeout=10, idle_timeout=1)
+
+    result = await tool.execute(command=command)
+
+    assert "produced no output for 1 seconds" in result
+
+
+async def test_exec_idle_timeout_allows_active_long_task(tmp_path) -> None:
+    script_file = tmp_path / "active_output.py"
+    script_file.write_text(
+        "import time\n"
+        "print('start', flush=True)\n"
+        "time.sleep(0.5)\n"
+        "print('done', flush=True)\n",
+        encoding="utf-8",
+    )
+    command = (
+        subprocess.list2cmdline([sys.executable, str(script_file)])
+        if sys.platform == "win32"
+        else f"{shlex.quote(sys.executable)} {shlex.quote(str(script_file))}"
+    )
+    tool = ExecTool(timeout=10, idle_timeout=1)
+
+    result = await tool.execute(command=command)
+
+    assert "start" in result
+    assert "done" in result
     assert "Exit code: 0" in result
 
 


### PR DESCRIPTION
## Summary

This PR addresses #3595 by changing `exec` timeout handling from a fixed runtime cap into a more flexible, agent-friendly timeout model.

Instead of only increasing the maximum timeout, this PR separates command execution control into two layers:

- **Hard timeout**: a config-level wall-clock limit for the whole command.
- **Idle timeout**: an activity-aware watchdog that kills commands only when they stop producing stdout/stderr for too long.

This allows trusted long-running tasks such as builds, installs, downloads, and tests to keep running when they are visibly making progress, while still protecting the agent from silent hangs.

## Feature Design

The key idea is to keep the model-facing tool call bounded, but give operators more control through trusted configuration.

- `exec(timeout=...)` supplied by the model remains capped at 600 seconds.
- `tools.exec.timeout` from config can now exceed 600 seconds.
- `tools.exec.timeout = 0` disables the config-level hard timeout for trusted environments.
- `tools.exec.idleTimeout` is added as a progress-sensitive guard.
- `tools.exec.idleTimeout = 0` disables the idle guard when explicitly needed.

This avoids using automatic retry/backoff for shell commands. Runtime-level retries are risky for `exec` because shell commands can have side effects, such as migrations, file writes, package installs, or deployment steps. Re-running them automatically could make failures harder to reason about. The idle watchdog is a safer fit for agent execution because it detects lack of progress without repeating commands.

## Affected Behavior

- Long-running `exec` commands can now be supported through config without changing the model-facing schema cap.
- Commands that continuously produce output are allowed to continue until the configured hard timeout.
- Commands that become silent for longer than `tools.exec.idleTimeout` are terminated.
- Main agent and subagents both receive the same exec timeout configuration.
- Documentation now describes both `tools.exec.timeout` and `tools.exec.idleTimeout`.

## Unaffected Behavior

- The public tool schema still caps model-supplied `exec(timeout=...)` at 600 seconds.
- Per-call `timeout=0` from the model does not disable timeout protection.
- Existing default behavior remains conservative:
  - `tools.exec.timeout` defaults to `60`.
  - `tools.exec.idleTimeout` defaults to `300`.
- Existing command guardrails, sandbox handling, workspace restrictions, env filtering, and output truncation remain unchanged.
- Cancellation still kills and reaps the subprocess.

## Tests

- `python -m ruff check nanobot/agent/tools/shell.py nanobot/config/schema.py nanobot/agent/loop.py nanobot/agent/subagent.py tests/tools/test_tool_validation.py`
- `python -m pytest tests/tools/test_tool_validation.py tests/tools/test_exec_security.py tests/tools/test_exec_env.py tests/tools/test_exec_platform.py`
- `python -m pytest tests/agent/tools/test_subagent_tools.py tests/agent/test_task_cancel.py::TestDispatch::test_exec_tool_not_registered_when_disabled`

