### PR TITLE
fix(exec): allow format in URL parameters while still blocking the format command

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -106,7 +106,7 @@ class ExecTool(Tool):
             r"\brm\s+-[rf]{1,2}\b",          # rm -r, rm -rf, rm -fr
             r"\bdel\s+/[fq]\b",              # del /f, del /q
             r"\brmdir\s+/s\b",               # rmdir /s
-            r"(?:^|[;&|]\s*)format\b",       # format (as standalone command only)
+            r"(?:^|[;&|]\s*)format(?!=)\b",   # format (as standalone command only)
             r"\b(mkfs|diskpart)\b",          # disk operations
             r"\bdd\s+if=",                   # dd
             r">\s*/dev/sd",                  # write to disk

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -243,3 +243,44 @@ def test_exec_still_blocks_real_outside_path_via_redirect(tmp_path):
     blocked = tool._guard_command("echo pwn > /etc/issue", str(workspace))
     assert blocked is not None
     assert "path outside working dir" in blocked
+
+
+# --- format command blocking -----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "format C: /q",
+        "format D: /fs:ntfs",
+        "&& format",
+        "| format",
+        "&format",
+        ";format",
+        "|format",
+    ],
+)
+def test_exec_blocks_format_command(command):
+    """The Windows ``format`` disk command must be denied."""
+    tool = ExecTool()
+    result = tool._guard_command(command, "/tmp")
+    assert result is not None
+    assert "deny pattern filter" in result.lower()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # URL parameter &format= must NOT be blocked (regression).
+        'curl -s "wttr.in/xxx?lang=zh&format=%l:+%c+%t+%h+%w&1"',
+        'curl -s "wttr.in/xxx?format=%l:+%c+%t+%h+%w&1"',
+        # format as a non-command word in a normal argument.
+        "echo format",
+        "echo reformat",
+    ],
+)
+def test_exec_allows_format_in_url_and_args(command):
+    """``format`` inside URL parameters or as a non-command arg must be allowed."""
+    tool = ExecTool()
+    result = tool._guard_command(command, "/tmp")
+    assert result is None


### PR DESCRIPTION
## Bug

The `format` command deny pattern in `ExecTool` incorrectly blocks shell commands that contain `format` as a URL query parameter (e.g. `&format=json` or
`?format=%l:+%c+%t`).

This causes legitimate commands like weather queries to fail:

```bash
curl -s "wttr.in/Shenzhen+Longhua?lang=zh&format=%l:+%c+%t+%h+%w&1"
```

**Error log from a real Feishu session:**

```
{"role": "tool", "tool_call_id": "619b1300-...", "name": "exec", "content": "Error: Command blocked by safety guard (dangerous pattern detected)"}
```

## Root Cause

In `nanobot/agent/tools/shell.py` line 109, the deny pattern:

```python
r"(?:^|[;&|]\s*)format\b"
```

matches `format` after `&` regardless of context. Since `&` is both a shell command separator AND a URL query parameter delimiter, the regex cannot
distinguish between:

- `echo foo & format C:` (command — should block)
- `curl "wttr.in/...&format=json"` (URL param — should allow)

## Fix

Added a negative lookahead `(?!=\)` after `format`:

```python
# Before
r"(?:^|[;&|]\s*)format\b"

# After
r"(?:^|[;&|]\s*)format(?!=)\b"
```

`(?!=\)` ensures that `format` followed by `=` (i.e. `format=` as a URL parameter key=value pair) is NOT matched. A standalone `format` command (followed
by whitespace, end-of-string, or a non-`=` character) is still correctly blocked.

This is semantically correct because `format=` in a URL is always a query parameter assignment, never a disk format command.

## Test Coverage

Added two parametrized test groups in `tests/tools/test_exec_security.py`:

**Blocked (7 cases):** `format C: /q`, `format D: /fs:ntfs`, `&& format`, `| format`, `&format`, `;format`, `|format`

**Allowed (3 cases):** the exact `curl wttr.in` command with `&format=`, `echo format`, `echo reformat`

All 49 tests in `test_exec_security.py` and 46 tests in other exec test files pass with zero regressions.