### PR TITLE
fix: clear media_paths after successful voice transcription

### DIFF
--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -265,6 +265,7 @@ class WhatsAppChannel(BaseChannel):
                     transcription = await self.transcribe_audio(media_paths[0])
                     if transcription:
                         content = transcription
+                        media_paths = []
                         self.logger.info("Transcribed voice from {}: {}...", sender_id, transcription[:50])
                     else:
                         content = "[Voice Message: Transcription failed]"


### PR DESCRIPTION
After transcribing a WhatsApp voice message, the .ogg file path remains in media_paths and gets appended as a [file: ...] tag. The LLM sees this tag and responds that it cannot process audio, even though the transcription already succeeded.