### PR TITLE
fix(codex): stabilize prompt cache key

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -56,7 +56,7 @@ class OpenAICodexProvider(LLMProvider):
             "input": input_items,
             "text": {"verbosity": "medium"},
             "include": ["reasoning.encrypted_content"],
-            "prompt_cache_key": _prompt_cache_key(messages),
+            "prompt_cache_key": _prompt_cache_key(messages[:2]),
             "tool_choice": tool_choice or "auto",
             "parallel_tool_calls": True,
         }

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nanobot.providers.openai_codex_provider import OpenAICodexProvider
+
+
+@pytest.mark.asyncio
+async def test_codex_prompt_cache_key_uses_stable_conversation_prefix(monkeypatch) -> None:
+    bodies: list[dict] = []
+
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_provider.get_codex_token",
+        lambda: SimpleNamespace(account_id="acct", access="token"),
+    )
+
+    async def fake_request(url, headers, body, verify, on_content_delta=None):
+        bodies.append(body)
+        return "ok", [], "stop"
+
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider._request_codex", fake_request)
+
+    provider = OpenAICodexProvider()
+    await provider.chat(
+        [
+            {"role": "system", "content": "You are nanobot."},
+            {"role": "user", "content": "first request"},
+            {"role": "assistant", "content": "first answer"},
+        ],
+    )
+    await provider.chat(
+        [
+            {"role": "system", "content": "You are nanobot."},
+            {"role": "user", "content": "first request"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "follow up"},
+        ],
+    )
+    await provider.chat(
+        [
+            {"role": "system", "content": "You are nanobot."},
+            {"role": "user", "content": "different request"},
+            {"role": "assistant", "content": "first answer"},
+        ],
+    )
+
+    assert bodies[0]["prompt_cache_key"] == bodies[1]["prompt_cache_key"]
+    assert bodies[0]["prompt_cache_key"] != bodies[2]["prompt_cache_key"]


### PR DESCRIPTION
## Summary

Fixes #2440.

- Stabilizes the Codex Responses API `prompt_cache_key` across follow-up turns in the same conversation.
- Keeps the cache key naturally isolated by the system prompt plus first user message.
- Leaves runner/base provider APIs unchanged.

## Problem / Root Cause

The Codex provider previously hashed the full `messages` payload for `prompt_cache_key`. Because nanobot history is append-only, each follow-up turn changes the message list and therefore changes the cache key, which defeats prompt cache reuse for the conversation.

## Scope

- Files/modules changed: `nanobot/providers/openai_codex_provider.py` and a focused provider test.
- Explicit non-goals: no runner changes, no base provider capability gate, no session-key based cache mechanism, no behavior changes for non-Codex providers.
- User-visible behavior changes: Codex conversations can reuse a stable prompt cache key across appended turns.
- Compatibility notes: request payload shape is unchanged; only the input used to derive `prompt_cache_key` is narrowed.

## Design

- Derive `prompt_cache_key` from `messages[:2]` instead of the full message history.
- This uses nanobot's existing append-only `[system, user, assistant, user, ...]` message shape to keep the key stable for a conversation while still differing for different initial prompts.
- The `_prompt_cache_key` helper remains unchanged.

## Safety / Risk

- Default behavior impact: only the OpenAI Codex provider's `prompt_cache_key` value changes.
- Config/API/channel/session/storage/network impact: no config/schema/storage changes and no new provider API parameters.
- Rollback plan: revert this commit to restore full-message cache key hashing.
- Residual risk: conversations with identical system prompt and first user message will share the same cache key, which follows from the proposed `messages[:2]` scoping.

## Validation

Passed:

- `uv run ruff check nanobot --select F401,F841`
- `uv run ruff check nanobot/providers/openai_codex_provider.py tests/providers/test_openai_codex_provider.py --select F401,F841`
- `uv run pytest tests/providers/test_openai_codex_provider.py tests/providers/test_provider_retry.py tests/agent/test_runner_core.py`

Also ran `uv run pytest tests/`: 3005 passed, 3 skipped, 8 failed. The failures are in `tests/channels/test_dingtalk_channel.py` media redirect/download tests because this environment cannot resolve `example.com`, so the DingTalk fake HTTP client is never reached. Those failures are outside the Codex prompt cache path changed here.
