### PR TITLE
fix(api): remove enable_compression to restore real SSE streaming

### DIFF
--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -239,7 +239,6 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
         resp.content_type = "text/event-stream"
         resp.headers["Cache-Control"] = "no-cache"
         resp.headers["Connection"] = "keep-alive"
-        resp.enable_compression()
         await resp.prepare(request)
 
         chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"


### PR DESCRIPTION
The HTTP compression buffer in aiohttp held all SSE chunks until the stream ended, making streaming appear batched instead of incremental. SSE payloads are small and frequent, so compression provides negligible benefit while breaking real-time delivery.