### PR TITLE
docs: update CLAUDE.md to reflect current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,14 +37,20 @@ Messages flow through an async `MessageBus` (`nanobot/bus/queue.py`) that decoup
 ### Key Subsystems
 
 - **Agent Loop** (`nanobot/agent/loop.py`, `runner.py`): The core processing engine. `AgentLoop` manages session keys, hooks, and context building. `AgentRunner` executes the multi-turn LLM conversation with tool execution.
-- **LLM Providers** (`nanobot/providers/`): Provider implementations (Anthropic, OpenAI-compatible, Azure, GitHub Copilot, etc.) built on a common base (`base.py`). `factory.py` and `registry.py` handle instantiation and model discovery.
-- **Channels** (`nanobot/channels/`): Platform integrations (Telegram, Discord, Slack, Feishu, Matrix, WhatsApp, QQ, WeChat, WebSocket, etc.). `manager.py` discovers and coordinates them. Channels are auto-discovered via `pkgutil` scan + entry-point plugins.
-- **Tools** (`nanobot/agent/tools/`): Agent capabilities exposed to the LLM: filesystem (read/write/edit/list), shell execution, web search/fetch, MCP servers, cron, notebook editing, subagent spawning, and `MyTool` for self-modification.
+- **LLM Providers** (`nanobot/providers/`): Provider implementations (Anthropic, OpenAI-compatible, OpenAI Responses API, Azure, Bedrock, GitHub Copilot, OpenAI Codex, etc.) built on a common base (`base.py`). Includes image generation (`image_generation.py`) and audio transcription (`transcription.py`). `factory.py` and `registry.py` handle instantiation and model discovery.
+- **Channels** (`nanobot/channels/`): Platform integrations (Telegram, Discord, Slack, Feishu, Matrix, WhatsApp, QQ, WeChat, WeCom, DingTalk, Email, MoChat, MS Teams, WebSocket). `manager.py` discovers and coordinates them. Channels are auto-discovered via `pkgutil` scan + entry-point plugins.
+- **Tools** (`nanobot/agent/tools/`): Agent capabilities exposed to the LLM: filesystem (read/write/edit/list), shell execution (with sandbox backends), web search/fetch, MCP servers, cron, notebook editing, subagent spawning, long-running tasks / sustained goals (`long_task.py`), image generation, and self-modification. Tools are auto-discovered via `pkgutil` scan + entry-point plugins.
 - **Memory** (`nanobot/agent/memory.py`): Session history persistence with Dream two-phase memory consolidation. Uses atomic writes with fsync for durability.
-- **Session Management** (`nanobot/session/manager.py`): Per-session history, context compaction, and TTL-based auto-compaction.
+- **Session Management** (`nanobot/session/`): Per-session history, context compaction, TTL-based auto-compaction (`manager.py`), and sustained goal state tracking (`goal_state.py`).
 - **Config** (`nanobot/config/schema.py`, `loader.py`): Pydantic-based configuration loaded from `~/.nanobot/config.json`. Supports camelCase aliases for JSON compatibility.
 - **Bridge** (`bridge/`): TypeScript services (e.g. WhatsApp bridge) bundled into the wheel via `pyproject.toml` `force-include`.
 - **WebUI** (`webui/`): Vite-based React SPA that talks to the gateway over a WebSocket multiplex protocol. The dev server proxies `/api`, `/webui`, `/auth`, and WebSocket traffic to the gateway.
+- **API Server** (`nanobot/api/server.py`): OpenAI-compatible HTTP API (`/v1/chat/completions`, `/v1/models`) for programmatic access.
+- **Command Router** (`nanobot/command/`): Slash command routing and built-in command handlers.
+- **Heartbeat** (`nanobot/heartbeat/`): Periodic agent wake-up service for scheduled task checking.
+- **Pairing** (`nanobot/pairing/`): DM sender approval store with persistent pairing codes per channel.
+- **Skills** (`nanobot/skills/`): Built-in skill definitions (long-goal, cron, github, image-generation, etc.) loaded into agent context.
+- **Security** (`nanobot/security/`): PTH file guard and other security measures activated at CLI entry.
 
 ### Entry Points
 


### PR DESCRIPTION
## Summary

CLAUDE.md had drifted behind the actual codebase. This PR brings it up to date:

### Changed
- **Channels**: Added WeCom, DingTalk, Email, MoChat, MS Teams (was missing)
- **Providers**: Added Bedrock, OpenAI Codex, Responses API, image generation, transcription modules
- **Tools**: Added `long_task`/sustained goals, `image_generation`, sandbox backends; removed stale `MyTool` reference
- **Session**: Added `goal_state.py` for sustained goal tracking

### Added (previously undocumented subsystems)
- **API Server** (`nanobot/api/`): OpenAI-compatible HTTP API
- **Command Router** (`nanobot/command/`): Slash command routing
- **Heartbeat** (`nanobot/heartbeat/`): Periodic agent wake-up
- **Pairing** (`nanobot/pairing/`): DM sender approval store
- **Skills** (`nanobot/skills/`): Built-in skill definitions
- **Security** (`nanobot/security/`): PTH guard and security measures