### PR TITLE
fix(agent): remove duplicate runtime context injection in mid-turn drain

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -33,7 +33,6 @@ from nanobot.config.schema import AgentDefaults, ModelPresetConfig
 from nanobot.providers.base import LLMProvider
 from nanobot.providers.factory import ProviderSnapshot
 from nanobot.session.goal_state import (
-    goal_state_runtime_lines,
     goal_state_ws_blob,
     runner_wall_llm_timeout_s,
 )
@@ -728,19 +727,7 @@ class AgentLoop:
                     content, media = extract_documents(content, media)
                     media = media or None
                 user_content = self.context._build_user_content(content, media)
-                extra = goal_state_runtime_lines(session.metadata) if session is not None else []
-                runtime_ctx = self.context._build_runtime_context(
-                    pending_msg.channel,
-                    self._runtime_chat_id(pending_msg),
-                    self.context.timezone,
-                    sender_id=pending_msg.sender_id,
-                    supplemental_lines=extra or None,
-                )
-                if isinstance(user_content, str):
-                    merged: str | list[dict[str, Any]] = f"{user_content}\n\n{runtime_ctx}"
-                else:
-                    merged = user_content + [{"type": "text", "text": runtime_ctx}]
-                return {"role": "user", "content": merged}
+                return {"role": "user", "content": user_content}
 
             items: list[dict[str, Any]] = []
             while len(items) < limit:


### PR DESCRIPTION
## 问题

`_drain_pending` 在 mid-turn 注入消息时会重新注入完整的 runtime context（包括 goal state），但 turn 的初始消息已经通过 `build_messages()` 携带了 runtime context。这导致 goal state（最多 4000 字符）在同一 turn 内的 LLM context window 中重复出现，浪费 token。

## 修复

`_drain_pending` 中的 `_to_user_message` 不再注入 runtime context + goal state，只保留用户原始消息内容。Runtime context 仅由 turn 初始消息携带。

## 测试

- 72 个相关单元测试全部通过
- 功能验证：正常对话、subagent mid-turn injection、工具执行均正常