### PR TITLE
Add configurable escalation for repeated tool-call loops

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -33,6 +33,7 @@ from nanobot.utils.runtime import (
     ensure_nonempty_tool_result,
     is_blank_text,
     repeated_external_lookup_error,
+    repeated_tool_call_escalation_error,
     repeated_workspace_violation_error,
 )
 
@@ -81,6 +82,7 @@ class AgentRunSpec:
     checkpoint_callback: Any | None = None
     injection_callback: Any | None = None
     llm_timeout_s: float | None = None
+    repeated_tool_call_escalation_threshold: int | None = None
 
 
 @dataclass(slots=True)
@@ -95,6 +97,10 @@ class AgentRunResult:
     error: str | None = None
     tool_events: list[dict[str, str]] = field(default_factory=list)
     had_injections: bool = False
+
+
+class ToolLoopEscalationInterrupt(RuntimeError):
+    """Raised when repeated identical tool-call patterns indicate a loop."""
 
 
 class AgentRunner:
@@ -241,6 +247,7 @@ class AgentRunner:
         stop_reason = "completed"
         tool_events: list[dict[str, str]] = []
         external_lookup_counts: dict[str, int] = {}
+        repeated_tool_call_counts: dict[str, int] = {}
         # Per-turn throttle for repeated attempts against the same outside target.
         workspace_violation_counts: dict[str, int] = {}
         empty_content_retries = 0
@@ -317,6 +324,7 @@ class AgentRunner:
                     spec,
                     tool_calls,
                     external_lookup_counts,
+                    repeated_tool_call_counts,
                     workspace_violation_counts,
                 )
                 tool_events.extend(new_events)
@@ -703,6 +711,7 @@ class AgentRunner:
         spec: AgentRunSpec,
         tool_calls: list[ToolCallRequest],
         external_lookup_counts: dict[str, int],
+        repeated_tool_call_counts: dict[str, int],
         workspace_violation_counts: dict[str, int],
     ) -> tuple[list[Any], list[dict[str, str]], BaseException | None]:
         batches = self._partition_tool_batches(spec, tool_calls)
@@ -711,7 +720,11 @@ class AgentRunner:
             if spec.concurrent_tools and len(batch) > 1:
                 batch_results = await asyncio.gather(*(
                     self._run_tool(
-                        spec, tool_call, external_lookup_counts, workspace_violation_counts,
+                        spec,
+                        tool_call,
+                        external_lookup_counts,
+                        repeated_tool_call_counts,
+                        workspace_violation_counts,
                     )
                     for tool_call in batch
                 ))
@@ -720,7 +733,11 @@ class AgentRunner:
                 batch_results = []
                 for tool_call in batch:
                     result = await self._run_tool(
-                        spec, tool_call, external_lookup_counts, workspace_violation_counts,
+                        spec,
+                        tool_call,
+                        external_lookup_counts,
+                        repeated_tool_call_counts,
+                        workspace_violation_counts,
                     )
                     tool_results.append(result)
                     batch_results.append(result)
@@ -744,9 +761,23 @@ class AgentRunner:
         spec: AgentRunSpec,
         tool_call: ToolCallRequest,
         external_lookup_counts: dict[str, int],
+        repeated_tool_call_counts: dict[str, int],
         workspace_violation_counts: dict[str, int],
     ) -> tuple[Any, dict[str, str], BaseException | None]:
         hint = "\n\n[Analyze the error above and try a different approach.]"
+        escalation_error = repeated_tool_call_escalation_error(
+            tool_call.name,
+            tool_call.arguments,
+            repeated_tool_call_counts,
+            spec.repeated_tool_call_escalation_threshold,
+        )
+        if escalation_error:
+            event = {
+                "name": tool_call.name,
+                "status": "error",
+                "detail": "repeated tool-call escalation triggered",
+            }
+            return escalation_error, event, ToolLoopEscalationInterrupt(escalation_error)
         lookup_error = repeated_external_lookup_error(
             tool_call.name,
             tool_call.arguments,

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import json
 from pathlib import Path
 from typing import Any
 
@@ -99,6 +100,41 @@ def repeated_external_lookup_error(
     return (
         "Error: repeated external lookup blocked. "
         "Use the results you already have to answer, or try a meaningfully different source."
+    )
+
+
+def tool_call_signature(tool_name: str, arguments: dict[str, Any]) -> str:
+    """Stable signature for repeated tool-call pattern detection."""
+    payload = arguments if isinstance(arguments, dict) else {"_raw_args": arguments}
+    try:
+        normalized_args = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    except (TypeError, ValueError):
+        normalized_args = str(payload)
+    return f"{tool_name}:{normalized_args}"
+
+
+def repeated_tool_call_escalation_error(
+    tool_name: str,
+    arguments: dict[str, Any],
+    seen_counts: dict[str, int],
+    threshold: int | None,
+) -> str | None:
+    """Return an escalation error once repeated identical tool-call threshold is exceeded."""
+    if threshold is None or threshold < 1:
+        return None
+    signature = tool_call_signature(tool_name, arguments)
+    count = seen_counts.get(signature, 0) + 1
+    seen_counts[signature] = count
+    if count <= threshold:
+        return None
+    logger.warning(
+        "Escalating repeated tool-call pattern {} on attempt {}",
+        signature[:160],
+        count,
+    )
+    return (
+        "Error: repetitive tool-call loop detected. "
+        "Stop reusing the same tool call and choose a different strategy."
     )
 
 

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -1025,6 +1025,7 @@ async def test_runner_batches_read_only_tools_before_exclusive_work():
         ],
         {},
         {},
+        {},
     )
 
     assert shared_events[0:2] == ["start:read_a", "start:read_b"]
@@ -1068,6 +1069,7 @@ async def test_runner_does_not_batch_exclusive_read_only_tools():
             ToolCallRequest(id="ddg1", name="ddg_like", arguments={}),
             ToolCallRequest(id="ro2", name="read_b", arguments={}),
         ],
+        {},
         {},
         {},
     )
@@ -1117,6 +1119,86 @@ async def test_runner_blocks_repeated_external_fetches():
         if msg.get("role") == "tool" and msg.get("tool_call_id") == "call_3"
     ][0]
     assert "repeated external lookup blocked" in blocked_tool_message["content"]
+
+
+@pytest.mark.asyncio
+async def test_runner_escalates_repeated_identical_tool_call_patterns():
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    call_count = {"n": 0}
+
+    async def chat_with_retry(**kwargs):
+        call_count["n"] += 1
+        if call_count["n"] <= 3:
+            return LLMResponse(
+                content="working",
+                tool_calls=[ToolCallRequest(id=f"call_{call_count['n']}", name="read_file", arguments={"path": "/tmp/a.txt"})],
+                usage={},
+            )
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="ok")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "task"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=4,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        repeated_tool_call_escalation_threshold=2,
+    ))
+
+    assert result.stop_reason == "tool_error"
+    assert "repetitive tool-call loop detected" in (result.final_content or "")
+    assert tools.execute.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_runner_does_not_escalate_when_tool_call_arguments_change():
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+
+    provider = MagicMock()
+    call_count = {"n": 0}
+
+    async def chat_with_retry(**kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return LLMResponse(
+                content="working",
+                tool_calls=[ToolCallRequest(id="call_1", name="read_file", arguments={"path": "/tmp/a.txt"})],
+                usage={},
+            )
+        if call_count["n"] == 2:
+            return LLMResponse(
+                content="working",
+                tool_calls=[ToolCallRequest(id="call_2", name="read_file", arguments={"path": "/tmp/b.txt"})],
+                usage={},
+            )
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="ok")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "task"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+        repeated_tool_call_escalation_threshold=1,
+    ))
+
+    assert result.stop_reason == "completed"
+    assert result.final_content == "done"
+    assert tools.execute.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #3700

Adds configurable turn-level escalation for repeated identical tool-call patterns, with deterministic interrupt behavior, logging, and tests.