### PR TITLE
fix(cli): handle retry-wait messages in interactive mode

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -235,22 +235,22 @@ def _print_cli_progress_line(text: str, thinking: ThinkingSpinner | None) -> Non
         console.print(f"  [dim]↳ {text}[/dim]")
 
 
-async def _print_interactive_progress_line(text: str, thinking: ThinkingSpinner | None) -> None:
-    """Print an interactive progress line, pausing the spinner if needed."""
+async def _print_interactive_progress_line(text: str, renderer: StreamRenderer | None) -> None:
+    """Print an interactive progress line, pausing the renderer's spinner if needed."""
     if not text.strip():
         return
-    with thinking.pause() if thinking else nullcontext():
+    with renderer.pause() if renderer else nullcontext():
         await _print_interactive_line(text)
 
 
 async def _maybe_print_interactive_progress(
     msg: Any,
-    thinking: ThinkingSpinner | None,
+    renderer: StreamRenderer | None,
     channels_config: Any,
 ) -> bool:
     metadata = msg.metadata or {}
     if metadata.get("_retry_wait"):
-        await _print_interactive_progress_line(msg.content, thinking)
+        await _print_interactive_progress_line(msg.content, renderer)
         return True
 
     if not metadata.get("_progress"):
@@ -262,7 +262,7 @@ async def _maybe_print_interactive_progress(
     if channels_config and not is_tool_hint and not channels_config.send_progress:
         return True
 
-    await _print_interactive_progress_line(msg.content, thinking)
+    await _print_interactive_progress_line(msg.content, renderer)
     return True
 
 
@@ -1204,7 +1204,7 @@ def agent(
 
                         if await _maybe_print_interactive_progress(
                             msg,
-                            _thinking,
+                            renderer,
                             agent_loop.channels_config,
                         ):
                             continue

--- a/nanobot/cli/stream.py
+++ b/nanobot/cli/stream.py
@@ -134,6 +134,13 @@ class StreamRenderer:
         """Stop spinner before user input to avoid prompt_toolkit conflicts."""
         self._stop_spinner()
 
+    def pause(self):
+        """Context manager: pause spinner for external output. No-op once streaming has started."""
+        from contextlib import nullcontext
+        if self._spinner:
+            return self._spinner.pause()
+        return nullcontext()
+
     async def close(self) -> None:
         """Stop spinner/live without rendering a final streamed round."""
         if self._live:


### PR DESCRIPTION
## Problem

In the interactive CLI, the spinner is not paused before printing retry or progress messages. When a transient LLM error triggers a retry, the spinner's background thread can interleave with the progress line output, producing terminal corruption.

## Root cause

`_maybe_print_interactive_progress` and `_print_interactive_progress_line` accept a `ThinkingSpinner | None` to pause the spinner before printing. In interactive mode the active spinner lives inside `renderer` (`StreamRenderer`), but `_thinking` — a `ThinkingSpinner | None` declared in the enclosing scope — was passed instead. `_thinking` is never assigned in the interactive path, so it is always `None` and the spinner pause is silently a no-op.

## Fix

- Change `_print_interactive_progress_line` and `_maybe_print_interactive_progress` to accept `StreamRenderer | None` instead of `ThinkingSpinner | None`
- Expose `StreamRenderer.pause()` delegating to the inner spinner, consistent with the existing `stop_for_input()` pattern
- Pass `renderer` at the call site instead of `_thinking`

## Test plan

```
uv run pytest tests/cli/
```

Verified manually by injecting a forced transient error:

```
🐈 Interactive mode (gemma-4-31b-it) — type exit or Ctrl+C to quit

You: hello
  ↳ Model request failed, retry in 1s (attempt 1).
  ↳ Model request failed, retry in 2s (attempt 2).
  ↳ Model request failed, retry in 4s (attempt 3).

🐈 nanobot
Hello Eugene. What's up?
```