### PR TITLE
perf(context): cache system prompt with mtime-based invalidation

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -6,12 +6,34 @@ import platform
 from contextlib import suppress
 from importlib.resources import files as pkg_files
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
 from nanobot.utils.helpers import build_assistant_message, current_time_str, detect_image_mime, truncate_text
 from nanobot.utils.prompt_templates import render_template
+
+
+class _PromptCacheKey(NamedTuple):
+    """Stable cache key for system prompt.
+
+    The prompt is rebuilt only when one of its inputs changes:
+    - ``channel``: drives per-channel Format Hint in identity.md
+    - ``fs_mtime``: maximum mtime across all workspace paths that feed the
+      prompt — bootstrap files (SOUL.md, USER.md, …), MEMORY.md,
+      history.jsonl (Recent History section), and the workspace skills
+      directory (skill add / remove).
+
+    A single float captures every relevant filesystem event: file edits bump
+    their own mtime, directory creates/deletes bump the parent directory mtime,
+    and Dream cursor advances always coincide with a history.jsonl write.
+
+    Intentionally excluded: wall-clock time (current_time_str lives in the
+    runtime context block that is merged into the *user* message, not system).
+    """
+
+    channel: str | None
+    fs_mtime: float
 
 
 class ContextBuilder:
@@ -28,13 +50,74 @@ class ContextBuilder:
         self.timezone = timezone
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace, disabled_skills=set(disabled_skills) if disabled_skills else None)
+        # One cached prompt per channel value. Invalidated by _PromptCacheKey mismatch.
+        self._prompt_cache: dict[str | None, tuple[_PromptCacheKey, str]] = {}
+
+    # ------------------------------------------------------------------
+    # Cache helpers
+    # ------------------------------------------------------------------
+
+    def _prompt_cache_key(self, channel: str | None) -> _PromptCacheKey:
+        """Compute the cache key for the given channel without building the prompt."""
+        return _PromptCacheKey(
+            channel=channel,
+            fs_mtime=self._workspace_mtime(),
+        )
+
+    def _workspace_mtime(self) -> float:
+        """Return the maximum mtime of all workspace paths that affect the system prompt.
+
+        Covers bootstrap files (SOUL.md, USER.md, …), MEMORY.md,
+        history.jsonl (Recent History section advances whenever new entries
+        are appended), and the workspace skills directory itself so that
+        adding or removing a skill also invalidates the cache.
+        """
+        watched: list[Path] = [self.workspace / f for f in self.BOOTSTRAP_FILES]
+        watched.append(self.memory.memory_file)
+        watched.append(self.memory.history_file)   # mtime advances on every append_history call
+        watched.append(self.skills.workspace_skills)  # directory mtime changes on skill add/remove
+        mtime = 0.0
+        for path in watched:
+            with suppress(OSError):
+                mtime = max(mtime, path.stat().st_mtime)
+        return mtime
+
+    def invalidate_prompt_cache(self) -> None:
+        """Explicitly drop all cached prompts (e.g. after a Dream git commit)."""
+        self._prompt_cache.clear()
 
     def build_system_prompt(
         self,
         skill_names: list[str] | None = None,
         channel: str | None = None,
     ) -> str:
-        """Build the system prompt from identity, bootstrap files, memory, and skills."""
+        """Build the system prompt from identity, bootstrap files, memory, and skills.
+
+        Results are cached per ``channel`` and invalidated automatically when
+        any contributing workspace file is modified (mtime-based).  The hot
+        path — back-to-back calls with no file changes — is a single dict
+        lookup and NamedTuple equality check.
+
+        ``skill_names`` is accepted for API compatibility but is not yet used
+        by any caller.  If a non-None value is passed the cache is bypassed to
+        avoid returning a stale result should this parameter be activated in
+        the future.
+        """
+        if skill_names is not None:
+            # skill_names is not part of the cache key; bypass to stay correct.
+            return self._build_system_prompt_uncached(channel)
+
+        key = self._prompt_cache_key(channel)
+        entry = self._prompt_cache.get(channel)
+        if entry is not None and entry[0] == key:
+            return entry[1]
+
+        prompt = self._build_system_prompt_uncached(channel)
+        self._prompt_cache[channel] = (key, prompt)
+        return prompt
+
+    def _build_system_prompt_uncached(self, channel: str | None) -> str:
+        """Unconditionally rebuild the system prompt (no cache read/write)."""
         parts = [self._get_identity(channel=channel)]
 
         bootstrap = self._load_bootstrap_files()

--- a/tests/agent/test_context_prompt_cache.py
+++ b/tests/agent/test_context_prompt_cache.py
@@ -355,3 +355,142 @@ def test_customized_memory_md_is_injected(tmp_path) -> None:
 
     assert "# Memory\n\n## Long-term Memory" in prompt
     assert "User prefers dark mode" in prompt
+
+
+# ---------------------------------------------------------------------------
+# System prompt mtime cache
+# ---------------------------------------------------------------------------
+
+def test_cache_hit_returns_same_object(tmp_path) -> None:
+    """Back-to-back calls with no file changes must return the identical string."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    prompt1 = builder.build_system_prompt(channel="telegram")
+    prompt2 = builder.build_system_prompt(channel="telegram")
+
+    assert prompt1 is prompt2, "expected cache hit — same object identity"
+
+
+def test_cache_miss_on_channel_change(tmp_path) -> None:
+    """Different channels produce different prompts and are cached independently."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    prompt_tg = builder.build_system_prompt(channel="telegram")
+    prompt_cli = builder.build_system_prompt(channel="cli")
+
+    assert prompt_tg is not prompt_cli
+    assert "messaging app" in prompt_tg   # telegram format hint
+    assert "messaging app" not in prompt_cli
+
+    # Second call for each channel must be a cache hit
+    assert builder.build_system_prompt(channel="telegram") is prompt_tg
+    assert builder.build_system_prompt(channel="cli") is prompt_cli
+
+
+def test_cache_invalidated_on_soul_edit(tmp_path) -> None:
+    """Editing SOUL.md must produce a new prompt on the next call."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    soul_path = workspace / "SOUL.md"
+    soul_path.write_text("# Soul v1\n\nOriginal soul.", encoding="utf-8")
+    prompt1 = builder.build_system_prompt()
+    assert "Original soul" in prompt1
+
+    # Bump mtime by writing a new version
+    soul_path.write_text("# Soul v2\n\nUpdated soul.", encoding="utf-8")
+    prompt2 = builder.build_system_prompt()
+
+    assert prompt1 is not prompt2
+    assert "Updated soul" in prompt2
+
+
+def test_cache_invalidated_on_memory_edit(tmp_path) -> None:
+    """Editing MEMORY.md must invalidate the cache."""
+    workspace = _make_workspace(tmp_path)
+    (workspace / "memory").mkdir(parents=True, exist_ok=True)
+    memory_path = workspace / "memory" / "MEMORY.md"
+    memory_path.write_text("# Long-term Memory\n\nFact A.", encoding="utf-8")
+
+    builder = ContextBuilder(workspace)
+    prompt1 = builder.build_system_prompt()
+    assert "Fact A" in prompt1
+
+    memory_path.write_text("# Long-term Memory\n\nFact B.", encoding="utf-8")
+    prompt2 = builder.build_system_prompt()
+
+    assert prompt1 is not prompt2
+    assert "Fact B" in prompt2
+
+
+def test_cache_invalidated_on_dream_cursor_advance(tmp_path) -> None:
+    """Advancing the dream cursor (new history entries) must invalidate the cache."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    prompt1 = builder.build_system_prompt()
+    assert "# Recent History" not in prompt1
+
+    builder.memory.append_history("User asked about nanobot internals")
+    prompt2 = builder.build_system_prompt()
+
+    assert prompt1 is not prompt2
+    assert "# Recent History" in prompt2
+    assert "nanobot internals" in prompt2
+
+
+def test_cache_invalidated_on_new_skill(tmp_path) -> None:
+    """Adding a new skill to the workspace skills directory invalidates the cache."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    prompt1 = builder.build_system_prompt()
+
+    # Create a new user-defined skill
+    skill_dir = workspace / "skills" / "my-custom-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-custom-skill\ndescription: A custom skill for testing.\n---\n# Custom\n",
+        encoding="utf-8",
+    )
+    prompt2 = builder.build_system_prompt()
+
+    assert prompt1 is not prompt2
+    assert "my-custom-skill" in prompt2
+
+
+def test_invalidate_prompt_cache_clears_all_channels(tmp_path) -> None:
+    """invalidate_prompt_cache() must drop cached entries for every channel."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    tg = builder.build_system_prompt(channel="telegram")
+    cli = builder.build_system_prompt(channel="cli")
+
+    builder.invalidate_prompt_cache()
+
+    # After explicit invalidation both channels must be rebuilt
+    assert builder.build_system_prompt(channel="telegram") is not tg
+    assert builder.build_system_prompt(channel="cli") is not cli
+
+
+def test_prompt_cache_key_excludes_wall_clock(tmp_path, monkeypatch) -> None:
+    """Cache key must not depend on the wall clock (clock tick ≠ cache miss)."""
+    workspace = _make_workspace(tmp_path)
+    builder = ContextBuilder(workspace)
+
+    key1 = builder._prompt_cache_key(channel=None)
+    # Advance the fake clock — key must stay identical
+    import datetime as datetime_module
+
+    class _Shifted(real_datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return real_datetime(2026, 6, 1, 0, 0)
+
+    monkeypatch.setattr(datetime_module, "datetime", _Shifted)
+    key2 = builder._prompt_cache_key(channel=None)
+
+    assert key1 == key2


### PR DESCRIPTION
## Background

While profiling a running gateway session I noticed that
`build_system_prompt()` is called more than once per inbound message:

1. **Consolidator token estimation** – `maybe_consolidate_by_tokens` calls
   the injected `build_messages` callback with a `[token-probe]` placeholder
   to measure the current prompt size before deciding whether to compress.
2. **Real LLM payload assembly** – `build_messages` is called again with the
   actual user content to produce `initial_messages` for `AgentRunner`.
3. **`ask_user` branch** – when a pending `ask_user` turn is detected,
   `build_system_prompt` is called directly a third time.
4. **Post-turn background re-check** – `_schedule_background` fires
   `maybe_consolidate_by_tokens` once more after the turn completes,
   triggering yet another estimation pass.

Each call unconditionally read several workspace files (`SOUL.md`,
`USER.md`, `MEMORY.md`, bootstrap files), scanned the workspace skills
directory with `iterdir()`, and re-rendered Jinja templates — even when
nothing on disk had changed between calls.

## What this PR does

Introduces a lightweight **mtime-based prompt cache** on `ContextBuilder`:

- **`_PromptCacheKey`** — a `NamedTuple(channel, fs_mtime)` where
  `fs_mtime` is the `max()` mtime across all workspace paths that
  contribute to the system prompt: bootstrap files, `MEMORY.md`,
  `history.jsonl`, and the workspace skills directory.
- **`_workspace_mtime()`** — a single O(n) `stat()` pass over ~7 paths.
  All filesystem errors are silently suppressed (`OSError`), so a missing
  file simply contributes `0.0` and does not break the cache.
- **`_prompt_cache`** — `dict[channel, (key, prompt)]`, one entry per
  channel value seen during the session (typically 1–2). The hot path is
  a dict lookup plus a NamedTuple equality check — no I/O, no template
  rendering.
- **`invalidate_prompt_cache()`** — explicit escape hatch for callers that
  need to force a rebuild without a filesystem write (e.g. a future
  post-Dream hook).

## Correctness

Every input that affects the system prompt is covered by the cache key:

| Change | Detected by |
|---|---|
| Edit `SOUL.md` / `USER.md` / `MEMORY.md` / bootstrap files | file `mtime` |
| Dream commit rewrites long-term memory files | file `mtime` |
| New history entries appended (`append_history`) | `history.jsonl` `mtime` |
| Skill added / removed in `workspace/skills/` | skills directory `mtime` |
| Channel switch (Format Hint in `identity.md`) | `channel` field in key |
| Wall-clock tick | ✅ excluded — `current_time_str` lives in the runtime context block merged into the **user** message, not the system prompt |
| `skill_names != None` | bypasses cache entirely (parameter is unused by all current callers; guard prevents silent stale results if it is activated later) |

## Tests

Eight new test cases added to `tests/agent/test_context_prompt_cache.py`:

- `test_cache_hit_returns_same_object` — back-to-back calls return identical object
- `test_cache_miss_on_channel_change` — different channels cached independently
- `test_cache_invalidated_on_soul_edit` — SOUL.md write triggers rebuild
- `test_cache_invalidated_on_memory_edit` — MEMORY.md write triggers rebuild
- `test_cache_invalidated_on_dream_cursor_advance` — `append_history` triggers rebuild
- `test_cache_invalidated_on_new_skill` — new skill directory triggers rebuild
- `test_invalidate_prompt_cache_clears_all_channels` — explicit invalidation works
- `test_prompt_cache_key_excludes_wall_clock` — clock tick does not cause cache miss

All 2553 existing tests continue to pass.