### PR TITLE
feat: add zero_api_key_web_search as web search provider

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -122,6 +122,8 @@ class WebSearchTool(Tool):
         if provider == "olostep":
             api_key = self.config.api_key or os.environ.get("OLOSTEP_API_KEY", "")
             return "olostep" if api_key else "duckduckgo"
+        if provider == "zero_api_key":
+            return "zero_api_key"
         return provider
 
     @property
@@ -139,7 +141,9 @@ class WebSearchTool(Tool):
 
         if provider == "olostep":
             return await self._search_olostep(query, n)
-        if provider == "duckduckgo":
+        elif provider == "zero_api_key":
+            return await self._search_zero_api_key(query, n)
+        elif provider == "duckduckgo":
             return await self._search_duckduckgo(query, n)
         elif provider == "tavily":
             return await self._search_tavily(query, n)
@@ -323,6 +327,33 @@ class WebSearchTool(Tool):
             return _format_results(query, items, n)
         except Exception as e:
             return f"Error: {e}"
+
+    async def _search_zero_api_key(self, query: str, n: int) -> str:
+        try:
+            from zero_api_key_web_search import UltimateSearcher
+        except ImportError:
+            return "Error: zero-api-key-web-search package not installed. Run: pip install zero-api-key-web-search"
+        try:
+            profile = self.config.api_key or os.environ.get("ZERO_SEARCH_BRIGHTDATA_API_KEY", "")
+            searcher_kwargs = {}
+            if profile:
+                searcher_kwargs["profile"] = "production"
+            searcher = UltimateSearcher(**searcher_kwargs)
+            answer = await asyncio.wait_for(
+                asyncio.to_thread(searcher.search, query=query),
+                timeout=self.config.timeout,
+            )
+            items = [
+                {"title": s.title, "url": s.url, "content": s.snippet or ""}
+                for s in answer.sources[:n]
+            ]
+            result = _format_results(query, items, n)
+            if answer.answer:
+                result = f"{answer.answer}\n\n{result}"
+            return result
+        except Exception as e:
+            logger.warning("zero_api_key_web_search failed: {}", e)
+            return f"Error: zero_api_key_web_search failed ({e})"
 
     async def _search_duckduckgo(self, query: str, n: int) -> str:
         try:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -190,7 +190,7 @@ class GatewayConfig(Base):
 class WebSearchConfig(Base):
     """Web search tool configuration."""
 
-    provider: str = "duckduckgo"  # brave, tavily, duckduckgo, searxng, jina, kagi, olostep
+    provider: str = "duckduckgo"  # brave, tavily, duckduckgo, searxng, jina, kagi, olostep, zero_api_key
     api_key: str = ""
     base_url: str = ""  # SearXNG base URL
     max_results: int = 5


### PR DESCRIPTION
## Summary

Adds `zero_api_key_web_search` as a new web search provider alongside the existing providers (brave, tavily, duckduckgo, searxng, jina, kagi, olostep).

### What it does

- **Free by default**: Uses DuckDuckGo backend with no API key required
- **Production SERP**: When `ZERO_SEARCH_BRIGHTDATA_API_KEY` is set, uses Bright Data SERP with 7 engines (Google, Bing, DuckDuckGo, Yandex, Baidu, Yahoo, Naver)
- **Claim verification**: Evidence-based fact checking
- **Page browsing**: Web page content extraction with optional Web Unlocker for blocked pages

### Changes

- `nanobot/config/schema.py`: Added `zero_api_key` to provider comment
- `nanobot/agent/tools/web.py`: Added `_search_zero_api_key()` method with lazy import, `_effective_provider()` routing, and `execute()` dispatch

### Usage

Set in config:
```yaml
web:
  search:
    provider: zero_api_key
```

Or with Bright Data production SERP:
```yaml
web:
  search:
    provider: zero_api_key
    api_key: ${ZERO_SEARCH_BRIGHTDATA_API_KEY}
```

## Test plan

- [x] Provider routes correctly in `_effective_provider()`
- [x] Lazy import with fallback error message when package not installed
- [x] Runs in thread pool to avoid blocking async loop (like DuckDuckGo)
- [x] Falls back gracefully on errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)