### PR TITLE
feat(provider): support provider-hosted web search

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -767,6 +767,24 @@ nanobot supports multiple web search providers. Configure in `~/.nanobot/config.
 
 By default, web search uses `duckduckgo`, and it works out of the box without an API key.
 
+Set `providerHosted` to `true` to prefer the active LLM provider's hosted web
+search tool when that provider supports one. If the active provider does not
+support provider-hosted web search, nanobot keeps using the local `web_search`
+tool and the configured search provider below. Currently this is supported by
+Azure OpenAI via the Responses API.
+
+```json
+{
+  "tools": {
+    "web": {
+      "search": {
+        "providerHosted": true
+      }
+    }
+  }
+}
+```
+
 | Provider | Config fields | Env var fallback | Free |
 |----------|--------------|------------------|------|
 | `brave` | `apiKey` | `BRAVE_API_KEY` | No |

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -408,13 +408,14 @@ class AgentLoop:
                 )
             )
         if self.web_config.enable:
-            self.tools.register(
-                WebSearchTool(
-                    config=self.web_config.search,
-                    proxy=self.web_config.proxy,
-                    user_agent=self.web_config.user_agent,
+            if not getattr(self.provider, "uses_provider_hosted_web_search", False):
+                self.tools.register(
+                    WebSearchTool(
+                        config=self.web_config.search,
+                        proxy=self.web_config.proxy,
+                        user_agent=self.web_config.user_agent,
+                    )
                 )
-            )
             self.tools.register(
                 WebFetchTool(
                     config=self.web_config.fetch,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -203,6 +203,9 @@ class WebSearchConfig(Base):
     base_url: str = ""  # SearXNG base URL
     max_results: int = 5
     timeout: int = 30  # Wall-clock timeout (seconds) for search operations
+    # Delegate web search to the LLM provider's hosted tool instead of the local implementation.
+    # Currently only Azure OpenAI (Responses API) is supported; other providers ignore this flag.
+    provider_hosted: bool = False
 
 
 class WebFetchConfig(Base):

--- a/nanobot/providers/azure_openai_provider.py
+++ b/nanobot/providers/azure_openai_provider.py
@@ -38,9 +38,12 @@ class AzureOpenAIProvider(LLMProvider):
         api_key: str = "",
         api_base: str = "",
         default_model: str = "gpt-5.2-chat",
+        hosted_web_search: bool = False,
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
+        self.hosted_web_search = hosted_web_search
+        self.uses_provider_hosted_web_search = hosted_web_search
 
         if not api_key:
             raise ValueError("Azure OpenAI api_key is required")
@@ -109,6 +112,12 @@ class AzureOpenAIProvider(LLMProvider):
         if tools:
             body["tools"] = convert_tools(tools)
             body["tool_choice"] = tool_choice or "auto"
+
+        if self.hosted_web_search:
+            existing = body.get("tools") or []
+            if not any(t.get("type") == "web_search" for t in existing):
+                body["tools"] = existing + [{"type": "web_search"}]
+            body.setdefault("tool_choice", tool_choice or "auto")
 
         return body
 

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -93,6 +93,7 @@ class LLMProvider(ABC):
     """Base class for LLM providers."""
 
     supports_progress_deltas = False
+    uses_provider_hosted_web_search = False
 
     _CHAT_RETRY_DELAYS = (1, 2, 4)
     _PERSISTENT_MAX_DELAY = 60

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -46,6 +46,7 @@ def make_provider(config: Config) -> LLMProvider:
             api_key=p.api_key,
             api_base=p.api_base,
             default_model=model,
+            hosted_web_search=config.tools.web.search.provider_hosted,
         )
     elif backend == "github_copilot":
         from nanobot.providers.github_copilot_provider import GitHubCopilotProvider
@@ -111,6 +112,7 @@ def provider_signature(config: Config) -> tuple[object, ...]:
         defaults.temperature,
         defaults.reasoning_effort,
         defaults.context_window_tokens,
+        config.tools.web.search.provider_hosted,
     )
 
 

--- a/nanobot/providers/openai_responses/converters.py
+++ b/nanobot/providers/openai_responses/converters.py
@@ -80,10 +80,19 @@ def convert_user_message(content: Any) -> dict[str, Any]:
 
 
 def convert_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Convert OpenAI function-calling tool schema to Responses API flat format."""
+    """Convert OpenAI function-calling tool schema to Responses API flat format.
+
+    Tools already declared with a non-``function`` ``type`` (e.g. Azure/OpenAI
+    hosted ``web_search``) are passed through unchanged so provider-native tools
+    can coexist with regular function tools.
+    """
     converted: list[dict[str, Any]] = []
     for tool in tools:
-        fn = (tool.get("function") or {}) if tool.get("type") == "function" else tool
+        declared_type = tool.get("type")
+        if declared_type and declared_type != "function":
+            converted.append(tool)
+            continue
+        fn = (tool.get("function") or {}) if declared_type == "function" else tool
         name = fn.get("name")
         if not name:
             continue

--- a/nanobot/providers/openai_responses/parsing.py
+++ b/nanobot/providers/openai_responses/parsing.py
@@ -19,6 +19,16 @@ FINISH_REASON_MAP = {
     "cancelled": "error",
 }
 
+# Provider-hosted tool item types absorbed server-side (no local handling needed).
+_HOSTED_TOOL_ITEM_TYPES = frozenset({"web_search_call"})
+
+# Lifecycle events emitted while a hosted tool is running; ignored by the parser.
+_HOSTED_TOOL_LIFECYCLE_EVENTS = frozenset({
+    "response.web_search_call.in_progress",
+    "response.web_search_call.searching",
+    "response.web_search_call.completed",
+})
+
 
 def map_finish_reason(status: str | None) -> str:
     """Map a Responses API status string to a Chat-Completions-style finish_reason."""
@@ -71,8 +81,12 @@ async def consume_sse(
 
     async for event in iter_sse(response):
         event_type = event.get("type")
+        if event_type in _HOSTED_TOOL_LIFECYCLE_EVENTS:
+            continue
         if event_type == "response.output_item.added":
             item = event.get("item") or {}
+            if item.get("type") in _HOSTED_TOOL_ITEM_TYPES:
+                continue
             if item.get("type") == "function_call":
                 call_id = item.get("call_id")
                 if not call_id:
@@ -97,6 +111,8 @@ async def consume_sse(
                 tool_call_buffers[call_id]["arguments"] = event.get("arguments") or ""
         elif event_type == "response.output_item.done":
             item = event.get("item") or {}
+            if item.get("type") in _HOSTED_TOOL_ITEM_TYPES:
+                continue
             if item.get("type") == "function_call":
                 call_id = item.get("call_id")
                 if not call_id:
@@ -148,6 +164,8 @@ def parse_response_output(response: Any) -> LLMResponse:
             item = dump() if callable(dump) else vars(item)
 
         item_type = item.get("type")
+        if item_type in _HOSTED_TOOL_ITEM_TYPES:
+            continue
         if item_type == "message":
             for block in item.get("content") or []:
                 if not isinstance(block, dict):
@@ -221,8 +239,12 @@ async def consume_sdk_stream(
 
     async for event in stream:
         event_type = getattr(event, "type", None)
+        if event_type in _HOSTED_TOOL_LIFECYCLE_EVENTS:
+            continue
         if event_type == "response.output_item.added":
             item = getattr(event, "item", None)
+            if item and getattr(item, "type", None) in _HOSTED_TOOL_ITEM_TYPES:
+                continue
             if item and getattr(item, "type", None) == "function_call":
                 call_id = getattr(item, "call_id", None)
                 if not call_id:
@@ -247,6 +269,8 @@ async def consume_sdk_stream(
                 tool_call_buffers[call_id]["arguments"] = getattr(event, "arguments", "") or ""
         elif event_type == "response.output_item.done":
             item = getattr(event, "item", None)
+            if item and getattr(item, "type", None) in _HOSTED_TOOL_ITEM_TYPES:
+                continue
             if item and getattr(item, "type", None) == "function_call":
                 call_id = getattr(item, "call_id", None)
                 if not call_id:

--- a/tests/agent/test_tool_registration.py
+++ b/tests/agent/test_tool_registration.py
@@ -1,0 +1,70 @@
+"""Tests for built-in tool registration rules on AgentLoop."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import WebSearchConfig, WebToolsConfig
+from nanobot.providers.base import LLMResponse
+
+
+def _make_loop(tmp_path: Path, web_config: WebToolsConfig) -> AgentLoop:
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.estimate_prompt_tokens.return_value = (10_000, "test")
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+    provider.generation.max_tokens = 4096
+    provider.uses_provider_hosted_web_search = False
+    return AgentLoop(
+        bus=bus,
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        context_window_tokens=128_000,
+        web_config=web_config,
+    )
+
+
+def test_local_web_search_registered_by_default(tmp_path: Path):
+    loop = _make_loop(tmp_path, WebToolsConfig(enable=True))
+    assert loop.tools.has("web_search")
+    assert loop.tools.has("web_fetch")
+
+
+def test_local_web_search_skipped_when_hosted(tmp_path: Path):
+    """Provider-hosted search suppresses the local web_search tool."""
+    cfg = WebToolsConfig(enable=True, search=WebSearchConfig(provider_hosted=True))
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    provider.estimate_prompt_tokens.return_value = (10_000, "test")
+    provider.chat_with_retry = AsyncMock(return_value=LLMResponse(content="ok", tool_calls=[]))
+    provider.generation.max_tokens = 4096
+    provider.uses_provider_hosted_web_search = True
+    loop = AgentLoop(
+        bus=MessageBus(),
+        provider=provider,
+        workspace=tmp_path,
+        model="test-model",
+        context_window_tokens=128_000,
+        web_config=cfg,
+    )
+    assert not loop.tools.has("web_search")
+    # web_fetch must remain so the model can still read full pages.
+    assert loop.tools.has("web_fetch")
+
+
+def test_provider_hosted_config_falls_back_to_local_when_provider_lacks_support(tmp_path: Path):
+    """provider_hosted=True is only honored when the active provider supports it."""
+    cfg = WebToolsConfig(enable=True, search=WebSearchConfig(provider_hosted=True))
+    loop = _make_loop(tmp_path, cfg)
+    assert loop.tools.has("web_search")
+    # web_fetch must remain so the model can still read full pages.
+    assert loop.tools.has("web_fetch")
+
+
+def test_web_tools_disabled_registers_neither(tmp_path: Path):
+    loop = _make_loop(tmp_path, WebToolsConfig(enable=False))
+    assert not loop.tools.has("web_search")
+    assert not loop.tools.has("web_fetch")

--- a/tests/providers/test_azure_openai_provider.py
+++ b/tests/providers/test_azure_openai_provider.py
@@ -125,6 +125,56 @@ def test_build_body_with_tools():
     assert body["tool_choice"] == "auto"
 
 
+def test_build_body_hosted_web_search_injected_without_other_tools():
+    """When hosted_web_search is enabled, {type: web_search} is added even if tools=None."""
+    provider = AzureOpenAIProvider(
+        api_key="k", api_base="https://r.com", default_model="gpt-4o",
+        hosted_web_search=True,
+    )
+    body = provider._build_body(
+        [{"role": "user", "content": "latest news?"}], None, None, 4096, 0.7, None, None,
+    )
+    assert {"type": "web_search"} in body["tools"]
+    assert body["tool_choice"] == "auto"
+
+
+def test_build_body_hosted_web_search_appended_to_function_tools():
+    """Hosted web_search should coexist with function tools, not replace them."""
+    provider = AzureOpenAIProvider(
+        api_key="k", api_base="https://r.com", default_model="gpt-4o",
+        hosted_web_search=True,
+    )
+    tools = [{"type": "function", "function": {"name": "calc", "parameters": {}}}]
+    body = provider._build_body(
+        [{"role": "user", "content": "hi"}], tools, None, 4096, 0.7, None, None,
+    )
+    types = [t.get("type") for t in body["tools"]]
+    assert types.count("function") == 1
+    assert types.count("web_search") == 1
+
+
+def test_build_body_hosted_web_search_disabled_by_default():
+    """Default construction must not inject the hosted tool."""
+    provider = AzureOpenAIProvider(api_key="k", api_base="https://r.com", default_model="gpt-4o")
+    body = provider._build_body(
+        [{"role": "user", "content": "hi"}], None, None, 4096, 0.7, None, None,
+    )
+    assert "tools" not in body or all(t.get("type") != "web_search" for t in body["tools"])
+
+
+def test_build_body_hosted_web_search_not_duplicated():
+    """Calling _build_body repeatedly must not add duplicate hosted tool entries."""
+    provider = AzureOpenAIProvider(
+        api_key="k", api_base="https://r.com", default_model="gpt-4o",
+        hosted_web_search=True,
+    )
+    tools = [{"type": "web_search"}]
+    body = provider._build_body(
+        [{"role": "user", "content": "hi"}], tools, None, 4096, 0.7, None, None,
+    )
+    assert [t.get("type") for t in body["tools"]].count("web_search") == 1
+
+
 def test_build_body_with_reasoning():
     provider = AzureOpenAIProvider(api_key="k", api_base="https://r.com", default_model="gpt-5-chat")
     body = provider._build_body(
@@ -421,3 +471,41 @@ def test_get_default_model():
         api_key="k", api_base="https://r.com", default_model="my-deploy",
     )
     assert provider.get_default_model() == "my-deploy"
+
+
+# ---------------------------------------------------------------------------
+# factory wiring
+# ---------------------------------------------------------------------------
+
+
+def test_factory_propagates_hosted_web_search_flag():
+    """make_provider must plumb tools.web.search.provider_hosted into the provider."""
+    from nanobot.config.schema import Config
+    from nanobot.providers.factory import make_provider
+
+    config = Config.model_validate({
+        "agents": {"defaults": {"provider": "azure_openai", "model": "my-deploy"}},
+        "providers": {
+            "azureOpenai": {"apiKey": "k", "apiBase": "https://r.openai.azure.com"},
+        },
+        "tools": {"web": {"search": {"providerHosted": True}}},
+    })
+
+    provider = make_provider(config)
+    assert provider.__class__.__name__ == "AzureOpenAIProvider"
+    assert provider.hosted_web_search is True
+
+
+def test_factory_defaults_hosted_web_search_off():
+    from nanobot.config.schema import Config
+    from nanobot.providers.factory import make_provider
+
+    config = Config.model_validate({
+        "agents": {"defaults": {"provider": "azure_openai", "model": "my-deploy"}},
+        "providers": {
+            "azureOpenai": {"apiKey": "k", "apiBase": "https://r.openai.azure.com"},
+        },
+    })
+
+    provider = make_provider(config)
+    assert provider.hosted_web_search is False

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -259,6 +259,30 @@ class TestConvertTools:
         ]
         assert len(convert_tools(tools)) == 2
 
+    def test_hosted_tool_passthrough(self):
+        """Non-function tool types (e.g. hosted web_search) must survive unchanged."""
+        tools = [{"type": "web_search"}]
+        assert convert_tools(tools) == [{"type": "web_search"}]
+
+    def test_hosted_tool_preserves_extra_fields(self):
+        tools = [{
+            "type": "web_search",
+            "search_context_size": "medium",
+            "filters": {"allowed_domains": ["example.com"]},
+        }]
+        assert convert_tools(tools) == tools
+
+    def test_hosted_and_function_tools_coexist(self):
+        tools = [
+            {"type": "function", "function": {"name": "f", "parameters": {}}},
+            {"type": "web_search"},
+        ]
+        result = convert_tools(tools)
+        assert len(result) == 2
+        assert result[0]["type"] == "function"
+        assert result[0]["name"] == "f"
+        assert result[1] == {"type": "web_search"}
+
 
 # ======================================================================
 # parsing - map_finish_reason
@@ -390,6 +414,22 @@ class TestParseResponseOutput:
         assert result.usage["completion_tokens"] == 50
         assert result.usage["total_tokens"] == 150
 
+    def test_hosted_web_search_call_item_ignored(self):
+        """web_search_call output items should be skipped without affecting the parsed answer."""
+        resp = {
+            "output": [
+                {"type": "web_search_call", "id": "ws_1", "status": "completed"},
+                {"type": "message", "role": "assistant",
+                 "content": [{"type": "output_text", "text": "Answer"}]},
+            ],
+            "status": "completed",
+            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        }
+        result = parse_response_output(resp)
+        assert result.content == "Answer"
+        assert result.tool_calls == []
+        assert result.finish_reason == "stop"
+
 
 # ======================================================================
 # parsing - consume_sdk_stream
@@ -520,3 +560,27 @@ class TestConsumeSdkStream:
         assert tool_calls[0].arguments == {"raw": "{bad"}
         mock_logger.warning.assert_called_once()
         assert "Failed to parse tool call arguments" in str(mock_logger.warning.call_args)
+
+    @pytest.mark.asyncio
+    async def test_hosted_web_search_call_events_ignored(self):
+        """Hosted web_search_call items and lifecycle events must not break parsing."""
+        item_added = MagicMock(type="web_search_call", id="ws_1")
+        ev_added = MagicMock(type="response.output_item.added", item=item_added)
+        ev_progress = MagicMock(type="response.web_search_call.in_progress")
+        ev_searching = MagicMock(type="response.web_search_call.searching")
+        ev_completed = MagicMock(type="response.web_search_call.completed")
+        item_done = MagicMock(type="web_search_call", id="ws_1")
+        ev_item_done = MagicMock(type="response.output_item.done", item=item_done)
+        ev_text = MagicMock(type="response.output_text.delta", delta="Result: 42")
+        resp_obj = MagicMock(status="completed", usage=None, output=[])
+        ev_final = MagicMock(type="response.completed", response=resp_obj)
+
+        async def stream():
+            for e in [ev_added, ev_progress, ev_searching, ev_completed,
+                      ev_item_done, ev_text, ev_final]:
+                yield e
+
+        content, tool_calls, finish_reason, _, _ = await consume_sdk_stream(stream())
+        assert content == "Result: 42"
+        assert tool_calls == []
+        assert finish_reason == "stop"


### PR DESCRIPTION
## Summary

This PR adds opt-in support for provider-hosted web search.

Some providers expose web search as a native/provider-hosted tool rather than a normal nanobot-executed function tool. Azure OpenAI Responses API is one example: it accepts `{ "type": "web_search" }` and returns provider-managed `web_search_call` output items/events.

Changes included:

- Add `tools.web.search.providerHosted`.
- Add a provider capability flag so nanobot only skips local `web_search` when the active provider actually supports hosted web search.
- Wire Azure OpenAI Responses API to inject the native `web_search` tool when enabled.
- Preserve Responses-native non-function tools during tool conversion.
- Ignore hosted `web_search_call` output items and lifecycle events in Responses parsing.
- Keep local `web_search` as a fallback when the active provider does not support hosted search.
- Document the new config option.

Closes #3741

## Behavior

```text
providerHosted=false
  -> use nanobot local web_search

providerHosted=true + provider supports hosted search
  -> use provider-hosted web search

providerHosted=true + provider does not support hosted search
  -> fall back to nanobot local web_search
```

## Azure Responses behavior verified

Azure OpenAI Responses API emits hosted search events such as:

- `response.web_search_call.in_progress`
- `response.web_search_call.searching`
- `response.web_search_call.completed`

It also returns `web_search_call` items in non-streaming `response.output`. These are provider-internal hosted tool calls, so nanobot ignores them while still parsing the final assistant message and usage.

Provider-specific hosted tool schemas are intentionally kept inside provider adapters, because different providers may use different tool names and request formats.

## Tests

```bash
python -m pytest tests/agent/test_tool_registration.py tests/providers/test_azure_openai_provider.py tests/providers/test_openai_responses.py
```