### PR TITLE
feat(whatsapp): add typing indicator and emoji reaction on inbound messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ webui/coverage/
 webui/.vite/
 *.tsbuildinfo
 
+# bridge
+bridge/node_modules
+
 # Python bytecode & caches
 *.pyc
 *.pyo

--- a/bridge/src/server.ts
+++ b/bridge/src/server.ts
@@ -21,7 +21,21 @@ interface SendMediaCommand {
   fileName?: string;
 }
 
-type BridgeCommand = SendCommand | SendMediaCommand;
+interface SendReactionCommand {
+  type: 'react';
+  to: string;
+  messageId: string;
+  emoji: string;
+  participant?: string;
+}
+
+interface SendPresenceCommand {
+  type: 'presence';
+  to: string;
+  presence: 'composing' | 'paused';
+}
+
+type BridgeCommand = SendCommand | SendMediaCommand | SendReactionCommand | SendPresenceCommand;
 
 interface BridgeMessage {
   type: 'message' | 'status' | 'qr' | 'error';
@@ -121,6 +135,10 @@ export class BridgeServer {
       await this.wa.sendMessage(cmd.to, cmd.text);
     } else if (cmd.type === 'send_media') {
       await this.wa.sendMedia(cmd.to, cmd.filePath, cmd.mimetype, cmd.caption, cmd.fileName);
+    } else if (cmd.type === 'react') {
+      await this.wa.sendReaction(cmd.to, cmd.messageId, cmd.emoji, cmd.participant);
+    } else if (cmd.type === 'presence') {
+      await this.wa.sendPresence(cmd.to, cmd.presence);
     }
   }
 

--- a/bridge/src/whatsapp.ts
+++ b/bridge/src/whatsapp.ts
@@ -29,6 +29,7 @@ export interface InboundMessage {
   content: string;
   timestamp: number;
   isGroup: boolean;
+  participant?: string;
   wasMentioned?: boolean;
   media?: string[];
 }
@@ -184,6 +185,7 @@ export class WhatsAppClient {
           content: finalContent,
           timestamp: msg.messageTimestamp as number,
           isGroup,
+          ...(isGroup && msg.key.participant ? { participant: msg.key.participant } : {}),
           ...(isGroup ? { wasMentioned } : {}),
           ...(mediaPaths.length > 0 ? { media: mediaPaths } : {}),
         });
@@ -287,6 +289,33 @@ export class WhatsAppClient {
       const name = fileName || basename(filePath);
       await this.sock.sendMessage(to, { document: buffer, mimetype, fileName: name });
     }
+  }
+
+  async sendReaction(
+    to: string,
+    messageId: string,
+    emoji: string,
+    participant?: string,
+  ): Promise<void> {
+    if (!this.sock) {
+      throw new Error('Not connected');
+    }
+    const key: { id: string; remoteJid: string; fromMe: boolean; participant?: string } = {
+      id: messageId,
+      remoteJid: to,
+      fromMe: false,
+    };
+    if (participant) {
+      key.participant = participant;
+    }
+    await this.sock.sendMessage(to, { react: { text: emoji, key } });
+  }
+
+  async sendPresence(to: string, presence: 'composing' | 'paused'): Promise<void> {
+    if (!this.sock) {
+      throw new Error('Not connected');
+    }
+    await this.sock.sendPresenceUpdate(presence, to);
   }
 
   async disconnect(): Promise<void> {

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -30,6 +30,7 @@ class WhatsAppConfig(Base):
     bridge_token: str = ""
     allow_from: list[str] = Field(default_factory=list)
     group_policy: Literal["open", "mention"] = "open"  # "open" responds to all, "mention" only when @mentioned
+    react_emoji: str = "👀"
 
 
 def _bridge_token_path() -> Path:
@@ -77,6 +78,7 @@ class WhatsAppChannel(BaseChannel):
         self._processed_message_ids: OrderedDict[str, None] = OrderedDict()
         self._lid_to_phone: dict[str, str] = {}
         self._bridge_token: str | None = None
+        self._typing_tasks: dict[str, asyncio.Task] = {}
 
     def _effective_bridge_token(self) -> str:
         """Resolve the bridge token, generating a local secret when needed."""
@@ -160,6 +162,9 @@ class WhatsAppChannel(BaseChannel):
         self._running = False
         self._connected = False
 
+        for chat_id in list(self._typing_tasks):
+            self._stop_typing(chat_id)
+
         if self._ws:
             await self._ws.close()
             self._ws = None
@@ -171,6 +176,13 @@ class WhatsAppChannel(BaseChannel):
             return
 
         chat_id = msg.chat_id
+
+        if not msg.metadata.get("_progress", False):
+            self._stop_typing(chat_id)
+            if message_id := msg.metadata.get("message_id"):
+                await self._remove_reaction(
+                    chat_id, message_id, msg.metadata.get("participant"),
+                )
 
         if msg.content:
             try:
@@ -194,6 +206,75 @@ class WhatsAppChannel(BaseChannel):
             except Exception:
                 self.logger.exception("Error sending media {}", media_path)
                 raise
+
+    def _start_typing(self, chat_id: str) -> None:
+        """Start sending composing presence for a chat."""
+        self._stop_typing(chat_id)
+        self._typing_tasks[chat_id] = asyncio.create_task(self._typing_loop(chat_id))
+
+    def _stop_typing(self, chat_id: str) -> None:
+        """Stop the composing presence for a chat."""
+        task = self._typing_tasks.pop(chat_id, None)
+        if task and not task.done():
+            task.cancel()
+
+    async def _typing_loop(self, chat_id: str) -> None:
+        """Repeatedly send composing presence until cancelled."""
+        try:
+            with suppress(asyncio.CancelledError):
+                while self._ws and self._connected:
+                    payload = {"type": "presence", "to": chat_id, "presence": "composing"}
+                    with suppress(Exception):
+                        await self._ws.send(json.dumps(payload))
+                    await asyncio.sleep(4)
+        except Exception as e:
+            self.logger.debug("Typing indicator stopped for {}: {}", chat_id, e)
+
+    async def _send_reaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+        participant: str | None = None,
+    ) -> None:
+        """Send a reaction payload through the bridge (best-effort).
+
+        For group messages, ``participant`` must be the original sender's JID
+        (from ``msg.key.participant``) so the reaction binds to the right message.
+        An empty ``emoji`` removes the bot's existing reaction on that message.
+        """
+        if not self._ws or not self._connected or not message_id:
+            return
+        try:
+            payload: dict[str, Any] = {
+                "type": "react", "to": chat_id, "messageId": message_id, "emoji": emoji,
+            }
+            if participant:
+                payload["participant"] = participant
+            await self._ws.send(json.dumps(payload))
+        except Exception as e:
+            self.logger.debug("reaction failed: {}", e)
+
+    async def _add_reaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+        participant: str | None = None,
+    ) -> None:
+        """Add an emoji reaction to a message (best-effort)."""
+        if not emoji:
+            return
+        await self._send_reaction(chat_id, message_id, emoji, participant)
+
+    async def _remove_reaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        participant: str | None = None,
+    ) -> None:
+        """Remove the bot's reaction from a message (best-effort)."""
+        await self._send_reaction(chat_id, message_id, "", participant)
 
     async def _handle_bridge_message(self, raw: str) -> None:
         """Handle a message from the bridge."""
@@ -279,6 +360,11 @@ class WhatsAppChannel(BaseChannel):
                     media_tag = f"[{media_type}: {p}]"
                     content = f"{content}\n{media_tag}" if content else media_tag
 
+            participant = data.get("participant") or None
+
+            self._start_typing(sender)
+            await self._add_reaction(sender, message_id, self.config.react_emoji, participant)
+
             await self._handle_message(
                 sender_id=sender_id,
                 chat_id=sender,  # Use full LID for replies
@@ -288,6 +374,7 @@ class WhatsAppChannel(BaseChannel):
                     "message_id": message_id,
                     "timestamp": data.get("timestamp"),
                     "is_group": data.get("isGroup", False),
+                    "participant": participant,
                 },
             )
 

--- a/tests/channels/test_whatsapp_channel.py
+++ b/tests/channels/test_whatsapp_channel.py
@@ -1,5 +1,6 @@
 """Tests for WhatsApp channel outbound media support."""
 
+import asyncio
 import json
 import os
 import sys
@@ -333,6 +334,288 @@ async def test_login_exports_effective_bridge_token(monkeypatch, tmp_path):
     assert kwargs["cwd"] == bridge_dir
     assert kwargs["env"]["AUTH_DIR"] == str(token_path.parent)
     assert kwargs["env"]["BRIDGE_TOKEN"] == token_path.read_text(encoding="utf-8")
+
+
+# ── typing indicator ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_inbound_message_starts_typing():
+    ch = WhatsAppChannel({"enabled": True, "allowFrom": ["*"]}, MagicMock())
+    ch._ws = AsyncMock()
+    ch._connected = True
+    ch._handle_message = AsyncMock()
+
+    await ch._handle_bridge_message(
+        json.dumps({
+            "type": "message",
+            "id": "t1",
+            "sender": "111@s.whatsapp.net",
+            "pn": "",
+            "content": "hello",
+            "timestamp": 1,
+        })
+    )
+
+    # A typing task must have been created for the chat
+    assert "111@s.whatsapp.net" in ch._typing_tasks
+
+
+@pytest.mark.asyncio
+async def test_send_stops_typing():
+    ch = _make_channel()
+    ch._typing_tasks["123@s.whatsapp.net"] = asyncio.create_task(asyncio.sleep(60))
+
+    msg = OutboundMessage(channel="whatsapp", chat_id="123@s.whatsapp.net", content="reply")
+    await ch.send(msg)
+
+    assert "123@s.whatsapp.net" not in ch._typing_tasks
+
+
+@pytest.mark.asyncio
+async def test_send_progress_message_does_not_stop_typing():
+    ch = _make_channel()
+    task = asyncio.create_task(asyncio.sleep(60))
+    ch._typing_tasks["123@s.whatsapp.net"] = task
+
+    msg = OutboundMessage(
+        channel="whatsapp",
+        chat_id="123@s.whatsapp.net",
+        content="...",
+        metadata={"_progress": True},
+    )
+    await ch.send(msg)
+
+    assert "123@s.whatsapp.net" in ch._typing_tasks
+    task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_typing_loop_sends_composing_presence():
+    ch = WhatsAppChannel({"enabled": True}, MagicMock())
+    ch._ws = AsyncMock()
+    ch._connected = True
+
+    task = asyncio.create_task(ch._typing_loop("abc@s.whatsapp.net"))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.sleep(0)  # let the loop settle; _typing_loop suppresses CancelledError internally
+
+    assert ch._ws.send.call_count >= 1
+    payload = json.loads(ch._ws.send.call_args_list[0][0][0])
+    assert payload == {"type": "presence", "to": "abc@s.whatsapp.net", "presence": "composing"}
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_typing_tasks():
+    ch = WhatsAppChannel({"enabled": True}, MagicMock())
+    task = asyncio.create_task(asyncio.sleep(60))
+    ch._typing_tasks["x@s.whatsapp.net"] = task
+    ch._ws = AsyncMock()
+
+    await ch.stop()
+    await asyncio.sleep(0)  # let the event loop process the cancellation
+
+    assert task.cancelled()
+    assert not ch._typing_tasks
+
+
+# ── emoji reaction ─────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_inbound_message_sends_reaction():
+    ch = WhatsAppChannel({"enabled": True, "allowFrom": ["*"]}, MagicMock())
+    ch._ws = AsyncMock()
+    ch._connected = True
+    ch._handle_message = AsyncMock()
+
+    await ch._handle_bridge_message(
+        json.dumps({
+            "type": "message",
+            "id": "msg99",
+            "sender": "222@s.whatsapp.net",
+            "pn": "",
+            "content": "hi",
+            "timestamp": 1,
+        })
+    )
+
+    sent_payloads = [json.loads(c[0][0]) for c in ch._ws.send.call_args_list]
+    react_calls = [p for p in sent_payloads if p.get("type") == "react"]
+    assert len(react_calls) == 1
+    assert react_calls[0]["to"] == "222@s.whatsapp.net"
+    assert react_calls[0]["messageId"] == "msg99"
+    assert react_calls[0]["emoji"] == "👀"
+
+
+@pytest.mark.asyncio
+async def test_react_emoji_uses_config_value():
+    ch = WhatsAppChannel({"enabled": True, "allowFrom": ["*"], "reactEmoji": "🔥"}, MagicMock())
+    ch._ws = AsyncMock()
+    ch._connected = True
+    ch._handle_message = AsyncMock()
+
+    await ch._handle_bridge_message(
+        json.dumps({
+            "type": "message",
+            "id": "rx1",
+            "sender": "333@s.whatsapp.net",
+            "pn": "",
+            "content": "fire",
+            "timestamp": 1,
+        })
+    )
+
+    sent_payloads = [json.loads(c[0][0]) for c in ch._ws.send.call_args_list]
+    react_calls = [p for p in sent_payloads if p.get("type") == "react"]
+    assert react_calls[0]["emoji"] == "🔥"
+
+
+@pytest.mark.asyncio
+async def test_group_message_reaction_includes_participant():
+    """In groups, the reaction key needs the original sender's JID to bind correctly."""
+    ch = WhatsAppChannel({"enabled": True, "allowFrom": ["*"], "groupPolicy": "open"}, MagicMock())
+    ch._ws = AsyncMock()
+    ch._connected = True
+    ch._handle_message = AsyncMock()
+
+    await ch._handle_bridge_message(
+        json.dumps({
+            "type": "message",
+            "id": "gm1",
+            "sender": "555@g.us",
+            "pn": "user@s.whatsapp.net",
+            "participant": "user@s.whatsapp.net",
+            "content": "hi group",
+            "timestamp": 1,
+            "isGroup": True,
+        })
+    )
+
+    sent_payloads = [json.loads(c[0][0]) for c in ch._ws.send.call_args_list]
+    react = next(p for p in sent_payloads if p.get("type") == "react")
+    assert react["to"] == "555@g.us"
+    assert react["participant"] == "user@s.whatsapp.net"
+    assert ch._handle_message.await_args.kwargs["metadata"]["participant"] == "user@s.whatsapp.net"
+
+
+@pytest.mark.asyncio
+async def test_dm_reaction_omits_participant():
+    """For 1:1 chats there is no participant — the field must not be sent."""
+    ch = WhatsAppChannel({"enabled": True, "allowFrom": ["*"]}, MagicMock())
+    ch._ws = AsyncMock()
+    ch._connected = True
+    ch._handle_message = AsyncMock()
+
+    await ch._handle_bridge_message(
+        json.dumps({
+            "type": "message",
+            "id": "dm1",
+            "sender": "777@s.whatsapp.net",
+            "pn": "",
+            "content": "hi",
+            "timestamp": 1,
+        })
+    )
+
+    sent_payloads = [json.loads(c[0][0]) for c in ch._ws.send.call_args_list]
+    react = next(p for p in sent_payloads if p.get("type") == "react")
+    assert "participant" not in react
+
+
+@pytest.mark.asyncio
+async def test_send_removes_reaction():
+    """When the agent's final reply lands, the original 👀 reaction is cleared."""
+    ch = _make_channel()
+    msg = OutboundMessage(
+        channel="whatsapp",
+        chat_id="123@s.whatsapp.net",
+        content="reply",
+        metadata={"message_id": "msg42"},
+    )
+
+    await ch.send(msg)
+
+    sent_payloads = [json.loads(c[0][0]) for c in ch._ws.send.call_args_list]
+    react = next(p for p in sent_payloads if p.get("type") == "react")
+    assert react["messageId"] == "msg42"
+    assert react["emoji"] == ""  # empty text removes the bot's reaction
+
+
+@pytest.mark.asyncio
+async def test_send_removes_reaction_with_participant_in_groups():
+    """In groups the removal must include participant so it targets the right message."""
+    ch = _make_channel()
+    msg = OutboundMessage(
+        channel="whatsapp",
+        chat_id="555@g.us",
+        content="reply",
+        metadata={"message_id": "gm1", "participant": "user@s.whatsapp.net"},
+    )
+
+    await ch.send(msg)
+
+    sent_payloads = [json.loads(c[0][0]) for c in ch._ws.send.call_args_list]
+    react = next(p for p in sent_payloads if p.get("type") == "react")
+    assert react["participant"] == "user@s.whatsapp.net"
+    assert react["emoji"] == ""
+
+
+@pytest.mark.asyncio
+async def test_send_progress_does_not_remove_reaction():
+    """Streaming/progress messages should not clear the reaction prematurely."""
+    ch = _make_channel()
+    msg = OutboundMessage(
+        channel="whatsapp",
+        chat_id="123@s.whatsapp.net",
+        content="...",
+        metadata={"_progress": True, "message_id": "msg42"},
+    )
+
+    await ch.send(msg)
+
+    sent_payloads = [json.loads(c[0][0]) for c in ch._ws.send.call_args_list]
+    assert not any(p.get("type") == "react" for p in sent_payloads)
+
+
+@pytest.mark.asyncio
+async def test_send_without_message_id_skips_reaction_removal():
+    """Outbound messages without an origin message_id (e.g. proactive sends) must not crash."""
+    ch = _make_channel()
+    msg = OutboundMessage(channel="whatsapp", chat_id="123@s.whatsapp.net", content="hi")
+
+    await ch.send(msg)
+
+    sent_payloads = [json.loads(c[0][0]) for c in ch._ws.send.call_args_list]
+    assert not any(p.get("type") == "react" for p in sent_payloads)
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_skipped_when_no_message_id():
+    ch = _make_channel()
+    await ch._add_reaction("abc@s.whatsapp.net", "", "👀")
+    ch._ws.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_skipped_when_no_emoji():
+    ch = WhatsAppChannel({"enabled": True, "reactEmoji": ""}, MagicMock())
+    ch._ws = AsyncMock()
+    ch._connected = True
+    ch._handle_message = AsyncMock()
+
+    await ch._handle_bridge_message(
+        json.dumps({
+            "type": "message",
+            "id": "nr1",
+            "sender": "444@s.whatsapp.net",
+            "pn": "",
+            "content": "no react",
+            "timestamp": 1,
+        })
+    )
+
+    sent_payloads = [json.loads(c[0][0]) for c in ch._ws.send.call_args_list]
+    assert not any(p.get("type") == "react" for p in sent_payloads)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

  Mirrors the Telegram channel's UX in WhatsApp: when a message arrives, the bot reacts with an emoji and
  shows a "typing…" presence until it responds. Both stop when the response is sent or the channel shuts
  down. The reaction is also cleared after the reply lands.

  - **Bridge** (`bridge/src/whatsapp.ts`, `bridge/src/server.ts`): two new commands (`react`, `presence`)
  plus `sendReaction` / `sendPresence` methods on `WhatsAppClient`. The bridge surfaces `msg.key.participant`
   for group messages so reactions bind to the right message.
  - **Python** (`nanobot/channels/whatsapp.py`): adds `react_emoji` config (default `👀`, matching Telegram),
   per-chat `_typing_tasks`, and `_start_typing` / `_stop_typing` / `_typing_loop` / `_add_reaction` /
  `_remove_reaction` helpers. Same shape and lifecycle as the Telegram channel. Typing is gated by the
  existing `_progress` metadata flag so streaming/tool-hint messages don't kill the indicator early.
  - **Tests** (`tests/channels/test_whatsapp_channel.py`): 16 new tests covering typing
  start/stop/loop/cleanup, reaction add/remove on send, custom emoji, group reactions including
  `participant`, DMs omitting `participant`, and skip conditions.

  ## Related

  Group `@mention` detection on newer WhatsApp builds requires the JID-normalization fix in #3514 — without
  it, mentions are missed entirely (separate concern; this PR works for 1:1 chats and open-policy groups
  regardless).

  ## Test plan
  - [x] `tsc` on the bridge — clean
  - [x] `pytest tests/channels/test_whatsapp_channel.py` — 31/31 passing
  - [x] Manual smoke test: 1:1 message and group `@mention` — reaction appears, "typing…" shows until the
  reply lands, reaction clears after the reply