### PR TITLE
Guard repeated identical local tool calls in a single turn

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -33,6 +33,7 @@ from nanobot.utils.runtime import (
     ensure_nonempty_tool_result,
     is_blank_text,
     repeated_external_lookup_error,
+    repeated_identical_local_call_error,
     repeated_workspace_violation_error,
 )
 
@@ -241,6 +242,7 @@ class AgentRunner:
         stop_reason = "completed"
         tool_events: list[dict[str, str]] = []
         external_lookup_counts: dict[str, int] = {}
+        local_tool_call_counts: dict[str, int] = {}
         # Per-turn throttle for repeated attempts against the same outside target.
         workspace_violation_counts: dict[str, int] = {}
         empty_content_retries = 0
@@ -317,6 +319,7 @@ class AgentRunner:
                     spec,
                     tool_calls,
                     external_lookup_counts,
+                    local_tool_call_counts,
                     workspace_violation_counts,
                 )
                 tool_events.extend(new_events)
@@ -703,6 +706,7 @@ class AgentRunner:
         spec: AgentRunSpec,
         tool_calls: list[ToolCallRequest],
         external_lookup_counts: dict[str, int],
+        local_tool_call_counts: dict[str, int],
         workspace_violation_counts: dict[str, int],
     ) -> tuple[list[Any], list[dict[str, str]], BaseException | None]:
         batches = self._partition_tool_batches(spec, tool_calls)
@@ -711,7 +715,11 @@ class AgentRunner:
             if spec.concurrent_tools and len(batch) > 1:
                 batch_results = await asyncio.gather(*(
                     self._run_tool(
-                        spec, tool_call, external_lookup_counts, workspace_violation_counts,
+                        spec,
+                        tool_call,
+                        external_lookup_counts,
+                        local_tool_call_counts,
+                        workspace_violation_counts,
                     )
                     for tool_call in batch
                 ))
@@ -720,7 +728,11 @@ class AgentRunner:
                 batch_results = []
                 for tool_call in batch:
                     result = await self._run_tool(
-                        spec, tool_call, external_lookup_counts, workspace_violation_counts,
+                        spec,
+                        tool_call,
+                        external_lookup_counts,
+                        local_tool_call_counts,
+                        workspace_violation_counts,
                     )
                     tool_results.append(result)
                     batch_results.append(result)
@@ -744,9 +756,24 @@ class AgentRunner:
         spec: AgentRunSpec,
         tool_call: ToolCallRequest,
         external_lookup_counts: dict[str, int],
+        local_tool_call_counts: dict[str, int],
         workspace_violation_counts: dict[str, int],
     ) -> tuple[Any, dict[str, str], BaseException | None]:
         hint = "\n\n[Analyze the error above and try a different approach.]"
+        repeated_local_call_error = repeated_identical_local_call_error(
+            tool_call.name,
+            tool_call.arguments,
+            local_tool_call_counts,
+        )
+        if repeated_local_call_error:
+            event = {
+                "name": tool_call.name,
+                "status": "error",
+                "detail": "repeated identical local tool call blocked",
+            }
+            if spec.fail_on_tool_error:
+                return repeated_local_call_error + hint, event, RuntimeError(repeated_local_call_error)
+            return repeated_local_call_error + hint, event, None
         lookup_error = repeated_external_lookup_error(
             tool_call.name,
             tool_call.arguments,

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import json
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ from loguru import logger
 from nanobot.utils.helpers import stringify_text_blocks
 
 _MAX_REPEAT_EXTERNAL_LOOKUPS = 2
+_MAX_REPEAT_IDENTICAL_LOCAL_CALLS = 2
 
 # Third same-target workspace violation in a turn escalates to "stop retrying".
 _MAX_REPEAT_WORKSPACE_VIOLATIONS = 2
@@ -100,6 +102,39 @@ def repeated_external_lookup_error(
         "Error: repeated external lookup blocked. "
         "Use the results you already have to answer, or try a meaningfully different source."
     )
+
+
+def local_tool_call_signature(tool_name: str, arguments: dict[str, Any]) -> str | None:
+    """Stable signature for repeated identical local tool calls we want to throttle."""
+    if tool_name not in {"read_file", "list_dir", "glob", "grep"}:
+        return None
+    payload = arguments if isinstance(arguments, dict) else {"_raw_args": arguments}
+    try:
+        normalized_args = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    except (TypeError, ValueError):
+        normalized_args = str(payload)
+    return f"{tool_name}:{normalized_args}"
+
+
+def repeated_identical_local_call_error(
+    tool_name: str,
+    arguments: dict[str, Any],
+    seen_counts: dict[str, int],
+) -> str | None:
+    """Block repeated identical local tool calls after a small retry budget."""
+    signature = local_tool_call_signature(tool_name, arguments)
+    if signature is None:
+        return None
+    count = seen_counts.get(signature, 0) + 1
+    seen_counts[signature] = count
+    if count <= _MAX_REPEAT_IDENTICAL_LOCAL_CALLS:
+        return None
+    logger.warning(
+        "Blocking repeated identical local tool call {} on attempt {}",
+        signature[:160],
+        count,
+    )
+    return "Error: repeated identical tool call blocked. Use the prior result or choose a different tool."
 
 
 # Workspace-boundary violations are soft errors, with per-target throttling.

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -1025,6 +1025,7 @@ async def test_runner_batches_read_only_tools_before_exclusive_work():
         ],
         {},
         {},
+        {},
     )
 
     assert shared_events[0:2] == ["start:read_a", "start:read_b"]
@@ -1068,6 +1069,7 @@ async def test_runner_does_not_batch_exclusive_read_only_tools():
             ToolCallRequest(id="ddg1", name="ddg_like", arguments={}),
             ToolCallRequest(id="ro2", name="read_b", arguments={}),
         ],
+        {},
         {},
         {},
     )
@@ -1117,6 +1119,102 @@ async def test_runner_blocks_repeated_external_fetches():
         if msg.get("role") == "tool" and msg.get("tool_call_id") == "call_3"
     ][0]
     assert "repeated external lookup blocked" in blocked_tool_message["content"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("read_file", {"path": "/tmp/foo.txt"}),
+        ("glob", {"pattern": "**/*.py", "path": "/tmp"}),
+        ("grep", {"pattern": "TODO", "path": "/tmp"}),
+    ],
+)
+async def test_runner_blocks_repeated_identical_local_tool_calls(tool_name, arguments):
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    captured_final_call: list[dict] = []
+    call_count = {"n": 0}
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] <= 3:
+            return LLMResponse(
+                content="working",
+                tool_calls=[ToolCallRequest(id=f"call_{call_count['n']}", name=tool_name, arguments=arguments)],
+                usage={},
+            )
+        captured_final_call[:] = messages
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="ok")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "task"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=4,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done"
+    assert tools.execute.await_count == 2
+    blocked_tool_message = [
+        msg for msg in captured_final_call
+        if msg.get("role") == "tool" and msg.get("tool_call_id") == "call_3"
+    ][0]
+    assert "repeated identical tool call blocked" in blocked_tool_message["content"]
+
+
+@pytest.mark.asyncio
+async def test_runner_allows_local_tool_calls_with_different_arguments():
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    captured_final_call: list[dict] = []
+    call_count = {"n": 0}
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return LLMResponse(
+                content="working",
+                tool_calls=[ToolCallRequest(id="call_1", name="read_file", arguments={"path": "/tmp/a.txt"})],
+                usage={},
+            )
+        if call_count["n"] == 2:
+            return LLMResponse(
+                content="working",
+                tool_calls=[ToolCallRequest(id="call_2", name="read_file", arguments={"path": "/tmp/b.txt"})],
+                usage={},
+            )
+        captured_final_call[:] = messages
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="ok")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "task"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done"
+    assert tools.execute.await_count == 2
+    tool_messages = [msg for msg in captured_final_call if msg.get("role") == "tool"]
+    assert len(tool_messages) == 2
+    assert all("repeated identical tool call blocked" not in msg["content"] for msg in tool_messages)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #3699

Adds a per-turn duplicate-call guard for repeated identical local tool calls (read_file, list_dir, glob, grep), with synthetic error short-circuiting and tests.