### PR TITLE
Handle MCP tool isError results

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -141,6 +141,42 @@ def _normalize_schema_for_openai(schema: Any) -> dict[str, Any]:
     return normalized
 
 
+def _extract_mcp_text(result: Any) -> str:
+    """Extract text from a call_tool result without assuming a concrete SDK class."""
+    try:
+        from mcp import types
+    except Exception:  # pragma: no cover - defensive fallback for import-time oddities
+        types = None
+
+    parts: list[str] = []
+    for block in getattr(result, "content", []) or []:
+        if types is not None and isinstance(block, types.TextContent):
+            parts.append(block.text)
+        elif hasattr(block, "text"):
+            parts.append(str(getattr(block, "text")))
+        else:
+            parts.append(str(block))
+    return "\n".join(parts) or "(no output)"
+
+
+def _is_mcp_error_result(result: Any) -> bool:
+    """MCP SDK models use isError; tolerate snake_case for tests/compat."""
+    return bool(getattr(result, "isError", False) or getattr(result, "is_error", False))
+
+
+def _as_runner_error(message: str) -> str:
+    """Return a tool failure string that nanobot runner/registry classify as error."""
+    text = message.strip() or "MCP tool call failed"
+    if text.startswith("Error"):
+        return text
+    if text.startswith("### Error"):
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        for line in lines:
+            if line.startswith("Error"):
+                return line
+    return f"Error: {text}"
+
+
 class MCPToolWrapper(Tool):
     """Wraps a single MCP server tool as a nanobot Tool."""
 
@@ -166,8 +202,6 @@ class MCPToolWrapper(Tool):
         return self._parameters
 
     async def execute(self, **kwargs: Any) -> str:
-        from mcp import types
-
         for attempt in range(2):  # At most 1 retry
             try:
                 result = await asyncio.wait_for(
@@ -213,14 +247,11 @@ class MCPToolWrapper(Tool):
                 )
                 return f"(MCP tool call failed: {type(exc).__name__})"
             else:
-                # Success — extract result
-                parts = []
-                for block in result.content:
-                    if isinstance(block, types.TextContent):
-                        parts.append(block.text)
-                    else:
-                        parts.append(str(block))
-                return "\n".join(parts) or "(no output)"
+                text = _extract_mcp_text(result)
+                if _is_mcp_error_result(result):
+                    return _as_runner_error(text)
+
+                return text
 
         return "(MCP tool call failed)"  # Unreachable, but satisfies type checkers
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -288,6 +288,21 @@ async def test_execute_returns_text_blocks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_marks_mcp_is_error_as_runner_error() -> None:
+    async def call_tool(_name: str, arguments: dict) -> object:
+        return SimpleNamespace(
+            isError=True,
+            content=[_FakeTextContent("### Error\nError: server-side failure")],
+        )
+
+    wrapper = _make_wrapper(SimpleNamespace(call_tool=call_tool))
+
+    result = await wrapper.execute()
+
+    assert result == "Error: server-side failure"
+
+
+@pytest.mark.asyncio
 async def test_execute_returns_timeout_message() -> None:
     async def call_tool(_name: str, arguments: dict) -> object:
         await asyncio.sleep(1)


### PR DESCRIPTION
## Summary
- Treat MCP `CallToolResult.isError` responses as tool failures instead of normal text output.
- Extract MCP text blocks through a helper that tolerates SDK/model shape differences.
- Preserve the existing successful-result behavior for non-error MCP tool calls.

## Why
Some MCP servers return tool-level failures as `CallToolResult(isError=True)` rather than throwing exceptions. Without checking that flag, nanobot passes the error text back as a successful tool result, so downstream runners and models can misclassify the failure.

## Validation
- `python -m pytest tests/tools/test_mcp_tool.py -q`
- `python -m ruff check nanobot/agent/tools/mcp.py tests/tools/test_mcp_tool.py`
- `git diff --check -- nanobot/agent/tools/mcp.py tests/tools/test_mcp_tool.py`
