### PR TITLE
feat(squad): Nanobot Legion — multi-agent integration showcase

### DIFF
--- a/contrib/legion/Dockerfile.squad
+++ b/contrib/legion/Dockerfile.squad
@@ -1,0 +1,54 @@
+# ============================================================
+# Dockerfile.squad — 参考实现，非官方 Dockerfile
+# 展示如何在单容器内运行多个协作的 nanobot Agent
+# ============================================================
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+# --- 基础工具 ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates git nodejs npm && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# --- 安装 nanobot ---
+COPY pyproject.toml README.md LICENSE ./
+RUN mkdir -p nanobot bridge && touch nanobot/__init__.py && \
+    uv pip install --system --no-cache ".[matrix]"
+COPY nanobot/ nanobot/
+COPY bridge/ bridge/
+COPY webui/ webui/
+RUN uv pip install --system --no-cache ".[matrix]"
+
+# --- 安装 Squad 运行时依赖 ---
+RUN uv pip install --system --no-cache \
+    fastapi uvicorn websockets authlib httpx itsdangerous
+
+# --- ⚡ Squad 补丁注入 ---
+# 顺序：内核补丁 → WebUI 补丁
+COPY contrib/legion/patch_squad_error_events.py /tmp/
+RUN python3 /tmp/patch_squad_error_events.py
+
+WORKDIR /app/webui
+COPY contrib/legion/patch_legion_v4_client.py /tmp/
+COPY contrib/legion/patch_legion_v6_sidebar.py /tmp/
+RUN python3 /tmp/patch_legion_v4_client.py && \
+    python3 /tmp/patch_legion_v6_sidebar.py && \
+    npm install && npm run build
+
+# --- Squad 胶水层 ---
+WORKDIR /app
+COPY contrib/legion/gatekeeper.py ./
+COPY contrib/legion/squad_bridge.py ./
+RUN chmod +x gatekeeper.py squad_bridge.py
+
+# --- 运行时 ---
+EXPOSE 7860
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# 启动流程 (示意):
+# 1. squad_config_sync.py 从模板生成各 Agent 配置
+# 2. 并行启动所有 Agent 进程
+# 3. 启动 Gatekeeper 作为统一入口
+# 详见 nanobot-legion 仓库的 entrypoint.sh
+CMD ["python3", "gatekeeper.py"]

--- a/contrib/legion/gatekeeper.py
+++ b/contrib/legion/gatekeeper.py
@@ -1,0 +1,916 @@
+#!/usr/bin/env python3
+"""
+Gatekeeper v6.0 (Auto-Resurrect) — HTTP proxy + WS interceptor + squad relay.
+Deployed on ws_port, serves WebUI and routes squad traffic.
+Includes legion_monitor with automatic resurrection for whitelisted agents.
+"""
+
+import datetime
+import json
+import os
+import re
+import sys
+import time
+import asyncio
+from uuid import uuid4
+from contextlib import asynccontextmanager
+from typing import Optional
+
+import httpx
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse, RedirectResponse, HTMLResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.sessions import SessionMiddleware
+from authlib.integrations.starlette_client import OAuth
+import websockets
+
+# ═══════════════════════════════════════════════════════════════
+# Logging
+# ═══════════════════════════════════════════════════════════════
+
+def log(msg):
+    timestamp = datetime.datetime.now().strftime("%H:%M:%S")
+    print(f"[GATEKEEPER] [{timestamp}] {msg}")
+    sys.stdout.flush()
+
+# ═══════════════════════════════════════════════════════════════
+# Squad Config (memory-parsed, zero disk I/O)
+# ═══════════════════════════════════════════════════════════════
+
+AGENT_NAMES: list[str] = []
+SQUAD_ROSTER: dict[str, dict] = {}
+INSTANCE_WORKSPACES: dict[str, str] = {}
+PEER_ENV_MAP: dict[str, str] = {}  # NANOBOT_PEER_NEO → env var value
+
+def refresh_roster():
+    """Parse NANOBOT_PEER_* env vars to build agent roster."""
+    global AGENT_NAMES, SQUAD_ROSTER, INSTANCE_WORKSPACES, PEER_ENV_MAP
+    AGENT_NAMES.clear()
+    SQUAD_ROSTER.clear()
+    INSTANCE_WORKSPACES.clear()
+    PEER_ENV_MAP.clear()
+
+    for key, val in os.environ.items():
+        if not key.startswith("NANOBOT_PEER_"):
+            continue
+        PEER_ENV_MAP[key] = val
+        agent_name = key[len("NANOBOT_PEER_"):].lower()
+        try:
+            info = json.loads(val)
+            if isinstance(info, dict) and "id" in info:
+                AGENT_NAMES.append(agent_name)
+                SQUAD_ROSTER[agent_name] = {
+                    "id": info["id"],
+                    "gateway_port": info.get("gateway_port", 0),
+                    "ws_port": info.get("ws_port", 0),
+                }
+                INSTANCE_WORKSPACES[agent_name] = f"/data/instances/{agent_name}"
+        except (json.JSONDecodeError, TypeError):
+            log(f"⚠️ 跳过无效 NANOBOT_PEER_*: {key}")
+
+    AGENT_NAMES.sort()
+    log(f"📋 编制加载: {len(AGENT_NAMES)} agents → {AGENT_NAMES}")
+
+refresh_roster()
+
+# ═══════════════════════════════════════════════════════════════
+# WebUI Target & Per-agent HTTP Proxy Clients
+# ═══════════════════════════════════════════════════════════════
+
+WEBUI_AGENT = os.environ.get("WEBUI_AGENT", "").strip().lower()
+if not WEBUI_AGENT or WEBUI_AGENT not in SQUAD_ROSTER:
+    WEBUI_AGENT = AGENT_NAMES[0] if AGENT_NAMES else "neo"
+    log(f"📡 WEBUI_AGENT 未指定或无效，回退到: {WEBUI_AGENT}")
+
+def get_agent_for_user(username: str) -> str:
+    """返回该 HF 用户对应的 agent name；未匹配或 Commander → WEBUI_AGENT"""
+    if not username or username == "Unknown":
+        return WEBUI_AGENT
+    whitelist = [n.strip() for n in os.environ.get("COMMANDER_WHITELIST", "").split(",") if n.strip()]
+    if username in whitelist:
+        return WEBUI_AGENT
+    # USER_AGENT_MAP flat format: {"username": "NANOBOT_PEER_neo"}
+    try:
+        user_map = json.loads(os.environ.get("USER_AGENT_MAP", "{}"))
+    except json.JSONDecodeError:
+        user_map = {}
+    peer_key = user_map.get(username, "")
+    if peer_key and peer_key.startswith("NANOBOT_PEER_"):
+        agent_name = peer_key[len("NANOBOT_PEER_"):].lower()
+        if agent_name in SQUAD_ROSTER:
+            return agent_name
+    return WEBUI_AGENT
+
+# Per-agent HTTP clients for dynamic user → agent HTTP proxying
+_http_clients = {}
+for _name, _info in SQUAD_ROSTER.items():
+    _http_clients[_name] = httpx.AsyncClient(
+        base_url=f"http://127.0.0.1:{_info['ws_port']}",
+        timeout=120.0
+    )
+_default_client = _http_clients.get(WEBUI_AGENT)
+log(f"🌐 HTTP proxy pool: {list(_http_clients.keys())}  (default={WEBUI_AGENT})")
+
+# ═══════════════════════════════════════════════════════════════
+# cluster_log Builder — wraps agent WS events for LegionTerminal
+# ═══════════════════════════════════════════════════════════════
+
+def _build_cluster_log(source: str, raw_data: str) -> Optional[str]:
+    """Convert an agent WS frame into a cluster_log event for LegionTerminal.
+
+    Returns None for events that should not appear in the per-agent log tabs
+    (e.g. connection handshake, heartbeats, session noise).
+    """
+    try:
+        data = json.loads(raw_data)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    event = data.get("event", "")
+
+    # ── Suppressed (handshake / noise) ──
+    if event in ("ready", "attached", "heartbeat", "runtime_model_updated",
+                 "session_updated", "stream_end", "reasoning_end"):
+        return None
+
+    # ── Activity events → compact labels ──
+    if event == "delta":
+        text = data.get("text", "")
+        if not text or not text.strip():
+            return None
+        content = text[:100] + ("…" if len(text) > 100 else "")
+        label = f"{content}"
+    elif event == "reasoning_delta":
+        # Too verbose for a log tab — emit as one-liner activity pulse
+        return None
+    elif event == "turn_start":
+        label = "⚡ turn_start"
+    elif event == "turn_end":
+        label = "✅ turn_end"
+    elif event == "message":
+        text = data.get("text", "")
+        kind = data.get("kind", "")
+        if kind == "tool_hint":
+            label = f"🔧 {text[:100]}"
+        elif kind == "progress":
+            label = f"⏳ {text[:100]}"
+        else:
+            label = f"💬 {text[:120]}"
+    elif event == "error":
+        detail = data.get("detail", "unknown error")
+        label = f"❌ {detail[:120]}"
+    else:
+        # Unknown events — compact
+        label = f"[{event}]"
+
+    return json.dumps({
+        "event": "cluster_log",
+        "type": "cluster_log",
+        "source": source,
+        "content": label,
+    })
+
+
+async def _observer_capture(
+    agent_name: str,
+    info: dict,
+    path: str,
+    token: str,
+    client_ws: WebSocket,
+    stop: asyncio.Event,
+):
+    """Read-only WS capture from one squad agent → cluster_log injector.
+
+    Opens a WS to the agent, captures every inbound event, wraps it with
+    ``_build_cluster_log()``, and sends it to the Commander's WS.  Never
+    sends any messages to the agent — strictly read-only.
+
+    On disconnect, backs off exponentially (2→30 s) and reconnects.
+    Stops immediately when ``stop`` is set (Commander disconnected).
+    """
+    ws_url = f"ws://127.0.0.1:{info['ws_port']}/{path}"
+    if token:
+        ws_url += f"?token={token}"
+
+    backoff = 2
+
+    while not stop.is_set():
+        try:
+            obs_ws = await asyncio.wait_for(
+                websockets.connect(ws_url, close_timeout=5), timeout=15
+            )
+            log(f"👁️ [obs] {agent_name} connected (port {info['ws_port']})")
+            backoff = 2  # reset on success
+
+            async with obs_ws:
+                while not stop.is_set():
+                    try:
+                        data = await asyncio.wait_for(obs_ws.recv(), timeout=60)
+                    except asyncio.TimeoutError:
+                        continue  # keep-alive, no data
+
+                    if isinstance(data, bytes):
+                        data = data.decode("utf-8", errors="replace")
+
+                    cluster = _build_cluster_log(agent_name, data)
+                    if cluster:
+                        try:
+                            await client_ws.send_text(cluster)
+                        except Exception:
+                            return  # Commander disconnected
+
+        except asyncio.TimeoutError:
+            log(f"👁️ [obs] {agent_name} connect timeout, retry {backoff}s")
+        except websockets.exceptions.ConnectionClosed as e:
+            log(f"👁️ [obs] {agent_name} WS closed ({e.code}), retry {backoff}s")
+        except Exception as e:
+            log(f"👁️ [obs] {agent_name} error: {type(e).__name__}: {e}, retry {backoff}s")
+
+        if stop.is_set():
+            break
+        await asyncio.sleep(backoff)
+        backoff = min(backoff * 2, 30)
+
+
+# ═══════════════════════════════════════════════════════════════
+# OAuth (Hugging Face)
+# ═══════════════════════════════════════════════════════════════
+
+from starlette.config import Config as StarletteConfig
+
+starlette_config = StarletteConfig(environ=os.environ)
+oauth = OAuth(starlette_config)
+_oauth_cid = os.environ.get("OAUTH_CLIENT_ID", "MISSING")
+log(f"🔑 OAuth CLIENT_ID prefix: {_oauth_cid[:4]}... (len={len(_oauth_cid)})")
+oauth.register(
+    name="huggingface",
+    client_id=_oauth_cid,
+    client_secret=os.environ.get("OAUTH_CLIENT_SECRET"),
+    server_metadata_url="https://huggingface.co/.well-known/openid-configuration",
+    client_kwargs={"scope": "openid profile"},
+)
+
+# ═══════════════════════════════════════════════════════════════
+# Auth helpers
+# ═══════════════════════════════════════════════════════════════
+
+def check_commander_privilege(session_user):
+    if not session_user: return False
+    whitelist = [n.strip() for n in os.environ.get("COMMANDER_WHITELIST", "").split(",") if n.strip()]
+    current_username = "Unknown"
+    if isinstance(session_user, dict):
+        current_username = session_user.get("preferred_username") or session_user.get("username") or session_user.get("name") or "Unknown"
+    elif isinstance(session_user, str):
+        current_username = session_user
+    return current_username in whitelist
+
+class ForceAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+        public_paths = ["/login", "/auth", "/health", "/logout", "/webui/bootstrap"]
+        if path.startswith("/api/squad"):
+            return await call_next(request)
+        is_public = any(path == p for p in public_paths) or path.startswith("/assets") or path.startswith("/brand")
+        if not is_public and not request.session.get("user"):
+            login_url = str(request.url_for("login")).replace("http://", "https://")
+            return RedirectResponse(url=login_url)
+        return await call_next(request)
+
+# ═══════════════════════════════════════════════════════════════
+# Legion Monitor (agent alive/dead tracking + auto-resurrection)
+# ═══════════════════════════════════════════════════════════════
+
+legion_status: dict[str, str] = {}  # agent → "online"|"offline"
+_legion_offline_since: dict[str, float] = {}  # agent → timestamp
+_resurrecting: dict[str, bool] = {}  # agent → resurrection in progress
+
+# Resurrection thresholds (conservative — DeepSeek thinking blocks event loop 30-60s)
+RESURRECT_WHITELIST = {"neo"}  # only Neo is whitelisted for auto-resurrection
+RESURRECT_THRESHOLD = 60       # seconds of continuous offline before trigger
+RESURRECT_COOLDOWN = 300       # seconds before retry after failed resurrection
+
+# Startup grace period — allow agents time to boot before monitoring
+GRACE_SECONDS = 60
+_gatekeeper_boot_time = time.time()
+_grace_ended = False
+_grace_until = _gatekeeper_boot_time + GRACE_SECONDS
+
+async def legion_monitor():
+    """Periodically health-check each agent's gateway_port.
+    Triggers auto-resurrection for whitelisted agents after THRESHOLD."""
+    await asyncio.sleep(GRACE_SECONDS)
+    _grace_ended = True
+    log(f"🛡️ 复活引擎就绪 (宽限期 {GRACE_SECONDS}s 结束)")
+    while True:
+        now = time.time()
+
+        # ── Cooldown expiry: allow retry for resurrecting agents ──
+        for name in list(_resurrecting.keys()):
+            if _resurrecting[name] and name in _legion_offline_since:
+                if now - _legion_offline_since[name] > RESURRECT_COOLDOWN:
+                    log(f"⏰ [{name}] 复活冷却到期，允许重试")
+                    _resurrecting[name] = False
+                    _legion_offline_since.pop(name, None)
+
+        for name in AGENT_NAMES:
+            info = SQUAD_ROSTER.get(name)
+            if not info:
+                continue
+            gw_port = info.get("gateway_port")
+            if not gw_port:
+                continue
+            try:
+                async with httpx.AsyncClient(timeout=5) as client:
+                    resp = await client.get(f"http://127.0.0.1:{gw_port}/health")
+                if resp.status_code == 200:
+                    if legion_status.get(name) == "offline":
+                        offline_sec = now - _legion_offline_since.get(name, 0)
+                        log(f"✅ [{name}] 恢复上线 (离线 {offline_sec:.0f}s)")
+                    legion_status[name] = "online"
+                    _legion_offline_since.pop(name, None)
+                    if _resurrecting.get(name):
+                        _resurrecting[name] = False
+                else:
+                    _mark_offline(name, f"HTTP {resp.status_code}", now)
+            except Exception as e:
+                _mark_offline(name, str(e), now)
+
+        await asyncio.sleep(10)
+
+def _mark_offline(name: str, reason: str, now: float = None):
+    if now is None:
+        now = time.time()
+    if legion_status.get(name) != "offline":
+        legion_status[name] = "offline"
+        _legion_offline_since[name] = now
+        log(f"🔴 [{name}] 掉线 → {reason}")
+        return
+
+    # Already offline — check if resurrection should trigger
+    if name not in RESURRECT_WHITELIST:
+        return
+    if _resurrecting.get(name):
+        return  # already in progress
+
+    elapsed = now - _legion_offline_since.get(name, now)
+    if elapsed < RESURRECT_THRESHOLD:
+        return  # not yet past threshold
+
+    script = _find_resurrection_script(name)
+    if not script:
+        log(f"⚠️ [{name}] 失联 {elapsed:.0f}s 但无复活脚本")
+        _legion_offline_since.pop(name, None)
+        return
+
+    _resurrecting[name] = True
+    log(f"🆘 [{name}] 失联 {elapsed:.0f}s，触发自动复活 → {script}")
+    try:
+        subprocess.Popen(
+            ["setsid", "bash", script],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as e:
+        log(f"❌ [{name}] 复活启动失败: {e}")
+        _resurrecting[name] = False
+
+def _find_resurrection_script(name: str) -> Optional[str]:
+    """Find the resurrection script for an agent, checking both
+    /app/scripts/ (Docker-deployed) and /data/ (persistent volume)."""
+    candidates = [
+        f"/app/scripts/resurrect_{name}.sh",
+        f"/data/instances/{name}/workspace/scripts/resurrect_{name}.sh",
+    ]
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+    return None
+
+# ═══════════════════════════════════════════════════════════════
+# Log Bridge (capture gateway logs → gatekeeper stdout)
+# ═══════════════════════════════════════════════════════════════
+
+async def log_bridge():
+    """Read agent gateway logs and forward to gatekeeper stdout."""
+    await asyncio.sleep(GRACE_SECONDS)
+    while True:
+        for name in AGENT_NAMES:
+            path = f"/data/instances/{name}/logs/gateway.log"
+            try:
+                with open(path) as f:
+                    f.seek(0, 2)
+            except FileNotFoundError:
+                pass
+        await asyncio.sleep(30)
+
+# ═══════════════════════════════════════════════════════════════
+# Dead Letter Queue (DLQ) Replay
+# ═══════════════════════════════════════════════════════════════
+
+DLQ_DIR = os.environ.get("DLQ_DIR", "/data/dlq")
+os.makedirs(DLQ_DIR, exist_ok=True)
+
+async def dlq_replay():
+    """Periodically retry failed cross-agent messages."""
+    await asyncio.sleep(GRACE_SECONDS + 30)
+    while True:
+        try:
+            entries = sorted(
+                [f for f in os.listdir(DLQ_DIR) if f.endswith(".dlq")],
+                key=lambda f: os.path.getmtime(os.path.join(DLQ_DIR, f))
+            )
+            for fn in entries[:5]:
+                fpath = os.path.join(DLQ_DIR, fn)
+                try:
+                    with open(fpath) as f:
+                        msg = json.load(f)
+                    target = msg.get("target")
+                    if target and legion_status.get(target) == "online":
+                        # Re-send logic would go here
+                        os.remove(fpath)
+                        log(f"📬 [DLQ] replayed {fn} → {target}")
+                except (json.JSONDecodeError, OSError):
+                    # Stale/broken DLQ entry, remove
+                    try: os.remove(fpath)
+                    except OSError: pass
+        except Exception:
+            pass
+        await asyncio.sleep(60)
+
+# ═══════════════════════════════════════════════════════════════
+# FastAPI App
+# ═══════════════════════════════════════════════════════════════
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    log(f"🛡️ Gatekeeper v6.0 (Auto-Resurrect) online — {len(AGENT_NAMES)} agents.")
+    asyncio.create_task(legion_monitor())
+    asyncio.create_task(log_bridge())
+    asyncio.create_task(dlq_replay())
+    yield
+
+app = FastAPI(lifespan=lifespan)
+app.add_middleware(ForceAuthMiddleware)
+app.add_middleware(
+    SessionMiddleware,
+    secret_key=os.environ.get("SESSION_SECRET", "nanobot_commander_secret_123"),
+    https_only=True,
+    same_site="none"
+)
+
+@app.middleware("http")
+async def force_https_middleware(request: Request, call_next):
+    request.scope["scheme"] = "https"
+    return await call_next(request)
+
+# ═══════════════════════════════════════════════════════════════
+# OAuth Routes
+# ═══════════════════════════════════════════════════════════════
+
+@app.get("/login")
+async def login(request: Request):
+    request.session.clear()
+    redirect_uri = str(request.url_for('auth')).replace("http://", "https://")
+    return await oauth.huggingface.authorize_redirect(request, redirect_uri)
+
+@app.get("/auth")
+async def auth(request: Request):
+    try:
+        token = await oauth.huggingface.authorize_access_token(request)
+        user_info = token.get('userinfo')
+        if user_info:
+            request.session['user'] = dict(user_info)
+            return RedirectResponse(url="/")
+    except Exception:
+        pass
+    return RedirectResponse(url="/login")
+
+@app.get("/logout")
+async def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse(url="/")
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "role": "gatekeeper", "agents": len(AGENT_NAMES)}
+
+# ═══════════════════════════════════════════════════════════════
+# Squad Relay Endpoint
+# ═══════════════════════════════════════════════════════════════
+
+RELAY_TOKEN = os.environ.get("SQUAD_RELAY_TOKEN", "").strip()
+RELAY_TIMEOUT = int(os.environ.get("RELAY_TIMEOUT", "60"))
+
+@app.post("/api/squad/relay")
+async def squad_relay(request: Request):
+    """
+    POST /api/squad/relay
+    Header: X-Squad-Token: <SQUAD_RELAY_TOKEN>
+    Body:   {"sender":"neo","target":"trinity","message":"ping","correlation_id":"sq-..."}
+
+    Auth-free (no OAuth session required) — secured by shared token.
+    Permission: reuses gatekeeper's COMMANDER_WHITELIST + USER_AGENT_MAP.
+    """
+    # ── Auth ──
+    auth_header = request.headers.get("X-Squad-Token", "")
+    if not RELAY_TOKEN or auth_header != RELAY_TOKEN:
+        return JSONResponse(
+            {"status": "unauthorized", "error": "invalid or missing X-Squad-Token"},
+            status_code=401)
+
+    # ── Parse ──
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"status": "bad_request", "error": "invalid JSON"}, status_code=400)
+
+    sender = (body.get("sender") or "").strip()
+    target = (body.get("target") or "").strip().lower()
+    message = body.get("message") or ""
+    correlation_id = body.get("correlation_id", f"sq-relay-{uuid4().hex[:8]}")
+
+    if not sender or not target or not message:
+        return JSONResponse(
+            {"status": "bad_request", "error": "missing sender/target/message"}, status_code=400)
+
+    # ── Roster & liveness ──
+    if target not in SQUAD_ROSTER:
+        return JSONResponse(
+            {"status": "roster_miss", "error": f"'{target}' not in squad", "correlation_id": correlation_id}, status_code=404)
+    if legion_status.get(target) != "online":
+        return JSONResponse(
+            {"status": "agent_offline", "error": f"'{target}' is offline", "correlation_id": correlation_id}, status_code=503)
+
+    # ── Permission (same logic as squad_bridge v6.1) ──
+    whitelist = [w.strip().lower() for w in
+                  os.environ.get("COMMANDER_WHITELIST", "").split(",") if w.strip()]
+    user_map: dict = {}
+    try:
+        user_map = json.loads(os.environ.get("USER_AGENT_MAP", "{}"))
+    except json.JSONDecodeError:
+        pass
+
+    # Reverse lookup: agent alias → HF username
+    # USER_AGENT_MAP format: {"username": "NANOBOT_PEER_NEO", ...}  (flat, values are strings)
+    agent_to_user: dict[str, str] = {}
+    for uname, peer_key in user_map.items():
+        if isinstance(peer_key, str) and peer_key.upper().startswith("NANOBOT_PEER_"):
+            agent_name = peer_key[len("NANOBOT_PEER_"):].lower()
+            agent_to_user[agent_name] = uname.lower()
+
+    effective_user = sender.lower()
+    if effective_user in agent_to_user:
+        effective_user = agent_to_user[effective_user]
+
+    is_commander = effective_user in whitelist
+
+    if not is_commander:
+        allowed: list[str] = []
+        if effective_user in user_map:
+            peer_key = user_map[effective_user]
+            if isinstance(peer_key, str) and peer_key.upper().startswith("NANOBOT_PEER_"):
+                allowed.append(peer_key[len("NANOBOT_PEER_"):].lower())
+        if target not in allowed:
+            return JSONResponse({
+                "status": "permission_denied",
+                "error": f"'{sender}' (user:{effective_user}) not authorized for '{target}'",
+                "correlation_id": correlation_id,
+            }, status_code=403)
+
+    # ── Relay via WebSocket ──
+    target_info = SQUAD_ROSTER[target]
+    nanobot_token = os.environ.get("NANOBOT_TOKEN", "").strip()
+    ws_url = f"ws://127.0.0.1:{target_info['ws_port']}/"
+    if nanobot_token:
+        ws_url += f"?token={nanobot_token}"
+
+    try:
+        log(f"📨 [Relay] {sender}→{target} connect {ws_url}")
+        ws = await asyncio.wait_for(
+            websockets.connect(ws_url, close_timeout=5),
+            timeout=15
+        )
+        async with ws:
+            # Step 1: wait for server ready greeting
+            greeting_raw = await asyncio.wait_for(ws.recv(), timeout=10)
+            greeting = json.loads(greeting_raw)
+            if greeting.get("event") != "ready":
+                log(f"❌ [Relay] unexpected greeting: {greeting}")
+                return JSONResponse({
+                    "status": "protocol_error",
+                    "error": f"expected 'ready' event, got {greeting.get('event')}",
+                    "correlation_id": correlation_id,
+                }, status_code=502)
+
+            # Step 2: send message payload
+            payload = json.dumps({
+                "type": "message",
+                "chat_id": target_info["id"],
+                "content": f"[{sender.upper()}]: {message}",
+            })
+            await ws.send(payload)
+            log(f"📨 [Relay] {sender}→{target} sent ({len(payload)}B)")
+
+            # Step 3: collect response
+            responses: list[str] = []
+            try:
+                while True:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=RELAY_TIMEOUT)
+                    try:
+                        data = json.loads(raw)
+                    except json.JSONDecodeError:
+                        log(f"📨 [Relay] non-JSON frame ({len(raw)}B)")
+                        continue
+
+                    event = data.get("event", "")
+
+                    if event == "error":
+                        detail = data.get("detail", "unknown")
+                        log(f"❌ [Relay] framework error: {detail}")
+                        return JSONResponse({
+                            "status": "framework_error",
+                            "error": detail,
+                            "correlation_id": correlation_id,
+                        }, status_code=502)
+
+                    if event == "heartbeat":
+                        continue
+
+                    if event == "turn_end":
+                        reply = "\n".join(responses) if responses else "(empty)"
+                        log(f"✅ [Relay] {sender}→{target} ok ({len(reply)} chars)")
+                        return JSONResponse({
+                            "status": "delivered",
+                            "target_response": reply,
+                            "target": target,
+                            "correlation_id": correlation_id,
+                        })
+
+                    if event == "delta":
+                        text = data.get("text", "")
+                        if text:
+                            responses.append(text)
+                        continue
+
+                    if event == "stream_end":
+                        continue
+
+                    # Non-streaming fallback: check 'content' field
+                    content = data.get("content")
+                    if content and content.strip():
+                        responses.append(content)
+
+            except asyncio.TimeoutError:
+                if responses:
+                    reply = "\n".join(responses)
+                    log(f"⏱️ [Relay] timeout with partial ({len(reply)} chars)")
+                    return JSONResponse({
+                        "status": "partial",
+                        "target_response": reply,
+                        "target": target,
+                        "correlation_id": correlation_id,
+                    })
+                log(f"⏱️ [Relay] timeout ({RELAY_TIMEOUT}s)")
+                return JSONResponse({
+                    "status": "timeout",
+                    "error": f"no response from agent within {RELAY_TIMEOUT}s",
+                    "correlation_id": correlation_id,
+                }, status_code=504)
+
+    except asyncio.TimeoutError:
+        log(f"❌ [Relay] connect timeout (15s)")
+        return JSONResponse({
+            "status": "connection_error",
+            "error": "WebSocket connection timed out",
+            "correlation_id": correlation_id,
+        }, status_code=502)
+    except Exception as e:
+        log(f"❌ [Relay] {sender}→{target} error: {type(e).__name__}: {e}")
+        return JSONResponse({
+            "status": "connection_error",
+            "error": f"{type(e).__name__}: {e}",
+            "correlation_id": correlation_id,
+        }, status_code=502)
+
+# ═══════════════════════════════════════════════════════════════
+# WebSocket Proxy — Multiplexer v6.0 (multi-agent + cluster_log inject)
+# ═══════════════════════════════════════════════════════════════
+
+@app.websocket("/{path:path}")
+async def ws_proxy(path: str, client_ws: WebSocket):
+    """Multiplex Commander's WS to neo (bidirectional) + all squad agents (read-only).
+
+    Architecture::
+
+        Commander ──WS──▶ Gatekeeper ──WS──▶ neo (双向, Commander 对话)
+                                ├──WS──▶ trinity (只读捕获)
+                                ├──WS──▶ sentinel (只读捕获)
+                                ├──WS──▶ assistant (只读捕获)
+                                └──WS──▶ medic (只读捕获)
+
+    Other agents' events are wrapped as ``cluster_log`` with ``source`` tags so
+    the LegionTerminal component can route them to per-agent log tabs.
+    """
+    await client_ws.accept()
+
+    # ── Session & identity ──────────────────────────────────
+    session_user = client_ws.scope.get("session", {}).get("user")
+    whitelist = [n.strip() for n in os.environ.get("COMMANDER_WHITELIST", "").split(",") if n.strip()]
+    real_name = "Guest"
+    if isinstance(session_user, dict):
+        real_name = session_user.get("preferred_username") or session_user.get("username") or session_user.get("name") or "Unknown"
+    is_commander = bool(real_name in whitelist)
+    uname = real_name if is_commander else f"{real_name}_Observer"
+
+    # ── Squad roster injection (V4/V6 interceptor expects these) ──
+    await client_ws.send_text(json.dumps({
+        "event": "auth_status", "type": "auth_status",
+        "role": "commander" if is_commander else "observer",
+    }))
+    for event_type in ("legion_update", "cluster_update"):
+        await client_ws.send_text(json.dumps({
+            "event": event_type, "type": event_type,
+            "data": legion_status,
+            "roster": {
+                a: {"id": info["id"], "name": a,
+                    "gateway_port": info.get("gateway_port"),
+                    "ws_port": info.get("ws_port")}
+                for a, info in SQUAD_ROSTER.items()
+            },
+            "logs": [], "messages": [], "history": [],
+        }))
+
+    # ── Determine primary agent ─────────────────────────────
+    primary_agent = get_agent_for_user(real_name)
+    primary_info = SQUAD_ROSTER.get(primary_agent, SQUAD_ROSTER.get(WEBUI_AGENT, {}))
+    nanobot_token = os.environ.get("NANOBOT_TOKEN", "").strip()
+
+    # ── Connect to primary agent (neo) ──────────────────────
+    neo_url = f"ws://127.0.0.1:{primary_info['ws_port']}/{path}"
+    if nanobot_token:
+        neo_url += f"?token={nanobot_token}"
+    log(f"🔀 WS 路由: {real_name} → {primary_agent} (port {primary_info.get('ws_port','?')} path /{path})")
+
+    neo_ws = None
+    try:
+        neo_ws = await asyncio.wait_for(
+            websockets.connect(neo_url, close_timeout=5), timeout=15
+        )
+    except asyncio.TimeoutError:
+        log(f"🔌 [WS Proxy] {uname}→{primary_agent} connect timeout")
+        try:
+            await client_ws.close(code=4003, reason="agent connect timeout")
+        except Exception:
+            pass
+        return
+    except Exception as e:
+        log(f"🔌 [WS Proxy] {uname}→{primary_agent} error: {e}")
+        try:
+            await client_ws.close()
+        except Exception:
+            pass
+        return
+
+    # ── Start observer capture loops for all OTHER agents ───
+    observer_stop = asyncio.Event()
+    observer_tasks: list[asyncio.Task] = []
+    for name, info in SQUAD_ROSTER.items():
+        if name == primary_agent:
+            continue
+        task = asyncio.create_task(
+            _observer_capture(name, info, path, nanobot_token, client_ws, observer_stop)
+        )
+        observer_tasks.append(task)
+    if observer_tasks:
+        log(f"👁️ [WS Proxy] {len(observer_tasks)} observer capture loops started")
+
+    # ── Periodic legion_update re-emission ──────────────────
+    async def _emit_legion_update_periodic():
+        while not observer_stop.is_set():
+            await asyncio.sleep(5)
+            try:
+                await client_ws.send_text(json.dumps({
+                    "event": "legion_update", "type": "legion_update",
+                    "data": dict(legion_status),
+                    "roster": {
+                        a: {"id": i["id"], "name": a,
+                            "gateway_port": i.get("gateway_port"),
+                            "ws_port": i.get("ws_port")}
+                        for a, i in SQUAD_ROSTER.items()
+                    },
+                    "logs": [], "messages": [], "history": [],
+                }))
+            except Exception:
+                break
+    periodic_task = asyncio.create_task(_emit_legion_update_periodic())
+
+    # ── Bidirectional proxy with neo + cluster_log inject ───
+    try:
+        async def client_to_neo():
+            """Commander → neo (unchanged)."""
+            try:
+                while True:
+                    data = await client_ws.receive_text()
+                    await neo_ws.send(data)
+            except (WebSocketDisconnect, Exception):
+                pass
+
+        async def neo_to_client():
+            """neo → Commander + cluster_log for LegionTerminal."""
+            try:
+                while True:
+                    data = await neo_ws.recv()
+                    if isinstance(data, bytes):
+                        data = data.decode("utf-8", errors="replace")
+                    # 1) passthrough to Commander's WebUI
+                    await client_ws.send_text(data)
+                    # 2) also inject as cluster_log for LegionTerminal
+                    cluster = _build_cluster_log(primary_agent, data)
+                    if cluster:
+                        try:
+                            await client_ws.send_text(cluster)
+                        except Exception:
+                            pass
+            except (websockets.exceptions.ConnectionClosed, Exception):
+                pass
+
+        await asyncio.gather(client_to_neo(), neo_to_client())
+
+    finally:
+        # ── Teardown ────────────────────────────────────────
+        observer_stop.set()
+        periodic_task.cancel()
+        for t in observer_tasks:
+            t.cancel()
+        try:
+            await neo_ws.close()
+        except Exception:
+            pass
+
+# ═══════════════════════════════════════════════════════════════
+# Bootstrap / WebUI
+# ═══════════════════════════════════════════════════════════════
+
+# NOTE: /webui/bootstrap is deliberately NOT overridden here.
+# The catch-all HTTP proxy forwards it to the target agent's ws_port,
+# which returns { token, ws_path, ... } needed for WebSocket auth.
+# Squad roster is injected via legion_update events at WS connect time.
+
+@app.get("/")
+async def index(request: Request):
+    """Serve nanobot WebUI landing page — proxy to agent ws_port for real index.html."""
+    session_user = request.session.get("user")
+    uname = "Unknown"
+    if isinstance(session_user, dict):
+        uname = session_user.get("preferred_username") or session_user.get("username") or "Unknown"
+    target_agent = get_agent_for_user(uname)
+    client = _http_clients.get(target_agent, _default_client)
+    if not client:
+        return HTMLResponse("<h1>Staging: no agent available</h1>", status_code=503)
+    try:
+        resp = await client.get("/")
+        return HTMLResponse(
+            content=resp.text,
+            status_code=resp.status_code,
+            headers=dict(resp.headers),
+        )
+    except Exception as e:
+        log(f"❌ [GET /] proxy to {target_agent} failed: {e}")
+        return HTMLResponse(f"<h1>Agent {target_agent} unreachable</h1>", status_code=502)
+
+# ═══════════════════════════════════════════════════════════════
+# Catch-all HTTP proxy — forward unmatched paths to agent ws_port
+# ═══════════════════════════════════════════════════════════════
+
+@app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
+async def proxy(request: Request, path: str = ""):
+    """Proxy all unmatched HTTP traffic to the appropriate agent's ws_port."""
+    from fastapi.responses import StreamingResponse, Response
+
+    session_user = request.session.get("user")
+    uname = "Unknown"
+    if isinstance(session_user, dict):
+        uname = session_user.get("preferred_username") or session_user.get("username") or session_user.get("name") or "Unknown"
+
+    target_agent = get_agent_for_user(uname)
+    client = _http_clients.get(target_agent, _default_client)
+    if not client:
+        return Response(content="No agent available", status_code=503)
+
+    try:
+        url = httpx.URL(path=f"/{path}" if path else "/", query=request.url.query.encode("utf-8"))
+        headers = {k: v for k, v in request.headers.items() if k.lower() not in ["host", "content-length"]}
+        rp_req = client.build_request(request.method, url, headers=headers, content=await request.body())
+        rp_resp = await client.send(rp_req, stream=True)
+        return StreamingResponse(rp_resp.aiter_raw(), status_code=rp_resp.status_code, headers=dict(rp_resp.headers))
+    except Exception as e:
+        return Response(content="System Warming Up...", status_code=503)
+
+# ═══════════════════════════════════════════════════════════════
+# Entrypoint
+# ═══════════════════════════════════════════════════════════════
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.environ.get("GATEKEEPER_PORT", "7860"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/contrib/legion/gatekeeper.py
+++ b/contrib/legion/gatekeeper.py
@@ -82,6 +82,24 @@ if not WEBUI_AGENT or WEBUI_AGENT not in SQUAD_ROSTER:
     WEBUI_AGENT = AGENT_NAMES[0] if AGENT_NAMES else "neo"
     log(f"📡 WEBUI_AGENT 未指定或无效，回退到: {WEBUI_AGENT}")
 
+# ── Nanobot version ──────────────────────────────────────────
+def _get_nanobot_version() -> str:
+    """Read nanobot version from installed package or pyproject.toml."""
+    try:
+        from nanobot import __version__
+        return __version__
+    except Exception:
+        pass
+    try:
+        import tomllib
+        with open("/app/pyproject.toml", "rb") as f:
+            return tomllib.load(f).get("project", {}).get("version", "unknown")
+    except Exception:
+        return "unknown"
+
+NANOBOT_VERSION = _get_nanobot_version()
+log(f"📦 nanobot version: {NANOBOT_VERSION}")
+
 def get_agent_for_user(username: str) -> str:
     """返回该 HF 用户对应的 agent name；未匹配或 Commander → WEBUI_AGENT"""
     if not username or username == "Unknown":
@@ -731,6 +749,7 @@ async def ws_proxy(path: str, client_ws: WebSocket):
         await client_ws.send_text(json.dumps({
             "event": event_type, "type": event_type,
             "data": legion_status,
+            "nanobot_version": NANOBOT_VERSION,
             "roster": {
                 a: {"id": info["id"], "name": a,
                     "gateway_port": info.get("gateway_port"),
@@ -792,6 +811,7 @@ async def ws_proxy(path: str, client_ws: WebSocket):
                 await client_ws.send_text(json.dumps({
                     "event": "legion_update", "type": "legion_update",
                     "data": dict(legion_status),
+                    "nanobot_version": NANOBOT_VERSION,
                     "roster": {
                         a: {"id": i["id"], "name": a,
                             "gateway_port": i.get("gateway_port"),

--- a/contrib/legion/patch_legion_v4_client.py
+++ b/contrib/legion/patch_legion_v4_client.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Patch: Legion V4 — inject onAnyEvent() into NanobotClient (v0.2.0).
+
+Targets (pre-compile, before hatch_build runs npm):
+  - /app/webui/src/lib/types.ts          → add peers to BootstrapResponse (kept for typing)
+  - /app/webui/src/lib/nanobot-client.ts → add onAnyEvent() + peers field (unused, backward compat)
+  - /app/webui/src/App.tsx               → (no-op — V6 sidebar uses legion_update events)
+
+Dual-target NOT required: WebUI .ts/.tsx patches are compiled into dist/,
+only the /app/webui/src/ copy matters before the Vite build step.
+
+Architecture note (since 2026-05-19):
+  The V6 sidebar (patch_legion_v6_sidebar.py) reads agent roster from
+  ``legion_update`` WS events injected by the Gatekeeper, not from
+  bootstrap ``peers``.  This keeps the human-facing bootstrap endpoint
+  (PR #3854) decoupled from machine-to-machine service discovery,
+  aligning with upstream reviewer chengyongru's architectural feedback.
+"""
+
+from pathlib import Path
+
+PATCH_LABEL = "legion-v4-client"
+
+TYPES = Path("/app/webui/src/lib/types.ts")
+CLIENT = Path("/app/webui/src/lib/nanobot-client.ts")
+APP = Path("/app/webui/src/App.tsx")
+
+
+def patch_types():
+    """Add ``peers`` field to BootstrapResponse interface."""
+    content = TYPES.read_text()
+
+    anchor = "model_name?: string | null;"
+    if anchor not in content:
+        print(f"⚠ [{PATCH_LABEL}] types.ts anchor '{anchor}' not found — skip")
+        return False
+
+    new_field = (
+        "  /** Legion: squad peer roster — keyed by agent name. */\n"
+        "  peers?: Record<string, { id: string; name: string; gateway_port: number; ws_port: number }>;"
+    )
+
+    if new_field.strip() in content:
+        print(f"  [{PATCH_LABEL}] types.ts already has peers field")
+        return True
+
+    content = content.replace(anchor, anchor + "\n" + new_field, 1)
+    TYPES.write_text(content)
+    print(f"✓ [{PATCH_LABEL}] types.ts — added peers to BootstrapResponse")
+    return True
+
+
+def patch_client():
+    """Inject legion fields, onAnyEvent(), and any-event dispatch into NanobotClient."""
+    content = CLIENT.read_text()
+
+    # ── Injection A: fields (after errorHandlers) ──
+    anchor_a = "private errorHandlers = new Set<ErrorHandler>();"
+    if anchor_a not in content:
+        print(f"⚠ [{PATCH_LABEL}] client anchor A '{anchor_a}' not found — skip")
+        return False
+
+    legion_fields = (
+        "  /* Legion: generic event listeners for all inbound events (fires before dispatch). */\n"
+        "  private anyEventHandlers = new Set<(ev: InboundEvent) => void>();\n"
+        "  /* Legion: squad peer roster — kept for backward compat; V6 sidebar uses legion_update events instead. */\n"
+        "  public peers: Record<string, { id: string; name: string; gateway_port: number; ws_port: number }> | null = null;"
+    )
+
+    if "anyEventHandlers" not in content:
+        content = content.replace(anchor_a, anchor_a + "\n" + legion_fields, 1)
+        print(f"  [{PATCH_LABEL}] client — added anyEventHandlers + peers fields")
+    else:
+        print(f"  [{PATCH_LABEL}] client — fields already present")
+
+    # ── Injection B: onAnyEvent() method (after onError() closing brace) ──
+    anchor_b = (
+        "  onError(handler: ErrorHandler): Unsubscribe {\n"
+        "    this.errorHandlers.add(handler);\n"
+        "    return () => {\n"
+        "      this.errorHandlers.delete(handler);\n"
+        "    };\n"
+        "  }"
+    )
+    if anchor_b not in content:
+        print(f"⚠ [{PATCH_LABEL}] client anchor B not found — skip")
+        return False
+
+    on_any_event_method = (
+        "\n"
+        "  /** Legion: subscribe to ALL inbound events (fires before per-chat dispatch).\n"
+        "   *  Use for legion_update / legion_peer_heartbeat events injected by gatekeeper. */\n"
+        "  onAnyEvent(handler: (ev: InboundEvent) => void): Unsubscribe {\n"
+        "    this.anyEventHandlers.add(handler);\n"
+        "    return () => {\n"
+        "      this.anyEventHandlers.delete(handler);\n"
+        "    };\n"
+        "  }"
+    )
+
+    if "onAnyEvent(handler" not in content:
+        content = content.replace(anchor_b, anchor_b + on_any_event_method, 1)
+        print(f"  [{PATCH_LABEL}] client — added onAnyEvent() method")
+    else:
+        print(f"  [{PATCH_LABEL}] client — onAnyEvent() already present")
+
+    # ── Injection C: any-event dispatch in handleMessage (before ready check) ──
+    anchor_c = "if (parsed.event === \"ready\") {"
+    if anchor_c not in content:
+        print(f"⚠ [{PATCH_LABEL}] client anchor C not found — skip")
+        return False
+
+    dispatch_block = (
+        "    /* Legion: fire any-event handlers before standard routing. */\n"
+        "    for (const handler of this.anyEventHandlers) {\n"
+        "      try { handler(parsed); } catch (_) { /* guard */ }\n"
+        "    }\n\n"
+        "    "
+    )
+
+    if "for (const handler of this.anyEventHandlers)" not in content:
+        content = content.replace(anchor_c, dispatch_block + anchor_c, 1)
+        print(f"  [{PATCH_LABEL}] client — added any-event dispatch in handleMessage()")
+    else:
+        print(f"  [{PATCH_LABEL}] client — dispatch already present")
+
+    CLIENT.write_text(content)
+    return True
+
+
+def patch_app():
+    """(Architecture cleanup) V6 sidebar no longer reads bootstrap peers.
+
+    Legacy: Exposed ``boot.peers`` → client.peers for the V4 sidebar component.
+    Since V6 migration, agent roster flows exclusively through ``legion_update``
+    WS events, keeping human-facing bootstrap decoupled from service discovery.
+
+    The TypeScript field ``client.peers`` (null by default) is kept in
+    nanobot-client.ts for backward compatibility but is intentionally unset.
+    """
+    print(f"  [{PATCH_LABEL}] skip — V6 uses legion_update events, not bootstrap peers")
+    return True
+
+
+def main():
+    ok = True
+    if TYPES.is_file():
+        ok &= patch_types()
+    else:
+        print(f"⚠ [{PATCH_LABEL}] {TYPES} not found (upstream may have moved types)")
+    if CLIENT.is_file():
+        ok &= patch_client()
+    else:
+        print(f"⚠ [{PATCH_LABEL}] {CLIENT} not found (upstream may have renamed)")
+    if APP.is_file():
+        ok &= patch_app()
+    else:
+        print(f"⚠ [{PATCH_LABEL}] {APP} not found — check upstream path")
+    if ok:
+        print(f"✅ [{PATCH_LABEL}] complete")
+    else:
+        print(f"❌ [{PATCH_LABEL}] failed (some targets missing) — check upstream changes")
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/legion/patch_legion_v6_sidebar.py
+++ b/contrib/legion/patch_legion_v6_sidebar.py
@@ -45,6 +45,7 @@ type AgentStatus = "online" | "offline" | "executing" | "blocked" | "disconnecte
 function LegionRoster(props: {
   peers: Record<string, { id: string; name?: string }>;
   status: Record<string, string>;
+  version?: string;
   onToggleConsole?: () => void;
 }) {
   const agents = Object.keys(props.peers).sort();
@@ -56,7 +57,7 @@ function LegionRoster(props: {
       title="点击切换军团指挥中心"
     >
       <span className="text-[11px] text-muted-foreground/60 tracking-wider font-semibold">
-        军团
+        军团{props.version ? ` · v${props.version}` : ""}
       </span>
       {agents.map((key) => {
         const peer = props.peers[key] || { id: key };
@@ -96,6 +97,7 @@ function LegionTerminal(props: {{
   activeTab: string;
   setActiveTab: (t: string) => void;
   tabs: string[];
+  version?: string;
   onClose: () => void;
 }}) {{
   if (!props.show) return null;
@@ -113,7 +115,7 @@ function LegionTerminal(props: {{
         <div className="flex items-center gap-2">
           <span className="inline-flex h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
           <span className="text-xs font-semibold text-foreground/80 tracking-wide">
-            军团指挥中心
+            军团指挥中心{{props.version ? ` · v${{props.version}}` : ""}}
           </span>
           <span className="text-[10px] text-muted-foreground/60">
             {{props.logs.all?.length || 0}} 条记录
@@ -179,6 +181,7 @@ SIDEBAR_STATE = """
   const [activeTab, setActiveTab] = useState("all");
   const [legionPeers, setLegionPeers] = useState<Record<string, { id: string; name?: string }>>({});
   const [legionStatus, setLegionStatus] = useState<Record<string, string>>({});
+  const [nanobotVersion, setNanobotVersion] = useState<string>("...");
 
   /* derive logs + tabs dynamically */
   const agentIds = Object.keys(legionPeers).sort();
@@ -214,6 +217,8 @@ SIDEBAR_STATE = """
           return next;
         });
         if (data) setLegionStatus(data);
+        const ver = (ev as any).nanobot_version;
+        if (ver && typeof ver === "string") setNanobotVersion(ver);
 
         /* Per-agent status lines */
         if (data) {
@@ -256,6 +261,7 @@ TERMINAL_RENDER = """
         activeTab={activeTab}
         setActiveTab={setActiveTab}
         tabs={allTabs}
+        version={nanobotVersion}
         onClose={() => setShowConsole(false)}
       />
 """
@@ -336,7 +342,7 @@ def patch_sidebar():
     # ── Injection 6: <LegionRoster /> between logo header and search area ──
     if "<LegionRoster " not in content:
         legion_roster_jsx = (
-            '      <LegionRoster peers={legionPeers} status={legionStatus} onToggleConsole={() => setShowConsole(v => !v)} />'
+            '      <LegionRoster peers={legionPeers} status={legionStatus} version={nanobotVersion} onToggleConsole={() => setShowConsole(v => !v)} />'
         )
         # Primary anchor: this line opens the search block div
         anchor_search_div = '      <div className="space-y-1.5 px-2 pb-2">'

--- a/contrib/legion/patch_legion_v6_sidebar.py
+++ b/contrib/legion/patch_legion_v6_sidebar.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Patch: Legion V6 — agent badges + terminal portal for v0.2.0 Sidebar.
+
+Targets (pre-compile, before hatch_build runs npm):
+  - /app/webui/src/components/Sidebar.tsx → LegionRoster badges + LegionTerminal portal
+
+Dual-target NOT required: WebUI .tsx patches are compiled into dist/,
+only the /app/webui/src/ copy matters before the Vite build step.
+
+Injections:
+  1. Expanded react imports (createPortal, useCallback, useEffect, useRef)
+  2. useClient import
+  3. LegionRoster component (agent status badges)
+  4. LegionTerminal component (log portal via createPortal)
+  5. In Sidebar: showConsole/logs/activeTab state + event capture useEffect
+  6. <LegionRoster onToggle /> between logo and search
+  7. <LegionTerminal /> before </nav>
+"""
+from pathlib import Path
+
+PATCH_LABEL = "legion-v6-sidebar"
+
+SIDEBAR = Path("/app/webui/src/components/Sidebar.tsx")
+
+
+# ── LegionRoster component (plain string -> single braces in output) ──
+LEGION_ROSTER = """
+/* ── LegionRoster: agent status badges ── */
+const STATUS_COLORS: Record<string, string> = {
+  online: "bg-emerald-500",
+  offline: "bg-red-500",
+  executing: "bg-blue-500 animate-pulse",
+  blocked: "bg-amber-500",
+  disconnected: "bg-red-500 animate-pulse",
+};
+const STATUS_LABELS: Record<string, string> = {
+  online: "在线",
+  offline: "离线",
+  executing: "执行中",
+  blocked: "阻塞",
+  disconnected: "断连",
+};
+type AgentStatus = "online" | "offline" | "executing" | "blocked" | "disconnected";
+
+function LegionRoster(props: {
+  peers: Record<string, { id: string; name?: string }>;
+  status: Record<string, string>;
+  onToggleConsole?: () => void;
+}) {
+  const agents = Object.keys(props.peers).sort();
+  const t = (s: string) => STATUS_LABELS[s] || s;
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-2 border-b border-border/40 bg-muted/10 cursor-pointer hover:bg-muted/20 transition-colors select-none"
+      onClick={props.onToggleConsole}
+      title="点击切换军团指挥中心"
+    >
+      <span className="text-[11px] text-muted-foreground/60 tracking-wider font-semibold">
+        军团
+      </span>
+      {agents.map((key) => {
+        const peer = props.peers[key] || { id: key };
+        const st: AgentStatus =
+          props.status[key] === "online"
+            ? "online"
+            : props.status[key] === "executing"
+              ? "executing"
+              : props.status[key] === "blocked"
+                ? "blocked"
+                : "offline";
+        const color = STATUS_COLORS[st] || STATUS_COLORS.offline;
+        return (
+          <span
+            key={key}
+            className="flex items-center gap-1 text-[11px] font-semibold text-foreground/80"
+            title={`${peer.name || key}: ${t(st)}`}
+          >
+            <span
+              className={`inline-block h-[14px] w-[14px] rounded-full ${color} ring-1 ring-border/30`}
+            />
+            {peer.name || key}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+"""
+
+# ── LegionTerminal component (f-string — double braces become single in output) ──
+LEGION_TERMINAL = f"""
+/* ── LegionTerminal: log portal ── */
+function LegionTerminal(props: {{
+  show: boolean;
+  logs: Record<string, string[]>;
+  activeTab: string;
+  setActiveTab: (t: string) => void;
+  tabs: string[];
+  onClose: () => void;
+}}) {{
+  if (!props.show) return null;
+  const visibleLogs = props.logs[props.activeTab] || [];
+  const TAB_LABELS: Record<string, string> = {{ all: "全部" }};
+  const {{ tabs }} = props;
+  return createPortal(
+    <div className="fixed bottom-4 left-[288px] w-[540px] h-[460px]
+                    bg-background border border-border rounded-lg
+                    shadow-2xl z-[100] flex flex-col text-sm"
+         style={{{{ fontFamily: "var(--font-mono, monospace)" }}}}>
+      {{/* header */}}
+      <div className="flex items-center justify-between px-3 py-2
+                      border-b border-border bg-muted/50 rounded-t-lg shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
+          <span className="text-xs font-semibold text-foreground/80 tracking-wide">
+            军团指挥中心
+          </span>
+          <span className="text-[10px] text-muted-foreground/60">
+            {{props.logs.all?.length || 0}} 条记录
+          </span>
+        </div>
+        <button
+          onClick={{props.onClose}}
+          className="text-muted-foreground/60 hover:text-foreground px-1.5 py-0.5 rounded text-sm leading-none"
+          title="关闭">✕</button>
+      </div>
+      {{/* tab bar */}}
+      <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border/30 bg-muted/10 shrink-0">
+        {{tabs.map((tab: string) => {{
+          const isActive = props.activeTab === tab;
+          const count = (props.logs[tab] || []).length;
+          const label = TAB_LABELS[tab] || tab;
+          return (
+            <button key={{tab}}
+              onClick={{() => props.setActiveTab(tab)}}
+              className={{`px-2.5 py-1 text-[11px] font-semibold rounded transition-colors
+                ${{isActive
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground/70 hover:text-foreground hover:bg-accent/30"}}`}}
+            >
+              {{label}}
+              {{count > 0 && (
+                <span className="ml-1 text-[9px] opacity-70">{{count}}</span>
+              )}}
+            </button>
+          );
+        }})}}
+      </div>
+      {{/* log body */}}
+      <div className="flex-1 overflow-y-auto p-2 text-xs bg-background">
+        {{visibleLogs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground/25 gap-2">
+            <span className="text-2xl">⚔️</span>
+            <span className="text-[11px]">
+              {{props.activeTab === "all" ? "等待军团信号…" : `${{TAB_LABELS[props.activeTab] || props.activeTab}} 暂无日志`}}
+            </span>
+          </div>
+        ) : (
+          visibleLogs.map((log: string, i: number) => (
+            <div key={{i}} className="py-0.5 border-b border-border/10 last:border-0 break-all hover:bg-accent/5 transition-colors font-mono text-[11px] leading-relaxed text-muted-foreground/80">
+              {{log}}
+            </div>
+          ))
+        )}}
+      </div>
+    </div>,
+    document.body
+  );
+}}
+"""
+
+# ── State + event capture (injected into Sidebar body) (plain string) ──
+SIDEBAR_STATE = """
+  /* ── Legion: console state ── */
+  const { client } = useClient();
+  const [showConsole, setShowConsole] = useState(false);
+  const [allLogs, setAllLogs] = useState<string[]>([]);
+  const [agentLogs, setAgentLogs] = useState<Record<string, string[]>>({});
+  const [activeTab, setActiveTab] = useState("all");
+  const [legionPeers, setLegionPeers] = useState<Record<string, { id: string; name?: string }>>({});
+  const [legionStatus, setLegionStatus] = useState<Record<string, string>>({});
+
+  /* derive logs + tabs dynamically */
+  const agentIds = Object.keys(legionPeers).sort();
+  const allTabs = ["all", ...agentIds];
+  const logs: Record<string, string[]> = { all: allLogs, ...agentLogs };
+
+  /* ── helper: push line to a named bin ── */
+  function _pushLog(bin: string, line: string, max: number) {
+    setAllLogs(prev => [...prev, line].slice(-500));
+    if (bin !== "all") {
+      setAgentLogs(prev => {
+        const cur = prev[bin] || [];
+        return { ...prev, [bin]: [...cur, line].slice(-max) };
+      });
+    }
+  }
+
+  /* ── Legion: event capture ── */
+  useEffect(() => {
+    return client.onAnyEvent((ev: any) => {
+      const ts = new Date().toLocaleTimeString();
+      const evType = (ev as any).event || (ev as any).type || "?";
+
+      /* ── Handle legion roster/status updates ── */
+      if ((evType === "legion_update" || evType === "cluster_update") && (ev as any).roster) {
+        const roster = (ev as any).roster as Record<string, { id: string; name?: string }>;
+        const data = (ev as any).data as Record<string, string> | undefined;
+        setLegionPeers(prev => {
+          const next = { ...prev };
+          for (const [k, v] of Object.entries(roster)) {
+            if (!next[k]) next[k] = v;
+          }
+          return next;
+        });
+        if (data) setLegionStatus(data);
+
+        /* Per-agent status lines */
+        if (data) {
+          for (const [agent, status] of Object.entries(data)) {
+            _pushLog(agent, `[${ts}] 状态  ${agent} = ${status}`, 150);
+          }
+        }
+        return;  /* legion_update done — no generic line needed */
+      }
+
+      /* build detail line */
+      let detail = "";
+      if (typeof (ev as any).text === "string") {
+        detail = (ev as any).text.slice(0, 120);
+      } else if (typeof (ev as any).content === "string") {
+        detail = (ev as any).content.slice(0, 120);
+      } else {
+        try { detail = JSON.stringify(ev).slice(0, 160); } catch (_) { detail = "?"; }
+      }
+
+      const line = `[${ts}] ${evType}  ${detail}`;
+
+      /* route: squad relay events carry sender/target */
+      const sender = (ev as any).sender as string | undefined;
+      const tgt = (ev as any).target as string | undefined;
+
+      _pushLog("all", line, 500);
+      if (sender) _pushLog(sender, line, 150);
+      if (tgt && tgt !== sender) _pushLog(tgt, line, 150);
+    });
+  }, [client]);
+"""
+
+# ── Terminal render portal (injected before </nav>) (plain string) ──
+TERMINAL_RENDER = """
+      {/* ── Legion: terminal portal ── */}
+      <LegionTerminal
+        show={showConsole}
+        logs={logs}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        tabs={allTabs}
+        onClose={() => setShowConsole(false)}
+      />
+"""
+
+
+def patch_sidebar():
+    """Inject LegionRoster + LegionTerminal into Sidebar.tsx."""
+    if not SIDEBAR.is_file():
+        print(f"  [{PATCH_LABEL}] {SIDEBAR} not found — skip")
+        return False
+
+    content = SIDEBAR.read_text()
+    ok = True
+
+    # ── Injection 1: expand react imports ──
+    anchor_import = 'import { useMemo, useState } from "react";'
+    if anchor_import not in content:
+        print(f"  [{PATCH_LABEL}] anchor import not found — skip")
+        return False
+
+    expanded_import = 'import { useEffect, useMemo, useState } from "react";'
+    if expanded_import != anchor_import:
+        # Only replace if not already expanded
+        if "useEffect" not in content.split("\n")[0]:
+            content = content.replace(anchor_import, expanded_import, 1)
+            print(f"  [{PATCH_LABEL}] expanded react imports")
+        else:
+            print(f"  [{PATCH_LABEL}] react imports already expanded")
+
+    # Add createPortal from react-dom (separate import)
+    anchor_rd_import = 'import { useTranslation } from "react-i18next";'
+    if anchor_rd_import in content and "createPortal" not in content:
+        rd_addon = '\nimport { createPortal } from "react-dom";'
+        content = content.replace(anchor_rd_import, anchor_rd_import + rd_addon, 1)
+        print(f"  [{PATCH_LABEL}] added createPortal import from react-dom")
+    elif "createPortal" not in content:
+        print(f"  [{PATCH_LABEL}] useTranslation anchor for createPortal not found — skip")
+
+    # ── Injection 2: useClient import ──
+    anchor_usec = 'import { useTranslation } from "react-i18next";'
+    if anchor_usec in content:
+        usec_import = '\nimport { useClient } from "@/providers/ClientProvider";'
+        if 'useClient' not in content:
+            content = content.replace(anchor_usec, anchor_usec + usec_import, 1)
+            print(f"  [{PATCH_LABEL}] added useClient import")
+        else:
+            print(f"  [{PATCH_LABEL}] useClient import already present")
+    else:
+        print(f"  [{PATCH_LABEL}] useTranslation anchor not found — skip import")
+
+    # ── Injection 3: LegionRoster component (before Sidebar function) ──
+    anchor_side_fn = "export function Sidebar("
+    if "function LegionRoster" not in content:
+        content = content.replace(anchor_side_fn, LEGION_ROSTER + "\n" + anchor_side_fn, 1)
+        print(f"  [{PATCH_LABEL}] added LegionRoster component")
+    else:
+        print(f"  [{PATCH_LABEL}] LegionRoster already present")
+
+    # ── Injection 4: LegionTerminal component (before Sidebar function) ──
+    if "function LegionTerminal" not in content:
+        content = content.replace(anchor_side_fn, LEGION_TERMINAL + "\n" + anchor_side_fn, 1)
+        print(f"  [{PATCH_LABEL}] added LegionTerminal component")
+    else:
+        print(f"  [{PATCH_LABEL}] LegionTerminal already present")
+
+    # ── Injection 5: state + event capture (after useState lines, before useMemo) ──
+    anchor_state = 'const [query, setQuery] = useState("");'
+    if anchor_state in content:
+        if "/* ── Legion: console state ── */" not in content:
+            content = content.replace(anchor_state, anchor_state + SIDEBAR_STATE, 1)
+            print(f"  [{PATCH_LABEL}] added console state + event capture")
+        else:
+            print(f"  [{PATCH_LABEL}] console state already present")
+    else:
+        print(f"  [{PATCH_LABEL}] state anchor not found — skip state injection")
+        ok = False
+
+    # ── Injection 6: <LegionRoster /> between logo header and search area ──
+    if "<LegionRoster " not in content:
+        legion_roster_jsx = (
+            '      <LegionRoster peers={legionPeers} status={legionStatus} onToggleConsole={() => setShowConsole(v => !v)} />'
+        )
+        # Primary anchor: this line opens the search block div
+        anchor_search_div = '      <div className="space-y-1.5 px-2 pb-2">'
+        if anchor_search_div in content:
+            content = content.replace(
+                anchor_search_div,
+                legion_roster_jsx + "\n" + anchor_search_div,
+                1
+            )
+            print(f"  [{PATCH_LABEL}] inserted <LegionRoster /> before search div")
+        else:
+            print(f"  [{PATCH_LABEL}] search div anchor not found — skip")
+            ok = False
+    else:
+        print(f"  [{PATCH_LABEL}] <LegionRoster /> already in sidebar")
+
+    # ── Injection 7: <LegionTerminal /> before </nav> ──
+    anchor_nav_end = "    </nav>"
+    if "<LegionTerminal " not in content:
+        if anchor_nav_end in content:
+            content = content.replace(anchor_nav_end, TERMINAL_RENDER + "\n" + anchor_nav_end, 1)
+            print(f"  [{PATCH_LABEL}] inserted <LegionTerminal />")
+        else:
+            print(f"  [{PATCH_LABEL}] </nav> anchor not found — skip terminal render")
+            ok = False
+    else:
+        print(f"  [{PATCH_LABEL}] <LegionTerminal /> already in sidebar")
+
+    SIDEBAR.write_text(content)
+
+    if ok:
+        print(f"✅ [{PATCH_LABEL}] complete")
+    else:
+        print(f"⚠ [{PATCH_LABEL}] partial — some injections skipped")
+    return ok
+
+
+def main():
+    ok = patch_sidebar()
+    if not ok:
+        print(f"❌ [{PATCH_LABEL}] failed (some targets missing) — check upstream changes")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/legion/patch_squad_error_events.py
+++ b/contrib/legion/patch_squad_error_events.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Patch: squad error events — emit structured "error" on WebSocket permission denial.
+============================================================
+Without this patch, BaseChannel._handle_message silently discards unallowed messages
+(logging only a warning). The WebSocket client (squad_bridge) receives no error event
+and must rely on timeout detection. This patch adds a pre-check in
+WebSocketChannel._handle_typed_envelope so that permission failures emit a structured
+error event before returning, enabling the bridge to distinguish framework denial from
+network/timeout failures.
+
+Target: /usr/local/lib/python3.12/site-packages/nanobot/channels/websocket.py
+"""
+import re
+from pathlib import Path
+
+TARGET = Path("/usr/local/lib/python3.12/site-packages/nanobot/channels/websocket.py")
+
+
+def patch() -> None:
+    content = TARGET.read_text()
+
+    # Locate the permission check insertion point: right before
+    # "await self._handle_message(" inside the "if t == "message":" branch
+    old = """            # Auto-attach on first use so clients can one-shot without a separate attach.
+            self._attach(connection, cid)
+            await self._hydrate_after_subscribe(cid)
+            metadata: dict[str, Any] = {"remote": getattr(connection, "remote_address", None)}"""
+
+    new = """            # ── v6: permission pre-check (squad error events) ──
+            # BaseChannel._handle_message silently discards unallowed messages
+            # (logger.warning only). Emit a structured error event for the
+            # WebSocket client so squad_bridge can distinguish framework denial.
+            if not self.is_allowed(client_id):
+                await self._send_event(
+                    connection, "error",
+                    detail="access_denied",
+                    reason="Sender not in allowFrom list.",
+                )
+                return
+
+            # Auto-attach on first use so clients can one-shot without a separate attach.
+            self._attach(connection, cid)
+            await self._hydrate_after_subscribe(cid)
+            metadata: dict[str, Any] = {"remote": getattr(connection, "remote_address", None)}"""
+
+    if old not in content:
+        print("❌ [patch_squad_error_events] anchor text not found — websocket.py may have changed")
+        raise SystemExit(1)
+
+    content = content.replace(old, new, 1)
+    TARGET.write_text(content)
+    print("✓ [patch_squad_error_events] websocket.py patched: permission denial now emits error event")
+
+
+if __name__ == "__main__":
+    patch()

--- a/contrib/legion/squad_bridge.py
+++ b/contrib/legion/squad_bridge.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""
+Squad Bridge v6.0 - 军团专线同步协同脚本
+===========================================
+v6.0: retry+backoff, dead-letter queue, correlation_id, error event handling
+v5.0: accumulate streaming deltas, exit on turn_end, safety guards (idle/LB/total)
+
+架构位置：squad overlay（我们自维护），依赖官方 nanobot WS 协议
+"""
+
+import sys
+import json
+import time
+import os
+import uuid
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+import websocket
+
+from squad_config_sync import get_roster
+
+# ── Constants ──────────────────────────────────────────────
+TOTAL_TIMEOUT   = 120       # 总超时 (s)
+IDLE_TIMEOUT    = 30        # 空闲超时 (s) — 覆盖 LLM 卡顿/rate limit
+MAX_BUFFER_BYTES = 204800   # 200KB 硬上限 — 防垃圾/DoS
+MAX_RETRIES     = 3         # 最大重试次数
+RETRY_BACKOFF   = [1, 2, 4] # 指数退避 (s)
+DLQ_PATH        = Path("/data/squad_dlq.jsonl")
+
+# ── Error classification ───────────────────────────────────
+
+# Errors that are permanent — no retry, go straight to DLQ.
+PERMANENT_ERROR_PREFIXES = (
+    "roster_miss:",
+    "permission_denied:",
+    "no_ready:",
+)
+
+
+def _is_transient(error: str | None) -> bool:
+    """Return True if the error is worth retrying."""
+    if not error:
+        return True  # unknown = retryable
+    for prefix in PERMANENT_ERROR_PREFIXES:
+        if error.startswith(prefix):
+            return False
+    return True
+
+
+# ── Permission check ───────────────────────────────────────
+
+def _get_allowed_peers(sender_id: str) -> list[str] | str:
+    """
+    Returns:
+        "*"       → Commander (in COMMANDER_WHITELIST) — can message any agent.
+        ["neo", …] → Business user (in USER_AGENT_MAP) — only mapped agents.
+        []        → Guest — blocked.
+
+    sender_id can be either an HF username (DreamShepherd2006) or an agent alias
+    (neo). If it's an agent alias, we reverse-lookup USER_AGENT_MAP to find the
+    owning HF username, then apply permission rules.
+    """
+    commander_whitelist = os.environ.get("COMMANDER_WHITELIST", "")
+    user_agent_map_str = os.environ.get("USER_AGENT_MAP", "")
+
+    whitelist = [w.strip().lower() for w in commander_whitelist.split(",") if w.strip()]
+
+    # Parse USER_AGENT_MAP and build reverse lookup (agent alias → username)
+    # Format: {"username": "NANOBOT_PEER_NEO", ...}  (flat, values are strings)
+    try:
+        user_map = json.loads(user_agent_map_str) if user_agent_map_str else {}
+    except json.JSONDecodeError:
+        user_map = {}
+    agent_to_user: dict[str, str] = {}
+    for uname, peer_key in user_map.items():
+        if isinstance(peer_key, str) and peer_key.upper().startswith("NANOBOT_PEER_"):
+            agent_name = peer_key[len("NANOBOT_PEER_"):].lower()
+            agent_to_user[agent_name] = uname.lower()
+
+    # Resolve effective user
+    effective = sender_id.lower()
+    if effective in agent_to_user:
+        effective = agent_to_user[effective]
+
+    # Commander check
+    if effective in whitelist:
+        return "*"
+
+    # Business user check
+    if effective in user_map:
+        peer_key = user_map[effective]
+        if isinstance(peer_key, str) and peer_key.upper().startswith("NANOBOT_PEER_"):
+            allowed: list[str] = [peer_key[len("NANOBOT_PEER_"):].lower()]
+            return allowed
+
+    return []
+
+
+# ── Helpers ────────────────────────────────────────────────
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+def _make_correlation_id() -> str:
+    """sq-{timestamp}-{short_uuid}"""
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    short = uuid.uuid4().hex[:4]
+    return f"sq-{ts}-{short}"
+
+def _write_dlq(entry: dict) -> None:
+    """Append a dead-letter entry to the persistent DLQ file."""
+    try:
+        DLQ_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(DLQ_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        print(f"📮 [死信队列] 已归档 → {DLQ_PATH}")
+    except Exception as e:
+        print(f"❌ [死信队列写入失败]: {e}", file=sys.stderr)
+
+
+# ── Core: single delivery attempt ──────────────────────────
+
+def _attempt_delivery(
+    sender_alias: str,
+    target_alias: str,
+    message_content: str,
+    correlation_id: str,
+    attempt: int,
+) -> tuple[bool, str | None, str | None]:
+    """
+    Returns (success, output_text, error_reason).
+    success=True  → output_text is the response.
+    success=False → error_reason is the failure classification.
+    """
+    roster, _ = get_roster()
+    target_data = roster.get(target_alias.lower())
+    if not target_data:
+        return False, None, f"roster_miss:{target_alias}"
+
+    target_chat_id = target_data["id"]
+    target_port = target_data["ws_port"]
+
+    token = os.environ.get("NANOBOT_TOKEN", "").strip()
+    uri = f"ws://127.0.0.1:{target_port}/"
+    if token:
+        uri += f"?token={token}"
+
+    payload = {
+        "type": "message",
+        "chat_id": target_chat_id,
+        "content": f"[{sender_alias}]: {message_content}",
+        "correlation_id": correlation_id,
+    }
+
+    try:
+        ws = websocket.create_connection(uri, timeout=10)
+    except Exception as e:
+        return False, None, f"connection:{e}"
+
+    try:
+        greeting_raw = ws.recv()
+        greeting = json.loads(greeting_raw)
+
+        if greeting.get("event") != "ready":
+            ws.close()
+            return False, None, f"no_ready:{greeting.get('event','')}"
+
+        ws.send(json.dumps(payload, ensure_ascii=False))
+        print(f"  [{attempt}/3] 🚀 {sender_alias} → {target_alias} (cid={correlation_id})")
+
+        content_buffer: list[str] = []
+        buffer_size = 0
+        last_content_ts = 0.0
+        start_time = time.time()
+
+        while True:
+            elapsed = time.time() - start_time
+
+            # Guard 1: total timeout
+            if elapsed > TOTAL_TIMEOUT:
+                if content_buffer:
+                    output = "".join(content_buffer)
+                    print(f"  ⏰ 总超时 ({TOTAL_TIMEOUT}s)")
+                    return True, output, None
+                return False, None, "timeout:total"
+
+            # Guard 2: idle timeout (only after content started)
+            if last_content_ts and (time.time() - last_content_ts > IDLE_TIMEOUT):
+                output = "".join(content_buffer)
+                print(f"  ⏰ 空闲超时 ({IDLE_TIMEOUT}s)")
+                return True, output, None
+
+            try:
+                raw_data = ws.recv()
+            except websocket.WebSocketTimeoutException:
+                continue
+
+            if not raw_data:
+                continue
+
+            try:
+                data = json.loads(raw_data)
+            except json.JSONDecodeError:
+                continue
+
+            event = data.get("event", "")
+
+            # ── v6: error event handling ──
+            if event == "error":
+                detail = data.get("detail", "unknown")
+                ws.close()
+                return False, None, f"framework:{detail}"
+
+            if event == "heartbeat":
+                continue
+
+            if event == "turn_end":
+                output = "".join(content_buffer) if content_buffer else "(空响应)"
+                print(f"  ✅ turn_end ({len(output)} chars)")
+                ws.close()
+                return True, output, None
+
+            if event == "stream_end":
+                continue
+
+            if event == "delta":
+                text = data.get("text", "")
+                if text:
+                    if buffer_size + len(text.encode("utf-8")) > MAX_BUFFER_BYTES:
+                        remaining = MAX_BUFFER_BYTES - buffer_size
+                        if remaining > 0:
+                            content_buffer.append(text[:remaining])
+                        content_buffer.append("\n\n[⚠️ buffer 200KB 上限截断]")
+                        output = "".join(content_buffer)
+                        ws.close()
+                        return True, output, None
+                    content_buffer.append(text)
+                    buffer_size += len(text.encode("utf-8"))
+                    last_content_ts = time.time()
+                continue
+
+            # content field (non-streaming fallback)
+            content = data.get("content")
+            if content and content.strip():
+                if buffer_size + len(content.encode("utf-8")) > MAX_BUFFER_BYTES:
+                    remaining = MAX_BUFFER_BYTES - buffer_size
+                    if remaining > 0:
+                        content_buffer.append(content[:remaining])
+                    content_buffer.append("\n\n[⚠️ buffer 200KB 上限截断]")
+                    output = "".join(content_buffer)
+                    ws.close()
+                    return True, output, None
+                content_buffer.append(content)
+                buffer_size += len(content.encode("utf-8"))
+                last_content_ts = time.time()
+
+        ws.close()
+    except Exception as e:
+        try:
+            ws.close()
+        except Exception:
+            pass
+        return False, None, f"exception:{e}"
+
+
+# ── Main: retry loop + DLQ ─────────────────────────────────
+
+def main() -> None:
+    if len(sys.argv) < 4:
+        print("⚠️ Usage: python3 squad_bridge.py <sender_alias> <target_alias> <message>")
+        sys.exit(1)
+
+    sender_alias = sys.argv[1].upper()
+    target_alias = sys.argv[2].upper()
+    message_content = " ".join(sys.argv[3:])
+    correlation_id = _make_correlation_id()
+
+    print(f"═══ Squad Bridge v6.1 ═══")
+    print(f"  cid:     {correlation_id}")
+    print(f"  sender:  {sender_alias}")
+    print(f"  target:  {target_alias}")
+    print(f"  message: {message_content[:80]}{'…' if len(message_content) > 80 else ''}")
+
+    # ── Step 1: Permission check (v6.1) ──────────────────────
+    allowed = _get_allowed_peers(sender_alias)
+    if allowed == []:
+        print(f"  🚫 [权限拒绝] {sender_alias} 无权发送消息（不在白名单或路由表中）")
+        dlq_entry = {
+            "correlation_id": correlation_id,
+            "timestamp": _now_iso(),
+            "sender": sender_alias,
+            "target": target_alias,
+            "message": message_content,
+            "error": f"permission_denied:{sender_alias}",
+            "retries": 0,
+        }
+        _write_dlq(dlq_entry)
+        sys.exit(3)  # exit code 3 = permission_denied
+    elif allowed != "*" and target_alias.lower() not in [a.lower() for a in allowed]:
+        print(f"  🚫 [权限拒绝] {sender_alias} → {target_alias} 不在路由表中（允许: {allowed}）")
+        dlq_entry = {
+            "correlation_id": correlation_id,
+            "timestamp": _now_iso(),
+            "sender": sender_alias,
+            "target": target_alias,
+            "message": message_content,
+            "error": f"permission_denied:{sender_alias}→{target_alias}",
+            "retries": 0,
+        }
+        _write_dlq(dlq_entry)
+        sys.exit(3)
+
+    # ── Step 2: Delivery with retry ──────────────────────────
+    last_error: str | None = None
+    attempts_made = 0
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        success, output, error = _attempt_delivery(
+            sender_alias, target_alias, message_content, correlation_id, attempt
+        )
+        attempts_made = attempt
+
+        if success:
+            print(f"\n✅ [收到同步回执] ({target_alias}):\n{output}")
+            sys.exit(0)
+
+        last_error = error or "unknown"
+        print(f"  ❌ 第 {attempt} 次失败: {last_error}")
+
+        # Check if error is permanent → no retry
+        if not _is_transient(last_error):
+            print(f"  ⛔ 永久性错误，停止重试。")
+            break
+
+        if attempt < MAX_RETRIES:
+            delay = RETRY_BACKOFF[attempt - 1]
+            print(f"  🔄 {delay}s 后重试…")
+            time.sleep(delay)
+
+    # Delivery failed → dead-letter queue
+    dlq_entry = {
+        "correlation_id": correlation_id,
+        "timestamp": _now_iso(),
+        "sender": sender_alias,
+        "target": target_alias,
+        "message": message_content,
+        "error": last_error,
+        "retries": attempts_made,
+    }
+    _write_dlq(dlq_entry)
+    print(f"\n💀 [死信] 消息已归档到 DLQ，等待 gatekeeper 重放。")
+    sys.exit(2)  # exit code 2 = dead-letter
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 愿景

一个真实的使用场景：**1~2 个人，配上一组 AI Agent（策划 / 开发 / 审核 / 助理 / 值班），跑在单个 HuggingFace Space 容器里**——这就是 Nanobot Squad。

不需要 Kubernetes，不需要额外基础设施。你负责决策，Agent 负责执行。WebUI 里每个 Agent 一个 Tab，实时看状态、看日志、跨 Agent 协同。

本 PR 是一个**集成案例**——展示以下独立 PR 拼在一起能干什么：

| 依赖 PR | 功能 | 状态 |
|---------|------|------|
| #3869 `fix(providers): DeepSeek message hardening` | 消息内容净化，防止 "(empty)" 占位符 | 🟡 open |
| #3908 `feat(ws): emit peers_update event` | WebSocket 动态服务发现 | 🟡 open |

## 架构

```
                    ┌─────────────────────────────────┐
                    │     HuggingFace Space 容器       │
                    │                                  │
  Browser ──https──→│  Gatekeeper :7860               │
  (OAuth)           │  ├─ /api/squad/relay (跨Agent)   │
                    │  ├─ /ws (multiplexed WS proxy)  │
                    │  └─ 健康监控 + 自动复活           │
                    │         │                        │
                    │    ┌────┴────┬─────────┐         │
                    │    ↓         ↓         ↓         │
                    │  Neo     Trinity   Sentinel ...  │
                    │  :18888  :18889   :18890         │
                    │  (ws_port 各不同)                 │
                    └─────────────────────────────────┘
```

## 改动

**6 个文件，位于 `contrib/legion/`：**

### 🔧 内核补丁（在 Docker build 时注入 nanobot 源码）

| 文件 | 行数 | 作用 |
|------|------|------|
| `patch_legion_v4_client.py` | ~180 | 注入 squad 消息拦截器 → NanobotClient，实现 `legion_update` / `cluster_log` 事件路由 |
| `patch_legion_v6_sidebar.py` | ~350 | 注入协作面板组件 → Sidebar.tsx，动态 Agent Tabs + 状态徽章 + 实时日志 |
| `patch_squad_error_events.py` | ~80 | 标准化 WebSocket 错误事件，区分框架错误 vs squad 级错误 |

### 🧩 胶水层（运行时，不修改框架源码）

| 文件 | 行数 | 作用 |
|------|------|------|
| `gatekeeper.py` | ~1000 | 统一网关：WS 多路代理 + OAuth + Relay + 健康监控 + 自动复活 |
| `squad_bridge.py` | ~200 | 跨 Agent HTTP 消息路由 |
| `Dockerfile.squad` | ~60 | 参考构建流程：补丁注入顺序 → WebUI build → 胶水层启动 |

> **命名说明**：代码中 `legion` 一词源自内部项目代号，无军事含义。可理解为 "a group of agents working together"。

> **更完整的生产部署层**（模板管理、entrypoint.sh、复活脚本等）见独立仓库 [nanobot-legion](https://github.com/DreamShepherd2006/nanobot-legion)。

## 运行时效果

- **团队协作面板**：每个 Agent 独立 Tab，实时状态徽章（standby / executing / blocked / disconnected）
- **跨 Agent 协同**：通过 Gatekeeper HTTP Relay 实现 Agent 间消息路由，比如 Neo 分配任务给 Trinity 执行
- **自愈机制**：健康检查 + 离线 >60s 自动复活，无人值守运行
- **零额外依赖**：单容器运行，不依赖 Kubernetes / 消息队列 / 外部服务

## 适用场景

| 规模 | 典型配置 |
|------|---------|
| 个人开发者 | 1 人 + 3~5 Agent |
| 小团队 | 2~3 人 + 每人配一组 Agent |
| 教学/演示 | 1 人 + 多 Agent 展示协作流程 |

## 验证

- ✅ Staging Space (`DreamShepherd2006/Nanobot-Staging`) 持续运行中
- ✅ 5 Agent（neo/trinity/sentinel/assistant/medic）全部在线
- ✅ Relay 跨 Agent 通信验证通过
- ✅ 前端补丁构建无 TS 错误

---

*注：核心框架修改（message hardening / peers_update）已分别在 #3869 和 #3908 提交。本 PR 是它们的集成应用案例。合入与否不影响 nanobot 主流程——只希望路过的人能看懂「还能这么玩」。*