### PR TITLE
fix(agent): centralize LLM concurrency gate to throttle background tasks

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-import os
 import time
-from contextlib import AsyncExitStack, nullcontext, suppress
+from contextlib import AsyncExitStack, suppress
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -257,11 +257,6 @@ class AgentLoop:
         # When a session has an active task, new messages for that session
         # are routed here instead of creating a new task.
         self._pending_queues: dict[str, asyncio.Queue] = {}
-        # NANOBOT_MAX_CONCURRENT_REQUESTS: <=0 means unlimited; default 3.
-        _max = int(os.environ.get("NANOBOT_MAX_CONCURRENT_REQUESTS", "3"))
-        self._concurrency_gate: asyncio.Semaphore | None = (
-            asyncio.Semaphore(_max) if _max > 0 else None
-        )
         self.consolidator = Consolidator(
             store=self.context.memory,
             provider=provider,
@@ -871,7 +866,6 @@ class AgentLoop:
         if session_key != msg.session_key:
             msg = dataclasses.replace(msg, session_key_override=session_key)
         lock = self._session_locks.setdefault(session_key, asyncio.Lock())
-        gate = self._concurrency_gate or nullcontext()
 
         # Register a pending queue so follow-up messages for this session are
         # routed here (mid-turn injection) instead of spawning a new task.
@@ -879,7 +873,7 @@ class AgentLoop:
         self._pending_queues[session_key] = pending
 
         try:
-            async with lock, gate:
+            async with lock:
                 try:
                     on_stream = on_stream_end = None
                     if msg.metadata.get("_wants_stream"):

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -5,8 +5,8 @@ import json
 import os
 import re
 from abc import ABC, abstractmethod
-from contextlib import nullcontext, suppress
 from collections.abc import Awaitable, Callable
+from contextlib import nullcontext, suppress
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -2,9 +2,10 @@
 
 import asyncio
 import json
+import os
 import re
 from abc import ABC, abstractmethod
-from contextlib import suppress
+from contextlib import nullcontext, suppress
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -167,6 +168,18 @@ class LLMProvider(ABC):
         self.api_key = api_key
         self.api_base = api_base
         self.generation: GenerationSettings = GenerationSettings()
+
+        # Shared concurrency gate for all LLM calls from this provider instance.
+        # NANOBOT_MAX_CONCURRENT_REQUESTS: <=0 means unlimited; default 3.
+        # Local models (Ollama, vLLM) often require serialization (MAX=1).
+        try:
+            raw_max = os.environ.get("NANOBOT_MAX_CONCURRENT_REQUESTS", "3")
+            _max = int(raw_max)
+        except (ValueError, TypeError):
+            _max = 3
+        self._concurrency_gate: asyncio.Semaphore | None = (
+            asyncio.Semaphore(_max) if _max > 0 else None
+        )
 
     @staticmethod
     def _sanitize_empty_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -713,7 +726,8 @@ class LLMProvider(ABC):
         identical_error_count = 0
         while True:
             attempt += 1
-            response = await call(**kw)
+            async with (self._concurrency_gate or nullcontext()):
+                response = await call(**kw)
             if response.finish_reason != "error":
                 return response
             last_response = response

--- a/tests/providers/test_concurrency.py
+++ b/tests/providers/test_concurrency.py
@@ -1,0 +1,62 @@
+import asyncio
+import os
+
+import pytest
+
+from nanobot.providers.base import LLMProvider, LLMResponse
+
+
+class MockProvider(LLMProvider):
+    async def chat(self, messages, **kwargs):
+        # Simulate some work
+        await asyncio.sleep(0.1)
+        return LLMResponse(content="ok")
+
+    def get_default_model(self):
+        return "mock"
+
+@pytest.mark.asyncio
+async def test_llm_provider_concurrency_gate():
+    # Set MAX_CONCURRENT_REQUESTS to 1 for testing
+    from unittest.mock import patch
+    with patch.dict(os.environ, {"NANOBOT_MAX_CONCURRENT_REQUESTS": "1"}):
+        provider = MockProvider()
+
+        start_time = asyncio.get_event_loop().time()
+
+        # Run 3 requests concurrently
+        responses = await asyncio.gather(
+            provider.chat_with_retry(messages=[{"role": "user", "content": "1"}]),
+            provider.chat_with_retry(messages=[{"role": "user", "content": "2"}]),
+            provider.chat_with_retry(messages=[{"role": "user", "content": "3"}]),
+        )
+
+        end_time = asyncio.get_event_loop().time()
+        duration = end_time - start_time
+
+        # With gate=1 and each taking 0.1s, total should be at least 0.3s
+        assert duration >= 0.3
+        assert all(r.content == "ok" for r in responses)
+
+@pytest.mark.asyncio
+async def test_llm_provider_no_gate():
+    # Set MAX_CONCURRENT_REQUESTS to 0 (unlimited)
+    from unittest.mock import patch
+    with patch.dict(os.environ, {"NANOBOT_MAX_CONCURRENT_REQUESTS": "0"}):
+        provider = MockProvider()
+
+        start_time = asyncio.get_event_loop().time()
+
+        # Run 3 requests concurrently
+        responses = await asyncio.gather(
+            provider.chat_with_retry(messages=[{"role": "user", "content": "1"}]),
+            provider.chat_with_retry(messages=[{"role": "user", "content": "2"}]),
+            provider.chat_with_retry(messages=[{"role": "user", "content": "3"}]),
+        )
+
+        end_time = asyncio.get_event_loop().time()
+        duration = end_time - start_time
+
+        # With gate=0, they should run in parallel, total ~0.1s
+        assert duration < 0.2
+        assert all(r.content == "ok" for r in responses)


### PR DESCRIPTION
## Description
Background tasks like `heartbeat`, `auto-compact`, and `dream` were previously bypassing the `AgentLoop`
concurrency gate. This caused multiple concurrent requests to local LLM endpoints (e.g., Ollama, vLLM), leading to
connection errors or timeouts when these tasks triggered simultaneously.

This PR centralizes the concurrency gate logic into the `LLMProvider` base class. By doing so, all LLM calls
across the framework now respect the `NANOBOT_MAX_CONCURRENT_REQUESTS` setting, ensuring stability when using
local models.

## Changes
- Moved `_concurrency_gate` (asyncio.Semaphore) from `AgentLoop` to `LLMProvider`.
- Wrapped `LLMProvider._run_with_retry` with the concurrency gate.
- Removed redundant semaphore logic from `AgentLoop`.

## Verification
- Added a unit test `tests/providers/test_concurrency.py` to verify the provider-level gate.
- Verified that existing agent tests (`test_stop_preserves_context.py`) still pass.