### PR TITLE
fix(mcp): shield aclose on failed connect to prevent event-loop spin

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -63,6 +63,14 @@ if TYPE_CHECKING:
 
 UNIFIED_SESSION_KEY = "unified:default"
 
+# Hard ceiling on how long _connect_mcp will wait for `connect_mcp_servers`
+# to return. The MCP SDK's HTTP transports rely on anyio task groups whose
+# cancellation cleanup is fragile — if a connect hangs (unreachable host,
+# black-hole TCP, broken keepalive), an unbounded wait risks leaving the
+# event loop in a state where anyio's _deliver_cancellation reschedules
+# itself forever. See #935.
+_MCP_CONNECT_TIMEOUT_S = 10.0
+
 
 class _LoopHook(AgentHook):
     """Core hook for the main loop."""
@@ -401,26 +409,63 @@ class AgentLoop:
             )
 
     async def _connect_mcp(self) -> None:
-        """Connect to configured MCP servers (one-time, lazy)."""
+        """Connect to configured MCP servers (one-time, lazy).
+
+        Bounded by ``_MCP_CONNECT_TIMEOUT_S``. On any failure path, any
+        AsyncExitStacks already accumulated in ``self._mcp_stacks`` are
+        ``aclose()``-ed under a shielded CancelScope before being cleared.
+        Naively ``.clear()``-ing the dict abandons the stacks (and the
+        anyio task groups they contain), which causes anyio's
+        ``_deliver_cancellation`` to reschedule itself forever in the
+        event loop. See #935.
+        """
         if self._mcp_connected or self._mcp_connecting or not self._mcp_servers:
             return
         self._mcp_connecting = True
         from nanobot.agent.tools.mcp import connect_mcp_servers
 
         try:
-            self._mcp_stacks = await connect_mcp_servers(self._mcp_servers, self.tools)
+            self._mcp_stacks = await asyncio.wait_for(
+                connect_mcp_servers(self._mcp_servers, self.tools),
+                timeout=_MCP_CONNECT_TIMEOUT_S,
+            )
             if self._mcp_stacks:
                 self._mcp_connected = True
             else:
                 logger.warning("No MCP servers connected successfully (will retry next message)")
+        except asyncio.TimeoutError:
+            logger.warning(
+                "MCP connection timed out after {}s (will retry next message)",
+                _MCP_CONNECT_TIMEOUT_S,
+            )
+            await self._close_mcp_stacks_shielded()
         except asyncio.CancelledError:
             logger.warning("MCP connection cancelled (will retry next message)")
-            self._mcp_stacks.clear()
+            await self._close_mcp_stacks_shielded()
+            raise
         except BaseException as e:
             logger.error("Failed to connect MCP servers (will retry next message): {}", e)
-            self._mcp_stacks.clear()
+            await self._close_mcp_stacks_shielded()
         finally:
             self._mcp_connecting = False
+
+    async def _close_mcp_stacks_shielded(self) -> None:
+        """Close any AsyncExitStacks left in ``self._mcp_stacks``.
+
+        The shielded scope ensures cleanup completes even if the enclosing
+        task is being cancelled — otherwise the stacks (and any anyio
+        task groups they hold) would be abandoned mid-close. See #935.
+        """
+        if not self._mcp_stacks:
+            return
+        import anyio
+        with anyio.CancelScope(shield=True):
+            for name, stack in list(self._mcp_stacks.items()):
+                try:
+                    await stack.aclose()
+                except BaseException as e:  # noqa: BLE001
+                    logger.debug("MCP server '{}' cleanup error (ignored): {}", name, e)
+        self._mcp_stacks.clear()
 
     def _set_tool_context(
         self, channel: str, chat_id: str,

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -591,26 +591,46 @@ async def connect_mcp_servers(
             )
             return name, server_stack
 
-        except Exception as e:
-            hint = ""
-            text = str(e).lower()
-            if any(
-                marker in text
-                for marker in (
-                    "parse error",
-                    "invalid json",
-                    "unexpected token",
-                    "jsonrpc",
-                    "content-length",
+        except BaseException as e:
+            # Catch BaseException (not just Exception) so a CancelledError
+            # mid-connect still triggers cleanup. Without this the partially
+            # entered context managers — including any anyio task groups —
+            # are orphaned, which causes anyio's _deliver_cancellation to
+            # reschedule itself indefinitely in the event loop. See #935.
+            is_cancelled = isinstance(e, asyncio.CancelledError)
+            if not is_cancelled:
+                hint = ""
+                text = str(e).lower()
+                if any(
+                    marker in text
+                    for marker in (
+                        "parse error",
+                        "invalid json",
+                        "unexpected token",
+                        "jsonrpc",
+                        "content-length",
+                    )
+                ):
+                    hint = (
+                        " Hint: this looks like stdio protocol pollution. Make sure the MCP server writes "
+                        "only JSON-RPC to stdout and sends logs/debug output to stderr instead."
+                    )
+                logger.error("MCP server '{}': failed to connect: {}{}", name, e, hint)
+            # Shielded cleanup — anyio cancel scopes inside server_stack must
+            # finish closing, even if our enclosing task is itself being
+            # cancelled. Otherwise the leaked task groups keep firing
+            # _deliver_cancellation forever.
+            import anyio
+            try:
+                with anyio.CancelScope(shield=True):
+                    await server_stack.aclose()
+            except BaseException as cleanup_err:  # noqa: BLE001
+                logger.debug(
+                    "MCP server '{}': cleanup error after failed connect (ignored): {}",
+                    name, cleanup_err,
                 )
-            ):
-                hint = (
-                    " Hint: this looks like stdio protocol pollution. Make sure the MCP server writes "
-                    "only JSON-RPC to stdout and sends logs/debug output to stderr instead."
-                )
-            logger.error("MCP server '{}': failed to connect: {}{}", name, e, hint)
-            with suppress(Exception):
-                await server_stack.aclose()
+            if is_cancelled:
+                raise
             return name, None
 
     server_stacks: dict[str, AsyncExitStack] = {}

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 import re
 import shutil
-from contextlib import AsyncExitStack, suppress
+from contextlib import AsyncExitStack
 from typing import Any
 
 import httpx


### PR DESCRIPTION
# fix(mcp): bound and shield MCP connect cleanup so failed connects don't wedge the event loop

## Summary

A failed MCP connect — DNS failure, refused TCP, black-hole route — currently orphans the `AsyncExitStack` containing the in-progress connection's anyio task group. anyio's `_deliver_cancellation` then reschedules itself via `loop.call_soon` on every event-loop iteration forever, pegging one core at 100% CPU. The agent loop stops processing inbound messages. The static `/health` endpoint keeps returning 200 because it answers between `call_soon` ticks, so the container never restarts. There is no log output once the spin starts.

This PR closes the leak with two small hunks:

1. `nanobot/agent/tools/mcp.py` — broaden `connect_single_server`'s failure handler from `except Exception` to `except BaseException`, shield `await server_stack.aclose()` with `anyio.CancelScope(shield=True)`, log instead of silently swallowing cleanup errors, and re-raise on `CancelledError` so cancel semantics are preserved.
2. `nanobot/agent/loop.py` — bound `connect_mcp_servers` with `asyncio.wait_for(timeout=_MCP_CONNECT_TIMEOUT_S)`; on any failure path, `aclose()` any retained stacks under a shielded scope before clearing the dict; re-raise on `CancelledError`.

Fixes #935.

## Behavior change

- **Unreachable / hung MCP server**: gateway logs a warning and continues without those tools. CPU stays at idle. The agent loop continues to process inbound messages. No spin.
- **Successful MCP connect**: unchanged. Same code path on the happy side.
- **Partial multi-server connect**: previously, a partial-success could leave failed-server stacks orphaned. Now they are `aclose()`-ed under shield before being dropped from the dict.
- **Gateway shutdown mid-connect**: previously, swallowed `CancelledError` could decouple cancellation from its scope. Now `CancelledError` re-raises after cleanup, and the shielded `aclose()` ensures cleanup completes before the cancel propagates.
- **Connect timeout**: new ceiling at `_MCP_CONNECT_TIMEOUT_S = 10.0` seconds. Servers that take longer to negotiate are treated as failed for this attempt; the next message triggers a retry. The previous behavior (unbounded wait) is recoverable via `asyncio.wait_for` shielding only the connect call, leaving in-progress server-side work to be torn down by the existing failure path.

## Implementation

### `nanobot/agent/tools/mcp.py` — `connect_single_server` cleanup

Changed:

```python
except Exception as e:
    ...
    logger.error("MCP server '{}': failed to connect: {}{}", name, e, hint)
    try:
        await server_stack.aclose()
    except Exception:
        pass
    return name, None
```

To:

```python
except BaseException as e:
    is_cancelled = isinstance(e, asyncio.CancelledError)
    if not is_cancelled:
        # ... existing error logging with hint ...
    import anyio
    try:
        with anyio.CancelScope(shield=True):
            await server_stack.aclose()
    except BaseException as cleanup_err:
        logger.debug(
            "MCP server '{}': cleanup error after failed connect (ignored): {}",
            name, cleanup_err,
        )
    if is_cancelled:
        raise
    return name, None
```

Why each part matters:

- `except BaseException` ensures `CancelledError` mid-connect triggers the cleanup branch instead of bypassing it. Without this, the partially-entered `streamable_http_client` task group (or stdio/sse equivalent) is abandoned.
- `with anyio.CancelScope(shield=True)`: the `aclose()` call must complete even if the enclosing task is itself being cancelled. Otherwise we get a half-closed task group, which is the exact state that causes `_deliver_cancellation` to spin.
- `logger.debug` instead of silent `pass`: cleanup errors are now visible at debug log level. Promoted from a silent swallow.
- `raise` after cancel cleanup: preserves cancel propagation up the stack so shutdown semantics still work.

### `nanobot/agent/loop.py` — `_connect_mcp`

Added module constant:

```python
_MCP_CONNECT_TIMEOUT_S = 10.0
```

Changed `_connect_mcp` to:

- Wrap `connect_mcp_servers` in `asyncio.wait_for(..., timeout=_MCP_CONNECT_TIMEOUT_S)`.
- New `asyncio.TimeoutError` handler: warn and call `_close_mcp_stacks_shielded()`.
- `CancelledError` handler now calls `_close_mcp_stacks_shielded()` then re-raises.
- `BaseException` handler now calls `_close_mcp_stacks_shielded()` instead of `.clear()`.

Added helper:

```python
async def _close_mcp_stacks_shielded(self) -> None:
    if not self._mcp_stacks:
        return
    import anyio
    with anyio.CancelScope(shield=True):
        for name, stack in list(self._mcp_stacks.items()):
            try:
                await stack.aclose()
            except BaseException as e:
                logger.debug("MCP server '{}' cleanup error (ignored): {}", name, e)
    self._mcp_stacks.clear()
```

Why a helper: the shielded-aclose-then-clear pattern is now used from three exception arms. Extracting it removes duplication and makes the contract explicit (close before clear, always under shield).

No new abstractions: reuses `AsyncExitStack.aclose()`, `anyio.CancelScope`, and `asyncio.wait_for` — all already in the dependency tree.

## Reproduce

Use the config from #935, or a synthetic equivalent with an unreachable host:

```json
"tools": {
  "mcpServers": {
    "test": {
      "type": "streamableHttp",
      "url": "http://does-not-exist.invalid:9001/mcp"
    }
  }
}
```

Send any message through any enabled channel.

- **Before**: process pegs one core at 100% indefinitely. `py-spy record -d 10` shows the main thread spending all its time in `anyio/_backends/_asyncio.py:_deliver_cancellation` rescheduling itself via `call_soon`. No log output. Static `/health` keeps returning 200. Container with `restart: unless-stopped` does not recover.
- **After**: warning logged (`MCP connection timed out after 10.0s (will retry next message)` or equivalent depending on the failure mode), CPU stays at idle, agent loop continues processing inbound messages, retry on the next message succeeds or fails the same way without accumulating state.

## Notes for reviewers

- The `_MCP_CONNECT_TIMEOUT_S = 10.0` ceiling is conservative. Stdio MCP servers usually connect in <100ms; remote HTTP transports usually <2s. Slow-cold-start servers can be made configurable in a follow-up if needed; this PR keeps the constant module-private to minimize surface area.
- The `import anyio` inside the helper avoids adding it to module top-level since anyio is already a transitive dependency via the MCP SDK and httpx; keeping the import scoped also signals it's only used in error paths.
- The `nanobot.agent.tools.mcp` change leaves the `connect_single_server` happy path unchanged — only the failure path is restructured.
- `_close_mcp_stacks_shielded` is idempotent and safe to call from any failure arm.
