### PR TITLE
fix(feishu): register no-op handlers for bot member events

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -363,6 +363,18 @@ class FeishuChannel(BaseChannel):
             "register_p2_im_chat_access_event_bot_p2p_chat_entered_v1",
             self._on_bot_p2p_chat_entered,
         )
+        # Silence "processor not found" errors when bots are added/removed from groups.
+        # These events carry no actionable data for the agent.
+        builder = self._register_optional_event(
+            builder,
+            "register_p2_im_chat_member_bot_added_v1",
+            lambda _: None,
+        )
+        builder = self._register_optional_event(
+            builder,
+            "register_p2_im_chat_member_bot_deleted_v1",
+            lambda _: None,
+        )
         event_handler = builder.build()
 
         # Create WebSocket client for long connection


### PR DESCRIPTION
## Summary

Register no-op event handlers for `im.chat.member.bot.added_v1` and `im.chat.member.bot.deleted_v1` to silence "processor not found" errors in Feishu WebSocket long connection mode.

## Problem

When using Feishu WebSocket, the platform pushes all group events to the bot — including events fired when *any* bot is added to or removed from the group. Since nanobot had no handler registered for these two event types, the lark-oapi SDK logged `processor not found, type: im.chat.member.bot.added_v1` errors.

This was reported in #3772. The issue title mentions "error when @mentioned by other bots" but the actual trigger is simply any bot membership change in the group, not an @mention. (Feishu's `im.message.receive_v1` excludes bot messages by design.)

## Changes

- Added two `_register_optional_event` calls with `lambda _: None` handlers for `register_p2_im_chat_member_bot_added_v1` and `register_p2_im_chat_member_bot_deleted_v1`

Closes #3772
