### PR TITLE
feat(webui): expose peer roster via bootstrap endpoint

### DIFF
--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -11,6 +11,7 @@ import hmac
 import http
 import json
 import mimetypes
+import os
 import re
 import secrets
 import shutil
@@ -198,6 +199,26 @@ def _resolve_bootstrap_model_name(
                 if stripped:
                     return stripped
     return _default_model_name_from_config()
+
+
+def _read_peers() -> list[dict[str, Any]] | None:
+    """Read multi-instance peer roster from ``NANOBOT_PEER_*`` env vars.
+
+    Each env var value must be JSON with at least ``id``, ``gateway_port``,
+    and ``ws_port`` fields.  Returns ``None`` when no peers are configured
+    (single-instance mode).
+    """
+    peers = []
+    for key, value in sorted(os.environ.items()):
+        if not key.startswith("NANOBOT_PEER_"):
+            continue
+        try:
+            peer = json.loads(value)
+            if isinstance(peer, dict):
+                peers.append(peer)
+        except (json.JSONDecodeError, ValueError):
+            logger.debug("webui bootstrap: failed to parse peer env {}", key)
+    return peers or None
 
 
 def _parse_request_path(path_with_query: str) -> tuple[str, dict[str, list[str]]]:
@@ -753,6 +774,7 @@ class WebSocketChannel(BaseChannel):
                 "ws_path": self._expected_path(),
                 "expires_in": self.config.token_ttl_s,
                 "model_name": _resolve_bootstrap_model_name(self._runtime_model_name),
+                "peers": _read_peers(),
             }
         )
 


### PR DESCRIPTION
## 摘要

为 `/webui/bootstrap` 端点增加一个最小化、可选的 peer 发现注入点。

当环境中存在 `NANOBOT_PEER_*` 变量（JSON 格式，含 `id`、`gateway_port`、`ws_port` 字段）时，bootstrap 响应会增加一个 `peers` 字段。无 peer 配置时 `peers` 为 `null`，行为完全不变。

## 动机

多实例编排场景（例如 HF Spaces 中运行多个 nanobot 容器）需要 WebUI 能发现其他 peer 实例，以支持跨 agent 消息、动态侧边栏 tab、状态监控等功能。目前 bootstrap 响应没有对应的扩展点——编排层只能在构建期 patch 源码。

本 PR 提供一个最小化、向后兼容的注入：
- 零新增依赖
- 单实例部署不受影响（`peers` 返回 `null`）
- 沿用已有 `_read_webui_model_name()` 的模式

## 变更

| 文件 | 变更 | 行数 |
|------|------|------|
| `nanobot/channels/websocket.py` | `+import os` | +1 |
| `nanobot/channels/websocket.py` | 新增 `_read_peers()` | +20 |
| `nanobot/channels/websocket.py` | bootstrap 响应中加入 `"peers": _read_peers()` | +1 |

### `_read_peers()` 设计

```python
def _read_peers() -> list[dict[str, Any]] | None:
    """从 ``NANOBOT_PEER_*`` 环境变量读取多实例 peer 列表。

    每个变量值需为 JSON，至少包含 ``id``、``gateway_port``、
    ``ws_port`` 字段。无 peer 配置时返回 ``None``（单实例模式）。
    """
    peers = []
    for key, value in sorted(os.environ.items()):
        if not key.startswith("NANOBOT_PEER_"):
            continue
        try:
            peer = json.loads(value)
            if isinstance(peer, dict):
                peers.append(peer)
        except (json.JSONDecodeError, ValueError):
            logger.debug("webui bootstrap: failed to parse peer env {}", key)
    return peers or None
```

关键特性：
- **惰性求值**：单次遍历 `os.environ`，不缓存
- **容错**：非法 JSON 仅打印 DEBUG 日志并跳过，不阻断启动
- **有序**：`sorted()` 保证 peer 顺序确定性
- **空值安全**：无 peer 时返回 `None`（非空列表），前端可区分「未配置」与「空列表」

## 测试

- ✅ AST 语法检查通过
- ✅ 仅增加 stdlib `os`，无额外依赖
- ✅ 改动限定单文件
- ✅ 单实例模式行为不变（无 `NANOBOT_PEER_*` → `peers: null`）

## 关联

此 PR 是 #3621（多实例编排全栈方案）中拆出的第一个独立模块。如被接受，后续 V4 消息拦截、V6 动态侧边栏等补丁将以独立 PR 形式逐一提交。
