### PR TITLE
fix(weixin): raise exceptions on message send failure to prevent silent loss

### DIFF
--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -940,12 +940,8 @@ class WeixinChannel(BaseChannel):
 
     async def send(self, msg: OutboundMessage) -> None:
         if not self._client or not self._token:
-            self.logger.warning("client not initialized or not authenticated")
-            return
-        try:
-            self._assert_session_active()
-        except RuntimeError:
-            return
+            raise RuntimeError("WeChat client not initialized or not authenticated")
+        self._assert_session_active()
 
         is_progress = bool((msg.metadata or {}).get("_progress", False))
         if not is_progress:
@@ -954,11 +950,9 @@ class WeixinChannel(BaseChannel):
         content = msg.content.strip()
         ctx_token = self._context_tokens.get(msg.chat_id, "")
         if not ctx_token:
-            self.logger.warning(
-                "no context_token for chat_id={}, cannot send",
-                msg.chat_id,
+            raise RuntimeError(
+                f"No context_token for chat_id={msg.chat_id}, cannot send"
             )
-            return
 
         typing_ticket = ""
         with suppress(Exception):
@@ -1128,10 +1122,8 @@ class WeixinChannel(BaseChannel):
         data = await self._api_post("ilink/bot/sendmessage", body)
         errcode = data.get("errcode", 0)
         if errcode and errcode != 0:
-            self.logger.warning(
-                "send error (code {}): {}",
-                errcode,
-                data.get("errmsg", ""),
+            raise RuntimeError(
+                f"WeChat send text error (code {errcode}): {data.get('errmsg', '')}"
             )
 
     async def _send_media_file(

--- a/nanobot/channels/weixin.py
+++ b/nanobot/channels/weixin.py
@@ -951,7 +951,7 @@ class WeixinChannel(BaseChannel):
         ctx_token = self._context_tokens.get(msg.chat_id, "")
         if not ctx_token:
             raise RuntimeError(
-                f"No context_token for chat_id={msg.chat_id}, cannot send"
+                f"WeChat context_token missing for chat_id={msg.chat_id}, cannot send"
             )
 
         typing_ticket = ""

--- a/tests/channels/test_weixin_channel.py
+++ b/tests/channels/test_weixin_channel.py
@@ -319,21 +319,22 @@ async def test_process_message_does_not_fallback_when_top_level_media_exists_but
 
 
 @pytest.mark.asyncio
-async def test_send_without_context_token_does_not_send_text() -> None:
+async def test_send_without_context_token_raises() -> None:
     channel, _bus = _make_channel()
     channel._client = object()
     channel._token = "token"
     channel._send_text = AsyncMock()
 
-    await channel.send(
-        type("Msg", (), {"chat_id": "unknown-user", "content": "pong", "media": [], "metadata": {}})()
-    )
+    with pytest.raises(RuntimeError, match="No context_token"):
+        await channel.send(
+            type("Msg", (), {"chat_id": "unknown-user", "content": "pong", "media": [], "metadata": {}})()
+        )
 
     channel._send_text.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_send_does_not_send_when_session_is_paused() -> None:
+async def test_send_raises_when_session_is_paused() -> None:
     channel, _bus = _make_channel()
     channel._client = object()
     channel._token = "token"
@@ -341,9 +342,10 @@ async def test_send_does_not_send_when_session_is_paused() -> None:
     channel._pause_session(60)
     channel._send_text = AsyncMock()
 
-    await channel.send(
-        type("Msg", (), {"chat_id": "wx-user", "content": "pong", "media": [], "metadata": {}})()
-    )
+    with pytest.raises(RuntimeError, match="session paused"):
+        await channel.send(
+            type("Msg", (), {"chat_id": "wx-user", "content": "pong", "media": [], "metadata": {}})()
+        )
 
     channel._send_text.assert_not_awaited()
 
@@ -1213,3 +1215,38 @@ async def test_send_media_network_error_does_not_double_api_calls() -> None:
     # _send_media_file called once, _send_text never called
     channel._send_media_file.assert_awaited_once()
     channel._send_text.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _send_text raising on API errors (previously silently swallowed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_text_raises_on_api_error() -> None:
+    """_send_text must raise RuntimeError when the API returns a non-zero errcode,
+    matching _send_media_file behavior. This ensures ChannelManager can retry."""
+    channel, _bus = _make_channel()
+    channel._client = httpx.AsyncClient()
+    channel._token = "token"
+    channel._api_post = AsyncMock(
+        return_value={"errcode": -14, "errmsg": "session expired"}
+    )
+
+    with pytest.raises(RuntimeError, match="WeChat send text error.*-14"):
+        await channel._send_text("wx-user", "hello", "ctx-expired")
+
+    channel._api_post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_text_succeeds_on_zero_errcode() -> None:
+    """_send_text must NOT raise when errcode is 0."""
+    channel, _bus = _make_channel()
+    channel._client = httpx.AsyncClient()
+    channel._token = "token"
+    channel._api_post = AsyncMock(return_value={"errcode": 0})
+
+    await channel._send_text("wx-user", "hello", "ctx-ok")
+
+    channel._api_post.assert_awaited_once()

--- a/tests/channels/test_weixin_channel.py
+++ b/tests/channels/test_weixin_channel.py
@@ -325,7 +325,7 @@ async def test_send_without_context_token_raises() -> None:
     channel._token = "token"
     channel._send_text = AsyncMock()
 
-    with pytest.raises(RuntimeError, match="No context_token"):
+    with pytest.raises(RuntimeError, match="context_token missing"):
         await channel.send(
             type("Msg", (), {"chat_id": "unknown-user", "content": "pong", "media": [], "metadata": {}})()
         )
@@ -1227,7 +1227,7 @@ async def test_send_text_raises_on_api_error() -> None:
     """_send_text must raise RuntimeError when the API returns a non-zero errcode,
     matching _send_media_file behavior. This ensures ChannelManager can retry."""
     channel, _bus = _make_channel()
-    channel._client = httpx.AsyncClient()
+    channel._client = object()
     channel._token = "token"
     channel._api_post = AsyncMock(
         return_value={"errcode": -14, "errmsg": "session expired"}
@@ -1243,7 +1243,7 @@ async def test_send_text_raises_on_api_error() -> None:
 async def test_send_text_succeeds_on_zero_errcode() -> None:
     """_send_text must NOT raise when errcode is 0."""
     channel, _bus = _make_channel()
-    channel._client = httpx.AsyncClient()
+    channel._client = object()
     channel._token = "token"
     channel._api_post = AsyncMock(return_value={"errcode": 0})
 


### PR DESCRIPTION
## Summary

WeChat channel was silently dropping messages when the API returned errors or the channel was in a degraded state. Messages would be permanently lost with no retry, and the channel would stay stuck until the user sent a new inbound message.

### Root Cause

Two compounding bugs in the outbound message pipeline:

1. **`_send_text()` swallowed API errors** — when the WeChat API returned a non-zero `errcode` (e.g., session expired, invalid token), `_send_text()` only logged a warning and returned normally. The caller (`ChannelManager._send_with_retry`) considered the send successful and never retried. This is inconsistent with `_send_media_file()`, which correctly raises on API errors.

2. **`send()` had three silent `return` paths** — when the client was uninitialized, the session was paused, or the `context_token` was missing, `send()` returned without raising an exception. This violated `BaseChannel.send()`'s contract: *"Implementations should raise on delivery failure so the channel manager can apply any retry policy in one place."*

### Why it couldn't self-recover

When `context_token` expired at the server, every subsequent `_send_text()` call received an error response but swallowed it. The channel stayed in this broken state indefinitely because there was no mechanism to detect or refresh the expired token. Only a new inbound message (processed by `_process_message`) would cache a fresh `context_token`, at which point sends would start working again.

### Fix

- Changed `_send_text()` to raise `RuntimeError` on non-zero errcode, matching `_send_media_file()` behavior
- Changed all three silent `return` paths in `send()` to raise `RuntimeError`, enabling `ChannelManager._send_with_retry` to apply its retry policy

## Test plan

- [x] Updated `test_send_without_context_token_does_not_send_text` → `test_send_without_context_token_raises`
- [x] Updated `test_send_does_not_send_when_session_is_paused` → `test_send_raises_when_session_is_paused`
- [x] Added `test_send_text_raises_on_api_error` — verifies `_send_text` raises on non-zero errcode
- [x] Added `test_send_text_succeeds_on_zero_errcode` — verifies no false positives
- [x] All 48 tests pass