### PR TITLE
fix(provider): specify thinking_style for MIMO

### DIFF
--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -375,6 +375,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="Xiaomi MIMO",
         backend="openai_compat",
         default_api_base="https://api.xiaomimimo.com/v1",
+        thinking_style="thinking_type",
     ),
     # LongCat: OpenAI-compatible API
     ProviderSpec(


### PR DESCRIPTION
  ## Summary

  - Set `thinking_style="thinking_type"` for the MIMO provider to correctly enable extended thinking.

  ## Background

  MIMO uses `thinking_type` as its thinking parameter style. Without this explicit setting, the default empty string
  causes the thinking-parameter injection to be skipped entirely, meaning `reasoningEffort` has no effect on MIMO
  requests. The existing `"thinking_type"` mapping already produces the correct wire format (`{"thinking": {"type":
  "enabled"/"disabled"}}`).