### PR TITLE
feat(feishu): add topic_isolation config switch

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -258,6 +258,7 @@ class FeishuConfig(Base):
     reply_to_message: bool = False  # If True, bot replies quote the user's original message
     streaming: bool = True
     domain: Literal["feishu", "lark"] = "feishu"  # Set to "lark" for international Lark
+    topic_isolation: bool = True  # If True, each topic in group chat gets its own session (isolation)
 
 
 _STREAM_ELEMENT_ID = "streaming_md"
@@ -1770,12 +1771,15 @@ class FeishuChannel(BaseChannel):
             if not content and not media_paths:
                 return
 
-            # Build topic-scoped session key for conversation isolation.
-            # Group chat: each topic gets its own session via root_id (replies
-            # inside a topic) or message_id (top-level messages start a new topic).
+            # Build session key for conversation isolation.
+            # If topic_isolation is True: each topic gets its own session via root_id/message_id.
+            # If topic_isolation is False: all messages in group share the same session.
             # Private chat: no override — same behavior as Telegram/Slack.
             if chat_type == "group":
-                session_key = f"feishu:{chat_id}:{root_id or message_id}"
+                if self.config.topic_isolation:
+                    session_key = f"feishu:{chat_id}:{root_id or message_id}"
+                else:
+                    session_key = f"feishu:{chat_id}"
             else:
                 session_key = None
 

--- a/tests/channels/test_feishu_reply.py
+++ b/tests/channels/test_feishu_reply.py
@@ -25,7 +25,11 @@ from nanobot.channels.feishu import FeishuChannel, FeishuConfig
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_feishu_channel(reply_to_message: bool = False, group_policy: str = "mention") -> FeishuChannel:
+def _make_feishu_channel(
+    reply_to_message: bool = False,
+    group_policy: str = "mention",
+    topic_isolation: bool = True,
+) -> FeishuChannel:
     config = FeishuConfig(
         enabled=True,
         app_id="cli_test",
@@ -33,6 +37,7 @@ def _make_feishu_channel(reply_to_message: bool = False, group_policy: str = "me
         allow_from=["*"],
         reply_to_message=reply_to_message,
         group_policy=group_policy,
+        topic_isolation=topic_isolation,
     )
     channel = FeishuChannel(config, MessageBus())
     channel._client = MagicMock()
@@ -93,6 +98,15 @@ def test_feishu_config_reply_to_message_defaults_false() -> None:
 def test_feishu_config_reply_to_message_can_be_enabled() -> None:
     config = FeishuConfig(reply_to_message=True)
     assert config.reply_to_message is True
+
+
+def test_feishu_config_topic_isolation_defaults_true() -> None:
+    assert FeishuConfig().topic_isolation is True
+
+
+def test_feishu_config_topic_isolation_can_be_disabled() -> None:
+    config = FeishuConfig(topic_isolation=False)
+    assert config.topic_isolation is False
 
 
 # ---------------------------------------------------------------------------
@@ -917,8 +931,7 @@ async def test_on_message_ignores_unauthorized_sender_before_side_effects() -> N
 @pytest.mark.asyncio
 async def test_session_key_with_topic_isolation_true_uses_thread_scoped() -> None:
     """When topic_isolation is True (default), group messages use thread-scoped session keys."""
-    channel = _make_feishu_channel(group_policy="open")
-    channel.config.topic_isolation = True
+    channel = _make_feishu_channel(group_policy="open", topic_isolation=True)
     bus_spy = []
     original_publish = channel.bus.publish_inbound
 
@@ -957,8 +970,7 @@ async def test_session_key_with_topic_isolation_true_uses_thread_scoped() -> Non
 @pytest.mark.asyncio
 async def test_session_key_with_topic_isolation_false_uses_group_scoped() -> None:
     """When topic_isolation is False, all group messages share the same session key (no isolation)."""
-    channel = _make_feishu_channel(group_policy="open")
-    channel.config.topic_isolation = False
+    channel = _make_feishu_channel(group_policy="open", topic_isolation=False)
     bus_spy = []
     original_publish = channel.bus.publish_inbound
 

--- a/tests/channels/test_feishu_reply.py
+++ b/tests/channels/test_feishu_reply.py
@@ -109,6 +109,11 @@ def test_feishu_config_topic_isolation_can_be_disabled() -> None:
     assert config.topic_isolation is False
 
 
+def test_feishu_config_topic_isolation_accepts_camel_case() -> None:
+    config = FeishuConfig.model_validate({"topicIsolation": False})
+    assert config.topic_isolation is False
+
+
 # ---------------------------------------------------------------------------
 # _get_message_content_sync tests
 # ---------------------------------------------------------------------------

--- a/tests/channels/test_feishu_reply.py
+++ b/tests/channels/test_feishu_reply.py
@@ -912,3 +912,95 @@ async def test_on_message_ignores_unauthorized_sender_before_side_effects() -> N
     channel._download_and_save_media.assert_not_awaited()
     channel.transcribe_audio.assert_not_awaited()
     channel._handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_session_key_with_topic_isolation_true_uses_thread_scoped() -> None:
+    """When topic_isolation is True (default), group messages use thread-scoped session keys."""
+    channel = _make_feishu_channel(group_policy="open")
+    channel.config.topic_isolation = True
+    bus_spy = []
+    original_publish = channel.bus.publish_inbound
+
+    async def capture(msg):
+        bus_spy.append(msg)
+        await original_publish(msg)
+
+    channel.bus.publish_inbound = capture
+    channel._download_and_save_media = AsyncMock(return_value=(None, ""))
+    channel.transcribe_audio = AsyncMock(return_value="")
+    channel._add_reaction = AsyncMock(return_value=None)
+
+    # Test with root_id
+    event1 = _make_feishu_event(
+        chat_type="group",
+        content='{"text": "hello"}',
+        root_id="om_root123",
+        message_id="om_child456",
+    )
+    await channel._on_message(event1)
+
+    # Test without root_id
+    event2 = _make_feishu_event(
+        chat_type="group",
+        content='{"text": "another"}',
+        root_id=None,
+        message_id="om_001",
+    )
+    await channel._on_message(event2)
+
+    assert len(bus_spy) == 2
+    assert bus_spy[0].session_key_override == "feishu:oc_abc:om_root123"
+    assert bus_spy[1].session_key_override == "feishu:oc_abc:om_001"
+
+
+@pytest.mark.asyncio
+async def test_session_key_with_topic_isolation_false_uses_group_scoped() -> None:
+    """When topic_isolation is False, all group messages share the same session key (no isolation)."""
+    channel = _make_feishu_channel(group_policy="open")
+    channel.config.topic_isolation = False
+    bus_spy = []
+    original_publish = channel.bus.publish_inbound
+
+    async def capture(msg):
+        bus_spy.append(msg)
+        await original_publish(msg)
+
+    channel.bus.publish_inbound = capture
+    channel._download_and_save_media = AsyncMock(return_value=(None, ""))
+    channel.transcribe_audio = AsyncMock(return_value="")
+    channel._add_reaction = AsyncMock(return_value=None)
+
+    # Test with root_id
+    event1 = _make_feishu_event(
+        chat_type="group",
+        content='{"text": "hello"}',
+        root_id="om_root123",
+        message_id="om_child456",
+    )
+    await channel._on_message(event1)
+
+    # Test without root_id
+    event2 = _make_feishu_event(
+        chat_type="group",
+        content='{"text": "another"}',
+        root_id=None,
+        message_id="om_001",
+    )
+    await channel._on_message(event2)
+
+    # Private chat still works
+    event3 = _make_feishu_event(
+        chat_type="p2p",
+        content='{"text": "private"}',
+        root_id=None,
+        message_id="om_private",
+    )
+    await channel._on_message(event3)
+
+    assert len(bus_spy) == 3
+    # Group messages all share the same key
+    assert bus_spy[0].session_key_override == "feishu:oc_abc"
+    assert bus_spy[1].session_key_override == "feishu:oc_abc"
+    # Private chat has no session key override
+    assert bus_spy[2].session_key_override is None


### PR DESCRIPTION

#### Feat: Add topic_isolation Config Switch

Adds a topic_isolation config switch for Feishu that lets users choose:

- On (default) : Each topic in a group chat gets its own isolated session
- Off : All messages in a group share a single unified session, regardless of topic

This maintains backward compatibility while giving users control over their preferred interaction style.

#### Related Issue
https://github.com/HKUDS/nanobot/issues/3692

#### Changes:
1. **FeishuConfig**: Add `topic_isolation: bool = True` config field
2. **Session Key Logic**: 
   - When `topic_isolation: true`: `feishu:{chat_id}:{root_id/message_id}` → each topic gets its own session
   - When `topic_isolation: false`: `feishu:{chat_id}` → entire group shares one session
3. **Tests**: 
   - Add config parsing tests (snake_case + camelCase)
   - Add session key logic tests

#### Usage:
```json
{
  "channels": {
    "feishu": {
      "enabled": true,
      "app_id": "cli_xxx",
      "app_secret": "yyy",
      "topic_isolation": false  // disable topic isolation
    }
  }
}
```

Both `topic_isolation` (snake_case) and `topicIsolation` (camelCase) work!

#### Backward Compatibility
- Default is `true`, so existing behavior preserved
