### PR TITLE
 fix(transcription): tolerate chat-style apiBase for Groq/OpenAI Whisper

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ruff check *)",
+      "Bash(.venv/Scripts/python.exe -m ruff check nanobot/providers/transcription.py)",
+      "Bash(.venv/Scripts/python.exe -m pytest tests/ -x -q)"
+    ]
+  }
+}

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -6,6 +6,22 @@ from pathlib import Path
 import httpx
 from loguru import logger
 
+_TRANSCRIPTIONS_PATH = "audio/transcriptions"
+
+
+def _resolve_transcription_url(api_base: str | None, default_url: str) -> str:
+    """Resolve the full transcription endpoint URL.
+
+    Accepts either a chat-style base (e.g. ``https://api.groq.com/openai/v1``)
+    or a full transcription URL already ending in ``/audio/transcriptions``.
+    """
+    if not api_base:
+        return default_url
+    base = api_base.rstrip("/")
+    if base.endswith(_TRANSCRIPTIONS_PATH):
+        return base
+    return f"{base}/{_TRANSCRIPTIONS_PATH}"
+
 
 class OpenAITranscriptionProvider:
     """Voice transcription provider using OpenAI's Whisper API."""
@@ -17,12 +33,12 @@ class OpenAITranscriptionProvider:
         language: str | None = None,
     ):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
-        self.api_url = (
-            api_base
-            or os.environ.get("OPENAI_TRANSCRIPTION_BASE_URL")
-            or "https://api.openai.com/v1/audio/transcriptions"
+        self.api_url = _resolve_transcription_url(
+            api_base or os.environ.get("OPENAI_TRANSCRIPTION_BASE_URL"),
+            "https://api.openai.com/v1/audio/transcriptions",
         )
         self.language = language or None
+        logger.debug("OpenAI transcription endpoint: {}", self.api_url)
 
     async def transcribe(self, file_path: str | Path) -> str:
         if not self.api_key:
@@ -63,8 +79,12 @@ class GroqTranscriptionProvider:
         language: str | None = None,
     ):
         self.api_key = api_key or os.environ.get("GROQ_API_KEY")
-        self.api_url = api_base or os.environ.get("GROQ_BASE_URL") or "https://api.groq.com/openai/v1/audio/transcriptions"
+        self.api_url = _resolve_transcription_url(
+            api_base or os.environ.get("GROQ_BASE_URL"),
+            "https://api.groq.com/openai/v1/audio/transcriptions",
+        )
         self.language = language or None
+        logger.debug("Groq transcription endpoint: {}", self.api_url)
 
     async def transcribe(self, file_path: str | Path) -> str:
         """


### PR DESCRIPTION
#3637 
 ## Summary
  - Normalize the transcription endpoint in `GroqTranscriptionProvider` and `OpenAITranscriptionProvider`: accept either a
  chat-style base (e.g. `https://api.groq.com/openai/v1`) or a full `/audio/transcriptions` URL.
  - Log the resolved transcription endpoint at `DEBUG` so misconfigurations don't require code edits to diagnose.

  ## Why
  Users who set `providers.groq.apiBase` for chat completions also had it picked up by transcription, which POSTed directly to the
   chat base and 404'd: