### PR TITLE
feat(providers): add APIFree support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,6 +153,7 @@ ANTHROPIC_API_KEY="$(bw get password api/anthropic)" nanobot agent
 | `mimo` | LLM (MiMo) | [platform.xiaomimimo.com](https://platform.xiaomimimo.com) |
 | `longcat` | LLM (LongCat) | [longcat.chat](https://longcat.chat/platform/docs/zh/) |
 | `ant_ling` | LLM (Ant Ling / 蚂蚁百灵) | [developer.ant-ling.com](https://developer.ant-ling.com/en/docs/api-reference/openai/) |
+| `apifree` | LLM (APIFree) | [apifree.ai](https://www.apifree.ai) |
 | `ollama` | LLM (local, Ollama) | — |
 | `lm_studio` | LLM (local, LM Studio) | — |
 | `atomic_chat` | LLM (local, [Atomic Chat](https://atomic.chat/)) | — |
@@ -470,6 +471,33 @@ only need to set `apiKey`.
 
 Official OpenAI-compatible model names include `Ling-2.6-1T`,
 `Ling-2.6-flash`, `Ling-2.5-1T`, `Ling-1T`, `Ring-2.5-1T`, and `Ring-1T`.
+
+</details>
+
+<details>
+<summary><b>APIFree (OpenAI-compatible)</b></summary>
+
+APIFree is available through nanobot's built-in OpenAI-compatible provider flow.
+The default API base points to `https://api.apifree.ai/agent/v1`, so you usually
+only need to set `apiKey`.
+
+```json
+{
+  "providers": {
+    "apifree": {
+      "apiKey": "${APIFREE_API_KEY}"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "provider": "apifree",
+      "model": "skywork-ai/skyclaw-v1"
+    }
+  }
+}
+```
+
+Available models include `skywork-ai/skyclaw-v1`.
 
 </details>
 

--- a/docs/image-generation.md
+++ b/docs/image-generation.md
@@ -46,7 +46,7 @@ The WebUI hides provider storage details from the user. The agent sees the saved
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `tools.imageGeneration.enabled` | boolean | `false` | Register the `generate_image` tool |
-| `tools.imageGeneration.provider` | string | `"openrouter"` | Image provider name. Supported values: `openrouter`, `aihubmix`, `minimax`, `gemini` |
+| `tools.imageGeneration.provider` | string | `"openrouter"` | Image provider name. Supported values: `openrouter`, `aihubmix`, `minimax`, `gemini`, `stepfun` |
 | `tools.imageGeneration.model` | string | `"openai/gpt-5.4-image-2"` | Provider model name |
 | `tools.imageGeneration.defaultAspectRatio` | string | `"1:1"` | Default ratio when the prompt/tool call does not specify one |
 | `tools.imageGeneration.defaultImageSize` | string | `"1K"` | Default size hint, for example `1K`, `2K`, `4K`, or `1024x1024` |
@@ -168,6 +168,58 @@ For reference-image edits, use a Gemini Flash image model:
 
 Imagen 4 supports the aspect ratios `1:1`, `9:16`, `16:9`, `3:4`, and `4:3`. Unsupported ratios are ignored and the model uses its default. The `defaultImageSize` setting has no effect on Gemini models; sizing is controlled by `defaultAspectRatio` only. Reference images passed with an Imagen model are ignored (with a warning logged).
 
+### StepFun
+
+StepFun (阶跃星辰) `step-image-edit-2` supports text-to-image generation.  The `step-1x-medium` variant additionally supports **style-reference** image edits, where a reference image guides the visual style of the output.
+
+Supported aspect ratios: `1:1`, `16:9`, `9:16`, `3:4`, `4:3`.  Sizes are specified as `WIDTHxHEIGHT` (e.g. `1024x1024`, `1280x800`, `800x1280`).
+
+```json
+{
+  "providers": {
+    "stepfun": {
+      "apiKey": "${STEPFUN_API_KEY}"
+    }
+  },
+  "tools": {
+    "imageGeneration": {
+      "enabled": true,
+      "provider": "stepfun",
+      "model": "step-image-edit-2"
+    }
+  }
+}
+```
+
+> [!NOTE]
+> The StepFun provider reuses the existing `providers.stepfun` config block (the same one used for StepFun's LLM API).  Set `providers.stepfun.apiKey` once and it is shared between text and image generation.
+>
+> When `step-image-edit-2` is used, `reference_images` are ignored (the model does not support style reference).  Switch to `step-1x-medium` to use reference-image-guided generation.
+
+#### StepPlan (Subscription)
+
+StepPlan is StepFun's subscription tier and uses a different API base URL. The image generation endpoint path is the same — just override `apiBase`:
+
+```json
+{
+  "providers": {
+    "stepfun": {
+      "apiKey": "${STEPFUN_API_KEY}",
+      "apiBase": "https://api.stepfun.com/step_plan/v1"
+    }
+  },
+  "tools": {
+    "imageGeneration": {
+      "enabled": true,
+      "provider": "stepfun",
+      "model": "step-image-edit-2"
+    }
+  }
+}
+```
+
+`apiBase` takes precedence over the registry default, so with the StepPlan base URL configured, image requests are sent to `https://api.stepfun.com/step_plan/v1/images/generations` — the same path prefix used for LLM calls. The API key is shared with the standard StepFun provider.
+
 ## Artifacts
 
 Generated images are stored under the active nanobot instance's media directory:
@@ -222,7 +274,7 @@ Use the reference image. Keep the same robot and composition, change the palette
 |---------|-------|
 | `generate_image` is not available | Set `tools.imageGeneration.enabled` to `true` and restart the gateway |
 | Missing API key error | Configure `providers.<provider>.apiKey`; if using `${VAR_NAME}`, confirm the environment variable is visible to the gateway process |
-| `unsupported image generation provider` | Use `openrouter`, `aihubmix`, `minimax`, or `gemini` |
+| `unsupported image generation provider` | Use `openrouter`, `aihubmix`, `minimax`, `gemini`, or `stepfun` |
 | AIHubMix says `Incorrect model ID` | Use `model: "gpt-image-2-free"`; nanobot expands it to the required `openai/gpt-image-2-free` model path internally |
 | Generation times out | Try a smaller/default image size, set AIHubMix `extraBody.quality` to `"low"`, or retry later |
 | Reference image rejected | Reference image paths must be inside the workspace or nanobot media directory and must be valid image files |

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -208,6 +208,7 @@ class ProvidersConfig(Base):
     xiaomi_mimo: ProviderConfig = Field(default_factory=ProviderConfig)  # Xiaomi MIMO (小米)
     longcat: ProviderConfig = Field(default_factory=ProviderConfig)  # LongCat
     ant_ling: ProviderConfig = Field(default_factory=ProviderConfig)  # Ant Ling
+    apifree: ProviderConfig = Field(default_factory=ProviderConfig)  # APIFree
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -400,6 +400,16 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_base_keyword="ant-ling.com",
         default_api_base="https://api.ant-ling.com/v1",
     ),
+    # APIFree: OpenAI-compatible API gateway with agent-optimised models.
+    ProviderSpec(
+        name="apifree",
+        keywords=("apifree", "api-free", "skyclaw"),
+        env_key="APIFREE_API_KEY",
+        display_name="APIFree",
+        backend="openai_compat",
+        detect_by_base_keyword="apifree.ai",
+        default_api_base="https://api.apifree.ai/agent/v1",
+    ),
     # === Local deployment (matched by config key, NOT by api_base) =========
     # vLLM / any OpenAI-compatible local server
     ProviderSpec(

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -1019,6 +1019,8 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
         assert providers["openrouter"]["api_key_required"] is True
         assert providers["ant_ling"]["label"] == "Ant Ling"
         assert providers["ant_ling"]["default_api_base"] == "https://api.ant-ling.com/v1"
+        assert providers["apifree"]["label"] == "APIFree"
+        assert providers["apifree"]["default_api_base"] == "https://api.apifree.ai/agent/v1"
         assert providers["atomic_chat"]["configured"] is False
         assert providers["atomic_chat"]["api_key_required"] is False
         assert providers["atomic_chat"]["default_api_base"] == "http://localhost:1337/v1"

--- a/tests/providers/test_apifree_provider.py
+++ b/tests/providers/test_apifree_provider.py
@@ -1,0 +1,71 @@
+"""Tests for the APIFree provider registration."""
+
+from unittest.mock import patch
+
+from nanobot.config.schema import Config, ProvidersConfig
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.providers.registry import PROVIDERS, find_by_name
+
+
+def test_apifree_config_field_exists() -> None:
+    config = ProvidersConfig()
+    assert hasattr(config, "apifree")
+
+
+def test_apifree_provider_in_registry() -> None:
+    specs = {spec.name: spec for spec in PROVIDERS}
+    assert "apifree" in specs
+
+    apifree = specs["apifree"]
+    assert apifree.backend == "openai_compat"
+    assert apifree.env_key == "APIFREE_API_KEY"
+    assert apifree.display_name == "APIFree"
+    assert apifree.default_api_base == "https://api.apifree.ai/agent/v1"
+
+
+def test_find_by_name_accepts_apifree_spellings() -> None:
+    spec = find_by_name("apifree")
+    assert spec is not None
+
+
+def test_apifree_model_auto_matches_with_default_api_base() -> None:
+    config = Config.model_validate(
+        {
+            "providers": {
+                "apifree": {
+                    "apiKey": "apifree-key",
+                },
+            },
+            "agents": {
+                "defaults": {
+                    "model": "skywork-ai/skyclaw-v1",
+                },
+            },
+        }
+    )
+
+    assert config.get_provider_name("skywork-ai/skyclaw-v1") == "apifree"
+    assert config.get_api_key("skywork-ai/skyclaw-v1") == "apifree-key"
+    assert config.get_api_base("skywork-ai/skyclaw-v1") == "https://api.apifree.ai/agent/v1"
+
+
+def test_apifree_preserves_official_model_name() -> None:
+    spec = find_by_name("apifree")
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider(
+            api_key="apifree-key",
+            default_model="skywork-ai/skyclaw-v1",
+            spec=spec,
+        )
+
+    kwargs = provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model="skywork-ai/skyclaw-v1",
+        max_tokens=1024,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assert kwargs["model"] == "skywork-ai/skyclaw-v1"

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -1247,6 +1247,7 @@ const PROVIDER_ICONS: Record<string, LucideIcon> = {
   byteplus_coding_plan: Cloud,
   qianfan: Database,
   ant_ling: Sparkles,
+  apifree: Sparkles,
   azure_openai: Cloud,
   bedrock: Database,
   vllm: Cpu,

--- a/webui/src/tests/app-layout.test.tsx
+++ b/webui/src/tests/app-layout.test.tsx
@@ -222,6 +222,13 @@ describe("App layout", () => {
                   default_api_base: "https://api.ant-ling.com/v1",
                 },
                 {
+                  name: "apifree",
+                  label: "APIFree",
+                  configured: false,
+                  api_key_required: true,
+                  default_api_base: "https://api.apifree.ai/agent/v1",
+                },
+                {
                   name: "azure_openai",
                   label: "Azure OpenAI",
                   configured: false,
@@ -309,6 +316,7 @@ describe("App layout", () => {
     expect(screen.getByRole("tab", { name: "Web Search" })).toBeInTheDocument();
     expect(screen.getByText("OpenRouter")).toBeInTheDocument();
     expect(screen.getByText("Ant Ling")).toBeInTheDocument();
+    expect(screen.getByText("APIFree")).toBeInTheDocument();
     expect(screen.getAllByText("Not configured").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByText("OpenAI"));
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));
@@ -321,6 +329,8 @@ describe("App layout", () => {
     expect(screen.queryByDisplayValue("unsaved-openai-key")).not.toBeInTheDocument();
     fireEvent.click(screen.getByText("Ant Ling"));
     expect(screen.getByDisplayValue("https://api.ant-ling.com/v1")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("APIFree"));
+    expect(screen.getByDisplayValue("https://api.apifree.ai/agent/v1")).toBeInTheDocument();
     fireEvent.click(screen.getByText("Atomic Chat"));
     expect(screen.getByDisplayValue("http://localhost:1337/v1")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();


### PR DESCRIPTION
Add APIFree as a built-in OpenAI-compatible provider. APIFree offers agent-optimised models such as `skywork-ai/skyclaw-v1` through an OpenAI-compatible API at https://api.apifree.ai/agent/v1.

Changes:
- Register `apifree` provider in the provider registry
- Add config schema field
- Add documentation with configuration example
- Add provider tests, websocket channel tests, and webui tests
- Add provider icon in settings UI

This follows the exact same pattern as the Ant Ling provider (#3900).