### PR TITLE
feat(api): stream tool progress SSE events

### DIFF
--- a/nanobot/api/server.py
+++ b/nanobot/api/server.py
@@ -102,6 +102,30 @@ def _sse_chunk(delta: str, model: str, chunk_id: str, finish_reason: str | None 
     return f"data: {_json.dumps(payload)}\n\n".encode()
 
 
+def _sse_event(event: str, data: dict[str, Any]) -> bytes:
+    """Format a named SSE event."""
+    return f"event: {event}\ndata: {_json.dumps(data, default=str)}\n\n".encode()
+
+
+def _tool_progress_payload(evt: dict[str, Any]) -> dict[str, Any]:
+    phase = evt.get("phase")
+    status = {
+        "start": "running",
+        "end": "completed",
+        "error": "error",
+    }.get(phase, str(phase or "unknown"))
+    payload = {
+        "tool": evt.get("name", ""),
+        "toolCallId": evt.get("call_id", ""),
+        "status": status,
+        "arguments": evt.get("arguments"),
+        "result": evt.get("result"),
+    }
+    if evt.get("error") is not None:
+        payload["error"] = evt.get("error")
+    return payload
+
+
 _SSE_DONE = b"data: [DONE]\n\n"
 
 # ---------------------------------------------------------------------------
@@ -242,7 +266,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
         await resp.prepare(request)
 
         chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
-        queue: asyncio.Queue[str | None] = asyncio.Queue()
+        queue: asyncio.Queue[bytes | None] = asyncio.Queue()
         stream_failed = False
         emitted_content = False
 
@@ -250,7 +274,23 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
             nonlocal emitted_content
             if token:
                 emitted_content = True
-            await queue.put(token)
+            await queue.put(_sse_chunk(token, model_name, chunk_id))
+
+        async def _on_progress(
+            _content: str,
+            *,
+            tool_hint: bool = False,
+            tool_events: list[dict[str, Any]] | None = None,
+        ) -> None:
+            if not tool_events:
+                return
+            for event in tool_events:
+                await queue.put(
+                    _sse_event(
+                        "nanobot.tool.progress",
+                        _tool_progress_payload(event),
+                    )
+                )
 
         async def _on_stream_end(*_a: Any, **_kw: Any) -> None:
             # Agent stream-end callbacks mark generation segment boundaries.
@@ -269,6 +309,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
                             session_key=session_key,
                             channel="api",
                             chat_id=API_CHAT_ID,
+                            on_progress=_on_progress,
                             on_stream=_on_stream,
                             on_stream_end=_on_stream_end,
                         ),
@@ -277,7 +318,7 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
                     if not emitted_content:
                         response_text = _response_text(response)
                         if response_text.strip():
-                            await queue.put(response_text)
+                            await queue.put(_sse_chunk(response_text, model_name, chunk_id))
             except Exception:
                 stream_failed = True
                 logger.exception("Streaming error for session {}", session_key)
@@ -287,10 +328,10 @@ async def handle_chat_completions(request: web.Request) -> web.Response:
         task = asyncio.create_task(_run())
         try:
             while True:
-                token = await queue.get()
-                if token is None:
+                event = await queue.get()
+                if event is None:
                     break
-                await resp.write(_sse_chunk(token, model_name, chunk_id))
+                await resp.write(event)
         finally:
             if not task.done():
                 task.cancel()

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -196,7 +196,7 @@ async def test_stream_sse_chunk_ids_are_consistent(aiohttp_client) -> None:
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
 @pytest.mark.asyncio
 async def test_stream_passes_on_stream_callbacks(aiohttp_client) -> None:
-    """process_direct should be called with on_stream and on_stream_end when streaming."""
+    """process_direct should be called with streaming callbacks when streaming."""
     captured_kwargs: dict = {}
 
     async def fake_process_direct(**kwargs):
@@ -218,8 +218,110 @@ async def test_stream_passes_on_stream_callbacks(aiohttp_client) -> None:
         json={"messages": [{"role": "user", "content": "hi"}], "stream": True},
     )
     assert resp.status == 200
+    assert captured_kwargs.get("on_progress") is not None
     assert captured_kwargs.get("on_stream") is not None
     assert captured_kwargs.get("on_stream_end") is not None
+
+
+@pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")
+@pytest.mark.asyncio
+async def test_stream_emits_tool_progress_sse_events(aiohttp_client) -> None:
+    """Structured tool_events should be exposed as named SSE events."""
+    agent = MagicMock()
+
+    async def fake_process_direct(
+        *, on_progress=None, on_stream=None, on_stream_end=None, **kwargs
+    ):
+        assert on_progress is not None
+        assert on_stream is not None
+        assert on_stream_end is not None
+        await on_progress(
+            'exec("ls")',
+            tool_hint=True,
+            tool_events=[
+                {
+                    "version": 1,
+                    "phase": "start",
+                    "call_id": "call-1",
+                    "name": "exec",
+                    "arguments": {"command": "ls"},
+                    "result": None,
+                    "error": None,
+                    "files": [],
+                    "embeds": [],
+                }
+            ],
+        )
+        await on_stream("done")
+        await on_progress(
+            "",
+            tool_events=[
+                {
+                    "version": 1,
+                    "phase": "end",
+                    "call_id": "call-1",
+                    "name": "exec",
+                    "arguments": {"command": "ls"},
+                    "result": "file.txt",
+                    "error": None,
+                    "files": [],
+                    "embeds": [],
+                }
+            ],
+        )
+        await on_stream_end(resuming=False)
+        return "done"
+
+    agent.process_direct = fake_process_direct
+    agent._connect_mcp = AsyncMock()
+    agent.close_mcp = AsyncMock()
+
+    app = create_app(agent, model_name="m")
+    client = await aiohttp_client(app)
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "run ls"}], "stream": True},
+    )
+
+    assert resp.status == 200
+    body = await resp.text()
+    blocks = [block for block in body.split("\n\n") if block.strip()]
+    progress_blocks = [
+        block for block in blocks if block.startswith("event: nanobot.tool.progress\n")
+    ]
+    assert len(progress_blocks) == 2
+
+    payloads = [
+        json.loads(block.split("\ndata: ", 1)[1])
+        for block in progress_blocks
+    ]
+    assert payloads == [
+        {
+            "tool": "exec",
+            "toolCallId": "call-1",
+            "status": "running",
+            "arguments": {"command": "ls"},
+            "result": None,
+        },
+        {
+            "tool": "exec",
+            "toolCallId": "call-1",
+            "status": "completed",
+            "arguments": {"command": "ls"},
+            "result": "file.txt",
+        },
+    ]
+
+    data_lines = [line for line in body.split("\n") if line.startswith("data: ")]
+    chunks = [
+        json.loads(line[len("data: "):])
+        for line in data_lines
+        if line != "data: [DONE]"
+    ]
+    chunks = [chunk for chunk in chunks if chunk.get("object") == "chat.completion.chunk"]
+    assert any(chunk["choices"][0]["delta"].get("content") == "done" for chunk in chunks)
+    assert data_lines[-1] == "data: [DONE]"
 
 
 @pytest.mark.skipif(not HAS_AIOHTTP, reason="aiohttp not installed")


### PR DESCRIPTION
## Summary

Fixes #3698.

- Emits structured `event: nanobot.tool.progress` SSE events from `/v1/chat/completions` when streaming is enabled.
- Keeps normal OpenAI-compatible `data:` chunks for assistant text unchanged.
- Maps nanobot tool event phases to client-friendly statuses: `running`, `completed`, and `error`.

## Problem / Root Cause

The API streaming path only forwarded assistant token deltas via `on_stream`. AgentLoop already emits structured tool progress through `on_progress(..., tool_events=...)`, but `handle_chat_completions` did not register an `on_progress` callback, so API clients could not observe tool start/finish events during streamed requests.

## Scope

- Files/modules changed: `nanobot/api/server.py`, `tests/test_api_stream.py`
- Explicit non-goals: no changes to channel streaming, WebSocket envelopes, AgentLoop tool event shape, or non-streaming API responses
- User-visible behavior changes: streaming API clients may now receive named SSE tool progress events alongside existing chat completion chunks
- Compatibility notes: ordinary OpenAI-compatible chunks and `[DONE]` remain in the same format

## Design

The API stream queue now carries already-formatted SSE bytes. Token deltas are still formatted with `_sse_chunk`, while tool events use a small named-event helper. This keeps the API-specific projection local to `server.py` and reuses the existing AgentLoop `on_progress` contract instead of adding another tool-event path.

## Safety / Risk

- Default behavior impact: only applies to `stream=true` API requests that produce tool events
- Config/API/channel/session/storage/network impact: API output adds optional named SSE events; no config, channel, session, storage, or network behavior changes
- Rollback plan: revert this PR to stop emitting named tool progress SSE events
- Residual risk: clients that assume every SSE `data:` line is an OpenAI chat chunk may need to ignore named events, which is standard SSE behavior

## Validation

- `uv run --extra dev ruff check nanobot --select F401,F841`
- `uv run --extra dev ruff check nanobot/api/server.py tests/test_api_stream.py --select F401,F841,E501,F821`
- `git diff --check`
- `uv run --extra dev pytest tests/test_api_stream.py tests/test_openai_api.py tests/agent/test_loop_progress.py`
- `uv run --extra dev pytest tests/`

## Reflection

Before:
- Source: upstream issue #3698
- Goal: expose structured tool progress events in API streaming
- Non-goals: do not alter channel/WebSocket streaming, AgentLoop event shape, or non-streaming API responses
- Risk boundary: OpenAI-compatible API SSE output format

After:
- The patch stayed within the API streaming path and tests.
- The implementation reused existing `on_progress` tool event metadata.
- Full test suite passed locally.
