### PR TITLE
feat: add LongCat (美团) provider support

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -172,6 +172,7 @@ class ProvidersConfig(Base):
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
     nvidia: ProviderConfig = Field(default_factory=ProviderConfig)  # NVIDIA NIM (nvapi- keys)
+    longcat: ProviderConfig = Field(default_factory=ProviderConfig)  # LongCat (美团)
 
 
 class HeartbeatConfig(Base):

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -460,6 +460,17 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         default_api_base="https://qianfan.baidubce.com/v2"
     ),
+    # LongCat (美团): OpenAI-compatible API at api.longcat.chat/openai
+    ProviderSpec(
+        name="longcat",
+        keywords=("longcat",),
+        env_key="LONGCAT_API_KEY",
+        display_name="LongCat",
+        backend="openai_compat",
+        is_gateway=False,
+        detect_by_base_keyword="longcat",
+        default_api_base="https://api.longcat.chat/openai",
+    ),
 )
 
 


### PR DESCRIPTION
- Add longcat provider to ProvidersConfig in config/schema.py
- Add ProviderSpec for LongCat with OpenAI-compatible API format
- Default API base: https://api.longcat.chat/openai
- Environment variable: LONGCAT_API_KEY
- Supports models: LongCat-Flash-Chat, LongCat-Flash-Thinking, etc.