### PR TITLE
fix(telegram): add polling watchdog to recover from silent hangs

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -286,6 +286,7 @@ class TelegramChannel(BaseChannel):
         self._bot_user_id: int | None = None
         self._bot_username: str | None = None
         self._stream_bufs: dict[str, _StreamBuf] = {}  # chat_id -> streaming state
+        self._last_update_time: float = time.monotonic()
 
     def is_allowed(self, sender_id: str) -> bool:
         """Preserve Telegram's legacy id|username allowlist matching."""
@@ -411,9 +412,33 @@ class TelegramChannel(BaseChannel):
             error_callback=self._on_polling_error,
         )
 
-        # Keep running until stopped
+        # Keep running until stopped; also act as a polling watchdog
         while self._running:
-            await asyncio.sleep(1)
+            await asyncio.sleep(10)
+            if not self._app:
+                continue
+            updater_running = getattr(self._app.updater, "running", True)
+            if not updater_running:
+                try:
+                    await self._app.updater.start_polling(
+                        allowed_updates=["message"],
+                        drop_pending_updates=False,
+                        error_callback=self._on_polling_error,
+                    )
+                    self._last_update_time = time.monotonic()
+                except Exception as e:
+                    logger.error("Failed to restart Telegram polling: {}", e)
+            elif time.monotonic() - self._last_update_time > 300:
+                try:
+                    await self._app.updater.stop()
+                    await self._app.updater.start_polling(
+                        allowed_updates=["message"],
+                        drop_pending_updates=False,
+                        error_callback=self._on_polling_error,
+                    )
+                    self._last_update_time = time.monotonic()
+                except Exception as e:
+                    logger.error("Failed to restart Telegram polling: {}", e)
 
     async def stop(self) -> None:
         """Stop the Telegram bot."""
@@ -1011,6 +1036,8 @@ class TelegramChannel(BaseChannel):
         """Handle incoming messages (text, photos, voice, documents)."""
         if not update.message or not update.effective_user:
             return
+
+        self._last_update_time = time.monotonic()
 
         message = update.message
         user = update.effective_user


### PR DESCRIPTION
## Problem

Telegram long polling can silently hang when the HTTP connection drops without notifying the client. The bot stays alive and can send messages, but stops receiving updates entirely. No error is logged.

See #3626 for full details.

## Solution

Add a lightweight watchdog in the existing `_run_polling` loop:

1. **Track activity**: `_last_update_time` records when any update was last received
2. **Detect stopped updater**: If `updater.running` is False, restart polling
3. **Detect silent hang**: If no updates for 5 minutes, stop and restart polling
4. **Minimal logging**: Only `logger.error` on actual restart failures — no noise from self-healing

The 5-minute threshold is conservative enough to avoid false positives on low-traffic bots.

## Changes

`nanobot/channels/telegram.py`:
- Add `_last_update_time` field to `__init__`
- Replace idle `asyncio.sleep(1)` with watchdog loop (`asyncio.sleep(10)`)
- Update `_last_update_time` in `_on_message` handler

## Testing

This fix has been running in production on a multi-user Telegram bot for 2+ weeks with no issues. The watchdog has successfully recovered from multiple silent hangs.

Closes #3626