### PR TITLE
fix(agent): prevent safety guard false positives and streamed message drop

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1135,7 +1135,7 @@ class AgentLoop:
             ask_user_options_from_messages(all_msgs) if stop_reason == "ask_user" else [],
             msg.channel,
         )
-        if on_stream is not None and stop_reason not in {"ask_user", "error"}:
+        if on_stream is not None and stop_reason not in {"ask_user", "error", "tool_error"}:
             meta["_streamed"] = True
         return OutboundMessage(
             channel=msg.channel,

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -349,14 +349,11 @@ class ExecTool(Tool):
                     continue
 
                 media_path = get_media_dir().resolve()
-                dev_path = Path("/dev").resolve()
                 if (p.is_absolute()
                     and cwd_path not in p.parents
                     and p != cwd_path
                     and media_path not in p.parents
                     and p != media_path
-                    and dev_path not in p.parents
-                    and p != dev_path
                 ):
                     return (
                         "Error: Command blocked by safety guard (path outside working dir)"

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -191,9 +191,12 @@ class ExecTool(Tool):
     ) -> asyncio.subprocess.Process:
         """Launch *command* in a platform-appropriate shell."""
         if _IS_WINDOWS:
-            comspec = env.get("COMSPEC", os.environ.get("COMSPEC", "cmd.exe"))
-            return await asyncio.create_subprocess_exec(
-                comspec, "/c", command,
+            # create_subprocess_exec re-quotes args via list2cmdline, which
+            # breaks commands containing paths with spaces (e.g. "D:\Program
+            # Files\python.exe" "script.py"). create_subprocess_shell passes
+            # the raw command string to COMSPEC without re-quoting.
+            return await asyncio.create_subprocess_shell(
+                command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
@@ -305,11 +308,14 @@ class ExecTool(Tool):
                     continue
 
                 media_path = get_media_dir().resolve()
+                dev_path = Path("/dev").resolve()
                 if (p.is_absolute()
                     and cwd_path not in p.parents
                     and p != cwd_path
                     and media_path not in p.parents
                     and p != media_path
+                    and dev_path not in p.parents
+                    and p != dev_path
                 ):
                     return "Error: Command blocked by safety guard (path outside working dir)"
 
@@ -321,5 +327,5 @@ class ExecTool(Tool):
         # NOTE: `*` is required so `C:\` (nothing after the slash) is still extracted.
         win_paths = re.findall(r"[A-Za-z]:\\[^\s\"'|><;]*", command)
         posix_paths = re.findall(r"(?:^|[\s|>'\"])(/[^\s\"'>;|<]+)", command) # POSIX: /absolute only
-        home_paths = re.findall(r"(?:^|[\s|>'\"])(~[^\s\"'>;|<]*)", command) # POSIX/Windows home shortcut: ~
+        home_paths = re.findall(r"(?:^|[\s>'\"])(~[^\s\"'>;|<]*)", command) # POSIX/Windows home shortcut: ~
         return win_paths + posix_paths + home_paths

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -1290,6 +1290,45 @@ async def test_streamed_flag_not_set_on_llm_error(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_streamed_flag_not_set_on_tool_error(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.events import InboundMessage
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    tool_call_resp = LLMResponse(
+        content="checking metadata",
+        tool_calls=[ToolCallRequest(
+            id="call_ssrf",
+            name="exec",
+            arguments={"command": "curl http://169.254.169.254/latest/meta-data/"},
+        )],
+        usage={},
+    )
+    provider.chat_stream_with_retry = AsyncMock(return_value=tool_call_resp)
+
+    loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+    loop.tools.get_definitions = MagicMock(return_value=[])
+    loop.tools.prepare_call = MagicMock(return_value=(None, {}, None))
+    loop.tools.execute = AsyncMock(return_value=(
+        "Error: Command blocked by safety guard (internal/private URL detected)"
+    ))
+
+    result = await loop._process_message(
+        InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="hi"),
+        on_stream=AsyncMock(),
+        on_stream_end=AsyncMock(),
+    )
+
+    assert result is not None
+    assert "internal/private URL detected" in result.content
+    assert not result.metadata.get("_streamed"), \
+        "_streamed must not be set when stop_reason is tool_error"
+
+
+@pytest.mark.asyncio
 async def test_next_turn_after_llm_error_keeps_turn_boundary(tmp_path):
     from nanobot.agent.loop import AgentLoop
     from nanobot.agent.runner import _PERSISTED_MODEL_ERROR_PLACEHOLDER

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -112,33 +112,31 @@ class TestSpawnUnix:
 class TestSpawnWindows:
 
     @pytest.mark.asyncio
-    async def test_uses_comspec_from_env(self):
+    async def test_uses_create_subprocess_shell(self):
         env = {"COMSPEC": r"C:\Windows\system32\cmd.exe", "PATH": ""}
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
-            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
         ):
-            mock_exec.return_value = AsyncMock()
-            await ExecTool._spawn("dir", r"C:\Users", env)
+            mock_shell.return_value = AsyncMock()
+            await ExecTool._spawn("dir", r"C:\work", env)
 
-        args = mock_exec.call_args[0]
-        assert "cmd.exe" in args[0]
-        assert "/c" in args
+        args = mock_shell.call_args[0]
         assert "dir" in args
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_default_comspec(self):
-        env = {"PATH": ""}
+    async def test_passes_cwd_and_env(self):
+        env = {"PATH": "/usr/bin"}
         with (
             patch("nanobot.agent.tools.shell._IS_WINDOWS", True),
-            patch.dict("os.environ", {}, clear=True),
-            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+            patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell,
         ):
-            mock_exec.return_value = AsyncMock()
-            await ExecTool._spawn("dir", r"C:\Users", env)
+            mock_shell.return_value = AsyncMock()
+            await ExecTool._spawn("echo hi", r"C:\work", env)
 
-        args = mock_exec.call_args[0]
-        assert args[0] == "cmd.exe"
+        kwargs = mock_shell.call_args[1]
+        assert kwargs["cwd"] == r"C:\work"
+        assert kwargs["env"] == env
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -330,6 +330,13 @@ def test_exec_guard_allows_dev_urandom(tmp_path) -> None:
     assert error is None
 
 
+def test_exec_guard_blocks_non_benign_dev_path(tmp_path) -> None:
+    tool = ExecTool(restrict_to_workspace=True)
+    error = tool._guard_command("cat /dev/sda", str(tmp_path))
+    assert error is not None
+    assert "path outside working dir" in error
+
+
 def test_exec_extract_absolute_paths_ignores_pipe_tilde() -> None:
     cmd = "python query.py --query '{job=\"app\"} |~ \"error\"'"
     paths = ExecTool._extract_absolute_paths(cmd)

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -303,6 +303,27 @@ def test_exec_guard_blocks_windows_drive_root_outside_workspace(monkeypatch) -> 
     assert error == "Error: Command blocked by safety guard (path outside working dir)"
 
 
+def test_exec_guard_allows_dev_null_redirect(tmp_path) -> None:
+    tool = ExecTool(restrict_to_workspace=True)
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    (ws / "file.txt").write_text("ok", encoding="utf-8")
+    error = tool._guard_command(f'rm "{ws / "file.txt"}" 2>/dev/null', str(ws))
+    assert error is None
+
+
+def test_exec_guard_allows_dev_urandom(tmp_path) -> None:
+    tool = ExecTool(restrict_to_workspace=True)
+    error = tool._guard_command("cat /dev/urandom | head -c 16 > random.bin", str(tmp_path))
+    assert error is None
+
+
+def test_exec_extract_absolute_paths_ignores_pipe_tilde() -> None:
+    cmd = "python query.py --query '{job=\"app\"} |~ \"error\"'"
+    paths = ExecTool._extract_absolute_paths(cmd)
+    assert not any(p.startswith("~") for p in paths)
+
+
 # --- cast_params tests ---
 
 


### PR DESCRIPTION
## Summary

Three independent fixes for bugs exposed by PR #3493 (workspace violation abort):

1. **`shell.py`: allow `/dev/*` paths** — Commands like `rm file.txt 2>/dev/null` were blocked because the regex captured `/dev/null` as a path outside workspace. `/dev` is now exempted like `media_path` already was. (#3599)

2. **`shell.py`: remove `|` from `home_paths` regex prefix** — The Loki query operator `|~` was misinterpreted as pipe + home directory (`~`), causing false workspace violation errors. (#3605)

3. **`loop.py`: add `"tool_error"` to `_streamed` exclusion set** — `stop_reason "tool_error"` was not in the exclusion set `{"ask_user", "error"}`, so `_streamed=True` was set on fatal errors. The channel manager then skipped `channel.send()` because it assumed the content was already streamed — but it never was. Now the exclusion set is `{"ask_user", "error", "tool_error"}`. (#3605)

Also fixes a pre-existing Windows bug in `_spawn` where `create_subprocess_exec` + `list2cmdline` breaks commands with paths containing spaces — switched to `create_subprocess_shell` which passes the raw command string without re-quoting.

**Note:** This PR is designed to complement a revert of #3493. The revert fixes the "agent stops trying" problem; this PR fixes the two independent bugs that remain after revert (regex false positives + streamed message drop).

## Test plan

- [x] `test_exec_guard_allows_dev_null_redirect` — `2>/dev/null` no longer triggers false positive
- [x] `test_exec_guard_allows_dev_urandom` — `/dev/urandom` paths are allowed
- [x] `test_exec_extract_absolute_paths_ignores_pipe_tilde` — `|~` not matched as home path
- [x] `test_exec_head_tail_truncation` — now passes on Windows (was pre-existing failure)
- [x] `test_exec_always_returns_exit_code` — still passes
- [x] `TestSpawnWindows` — updated to mock `create_subprocess_shell`
- [x] `test_runner_pauses_on_ask_user_without_executing_later_tools` — `_streamed` not set for `ask_user`
- [x] All 70 tests in affected suites pass (0 failures)