### PR TITLE
refactor(logging): preserve tracebacks in remaining except blocks

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -616,7 +616,7 @@ async def connect_mcp_servers(
         try:
             result = await connect_single_server(name, cfg)
         except Exception as e:
-            logger.error("MCP server '{}' connection failed: {}", name, e)
+            logger.exception("MCP server '{}' connection failed: {}", name, e)
             continue
         if result is not None and result[1] is not None:
             server_stacks[result[0]] = result[1]

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -24,8 +24,7 @@ if os.environ.get("LANGFUSE_SECRET_KEY") and importlib.util.find_spec("langfuse"
     from langfuse.openai import AsyncOpenAI
 else:
     if os.environ.get("LANGFUSE_SECRET_KEY"):
-        import logging
-        logging.getLogger(__name__).warning(
+        logger.warning(
             "LANGFUSE_SECRET_KEY is set but langfuse is not installed; "
             "install with `pip install langfuse` to enable tracing"
         )

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -45,7 +45,7 @@ async def _post_transcription_with_retry(
     try:
         data = path.read_bytes()
     except OSError as e:
-        logger.error("{} transcription error: cannot read audio file: {}", provider_label, e)
+        logger.exception("{} transcription error: cannot read audio file: {}", provider_label, e)
         return ""
     headers = {"Authorization": f"Bearer {api_key}"}
 
@@ -70,7 +70,7 @@ async def _post_transcription_with_retry(
                     )
                     await asyncio.sleep(_BACKOFF_S[attempt])
                     continue
-                logger.error(
+                logger.exception(
                     "{} transcription error after {} attempts: {}",
                     provider_label,
                     _MAX_RETRIES + 1,
@@ -78,7 +78,7 @@ async def _post_transcription_with_retry(
                 )
                 return ""
             except Exception as e:
-                logger.error("{} transcription error: {}", provider_label, e)
+                logger.exception("{} transcription error: {}", provider_label, e)
                 return ""
 
             if response.status_code in _RETRYABLE_STATUS and attempt < _MAX_RETRIES:
@@ -95,13 +95,13 @@ async def _post_transcription_with_retry(
             try:
                 response.raise_for_status()
             except Exception as e:
-                logger.error("{} transcription error: {}", provider_label, e)
+                logger.exception("{} transcription error: {}", provider_label, e)
                 return ""
 
             try:
                 payload = response.json()
             except Exception as e:
-                logger.error(
+                logger.exception(
                     "{} transcription error: malformed response body: {}",
                     provider_label,
                     e,


### PR DESCRIPTION
## Summary

Follow-up to PR #3651. This PR completes the logging normalization by replacing the remaining `logger.error` calls inside `except` blocks with `logger.exception`, ensuring stack traces are preserved. It also removes the last ad-hoc stdlib `logging.getLogger` usage.

## Changes

- **`providers/transcription.py`** — 5 occurrences of `logger.error` → `logger.exception` inside `except` blocks
- **`agent/tools/mcp.py`** — 1 occurrence of `logger.error` → `logger.exception` inside `except Exception`
- **`providers/openai_compat_provider.py`** — Replace `logging.getLogger(__name__).warning(...)` with `logger.warning(...)`

## Test plan

- [x] `pytest tests/tools/test_mcp_tool.py` — 45 passed
- [x] `pytest tests/ -k transcription` — 41 passed, 2 skipped