### PR TITLE
fix: handle corrupted session files where last_consolidated exceeds message count

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,7 @@
+name: Test PR Trigger
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Workflow triggered successfully"

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -84,16 +84,6 @@ class Session:
         token budget from the tail (``max_tokens``) when provided.
         """
         unconsolidated = self.messages[self.last_consolidated:]
-        if not unconsolidated and self.last_consolidated > 0 and self.messages:
-            logger.warning(
-                "Session {} has last_consolidated {} >= len(messages) {}, resetting to 0. "
-                "This may indicate file corruption or migration issues.",
-                self.key,
-                self.last_consolidated,
-                len(self.messages),
-            )
-            self.last_consolidated = 0
-            unconsolidated = self.messages
         max_messages = max_messages if max_messages > 0 else 120
         sliced = unconsolidated[-max_messages:]
 

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -84,6 +84,16 @@ class Session:
         token budget from the tail (``max_tokens``) when provided.
         """
         unconsolidated = self.messages[self.last_consolidated:]
+        if not unconsolidated and self.last_consolidated > 0 and self.messages:
+            logger.warning(
+                "Session {} has last_consolidated {} >= len(messages) {}, resetting to 0. "
+                "This may indicate file corruption or migration issues.",
+                self.key,
+                self.last_consolidated,
+                len(self.messages),
+            )
+            self.last_consolidated = 0
+            unconsolidated = self.messages
         max_messages = max_messages if max_messages > 0 else 120
         sliced = unconsolidated[-max_messages:]
 
@@ -377,6 +387,15 @@ class SessionManager:
 
             if not messages and not metadata:
                 return None
+
+            if last_consolidated > len(messages):
+                logger.warning(
+                    "Session {} repair: last_consolidated {} > len(messages) {}, resetting to 0",
+                    key,
+                    last_consolidated,
+                    len(messages),
+                )
+                last_consolidated = 0
 
             return Session(
                 key=key,

--- a/tests/agent/test_session_atomic.py
+++ b/tests/agent/test_session_atomic.py
@@ -205,7 +205,8 @@ class TestRepairCorruptFile:
 
         session = mgr._load("test:badts")
         assert session is not None
-        assert session.last_consolidated == 5
+        # last_consolidated=5 > len(messages)=1, repair resets to 0
+        assert session.last_consolidated == 0
         assert isinstance(session.created_at, datetime)
 
     def test_read_session_file_repairs_corrupt_jsonl(self, tmp_path: Path):


### PR DESCRIPTION
When last_consolidated exceeds the actual message count in session files, the bot loses all conversation history. This adds a sanity check to reset last_consolidated to 0 when this happens.