### PR TITLE
fix(bridge): support WhatsApp voice message download

### DIFF
--- a/bridge/src/whatsapp.ts
+++ b/bridge/src/whatsapp.ts
@@ -165,6 +165,10 @@ export class WhatsAppClient {
           fallbackContent = '[Video]';
           const path = await this.downloadMedia(msg, unwrapped.videoMessage.mimetype ?? undefined);
           if (path) mediaPaths.push(path);
+        } else if (unwrapped.audioMessage) {
+          fallbackContent = '[Voice Message]';
+          const path = await this.downloadMedia(msg, unwrapped.audioMessage.mimetype ?? undefined);
+          if (path) mediaPaths.push(path);
         }
 
         const finalContent = content || (mediaPaths.length === 0 ? fallbackContent : '') || '';


### PR DESCRIPTION
## Description

Fixes issue https://github.com/HKUDS/nanobot/issues/3604 where WhatsApp voice messages weren't being downloaded and couldn't be understood by LLMs.

## Changes

- Added `audioMessage` handling branch in `bridge/src/whatsapp.ts`
- WhatsApp voice messages are now downloaded like other media types (image/document/video)
- The voice message file path is passed in the `media` field, enabling transcription by LLM