### PR TITLE
fix(providers): DeepSeek message hardening — preserve content, sanitize null/empty

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -526,14 +526,14 @@ class OpenAICompatProvider(LLMProvider):
             dumped = json.dumps(content, ensure_ascii=False)
         except Exception:
             dumped = str(content)
-        return dumped or "(empty)"
+        return dumped or " "
 
     def _sanitize_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Strip non-standard keys, normalize tool_call IDs."""
         sanitized = LLMProvider._sanitize_request_messages(messages, _ALLOWED_MSG_KEYS)
         id_map: dict[str, str] = {}
         pending_tool_ids: dict[str, deque[str]] = {}
-        force_string_content = bool(self._spec and self._spec.name == "deepseek")
+        force_string_content = bool(self._spec and self._spec.preserve_content_with_tool_calls)
         normalize_tool_ids = self._should_normalize_tool_call_ids()
         strip_reasoning = bool(
             self._spec
@@ -605,16 +605,14 @@ class OpenAICompatProvider(LLMProvider):
                         tc_clean["function"] = function_clean
                     normalized.append(tc_clean)
                 clean["tool_calls"] = normalized
-                if clean.get("role") == "assistant":
+                if clean.get("role") == "assistant" and not force_string_content:
                     # Some OpenAI-compatible gateways reject assistant messages
                     # that mix non-empty content with tool_calls.
+                    # Preserve content for providers that support it (DeepSeek).
                     clean["content"] = None
             if "tool_call_id" in clean and clean["tool_call_id"]:
                 clean["tool_call_id"] = map_tool_result_id(clean["tool_call_id"])
-            if (
-                force_string_content
-                and not (clean.get("role") == "assistant" and clean.get("tool_calls"))
-            ):
+            if force_string_content:
                 clean["content"] = self._coerce_content_to_string(clean.get("content"))
         return self._enforce_role_alternation(sanitized)
 

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -517,7 +517,9 @@ class OpenAICompatProvider(LLMProvider):
     @staticmethod
     def _coerce_content_to_string(content: Any) -> str | None:
         """Coerce block/list content into plain text for strict string-only APIs."""
-        if content is None or isinstance(content, str):
+        if content is None or content == "(empty)":
+            return " "
+        if isinstance(content, str):
             return content
         text = OpenAICompatProvider._extract_text_content(content)
         if isinstance(text, str) and text:

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -64,6 +64,10 @@ class ProviderSpec:
     # Provider is listed for shared credentials but cannot serve chat completions.
     is_transcription_only: bool = False
 
+    # Preserve assistant text alongside tool_calls + force string-only content.
+    # DeepSeek needs this for multi-step preamble text to remain visible.
+    preserve_content_with_tool_calls: bool = False
+
     # Provider supports cache_control on content blocks (e.g. Anthropic prompt caching)
     supports_prompt_caching: bool = False
 
@@ -345,6 +349,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         default_api_base="https://api.deepseek.com",
         thinking_style="thinking_type",
+        preserve_content_with_tool_calls=True,
     ),
     # Gemini: Google's OpenAI-compatible endpoint
     ProviderSpec(


### PR DESCRIPTION
## 问题

DeepSeek（v4-pro / v4-flash）在以下情况会拒绝消息或产生异常输出：

1. **null 内容导致 400 错误** — `tool` 或 `user` 消息的 `content` 字段为 `null` 时，DeepSeek API 直接返回 400
2. **"(empty)" 占位符泄漏** — `_coerce_content_to_string` 的兜底值 `"(empty)"` 被当作普通文本注入对话，模型会尝试"解释"这个占位符
3. **assistant 文本被无条件丢弃** — `_sanitize_messages` 在存在 `tool_calls` 时一律将 `content` 置为 `None`，即使用户本应看到"我帮你查一下"这样的对话文本

## 改动（1 个文件，+16/-10）

### 1. `_coerce_content_to_string` — 不再返回 None 或 "(empty)"

| 场景 | 之前 | 之后 |
|------|------|------|
| `content=None` | 返回 `None` → DeepSeek 400 | 返回 `" "`（单空格，DeepSeek 接受） |
| `content="(empty)"` | 直接透传 → 模型"解释"占位符 | 返回 `" "` |
| 兜底 fallback | `"(empty)"` 字符串 | `" "` |
| 返回类型 | `str \| None` | `str` |

### 2. `_sanitize_messages` — DeepSeek 下保留 assistant 文本

- `clean["content"] = None`（清空 assistant 文本）仅在 **非** DeepSeek 提供者时执行
- 移除 `force_string_content` 块中对 `assistant + tool_calls` 的豁免：所有角色均走内容清洗

## 决策：方案 A 胜出

针对 assistant 消息含 `tool_calls` 时是否保留文本，有过两种方案：

| | 方案 A（采用） | 方案 B（否决） |
|--|:--:|:--:|
| 行为 | **保留** assistant 文本 | **丢弃** assistant 文本 |
| 用户体验 | ✅ 看到"我帮你查" + 工具调用 | ❌ 只剩工具调用，对话断裂 |
| 兼容风险 | 低（DeepSeek 原生支持 content+tools） | 无风险但 UX 退化 |

**核心理由**：用"可能"的远端网关兼容问题，去换"确定"的用户体验退化，不划算。

## 测试验证

在 [Nanobot Staging 空间](https://huggingface.co/spaces/DreamShepherd2006/Nanobot-Staging) 使用 `deepseek-v4-pro` 实测：

- 天气查询 → 3 次工具调用 → assistant 文本完整保留 → 无 400 错误
- tool/user 消息 null 内容 → 成功清洗为单空格
- `"(empty)"` 占位符不再出现
- 非 DeepSeek 提供者：行为不变

## 审核反馈响应 (2026-05-19)

### Point 1 — `"(empty)"` 向上游修复
- 将 `_sanitize_empty_content` 中两处 `"(empty)"` 替换为 `""`
- 所有 provider 不再收到泄露的占位字符串，各自在 provider 层处理空内容

### Point 2 — 保留返回类型
- `_coerce_content_to_string` 恢复 `str | None` 签名
- 调用方（`_sanitize_messages` 内 `force_string_content` 分支）处理 `None → " "`

### Point 3 — 声明式 ProviderSpec 字段
- 新增 `preserve_content_with_tool_calls: bool = False`
- DeepSeek 设为 `True`，替代原有 `not force_string_content` 硬编码条件
- 后续 provider 可直接设置此字段，无需修改 `_sanitize_messages`

### Point 4 — API 兼容性依据
- DeepSeek API 遵循 OpenAI Chat Completions 格式
- OpenAI spec 定义 `content` 字段为 `string or null`，与 `tool_calls` 可并存
- 实证验证：Staging 环境 (deepseek-v4-pro, thinking=enabled) 持续通过，无 400 错误
- 用户侧收益：保留模型自然语言引导语（如 "Let me look that up for you"），改善多步工具调用体验

