### PR TITLE
feat(telegram): add per-chat access rules

### DIFF
--- a/docs/chat-apps.md
+++ b/docs/chat-apps.md
@@ -34,7 +34,11 @@ Connect nanobot to your favorite chat platform. Want to build your own? See the 
     "telegram": {
       "enabled": true,
       "token": "YOUR_BOT_TOKEN",
-      "allowFrom": ["YOUR_USER_ID"]
+      "allowFrom": ["YOUR_USER_ID"],
+      "chatAccess": {
+        "-1005556656": "*",
+        "-1007778889": ["YOUR_USER_ID", "trusted_username"]
+      }
     }
   }
 }
@@ -42,6 +46,10 @@ Connect nanobot to your favorite chat platform. Want to build your own? See the 
 
 > You can find your **User ID** in Telegram settings. It is shown as `@yourUserId`.
 > Copy this value **without the `@` symbol** and paste it into the config file.
+> `chatAccess` is optional. Use it when a group chat needs its own access rule:
+> `"*"` allows every sender in that chat, while a list allows only those user IDs
+> or usernames in that chat. Chats not listed in `chatAccess` fall back to
+> `allowFrom`.
 
 
 **3. Run**

--- a/docs/chat-apps.md
+++ b/docs/chat-apps.md
@@ -49,7 +49,8 @@ Connect nanobot to your favorite chat platform. Want to build your own? See the 
 > `chatAccess` is optional. Use it when a group chat needs its own access rule:
 > `"*"` allows every sender in that chat, while a list allows only those user IDs
 > or usernames in that chat. Chats not listed in `chatAccess` fall back to
-> `allowFrom`.
+> `allowFrom`. This setting controls access only; with `groupPolicy: "mention"`,
+> group messages still need to mention the bot or reply to it.
 
 
 **3. Run**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1143,6 +1143,7 @@ MCP tools are automatically discovered and registered on startup. The LLM can us
 | `tools.exec.enable` | `true` | When `false`, the shell `exec` tool is not registered at all. Use this to completely disable shell command execution. |
 | `tools.exec.pathAppend` | `""` | Extra directories to append to `PATH` when running shell commands (e.g. `/usr/sbin` for `ufw`). |
 | `channels.*.allowFrom` | omitted | Access control per channel. Omit to use pairing-only mode; set `["*"]` to allow everyone; or list specific user IDs. See [Pairing](#pairing) for details. |
+| `channels.telegram.chatAccess` | `{}` | Optional per-chat access rules for Telegram. Each key is a Telegram `chat_id`; each value is either `"*"` to allow every sender in that chat, or a list of user IDs/usernames allowed only in that chat. Chats not listed here fall back to `allowFrom`. This controls who may talk to the bot; `groupPolicy` still controls whether plain group messages are accepted or a mention/reply is required. |
 
 **Docker security**: The official Docker image runs as a non-root user (`nanobot`, UID 1000) with bubblewrap pre-installed. When using `docker-compose.yml`, the container drops all Linux capabilities except `SYS_ADMIN` (required for bwrap's namespace isolation).
 

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -24,7 +24,7 @@ from telegram.error import BadRequest, NetworkError, TimedOut
 from telegram.ext import Application, CallbackQueryHandler, ContextTypes, MessageHandler, filters
 from telegram.request import HTTPXRequest
 
-from nanobot.bus.events import OutboundMessage
+from nanobot.bus.events import InboundMessage, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.command.builtin import build_help_text
@@ -231,6 +231,7 @@ class TelegramConfig(Base):
     enabled: bool = False
     token: str = ""
     allow_from: list[str] = Field(default_factory=list)
+    chat_access: dict[str, str | list[str]] = Field(default_factory=dict)
     proxy: str | None = None
     reply_to_message: bool = False
     react_emoji: str = "👀"
@@ -295,24 +296,74 @@ class TelegramChannel(BaseChannel):
         self._bot_username: str | None = None
         self._stream_bufs: dict[str, _StreamBuf] = {}  # chat_id -> streaming state
 
-    def is_allowed(self, sender_id: str) -> bool:
-        """Preserve Telegram's legacy id|username allowlist matching."""
-        if super().is_allowed(sender_id):
-            return True
-
-        allow_list = getattr(self.config, "allow_from", [])
-        if not allow_list or "*" in allow_list:
+    @staticmethod
+    def _sender_matches_allow_list(sender_id: str, allow_list: list[str]) -> bool:
+        """Match Telegram sender ids by exact value, numeric id, or username."""
+        if not allow_list:
             return False
-
+        if "*" in allow_list or str(sender_id) in allow_list:
+            return True
         sender_str = str(sender_id)
         if sender_str.count("|") != 1:
             return False
-
         sid, username = sender_str.split("|", 1)
         if not sid.isdigit() or not username:
             return False
-
         return sid in allow_list or username in allow_list
+
+    def is_allowed(self, sender_id: str) -> bool:
+        """Preserve Telegram's legacy id|username allowlist matching."""
+        allow_list = getattr(self.config, "allow_from", [])
+        if not allow_list:
+            logger.warning("{}: allow_from is empty — all access denied", self.name)
+        return self._sender_matches_allow_list(sender_id, allow_list)
+
+    def _chat_access_rule(self, chat_id: str | int) -> str | list[str] | None:
+        return getattr(self.config, "chat_access", {}).get(str(chat_id))
+
+    def _is_chat_sender_allowed(self, chat_id: str | int, sender_id: str) -> bool:
+        rule = self._chat_access_rule(chat_id)
+        if rule is None:
+            return self.is_allowed(sender_id)
+        if rule == "*":
+            return True
+        if isinstance(rule, list):
+            return self._sender_matches_allow_list(sender_id, rule)
+        return False
+
+    async def _handle_message(
+        self,
+        sender_id: str,
+        chat_id: str,
+        content: str,
+        media: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        session_key: str | None = None,
+    ) -> None:
+        """Handle Telegram ACLs, including per-chat access rules."""
+        if not self._is_chat_sender_allowed(chat_id, sender_id):
+            logger.warning(
+                "Access denied for sender {} in Telegram chat {}. "
+                "Add them to allowFrom or channels.telegram.chatAccess to grant access.",
+                sender_id, chat_id,
+            )
+            return
+
+        meta = metadata or {}
+        if self.supports_streaming:
+            meta = {**meta, "_wants_stream": True}
+
+        msg = InboundMessage(
+            channel=self.name,
+            sender_id=str(sender_id),
+            chat_id=str(chat_id),
+            content=content,
+            media=media or [],
+            metadata=meta,
+            session_key_override=session_key,
+        )
+
+        await self.bus.publish_inbound(msg)
 
     @staticmethod
     def _normalize_telegram_command(content: str) -> str:
@@ -961,6 +1012,8 @@ class TelegramChannel(BaseChannel):
     async def _is_group_message_for_bot(self, message) -> bool:
         """Allow group messages when policy is open, @mentioned, or replying to the bot."""
         if message.chat.type == "private" or self.config.group_policy == "open":
+            return True
+        if self._chat_access_rule(message.chat_id) is not None:
             return True
 
         bot_id, bot_username = await self._ensure_bot_identity()

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -315,7 +315,7 @@ class TelegramChannel(BaseChannel):
         """Preserve Telegram's legacy id|username allowlist matching."""
         allow_list = getattr(self.config, "allow_from", [])
         if not allow_list:
-            logger.warning("{}: allow_from is empty — all access denied", self.name)
+            self.logger.warning("allow_from is empty — all access denied")
         return self._sender_matches_allow_list(sender_id, allow_list)
 
     def _chat_access_rule(self, chat_id: str | int) -> str | list[str] | None:
@@ -342,7 +342,7 @@ class TelegramChannel(BaseChannel):
     ) -> None:
         """Handle Telegram ACLs, including per-chat access rules."""
         if not self._is_chat_sender_allowed(chat_id, sender_id):
-            logger.warning(
+            self.logger.warning(
                 "Access denied for sender {} in Telegram chat {}. "
                 "Add them to allowFrom or channels.telegram.chatAccess to grant access.",
                 sender_id, chat_id,
@@ -1055,7 +1055,7 @@ class TelegramChannel(BaseChannel):
         message = update.message
         user = update.effective_user
         sender_id = self._sender_id(user)
-        if not self.is_allowed(sender_id):
+        if not self._is_chat_sender_allowed(message.chat_id, sender_id):
             return
         self._remember_thread_context(message)
 
@@ -1085,7 +1085,7 @@ class TelegramChannel(BaseChannel):
         user = update.effective_user
         chat_id = message.chat_id
         sender_id = self._sender_id(user)
-        if not self.is_allowed(sender_id):
+        if not self._is_chat_sender_allowed(chat_id, sender_id):
             return
         self._remember_thread_context(message)
 

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -1013,8 +1013,6 @@ class TelegramChannel(BaseChannel):
         """Allow group messages when policy is open, @mentioned, or replying to the bot."""
         if message.chat.type == "private" or self.config.group_policy == "open":
             return True
-        if self._chat_access_rule(message.chat_id) is not None:
-            return True
 
         bot_id, bot_username = await self._ensure_bot_identity()
         if bot_username:

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -889,7 +889,7 @@ async def test_group_policy_mention_ignores_unmentioned_group_message() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chat_access_bypasses_group_mention_policy() -> None:
+async def test_chat_access_keeps_group_mention_policy_for_plain_messages() -> None:
     channel = TelegramChannel(
         TelegramConfig(
             enabled=True,
@@ -912,10 +912,8 @@ async def test_chat_access_bypasses_group_mention_policy() -> None:
 
     await channel._on_message(_make_telegram_update(text="hello everyone"), None)
 
-    assert len(handled) == 1
-    assert handled[0]["sender_id"] == "12345|alice"
-    assert handled[0]["chat_id"] == "-100123"
-    assert channel._app.bot.get_me_calls == 0
+    assert handled == []
+    assert channel._app.bot.get_me_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -695,6 +695,51 @@ def test_is_allowed_rejects_invalid_legacy_telegram_sender_shapes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_chat_access_wildcard_accepts_any_sender_in_configured_chat() -> None:
+    bus = MessageBus()
+    channel = TelegramChannel(
+        TelegramConfig(allow_from=["84131737"], chat_access={"5556656": "*"}),
+        bus,
+    )
+
+    await channel._handle_message(
+        sender_id="999999|stranger",
+        chat_id="5556656",
+        content="hello from group",
+    )
+
+    msg = await bus.consume_inbound()
+    assert msg.sender_id == "999999|stranger"
+    assert msg.chat_id == "5556656"
+    assert msg.content == "hello from group"
+
+
+@pytest.mark.asyncio
+async def test_chat_access_list_uses_telegram_sender_matching() -> None:
+    bus = MessageBus()
+    channel = TelegramChannel(
+        TelegramConfig(allow_from=["84131737"], chat_access={"5556656": ["alice"]}),
+        bus,
+    )
+
+    await channel._handle_message(
+        sender_id="999999|alice",
+        chat_id="5556656",
+        content="allowed by chat username",
+    )
+    await channel._handle_message(
+        sender_id="999999|bob",
+        chat_id="5556656",
+        content="denied by chat username",
+    )
+
+    msg = await bus.consume_inbound()
+    assert msg.sender_id == "999999|alice"
+    assert msg.content == "allowed by chat username"
+    assert bus.inbound_size == 0
+
+
+@pytest.mark.asyncio
 async def test_send_progress_keeps_message_in_topic() -> None:
     config = TelegramConfig(enabled=True, token="123:abc", allow_from=["*"])
     channel = TelegramChannel(config, MessageBus())
@@ -841,6 +886,36 @@ async def test_group_policy_mention_ignores_unmentioned_group_message() -> None:
 
     assert handled == []
     assert channel._app.bot.get_me_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_access_bypasses_group_mention_policy() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(
+            enabled=True,
+            token="123:abc",
+            allow_from=["84131737"],
+            chat_access={"-100123": "*"},
+            group_policy="mention",
+        ),
+        MessageBus(),
+    )
+    channel._app = _FakeApp(lambda: None)
+
+    handled = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle
+    channel._start_typing = lambda _chat_id: None
+
+    await channel._on_message(_make_telegram_update(text="hello everyone"), None)
+
+    assert len(handled) == 1
+    assert handled[0]["sender_id"] == "12345|alice"
+    assert handled[0]["chat_id"] == "-100123"
+    assert channel._app.bot.get_me_calls == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add Telegram chatAccess rules for per-chat authorization
- allow a configured chat to use either "*" for all senders or a sender allowlist
- document chatAccess in chat app and configuration docs

## Validation
- uv run --extra dev pytest -q tests/channels/test_telegram_channel.py
- uv run --extra dev ruff check nanobot/channels/telegram.py tests/channels/test_telegram_channel.py docs/chat-apps.md docs/configuration.md