### PR TITLE
fix(web): add ssl_verify config for corporate proxy SSL verification

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -44,6 +44,7 @@ class WebToolsConfig(Base):
     enable: bool = True
     proxy: str | None = None
     user_agent: str | None = None
+    ssl_verify: str | bool = True
     search: WebSearchConfig = Field(default_factory=WebSearchConfig)
     fetch: WebFetchConfig = Field(default_factory=WebFetchConfig)
 
@@ -134,6 +135,7 @@ class WebSearchTool(Tool):
             config=ctx.config.web.search,
             proxy=ctx.config.web.proxy,
             user_agent=ctx.config.web.user_agent,
+            ssl_verify=ctx.config.web.ssl_verify,
             config_loader=config_loader,
         )
 
@@ -142,11 +144,13 @@ class WebSearchTool(Tool):
         config: WebSearchConfig | None = None,
         proxy: str | None = None,
         user_agent: str | None = None,
+        ssl_verify: str | bool = True,
         config_loader: Callable[[], WebSearchConfig] | None = None,
     ):
         self.config = config if config is not None else WebSearchConfig()
         self.proxy = proxy
         self.user_agent = user_agent if user_agent is not None else _DEFAULT_USER_AGENT
+        self.ssl_verify = ssl_verify
         self._config_loader = config_loader
 
     def _refresh_config(self) -> None:
@@ -232,6 +236,7 @@ class WebSearchTool(Tool):
                         await http_client.aclose()
                         transport._client = httpx.AsyncClient(  # type: ignore[attr-defined]
                             proxy=self.proxy,
+                            verify=self.ssl_verify,
                             headers=dict(http_client.headers),
                             timeout=http_client.timeout,
                             limits=httpx.Limits(
@@ -272,7 +277,7 @@ class WebSearchTool(Tool):
             logger.warning("BRAVE_API_KEY not set, falling back to DuckDuckGo")
             return await self._search_duckduckgo(query, n)
         try:
-            async with httpx.AsyncClient(proxy=self.proxy) as client:
+            async with httpx.AsyncClient(proxy=self.proxy, verify=self.ssl_verify) as client:
                 r = await client.get(
                     "https://api.search.brave.com/res/v1/web/search",
                     params={"q": query, "count": n},
@@ -298,7 +303,7 @@ class WebSearchTool(Tool):
             logger.warning("TAVILY_API_KEY not set, falling back to DuckDuckGo")
             return await self._search_duckduckgo(query, n)
         try:
-            async with httpx.AsyncClient(proxy=self.proxy) as client:
+            async with httpx.AsyncClient(proxy=self.proxy, verify=self.ssl_verify) as client:
                 r = await client.post(
                     "https://api.tavily.com/search",
                     headers={"Authorization": f"Bearer {api_key}", "User-Agent": self.user_agent},
@@ -320,7 +325,7 @@ class WebSearchTool(Tool):
         if not is_valid:
             return f"Error: invalid SearXNG URL: {error_msg}"
         try:
-            async with httpx.AsyncClient(proxy=self.proxy) as client:
+            async with httpx.AsyncClient(proxy=self.proxy, verify=self.ssl_verify) as client:
                 r = await client.get(
                     endpoint,
                     params={"q": query, "format": "json"},
@@ -344,7 +349,7 @@ class WebSearchTool(Tool):
                 "User-Agent": self.user_agent,
             }
             encoded_query = quote(query, safe="")
-            async with httpx.AsyncClient(proxy=self.proxy) as client:
+            async with httpx.AsyncClient(proxy=self.proxy, verify=self.ssl_verify) as client:
                 r = await client.get(
                     f"https://s.jina.ai/{encoded_query}",
                     headers=headers,
@@ -367,7 +372,7 @@ class WebSearchTool(Tool):
             logger.warning("KAGI_API_KEY not set, falling back to DuckDuckGo")
             return await self._search_duckduckgo(query, n)
         try:
-            async with httpx.AsyncClient(proxy=self.proxy) as client:
+            async with httpx.AsyncClient(proxy=self.proxy, verify=self.ssl_verify) as client:
                 r = await client.get(
                     "https://kagi.com/api/v0/search",
                     params={"q": query, "limit": n},
@@ -446,12 +451,14 @@ class WebFetchTool(Tool):
             config=ctx.config.web.fetch,
             proxy=ctx.config.web.proxy,
             user_agent=ctx.config.web.user_agent,
+            ssl_verify=ctx.config.web.ssl_verify,
         )
 
-    def __init__(self, config: WebFetchConfig | None = None, proxy: str | None = None, user_agent: str | None = None, max_chars: int = 50000):
+    def __init__(self, config: WebFetchConfig | None = None, proxy: str | None = None, user_agent: str | None = None, ssl_verify: str | bool = True, max_chars: int = 50000):
         self.config = config if config is not None else WebFetchConfig()
         self.proxy = proxy
         self.user_agent = user_agent or _DEFAULT_USER_AGENT
+        self.ssl_verify = ssl_verify
         self.max_chars = max_chars
 
     @property
@@ -474,7 +481,7 @@ class WebFetchTool(Tool):
 
         # Detect and fetch images directly to avoid Jina's textual image captioning
         try:
-            async with httpx.AsyncClient(proxy=self.proxy, follow_redirects=True, max_redirects=MAX_REDIRECTS, timeout=15.0) as client:
+            async with httpx.AsyncClient(proxy=self.proxy, verify=self.ssl_verify, follow_redirects=True, max_redirects=MAX_REDIRECTS, timeout=15.0) as client:
                 async with client.stream("GET", url, headers={"User-Agent": self.user_agent}) as r:
                     from nanobot.security.network import validate_resolved_url
 
@@ -504,7 +511,7 @@ class WebFetchTool(Tool):
             jina_key = os.environ.get("JINA_API_KEY", "")
             if jina_key:
                 headers["Authorization"] = f"Bearer {jina_key}"
-            async with httpx.AsyncClient(proxy=self.proxy, timeout=20.0) as client:
+            async with httpx.AsyncClient(proxy=self.proxy, verify=self.ssl_verify, timeout=20.0) as client:
                 r = await client.get(f"https://r.jina.ai/{url}", headers=headers)
                 if r.status_code == 429:
                     logger.debug("Jina Reader rate limited, falling back to readability")
@@ -543,6 +550,7 @@ class WebFetchTool(Tool):
                 max_redirects=MAX_REDIRECTS,
                 timeout=30.0,
                 proxy=self.proxy,
+                verify=self.ssl_verify,
             ) as client:
                 r = await client.get(url, headers={"User-Agent": self.user_agent})
                 r.raise_for_status()

--- a/tests/tools/test_web_ssl_verify.py
+++ b/tests/tools/test_web_ssl_verify.py
@@ -1,0 +1,190 @@
+"""Tests for ssl_verify config flow in web tools."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from nanobot.agent.tools.web import (
+    WebFetchTool,
+    WebSearchTool,
+    WebToolsConfig,
+)
+from nanobot.config.schema import WebSearchConfig
+
+
+def _fake_resolve_public(hostname, port, family=0, type_=0):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+
+# --- Config-level tests ---
+
+
+def test_ssl_verify_default_is_true():
+    config = WebToolsConfig()
+    assert config.ssl_verify is True
+
+
+def test_ssl_verify_config_accepts_false():
+    config = WebToolsConfig(ssl_verify=False)
+    assert config.ssl_verify is False
+
+
+def test_ssl_verify_config_accepts_ca_path():
+    config = WebToolsConfig(ssl_verify="/path/to/corporate-ca.pem")
+    assert config.ssl_verify == "/path/to/corporate-ca.pem"
+
+
+# --- Tool constructor propagation tests ---
+
+
+def test_web_fetch_tool_receives_ssl_verify():
+    tool = WebFetchTool(ssl_verify=False)
+    assert tool.ssl_verify is False
+
+
+def test_web_fetch_tool_defaults_ssl_verify_to_true():
+    tool = WebFetchTool()
+    assert tool.ssl_verify is True
+
+
+def test_web_search_tool_receives_ssl_verify():
+    tool = WebSearchTool(
+        config=WebSearchConfig(),
+        ssl_verify=False,
+    )
+    assert tool.ssl_verify is False
+
+
+def test_web_search_tool_defaults_ssl_verify_to_true():
+    tool = WebSearchTool(config=WebSearchConfig())
+    assert tool.ssl_verify is True
+
+
+# --- httpx.AsyncClient verifies receive the param ---
+
+
+class FakeClient:
+    """Fake httpx.AsyncClient that captures __init__ kwargs."""
+
+    captured_kwargs: dict = {}
+
+    def __init__(self, *args, **kwargs):
+        self.captured_kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_async_client_receives_verify_false_for_fetch(monkeypatch):
+    """WebFetchTool with ssl_verify=False must pass verify=False to httpx.AsyncClient."""
+    captured: list[dict] = []
+
+    class TrackingClient:
+        nonlocal captured  # type: ignore[misc]
+
+        def __init__(self, *args, **kwargs):
+            captured.append(dict(kwargs))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, headers=None):
+            class FakeStream:
+                headers = {"content-type": "text/html"}
+                url = "https://example.com/page"
+
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, *a):
+                    return False
+
+            return FakeStream()
+
+        async def get(self, url, **kw):
+            class FakeResp:
+                status_code = 200
+                url = "https://example.com/page"
+                text = "<html><body><p>ok</p></body></html>"
+                headers = {"content-type": "text/html"}
+
+                def raise_for_status(self):
+                    return None
+
+                def json(self):
+                    return {}
+
+            return FakeResp()
+
+    monkeypatch.setattr("nanobot.agent.tools.web.httpx.AsyncClient", TrackingClient)
+
+    tool = WebFetchTool(ssl_verify=False)
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+        await tool.execute(url="https://example.com/page")
+
+    # All 3 calls (image detection, Jina, readability) should pass verify=False
+    for call_kwargs in captured:
+        assert call_kwargs.get("verify") is False, f"verify was {call_kwargs.get('verify')}"
+
+
+@pytest.mark.asyncio
+async def test_async_client_receives_verify_true_default_for_fetch(monkeypatch):
+    """WebFetchTool with default ssl_verify=True must pass verify=True."""
+    captured: list[dict] = []
+
+    class TrackingClient:
+        def __init__(self, *args, **kwargs):
+            captured.append(dict(kwargs))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, headers=None):
+            class FakeStream:
+                headers = {"content-type": "text/html"}
+                url = "https://example.com/page"
+
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, *a):
+                    return False
+
+            return FakeStream()
+
+        async def get(self, url, **kw):
+            class FakeResp:
+                status_code = 200
+                url = "https://example.com/page"
+                text = "<html><body><p>ok</p></body></html>"
+                headers = {"content-type": "text/html"}
+
+                def raise_for_status(self):
+                    return None
+
+                def json(self):
+                    return {}
+
+            return FakeResp()
+
+    monkeypatch.setattr("nanobot.agent.tools.web.httpx.AsyncClient", TrackingClient)
+
+    tool = WebFetchTool()  # default ssl_verify=True
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+        await tool.execute(url="https://example.com/page")
+
+    for call_kwargs in captured:
+        assert call_kwargs.get("verify") is True, f"verify was {call_kwargs.get('verify')}"


### PR DESCRIPTION
## Problem

When operating behind a corporate proxy that performs SSL MITM interception (self-signed CA), all web tool operations fail with:

```
httpx.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain
```

This affects both `web_fetch` and `web_search` tools.

## Solution

Add `ssl_verify: str | bool = True` to `WebToolsConfig` and propagate `verify=` to all 9 `httpx.AsyncClient` instantiations.

Users can configure via `~/.nanobot/config.json`:
- `false` — disable SSL verification (corporate proxy)
- custom path string — use custom CA bundle
- Default: `true` (no change in security behavior)

## Changes

- nanobot/agent/tools/web.py: Add ssl_verify field to WebToolsConfig, plumb through both WebSearchTool and WebFetchTool, apply verify= to all httpx.AsyncClient sites
- tests/tools/test_web_ssl_verify.py: 9 unit tests covering config defaults, tool propagation, and httpx client integration

## Testing

- ruff check nanobot/agent/tools/web.py — pass
- pytest tests/tools/test_web_* — 51/51 pass (42 existing + 9 new)