### PR TITLE
fix(agent): skip _streamed flag for tool_error and empty_final_respon…

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1125,7 +1125,7 @@ class AgentLoop:
             ask_user_options_from_messages(all_msgs) if stop_reason == "ask_user" else [],
             msg.channel,
         )
-        if on_stream is not None and stop_reason not in {"ask_user", "error"}:
+        if on_stream is not None and stop_reason not in {"ask_user", "error", "tool_error", "empty_final_response"}:
             meta["_streamed"] = True
         return OutboundMessage(
             channel=msg.channel,


### PR DESCRIPTION
When a tool fails with fatal_error (e.g. safety guard blocks a command), the runner sets stop_reason="tool_error" and returns error content. However, _process_message still sets _streamed=True on the OutboundMessage because "tool_error" was not in the exclusion set. The consumer then discards the error content via the _streamed continue path, making the error invisible to the user.

Similarly, when the LLM returns only thinking tags and no visible content, strip_think filters everything, zero _stream_delta messages are emitted, but stop_reason="empty_final_response" still gets _streamed=True, causing the empty-but-valid response to be silently dropped.

This extends the existing exclusion set (which already covers "ask_user" and "error") to also cover "tool_error" and "empty_final_response" — these stop reasons indicate content was NOT actually streamed to the user, so the consumer must process them through the normal display path.