### PR TITLE
fix(webui): require token_issue_secret for LAN bootstrap with frontend auth

### DIFF
--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -128,6 +128,17 @@ class WebSocketConfig(Base):
             raise ValueError("token_issue_path must differ from path (the WebSocket upgrade path)")
         return self
 
+    @model_validator(mode="after")
+    def wildcard_host_requires_auth(self) -> Self:
+        if self.host not in ("0.0.0.0", "::"):
+            return self
+        if self.token.strip() or self.token_issue_secret.strip():
+            return self
+        raise ValueError(
+            "host is 0.0.0.0 (all interfaces) but neither token nor "
+            "token_issue_secret is set — set one to prevent unauthenticated access"
+        )
+
 
 def _http_json_response(data: dict[str, Any], *, status: int = 200) -> Response:
     body = json.dumps(data, ensure_ascii=False).encode("utf-8")
@@ -607,10 +618,10 @@ class WebSocketChannel(BaseChannel):
                 self._api_tokens.pop(token_key, None)
 
     def _handle_webui_bootstrap(self, connection: Any, request: Any) -> Response:
-        # When token_issue_secret is configured, validate it regardless of
-        # source IP.  This secures deployments behind a reverse proxy (e.g.
-        # nginx) where all connections appear as localhost.
-        secret = self.config.token_issue_secret.strip()
+        # When a secret is configured (token_issue_secret or static token),
+        # validate it regardless of source IP.  This secures deployments
+        # behind a reverse proxy where all connections appear as localhost.
+        secret = self.config.token_issue_secret.strip() or self.config.token.strip()
         if secret:
             if not _issue_route_secret_matches(request.headers, secret):
                 return _http_error(401, "Unauthorized")

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -531,9 +531,9 @@ class WebSocketChannel(BaseChannel):
             if got == issue_expected:
                 return self._handle_token_issue_http(connection, request)
 
-        # 2. WebUI bootstrap: localhost-only, mints tokens for the embedded UI.
+        # 2. WebUI bootstrap: mints tokens for the embedded UI.
         if got == "/webui/bootstrap":
-            return self._handle_webui_bootstrap(connection)
+            return self._handle_webui_bootstrap(connection, request)
 
         # 3. REST surface for the embedded UI.
         if got == "/api/sessions":
@@ -606,10 +606,16 @@ class WebSocketChannel(BaseChannel):
             if now > expiry:
                 self._api_tokens.pop(token_key, None)
 
-    def _handle_webui_bootstrap(self, connection: Any) -> Response:
-        if self.config.host not in ("0.0.0.0", "::") and not _is_localhost(
-            connection,
-        ):
+    def _handle_webui_bootstrap(self, connection: Any, request: Any) -> Response:
+        # When token_issue_secret is configured, validate it regardless of
+        # source IP.  This secures deployments behind a reverse proxy (e.g.
+        # nginx) where all connections appear as localhost.
+        secret = self.config.token_issue_secret.strip()
+        if secret:
+            if not _issue_route_secret_matches(request.headers, secret):
+                return _http_error(401, "Unauthorized")
+        elif not _is_localhost(connection):
+            # No secret configured: only allow localhost (local dev mode).
             return _http_error(403, "webui bootstrap is localhost-only")
         # Cap outstanding tokens to avoid runaway growth from a misbehaving client.
         self._purge_expired_issued_tokens()

--- a/tests/channels/test_websocket_http_routes.py
+++ b/tests/channels/test_websocket_http_routes.py
@@ -405,13 +405,52 @@ _LOCAL = _FakeConn(("127.0.0.1", 12345))
 _NO_HEADERS = _FakeReq()
 
 
-def test_bootstrap_rejects_non_localhost_without_secret(bus: MagicMock) -> None:
-    channel = _ch(bus, host="0.0.0.0")
-    resp = channel._handle_webui_bootstrap(_REMOTE, _NO_HEADERS)
-    assert resp.status_code == 403
+def test_wildcard_host_without_auth_raises_on_startup(bus: MagicMock) -> None:
+    import pytest
+    from pydantic_core import ValidationError
+
+    with pytest.raises(ValidationError, match="token"):
+        _ch(bus, host="0.0.0.0")
 
 
-def test_bootstrap_allows_localhost_without_secret(bus: MagicMock) -> None:
+def test_wildcard_host_with_token_is_valid(bus: MagicMock) -> None:
+    channel = _ch(bus, host="0.0.0.0", token="my-token")
+    assert channel.config.host == "0.0.0.0"
+
+
+def test_wildcard_host_with_secret_is_valid(bus: MagicMock) -> None:
+    channel = _ch(bus, host="0.0.0.0", tokenIssueSecret="s3cret")
+    assert channel.config.host == "0.0.0.0"
+
+
+def test_wildcard_ipv6_without_auth_raises(bus: MagicMock) -> None:
+    import pytest
+    from pydantic_core import ValidationError
+
+    with pytest.raises(ValidationError, match="token"):
+        _ch(bus, host="::")
+
+
+def test_wildcard_ipv6_with_secret_is_valid(bus: MagicMock) -> None:
+    channel = _ch(bus, host="::", tokenIssueSecret="s3cret")
+    resp = channel._handle_webui_bootstrap(
+        _REMOTE, _FakeReq({"X-Nanobot-Auth": "s3cret"})
+    )
+    assert resp.status_code == 200
+
+
+def test_bootstrap_accepts_static_token_as_secret(bus: MagicMock) -> None:
+    """When only token (not token_issue_secret) is set, bootstrap accepts it."""
+    channel = _ch(bus, host="0.0.0.0", token="static-tok")
+    resp = channel._handle_webui_bootstrap(
+        _REMOTE, _FakeReq({"Authorization": "Bearer static-tok"})
+    )
+    assert resp.status_code == 200
+    body = json.loads(resp.body)
+    assert body["token"].startswith("nbwt_")
+
+
+def test_localhost_without_auth_is_valid(bus: MagicMock) -> None:
     channel = _ch(bus, host="127.0.0.1")
     resp = channel._handle_webui_bootstrap(_LOCAL, _NO_HEADERS)
     assert resp.status_code == 200

--- a/tests/channels/test_websocket_http_routes.py
+++ b/tests/channels/test_websocket_http_routes.py
@@ -393,27 +393,58 @@ class _FakeConn:
         return Response(status=status, body=body.encode())
 
 
-def test_bootstrap_rejects_non_localhost_by_default(bus: MagicMock) -> None:
-    channel = _ch(bus, host="127.0.0.1")
-    conn = _FakeConn(("192.168.1.5", 12345))
-    resp = channel._handle_webui_bootstrap(conn)
+class _FakeReq:
+    """Minimal request stub with configurable headers."""
+
+    def __init__(self, headers: dict[str, str] | None = None):
+        self.headers = headers or {}
+
+
+_REMOTE = _FakeConn(("192.168.1.5", 12345))
+_LOCAL = _FakeConn(("127.0.0.1", 12345))
+_NO_HEADERS = _FakeReq()
+
+
+def test_bootstrap_rejects_non_localhost_without_secret(bus: MagicMock) -> None:
+    channel = _ch(bus, host="0.0.0.0")
+    resp = channel._handle_webui_bootstrap(_REMOTE, _NO_HEADERS)
     assert resp.status_code == 403
 
 
-def test_bootstrap_allows_non_localhost_when_host_is_wildcard(bus: MagicMock) -> None:
-    channel = _ch(bus, host="0.0.0.0")
-    conn = _FakeConn(("192.168.1.5", 12345))
-    resp = channel._handle_webui_bootstrap(conn)
+def test_bootstrap_allows_localhost_without_secret(bus: MagicMock) -> None:
+    channel = _ch(bus, host="127.0.0.1")
+    resp = channel._handle_webui_bootstrap(_LOCAL, _NO_HEADERS)
+    assert resp.status_code == 200
+
+
+def test_bootstrap_rejects_wrong_secret(bus: MagicMock) -> None:
+    channel = _ch(bus, host="0.0.0.0", tokenIssueSecret="correct")
+    resp = channel._handle_webui_bootstrap(
+        _REMOTE, _FakeReq({"Authorization": "Bearer wrong"})
+    )
+    assert resp.status_code == 401
+
+
+def test_bootstrap_accepts_remote_with_valid_secret(bus: MagicMock) -> None:
+    channel = _ch(bus, host="0.0.0.0", tokenIssueSecret="s3cret")
+    resp = channel._handle_webui_bootstrap(
+        _REMOTE, _FakeReq({"Authorization": "Bearer s3cret"})
+    )
     assert resp.status_code == 200
     body = json.loads(resp.body)
     assert body["token"].startswith("nbwt_")
-    assert body["ws_path"] == "/"
 
 
-def test_bootstrap_allows_non_localhost_when_host_is_ipv6_wildcard(
-    bus: MagicMock,
-) -> None:
-    channel = _ch(bus, host="::")
-    conn = _FakeConn(("192.168.1.5", 12345))
-    resp = channel._handle_webui_bootstrap(conn)
+def test_bootstrap_accepts_x_nanobot_auth_header(bus: MagicMock) -> None:
+    channel = _ch(bus, host="0.0.0.0", tokenIssueSecret="s3cret")
+    resp = channel._handle_webui_bootstrap(
+        _REMOTE, _FakeReq({"X-Nanobot-Auth": "s3cret"})
+    )
     assert resp.status_code == 200
+
+
+def test_bootstrap_secret_also_enforced_on_localhost(bus: MagicMock) -> None:
+    """When secret is set, even localhost must provide it (reverse-proxy safety)."""
+    channel = _ch(bus, host="0.0.0.0", tokenIssueSecret="s3cret")
+    resp = channel._handle_webui_bootstrap(_LOCAL, _NO_HEADERS)
+    assert resp.status_code == 401

--- a/webui/README.md
+++ b/webui/README.md
@@ -74,7 +74,7 @@ NANOBOT_API_URL=http://127.0.0.1:9000 bun run dev
 
 ### Access from another device (LAN)
 
-To use the webui from another device on the same network, set `host` to `"0.0.0.0"` and configure `token_issue_secret` in `~/.nanobot/config.json`:
+To use the webui from another device on the same network, set `host` to `"0.0.0.0"` and configure a `token` or `tokenIssueSecret` in `~/.nanobot/config.json`:
 
 ```json
 {
@@ -89,9 +89,9 @@ To use the webui from another device on the same network, set `host` to `"0.0.0.
 }
 ```
 
-Then open `http://<your-ip>:8765` on the other device. The bootstrap endpoint requires the secret via the `Authorization: Bearer <secret>` header (or `X-Nanobot-Auth`). Without a configured secret, only localhost connections can bootstrap.
+The gateway will refuse to start if `host` is `"0.0.0.0"` and neither `token` nor `tokenIssueSecret` is set.
 
-> **Note:** This exposes the gateway to all interfaces. Always set `tokenIssueSecret` on non-local networks.
+Then open `http://<your-ip>:8765` on the other device. The webui will show an authentication form where you enter the secret. It is saved in your browser so you only need to enter it once.
 
 ## Build for packaged runtime
 

--- a/webui/README.md
+++ b/webui/README.md
@@ -74,7 +74,7 @@ NANOBOT_API_URL=http://127.0.0.1:9000 bun run dev
 
 ### Access from another device (LAN)
 
-To use the webui from another device on the same network, set `host` to `"0.0.0.0"` in `~/.nanobot/config.json`:
+To use the webui from another device on the same network, set `host` to `"0.0.0.0"` and configure `token_issue_secret` in `~/.nanobot/config.json`:
 
 ```json
 {
@@ -82,15 +82,16 @@ To use the webui from another device on the same network, set `host` to `"0.0.0.
     "websocket": {
       "enabled": true,
       "host": "0.0.0.0",
-      "port": 8765
+      "port": 8765,
+      "tokenIssueSecret": "your-secret-here"
     }
   }
 }
 ```
 
-Then open `http://<your-ip>:8765` on the other device. When `host` is `"0.0.0.0"`, the bootstrap endpoint accepts requests from any source instead of restricting to localhost.
+Then open `http://<your-ip>:8765` on the other device. The bootstrap endpoint requires the secret via the `Authorization: Bearer <secret>` header (or `X-Nanobot-Auth`). Without a configured secret, only localhost connections can bootstrap.
 
-> **Note:** This exposes the gateway to all interfaces. Only use on trusted networks.
+> **Note:** This exposes the gateway to all interfaces. Always set `tokenIssueSecret` on non-local networks.
 
 ## Build for packaged runtime
 

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -9,14 +9,23 @@ import { preloadMarkdownText } from "@/components/MarkdownText";
 import { useSessions } from "@/hooks/useSessions";
 import { useTheme } from "@/hooks/useTheme";
 import { cn } from "@/lib/utils";
-import { deriveWsUrl, fetchBootstrap } from "@/lib/bootstrap";
+import {
+  clearSavedSecret,
+  deriveWsUrl,
+  fetchBootstrap,
+  loadSavedSecret,
+  saveSecret,
+} from "@/lib/bootstrap";
 import { NanobotClient } from "@/lib/nanobot-client";
 import { ClientProvider } from "@/providers/ClientProvider";
 import type { ChatSummary } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 type BootState =
   | { status: "loading" }
   | { status: "error"; message: string }
+  | { status: "auth"; failed?: boolean }
   | {
       status: "ready";
       client: NanobotClient;
@@ -27,6 +36,60 @@ type BootState =
 const SIDEBAR_STORAGE_KEY = "nanobot-webui.sidebar";
 const SIDEBAR_WIDTH = 272;
 type ShellView = "chat" | "settings";
+
+function AuthForm({
+  failed,
+  onSecret,
+}: {
+  failed: boolean;
+  onSecret: (secret: string) => void;
+}) {
+  const { t } = useTranslation();
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const secret = value.trim();
+    if (!secret) return;
+    setSubmitting(true);
+    onSecret(secret);
+  };
+
+  return (
+    <div className="flex h-full w-full items-center justify-center px-6">
+      <form
+        onSubmit={handleSubmit}
+        className="flex w-full max-w-sm flex-col gap-4"
+      >
+        <div className="flex flex-col items-center gap-1 text-center">
+          <p className="text-lg font-semibold">{t("app.auth.title")}</p>
+          <p className="text-sm text-muted-foreground">{t("app.auth.hint")}</p>
+        </div>
+        {failed && (
+          <p className="text-center text-sm text-destructive">
+            {t("app.auth.invalid")}
+          </p>
+        )}
+        <Input
+          type="password"
+          placeholder={t("app.auth.placeholder")}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          disabled={submitting}
+          autoFocus
+        />
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={!value.trim() || submitting}
+        >
+          {t("app.auth.submit")}
+        </Button>
+      </form>
+    </div>
+  );
+}
 
 function readSidebarOpen(): boolean {
   if (typeof window === "undefined") return true;
@@ -43,40 +106,55 @@ export default function App() {
   const { t } = useTranslation();
   const [state, setState] = useState<BootState>({ status: "loading" });
 
+  const bootstrapWithSecret = useCallback(
+    (secret: string) => {
+      let cancelled = false;
+      (async () => {
+        setState({ status: "loading" });
+        try {
+          const boot = await fetchBootstrap("", secret);
+          if (cancelled) return;
+          if (secret) saveSecret(secret);
+          const url = deriveWsUrl(boot.ws_path, boot.token);
+          const client = new NanobotClient({
+            url,
+            onReauth: async () => {
+              try {
+                const refreshed = await fetchBootstrap("", secret);
+                return deriveWsUrl(refreshed.ws_path, refreshed.token);
+              } catch {
+                return null;
+              }
+            },
+          });
+          client.connect();
+          setState({
+            status: "ready",
+            client,
+            token: boot.token,
+            modelName: boot.model_name ?? null,
+          });
+        } catch (e) {
+          if (cancelled) return;
+          const msg = (e as Error).message;
+          if (msg.includes("HTTP 401") || msg.includes("HTTP 403")) {
+            setState({ status: "auth", failed: true });
+          } else {
+            setState({ status: "error", message: msg });
+          }
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
+    },
+    [],
+  );
+
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const boot = await fetchBootstrap();
-        if (cancelled) return;
-        const url = deriveWsUrl(boot.ws_path, boot.token);
-        const client = new NanobotClient({
-          url,
-          onReauth: async () => {
-            try {
-              const refreshed = await fetchBootstrap();
-              return deriveWsUrl(refreshed.ws_path, refreshed.token);
-            } catch {
-              return null;
-            }
-          },
-        });
-        client.connect();
-        setState({
-          status: "ready",
-          client,
-          token: boot.token,
-          modelName: boot.model_name ?? null,
-        });
-      } catch (e) {
-        if (cancelled) return;
-        setState({ status: "error", message: (e as Error).message });
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    const saved = loadSavedSecret();
+    return bootstrapWithSecret(saved);
+  }, [bootstrapWithSecret]);
 
   useEffect(() => {
     const warm = () => preloadMarkdownText();
@@ -110,6 +188,14 @@ export default function App() {
       </div>
     );
   }
+  if (state.status === "auth") {
+    return (
+      <AuthForm
+        failed={!!state.failed}
+        onSecret={(s) => bootstrapWithSecret(s)}
+      />
+    );
+  }
   if (state.status === "error") {
     return (
       <div className="flex h-full w-full items-center justify-center px-4 text-center">
@@ -130,18 +216,26 @@ export default function App() {
     );
   };
 
+  const handleLogout = () => {
+    if (state.status === "ready") {
+      state.client.close();
+    }
+    clearSavedSecret();
+    setState({ status: "auth" });
+  };
+
   return (
     <ClientProvider
       client={state.client}
       token={state.token}
       modelName={state.modelName}
     >
-      <Shell onModelNameChange={handleModelNameChange} />
+      <Shell onModelNameChange={handleModelNameChange} onLogout={handleLogout} />
     </ClientProvider>
   );
 }
 
-function Shell({ onModelNameChange }: { onModelNameChange: (modelName: string | null) => void }) {
+function Shell({ onModelNameChange, onLogout }: { onModelNameChange: (modelName: string | null) => void; onLogout: () => void }) {
   const { t, i18n } = useTranslation();
   const { theme, toggle } = useTheme();
   const { sessions, loading, refresh, createChat, deleteChat } = useSessions();
@@ -319,6 +413,7 @@ function Shell({ onModelNameChange }: { onModelNameChange: (modelName: string | 
             onToggleTheme={toggle}
             onBackToChat={() => setView("chat")}
             onModelNameChange={onModelNameChange}
+            onLogout={onLogout}
           />
         ) : (
           <ThreadShell

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronLeft, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { Button } from "@/components/ui/button";
@@ -14,11 +15,13 @@ interface SettingsViewProps {
   onToggleTheme: () => void;
   onBackToChat: () => void;
   onModelNameChange: (modelName: string | null) => void;
+  onLogout?: () => void;
 }
 
 export function SettingsView({
   onBackToChat,
   onModelNameChange,
+  onLogout,
 }: SettingsViewProps) {
   const { token } = useClient();
   const [settings, setSettings] = useState<SettingsPayload | null>(null);
@@ -115,6 +118,7 @@ export function SettingsView({
             dirty={dirty}
             saving={saving}
             onSave={save}
+            onLogout={onLogout}
           />
         ) : null}
       </main>
@@ -129,6 +133,7 @@ function SettingsSection({
   dirty,
   saving,
   onSave,
+  onLogout,
 }: {
   form: {
     model: string;
@@ -142,7 +147,9 @@ function SettingsSection({
   dirty: boolean;
   saving: boolean;
   onSave: () => void;
+  onLogout?: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-7">
       <section>
@@ -192,6 +199,19 @@ function SettingsSection({
           </SettingsRow>
         </SettingsGroup>
       </section>
+
+      {onLogout && (
+        <section>
+          <h2 className="mb-2 px-2 text-xs font-medium text-muted-foreground">{t("app.account.section")}</h2>
+          <SettingsGroup>
+            <SettingsRow title={t("app.account.logoutHint")}>
+              <Button size="sm" variant="outline" onClick={onLogout}>
+                {t("app.account.logout")}
+              </Button>
+            </SettingsRow>
+          </SettingsGroup>
+        </section>
+      )}
     </div>
   );
 }

--- a/webui/src/i18n/locales/en/common.json
+++ b/webui/src/i18n/locales/en/common.json
@@ -9,6 +9,18 @@
       "title": "Couldn't reach nanobot",
       "gatewayHint": "Make sure the gateway is running (`nanobot gateway`) and that this page is open on the same machine."
     },
+    "auth": {
+      "title": "Authentication required",
+      "hint": "Enter the secret configured as tokenIssueSecret in your gateway config.",
+      "placeholder": "Password",
+      "submit": "Connect",
+      "invalid": "Invalid password. Try again."
+    },
+    "account": {
+      "section": "Account",
+      "logoutHint": "Disconnect this browser from the gateway.",
+      "logout": "Sign out"
+    },
     "documentTitle": {
       "base": "nanobot",
       "chat": "{{title}} · nanobot"

--- a/webui/src/lib/bootstrap.ts
+++ b/webui/src/lib/bootstrap.ts
@@ -1,15 +1,51 @@
 import type { BootstrapResponse } from "./types";
 
+const SECRET_STORAGE_KEY = "nanobot-webui.bootstrap-secret";
+
+/** Read a previously saved bootstrap secret from localStorage. */
+export function loadSavedSecret(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    return window.localStorage.getItem(SECRET_STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** Persist the bootstrap secret so page reloads don't re-prompt. */
+export function saveSecret(secret: string): void {
+  try {
+    window.localStorage.setItem(SECRET_STORAGE_KEY, secret);
+  } catch {
+    // ignore storage errors (private mode, etc.)
+  }
+}
+
+/** Clear the saved bootstrap secret (sign out). */
+export function clearSavedSecret(): void {
+  try {
+    window.localStorage.removeItem(SECRET_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
 /**
  * Fetch a short-lived token + the WebSocket path from the gateway's
- * ``/webui/bootstrap`` endpoint. Localhost-only on the server side.
+ * ``/webui/bootstrap`` endpoint.
  */
 export async function fetchBootstrap(
   baseUrl: string = "",
+  secret: string = "",
 ): Promise<BootstrapResponse> {
+  const headers: Record<string, string> = {};
+  if (secret) {
+    headers["X-Nanobot-Auth"] = secret;
+  }
   const res = await fetch(`${baseUrl}/webui/bootstrap`, {
     method: "GET",
     credentials: "same-origin",
+    headers,
   });
   if (!res.ok) {
     throw new Error(`bootstrap failed: HTTP ${res.status}`);

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -46,6 +46,9 @@ vi.mock("@/lib/bootstrap", () => ({
     expires_in: 300,
   }),
   deriveWsUrl: vi.fn(() => "ws://test"),
+  loadSavedSecret: vi.fn(() => ""),
+  saveSecret: vi.fn(),
+  clearSavedSecret: vi.fn(),
 }));
 
 vi.mock("@/lib/nanobot-client", () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #3656 which relaxed the bootstrap localhost check for `host: "0.0.0.0"` but did not require any authentication, allowing any LAN device to obtain tokens without credentials.

### Backend (`nanobot/channels/websocket.py`)

- **Startup validation**: `host: "0.0.0.0"` / `"::"` requires `token` or `token_issue_secret` — gateway refuses to start without one
- **Bootstrap auth**: validates `token_issue_secret` or `token` via `Authorization: Bearer` / `X-Nanobot-Auth` header when configured (handles reverse-proxy scenarios where all connections appear as localhost)
- **Localhost fallback**: no secret configured → only localhost can bootstrap (local dev mode, unchanged)

### Frontend (`webui/src/`)

- `AuthForm` component shown when bootstrap returns 401/403
- Secret persisted in `localStorage`, reused on reload/reconnect
- Wrong password shows error message ("Invalid password. Try again.")
- Logout button in Settings → Account clears secret and disconnects
- Mobile-friendly layout (full-width button, larger padding)
- All strings i18n'd

### Docs (`webui/README.md`)

- LAN access section with configuration example and auth requirement

## Test plan

- [x] Localhost without secret → webui loads as before (no auth form)
- [x] `host: "0.0.0.0"` without auth → gateway refuses to start
- [x] `host: "0.0.0.0"` with `token` only → bootstrap accepts it
- [x] `host: "0.0.0.0"` with `tokenIssueSecret` → password input required
- [x] Wrong password → error message shown, stays on auth form
- [x] Valid password → connects, secret persisted
- [x] Page reload → auto-reconnects with saved secret
- [x] Sign out → clears secret, returns to auth form
- [x] Backend: 22 tests pass (11 new: startup validation, bootstrap auth, IPv6 wildcard)
- [x] Frontend: 60 tests pass