### PR TITLE
feat(exec): allow custom bwrap bind mounts via tools.exec.sandboxBindsRo/Rw

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1002,11 +1002,30 @@ MCP tools are automatically discovered and registered on startup. The LLM can us
 |--------|---------|-------------|
 | `tools.restrictToWorkspace` | `false` | When `true`, restricts **all** agent tools (shell, file read/write/edit, list) to the workspace directory. Prevents path traversal and out-of-scope access. |
 | `tools.exec.sandbox` | `""` | Sandbox backend for shell commands. Set to `"bwrap"` to wrap exec calls in a [bubblewrap](https://github.com/containers/bubblewrap) sandbox — the process can only see the workspace (read-write) and media directory (read-only); config files and API keys are hidden. Automatically enables `restrictToWorkspace` for file tools. **Linux only** — requires `bwrap` installed (`apt install bubblewrap`; pre-installed in the Docker image). Not available on macOS or Windows (bwrap depends on Linux kernel namespaces). |
+| `tools.exec.sandboxBindsRo` | `[]` | Extra **read-only** bind mounts for the sandbox. Each entry is an absolute host path bound to the same path inside the sandbox. Strict: missing host paths cause `bwrap` to fail. Useful for granting read access to toolchains, CA bundles, or pip configs without exposing the rest of the host (e.g. `["/opt/toolchain", "/etc/pip.conf"]`). |
+| `tools.exec.sandboxBindsRw` | `[]` | Extra **read-write** bind mounts for the sandbox. Same shape as `sandboxBindsRo`. Use sparingly — every entry widens the sandbox. Typical use is a shared build cache (e.g. `["/var/cache/builds"]`). |
 | `tools.exec.enable` | `true` | When `false`, the shell `exec` tool is not registered at all. Use this to completely disable shell command execution. |
 | `tools.exec.pathAppend` | `""` | Extra directories to append to `PATH` when running shell commands (e.g. `/usr/sbin` for `ufw`). |
 | `channels.*.allowFrom` | `[]` (deny all) | Whitelist of user IDs. Empty denies all; use `["*"]` to allow everyone. |
 
 **Docker security**: The official Docker image runs as a non-root user (`nanobot`, UID 1000) with bubblewrap pre-installed. When using `docker-compose.yml`, the container drops all Linux capabilities except `SYS_ADMIN` (required for bwrap's namespace isolation).
+
+**Example — extra sandbox binds**:
+
+```json
+{
+  "tools": {
+    "exec": {
+      "sandbox": "bwrap",
+      "sandboxBindsRo": ["/opt/toolchain", "/etc/pip.conf"],
+      "sandboxBindsRw": ["/var/cache/builds"]
+    }
+  }
+}
+```
+
+> [!WARNING]
+> Each bind widens the sandbox. The agent gets exactly the host access you grant — prefer read-only over read-write, and avoid binding directories that contain secrets.
 
 
 ## Subagent Concurrency

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -372,6 +372,8 @@ class AgentLoop:
                     timeout=self.exec_config.timeout,
                     restrict_to_workspace=self.restrict_to_workspace,
                     sandbox=self.exec_config.sandbox,
+                    sandbox_binds_ro=self.exec_config.sandbox_binds_ro,
+                    sandbox_binds_rw=self.exec_config.sandbox_binds_rw,
                     path_append=self.exec_config.path_append,
                     allowed_env_keys=self.exec_config.allowed_env_keys,
                     allow_patterns=self.exec_config.allow_patterns,

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -188,6 +188,8 @@ class SubagentManager:
                     timeout=self.exec_config.timeout,
                     restrict_to_workspace=self.restrict_to_workspace,
                     sandbox=self.exec_config.sandbox,
+                    sandbox_binds_ro=self.exec_config.sandbox_binds_ro,
+                    sandbox_binds_rw=self.exec_config.sandbox_binds_rw,
                     path_append=self.exec_config.path_append,
                     allowed_env_keys=self.exec_config.allowed_env_keys,
                     allow_patterns=self.exec_config.allow_patterns,

--- a/nanobot/agent/tools/sandbox.py
+++ b/nanobot/agent/tools/sandbox.py
@@ -11,12 +11,21 @@ from pathlib import Path
 from nanobot.config.paths import get_media_dir
 
 
-def _bwrap(command: str, workspace: str, cwd: str) -> str:
+def _bwrap(
+    command: str,
+    workspace: str,
+    cwd: str,
+    binds_ro: list[str] | None = None,
+    binds_rw: list[str] | None = None,
+) -> str:
     """Wrap command in a bubblewrap sandbox (requires bwrap in container).
 
     Only the workspace is bind-mounted read-write; its parent dir (which holds
     config.json) is hidden behind a fresh tmpfs.  The media directory is
     bind-mounted read-only so exec commands can read uploaded attachments.
+
+    *binds_ro* / *binds_rw* are extra absolute host paths bind-mounted at the
+    same path inside the sandbox.  Strict: missing host paths fail loudly.
     """
     ws = Path(workspace).resolve()
     media = get_media_dir().resolve()
@@ -39,17 +48,25 @@ def _bwrap(command: str, workspace: str, cwd: str) -> str:
         "--dir", str(ws),                 # recreate workspace mount point
         "--bind", str(ws), str(ws),
         "--ro-bind-try", str(media), str(media),  # read-only access to media
-        "--chdir", sandbox_cwd,
-        "--", "sh", "-c", command,
     ]
+    for p in binds_ro or []: args += ["--ro-bind", p, p]
+    for p in binds_rw or []: args += ["--bind",    p, p]
+    args += ["--chdir", sandbox_cwd, "--", "sh", "-c", command]
     return shlex.join(args)
 
 
 _BACKENDS = {"bwrap": _bwrap}
 
 
-def wrap_command(sandbox: str, command: str, workspace: str, cwd: str) -> str:
+def wrap_command(
+    sandbox: str,
+    command: str,
+    workspace: str,
+    cwd: str,
+    binds_ro: list[str] | None = None,
+    binds_rw: list[str] | None = None,
+) -> str:
     """Wrap *command* using the named sandbox backend."""
     if backend := _BACKENDS.get(sandbox):
-        return backend(command, workspace, cwd)
+        return backend(command, workspace, cwd, binds_ro=binds_ro, binds_rw=binds_rw)
     raise ValueError(f"Unknown sandbox backend {sandbox!r}. Available: {list(_BACKENDS)}")

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -56,12 +56,16 @@ class ExecTool(Tool):
         allow_patterns: list[str] | None = None,
         restrict_to_workspace: bool = False,
         sandbox: str = "",
+        sandbox_binds_ro: list[str] | None = None,
+        sandbox_binds_rw: list[str] | None = None,
         path_append: str = "",
         allowed_env_keys: list[str] | None = None,
     ):
         self.timeout = timeout
         self.working_dir = working_dir
         self.sandbox = sandbox
+        self.sandbox_binds_ro = sandbox_binds_ro or []
+        self.sandbox_binds_rw = sandbox_binds_rw or []
         self.deny_patterns = (deny_patterns or []) + [
             r"\brm\s+-[rf]{1,2}\b",          # rm -r, rm -rf, rm -fr
             r"\bdel\s+/[fq]\b",              # del /f, del /q
@@ -158,7 +162,14 @@ class ExecTool(Tool):
                 )
             else:
                 workspace = self.working_dir or cwd
-                command = wrap_command(self.sandbox, command, workspace, cwd)
+                command = wrap_command(
+                    self.sandbox,
+                    command,
+                    workspace,
+                    cwd,
+                    binds_ro=self.sandbox_binds_ro,
+                    binds_rw=self.sandbox_binds_rw,
+                )
                 cwd = str(Path(workspace).resolve())
 
         effective_timeout = min(timeout or self.timeout, self._MAX_TIMEOUT)

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
 
@@ -223,9 +223,19 @@ class ExecToolConfig(Base):
     timeout: int = 60
     path_append: str = ""
     sandbox: str = ""  # sandbox backend: "" (none) or "bwrap"
+    sandbox_binds_ro: list[str] = Field(default_factory=list)  # Extra read-only bind mounts for the sandbox; absolute host paths bound to the same path inside (e.g. ["/opt/toolchain"])
+    sandbox_binds_rw: list[str] = Field(default_factory=list)  # Extra read-write bind mounts for the sandbox; absolute host paths bound to the same path inside (e.g. ["/var/cache/builds"])
     allowed_env_keys: list[str] = Field(default_factory=list)  # Env var names to pass through to subprocess (e.g. ["GOPATH", "JAVA_HOME"])
     allow_patterns: list[str] = Field(default_factory=list)  # Regex patterns that bypass deny_patterns (e.g. [r"rm\s+-rf\s+/tmp/"])
     deny_patterns: list[str] = Field(default_factory=list)  # Extra regex patterns to block (appended to built-in list)
+
+    @field_validator("sandbox_binds_ro", "sandbox_binds_rw")
+    @classmethod
+    def _validate_absolute_paths(cls, v: list[str]) -> list[str]:
+        for p in v:
+            if not p or not Path(p).is_absolute():
+                raise ValueError(f"sandbox bind path must be absolute, got {p!r}")
+        return v
 
 class MCPServerConfig(Base):
     """MCP server connection configuration (stdio or HTTP)."""

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -1,10 +1,16 @@
 """Tests for nanobot.agent.tools.sandbox."""
 
 import shlex
+import sys
 
 import pytest
 
 from nanobot.agent.tools.sandbox import wrap_command
+
+_SKIP_WINDOWS = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bwrap sandbox is Linux-only",
+)
 
 
 def _parse(cmd: str) -> list[str]:
@@ -109,6 +115,7 @@ class TestBwrapBackend:
         assert (str(fake_media), str(fake_media)) in try_pairs
 
 
+@_SKIP_WINDOWS
 class TestUserBinds:
     def test_default_no_extra_binds(self, tmp_path):
         ws = str(tmp_path / "project")
@@ -178,6 +185,7 @@ class TestUnknownBackend:
             wrap_command("", "ls", ws, ws)
 
 
+@_SKIP_WINDOWS
 class TestSandboxBindsConfig:
     """ExecToolConfig must reject relative or empty bind paths up front."""
 

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -9,7 +9,7 @@ from nanobot.agent.tools.sandbox import wrap_command
 
 _SKIP_WINDOWS = pytest.mark.skipif(
     sys.platform == "win32",
-    reason="bwrap sandbox is Linux-only",
+    reason="tests use POSIX-style absolute paths; runs on Linux and macOS",
 )
 
 

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -109,6 +109,63 @@ class TestBwrapBackend:
         assert (str(fake_media), str(fake_media)) in try_pairs
 
 
+class TestUserBinds:
+    def test_default_no_extra_binds(self, tmp_path):
+        ws = str(tmp_path / "project")
+        result = wrap_command("bwrap", "ls", ws, ws)
+        tokens = _parse(result)
+
+        # Without extras, /opt/foo should not appear anywhere.
+        assert "/opt/foo" not in tokens
+
+    def test_ro_binds_appended_strict(self, tmp_path):
+        ws = str(tmp_path / "project")
+        result = wrap_command(
+            "bwrap", "ls", ws, ws,
+            binds_ro=["/opt/toolchain", "/etc/pip.conf"],
+        )
+        tokens = _parse(result)
+
+        ro_pairs = {(tokens[i + 1], tokens[i + 2])
+                    for i, t in enumerate(tokens) if t == "--ro-bind"}
+        assert ("/opt/toolchain", "/opt/toolchain") in ro_pairs
+        assert ("/etc/pip.conf",  "/etc/pip.conf")  in ro_pairs
+
+        # Strict: user paths use --ro-bind, never --ro-bind-try.
+        try_pairs = {(tokens[i + 1], tokens[i + 2])
+                     for i, t in enumerate(tokens) if t == "--ro-bind-try"}
+        assert ("/opt/toolchain", "/opt/toolchain") not in try_pairs
+
+    def test_rw_binds_appended_strict(self, tmp_path):
+        ws = str(tmp_path / "project")
+        result = wrap_command(
+            "bwrap", "ls", ws, ws,
+            binds_rw=["/var/cache/builds"],
+        )
+        tokens = _parse(result)
+
+        bind_pairs = {(tokens[i + 1], tokens[i + 2])
+                      for i, t in enumerate(tokens) if t == "--bind"}
+        assert ("/var/cache/builds", "/var/cache/builds") in bind_pairs
+
+    def test_user_binds_before_chdir(self, tmp_path):
+        """User binds must be emitted before --chdir so bwrap mounts before cd."""
+        ws = str(tmp_path / "project")
+        result = wrap_command(
+            "bwrap", "ls", ws, ws,
+            binds_ro=["/opt/x"], binds_rw=["/opt/y"],
+        )
+        tokens = _parse(result)
+        chdir_idx = tokens.index("--chdir")
+        # The bind targets appear at i+1; check they precede --chdir.
+        ro_idx = next(i for i, t in enumerate(tokens)
+                      if t == "--ro-bind" and tokens[i + 1] == "/opt/x")
+        rw_idx = next(i for i, t in enumerate(tokens)
+                      if t == "--bind" and tokens[i + 1] == "/opt/y")
+        assert ro_idx < chdir_idx
+        assert rw_idx < chdir_idx
+
+
 class TestUnknownBackend:
     def test_raises_value_error(self, tmp_path):
         ws = str(tmp_path / "project")
@@ -119,3 +176,41 @@ class TestUnknownBackend:
         ws = str(tmp_path / "project")
         with pytest.raises(ValueError):
             wrap_command("", "ls", ws, ws)
+
+
+class TestSandboxBindsConfig:
+    """ExecToolConfig must reject relative or empty bind paths up front."""
+
+    def test_relative_ro_path_rejected(self):
+        from nanobot.config.schema import ExecToolConfig
+        with pytest.raises(ValueError, match="must be absolute"):
+            ExecToolConfig(sandbox_binds_ro=["relative/path"])
+
+    def test_relative_rw_path_rejected(self):
+        from nanobot.config.schema import ExecToolConfig
+        with pytest.raises(ValueError, match="must be absolute"):
+            ExecToolConfig(sandbox_binds_rw=["./cache"])
+
+    def test_empty_string_rejected(self):
+        from nanobot.config.schema import ExecToolConfig
+        with pytest.raises(ValueError):
+            ExecToolConfig(sandbox_binds_ro=[""])
+
+    def test_absolute_paths_accepted(self):
+        from nanobot.config.schema import ExecToolConfig
+        cfg = ExecToolConfig(
+            sandbox_binds_ro=["/opt/toolchain"],
+            sandbox_binds_rw=["/var/cache/builds"],
+        )
+        assert cfg.sandbox_binds_ro == ["/opt/toolchain"]
+        assert cfg.sandbox_binds_rw == ["/var/cache/builds"]
+
+    def test_camel_case_alias(self):
+        """Config files use camelCase keys via the Base alias generator."""
+        from nanobot.config.schema import ExecToolConfig
+        cfg = ExecToolConfig.model_validate({
+            "sandboxBindsRo": ["/opt/x"],
+            "sandboxBindsRw": ["/var/y"],
+        })
+        assert cfg.sandbox_binds_ro == ["/opt/x"]
+        assert cfg.sandbox_binds_rw == ["/var/y"]


### PR DESCRIPTION
## Summary
- Add `tools.exec.sandboxBindsRo` and `tools.exec.sandboxBindsRw` to `ExecToolConfig` so users can grant the bwrap sandbox extra read-only or read-write host paths without patching source.
- Strict mode: each bind uses `--ro-bind` / `--bind` (not the `-try` variants), so a missing host path fails loudly instead of silently turning into a no-op.
- Validates absolute paths at config load. Bind args are emitted **before** `--chdir` so mounts exist by the time bwrap cd's into the workspace.

## Why
Today the bwrap sandbox grants exactly two paths: workspace (RW) and the media dir (RO). Anything else is unreachable, forcing users to either disable the sandbox entirely or fork. Concrete things that break under the current sandbox and motivated this change:

- **Anaconda/Miniconda-managed Python** living under `~/miniconda3` or `/opt/conda` — the interpreter, site-packages, and conda envs sit outside `/usr`.
- **NVM-managed Node.js** under `~/.nvm/versions/node/...` — `node`/`npm` shims and the active version's libs are invisible.
- **Claude Code / OpenCode / other agent CLIs** installed via `npm i -g` into an NVM prefix, or as standalone binaries under `~/.local/bin` or `/opt/<vendor>`.
- **Toolchains pinned outside `/usr`** (Rust via rustup at `~/.cargo` and `~/.rustup`, Go at `/usr/local/go`, JDKs under `/opt`).
- **Shared build/dep caches** the user wants writeable across runs (`~/.cache/pip`, `~/.cache/uv`, `/var/cache/builds`).

This adds a narrow, opt-in escape hatch so users can keep the sandbox on instead of disabling it.

## Config example
```json
{
  "tools": {
    "exec": {
      "sandbox": "bwrap",
      "sandboxBindsRo": ["/opt/conda", "/home/me/.nvm", "/home/me/.local/bin"],
      "sandboxBindsRw": ["/home/me/.cache/uv"]
    }
  }
}
```

## Test plan
- [x] `pytest tests/tools/test_sandbox.py` — 20 tests pass (12 existing + 8 new covering RO/RW injection, strict mode, ordering before `--chdir`, schema validation, and camelCase alias).
- [x] `pytest tests/agent/tools/test_subagent_tools.py tests/agent/test_task_cancel.py tests/config/` — no regressions (93 passed total in the focused sweep).
- [ ] Manual smoke on Linux with `sandbox: bwrap` + a user RO bind (e.g. `/opt/conda`) to confirm the bind shows up inside the sandbox and `python` resolves.