### PR TITLE
fix(providers): require api_base before local provider wins on keyword match

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -504,6 +504,7 @@ class Config(BaseSettings):
         model_normalized = model_lower.replace("-", "_")
         model_prefix = model_lower.split("/", 1)[0] if "/" in model_lower else ""
         normalized_prefix = model_prefix.replace("-", "_")
+        prefixed_provider = find_by_name(model_prefix) if model_prefix else None
 
         def _kw_matches(kw: str) -> bool:
             kw = kw.lower()
@@ -540,8 +541,15 @@ class Config(BaseSettings):
                 # honor a local keyword match when the user has actually
                 # configured that local endpoint via `api_base` — mirrors the
                 # gate already used by the local-fallback loop below.
-                if spec.is_local and not p.api_base:
-                    continue
+                if spec.is_local:
+                    # A qualified model belongs to its explicit provider or a
+                    # gateway fallback, never to a different local provider
+                    # whose model-family keyword happens to match.
+                    foreign_prefix = bool(
+                        prefixed_provider is not None and prefixed_provider.name != spec.name
+                    )
+                    if not p.api_base or foreign_prefix:
+                        continue
                 if spec.is_oauth or spec.is_local or spec.is_direct or p.api_key:
                     return p, spec.name
 
@@ -550,16 +558,17 @@ class Config(BaseSettings):
         # Prefer providers whose detect_by_base_keyword matches the configured api_base
         # (e.g. Ollama's "11434" in "http://localhost:11434") over plain registry order.
         local_fallback: tuple[ProviderConfig, str] | None = None
-        for spec in PROVIDERS:
-            if not spec.is_local:
-                continue
-            p = getattr(self.providers, spec.name, None)
-            if not (p and p.api_base):
-                continue
-            if spec.detect_by_base_keyword and spec.detect_by_base_keyword in p.api_base:
-                return p, spec.name
-            if local_fallback is None:
-                local_fallback = (p, spec.name)
+        if prefixed_provider is None:
+            for spec in PROVIDERS:
+                if not spec.is_local:
+                    continue
+                p = getattr(self.providers, spec.name, None)
+                if not (p and p.api_base):
+                    continue
+                if spec.detect_by_base_keyword and spec.detect_by_base_keyword in p.api_base:
+                    return p, spec.name
+                if local_fallback is None:
+                    local_fallback = (p, spec.name)
         if local_fallback:
             return local_fallback
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -533,6 +533,15 @@ class Config(BaseSettings):
                 continue
             p = getattr(self.providers, spec.name, None)
             if p and any(_kw_matches(kw) for kw in spec.keywords):
+                # Local providers (Ollama, vLLM, …) keep model-family keywords
+                # like "nemotron" or "llama" to enable bare-model auto-routing,
+                # but those keywords collide with cloud-hosted variants of the
+                # same family (e.g. `nvidia/nemotron-...` via OpenRouter). Only
+                # honor a local keyword match when the user has actually
+                # configured that local endpoint via `api_base` — mirrors the
+                # gate already used by the local-fallback loop below.
+                if spec.is_local and not p.api_base:
+                    continue
                 if spec.is_oauth or spec.is_local or spec.is_direct or p.api_key:
                     return p, spec.name
 

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1160,6 +1160,42 @@ def test_config_falls_back_to_vllm_when_ollama_not_configured():
     assert config.get_api_base() == "http://localhost:8000"
 
 
+def test_config_cloud_nemotron_is_not_hijacked_by_unconfigured_ollama():
+    """`nvidia/nemotron-*` via a gateway must not route to Ollama when no
+    Ollama endpoint is configured. Ollama keeps "nemotron" in its keywords
+    for bare-model auto-routing (PR #1863), which previously hijacked
+    cloud-hosted nemotron variants and silently sent traffic to
+    http://localhost:11434/v1."""
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "auto",
+                    "model": "nvidia/nemotron-3-super-120b-a12b",
+                }
+            },
+            "providers": {"openrouter": {"apiKey": "sk-or-test"}},
+        }
+    )
+
+    assert config.get_provider_name() == "openrouter"
+    assert config.get_api_base() == "https://openrouter.ai/api/v1"
+
+
+def test_config_bare_nemotron_still_auto_routes_to_configured_ollama():
+    """Preserves PR #1863 intent: when the user has actually configured an
+    Ollama endpoint, a bare nemotron model still auto-routes there."""
+    config = Config.model_validate(
+        {
+            "agents": {"defaults": {"provider": "auto", "model": "nemotron-3-nano"}},
+            "providers": {"ollama": {"apiBase": "http://localhost:11434/v1"}},
+        }
+    )
+
+    assert config.get_provider_name() == "ollama"
+    assert config.get_api_base() == "http://localhost:11434/v1"
+
+
 def test_openai_compat_provider_passes_model_through():
     from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1196,6 +1196,27 @@ def test_config_bare_nemotron_still_auto_routes_to_configured_ollama():
     assert config.get_api_base() == "http://localhost:11434/v1"
 
 
+def test_config_cloud_nemotron_is_not_hijacked_by_configured_ollama():
+    """An explicit cloud namespace takes precedence over local keywords."""
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "auto",
+                    "model": "nvidia/nemotron-3-super-120b-a12b",
+                }
+            },
+            "providers": {
+                "ollama": {"apiBase": "http://localhost:11434/v1"},
+                "openrouter": {"apiKey": "sk-or-test"},
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "openrouter"
+    assert config.get_api_base() == "https://openrouter.ai/api/v1"
+
+
 def test_openai_compat_provider_passes_model_through():
     from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 


### PR DESCRIPTION
## Summary

The `_match_provider` keyword loop accepts any local provider on `spec.is_local` alone — with no `api_base` check. That asymmetry vs. the local-fallback loop directly below it causes silent hijacking of cloud-hosted models when a local provider claims the same model-family keyword.

Specifically: Ollama's spec keeps `"nemotron"` as a keyword so a bare `nemotron-3-nano` model name auto-routes to a configured Ollama install (per PR #1863). NVIDIA NIM was later registered with the same `"nemotron"` keyword in commit 046d0831, creating the only keyword collision in the registry today (`{'nemotron': ['ollama', 'nvidia']}`).

With `provider: "auto"`, a model like `nvidia/nemotron-3-super-120b-a12b` (intended for OpenRouter or NVIDIA NIM) is matched by Ollama first because Ollama comes earlier in registry order and `spec.is_local` satisfies the gate even without an api_key. `get_api_base()` then falls back to Ollama's `default_api_base = http://localhost:11434/v1`, and the agent silently sends every LLM call to a service the user never configured.

This affected Discord turns, heartbeats, WebUI traffic, and cron jobs in my setup — all silently broken until I dug into the routing logic.

## Fix

In the keyword loop, require local providers to have an explicit `api_base` configured before they can win a keyword match. Mirrors the gate the local-fallback loop already uses:

```python
if spec.is_local and not p.api_base:
    continue
```

- Preserves PR #1863's intent: users with `providers.ollama.apiBase` configured still get bare-model auto-routing for `nemotron-3-nano`, `llama3.2`, etc.
- Cloud-hosted variants of the same families now flow through to the normal gateway / api-key fallback instead of being hijacked.

## Tests

Two regression tests in `tests/cli/test_commands.py`:
- `test_config_cloud_nemotron_is_not_hijacked_by_unconfigured_ollama` — pins the bug.
- `test_config_bare_nemotron_still_auto_routes_to_configured_ollama` — pins PR #1863's intent.

All 167 tests across `tests/cli/test_commands.py` and the five routing-relevant `tests/providers/*.py` files pass. `ruff check` clean on the schema change.
