### PR TITLE
feat(telegram): add polling healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p nanobot bridge && touch nanobot/__init__.py && \
 # Copy the full source and install
 COPY nanobot/ nanobot/
 COPY bridge/ bridge/
+COPY docs/ docs/
 RUN uv pip install --system --no-cache .
 
 # Build the WhatsApp bridge

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,11 @@ ENV HOME=/home/nanobot
 # Gateway default port
 EXPOSE 18790
 
+ENV NANOBOT_TELEGRAM_HEALTH_PATH=/tmp/nanobot-telegram-health.json \
+    NANOBOT_TELEGRAM_HEALTH_MAX_AGE_S=120
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=1 \
+    CMD ["python", "-m", "nanobot.telegram_healthcheck"]
+
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["status"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 # Install Python dependencies first (cached layer)
-COPY pyproject.toml README.md LICENSE ./
+COPY pyproject.toml README.md LICENSE hatch_build.py ./
 RUN mkdir -p nanobot bridge && touch nanobot/__init__.py && \
     uv pip install --system --no-cache . && \
     rm -rf nanobot bridge

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,14 @@ ENV HOME=/home/nanobot
 EXPOSE 18790
 
 ENV NANOBOT_TELEGRAM_HEALTH_PATH=/tmp/nanobot-telegram-health.json \
-    NANOBOT_TELEGRAM_HEALTH_MAX_AGE_S=120
+    NANOBOT_TELEGRAM_HEALTH_MAX_AGE_S=120 \
+    NANOBOT_RUNTIME_HEALTH_PATH=/tmp/nanobot-runtime-health.json \
+    NANOBOT_RUNTIME_HEALTH_AGENT_MAX_AGE_S=180 \
+    NANOBOT_RUNTIME_HEALTH_DISPATCH_MAX_AGE_S=900 \
+    NANOBOT_RUNTIME_HEALTH_SEND_MAX_AGE_S=180
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=1 \
-    CMD ["python", "-m", "nanobot.telegram_healthcheck"]
+    CMD ["sh", "/app/nanobot/telegram_healthcheck.sh"]
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["status"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     <<: *common-config
     command: ["gateway"]
     restart: unless-stopped
+    environment:
+      NANOBOT_TELEGRAM_HEALTH_PATH: /tmp/nanobot-telegram-health.json
+      NANOBOT_TELEGRAM_HEALTH_MAX_AGE_S: "120"
     ports:
       - 18790:18790
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,10 @@ services:
     environment:
       NANOBOT_TELEGRAM_HEALTH_PATH: /tmp/nanobot-telegram-health.json
       NANOBOT_TELEGRAM_HEALTH_MAX_AGE_S: "120"
+      NANOBOT_RUNTIME_HEALTH_PATH: /tmp/nanobot-runtime-health.json
+      NANOBOT_RUNTIME_HEALTH_AGENT_MAX_AGE_S: "180"
+      NANOBOT_RUNTIME_HEALTH_DISPATCH_MAX_AGE_S: "900"
+      NANOBOT_RUNTIME_HEALTH_SEND_MAX_AGE_S: "180"
     ports:
       - 18790:18790
     deploy:

--- a/docs/plans/2026-04-11-telegram-healthcheck-installation.md
+++ b/docs/plans/2026-04-11-telegram-healthcheck-installation.md
@@ -1,0 +1,160 @@
+# Telegram Healthcheck Installation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Safely apply the Telegram polling healthcheck patch to the current nanobot checkout, verify it with tests, and confirm the repo remains buildable.
+
+**Architecture:** The patch adds a small JSON-backed Telegram polling liveness tracker, wires it into the Telegram channel polling request path, and exposes a Docker `HEALTHCHECK` entrypoint that reports healthy only when Telegram polling is fresh. Installation should use TDD for the newly introduced behavior, then apply the minimal production changes, then verify targeted tests and patch application state.
+
+**Tech Stack:** Python 3.11+, pytest, uv, Dockerfile/docker-compose, python-telegram-bot.
+
+---
+
+### Task 1: Add failing tests for the new healthcheck modules
+
+**Files:**
+- Create: `tests/channels/test_telegram_healthcheck.py`
+- Test: `tests/channels/test_telegram_healthcheck.py`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+- `TelegramHealthState.mark_ok()` writing a JSON state file with `status == "ok"` and `last_ok`
+- `run_healthcheck()` returning success when Telegram is disabled in config
+- `run_healthcheck()` returning failure when Telegram is enabled but state file is missing
+- `TelegramPollingHealthRequest.do_request()` marking success/error around delegated requests
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run --extra dev pytest -q tests/channels/test_telegram_healthcheck.py`
+Expected: FAIL because the healthcheck modules do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Use the patch contents to add:
+- `nanobot/telegram_polling_health.py`
+- `nanobot/telegram_healthcheck.py`
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run --extra dev pytest -q tests/channels/test_telegram_healthcheck.py`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/channels/test_telegram_healthcheck.py nanobot/telegram_polling_health.py nanobot/telegram_healthcheck.py
+git commit -m "test: cover telegram healthcheck modules"
+```
+
+### Task 2: Add failing integration tests for Telegram channel wiring
+
+**Files:**
+- Modify: `tests/channels/test_telegram_channel.py`
+- Modify: `nanobot/channels/telegram.py`
+- Test: `tests/channels/test_telegram_channel.py`
+
+**Step 1: Write the failing test**
+
+Add tests that verify:
+- `TelegramChannel` initializes `_health_state`
+- `_on_polling_error()` calls `mark_error()`
+- startup marks starting/ok around polling setup if that path is unit-testable without real network I/O
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run --extra dev pytest -q tests/channels/test_telegram_channel.py -k health`
+Expected: FAIL because the channel is not wired to the health state yet.
+
+**Step 3: Write minimal implementation**
+
+Apply the minimal `nanobot/channels/telegram.py` changes from the patch.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run --extra dev pytest -q tests/channels/test_telegram_channel.py -k health`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/channels/test_telegram_channel.py nanobot/channels/telegram.py
+git commit -m "feat: track telegram polling health"
+```
+
+### Task 3: Apply container healthcheck changes and verify config/build files
+
+**Files:**
+- Modify: `Dockerfile`
+- Modify: `docker-compose.yml`
+- Test: `Dockerfile`
+- Test: `docker-compose.yml`
+
+**Step 1: Write the failing test**
+
+Use a lightweight assertion test or command-based check that confirms:
+- `Dockerfile` contains `HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=1`
+- `Dockerfile` runs `python -m nanobot.telegram_healthcheck`
+- `docker-compose.yml` exports `NANOBOT_TELEGRAM_HEALTH_PATH` and `NANOBOT_TELEGRAM_HEALTH_MAX_AGE_S`
+
+**Step 2: Run test to verify it fails**
+
+Run: `python - <<'PY'
+from pathlib import Path
+text = Path('Dockerfile').read_text()
+assert 'nanobot.telegram_healthcheck' in text
+PY`
+Expected: FAIL before the file is changed.
+
+**Step 3: Write minimal implementation**
+
+Apply the `Dockerfile` and `docker-compose.yml` changes from the patch.
+
+**Step 4: Run test to verify it passes**
+
+Run the same assertions again and expect success.
+
+**Step 5: Commit**
+
+```bash
+git add Dockerfile docker-compose.yml
+git commit -m "chore: add docker telegram healthcheck"
+```
+
+### Task 4: Full verification
+
+**Files:**
+- Test: `tests/channels/test_telegram_healthcheck.py`
+- Test: `tests/channels/test_telegram_channel.py`
+- Test: `Dockerfile`
+- Test: `docker-compose.yml`
+
+**Step 1: Run targeted tests**
+
+```bash
+uv run --extra dev pytest -q tests/channels/test_telegram_healthcheck.py tests/channels/test_telegram_channel.py
+```
+
+Expected: PASS.
+
+**Step 2: Run lint-style sanity checks for changed container files**
+
+```bash
+python -m nanobot.telegram_healthcheck || true
+python - <<'PY'
+from pathlib import Path
+assert 'HEALTHCHECK' in Path('Dockerfile').read_text()
+assert 'NANOBOT_TELEGRAM_HEALTH_PATH' in Path('docker-compose.yml').read_text()
+print('container file checks ok')
+PY
+```
+
+Expected: module import succeeds and file assertions pass.
+
+**Step 3: Inspect final diff**
+
+```bash
+git diff -- Dockerfile docker-compose.yml nanobot/channels/telegram.py nanobot/telegram_healthcheck.py nanobot/telegram_polling_health.py tests/channels/test_telegram_healthcheck.py tests/channels/test_telegram_channel.py
+```
+
+Expected: only the intended Telegram healthcheck changes appear.

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
         ToolsConfig,
     )
     from nanobot.cron.service import CronService
+    from nanobot.runtime_health import RuntimeHealthState
 
 
 UNIFIED_SESSION_KEY = "unified:default"
@@ -185,6 +186,7 @@ class AgentLoop:
         model_preset: str | None = None,
         preset_snapshot_loader: preset_helpers.PresetSnapshotLoader | None = None,
         runtime_model_publisher: Callable[[str, str | None], None] | None = None,
+        runtime_health: RuntimeHealthState | None = None,
     ):
         from nanobot.config.schema import ToolsConfig
 
@@ -196,6 +198,7 @@ class AgentLoop:
         self._provider_snapshot_loader = provider_snapshot_loader
         self._preset_snapshot_loader = preset_snapshot_loader
         self._runtime_model_publisher = runtime_model_publisher
+        self._runtime_health = runtime_health
         self._provider_signature = provider_signature
         self._default_selection_signature = preset_helpers.default_selection_signature(provider_signature)
         self.workspace = workspace
@@ -813,6 +816,11 @@ class AgentLoop:
             try:
                 msg = await asyncio.wait_for(self.bus.consume_inbound(), timeout=1.0)
             except asyncio.TimeoutError:
+                if self._runtime_health is not None:
+                    self._runtime_health.mark_agent_tick(
+                        inbound_queue=self.bus.inbound_size,
+                        outbound_queue=self.bus.outbound_size,
+                    )
                 self.auto_compact.check_expired(
                     self._schedule_background,
                     active_session_keys=self._pending_queues.keys(),
@@ -829,6 +837,11 @@ class AgentLoop:
                 continue
 
             raw = msg.content.strip()
+            if self._runtime_health is not None:
+                self._runtime_health.mark_inbound_received(
+                    inbound_queue=self.bus.inbound_size,
+                    outbound_queue=self.bus.outbound_size,
+                )
             if self.commands.is_priority(raw):
                 await self._dispatch_command_inline(
                     msg, msg.session_key, raw,
@@ -883,6 +896,9 @@ class AgentLoop:
         session_key = self._effective_session_key(msg)
         if session_key != msg.session_key:
             msg = dataclasses.replace(msg, session_key_override=session_key)
+        dispatch_id = f"{session_key}:{time.time_ns()}"
+        if self._runtime_health is not None:
+            self._runtime_health.mark_dispatch_start(dispatch_id)
         lock = self._session_locks.setdefault(session_key, asyncio.Lock())
         gate = self._concurrency_gate or nullcontext()
 
@@ -1003,6 +1019,8 @@ class AgentLoop:
                         content="Sorry, I encountered an error.",
                     ))
         finally:
+            if self._runtime_health is not None:
+                self._runtime_health.mark_dispatch_end(dispatch_id)
             # Drain any messages still in the pending queue and re-publish
             # them to the bus so they are processed as fresh inbound messages
             # rather than silently lost.

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -18,6 +18,7 @@ from nanobot.config.schema import Config
 from nanobot.utils.restart import consume_restart_notice_from_env, format_restart_completed_message
 
 if TYPE_CHECKING:
+    from nanobot.runtime_health import RuntimeHealthState
     from nanobot.session.manager import SessionManager
 
 
@@ -57,11 +58,13 @@ class ChannelManager:
         *,
         session_manager: "SessionManager | None" = None,
         webui_runtime_model_name: Callable[[], str | None] | None = None,
+        runtime_health: "RuntimeHealthState | None" = None,
     ):
         self.config = config
         self.bus = bus
         self._session_manager = session_manager
         self._webui_runtime_model_name = webui_runtime_model_name
+        self._runtime_health = runtime_health
         self.channels: dict[str, BaseChannel] = {}
         self._dispatch_task: asyncio.Task | None = None
         self._origin_reply_fingerprints: dict[tuple[str, str, str], str] = {}
@@ -431,12 +434,21 @@ class ChannelManager:
 
         for attempt in range(max_attempts):
             try:
+                if self._runtime_health is not None:
+                    self._runtime_health.mark_outbound_send_start(channel=msg.channel)
                 await self._send_once(channel, msg)
+                if self._runtime_health is not None:
+                    self._runtime_health.mark_outbound_send_ok(channel=msg.channel)
                 return  # Send succeeded
             except asyncio.CancelledError:
                 raise  # Propagate cancellation for graceful shutdown
             except Exception as e:
                 if attempt == max_attempts - 1:
+                    if self._runtime_health is not None:
+                        self._runtime_health.mark_outbound_send_error(
+                            channel=msg.channel,
+                            error=f"{type(e).__name__}: {e}",
+                        )
                     logger.exception(
                         "Failed to send to {} after {} attempts",
                         msg.channel, max_attempts

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -25,6 +25,7 @@ from telegram.ext import Application, CallbackQueryHandler, ContextTypes, Messag
 from telegram.request import HTTPXRequest
 
 from nanobot.bus.events import OutboundMessage
+from nanobot.telegram_polling_health import TelegramHealthState, TelegramPollingHealthRequest
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.command.builtin import build_help_text
@@ -294,6 +295,7 @@ class TelegramChannel(BaseChannel):
         self._bot_user_id: int | None = None
         self._bot_username: str | None = None
         self._stream_bufs: dict[str, _StreamBuf] = {}  # chat_id -> streaming state
+        self._health_state = TelegramHealthState()
 
     def is_allowed(self, sender_id: str) -> bool:
         """Preserve Telegram's legacy id|username allowlist matching."""
@@ -332,6 +334,7 @@ class TelegramChannel(BaseChannel):
             return
 
         self._running = True
+        self._health_state.mark_starting("telegram polling starting")
 
         proxy = self.config.proxy or None
 
@@ -343,12 +346,13 @@ class TelegramChannel(BaseChannel):
             read_timeout=30.0,
             proxy=proxy,
         )
-        poll_request = HTTPXRequest(
+        poll_request = TelegramPollingHealthRequest(
             connection_pool_size=4,
             pool_timeout=self.config.pool_timeout,
             connect_timeout=30.0,
             read_timeout=30.0,
             proxy=proxy,
+            health_state=self._health_state,
         )
         builder = (
             Application.builder()
@@ -418,6 +422,7 @@ class TelegramChannel(BaseChannel):
             drop_pending_updates=False,  # Process pending messages on startup
             error_callback=self._on_polling_error,
         )
+        self._health_state.mark_ok("telegram polling started")
 
         # Keep running until stopped
         while self._running:
@@ -442,6 +447,7 @@ class TelegramChannel(BaseChannel):
             await self._app.stop()
             await self._app.shutdown()
             self._app = None
+        self._health_state.mark_stopped()
 
     @staticmethod
     def _get_media_type(path: str) -> str:
@@ -1201,6 +1207,7 @@ class TelegramChannel(BaseChannel):
     def _on_polling_error(self, exc: Exception) -> None:
         """Keep long-polling network failures to a single readable line."""
         summary = self._format_telegram_error(exc)
+        self._health_state.mark_error(summary)
         if isinstance(exc, (NetworkError, TimedOut)):
             self.logger.warning("polling network issue: {}", summary)
         else:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -668,6 +668,7 @@ def _run_gateway(
     from nanobot.cron.types import CronJob
     from nanobot.heartbeat.service import HeartbeatService
     from nanobot.providers.factory import build_provider_snapshot, load_provider_snapshot
+    from nanobot.runtime_health import RuntimeHealthState
     from nanobot.session.manager import SessionManager
 
     port = port if port is not None else config.gateway.port
@@ -675,6 +676,8 @@ def _run_gateway(
     console.print(f"{__logo__} Starting nanobot gateway version {__version__} on port {port}...")
     sync_workspace_templates(config.workspace_path)
     bus = MessageBus()
+    runtime_health = RuntimeHealthState()
+    runtime_health.mark_gateway_starting()
     try:
         provider_snapshot = build_provider_snapshot(config)
     except ValueError as exc:
@@ -709,6 +712,7 @@ def _run_gateway(
             preset,
         ),
         provider_signature=provider_snapshot.signature,
+        runtime_health=runtime_health,
     )
 
     from nanobot.agent.loop import UNIFIED_SESSION_KEY
@@ -843,6 +847,7 @@ def _run_gateway(
         bus,
         session_manager=session_manager,
         webui_runtime_model_name=_webui_runtime_model_name,
+        runtime_health=runtime_health,
     )
 
     def _pick_heartbeat_target() -> tuple[str, str]:

--- a/nanobot/runtime_health.py
+++ b/nanobot/runtime_health.py
@@ -1,0 +1,131 @@
+"""Lightweight runtime health state for gateway pipeline checks."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_STATE_PATH = "/tmp/nanobot-runtime-health.json"
+
+
+def _env_path(name: str, default: str) -> Path:
+    return Path(os.getenv(name, default)).expanduser()
+
+
+class RuntimeHealthState:
+    """Track gateway pipeline liveness without doing work in the healthcheck."""
+
+    def __init__(self, path: Path | None = None, *, min_write_interval_s: float = 5.0) -> None:
+        self.path = path or _env_path("NANOBOT_RUNTIME_HEALTH_PATH", _DEFAULT_STATE_PATH)
+        self._min_write_interval_s = min_write_interval_s
+        self._last_write = 0.0
+        self._active_dispatches: dict[str, float] = {}
+        self._state: dict[str, Any] = {
+            "status": "starting",
+            "pid": os.getpid(),
+            "active_dispatches": 0,
+            "outbound_active": 0,
+            "inbound_queue": 0,
+            "outbound_queue": 0,
+        }
+
+    def mark_gateway_starting(self) -> None:
+        self._update(status="starting", force=True)
+
+    def mark_agent_tick(self, *, inbound_queue: int, outbound_queue: int) -> None:
+        self._update(
+            status="ok",
+            last_agent_tick=time.time(),
+            inbound_queue=inbound_queue,
+            outbound_queue=outbound_queue,
+        )
+
+    def mark_inbound_received(self, *, inbound_queue: int, outbound_queue: int) -> None:
+        now = time.time()
+        self._update(
+            status="ok",
+            last_agent_tick=now,
+            last_inbound_at=now,
+            inbound_queue=inbound_queue,
+            outbound_queue=outbound_queue,
+            force=True,
+        )
+
+    def mark_dispatch_start(self, dispatch_id: str) -> None:
+        self._active_dispatches[dispatch_id] = time.time()
+        self._write_dispatch_state(force=True)
+
+    def mark_dispatch_end(self, dispatch_id: str) -> None:
+        self._active_dispatches.pop(dispatch_id, None)
+        self._write_dispatch_state(force=True)
+
+    def mark_outbound_send_start(self, *, channel: str) -> None:
+        self._update(
+            status="ok",
+            outbound_active=1,
+            outbound_channel=channel,
+            outbound_send_started_at=time.time(),
+            force=True,
+        )
+
+    def mark_outbound_send_ok(self, *, channel: str) -> None:
+        self._update(
+            status="ok",
+            outbound_active=0,
+            last_outbound_ok_at=time.time(),
+            outbound_channel=channel,
+            last_outbound_error="",
+            force=True,
+        )
+
+    def mark_outbound_send_error(self, *, channel: str, error: str) -> None:
+        self._update(
+            status="error",
+            outbound_active=0,
+            outbound_channel=channel,
+            last_outbound_error=error,
+            last_outbound_error_at=time.time(),
+            force=True,
+        )
+
+    def _write_dispatch_state(self, *, force: bool) -> None:
+        oldest = min(self._active_dispatches.values()) if self._active_dispatches else None
+        self._update(
+            status="ok",
+            active_dispatches=len(self._active_dispatches),
+            oldest_dispatch_started_at=oldest,
+            force=force,
+        )
+
+    def _update(self, *, force: bool = False, **values: Any) -> None:
+        now = time.time()
+        self._state.update(values)
+        self._state["updated_at"] = now
+        self._state["pid"] = os.getpid()
+        if force or now - self._last_write >= self._min_write_interval_s:
+            self._write()
+            self._last_write = now
+
+    def _write(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            suffix=".tmp",
+            dir=self.path.parent,
+            text=True,
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(self._state, f, ensure_ascii=False, indent=2, sort_keys=True)
+                f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, self.path)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise

--- a/nanobot/telegram_healthcheck.py
+++ b/nanobot/telegram_healthcheck.py
@@ -1,0 +1,114 @@
+"""Docker healthcheck for Telegram long-polling liveness."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_STATE_PATH = "/tmp/nanobot-telegram-health.json"
+_DEFAULT_CONFIG_PATH = "/root/.nanobot/config.json"
+_DEFAULT_MAX_AGE_S = 120.0
+
+
+def _env_path(name: str, default: str) -> Path:
+    return Path(os.getenv(name, default)).expanduser()
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _proc1_cmdline() -> list[str]:
+    try:
+        raw = Path("/proc/1/cmdline").read_bytes()
+    except OSError:
+        return []
+    return [part.decode("utf-8", errors="ignore") for part in raw.split(b"\x00") if part]
+
+
+def _is_gateway_process(args: list[str]) -> bool:
+    return any(arg == "gateway" or arg.endswith("/gateway") for arg in args)
+
+
+def _config_path_from_args(args: list[str]) -> Path:
+    env_override = os.getenv("NANOBOT_HEALTHCHECK_CONFIG_PATH")
+    if env_override:
+        return Path(env_override).expanduser()
+
+    for index, arg in enumerate(args):
+        if arg in {"--config", "-c"} and index + 1 < len(args):
+            return Path(args[index + 1]).expanduser()
+        if arg.startswith("--config="):
+            return Path(arg.split("=", 1)[1]).expanduser()
+    return Path(_DEFAULT_CONFIG_PATH).expanduser()
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _telegram_enabled(config_path: Path) -> bool:
+    data = _load_json(config_path)
+    if not data:
+        return False
+    channels = data.get("channels")
+    if not isinstance(channels, dict):
+        return False
+    telegram = channels.get("telegram")
+    if not isinstance(telegram, dict):
+        return False
+    return bool(telegram.get("enabled", False))
+
+
+def run_healthcheck() -> int:
+    cmdline = _proc1_cmdline()
+    if cmdline and not _is_gateway_process(cmdline):
+        print("healthy: nanobot is not running in gateway mode")
+        return 0
+
+    config_path = _config_path_from_args(cmdline)
+    if not _telegram_enabled(config_path):
+        print(f"healthy: telegram channel is disabled in {config_path}")
+        return 0
+
+    state_path = _env_path("NANOBOT_TELEGRAM_HEALTH_PATH", _DEFAULT_STATE_PATH)
+    state = _load_json(state_path)
+    if not state:
+        print(f"unhealthy: telegram polling state file is missing or unreadable: {state_path}")
+        return 1
+
+    max_age_s = _env_float("NANOBOT_TELEGRAM_HEALTH_MAX_AGE_S", _DEFAULT_MAX_AGE_S)
+    last_ok = state.get("last_ok")
+    if not isinstance(last_ok, (float, int)):
+        print(f"unhealthy: telegram polling has not reported a successful cycle yet: {state_path}")
+        return 1
+
+    age_s = max(0.0, time.time() - float(last_ok))
+    if age_s > max_age_s:
+        detail = state.get("last_error") or state.get("detail") or state.get("status") or "stale"
+        print(f"unhealthy: last successful Telegram poll was {age_s:.1f}s ago ({detail})")
+        return 1
+
+    print(f"healthy: last successful Telegram poll was {age_s:.1f}s ago")
+    return 0
+
+
+def main() -> int:
+    return run_healthcheck()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nanobot/telegram_healthcheck.sh
+++ b/nanobot/telegram_healthcheck.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+set -eu
+
+telegram_state="${NANOBOT_TELEGRAM_HEALTH_PATH:-/tmp/nanobot-telegram-health.json}"
+runtime_state="${NANOBOT_RUNTIME_HEALTH_PATH:-/tmp/nanobot-runtime-health.json}"
+telegram_max_age="${NANOBOT_TELEGRAM_HEALTH_MAX_AGE_S:-120}"
+agent_tick_max_age="${NANOBOT_RUNTIME_HEALTH_AGENT_MAX_AGE_S:-180}"
+dispatch_max_age="${NANOBOT_RUNTIME_HEALTH_DISPATCH_MAX_AGE_S:-900}"
+send_max_age="${NANOBOT_RUNTIME_HEALTH_SEND_MAX_AGE_S:-180}"
+
+cmdline="${NANOBOT_HEALTHCHECK_CMDLINE:-}"
+if [ -z "$cmdline" ]; then
+  cmdline="$(tr '\000' ' ' < /proc/1/cmdline 2>/dev/null || true)"
+fi
+case " $cmdline " in
+  *" gateway "*|*" /gateway "*) ;;
+  *)
+    echo "healthy: nanobot is not running in gateway mode"
+    exit 0
+    ;;
+esac
+
+config_path="${NANOBOT_HEALTHCHECK_CONFIG_PATH:-}"
+if [ -z "$config_path" ]; then
+  set -- $cmdline
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --config|-c)
+        shift
+        config_path="${1:-}"
+        break
+        ;;
+      --config=*)
+        config_path="${1#--config=}"
+        break
+        ;;
+    esac
+    shift || break
+  done
+fi
+config_path="${config_path:-$HOME/.nanobot/config.json}"
+
+telegram_enabled=0
+if [ -r "$config_path" ]; then
+  compact_config="$(tr -d '[:space:]' < "$config_path")"
+  if printf '%s' "$compact_config" | grep -q '"telegram":{[^}]*"enabled":true'; then
+    telegram_enabled=1
+  fi
+fi
+
+json_number() {
+  key="$1"
+  file="$2"
+  sed -n 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*\([0-9][0-9.]*\).*/\1/p' "$file" 2>/dev/null | tail -n 1
+}
+
+json_string() {
+  key="$1"
+  file="$2"
+  sed -n 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$file" 2>/dev/null | tail -n 1
+}
+
+age_gt() {
+  timestamp="$1"
+  max_age="$2"
+  [ -n "$timestamp" ] || return 0
+  now="$(date +%s)"
+  awk -v now="$now" -v ts="$timestamp" -v max="$max_age" 'BEGIN { exit !((now - ts) > max) }'
+}
+
+if [ "$telegram_enabled" -eq 1 ]; then
+  if [ ! -r "$telegram_state" ]; then
+    echo "unhealthy: telegram polling state file is missing or unreadable: $telegram_state"
+    exit 1
+  fi
+  last_ok="$(json_number last_ok "$telegram_state")"
+  if [ -z "$last_ok" ]; then
+    echo "unhealthy: telegram polling has not reported a successful cycle yet: $telegram_state"
+    exit 1
+  fi
+  if age_gt "$last_ok" "$telegram_max_age"; then
+    detail="$(json_string last_error "$telegram_state")"
+    [ -n "$detail" ] || detail="$(json_string detail "$telegram_state")"
+    [ -n "$detail" ] || detail="stale"
+    echo "unhealthy: telegram polling is stale ($detail)"
+    exit 1
+  fi
+fi
+
+if [ ! -r "$runtime_state" ]; then
+  echo "unhealthy: runtime health state file is missing or unreadable: $runtime_state"
+  exit 1
+fi
+
+last_tick="$(json_number last_agent_tick "$runtime_state")"
+if [ -z "$last_tick" ]; then
+  echo "unhealthy: agent loop has not reported a tick yet: $runtime_state"
+  exit 1
+fi
+if age_gt "$last_tick" "$agent_tick_max_age"; then
+  echo "unhealthy: agent loop tick is stale"
+  exit 1
+fi
+
+active_dispatches="$(json_number active_dispatches "$runtime_state")"
+oldest_dispatch="$(json_number oldest_dispatch_started_at "$runtime_state")"
+if [ "${active_dispatches:-0}" -gt 0 ] && age_gt "$oldest_dispatch" "$dispatch_max_age"; then
+  echo "unhealthy: message dispatch has been active too long"
+  exit 1
+fi
+
+outbound_active="$(json_number outbound_active "$runtime_state")"
+send_started="$(json_number outbound_send_started_at "$runtime_state")"
+if [ "${outbound_active:-0}" -gt 0 ] && age_gt "$send_started" "$send_max_age"; then
+  echo "unhealthy: outbound send has been active too long"
+  exit 1
+fi
+
+echo "healthy: telegram polling and gateway pipeline are fresh"
+exit 0

--- a/nanobot/telegram_polling_health.py
+++ b/nanobot/telegram_polling_health.py
@@ -1,0 +1,106 @@
+"""Telegram polling liveness tracking for long-polling bots."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from telegram.request import HTTPXRequest
+
+_DEFAULT_STATE_PATH = "/tmp/nanobot-telegram-health.json"
+
+
+def _env_path(name: str, default: str) -> Path:
+    return Path(os.getenv(name, default)).expanduser()
+
+
+def _format_error(exc: Exception) -> str:
+    text = str(exc).strip()
+    return text or exc.__class__.__name__
+
+
+@dataclass(slots=True)
+class TelegramHealthState:
+    """Track the last successful Telegram polling cycle in a small JSON file."""
+
+    path: Path = field(default_factory=lambda: _env_path("NANOBOT_TELEGRAM_HEALTH_PATH", _DEFAULT_STATE_PATH))
+    _last_ok: float = 0.0
+    _last_error: str = ""
+    _consecutive_errors: int = 0
+
+    def mark_starting(self, detail: str = "starting") -> None:
+        self._write(status="starting", detail=detail)
+
+    def mark_ok(self, detail: str = "getUpdates ok") -> None:
+        self._last_ok = time.time()
+        self._last_error = ""
+        self._consecutive_errors = 0
+        self._write(status="ok", detail=detail)
+
+    def mark_error(self, exc: Exception | str) -> None:
+        self._consecutive_errors += 1
+        self._last_error = _format_error(exc) if isinstance(exc, Exception) else str(exc)
+        self._write(status="error", detail=self._last_error)
+
+    def mark_stopped(self, detail: str = "stopped") -> None:
+        self._write(status="stopped", detail=detail)
+
+    def _write(self, *, status: str, detail: str) -> None:
+        now = time.time()
+        last_ok = self._last_ok or None
+        payload: dict[str, Any] = {
+            "status": status,
+            "detail": detail,
+            "updated_at": now,
+            "pid": os.getpid(),
+            "consecutive_errors": self._consecutive_errors,
+        }
+        if last_ok is not None:
+            payload["last_ok"] = last_ok
+            payload["last_ok_age_s"] = round(max(0.0, now - last_ok), 3)
+        if self._last_error:
+            payload["last_error"] = self._last_error
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_name(f".{self.path.name}.tmp")
+        tmp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        tmp_path.replace(self.path)
+
+
+class TelegramPollingHealthRequest(HTTPXRequest):
+    """HTTPX request object that records successful/failed getUpdates cycles."""
+
+    def __init__(self, *args: Any, health_state: TelegramHealthState | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._health_state = health_state or TelegramHealthState()
+
+    async def do_request(
+        self,
+        url: str,
+        method: str,
+        request_data: Any = None,
+        read_timeout: float | None = None,
+        write_timeout: float | None = None,
+        connect_timeout: float | None = None,
+        pool_timeout: float | None = None,
+    ) -> Any:
+        try:
+            result = await super().do_request(
+                url,
+                method,
+                request_data=request_data,
+                read_timeout=read_timeout,
+                write_timeout=write_timeout,
+                connect_timeout=connect_timeout,
+                pool_timeout=pool_timeout,
+            )
+        except Exception as exc:
+            self._health_state.mark_error(exc)
+            raise
+        else:
+            self._health_state.mark_ok()
+            return result

--- a/nanobot/telegram_polling_health.py
+++ b/nanobot/telegram_polling_health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -66,9 +67,23 @@ class TelegramHealthState:
             payload["last_error"] = self._last_error
 
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = self.path.with_name(f".{self.path.name}.tmp")
-        tmp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
-        tmp_path.replace(self.path)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            suffix=".tmp",
+            dir=self.path.parent,
+            text=True,
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2, sort_keys=True)
+                f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, self.path)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
 
 
 class TelegramPollingHealthRequest(HTTPXRequest):

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -18,6 +20,7 @@ from nanobot.channels.telegram import (
     TelegramConfig,
     _StreamBuf,
 )
+from nanobot.telegram_polling_health import TelegramPollingHealthRequest
 
 
 class _FakeHTTPXRequest:
@@ -165,6 +168,16 @@ def _make_telegram_update(
 
 
 @pytest.mark.asyncio
+async def test_channel_initializes_health_state() -> None:
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+
+    assert channel._health_state is not None
+
+
+@pytest.mark.asyncio
 async def test_start_creates_separate_pools_with_proxy(monkeypatch) -> None:
     _FakeHTTPXRequest.clear()
     config = TelegramConfig(
@@ -186,20 +199,36 @@ async def test_start_creates_separate_pools_with_proxy(monkeypatch) -> None:
 
     await channel.start()
 
-    assert len(_FakeHTTPXRequest.instances) == 2
-    api_req, poll_req = _FakeHTTPXRequest.instances
+    assert len(_FakeHTTPXRequest.instances) == 1
+    api_req = _FakeHTTPXRequest.instances[0]
+    poll_req = builder.get_updates_request_value
     assert api_req.kwargs["proxy"] == config.proxy
-    assert poll_req.kwargs["proxy"] == config.proxy
+    assert poll_req._client_kwargs["proxy"] == config.proxy
     assert api_req.kwargs["connection_pool_size"] == 32
-    assert poll_req.kwargs["connection_pool_size"] == 4
+    assert poll_req._client_kwargs["limits"].max_connections == 4
     assert builder.request_value is api_req
-    assert builder.get_updates_request_value is poll_req
+    assert isinstance(poll_req, TelegramPollingHealthRequest)
     assert callable(app.updater.start_polling_kwargs["error_callback"])
     assert any(cmd.command == "status" for cmd in app.bot.commands)
     assert any(cmd.command == "history" for cmd in app.bot.commands)
     assert any(cmd.command == "dream" for cmd in app.bot.commands)
     assert any(cmd.command == "dream_log" for cmd in app.bot.commands)
     assert any(cmd.command == "dream_restore" for cmd in app.bot.commands)
+
+
+@pytest.mark.asyncio
+async def test_on_polling_error_marks_health_state(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("NANOBOT_TELEGRAM_HEALTH_PATH", str(tmp_path / "telegram-health.json"))
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, token="123:abc", allow_from=["*"]),
+        MessageBus(),
+    )
+
+    channel._on_polling_error(RuntimeError("boom"))
+
+    payload = json.loads(channel._health_state.path.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert payload["last_error"] == "boom"
 
 
 @pytest.mark.asyncio
@@ -226,10 +255,10 @@ async def test_start_respects_custom_pool_config(monkeypatch) -> None:
     await channel.start()
 
     api_req = _FakeHTTPXRequest.instances[0]
-    poll_req = _FakeHTTPXRequest.instances[1]
+    poll_req = builder.get_updates_request_value
     assert api_req.kwargs["connection_pool_size"] == 32
     assert api_req.kwargs["pool_timeout"] == 10.0
-    assert poll_req.kwargs["pool_timeout"] == 10.0
+    assert poll_req._client_kwargs["timeout"].pool == 10.0
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_telegram_healthcheck.py
+++ b/tests/channels/test_telegram_healthcheck.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.telegram_healthcheck import run_healthcheck
+from nanobot.telegram_polling_health import TelegramHealthState, TelegramPollingHealthRequest
+
+
+def test_telegram_health_state_mark_ok_writes_state_file(tmp_path: Path) -> None:
+    state_path = tmp_path / "telegram-health.json"
+    state = TelegramHealthState(path=state_path)
+
+    state.mark_ok("poll ok")
+
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "ok"
+    assert payload["detail"] == "poll ok"
+    assert isinstance(payload["last_ok"], float)
+    assert payload["consecutive_errors"] == 0
+
+
+def test_run_healthcheck_is_healthy_when_telegram_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"channels": {"telegram": {"enabled": false}}}', encoding="utf-8")
+
+    monkeypatch.setattr("nanobot.telegram_healthcheck._proc1_cmdline", lambda: ["nanobot", "gateway"])
+    monkeypatch.setattr("nanobot.telegram_healthcheck._config_path_from_args", lambda _args: config_path)
+
+    assert run_healthcheck() == 0
+
+
+def test_run_healthcheck_is_unhealthy_when_state_file_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"channels": {"telegram": {"enabled": true}}}', encoding="utf-8")
+    state_path = tmp_path / "missing-health.json"
+
+    monkeypatch.setattr("nanobot.telegram_healthcheck._proc1_cmdline", lambda: ["nanobot", "gateway"])
+    monkeypatch.setattr("nanobot.telegram_healthcheck._config_path_from_args", lambda _args: config_path)
+    monkeypatch.setattr("nanobot.telegram_healthcheck._env_path", lambda _name, _default: state_path)
+
+    assert run_healthcheck() == 1
+
+
+@pytest.mark.asyncio
+async def test_polling_health_request_marks_ok_on_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state = TelegramHealthState(path=tmp_path / "telegram-health.json")
+    request = object.__new__(TelegramPollingHealthRequest)
+    request._health_state = state
+
+    async def fake_do_request(self, url: str, method: str, **kwargs):
+        return (200, b"{}")
+
+    monkeypatch.setattr("telegram.request.HTTPXRequest.do_request", fake_do_request)
+
+    result = await request.do_request("https://example.com", "GET")
+
+    payload = json.loads(state.path.read_text(encoding="utf-8"))
+    assert result == (200, b"{}")
+    assert payload["status"] == "ok"
+    assert payload["consecutive_errors"] == 0
+
+
+@pytest.mark.asyncio
+async def test_polling_health_request_marks_error_on_exception(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state = TelegramHealthState(path=tmp_path / "telegram-health.json")
+    request = object.__new__(TelegramPollingHealthRequest)
+    request._health_state = state
+
+    async def fake_do_request(self, url: str, method: str, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("telegram.request.HTTPXRequest.do_request", fake_do_request)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await request.do_request("https://example.com", "GET")
+
+    payload = json.loads(state.path.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert payload["last_error"] == "boom"
+    assert payload["consecutive_errors"] == 1

--- a/tests/channels/test_telegram_shell_healthcheck.py
+++ b/tests/channels/test_telegram_shell_healthcheck.py
@@ -1,0 +1,87 @@
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "nanobot" / "telegram_healthcheck.sh"
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _run_healthcheck(tmp_path: Path, *, config: dict, telegram: dict | None, runtime: dict | None):
+    config_path = tmp_path / "config.json"
+    telegram_path = tmp_path / "telegram-health.json"
+    runtime_path = tmp_path / "runtime-health.json"
+    _write_json(config_path, config)
+    if telegram is not None:
+        _write_json(telegram_path, telegram)
+    if runtime is not None:
+        _write_json(runtime_path, runtime)
+
+    env = {
+        **os.environ,
+        "NANOBOT_HEALTHCHECK_CMDLINE": f"nanobot gateway --config {config_path}",
+        "NANOBOT_HEALTHCHECK_CONFIG_PATH": str(config_path),
+        "NANOBOT_TELEGRAM_HEALTH_PATH": str(telegram_path),
+        "NANOBOT_RUNTIME_HEALTH_PATH": str(runtime_path),
+        "NANOBOT_TELEGRAM_HEALTH_MAX_AGE_S": "120",
+        "NANOBOT_RUNTIME_HEALTH_AGENT_MAX_AGE_S": "180",
+        "NANOBOT_RUNTIME_HEALTH_DISPATCH_MAX_AGE_S": "900",
+        "NANOBOT_RUNTIME_HEALTH_SEND_MAX_AGE_S": "180",
+    }
+    return subprocess.run(
+        ["sh", str(SCRIPT)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_shell_healthcheck_accepts_fresh_polling_and_runtime_state(tmp_path: Path) -> None:
+    now = time.time()
+
+    result = _run_healthcheck(
+        tmp_path,
+        config={"channels": {"telegram": {"enabled": True}}},
+        telegram={"last_ok": now},
+        runtime={"last_agent_tick": now, "active_dispatches": 0, "outbound_active": 0},
+    )
+
+    assert result.returncode == 0
+    assert "healthy:" in result.stdout
+
+
+def test_shell_healthcheck_fails_when_dispatch_is_stuck(tmp_path: Path) -> None:
+    now = time.time()
+
+    result = _run_healthcheck(
+        tmp_path,
+        config={"channels": {"telegram": {"enabled": True}}},
+        telegram={"last_ok": now},
+        runtime={
+            "last_agent_tick": now,
+            "active_dispatches": 1,
+            "oldest_dispatch_started_at": now - 901,
+            "outbound_active": 0,
+        },
+    )
+
+    assert result.returncode == 1
+    assert "dispatch has been active too long" in result.stdout
+
+
+def test_shell_healthcheck_skips_telegram_state_when_telegram_disabled(tmp_path: Path) -> None:
+    now = time.time()
+
+    result = _run_healthcheck(
+        tmp_path,
+        config={"channels": {"telegram": {"enabled": False}}},
+        telegram=None,
+        runtime={"last_agent_tick": now, "active_dispatches": 0, "outbound_active": 0},
+    )
+
+    assert result.returncode == 0

--- a/tests/test_runtime_health.py
+++ b/tests/test_runtime_health.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+from nanobot.runtime_health import RuntimeHealthState
+
+
+def test_runtime_health_tracks_active_dispatches(tmp_path: Path) -> None:
+    state_path = tmp_path / "runtime-health.json"
+    state = RuntimeHealthState(path=state_path, min_write_interval_s=999)
+
+    state.mark_dispatch_start("telegram:1")
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["active_dispatches"] == 1
+    assert isinstance(payload["oldest_dispatch_started_at"], float)
+
+    state.mark_dispatch_end("telegram:1")
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["active_dispatches"] == 0
+    assert payload["oldest_dispatch_started_at"] is None
+
+
+def test_runtime_health_tracks_outbound_send(tmp_path: Path) -> None:
+    state_path = tmp_path / "runtime-health.json"
+    state = RuntimeHealthState(path=state_path, min_write_interval_s=999)
+
+    state.mark_outbound_send_start(channel="telegram")
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["outbound_active"] == 1
+    assert payload["outbound_channel"] == "telegram"
+
+    state.mark_outbound_send_ok(channel="telegram")
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["outbound_active"] == 0
+    assert payload["last_outbound_error"] == ""


### PR DESCRIPTION
## Summary
- add Telegram polling health state tracking
- add a healthcheck entrypoint for Telegram polling deployments
- wire the healthcheck into Docker configuration and tests

## Validation
- uv run --extra dev pytest -q tests/channels/test_telegram_healthcheck.py tests/channels/test_telegram_channel.py
- uv run --extra dev ruff check nanobot/telegram_healthcheck.py nanobot/telegram_polling_health.py tests/channels/test_telegram_healthcheck.py tests/channels/test_telegram_channel.py