### PR TITLE
️ Enhance(skill): Introduce skill_load tool to prevent skill content loss in multi-turn conversations

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -440,6 +440,7 @@ class AgentLoop:
             provider_snapshot_loader=self._provider_snapshot_loader,
             image_generation_provider_configs=self._image_generation_provider_configs,
             timezone=self.context.timezone or "UTC",
+            skills_loader=self.context.skills,
         )
         loader = ToolLoader()
         registered = loader.load(ctx, self.tools)

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -1079,6 +1079,8 @@ class AgentRunner:
 
         stale = compactable_indices[: len(compactable_indices) - _MICROCOMPACT_KEEP_RECENT]
         updated: list[dict[str, Any]] | None = None
+        skill_count = 0
+        last_skill_idx = -1
         for idx in stale:
             msg = messages[idx]
             content = msg.get("content")
@@ -1088,6 +1090,12 @@ class AgentRunner:
             summary = f"[{name} result omitted from context]"
             if updated is None:
                 updated = [dict(m) for m in messages]
+            if name == "skill_load":
+                skill_count += 1
+                if skill_count > 1:
+                    updated[last_skill_idx]["content"] = summary
+                last_skill_idx = idx
+                continue
             updated[idx]["content"] = summary
 
         return updated if updated is not None else messages

--- a/nanobot/agent/tools/context.py
+++ b/nanobot/agent/tools/context.py
@@ -32,3 +32,4 @@ class ToolContext:
     provider_snapshot_loader: Callable[[], Any] | None = None
     image_generation_provider_configs: dict[str, Any] | None = None
     timezone: str = "UTC"
+    skills_loader: Any = field(default=None)

--- a/nanobot/agent/tools/skill_load.py
+++ b/nanobot/agent/tools/skill_load.py
@@ -55,12 +55,24 @@ class SkillLoadTool(Tool):
             if self._skills_loader is None:
                 return "Error: skills_loader is not initialized"
 
+            all_skills = self._skills_loader.list_skills(filter_unavailable=False)
+            all_names = {skill["name"] for skill in all_skills}
+            if skill_name not in all_names:
+                available = ", ".join(sorted(all_names)) or "(none)"
+                return f"Error: skill '{skill_name}' not found. Available skills: {available}"
+
+            available_names = {
+                skill["name"] for skill in self._skills_loader.list_skills(filter_unavailable=True)
+            }
+            if skill_name not in available_names:
+                meta = self._skills_loader._get_skill_meta(skill_name)
+                missing = self._skills_loader._get_missing_requirements(meta)
+                detail = f": {missing}" if missing else ""
+                return f"Error: skill '{skill_name}' is unavailable{detail}"
+
             content = self._skills_loader.load_skills_for_context([skill_name])
             if not content:
-                available = [
-                    s["name"] for s in self._skills_loader.list_skills(filter_unavailable=False)
-                ]
-                return f"Error: skill '{skill_name}' not found. Available skills: {', '.join(available)}"
+                return f"Error: skill '{skill_name}' has no loadable content"
             return content
         except Exception as e:
             return f"Error loading skill: {e}"

--- a/nanobot/agent/tools/skill_load.py
+++ b/nanobot/agent/tools/skill_load.py
@@ -10,10 +10,12 @@ from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
 
 
-@tool_parameters(tool_parameters_schema(
-    skill_name=StringSchema("Name of the skill to load"),
-    required=["skill_name"],
-))
+@tool_parameters(
+    tool_parameters_schema(
+        skill_name=StringSchema("Name of the skill to load"),
+        required=["skill_name"],
+    )
+)
 class SkillLoadTool(Tool):
     """Load the full content of a skill by name."""
 
@@ -44,7 +46,7 @@ class SkillLoadTool(Tool):
                 return "Error: skill_name is required"
 
             loader = SkillsLoader(self._workspace or Path("."))
-            content = loader.load_skill(skill_name)
+            content = loader.load_skills_for_context([skill_name])
             if content is None:
                 available = [s["name"] for s in loader.list_skills(filter_unavailable=False)]
                 return f"Error: skill '{skill_name}' not found. Available skills: {', '.join(available)}"

--- a/nanobot/agent/tools/skill_load.py
+++ b/nanobot/agent/tools/skill_load.py
@@ -21,12 +21,19 @@ class SkillLoadTool(Tool):
 
     _scopes = {"core", "subagent"}
 
-    def __init__(self, workspace: Path | None = None) -> None:
+    def __init__(
+        self, workspace: Path | None = None, skills_loader: SkillsLoader | None = None
+    ) -> None:
         self._workspace = workspace
+        self._skills_loader = skills_loader
+        if self._skills_loader is None:
+            self._skills_loader = SkillsLoader(workspace or Path("."))
 
     @classmethod
     def create(cls, ctx: Any) -> Tool:
-        return cls(workspace=Path(ctx.workspace) if ctx.workspace else None)
+        workspace = Path(ctx.workspace) if ctx.workspace else None
+        loader = ctx.skills_loader if ctx.skills_loader else SkillsLoader(workspace or Path("."))
+        return cls(workspace=workspace, skills_loader=loader)
 
     @property
     def name(self) -> str:
@@ -45,10 +52,14 @@ class SkillLoadTool(Tool):
             if not skill_name:
                 return "Error: skill_name is required"
 
-            loader = SkillsLoader(self._workspace or Path("."))
-            content = loader.load_skills_for_context([skill_name])
-            if content is None:
-                available = [s["name"] for s in loader.list_skills(filter_unavailable=False)]
+            if self._skills_loader is None:
+                return "Error: skills_loader is not initialized"
+
+            content = self._skills_loader.load_skills_for_context([skill_name])
+            if not content:
+                available = [
+                    s["name"] for s in self._skills_loader.list_skills(filter_unavailable=False)
+                ]
                 return f"Error: skill '{skill_name}' not found. Available skills: {', '.join(available)}"
             return content
         except Exception as e:

--- a/nanobot/agent/tools/skill_load.py
+++ b/nanobot/agent/tools/skill_load.py
@@ -1,0 +1,53 @@
+"""Load skill content by name."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from nanobot.agent.skills import SkillsLoader
+from nanobot.agent.tools.base import Tool, tool_parameters
+from nanobot.agent.tools.schema import StringSchema, tool_parameters_schema
+
+
+@tool_parameters(tool_parameters_schema(
+    skill_name=StringSchema("Name of the skill to load"),
+    required=["skill_name"],
+))
+class SkillLoadTool(Tool):
+    """Load the full content of a skill by name."""
+
+    _scopes = {"core", "subagent"}
+
+    def __init__(self, workspace: Path | None = None) -> None:
+        self._workspace = workspace
+
+    @classmethod
+    def create(cls, ctx: Any) -> Tool:
+        return cls(workspace=Path(ctx.workspace) if ctx.workspace else None)
+
+    @property
+    def name(self) -> str:
+        return "skill_load"
+
+    @property
+    def description(self) -> str:
+        return "Load the full content of a skill by name."
+
+    @property
+    def read_only(self) -> bool:
+        return True
+
+    async def execute(self, skill_name: str = "", **kwargs: Any) -> str:
+        try:
+            if not skill_name:
+                return "Error: skill_name is required"
+
+            loader = SkillsLoader(self._workspace or Path("."))
+            content = loader.load_skill(skill_name)
+            if content is None:
+                available = [s["name"] for s in loader.list_skills(filter_unavailable=False)]
+                return f"Error: skill '{skill_name}' not found. Available skills: {', '.join(available)}"
+            return content
+        except Exception as e:
+            return f"Error loading skill: {e}"

--- a/nanobot/templates/agent/skills_section.md
+++ b/nanobot/templates/agent/skills_section.md
@@ -1,6 +1,6 @@
 # Skills
 
-The following skills extend your capabilities. To use a skill, read its SKILL.md file using the read_file tool.
+The following skills extend your capabilities. To use a skill, read its SKILL.md file using the skill_load tool.
 Unavailable skills need dependencies installed first — you can try installing them with apt/brew.
 
 {{ skills_summary }}

--- a/tests/agent/test_context_builder.py
+++ b/tests/agent/test_context_builder.py
@@ -263,6 +263,20 @@ class TestBuildSystemPrompt:
         assert "## AGENTS.md" not in result
         assert "[Archived Context Summary]" not in result
 
+    def test_skills_section_guides_model_to_skill_load(self, tmp_path):
+        skill_dir = tmp_path / "skills" / "alpha"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: alpha\ndescription: Alpha skill.\n---\n\n# Alpha\n",
+            encoding="utf-8",
+        )
+        builder = _builder(tmp_path)
+
+        result = builder.build_system_prompt()
+
+        assert "using the skill_load tool" in result
+        assert "using the read_file tool" not in result
+
 
 # ---------------------------------------------------------------------------
 # build_messages

--- a/tests/agent/test_skills_loader.py
+++ b/tests/agent/test_skills_loader.py
@@ -23,7 +23,7 @@ def _write_skill(
     lines = ["---"]
     if metadata_json is not None:
         payload = json.dumps({"nanobot": metadata_json}, separators=(",", ":"))
-        lines.append(f'metadata: {payload}')
+        lines.append(f"metadata: {payload}")
     lines.extend(["---", "", body])
     path = skill_dir / "SKILL.md"
     path.write_text("\n".join(lines), encoding="utf-8")
@@ -229,7 +229,9 @@ def test_list_skills_openclaw_metadata_parsed_for_requirements(
     skill_dir = skills_root / "openclaw_skill"
     skill_dir.mkdir(parents=True)
     skill_path = skill_dir / "SKILL.md"
-    oc_payload = json.dumps({"openclaw": {"requires": {"bins": ["nanobot_oc_bin"]}}}, separators=(",", ":"))
+    oc_payload = json.dumps(
+        {"openclaw": {"requires": {"bins": ["nanobot_oc_bin"]}}}, separators=(",", ":")
+    )
     skill_path.write_text(
         "\n".join(["---", f"metadata: {oc_payload}", "---", "", "# OC"]),
         encoding="utf-8",
@@ -328,7 +330,7 @@ def test_build_skills_summary_folded_description(tmp_path: Path) -> None:
         "name: pdf\n"
         "description: >\n"
         "  Use this skill when visual quality and design identity matter for a PDF.\n"
-        "  CREATE (generate from scratch): \"make a PDF\".\n"
+        '  CREATE (generate from scratch): "make a PDF".\n'
         "---\n\n# PDF Skill\n",
         encoding="utf-8",
     )
@@ -377,14 +379,12 @@ def test_get_skill_metadata_handles_yaml_types(tmp_path: Path) -> None:
     ws_skills.mkdir(parents=True)
     skill_dir = ws_skills / "typed"
     skill_dir.mkdir(parents=True)
-    payload = json.dumps({"nanobot": {"requires": {"bins": ["gh"]}, "always": True}}, separators=(",", ":"))
+    payload = json.dumps(
+        {"nanobot": {"requires": {"bins": ["gh"]}, "always": True}}, separators=(",", ":")
+    )
     skill_path = skill_dir / "SKILL.md"
     skill_path.write_text(
-        "---\n"
-        "name: typed\n"
-        f"metadata: {payload}\n"
-        "always: true\n"
-        "---\n\n# Typed\n",
+        f"---\nname: typed\nmetadata: {payload}\nalways: true\n---\n\n# Typed\n",
         encoding="utf-8",
     )
     builtin = tmp_path / "builtin"
@@ -397,3 +397,89 @@ def test_get_skill_metadata_handles_yaml_types(tmp_path: Path) -> None:
     assert meta.get("always") is True
     # metadata is a parsed dict, not a JSON string
     assert isinstance(meta.get("metadata"), dict)
+
+
+def test_skill_content_gets_microcompacted():
+    """Skill content read via read_file get dropped after 10+ new tool results"""
+    from nanobot.agent.runner import _MICROCOMPACT_KEEP_RECENT, AgentRunner
+
+    # skill content
+    skill_content = "for test for test for test" * 100
+
+    # llm messages list
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "please do something"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "test0", "function": {"name": "read_file", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "test0", "name": "read_file", "content": skill_content},
+    ]
+
+    for i in range(1, _MICROCOMPACT_KEEP_RECENT + 10):
+        messages.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": f"test{i}", "function": {"name": "exec", "arguments": "{}"}}],
+            },
+        )
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": f"test{i}",
+                "name": "read_file",
+                "content": "something..." * 100,
+            },
+        )
+
+    result = AgentRunner._microcompact(messages)
+
+    skill_msg = result[3]
+
+    assert skill_msg["content"] == "[read_file result omitted from context]"
+
+
+def test_load_skill_content_gets_microcompacted():
+    """Skill content read via read_file get dropped after 10+ new tool results"""
+    from nanobot.agent.runner import _MICROCOMPACT_KEEP_RECENT, AgentRunner
+
+    # skill content
+    skill_content = "for test" * 100
+
+    # llm messages list
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "please do something"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "test0", "function": {"name": "skill_load", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "test0", "name": "skill_load", "content": skill_content},
+    ]
+
+    for i in range(1, _MICROCOMPACT_KEEP_RECENT + 10):
+        messages.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": f"test{i}", "function": {"name": "exec", "arguments": "{}"}}],
+            },
+        )
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": f"test{i}",
+                "name": "exec",
+                "content": "something..." * 100,
+            },
+        )
+
+    result = AgentRunner._microcompact(messages)
+
+    skill_msg = result[3]
+
+    assert skill_msg["content"] == skill_content

--- a/tests/tools/test_skill_load_tool.py
+++ b/tests/tools/test_skill_load_tool.py
@@ -1,0 +1,64 @@
+"""Tests for the skill_load tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nanobot.agent.skills import SkillsLoader
+from nanobot.agent.tools.skill_load import SkillLoadTool
+
+
+def _write_skill(
+    workspace: Path,
+    name: str,
+    *,
+    metadata_json: dict | None = None,
+    body: str = "# Skill\nUse this skill carefully.",
+) -> Path:
+    skill_dir = workspace / "skills" / name
+    skill_dir.mkdir(parents=True)
+    lines = ["---", f"name: {name}", f"description: {name} skill."]
+    if metadata_json is not None:
+        payload = json.dumps({"nanobot": metadata_json}, separators=(",", ":"))
+        lines.append(f"metadata: {payload}")
+    lines.extend(["---", "", body])
+    path = skill_dir / "SKILL.md"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+async def test_skill_load_returns_formatted_skill_content(tmp_path: Path) -> None:
+    _write_skill(tmp_path, "alpha", body="# Alpha\nDo alpha work.")
+    tool = SkillLoadTool(workspace=tmp_path, skills_loader=SkillsLoader(tmp_path))
+
+    result = await tool.execute(skill_name="alpha")
+
+    assert result.startswith("### Skill: alpha")
+    assert "# Alpha" in result
+    assert "Do alpha work." in result
+    assert "---" not in result
+
+
+async def test_skill_load_returns_clear_error_for_missing_skill(tmp_path: Path) -> None:
+    _write_skill(tmp_path, "alpha")
+    tool = SkillLoadTool(workspace=tmp_path, skills_loader=SkillsLoader(tmp_path))
+
+    result = await tool.execute(skill_name="missing")
+
+    assert "Error: skill 'missing' not found" in result
+    assert "alpha" in result
+
+
+async def test_skill_load_rejects_unavailable_skill(tmp_path: Path) -> None:
+    _write_skill(
+        tmp_path,
+        "needs-tool",
+        metadata_json={"requires": {"bins": ["definitely_missing_nanobot_test_bin"]}},
+    )
+    tool = SkillLoadTool(workspace=tmp_path, skills_loader=SkillsLoader(tmp_path))
+
+    result = await tool.execute(skill_name="needs-tool")
+
+    assert result.startswith("Error: skill 'needs-tool' is unavailable")
+    assert "definitely_missing_nanobot_test_bin" in result

--- a/tests/tools/test_tool_loader.py
+++ b/tests/tools/test_tool_loader.py
@@ -91,6 +91,7 @@ def test_discover_finds_concrete_tools():
     class_names = {cls.__name__ for cls in discovered}
     assert "ExecTool" in class_names
     assert "MessageTool" in class_names
+    assert "SkillLoadTool" in class_names
     assert "SpawnTool" in class_names
 
 


### PR DESCRIPTION
## Description

This PR introduces a new skill_load tool to nanobot. This change addresses a critical issue where the content of skill.md files was being lost or overwritten during multi-turn conversations when relying solely on the standard read_file tool.

Previously, when the bot used the read_file tool to load a skill, the system struggled to maintain the full context of the skill.md file across subsequent dialogue turns. This often resulted in the skill's core instructions and definitions being dropped from the active context window, leading to degraded performance and loss of intended behavior.

## The Solution

Added skill_load tool specifically designed to distinguish read_file and skill load. 


## Testing

I have added a new test suite to verify the context persistence behavior. The tests explicitly compare the two approaches:

Baseline Test: Uses read_file to load a skill and asserts that the skill.md content is eventually lost/overwritten in later turns.
Regression Test: Uses the new skill_load tool and asserts that the skill.md content remains intact and accessible throughout the conversation.

## Type of Change

[x] Bug fix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)

releated to #3846