### PR TITLE
feat: add Atomic Chat as OpenAI-compatible local LLM provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,7 @@ IMAP_PASSWORD=your-password-here
 | `longcat` | LLM (LongCat) | [longcat.chat](https://longcat.chat/platform/docs/zh/) |
 | `ollama` | LLM (local, Ollama) | — |
 | `lm_studio` | LLM (local, LM Studio) | — |
+| `atomic_chat` | LLM (local, [Atomic Chat](https://atomic.chat/)) | — |
 | `mistral` | LLM | [docs.mistral.ai](https://docs.mistral.ai/) |
 | `stepfun` | LLM (Step Fun/阶跃星辰) | [platform.stepfun.com](https://platform.stepfun.com) |
 | `ovms` | LLM (local, OpenVINO Model Server) | [docs.openvino.ai](https://docs.openvino.ai/2026/model-server/ovms_docs_llm_quickstart.html) |
@@ -499,6 +500,36 @@ ollama run llama3.2
 
 > **Note:** Set `apiKey` to `null` for LM Studio since it runs locally and doesn't require authentication. The model name should match what's shown in the LM Studio UI.
 > `provider: "auto"` also works when `providers.lm_studio.apiBase` is configured, but setting `"provider": "lm_studio"` is the clearest option.
+
+</details>
+
+<details>
+<summary><b>Atomic Chat (local)</b></summary>
+
+[Atomic Chat](https://atomic.chat/) is a local-first desktop app that exposes an **OpenAI-compatible** HTTP API (default `http://localhost:1337/v1`). Start Atomic Chat and enable the local API server, then point nanobot at it.
+
+**1. Add to config** (partial — merge into `~/.nanobot/config.json`):
+
+```json
+{
+  "providers": {
+    "atomic_chat": {
+      "apiKey": null,
+      "apiBase": "http://localhost:1337/v1"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "provider": "atomic_chat",
+      "model": "your-model-id-from-atomic-chat"
+    }
+  }
+}
+```
+
+> **Note:** Set `apiKey` to `null` if your Atomic Chat server does not require a key. If it does, set `apiKey` (or the `ATOMIC_CHAT_API_KEY` environment variable) to the value Atomic Chat expects. The `model` string must match the model id Atomic Chat exposes on its OpenAI-compatible endpoint.
+
+> `provider: "auto"` also works when `providers.atomic_chat.apiBase` is configured, but setting `"provider": "atomic_chat"` is the clearest option.
 
 </details>
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -153,6 +153,7 @@ class ProvidersConfig(Base):
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     ollama: ProviderConfig = Field(default_factory=ProviderConfig)  # Ollama local models
     lm_studio: ProviderConfig = Field(default_factory=ProviderConfig)  # LM Studio local models
+    atomic_chat: ProviderConfig = Field(default_factory=ProviderConfig)  # Atomic Chat local models
     ovms: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenVINO Model Server (OVMS)
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
     moonshot: ProviderConfig = Field(default_factory=ProviderConfig)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -420,6 +420,17 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_base_keyword="1234",
         default_api_base="http://localhost:1234/v1",
     ),
+    # Atomic Chat (local, OpenAI-compatible) — https://atomic.chat/
+    ProviderSpec(
+        name="atomic_chat",
+        keywords=("atomic-chat", "atomic_chat", "atomicchat"),
+        env_key="ATOMIC_CHAT_API_KEY",
+        display_name="Atomic Chat",
+        backend="openai_compat",
+        is_local=True,
+        detect_by_base_keyword="1337",
+        default_api_base="http://localhost:1337/v1",
+    ),
     # === OpenVINO Model Server (direct, local, OpenAI-compatible at /v3) ===
     ProviderSpec(
         name="ovms",

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -371,6 +371,28 @@ def test_config_accepts_lm_studio_without_api_key_and_uses_default_localhost_api
     assert config.get_api_base() == "http://localhost:1234/v1"
 
 
+def test_config_accepts_atomic_chat_without_api_key_and_uses_default_localhost_api_base():
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {
+                    "provider": "atomic_chat",
+                    "model": "local-model",
+                }
+            },
+            "providers": {
+                "atomicChat": {
+                    "apiKey": None,
+                }
+            },
+        }
+    )
+
+    assert config.get_provider_name() == "atomic_chat"
+    assert config.get_api_key() is None
+    assert config.get_api_base() == "http://localhost:1337/v1"
+
+
 def test_find_by_name_accepts_camel_case_and_hyphen_aliases():
     assert find_by_name("volcengineCodingPlan") is not None
     assert find_by_name("volcengineCodingPlan").name == "volcengine_coding_plan"
@@ -378,6 +400,8 @@ def test_find_by_name_accepts_camel_case_and_hyphen_aliases():
     assert find_by_name("github-copilot").name == "github_copilot"
     assert find_by_name("longcat") is not None
     assert find_by_name("longcat").name == "longcat"
+    assert find_by_name("atomic-chat") is not None
+    assert find_by_name("atomic-chat").name == "atomic_chat"
 
 
 def test_config_explicit_longcat_provider_resolves_provider_name():


### PR DESCRIPTION
## Summary

Adds first-class support for [Atomic Chat](https://atomic.chat/) as a local OpenAI-compatible LLM backend (same pattern as LM Studio / Ollama).

## Changes

- Register `atomic_chat` in `nanobot/providers/registry.py`:
  - `default_api_base`: `http://localhost:1337/v1`
  - `is_local=True`, `backend=openai_compat`
  - Keywords: `atomic-chat`, `atomic_chat`, `atomicchat`
  - Env var for API key: `ATOMIC_CHAT_API_KEY`
  - `detect_by_base_keyword="1337"` for `apiBase`-based auto routing when `provider` is `auto`
- Add `providers.atomic_chat` to `nanobot/config/schema.py` (`ProvidersConfig`)
- Document usage in `docs/configuration.md` (provider table + collapsible section with sample `config.json`)
- Add tests in `tests/cli/test_commands.py` for default `apiBase` and `find_by_name("atomic-chat")`

## Example config

```json
{
  "providers": {
    "atomic_chat": {
      "apiKey": null,
      "apiBase": "http://localhost:1337/v1"
    }
  },
  "agents": {
    "defaults": {
      "provider": "atomic_chat",
      "model": "<model-id-from-atomic-chat>"
    }
  }
}
```
(model must match the id exposed by Atomic Chat’s OpenAI-compatible API; set apiKey / ATOMIC_CHAT_API_KEY if the local server requires it.)

## Testing
 pytest tests/cli/test_commands.py -k "atomic_chat or find_by_name" (not run in CI-less agent environment; please run locally with Python ≥ 3.11)
 
##  Notes
No new runtime dependencies.
Follows the existing “add ProviderSpec + ProvidersConfig field + docs” provider checklist from the README.
