### PR TITLE
fix(provider): retry blank Codex failures

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -81,9 +81,15 @@ class OpenAICodexProvider(LLMProvider):
                 )
             return LLMResponse(content=content, tool_calls=tool_calls, finish_reason=finish_reason)
         except Exception as e:
-            msg = f"Error calling Codex: {e}"
+            msg = _codex_error_message(e)
             retry_after = getattr(e, "retry_after", None) or self._extract_retry_after(msg)
-            return LLMResponse(content=msg, finish_reason="error", retry_after=retry_after)
+            return LLMResponse(
+                content=msg,
+                finish_reason="error",
+                retry_after=retry_after,
+                error_kind=_codex_error_kind(e),
+                error_should_retry=_codex_error_should_retry(e, retry_after),
+            )
 
     async def chat(
         self, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None,
@@ -122,6 +128,33 @@ def _build_headers(account_id: str, token: str) -> dict[str, str]:
         "accept": "text/event-stream",
         "content-type": "application/json",
     }
+
+
+def _codex_error_message(exc: Exception) -> str:
+    detail = str(exc).strip()
+    if detail:
+        return f"Error calling Codex: {detail}"
+    return "Error calling Codex: request failed without details"
+
+
+def _codex_error_kind(exc: Exception) -> str | None:
+    if isinstance(exc, (asyncio.TimeoutError, httpx.TimeoutException)):
+        return "timeout"
+    if isinstance(exc, (httpx.TransportError, ConnectionError)):
+        return "connection"
+    if not str(exc).strip():
+        return "connection"
+    return None
+
+
+def _codex_error_should_retry(exc: Exception, retry_after: float | None) -> bool | None:
+    if retry_after is not None:
+        return True
+    if _codex_error_kind(exc) in {"timeout", "connection"}:
+        return True
+    if not str(exc).strip():
+        return True
+    return None
 
 
 class _CodexHTTPError(RuntimeError):

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+
+import pytest
+
+import nanobot.providers.openai_codex_provider as codex_provider
+from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+
+
+def _stub_codex_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        codex_provider,
+        "get_codex_token",
+        lambda: SimpleNamespace(account_id="account", access="token"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_empty_exception_is_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_codex_token(monkeypatch)
+
+    async def fake_request(*args, **kwargs):
+        raise Exception()
+
+    monkeypatch.setattr(codex_provider, "_request_codex", fake_request)
+
+    response = await OpenAICodexProvider().chat(
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    assert response.finish_reason == "error"
+    assert response.error_kind == "connection"
+    assert response.error_should_retry is True
+    assert response.content == "Error calling Codex: request failed without details"
+
+
+@pytest.mark.asyncio
+async def test_codex_empty_exception_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_codex_token(monkeypatch)
+    calls = 0
+    delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    async def fake_request(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise Exception()
+        return "ok", [], "stop"
+
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr(codex_provider, "_request_codex", fake_request)
+
+    response = await OpenAICodexProvider().chat_with_retry(
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    assert response.finish_reason == "stop"
+    assert response.content == "ok"
+    assert calls == 2
+    assert delays == [1]


### PR DESCRIPTION
## Summary
- Normalize blank Codex provider exceptions into a readable error message.
- Mark blank, timeout, and transport Codex failures as retryable so the provider retry loop handles transient stream failures.
- Add focused tests for retry metadata and retry recovery.

## Tests
- /home/timur/nanobot/.venv/bin/pytest tests/providers/test_openai_codex_provider.py tests/providers/test_provider_retry.py -q
- python3 -m py_compile nanobot/providers/openai_codex_provider.py