### PR TITLE
docs(contributing): warn that `ruff format` predates the codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,11 @@ pytest
 # Lint code
 ruff check nanobot/
 
-# Format code
-ruff format nanobot/
+# Format code — optional. The existing tree predates `ruff format`,
+# so running it across `nanobot/` produces a large unrelated diff
+# (E501 is ignored, so many existing lines exceed the 100-char setting).
+# Format only files you've actually touched, not the whole package.
+ruff format <files-you-changed>
 ```
 
 ## Contribution License


### PR DESCRIPTION
## Summary

- Closes #3849
- The `Development Setup` block told new contributors to run `ruff format nanobot/`, but the tree predates the formatter and `E501` is ignored in lint, so the command produces an ~80-file / ~2500-insertion unrelated diff on a fresh clone.
- Replace the unscoped command with a short warning + a per-file usage pattern, so the doc matches reality.

## Diff

```diff
-# Format code
-ruff format nanobot/
+# Format code — optional. The existing tree predates `ruff format`,
+# so running it across `nanobot/` produces a large unrelated diff
+# (E501 is ignored, so many existing lines exceed the 100-char setting).
+# Format only files you've actually touched, not the whole package.
+ruff format <files-you-changed>
```

## Test plan

- [x] Doc-only change — no code paths touched
- [x] `ruff check nanobot/` behavior unchanged
- [x] Targets `main` per CONTRIBUTING L37-44 (docs → `main`)