### PR TITLE
fix(utils): remove unreachable dead code in find_legal_message_start

### DIFF
--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -165,11 +165,6 @@ def find_legal_message_start(messages: list[dict[str, Any]]) -> int:
             if tid and str(tid) not in declared:
                 start = i + 1
                 declared.clear()
-                for prev in messages[start : i + 1]:
-                    if prev.get("role") == "assistant":
-                        for tc in prev.get("tool_calls") or []:
-                            if isinstance(tc, dict) and tc.get("id"):
-                                declared.add(str(tc["id"]))
     return start
 
 


### PR DESCRIPTION
## Summary
Removes unreachable dead code in `nanobot/utils/helpers.py::find_legal_message_start`.

The for loop at line 168 never executes because `start` is assigned `i + 1` immediately before slicing `messages[start : i + 1]`, which is always an empty list.

Fixes #3716

## Test plan
- [x] Relevant agent tests pass (`test_session_manager_history.py`, `test_runner.py`)