### PR TITLE
fix(exec): detach stdin for shell commands

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -266,6 +266,7 @@ class ExecTool(Tool):
             # the raw command string to COMSPEC without re-quoting.
             return await asyncio.create_subprocess_shell(
                 command,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
@@ -274,6 +275,7 @@ class ExecTool(Tool):
         bash = shutil.which("bash") or "/bin/bash"
         return await asyncio.create_subprocess_exec(
             bash, "-l", "-c", command,
+            stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -5,6 +5,7 @@ strategy, and sandbox behaviour per platform — without actually running
 platform-specific binaries (all subprocess calls are mocked).
 """
 
+import asyncio
 import sys
 from unittest.mock import AsyncMock, patch
 
@@ -108,6 +109,9 @@ class TestSpawnUnix:
         assert "-c" in args
         assert "echo hi" in args
 
+        kwargs = mock_exec.call_args[1]
+        assert kwargs["stdin"] == asyncio.subprocess.DEVNULL
+
 
 class TestSpawnWindows:
 
@@ -123,6 +127,9 @@ class TestSpawnWindows:
 
         args = mock_shell.call_args[0]
         assert "dir" in args
+
+        kwargs = mock_shell.call_args[1]
+        assert kwargs["stdin"] == asyncio.subprocess.DEVNULL
 
     @pytest.mark.asyncio
     async def test_passes_cwd_and_env(self):


### PR DESCRIPTION
## Summary

`ExecTool._spawn()` launched shell commands with stdout/stderr piped, but left `stdin` unset. In `asyncio.create_subprocess_exec()` and `asyncio.create_subprocess_shell()`, that means the child process inherits nanobot's stdin.

For normal short commands this is mostly invisible, but it becomes a problem when nanobot is running from a terminal and a gateway/background path asks `exec` to run a program that reads stdin. A concrete example is `ffmpeg`: unless started with `-nostdin`, it polls stdin for interactive commands such as `q`. If that subprocess belongs to a background process group while still inheriting the controlling terminal, POSIX job control can send `SIGTTIN`, stopping the subprocess and leaving the exec call waiting forever.

This PR makes `exec` explicitly non-interactive by routing subprocess stdin to `asyncio.subprocess.DEVNULL` on both Unix and Windows spawn paths.

## Why this fix

The exec tool already captures stdout/stderr and returns command output programmatically, so it is not designed as an interactive terminal session. Detaching stdin matches that contract and avoids accidental reads from the parent terminal. Commands that need interactive stdin are not a good fit for this tool; commands that merely probe stdin now see EOF/devnull instead of suspending the process chain.

## Changes

- Pass `stdin=asyncio.subprocess.DEVNULL` to Unix `create_subprocess_exec()`.
- Pass `stdin=asyncio.subprocess.DEVNULL` to Windows `create_subprocess_shell()`.
- Add platform tests that assert both spawn paths detach stdin.

## Tests

- `/tmp/nanobot-exec-stdin-devnull-venv/bin/python -m pytest tests/tools/test_exec_platform.py`
- `/tmp/nanobot-exec-stdin-devnull-venv/bin/python -m ruff check nanobot/agent/tools/shell.py tests/tools/test_exec_platform.py`
