### PR TITLE
fix(providers): inject OpenRouter `reasoning.effort` for thinking models (follow-up to #3851)

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -586,6 +586,27 @@ class OpenAICompatProvider(LLMProvider):
                 {"thinking": {"type": "enabled" if thinking_enabled else "disabled"}}
             )
 
+        # OpenRouter uses its own unified `reasoning` field and does not
+        # forward provider-specific thinking shapes (the Kimi/MiMo
+        # extra_body.thinking above) to upstream. Reported as the follow-up
+        # to #3845/#3851: MiMo via OR kept thinking despite our injection.
+        # For known thinking-capable models routed via OR, mirror the
+        # effort signal into reasoning.effort (OR's documented enum:
+        # "none"|"minimal"|"low"|"medium"|"high"|"xhigh"), which OR
+        # translates to the upstream model's native shape.
+        if (
+            spec
+            and spec.name == "openrouter"
+            and reasoning_effort is not None
+            and (
+                _is_kimi_thinking_model(model_name)
+                or _is_mimo_thinking_model(model_name)
+            )
+        ):
+            kwargs.setdefault("extra_body", {}).update(
+                {"reasoning": {"effort": semantic_effort}}
+            )
+
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -78,41 +78,43 @@ _THINKING_STYLE_MAP: dict[str, Any] = {
     "enable_thinking": lambda on: {"enable_thinking": on},
     "reasoning_split": lambda on: {"reasoning_split": on},
 }
+_GATEWAY_REASONING_STYLE_MAP: dict[str, Any] = {
+    "reasoning_effort": lambda effort: {"reasoning": {"effort": effort}},
+}
+_MODEL_THINKING_STYLES: dict[str, str] = {
+    **dict.fromkeys(_KIMI_THINKING_MODELS, "thinking_type"),
+    **dict.fromkeys(_MIMO_THINKING_MODELS, "thinking_type"),
+}
 
 
-def _is_kimi_thinking_model(model_name: str) -> bool:
-    """Return True if model_name refers to a Kimi thinking-capable model.
-
-    Supports two forms:
-    - Exact match: e.g. kimi-k2.5 / kimi-k2.6 in _KIMI_THINKING_MODELS
-    - Slug match:  moonshotai/kimi-k2.5 -> the part after the last "/"
-                   is checked against _KIMI_THINKING_MODELS
-
-    This covers both the native Moonshot provider (bare slug) and
-    OpenRouter-style names (``"publisher/slug"``).
-    """
-    name = model_name.lower()
-    if name in _KIMI_THINKING_MODELS:
-        return True
-    if "/" in name and name.rsplit("/", 1)[1] in _KIMI_THINKING_MODELS:
-        return True
-    return False
+def _model_slug(model_name: str) -> str:
+    return model_name.lower().rsplit("/", 1)[-1]
 
 
-def _is_mimo_thinking_model(model_name: str) -> bool:
-    """Return True if model_name refers to a MiMo thinking-capable model.
+def _model_thinking_style(model_name: str) -> str:
+    return _MODEL_THINKING_STYLES.get(_model_slug(model_name), "")
 
-    Mirrors _is_kimi_thinking_model: gateway providers (e.g. OpenRouter
-    routing ``xiaomi/mimo-v2.5-pro``) have no ``thinking_style`` on their
-    spec, so the spec-driven branch in _build_kwargs misses them. The
-    model-name path catches those cases.
-    """
-    name = model_name.lower()
-    if name in _MIMO_THINKING_MODELS:
-        return True
-    if "/" in name and name.rsplit("/", 1)[1] in _MIMO_THINKING_MODELS:
-        return True
-    return False
+
+def _thinking_styles_for(spec: ProviderSpec | None, model_name: str) -> list[str]:
+    styles: list[str] = []
+    if spec and spec.thinking_style:
+        styles.append(spec.thinking_style)
+    model_style = _model_thinking_style(model_name)
+    if model_style and model_style not in styles:
+        styles.append(model_style)
+    return styles
+
+
+def _thinking_extra_body(style: str, thinking_enabled: bool) -> dict[str, Any] | None:
+    builder = _THINKING_STYLE_MAP.get(style)
+    return builder(thinking_enabled) if builder else None
+
+
+def _gateway_reasoning_extra_body(style: str, effort: str | None) -> dict[str, Any] | None:
+    if not effort:
+        return None
+    builder = _GATEWAY_REASONING_STYLE_MAP.get(style)
+    return builder(effort) if builder else None
 
 
 def _openai_compat_timeout_s() -> float:
@@ -552,60 +554,19 @@ class OpenAICompatProvider(LLMProvider):
         if wire_effort and semantic_effort != "none":
             kwargs["reasoning_effort"] = wire_effort
 
-        # Provider-specific thinking parameters.
-        # Only sent when reasoning_effort is explicitly configured so that
-        # the provider default is preserved otherwise.
-        # The mapping is driven by ProviderSpec.thinking_style so that adding
-        # a new provider never requires touching this function.
-        if spec and spec.thinking_style and reasoning_effort is not None:
+        # Only send thinking controls when reasoning_effort is explicit so
+        # omitting the config preserves each provider's default.
+        if reasoning_effort is not None:
             thinking_enabled = semantic_effort not in ("none", "minimal")
-            extra = _THINKING_STYLE_MAP.get(spec.thinking_style, lambda _: None)(thinking_enabled)
-            if extra:
-                kwargs.setdefault("extra_body", {}).update(extra)
-
-        # Model-level thinking injection for Kimi thinking-capable models.
-        # Strip any provider prefix (e.g. "moonshotai/") before the set lookup
-        # so that OpenRouter-style names like "moonshotai/kimi-k2.5" are handled
-        # identically to bare names like "kimi-k2.5".
-        if reasoning_effort is not None and _is_kimi_thinking_model(model_name):
-            thinking_enabled = semantic_effort not in ("none", "minimal")
-            kwargs.setdefault("extra_body", {}).update(
-                {"thinking": {"type": "enabled" if thinking_enabled else "disabled"}}
-            )
-
-        # Model-level thinking injection for MiMo thinking-capable models.
-        # Same shape as Kimi: gateway providers (OpenRouter, etc.) lack the
-        # xiaomi_mimo spec's thinking_style, so the spec-driven branch above
-        # misses them — match by model name to catch "xiaomi/mimo-v2.5-pro"
-        # and friends. (Direct xiaomi_mimo requests are also covered here;
-        # both branches write the same payload, so the dict update is a
-        # safe no-op for already-handled cases.)
-        if reasoning_effort is not None and _is_mimo_thinking_model(model_name):
-            thinking_enabled = semantic_effort not in ("none", "minimal")
-            kwargs.setdefault("extra_body", {}).update(
-                {"thinking": {"type": "enabled" if thinking_enabled else "disabled"}}
-            )
-
-        # OpenRouter uses its own unified `reasoning` field and does not
-        # forward provider-specific thinking shapes (the Kimi/MiMo
-        # extra_body.thinking above) to upstream. Reported as the follow-up
-        # to #3845/#3851: MiMo via OR kept thinking despite our injection.
-        # For known thinking-capable models routed via OR, mirror the
-        # effort signal into reasoning.effort (OR's documented enum:
-        # "none"|"minimal"|"low"|"medium"|"high"|"xhigh"), which OR
-        # translates to the upstream model's native shape.
-        if (
-            spec
-            and spec.name == "openrouter"
-            and reasoning_effort is not None
-            and (
-                _is_kimi_thinking_model(model_name)
-                or _is_mimo_thinking_model(model_name)
-            )
-        ):
-            kwargs.setdefault("extra_body", {}).update(
-                {"reasoning": {"effort": semantic_effort}}
-            )
+            for thinking_style in _thinking_styles_for(spec, model_name):
+                extra = _thinking_extra_body(thinking_style, thinking_enabled)
+                if extra:
+                    kwargs.setdefault("extra_body", {}).update(extra)
+            gateway_style = getattr(spec, "gateway_reasoning_style", "") if spec else ""
+            if gateway_style and _model_thinking_style(model_name):
+                extra = _gateway_reasoning_extra_body(gateway_style, semantic_effort)
+                if extra:
+                    kwargs.setdefault("extra_body", {}).update(extra)
 
         if tools:
             kwargs["tools"] = tools
@@ -620,8 +581,7 @@ class OpenAICompatProvider(LLMProvider):
             and semantic_effort not in ("none", "minimal")
             and (
                 (spec and spec.thinking_style)
-                or _is_kimi_thinking_model(model_name)
-                or _is_mimo_thinking_model(model_name)
+                or _model_thinking_style(model_name)
             )
         )
         implicit_deepseek_thinking = (

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -71,6 +71,11 @@ class ProviderSpec:
     # "reasoning_split" — {"reasoning_split": true/false}  (MiniMax)
     thinking_style: str = ""
 
+    # Gateway-native reasoning control to pair with model-level thinking styles.
+    # "reasoning_effort" — {"reasoning": {"effort": <none|minimal|...>}}
+    #                      (OpenRouter)
+    gateway_reasoning_style: str = ""
+
     # When True, treat the "reasoning" response field as formal content
     # when "content" is empty.  Only set this for providers (e.g. StepFun)
     # whose API returns the actual answer in "reasoning" instead of "content".
@@ -142,6 +147,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_base_keyword="openrouter",
         default_api_base="https://openrouter.ai/api/v1",
         supports_prompt_caching=True,
+        gateway_reasoning_style="reasoning_effort",
     ),
     # Hugging Face Inference Providers: OpenAI-compatible router for chat models.
     ProviderSpec(

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -1173,9 +1173,16 @@ def test_kimi_k25_no_extra_body_when_reasoning_effort_none() -> None:
 
 
 def test_kimi_k25_thinking_enabled_with_openrouter_prefix() -> None:
-    """OpenRouter-style model names like moonshotai/kimi-k2.5 must trigger thinking."""
+    """OpenRouter-style model names like moonshotai/kimi-k2.5 must trigger thinking.
+
+    OR drops upstream-provider `thinking` fields, so the same intent also has
+    to go through OR's `reasoning.effort` shape (#3851 follow-up).
+    """
     kw = _build_kwargs_for("openrouter", "moonshotai/kimi-k2.5", reasoning_effort="medium")
-    assert kw.get("extra_body") == {"thinking": {"type": "enabled"}}
+    assert kw.get("extra_body") == {
+        "thinking": {"type": "enabled"},
+        "reasoning": {"effort": "medium"},
+    }
 
 
 def test_kimi_k26_thinking_enabled() -> None:
@@ -1185,9 +1192,13 @@ def test_kimi_k26_thinking_enabled() -> None:
 
 
 def test_kimi_k26_thinking_enabled_with_openrouter_prefix() -> None:
-    """OpenRouter-style names like moonshotai/kimi-k2.6 must trigger thinking."""
+    """OpenRouter-style names like moonshotai/kimi-k2.6 must trigger thinking
+    via both upstream `thinking` and OR's `reasoning.effort`."""
     kw = _build_kwargs_for("openrouter", "moonshotai/kimi-k2.6", reasoning_effort="medium")
-    assert kw.get("extra_body") == {"thinking": {"type": "enabled"}}
+    assert kw.get("extra_body") == {
+        "thinking": {"type": "enabled"},
+        "reasoning": {"effort": "medium"},
+    }
 
 
 def test_moonshot_kimi_k26_temperature_override() -> None:

--- a/tests/providers/test_xiaomi_mimo_thinking.py
+++ b/tests/providers/test_xiaomi_mimo_thinking.py
@@ -32,7 +32,7 @@ def _mimo_spec():
 
 
 def _openrouter_spec():
-    """Return the registered OpenRouter ProviderSpec (no thinking_style)."""
+    """Return the registered OpenRouter ProviderSpec."""
     specs = {s.name: s for s in PROVIDERS}
     return specs["openrouter"]
 
@@ -75,6 +75,13 @@ def test_xiaomi_mimo_uses_thinking_type_style():
     assert spec.thinking_style == "thinking_type"
     assert spec.backend == "openai_compat"
     assert spec.default_api_base == "https://api.xiaomimimo.com/v1"
+
+
+def test_openrouter_declares_gateway_reasoning_style():
+    """OpenRouter uses its own reasoning.effort field for routed thinking models."""
+    spec = _openrouter_spec()
+    assert spec.thinking_style == ""
+    assert spec.gateway_reasoning_style == "reasoning_effort"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_xiaomi_mimo_thinking.py
+++ b/tests/providers/test_xiaomi_mimo_thinking.py
@@ -142,9 +142,11 @@ def test_mimo_reasoning_effort_unset_preserves_provider_default():
 
 
 def test_mimo_via_openrouter_reasoning_effort_none_disables_thinking():
-    """OpenRouter routes MiMo as "xiaomi/mimo-v2.5-pro"; the openrouter spec
-    has no thinking_style, so the disable signal must come from the
-    model-name path (#3845)."""
+    """OpenRouter routes MiMo as "xiaomi/mimo-v2.5-pro" and does NOT forward
+    extra_body.thinking to upstream, so a disable signal must also reach OR
+    in its own `reasoning.effort` shape. Verifies both the upstream-MiMo
+    payload (#3845) and the OR-native payload (#3851 follow-up) are sent.
+    """
     provider = _openrouter_provider("xiaomi/mimo-v2.5-pro")
     kwargs = provider._build_kwargs(
         messages=_simple_messages(),
@@ -152,11 +154,15 @@ def test_mimo_via_openrouter_reasoning_effort_none_disables_thinking():
         temperature=0.7, reasoning_effort="none", tool_choice=None,
     )
     assert "reasoning_effort" not in kwargs
-    assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+    assert kwargs["extra_body"] == {
+        "thinking": {"type": "disabled"},
+        "reasoning": {"effort": "none"},
+    }
 
 
 def test_mimo_via_openrouter_reasoning_effort_medium_enables_thinking():
-    """Same as the direct path: any non-none/minimal effort enables thinking."""
+    """Non-none/minimal effort enables thinking and the OR `reasoning.effort`
+    field mirrors the requested effort level."""
     provider = _openrouter_provider("xiaomi/mimo-v2.5-pro")
     kwargs = provider._build_kwargs(
         messages=_simple_messages(),
@@ -164,7 +170,10 @@ def test_mimo_via_openrouter_reasoning_effort_medium_enables_thinking():
         temperature=0.7, reasoning_effort="medium", tool_choice=None,
     )
     assert kwargs.get("reasoning_effort") == "medium"
-    assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+    assert kwargs["extra_body"] == {
+        "thinking": {"type": "enabled"},
+        "reasoning": {"effort": "medium"},
+    }
 
 
 def test_mimo_via_openrouter_bare_slug_also_matches():
@@ -176,12 +185,16 @@ def test_mimo_via_openrouter_bare_slug_also_matches():
         tools=None, model=None, max_tokens=100,
         temperature=0.7, reasoning_effort="none", tool_choice=None,
     )
-    assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+    assert kwargs["extra_body"] == {
+        "thinking": {"type": "disabled"},
+        "reasoning": {"effort": "none"},
+    }
 
 
 def test_mimo_flash_via_openrouter_does_not_inject_thinking():
     """mimo-v2-flash has no thinking mode per Xiaomi docs; the allowlist
-    excludes it, so no thinking field should be injected on the gateway path."""
+    excludes it, so neither the upstream `thinking` field nor OR's
+    `reasoning.effort` should be injected on the gateway path."""
     provider = _openrouter_provider("xiaomi/mimo-v2-flash")
     kwargs = provider._build_kwargs(
         messages=_simple_messages(),
@@ -200,3 +213,18 @@ def test_non_mimo_model_via_openrouter_unaffected():
         temperature=0.7, reasoning_effort="none", tool_choice=None,
     )
     assert "extra_body" not in kwargs
+
+
+def test_kimi_via_openrouter_also_injects_reasoning_effort():
+    """Kimi has the same gateway problem as MiMo: OR drops the upstream
+    `thinking` field. The same OR-reasoning injection should fire."""
+    provider = _openrouter_provider("moonshotai/kimi-k2.5")
+    kwargs = provider._build_kwargs(
+        messages=_simple_messages(),
+        tools=None, model=None, max_tokens=100,
+        temperature=0.7, reasoning_effort="none", tool_choice=None,
+    )
+    assert kwargs["extra_body"] == {
+        "thinking": {"type": "disabled"},
+        "reasoning": {"effort": "none"},
+    }


### PR DESCRIPTION
## Summary

Follow-up to **#3851** (which closed **#3845**). After that PR merged, [@ClearPlume reported on #3851](https://github.com/HKUDS/nanobot/pull/3851#issuecomment-4467327871) that MiMo via OpenRouter still thinks despite `reasoning_effort="none"`. The attached log shows the exact failure mode:

```
# Run 1 — OpenRouter (xiaomi/mimo-v2.5-pro)
kwargs["extra_body"] {'thinking': {'type': 'disabled'}}nanobot
✻ The user is asking …            ← still thinking
✻  about uv …

# Run 2 — switched provider to xiaomiMimo direct, everything else identical
kwargs["extra_body"] {'thinking': {'type': 'disabled'}}
nanobot
对，大致没错…                       ← thinking suppressed
```

**Root cause:** OpenRouter doesn't forward provider-specific thinking shapes (`extra_body.thinking`) to upstream — it strips unknown fields and uses its own unified [`reasoning` parameter](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens). Our previous injection was correct in shape for *direct* MiMo (and the Kimi K2.5/K2.6 model-name path), but dead-on-arrival when routed via OR. Same latent bug existed for Kimi via OR.

## Fix

For known thinking-capable models (Kimi, MiMo) routed via the `openrouter` spec, also inject `extra_body.reasoning = {effort: <effort>}` in OR's documented enum (`none|minimal|low|medium|high|xhigh`). OR translates this to the upstream model's native shape.

```diff
+        # OpenRouter uses its own unified `reasoning` field and does not
+        # forward provider-specific thinking shapes (the Kimi/MiMo
+        # extra_body.thinking above) to upstream...
+        if (
+            spec
+            and spec.name == "openrouter"
+            and reasoning_effort is not None
+            and (
+                _is_kimi_thinking_model(model_name)
+                or _is_mimo_thinking_model(model_name)
+            )
+        ):
+            kwargs.setdefault("extra_body", {}).update(
+                {"reasoning": {"effort": semantic_effort}}
+            )
```

The existing upstream-`thinking` injection is preserved — both fields go out together. OR honors `reasoning.effort`; direct providers still honor `thinking`. No regression on either path.

## Scope notes

- **Gated on `spec.name == "openrouter"`** so direct `xiaomi_mimo` / `moonshot` paths are byte-for-byte unchanged.
- **Gated on known-thinking models** (Kimi K2.5/K2.6/k2.6-code-preview, MiMo v2.5/v2.5-pro/v2-pro/v2-omni). `mimo-v2-flash` and non-thinking models on OR continue to receive no `extra_body` injection — preserved by the same allowlist gates.
- Other gateways (HuggingFace, Fireworks, etc.) likely have the same systemic issue but with their own reasoning-control shape. Out of scope here — file separately if seen in the wild.

## Test plan

- [x] `pytest tests/providers/test_xiaomi_mimo_thinking.py -v` — **12 passed** (6 existing direct + 6 OR-path, including a new Kimi-via-OR test)
- [x] `pytest tests/providers/ -q` — **409 passed**, no regressions
- [x] `ruff check` clean on touched files (test_litellm_kwargs.py has pre-existing N806s unrelated to this PR)
- [x] Two existing Kimi-via-OR tests in `test_litellm_kwargs.py` updated to expect both `thinking` and `reasoning` fields on the OR path
- [ ] Production verification against actual OpenRouter once merged