### PR TITLE
feat(auth): multi-tenant WebUI accounts + per-user state isolation

### DIFF
--- a/.agent/security.md
+++ b/.agent/security.md
@@ -23,3 +23,15 @@ The only escape hatch is `configure_ssrf_whitelist(cidrs)`, which reads from `co
 `tools/sandbox.py` provides optional command wrapping. The only backend currently shipped is `bwrap` (bubblewrap), intended for containerized deployments. On Windows and bare-metal Linux without `bwrap`, commands run in the native shell with workspace restriction as the only guard.
 
 **Rule**: If adding a new sandbox backend, implement `_wrap_<name>(command, workspace, cwd) -> str` and register it in `_BACKENDS`.
+
+## Multi-Tenant Boundaries
+
+Per-user isolation depends on the `current_user_ctx: ContextVar[UserContext | None]` declared in `nanobot/auth/context.py`. The agent loop sets it at the start of every `_dispatch` call and resets it in the `finally` clause. Tools, `SessionManager`, `ContextBuilder.memory`, and `ContextBuilder.skills` consult it to rebase paths under `~/.nanobot/users/<uid>/`.
+
+**Rule**: When adding a new tool that touches the filesystem or persists per-conversation state, route through `current_user_ctx.get()` (or accept a `user_ctx` parameter from the call site). Tools that bind workspace-relative paths in `__init__` and never re-read them on `execute()` will silently leak across users — see `_FsTool._active_paths()` and `ExecTool.working_dir` for the property pattern.
+
+**Rule**: HTTP routes that mutate user state must require admin role via `_require_admin(req, svc)` (`nanobot/auth/routes.py`) AND pass the double-submit CSRF check. The dispatcher at `commands.py` invokes `dispatch(..., require_csrf=True)` so this is enforced for all production traffic; tests bypass with `require_csrf=False`.
+
+**Rule**: Channel adapters (Telegram, Slack, Discord, etc.) stay admin-scoped in v1 — do NOT thread `UserContext` through them. The mapping from chat-side user IDs to WebUI accounts is an open v2 design problem.
+
+See [`docs/auth.md`](../docs/auth.md) for the full operator surface and threat model.

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Browse the [repo docs](./docs/README.md) for the latest features and GitHub deve
 - Configure providers, web search, MCP, and runtime behavior: [Configuration](./docs/configuration.md)
 - Integrate nanobot with local tools and automations: [OpenAI-Compatible API](./docs/openai-api.md) · [Python SDK](./docs/python-sdk.md)
 - Run nanobot with Docker or as a Linux service: [Deployment](./docs/deployment.md)
+- Manage WebUI accounts, roles, and per-user state: [Auth & Multi-tenant](./docs/auth.md)
 
 ## 🤝 Contribute & Roadmap
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,205 @@
+# Multi-Tenant Auth & Per-User State
+
+Multi-tenant nanobot serves many users from a single gateway process. Each
+WebUI account gets an isolated workspace, sessions, memory, media, and
+tool-result spill area under `~/.nanobot/users/<user_id>/`. Chat channels
+(Telegram, Slack, Discord, etc.) remain admin-scoped in v1; only the WebUI
+is per-user.
+
+This document is for **operators** standing up nanobot in a shared/multi-user
+deployment. For end-user UX, see the WebUI directly.
+
+## TL;DR
+
+```bash
+# 1. Start the gateway. On first run with legacy single-tenant state
+#    on disk, the old layout is auto-archived to ~/.nanobot.legacy.<date>/.
+nanobot gateway
+
+# 2. Create the first admin (CLI is the only path until you have one).
+nanobot user create admin@yourorg --role admin
+# (you'll be prompted for a password; min 12 chars)
+
+# 3. Open the WebUI. Sign in as that admin.
+#    Use the "Users" link in the sidebar to manage other accounts.
+```
+
+The WebUI is gated by an HTTP-only `nanobot_session` cookie. The first
+visitor sees a sign-in page; signup is open by default (single-team
+deployments). Disable open signup at the reverse-proxy layer if needed.
+
+---
+
+## Filesystem Layout
+
+```
+~/.nanobot/
+  config.json                       # admin / system-wide (LLM keys, channels)
+  auth.db                           # SQLite: users, web_sessions, audit_log
+  bridge/                           # WhatsApp bridge (admin)
+  cron/                             # gateway-level cron (heartbeat, dream)
+  logs/                             # gateway logs
+  users/<user_id>/
+    workspace/                      # per-user workspace (tools write here)
+      memory/                       # per-user memory (MEMORY.md, history.jsonl)
+      .nanobot/tool-results/        # tool-output spill files
+    sessions/                       # per-user session JSONLs
+    media/<channel>/                # per-user media uploads
+    file_state/                     # per-user file read/write tracker (planned)
+```
+
+`<user_id>` is a 26-char Crockford-base32 ULID generated at signup. It is
+stable across email or display-name changes and never appears in URLs.
+
+**What stays global:** `config.json`, `bridge/`, channel adapters,
+gateway-level cron jobs, `auth.db`. LLM provider API keys are
+admin-supplied — there is no per-user BYOK in v1.
+
+## Auth Mechanism
+
+| Surface | Auth |
+|---|---|
+| WebUI HTTP/WS | `nanobot_session` cookie (HttpOnly, SameSite=Lax, Secure when TLS) |
+| Chat channels | Existing channel-specific tokens (Telegram bot token, Slack OAuth, etc.) |
+| Static-token WS clients | Legacy `?token=` query param (admin-only, kept for non-browser clients) |
+| Operator CLI | Direct SQLite access — no remote auth |
+
+Cookie minted at successful login or signup. Persisted server-side as
+`sha256(token)` in `auth.db.web_sessions`; the raw token never lands on
+disk. Sliding 30-day TTL — every request that successfully verifies the
+cookie extends `expires_at`.
+
+Passwords hashed with **argon2id** (`argon2-cffi`, time_cost=3,
+memory_cost=64MB, parallelism=2). Wrong password and unknown email both
+return the same generic error to avoid email enumeration.
+
+## CSRF
+
+Every response from the gateway sets a `nanobot_csrf` cookie if the request
+didn't already carry one. The cookie is **not** HttpOnly so JS can read it.
+State-changing requests (POST/PUT/PATCH/DELETE on `/auth/*` and `/admin/*`)
+must echo the cookie value in the `X-CSRF-Token` header. The webui's
+`authFetch` helper does this automatically. Combined with `SameSite=Lax`
+on the session cookie, this protects against cross-origin POSTs (defence in
+depth — the SameSite cookie alone already blocks the obvious vectors).
+
+## Rate Limiting
+
+In-memory token bucket per `(path, IP)`:
+
+| Endpoint | Limit |
+|---|---|
+| `POST /auth/login`  | 5 attempts / minute |
+| `POST /auth/signup` | 3 attempts / minute |
+
+Over-limit responses return 429 with a `Retry-After: <seconds>` header.
+Each trip writes a `ratelimit.trip` row to `audit_log`. Suitable for a
+single-instance gateway behind a reverse proxy; replace with Redis-backed
+limiter if you scale horizontally.
+
+## CLI Reference
+
+`nanobot user …` — operator-only, requires shell access to the host:
+
+| Command | Description |
+|---|---|
+| `nanobot user list` | Tabular list of accounts (id, email, role, created, last login, disabled). |
+| `nanobot user create <email> [--role admin] [--display-name "X"]` | Create an account. Prompts for password (min 12 chars). |
+| `nanobot user promote <email-or-id>` | Grant admin role. |
+| `nanobot user demote <email-or-id>` | Revoke admin role. |
+| `nanobot user reset-password <email-or-id>` | Set new password and revoke all of the user's active sessions. |
+| `nanobot user disable <email-or-id> [--off]` | Disable (default) or re-enable an account. Disabling also revokes live sessions. |
+| `nanobot user delete <email-or-id> [--yes]` | Delete the account and cascade its sessions. **Filesystem data under `~/.nanobot/users/<id>/` is NOT removed automatically** — operator removes manually after auditing. |
+
+Identifiers may be either an email or a ULID.
+
+Every CLI command writes an `audit_log` row with `actor_user_id=NULL`
+(system actor).
+
+## Admin HTTP API
+
+Authenticated as a non-disabled `role='admin'` user (cookie). State-changing
+verbs require the CSRF header. Returns 401 (no session), 403 (not admin
+or disabled).
+
+| Endpoint | Description |
+|---|---|
+| `GET    /admin/users` | List all users (no pagination in v1; revisit at >100). |
+| `POST   /admin/users/<id>/role`     `{role: "user" \| "admin"}` | Promote/demote. |
+| `POST   /admin/users/<id>/disabled` `{disabled: bool}` | Disable cascades to session revocation. |
+| `DELETE /admin/users/<id>` | Self-delete blocked with 400 — prevents operator lockout. |
+
+## Legacy Migration
+
+When you upgrade a host that ran pre-multi-tenant nanobot, the old layout
+(`sessions/`, `workspace/`, `memory/` directly under `~/.nanobot`) is moved
+out of the way on first gateway start:
+
+```
+~/.nanobot                ->  ~/.nanobot.legacy.YYYYMMDD-HHMMSS/
+~/.nanobot/config.json    (preserved into the new ~/.nanobot)
+~/.nanobot/users/         (created empty)
+```
+
+A loud warning prints to console with the rollback command:
+
+```bash
+mv ~/.nanobot.legacy.<date> ~/.nanobot
+```
+
+Skip the migration entirely with `NANOBOT_SKIP_LEGACY_MIGRATION=1` (useful
+when running multiple gateway instances against shared state, or when
+you've already manually migrated). Contention is guarded by a
+`filelock` on `~/.nanobot/.migration.lock`.
+
+## Threat Model Summary
+
+| Risk | Mitigation |
+|---|---|
+| Brute-force login | 5/min/IP rate limit on `/auth/login`; argon2id is intentionally slow. |
+| Session theft | HttpOnly + SameSite=Lax cookie; Secure when behind TLS. Logout deletes the row. |
+| Email enumeration on login | Generic error response; constant-time hash even on unknown email. |
+| Cross-origin CSRF | Double-submit `X-CSRF-Token` header + SameSite=Lax cookie. |
+| Path traversal via user_id | All per-user paths derive from a ULID-validated UserContext, never raw input. |
+| Cross-user data leak via tools | Tools (filesystem, shell, memory, media, tool-results) consult `current_user_ctx` ContextVar; per-user keying in `FileStateStore`. |
+| Disabled-admin still has cookie | `_require_admin` blocks any admin route call from a disabled account; disable cascades to session revocation. |
+| Self-lockout | `DELETE /admin/users/<id>` blocks self; UI disables self-row buttons. |
+
+## Known Limitations (v1, deferred to follow-ups)
+
+- **No SSO / OAuth** (Google, GitHub, Magic-link). Local accounts only.
+- **No email verification or self-serve password reset.** Operator uses
+  `nanobot user reset-password`. SMTP infra is out of scope for v1.
+- **Per-user channels not supported.** Telegram/Slack/Discord stay
+  admin-scoped. A v2 mapping (`/link` chat command + per-user bot tokens)
+  is in the backlog.
+- **No per-user LLM API keys (BYOK).** Admin keys are shared across users.
+- **No per-user cron jobs.** `nanobot.agent.tools.cron` is gateway-level.
+- **No per-user MCP allowlist.** MCP servers are admin-scoped.
+- **Dream consolidation runs as a global cron job.** It does not
+  iterate per-user `memory/` directories. A per-user dream cycle needs
+  its own scheduler design.
+- **Signed media URLs are not user-bound.** `_handle_media_fetch` validates
+  the HMAC against the global media root. An attacker who can sign URLs
+  for one user could fetch another's media. Per-user uploads land in
+  distinct directories so the attack requires forging an HMAC, but the
+  cookie-binding hardening is tracked.
+- **`image_generation` and `message` tools** still bind to the gateway
+  workspace; their per-user wiring lands alongside the signed-URL
+  hardening above.
+- **Memory directory layout** lives under `users/<uid>/workspace/memory/`
+  (one level deeper than the `users/<uid>/memory/` shown in early plans)
+  because `GitStore` tracks files relative to the workspace root.
+- **Audit log has no UI.** Rows are written to `auth.db.audit_log`;
+  query with sqlite3 directly.
+
+## Operator Recovery Cheatsheet
+
+| Situation | Recovery |
+|---|---|
+| Forgot the admin password | `nanobot user reset-password <email>` |
+| Locked out (no admin exists) | `nanobot user create newadmin@x --role admin` |
+| Need to inspect login attempts | `sqlite3 ~/.nanobot/auth.db "SELECT * FROM audit_log ORDER BY ts DESC LIMIT 50"` |
+| Need to disable a noisy user | `nanobot user disable <email>` (revokes sessions immediately) |
+| Want to wipe a user's data | `nanobot user delete <email> --yes` then `rm -rf ~/.nanobot/users/<id>/` |
+| Roll back a bad legacy migration | `mv ~/.nanobot.legacy.<date> ~/.nanobot` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1157,3 +1157,26 @@ Set `agents.defaults.toolHintMaxLength` to control the truncation threshold:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `agents.defaults.toolHintMaxLength` | `40` | Maximum characters for tool hint display. Range: 20–500. Higher values show more of the command or path; lower values keep hints compact. |
+
+## Multi-Tenant State Layout
+
+Nanobot serves WebUI users out of a single shared gateway process and
+isolates per-user state under `~/.nanobot/users/<user_id>/`. See
+[`docs/auth.md`](auth.md) for the full operator guide.
+
+```
+~/.nanobot/
+  config.json           # this file — global, admin-supplied
+  auth.db               # SQLite users / sessions / audit log
+  bridge/, cron/, logs/ # global gateway state
+  users/<user_id>/      # per-user state (workspace, sessions, memory, media)
+```
+
+The schema in `config.json` is **global only**. Per-user preferences are
+not configurable in v1 (no BYOK LLM keys, no per-user channel tokens).
+
+Environment knobs that affect multi-tenant startup:
+
+| Env | Effect |
+|---|---|
+| `NANOBOT_SKIP_LEGACY_MIGRATION=1` | Skip the one-shot single-tenant → multi-tenant filesystem rename. Use after manual migration or for shared-state replicas. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,14 @@
 # Deployment
 
+> [!IMPORTANT]
+> **Multi-tenant default:** since the addition of WebUI accounts, nanobot
+> isolates per-user state under `~/.nanobot/users/<user_id>/`. On first
+> gateway start, any pre-existing single-tenant layout is auto-archived
+> to `~/.nanobot.legacy.<date>/` (a loud warning prints with the rollback
+> command). Skip with `NANOBOT_SKIP_LEGACY_MIGRATION=1`. See
+> [`docs/auth.md`](auth.md) for operator setup, CLI commands, and the
+> threat model.
+
 ## Docker
 
 > [!TIP]

--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
 from loguru import logger
+
 from nanobot.session.manager import Session, SessionManager
 
 if TYPE_CHECKING:
@@ -106,18 +107,24 @@ class AutoCompact:
         finally:
             self._archiving.discard(key)
 
-    def prepare_session(self, session: Session, key: str) -> tuple[Session, str | None]:
+    def prepare_session(
+        self,
+        session: Session,
+        key: str,
+        sessions: SessionManager | None = None,
+    ) -> tuple[Session, str | None]:
+        # Use the per-request SessionManager when provided so per-user sessions
+        # don't get clobbered with whatever the global manager has cached.
+        sm = sessions if sessions is not None else self.sessions
         if key in self._archiving or self._is_expired(session.updated_at):
             logger.info("Auto-compact: reloading session {} (archiving={})", key, key in self._archiving)
-            session = self.sessions.get_or_create(key)
-        # Hot path: summary from in-memory dict (process hasn't restarted).
-        # Also clean metadata copy so stale _last_summary never leaks to disk.
+            session = sm.get_or_create(key)
         entry = self._summaries.pop(key, None)
         if entry:
             session.metadata.pop("_last_summary", None)
             return session, self._format_summary(entry[0], entry[1])
         if "_last_summary" in session.metadata:
             meta = session.metadata.pop("_last_summary")
-            self.sessions.save(session)
+            sm.save(session)
             return session, self._format_summary(meta["text"], datetime.fromisoformat(meta["last_active"]))
         return session, None

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -10,7 +10,12 @@ from typing import Any
 
 from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
-from nanobot.utils.helpers import build_assistant_message, current_time_str, detect_image_mime, truncate_text
+from nanobot.utils.helpers import (
+    build_assistant_message,
+    current_time_str,
+    detect_image_mime,
+    truncate_text,
+)
 from nanobot.utils.prompt_templates import render_template
 
 
@@ -24,10 +29,50 @@ class ContextBuilder:
     _RUNTIME_CONTEXT_END = "[/Runtime Context]"
 
     def __init__(self, workspace: Path, timezone: str | None = None, disabled_skills: list[str] | None = None):
-        self.workspace = workspace
+        self._default_workspace = workspace
         self.timezone = timezone
-        self.memory = MemoryStore(workspace)
-        self.skills = SkillsLoader(workspace, disabled_skills=set(disabled_skills) if disabled_skills else None)
+        self._default_memory = MemoryStore(workspace)
+        self._user_memory: dict[str, MemoryStore] = {}
+        self._disabled_skills = set(disabled_skills) if disabled_skills else None
+        self._default_skills = SkillsLoader(workspace, disabled_skills=self._disabled_skills)
+        self._user_skills: dict[str, SkillsLoader] = {}
+
+    @property
+    def workspace(self) -> Path:
+        """Active workspace, honoring the per-request UserContext."""
+        from nanobot.auth.context import current_user_ctx
+
+        ctx = current_user_ctx.get()
+        return ctx.workspace_path() if ctx is not None else self._default_workspace
+
+    @property
+    def memory(self) -> MemoryStore:
+        """Per-user MemoryStore when a UserContext is active, else the default."""
+        from nanobot.auth.context import current_user_ctx
+
+        ctx = current_user_ctx.get()
+        if ctx is None:
+            return self._default_memory
+        store = self._user_memory.get(ctx.user_id)
+        if store is None:
+            store = MemoryStore(ctx.workspace_path())
+            self._user_memory[ctx.user_id] = store
+        return store
+
+    @property
+    def skills(self) -> SkillsLoader:
+        from nanobot.auth.context import current_user_ctx
+
+        ctx = current_user_ctx.get()
+        if ctx is None:
+            return self._default_skills
+        loader = self._user_skills.get(ctx.user_id)
+        if loader is None:
+            loader = SkillsLoader(
+                ctx.workspace_path(), disabled_skills=self._disabled_skills
+            )
+            self._user_skills[ctx.user_id] = loader
+        return loader
 
     def build_system_prompt(
         self,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -872,11 +872,12 @@ class AgentLoop:
                             content="", metadata={**msg.metadata, "_turn_end": True},
                         ))
                         if msg.metadata.get("webui") is True:
+                            title_sessions = self._sessions_for(msg.user_context)
                             async def _generate_title_and_notify() -> None:
                                 generated = await maybe_generate_webui_title_after_turn(
                                     channel=msg.channel,
                                     metadata=msg.metadata,
-                                    sessions=self.sessions,
+                                    sessions=title_sessions,
                                     session_key=session_key,
                                     provider=self.provider,
                                     model=self.model,
@@ -995,7 +996,7 @@ class AgentLoop:
             if self._restore_pending_user_turn(session):
                 sessions.save(session)
 
-            session, pending = self.auto_compact.prepare_session(session, key)
+            session, pending = self.auto_compact.prepare_session(session, key, sessions=sessions)
             if pending:
                 logger.info("Memory compact triggered for session {}", key)
 
@@ -1003,6 +1004,7 @@ class AgentLoop:
                 session,
                 session_summary=pending,
                 replay_max_messages=self._max_messages,
+                sessions=sessions,
             )
             # Persist subagent follow-ups into durable history BEFORE prompt
             # assembly. ContextBuilder merges adjacent same-role messages for
@@ -1052,6 +1054,7 @@ class AgentLoop:
                 self.consolidator.maybe_consolidate_by_tokens(
                     session,
                     replay_max_messages=self._max_messages,
+                    sessions=sessions,
                 )
             )
             options = ask_user_options_from_messages(all_msgs) if stop_reason == "ask_user" else []
@@ -1095,7 +1098,7 @@ class AgentLoop:
         if self._restore_pending_user_turn(session):
             sessions.save(session)
 
-        session, pending = self.auto_compact.prepare_session(session, key)
+        session, pending = self.auto_compact.prepare_session(session, key, sessions=sessions)
 
         # Slash commands
         raw = msg.content.strip()
@@ -1107,6 +1110,7 @@ class AgentLoop:
             session,
             session_summary=pending,
             replay_max_messages=self._max_messages,
+            sessions=sessions,
         )
 
         self._set_tool_context(
@@ -1225,6 +1229,7 @@ class AgentLoop:
             self.consolidator.maybe_consolidate_by_tokens(
                 session,
                 replay_max_messages=self._max_messages,
+                sessions=sessions,
             )
         )
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -61,6 +61,7 @@ from nanobot.utils.runtime import EMPTY_FINAL_RESPONSE_MESSAGE
 from nanobot.utils.webui_titles import mark_webui_session, maybe_generate_webui_title_after_turn
 
 if TYPE_CHECKING:
+    from nanobot.auth.context import UserContext
     from nanobot.config.schema import (
         ChannelsConfig,
         ExecToolConfig,
@@ -276,6 +277,9 @@ class AgentLoop:
 
         self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
         self.sessions = session_manager or SessionManager(workspace)
+        # Per-user SessionManager cache. Built lazily when an inbound message carries
+        # a UserContext (WebUI auth path). Channel-admin / CLI paths share self.sessions.
+        self._user_session_managers: dict[str, SessionManager] = {}
         self.tools = ToolRegistry()
         # One file-read/write tracker per logical session. The tool registry is
         # shared by this loop, so tools resolve the active state via contextvars.
@@ -537,6 +541,16 @@ class AgentLoop:
         sub_cancelled = await self.subagents.cancel_by_session(key)
         return cancelled + sub_cancelled
 
+    def _sessions_for(self, user_ctx: "UserContext | None") -> SessionManager:
+        """Return the SessionManager for the request's user; fall back to global."""
+        if user_ctx is None:
+            return self.sessions
+        cached = self._user_session_managers.get(user_ctx.user_id)
+        if cached is None:
+            cached = SessionManager(self.workspace, user_ctx=user_ctx)
+            self._user_session_managers[user_ctx.user_id] = cached
+        return cached
+
     def _effective_session_key(self, msg: InboundMessage) -> str:
         """Return the session key used for task routing and mid-turn injections."""
         if self._unified_session and not msg.session_key_override:
@@ -570,6 +584,7 @@ class AgentLoop:
         metadata: dict[str, Any] | None = None,
         session_key: str | None = None,
         pending_queue: asyncio.Queue | None = None,
+        sessions: SessionManager | None = None,
     ) -> tuple[str | None, list[str], list[dict], str, bool]:
         """Run the agent iteration loop.
 
@@ -600,7 +615,7 @@ class AgentLoop:
         async def _checkpoint(payload: dict[str, Any]) -> None:
             if session is None:
                 return
-            self._set_runtime_checkpoint(session, payload)
+            self._set_runtime_checkpoint(session, payload, sessions=sessions)
 
         async def _drain_pending(*, limit: int = _MAX_INJECTIONS_PER_TURN) -> list[dict[str, Any]]:
             """Drain follow-up messages from the pending queue.
@@ -871,10 +886,11 @@ class AgentLoop:
                     # next conversation turn.
                     try:
                         key = self._effective_session_key(msg)
-                        session = self.sessions.get_or_create(key)
+                        sessions = self._sessions_for(msg.user_context)
+                        session = sessions.get_or_create(key)
                         if self._restore_runtime_checkpoint(session):
                             self._clear_pending_user_turn(session)
-                            self.sessions.save(session)
+                            sessions.save(session)
                             logger.info(
                                 "Restored partial context for cancelled session {}",
                                 key,
@@ -946,6 +962,7 @@ class AgentLoop:
     ) -> OutboundMessage | None:
         """Process a single inbound message and return the response."""
         self._refresh_provider_snapshot()
+        sessions = self._sessions_for(msg.user_context)
         # System messages: parse origin from chat_id ("channel:chat_id")
         if msg.channel == "system":
             channel, chat_id = (
@@ -956,11 +973,11 @@ class AgentLoop:
             # callers route to the originating thread session, not the
             # channel-level session derived from chat_id.
             key = msg.session_key_override or f"{channel}:{chat_id}"
-            session = self.sessions.get_or_create(key)
+            session = sessions.get_or_create(key)
             if self._restore_runtime_checkpoint(session):
-                self.sessions.save(session)
+                sessions.save(session)
             if self._restore_pending_user_turn(session):
-                self.sessions.save(session)
+                sessions.save(session)
 
             session, pending = self.auto_compact.prepare_session(session, key)
             if pending:
@@ -979,7 +996,7 @@ class AgentLoop:
             is_subagent = msg.sender_id == "subagent"
             if is_subagent and self._persist_subagent_followup(session, msg):
                 logger.debug("Subagent result persisted for session {}", key)
-                self.sessions.save(session)
+                sessions.save(session)
             self._set_tool_context(
                 channel, chat_id, msg.metadata.get("message_id"),
                 msg.metadata, session_key=key,
@@ -1009,11 +1026,12 @@ class AgentLoop:
                 metadata=msg.metadata,
                 session_key=key,
                 pending_queue=pending_queue,
+                sessions=sessions,
             )
             self._save_turn(session, all_msgs, 1 + len(history))
             session.enforce_file_cap(on_archive=self.context.memory.raw_archive)
             self._clear_runtime_checkpoint(session)
-            self.sessions.save(session)
+            sessions.save(session)
             self._schedule_background(
                 self.consolidator.maybe_consolidate_by_tokens(
                     session,
@@ -1054,12 +1072,12 @@ class AgentLoop:
         logger.info("Processing message from {}:{}: {}", msg.channel, msg.sender_id, preview)
 
         key = session_key or msg.session_key
-        session = self.sessions.get_or_create(key)
+        session = sessions.get_or_create(key)
         mark_webui_session(session, msg.metadata)
         if self._restore_runtime_checkpoint(session):
-            self.sessions.save(session)
+            sessions.save(session)
         if self._restore_pending_user_turn(session):
-            self.sessions.save(session)
+            sessions.save(session)
 
         session, pending = self.auto_compact.prepare_session(session, key)
 
@@ -1153,7 +1171,7 @@ class AgentLoop:
             text = msg.content if isinstance(msg.content, str) else ""
             session.add_message("user", text, **extra)
             self._mark_pending_user_turn(session)
-            self.sessions.save(session)
+            sessions.save(session)
             user_persisted_early = True
 
         final_content, _, all_msgs, stop_reason, had_injections = await self._run_agent_loop(
@@ -1169,6 +1187,7 @@ class AgentLoop:
             metadata=msg.metadata,
             session_key=key,
             pending_queue=pending_queue,
+            sessions=sessions,
         )
 
         if final_content is None or not final_content.strip():
@@ -1185,7 +1204,7 @@ class AgentLoop:
         session.enforce_file_cap(on_archive=self.context.memory.raw_archive)
         self._clear_pending_user_turn(session)
         self._clear_runtime_checkpoint(session)
-        self.sessions.save(session)
+        sessions.save(session)
         self._schedule_background(
             self.consolidator.maybe_consolidate_by_tokens(
                 session,
@@ -1332,10 +1351,16 @@ class AgentLoop:
         )
         return True
 
-    def _set_runtime_checkpoint(self, session: Session, payload: dict[str, Any]) -> None:
+    def _set_runtime_checkpoint(
+        self,
+        session: Session,
+        payload: dict[str, Any],
+        *,
+        sessions: SessionManager | None = None,
+    ) -> None:
         """Persist the latest in-flight turn state into session metadata."""
         session.metadata[self._RUNTIME_CHECKPOINT_KEY] = payload
-        self.sessions.save(session)
+        (sessions or self.sessions).save(session)
 
     def _mark_pending_user_turn(self, session: Session) -> None:
         session.metadata[self._PENDING_USER_TURN_KEY] = True

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -680,6 +680,14 @@ class AgentLoop:
         active_session_key = session.key if session else session_key
         file_state_token = bind_file_states(self._file_state_store.for_session(active_session_key))
         try:
+            # Use the per-request workspace when a UserContext is bound — keeps
+            # tool-result spill files under users/<uid>/workspace/.nanobot/tool-results.
+            from nanobot.auth.context import current_user_ctx as _cuc
+
+            _active_ws = (
+                _cuc.get().workspace_path() if _cuc.get() is not None else self.workspace
+            )
+
             result = await self.runner.run(AgentRunSpec(
                 initial_messages=initial_messages,
                 tools=self.tools,
@@ -689,7 +697,7 @@ class AgentLoop:
                 hook=hook,
                 error_message="Sorry, I encountered an error calling the AI model.",
                 concurrent_tools=True,
-                workspace=self.workspace,
+                workspace=_active_ws,
                 session_key=session.key if session else None,
                 context_window_tokens=self.context_window_tokens,
                 context_block_limit=self.context_block_limit,
@@ -791,6 +799,8 @@ class AgentLoop:
 
     async def _dispatch(self, msg: InboundMessage) -> None:
         """Process a message: per-session serial, cross-session concurrent."""
+        from nanobot.auth.context import current_user_ctx
+
         session_key = self._effective_session_key(msg)
         if session_key != msg.session_key:
             msg = dataclasses.replace(msg, session_key_override=session_key)
@@ -801,6 +811,11 @@ class AgentLoop:
         # routed here (mid-turn injection) instead of spawning a new task.
         pending = asyncio.Queue(maxsize=20)
         self._pending_queues[session_key] = pending
+
+        # Set per-request UserContext so workspace-rooted tools (filesystem,
+        # shell, etc.) resolve paths under users/<uid>/workspace. None for
+        # channel-admin / CLI paths preserves legacy global behaviour.
+        ctx_token = current_user_ctx.set(msg.user_context)
 
         try:
             async with lock, gate:
@@ -909,6 +924,7 @@ class AgentLoop:
                         content="Sorry, I encountered an error.",
                     ))
         finally:
+            current_user_ctx.reset(ctx_token)
             # Drain any messages still in the pending queue and re-publish
             # them to the bus so they are processed as fresh inbound messages
             # rather than silently lost.

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -560,8 +560,10 @@ class Consolidator:
         self,
         session: Session,
         replay_max_messages: int | None,
+        sessions: "SessionManager | None" = None,
     ) -> str | None:
         """Archive messages that would be hidden by the replay message window."""
+        sm = sessions if sessions is not None else self.sessions
         end_idx = self._replay_overflow_boundary(session, replay_max_messages)
         if end_idx is None:
             return None
@@ -576,16 +578,22 @@ class Consolidator:
         )
         summary = await self.archive(chunk)
         session.last_consolidated = end_idx
-        self.sessions.save(session)
+        sm.save(session)
         return summary
 
-    def _persist_last_summary(self, session: Session, summary: str | None) -> None:
+    def _persist_last_summary(
+        self,
+        session: Session,
+        summary: str | None,
+        sessions: "SessionManager | None" = None,
+    ) -> None:
+        sm = sessions if sessions is not None else self.sessions
         if summary and summary != "(nothing)":
             session.metadata["_last_summary"] = {
                 "text": summary,
                 "last_active": session.updated_at.isoformat(),
             }
-            self.sessions.save(session)
+            sm.save(session)
 
     def estimate_session_prompt_tokens(
         self,
@@ -671,6 +679,7 @@ class Consolidator:
         *,
         session_summary: str | None = None,
         replay_max_messages: int | None = None,
+        sessions: "SessionManager | None" = None,
     ) -> None:
         """Loop: archive old messages until prompt fits within safe budget.
 
@@ -684,9 +693,11 @@ class Consolidator:
         async with lock:
             budget = self._input_token_budget
             target = int(budget * self.consolidation_ratio)
+            sm = sessions if sessions is not None else self.sessions
             last_summary = await self._consolidate_replay_overflow(
                 session,
                 replay_max_messages,
+                sessions=sm,
             )
             try:
                 estimated, source = self.estimate_session_prompt_tokens(
@@ -697,7 +708,7 @@ class Consolidator:
                 logger.exception("Token estimation failed for {}", session.key)
                 estimated, source = 0, "error"
             if estimated <= 0:
-                self._persist_last_summary(session, last_summary)
+                self._persist_last_summary(session, last_summary, sessions=sessions)
                 return
             if estimated < budget:
                 unconsolidated_count = len(session.messages) - session.last_consolidated
@@ -709,7 +720,7 @@ class Consolidator:
                     source,
                     unconsolidated_count,
                 )
-                self._persist_last_summary(session, last_summary)
+                self._persist_last_summary(session, last_summary, sessions=sessions)
                 return
 
             for round_num in range(self._MAX_CONSOLIDATION_ROUNDS):
@@ -748,7 +759,7 @@ class Consolidator:
                 if summary:
                     last_summary = summary
                 session.last_consolidated = end_idx
-                self.sessions.save(session)
+                sm.save(session)
                 if not summary:
                     # LLM is degraded — stop hammering it this call;
                     # the next invocation can retry a fresh chunk.
@@ -768,7 +779,7 @@ class Consolidator:
             # Persist the last summary to session metadata so it can be injected
             # into the runtime context on the next prepare_session() call, aligning
             # the summary injection strategy with AutoCompact._archive().
-            self._persist_last_summary(session, last_summary)
+            self._persist_last_summary(session, last_summary, sessions=sessions)
 
 
 # ---------------------------------------------------------------------------

--- a/nanobot/agent/tools/file_state.py
+++ b/nanobot/agent/tools/file_state.py
@@ -139,7 +139,14 @@ class FileStateStore:
         self._states_by_key: dict[str, FileStates] = {}
 
     def for_session(self, session_key: str | None) -> FileStates:
-        key = session_key or "__default__"
+        # Namespace by user_id when a per-request UserContext is bound so two
+        # users with colliding session_keys can't share the read/write state
+        # (which would let one peek at the other's file_state tracking).
+        from nanobot.auth.context import current_user_ctx
+
+        ctx = current_user_ctx.get()
+        base = session_key or "__default__"
+        key = f"{ctx.user_id}::{base}" if ctx is not None else base
         states = self._states_by_key.get(key)
         if states is None:
             states = FileStates()

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -83,19 +83,22 @@ class _FsTool(Tool):
         self._fallback_file_states = FileStates()
 
     def _active_paths(self) -> tuple[Path | None, Path | None]:
-        """Return (workspace, allowed_dir) honoring the current UserContext."""
+        """Return (workspace, allowed_dir) honoring the current UserContext.
+
+        When a UserContext is bound we ALWAYS confine the tool to that user's
+        workspace, even when the loop was started with
+        ``restrict_to_workspace=False``. The multi-tenant gate is independent
+        of the legacy single-tenant gate: without this confinement an
+        authenticated WebUI user could `read_file('/etc/passwd')` through the
+        agent on a permissive loop.
+        """
         from nanobot.auth.context import current_user_ctx
 
         ctx = current_user_ctx.get()
         if ctx is None:
             return self._default_workspace, self._default_allowed_dir
         user_ws = ctx.workspace_path()
-        # When the loop opted into restricting writes to the (global) workspace,
-        # rebind the restriction to the user's own workspace; otherwise leave
-        # the allowed_dir alone (None => no restriction).
-        if self._default_allowed_dir is not None:
-            return user_ws, user_ws
-        return user_ws, None
+        return user_ws, user_ws
 
     # Backwards-compat property for code that read ``self._workspace`` directly.
     @property

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -8,11 +8,15 @@ from pathlib import Path
 from typing import Any
 
 from nanobot.agent.tools.base import Tool, tool_parameters
-from nanobot.agent.tools.schema import BooleanSchema, IntegerSchema, StringSchema, tool_parameters_schema
 from nanobot.agent.tools.file_state import FileStates, _hash_file, current_file_states
-from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
+from nanobot.agent.tools.schema import (
+    BooleanSchema,
+    IntegerSchema,
+    StringSchema,
+    tool_parameters_schema,
+)
 from nanobot.config.paths import get_media_dir
-
+from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
 
 _FS_WORKSPACE_BOUNDARY_NOTE = (
     " (this is a hard policy boundary, not a transient failure; "
@@ -34,7 +38,7 @@ def _resolve_path(
     resolved = p.resolve()
     if allowed_dir:
         media_path = get_media_dir().resolve()
-        all_dirs = [allowed_dir] + [media_path] + (extra_allowed_dirs or []) 
+        all_dirs = [allowed_dir] + [media_path] + (extra_allowed_dirs or [])
         if not any(_is_under(resolved, d) for d in all_dirs):
             raise PermissionError(
                 f"Path {path} is outside allowed directory {allowed_dir}"
@@ -52,7 +56,15 @@ def _is_under(path: Path, directory: Path) -> bool:
 
 
 class _FsTool(Tool):
-    """Shared base for filesystem tools — common init and path resolution."""
+    """Shared base for filesystem tools — common init and path resolution.
+
+    Per-user routing: when an inbound message carries a ``UserContext`` (WebUI
+    auth path), the agent loop sets ``current_user_ctx`` for the duration of
+    the request. The resolved ``_workspace`` / ``_allowed_dir`` then point
+    into ``~/.nanobot/users/<uid>/workspace`` so writes are isolated. For
+    CLI / channel-admin code paths the contextvar is unset and the ctor
+    fallbacks apply.
+    """
 
     def __init__(
         self,
@@ -61,14 +73,38 @@ class _FsTool(Tool):
         extra_allowed_dirs: list[Path] | None = None,
         file_states: FileStates | None = None,
     ):
-        self._workspace = workspace
-        self._allowed_dir = allowed_dir
+        self._default_workspace = workspace
+        self._default_allowed_dir = allowed_dir
         self._extra_allowed_dirs = extra_allowed_dirs
         # Explicit state is used by isolated runners like Dream/subagents.
         # Main AgentLoop tools leave this unset and resolve state from the
         # current async task, which keeps shared tool instances session-safe.
         self._explicit_file_states = file_states
         self._fallback_file_states = FileStates()
+
+    def _active_paths(self) -> tuple[Path | None, Path | None]:
+        """Return (workspace, allowed_dir) honoring the current UserContext."""
+        from nanobot.auth.context import current_user_ctx
+
+        ctx = current_user_ctx.get()
+        if ctx is None:
+            return self._default_workspace, self._default_allowed_dir
+        user_ws = ctx.workspace_path()
+        # When the loop opted into restricting writes to the (global) workspace,
+        # rebind the restriction to the user's own workspace; otherwise leave
+        # the allowed_dir alone (None => no restriction).
+        if self._default_allowed_dir is not None:
+            return user_ws, user_ws
+        return user_ws, None
+
+    # Backwards-compat property for code that read ``self._workspace`` directly.
+    @property
+    def _workspace(self) -> Path | None:
+        return self._active_paths()[0]
+
+    @property
+    def _allowed_dir(self) -> Path | None:
+        return self._active_paths()[1]
 
     @property
     def _file_states(self) -> FileStates:
@@ -77,7 +113,8 @@ class _FsTool(Tool):
         return current_file_states(self._fallback_file_states)
 
     def _resolve(self, path: str) -> Path:
-        return _resolve_path(path, self._workspace, self._allowed_dir, self._extra_allowed_dirs)
+        workspace, allowed = self._active_paths()
+        return _resolve_path(path, workspace, allowed, self._extra_allowed_dirs)
 
 
 # ---------------------------------------------------------------------------

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -60,7 +60,7 @@ class ExecTool(Tool):
         allowed_env_keys: list[str] | None = None,
     ):
         self.timeout = timeout
-        self.working_dir = working_dir
+        self._default_working_dir = working_dir
         self.sandbox = sandbox
         self.deny_patterns = (deny_patterns or []) + [
             r"\brm\s+-[rf]{1,2}\b",          # rm -r, rm -rf, rm -fr
@@ -85,6 +85,16 @@ class ExecTool(Tool):
         self.restrict_to_workspace = restrict_to_workspace
         self.path_append = path_append
         self.allowed_env_keys = allowed_env_keys or []
+
+    @property
+    def working_dir(self) -> str | None:
+        """Active working dir — honors per-request UserContext when set."""
+        from nanobot.auth.context import current_user_ctx
+
+        ctx = current_user_ctx.get()
+        if ctx is None:
+            return self._default_working_dir
+        return str(ctx.workspace_path())
 
     @property
     def name(self) -> str:

--- a/nanobot/auth/__init__.py
+++ b/nanobot/auth/__init__.py
@@ -1,6 +1,6 @@
 """Authentication and per-user identity for nanobot multi-tenant mode."""
 
-from nanobot.auth.context import UserContext
+from nanobot.auth.context import UserContext, current_user_ctx
 from nanobot.auth.ids import assert_ulid, is_ulid, new_ulid
 from nanobot.auth.schema import AUTH_DB_FILENAME, init_auth_db, open_auth_db
 from nanobot.auth.service import (
@@ -19,6 +19,7 @@ __all__ = [
     "SessionRecord",
     "UserContext",
     "UserRecord",
+    "current_user_ctx",
     "assert_ulid",
     "init_auth_db",
     "is_ulid",

--- a/nanobot/auth/__init__.py
+++ b/nanobot/auth/__init__.py
@@ -2,6 +2,7 @@
 
 from nanobot.auth.context import UserContext, current_user_ctx
 from nanobot.auth.ids import assert_ulid, is_ulid, new_ulid
+from nanobot.auth.migration import migrate_legacy_layout_if_needed
 from nanobot.auth.schema import AUTH_DB_FILENAME, init_auth_db, open_auth_db
 from nanobot.auth.service import (
     AuthError,
@@ -23,6 +24,7 @@ __all__ = [
     "assert_ulid",
     "init_auth_db",
     "is_ulid",
+    "migrate_legacy_layout_if_needed",
     "new_ulid",
     "open_auth_db",
 ]

--- a/nanobot/auth/__init__.py
+++ b/nanobot/auth/__init__.py
@@ -1,0 +1,27 @@
+"""Authentication and per-user identity for nanobot multi-tenant mode."""
+
+from nanobot.auth.context import UserContext
+from nanobot.auth.ids import assert_ulid, is_ulid, new_ulid
+from nanobot.auth.schema import AUTH_DB_FILENAME, init_auth_db, open_auth_db
+from nanobot.auth.service import (
+    AuthError,
+    AuthService,
+    EmailTakenError,
+    SessionRecord,
+    UserRecord,
+)
+
+__all__ = [
+    "AUTH_DB_FILENAME",
+    "AuthError",
+    "AuthService",
+    "EmailTakenError",
+    "SessionRecord",
+    "UserContext",
+    "UserRecord",
+    "assert_ulid",
+    "init_auth_db",
+    "is_ulid",
+    "new_ulid",
+    "open_auth_db",
+]

--- a/nanobot/auth/context.py
+++ b/nanobot/auth/context.py
@@ -1,0 +1,65 @@
+"""Per-user runtime context.
+
+``UserContext`` is the single object threaded through the request lifecycle
+(WebSocket inbound → AgentLoop → AgentRunner → tools) so every path lookup
+resolves under the caller's isolated directory subtree:
+
+    ~/.nanobot/users/<user_id>/
+        profile.json
+        workspace/
+        sessions/
+        memory/
+        media/[<channel>/]
+        tool-results/
+        file_state/
+
+CLI / channel-admin call sites that do not have a UserContext continue to
+use the legacy global helpers in ``nanobot.config.paths`` — that branch is
+left untouched in this slice and is wired per-tool in Slice C.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from nanobot.auth.ids import assert_ulid
+from nanobot.config.paths import get_user_root
+from nanobot.utils.helpers import ensure_dir
+
+
+@dataclass(frozen=True)
+class UserContext:
+    """Resolves per-user filesystem paths. Frozen + hashable so it's safe to
+    pass through async boundaries.
+    """
+
+    user_id: str
+
+    def __post_init__(self) -> None:
+        assert_ulid(self.user_id)
+
+    def root(self) -> Path:
+        return get_user_root(self.user_id)
+
+    def profile_path(self) -> Path:
+        return self.root() / "profile.json"
+
+    def workspace_path(self) -> Path:
+        return ensure_dir(self.root() / "workspace")
+
+    def sessions_dir(self) -> Path:
+        return ensure_dir(self.root() / "sessions")
+
+    def memory_dir(self) -> Path:
+        return ensure_dir(self.root() / "memory")
+
+    def media_dir(self, channel: str | None = None) -> Path:
+        base = ensure_dir(self.root() / "media")
+        return ensure_dir(base / channel) if channel else base
+
+    def tool_results_dir(self) -> Path:
+        return ensure_dir(self.root() / "tool-results")
+
+    def file_state_dir(self) -> Path:
+        return ensure_dir(self.root() / "file_state")

--- a/nanobot/auth/context.py
+++ b/nanobot/auth/context.py
@@ -20,6 +20,7 @@ left untouched in this slice and is wired per-tool in Slice C.
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -63,3 +64,12 @@ class UserContext:
 
     def file_state_dir(self) -> Path:
         return ensure_dir(self.root() / "file_state")
+
+
+# Per-request UserContext, set by the agent loop before a turn is dispatched
+# and reset on exit. Tools that need to resolve a per-user workspace path can
+# consult this directly via ``current_user_ctx.get()`` — None means we're on
+# the CLI / channel-admin code path that uses global paths.
+current_user_ctx: ContextVar["UserContext | None"] = ContextVar(
+    "nanobot_current_user_ctx", default=None
+)

--- a/nanobot/auth/ids.py
+++ b/nanobot/auth/ids.py
@@ -1,0 +1,48 @@
+"""ULID generation + validation for stable user identifiers.
+
+A ULID is 128 bits encoded as 26 Crockford base32 characters:
+  - first 10 chars  = 48-bit Unix epoch milliseconds (lexicographically sortable)
+  - last  16 chars  = 80 bits of cryptographic randomness
+
+Inline implementation avoids a third-party dep for ~30 lines of logic.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import time
+
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+_ULID_LEN = 26
+
+
+def _encode_int(value: int, length: int) -> str:
+    chars = []
+    for _ in range(length):
+        chars.append(_CROCKFORD[value & 0x1F])
+        value >>= 5
+    return "".join(reversed(chars))
+
+
+def new_ulid(*, now_ms: int | None = None) -> str:
+    """Return a fresh 26-char Crockford-base32 ULID."""
+    ts = now_ms if now_ms is not None else int(time.time() * 1000)
+    if ts < 0 or ts >= (1 << 48):
+        raise ValueError(f"timestamp out of ULID range: {ts}")
+    rand_bytes = secrets.token_bytes(10)
+    rand_int = int.from_bytes(rand_bytes, "big")
+    return _encode_int(ts, 10) + _encode_int(rand_int, 16)
+
+
+def is_ulid(value: str) -> bool:
+    """Return True if value is a syntactically valid ULID string."""
+    return isinstance(value, str) and len(value) == _ULID_LEN and bool(_ULID_RE.match(value))
+
+
+def assert_ulid(value: str) -> str:
+    """Return value if valid ULID; raise ValueError otherwise."""
+    if not is_ulid(value):
+        raise ValueError(f"invalid ULID: {value!r}")
+    return value

--- a/nanobot/auth/migration.py
+++ b/nanobot/auth/migration.py
@@ -1,0 +1,93 @@
+"""One-shot legacy → multi-tenant migration for ``~/.nanobot``.
+
+When an operator upgrades to a multi-tenant build on a host that ran the
+pre-Slice-A single-user nanobot, the old layout (``sessions/``,
+``workspace/``, ``memory/`` directly under ``~/.nanobot``) is incompatible
+with the new per-user tree (``users/<uid>/…``). On gateway startup we
+detect the legacy shape and rename the whole tree out of the way:
+
+    ~/.nanobot                  ->  ~/.nanobot.legacy.<ISO-date>
+    ~/.nanobot/config.json      (copied back into the new ~/.nanobot)
+
+This is loud and reversible (mv it back). Pass ``NANOBOT_SKIP_LEGACY_MIGRATION=1``
+to skip — useful when running tests against ``~/.nanobot`` directly.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from filelock import FileLock
+from loguru import logger
+
+# Legacy single-tenant subdirs whose presence (without ``users/``) indicates
+# the host is running an upgrade-from-single-tenant migration scenario.
+_LEGACY_SUBDIRS = ("sessions", "workspace", "memory")
+_MIGRATION_LOCK_FILENAME = ".migration.lock"
+_SKIP_ENV_VAR = "NANOBOT_SKIP_LEGACY_MIGRATION"
+
+
+def _now_iso() -> str:
+    """Return a filesystem-safe ISO-ish timestamp suffix."""
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def _needs_migration(data_dir: Path) -> bool:
+    if not data_dir.exists():
+        return False
+    if (data_dir / "users").exists():
+        return False
+    return any((data_dir / sub).is_dir() for sub in _LEGACY_SUBDIRS)
+
+
+def _archive_target(parent: Path, base_name: str) -> Path:
+    """Pick a unique archive name; append a counter if the bare ISO suffix collides."""
+    base = parent / f"{base_name}.legacy.{_now_iso()}"
+    candidate = base
+    counter = 1
+    while candidate.exists():
+        candidate = Path(f"{base}.{counter}")
+        counter += 1
+    return candidate
+
+
+def migrate_legacy_layout_if_needed(data_dir: Path | None = None) -> Path | None:
+    """Detect legacy single-tenant state and move it aside.
+
+    Returns the archive path if a migration ran, else ``None``.
+
+    Idempotent: a second call after the rename observes ``users/`` (created
+    by ``ensure_dir`` elsewhere) and does nothing.
+
+    Honors ``NANOBOT_SKIP_LEGACY_MIGRATION=1`` for tests and rescue runs.
+    """
+    if os.environ.get(_SKIP_ENV_VAR) == "1":
+        return None
+    base_dir = data_dir if data_dir is not None else Path.home() / ".nanobot"
+    if not _needs_migration(base_dir):
+        return None
+
+    lock = FileLock(str(base_dir / _MIGRATION_LOCK_FILENAME))
+    with lock:
+        if not _needs_migration(base_dir):
+            return None  # Another process raced and migrated first.
+        archive = _archive_target(base_dir.parent, base_dir.name)
+        config_src = base_dir / "config.json"
+        config_bytes: bytes | None = None
+        if config_src.is_file():
+            config_bytes = config_src.read_bytes()
+        shutil.move(str(base_dir), str(archive))
+        base_dir.mkdir(parents=True, exist_ok=True)
+        (base_dir / "users").mkdir(exist_ok=True)
+        if config_bytes is not None:
+            (base_dir / "config.json").write_bytes(config_bytes)
+        logger.warning(
+            "Legacy single-tenant state detected at {} — archived to {}. "
+            "Fresh multi-tenant tree initialised. Rollback: `mv {} {}` "
+            "(or set {}=1 to skip on next start).",
+            base_dir, archive, archive, base_dir, _SKIP_ENV_VAR,
+        )
+        return archive

--- a/nanobot/auth/migration.py
+++ b/nanobot/auth/migration.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import os
 import shutil
+import stat
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -70,7 +72,11 @@ def migrate_legacy_layout_if_needed(data_dir: Path | None = None) -> Path | None
     if not _needs_migration(base_dir):
         return None
 
-    lock = FileLock(str(base_dir / _MIGRATION_LOCK_FILENAME))
+    # Lock OUTSIDE the directory we're about to rename — keeping the lockfile
+    # inside base_dir would leave its descriptor pointing at the archived path
+    # on POSIX and crash the cleanup on Windows.
+    lock_path = base_dir.parent / f"{base_dir.name}{_MIGRATION_LOCK_FILENAME}"
+    lock = FileLock(str(lock_path))
     with lock:
         if not _needs_migration(base_dir):
             return None  # Another process raced and migrated first.
@@ -79,15 +85,29 @@ def migrate_legacy_layout_if_needed(data_dir: Path | None = None) -> Path | None
         config_bytes: bytes | None = None
         if config_src.is_file():
             config_bytes = config_src.read_bytes()
+        # Print the rollback hint BEFORE the destructive move so a partial
+        # failure between move() and the recreate steps below doesn't leave
+        # the operator without the archive path.
+        logger.warning(
+            "Legacy single-tenant state detected at {} — archiving to {}. "
+            "Rollback: `mv {} {}` (or set {}=1 to skip on next start).",
+            base_dir, archive, archive, base_dir, _SKIP_ENV_VAR,
+        )
         shutil.move(str(base_dir), str(archive))
+        # Lock down the archive — it carries the old auth.db hashes and any
+        # session JSONLs that were sitting in the legacy layout.
+        if sys.platform != "win32":
+            try:
+                os.chmod(archive, stat.S_IRWXU)  # 0o700
+            except OSError as exc:
+                logger.warning("could not chmod archive {}: {}", archive, exc)
         base_dir.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            try:
+                os.chmod(base_dir, stat.S_IRWXU)  # 0o700
+            except OSError as exc:
+                logger.warning("could not chmod fresh base {}: {}", base_dir, exc)
         (base_dir / "users").mkdir(exist_ok=True)
         if config_bytes is not None:
             (base_dir / "config.json").write_bytes(config_bytes)
-        logger.warning(
-            "Legacy single-tenant state detected at {} — archived to {}. "
-            "Fresh multi-tenant tree initialised. Rollback: `mv {} {}` "
-            "(or set {}=1 to skip on next start).",
-            base_dir, archive, archive, base_dir, _SKIP_ENV_VAR,
-        )
         return archive

--- a/nanobot/auth/ratelimit.py
+++ b/nanobot/auth/ratelimit.py
@@ -27,11 +27,22 @@ class RateLimiter:
     is False the response should include ``Retry-After: retry_after_s``.
     """
 
+    _SWEEP_EVERY = 256  # number of try_consume calls between sweeps
+    _MAX_BUCKETS = 50_000  # hard cap; sweep on hit to bound memory
+
     def __init__(self, *, now: Callable[[], float] | None = None) -> None:
         self._buckets: dict[tuple[str, str], _Bucket] = {}
         self._now = now or time.monotonic
+        self._calls_since_sweep = 0
 
     def try_consume(self, key: tuple[str, str], *, max_attempts: int, window_s: float) -> tuple[bool, int]:
+        self._calls_since_sweep += 1
+        if (
+            self._calls_since_sweep >= self._SWEEP_EVERY
+            or len(self._buckets) >= self._MAX_BUCKETS
+        ):
+            self.sweep(window_s=window_s)
+            self._calls_since_sweep = 0
         now = self._now()
         bucket = self._buckets.setdefault(key, _Bucket())
         cutoff = now - window_s
@@ -41,7 +52,24 @@ class RateLimiter:
             retry_after = max(1, int(bucket.hits[0] + window_s - now) + 1)
             return False, retry_after
         bucket.hits.append(now)
+        # Drop empty buckets so an IPv6-rotating attacker can't grow this
+        # dict without bound. The append above guarantees we never reap a
+        # bucket we just touched.
+        if not bucket.hits:  # pragma: no cover — defensive, append makes this unreachable
+            self._buckets.pop(key, None)
         return True, 0
+
+    def sweep(self, *, window_s: float) -> int:
+        """Remove buckets whose newest hit is older than ``window_s``.
+
+        Safe to call opportunistically. Returns the number of buckets removed.
+        """
+        now = self._now()
+        cutoff = now - window_s
+        dead = [k for k, b in self._buckets.items() if not b.hits or b.hits[-1] < cutoff]
+        for k in dead:
+            self._buckets.pop(k, None)
+        return len(dead)
 
     def reset(self) -> None:
         self._buckets.clear()

--- a/nanobot/auth/ratelimit.py
+++ b/nanobot/auth/ratelimit.py
@@ -1,0 +1,47 @@
+"""In-memory token bucket for /auth/* endpoints.
+
+Simple sliding-window counter keyed by (path, ip). Suitable for a
+single-instance gateway. Replace with a Redis-backed limiter when we
+horizontally scale.
+
+Thread-safety: callers are async-single-threaded (asyncio event loop).
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Callable
+
+
+@dataclass
+class _Bucket:
+    hits: deque[float] = field(default_factory=deque)
+
+
+class RateLimiter:
+    """Per-(path, ip) sliding-window limiter.
+
+    ``try_consume`` returns ``(allowed, retry_after_s)``. When ``allowed``
+    is False the response should include ``Retry-After: retry_after_s``.
+    """
+
+    def __init__(self, *, now: Callable[[], float] | None = None) -> None:
+        self._buckets: dict[tuple[str, str], _Bucket] = {}
+        self._now = now or time.monotonic
+
+    def try_consume(self, key: tuple[str, str], *, max_attempts: int, window_s: float) -> tuple[bool, int]:
+        now = self._now()
+        bucket = self._buckets.setdefault(key, _Bucket())
+        cutoff = now - window_s
+        while bucket.hits and bucket.hits[0] < cutoff:
+            bucket.hits.popleft()
+        if len(bucket.hits) >= max_attempts:
+            retry_after = max(1, int(bucket.hits[0] + window_s - now) + 1)
+            return False, retry_after
+        bucket.hits.append(now)
+        return True, 0
+
+    def reset(self) -> None:
+        self._buckets.clear()

--- a/nanobot/auth/routes.py
+++ b/nanobot/auth/routes.py
@@ -1,16 +1,21 @@
-"""HTTP auth routes for the gateway health-port server.
+"""HTTP auth + admin routes for the gateway health-port server.
 
 The gateway speaks raw HTTP/1.0 on its health port (see ``commands.py``).
 This module exposes pure ``Request -> Response`` handlers so the wire-level
 glue stays trivial and the logic is unit-testable without spinning a
 real socket.
 
-Routes (v1):
-  POST /auth/login   {email, password}   -> sets ``nanobot_session`` cookie
-  POST /auth/logout                       -> clears cookie, revokes session
-  GET  /auth/me                           -> returns current user from cookie
+Routes:
+  POST   /auth/signup                      -> creates user, mints session
+  POST   /auth/login                       -> sets ``nanobot_session`` cookie
+  POST   /auth/logout                      -> clears cookie, revokes session
+  GET    /auth/me                          -> returns current user from cookie
 
-A subsequent slice adds ``POST /auth/signup``.
+Admin (require ``role='admin'`` on the cookie's user):
+  GET    /admin/users                      -> list all users
+  POST   /admin/users/<id>/role            -> {role: 'user' | 'admin'}
+  POST   /admin/users/<id>/disabled        -> {disabled: bool}
+  DELETE /admin/users/<id>                 -> remove user + sessions
 """
 
 from __future__ import annotations
@@ -211,18 +216,167 @@ _DISPATCH = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Admin routes
+# ---------------------------------------------------------------------------
+
+
+def _current_user_or_none(req: Request, svc: AuthService) -> UserRecord | None:
+    cookies = _parse_cookies(req.headers.get("cookie"))
+    token = cookies.get(SESSION_COOKIE, "")
+    if not token:
+        return None
+    try:
+        return svc.verify_session(token)
+    except AuthError:
+        return None
+
+
+def _require_admin(req: Request, svc: AuthService) -> tuple[UserRecord | None, Response | None]:
+    user = _current_user_or_none(req, svc)
+    if user is None:
+        return None, _error(401, "unauthenticated")
+    if user.role != "admin" or user.disabled:
+        return user, _error(403, "forbidden")
+    return user, None
+
+
+def _user_to_admin_payload(row: dict) -> dict:
+    return {
+        "id": row["id"],
+        "email": row["email"],
+        "role": row["role"],
+        "display_name": row["display_name"],
+        "created_at": row["created_at"],
+        "last_login_at": row["last_login_at"],
+        "disabled": bool(row["disabled"]),
+    }
+
+
+def handle_admin_users_list(req: Request, svc: AuthService) -> Response:
+    if req.method != "GET":
+        return _error(405, "method not allowed")
+    actor, deny = _require_admin(req, svc)
+    if deny is not None:
+        return deny
+    rows = svc._conn.execute(  # noqa: SLF001
+        "SELECT id, email, role, display_name, created_at, last_login_at, disabled "
+        "FROM users ORDER BY created_at"
+    ).fetchall()
+    return _json_response(200, {"users": [_user_to_admin_payload(r) for r in rows]})
+
+
+def handle_admin_set_role(req: Request, svc: AuthService, target_id: str) -> Response:
+    if req.method != "POST":
+        return _error(405, "method not allowed")
+    actor, deny = _require_admin(req, svc)
+    if deny is not None:
+        return deny
+    try:
+        data = _parse_json_body(req)
+    except AuthError as exc:
+        return _error(400, str(exc))
+    role = data.get("role")
+    if role not in ("user", "admin"):
+        return _error(400, "role must be 'user' or 'admin'")
+    try:
+        target = svc.get_user(target_id)
+    except (AuthError, ValueError):
+        return _error(404, "not found")
+    svc._conn.execute("UPDATE users SET role = ? WHERE id = ?", (role, target.id))  # noqa: SLF001
+    event = "promote" if role == "admin" else "demote"
+    svc._audit(event, actor_user_id=actor.id, target_user_id=target.id, ip=req.remote_ip)  # noqa: SLF001
+    return _json_response(200, {"user": _user_to_admin_payload(
+        svc._conn.execute(  # noqa: SLF001
+            "SELECT id, email, role, display_name, created_at, last_login_at, disabled "
+            "FROM users WHERE id = ?",
+            (target.id,),
+        ).fetchone()
+    )})
+
+
+def handle_admin_set_disabled(req: Request, svc: AuthService, target_id: str) -> Response:
+    if req.method != "POST":
+        return _error(405, "method not allowed")
+    actor, deny = _require_admin(req, svc)
+    if deny is not None:
+        return deny
+    try:
+        data = _parse_json_body(req)
+    except AuthError as exc:
+        return _error(400, str(exc))
+    disabled = data.get("disabled")
+    if not isinstance(disabled, bool):
+        return _error(400, "disabled must be a boolean")
+    try:
+        target = svc.get_user(target_id)
+    except (AuthError, ValueError):
+        return _error(404, "not found")
+    svc._conn.execute(  # noqa: SLF001
+        "UPDATE users SET disabled = ? WHERE id = ?", (1 if disabled else 0, target.id)
+    )
+    if disabled:
+        svc.revoke_all_sessions(target.id)
+    event = "disable" if disabled else "enable"
+    svc._audit(event, actor_user_id=actor.id, target_user_id=target.id, ip=req.remote_ip)  # noqa: SLF001
+    return _json_response(200, {"ok": True})
+
+
+def handle_admin_delete(req: Request, svc: AuthService, target_id: str) -> Response:
+    if req.method != "DELETE":
+        return _error(405, "method not allowed")
+    actor, deny = _require_admin(req, svc)
+    if deny is not None:
+        return deny
+    try:
+        target = svc.get_user(target_id)
+    except (AuthError, ValueError):
+        return _error(404, "not found")
+    if target.id == actor.id:
+        return _error(400, "cannot delete the currently signed-in admin")
+    svc._conn.execute("DELETE FROM users WHERE id = ?", (target.id,))  # noqa: SLF001
+    svc._audit(  # noqa: SLF001
+        "delete", actor_user_id=actor.id, target_user_id=target.id,
+        ip=req.remote_ip, detail=target.email,
+    )
+    return _json_response(200, {"ok": True})
+
+
+_ADMIN_USER_PATH_PREFIX = "/admin/users"
+
+
+def _dispatch_admin(req: Request, svc: AuthService) -> Response | None:
+    if not req.path.startswith("/admin/"):
+        return None
+    if req.path == _ADMIN_USER_PATH_PREFIX:
+        return handle_admin_users_list(req, svc)
+    if req.path.startswith(_ADMIN_USER_PATH_PREFIX + "/"):
+        rest = req.path[len(_ADMIN_USER_PATH_PREFIX) + 1 :]
+        parts = rest.split("/")
+        if len(parts) == 1 and parts[0]:
+            # /admin/users/<id>
+            return handle_admin_delete(req, svc, parts[0])
+        if len(parts) == 2 and parts[0] and parts[1] == "role":
+            return handle_admin_set_role(req, svc, parts[0])
+        if len(parts) == 2 and parts[0] and parts[1] == "disabled":
+            return handle_admin_set_disabled(req, svc, parts[0])
+    return _error(404, "not found")
+
+
 def dispatch(
     req: Request,
     svc: AuthService,
     *,
     limiter: RateLimiter | None = None,
 ) -> Response | None:
-    """Return a response for known /auth/* routes, else None.
+    """Return a response for known /auth/* or /admin/* routes, else None.
 
     When ``limiter`` is provided, requests to rate-limited endpoints are
     counted per (path, remote_ip) and 429 is returned when the policy
     threshold trips.
     """
+    if req.path.startswith("/admin/"):
+        return _dispatch_admin(req, svc)
     if not req.path.startswith("/auth/"):
         return None
     handler = _DISPATCH.get((req.method, req.path))

--- a/nanobot/auth/routes.py
+++ b/nanobot/auth/routes.py
@@ -1,0 +1,185 @@
+"""HTTP auth routes for the gateway health-port server.
+
+The gateway speaks raw HTTP/1.0 on its health port (see ``commands.py``).
+This module exposes pure ``Request -> Response`` handlers so the wire-level
+glue stays trivial and the logic is unit-testable without spinning a
+real socket.
+
+Routes (v1):
+  POST /auth/login   {email, password}   -> sets ``nanobot_session`` cookie
+  POST /auth/logout                       -> clears cookie, revokes session
+  GET  /auth/me                           -> returns current user from cookie
+
+A subsequent slice adds ``POST /auth/signup``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from nanobot.auth.service import AuthError, AuthService, UserRecord
+
+SESSION_COOKIE = "nanobot_session"
+SESSION_COOKIE_MAX_AGE_S = 30 * 24 * 60 * 60  # 30 days
+
+
+@dataclass(frozen=True)
+class Request:
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
+    remote_ip: str | None = None
+
+
+@dataclass
+class Response:
+    status: int
+    body: bytes = b""
+    headers: dict[str, str] = field(default_factory=dict)
+    cookies: list[str] = field(default_factory=list)  # raw Set-Cookie values
+
+
+def _parse_cookies(header: str | None) -> dict[str, str]:
+    """Parse a ``Cookie:`` header value into a flat mapping."""
+    if not header:
+        return {}
+    out: dict[str, str] = {}
+    for chunk in header.split(";"):
+        if "=" in chunk:
+            k, v = chunk.split("=", 1)
+            out[k.strip()] = v.strip()
+    return out
+
+
+def _json_response(status: int, payload: dict[str, Any]) -> Response:
+    body = json.dumps(payload).encode("utf-8")
+    return Response(
+        status=status,
+        body=body,
+        headers={"Content-Type": "application/json", "Cache-Control": "no-store"},
+    )
+
+
+def _error(status: int, message: str) -> Response:
+    return _json_response(status, {"error": message})
+
+
+def _user_payload(user: UserRecord) -> dict[str, Any]:
+    return {
+        "id": user.id,
+        "email": user.email,
+        "display_name": user.display_name,
+        "role": user.role,
+    }
+
+
+def _build_session_cookie(token: str, *, secure: bool) -> str:
+    parts = [
+        f"{SESSION_COOKIE}={token}",
+        "Path=/",
+        "HttpOnly",
+        "SameSite=Lax",
+        f"Max-Age={SESSION_COOKIE_MAX_AGE_S}",
+    ]
+    if secure:
+        parts.append("Secure")
+    return "; ".join(parts)
+
+
+def _clear_session_cookie() -> str:
+    return f"{SESSION_COOKIE}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
+
+
+def _detect_secure(req: Request) -> bool:
+    # Behind a TLS terminator, the proxy sets X-Forwarded-Proto.
+    proto = req.headers.get("x-forwarded-proto", "").lower()
+    return proto == "https"
+
+
+def _parse_json_body(req: Request) -> dict[str, Any]:
+    if not req.body:
+        return {}
+    try:
+        loaded = json.loads(req.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AuthError("invalid request body") from exc
+    if not isinstance(loaded, dict):
+        raise AuthError("invalid request body")
+    return loaded
+
+
+def handle_login(req: Request, svc: AuthService) -> Response:
+    if req.method != "POST":
+        return _error(405, "method not allowed")
+    try:
+        data = _parse_json_body(req)
+    except AuthError as exc:
+        return _error(400, str(exc))
+    email = (data.get("email") or "").strip()
+    password = data.get("password") or ""
+    if not email or not password:
+        return _error(400, "email and password required")
+    try:
+        user = svc.verify_password(email, password, ip=req.remote_ip)
+    except AuthError:
+        return _error(401, "invalid credentials")
+    session = svc.mint_session(
+        user.id,
+        user_agent=req.headers.get("user-agent"),
+        ip=req.remote_ip,
+    )
+    resp = _json_response(200, {"user": _user_payload(user)})
+    resp.cookies.append(_build_session_cookie(session.token, secure=_detect_secure(req)))
+    return resp
+
+
+def handle_logout(req: Request, svc: AuthService) -> Response:
+    if req.method != "POST":
+        return _error(405, "method not allowed")
+    cookies = _parse_cookies(req.headers.get("cookie"))
+    token = cookies.get(SESSION_COOKIE, "")
+    svc.revoke_session(token)
+    resp = _json_response(200, {"ok": True})
+    resp.cookies.append(_clear_session_cookie())
+    return resp
+
+
+def handle_me(req: Request, svc: AuthService) -> Response:
+    if req.method != "GET":
+        return _error(405, "method not allowed")
+    cookies = _parse_cookies(req.headers.get("cookie"))
+    token = cookies.get(SESSION_COOKIE, "")
+    try:
+        user = svc.verify_session(token)
+    except AuthError:
+        return _error(401, "unauthenticated")
+    return _json_response(200, {"user": _user_payload(user)})
+
+
+_DISPATCH = {
+    ("POST", "/auth/login"): handle_login,
+    ("POST", "/auth/logout"): handle_logout,
+    ("GET", "/auth/me"): handle_me,
+}
+
+
+def dispatch(req: Request, svc: AuthService) -> Response | None:
+    """Return a response for known /auth/* routes, else None.
+
+    The gateway server falls back to its own 404 (or other routes such as
+    ``/health``) when this returns None.
+    """
+    if not req.path.startswith("/auth/"):
+        return None
+    handler = _DISPATCH.get((req.method, req.path))
+    if handler is None:
+        # Known prefix but no method match — return 405 vs 404 only when the
+        # path matches a registered route under a different verb.
+        for method, path in _DISPATCH:
+            if path == req.path:
+                return _error(405, "method not allowed")
+        return _error(404, "not found")
+    return handler(req, svc)

--- a/nanobot/auth/routes.py
+++ b/nanobot/auth/routes.py
@@ -19,10 +19,17 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
-from nanobot.auth.service import AuthError, AuthService, UserRecord
+from nanobot.auth.ratelimit import RateLimiter
+from nanobot.auth.service import AuthError, AuthService, EmailTakenError, UserRecord
 
 SESSION_COOKIE = "nanobot_session"
 SESSION_COOKIE_MAX_AGE_S = 30 * 24 * 60 * 60  # 30 days
+
+# Per-endpoint policy: (max_attempts, window_seconds). Tuned for v1 single-instance.
+RATE_LIMIT_POLICY: dict[str, tuple[int, float]] = {
+    "/auth/login": (5, 60.0),
+    "/auth/signup": (3, 60.0),
+}
 
 
 @dataclass(frozen=True)
@@ -111,6 +118,43 @@ def _parse_json_body(req: Request) -> dict[str, Any]:
     return loaded
 
 
+def handle_signup(req: Request, svc: AuthService) -> Response:
+    if req.method != "POST":
+        return _error(405, "method not allowed")
+    try:
+        data = _parse_json_body(req)
+    except AuthError as exc:
+        return _error(400, str(exc))
+    email = (data.get("email") or "").strip()
+    password = data.get("password") or ""
+    display_name = data.get("display_name")
+    if isinstance(display_name, str):
+        display_name = display_name.strip() or None
+    else:
+        display_name = None
+    if not email or not password:
+        return _error(400, "email and password required")
+    try:
+        user = svc.create_user(
+            email,
+            password,
+            display_name=display_name,
+            ip=req.remote_ip,
+        )
+    except EmailTakenError:
+        return _error(409, "email already registered")
+    except AuthError as exc:
+        return _error(400, str(exc))
+    session = svc.mint_session(
+        user.id,
+        user_agent=req.headers.get("user-agent"),
+        ip=req.remote_ip,
+    )
+    resp = _json_response(200, {"user": _user_payload(user)})
+    resp.cookies.append(_build_session_cookie(session.token, secure=_detect_secure(req)))
+    return resp
+
+
 def handle_login(req: Request, svc: AuthService) -> Response:
     if req.method != "POST":
         return _error(405, "method not allowed")
@@ -160,26 +204,50 @@ def handle_me(req: Request, svc: AuthService) -> Response:
 
 
 _DISPATCH = {
+    ("POST", "/auth/signup"): handle_signup,
     ("POST", "/auth/login"): handle_login,
     ("POST", "/auth/logout"): handle_logout,
     ("GET", "/auth/me"): handle_me,
 }
 
 
-def dispatch(req: Request, svc: AuthService) -> Response | None:
+def dispatch(
+    req: Request,
+    svc: AuthService,
+    *,
+    limiter: RateLimiter | None = None,
+) -> Response | None:
     """Return a response for known /auth/* routes, else None.
 
-    The gateway server falls back to its own 404 (or other routes such as
-    ``/health``) when this returns None.
+    When ``limiter`` is provided, requests to rate-limited endpoints are
+    counted per (path, remote_ip) and 429 is returned when the policy
+    threshold trips.
     """
     if not req.path.startswith("/auth/"):
         return None
     handler = _DISPATCH.get((req.method, req.path))
     if handler is None:
-        # Known prefix but no method match — return 405 vs 404 only when the
-        # path matches a registered route under a different verb.
         for method, path in _DISPATCH:
             if path == req.path:
                 return _error(405, "method not allowed")
         return _error(404, "not found")
+    if limiter is not None and req.path in RATE_LIMIT_POLICY:
+        max_attempts, window_s = RATE_LIMIT_POLICY[req.path]
+        ip = req.remote_ip or "-"
+        ok, retry_after = limiter.try_consume(
+            (req.path, ip), max_attempts=max_attempts, window_s=window_s
+        )
+        if not ok:
+            try:
+                svc._audit(  # noqa: SLF001 — intentional cross-module audit
+                    "ratelimit.trip",
+                    target_user_id=None,
+                    ip=ip,
+                    detail=req.path,
+                )
+            except Exception:
+                pass
+            resp = _error(429, "too many requests")
+            resp.headers["Retry-After"] = str(retry_after)
+            return resp
     return handler(req, svc)

--- a/nanobot/auth/routes.py
+++ b/nanobot/auth/routes.py
@@ -20,7 +20,9 @@ Admin (require ``role='admin'`` on the cookie's user):
 
 from __future__ import annotations
 
+import hmac
 import json
+import secrets
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -29,6 +31,14 @@ from nanobot.auth.service import AuthError, AuthService, EmailTakenError, UserRe
 
 SESSION_COOKIE = "nanobot_session"
 SESSION_COOKIE_MAX_AGE_S = 30 * 24 * 60 * 60  # 30 days
+
+# Double-submit CSRF cookie. Read by JS (NOT HttpOnly) and echoed in the
+# X-CSRF-Token header on state-changing requests; the server verifies the
+# header matches the cookie. Combined with SameSite=Lax on the session
+# cookie this gives defense-in-depth against cross-origin POSTs.
+CSRF_COOKIE = "nanobot_csrf"
+CSRF_HEADER = "x-csrf-token"
+CSRF_COOKIE_MAX_AGE_S = 30 * 24 * 60 * 60
 
 # Per-endpoint policy: (max_attempts, window_seconds). Tuned for v1 single-instance.
 RATE_LIMIT_POLICY: dict[str, tuple[int, float]] = {
@@ -103,6 +113,38 @@ def _build_session_cookie(token: str, *, secure: bool) -> str:
 
 def _clear_session_cookie() -> str:
     return f"{SESSION_COOKIE}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
+
+
+def _build_csrf_cookie(token: str, *, secure: bool) -> str:
+    # NOT HttpOnly — JS needs to read it to echo into the X-CSRF-Token header.
+    parts = [
+        f"{CSRF_COOKIE}={token}",
+        "Path=/",
+        "SameSite=Lax",
+        f"Max-Age={CSRF_COOKIE_MAX_AGE_S}",
+    ]
+    if secure:
+        parts.append("Secure")
+    return "; ".join(parts)
+
+
+def _ensure_csrf(resp: Response, req: Request) -> Response:
+    """Issue a CSRF cookie if the request didn't carry one."""
+    cookies = _parse_cookies(req.headers.get("cookie"))
+    if cookies.get(CSRF_COOKIE):
+        return resp
+    token = secrets.token_urlsafe(32)
+    resp.cookies.append(_build_csrf_cookie(token, secure=_detect_secure(req)))
+    return resp
+
+
+def _csrf_ok(req: Request) -> bool:
+    cookies = _parse_cookies(req.headers.get("cookie"))
+    cookie_val = cookies.get(CSRF_COOKIE, "")
+    header_val = req.headers.get(CSRF_HEADER, "")
+    if not cookie_val or not header_val:
+        return False
+    return hmac.compare_digest(cookie_val, header_val)
 
 
 def _detect_secure(req: Request) -> bool:
@@ -363,45 +405,71 @@ def _dispatch_admin(req: Request, svc: AuthService) -> Response | None:
     return _error(404, "not found")
 
 
+def _is_state_changing(method: str) -> bool:
+    return method in {"POST", "PUT", "PATCH", "DELETE"}
+
+
 def dispatch(
     req: Request,
     svc: AuthService,
     *,
     limiter: RateLimiter | None = None,
+    require_csrf: bool = False,
 ) -> Response | None:
     """Return a response for known /auth/* or /admin/* routes, else None.
 
     When ``limiter`` is provided, requests to rate-limited endpoints are
     counted per (path, remote_ip) and 429 is returned when the policy
     threshold trips.
+
+    When ``require_csrf`` is True, state-changing requests must echo the
+    ``nanobot_csrf`` cookie value in the ``X-CSRF-Token`` header. The cookie
+    itself is auto-issued on every response to clients that don't have
+    one yet — the webui's GET /auth/me on mount establishes it before any
+    login POST is sent.
     """
-    if req.path.startswith("/admin/"):
-        return _dispatch_admin(req, svc)
-    if not req.path.startswith("/auth/"):
+    is_admin = req.path.startswith("/admin/")
+    is_auth = req.path.startswith("/auth/")
+    if not (is_admin or is_auth):
         return None
-    handler = _DISPATCH.get((req.method, req.path))
-    if handler is None:
-        for method, path in _DISPATCH:
-            if path == req.path:
-                return _error(405, "method not allowed")
-        return _error(404, "not found")
-    if limiter is not None and req.path in RATE_LIMIT_POLICY:
-        max_attempts, window_s = RATE_LIMIT_POLICY[req.path]
-        ip = req.remote_ip or "-"
-        ok, retry_after = limiter.try_consume(
-            (req.path, ip), max_attempts=max_attempts, window_s=window_s
-        )
-        if not ok:
-            try:
-                svc._audit(  # noqa: SLF001 — intentional cross-module audit
-                    "ratelimit.trip",
-                    target_user_id=None,
-                    ip=ip,
-                    detail=req.path,
+
+    if require_csrf and _is_state_changing(req.method) and not _csrf_ok(req):
+        resp = _error(403, "csrf token missing or invalid")
+        return _ensure_csrf(resp, req)
+
+    if is_admin:
+        resp = _dispatch_admin(req, svc)
+    else:
+        handler = _DISPATCH.get((req.method, req.path))
+        if handler is None:
+            for method, path in _DISPATCH:
+                if path == req.path:
+                    resp = _error(405, "method not allowed")
+                    break
+            else:
+                resp = _error(404, "not found")
+        else:
+            if limiter is not None and req.path in RATE_LIMIT_POLICY:
+                max_attempts, window_s = RATE_LIMIT_POLICY[req.path]
+                ip = req.remote_ip or "-"
+                ok, retry_after = limiter.try_consume(
+                    (req.path, ip), max_attempts=max_attempts, window_s=window_s
                 )
-            except Exception:
-                pass
-            resp = _error(429, "too many requests")
-            resp.headers["Retry-After"] = str(retry_after)
-            return resp
-    return handler(req, svc)
+                if not ok:
+                    try:
+                        svc._audit(  # noqa: SLF001 — intentional cross-module audit
+                            "ratelimit.trip",
+                            target_user_id=None,
+                            ip=ip,
+                            detail=req.path,
+                        )
+                    except Exception:
+                        pass
+                    resp = _error(429, "too many requests")
+                    resp.headers["Retry-After"] = str(retry_after)
+                    return _ensure_csrf(resp, req)
+            resp = handler(req, svc)
+
+    if resp is not None:
+        _ensure_csrf(resp, req)
+    return resp

--- a/nanobot/auth/schema.py
+++ b/nanobot/auth/schema.py
@@ -1,0 +1,93 @@
+"""SQLite schema for nanobot auth (users, web sessions, audit log).
+
+The auth DB lives at ``~/.nanobot/auth.db`` (or the equivalent under
+``get_data_dir()``). Schema creation is idempotent. A file lock guards
+init so concurrent gateway + CLI startups cannot race.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from filelock import FileLock
+from loguru import logger
+
+from nanobot.config.paths import get_data_dir
+
+AUTH_DB_FILENAME = "auth.db"
+_INIT_LOCK_FILENAME = ".auth-init.lock"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+    id              TEXT PRIMARY KEY,
+    email           TEXT UNIQUE NOT NULL COLLATE NOCASE,
+    password_hash   TEXT NOT NULL,
+    display_name    TEXT,
+    role            TEXT NOT NULL DEFAULT 'user',
+    created_at      INTEGER NOT NULL,
+    last_login_at   INTEGER,
+    disabled        INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS web_sessions (
+    token_hash      TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at      INTEGER NOT NULL,
+    expires_at      INTEGER NOT NULL,
+    last_seen_at    INTEGER NOT NULL,
+    user_agent      TEXT,
+    ip              TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_user ON web_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_expires ON web_sessions(expires_at);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts              INTEGER NOT NULL,
+    actor_user_id   TEXT,
+    event           TEXT NOT NULL,
+    target_user_id  TEXT,
+    ip              TEXT,
+    detail          TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_log(ts);
+"""
+
+
+def get_auth_db_path(data_dir: Path | None = None) -> Path:
+    """Resolve the on-disk path for the auth database."""
+    base = data_dir if data_dir is not None else get_data_dir()
+    return base / AUTH_DB_FILENAME
+
+
+def open_auth_db(data_dir: Path | None = None) -> sqlite3.Connection:
+    """Open a connection to the auth DB with sane pragmas.
+
+    Callers own the connection lifecycle. Use ``init_auth_db`` once at
+    process startup to materialize the schema.
+    """
+    path = get_auth_db_path(data_dir)
+    conn = sqlite3.connect(path, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = NORMAL")
+    return conn
+
+
+def init_auth_db(data_dir: Path | None = None) -> Path:
+    """Create the auth DB and schema if absent. Idempotent and lock-guarded."""
+    base = data_dir if data_dir is not None else get_data_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    db_path = get_auth_db_path(base)
+    lock = FileLock(str(base / _INIT_LOCK_FILENAME))
+    with lock:
+        first = not db_path.exists()
+        with open_auth_db(base) as conn:
+            conn.executescript(_SCHEMA)
+        if first:
+            logger.info(f"Auth: initialized {db_path}")
+        else:
+            logger.debug(f"Auth: schema verified at {db_path}")
+    return db_path

--- a/nanobot/auth/schema.py
+++ b/nanobot/auth/schema.py
@@ -7,7 +7,10 @@ init so concurrent gateway + CLI startups cannot race.
 
 from __future__ import annotations
 
+import os
 import sqlite3
+import stat
+import sys
 from pathlib import Path
 
 from filelock import FileLock
@@ -76,6 +79,15 @@ def open_auth_db(data_dir: Path | None = None) -> sqlite3.Connection:
     return conn
 
 
+def _chmod_quiet(path: Path, mode: int) -> None:
+    if sys.platform == "win32":
+        return
+    try:
+        os.chmod(path, mode)
+    except OSError as exc:
+        logger.warning("could not chmod {} to {:o}: {}", path, mode, exc)
+
+
 def init_auth_db(data_dir: Path | None = None) -> Path:
     """Create the auth DB and schema if absent. Idempotent and lock-guarded."""
     base = data_dir if data_dir is not None else get_data_dir()
@@ -86,6 +98,9 @@ def init_auth_db(data_dir: Path | None = None) -> Path:
         first = not db_path.exists()
         with open_auth_db(base) as conn:
             conn.executescript(_SCHEMA)
+        # auth.db holds argon2 password hashes — lock to owner-read/write only
+        # so a shared-host setup can't expose hashes to other local users.
+        _chmod_quiet(db_path, stat.S_IRUSR | stat.S_IWUSR)
         if first:
             logger.info(f"Auth: initialized {db_path}")
         else:

--- a/nanobot/auth/service.py
+++ b/nanobot/auth/service.py
@@ -33,6 +33,15 @@ MIN_PASSWORD_LEN = 12
 
 _HASHER = PasswordHasher(time_cost=3, memory_cost=64 * 1024, parallelism=2)
 
+# Real argon2id hash used to mask the unknown-email branch in verify_password.
+# A static literal hash was previously used but argon2-cffi rejected its
+# salt segment cheaply (~0.03 ms vs. ~63 ms for a real verify) — that gap
+# was a measurable timing oracle for email enumeration. Hashing a constant
+# at module import gives us a wire-format hash that argon2-cffi will
+# actually process all the way through, so the unknown-email and
+# wrong-password paths take the same time.
+_DUMMY_HASH = _HASHER.hash("__nanobot_dummy_for_timing__")
+
 
 class AuthError(Exception):
     """Generic auth failure; safe to surface to clients."""
@@ -150,10 +159,12 @@ class AuthService:
         """
         user = self.get_user_by_email(email)
         if user is None:
-            # Run hash to keep timing roughly constant against enumeration.
+            # Constant-time mask against email enumeration. ``_DUMMY_HASH`` is
+            # a real argon2id hash so the verify takes the same wall-clock
+            # time as the legitimate wrong-password branch.
             try:
-                _HASHER.verify("$argon2id$v=19$m=65536,t=3,p=2$xxxxxxxxxxxxxxxx$" + "x" * 43, password)
-            except Exception:
+                _HASHER.verify(_DUMMY_HASH, password)
+            except VerifyMismatchError:
                 pass
             self._audit("login.fail", target_user_id=None, ip=ip, detail=email.strip().lower())
             raise AuthError("invalid credentials")

--- a/nanobot/auth/service.py
+++ b/nanobot/auth/service.py
@@ -1,0 +1,270 @@
+"""AuthService: user creation, password verification, session lifecycle, audit log.
+
+Single class owns all auth-DB interactions. Callers obtain an instance via the
+default factory ``AuthService.default()`` which opens a connection against
+``~/.nanobot/auth.db``. Tests pass an explicit ``data_dir``.
+
+Security choices:
+  - Passwords hashed with argon2id (time_cost=3, memory_cost=64MB, parallelism=2).
+  - Session tokens: 32 random URL-safe bytes; only sha256(token) is persisted.
+  - Sliding TTL: ``verify_session`` extends ``expires_at`` on each hit.
+  - Every state-changing call writes an ``audit_log`` row (success or failure).
+  - Login errors are intentionally generic — no distinction between
+    "unknown email" and "wrong password" reaches the caller.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+
+from nanobot.auth.ids import assert_ulid, new_ulid
+from nanobot.auth.schema import init_auth_db, open_auth_db
+
+DEFAULT_SESSION_TTL_S = 30 * 24 * 60 * 60  # 30 days
+MIN_PASSWORD_LEN = 12
+
+_HASHER = PasswordHasher(time_cost=3, memory_cost=64 * 1024, parallelism=2)
+
+
+class AuthError(Exception):
+    """Generic auth failure; safe to surface to clients."""
+
+
+class EmailTakenError(AuthError):
+    """Raised when create_user is called with a duplicate email."""
+
+
+@dataclass(frozen=True)
+class UserRecord:
+    id: str
+    email: str
+    display_name: str | None
+    role: str
+    created_at: int
+    last_login_at: int | None
+    disabled: bool
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    token: str  # raw token — only returned at mint time
+    user_id: str
+    expires_at: int
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _row_to_user(row: sqlite3.Row) -> UserRecord:
+    return UserRecord(
+        id=row["id"],
+        email=row["email"],
+        display_name=row["display_name"],
+        role=row["role"],
+        created_at=row["created_at"],
+        last_login_at=row["last_login_at"],
+        disabled=bool(row["disabled"]),
+    )
+
+
+class AuthService:
+    """Synchronous auth operations against the SQLite auth DB."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    @classmethod
+    def default(cls, data_dir: Path | None = None) -> "AuthService":
+        init_auth_db(data_dir)
+        return cls(open_auth_db(data_dir))
+
+    def close(self) -> None:
+        self._conn.close()
+
+    # ----- user lifecycle ----------------------------------------------------
+
+    def create_user(
+        self,
+        email: str,
+        password: str,
+        *,
+        display_name: str | None = None,
+        role: str = "user",
+        ip: str | None = None,
+    ) -> UserRecord:
+        email_norm = email.strip().lower()
+        if not email_norm or "@" not in email_norm:
+            raise AuthError("invalid email")
+        if len(password) < MIN_PASSWORD_LEN:
+            raise AuthError(f"password must be at least {MIN_PASSWORD_LEN} characters")
+        if role not in ("user", "admin"):
+            raise AuthError(f"invalid role: {role}")
+
+        user_id = new_ulid()
+        pwd_hash = _HASHER.hash(password)
+        now = _now()
+        try:
+            self._conn.execute(
+                "INSERT INTO users (id, email, password_hash, display_name, role, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (user_id, email_norm, pwd_hash, display_name, role, now),
+            )
+        except sqlite3.IntegrityError as exc:
+            self._audit("signup.fail", target_user_id=None, ip=ip, detail=email_norm)
+            raise EmailTakenError("email already registered") from exc
+        self._audit("signup", target_user_id=user_id, ip=ip, detail=email_norm)
+        return self.get_user(user_id)
+
+    def get_user(self, user_id: str) -> UserRecord:
+        assert_ulid(user_id)
+        row = self._conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
+        if row is None:
+            raise AuthError("user not found")
+        return _row_to_user(row)
+
+    def get_user_by_email(self, email: str) -> UserRecord | None:
+        row = self._conn.execute(
+            "SELECT * FROM users WHERE email = ?", (email.strip().lower(),)
+        ).fetchone()
+        return _row_to_user(row) if row else None
+
+    # ----- password verification --------------------------------------------
+
+    def verify_password(self, email: str, password: str, *, ip: str | None = None) -> UserRecord:
+        """Return user on success; raise AuthError on any failure.
+
+        Generic error to avoid leaking whether email is registered.
+        """
+        user = self.get_user_by_email(email)
+        if user is None:
+            # Run hash to keep timing roughly constant against enumeration.
+            try:
+                _HASHER.verify("$argon2id$v=19$m=65536,t=3,p=2$xxxxxxxxxxxxxxxx$" + "x" * 43, password)
+            except Exception:
+                pass
+            self._audit("login.fail", target_user_id=None, ip=ip, detail=email.strip().lower())
+            raise AuthError("invalid credentials")
+        if user.disabled:
+            self._audit("login.fail", target_user_id=user.id, ip=ip, detail="disabled")
+            raise AuthError("invalid credentials")
+        row = self._conn.execute(
+            "SELECT password_hash FROM users WHERE id = ?", (user.id,)
+        ).fetchone()
+        try:
+            _HASHER.verify(row["password_hash"], password)
+        except VerifyMismatchError:
+            self._audit("login.fail", target_user_id=user.id, ip=ip, detail="bad_password")
+            raise AuthError("invalid credentials") from None
+        if _HASHER.check_needs_rehash(row["password_hash"]):
+            self._conn.execute(
+                "UPDATE users SET password_hash = ? WHERE id = ?",
+                (_HASHER.hash(password), user.id),
+            )
+        self._conn.execute("UPDATE users SET last_login_at = ? WHERE id = ?", (_now(), user.id))
+        self._audit("login.ok", target_user_id=user.id, ip=ip)
+        return user
+
+    def set_password(self, user_id: str, new_password: str, *, ip: str | None = None) -> None:
+        assert_ulid(user_id)
+        if len(new_password) < MIN_PASSWORD_LEN:
+            raise AuthError(f"password must be at least {MIN_PASSWORD_LEN} characters")
+        pwd_hash = _HASHER.hash(new_password)
+        self._conn.execute("UPDATE users SET password_hash = ? WHERE id = ?", (pwd_hash, user_id))
+        # Reset all sessions for this user — force re-login.
+        self._conn.execute("DELETE FROM web_sessions WHERE user_id = ?", (user_id,))
+        self._audit("reset", target_user_id=user_id, ip=ip)
+
+    # ----- sessions ----------------------------------------------------------
+
+    def mint_session(
+        self,
+        user_id: str,
+        *,
+        user_agent: str | None = None,
+        ip: str | None = None,
+        ttl_seconds: int = DEFAULT_SESSION_TTL_S,
+    ) -> SessionRecord:
+        assert_ulid(user_id)
+        token = secrets.token_urlsafe(32)
+        now = _now()
+        expires = now + ttl_seconds
+        self._conn.execute(
+            "INSERT INTO web_sessions "
+            "(token_hash, user_id, created_at, expires_at, last_seen_at, user_agent, ip) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (_hash_token(token), user_id, now, expires, now, user_agent, ip),
+        )
+        return SessionRecord(token=token, user_id=user_id, expires_at=expires)
+
+    def verify_session(
+        self,
+        token: str,
+        *,
+        sliding: bool = True,
+        ttl_seconds: int = DEFAULT_SESSION_TTL_S,
+    ) -> UserRecord:
+        """Return the owning user if token is valid and unexpired; else raise."""
+        if not token:
+            raise AuthError("missing session token")
+        token_hash = _hash_token(token)
+        row = self._conn.execute(
+            "SELECT s.user_id, s.expires_at FROM web_sessions s WHERE s.token_hash = ?",
+            (token_hash,),
+        ).fetchone()
+        if row is None:
+            raise AuthError("invalid session")
+        now = _now()
+        if row["expires_at"] <= now:
+            self._conn.execute("DELETE FROM web_sessions WHERE token_hash = ?", (token_hash,))
+            self._audit("session.expire", target_user_id=row["user_id"])
+            raise AuthError("invalid session")
+        if sliding:
+            self._conn.execute(
+                "UPDATE web_sessions SET last_seen_at = ?, expires_at = ? WHERE token_hash = ?",
+                (now, now + ttl_seconds, token_hash),
+            )
+        return self.get_user(row["user_id"])
+
+    def revoke_session(self, token: str) -> None:
+        if not token:
+            return
+        self._conn.execute("DELETE FROM web_sessions WHERE token_hash = ?", (_hash_token(token),))
+
+    def revoke_all_sessions(self, user_id: str) -> int:
+        assert_ulid(user_id)
+        cur = self._conn.execute("DELETE FROM web_sessions WHERE user_id = ?", (user_id,))
+        return cur.rowcount or 0
+
+    def expire_sessions(self) -> int:
+        cur = self._conn.execute("DELETE FROM web_sessions WHERE expires_at <= ?", (_now(),))
+        return cur.rowcount or 0
+
+    # ----- audit -------------------------------------------------------------
+
+    def _audit(
+        self,
+        event: str,
+        *,
+        actor_user_id: str | None = None,
+        target_user_id: str | None = None,
+        ip: str | None = None,
+        detail: str | None = None,
+    ) -> None:
+        self._conn.execute(
+            "INSERT INTO audit_log (ts, actor_user_id, event, target_user_id, ip, detail) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (_now(), actor_user_id, event, target_user_id, ip, detail),
+        )

--- a/nanobot/bus/events.py
+++ b/nanobot/bus/events.py
@@ -2,7 +2,10 @@
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nanobot.auth.context import UserContext
 
 
 @dataclass
@@ -17,6 +20,7 @@ class InboundMessage:
     media: list[str] = field(default_factory=list)  # Media URLs
     metadata: dict[str, Any] = field(default_factory=dict)  # Channel-specific data
     session_key_override: str | None = None  # Optional override for thread-scoped sessions
+    user_context: "UserContext | None" = None  # Per-user runtime context (WebUI auth)
 
     @property
     def session_key(self) -> str:

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -151,6 +151,7 @@ class BaseChannel(ABC):
         media: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
         session_key: str | None = None,
+        user_context: Any = None,
     ) -> None:
         """
         Handle an incoming message from the chat platform.
@@ -164,6 +165,7 @@ class BaseChannel(ABC):
             media: Optional list of media URLs.
             metadata: Optional channel-specific metadata.
             session_key: Optional session key override (e.g. thread-scoped sessions).
+            user_context: Optional per-user runtime context (WebUI auth path).
         """
         if not self.is_allowed(sender_id):
             self.logger.warning(
@@ -185,6 +187,7 @@ class BaseChannel(ABC):
             media=media or [],
             metadata=meta,
             session_key_override=session_key,
+            user_context=user_context,
         )
 
         await self.bus.publish_inbound(msg)

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -483,7 +483,15 @@ class WebSocketChannel(BaseChannel):
         return out
 
     def _user_id_from_request(self, request: Any) -> str | None:
-        """Verify a webui session cookie and return the owning user_id, else None."""
+        """Verify a webui session cookie and return the owning user_id, else None.
+
+        Includes a cross-origin guard: SameSite=Lax on the cookie does NOT
+        block WebSocket upgrades the way it blocks fetch POSTs (browsers
+        historically send cookies on WS handshakes regardless). To prevent
+        a cross-origin page from opening a WS bound to the victim's cookie,
+        we require the ``Origin`` header to match the gateway's ``Host``
+        when a session cookie is being honored.
+        """
         try:
             headers = request.headers if request is not None else None
             raw = headers.get("Cookie") if headers is not None else None
@@ -493,9 +501,33 @@ class WebSocketChannel(BaseChannel):
         token = cookies.get("nanobot_session", "")
         if not token:
             return None
+
+        # Cross-origin guard on cookie-auth handshakes.
+        try:
+            origin_header = headers.get("Origin") if headers is not None else None
+            host_header = headers.get("Host") if headers is not None else None
+        except Exception:
+            return None
+        if origin_header:
+            from urllib.parse import urlparse
+
+            origin_host = urlparse(origin_header).netloc.lower()
+            request_host = (host_header or "").lower()
+            if origin_host and request_host and origin_host != request_host:
+                self.logger.warning(
+                    "rejecting cookie-auth WS upgrade — Origin {} != Host {}",
+                    origin_host,
+                    request_host,
+                )
+                return None
+        # No Origin header at all (non-browser client / curl). Cookies don't
+        # ride curl unless explicitly attached, so treat as legitimate.
+
+        from nanobot.auth import AuthError
+
         try:
             user = self._auth_service().verify_session(token)
-        except Exception:
+        except AuthError:
             return None
         return user.id
 

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -423,6 +423,10 @@ class WebSocketChannel(BaseChannel):
         self._conn_chats: dict[Any, set[str]] = {}
         # connection -> default chat_id for legacy frames that omit routing.
         self._conn_default: dict[Any, str] = {}
+        # connection -> authenticated WebUI user_id (None when unauthenticated).
+        self._conn_user_id: dict[Any, str] = {}
+        # Cached AuthService instance; lazily built on first cookie-auth request.
+        self._auth_svc_cache: Any = None
         # Single-use tokens consumed at WebSocket handshake.
         self._issued_tokens: dict[str, float] = {}
         # Multi-use tokens for the embedded webui's REST surface; checked but not consumed.
@@ -457,6 +461,52 @@ class WebSocketChannel(BaseChannel):
             if not subs:
                 self._subs.pop(cid, None)
         self._conn_default.pop(connection, None)
+        self._conn_user_id.pop(connection, None)
+
+    def _auth_service(self) -> Any:
+        """Lazy-build a process-shared AuthService for cookie verification."""
+        if self._auth_svc_cache is None:
+            from nanobot.auth.service import AuthService
+
+            self._auth_svc_cache = AuthService.default()
+        return self._auth_svc_cache
+
+    @staticmethod
+    def _parse_cookie_header(raw: str | None) -> dict[str, str]:
+        out: dict[str, str] = {}
+        if not raw:
+            return out
+        for chunk in raw.split(";"):
+            if "=" in chunk:
+                k, v = chunk.split("=", 1)
+                out[k.strip()] = v.strip()
+        return out
+
+    def _user_id_from_request(self, request: Any) -> str | None:
+        """Verify a webui session cookie and return the owning user_id, else None."""
+        try:
+            headers = request.headers if request is not None else None
+            raw = headers.get("Cookie") if headers is not None else None
+        except Exception:
+            return None
+        cookies = self._parse_cookie_header(raw)
+        token = cookies.get("nanobot_session", "")
+        if not token:
+            return None
+        try:
+            user = self._auth_service().verify_session(token)
+        except Exception:
+            return None
+        return user.id
+
+    def _user_context_for(self, connection: Any) -> Any:
+        """Return a UserContext for the connection's bound user, or None."""
+        user_id = self._conn_user_id.get(connection)
+        if not user_id:
+            return None
+        from nanobot.auth.context import UserContext
+
+        return UserContext(user_id=user_id)
 
     async def _send_event(self, connection: Any, event: str, **fields: Any) -> None:
         """Send a control event (attached, error, ...) to a single connection."""
@@ -1116,6 +1166,12 @@ class WebSocketChannel(BaseChannel):
             self.logger.warning("client_id too long ({} chars), truncating", len(client_id))
             client_id = client_id[:128]
 
+        # WebUI auth: if the upgrade carried a valid session cookie, bind this
+        # connection to that user_id so per-user state isolation applies.
+        bound_user_id = self._user_id_from_request(request)
+        if bound_user_id:
+            self._conn_user_id[connection] = bound_user_id
+
         default_chat_id = str(uuid.uuid4())
 
         try:
@@ -1154,6 +1210,7 @@ class WebSocketChannel(BaseChannel):
                     chat_id=default_chat_id,
                     content=content,
                     metadata={"remote": getattr(connection, "remote_address", None)},
+                    user_context=self._user_context_for(connection),
                 )
         except Exception as e:
             self.logger.debug("connection ended: {}", e)
@@ -1299,6 +1356,7 @@ class WebSocketChannel(BaseChannel):
                 content=content,
                 media=media_paths or None,
                 metadata=metadata,
+                user_context=self._user_context_for(connection),
             )
             return
         await self._send_event(connection, "error", detail=f"unknown type: {t!r}")

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -1220,6 +1220,8 @@ class WebSocketChannel(BaseChannel):
     def _save_envelope_media(
         self,
         media: list[Any],
+        *,
+        user_ctx: Any = None,
     ) -> tuple[list[str], str | None]:
         """Decode and persist ``media`` items from a ``message`` envelope.
 
@@ -1245,7 +1247,9 @@ class WebSocketChannel(BaseChannel):
         if video_count > _MAX_VIDEOS_PER_MESSAGE:
             return [], "too_many_videos"
 
-        media_dir = get_media_dir("websocket")
+        media_dir = (
+            user_ctx.media_dir("websocket") if user_ctx is not None else get_media_dir("websocket")
+        )
         paths: list[str] = []
 
         def _abort(reason: str) -> tuple[list[str], str]:
@@ -1325,7 +1329,9 @@ class WebSocketChannel(BaseChannel):
                         detail="image_rejected", reason="malformed",
                     )
                     return
-                media_paths, reason = self._save_envelope_media(raw_media)
+                media_paths, reason = self._save_envelope_media(
+                    raw_media, user_ctx=self._user_context_for(connection)
+                )
                 if reason is not None:
                     await self._send_event(
                         connection, "error",

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -427,6 +427,11 @@ class WebSocketChannel(BaseChannel):
         self._conn_user_id: dict[Any, str] = {}
         # Cached AuthService instance; lazily built on first cookie-auth request.
         self._auth_svc_cache: Any = None
+        # Per-user SessionManager cache for the read-side REST routes
+        # (/api/sessions list, messages, delete). Mirrors the cache the
+        # AgentLoop keeps so the sidebar sees per-user data instead of the
+        # global workspace.
+        self._user_session_managers: dict[str, Any] = {}
         # Single-use tokens consumed at WebSocket handshake.
         self._issued_tokens: dict[str, float] = {}
         # Multi-use tokens for the embedded webui's REST surface; checked but not consumed.
@@ -539,6 +544,31 @@ class WebSocketChannel(BaseChannel):
         from nanobot.auth.context import UserContext
 
         return UserContext(user_id=user_id)
+
+    def _session_manager_for_request(self, request: Any) -> Any:
+        """Return the per-user SessionManager when the request carries a
+        valid auth cookie; fall back to the global manager otherwise.
+
+        The REST surface (`/api/sessions*`) is request-scoped, not
+        connection-scoped, so we re-derive user_id from the cookie on each
+        call instead of consulting ``_conn_user_id``.
+        """
+        if self._session_manager is None:
+            return None
+        user_id = self._user_id_from_request(request)
+        if user_id is None:
+            return self._session_manager
+        cached = self._user_session_managers.get(user_id)
+        if cached is None:
+            from nanobot.auth.context import UserContext
+            from nanobot.session.manager import SessionManager
+
+            cached = SessionManager(
+                self._session_manager.workspace,
+                user_ctx=UserContext(user_id=user_id),
+            )
+            self._user_session_managers[user_id] = cached
+        return cached
 
     async def _send_event(self, connection: Any, event: str, **fields: Any) -> None:
         """Send a control event (attached, error, ...) to a single connection."""
@@ -755,9 +785,10 @@ class WebSocketChannel(BaseChannel):
     def _handle_sessions_list(self, request: WsRequest) -> Response:
         if not self._check_api_token(request):
             return _http_error(401, "Unauthorized")
-        if self._session_manager is None:
+        sm = self._session_manager_for_request(request)
+        if sm is None:
             return _http_error(503, "session manager unavailable")
-        sessions = self._session_manager.list_sessions()
+        sessions = sm.list_sessions()
         # The webui is only meaningful for websocket-channel chats — CLI /
         # Slack / Lark / Discord sessions can't be resumed from the browser,
         # so leaking them into the sidebar is just noise. Filter to the
@@ -911,7 +942,8 @@ class WebSocketChannel(BaseChannel):
     def _handle_session_messages(self, request: WsRequest, key: str) -> Response:
         if not self._check_api_token(request):
             return _http_error(401, "Unauthorized")
-        if self._session_manager is None:
+        sm = self._session_manager_for_request(request)
+        if sm is None:
             return _http_error(503, "session manager unavailable")
         decoded_key = _decode_api_key(key)
         if decoded_key is None:
@@ -921,7 +953,7 @@ class WebSocketChannel(BaseChannel):
         # caller probe arbitrary CLI / Slack / Lark history by handcrafted URL.
         if not self._is_webui_session_key(decoded_key):
             return _http_error(404, "session not found")
-        data = self._session_manager.read_session_file(decoded_key)
+        data = sm.read_session_file(decoded_key)
         if data is None:
             return _http_error(404, "session not found")
         # Decorate persisted user messages with signed media URLs so the
@@ -1060,7 +1092,8 @@ class WebSocketChannel(BaseChannel):
     def _handle_session_delete(self, request: WsRequest, key: str) -> Response:
         if not self._check_api_token(request):
             return _http_error(401, "Unauthorized")
-        if self._session_manager is None:
+        sm = self._session_manager_for_request(request)
+        if sm is None:
             return _http_error(503, "session manager unavailable")
         decoded_key = _decode_api_key(key)
         if decoded_key is None:
@@ -1070,7 +1103,7 @@ class WebSocketChannel(BaseChannel):
         # JSONL, so keep the blast radius narrow and explicit.
         if not self._is_webui_session_key(decoded_key):
             return _http_error(404, "session not found")
-        deleted = self._session_manager.delete_session(decoded_key)
+        deleted = sm.delete_session(decoded_key)
         return _http_json_response({"deleted": bool(deleted)})
 
     def _serve_static(self, request_path: str) -> Response | None:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1012,6 +1012,12 @@ def _run_gateway(
 
         auth_svc = _AuthService.default()
         auth_limiter = _RateLimiter()
+        # Honor X-Forwarded-For only when the operator opts in. Without this,
+        # a reverse-proxied gateway sees every peer as 127.0.0.1 and the
+        # rate-limit / audit-log IPs are useless. The env knob is explicit
+        # so the trusted-proxy posture is a deployment choice, never a
+        # client-controllable spoof vector.
+        trust_proxy_headers = os.environ.get("NANOBOT_TRUST_PROXY_HEADERS") == "1"
 
         async def handle(reader, writer):
             try:
@@ -1026,6 +1032,19 @@ def _run_gateway(
                 if req is None:
                     writer.close()
                     return
+
+                if trust_proxy_headers:
+                    xff = req.headers.get("x-forwarded-for", "")
+                    if xff:
+                        forwarded_ip = xff.split(",", 1)[0].strip()
+                        if forwarded_ip:
+                            req = _AuthRequest(
+                                method=req.method,
+                                path=req.path,
+                                headers=req.headers,
+                                body=req.body,
+                                remote_ip=forwarded_ip,
+                            )
 
                 if req.method == "GET" and req.path == "/health":
                     body = _json.dumps({"status": "ok"}).encode("utf-8")

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -672,8 +672,14 @@ def _run_gateway(
 
     console.print(f"{__logo__} Starting nanobot gateway version {__version__} on port {port}...")
     sync_workspace_templates(config.workspace_path)
-    from nanobot.auth import init_auth_db
+    from nanobot.auth import init_auth_db, migrate_legacy_layout_if_needed
 
+    archive = migrate_legacy_layout_if_needed()
+    if archive is not None:
+        console.print(
+            f"[yellow]⚠ Legacy single-tenant state moved to[/yellow] {archive}\n"
+            f"[yellow]  Rollback with[/yellow] `mv {archive} ~/.nanobot`"
+        )
     init_auth_db()
     bus = MessageBus()
     try:
@@ -1028,7 +1034,7 @@ def _run_gateway(
                     )
                 else:
                     auth_resp: _AuthResponse | None = _auth_dispatch(
-                        req, auth_svc, limiter=auth_limiter
+                        req, auth_svc, limiter=auth_limiter, require_csrf=True
                     )
                     if auth_resp is not None:
                         out = _write_response(

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -88,6 +88,10 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+from nanobot.cli.user import user_app  # noqa: E402 — typer sub-app registration
+
+app.add_typer(user_app, name="user")
+
 console = Console()
 EXIT_COMMANDS = {"exit", "quit", "/exit", "/quit", ":q"}
 
@@ -947,6 +951,7 @@ def _run_gateway(
             200: "OK",
             400: "Bad Request",
             401: "Unauthorized",
+            403: "Forbidden",
             404: "Not Found",
             405: "Method Not Allowed",
             409: "Conflict",

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -668,6 +668,9 @@ def _run_gateway(
 
     console.print(f"{__logo__} Starting nanobot gateway version {__version__} on port {port}...")
     sync_workspace_templates(config.workspace_path)
+    from nanobot.auth import init_auth_db
+
+    init_auth_db()
     bus = MessageBus()
     try:
         provider_snapshot = build_provider_snapshot(config)
@@ -931,47 +934,119 @@ def _run_gateway(
     console.print(f"[green]✓[/green] Heartbeat: every {hb_cfg.interval_s}s")
 
     async def _health_server(host: str, health_port: int):
-        """Lightweight HTTP health endpoint on the gateway port."""
+        """Lightweight HTTP/1.0 server: /health plus /auth/* dispatch."""
         import json as _json
+
+        from nanobot.auth.routes import Request as _AuthRequest
+        from nanobot.auth.routes import Response as _AuthResponse
+        from nanobot.auth.routes import dispatch as _auth_dispatch
+        from nanobot.auth.service import AuthService as _AuthService
+
+        _STATUS_TEXT = {
+            200: "OK",
+            400: "Bad Request",
+            401: "Unauthorized",
+            404: "Not Found",
+            405: "Method Not Allowed",
+            409: "Conflict",
+            429: "Too Many Requests",
+            500: "Internal Server Error",
+        }
+
+        def _write_response(status: int, body: bytes, headers: dict, cookies: list) -> bytes:
+            lines = [f"HTTP/1.0 {status} {_STATUS_TEXT.get(status, 'OK')}"]
+            merged = {"Content-Length": str(len(body)), **headers}
+            for k, v in merged.items():
+                lines.append(f"{k}: {v}")
+            for c in cookies:
+                lines.append(f"Set-Cookie: {c}")
+            return ("\r\n".join(lines) + "\r\n\r\n").encode("utf-8") + body
+
+        async def _read_request(reader, peer_ip: str | None):
+            head = b""
+            while b"\r\n\r\n" not in head:
+                chunk = await asyncio.wait_for(reader.read(4096), timeout=5)
+                if not chunk:
+                    break
+                head += chunk
+                if len(head) > 65536:
+                    raise ValueError("request headers too large")
+            if b"\r\n\r\n" not in head:
+                return None
+            header_block, _, leftover = head.partition(b"\r\n\r\n")
+            lines = header_block.decode("utf-8", errors="replace").split("\r\n")
+            if not lines:
+                return None
+            request_line = lines[0]
+            parts = request_line.split(" ")
+            method = parts[0] if len(parts) > 0 else ""
+            path = parts[1] if len(parts) > 1 else ""
+            headers: dict[str, str] = {}
+            for line in lines[1:]:
+                if ":" in line:
+                    k, v = line.split(":", 1)
+                    headers[k.strip().lower()] = v.strip()
+            content_length = int(headers.get("content-length") or 0)
+            body = leftover
+            while len(body) < content_length:
+                chunk = await asyncio.wait_for(reader.read(4096), timeout=5)
+                if not chunk:
+                    break
+                body += chunk
+            body = body[:content_length] if content_length else body
+            return _AuthRequest(
+                method=method, path=path, headers=headers, body=body, remote_ip=peer_ip
+            )
+
+        auth_svc = _AuthService.default()
 
         async def handle(reader, writer):
             try:
-                data = await asyncio.wait_for(reader.read(4096), timeout=5)
-            except (asyncio.TimeoutError, ConnectionError):
-                writer.close()
-                return
+                get_extra = getattr(writer, "get_extra_info", None)
+                peer = get_extra("peername") if get_extra else None
+                peer_ip = peer[0] if peer else None
+                try:
+                    req = await _read_request(reader, peer_ip)
+                except (asyncio.TimeoutError, ConnectionError, ValueError):
+                    writer.close()
+                    return
+                if req is None:
+                    writer.close()
+                    return
 
-            request_line = data.split(b"\r\n", 1)[0].decode("utf-8", errors="replace")
-            method, path = "", ""
-            parts = request_line.split(" ")
-            if len(parts) >= 2:
-                method, path = parts[0], parts[1]
+                if req.method == "GET" and req.path == "/health":
+                    body = _json.dumps({"status": "ok"}).encode("utf-8")
+                    out = _write_response(
+                        200, body, {"Content-Type": "application/json"}, []
+                    )
+                else:
+                    auth_resp: _AuthResponse | None = _auth_dispatch(req, auth_svc)
+                    if auth_resp is not None:
+                        out = _write_response(
+                            auth_resp.status,
+                            auth_resp.body,
+                            auth_resp.headers,
+                            auth_resp.cookies,
+                        )
+                    else:
+                        body = b"Not Found"
+                        out = _write_response(
+                            404, body, {"Content-Type": "text/plain"}, []
+                        )
 
-            if method == "GET" and path == "/health":
-                body = _json.dumps({"status": "ok"})
-                resp = (
-                    f"HTTP/1.0 200 OK\r\n"
-                    f"Content-Type: application/json\r\n"
-                    f"Content-Length: {len(body)}\r\n"
-                    f"\r\n{body}"
-                )
-            else:
-                body = "Not Found"
-                resp = (
-                    f"HTTP/1.0 404 Not Found\r\n"
-                    f"Content-Type: text/plain\r\n"
-                    f"Content-Length: {len(body)}\r\n"
-                    f"\r\n{body}"
-                )
-
-            writer.write(resp.encode())
-            await writer.drain()
-            writer.close()
+                writer.write(out)
+                await writer.drain()
+            finally:
+                with suppress(Exception):
+                    writer.close()
 
         server = await asyncio.start_server(handle, host, health_port)
         console.print(f"[green]✓[/green] Health endpoint: http://{host}:{health_port}/health")
-        async with server:
-            await server.serve_forever()
+        try:
+            async with server:
+                await server.serve_forever()
+        finally:
+            auth_svc.close()
     # Register Dream system job (always-on, idempotent on restart)
     dream_cfg = config.agents.defaults.dream
     if dream_cfg.model_override:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -937,6 +937,7 @@ def _run_gateway(
         """Lightweight HTTP/1.0 server: /health plus /auth/* dispatch."""
         import json as _json
 
+        from nanobot.auth.ratelimit import RateLimiter as _RateLimiter
         from nanobot.auth.routes import Request as _AuthRequest
         from nanobot.auth.routes import Response as _AuthResponse
         from nanobot.auth.routes import dispatch as _auth_dispatch
@@ -999,6 +1000,7 @@ def _run_gateway(
             )
 
         auth_svc = _AuthService.default()
+        auth_limiter = _RateLimiter()
 
         async def handle(reader, writer):
             try:
@@ -1020,7 +1022,9 @@ def _run_gateway(
                         200, body, {"Content-Type": "application/json"}, []
                     )
                 else:
-                    auth_resp: _AuthResponse | None = _auth_dispatch(req, auth_svc)
+                    auth_resp: _AuthResponse | None = _auth_dispatch(
+                        req, auth_svc, limiter=auth_limiter
+                    )
                     if auth_resp is not None:
                         out = _write_response(
                             auth_resp.status,

--- a/nanobot/cli/user.py
+++ b/nanobot/cli/user.py
@@ -1,0 +1,223 @@
+"""CLI: ``nanobot user …`` operator subcommands.
+
+Wraps :class:`nanobot.auth.service.AuthService` so a sysadmin can manage
+WebUI accounts without the gateway being up. Each command writes an
+audit_log row with ``actor_user_id=None`` (system actor).
+"""
+
+from __future__ import annotations
+
+import getpass
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from nanobot.auth import AuthError, AuthService, EmailTakenError
+
+user_app = typer.Typer(
+    name="user",
+    help="Manage WebUI user accounts (create, list, promote, demote, reset, delete).",
+    no_args_is_help=True,
+)
+console = Console()
+
+
+def _service() -> AuthService:
+    return AuthService.default()
+
+
+def _format_ts(epoch: int | None) -> str:
+    if not epoch:
+        return "-"
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _prompt_password() -> str:
+    pwd = getpass.getpass("Password (input hidden): ")
+    confirm = getpass.getpass("Confirm password: ")
+    if pwd != confirm:
+        console.print("[red]Passwords do not match.[/red]")
+        raise typer.Exit(1)
+    return pwd
+
+
+@user_app.command("list")
+def list_users() -> None:
+    """List all WebUI users."""
+    svc = _service()
+    try:
+        rows = svc._conn.execute(  # noqa: SLF001 — operator tooling reads directly
+            "SELECT id, email, role, display_name, created_at, last_login_at, disabled "
+            "FROM users ORDER BY created_at"
+        ).fetchall()
+    finally:
+        svc.close()
+    if not rows:
+        console.print("[dim]No users.[/dim]")
+        return
+    table = Table(show_lines=False, header_style="bold")
+    table.add_column("ID")
+    table.add_column("Email")
+    table.add_column("Role")
+    table.add_column("Display name")
+    table.add_column("Created")
+    table.add_column("Last login")
+    table.add_column("Disabled")
+    for r in rows:
+        table.add_row(
+            r["id"],
+            r["email"],
+            r["role"],
+            r["display_name"] or "-",
+            _format_ts(r["created_at"]),
+            _format_ts(r["last_login_at"]),
+            "yes" if r["disabled"] else "no",
+        )
+    console.print(table)
+
+
+@user_app.command("create")
+def create_user(
+    email: str = typer.Argument(..., help="Email address (case-insensitive)."),
+    role: str = typer.Option(
+        "user", "--role", "-r", help="Role: 'user' or 'admin'."
+    ),
+    display_name: Optional[str] = typer.Option(
+        None, "--display-name", "-n", help="Optional display name."
+    ),
+) -> None:
+    """Create a new WebUI account."""
+    if role not in ("user", "admin"):
+        console.print(f"[red]Invalid role '{role}'. Use 'user' or 'admin'.[/red]")
+        raise typer.Exit(1)
+    password = _prompt_password()
+    svc = _service()
+    try:
+        user = svc.create_user(email, password, display_name=display_name, role=role)
+    except EmailTakenError:
+        console.print(f"[red]Email '{email}' is already registered.[/red]")
+        raise typer.Exit(1) from None
+    except AuthError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from None
+    finally:
+        svc.close()
+    console.print(f"[green]Created[/green] {user.email} (id={user.id}, role={user.role})")
+
+
+def _resolve_user_id(svc: AuthService, identifier: str) -> str:
+    """Accept either email or ULID; return the canonical ULID."""
+    user = svc.get_user_by_email(identifier)
+    if user is not None:
+        return user.id
+    try:
+        return svc.get_user(identifier).id
+    except (AuthError, ValueError):
+        console.print(f"[red]No user matches '{identifier}'.[/red]")
+        raise typer.Exit(1) from None
+
+
+def _set_role(identifier: str, target_role: str, event: str) -> None:
+    svc = _service()
+    try:
+        user_id = _resolve_user_id(svc, identifier)
+        svc._conn.execute("UPDATE users SET role = ? WHERE id = ?", (target_role, user_id))
+        svc._audit(event, target_user_id=user_id)
+        user = svc.get_user(user_id)
+        console.print(
+            f"[green]{event}[/green] {user.email} → role={user.role}"
+        )
+    finally:
+        svc.close()
+
+
+@user_app.command("promote")
+def promote(identifier: str = typer.Argument(..., help="Email or user ID.")) -> None:
+    """Grant admin role to a user."""
+    _set_role(identifier, "admin", "promote")
+
+
+@user_app.command("demote")
+def demote(identifier: str = typer.Argument(..., help="Email or user ID.")) -> None:
+    """Revoke admin role; user becomes a regular user."""
+    _set_role(identifier, "user", "demote")
+
+
+@user_app.command("reset-password")
+def reset_password(identifier: str = typer.Argument(..., help="Email or user ID.")) -> None:
+    """Set a new password and revoke all of the user's active sessions."""
+    password = _prompt_password()
+    svc = _service()
+    try:
+        user_id = _resolve_user_id(svc, identifier)
+        try:
+            svc.set_password(user_id, password)
+        except AuthError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from None
+        user = svc.get_user(user_id)
+        console.print(f"[green]Password reset[/green] for {user.email}; sessions revoked.")
+    finally:
+        svc.close()
+
+
+@user_app.command("delete")
+def delete(
+    identifier: str = typer.Argument(..., help="Email or user ID."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+) -> None:
+    """Delete a user account and all of its sessions.
+
+    The on-disk per-user directory ``~/.nanobot/users/<id>`` is NOT removed
+    automatically — an operator should clean it up manually after auditing
+    the contents.
+    """
+    svc = _service()
+    try:
+        user_id = _resolve_user_id(svc, identifier)
+        user = svc.get_user(user_id)
+        if not yes:
+            confirm = typer.confirm(
+                f"Delete account {user.email} (id={user.id})?",
+                default=False,
+            )
+            if not confirm:
+                console.print("[yellow]Aborted.[/yellow]")
+                raise typer.Exit(0)
+        svc._conn.execute("DELETE FROM users WHERE id = ?", (user_id,))
+        svc._audit("delete", target_user_id=user_id, detail=user.email)
+        console.print(
+            f"[green]Deleted[/green] {user.email}. Filesystem data under "
+            f"~/.nanobot/users/{user.id}/ is preserved; remove manually if appropriate."
+        )
+    finally:
+        svc.close()
+
+
+@user_app.command("disable")
+def disable(
+    identifier: str = typer.Argument(..., help="Email or user ID."),
+    on: bool = typer.Option(True, "--on/--off", help="Set the disabled flag."),
+) -> None:
+    """Disable (or re-enable) a user account without deleting it."""
+    svc = _service()
+    try:
+        user_id = _resolve_user_id(svc, identifier)
+        svc._conn.execute("UPDATE users SET disabled = ? WHERE id = ?", (1 if on else 0, user_id))
+        if on:
+            # Revoke any live sessions on disable.
+            svc.revoke_all_sessions(user_id)
+        event = "disable" if on else "enable"
+        svc._audit(event, target_user_id=user_id)
+        user = svc.get_user(user_id)
+        console.print(f"[green]{event}d[/green] {user.email}")
+    finally:
+        svc.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    user_app(sys.argv[1:])

--- a/nanobot/config/paths.py
+++ b/nanobot/config/paths.py
@@ -60,3 +60,13 @@ def get_bridge_install_dir() -> Path:
 def get_legacy_sessions_dir() -> Path:
     """Return the legacy global session directory used for migration fallback."""
     return Path.home() / ".nanobot" / "sessions"
+
+
+def get_users_root() -> Path:
+    """Return the directory holding all per-user state subtrees."""
+    return ensure_dir(get_data_dir() / "users")
+
+
+def get_user_root(user_id: str) -> Path:
+    """Return the on-disk root for a single user. Caller validates the ULID."""
+    return ensure_dir(get_users_root() / user_id)

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -8,9 +8,12 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    from nanobot.auth.context import UserContext
 
 from nanobot.config.paths import get_legacy_sessions_dir
 from nanobot.utils.helpers import (
@@ -262,9 +265,13 @@ class SessionManager:
     Sessions are stored as JSONL files in the sessions directory.
     """
 
-    def __init__(self, workspace: Path):
+    def __init__(self, workspace: Path, *, user_ctx: "UserContext | None" = None):
         self.workspace = workspace
-        self.sessions_dir = ensure_dir(self.workspace / "sessions")
+        self.user_ctx = user_ctx
+        if user_ctx is not None:
+            self.sessions_dir = user_ctx.sessions_dir()
+        else:
+            self.sessions_dir = ensure_dir(self.workspace / "sessions")
         self.legacy_sessions_dir = get_legacy_sessions_dir()
         self._cache: dict[str, Session] = {}
 

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -311,7 +311,10 @@ class SessionManager:
     def _load(self, key: str) -> Session | None:
         """Load a session from disk."""
         path = self._get_session_path(key)
-        if not path.exists():
+        # Per-user managers must never adopt the legacy global ~/.nanobot/sessions/
+        # tree — that would let the first authenticated user with a matching
+        # session_key silently steal a leftover global session.
+        if not path.exists() and self.user_ctx is None:
             legacy_path = self._get_legacy_session_path(key)
             if legacy_path.exists():
                 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "python-pptx>=1.0.0,<2.0.0",
     "filelock>=3.25.2",
     "boto3>=1.43.0",
+    "argon2-cffi>=23.1.0,<24.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,0 +1,301 @@
+# Implementation Plan: Multi-Tenant Auth + Per-User State
+
+## Overview
+
+Convert nanobot from single-tenant (`~/.nanobot/`) to multi-user. Each WebUI user gets an isolated profile, workspace, sessions, memory, media, tool-state. One shared gateway process serves all users; per-user state is carved out by `user_id`. Channels (Telegram/Slack/etc.) stay admin-scoped for v1 — only the WebUI is per-user.
+
+Auth: email + password, local accounts (argon2id), no SMTP, no email verification, no self-serve reset. Signup open; admin promotion via CLI (`nanobot user promote <email>`). LLM provider keys remain system-wide in `~/.nanobot/config.json` (admin-supplied).
+
+Migration: on startup with multi-tenant build, if legacy single-user layout detected (`~/.nanobot/sessions/`, `workspace/`, `memory/` present and `~/.nanobot/users/` absent), archive existing dir to `~/.nanobot.legacy.<ISO-date>/` and start fresh. Loud warning to operator with copy-paste recovery instructions.
+
+## Decisions Locked
+
+| Decision | Choice | Source |
+|---|---|---|
+| Process model | Shared agent, per-user state | User Q1 |
+| Auth method | Email + password (local) | User Q2 |
+| Key model | Admin-supplied, system-wide | User Q3 |
+| Channel scope | Admin-only for v1 | User Q4 |
+| Signup | Open; admin promotion via CLI | User Q5 |
+| Email features | None in v1 | User Q6 |
+| Migration | Fresh start, archive legacy | User Q7 |
+
+## Architecture
+
+### Per-User Filesystem Layout
+
+```
+~/.nanobot/
+  config.json                       # admin/system-wide (LLM keys, channel tokens)
+  auth.db                           # SQLite: users, web_sessions, audit_log
+  bridge/                           # global WhatsApp bridge (admin)
+  cron/                             # global gateway cron (heartbeat, dream)
+  logs/                             # global gateway logs
+  users/
+    <uid>/                          # uid = ULID, stable across renames
+      profile.json                  # email, display_name, role, created_at
+      workspace/
+      sessions/
+      memory/
+      media/
+      tool-results/
+      file_state/
+```
+
+Admin is a role flag on the user row — admin's data lives under `users/<uid>/` like any other user.
+
+### Identity Threading
+
+1. **HTTP login** — `POST /auth/login {email, password}` → argon2 verify → server issues `nanobot_session` HttpOnly cookie (32-byte random, SameSite=Lax, Secure when TLS) and persists `(sha256(token), user_id, expires_at)` in `auth.db.web_sessions`.
+2. **WebSocket handshake** — gateway upgrade path reads `Cookie: nanobot_session=…`, verifies token against `auth.db`, attaches `user_id` to the connection. Existing static-token / `?token=` flow retained for admin / non-browser clients.
+3. **Inbound message** — websocket channel sets `InboundMessage.user_id` (new optional field). Loop resolves a `UserContext` per inbound and threads it through `AgentRunner` and tool invocations.
+4. **Tool / path resolution** — new `UserContext` carries `user_id` + resolved paths. Helpers in `nanobot/config/paths.py` accept an optional `UserContext` and branch: with ctx → `~/.nanobot/users/<uid>/<subdir>`, without ctx (CLI, channel-admin path) → legacy global path (preserved for channel-side behavior).
+
+### What Stays Global vs Per-User
+
+| Resource | Scope | Reason |
+|---|---|---|
+| `config.json` (LLM keys, channels, agent defaults) | Global | Admin-supplied (Q3); channels admin-only (Q4) |
+| Bridge (WhatsApp) | Global | Channels admin-scoped |
+| Channel inbound (Telegram/Slack/Discord) | Global | Q4 — admin-only for v1 |
+| Gateway cron (heartbeat, dream) | Global | System jobs |
+| WebUI sessions, memory, workspace, media | Per-user | Core isolation requirement |
+| Tool-results, file_state | Per-user | Per-conversation artifacts |
+| `auth.db` | Global | User identity store |
+
+### Auth DB Schema (SQLite)
+
+```sql
+CREATE TABLE users (
+  id              TEXT PRIMARY KEY,           -- ULID
+  email           TEXT UNIQUE NOT NULL COLLATE NOCASE,
+  password_hash   TEXT NOT NULL,              -- argon2id
+  display_name    TEXT,
+  role            TEXT NOT NULL DEFAULT 'user',  -- 'user' | 'admin'
+  created_at      INTEGER NOT NULL,
+  last_login_at   INTEGER,
+  disabled        INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE web_sessions (
+  token_hash      TEXT PRIMARY KEY,           -- sha256(token); raw token never stored
+  user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at      INTEGER NOT NULL,
+  expires_at      INTEGER NOT NULL,
+  last_seen_at    INTEGER NOT NULL,
+  user_agent      TEXT,
+  ip              TEXT
+);
+CREATE INDEX idx_sessions_user ON web_sessions(user_id);
+CREATE INDEX idx_sessions_expires ON web_sessions(expires_at);
+
+CREATE TABLE audit_log (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts              INTEGER NOT NULL,
+  actor_user_id   TEXT,                       -- nullable for failed login
+  event           TEXT NOT NULL,              -- 'login.ok','login.fail','signup','promote','reset','delete','session.expire'
+  target_user_id  TEXT,
+  ip              TEXT,
+  detail          TEXT
+);
+```
+
+Password hashing: **argon2id** via `argon2-cffi` (new dep). Bcrypt acceptable fallback if argon2 wheel missing on target arch.
+
+Session token: 32 random bytes → urlsafe-b64 → stored as `sha256(token)` server-side. TTL 30 days, sliding on activity. Logout deletes row.
+
+### Threat Model Quickref
+
+- **Brute-force login** → rate limit `/auth/login` to 5 attempts/min/IP (in-memory token bucket; fine for single-instance gateway).
+- **Session theft** → HttpOnly + SameSite=Lax cookie; Secure when TLS; rotate token on privilege elevation.
+- **Mass enumeration via signup** → registration open per Q5; mitigate with rate limit + CAPTCHA hook stub (no-op v1) for later.
+- **Path traversal** → all user-scoped paths derived from validated ULID, never from raw client input.
+- **CSRF on /auth/login & /auth/signup** → double-submit token pattern; cookie SameSite=Lax already mitigates most cases.
+- **Cross-user data leak via tool registry** → registry rebuilt per request from `UserContext`, not memoized globally.
+
+### Dependency Graph
+
+```
+auth_schema (SQLite migration)
+    │
+    ├── AuthService (hash/verify, session mint/verify, audit)
+    │       │
+    │       ├── HTTP routes: /auth/signup /auth/login /auth/logout /auth/me
+    │       │       └── WebUI login/signup pages
+    │       │
+    │       └── WS handshake auth (cookie → user_id)
+    │               └── InboundMessage.user_id
+    │                       └── UserContext (path resolver)
+    │                               ├── SessionManager (per-user history root)
+    │                               ├── Memory store (per-user)
+    │                               ├── Workspace tools (filesystem/shell/cron/file_state)
+    │                               ├── Media uploads (per-user dir)
+    │                               └── Tool registry instantiation (per-request)
+    │
+    ├── CLI: nanobot user {list,create,promote,demote,reset-password,delete}
+    │
+    └── Startup migration: legacy detect → archive
+```
+
+### Vertical Slices
+
+Each slice is a thin end-to-end path — all layers touched for one scenario, verified before moving on.
+
+---
+
+## Slice A — Thin Slice: One User, Cookie Auth, Isolated Sessions
+
+**Goal:** A test user created via CLI can log in via WebUI, send a chat message, and have that message land in `~/.nanobot/users/<uid>/sessions/` — not `~/.nanobot/sessions/`.
+
+**Tasks A1–A6 (see todo.md).** Touches every layer at minimum depth:
+
+- SQLite schema + AuthService stub (no admin role logic yet — just user/session)
+- `/auth/login` + `/auth/logout` + `/auth/me` HTTP routes on gateway
+- Cookie-based WS handshake auth (Cookie → user_id) — keep static token fallback for admin tooling
+- `UserContext` + `paths.py` ctx-aware helpers
+- `SessionManager` accepts UserContext
+- WebUI login page + auth context
+
+**Verification:** integration test creates user → logs in → opens WS → sends message → asserts session file exists under user dir AND NOT under legacy global dir. Manual smoke via webui at `localhost:5173`.
+
+**Checkpoint:** human review before Slice B. Path-resolution change is the biggest blast radius; confirm scope didn't sprawl beyond planned files.
+
+## Slice B — Multi-User: Signup + Two Users Isolated
+
+**Goal:** Two users sign up via WebUI, log in concurrently, cannot see each other's session list / messages / files.
+
+**Tasks B1–B4.** Adds:
+
+- `/auth/signup` HTTP route
+- WebUI signup page + auth context (login state, logout button)
+- Rate limit on `/auth/login` + `/auth/signup`
+- Tests: concurrent user isolation, session list scoped to caller
+
+**Verification:** integration test with two `httpx.AsyncClient` instances signing up, logging in, asserting non-overlapping session lists. Manual smoke: two private windows, sign up as A and B, send messages, confirm separate histories.
+
+**Checkpoint:** human review before Slice C — confirm UX & route protection feel right.
+
+## Slice C — Per-User Tool State + Memory + Media
+
+**Goal:** All tools that previously wrote to `~/.nanobot/*` now write under `~/.nanobot/users/<uid>/`. Memory consolidation runs per-user. Media uploads namespaced.
+
+**Tasks C1–C5.** Wires `UserContext` into:
+
+- Filesystem / shell / read / write / edit / list tools (workspace root)
+- Memory store + Dream cycle (per-user keyspace, scheduler still global)
+- Media dir resolution in WS channel (`get_media_dir` ctx-aware)
+- Tool-results dir (`_TOOL_RESULTS_DIR` in `utils/helpers.py`)
+- File-state store (`file_state_store.for_session` already keyed — audit for cross-user safety)
+
+MCP, cron, subagent, my_tool: audit but leave per-user wiring as deferred work unless trivial.
+
+**Verification:** integration test — two users invoke filesystem tools, assert files land in respective workspaces. Memory dream cycle test asserts per-user keys. Manual smoke: user A creates `/notes.md`; user B cannot see it via WebUI file picker or shell tool.
+
+**Checkpoint:** human review before Slice D — this is where tool-registry refactor either stays surgical or sprawls. Re-evaluate scope.
+
+## Slice D — Admin CLI + Role + Admin Page
+
+**Goal:** Operator manages users from CLI. Admin role exists and gates an admin-only page.
+
+**Tasks D1–D4.** Adds:
+
+- `nanobot user list|create|promote|demote|reset-password|delete` subcommands
+- Role check middleware on gateway HTTP routes
+- `/admin/users` JSON endpoint + minimal WebUI admin page (table of users, disable toggle, role badge)
+- Audit log writes on every admin action
+
+**Verification:** unit tests per CLI subcommand. Integration test: non-admin user gets 403 on `/admin/users`. CLI smoke: create, promote, list, demote, delete a test account.
+
+**Checkpoint:** human review before Slice E.
+
+## Slice E — Migration + Hardening + Docs
+
+**Goal:** Multi-tenant build is safe to deploy on a box with existing single-user state. Operator gets a clear migration path. Security knobs documented.
+
+**Tasks E1–E5.** Adds:
+
+- Startup migration: detect legacy layout → archive `~/.nanobot/` → `~/.nanobot.legacy.<ISO-date>/` with loud log; leave `auth.db`, `users/`, `config.json` re-created blank
+- Operator override env `NANOBOT_SKIP_LEGACY_MIGRATION=1` to disable
+- Update `docs/configuration.md` + `docs/deployment.md` with multi-user section
+- New `docs/auth.md` covering operator setup, CLI commands, threat model summary
+- `argon2-cffi` added to `pyproject.toml`; CI lint + tests green
+- `.agent/security.md` updated to note multi-tenant boundaries
+
+**Verification:**
+
+- Migration test: temp dir with synthetic legacy state → startup → assert archive created and fresh tree exists.
+- Skip-flag test.
+- Doc lint: links resolve.
+- Full test suite green; `ruff check nanobot/`; webui `bun run test` + `bun run build` clean.
+
+**Checkpoint:** final human review. Merge to a feature branch (`feature/multi-tenant-auth`), open PR against `nightly` per CONTRIBUTING.md.
+
+---
+
+## Out of Scope (v1)
+
+Deferred — call out in PR description, file follow-up issues:
+
+- Email verification, password reset email, magic links (no SMTP per Q6)
+- Per-user channels (Telegram/Slack token per user) — Q4 v1 = admin-only
+- Per-user BYOK LLM keys — Q3 v1 = admin-supplied
+- Per-user cron jobs
+- SSO / OAuth providers (Google/GitHub) — scaffolding NOT included; defer to v2
+- Quotas / rate limits per user (only auth-endpoint rate limit in v1)
+- Real-time presence ("user A is typing")
+- Team / org / workspace concepts
+- Per-user MCP server allowlist
+- Audit log UI (rows exist, no admin view in v1)
+
+## Test Strategy
+
+- **Unit** — AuthService (hash, verify, session mint/verify/expire), path helpers (ctx vs no-ctx), CLI command parsers.
+- **Integration** — full HTTP/WS auth flow, cross-user isolation, migration script, role enforcement. Use existing `pytest-asyncio` + `aiohttp` test infra; spin gateway on ephemeral port.
+- **WebUI** — vitest for login/signup form validation, auth context state machine, route protection. Manual smoke per slice in browser.
+- **Security** — explicit tests for: argon2 verify, brute-force rate limit, cookie flags, path-traversal on user_id input, session expiry, cross-user data fetch returns 403/404.
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Path-resolution refactor leaks legacy global writes | M | H | Add a debug logger warning when `get_*_dir()` is called without ctx during a user-request lifecycle. Burn-down list in tests. |
+| Concurrent migration races (gateway + CLI both start at once) | L | H | `filelock` (already a dep) on `~/.nanobot/.migration.lock`. |
+| Argon2 wheel missing on target arch | M | M | Bcrypt fallback behind feature flag; documented in deploy guide. |
+| WS reconnect drops user identity | M | M | WS handshake re-reads cookie on every connect; cookie persists, identity recovers. |
+| Tool registry caches across users | H | H | Build registry **per-request** from UserContext; never cache at module level. Slice C explicit test. |
+| Channels accidentally inherit user state | L | M | Channels keep using legacy global paths; do NOT pass UserContext to channel adapters in v1. |
+
+## File Touch Estimate
+
+| Area | New | Modified | Notes |
+|---|---|---|---|
+| `nanobot/auth/` | 4 (service.py, schema.py, routes.py, __init__.py) | 0 | New module |
+| `nanobot/config/paths.py` | 0 | 1 | Ctx-aware helpers |
+| `nanobot/cli/commands.py` + new `nanobot/cli/user.py` | 1 | 1 | CLI subcommands |
+| `nanobot/channels/websocket.py` | 0 | 1 | Cookie auth + user_id attach |
+| `nanobot/agent/loop.py` | 0 | 1 | Thread UserContext (small) |
+| `nanobot/agent/runner.py` | 0 | 1 | Accept UserContext (small) |
+| `nanobot/session/manager.py` | 0 | 1 | Ctx-aware history root |
+| `nanobot/agent/memory.py` | 0 | 1 | Ctx-aware paths |
+| `nanobot/agent/tools/*` | 0 | ~5 | Ctx propagation |
+| `nanobot/utils/helpers.py` | 0 | 1 | Ctx-aware tool-results dir |
+| `webui/src/auth/` | ~4 | 0 | LoginPage, SignupPage, AuthContext, route guard |
+| `webui/src/lib/api.ts` | 0 | 1 | Wire login/logout/me |
+| `webui/src/App.tsx` | 0 | 1 | Auth gating |
+| `tests/auth/` | ~5 | 0 | New test files |
+| `docs/auth.md` | 1 | 0 | New |
+| `docs/configuration.md`, `docs/deployment.md` | 0 | 2 | Multi-user sections |
+| `pyproject.toml` | 0 | 1 | argon2-cffi dep |
+
+Rough order: ~20 new files, ~20 modified. Plan size is on the larger end — slice gates prevent it landing as one mega-PR.
+
+## Success Criteria
+
+The change ships when:
+
+1. Two users can sign up via WebUI and operate concurrently with zero state overlap.
+2. `nanobot user list/create/promote/demote/reset-password/delete` all work end-to-end.
+3. Migration is safe on a box with existing single-user state — legacy archive intact, fresh tree empty, operator instructions printed.
+4. Test suite green: `pytest`, `ruff check`, `bun run test`, `bun run build`.
+5. Manual smoke: two private windows; sign up A and B; chat in each; verify isolation in files, sessions, memory dir.
+6. No regression in CLI (`nanobot agent`) or chat channels (Telegram/Slack still work, admin-scoped).
+7. `.agent/design.md` invariants preserved — `loop.py` / `runner.py` diffs minimal and justified.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -143,9 +143,9 @@ Confirm UX feels right (login/signup flows). Confirm test coverage credible.
 
 ### C1. Workspace tools (filesystem/shell/read/write/edit/list)
 
-- [ ] Tool factory/registry in `nanobot/agent/tools/registry.py` accepts `UserContext`; passes `ctx.workspace_path()` to filesystem-rooted tools instead of `get_workspace_path()`
-- [ ] Audit each tool in `nanobot/agent/tools/`: replace direct `Path.home() / ".nanobot"` with ctx-aware helper or accept workspace via constructor
-- [ ] Tool registry built **per-request** in `AgentRunner` from `UserContext`; never cached at module level
+- [x] ~~Tool factory/registry in `nanobot/agent/tools/registry.py` accepts `UserContext`~~ — **deviation:** chose a `ContextVar`-based approach instead. `nanobot/auth/context.py:current_user_ctx` is set/reset by `AgentLoop._dispatch` for the duration of each request; `_FsTool` and `ExecTool` consult it dynamically to rebase `workspace`/`allowed_dir`/`working_dir` under `users/<uid>/workspace`. Avoids rebuilding the registry per request and per-user instance caching. Tools stay singletons; user routing is async-task-scoped.
+- [x] Audit each tool — `filesystem.py`'s `_FsTool` base (covers ReadFile/WriteFile/EditFile/ListDir/Glob/Grep/NotebookEdit since they all extend it) and `shell.py`'s `ExecTool`. `Path.home() / ".nanobot"` is not used by request-path tools; channel/media helpers already accept ctx (Slice A4) or stay global by design.
+- [ ] ~~Tool registry built **per-request**~~ — superseded by contextvar (above). No module-level caching to remove; the existing module-level tool instances are now context-aware.
 
 **Acceptance:** Integration test — alice's filesystem write creates file under `users/<alice>/workspace/`; bob's shell ls of `~/` (when sandboxed to workspace) does not see alice's files.
 
@@ -153,9 +153,10 @@ Confirm UX feels right (login/signup flows). Confirm test coverage credible.
 
 ### C2. Memory store per-user
 
-- [ ] `nanobot/agent/memory.py`: memory file path resolved via `ctx.memory_dir()` instead of global
-- [ ] Dream consolidation scheduler stays global, but each cycle iterates user dirs via `users/<uid>/memory/`
-- [ ] Atomic writes + fsync preserved per-user
+- [x] Memory file paths now resolved per-user — `ContextBuilder.memory` became a property that returns a per-user `MemoryStore` cached by `user_id`. The store is rooted at `ctx.workspace_path()` so memory lives at `users/<uid>/workspace/memory/` (kept inside the workspace because `GitStore` tracks files relative to the workspace root). **Deviation from plan path layout** (plan had `users/<uid>/memory/` as a sibling of workspace; that doesn't compose with GitStore — refactor to a unified layout is a follow-up).
+- [ ] ~~Dream consolidation scheduler iterates user dirs~~ — **deferred**: Dream is a global cron job that operates on the loop's default workspace. Per-user dream cycles need their own scheduler design; out of scope for v1.
+- [x] Atomic writes + fsync preserved per-user — `MemoryStore` internals unchanged; only its workspace root is routed via the contextvar.
+- [x] `SkillsLoader` also routed per-user (was bundled with MemoryStore construction).
 
 **Acceptance:** Test: alice writes a fact via memory tool → bob's memory recall returns empty. Dream cycle running for both users produces two separate consolidation logs.
 
@@ -163,9 +164,9 @@ Confirm UX feels right (login/signup flows). Confirm test coverage credible.
 
 ### C3. Media uploads + tool-results
 
-- [ ] WS channel media save: route to `ctx.media_dir()` instead of global `get_media_dir()`
-- [ ] `nanobot/utils/helpers.py` `_TOOL_RESULTS_DIR`: accept optional ctx; resolve under user dir when present
-- [ ] Media URL signing: include user_id in signed URL; `/api/media/...` route verifies signed url's user matches request cookie
+- [x] WS channel media save: `_save_envelope_media` now accepts `user_ctx` and routes to `ctx.media_dir("websocket")` when present; falls back to global `get_media_dir("websocket")` for unauth/CLI paths
+- [x] Tool-results dir follows per-user — `AgentRunSpec.workspace` is now derived from `current_user_ctx` at run-spec construction so `maybe_persist_tool_result(workspace, …)` writes under `users/<uid>/workspace/.nanobot/tool-results`
+- [ ] ~~Media URL signing: include user_id in signed URL; verify against request cookie~~ — **deferred**: requires reshaping the HMAC payload (currently encodes a relative path under the global media root) and adding cookie verification on `/api/media/...`. Per-user uploads already land in distinct directories so cross-user fetch would need an attacker to forge a signed URL for another user's path. Hardening tracked for Slice E (security hardening).
 
 **Acceptance:** Test: alice uploads image → file at `users/<alice>/media/...`; bob requesting `/api/media/<alice's path>` returns 403 even with valid cookie.
 
@@ -173,8 +174,8 @@ Confirm UX feels right (login/signup flows). Confirm test coverage credible.
 
 ### C4. file_state store audit
 
-- [ ] Audit `nanobot/agent/state/file_state.py` (or similar): already keyed by session, confirm no cross-user key collision possible
-- [ ] If keyspace collision possible, prefix keys with `user_id`
+- [x] Audited `nanobot/agent/tools/file_state.py`: `FileStateStore.for_session` keyed by `session_key` only. Two users sharing a `session_key` (e.g. unified_session or a forced override) would have **collided** — fixed.
+- [x] Prefixed keys with `user_id::` when `current_user_ctx` is bound, leaving the legacy key shape intact for CLI/channel paths.
 
 **Acceptance:** Test or code review confirms no shared mutable map across users.
 
@@ -182,9 +183,24 @@ Confirm UX feels right (login/signup flows). Confirm test coverage credible.
 
 ### C5. MCP / subagent / cron audit (deferred wiring OK)
 
-- [ ] Read each tool file; document whether per-user state matters
-- [ ] If trivial to ctx-thread, do it; otherwise log a follow-up item in PR description
-- [ ] Document any deferred items in `docs/auth.md` "Known limitations" section
+- [x] Audited each remaining tool:
+
+  | Tool | Per-user-relevant? | Status | Rationale |
+  |---|---|---|---|
+  | filesystem | yes | **done** (C1) | `_FsTool` consults `current_user_ctx` |
+  | shell (`exec`) | yes | **done** (C1) | `ExecTool.working_dir` is a property |
+  | tool-results spill | yes | **done** (C3) | `AgentRunSpec.workspace` from contextvar |
+  | media uploads (WS) | yes | **done** (C3) | `_save_envelope_media(user_ctx=)` |
+  | memory | yes | **done** (C2) | `ContextBuilder.memory` is a property |
+  | skills loader | yes | **done** (C2) | `ContextBuilder.skills` is a property |
+  | file_state | yes | **done** (C4) | key prefixed by user_id |
+  | `image_generation` | yes | **deferred** | `self.workspace` is set at ctor; same property pattern would work but artifact paths flow into provider configs and signed media URLs — better landed alongside C3's signed-URL hardening |
+  | `message` (send) | partial | **deferred** | uses workspace for outbound media staging only; channel-admin scope dominates |
+  | `spawn` (subagent) | yes | **deferred** | subagent inherits parent loop's tools and workspace; the parent already routes per-user, so subagents inherit isolation transitively as long as they don't re-bind the contextvar before invocation |
+  | `self` (MyTool) | n/a | **deferred** | self-modification is admin-only |
+  | MCP servers | shared | **keep global** | MCP processes are gateway-scoped resources; per-user MCP allowlist is an explicit non-goal for v1 (plan.md Out of Scope) |
+  | cron (gateway) | shared | **keep global** | per-user cron is an explicit non-goal for v1 |
+- [x] Follow-ups recorded inline in this table; will be hoisted into `docs/auth.md` "Known limitations" during Slice E.
 
 **Acceptance:** PR description includes audit table: tool / per-user-relevant? / done-or-deferred / rationale.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -93,11 +93,11 @@ Before continuing: confirm path-resolution refactor stayed scoped to listed file
 
 ### B1. /auth/signup route + WebUI signup page
 
-- [ ] `POST /auth/signup {email, password, display_name?}` → creates user (role='user'), mints session, returns same shape as `/auth/login`
-- [ ] Reject duplicate email with 409
-- [ ] Password policy: min 12 chars (configurable later, hardcoded for v1)
-- [ ] `webui/src/auth/SignupPage.tsx`: form + "have an account? log in" link
-- [ ] Route between login/signup via tab or button
+- [x] `POST /auth/signup {email, password, display_name?}` → creates user (role='user'), mints session, returns same shape as `/auth/login`
+- [x] Reject duplicate email with 409
+- [x] Password policy: min 12 chars (configurable later, hardcoded for v1)
+- [x] `webui/src/auth/SignupPage.tsx`: form + "have an account? log in" link
+- [x] Route between login/signup via tab/button — `<AuthGate>` flips between `<LoginPage onSwitchToSignup>` and `<SignupPage onSwitchToLogin>` via local `mode` state
 
 **Acceptance:** Integration test: signup → cookie set → GET /auth/me returns new user → repeat signup with same email returns 409.
 
@@ -105,9 +105,9 @@ Before continuing: confirm path-resolution refactor stayed scoped to listed file
 
 ### B2. Rate limit on /auth/* endpoints
 
-- [ ] In-memory token bucket: 5 attempts / min / IP for `/auth/login`, 3 / min / IP for `/auth/signup`
-- [ ] On limit hit return 429 + `Retry-After` header
-- [ ] Audit log row on each failed attempt and each rate-limit trip
+- [x] In-memory token bucket: 5 attempts / min / IP for `/auth/login`, 3 / min / IP for `/auth/signup` — `nanobot/auth/ratelimit.py:RateLimiter` (sliding window, injectable clock for tests)
+- [x] On limit hit return 429 + `Retry-After` header
+- [x] Audit log row on each failed attempt and each rate-limit trip — login.fail rows already written by AuthService; new `ratelimit.trip` event emitted when limit trips
 
 **Acceptance:** Test: 6 rapid login attempts → 6th returns 429. Test: timer advances, attempts allowed again after window.
 
@@ -115,9 +115,9 @@ Before continuing: confirm path-resolution refactor stayed scoped to listed file
 
 ### B3. Logout button + auth state in WebUI
 
-- [ ] Add logout button to existing webui header / user menu
-- [ ] On logout: clear React auth context, hard-redirect to `/`
-- [ ] Add `user.display_name` (or email) in header when authed
+- [x] Add logout button to existing webui header / user menu — placed in `Sidebar.tsx` footer row alongside display name
+- [x] On logout: clear React auth context — `AuthContext.logout()` already drops to anon; AuthGate immediately renders `<LoginPage />` again (no hard redirect needed, SPA re-renders)
+- [x] Add `user.display_name` (or email) in header when authed — `displayLabel = user.display_name?.trim() || user.email`
 
 **Acceptance:** Manual smoke: log in → see name in header → click logout → returned to login page; cookies cleared.
 
@@ -125,9 +125,9 @@ Before continuing: confirm path-resolution refactor stayed scoped to listed file
 
 ### B4. Cross-user isolation tests
 
-- [ ] Integration test spawns gateway on ephemeral port, two `httpx.AsyncClient` sign up as alice@/bob@, log in, list sessions, send messages, list sessions again
-- [ ] Assert alice's session list excludes bob's session ids
-- [ ] Assert filesystem: `~/.nanobot/users/<alice>/sessions/*` disjoint from `~/.nanobot/users/<bob>/sessions/*`
+- [x] ~~Spawn gateway on ephemeral port~~ — **deviation:** drove the auth dispatcher directly (`dispatch(req, svc)`) rather than spinning a real socket. Same code path, no flaky port allocation. Live HTTP smoke through vite proxy already validates the socket layer end-to-end.
+- [x] Assert alice's per-user dir disjoint from bob's — covered by `test_two_users_signup_login_no_state_overlap` and `test_concurrent_session_dirs_disjoint_on_disk`
+- [x] Assert filesystem: `~/.nanobot/users/<alice>/sessions/*` disjoint from `~/.nanobot/users/<bob>/sessions/*`
 
 **Acceptance:** Test passes deterministically.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,322 @@
+# Todo: Multi-Tenant Auth + Per-User State
+
+Sequential within a slice; each slice ends at a human-review checkpoint. See `tasks/plan.md` for architecture, decisions, threat model.
+
+Branch: `feature/multi-tenant-auth` off `nightly` (per CONTRIBUTING.md).
+
+Legend: `[ ]` not started · `[~]` in progress · `[x]` done · `[!]` blocked
+
+---
+
+## Slice A — Thin Slice: One User, Cookie Auth, Isolated Sessions
+
+Walking-skeleton: cookie-auth end to end, one user, one path proven isolated. No UI signup yet, no admin role, no migration.
+
+### A1. AuthDB schema + first migration
+
+- [x] Add `argon2-cffi>=23.1.0,<24` to `pyproject.toml`
+- [x] Create `nanobot/auth/__init__.py`, `nanobot/auth/schema.py` with SQL DDL from plan
+- [x] On gateway startup, open `~/.nanobot/auth.db`, run `CREATE TABLE IF NOT EXISTS …`
+- [x] Use `filelock` on `~/.nanobot/.auth-init.lock` during init to dodge races
+
+**Acceptance:** `auth.db` exists with `users`, `web_sessions`, `audit_log` tables after gateway start. Re-running gateway is idempotent (no errors, no duplicate rows).
+
+**Verify:** `sqlite3 ~/.nanobot/auth.db '.schema'` shows three tables and expected indices.
+
+### A2. AuthService — argon2 hash, session mint/verify
+
+- [x] `nanobot/auth/service.py`: class `AuthService` with `create_user(email, password, role='user')`, `verify_password(email, password)`, `mint_session(user_id, ua, ip)`, `verify_session(token)`, `revoke_session(token)`, `expire_sessions()`
+- [x] Token: `secrets.token_urlsafe(32)`; persist `sha256(token)`
+- [x] Argon2id parameters: time_cost=3, memory_cost=64MB, parallelism=2 (tune per benchmark)
+- [x] Write audit_log row on every state change (login.ok/fail, signup, session.expire)
+
+**Acceptance:** Unit tests pass: hash+verify roundtrip, wrong password rejected, session minted and verified, expired session rejected, revoked session rejected.
+
+**Verify:** `pytest tests/auth/test_service.py -v` — all green.
+
+### A3. Gateway HTTP auth routes — login, logout, me
+
+- [x] `nanobot/auth/routes.py`: registers `/auth/login`, `/auth/logout`, `/auth/me` on existing gateway HTTP listener (port 18790)
+- [x] `/auth/login` accepts JSON `{email, password}`, returns `{user: {...}}` and sets `nanobot_session` cookie (HttpOnly, SameSite=Lax, Secure if TLS, Max-Age=30d)
+- [x] `/auth/logout` revokes session, clears cookie
+- [x] `/auth/me` returns current user from cookie or 401
+- [x] Generic error messages for login (no "user not found" vs "wrong password" distinction)
+
+**Acceptance:** Integration test: create user via AuthService → POST /auth/login → cookie set → GET /auth/me returns user → POST /auth/logout → GET /auth/me returns 401.
+
+**Verify:** `pytest tests/auth/test_routes.py -v`. `curl -i` smoke shows cookie flags.
+
+### A4. UserContext + ctx-aware path helpers
+
+- [x] `nanobot/auth/context.py`: dataclass `UserContext(user_id: str)` with methods `workspace_path()`, `sessions_dir()`, `memory_dir()`, `media_dir(channel=None)`, `tool_results_dir()`, `file_state_dir()`
+- [x] ~~Update `nanobot/config/paths.py`: each `get_*` helper accepts optional `ctx`~~ — **deviation:** kept globals untouched; added `get_users_root()` + `get_user_root(user_id)` and put per-user resolution exclusively on `UserContext` methods. Forces every call site in Slice C to explicitly opt into per-user via `ctx.<method>()` rather than risk silent leaks from a forgotten `ctx=` kwarg. Aligns with `.agent/design.md` "Explicit over magical".
+- [x] Validate `user_id` against ULID regex before path interpolation (path-traversal guard) — `UserContext.__post_init__` calls `assert_ulid`; `get_user_root` accepts only what UserContext passes.
+- [ ] ~~Debug log when ctx-aware helper called with `ctx=None` during a known user-request lifecycle~~ — deferred to Slice C: contextvar + warning to be added together with first ctx-threaded call site, so the warning has actual call sites to catch leaks against. No dead code now.
+
+**Acceptance:** Unit tests: with-ctx path resolves under `users/<uid>/`; without-ctx path identical to legacy; malformed user_id raises `ValueError`.
+
+**Verify:** `pytest tests/config/test_paths.py -v`. Grep `Path.home() / ".nanobot"` in agent/ tools/ — all call sites traced to either ctx-aware helper or known-global path (channels, bridge).
+
+### A5. SessionManager + WS handshake → UserContext
+
+- [x] `nanobot/session/manager.py`: `SessionManager` accepts optional `UserContext` in constructor; history root resolved via `ctx.sessions_dir()` when present, legacy path otherwise
+- [x] `nanobot/channels/websocket.py`: handshake reads `Cookie: nanobot_session=…` → calls `AuthService.verify_session()` → sets `connection.user_id`. Static-token / `?token=` path retained for non-browser clients (admin only)
+- [x] On inbound message: build `UserContext(connection.user_id)` and attach to `InboundMessage.user_context` (new optional field on `InboundMessage`)
+- [x] `AgentLoop`: when `msg.user_context` present, pass through to `AgentRunner` and tool registry instantiation — implemented via `_sessions_for(user_ctx)` factory cached per-user; threaded through `_dispatch`, `_process_message` (system + regular branches), `_run_agent_loop`, `_set_runtime_checkpoint`
+- [ ] ~~`AgentRunner`: per-request tool registry built from `UserContext`~~ — **deferred to Slice C** (per plan: "MCP, cron, subagent, my_tool: audit but leave per-user wiring as deferred work"). For A5 acceptance, session isolation alone proves the threading; tool registry still binds to global workspace until Slice C1 rewires it.
+
+**Acceptance:** Integration test: create user → login via HTTP → open WS with cookie → send `{type:"user",content:"hello"}` → assert file in `~/.nanobot/users/<uid>/sessions/` exists AND no new file in `~/.nanobot/sessions/`.
+
+**Verify:** `pytest tests/auth/test_session_isolation.py -v`. Manual: log in via webui, send message, `ls ~/.nanobot/users/*/sessions/`.
+
+### A6. WebUI login page + auth context
+
+- [x] `webui/src/auth/AuthContext.tsx`: React context holding `{user, status: 'loading'|'authed'|'anon'}`; on mount calls `/auth/me`
+- [x] `webui/src/auth/LoginPage.tsx`: email + password form, submits to `/auth/login`; on success refreshes auth context and redirects to chat
+- [x] Gate main chat surface — implemented as `<AuthGate>` wrapping `<App />` in `main.tsx` (cleaner than editing App.tsx) — shows `<LoginPage />` when `status === 'anon'`, "Loading…" on `loading`
+- [x] `webui/src/lib/api.ts`: new `authFetch` helper with `credentials: 'include'`; `authMe()`, `authLogin()`, `authLogout()` exported. Existing Bearer-token helpers left unchanged (orthogonal — chat WS bootstrap still uses ?token= for now).
+- [ ] ~~WS client: drop manual `?token=` for browser path~~ — **deferred** to a follow-up cleanup commit. Cookie path already works on the WS handshake (A5 proved it), and the static `?token=` path is retained in parallel. Removing one without the other in a single commit risks lockout in production where token-issue-secret is configured. Will land after Slice B (signup) when cookie path is the canonical UX.
+- [x] **Bonus fix:** ported `localStorage` shim from `main` into `webui/src/tests/setup.ts` — pre-existing infra gap on `nightly` that blocked any vitest run. Test suite went 0/80 → 84/84.
+- [x] **Note:** `/auth/*` lives on gateway port 18790 (not the WS channel 8765, which can't parse POST bodies). Vite proxy `/auth` rewritten to `authTarget` (`NANOBOT_AUTH_URL` env or default `http://127.0.0.1:18790`).
+
+**Acceptance:** Vitest passes for AuthContext state machine (loading→anon→authed→anon). Manual smoke: visit `localhost:5173` → see login page → log in with test user → chat surface appears → reload → still logged in.
+
+**Verify:** `cd webui && bun run test`. `bun run build` clean. Browser manual smoke.
+
+### ✋ Checkpoint A — Human Review
+
+Before continuing: confirm path-resolution refactor stayed scoped to listed files; no unintended sprawl into channels or providers. Re-read `.agent/design.md` core invariants.
+
+---
+
+## Slice B — Multi-User: Signup + Two Users Isolated
+
+### B1. /auth/signup route + WebUI signup page
+
+- [ ] `POST /auth/signup {email, password, display_name?}` → creates user (role='user'), mints session, returns same shape as `/auth/login`
+- [ ] Reject duplicate email with 409
+- [ ] Password policy: min 12 chars (configurable later, hardcoded for v1)
+- [ ] `webui/src/auth/SignupPage.tsx`: form + "have an account? log in" link
+- [ ] Route between login/signup via tab or button
+
+**Acceptance:** Integration test: signup → cookie set → GET /auth/me returns new user → repeat signup with same email returns 409.
+
+**Verify:** `pytest tests/auth/test_routes.py::test_signup -v`. Webui vitest. Manual.
+
+### B2. Rate limit on /auth/* endpoints
+
+- [ ] In-memory token bucket: 5 attempts / min / IP for `/auth/login`, 3 / min / IP for `/auth/signup`
+- [ ] On limit hit return 429 + `Retry-After` header
+- [ ] Audit log row on each failed attempt and each rate-limit trip
+
+**Acceptance:** Test: 6 rapid login attempts → 6th returns 429. Test: timer advances, attempts allowed again after window.
+
+**Verify:** `pytest tests/auth/test_ratelimit.py -v`.
+
+### B3. Logout button + auth state in WebUI
+
+- [ ] Add logout button to existing webui header / user menu
+- [ ] On logout: clear React auth context, hard-redirect to `/`
+- [ ] Add `user.display_name` (or email) in header when authed
+
+**Acceptance:** Manual smoke: log in → see name in header → click logout → returned to login page; cookies cleared.
+
+**Verify:** Manual browser smoke. Vitest for AuthContext logout transition.
+
+### B4. Cross-user isolation tests
+
+- [ ] Integration test spawns gateway on ephemeral port, two `httpx.AsyncClient` sign up as alice@/bob@, log in, list sessions, send messages, list sessions again
+- [ ] Assert alice's session list excludes bob's session ids
+- [ ] Assert filesystem: `~/.nanobot/users/<alice>/sessions/*` disjoint from `~/.nanobot/users/<bob>/sessions/*`
+
+**Acceptance:** Test passes deterministically.
+
+**Verify:** `pytest tests/auth/test_isolation_multi.py -v`.
+
+### ✋ Checkpoint B — Human Review
+
+Confirm UX feels right (login/signup flows). Confirm test coverage credible.
+
+---
+
+## Slice C — Per-User Tool State + Memory + Media
+
+### C1. Workspace tools (filesystem/shell/read/write/edit/list)
+
+- [ ] Tool factory/registry in `nanobot/agent/tools/registry.py` accepts `UserContext`; passes `ctx.workspace_path()` to filesystem-rooted tools instead of `get_workspace_path()`
+- [ ] Audit each tool in `nanobot/agent/tools/`: replace direct `Path.home() / ".nanobot"` with ctx-aware helper or accept workspace via constructor
+- [ ] Tool registry built **per-request** in `AgentRunner` from `UserContext`; never cached at module level
+
+**Acceptance:** Integration test — alice's filesystem write creates file under `users/<alice>/workspace/`; bob's shell ls of `~/` (when sandboxed to workspace) does not see alice's files.
+
+**Verify:** `pytest tests/auth/test_tool_isolation.py -v`. Grep for module-level tool caches.
+
+### C2. Memory store per-user
+
+- [ ] `nanobot/agent/memory.py`: memory file path resolved via `ctx.memory_dir()` instead of global
+- [ ] Dream consolidation scheduler stays global, but each cycle iterates user dirs via `users/<uid>/memory/`
+- [ ] Atomic writes + fsync preserved per-user
+
+**Acceptance:** Test: alice writes a fact via memory tool → bob's memory recall returns empty. Dream cycle running for both users produces two separate consolidation logs.
+
+**Verify:** `pytest tests/auth/test_memory_isolation.py -v`.
+
+### C3. Media uploads + tool-results
+
+- [ ] WS channel media save: route to `ctx.media_dir()` instead of global `get_media_dir()`
+- [ ] `nanobot/utils/helpers.py` `_TOOL_RESULTS_DIR`: accept optional ctx; resolve under user dir when present
+- [ ] Media URL signing: include user_id in signed URL; `/api/media/...` route verifies signed url's user matches request cookie
+
+**Acceptance:** Test: alice uploads image → file at `users/<alice>/media/...`; bob requesting `/api/media/<alice's path>` returns 403 even with valid cookie.
+
+**Verify:** `pytest tests/auth/test_media_isolation.py -v`. Manual: paste image in webui for both users, inspect filesystem.
+
+### C4. file_state store audit
+
+- [ ] Audit `nanobot/agent/state/file_state.py` (or similar): already keyed by session, confirm no cross-user key collision possible
+- [ ] If keyspace collision possible, prefix keys with `user_id`
+
+**Acceptance:** Test or code review confirms no shared mutable map across users.
+
+**Verify:** Code review note in PR; targeted test if collision was found.
+
+### C5. MCP / subagent / cron audit (deferred wiring OK)
+
+- [ ] Read each tool file; document whether per-user state matters
+- [ ] If trivial to ctx-thread, do it; otherwise log a follow-up item in PR description
+- [ ] Document any deferred items in `docs/auth.md` "Known limitations" section
+
+**Acceptance:** PR description includes audit table: tool / per-user-relevant? / done-or-deferred / rationale.
+
+**Verify:** PR description complete; follow-up issues filed for deferred.
+
+### ✋ Checkpoint C — Human Review
+
+Confirm tool-registry refactor stayed surgical. Confirm test matrix actually covers cross-user paths (not just same-user happy path).
+
+---
+
+## Slice D — Admin CLI + Role + Admin Page
+
+### D1. CLI user subcommands
+
+- [ ] `nanobot/cli/user.py`: typer sub-app with `list`, `create`, `promote`, `demote`, `reset-password`, `delete`
+- [ ] Register under `nanobot user ...` in `nanobot/cli/commands.py`
+- [ ] All commands write audit_log entries with `actor_user_id=None` (CLI = system actor)
+
+**Acceptance:** Each subcommand has a unit test + a smoke test. `nanobot user list` shows all users with role, last_login, disabled flag.
+
+**Verify:** `pytest tests/cli/test_user_commands.py -v`. Manual: run each subcommand against a fresh `auth.db`.
+
+### D2. Role check middleware
+
+- [ ] HTTP route registry tags routes as `public` / `authed` / `admin`
+- [ ] Middleware: `admin` routes require `user.role == 'admin'`, else 403
+- [ ] Apply to (new) `/admin/users` endpoint
+
+**Acceptance:** Test: non-admin user with valid cookie → 403 on `/admin/users`. Admin user → 200.
+
+**Verify:** `pytest tests/auth/test_role_middleware.py -v`.
+
+### D3. /admin/users JSON endpoint
+
+- [ ] GET `/admin/users` → list users (paginated if >100)
+- [ ] POST `/admin/users/<id>/role {role}` → promote/demote
+- [ ] POST `/admin/users/<id>/disabled {disabled}` → toggle
+- [ ] DELETE `/admin/users/<id>` → delete user + cascade sessions + leave `users/<id>/` filesystem in place (operator removes manually; log path)
+
+**Acceptance:** Integration tests for each verb. Filesystem residue documented (not auto-deleted to prevent data loss).
+
+**Verify:** `pytest tests/auth/test_admin_routes.py -v`.
+
+### D4. WebUI admin page
+
+- [ ] `webui/src/admin/AdminUsersPage.tsx`: table of users (id, email, role, disabled, last_login)
+- [ ] Action buttons: promote/demote, disable/enable, delete (with confirm modal)
+- [ ] Link in header visible only when `user.role === 'admin'`
+- [ ] Vitest for permission gate (non-admin sees nothing)
+
+**Acceptance:** Manual smoke: log in as admin → see Admin link → manage another user → log in as that user → no Admin link.
+
+**Verify:** Webui vitest + browser smoke.
+
+### ✋ Checkpoint D — Human Review
+
+Confirm admin UX is minimal but functional. Confirm no admin actions are exposed without role check.
+
+---
+
+## Slice E — Migration + Hardening + Docs
+
+### E1. Legacy-state migration on startup
+
+- [ ] `nanobot/auth/migration.py`: on gateway startup, check if `~/.nanobot/users/` absent AND any of `sessions/`, `workspace/`, `memory/` present
+- [ ] If yes: rename `~/.nanobot/` to `~/.nanobot.legacy.<ISO-date>/`, recreate fresh `~/.nanobot/` with empty `users/`, copy over `config.json` if present
+- [ ] Log loud warning with copy-paste rollback instructions (`mv ~/.nanobot.legacy.<date>/ ~/.nanobot/` if you didn't want this)
+- [ ] Honor `NANOBOT_SKIP_LEGACY_MIGRATION=1` env to bypass
+- [ ] `filelock` on `~/.nanobot/.migration.lock` to dodge gateway+CLI startup races
+
+**Acceptance:** Test with temp HOME and synthetic legacy tree → migration runs, archive exists, fresh tree exists, config preserved. Second startup: no-op. With skip flag: no archive.
+
+**Verify:** `pytest tests/auth/test_migration.py -v`.
+
+### E2. Cookie + CSRF hardening
+
+- [ ] Confirm `Secure` flag auto-set when gateway runs behind TLS (detect via `X-Forwarded-Proto` or explicit config)
+- [ ] Implement double-submit CSRF token for `/auth/login` + `/auth/signup` + `/admin/*` state-changing routes
+- [ ] Document SameSite=Lax limitations re: cross-origin
+
+**Acceptance:** Test: state-changing request without CSRF token → 403. Same with → 200.
+
+**Verify:** `pytest tests/auth/test_csrf.py -v`.
+
+### E3. docs/auth.md (new)
+
+- [ ] Operator setup: env vars, first-run UX, creating first admin
+- [ ] CLI reference for `nanobot user ...`
+- [ ] Threat model summary (link to plan.md if kept in tree, or inline)
+- [ ] Known limitations & deferred items (no email verify, admin-only channels, etc.)
+
+**Acceptance:** Doc renders, link checker clean, covers operator's must-know surface.
+
+**Verify:** `markdownlint docs/auth.md` (if configured); manual read.
+
+### E4. Update existing docs
+
+- [ ] `docs/configuration.md`: per-user dir layout, what's global vs per-user
+- [ ] `docs/deployment.md`: note multi-tenant default; first-run migration warning
+- [ ] `.agent/security.md`: multi-tenant boundary notes
+- [ ] `README.md`: brief mention with link to `docs/auth.md`
+
+**Acceptance:** All four files updated; cross-links work.
+
+**Verify:** `grep -r "single-tenant\|single-user" docs/` shows no stale claims.
+
+### E5. CI + release
+
+- [ ] `pyproject.toml`: `argon2-cffi` dep added
+- [ ] CI workflow updated (if needed) to run new auth tests
+- [ ] `ruff check nanobot/` clean
+- [ ] Webui `bun run test` + `bun run build` clean
+- [ ] Open PR against `nightly` with:
+  - links to plan.md & this todo
+  - manual smoke checklist
+  - audit table for deferred per-user wiring (from C5)
+  - rollback plan (mv legacy archive back)
+
+**Acceptance:** CI green. PR opened, reviewer assigned.
+
+**Verify:** `gh pr view` shows green checks.
+
+### ✋ Checkpoint E — Final Review
+
+Pre-merge: walk through every Success Criterion in plan.md. If any fail, fix before merge.
+
+---
+
+## Working Notes
+
+- Branch off `nightly` per CONTRIBUTING.md, not `main`.
+- Keep `loop.py` / `runner.py` diffs minimal per `.agent/design.md`. If a slice's loop diff grows past ~30 lines, stop and re-design — likely belongs in a helper / tool registry layer.
+- Per `.agent/design.md` "Explicit over magical": every path resolution must trace from a `UserContext` (or be intentionally global). No silent "default to global" fallbacks inside user-request code.
+- Update this todo as you go (`[~]` while in progress, `[x]` when done).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -216,9 +216,9 @@ Confirm tool-registry refactor stayed surgical. Confirm test matrix actually cov
 
 ### D1. CLI user subcommands
 
-- [ ] `nanobot/cli/user.py`: typer sub-app with `list`, `create`, `promote`, `demote`, `reset-password`, `delete`
-- [ ] Register under `nanobot user ...` in `nanobot/cli/commands.py`
-- [ ] All commands write audit_log entries with `actor_user_id=None` (CLI = system actor)
+- [x] `nanobot/cli/user.py`: typer sub-app with `list`, `create`, `promote`, `demote`, `reset-password`, `delete` (+ bonus `disable --on/--off`)
+- [x] Registered under `nanobot user …` in `nanobot/cli/commands.py`
+- [x] All commands write audit_log entries with `actor_user_id=None` (CLI = system actor) via `AuthService._audit`
 
 **Acceptance:** Each subcommand has a unit test + a smoke test. `nanobot user list` shows all users with role, last_login, disabled flag.
 
@@ -226,9 +226,9 @@ Confirm tool-registry refactor stayed surgical. Confirm test matrix actually cov
 
 ### D2. Role check middleware
 
-- [ ] HTTP route registry tags routes as `public` / `authed` / `admin`
-- [ ] Middleware: `admin` routes require `user.role == 'admin'`, else 403
-- [ ] Apply to (new) `/admin/users` endpoint
+- [x] ~~HTTP route registry tags routes as public/authed/admin~~ — **deviation:** kept the existing flat dispatch and inlined a `_require_admin(req, svc)` helper. Three lines per admin handler, no registry abstraction. Aligns with `.agent/design.md` "less structure, more intelligence".
+- [x] Admin routes require `user.role == 'admin'` (and not disabled), else 401/403
+- [x] `/admin/users` endpoint live; verified via curl through the vite proxy
 
 **Acceptance:** Test: non-admin user with valid cookie → 403 on `/admin/users`. Admin user → 200.
 
@@ -236,10 +236,10 @@ Confirm tool-registry refactor stayed surgical. Confirm test matrix actually cov
 
 ### D3. /admin/users JSON endpoint
 
-- [ ] GET `/admin/users` → list users (paginated if >100)
-- [ ] POST `/admin/users/<id>/role {role}` → promote/demote
-- [ ] POST `/admin/users/<id>/disabled {disabled}` → toggle
-- [ ] DELETE `/admin/users/<id>` → delete user + cascade sessions + leave `users/<id>/` filesystem in place (operator removes manually; log path)
+- [x] GET `/admin/users` → list users. ~~Pagination~~ deferred — v1 deployments are single-team scale; revisit when >100 users is real.
+- [x] POST `/admin/users/<id>/role {role}` → promote/demote (writes `promote`/`demote` audit event)
+- [x] POST `/admin/users/<id>/disabled {disabled}` → toggle; disabling also revokes active sessions
+- [x] DELETE `/admin/users/<id>` → delete user + cascade sessions (foreign-key ON DELETE CASCADE). On-disk `users/<id>/` directory left in place; admin gets a CLI hint. Self-delete blocked with 400.
 
 **Acceptance:** Integration tests for each verb. Filesystem residue documented (not auto-deleted to prevent data loss).
 
@@ -247,10 +247,10 @@ Confirm tool-registry refactor stayed surgical. Confirm test matrix actually cov
 
 ### D4. WebUI admin page
 
-- [ ] `webui/src/admin/AdminUsersPage.tsx`: table of users (id, email, role, disabled, last_login)
-- [ ] Action buttons: promote/demote, disable/enable, delete (with confirm modal)
-- [ ] Link in header visible only when `user.role === 'admin'`
-- [ ] Vitest for permission gate (non-admin sees nothing)
+- [x] `webui/src/admin/AdminUsersPage.tsx`: table with email/display_name, role, created, last_login, disabled
+- [x] Promote/demote, disable/enable, delete (confirm modal). Self-row actions are disabled in the UI to prevent operator lockout.
+- [x] Admin link in the **sidebar footer** (cleaner than header alongside settings/logout), gated on `user.role === 'admin'`
+- [x] Vitest covers self-row lockout, list rendering, error surfacing, promote payload, delete confirm flow. ~~"non-admin sees nothing"~~ — admin link is conditional in Sidebar (rendered only when role==='admin'); no separate vitest because the conditional is one line of code.
 
 **Acceptance:** Manual smoke: log in as admin → see Admin link → manage another user → log in as that user → no Admin link.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -266,11 +266,11 @@ Confirm admin UX is minimal but functional. Confirm no admin actions are exposed
 
 ### E1. Legacy-state migration on startup
 
-- [ ] `nanobot/auth/migration.py`: on gateway startup, check if `~/.nanobot/users/` absent AND any of `sessions/`, `workspace/`, `memory/` present
-- [ ] If yes: rename `~/.nanobot/` to `~/.nanobot.legacy.<ISO-date>/`, recreate fresh `~/.nanobot/` with empty `users/`, copy over `config.json` if present
-- [ ] Log loud warning with copy-paste rollback instructions (`mv ~/.nanobot.legacy.<date>/ ~/.nanobot/` if you didn't want this)
-- [ ] Honor `NANOBOT_SKIP_LEGACY_MIGRATION=1` env to bypass
-- [ ] `filelock` on `~/.nanobot/.migration.lock` to dodge gateway+CLI startup races
+- [x] `nanobot/auth/migration.py` — `migrate_legacy_layout_if_needed(data_dir)`. Triggers when `users/` absent AND one of `sessions/workspace/memory` is present.
+- [x] Renames base dir to `<base>.legacy.<UTC-ISO>` (with numeric suffix on collision); recreates fresh base, scaffolds empty `users/`, copies `config.json` if present.
+- [x] Loud warning logged + console line printed in `commands.py` with the literal `mv` rollback command.
+- [x] `NANOBOT_SKIP_LEGACY_MIGRATION=1` short-circuits.
+- [x] `filelock` on `<base>/.migration.lock` (re-checks need-state under the lock).
 
 **Acceptance:** Test with temp HOME and synthetic legacy tree → migration runs, archive exists, fresh tree exists, config preserved. Second startup: no-op. With skip flag: no archive.
 
@@ -278,9 +278,12 @@ Confirm admin UX is minimal but functional. Confirm no admin actions are exposed
 
 ### E2. Cookie + CSRF hardening
 
-- [ ] Confirm `Secure` flag auto-set when gateway runs behind TLS (detect via `X-Forwarded-Proto` or explicit config)
-- [ ] Implement double-submit CSRF token for `/auth/login` + `/auth/signup` + `/admin/*` state-changing routes
-- [ ] Document SameSite=Lax limitations re: cross-origin
+- [x] `Secure` flag set when `X-Forwarded-Proto: https` (already done in Slice A; tested in `test_login_secure_flag_when_https`).
+- [x] Double-submit CSRF wired:
+  - `nanobot_csrf` cookie auto-issued on every response (Path=/, SameSite=Lax, Secure when TLS, **not** HttpOnly so JS reads it).
+  - Production dispatcher passes `require_csrf=True`; state-changing requests (`POST/PUT/PATCH/DELETE`) on `/auth/*` and `/admin/*` must echo the cookie value in `X-CSRF-Token`.
+  - `webui/src/lib/api.ts:authFetch` reads the cookie and sets the header automatically.
+- [x] SameSite=Lax limitations documented in `docs/auth.md` §CSRF: the cookie alone blocks the obvious cross-origin POSTs; double-submit is defence in depth.
 
 **Acceptance:** Test: state-changing request without CSRF token → 403. Same with → 200.
 
@@ -288,10 +291,7 @@ Confirm admin UX is minimal but functional. Confirm no admin actions are exposed
 
 ### E3. docs/auth.md (new)
 
-- [ ] Operator setup: env vars, first-run UX, creating first admin
-- [ ] CLI reference for `nanobot user ...`
-- [ ] Threat model summary (link to plan.md if kept in tree, or inline)
-- [ ] Known limitations & deferred items (no email verify, admin-only channels, etc.)
+- [x] `docs/auth.md` written. Covers TL;DR, filesystem layout, auth mechanism, CSRF, rate limiting, CLI reference, admin HTTP API, legacy migration, threat model, known limitations, operator recovery cheatsheet.
 
 **Acceptance:** Doc renders, link checker clean, covers operator's must-know surface.
 
@@ -299,10 +299,10 @@ Confirm admin UX is minimal but functional. Confirm no admin actions are exposed
 
 ### E4. Update existing docs
 
-- [ ] `docs/configuration.md`: per-user dir layout, what's global vs per-user
-- [ ] `docs/deployment.md`: note multi-tenant default; first-run migration warning
-- [ ] `.agent/security.md`: multi-tenant boundary notes
-- [ ] `README.md`: brief mention with link to `docs/auth.md`
+- [x] `docs/configuration.md` — Multi-Tenant State Layout section + `NANOBOT_SKIP_LEGACY_MIGRATION` env.
+- [x] `docs/deployment.md` — multi-tenant default warning + migration callout at top.
+- [x] `.agent/security.md` — Multi-Tenant Boundaries section: contextvar rule, admin-route rule, channel-adapter rule.
+- [x] `README.md` — Docs index entry pointing at `docs/auth.md`.
 
 **Acceptance:** All four files updated; cross-links work.
 
@@ -310,10 +310,10 @@ Confirm admin UX is minimal but functional. Confirm no admin actions are exposed
 
 ### E5. CI + release
 
-- [ ] `pyproject.toml`: `argon2-cffi` dep added
-- [ ] CI workflow updated (if needed) to run new auth tests
-- [ ] `ruff check nanobot/` clean
-- [ ] Webui `bun run test` + `bun run build` clean
+- [x] `pyproject.toml` — `argon2-cffi>=23.1.0,<24.0.0` (Slice A1).
+- [x] CI workflow — no changes needed; existing pytest collects `tests/auth/` automatically.
+- [x] `ruff check` clean on all Slice A–E touched files.
+- [x] Webui `bun run test` (94 pass) + `bun run build` clean.
 - [ ] Open PR against `nightly` with:
   - links to plan.md & this todo
   - manual smoke checklist

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -205,11 +205,16 @@ async def test_preflight_consolidation_receives_pending_summary(tmp_path) -> Non
 
     await loop.process_direct("hello", session_key="cli:test")
 
-    loop.consolidator.maybe_consolidate_by_tokens.assert_any_await(
-        session,
-        session_summary="Previous conversation summary: earlier context",
-        replay_max_messages=loop._max_messages,
-    )
+    # The per-user routing pass added a ``sessions=<SessionManager>`` kwarg;
+    # accept it without binding to a specific instance.
+    calls = loop.consolidator.maybe_consolidate_by_tokens.await_args_list
+    matched = [
+        c for c in calls
+        if c.args == (session,)
+        and c.kwargs.get("session_summary") == "Previous conversation summary: earlier context"
+        and c.kwargs.get("replay_max_messages") == loop._max_messages
+    ]
+    assert matched, f"expected preflight call not found in {calls}"
 
 
 @pytest.mark.asyncio

--- a/tests/auth/test_admin_routes.py
+++ b/tests/auth/test_admin_routes.py
@@ -1,0 +1,178 @@
+"""Slice D2/D3 — /admin/users routes + role gating."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth.routes import (
+    SESSION_COOKIE,
+    Request,
+    dispatch,
+)
+from nanobot.auth.service import AuthService
+
+
+@pytest.fixture()
+def svc(tmp_path: Path) -> AuthService:
+    yield AuthService.default(tmp_path)
+
+
+def _admin_cookie(svc: AuthService) -> str:
+    """Create an admin user and return the auth cookie string."""
+    u = svc.create_user("admin@nanobot", "correct horse battery staple", role="admin")
+    s = svc.mint_session(u.id)
+    return f"{SESSION_COOKIE}={s.token}"
+
+
+def _user_cookie(svc: AuthService, email: str = "regular@nanobot") -> str:
+    u = svc.create_user(email, "correct horse battery staple")
+    s = svc.mint_session(u.id)
+    return f"{SESSION_COOKIE}={s.token}"
+
+
+def _req(method: str, path: str, *, cookie: str | None = None, body: dict | None = None) -> Request:
+    headers = {"content-type": "application/json"}
+    if cookie:
+        headers["cookie"] = cookie
+    return Request(
+        method=method,
+        path=path,
+        headers=headers,
+        body=json.dumps(body).encode() if body is not None else b"",
+        remote_ip="127.0.0.1",
+    )
+
+
+def test_admin_list_requires_admin(svc: AuthService) -> None:
+    # Unauth: 401.
+    r = dispatch(_req("GET", "/admin/users"), svc)
+    assert r.status == 401
+    # Regular user: 403.
+    r = dispatch(_req("GET", "/admin/users", cookie=_user_cookie(svc)), svc)
+    assert r.status == 403
+
+
+def test_admin_list_returns_users(svc: AuthService) -> None:
+    cookie = _admin_cookie(svc)
+    svc.create_user("a@x", "correct horse battery staple")
+    svc.create_user("b@x", "correct horse battery staple")
+    r = dispatch(_req("GET", "/admin/users", cookie=cookie), svc)
+    assert r.status == 200
+    payload = json.loads(r.body)
+    emails = {u["email"] for u in payload["users"]}
+    assert {"a@x", "b@x", "admin@nanobot"} <= emails
+
+
+def test_admin_set_role_promotes(svc: AuthService) -> None:
+    cookie = _admin_cookie(svc)
+    target = svc.create_user("plain@x", "correct horse battery staple")
+    r = dispatch(
+        _req("POST", f"/admin/users/{target.id}/role", cookie=cookie, body={"role": "admin"}),
+        svc,
+    )
+    assert r.status == 200
+    assert svc.get_user(target.id).role == "admin"
+
+
+def test_admin_set_role_rejects_bad_value(svc: AuthService) -> None:
+    cookie = _admin_cookie(svc)
+    target = svc.create_user("plain@x", "correct horse battery staple")
+    r = dispatch(
+        _req("POST", f"/admin/users/{target.id}/role", cookie=cookie, body={"role": "tsar"}),
+        svc,
+    )
+    assert r.status == 400
+
+
+def test_admin_set_role_requires_admin(svc: AuthService) -> None:
+    target = svc.create_user("plain@x", "correct horse battery staple")
+    r = dispatch(
+        _req("POST", f"/admin/users/{target.id}/role", cookie=_user_cookie(svc), body={"role": "admin"}),
+        svc,
+    )
+    assert r.status == 403
+
+
+def test_admin_set_disabled_disables_and_revokes(svc: AuthService) -> None:
+    cookie = _admin_cookie(svc)
+    target = svc.create_user("plain@x", "correct horse battery staple")
+    live = svc.mint_session(target.id)
+    r = dispatch(
+        _req("POST", f"/admin/users/{target.id}/disabled", cookie=cookie, body={"disabled": True}),
+        svc,
+    )
+    assert r.status == 200
+    assert svc.get_user(target.id).disabled is True
+    # Their existing session must no longer verify.
+    from nanobot.auth import AuthError
+
+    with pytest.raises(AuthError):
+        svc.verify_session(live.token)
+
+
+def test_admin_set_disabled_invalid_body(svc: AuthService) -> None:
+    cookie = _admin_cookie(svc)
+    target = svc.create_user("plain@x", "correct horse battery staple")
+    r = dispatch(
+        _req("POST", f"/admin/users/{target.id}/disabled", cookie=cookie, body={"disabled": "yes"}),
+        svc,
+    )
+    assert r.status == 400
+
+
+def test_admin_delete_removes_user(svc: AuthService) -> None:
+    cookie = _admin_cookie(svc)
+    target = svc.create_user("doomed@x", "correct horse battery staple")
+    r = dispatch(_req("DELETE", f"/admin/users/{target.id}", cookie=cookie), svc)
+    assert r.status == 200
+    assert svc.get_user_by_email("doomed@x") is None
+
+
+def test_admin_cannot_self_delete(svc: AuthService) -> None:
+    u = svc.create_user("admin@x", "correct horse battery staple", role="admin")
+    s = svc.mint_session(u.id)
+    cookie = f"{SESSION_COOKIE}={s.token}"
+    r = dispatch(_req("DELETE", f"/admin/users/{u.id}", cookie=cookie), svc)
+    assert r.status == 400
+
+
+def test_admin_unknown_user_returns_404(svc: AuthService) -> None:
+    cookie = _admin_cookie(svc)
+    # Syntactically valid ULID, but no row.
+    fake = "01ZZZZZZZZZZZZZZZZZZZZZZZZ"
+    r = dispatch(_req("DELETE", f"/admin/users/{fake}", cookie=cookie), svc)
+    assert r.status == 404
+
+
+def test_admin_role_change_writes_audit_row(svc: AuthService, tmp_path: Path) -> None:
+    import sqlite3
+
+    from nanobot.auth.schema import get_auth_db_path
+
+    cookie = _admin_cookie(svc)
+    target = svc.create_user("plain@x", "correct horse battery staple")
+    dispatch(
+        _req("POST", f"/admin/users/{target.id}/role", cookie=cookie, body={"role": "admin"}),
+        svc,
+    )
+    events = [
+        r[0]
+        for r in sqlite3.connect(get_auth_db_path(tmp_path)).execute(
+            "SELECT event FROM audit_log"
+        )
+    ]
+    assert "promote" in events
+
+
+def test_admin_disabled_admin_blocked(svc: AuthService) -> None:
+    """A disabled admin can't perform admin actions even with a valid session."""
+    admin = svc.create_user("admin@x", "correct horse battery staple", role="admin")
+    s = svc.mint_session(admin.id)
+    # Manually flip disabled (simulate another admin disabling them).
+    svc._conn.execute("UPDATE users SET disabled = 1 WHERE id = ?", (admin.id,))
+    cookie = f"{SESSION_COOKIE}={s.token}"
+    r = dispatch(_req("GET", "/admin/users", cookie=cookie), svc)
+    assert r.status == 403

--- a/tests/auth/test_context.py
+++ b/tests/auth/test_context.py
@@ -1,0 +1,69 @@
+"""Tests for nanobot.auth.context.UserContext."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth.context import UserContext
+from nanobot.auth.ids import new_ulid
+
+
+@pytest.fixture()
+def ctx(monkeypatch, tmp_path: Path) -> UserContext:
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    return UserContext(user_id=new_ulid())
+
+
+def test_invalid_user_id_rejected() -> None:
+    with pytest.raises(ValueError):
+        UserContext(user_id="not-a-ulid")
+    with pytest.raises(ValueError):
+        UserContext(user_id="")
+
+
+def test_root_under_users_dir(ctx: UserContext, tmp_path: Path) -> None:
+    assert ctx.root() == tmp_path / "users" / ctx.user_id
+    assert ctx.root().is_dir()
+
+
+def test_subdirs_resolve_under_root(ctx: UserContext) -> None:
+    root = ctx.root()
+    assert ctx.workspace_path() == root / "workspace"
+    assert ctx.sessions_dir() == root / "sessions"
+    assert ctx.memory_dir() == root / "memory"
+    assert ctx.media_dir() == root / "media"
+    assert ctx.media_dir("telegram") == root / "media" / "telegram"
+    assert ctx.tool_results_dir() == root / "tool-results"
+    assert ctx.file_state_dir() == root / "file_state"
+    assert ctx.profile_path() == root / "profile.json"
+
+
+def test_directories_are_created(ctx: UserContext) -> None:
+    assert ctx.workspace_path().is_dir()
+    assert ctx.sessions_dir().is_dir()
+    assert ctx.memory_dir().is_dir()
+    assert ctx.media_dir("slack").is_dir()
+    assert ctx.tool_results_dir().is_dir()
+    assert ctx.file_state_dir().is_dir()
+
+
+def test_two_contexts_isolated(monkeypatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    a = UserContext(user_id=new_ulid())
+    b = UserContext(user_id=new_ulid())
+    assert a.root() != b.root()
+    assert a.workspace_path() != b.workspace_path()
+
+
+def test_context_is_hashable_and_frozen() -> None:
+    uid = new_ulid()
+    ctx = UserContext(user_id=uid)
+    # Hashable
+    assert {ctx} == {UserContext(user_id=uid)}
+    # Frozen
+    with pytest.raises(Exception):
+        ctx.user_id = new_ulid()  # type: ignore[misc]

--- a/tests/auth/test_csrf.py
+++ b/tests/auth/test_csrf.py
@@ -1,0 +1,177 @@
+"""Slice E2 — double-submit CSRF on state-changing /auth/* and /admin/* routes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth.routes import (
+    CSRF_COOKIE,
+    CSRF_HEADER,
+    SESSION_COOKIE,
+    Request,
+    dispatch,
+)
+from nanobot.auth.service import AuthService
+
+
+@pytest.fixture()
+def svc(tmp_path: Path) -> AuthService:
+    yield AuthService.default(tmp_path)
+
+
+def _get(path: str, *, cookie: str = "") -> Request:
+    headers = {}
+    if cookie:
+        headers["cookie"] = cookie
+    return Request(method="GET", path=path, headers=headers, body=b"", remote_ip="1.1.1.1")
+
+
+def _post(
+    path: str, body: dict, *, cookie: str = "", csrf_header: str | None = None
+) -> Request:
+    headers = {"content-type": "application/json"}
+    if cookie:
+        headers["cookie"] = cookie
+    if csrf_header is not None:
+        headers[CSRF_HEADER] = csrf_header
+    return Request(
+        method="POST",
+        path=path,
+        headers=headers,
+        body=json.dumps(body).encode(),
+        remote_ip="1.1.1.1",
+    )
+
+
+def _csrf_from_response(resp) -> str | None:
+    for raw in resp.cookies:
+        if raw.startswith(CSRF_COOKIE + "="):
+            return raw.split("=", 1)[1].split(";", 1)[0]
+    return None
+
+
+def test_get_response_issues_csrf_cookie(svc: AuthService) -> None:
+    resp = dispatch(_get("/auth/me"), svc, require_csrf=True)
+    assert resp.status == 401
+    token = _csrf_from_response(resp)
+    assert token is not None
+    assert len(token) >= 32
+
+
+def test_post_without_csrf_header_rejected(svc: AuthService) -> None:
+    svc.create_user("a@b.com", "correct horse battery staple")
+    resp = dispatch(
+        _post("/auth/login", {"email": "a@b.com", "password": "correct horse battery staple"}),
+        svc,
+        require_csrf=True,
+    )
+    assert resp.status == 403
+    payload = json.loads(resp.body)
+    assert "csrf" in payload["error"].lower()
+
+
+def test_post_with_matching_csrf_header_accepted(svc: AuthService) -> None:
+    # Step 1: GET issues a CSRF cookie.
+    bootstrap = dispatch(_get("/auth/me"), svc, require_csrf=True)
+    csrf = _csrf_from_response(bootstrap)
+    assert csrf
+
+    svc.create_user("a@b.com", "correct horse battery staple")
+    cookie_header = f"{CSRF_COOKIE}={csrf}"
+    resp = dispatch(
+        _post(
+            "/auth/login",
+            {"email": "a@b.com", "password": "correct horse battery staple"},
+            cookie=cookie_header,
+            csrf_header=csrf,
+        ),
+        svc,
+        require_csrf=True,
+    )
+    assert resp.status == 200
+
+
+def test_post_with_mismatched_csrf_rejected(svc: AuthService) -> None:
+    bootstrap = dispatch(_get("/auth/me"), svc, require_csrf=True)
+    csrf = _csrf_from_response(bootstrap)
+    cookie_header = f"{CSRF_COOKIE}={csrf}"
+    svc.create_user("a@b.com", "correct horse battery staple")
+    resp = dispatch(
+        _post(
+            "/auth/login",
+            {"email": "a@b.com", "password": "correct horse battery staple"},
+            cookie=cookie_header,
+            csrf_header="not-the-same-token",
+        ),
+        svc,
+        require_csrf=True,
+    )
+    assert resp.status == 403
+
+
+def test_admin_post_requires_csrf(svc: AuthService) -> None:
+    admin = svc.create_user("admin@x", "correct horse battery staple", role="admin")
+    s = svc.mint_session(admin.id)
+    target = svc.create_user("u@x", "correct horse battery staple")
+    cookie = f"{SESSION_COOKIE}={s.token}"
+
+    # Without CSRF header → 403.
+    r = dispatch(
+        _post(
+            f"/admin/users/{target.id}/role",
+            {"role": "admin"},
+            cookie=cookie,
+        ),
+        svc,
+        require_csrf=True,
+    )
+    assert r.status == 403
+
+    # With CSRF cookie+header → 200.
+    csrf = "test-csrf-token-123456"
+    r = dispatch(
+        _post(
+            f"/admin/users/{target.id}/role",
+            {"role": "admin"},
+            cookie=f"{cookie}; {CSRF_COOKIE}={csrf}",
+            csrf_header=csrf,
+        ),
+        svc,
+        require_csrf=True,
+    )
+    assert r.status == 200
+
+
+def test_get_admin_does_not_require_csrf(svc: AuthService) -> None:
+    """Read-only admin requests don't need CSRF; only state-changing ones do."""
+    admin = svc.create_user("admin@x", "correct horse battery staple", role="admin")
+    s = svc.mint_session(admin.id)
+    cookie = f"{SESSION_COOKIE}={s.token}"
+    r = dispatch(_get("/admin/users", cookie=cookie), svc, require_csrf=True)
+    assert r.status == 200
+
+
+def test_default_dispatch_does_not_require_csrf(svc: AuthService) -> None:
+    """Existing tests / scripts that don't pass require_csrf=True still work."""
+    svc.create_user("a@b.com", "correct horse battery staple")
+    r = dispatch(
+        _post("/auth/login", {"email": "a@b.com", "password": "correct horse battery staple"}),
+        svc,
+    )
+    assert r.status == 200
+
+
+def test_existing_csrf_cookie_not_rotated(svc: AuthService) -> None:
+    """Subsequent requests with a CSRF cookie do not get a new one minted."""
+    bootstrap = dispatch(_get("/auth/me"), svc, require_csrf=True)
+    csrf = _csrf_from_response(bootstrap)
+    second = dispatch(
+        _get("/auth/me", cookie=f"{CSRF_COOKIE}={csrf}"),
+        svc,
+        require_csrf=True,
+    )
+    # No new CSRF cookie issued because client already had one.
+    assert _csrf_from_response(second) is None

--- a/tests/auth/test_isolation_multi.py
+++ b/tests/auth/test_isolation_multi.py
@@ -1,0 +1,184 @@
+"""Slice B4 — full HTTP→AuthService→FS isolation across two users.
+
+Drives the auth dispatcher directly (no socket) so the test is hermetic and
+fast. Stops short of spawning a real gateway server; that round-trip is
+already exercised by the manual smoke logged in A5.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth.context import UserContext
+from nanobot.auth.routes import SESSION_COOKIE, Request, dispatch
+from nanobot.auth.service import AuthService
+from nanobot.session.manager import SessionManager
+
+
+@pytest.fixture()
+def isolate_data_dir(monkeypatch, tmp_path: Path) -> Path:
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    return tmp_path
+
+
+@pytest.fixture()
+def svc(isolate_data_dir: Path) -> AuthService:
+    yield AuthService.default(isolate_data_dir)
+
+
+def _post(path: str, body: dict, *, cookie: str | None = None) -> Request:
+    headers = {"content-type": "application/json"}
+    if cookie:
+        headers["cookie"] = cookie
+    return Request(
+        method="POST",
+        path=path,
+        headers=headers,
+        body=json.dumps(body).encode("utf-8"),
+        remote_ip="127.0.0.1",
+    )
+
+
+def _get(path: str, *, cookie: str | None = None) -> Request:
+    headers = {}
+    if cookie:
+        headers["cookie"] = cookie
+    return Request(
+        method="GET", path=path, headers=headers, body=b"", remote_ip="127.0.0.1"
+    )
+
+
+def _cookie(resp) -> str:
+    return resp.cookies[0].split(";", 1)[0]
+
+
+def _user_id_from_response(resp) -> str:
+    return json.loads(resp.body)["user"]["id"]
+
+
+def _send_session_message(workspace: Path, user_id: str, key: str, body: str) -> Path:
+    """Mimic what the agent loop does at the SessionManager boundary."""
+    ctx = UserContext(user_id=user_id)
+    sm = SessionManager(workspace, user_ctx=ctx)
+    session = sm.get_or_create(key)
+    session.add_message("user", body)
+    sm.save(session)
+    return sm._get_session_path(key)  # noqa: SLF001 — test introspection
+
+
+def test_two_users_signup_login_no_state_overlap(
+    svc: AuthService, isolate_data_dir: Path
+) -> None:
+    workspace = isolate_data_dir / "workspace"
+    workspace.mkdir()
+
+    # Alice signs up via /auth/signup.
+    alice_resp = dispatch(
+        _post("/auth/signup", {"email": "alice@example.com", "password": "correct horse battery staple"}),
+        svc,
+    )
+    assert alice_resp.status == 200
+    alice_cookie = _cookie(alice_resp)
+    alice_id = _user_id_from_response(alice_resp)
+
+    # Bob signs up.
+    bob_resp = dispatch(
+        _post("/auth/signup", {"email": "bob@example.com", "password": "correct horse battery staple"}),
+        svc,
+    )
+    assert bob_resp.status == 200
+    bob_cookie = _cookie(bob_resp)
+    bob_id = _user_id_from_response(bob_resp)
+
+    assert alice_id != bob_id
+
+    # Both sessions resolve their own user via /auth/me.
+    alice_me = dispatch(_get("/auth/me", cookie=alice_cookie), svc)
+    bob_me = dispatch(_get("/auth/me", cookie=bob_cookie), svc)
+    assert json.loads(alice_me.body)["user"]["email"] == "alice@example.com"
+    assert json.loads(bob_me.body)["user"]["email"] == "bob@example.com"
+
+    # Alice's cookie does NOT resolve to Bob's user.
+    assert json.loads(alice_me.body)["user"]["id"] == alice_id
+    assert json.loads(bob_me.body)["user"]["id"] == bob_id
+
+    # On the agent side, the two users write to disjoint session dirs.
+    alice_path = _send_session_message(
+        workspace, alice_id, "websocket:web-1", "alice writes here"
+    )
+    bob_path = _send_session_message(
+        workspace, bob_id, "websocket:web-1", "bob writes here"
+    )
+
+    assert alice_path != bob_path
+    assert "alice" in alice_path.read_text()
+    assert "bob" in bob_path.read_text()
+    assert "alice" not in bob_path.read_text()
+    assert "bob" not in alice_path.read_text()
+
+
+def test_alice_cookie_cannot_impersonate_bob(svc: AuthService) -> None:
+    alice = dispatch(
+        _post("/auth/signup", {"email": "alice2@x.com", "password": "correct horse battery staple"}),
+        svc,
+    )
+    dispatch(
+        _post("/auth/signup", {"email": "bob2@x.com", "password": "correct horse battery staple"}),
+        svc,
+    )
+    alice_id = _user_id_from_response(alice)
+    me = dispatch(_get("/auth/me", cookie=_cookie(alice)), svc)
+    assert json.loads(me.body)["user"]["id"] == alice_id
+
+
+def test_signed_out_user_cannot_use_revoked_cookie(svc: AuthService) -> None:
+    s = dispatch(
+        _post("/auth/signup", {"email": "logout@x.com", "password": "correct horse battery staple"}),
+        svc,
+    )
+    cookie = _cookie(s)
+    dispatch(_post("/auth/logout", {}, cookie=cookie), svc)
+    me = dispatch(_get("/auth/me", cookie=cookie), svc)
+    assert me.status == 401
+
+
+def test_concurrent_session_dirs_disjoint_on_disk(
+    svc: AuthService, isolate_data_dir: Path
+) -> None:
+    """After two users sign up, their per-user directories under
+    ``users/<uid>/sessions`` are physically separate trees."""
+    workspace = isolate_data_dir / "workspace"
+    workspace.mkdir()
+
+    ids = []
+    for email in ("u1@x.com", "u2@x.com"):
+        r = dispatch(
+            _post("/auth/signup", {"email": email, "password": "correct horse battery staple"}),
+            svc,
+        )
+        ids.append(_user_id_from_response(r))
+        # Materialize a session for each.
+        _send_session_message(workspace, ids[-1], "websocket:k", f"hi from {email}")
+
+    a_dir = isolate_data_dir / "users" / ids[0] / "sessions"
+    b_dir = isolate_data_dir / "users" / ids[1] / "sessions"
+    assert a_dir.is_dir() and b_dir.is_dir()
+    assert a_dir != b_dir
+    assert {p.name for p in a_dir.iterdir()} == {p.name for p in b_dir.iterdir()}
+    # Same filename, disjoint trees: peeking inside proves no cross-leak.
+    assert a_dir.iterdir().__next__().read_text() != b_dir.iterdir().__next__().read_text()
+
+
+def test_cookie_strings_are_not_reused_between_users(svc: AuthService) -> None:
+    """Two independent signups must produce distinct opaque tokens."""
+    a = dispatch(_post("/auth/signup", {"email": "a@token.com", "password": "correct horse battery staple"}), svc)
+    b = dispatch(_post("/auth/signup", {"email": "b@token.com", "password": "correct horse battery staple"}), svc)
+    a_tok = _cookie(a).split("=", 1)[1]
+    b_tok = _cookie(b).split("=", 1)[1]
+    assert a_tok != b_tok
+    assert len(a_tok) >= 32  # urlsafe-b64(32 bytes) → ≥43 chars
+    assert SESSION_COOKIE in a.cookies[0]

--- a/tests/auth/test_media_isolation.py
+++ b/tests/auth/test_media_isolation.py
@@ -1,0 +1,94 @@
+"""Slice C3 — WS channel media uploads + tool-results route per-user."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth.context import UserContext, current_user_ctx
+from nanobot.auth.ids import new_ulid
+
+
+@pytest.fixture()
+def isolate_data_dir(monkeypatch, tmp_path: Path) -> Path:
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    return tmp_path
+
+
+@pytest.fixture()
+def restore_ctx():
+    token = current_user_ctx.set(None)
+    yield
+    current_user_ctx.reset(token)
+
+
+def _png_data_url() -> str:
+    # 1x1 transparent PNG.
+    raw = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    )
+    return "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+
+
+def _build_channel(isolate_data_dir: Path):
+    """Construct a minimal WebSocketChannel for unit-level access."""
+    from nanobot.bus.queue import MessageBus
+    from nanobot.channels.websocket import WebSocketChannel, WebSocketConfig
+
+    cfg = WebSocketConfig(host="127.0.0.1", port=18800, websocket_requires_token=False)
+    bus = MessageBus()
+    return WebSocketChannel(cfg, bus)
+
+
+def test_envelope_media_writes_under_user_dir(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    channel = _build_channel(isolate_data_dir)
+    ctx = UserContext(user_id=new_ulid())
+    paths, reason = channel._save_envelope_media(
+        [{"data_url": _png_data_url(), "name": "shot.png"}], user_ctx=ctx
+    )
+    assert reason is None, reason
+    assert len(paths) == 1
+    saved = Path(paths[0])
+    assert saved.is_file()
+    user_media = ctx.media_dir("websocket")
+    assert saved.parent == user_media
+
+
+def test_envelope_media_without_ctx_uses_global_dir(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    from nanobot.config.paths import get_media_dir
+
+    channel = _build_channel(isolate_data_dir)
+    paths, reason = channel._save_envelope_media(
+        [{"data_url": _png_data_url(), "name": "shot.png"}]
+    )
+    assert reason is None
+    saved = Path(paths[0])
+    assert saved.parent == get_media_dir("websocket")
+
+
+def test_envelope_media_two_users_disjoint(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    channel = _build_channel(isolate_data_dir)
+    alice = UserContext(user_id=new_ulid())
+    bob = UserContext(user_id=new_ulid())
+    a_paths, _ = channel._save_envelope_media(
+        [{"data_url": _png_data_url(), "name": "a.png"}], user_ctx=alice
+    )
+    b_paths, _ = channel._save_envelope_media(
+        [{"data_url": _png_data_url(), "name": "b.png"}], user_ctx=bob
+    )
+    a = Path(a_paths[0])
+    b = Path(b_paths[0])
+    assert a.parent != b.parent
+    assert alice.user_id in str(a)
+    assert bob.user_id in str(b)
+    assert alice.user_id not in str(b)
+    assert bob.user_id not in str(a)

--- a/tests/auth/test_memory_isolation.py
+++ b/tests/auth/test_memory_isolation.py
@@ -1,0 +1,120 @@
+"""Slice C2 — MemoryStore + ContextBuilder honor per-user UserContext."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nanobot.agent.context import ContextBuilder
+from nanobot.auth.context import UserContext, current_user_ctx
+from nanobot.auth.ids import new_ulid
+
+
+@pytest.fixture()
+def isolate_data_dir(monkeypatch, tmp_path: Path) -> Path:
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    return tmp_path
+
+
+@pytest.fixture()
+def restore_ctx():
+    token = current_user_ctx.set(None)
+    yield
+    current_user_ctx.reset(token)
+
+
+def test_context_workspace_follows_user_context(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    ctx = UserContext(user_id=new_ulid())
+    builder = ContextBuilder(global_ws)
+    # Pre-ctx: workspace = global.
+    assert builder.workspace == global_ws
+    token = current_user_ctx.set(ctx)
+    try:
+        assert builder.workspace == ctx.workspace_path()
+    finally:
+        current_user_ctx.reset(token)
+    assert builder.workspace == global_ws
+
+
+def test_memorystore_per_user(isolate_data_dir: Path, restore_ctx) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    builder = ContextBuilder(global_ws)
+    alice = UserContext(user_id=new_ulid())
+    bob = UserContext(user_id=new_ulid())
+
+    # Write a memory line as alice.
+    token = current_user_ctx.set(alice)
+    try:
+        builder.memory.append_history("alice fact")
+        alice_dir = builder.memory.memory_dir
+        alice_history = builder.memory.history_file.read_text()
+    finally:
+        current_user_ctx.reset(token)
+
+    # Write a memory line as bob.
+    token = current_user_ctx.set(bob)
+    try:
+        builder.memory.append_history("bob fact")
+        bob_dir = builder.memory.memory_dir
+        bob_history = builder.memory.history_file.read_text()
+    finally:
+        current_user_ctx.reset(token)
+
+    assert alice_dir != bob_dir
+    # Both should be under per-user workspaces.
+    assert str(alice.user_id) in str(alice_dir)
+    assert str(bob.user_id) in str(bob_dir)
+    # Bob's history should not contain alice's fact (and vice versa).
+    assert "alice fact" not in bob_history
+    assert "alice fact" in alice_history
+    assert "bob fact" in bob_history
+    assert "bob fact" not in alice_history
+
+
+def test_memorystore_unset_ctx_returns_default(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    builder = ContextBuilder(global_ws)
+    default = builder.memory
+    # Repeated access without ctx returns the same singleton (cached default).
+    assert builder.memory is default
+    assert default.memory_dir == global_ws / "memory"
+
+
+def test_memorystore_is_cached_per_user(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    builder = ContextBuilder(global_ws)
+    ctx = UserContext(user_id=new_ulid())
+    token = current_user_ctx.set(ctx)
+    try:
+        first = builder.memory
+        second = builder.memory
+    finally:
+        current_user_ctx.reset(token)
+    assert first is second
+
+
+def test_skills_loader_per_user(isolate_data_dir: Path, restore_ctx) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    builder = ContextBuilder(global_ws)
+    ctx = UserContext(user_id=new_ulid())
+    default = builder.skills
+    token = current_user_ctx.set(ctx)
+    try:
+        user_loader = builder.skills
+    finally:
+        current_user_ctx.reset(token)
+    assert default is not user_loader

--- a/tests/auth/test_migration.py
+++ b/tests/auth/test_migration.py
@@ -1,0 +1,116 @@
+"""Slice E1 — legacy single-tenant migration on startup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth.migration import migrate_legacy_layout_if_needed
+
+
+def _seed_legacy(base: Path, *, with_config: bool = True) -> None:
+    """Materialise a synthetic single-tenant tree under ``base``."""
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "sessions").mkdir()
+    (base / "workspace").mkdir()
+    (base / "memory").mkdir()
+    (base / "sessions" / "old.jsonl").write_text("legacy data")
+    (base / "workspace" / "AGENTS.md").write_text("# legacy AGENTS")
+    if with_config:
+        (base / "config.json").write_text('{"legacy": true}')
+
+
+def test_legacy_layout_archived_and_fresh_tree_created(tmp_path: Path) -> None:
+    base = tmp_path / ".nanobot"
+    _seed_legacy(base)
+
+    archive = migrate_legacy_layout_if_needed(base)
+
+    assert archive is not None
+    assert archive.is_dir()
+    assert archive.name.startswith(".nanobot.legacy.")
+    assert (archive / "sessions" / "old.jsonl").read_text() == "legacy data"
+    # Fresh tree exists with users/ scaffold and config carried over.
+    assert base.is_dir()
+    assert (base / "users").is_dir()
+    assert (base / "config.json").read_text() == '{"legacy": true}'
+    # No legacy subdirs in the fresh tree.
+    assert not (base / "sessions").exists()
+    assert not (base / "workspace").exists()
+
+
+def test_idempotent_when_users_dir_present(tmp_path: Path) -> None:
+    base = tmp_path / ".nanobot"
+    base.mkdir()
+    (base / "users").mkdir()
+    (base / "sessions").mkdir()  # would normally trigger but users/ wins
+    archive = migrate_legacy_layout_if_needed(base)
+    assert archive is None
+    assert (base / "sessions").is_dir()
+
+
+def test_no_op_on_missing_dir(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    archive = migrate_legacy_layout_if_needed(missing)
+    assert archive is None
+    assert not missing.exists()
+
+
+def test_no_op_on_clean_directory(tmp_path: Path) -> None:
+    base = tmp_path / ".nanobot"
+    base.mkdir()
+    (base / "users").mkdir()
+    archive = migrate_legacy_layout_if_needed(base)
+    assert archive is None
+
+
+def test_skip_env_short_circuits(tmp_path: Path, monkeypatch) -> None:
+    base = tmp_path / ".nanobot"
+    _seed_legacy(base)
+    monkeypatch.setenv("NANOBOT_SKIP_LEGACY_MIGRATION", "1")
+    archive = migrate_legacy_layout_if_needed(base)
+    assert archive is None
+    # Legacy tree untouched.
+    assert (base / "sessions" / "old.jsonl").exists()
+
+
+def test_archive_name_disambiguates_on_collision(tmp_path: Path, monkeypatch) -> None:
+    """If two migrations happen within the same second, the second picks a
+    suffixed archive path so neither overwrites the other."""
+    base = tmp_path / ".nanobot"
+    _seed_legacy(base)
+    # Force the timestamp helper to return a fixed value so we can collide.
+    fixed = "20260511-153000"
+    monkeypatch.setattr("nanobot.auth.migration._now_iso", lambda: fixed)
+    # Pre-create the path the first migration would target.
+    (tmp_path / f".nanobot.legacy.{fixed}").mkdir()
+    archive = migrate_legacy_layout_if_needed(base)
+    assert archive is not None
+    assert archive.name.endswith(".1") or archive.name.endswith(".2")
+
+
+def test_migration_runs_without_config_json(tmp_path: Path) -> None:
+    base = tmp_path / ".nanobot"
+    _seed_legacy(base, with_config=False)
+    archive = migrate_legacy_layout_if_needed(base)
+    assert archive is not None
+    assert (base / "users").is_dir()
+    assert not (base / "config.json").exists()
+
+
+def test_does_not_run_when_only_unrelated_files_present(tmp_path: Path) -> None:
+    base = tmp_path / ".nanobot"
+    base.mkdir()
+    (base / "auth.db").touch()
+    (base / "config.json").write_text("{}")
+    archive = migrate_legacy_layout_if_needed(base)
+    assert archive is None
+    assert (base / "auth.db").exists()
+
+
+@pytest.fixture(autouse=True)
+def _unset_skip_env(monkeypatch):
+    """Always start each test with the skip flag unset, regardless of host env."""
+    monkeypatch.delenv("NANOBOT_SKIP_LEGACY_MIGRATION", raising=False)
+    yield

--- a/tests/auth/test_ratelimit.py
+++ b/tests/auth/test_ratelimit.py
@@ -1,0 +1,118 @@
+"""Slice B2 — rate limit on /auth/login + /auth/signup."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth.ratelimit import RateLimiter
+from nanobot.auth.routes import Request, dispatch
+from nanobot.auth.service import AuthService
+
+
+@pytest.fixture()
+def svc(tmp_path: Path) -> AuthService:
+    yield AuthService.default(tmp_path)
+
+
+def _login(ip: str = "1.2.3.4") -> Request:
+    return Request(
+        method="POST",
+        path="/auth/login",
+        headers={"content-type": "application/json"},
+        body=json.dumps({"email": "a@b.com", "password": "wrong password long enough"}).encode(),
+        remote_ip=ip,
+    )
+
+
+def _signup(seq: int, ip: str = "1.2.3.4") -> Request:
+    return Request(
+        method="POST",
+        path="/auth/signup",
+        headers={"content-type": "application/json"},
+        body=json.dumps(
+            {"email": f"u{seq}@example.com", "password": "correct horse battery staple"}
+        ).encode(),
+        remote_ip=ip,
+    )
+
+
+def test_login_rate_limit_kicks_in_after_5_attempts(svc: AuthService) -> None:
+    clock = [1000.0]
+    limiter = RateLimiter(now=lambda: clock[0])
+    statuses = [dispatch(_login(), svc, limiter=limiter).status for _ in range(6)]
+    assert statuses == [401, 401, 401, 401, 401, 429]
+
+
+def test_signup_rate_limit_kicks_in_after_3_attempts(svc: AuthService) -> None:
+    clock = [2000.0]
+    limiter = RateLimiter(now=lambda: clock[0])
+    # First three should be allowed (and create users); 4th 429.
+    r1 = dispatch(_signup(1), svc, limiter=limiter)
+    r2 = dispatch(_signup(2), svc, limiter=limiter)
+    r3 = dispatch(_signup(3), svc, limiter=limiter)
+    r4 = dispatch(_signup(4), svc, limiter=limiter)
+    assert r1.status == 200
+    assert r2.status == 200
+    assert r3.status == 200
+    assert r4.status == 429
+
+
+def test_rate_limit_response_has_retry_after_header(svc: AuthService) -> None:
+    clock = [3000.0]
+    limiter = RateLimiter(now=lambda: clock[0])
+    for _ in range(5):
+        dispatch(_login(), svc, limiter=limiter)
+    blocked = dispatch(_login(), svc, limiter=limiter)
+    assert blocked.status == 429
+    assert "Retry-After" in blocked.headers
+    assert int(blocked.headers["Retry-After"]) >= 1
+
+
+def test_rate_limit_clears_after_window_expires(svc: AuthService) -> None:
+    clock = [4000.0]
+    limiter = RateLimiter(now=lambda: clock[0])
+    for _ in range(5):
+        dispatch(_login(), svc, limiter=limiter)
+    assert dispatch(_login(), svc, limiter=limiter).status == 429
+    # Advance past the 60s window.
+    clock[0] += 61.0
+    assert dispatch(_login(), svc, limiter=limiter).status == 401
+
+
+def test_rate_limit_per_ip(svc: AuthService) -> None:
+    clock = [5000.0]
+    limiter = RateLimiter(now=lambda: clock[0])
+    for _ in range(5):
+        dispatch(_login(ip="1.1.1.1"), svc, limiter=limiter)
+    # IP 1 is over the limit.
+    assert dispatch(_login(ip="1.1.1.1"), svc, limiter=limiter).status == 429
+    # IP 2 is fresh.
+    assert dispatch(_login(ip="2.2.2.2"), svc, limiter=limiter).status == 401
+
+
+def test_no_limiter_means_no_throttling(svc: AuthService) -> None:
+    """If no limiter is passed (e.g. tests, CLI), behaviour is unrestricted."""
+    for _ in range(20):
+        resp = dispatch(_login(), svc)
+        assert resp.status == 401
+
+
+def test_ratelimit_audit_row_written(svc: AuthService, tmp_path: Path) -> None:
+    import sqlite3
+
+    from nanobot.auth.schema import get_auth_db_path
+
+    clock = [6000.0]
+    limiter = RateLimiter(now=lambda: clock[0])
+    for _ in range(6):
+        dispatch(_login(), svc, limiter=limiter)
+    events = [
+        r[0]
+        for r in sqlite3.connect(get_auth_db_path(tmp_path)).execute(
+            "SELECT event FROM audit_log"
+        )
+    ]
+    assert "ratelimit.trip" in events

--- a/tests/auth/test_routes.py
+++ b/tests/auth/test_routes.py
@@ -1,0 +1,156 @@
+"""Tests for nanobot.auth.routes — request/response level."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth.routes import (
+    SESSION_COOKIE,
+    Request,
+    Response,
+    dispatch,
+)
+from nanobot.auth.service import AuthService
+
+
+@pytest.fixture()
+def svc(tmp_path: Path) -> AuthService:
+    yield AuthService.default(tmp_path)
+
+
+def _post(path: str, body: dict, *, cookie: str | None = None) -> Request:
+    headers = {"content-type": "application/json"}
+    if cookie is not None:
+        headers["cookie"] = cookie
+    return Request(
+        method="POST", path=path, headers=headers,
+        body=json.dumps(body).encode("utf-8"), remote_ip="127.0.0.1",
+    )
+
+
+def _get(path: str, *, cookie: str | None = None) -> Request:
+    headers = {}
+    if cookie is not None:
+        headers["cookie"] = cookie
+    return Request(
+        method="GET", path=path, headers=headers, body=b"", remote_ip="127.0.0.1",
+    )
+
+
+def _cookie_from_response(resp: Response) -> str:
+    assert resp.cookies, "expected Set-Cookie on response"
+    raw = resp.cookies[0]
+    token = raw.split(";", 1)[0]  # "nanobot_session=<token>"
+    return token
+
+
+def test_login_success_sets_cookie(svc: AuthService) -> None:
+    svc.create_user("a@b.com", "correct horse battery staple")
+    resp = dispatch(_post("/auth/login", {"email": "a@b.com", "password": "correct horse battery staple"}), svc)
+    assert resp.status == 200
+    payload = json.loads(resp.body)
+    assert payload["user"]["email"] == "a@b.com"
+    cookie = _cookie_from_response(resp)
+    assert cookie.startswith(f"{SESSION_COOKIE}=")
+    flags = "; ".join(resp.cookies[0].split(";")[1:]).lower()
+    assert "httponly" in flags
+    assert "samesite=lax" in flags
+    assert "path=/" in flags
+
+
+def test_login_bad_password_returns_401(svc: AuthService) -> None:
+    svc.create_user("a@b.com", "correct horse battery staple")
+    resp = dispatch(_post("/auth/login", {"email": "a@b.com", "password": "wrong password long enough"}), svc)
+    assert resp.status == 401
+    assert not resp.cookies
+
+
+def test_login_unknown_email_returns_401(svc: AuthService) -> None:
+    resp = dispatch(_post("/auth/login", {"email": "nobody@b.com", "password": "any pwd long enough"}), svc)
+    assert resp.status == 401
+
+
+def test_login_missing_fields_returns_400(svc: AuthService) -> None:
+    resp = dispatch(_post("/auth/login", {"email": ""}), svc)
+    assert resp.status == 400
+
+
+def test_login_secure_flag_when_https(svc: AuthService) -> None:
+    svc.create_user("a@b.com", "correct horse battery staple")
+    req = _post("/auth/login", {"email": "a@b.com", "password": "correct horse battery staple"})
+    req = Request(
+        method=req.method, path=req.path,
+        headers={**req.headers, "x-forwarded-proto": "https"},
+        body=req.body, remote_ip=req.remote_ip,
+    )
+    resp = dispatch(req, svc)
+    assert resp.status == 200
+    assert "Secure" in resp.cookies[0]
+
+
+def test_me_returns_user_when_authed(svc: AuthService) -> None:
+    svc.create_user("a@b.com", "correct horse battery staple")
+    login = dispatch(_post("/auth/login", {"email": "a@b.com", "password": "correct horse battery staple"}), svc)
+    cookie = _cookie_from_response(login)
+    resp = dispatch(_get("/auth/me", cookie=cookie), svc)
+    assert resp.status == 200
+    assert json.loads(resp.body)["user"]["email"] == "a@b.com"
+
+
+def test_me_returns_401_without_cookie(svc: AuthService) -> None:
+    resp = dispatch(_get("/auth/me"), svc)
+    assert resp.status == 401
+
+
+def test_me_returns_401_with_bad_cookie(svc: AuthService) -> None:
+    resp = dispatch(_get("/auth/me", cookie=f"{SESSION_COOKIE}=garbage"), svc)
+    assert resp.status == 401
+
+
+def test_logout_clears_cookie_and_revokes_session(svc: AuthService) -> None:
+    svc.create_user("a@b.com", "correct horse battery staple")
+    login = dispatch(_post("/auth/login", {"email": "a@b.com", "password": "correct horse battery staple"}), svc)
+    cookie = _cookie_from_response(login)
+
+    resp = dispatch(_post("/auth/logout", {}, cookie=cookie), svc)
+    assert resp.status == 200
+    assert any("Max-Age=0" in c for c in resp.cookies)
+
+    me = dispatch(_get("/auth/me", cookie=cookie), svc)
+    assert me.status == 401
+
+
+def test_unknown_auth_path_returns_404(svc: AuthService) -> None:
+    resp = dispatch(_post("/auth/does-not-exist", {}), svc)
+    assert resp.status == 404
+
+
+def test_wrong_method_on_known_route_returns_405(svc: AuthService) -> None:
+    resp = dispatch(_get("/auth/login"), svc)
+    assert resp.status == 405
+
+
+def test_non_auth_path_returns_none(svc: AuthService) -> None:
+    resp = dispatch(_get("/health"), svc)
+    assert resp is None
+
+
+def test_malformed_json_returns_400(svc: AuthService) -> None:
+    req = Request(
+        method="POST", path="/auth/login",
+        headers={"content-type": "application/json"},
+        body=b"{not-json", remote_ip="127.0.0.1",
+    )
+    resp = dispatch(req, svc)
+    assert resp.status == 400
+
+
+def test_login_generic_error_does_not_distinguish_unknown_vs_wrong(svc: AuthService) -> None:
+    svc.create_user("a@b.com", "correct horse battery staple")
+    bad_pwd = dispatch(_post("/auth/login", {"email": "a@b.com", "password": "wrong password long enough"}), svc)
+    unknown = dispatch(_post("/auth/login", {"email": "nobody@b.com", "password": "any password long enough"}), svc)
+    assert bad_pwd.status == unknown.status == 401
+    assert json.loads(bad_pwd.body) == json.loads(unknown.body)

--- a/tests/auth/test_routes.py
+++ b/tests/auth/test_routes.py
@@ -154,3 +154,89 @@ def test_login_generic_error_does_not_distinguish_unknown_vs_wrong(svc: AuthServ
     unknown = dispatch(_post("/auth/login", {"email": "nobody@b.com", "password": "any password long enough"}), svc)
     assert bad_pwd.status == unknown.status == 401
     assert json.loads(bad_pwd.body) == json.loads(unknown.body)
+
+
+# ---------------------------------------------------------------------------
+# Slice B — /auth/signup
+# ---------------------------------------------------------------------------
+
+
+def test_signup_creates_user_and_sets_cookie(svc: AuthService) -> None:
+    resp = dispatch(
+        _post(
+            "/auth/signup",
+            {
+                "email": "new@example.com",
+                "password": "correct horse battery staple",
+                "display_name": "New User",
+            },
+        ),
+        svc,
+    )
+    assert resp.status == 200
+    payload = json.loads(resp.body)
+    assert payload["user"]["email"] == "new@example.com"
+    assert payload["user"]["display_name"] == "New User"
+    assert payload["user"]["role"] == "user"
+    cookie = _cookie_from_response(resp)
+    assert cookie.startswith(f"{SESSION_COOKIE}=")
+
+
+def test_signup_minted_session_works_for_me(svc: AuthService) -> None:
+    signup = dispatch(
+        _post("/auth/signup", {"email": "x@y.com", "password": "correct horse battery staple"}),
+        svc,
+    )
+    cookie = _cookie_from_response(signup)
+    me = dispatch(_get("/auth/me", cookie=cookie), svc)
+    assert me.status == 200
+    assert json.loads(me.body)["user"]["email"] == "x@y.com"
+
+
+def test_signup_duplicate_email_returns_409(svc: AuthService) -> None:
+    payload = {"email": "dup@example.com", "password": "correct horse battery staple"}
+    first = dispatch(_post("/auth/signup", payload), svc)
+    assert first.status == 200
+    again = dispatch(_post("/auth/signup", payload), svc)
+    assert again.status == 409
+    assert not again.cookies
+
+
+def test_signup_rejects_short_password(svc: AuthService) -> None:
+    resp = dispatch(
+        _post("/auth/signup", {"email": "short@example.com", "password": "tooshort"}),
+        svc,
+    )
+    assert resp.status == 400
+
+
+def test_signup_rejects_invalid_email(svc: AuthService) -> None:
+    resp = dispatch(
+        _post("/auth/signup", {"email": "not-an-email", "password": "correct horse battery staple"}),
+        svc,
+    )
+    assert resp.status == 400
+
+
+def test_signup_missing_fields_returns_400(svc: AuthService) -> None:
+    resp = dispatch(_post("/auth/signup", {"email": "a@b.com"}), svc)
+    assert resp.status == 400
+
+
+def test_signup_email_case_insensitive_duplicate(svc: AuthService) -> None:
+    dispatch(_post("/auth/signup", {"email": "Mix@Case.com", "password": "correct horse battery staple"}), svc)
+    again = dispatch(
+        _post("/auth/signup", {"email": "mix@case.COM", "password": "correct horse battery staple"}),
+        svc,
+    )
+    assert again.status == 409
+
+
+def test_signup_login_with_new_credentials(svc: AuthService) -> None:
+    """After signup, login with the same credentials should also succeed."""
+    dispatch(_post("/auth/signup", {"email": "round@trip.com", "password": "correct horse battery staple"}), svc)
+    login = dispatch(
+        _post("/auth/login", {"email": "round@trip.com", "password": "correct horse battery staple"}),
+        svc,
+    )
+    assert login.status == 200

--- a/tests/auth/test_routes.py
+++ b/tests/auth/test_routes.py
@@ -65,7 +65,8 @@ def test_login_bad_password_returns_401(svc: AuthService) -> None:
     svc.create_user("a@b.com", "correct horse battery staple")
     resp = dispatch(_post("/auth/login", {"email": "a@b.com", "password": "wrong password long enough"}), svc)
     assert resp.status == 401
-    assert not resp.cookies
+    # No session cookie set on failed login (CSRF cookie auto-issue is fine).
+    assert not any(c.startswith(f"{SESSION_COOKIE}=") and "Max-Age=0" not in c for c in resp.cookies)
 
 
 def test_login_unknown_email_returns_401(svc: AuthService) -> None:
@@ -199,7 +200,8 @@ def test_signup_duplicate_email_returns_409(svc: AuthService) -> None:
     assert first.status == 200
     again = dispatch(_post("/auth/signup", payload), svc)
     assert again.status == 409
-    assert not again.cookies
+    # 409 must not mint a session cookie (CSRF cookie auto-issue is fine).
+    assert not any(c.startswith(f"{SESSION_COOKIE}=") and "Max-Age=0" not in c for c in again.cookies)
 
 
 def test_signup_rejects_short_password(svc: AuthService) -> None:

--- a/tests/auth/test_service.py
+++ b/tests/auth/test_service.py
@@ -130,6 +130,28 @@ def test_expire_sessions_purges_old_rows(svc: AuthService) -> None:
     assert svc.expire_sessions() >= 1
 
 
+def test_unknown_email_dummy_hash_is_parseable(svc: AuthService) -> None:
+    """Regression: ``_DUMMY_HASH`` must round-trip through argon2 so the
+    unknown-email branch and the wrong-password branch take the same time.
+    A wire-format failure on _DUMMY_HASH would reintroduce a sub-millisecond
+    timing oracle for email enumeration."""
+    from argon2.exceptions import InvalidHash, VerificationError, VerifyMismatchError
+
+    from nanobot.auth.service import _DUMMY_HASH, _HASHER
+
+    raised: Exception | None = None
+    try:
+        _HASHER.verify(_DUMMY_HASH, "not-the-real-password")
+    except VerifyMismatchError as exc:
+        raised = exc
+    except (InvalidHash, VerificationError) as exc:  # pragma: no cover
+        raised = exc
+    assert isinstance(raised, VerifyMismatchError), (
+        "Dummy hash must fail with VerifyMismatchError (i.e. argon2 processed it "
+        "to completion), not InvalidHash/VerificationError (which would short-circuit)."
+    )
+
+
 def test_audit_log_records_events(svc: AuthService, tmp_path: Path) -> None:
     svc.create_user("a@b.com", "correct horse battery staple")
     try:

--- a/tests/auth/test_service.py
+++ b/tests/auth/test_service.py
@@ -1,0 +1,145 @@
+"""Tests for nanobot.auth.service."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth import (
+    AuthError,
+    AuthService,
+    EmailTakenError,
+    init_auth_db,
+    is_ulid,
+)
+from nanobot.auth.schema import get_auth_db_path
+
+
+@pytest.fixture()
+def svc(tmp_path: Path) -> AuthService:
+    init_auth_db(tmp_path)
+    yield AuthService.default(tmp_path)
+
+
+def test_create_user_returns_ulid(svc: AuthService) -> None:
+    u = svc.create_user("Alice@Example.com", "correct horse battery staple")
+    assert is_ulid(u.id)
+    assert u.email == "alice@example.com"
+    assert u.role == "user"
+    assert u.disabled is False
+
+
+def test_create_user_duplicate_email_raises(svc: AuthService) -> None:
+    svc.create_user("a@b.com", "correct horse battery staple")
+    with pytest.raises(EmailTakenError):
+        svc.create_user("A@B.COM", "another password long enough")
+
+
+def test_create_user_rejects_short_password(svc: AuthService) -> None:
+    with pytest.raises(AuthError):
+        svc.create_user("a@b.com", "short")
+
+
+def test_create_user_rejects_bad_email(svc: AuthService) -> None:
+    with pytest.raises(AuthError):
+        svc.create_user("not-an-email", "correct horse battery staple")
+
+
+def test_verify_password_success_and_failure(svc: AuthService) -> None:
+    pwd = "correct horse battery staple"
+    u = svc.create_user("a@b.com", pwd)
+    assert svc.verify_password("a@b.com", pwd).id == u.id
+
+    with pytest.raises(AuthError):
+        svc.verify_password("a@b.com", "wrong password long enough")
+
+    with pytest.raises(AuthError):
+        svc.verify_password("unknown@b.com", pwd)
+
+
+def test_verify_password_rejects_disabled_user(svc: AuthService, tmp_path: Path) -> None:
+    u = svc.create_user("a@b.com", "correct horse battery staple")
+    conn = sqlite3.connect(get_auth_db_path(tmp_path))
+    conn.execute("UPDATE users SET disabled=1 WHERE id=?", (u.id,))
+    conn.commit()
+    conn.close()
+    with pytest.raises(AuthError):
+        svc.verify_password("a@b.com", "correct horse battery staple")
+
+
+def test_mint_and_verify_session(svc: AuthService) -> None:
+    u = svc.create_user("a@b.com", "correct horse battery staple")
+    s = svc.mint_session(u.id, user_agent="UA/1", ip="1.2.3.4")
+    assert s.user_id == u.id
+    assert s.expires_at > int(time.time())
+
+    verified = svc.verify_session(s.token)
+    assert verified.id == u.id
+
+
+def test_verify_session_rejects_bad_token(svc: AuthService) -> None:
+    with pytest.raises(AuthError):
+        svc.verify_session("not-a-real-token")
+    with pytest.raises(AuthError):
+        svc.verify_session("")
+
+
+def test_revoked_session_rejected(svc: AuthService) -> None:
+    u = svc.create_user("a@b.com", "correct horse battery staple")
+    s = svc.mint_session(u.id)
+    svc.revoke_session(s.token)
+    with pytest.raises(AuthError):
+        svc.verify_session(s.token)
+
+
+def test_expired_session_rejected(svc: AuthService) -> None:
+    u = svc.create_user("a@b.com", "correct horse battery staple")
+    s = svc.mint_session(u.id, ttl_seconds=1)
+    time.sleep(1.2)
+    with pytest.raises(AuthError):
+        svc.verify_session(s.token)
+
+
+def test_sliding_ttl_extends(svc: AuthService, tmp_path: Path) -> None:
+    u = svc.create_user("a@b.com", "correct horse battery staple")
+    s = svc.mint_session(u.id, ttl_seconds=10)
+    time.sleep(1.1)
+    svc.verify_session(s.token, sliding=True, ttl_seconds=10)
+    row = sqlite3.connect(get_auth_db_path(tmp_path)).execute(
+        "SELECT expires_at FROM web_sessions ORDER BY created_at DESC LIMIT 1"
+    ).fetchone()
+    assert row[0] > s.expires_at
+
+
+def test_set_password_revokes_existing_sessions(svc: AuthService) -> None:
+    u = svc.create_user("a@b.com", "correct horse battery staple")
+    s = svc.mint_session(u.id)
+    svc.set_password(u.id, "new password also long enough")
+    with pytest.raises(AuthError):
+        svc.verify_session(s.token)
+    svc.verify_password("a@b.com", "new password also long enough")
+
+
+def test_expire_sessions_purges_old_rows(svc: AuthService) -> None:
+    u = svc.create_user("a@b.com", "correct horse battery staple")
+    svc.mint_session(u.id, ttl_seconds=1)
+    time.sleep(1.2)
+    assert svc.expire_sessions() >= 1
+
+
+def test_audit_log_records_events(svc: AuthService, tmp_path: Path) -> None:
+    svc.create_user("a@b.com", "correct horse battery staple")
+    try:
+        svc.verify_password("a@b.com", "wrong password long enough")
+    except AuthError:
+        pass
+    svc.verify_password("a@b.com", "correct horse battery staple")
+
+    conn = sqlite3.connect(get_auth_db_path(tmp_path))
+    events = [r[0] for r in conn.execute("SELECT event FROM audit_log ORDER BY id")]
+    assert "signup" in events
+    assert "login.fail" in events
+    assert "login.ok" in events

--- a/tests/auth/test_session_isolation.py
+++ b/tests/auth/test_session_isolation.py
@@ -1,0 +1,104 @@
+"""Slice A5 integration: per-user SessionManager + AgentLoop routing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nanobot.auth import UserContext
+from nanobot.auth.ids import new_ulid
+from nanobot.config.paths import get_user_root, get_users_root
+from nanobot.session.manager import SessionManager
+
+
+@pytest.fixture()
+def isolate_data_dir(monkeypatch, tmp_path: Path):
+    """Redirect nanobot.config.paths.get_data_dir to a temp directory."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    return tmp_path
+
+
+def test_session_manager_with_user_ctx_writes_under_user_dir(isolate_data_dir: Path) -> None:
+    """SessionManager with user_ctx must persist sessions under users/<uid>/sessions/."""
+    workspace = isolate_data_dir / "workspace"
+    workspace.mkdir()
+    uid = new_ulid()
+    ctx = UserContext(user_id=uid)
+    sm = SessionManager(workspace, user_ctx=ctx)
+
+    session = sm.get_or_create("websocket:web-1")
+    session.add_message("user", "hello")
+    sm.save(session)
+
+    user_path = get_user_root(uid) / "sessions" / "websocket_web-1.jsonl"
+    legacy_path = workspace / "sessions" / "websocket_web-1.jsonl"
+    assert user_path.exists(), f"session file should land under {user_path}"
+    assert not legacy_path.exists(), f"session file leaked to legacy path {legacy_path}"
+
+
+def test_two_users_have_disjoint_session_files(isolate_data_dir: Path) -> None:
+    workspace = isolate_data_dir / "workspace"
+    workspace.mkdir()
+    alice = UserContext(user_id=new_ulid())
+    bob = UserContext(user_id=new_ulid())
+    sm_a = SessionManager(workspace, user_ctx=alice)
+    sm_b = SessionManager(workspace, user_ctx=bob)
+
+    sa = sm_a.get_or_create("websocket:shared-key")
+    sa.add_message("user", "alice message")
+    sm_a.save(sa)
+
+    sb = sm_b.get_or_create("websocket:shared-key")
+    sb.add_message("user", "bob message")
+    sm_b.save(sb)
+
+    a_path = get_user_root(alice.user_id) / "sessions" / "websocket_shared-key.jsonl"
+    b_path = get_user_root(bob.user_id) / "sessions" / "websocket_shared-key.jsonl"
+    assert a_path.exists()
+    assert b_path.exists()
+    assert a_path != b_path
+    assert "alice" in a_path.read_text()
+    assert "bob" in b_path.read_text()
+    assert "alice" not in b_path.read_text()
+    assert "bob" not in a_path.read_text()
+
+
+def test_global_session_manager_unchanged(isolate_data_dir: Path) -> None:
+    """SessionManager without user_ctx keeps legacy workspace/sessions/ layout."""
+    workspace = isolate_data_dir / "workspace"
+    workspace.mkdir()
+    sm = SessionManager(workspace)
+
+    session = sm.get_or_create("cli:default")
+    session.add_message("user", "cli message")
+    sm.save(session)
+
+    assert (workspace / "sessions" / "cli_default.jsonl").exists()
+    # Crucially, nothing landed under users/ for this path.
+    if get_users_root().exists():
+        assert not list(get_users_root().rglob("cli_default.jsonl"))
+
+
+def test_agent_loop_sessions_for_routing(isolate_data_dir: Path) -> None:
+    """AgentLoop._sessions_for returns global for None ctx and a per-user
+    SessionManager for a UserContext (cached across calls)."""
+    from nanobot.agent.loop import AgentLoop  # local import: heavy module
+
+    workspace = isolate_data_dir / "workspace"
+    workspace.mkdir()
+    loop = AgentLoop.__new__(AgentLoop)
+    # Wire only the attributes _sessions_for depends on, to avoid full ctor cost.
+    loop.workspace = workspace
+    loop.sessions = SessionManager(workspace)
+    loop._user_session_managers = {}
+
+    assert loop._sessions_for(None) is loop.sessions
+
+    ctx = UserContext(user_id=new_ulid())
+    sm1 = loop._sessions_for(ctx)
+    sm2 = loop._sessions_for(ctx)
+    assert sm1 is sm2  # cached
+    assert sm1 is not loop.sessions
+    assert sm1.sessions_dir == ctx.sessions_dir()

--- a/tests/auth/test_tool_isolation.py
+++ b/tests/auth/test_tool_isolation.py
@@ -1,0 +1,162 @@
+"""Slice C1 — filesystem & shell tools honor per-user UserContext."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from nanobot.agent.tools.filesystem import (
+    EditFileTool,
+    ListDirTool,
+    ReadFileTool,
+    WriteFileTool,
+)
+from nanobot.agent.tools.shell import ExecTool
+from nanobot.auth.context import UserContext, current_user_ctx
+from nanobot.auth.ids import new_ulid
+
+
+@pytest.fixture()
+def isolate_data_dir(monkeypatch, tmp_path: Path) -> Path:
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    return tmp_path
+
+
+@pytest.fixture()
+def restore_ctx():
+    """Always restore the contextvar after a test."""
+    token = current_user_ctx.set(None)
+    yield
+    current_user_ctx.reset(token)
+
+
+def _make_fs_tools(workspace: Path):
+    return {
+        "write": WriteFileTool(workspace=workspace, allowed_dir=workspace),
+        "read": ReadFileTool(workspace=workspace, allowed_dir=workspace),
+        "edit": EditFileTool(workspace=workspace, allowed_dir=workspace),
+        "ls": ListDirTool(workspace=workspace, allowed_dir=workspace),
+    }
+
+
+def test_filesystem_tool_writes_under_user_workspace(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    tools = _make_fs_tools(global_ws)
+    uid = new_ulid()
+    ctx = UserContext(user_id=uid)
+    token = current_user_ctx.set(ctx)
+    try:
+        asyncio.run(tools["write"].execute(path="notes.md", content="user-scoped file"))
+    finally:
+        current_user_ctx.reset(token)
+
+    expected = isolate_data_dir / "users" / uid / "workspace" / "notes.md"
+    assert expected.is_file()
+    assert expected.read_text() == "user-scoped file"
+    # The legacy workspace must stay untouched.
+    assert not (global_ws / "notes.md").exists()
+
+
+def test_filesystem_tool_writes_to_global_when_ctx_unset(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    tools = _make_fs_tools(global_ws)
+    # current_user_ctx is None by virtue of the fixture; CLI / channel path.
+    asyncio.run(tools["write"].execute(path="cli.md", content="from cli"))
+    assert (global_ws / "cli.md").is_file()
+
+
+def test_filesystem_tools_for_two_users_disjoint(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    tools = _make_fs_tools(global_ws)
+    alice = UserContext(user_id=new_ulid())
+    bob = UserContext(user_id=new_ulid())
+
+    token = current_user_ctx.set(alice)
+    try:
+        asyncio.run(tools["write"].execute(path="secret.txt", content="alice-secret"))
+    finally:
+        current_user_ctx.reset(token)
+
+    # Bob's list should NOT see alice's file.
+    token = current_user_ctx.set(bob)
+    try:
+        listing = asyncio.run(tools["ls"].execute(path="."))
+    finally:
+        current_user_ctx.reset(token)
+
+    assert "secret.txt" not in str(listing)
+
+    alice_path = isolate_data_dir / "users" / alice.user_id / "workspace" / "secret.txt"
+    bob_path = isolate_data_dir / "users" / bob.user_id / "workspace" / "secret.txt"
+    assert alice_path.is_file()
+    assert not bob_path.exists()
+
+
+def test_filesystem_tool_read_back_within_user_context(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    tools = _make_fs_tools(global_ws)
+    ctx = UserContext(user_id=new_ulid())
+    token = current_user_ctx.set(ctx)
+    try:
+        asyncio.run(tools["write"].execute(path="round.txt", content="hello round trip"))
+        result = asyncio.run(tools["read"].execute(path="round.txt"))
+    finally:
+        current_user_ctx.reset(token)
+    assert "hello round trip" in str(result)
+
+
+def test_exec_tool_working_dir_follows_user_context(
+    isolate_data_dir: Path, restore_ctx
+) -> None:
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    tool = ExecTool(working_dir=str(global_ws), restrict_to_workspace=True)
+    ctx = UserContext(user_id=new_ulid())
+    user_ws = isolate_data_dir / "users" / ctx.user_id / "workspace"
+
+    assert tool.working_dir == str(global_ws)
+    token = current_user_ctx.set(ctx)
+    try:
+        assert tool.working_dir == str(user_ws)
+    finally:
+        current_user_ctx.reset(token)
+    # Reverts on reset.
+    assert tool.working_dir == str(global_ws)
+
+
+def test_filesystem_tool_blocks_escape_outside_user_workspace(
+    isolate_data_dir: Path, restore_ctx, tmp_path: Path
+) -> None:
+    """When the loop restricted writes to the workspace, that restriction
+    must rebind to the user's workspace under a UserContext — not stay on
+    the global workspace."""
+    global_ws = isolate_data_dir / "workspace"
+    global_ws.mkdir()
+    tools = _make_fs_tools(global_ws)
+    ctx = UserContext(user_id=new_ulid())
+    other = tmp_path / "outside"
+    other.mkdir()
+
+    token = current_user_ctx.set(ctx)
+    try:
+        result = asyncio.run(
+            tools["write"].execute(path=str(other / "leak.txt"), content="x")
+        )
+    finally:
+        current_user_ctx.reset(token)
+    assert "outside allowed directory" in str(result).lower() or "permission" in str(result).lower()

--- a/tests/cli/test_user_commands.py
+++ b/tests/cli/test_user_commands.py
@@ -1,0 +1,214 @@
+"""Slice D1 — `nanobot user …` CLI subcommands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from nanobot.auth import AuthService
+from nanobot.cli.user import user_app
+
+
+@pytest.fixture()
+def isolate_data_dir(monkeypatch, tmp_path: Path) -> Path:
+    """Redirect AuthService.default() to a temp data dir."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    return tmp_path
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_list_empty(runner: CliRunner, isolate_data_dir: Path) -> None:
+    result = runner.invoke(user_app, ["list"])
+    assert result.exit_code == 0
+    assert "No users." in result.output
+
+
+def test_create_and_list_user(
+    runner: CliRunner, isolate_data_dir: Path, monkeypatch
+) -> None:
+    pwds = iter(["correct horse battery staple", "correct horse battery staple"])
+    monkeypatch.setattr("nanobot.cli.user.getpass.getpass", lambda *_: next(pwds))
+    result = runner.invoke(user_app, ["create", "alice@x.com", "--display-name", "Alice"])
+    assert result.exit_code == 0, result.output
+    assert "Created" in result.output
+    assert "alice@x.com" in result.output
+
+    listing = runner.invoke(user_app, ["list"])
+    # Rich truncates email columns in narrow test consoles, so match a stable prefix.
+    assert "alice@x" in listing.output
+    assert "Alice" in listing.output
+
+
+def test_create_rejects_short_password(
+    runner: CliRunner, isolate_data_dir: Path, monkeypatch
+) -> None:
+    pwds = iter(["short", "short"])
+    monkeypatch.setattr("nanobot.cli.user.getpass.getpass", lambda *_: next(pwds))
+    result = runner.invoke(user_app, ["create", "alice@x.com"])
+    assert result.exit_code == 1
+
+
+def test_create_rejects_password_mismatch(
+    runner: CliRunner, isolate_data_dir: Path, monkeypatch
+) -> None:
+    pwds = iter(["correct horse battery staple", "different one entirely"])
+    monkeypatch.setattr("nanobot.cli.user.getpass.getpass", lambda *_: next(pwds))
+    result = runner.invoke(user_app, ["create", "alice@x.com"])
+    assert result.exit_code == 1
+    assert "do not match" in result.output.lower()
+
+
+def test_create_duplicate_email(
+    runner: CliRunner, isolate_data_dir: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "nanobot.cli.user.getpass.getpass", lambda *_: "correct horse battery staple"
+    )
+    assert runner.invoke(user_app, ["create", "alice@x.com"]).exit_code == 0
+    second = runner.invoke(user_app, ["create", "alice@x.com"])
+    assert second.exit_code == 1
+    assert "already registered" in second.output
+
+
+def test_promote_then_demote(
+    runner: CliRunner, isolate_data_dir: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "nanobot.cli.user.getpass.getpass", lambda *_: "correct horse battery staple"
+    )
+    runner.invoke(user_app, ["create", "alice@x.com"])
+
+    p = runner.invoke(user_app, ["promote", "alice@x.com"])
+    assert p.exit_code == 0, p.output
+    svc = AuthService.default(isolate_data_dir)
+    try:
+        assert svc.get_user_by_email("alice@x.com").role == "admin"
+    finally:
+        svc.close()
+
+    d = runner.invoke(user_app, ["demote", "alice@x.com"])
+    assert d.exit_code == 0
+    svc = AuthService.default(isolate_data_dir)
+    try:
+        assert svc.get_user_by_email("alice@x.com").role == "user"
+    finally:
+        svc.close()
+
+
+def test_reset_password_revokes_sessions(
+    runner: CliRunner, isolate_data_dir: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "nanobot.cli.user.getpass.getpass", lambda *_: "correct horse battery staple"
+    )
+    runner.invoke(user_app, ["create", "alice@x.com"])
+
+    svc = AuthService.default(isolate_data_dir)
+    try:
+        alice = svc.get_user_by_email("alice@x.com")
+        live = svc.mint_session(alice.id)
+    finally:
+        svc.close()
+
+    new_pwds = iter(["new strong password 1234", "new strong password 1234"])
+    monkeypatch.setattr("nanobot.cli.user.getpass.getpass", lambda *_: next(new_pwds))
+    r = runner.invoke(user_app, ["reset-password", "alice@x.com"])
+    assert r.exit_code == 0
+
+    svc = AuthService.default(isolate_data_dir)
+    try:
+        # The old session must no longer verify.
+        from nanobot.auth import AuthError
+
+        with pytest.raises(AuthError):
+            svc.verify_session(live.token)
+        # New password works.
+        svc.verify_password("alice@x.com", "new strong password 1234")
+    finally:
+        svc.close()
+
+
+def test_delete_with_yes_flag(
+    runner: CliRunner, isolate_data_dir: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "nanobot.cli.user.getpass.getpass", lambda *_: "correct horse battery staple"
+    )
+    runner.invoke(user_app, ["create", "alice@x.com"])
+    r = runner.invoke(user_app, ["delete", "alice@x.com", "--yes"])
+    assert r.exit_code == 0
+    assert "Deleted" in r.output
+
+    svc = AuthService.default(isolate_data_dir)
+    try:
+        assert svc.get_user_by_email("alice@x.com") is None
+    finally:
+        svc.close()
+
+
+def test_disable_blocks_login(
+    runner: CliRunner, isolate_data_dir: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "nanobot.cli.user.getpass.getpass", lambda *_: "correct horse battery staple"
+    )
+    runner.invoke(user_app, ["create", "alice@x.com"])
+
+    svc = AuthService.default(isolate_data_dir)
+    try:
+        svc.verify_password("alice@x.com", "correct horse battery staple")
+    finally:
+        svc.close()
+
+    r = runner.invoke(user_app, ["disable", "alice@x.com"])
+    assert r.exit_code == 0
+
+    svc = AuthService.default(isolate_data_dir)
+    try:
+        from nanobot.auth import AuthError
+
+        with pytest.raises(AuthError):
+            svc.verify_password("alice@x.com", "correct horse battery staple")
+    finally:
+        svc.close()
+
+    # Re-enable.
+    r = runner.invoke(user_app, ["disable", "alice@x.com", "--off"])
+    assert r.exit_code == 0
+    svc = AuthService.default(isolate_data_dir)
+    try:
+        svc.verify_password("alice@x.com", "correct horse battery staple")
+    finally:
+        svc.close()
+
+
+def test_unknown_user_errors_cleanly(
+    runner: CliRunner, isolate_data_dir: Path
+) -> None:
+    result = runner.invoke(user_app, ["promote", "ghost@nowhere"])
+    assert result.exit_code == 1
+    assert "No user matches" in result.output
+
+
+def test_resolve_by_user_id(
+    runner: CliRunner, isolate_data_dir: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "nanobot.cli.user.getpass.getpass", lambda *_: "correct horse battery staple"
+    )
+    runner.invoke(user_app, ["create", "alice@x.com"])
+    svc = AuthService.default(isolate_data_dir)
+    try:
+        uid = svc.get_user_by_email("alice@x.com").id
+    finally:
+        svc.close()
+
+    r = runner.invoke(user_app, ["promote", uid])
+    assert r.exit_code == 0

--- a/tests/config/test_config_paths.py
+++ b/tests/config/test_config_paths.py
@@ -9,6 +9,8 @@ from nanobot.config.paths import (
     get_logs_dir,
     get_media_dir,
     get_runtime_subdir,
+    get_user_root,
+    get_users_root,
     get_workspace_path,
     is_default_workspace,
 )
@@ -47,3 +49,18 @@ def test_is_default_workspace_distinguishes_default_and_custom_paths() -> None:
     assert is_default_workspace(None) is True
     assert is_default_workspace(Path.home() / ".nanobot" / "workspace") is True
     assert is_default_workspace("~/custom-workspace") is False
+
+
+def test_users_root_under_data_dir(monkeypatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "instance-c" / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    assert get_users_root() == config_file.parent / "users"
+    assert get_users_root().is_dir()
+
+
+def test_user_root_resolves_under_users_root(monkeypatch, tmp_path: Path) -> None:
+    config_file = tmp_path / "instance-d" / "config.json"
+    monkeypatch.setattr("nanobot.config.paths.get_config_path", lambda: config_file)
+    uid = "01KRBNKY41FNHW9V0T20SRNA9A"
+    assert get_user_root(uid) == config_file.parent / "users" / uid
+    assert get_user_root(uid).is_dir()

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -218,12 +218,23 @@ export default function App() {
     );
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     if (state.status === "ready") {
       state.client.close();
     }
     clearSavedSecret();
+    // Also drop the cookie-auth session so the next visit goes to the
+    // LoginPage instead of silently resuming as the previous user.
+    try {
+      const { authLogout } = await import("@/lib/api");
+      await authLogout();
+    } catch {
+      /* network failures are fine — the cookie still expires server-side */
+    }
     setState({ status: "auth" });
+    // Hard reload to fully reset both AuthProvider and the bootstrap state
+    // machine; otherwise React caches the in-memory auth context.
+    window.location.reload();
   };
 
   return (

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AdminUsersPage } from "@/admin/AdminUsersPage";
 import { DeleteConfirm } from "@/components/DeleteConfirm";
 import { Sidebar } from "@/components/Sidebar";
 import { SettingsView } from "@/components/settings/SettingsView";
@@ -36,7 +37,7 @@ type BootState =
 const SIDEBAR_STORAGE_KEY = "nanobot-webui.sidebar";
 const RESTART_STARTED_KEY = "nanobot-webui.restartStartedAt";
 const SIDEBAR_WIDTH = 272;
-type ShellView = "chat" | "settings";
+type ShellView = "chat" | "settings" | "admin";
 
 function AuthForm({
   failed,
@@ -331,6 +332,11 @@ function Shell({ onModelNameChange, onLogout }: { onModelNameChange: (modelName:
     setMobileSidebarOpen(false);
   }, []);
 
+  const onOpenAdmin = useCallback(() => {
+    setView("admin");
+    setMobileSidebarOpen(false);
+  }, []);
+
   const onBackToChat = useCallback(() => {
     setView("chat");
     setMobileSidebarOpen(false);
@@ -430,8 +436,9 @@ function Shell({ onModelNameChange, onLogout }: { onModelNameChange: (modelName:
     onRequestDelete: (key: string, label: string) =>
       setPendingDelete({ key, label }),
     onOpenSettings,
+    onOpenAdmin,
   };
-  const showMainSidebar = view !== "settings";
+  const showMainSidebar = view === "chat";
 
   return (
     <div className="relative flex h-full w-full overflow-hidden">
@@ -484,6 +491,8 @@ function Shell({ onModelNameChange, onLogout }: { onModelNameChange: (modelName:
             onRestart={onRestart}
             isRestarting={isRestarting}
           />
+        ) : view === "admin" ? (
+          <AdminUsersPage onBack={onBackToChat} />
         ) : (
           <ThreadShell
             session={activeSession}

--- a/webui/src/admin/AdminUsersPage.tsx
+++ b/webui/src/admin/AdminUsersPage.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  ApiError,
+  adminDeleteUser,
+  adminListUsers,
+  adminSetDisabled,
+  adminSetRole,
+  type AdminUserRow,
+} from "@/lib/api";
+import { useAuth } from "@/auth/AuthContext";
+
+interface AdminUsersPageProps {
+  onBack: () => void;
+}
+
+function formatTimestamp(epoch: number | null): string {
+  if (!epoch) return "—";
+  return new Date(epoch * 1000).toLocaleString();
+}
+
+export function AdminUsersPage({ onBack }: AdminUsersPageProps) {
+  const { user: currentUser } = useAuth();
+  const [users, setUsers] = useState<AdminUserRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<AdminUserRow | null>(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const rows = await adminListUsers();
+      setUsers(rows);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to load users.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const wrap = async (id: string, action: () => Promise<unknown>) => {
+    setPendingId(id);
+    setError(null);
+    try {
+      await action();
+      await refresh();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Action failed.");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const onTogglePromote = (u: AdminUserRow) =>
+    wrap(u.id, () => adminSetRole(u.id, u.role === "admin" ? "user" : "admin"));
+  const onToggleDisabled = (u: AdminUserRow) =>
+    wrap(u.id, () => adminSetDisabled(u.id, !u.disabled));
+  const onConfirmDelete = (u: AdminUserRow) => setConfirmDelete(u);
+  const onCancelDelete = () => setConfirmDelete(null);
+  const onExecuteDelete = () => {
+    if (!confirmDelete) return;
+    const target = confirmDelete;
+    setConfirmDelete(null);
+    return wrap(target.id, () => adminDeleteUser(target.id));
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col bg-background p-6">
+      <header className="mb-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Users</h1>
+          <p className="text-sm text-muted-foreground">
+            Manage WebUI accounts. You are signed in as {currentUser?.email}.
+          </p>
+        </div>
+        <Button variant="ghost" onClick={onBack}>
+          Back to chat
+        </Button>
+      </header>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      {users === null ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : users.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No users yet.</p>
+      ) : (
+        <div className="overflow-auto rounded-md border border-border" data-testid="admin-users-table">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2">Email</th>
+                <th className="px-3 py-2">Role</th>
+                <th className="px-3 py-2">Created</th>
+                <th className="px-3 py-2">Last login</th>
+                <th className="px-3 py-2">Disabled</th>
+                <th className="px-3 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((u) => {
+                const isSelf = currentUser?.id === u.id;
+                const busy = pendingId === u.id;
+                return (
+                  <tr key={u.id} className="border-t border-border" data-testid={`row-${u.email}`}>
+                    <td className="px-3 py-2 font-medium">
+                      {u.display_name ? `${u.display_name} (${u.email})` : u.email}
+                    </td>
+                    <td className="px-3 py-2 capitalize">{u.role}</td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {formatTimestamp(u.created_at)}
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {formatTimestamp(u.last_login_at)}
+                    </td>
+                    <td className="px-3 py-2">{u.disabled ? "yes" : "no"}</td>
+                    <td className="space-x-2 px-3 py-2 text-right">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={busy || isSelf}
+                        onClick={() => onTogglePromote(u)}
+                      >
+                        {u.role === "admin" ? "Demote" : "Promote"}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={busy || isSelf}
+                        onClick={() => onToggleDisabled(u)}
+                      >
+                        {u.disabled ? "Enable" : "Disable"}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={busy || isSelf}
+                        onClick={() => onConfirmDelete(u)}
+                      >
+                        Delete
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {confirmDelete && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+        >
+          <div className="w-full max-w-sm rounded-lg border border-border bg-card p-5 shadow-lg">
+            <h2 className="text-lg font-semibold">Delete user?</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              This will remove <strong>{confirmDelete.email}</strong> and revoke their sessions.
+              The user's filesystem data is preserved and must be removed manually if needed.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button variant="ghost" onClick={onCancelDelete}>
+                Cancel
+              </Button>
+              <Button variant="destructive" onClick={onExecuteDelete}>
+                Delete
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webui/src/auth/AuthContext.tsx
+++ b/webui/src/auth/AuthContext.tsx
@@ -1,0 +1,88 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { ApiError, authLogin, authLogout, authMe, type AuthUser } from "@/lib/api";
+
+type AuthStatus = "loading" | "anon" | "authed";
+
+interface AuthState {
+  status: AuthStatus;
+  user: AuthUser | null;
+}
+
+interface AuthApi extends AuthState {
+  login: (email: string, password: string) => Promise<AuthUser>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthApi | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AuthState>({
+    status: "loading",
+    user: null,
+  });
+
+  const refresh = useCallback(async () => {
+    try {
+      const user = await authMe();
+      setState({ status: "authed", user });
+    } catch (err) {
+      // 401 (or any failure) keeps us anon. Other errors are silent — the
+      // user lands on the login screen and any backend-side issue surfaces
+      // there.
+      if (!(err instanceof ApiError) || err.status !== 401) {
+        // Surface unexpected failures to the console for operator triage.
+        // eslint-disable-next-line no-console
+        console.warn("auth/me failed:", err);
+      }
+      setState({ status: "anon", user: null });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      const user = await authLogin(email, password);
+      setState({ status: "authed", user });
+      return user;
+    },
+    [],
+  );
+
+  const logout = useCallback(async () => {
+    try {
+      await authLogout();
+    } catch {
+      // Even if the network call fails we still drop local state — the
+      // cookie remains set on the browser; we'll naturally hit the login
+      // screen on the next page load.
+    }
+    setState({ status: "anon", user: null });
+  }, []);
+
+  const value = useMemo<AuthApi>(
+    () => ({ ...state, login, logout, refresh }),
+    [state, login, logout, refresh],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthApi {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used inside <AuthProvider>");
+  }
+  return ctx;
+}

--- a/webui/src/auth/AuthContext.tsx
+++ b/webui/src/auth/AuthContext.tsx
@@ -7,7 +7,14 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { ApiError, authLogin, authLogout, authMe, type AuthUser } from "@/lib/api";
+import {
+  ApiError,
+  authLogin,
+  authLogout,
+  authMe,
+  authSignup,
+  type AuthUser,
+} from "@/lib/api";
 
 type AuthStatus = "loading" | "anon" | "authed";
 
@@ -18,11 +25,32 @@ interface AuthState {
 
 interface AuthApi extends AuthState {
   login: (email: string, password: string) => Promise<AuthUser>;
+  signup: (
+    email: string,
+    password: string,
+    displayName?: string,
+  ) => Promise<AuthUser>;
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
 }
 
-const AuthContext = createContext<AuthApi | null>(null);
+// Fault-tolerant default: pre-provider renders (e.g. component tests that
+// render <Sidebar /> without wrapping in <AuthProvider>) get a no-op API
+// that reports anon. Real auth flows always run inside <AuthProvider>.
+const NO_OP_AUTH: AuthApi = {
+  status: "anon",
+  user: null,
+  login: async () => {
+    throw new Error("AuthProvider missing");
+  },
+  signup: async () => {
+    throw new Error("AuthProvider missing");
+  },
+  logout: async () => {},
+  refresh: async () => {},
+};
+
+const AuthContext = createContext<AuthApi>(NO_OP_AUTH);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<AuthState>({
@@ -60,6 +88,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  const signup = useCallback(
+    async (email: string, password: string, displayName?: string) => {
+      const user = await authSignup(email, password, displayName);
+      setState({ status: "authed", user });
+      return user;
+    },
+    [],
+  );
+
   const logout = useCallback(async () => {
     try {
       await authLogout();
@@ -72,17 +109,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const value = useMemo<AuthApi>(
-    () => ({ ...state, login, logout, refresh }),
-    [state, login, logout, refresh],
+    () => ({ ...state, login, signup, logout, refresh }),
+    [state, login, signup, logout, refresh],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth(): AuthApi {
-  const ctx = useContext(AuthContext);
-  if (!ctx) {
-    throw new Error("useAuth must be used inside <AuthProvider>");
-  }
-  return ctx;
+  return useContext(AuthContext);
 }

--- a/webui/src/auth/AuthGate.tsx
+++ b/webui/src/auth/AuthGate.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import { useAuth } from "@/auth/AuthContext";
+import { LoginPage } from "@/auth/LoginPage";
+
+export function AuthGate({ children }: { children: ReactNode }) {
+  const { status } = useAuth();
+
+  if (status === "loading") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      </div>
+    );
+  }
+
+  if (status === "anon") {
+    return <LoginPage />;
+  }
+
+  return <>{children}</>;
+}

--- a/webui/src/auth/AuthGate.tsx
+++ b/webui/src/auth/AuthGate.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { useAuth } from "@/auth/AuthContext";
 import { LoginPage } from "@/auth/LoginPage";
+import { SignupPage } from "@/auth/SignupPage";
 
 export function AuthGate({ children }: { children: ReactNode }) {
   const { status } = useAuth();
+  const [mode, setMode] = useState<"login" | "signup">("login");
 
   if (status === "loading") {
     return (
@@ -14,7 +16,11 @@ export function AuthGate({ children }: { children: ReactNode }) {
   }
 
   if (status === "anon") {
-    return <LoginPage />;
+    return mode === "login" ? (
+      <LoginPage onSwitchToSignup={() => setMode("signup")} />
+    ) : (
+      <SignupPage onSwitchToLogin={() => setMode("login")} />
+    );
   }
 
   return <>{children}</>;

--- a/webui/src/auth/LoginPage.tsx
+++ b/webui/src/auth/LoginPage.tsx
@@ -4,7 +4,11 @@ import { Input } from "@/components/ui/input";
 import { ApiError } from "@/lib/api";
 import { useAuth } from "@/auth/AuthContext";
 
-export function LoginPage() {
+interface LoginPageProps {
+  onSwitchToSignup?: () => void;
+}
+
+export function LoginPage({ onSwitchToSignup }: LoginPageProps = {}) {
   const { login } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -83,10 +87,19 @@ export function LoginPage() {
           {submitting ? "Signing in…" : "Sign in"}
         </Button>
 
-        <p className="text-center text-xs text-muted-foreground">
-          New users are created via the CLI (<code>nanobot user create</code>) until
-          self-serve signup ships in Slice&nbsp;B.
-        </p>
+        {onSwitchToSignup && (
+          <p className="text-center text-xs text-muted-foreground">
+            No account yet?{" "}
+            <button
+              type="button"
+              onClick={onSwitchToSignup}
+              className="font-medium underline-offset-2 hover:underline"
+              disabled={submitting}
+            >
+              Create one
+            </button>
+          </p>
+        )}
       </form>
     </div>
   );

--- a/webui/src/auth/LoginPage.tsx
+++ b/webui/src/auth/LoginPage.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ApiError } from "@/lib/api";
+import { useAuth } from "@/auth/AuthContext";
+
+export function LoginPage() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      await login(email.trim(), password);
+    } catch (err) {
+      const msg =
+        err instanceof ApiError ? err.message : "Could not sign in. Please try again.";
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm"
+      >
+        <div>
+          <h1 className="text-xl font-semibold">Sign in to nanobot</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Enter your account email and password.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="auth-email">
+            Email
+          </label>
+          <Input
+            id="auth-email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            disabled={submitting}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="auth-password">
+            Password
+          </label>
+          <Input
+            id="auth-password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            disabled={submitting}
+          />
+        </div>
+
+        {error && (
+          <p
+            role="alert"
+            className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" className="w-full" disabled={submitting}>
+          {submitting ? "Signing in…" : "Sign in"}
+        </Button>
+
+        <p className="text-center text-xs text-muted-foreground">
+          New users are created via the CLI (<code>nanobot user create</code>) until
+          self-serve signup ships in Slice&nbsp;B.
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/webui/src/auth/SignupPage.tsx
+++ b/webui/src/auth/SignupPage.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ApiError } from "@/lib/api";
+import { useAuth } from "@/auth/AuthContext";
+
+const MIN_PASSWORD_LEN = 12;
+
+interface SignupPageProps {
+  onSwitchToLogin: () => void;
+}
+
+export function SignupPage({ onSwitchToLogin }: SignupPageProps) {
+  const { signup } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    if (password.length < MIN_PASSWORD_LEN) {
+      setError(`Password must be at least ${MIN_PASSWORD_LEN} characters.`);
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await signup(email.trim(), password, displayName);
+    } catch (err) {
+      const msg =
+        err instanceof ApiError ? err.message : "Could not sign up. Please try again.";
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm"
+      >
+        <div>
+          <h1 className="text-xl font-semibold">Create your nanobot account</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Sign up to chat with your own isolated nanobot workspace.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="signup-email">
+            Email
+          </label>
+          <Input
+            id="signup-email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            disabled={submitting}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="signup-name">
+            Display name <span className="text-muted-foreground">(optional)</span>
+          </label>
+          <Input
+            id="signup-name"
+            type="text"
+            autoComplete="name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            disabled={submitting}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="signup-password">
+            Password
+          </label>
+          <Input
+            id="signup-password"
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={MIN_PASSWORD_LEN}
+            disabled={submitting}
+          />
+          <p className="text-xs text-muted-foreground">
+            At least {MIN_PASSWORD_LEN} characters.
+          </p>
+        </div>
+
+        {error && (
+          <p
+            role="alert"
+            className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" className="w-full" disabled={submitting}>
+          {submitting ? "Creating account…" : "Create account"}
+        </Button>
+
+        <p className="text-center text-xs text-muted-foreground">
+          Already have an account?{" "}
+          <button
+            type="button"
+            onClick={onSwitchToLogin}
+            className="font-medium underline-offset-2 hover:underline"
+            disabled={submitting}
+          >
+            Sign in
+          </button>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   Menu,
   Search,
   Settings,
+  Shield,
   SquarePen,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -24,6 +25,7 @@ interface SidebarProps {
   onSelect: (key: string) => void;
   onRequestDelete: (key: string, label: string) => void;
   onOpenSettings: () => void;
+  onOpenAdmin?: () => void;
   onCollapse: () => void;
 }
 
@@ -129,6 +131,18 @@ export function Sidebar(props: SidebarProps) {
           <Settings className="h-3.5 w-3.5" aria-hidden />
           {t("sidebar.settings")}
         </Button>
+        {user?.role === "admin" && props.onOpenAdmin && (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={props.onOpenAdmin}
+            className="h-8 w-full justify-start gap-2 rounded-full px-2.5 text-[12.5px] font-medium text-sidebar-foreground/85 hover:bg-sidebar-accent/75 hover:text-sidebar-foreground"
+            data-testid="sidebar-admin"
+          >
+            <Shield className="h-3.5 w-3.5" aria-hidden />
+            Users
+          </Button>
+        )}
         {user && (
           <div
             className="flex items-center gap-2 rounded-full px-2.5 py-1.5"

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import {
+  LogOut,
   Menu,
   Search,
   Settings,
@@ -7,6 +8,7 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
+import { useAuth } from "@/auth/AuthContext";
 import { ChatList } from "@/components/ChatList";
 import { ConnectionBadge } from "@/components/ConnectionBadge";
 import { Button } from "@/components/ui/button";
@@ -27,7 +29,9 @@ interface SidebarProps {
 
 export function Sidebar(props: SidebarProps) {
   const { t } = useTranslation();
+  const { user, logout } = useAuth();
   const [query, setQuery] = useState("");
+  const displayLabel = user?.display_name?.trim() || user?.email || "";
   const normalizedQuery = query.trim().toLowerCase();
   const filteredSessions = useMemo(() => {
     if (!normalizedQuery) return props.sessions;
@@ -125,6 +129,30 @@ export function Sidebar(props: SidebarProps) {
           <Settings className="h-3.5 w-3.5" aria-hidden />
           {t("sidebar.settings")}
         </Button>
+        {user && (
+          <div
+            className="flex items-center gap-2 rounded-full px-2.5 py-1.5"
+            data-testid="sidebar-user"
+          >
+            <span
+              className="flex-1 truncate text-[12.5px] font-medium text-sidebar-foreground/85"
+              title={displayLabel}
+            >
+              {displayLabel}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => void logout()}
+              className="h-7 w-7 rounded-full text-sidebar-foreground/70 hover:bg-sidebar-accent/75 hover:text-sidebar-foreground"
+              aria-label="Sign out"
+              title="Sign out"
+            >
+              <LogOut className="h-3.5 w-3.5" aria-hidden />
+            </Button>
+          </div>
+        )}
         <ConnectionBadge />
       </div>
     </nav>

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -227,6 +227,23 @@ export async function authLogin(
   return data.user;
 }
 
+export async function authSignup(
+  email: string,
+  password: string,
+  displayName?: string,
+  base: string = "",
+): Promise<AuthUser> {
+  const body: Record<string, string> = { email, password };
+  if (displayName && displayName.trim()) {
+    body.display_name = displayName.trim();
+  }
+  const data = await authFetch<{ user: AuthUser }>(`${base}/auth/signup`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  return data.user;
+}
+
 export async function authLogout(base: string = ""): Promise<void> {
   await authFetch<{ ok: boolean }>(`${base}/auth/logout`, { method: "POST" });
 }

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -182,16 +182,33 @@ export interface AuthUser {
   role: "user" | "admin";
 }
 
+function readCookie(name: string): string {
+  if (typeof document === "undefined") return "";
+  const prefix = `${name}=`;
+  for (const part of document.cookie.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(prefix)) return trimmed.slice(prefix.length);
+  }
+  return "";
+}
+
 async function authFetch<T>(
   url: string,
   init?: RequestInit,
 ): Promise<T> {
+  const method = (init?.method ?? "GET").toUpperCase();
+  const stateChanging = method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(init?.headers as Record<string, string> | undefined ?? {}),
+  };
+  if (stateChanging) {
+    const csrf = readCookie("nanobot_csrf");
+    if (csrf) headers["X-CSRF-Token"] = csrf;
+  }
   const res = await fetch(url, {
     ...(init ?? {}),
-    headers: {
-      "Content-Type": "application/json",
-      ...(init?.headers ?? {}),
-    },
+    headers,
     credentials: "include",
   });
   let payload: unknown = null;

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -168,3 +168,65 @@ export async function updateProviderSettings(
     token,
   );
 }
+
+// ---------------------------------------------------------------------------
+// WebUI auth: cookie-based login/logout/me. These endpoints live on the
+// gateway port (default 18790) — the vite dev proxy rewrites ``/auth/*`` to
+// that target, so the same relative paths work in dev and prod.
+// ---------------------------------------------------------------------------
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  display_name: string | null;
+  role: "user" | "admin";
+}
+
+async function authFetch<T>(
+  url: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(url, {
+    ...(init ?? {}),
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    credentials: "include",
+  });
+  let payload: unknown = null;
+  try {
+    payload = await res.json();
+  } catch {
+    payload = null;
+  }
+  if (!res.ok) {
+    const message =
+      typeof payload === "object" && payload && "error" in payload
+        ? String((payload as { error: unknown }).error)
+        : `HTTP ${res.status}`;
+    throw new ApiError(res.status, message);
+  }
+  return payload as T;
+}
+
+export async function authMe(base: string = ""): Promise<AuthUser> {
+  const data = await authFetch<{ user: AuthUser }>(`${base}/auth/me`);
+  return data.user;
+}
+
+export async function authLogin(
+  email: string,
+  password: string,
+  base: string = "",
+): Promise<AuthUser> {
+  const data = await authFetch<{ user: AuthUser }>(`${base}/auth/login`, {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  return data.user;
+}
+
+export async function authLogout(base: string = ""): Promise<void> {
+  await authFetch<{ ok: boolean }>(`${base}/auth/logout`, { method: "POST" });
+}

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -247,3 +247,54 @@ export async function authSignup(
 export async function authLogout(base: string = ""): Promise<void> {
   await authFetch<{ ok: boolean }>(`${base}/auth/logout`, { method: "POST" });
 }
+
+// ---------------------------------------------------------------------------
+// Admin
+// ---------------------------------------------------------------------------
+
+export interface AdminUserRow {
+  id: string;
+  email: string;
+  role: "user" | "admin";
+  display_name: string | null;
+  created_at: number;
+  last_login_at: number | null;
+  disabled: boolean;
+}
+
+export async function adminListUsers(base: string = ""): Promise<AdminUserRow[]> {
+  const data = await authFetch<{ users: AdminUserRow[] }>(`${base}/admin/users`);
+  return data.users;
+}
+
+export async function adminSetRole(
+  userId: string,
+  role: "user" | "admin",
+  base: string = "",
+): Promise<AdminUserRow> {
+  const data = await authFetch<{ user: AdminUserRow }>(
+    `${base}/admin/users/${userId}/role`,
+    { method: "POST", body: JSON.stringify({ role }) },
+  );
+  return data.user;
+}
+
+export async function adminSetDisabled(
+  userId: string,
+  disabled: boolean,
+  base: string = "",
+): Promise<void> {
+  await authFetch<{ ok: boolean }>(`${base}/admin/users/${userId}/disabled`, {
+    method: "POST",
+    body: JSON.stringify({ disabled }),
+  });
+}
+
+export async function adminDeleteUser(
+  userId: string,
+  base: string = "",
+): Promise<void> {
+  await authFetch<{ ok: boolean }>(`${base}/admin/users/${userId}`, {
+    method: "DELETE",
+  });
+}

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import App from "./App";
+import { AuthGate } from "./auth/AuthGate";
+import { AuthProvider } from "./auth/AuthContext";
 import "./globals.css";
 import "./i18n";
 
@@ -10,6 +12,10 @@ if (!root) throw new Error("root element missing");
 
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <AuthGate>
+        <App />
+      </AuthGate>
+    </AuthProvider>
   </React.StrictMode>,
 );

--- a/webui/src/tests/admin-users-page.test.tsx
+++ b/webui/src/tests/admin-users-page.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { AdminUsersPage } from "@/admin/AdminUsersPage";
+import { AuthProvider } from "@/auth/AuthContext";
+
+const adminUser = {
+  user: { id: "01AAA", email: "admin@x", display_name: null, role: "admin" },
+};
+const userList = (rows: object[]) => ({ users: rows });
+const noop = () => {};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface RouteMap {
+  "/auth/me"?: Response;
+  "/admin/users"?: Response[];
+  /** Sequential responses for any URL containing this substring. */
+  match?: { pattern: string; responses: Response[] }[];
+}
+
+function mockRoutes(routes: RouteMap) {
+  const adminUsersQueue = [...(routes["/admin/users"] ?? [])];
+  const matchQueues = (routes.match ?? []).map((m) => ({ ...m, queue: [...m.responses] }));
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.includes("/auth/me")) {
+      return routes["/auth/me"]?.clone() ?? new Response("{}", { status: 401 });
+    }
+    for (const m of matchQueues) {
+      if (url.includes(m.pattern) && m.queue.length > 0) {
+        return m.queue.shift()!;
+      }
+    }
+    if (url.endsWith("/admin/users") && adminUsersQueue.length > 0) {
+      return adminUsersQueue.shift()!;
+    }
+    return new Response("{}", { status: 500 });
+  });
+}
+
+beforeEach(() => vi.restoreAllMocks());
+
+const ROW_ADMIN = { id: "01AAA", email: "admin@x", role: "admin" as const, display_name: null, created_at: 1, last_login_at: 2, disabled: false };
+const ROW_ALICE = { id: "01BBB", email: "alice@x", role: "user" as const, display_name: "Alice", created_at: 3, last_login_at: null, disabled: false };
+
+describe("AdminUsersPage", () => {
+  it("renders the user list returned by /admin/users", async () => {
+    mockRoutes({
+      "/auth/me": jsonResponse(adminUser),
+      "/admin/users": [jsonResponse(userList([ROW_ADMIN, ROW_ALICE]))],
+    });
+    render(
+      <AuthProvider>
+        <AdminUsersPage onBack={noop} />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("admin-users-table")).toBeInTheDocument());
+    expect(screen.getByTestId("row-alice@x").textContent).toContain("alice@x");
+    expect(screen.getByTestId("row-alice@x").textContent).toContain("user");
+  });
+
+  it("surfaces API errors", async () => {
+    mockRoutes({
+      "/auth/me": jsonResponse(adminUser),
+      "/admin/users": [jsonResponse({ error: "forbidden" }, 403)],
+    });
+    render(
+      <AuthProvider>
+        <AdminUsersPage onBack={noop} />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("forbidden"));
+  });
+
+  it("promote click fires POST /admin/users/:id/role and refreshes", async () => {
+    const fetchMock = mockRoutes({
+      "/auth/me": jsonResponse(adminUser),
+      "/admin/users": [
+        jsonResponse(userList([ROW_ADMIN, ROW_ALICE])),
+        jsonResponse(userList([ROW_ADMIN, { ...ROW_ALICE, role: "admin" }])),
+      ],
+      match: [
+        {
+          pattern: "/admin/users/01BBB/role",
+          responses: [jsonResponse({ user: { ...ROW_ALICE, role: "admin" } })],
+        },
+      ],
+    });
+    render(
+      <AuthProvider>
+        <AdminUsersPage onBack={noop} />
+      </AuthProvider>,
+    );
+    const row = await screen.findByTestId("row-alice@x");
+    await act(async () => {
+      row.querySelector<HTMLButtonElement>("button:nth-of-type(1)")?.click();
+    });
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([url]) => String(url).includes("/admin/users/01BBB/role"));
+      expect(call).toBeTruthy();
+      expect(JSON.parse(String(call?.[1]?.body))).toEqual({ role: "admin" });
+    });
+  });
+
+  it("delete shows a confirm dialog before firing DELETE", async () => {
+    const fetchMock = mockRoutes({
+      "/auth/me": jsonResponse(adminUser),
+      "/admin/users": [
+        jsonResponse(userList([ROW_ADMIN, ROW_ALICE])),
+        jsonResponse(userList([ROW_ADMIN])),
+      ],
+      match: [
+        { pattern: "/admin/users/01BBB", responses: [jsonResponse({ ok: true })] },
+      ],
+    });
+    render(
+      <AuthProvider>
+        <AdminUsersPage onBack={noop} />
+      </AuthProvider>,
+    );
+    const row = await screen.findByTestId("row-alice@x");
+    await act(async () => {
+      const buttons = row.querySelectorAll<HTMLButtonElement>("button");
+      buttons[buttons.length - 1].click();
+    });
+    expect(screen.getByRole("dialog").textContent).toContain("Delete user?");
+    await act(async () => {
+      const dialogButtons = screen.getByRole("dialog").querySelectorAll<HTMLButtonElement>("button");
+      dialogButtons[dialogButtons.length - 1].click();
+    });
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          String(url).includes("/admin/users/01BBB") &&
+          (init as { method?: string } | undefined)?.method === "DELETE",
+      );
+      expect(call).toBeTruthy();
+    });
+  });
+
+  it("disables self-row actions to prevent operator lockout", async () => {
+    mockRoutes({
+      "/auth/me": jsonResponse(adminUser),
+      "/admin/users": [jsonResponse(userList([ROW_ADMIN]))],
+    });
+    render(
+      <AuthProvider>
+        <AdminUsersPage onBack={noop} />
+      </AuthProvider>,
+    );
+    const row = await screen.findByTestId("row-admin@x");
+    const actionButtons = row.querySelectorAll<HTMLButtonElement>("button");
+    for (const btn of actionButtons) {
+      expect(btn.disabled).toBe(true);
+    }
+  });
+});

--- a/webui/src/tests/auth-context.test.tsx
+++ b/webui/src/tests/auth-context.test.tsx
@@ -11,6 +11,17 @@ function Probe() {
       <button onClick={() => void auth.login("a@b.com", "pwd-long-enough-1234")}>
         login
       </button>
+      <button
+        onClick={() =>
+          void auth
+            .signup("new@b.com", "pwd-long-enough-1234", "New")
+            .catch(() => {
+              /* swallow for tests */
+            })
+        }
+      >
+        signup
+      </button>
       <button onClick={() => void auth.logout()}>logout</button>
     </div>
   );
@@ -84,6 +95,63 @@ describe("AuthContext", () => {
     // Confirm credentials propagated.
     const loginCall = fetchMock.mock.calls.find(([url]) => String(url).includes("/auth/login"));
     expect(loginCall?.[1]).toMatchObject({ credentials: "include" });
+  });
+
+  it("signup() flips to authed and hits POST /auth/signup with display_name", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response("{}", { status: 401, headers: { "Content-Type": "application/json" } }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { id: "01XYZ", email: "new@b.com", display_name: "New", role: "user" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("anon"));
+    await act(async () => {
+      screen.getByText("signup").click();
+    });
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("authed"));
+    expect(screen.getByTestId("email").textContent).toBe("new@b.com");
+    const signupCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("/auth/signup"),
+    );
+    expect(signupCall?.[1]).toMatchObject({ method: "POST", credentials: "include" });
+    const body = JSON.parse(String(signupCall?.[1]?.body));
+    expect(body).toEqual({ email: "new@b.com", password: "pwd-long-enough-1234", display_name: "New" });
+  });
+
+  it("signup() with duplicate email surfaces a 409 ApiError without changing state", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response("{}", { status: 401, headers: { "Content-Type": "application/json" } }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "email already registered" }), {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("anon"));
+    await act(async () => {
+      screen.getByText("signup").click();
+    });
+    // Status stays anon because the API call rejected.
+    expect(screen.getByTestId("status").textContent).toBe("anon");
   });
 
   it("logout() drops to anon even if the network call fails", async () => {

--- a/webui/src/tests/auth-context.test.tsx
+++ b/webui/src/tests/auth-context.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { AuthProvider, useAuth } from "@/auth/AuthContext";
+
+function Probe() {
+  const auth = useAuth();
+  return (
+    <div>
+      <span data-testid="status">{auth.status}</span>
+      <span data-testid="email">{auth.user?.email ?? "<none>"}</span>
+      <button onClick={() => void auth.login("a@b.com", "pwd-long-enough-1234")}>
+        login
+      </button>
+      <button onClick={() => void auth.logout()}>logout</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AuthContext", () => {
+  it("starts in loading then anon on 401 from /auth/me", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "unauthenticated" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    expect(screen.getByTestId("status").textContent).toBe("loading");
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("anon"));
+  });
+
+  it("transitions to authed when /auth/me returns a user", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          user: { id: "01ABC", email: "a@b.com", display_name: null, role: "user" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("authed"));
+    expect(screen.getByTestId("email").textContent).toBe("a@b.com");
+  });
+
+  it("login() flips status to authed and exposes the returned user", async () => {
+    // First call (/auth/me) is 401, second call (/auth/login) is 200.
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response("{}", { status: 401, headers: { "Content-Type": "application/json" } }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { id: "01ABC", email: "c@d.com", display_name: null, role: "user" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("anon"));
+    await act(async () => {
+      screen.getByText("login").click();
+    });
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("authed"));
+    expect(screen.getByTestId("email").textContent).toBe("c@d.com");
+    // Confirm credentials propagated.
+    const loginCall = fetchMock.mock.calls.find(([url]) => String(url).includes("/auth/login"));
+    expect(loginCall?.[1]).toMatchObject({ credentials: "include" });
+  });
+
+  it("logout() drops to anon even if the network call fails", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { id: "01ABC", email: "a@b.com", display_name: null, role: "user" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockRejectedValueOnce(new Error("offline"));
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("authed"));
+    await act(async () => {
+      screen.getByText("logout").click();
+    });
+    await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("anon"));
+  });
+});

--- a/webui/src/tests/setup.ts
+++ b/webui/src/tests/setup.ts
@@ -16,6 +16,38 @@ if (!("randomUUID" in globalThis.crypto)) {
   });
 }
 
+// Bun's test runtime injects its own ``localStorage`` stub before happy-dom
+// can install a working one, so we override both ``window.localStorage`` and
+// ``globalThis.localStorage`` with a minimal in-memory Storage implementation
+// so ``getItem``/``setItem`` are real functions in tests.
+const installStorageShim = () => {
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => (store.has(key) ? (store.get(key) as string) : null),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(String(key), String(value));
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    value: shim,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    value: shim,
+    configurable: true,
+  });
+};
+
+installStorageShim();
+
 beforeEach(async () => {
   await i18n.changeLanguage("en");
   document.documentElement.lang = "en";

--- a/webui/src/tests/sidebar-auth.test.tsx
+++ b/webui/src/tests/sidebar-auth.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { AuthProvider } from "@/auth/AuthContext";
+
+// ConnectionBadge depends on the WS client provider which isn't relevant
+// here; stub it so we can render the Sidebar in isolation.
+vi.mock("@/components/ConnectionBadge", () => ({
+  ConnectionBadge: () => null,
+}));
+
+import { Sidebar } from "@/components/Sidebar";
+
+const noop = () => {};
+
+function renderWithAuth(meResponse: Response) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(meResponse);
+  return render(
+    <AuthProvider>
+      <Sidebar
+        sessions={[]}
+        activeKey={null}
+        loading={false}
+        onNewChat={noop}
+        onSelect={noop}
+        onRequestDelete={noop}
+        onOpenSettings={noop}
+        onCollapse={noop}
+      />
+    </AuthProvider>,
+  );
+}
+
+describe("Sidebar — auth footer", () => {
+  it("shows display_name when authed", async () => {
+    renderWithAuth(
+      new Response(
+        JSON.stringify({
+          user: { id: "01ABC", email: "a@b.com", display_name: "Alice", role: "user" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    // Wait one microtask for /auth/me to resolve.
+    await act(async () => {});
+    const row = await screen.findByTestId("sidebar-user");
+    expect(row.textContent).toContain("Alice");
+    expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
+  });
+
+  it("falls back to email when display_name is null", async () => {
+    renderWithAuth(
+      new Response(
+        JSON.stringify({
+          user: { id: "01ABC", email: "fallback@b.com", display_name: null, role: "user" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    await act(async () => {});
+    const row = await screen.findByTestId("sidebar-user");
+    expect(row.textContent).toContain("fallback@b.com");
+  });
+
+  it("hides the user row when /auth/me returns 401", async () => {
+    renderWithAuth(
+      new Response("{}", { status: 401, headers: { "Content-Type": "application/json" } }),
+    );
+    await act(async () => {});
+    expect(screen.queryByTestId("sidebar-user")).toBeNull();
+  });
+});

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig(({ mode }) => {
         "/webui": { target, changeOrigin: true },
         "/api": { target, changeOrigin: true },
         "/auth": { target: authTarget, changeOrigin: true },
+        "/admin": { target: authTarget, changeOrigin: true },
         // Forward only WebSocket upgrades on ``/`` to the nanobot gateway;
         // plain HTTP GETs on ``/`` must stay with Vite so it can serve the SPA.
         // ``bypass`` returning the original URL skips the proxy for that

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -6,6 +6,9 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const target = env.NANOBOT_API_URL ?? "http://127.0.0.1:8765";
   const wsTarget = target.replace(/^http/, "ws");
+  // /auth/* lives on the gateway port (default 18790), separate from the
+  // WS channel (8765) that serves /webui, /api, and the WS upgrade.
+  const authTarget = env.NANOBOT_AUTH_URL ?? "http://127.0.0.1:18790";
 
   return {
     plugins: [react()],
@@ -41,7 +44,7 @@ export default defineConfig(({ mode }) => {
       proxy: {
         "/webui": { target, changeOrigin: true },
         "/api": { target, changeOrigin: true },
-        "/auth": { target, changeOrigin: true },
+        "/auth": { target: authTarget, changeOrigin: true },
         // Forward only WebSocket upgrades on ``/`` to the nanobot gateway;
         // plain HTTP GETs on ``/`` must stay with Vite so it can serve the SPA.
         // ``bypass`` returning the original URL skips the proxy for that


### PR DESCRIPTION
## Summary

Converts nanobot from single-tenant (`~/.nanobot/`) to multi-user. One shared gateway serves many users; per-user state isolates under `~/.nanobot/users/<ulid>/`. Chat channels (Telegram/Slack/Discord/etc.) remain admin-scoped in v1 — only the WebUI is per-user.

- **Auth**: email + password (argon2id), HttpOnly `nanobot_session` cookie, SameSite=Lax, Secure when `X-Forwarded-Proto: https`. CSRF: double-submit `nanobot_csrf` cookie + `X-CSRF-Token` header on state-changing requests. Rate-limit 5/min/IP on `/auth/login`, 3/min/IP on `/auth/signup`.
- **Per-user isolation**: a `current_user_ctx: ContextVar` is set by `AgentLoop._dispatch` and consulted by `_FsTool`, `ExecTool`, `SessionManager`, `ContextBuilder.memory`, `ContextBuilder.skills`, `FileStateStore`, and the WS media uploader to rebase paths under `users/<uid>/`.
- **Admin**: `nanobot user list/create/promote/demote/reset-password/disable/delete` CLI + role-gated `/admin/users` HTTP routes + WebUI admin page. Self-delete blocked.
- **Legacy migration**: on gateway startup, if the host has pre-Slice-A state (`sessions/`/`workspace/`/`memory/` directly under `~/.nanobot`), the whole tree is archived to `~/.nanobot.legacy.<UTC-ISO>/` (loud warning + rollback command logged). Skip with `NANOBOT_SKIP_LEGACY_MIGRATION=1`.

Plan & ledger in `tasks/plan.md` and `tasks/todo.md`. Operator surface + threat model in `docs/auth.md`.

### Commits

| Slice | Commit | Scope |
|---|---|---|
| A | `3ab43cc` | Cookie auth + per-user session isolation |
| B | `5fc894d` | Signup + rate limit + logout UI + multi-user tests |
| C | `1abfd08` | Per-user tools, memory, media, file-state |
| D | `8e5152c` | Admin CLI + role-gated admin routes + admin page |
| E | `8507524` | Legacy migration + CSRF + docs |
| Hardening | `2690526` | Post-review fixes (Consolidator/AutoCompact routing, argon2 dummy hash, XFF, bucket GC, archive perms, FS allowed_dir rebind, WS Origin, dual-logout) |

### Verification

- `pytest tests/` — **2825 pass / 5 skip / 0 fail** (101 new auth tests + 14 new vitest cases)
- `cd webui && bun run test` — **94 pass**
- `bun run build` — clean
- `ruff check` — clean on every touched file
- Live HTTP smoke through the vite proxy: signup → 200 + cookie, duplicate → 409, /me → 200, /admin/users with admin → 200, with regular user → 403, rate-limit kicks in on 6th login.
- Live WS smoke: cookie-auth → /dispatch → message → session file lands under `users/<uid>/sessions/`, no leak to legacy paths.

### Post-review hardening

Two reviewers (correctness + security) ran before merge. Blockers fixed in commit `2690526`:

- **Correctness**: AutoCompact / Consolidator / webui title generator were binding every per-user save through the global SessionManager. Threaded `sessions` kwarg through all five paths.
- **Correctness**: `SessionManager._load` legacy fallback could let one user adopt a leftover global session — disabled when `user_ctx` is set.
- **Security**: `_DUMMY_HASH` in `verify_password` was an unparseable literal (~0.03 ms reject vs ~63 ms real verify) — replaced with a real argon2id hash. Email enumeration timing oracle closed. Regression test asserts the verify raises `VerifyMismatchError` only.
- **Security**: `NANOBOT_TRUST_PROXY_HEADERS=1` opt-in for X-Forwarded-For (otherwise rate-limit / audit are useless behind a reverse proxy).
- **Security**: `RateLimiter` sweeps stale buckets every 256 calls / 50k entries cap — IPv6-rotating memory-DoS closed.
- **Security**: Migration archive + base + `auth.db` get chmod 0o700 / 0o600 — shared-host hash exposure closed.
- **Security**: `_FsTool` rebinds `allowed_dir` to user workspace under a UserContext regardless of `restrict_to_workspace` — authenticated user can no longer read `/etc/passwd` on a permissive loop.
- **Security**: WS handshake requires `Origin == Host` when cookie-auth is honored — closes cross-origin WS hijack.
- **Security**: App.tsx `handleLogout` now calls `authLogout` — closes the dual-logout gap where the cookie outlived the Settings → logout click.

## Known limitations (deferred — see `docs/auth.md` "Known Limitations")

- No SSO / OAuth (Google, GitHub, magic-link).
- No email verification, no self-serve password reset (admin uses CLI reset).
- Per-user channels (Telegram/Slack/Discord) — admin-scoped in v1.
- No per-user BYOK LLM keys.
- Per-user cron + per-user MCP allowlist.
- Dream consolidation is a global cron in v1.
- Signed media URLs not user-bound (per-user uploads land in distinct dirs; HMAC forge required for cross-user fetch).
- `image_generation` / `message` tools still bind to gateway workspace.
- `AuthService.set_role/set_disabled/delete_user` methods unwritten — both CLI and routes reach `svc._conn` directly. Refactor PR will follow.
- WS connection auth not re-checked mid-stream after logout/disable.
- Security headers (CSP, HSTS, X-Frame-Options) not yet set.
- Audit log has no UI (rows are in `auth.db.audit_log`).

## Test plan

- [ ] CI green on this PR.
- [ ] Reviewer pulls the branch and runs `pytest tests/auth/` (101 tests) locally.
- [ ] Reviewer creates a test user via `nanobot user create reviewer@x --role admin`, logs in via the webui, sends a chat message, verifies the session file lands under `~/.nanobot/users/<uid>/sessions/`.
- [ ] Reviewer creates a second non-admin account, verifies it can't reach `/admin/users` (403).
- [ ] Reviewer hits `/auth/login` six times rapidly and verifies the 6th returns 429.
- [ ] Reviewer reads `docs/auth.md` end-to-end and signs off on the documented threat model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)