### PR TITLE
[security] fix(feishu): confine downloaded media filenames

### DIFF
--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -22,6 +22,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
+from nanobot.utils.helpers import safe_filename
 from nanobot.utils.logging_bridge import redirect_lib_logging
 
 FEISHU_AVAILABLE = importlib.util.find_spec("lark_oapi") is not None
@@ -1044,6 +1045,19 @@ class FeishuChannel(BaseChannel):
             self.logger.exception("Error downloading {} {}", resource_type, file_key)
             return None, None
 
+    @staticmethod
+    def _safe_media_filename(filename: str | None, fallback: str) -> str:
+        """Return a local-only filename for downloaded Feishu media."""
+        candidate = filename or fallback
+        # Feishu/Lark filenames come from message metadata. Treat both POSIX
+        # and Windows separators as path boundaries before applying the shared
+        # filename sanitizer so downloads cannot escape the channel media dir.
+        candidate = os.path.basename(candidate.replace("\\", "/"))
+        candidate = safe_filename(candidate)
+        if candidate in ("", ".", ".."):
+            return safe_filename(fallback) or uuid.uuid4().hex
+        return candidate
+
     async def _download_and_save_media(
         self, msg_type: str, content_json: dict, message_id: str | None = None
     ) -> tuple[str | None, str]:
@@ -1057,15 +1071,17 @@ class FeishuChannel(BaseChannel):
         media_dir = get_media_dir("feishu")
 
         data, filename = None, None
+        fallback_filename = uuid.uuid4().hex
 
         if msg_type == "image":
             image_key = content_json.get("image_key")
             if image_key and message_id:
+                fallback_filename = f"{image_key[:16]}.jpg"
                 data, filename = await loop.run_in_executor(
                     None, self._download_image_sync, message_id, image_key
                 )
                 if not filename:
-                    filename = f"{image_key[:16]}.jpg"
+                    filename = fallback_filename
 
         elif msg_type in ("audio", "file", "media"):
             file_key = content_json.get("file_key")
@@ -1076,6 +1092,7 @@ class FeishuChannel(BaseChannel):
                 self.logger.warning("{} message missing message_id", msg_type)
                 return None, f"[{msg_type}: missing message_id]"
 
+            fallback_filename = file_key[:16]
             data, filename = await loop.run_in_executor(
                 None, self._download_file_sync, message_id, file_key, msg_type
             )
@@ -1085,7 +1102,9 @@ class FeishuChannel(BaseChannel):
                 return None, f"[{msg_type}: download failed]"
 
             if not filename:
-                filename = file_key[:16]
+                filename = fallback_filename
+
+            filename = self._safe_media_filename(filename, fallback_filename)
 
             # Feishu voice messages are opus in OGG container.
             # Use .ogg extension for better Whisper compatibility.
@@ -1094,6 +1113,7 @@ class FeishuChannel(BaseChannel):
                     filename = f"{filename}.ogg"
 
         if data and filename:
+            filename = self._safe_media_filename(filename, fallback_filename)
             file_path = media_dir / filename
             file_path.write_bytes(data)
             path_str = str(file_path)

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -1104,8 +1104,6 @@ class FeishuChannel(BaseChannel):
             if not filename:
                 filename = fallback_filename
 
-            filename = self._safe_media_filename(filename, fallback_filename)
-
             # Feishu voice messages are opus in OGG container.
             # Use .ogg extension for better Whisper compatibility.
             if msg_type == "audio":

--- a/tests/channels/test_feishu_media_filename_security.py
+++ b/tests/channels/test_feishu_media_filename_security.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from nanobot.channels import feishu as feishu_module
+from nanobot.channels.feishu import FeishuChannel
+
+
+@pytest.mark.asyncio
+async def test_feishu_downloaded_media_filename_cannot_escape_media_dir(monkeypatch, tmp_path):
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+    outside = tmp_path / "escaped.txt"
+
+    monkeypatch.setattr(feishu_module, "get_media_dir", lambda _channel: media_dir)
+
+    channel = FeishuChannel.__new__(FeishuChannel)
+    channel.logger = SimpleNamespace(
+        debug=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+    )
+
+    def fake_download(_message_id, _file_key, _resource_type):
+        return b"owned", "../escaped.txt"
+
+    channel._download_file_sync = fake_download
+
+    path_str, content = await channel._download_and_save_media(
+        "file", {"file_key": "fk_123"}, "msg_123"
+    )
+
+    saved_path = Path(path_str)
+    assert not outside.exists()
+    assert saved_path.parent == media_dir
+    assert saved_path.name == "escaped.txt"
+    assert saved_path.read_bytes() == b"owned"
+    assert content == f"[file: {saved_path}]"


### PR DESCRIPTION
## Summary

This PR hardens Feishu/Lark inbound media downloads so provider-returned filenames are treated as local filenames only, not filesystem paths.

`_download_and_save_media()` previously joined the filename returned by the Feishu/Lark API under `get_media_dir("feishu")`. This PR normalizes downloaded media filenames to a basename, applies the shared `safe_filename()` sanitizer immediately before the local write, and adds a regression test for traversal-style provider filenames.

## Security issues covered

| Issue | Scope | Fix |
| --- | --- | --- |
| Feishu/Lark downloaded media filename containment | Inbound media saved by `nanobot/channels/feishu.py` | Strip path components, apply the shared `safe_filename()` sanitizer, and fall back to generated local names when needed |

## Before this PR

- Feishu/Lark media download helpers could return filenames from message/file metadata.
- `_download_and_save_media()` joined that filename directly under `get_media_dir("feishu")`.
- If a provider-returned filename ever contained path separators, the local write path was not explicitly constrained to the Feishu media directory.

## After this PR

- Provider-returned media names are normalized to a basename before writing.
- Both POSIX `/` and Windows `\\` separators are treated as path boundaries.
- The shared `safe_filename()` helper is applied at the unified write point for image, audio, file, and media downloads.
- Empty, current-directory, and parent-directory names fall back to generated safe names.
- Existing Feishu voice-message `.ogg` extension handling is preserved.

## Why this matters

Downloaded chat attachment metadata should not be trusted as a filesystem path segment. Even if Feishu/Lark normally sanitizes upload filenames before returning them through the SDK, the channel adapter should enforce the local media-directory boundary before writing downloaded bytes.

This is therefore framed as defense-in-depth hardening for a local file-write boundary, not as a demonstrated high-severity exploit against Feishu/Lark production metadata.

## Affected code

- `nanobot/channels/feishu.py`
  - `_download_and_save_media()`
  - Feishu image/file/audio/media save path construction

## Root cause

- Provider-returned filenames were used as local filename segments without first reducing them to a basename.
- The Feishu adapter did not normalize POSIX/Windows path separators before joining the filename with the media directory.
- Existing fallback names were safe, but only used when no provider filename was returned.

## Severity assessment

- Issue: Feishu/Lark downloaded media filename containment during local attachment save
- Severity: Defense-in-depth / hardening
- Rationale: `response.file_name` is parsed from Feishu/Lark API metadata through the SDK, and the platform is expected to sanitize ordinary upload filenames. This PR does not claim a practical high-severity exploit, arbitrary code execution, credential disclosure, or unrestricted filesystem access. The fix makes the local channel invariant explicit: provider metadata can influence only a sanitized filename under the Feishu media directory, not a directory path.

## Safe reproduction steps

The regression test added in this PR safely stubs the Feishu file download helper so no external Feishu service is required:

1. Override the Feishu media directory with a temporary directory.
2. Stub `_download_file_sync()` to return media bytes with the filename `../escaped.txt`.
3. Call `_download_and_save_media("file", {"file_key": "..."}, message_id="...")`.
4. Assert that:
   - the returned file path remains inside the Feishu media directory,
   - no sibling file is created outside that directory,
   - the downloaded bytes are still written successfully.

## Expected vulnerable behavior in the harness

On the pre-fix code path, the same stubbed download attempts to write outside the Feishu media directory because `../escaped.txt` is joined directly with `get_media_dir("feishu")`.

## Changes in this PR

- Adds `_safe_media_filename()` for Feishu media downloads.
- Normalizes provider filenames by stripping POSIX and Windows path components.
- Applies the shared `safe_filename()` helper once at the unified write point before local writes.
- Adds a regression test covering traversal-style Feishu media filenames.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Feishu channel hardening | `nanobot/channels/feishu.py` | Sanitizes provider-returned media filenames before writing downloaded bytes |
| Regression test | `tests/channels/test_feishu_media_filename_security.py` | Verifies traversal-style filenames cannot escape the Feishu media directory |

## Maintainer impact

- Legitimate downloaded media files continue to be saved under the Feishu media directory.
- Filenames may be normalized if they contain directory separators or unsafe characters.
- Existing fallback filename behavior remains in place for media without provider filenames.
- Voice-message `.ogg` compatibility behavior is preserved.

## Fix rationale

The local save boundary should be enforced at the point where external provider metadata becomes a filesystem path. Sanitizing immediately before the write makes the invariant explicit: Feishu media downloads can select a sanitized local filename, but cannot select a directory.

## Reviewer feedback addressed

- Removed the redundant early `_safe_media_filename()` call on the file/audio/media path; sanitization now happens once at the unified write point for all media types.
- Reframed the PR severity and description as defense-in-depth hardening rather than a High-severity demonstrated exploit.
- Kept the scope bounded to Feishu/Lark; other channel adapters can be audited separately as follow-up work.

## Type of change

- [x] Security hardening / defense-in-depth
- [x] Regression test
- [ ] Breaking change
- [ ] Documentation-only change

## Test plan

Validated locally with three focused loops:

```bash
uv run --extra dev python -m ruff check nanobot/channels/feishu.py tests/channels/test_feishu_media_filename_security.py tests/channels/test_feishu_reply.py
uv run --extra dev python -m pytest tests/channels/test_feishu_media_filename_security.py tests/channels/test_feishu_reply.py -q
```

Each loop passed:

- Ruff: `All checks passed!`
- Pytest: `46 passed, 4 warnings`

Also ran:

```bash
git diff --check
```

No whitespace errors were reported.

## Disclosure notes

This PR is intentionally bounded to Feishu/Lark downloaded media filename containment. It does not claim remote code execution, unrestricted filesystem access, credential disclosure, or vulnerabilities in other channel adapters.
