### PR TITLE
fix(web): back off Brave search rate limits

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -272,23 +272,37 @@ class WebSearchTool(Tool):
             logger.warning("BRAVE_API_KEY not set, falling back to DuckDuckGo")
             return await self._search_duckduckgo(query, n)
         try:
+            headers = {
+                "Accept": "application/json",
+                "X-Subscription-Token": api_key,
+                "User-Agent": self.user_agent,
+            }
             async with httpx.AsyncClient(proxy=self.proxy) as client:
-                r = await client.get(
-                    "https://api.search.brave.com/res/v1/web/search",
-                    params={"q": query, "count": n},
-                    headers={
-                        "Accept": "application/json",
-                        "X-Subscription-Token": api_key,
-                        "User-Agent": self.user_agent,
-                    },
-                    timeout=10.0,
-                )
+                for attempt in range(2):
+                    r = await client.get(
+                        "https://api.search.brave.com/res/v1/web/search",
+                        params={"q": query, "count": n},
+                        headers=headers,
+                        timeout=10.0,
+                    )
+                    if r.status_code != 429:
+                        break
+                    if attempt == 0:
+                        logger.warning("Brave search rate limited; retrying once in 1.0s")
+                        await asyncio.sleep(1.0)
                 r.raise_for_status()
             items = [
                 {"title": x.get("title", ""), "url": x.get("url", ""), "content": x.get("description", "")}
                 for x in r.json().get("web", {}).get("results", [])
             ]
             return _format_results(query, items, n)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                return (
+                    "Error: Brave search rate limited after retry. "
+                    "Retry later or reduce consecutive web_search calls."
+                )
+            return f"Error: {e}"
         except Exception as e:
             return f"Error: {e}"
 

--- a/tests/tools/test_web_search_tool.py
+++ b/tests/tools/test_web_search_tool.py
@@ -19,7 +19,10 @@ def _tool(
     )
 
 
-def _response(status: int = 200, json: dict | None = None) -> httpx.Response:
+def _response(
+    status: int = 200,
+    json: dict | None = None,
+) -> httpx.Response:
     """Build a mock httpx.Response with a dummy request attached."""
     r = httpx.Response(status, json=json)
     r._request = httpx.Request("GET", "https://mock")
@@ -60,6 +63,55 @@ async def test_brave_search(monkeypatch):
     result = await tool.execute(query="nanobot", count=1)
     assert "NanoBot" in result
     assert "https://example.com" in result
+
+
+@pytest.mark.asyncio
+async def test_brave_search_retries_rate_limit_once(monkeypatch):
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    async def mock_sleep(delay: float):
+        sleeps.append(delay)
+
+    async def mock_get(self, url, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _response(status=429, json={"error": "rate limit"})
+        return _response(json={
+            "web": {"results": [{"title": "Recovered", "url": "https://example.com", "description": "ok"}]}
+        })
+
+    monkeypatch.setattr("nanobot.agent.tools.web.asyncio.sleep", mock_sleep)
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+
+    tool = _tool(provider="brave", api_key="brave-key")
+    result = await tool.execute(query="nanobot", count=1)
+
+    assert calls["n"] == 2
+    assert "Recovered" in result
+    assert sleeps == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_brave_search_returns_clear_rate_limit_after_retries(monkeypatch):
+    calls = {"n": 0}
+
+    async def mock_sleep(delay: float):
+        return None
+
+    async def mock_get(self, url, **kw):
+        calls["n"] += 1
+        return _response(status=429, json={"error": "rate limit"})
+
+    monkeypatch.setattr("nanobot.agent.tools.web.asyncio.sleep", mock_sleep)
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+
+    tool = _tool(provider="brave", api_key="brave-key")
+    result = await tool.execute(query="nanobot", count=1)
+
+    assert calls["n"] == 2
+    assert "Brave search rate limited" in result
+    assert "consecutive web_search" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #2560.

- Retries Brave `web_search` once when the provider returns HTTP 429.
- Waits 1 second before the retry to handle transient serial-tool-call rate limits.
- Returns a clearer Brave rate-limit message if the retry also receives 429.

## Problem / Root Cause

Brave searches were issued once and then surfaced `httpx`'s raw HTTP error on 429. Multi-search agent flows can make a small number of serial Brave requests in one turn, so an occasional provider rate limit should be retried before failing the tool call.

## Scope

- Files/modules changed: Brave branch of `WebSearchTool` and web search tests.
- Explicit non-goals: no global tool scheduler changes, no provider fallback policy changes, no `Retry-After` parser, no per-provider locking or pacing state, and no changes to DuckDuckGo/Tavily/Jina/Kagi/SearXNG.
- User-visible behavior changes: Brave 429 responses get one short retry before returning a clearer rate-limit error.
- Compatibility notes: successful Brave responses and non-429 errors keep existing behavior.

## Design

- Keep the retry local to `_search_brave`, around the existing Brave `client.get` call.
- Retry only once after a fixed 1-second sleep, matching the small serial request volume expected from agent tool calls.
- Avoid persistent rate-limit state, locks, and cross-request coordination.

## Safety / Risk

- Default behavior impact: only Brave search requests with an API key.
- Config/API/channel/session/storage/network impact: no config/schema/storage changes; a Brave 429 can add one 1-second wait and one retry request.
- Rollback plan: revert this commit to restore single-attempt Brave requests.
- Residual risk: repeated provider-side 429s still fail after the retry instead of blocking the agent turn for longer.

## Validation

Passed:

- `uv run ruff check nanobot --select F401,F841`
- `uv run ruff check nanobot/agent/tools/web.py tests/tools/test_web_search_tool.py --select F401,F841`
- `uv run pytest tests/tools/test_web_search_tool.py tests/tools/test_search_tools.py::test_web_search_tool_refreshes_dynamic_config_loader`

Also ran `uv run pytest tests/`: 3006 passed, 3 skipped, 8 failed. The failures are in `tests/channels/test_dingtalk_channel.py` media redirect/download tests because this environment cannot resolve `example.com`, so the DingTalk fake HTTP client is never reached. Those failures are outside the Brave web search path changed here.
