### PR TITLE
fix(webui): shim crypto.randomUUID for non-secure contexts

### DIFF
--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -5,6 +5,22 @@ import App from "./App";
 import "./globals.css";
 import "./i18n";
 
+// `crypto.randomUUID` is only defined in secure contexts (HTTPS or localhost).
+// LAN access over plain HTTP leaves it undefined, which crashes components that
+// generate client-side message IDs. Shim a v4-ish fallback so call sites stay
+// uniform across secure and non-secure contexts.
+if (typeof globalThis.crypto !== "undefined" && !("randomUUID" in globalThis.crypto)) {
+  Object.defineProperty(globalThis.crypto, "randomUUID", {
+    value: () =>
+      "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+        const r = (Math.random() * 16) | 0;
+        const v = c === "x" ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+      }),
+    configurable: true,
+  });
+}
+
 const root = document.getElementById("root");
 if (!root) throw new Error("root element missing");
 

--- a/webui/src/tests/main-randomuuid.test.tsx
+++ b/webui/src/tests/main-randomuuid.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const render = vi.fn();
+const createRoot = vi.fn(() => ({ render }));
+
+vi.mock("react-dom/client", () => ({
+  default: { createRoot },
+}));
+
+vi.mock("@/App", () => ({
+  default: () => null,
+}));
+
+describe("main entry crypto shim", () => {
+  const originalRandomUUID = globalThis.crypto.randomUUID;
+
+  beforeEach(() => {
+    vi.resetModules();
+    createRoot.mockClear();
+    render.mockClear();
+    document.body.innerHTML = '<div id="root"></div>';
+    delete (globalThis.crypto as Crypto & { randomUUID?: Crypto["randomUUID"] }).randomUUID;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis.crypto, "randomUUID", {
+      value: originalRandomUUID,
+      configurable: true,
+    });
+    document.body.innerHTML = "";
+  });
+
+  it("installs a randomUUID fallback when the browser omits it", async () => {
+    await import("../main");
+
+    expect(globalThis.crypto.randomUUID).toEqual(expect.any(Function));
+    expect(globalThis.crypto.randomUUID()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(createRoot).toHaveBeenCalledWith(document.getElementById("root"));
+  });
+});


### PR DESCRIPTION
## Summary
- `crypto.randomUUID` is only defined in secure contexts (HTTPS or localhost). With recent commits enabling LAN access over plain HTTP (`bad584cb`, `034bea1a`, `4efd904c`), the WebUI now runs in non-secure contexts where `window.crypto.randomUUID` is undefined.
- `ChatPane.tsx:53` calls it inside the welcome-composer flush effect. The first submit throws `TypeError: crypto.randomUUID is not a function` during render, React unmounts the tree (no error boundary), and the user sees a blank page. Four more call sites in `useNanobotStream.ts` would fail the same way once streaming starts.
- Fix: install a Math.random-backed v4-ish fallback at app entry, gated on the feature being missing. Mirrors the shim already used in `webui/src/tests/setup.ts` for happy-dom. Single shim covers all six call sites without touching them.

## Why this approach
- The two existing per-call fallbacks (`lib/imageEncode.ts`, `hooks/useAttachedImages.ts`) hint the team already knew about the gap — this just centralizes it instead of duplicating the guard at every call site.
- These IDs are client-side message keys, never auth tokens, so non-cryptographic randomness is appropriate.
- Not adding an error boundary in this PR — that's a separate hardening change and would only mask the bug.

## Test plan
- [x] `bunx tsc --noEmit -p webui/tsconfig.json` clean
- [x] `bun run build` succeeds
- [ ] Manually verified: load WebUI over LAN HTTP, submit a message, page no longer blanks
- [ ] Confirm existing tests still pass (`cd webui && bun run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)