### PR TITLE
fix(providers): set supports_max_completion_tokens for VolcEngine providers

### DIFF
--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -192,6 +192,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_base_keyword="volces",
         default_api_base="https://ark.cn-beijing.volces.com/api/v3",
         thinking_style="thinking_type",
+        supports_max_completion_tokens=True,
     ),
 
     # VolcEngine Coding Plan (火山引擎 Coding Plan): same key as volcengine
@@ -205,6 +206,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://ark.cn-beijing.volces.com/api/coding/v3",
         strip_model_prefix=True,
         thinking_style="thinking_type",
+        supports_max_completion_tokens=True,
     ),
 
     # BytePlus: VolcEngine international, pay-per-use models

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -847,6 +847,18 @@ def test_volcengine_thinking_enabled() -> None:
     assert kw["extra_body"] == {"thinking": {"type": "enabled"}}
 
 
+def test_volcengine_uses_max_completion_tokens() -> None:
+    kw = _build_kwargs_for("volcengine", "doubao-seed-2-0-pro")
+    assert kw["max_completion_tokens"] == 1024
+    assert "max_tokens" not in kw
+
+
+def test_volcengine_coding_plan_uses_max_completion_tokens() -> None:
+    kw = _build_kwargs_for("volcengine_coding_plan", "doubao-seed-2-0-pro")
+    assert kw["max_completion_tokens"] == 1024
+    assert "max_tokens" not in kw
+
+
 def test_byteplus_thinking_disabled_for_minimal() -> None:
     kw = _build_kwargs_for("byteplus", "doubao-seed-2-0-pro", reasoning_effort="minimal")
     assert kw["extra_body"] == {"thinking": {"type": "disabled"}}


### PR DESCRIPTION
## Problem

VolcEngine's OpenAI-compatible gateway rejects requests when both `max_tokens` and `max_completion_tokens` are present in the request body:

> The parameter max_tokens specified in the request are not valid: max_tokens and max_completion_tokens cannot be set at the same time.

This happens because openai-python SDK v2.x serializes `max_tokens` in a way that also exposes `max_completion_tokens` on the wire, and VolcEngine's gateway strictly validates against both parameters being present.

Other domestic providers (zhipu, qianfan, kimi) are lenient and ignore the conflict, but VolcEngine returns a 400 BadRequest.

## Fix

Set `supports_max_completion_tokens=True` on the VolcEngine provider specs so that nanobot sends `max_completion_tokens` instead of `max_tokens`.

Affected providers:
- `volcengine`
- `volcengine_coding_plan`

## Testing

Verified that with this change, requests to `ark.cn-beijing.volces.com` use `max_completion_tokens` only and no longer trigger the `InvalidParameter` error.