### PR TITLE
docs: add WebUI Docker config requirements and bwrap security flags

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,8 +36,39 @@ docker run -v ~/.nanobot:/home/nanobot/.nanobot --rm nanobot onboard
 # Edit config on host to add API keys
 vim ~/.nanobot/config.json
 
+> [!IMPORTANT]
+> **Docker configuration for WebUI access:** When running nanobot in Docker, connections from the browser arrive from the Docker gateway IP (e.g. `172.17.0.1`), not `127.0.0.1`. You must:
+> 1. Set `channels.websocket.host` to `"0.0.0.0"` in `~/.nanobot/config.json`
+> 2. Set `gateway.host` to `"0.0.0.0"` so that `http://localhost:18790/health` is reachable
+> 3. Set `channels.websocket.tokenIssueSecret` to a strong secret for authentication
+>
+> Example snippet for `config.json`:
+> ```json
+> {
+>   "gateway": { "host": "0.0.0.0" },
+>   "channels": {
+>     "websocket": {
+>       "enabled": true,
+>       "host": "0.0.0.0",
+>       "port": 8765,
+>       "tokenIssueSecret": "your-strong-secret-here"
+>     }
+>   }
+> }
+> ```
+> Without `tokenIssueSecret`, the WebUI bootstrap endpoint is restricted to localhost connections only (local dev mode). See [`webui/README.md`](../webui/README.md#access-from-another-device-lan) for details.
+
 # Run gateway (connects to enabled channels, e.g. Telegram/Discord/Mochat)
-docker run -v ~/.nanobot:/home/nanobot/.nanobot -p 18790:18790 nanobot gateway
+#   --cap-drop ALL --cap-add SYS_ADMIN: required when tools.exec.sandbox is "bwrap"
+#   --security-opt: required for bwrap sandbox on Docker
+#   -p 8765:8765: exposes the WebUI/WebSocket port (bundled in the wheel)
+docker run \
+  --cap-drop ALL --cap-add SYS_ADMIN \
+  --security-opt apparmor=unconfined \
+  --security-opt seccomp=unconfined \
+  -v ~/.nanobot:/home/nanobot/.nanobot \
+  -p 18790:18790 -p 8765:8765 \
+  nanobot gateway
 
 # Or run a single command
 docker run -v ~/.nanobot:/home/nanobot/.nanobot --rm nanobot agent -m "Hello!"


### PR DESCRIPTION
## Summary

Fixes #3873

The Docker deployment documentation was missing critical configuration details needed for WebUI access and bwrap sandbox support. Users following the docs would hit 403 errors on WebUI bootstrap, unreachable health endpoints, and failed bwrap sandbox execution.

## Root Cause

Three documentation gaps existed in `docs/deployment.md`:

1. **Missing Docker WebUI config note**: The `gateway.host` defaults to `127.0.0.1` and the WebUI bootstrap endpoint is localhost-only when no `tokenIssueSecret` is configured. Docker bridge network connections arrive from `172.17.0.1` (not `127.0.0.1`), causing 403 errors and unreachable health endpoints.

2. **Missing bwrap security flags in `docker run` example**: The `docker-compose.yml` correctly includes `--cap-drop ALL`, `--cap-add SYS_ADMIN`, and `--security-opt` flags (lines 7-13), but the standalone `docker run` example on line 40 had none of these, making bwrap sandbox silently broken.

3. **Missing WebUI port mapping**: The `docker run` example only exposed `-p 18790:18790`, omitting `-p 8765:8765` for the WebUI.

## Fix

- Added an `IMPORTANT` callout documenting the required `gateway.host`, `channels.websocket.host`, and `tokenIssueSecret` config fields, with a ready-to-copy JSON snippet
- Updated the `docker run` example with all security flags matching `docker-compose.yml`
- Added `-p 8765:8765` port mapping and explanatory comments

## Changes

- `docs/deployment.md`: added IMPORTANT config note + updated docker run example (`+32 -1` lines)

## Testing

- **Fresh Docker setup following updated docs**: WebUI accessible at `http://localhost:8765`, bootstrap returns 200 ✅
- **bwrap sandbox enabled (`tools.exec.sandbox: "bwrap"`)**: sandbox commands execute without permission errors ✅
- **Health endpoint**: `http://localhost:18790/health` responds from Docker bridge network ✅
- **Backward compatibility**: existing local dev workflow (no tokenIssueSecret, localhost) continues to work unchanged ✅