### PR TITLE
feat(ws): emit peers_update event from NANOBOT_PEER_* env vars

### DIFF
--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -11,6 +11,7 @@ import hmac
 import http
 import json
 import mimetypes
+import os
 import re
 import secrets
 import shutil
@@ -130,6 +131,7 @@ class WebSocketConfig(Base):
     token_ttl_s: int = Field(default=300, ge=30, le=86_400)
     websocket_requires_token: bool = True
     allow_from: list[str] = Field(default_factory=lambda: ["*"])
+    peers_enabled: bool = False
     streaming: bool = True
     # Default 36 MB, upper 40 MB: supports up to 4 images at ~6 MB each after
     # client-side Worker normalization (see webui Composer). 4 × 6 MB × 1.37
@@ -237,6 +239,35 @@ def _resolve_bootstrap_model_name(
                 if stripped:
                     return stripped
     return _default_model_name_from_config()
+
+
+def _read_peers() -> dict | None:
+    """Build a peer roster from ``NANOBOT_PEER_*`` environment variables.
+
+    Each var should contain a JSON object with at least ``"id"``::
+
+        NANOBOT_PEER_NEO={"id":"abc123","gateway_port":8000,"ws_port":8001}
+
+    Returns a dict ``{name: {id, gateway_port, ws_port}}``, or ``None``
+    when no ``NANOBOT_PEER_*`` variables are configured.
+    """
+    peers: dict[str, dict[str, object]] = {}
+    for key, value in sorted(os.environ.items()):
+        if not key.startswith("NANOBOT_PEER_"):
+            continue
+        try:
+            info = json.loads(value)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(info, dict) or "id" not in info:
+            continue
+        name = key[len("NANOBOT_PEER_"):].lower()
+        peers[name] = {
+            "id": str(info["id"]),
+            "gateway_port": int(info.get("gateway_port", 0)),
+            "ws_port": int(info.get("ws_port", 0)),
+        }
+    return peers if peers else None
 
 
 def _parse_request_path(path_with_query: str) -> tuple[str, dict[str, list[str]]]:
@@ -1420,6 +1451,19 @@ class WebSocketChannel(BaseChannel):
             self._conn_default[connection] = default_chat_id
             self._attach(connection, default_chat_id)
             await self._hydrate_after_subscribe(default_chat_id)
+
+            # Emit peers_update event when NANOBOT_PEER_* env vars are configured.
+            # This provides machine-level peer discovery on the already-authenticated
+            # WS channel, keeping /webui/bootstrap clean of service-discovery data.
+            if self.config.peers_enabled:
+                peers = _read_peers()
+                if peers:
+                    await connection.send(
+                        json.dumps(
+                            {"event": "peers_update", "peers": peers},
+                            ensure_ascii=False,
+                        )
+                    )
 
             async for raw in connection:
                 if isinstance(raw, bytes):


### PR DESCRIPTION
# PR: feat(ws): emit peers_update event from NANOBOT_PEER_* env vars

**Target:** `upstream:nightly` ← `feat/peers-update-ws-event`

**Link:** https://github.com/DreamShepherd2006/nanobot/compare/nightly...feat/peers-update-ws-event?expand=1

---

## 问题

`NANOBOT_PEER_*` 环境变量允许用户声明多 agent 拓扑信息，但前端无法获取这些数据——既不能走 `/webui/bootstrap`（那是 human-facing 的 token 端点），也没有其他机制暴露。

## 改动

1 个文件 (`nanobot/channels/websocket.py`)，+46/-0。

| 改动 | 说明 |
|------|------|
| `import os` | `_read_peers()` 需要读环境变量 |
| `WebSocketConfig.peers_enabled: bool = False` | 新配置项，默认关闭，向后兼容 |
| `_read_peers()` 函数 | 解析所有 `NANOBOT_PEER_*` env var，返回 `{name: {id, gateway_port, ws_port}}` |
| `peers_update` WS 事件 | 在 `_connection_loop()` 中，hydration 完成后立即 emit |

**数据流：**

```
NANOBOT_PEER_* (env)
       ↓
WS connect → auth → ready → hydrate
       ↓
peers_update event (if peers_enabled and peers exist)
       ↓
Frontend via onAnyEvent listener
```

## 决策

| 方案 | 位置 | 结论 |
|------|------|------|
| A. 注入 bootstrap 响应 | HTTP，未认证可访问 | ❌ bootstrap 是 human-facing token 端点，不应承载服务发现数据 |
| B. 独立 `/api/peers` 端点 | HTTP，需认证 | ❌ 需要额外认证层，WS 已有认证通道 |
| **C. WS `peers_update` 事件** | **WebSocket，已认证** | **✅ 与现有 WS 通道一致，hydration 后立即推送** |

**关键设计决策：**

- **默认关闭** (`peers_enabled=False`)：单 agent 部署不受影响，多 agent 用户 opt-in
- **无外部依赖**：仅用 stdlib (`os`, `json`)，不引入 squad_config_sync 等定制逻辑
- **防御性解析**：非法 JSON / 缺失 `id` 字段 → skip，不抛异常

## 验证

Staging 环境测试通过：

```
$ python3 -c "
import asyncio, websockets, json, os
async def test():
    ws = await websockets.connect(f'ws://127.0.0.1:{ws_port}/?token={token}')
    for _ in range(3):
        evt = json.loads(await ws.recv())
        print(evt['event'])

#1 → ready
#2 → peers_update    ✅
#3 → (timeout, no more events)
```

`peers_update` 在 WS 握手后作为第 2 个事件推送，紧跟 `ready`。
