### PR TITLE
fix(providers): recognize Chinese rate-limit marker '访问量过大' as transient error

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -112,6 +112,7 @@ class LLMProvider(ABC):
         "server error",
         "temporarily unavailable",
         "速率限制",
+        "访问量过大",
     )
     _RETRYABLE_STATUS_CODES = frozenset({408, 409, 429})
     _TRANSIENT_ERROR_KINDS = frozenset({"timeout", "connection"})


### PR DESCRIPTION
Cherry-pick of nightly commit 82c323c2.

The error `{'code': '1305', 'message': '该模型当前访问量过大，请您稍后再试'}` from some Chinese LLM providers is a rate-limit response but was not recognized as transient, so it was never retried.

Add `访问量过大` to `_TRANSIENT_ERROR_MARKERS` so these errors are automatically retried.