### PR TITLE
feat(providers): add OpenCode Go gateway support (OpenAI + Anthropic compat)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,8 @@ IMAP_PASSWORD=your-password-here
 > - **MiniMax thinking mode**: Use `providers.minimaxAnthropic` when you want `reasoningEffort` / thinking mode. MiniMax exposes that capability through its Anthropic-compatible endpoint, so nanobot keeps it as a separate provider instead of guessing MiniMax-specific thinking parameters on the generic OpenAI-compatible `minimax` endpoint. It uses the same `MINIMAX_API_KEY`. Default Anthropic-compatible base URL: `https://api.minimax.io/anthropic`; for mainland China use `https://api.minimaxi.com/anthropic`.
 > - **VolcEngine / BytePlus Coding Plan**: Use dedicated providers `volcengineCodingPlan` or `byteplusCodingPlan` instead of the pay-per-use `volcengine` / `byteplus` providers.
 > - **Zhipu Coding Plan**: If you're on Zhipu's coding plan, set `"apiBase": "https://open.bigmodel.cn/api/coding/paas/v4"` in your zhipu provider config.
+> - **OpenCode Go**: Aggregated gateway for GLM, Kimi, DeepSeek, MiMo, Qwen, and MiniMax through one API key and subscription. Model IDs use `opencode-go/<model-id>` format. Subscribe: [opencode.ai](https://opencode.ai)
+> - **OpenCode Go Anthropic**: Use `opencode-go-anthropic` for MiniMax M2.5 / M2.7 thinking mode via the Anthropic-compatible endpoint. Uses the same `OPENCODE_GO_API_KEY`.
 > - **Alibaba Cloud BaiLian**: If you're using Alibaba Cloud BaiLian's OpenAI-compatible endpoint, set `"apiBase": "https://dashscope.aliyuncs.com/compatible-mode/v1"` in your dashscope provider config.
 > - **Step Fun (Mainland China)**: If your API key is from Step Fun's mainland China platform (stepfun.com), set `"apiBase": "https://api.stepfun.com/v1"` in your stepfun provider config.
 > - **Xiaomi MiMo thinking mode**: MiMo models (e.g. `mimo-v2.5-pro`) default to enabled thinking. Use `agents.defaults.reasoningEffort: "none"` to disable it, or `"low"` / `"medium"` / `"high"` to keep it on. Omitting the field preserves the provider's per-model default.
@@ -70,6 +72,8 @@ IMAP_PASSWORD=your-password-here
 | `groq` | LLM + Voice transcription (Whisper, default) | [console.groq.com](https://console.groq.com) |
 | `minimax` | LLM (MiniMax direct) | [platform.minimaxi.com](https://platform.minimaxi.com) |
 | `minimax_anthropic` | LLM (MiniMax Anthropic-compatible endpoint, thinking mode) | [platform.minimaxi.com](https://platform.minimaxi.com) |
+| `opencode_go` | LLM (OpenCode Go gateway, OpenAI compat) | [opencode.ai](https://opencode.ai) |
+| `opencode_go_anthropic` | LLM (OpenCode Go gateway, Anthropic compat, thinking mode) | [opencode.ai](https://opencode.ai) |
 | `gemini` | LLM (Gemini direct) | [aistudio.google.com](https://aistudio.google.com) |
 | `aihubmix` | LLM (API gateway, access to all models) | [aihubmix.com](https://aihubmix.com) |
 | `siliconflow` | LLM (SiliconFlow/硅基流动) | [siliconflow.cn](https://siliconflow.cn) |

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -214,6 +214,8 @@ class ProvidersConfig(Base):
     byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
+    opencode_go: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenCode Go gateway (OpenAI compat)
+    opencode_go_anthropic: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenCode Go gateway (Anthropic compat)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
     nvidia: ProviderConfig = Field(default_factory=ProviderConfig)  # NVIDIA NIM (nvapi- keys)
 

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -34,10 +34,12 @@ class AnthropicProvider(LLMProvider):
         api_base: str | None = None,
         default_model: str = "claude-sonnet-4-20250514",
         extra_headers: dict[str, str] | None = None,
+        spec=None,  # ProviderSpec | None — for strip_model_prefix, etc.
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
+        self._spec = spec
 
         from anthropic import AsyncAnthropic
 
@@ -108,8 +110,9 @@ class AnthropicProvider(LLMProvider):
             error_should_retry=should_retry,
         )
 
-    @staticmethod
-    def _strip_prefix(model: str) -> str:
+    def _strip_prefix(self, model: str) -> str:
+        if self._spec and self._spec.strip_model_prefix:
+            return model.split("/")[-1]
         if model.startswith("anthropic/"):
             return model[len("anthropic/"):]
         return model

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -76,6 +76,7 @@ def _make_provider_core(
             api_base=config.get_api_base(model, preset=resolved),
             default_model=model,
             extra_headers=p.extra_headers if p else None,
+            spec=spec,
         )
     elif backend == "bedrock":
         from nanobot.providers.bedrock_provider import BedrockProvider

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -236,6 +236,43 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         thinking_style="thinking_type",
     ),
 
+    # OpenCode Go: gateway aggregating GLM, Kimi, DeepSeek, MiMo, Qwen, MiniMax.
+    # Model IDs use opencode-go/<model-id> format; strip before sending to API.
+    # OpenAI-compatible endpoint at /zen/go/v1/chat/completions.
+    ProviderSpec(
+        name="opencode_go",
+        keywords=(
+            "opencode-go",
+            "glm-5",
+            "kimi-k2",
+            "deepseek-v4",
+            "mimo-v2",
+            "qwen3",
+        ),
+        env_key="OPENCODE_GO_API_KEY",
+        display_name="OpenCode Go",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_base_keyword="opencode",
+        default_api_base="https://opencode.ai/zen/go/v1",
+        strip_model_prefix=True,
+        supports_max_completion_tokens=True,
+    ),
+
+    # OpenCode Go Anthropic-compatible endpoint at /zen/go/v1/messages.
+    # For MiniMax M2.5 / M2.7 models served via Anthropic Messages API.
+    ProviderSpec(
+        name="opencode_go_anthropic",
+        keywords=("opencode-go-anthropic",),
+        env_key="OPENCODE_GO_API_KEY",
+        display_name="OpenCode Go Anthropic",
+        backend="anthropic",
+        is_gateway=True,
+        detect_by_base_keyword="opencode",
+        default_api_base="https://opencode.ai/zen/go/v1",
+        strip_model_prefix=True,
+    ),
+
 
     # === Standard providers (matched by model-name keywords) ===============
     # Anthropic: native Anthropic SDK

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.5.post3"
 description = "A lightweight personal AI assistant framework"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
-license = {text = "MIT"}
+license = "MIT"
 authors = [
     {name = "Xubin Ren"},
     {name = "the nanobot contributors"}

--- a/tests/providers/test_opencode_go_provider.py
+++ b/tests/providers/test_opencode_go_provider.py
@@ -1,0 +1,200 @@
+"""Tests for OpenCode Go provider registration, matching, and prefix stripping."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nanobot.config.schema import Config, ProvidersConfig
+from nanobot.providers.registry import PROVIDERS, find_by_name
+
+
+# ── registry 注册验证 ──────────────────────────────────────────────────
+
+
+def test_opencode_go_spec_exists_in_registry():
+    """OpenCode Go (OpenAI compat) 应在 PROVIDERS 中注册。"""
+    spec = find_by_name("opencode_go")
+    assert spec is not None
+    assert spec.backend == "openai_compat"
+    assert spec.is_gateway is True
+    assert spec.strip_model_prefix is True
+    assert spec.env_key == "OPENCODE_GO_API_KEY"
+    assert spec.default_api_base == "https://opencode.ai/zen/go/v1"
+    assert "opencode-go" in spec.keywords
+    assert "kimi-k2" in spec.keywords
+    assert "deepseek-v4" in spec.keywords
+    assert spec.display_name == "OpenCode Go"
+
+
+def test_opencode_go_anthropic_spec_exists_in_registry():
+    """OpenCode Go (Anthropic compat) 应在 PROVIDERS 中注册。"""
+    spec = find_by_name("opencode_go_anthropic")
+    assert spec is not None
+    assert spec.backend == "anthropic"
+    assert spec.is_gateway is True
+    assert spec.strip_model_prefix is True
+    assert spec.env_key == "OPENCODE_GO_API_KEY"
+    assert spec.default_api_base == "https://opencode.ai/zen/go/v1"
+    assert spec.display_name == "OpenCode Go Anthropic"
+
+
+# ── schema 配置字段验证 ────────────────────────────────────────────────
+
+
+def test_opencode_go_config_field_exists():
+    """ProvidersConfig 应包含 opencode_go 和 opencode_go_anthropic 字段。"""
+    cfg = ProvidersConfig()
+    assert hasattr(cfg, "opencode_go")
+    assert hasattr(cfg, "opencode_go_anthropic")
+
+
+def test_opencode_go_field_is_not_excluded():
+    """OpenCode Go 不是 OAuth provider，不应被 exclude。"""
+    cfg = ProvidersConfig()
+    dumped = cfg.model_dump(by_alias=True)
+    assert "opencodeGo" in dumped
+    assert "opencodeGoAnthropic" in dumped
+
+
+# ── 模型匹配验证 ─────────────────────────────────────────────────────
+
+
+def test_config_matches_opencode_go_by_prefix():
+    """通过 opencode-go/ 前缀匹配到 opencode_go provider。"""
+    config = Config()
+    config.agents.defaults.model = "opencode-go/kimi-k2.6"
+    config.providers.opencode_go.api_key = "sk-test"
+
+    assert config.get_provider_name() == "opencode_go"
+    assert config.get_api_base() == "https://opencode.ai/zen/go/v1"
+
+
+def test_config_matches_opencode_go_anthropic_by_prefix():
+    """通过 opencode-go-anthropic/ 前缀匹配到 opencode_go_anthropic provider。"""
+    config = Config()
+    config.agents.defaults.model = "opencode-go-anthropic/minimax-m2.7"
+    config.providers.opencode_go_anthropic.api_key = "sk-test"
+
+    assert config.get_provider_name() == "opencode_go_anthropic"
+    assert config.get_api_base() == "https://opencode.ai/zen/go/v1"
+
+
+def test_config_matches_opencode_go_by_keyword():
+    """通过关键词 kimi-k2 匹配到 opencode_go provider（无前缀时）。"""
+    config = Config()
+    config.agents.defaults.model = "kimi-k2.6"
+    config.providers.opencode_go.api_key = "sk-test"
+
+    assert config.get_provider_name() == "opencode_go"
+
+
+def test_config_matches_opencode_go_by_deepseek_keyword():
+    """通过关键词 deepseek-v4 匹配到 opencode_go provider。"""
+    config = Config()
+    config.agents.defaults.model = "deepseek-v4-pro"
+    config.providers.opencode_go.api_key = "sk-test"
+
+    assert config.get_provider_name() == "opencode_go"
+
+
+def test_config_opencode_go_falls_back_to_default_api_base():
+    """未配置 api_base 时，回退到 ProviderSpec.default_api_base。"""
+    config = Config()
+    config.agents.defaults.model = "opencode-go/kimi-k2.6"
+    config.providers.opencode_go.api_key = "sk-test"
+    # 不设置 api_base
+
+    assert config.get_api_base() == "https://opencode.ai/zen/go/v1"
+
+
+# ── 前缀剥离验证（OpenAI compat） ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_opencode_go_openai_strips_model_prefix():
+    """OpenAI compat 路径下，strip_model_prefix=True 应剥离 opencode-go/ 前缀。"""
+    from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+
+    mock_create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="ok"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+        )
+    )
+    spec = find_by_name("opencode_go")
+
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI") as MockClient:
+        client_instance = MockClient.return_value
+        client_instance.chat.completions.create = mock_create
+
+        provider = OpenAICompatProvider(
+            api_key="sk-test",
+            api_base="https://opencode.ai/zen/go/v1",
+            default_model="opencode-go/kimi-k2.6",
+            spec=spec,
+        )
+        await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            model="opencode-go/kimi-k2.6",
+        )
+
+    call_kwargs = mock_create.call_args.kwargs
+    assert call_kwargs["model"] == "kimi-k2.6"
+
+
+# ── 前缀剥离验证（Anthropic compat） ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_opencode_go_anthropic_strips_model_prefix():
+    """Anthropic 路径下，strip_model_prefix=True 应剥离 opencode-go-anthropic/ 前缀。"""
+    from nanobot.providers.anthropic_provider import AnthropicProvider
+
+    mock_create = AsyncMock(
+        return_value=SimpleNamespace(
+            content=[SimpleNamespace(text="ok", type="text")],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=1, output_tokens=2),
+            model="minimax-m2.7",
+        )
+    )
+    spec = find_by_name("opencode_go_anthropic")
+
+    with patch("nanobot.providers.anthropic_provider.AsyncAnthropic") as MockClient:
+        client_instance = MockClient.return_value
+        client_instance.messages.create = mock_create
+
+        provider = AnthropicProvider(
+            api_key="sk-test",
+            api_base="https://opencode.ai/zen/go/v1",
+            default_model="opencode-go-anthropic/minimax-m2.7",
+            spec=spec,
+        )
+        await provider.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            model="opencode-go-anthropic/minimax-m2.7",
+        )
+
+    call_kwargs = mock_create.call_args.kwargs
+    assert call_kwargs["model"] == "minimax-m2.7"
+
+
+# ── api_base 传递验证 ─────────────────────────────────────────────────
+
+
+def test_opencode_go_custom_api_base_overrides_default():
+    """用户自定义 api_base 应覆盖 ProviderSpec.default_api_base。"""
+    config = Config()
+    config.agents.defaults.model = "opencode-go/kimi-k2.6"
+    config.providers.opencode_go.api_key = "sk-test"
+    config.providers.opencode_go.api_base = "https://custom-proxy.example.com/v1"
+
+    assert config.get_api_base() == "https://custom-proxy.example.com/v1"


### PR DESCRIPTION
## Summary

Add OpenCode Go gateway provider support, enabling nanobot to use the aggregated API gateway for GLM, Kimi, DeepSeek, MiMo, Qwen, and MiniMax models through a single API key and subscription.

## Changes

- **Registry**: Add `opencode_go` (OpenAI compat) and `opencode_go_anthropic` (Anthropic compat) provider specs with model prefix stripping
- **Schema**: Add `opencode_go` and `opencode_go_anthropic` fields to `ProvidersConfig`
- **AnthropicProvider**: Support gateway-aware model prefix stripping via `ProviderSpec.strip_model_prefix`
- **Factory**: Wire `spec` parameter into `AnthropicProvider` constructor
- **Docs**: Document OpenCode Go usage and env key (`OPENCODE_GO_API_KEY`)
- **Tests**: 200-line test suite covering registry registration, config schema, model matching, prefix stripping, and API base fallback