### PR TITLE
Prepare Sen local setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md
+
+## Mục tiêu repo trong workspace này
+
+Repo này đang được chuẩn bị để phát triển Sen, D's Agent 01, dựa trên Nanobot và GBrain.
+
+Ưu tiên hiện tại:
+
+- Giữ Nanobot là runtime agent nền.
+- Dùng GBrain qua MCP để đọc/làm việc với tri thức cá nhân.
+- Tách rõ tài liệu, config mẫu, runtime thật và dữ liệu thật.
+- Làm bản đơn giản chạy được trước, dễ kiểm tra, dễ sửa.
+
+## Ranh giới an toàn
+
+Không được tự ý sửa các đường dẫn thật sau:
+
+- `~/.nanobot/sen/config.json`
+- `~/.nanobot/sen/workspace`
+- `~/gbrain`
+- `~/brain`
+- `~/.zshrc`
+
+Không được in, ghi, commit hoặc sao chép API key, private key, token, secret hoặc dữ liệu nhạy cảm.
+
+Khi cần minh họa config, chỉ dùng placeholder như `${OPENROUTER_API_KEY}` hoặc `REPLACE_ME`.
+
+## Cách làm việc với Sen
+
+- Tài liệu riêng của Sen đặt trong `docs/sen/`.
+- Config mẫu riêng của Sen đặt trong `examples/sen/`.
+- Không đọc config thật chỉ để viết docs hoặc example.
+- Không chạy command có thể thay đổi runtime thật nếu Dũng chưa xác nhận rõ.
+- Nếu cần smoke test, ưu tiên lệnh đọc-only hoặc lệnh một lần dùng `--config` và `--workspace` rõ ràng.
+
+## Local paths đã biết
+
+Các path này dùng để viết tài liệu và ví dụ, không dùng để tự sửa runtime:
+
+- Sen config thật: `~/.nanobot/sen/config.json`
+- Sen workspace: `~/.nanobot/sen/workspace`
+- GBrain repo: `~/gbrain`
+- Brain corpus: `~/brain`
+- GBrain MCP command: `/Users/dzungbui/.bun/bin/gbrain serve`
+- Provider chính: `openrouter`
+- Model chính: `moonshotai/kimi-k2.6`
+
+## Lệnh repo
+
+Không tự bịa lệnh test/build. Đọc `README.md`, `docs/`, `pyproject.toml` và file liên quan trước khi chạy.
+
+Các lệnh thường dùng trong repo Nanobot:
+
+```bash
+python3 -m pytest
+ruff check .
+```
+
+Với thay đổi chỉ gồm tài liệu/config mẫu, kiểm tra tối thiểu nên là:
+
+```bash
+python3 -m json.tool examples/sen/config.example.json
+```

--- a/docs/sen/SEN_LOCAL_SETUP.md
+++ b/docs/sen/SEN_LOCAL_SETUP.md
@@ -1,0 +1,103 @@
+# Sen Local Setup
+
+Tài liệu này chuẩn bị repo để phát triển Sen, D's Agent 01, trên nền Nanobot + GBrain.
+
+Mục tiêu là giữ runtime thật an toàn: repo chỉ chứa tài liệu và config mẫu. Config thật vẫn nằm ngoài repo.
+
+## Bản đồ local
+
+| Thành phần | Đường dẫn / giá trị |
+| --- | --- |
+| Sen config thật | `~/.nanobot/sen/config.json` |
+| Sen workspace | `~/.nanobot/sen/workspace` |
+| GBrain repo | `~/gbrain` |
+| Brain corpus | `~/brain` |
+| GBrain MCP command | `/Users/dzungbui/.bun/bin/gbrain serve` |
+| Provider chính | `openrouter` |
+| Model chính | `moonshotai/kimi-k2.6` |
+
+## Nguyên tắc an toàn
+
+- Không commit `~/.nanobot/sen/config.json`.
+- Không ghi API key vào repo.
+- Không in API key ra terminal, log, docs hoặc issue.
+- Không sửa `~/brain`, `~/gbrain`, `~/.zshrc` khi chỉ đang chuẩn bị repo.
+- Config mẫu chỉ dùng placeholder như `${OPENROUTER_API_KEY}`.
+
+## Config mẫu
+
+Config mẫu nằm ở:
+
+```text
+examples/sen/config.example.json
+```
+
+File này mô tả các phần chính:
+
+- `agents.defaults.workspace`: trỏ tới workspace riêng của Sen.
+- `agents.defaults.provider`: dùng `openrouter`.
+- `agents.defaults.model`: dùng `moonshotai/kimi-k2.6`.
+- `providers.openrouter.apiKey`: dùng biến môi trường `${OPENROUTER_API_KEY}`, không ghi key thật.
+- `tools.mcpServers.gbrain`: chạy GBrain MCP bằng command local.
+
+Để dùng thật, hãy copy nội dung mẫu vào config thật bằng tay, rồi tự điền hoặc export secret ngoài repo.
+
+Ví dụ biến môi trường:
+
+```bash
+export OPENROUTER_API_KEY="REPLACE_WITH_YOUR_OPENROUTER_KEY"
+```
+
+Không commit file shell chứa key.
+
+## Khởi tạo instance Sen nếu chưa có
+
+Nếu `~/.nanobot/sen/config.json` chưa tồn tại, có thể tạo instance riêng bằng:
+
+```bash
+nanobot onboard --config ~/.nanobot/sen/config.json --workspace ~/.nanobot/sen/workspace
+```
+
+Sau đó merge các phần cần thiết từ `examples/sen/config.example.json` vào config thật.
+
+Không thay toàn bộ config thật nếu trong đó đã có setting khác cần giữ.
+
+## Smoke test để Dũng tự chạy
+
+Kiểm tra config mẫu là JSON hợp lệ:
+
+```bash
+python3 -m json.tool examples/sen/config.example.json
+```
+
+Kiểm tra Nanobot đọc được config thật và gọi một lượt ngắn:
+
+```bash
+nanobot agent \
+  --config ~/.nanobot/sen/config.json \
+  --workspace ~/.nanobot/sen/workspace \
+  -m "Reply with: Sen ready"
+```
+
+Nếu muốn test MCP GBrain, hỏi Sen một câu ngắn cần dùng GBrain. Ví dụ:
+
+```bash
+nanobot agent \
+  --config ~/.nanobot/sen/config.json \
+  --workspace ~/.nanobot/sen/workspace \
+  -m "Check whether the GBrain MCP tools are available. Do not modify files."
+```
+
+## Khi có lỗi thường gặp
+
+Nếu lỗi provider hoặc auth:
+
+- Kiểm tra biến môi trường `OPENROUTER_API_KEY`.
+- Kiểm tra `providers.openrouter.apiKey` đang là `${OPENROUTER_API_KEY}` hoặc key thật nằm ngoài repo.
+- Kiểm tra model là `moonshotai/kimi-k2.6`.
+
+Nếu lỗi MCP:
+
+- Kiểm tra command `/Users/dzungbui/.bun/bin/gbrain` có tồn tại.
+- Kiểm tra `~/gbrain` và `~/brain` có sẵn trên máy.
+- Không sửa dữ liệu trong `~/brain` hoặc `~/gbrain` chỉ để debug config.

--- a/examples/sen/config.example.json
+++ b/examples/sen/config.example.json
@@ -1,0 +1,30 @@
+{
+  "agents": {
+    "defaults": {
+      "workspace": "~/.nanobot/sen/workspace",
+      "provider": "openrouter",
+      "model": "moonshotai/kimi-k2.6",
+      "maxTokens": 8192,
+      "contextWindowTokens": 65536,
+      "temperature": 0.1,
+      "timezone": "Asia/Ho_Chi_Minh"
+    }
+  },
+  "providers": {
+    "openrouter": {
+      "apiKey": "${OPENROUTER_API_KEY}"
+    }
+  },
+  "tools": {
+    "restrictToWorkspace": false,
+    "mcpServers": {
+      "gbrain": {
+        "type": "stdio",
+        "command": "/Users/dzungbui/.bun/bin/gbrain",
+        "args": ["serve"],
+        "toolTimeout": 60,
+        "enabledTools": ["*"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Tóm tắt

Chuẩn bị tài liệu cục bộ cho Sen, D's Agent 01.

Đã thêm:

- AGENTS.md

- docs/sen/SEN_LOCAL_SETUP.md

- examples/sen/config.example.json

## Ghi chú

Bản cập nhật này không sửa đổi cấu hình thời gian chạy.

Nó không bao gồm các thông tin bí mật.

Nó không thay đổi logic mã nguồn của Nanobot.

## Kiểm tra xác thực

- Đã kiểm tra cú pháp JSON của cấu hình ví dụ.

- Đã kiểm thử sơ bộ thời gian chạy của Sen một cách riêng biệt với:

nanobot agent --config ~/.nanobot/sen/config.json --workspace ~/.nanobot/sen/workspace

Kết quả:

- Sen khởi động chính xác.

- Các công cụ GBrain MCP khả dụng.

- GBrain get_stats hoạt động.