### PR TITLE
feat(cli): add provider logout command

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1492,7 +1492,7 @@ _LOGOUT_HANDLERS: dict[str, Any] = {}
 
 
 def _register_login(name: str):
-    """注册 OAuth 登录处理器。"""
+    """Register an OAuth login handler."""
     def decorator(fn):
         _LOGIN_HANDLERS[name] = fn
         return fn
@@ -1501,7 +1501,7 @@ def _register_login(name: str):
 
 
 def _register_logout(name: str):
-    """注册 OAuth 登出处理器。"""
+    """Register an OAuth logout handler."""
     def decorator(fn):
         _LOGOUT_HANDLERS[name] = fn
         return fn
@@ -1509,7 +1509,7 @@ def _register_logout(name: str):
 
 
 def _resolve_oauth_provider(provider: str):
-    """解析并校验 OAuth provider 配置。"""
+    """Resolve and validate an OAuth provider configuration."""
     from nanobot.providers.registry import PROVIDERS
 
     key = provider.replace("-", "_")
@@ -1578,7 +1578,7 @@ def _login_openai_codex() -> None:
 
 @_register_logout("openai_codex")
 def _logout_openai_codex() -> None:
-    """清理 OpenAI Codex 的本地 OAuth 凭证。"""
+    """Clear local OAuth credentials for OpenAI Codex."""
     try:
         from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
         from oauth_cli_kit.storage import FileTokenStorage

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -5,6 +5,7 @@ import os
 import select
 import signal
 import sys
+from collections.abc import Callable
 from contextlib import nullcontext, suppress
 from pathlib import Path
 from typing import Any
@@ -1487,8 +1488,13 @@ provider_app = typer.Typer(help="Manage providers")
 app.add_typer(provider_app, name="provider")
 
 
-_LOGIN_HANDLERS: dict[str, Any] = {}
-_LOGOUT_HANDLERS: dict[str, Any] = {}
+_LOGIN_HANDLERS: dict[str, Callable[[], None]] = {}
+_LOGOUT_HANDLERS: dict[str, Callable[[], None]] = {}
+
+_PROVIDER_DISPLAY: dict[str, str] = {
+    "openai_codex": "OpenAI Codex",
+    "github_copilot": "GitHub Copilot",
+}
 
 
 def _register_login(name: str):
@@ -1587,20 +1593,46 @@ def _logout_openai_codex() -> None:
         raise typer.Exit(1)
 
     storage = FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename)
+    _delete_oauth_files(storage.get_token_path(), _PROVIDER_DISPLAY["openai_codex"])
+
+
+@_register_logout("github_copilot")
+def _logout_github_copilot() -> None:
+    """Clear local OAuth credentials for GitHub Copilot."""
+    try:
+        from nanobot.providers.github_copilot_provider import get_storage
+    except ImportError:
+        console.print("[red]GitHub Copilot provider unavailable. Ensure oauth-cli-kit is installed.[/red]")
+        raise typer.Exit(1)
+
+    storage = get_storage()
+    _delete_oauth_files(storage.get_token_path(), _PROVIDER_DISPLAY["github_copilot"])
+
+
+def _delete_oauth_files(token_path: Path, provider_label: str) -> None:
+    """Delete OAuth token and lock files, reporting the result."""
     removed_paths: list[Path] = []
-
-    for path in (storage.get_token_path(), storage.get_token_path().with_suffix(".lock")):
-        if path.exists():
+    skipped: list[tuple[Path, OSError]] = []
+    for path in (token_path, token_path.with_suffix(".lock")):
+        try:
             path.unlink()
-            removed_paths.append(path)
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            skipped.append((path, exc))
+            continue
+        removed_paths.append(path)
 
-    if not removed_paths:
-        console.print("[yellow]! No local OAuth credentials found for OpenAI Codex[/yellow]")
+    if not removed_paths and not skipped:
+        console.print(f"[yellow]! No local OAuth credentials found for {provider_label}[/yellow]")
         return
 
-    console.print("[green]✓ Logged out from OpenAI Codex[/green]")
-    for path in removed_paths:
-        console.print(f"[dim]Removed: {path}[/dim]")
+    if removed_paths:
+        console.print(f"[green]✓ Logged out from {provider_label}[/green]")
+        for path in removed_paths:
+            console.print(f"[dim]Removed: {path}[/dim]")
+    for path, exc in skipped:
+        console.print(f"[yellow]! Could not remove {path}: {exc}[/yellow]")
 
 
 @_register_login("github_copilot")

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1487,10 +1487,12 @@ provider_app = typer.Typer(help="Manage providers")
 app.add_typer(provider_app, name="provider")
 
 
-_LOGIN_HANDLERS: dict[str, callable] = {}
+_LOGIN_HANDLERS: dict[str, Any] = {}
+_LOGOUT_HANDLERS: dict[str, Any] = {}
 
 
 def _register_login(name: str):
+    """注册 OAuth 登录处理器。"""
     def decorator(fn):
         _LOGIN_HANDLERS[name] = fn
         return fn
@@ -1498,11 +1500,16 @@ def _register_login(name: str):
     return decorator
 
 
-@provider_app.command("login")
-def provider_login(
-    provider: str = typer.Argument(..., help="OAuth provider (e.g. 'openai-codex', 'github-copilot')"),
-):
-    """Authenticate with an OAuth provider."""
+def _register_logout(name: str):
+    """注册 OAuth 登出处理器。"""
+    def decorator(fn):
+        _LOGOUT_HANDLERS[name] = fn
+        return fn
+    return decorator
+
+
+def _resolve_oauth_provider(provider: str):
+    """解析并校验 OAuth provider 配置。"""
     from nanobot.providers.registry import PROVIDERS
 
     key = provider.replace("-", "_")
@@ -1511,6 +1518,15 @@ def provider_login(
         names = ", ".join(s.name.replace("_", "-") for s in PROVIDERS if s.is_oauth)
         console.print(f"[red]Unknown OAuth provider: {provider}[/red]  Supported: {names}")
         raise typer.Exit(1)
+    return spec
+
+
+@provider_app.command("login")
+def provider_login(
+    provider: str = typer.Argument(..., help="OAuth provider (e.g. 'openai-codex', 'github-copilot')"),
+):
+    """Authenticate with an OAuth provider."""
+    spec = _resolve_oauth_provider(provider)
 
     handler = _LOGIN_HANDLERS.get(spec.name)
     if not handler:
@@ -1518,6 +1534,22 @@ def provider_login(
         raise typer.Exit(1)
 
     console.print(f"{__logo__} OAuth Login - {spec.label}\n")
+    handler()
+
+
+@provider_app.command("logout")
+def provider_logout(
+    provider: str = typer.Argument(..., help="OAuth provider (e.g. 'openai-codex', 'github-copilot')"),
+):
+    """Log out from an OAuth provider."""
+    spec = _resolve_oauth_provider(provider)
+
+    handler = _LOGOUT_HANDLERS.get(spec.name)
+    if not handler:
+        console.print(f"[red]Logout not implemented for {spec.label}[/red]")
+        raise typer.Exit(1)
+
+    console.print(f"{__logo__} OAuth Logout - {spec.label}\n")
     handler()
 
 
@@ -1542,6 +1574,33 @@ def _login_openai_codex() -> None:
     except ImportError:
         console.print("[red]oauth_cli_kit not installed. Run: pip install oauth-cli-kit[/red]")
         raise typer.Exit(1)
+
+
+@_register_logout("openai_codex")
+def _logout_openai_codex() -> None:
+    """清理 OpenAI Codex 的本地 OAuth 凭证。"""
+    try:
+        from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
+        from oauth_cli_kit.storage import FileTokenStorage
+    except ImportError:
+        console.print("[red]oauth_cli_kit not installed. Run: pip install oauth-cli-kit[/red]")
+        raise typer.Exit(1)
+
+    storage = FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename)
+    removed_paths: list[Path] = []
+
+    for path in (storage.get_token_path(), storage.get_token_path().with_suffix(".lock")):
+        if path.exists():
+            path.unlink()
+            removed_paths.append(path)
+
+    if not removed_paths:
+        console.print("[yellow]! No local OAuth credentials found for OpenAI Codex[/yellow]")
+        return
+
+    console.print("[green]✓ Logged out from OpenAI Codex[/green]")
+    for path in removed_paths:
+        console.print(f"[dim]Removed: {path}[/dim]")
 
 
 @_register_login("github_copilot")

--- a/nanobot/providers/github_copilot_provider.py
+++ b/nanobot/providers/github_copilot_provider.py
@@ -29,7 +29,7 @@ _EXPIRY_SKEW_SECONDS = 60
 _LONG_LIVED_TOKEN_SECONDS = 315360000
 
 
-def _storage() -> FileTokenStorage:
+def get_storage() -> FileTokenStorage:
     return FileTokenStorage(
         token_filename=TOKEN_FILENAME,
         app_name=TOKEN_APP_NAME,
@@ -48,7 +48,7 @@ def _copilot_headers(token: str) -> dict[str, str]:
 
 
 def _load_github_token() -> OAuthToken | None:
-    token = _storage().load()
+    token = get_storage().load()
     if not token or not token.access:
         return None
     return token
@@ -150,7 +150,7 @@ def login_github_copilot(
         expires=expires_ms,
         account_id=str(account_id) if account_id else None,
     )
-    _storage().save(token)
+    get_storage().save(token)
     return token
 
 

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -221,7 +221,7 @@ def test_config_dump_excludes_oauth_provider_blocks():
 
 
 def test_provider_logout_openai_codex_removes_local_oauth_files(tmp_path, monkeypatch):
-    token_path = tmp_path / "auth" / "oauth.json"
+    token_path = tmp_path / "auth" / "codex.json"
     lock_path = token_path.with_suffix(".lock")
     token_path.parent.mkdir(parents=True, exist_ok=True)
     token_path.write_text("{}", encoding="utf-8")
@@ -237,13 +237,70 @@ def test_provider_logout_openai_codex_removes_local_oauth_files(tmp_path, monkey
 
 
 def test_provider_logout_openai_codex_succeeds_when_no_local_oauth_file(monkeypatch, tmp_path):
-    token_path = tmp_path / "auth" / "oauth.json"
+    token_path = tmp_path / "auth" / "codex.json"
     monkeypatch.setenv("OAUTH_CLI_KIT_TOKEN_PATH", str(token_path))
 
     result = runner.invoke(app, ["provider", "logout", "openai-codex"])
 
     assert result.exit_code == 0
     assert "No local OAuth credentials found for OpenAI Codex" in result.stdout
+
+
+def test_provider_logout_github_copilot_removes_local_oauth_files(tmp_path, monkeypatch):
+    token_path = tmp_path / "auth" / "github-copilot.json"
+    lock_path = token_path.with_suffix(".lock")
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text("{}", encoding="utf-8")
+    lock_path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("OAUTH_CLI_KIT_TOKEN_PATH", str(token_path))
+
+    result = runner.invoke(app, ["provider", "logout", "github-copilot"])
+
+    assert result.exit_code == 0
+    assert not token_path.exists()
+    assert not lock_path.exists()
+    assert "Logged out from GitHub Copilot" in result.stdout
+
+
+def test_provider_logout_github_copilot_succeeds_when_no_local_oauth_file(monkeypatch, tmp_path):
+    token_path = tmp_path / "auth" / "github-copilot.json"
+    monkeypatch.setenv("OAUTH_CLI_KIT_TOKEN_PATH", str(token_path))
+
+    result = runner.invoke(app, ["provider", "logout", "github-copilot"])
+
+    assert result.exit_code == 0
+    assert "No local OAuth credentials found for GitHub Copilot" in result.stdout
+
+
+def test_provider_logout_rejects_unknown_provider():
+    result = runner.invoke(app, ["provider", "logout", "not-a-real-provider"])
+
+    assert result.exit_code == 1
+    assert "Unknown OAuth provider" in result.stdout
+
+
+def test_provider_logout_paths_resolve_to_expected_files():
+    from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
+    from oauth_cli_kit.storage import FileTokenStorage
+
+    from nanobot.providers.github_copilot_provider import get_storage
+
+    codex_storage = FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename)
+    codex_path = codex_storage.get_token_path()
+    assert codex_path.name == "codex.json"
+    assert codex_path.parent.name == "auth"
+
+    gh_storage = get_storage()
+    gh_path = gh_storage.get_token_path()
+    assert gh_path.name == "github-copilot.json"
+    assert gh_path.parent.name == "auth"
+
+
+def test_provider_login_rejects_unknown_provider():
+    result = runner.invoke(app, ["provider", "login", "not-a-real-provider"])
+
+    assert result.exit_code == 1
+    assert "Unknown OAuth provider" in result.stdout
 
 
 def test_config_matches_explicit_ollama_prefix_without_api_key():

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -220,6 +220,32 @@ def test_config_dump_excludes_oauth_provider_blocks():
     assert "githubCopilot" not in providers
 
 
+def test_provider_logout_openai_codex_removes_local_oauth_files(tmp_path, monkeypatch):
+    token_path = tmp_path / "auth" / "oauth.json"
+    lock_path = token_path.with_suffix(".lock")
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text("{}", encoding="utf-8")
+    lock_path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("OAUTH_CLI_KIT_TOKEN_PATH", str(token_path))
+
+    result = runner.invoke(app, ["provider", "logout", "openai-codex"])
+
+    assert result.exit_code == 0
+    assert not token_path.exists()
+    assert not lock_path.exists()
+    assert "Logged out from OpenAI Codex" in result.stdout
+
+
+def test_provider_logout_openai_codex_succeeds_when_no_local_oauth_file(monkeypatch, tmp_path):
+    token_path = tmp_path / "auth" / "oauth.json"
+    monkeypatch.setenv("OAUTH_CLI_KIT_TOKEN_PATH", str(token_path))
+
+    result = runner.invoke(app, ["provider", "logout", "openai-codex"])
+
+    assert result.exit_code == 0
+    assert "No local OAuth credentials found for OpenAI Codex" in result.stdout
+
+
 def test_config_matches_explicit_ollama_prefix_without_api_key():
     config = Config()
     config.agents.defaults.model = "ollama/llama3.2"


### PR DESCRIPTION
## Summary

Add `nanobot provider logout <provider>` command to clear OAuth credentials, with handlers for `openai-codex` and `github-copilot`.

- Implement `provider logout <provider>` to clear OAuth credentials
- Add `_LOGOUT_HANDLERS` registration mechanism mirroring login
- Implement logout for `openai-codex` by deleting local `oauth-cli-kit` token and lock files
- Add `github-copilot` logout handler sharing token deletion via `_delete_oauth_files`
- Fallback gracefully when attempting to logout from providers lacking local credentials or implementations
- Fixes #2665

@mikaku9944 thanks for your contribution

(cherry-picked from #2727)