### PR TITLE
fix(telegram): wire transcription config fields through to the channel

### DIFF
--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -42,6 +42,21 @@ class BaseChannel(ABC):
         self.logger = logger.bind(channel=self.name)
         self.bus = bus
         self._running = False
+        # Hydrate transcription/render attrs from the channel config when
+        # provided. Channel configs use Pydantic `extra="allow"` so callers
+        # can override these per-channel without bloating the schema; the
+        # class-level defaults above kick in only when nothing was set.
+        for attr in (
+            "transcription_provider",
+            "transcription_api_key",
+            "transcription_api_base",
+            "transcription_language",
+            "send_progress",
+            "send_tool_hints",
+        ):
+            val = getattr(config, attr, None)
+            if val is not None and val != "":
+                setattr(self, attr, val)
 
     async def transcribe_audio(self, file_path: str | Path) -> str:
         """Transcribe an audio file via Whisper (OpenAI or Groq). Returns empty string on failure."""

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -241,6 +241,12 @@ class TelegramConfig(Base):
     # Enable inline keyboard buttons in Telegram messages.
     inline_keyboards: bool = False
     stream_edit_interval: float = Field(default=_STREAM_EDIT_INTERVAL_DEFAULT, ge=0.1)
+    # Voice/audio transcription. Empty api_key disables transcription
+    # entirely; messages then reach the agent as the raw [voice: <path>] tag.
+    transcription_provider: Literal["groq", "openai"] = "groq"
+    transcription_api_key: str = ""
+    transcription_api_base: str = ""
+    transcription_language: str | None = Field(default=None, pattern=r"^[a-z]{2,3}$")
 
 
 class TelegramChannel(BaseChannel):


### PR DESCRIPTION
## Problem

Setting `transcription_provider` / `transcription_api_key` / `transcription_language` on a Telegram channel in `config.json` has no effect: voice messages still reach the agent as the raw `[voice: <path>]` tag instead of the transcribed text.

There are two independent issues, both fixed in this PR:

### 1. `TelegramConfig` silently drops the fields

`TelegramConfig` doesn't declare the transcription fields and doesn't set `model_config = ConfigDict(extra="allow")`. Pydantic therefore strips them during `TelegramConfig.model_validate(dict)`:

```python
>>> raw = {"enabled": True, "transcription_provider": "groq", "transcription_api_key": "gsk_..."}
>>> TelegramConfig.model_validate(raw).model_dump().keys()
# transcription_* are gone
```

### 2. `BaseChannel.__init__` doesn't hydrate the class defaults

Even if the fields survived validation, `BaseChannel` declares them as **class-level** defaults (`transcription_api_key: str = ""`) and never copies the per-instance value from `config` onto `self`. `transcribe_audio()` reads `self.transcription_api_key`, sees the empty class default, hits the silent early-return at `if not self.transcription_api_key: return ""`, and the agent receives `[voice: <path>]` instead of a transcript.

## Fix

- `TelegramConfig`: declare `transcription_provider` / `transcription_api_key` / `transcription_api_base` / `transcription_language` as proper fields so they survive validation.
- `BaseChannel.__init__`: walk a small known list of transcription/render attrs and copy any non-empty value off `config`. Class-level defaults still kick in when nothing was configured.

## Verification

End-to-end on a server with `transcription_provider: "groq"`, `transcription_api_key: "${GROQ_API_KEY}"`, `transcription_language: "uk"`:

```
prov: groq
key_len: 56
key_prefix: gsk_9nOk3l
lang: uk

# transcribe_audio on a real Ukrainian voice message:
transcription: ' Я говорю це українською.'
```

Before the fix: `transcription` was always `""`, and the agent saw the raw path tag.