### PR TITLE
feat: add Novita AI provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,7 @@ ANTHROPIC_API_KEY="$(bw get password api/anthropic)" nanobot agent
 | `gemini` | LLM (Gemini direct) | [aistudio.google.com](https://aistudio.google.com) |
 | `aihubmix` | LLM (API gateway, access to all models) | [aihubmix.com](https://aihubmix.com) |
 | `siliconflow` | LLM (SiliconFlow/硅基流动) | [siliconflow.cn](https://siliconflow.cn) |
-| `novita` | LLM (Novita AI, OpenAI-compatible gateway) | [novita.ai](https://novita.ai) |
+| `novita` | LLM (NovitaAI Model API: 200+ models on an AI-native cloud for builders and agents) | [novita.ai](https://novita.ai) |
 | `dashscope` | LLM (Qwen) | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
 | `moonshot` | LLM (Moonshot/Kimi) | [platform.moonshot.cn](https://platform.moonshot.cn) |
 | `zhipu` | LLM (Zhipu GLM) | [open.bigmodel.cn](https://open.bigmodel.cn) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,7 @@ ANTHROPIC_API_KEY="$(bw get password api/anthropic)" nanobot agent
 | `gemini` | LLM (Gemini direct) | [aistudio.google.com](https://aistudio.google.com) |
 | `aihubmix` | LLM (API gateway, access to all models) | [aihubmix.com](https://aihubmix.com) |
 | `siliconflow` | LLM (SiliconFlow/硅基流动) | [siliconflow.cn](https://siliconflow.cn) |
+| `novita` | LLM (Novita AI, OpenAI-compatible gateway) | [novita.ai](https://novita.ai) |
 | `dashscope` | LLM (Qwen) | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
 | `moonshot` | LLM (Moonshot/Kimi) | [platform.moonshot.cn](https://platform.moonshot.cn) |
 | `zhipu` | LLM (Zhipu GLM) | [open.bigmodel.cn](https://open.bigmodel.cn) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,7 @@ ANTHROPIC_API_KEY="$(bw get password api/anthropic)" nanobot agent
 | `gemini` | LLM (Gemini direct) | [aistudio.google.com](https://aistudio.google.com) |
 | `aihubmix` | LLM (API gateway, access to all models) | [aihubmix.com](https://aihubmix.com) |
 | `siliconflow` | LLM (SiliconFlow/硅基流动) | [siliconflow.cn](https://siliconflow.cn) |
-| `novita` | LLM (NovitaAI Model API: 200+ models on an AI-native cloud for builders and agents) | [novita.ai](https://novita.ai) |
+| `novita` | LLM (Novita AI OpenAI-compatible gateway) | [novita.ai](https://novita.ai) |
 | `dashscope` | LLM (Qwen) | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
 | `moonshot` | LLM (Moonshot/Kimi) | [platform.moonshot.cn](https://platform.moonshot.cn) |
 | `zhipu` | LLM (Zhipu GLM) | [open.bigmodel.cn](https://open.bigmodel.cn) |

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -211,6 +211,7 @@ class ProvidersConfig(Base):
     ant_ling: ProviderConfig = Field(default_factory=ProviderConfig)  # Ant Ling
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
     siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
+    novita: ProviderConfig = Field(default_factory=ProviderConfig)  # Novita AI
     volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)
     volcengine_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine Coding Plan
     byteplus: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus (VolcEngine international)

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -193,6 +193,18 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://api.siliconflow.cn/v1",
     ),
 
+    # Novita AI: OpenAI-compatible gateway for hosted model APIs.
+    ProviderSpec(
+        name="novita",
+        keywords=("novita",),
+        env_key="NOVITA_API_KEY",
+        display_name="Novita AI",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_base_keyword="novita",
+        default_api_base="https://api.novita.ai/openai",
+    ),
+
     # VolcEngine (火山引擎): OpenAI-compatible gateway, pay-per-use models
     ProviderSpec(
         name="volcengine",

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -193,7 +193,8 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://api.siliconflow.cn/v1",
     ),
 
-    # Novita AI: OpenAI-compatible gateway for hosted model APIs.
+    # NovitaAI: AI-native cloud for builders and agents. Model API exposes
+    # 200+ models through an OpenAI-compatible gateway.
     ProviderSpec(
         name="novita",
         keywords=("novita",),

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -193,8 +193,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://api.siliconflow.cn/v1",
     ),
 
-    # NovitaAI: AI-native cloud for builders and agents. Model API exposes
-    # 200+ models through an OpenAI-compatible gateway.
+    # Novita AI: OpenAI-compatible gateway for hosted model APIs.
     ProviderSpec(
         name="novita",
         keywords=("novita",),

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -194,14 +194,15 @@ def test_match_provider_uses_preset_provider_when_forced() -> None:
     assert name == "anthropic"
 
 
-def test_match_provider_routes_novita_prefixed_models() -> None:
+def test_match_provider_routes_forced_novita_model_api_models() -> None:
     config = Config.model_validate({
         "providers": {
             "novita": {"apiKey": "sk-test"},
         },
         "agents": {
             "defaults": {
-                "model": "novita/deepseek/deepseek-v4-pro",
+                "model": "deepseek-v4-pro",
+                "provider": "novita",
             }
         },
     })

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -192,3 +192,19 @@ def test_match_provider_uses_preset_provider_when_forced() -> None:
     })
     name = config.get_provider_name()
     assert name == "anthropic"
+
+
+def test_match_provider_routes_novita_prefixed_models() -> None:
+    config = Config.model_validate({
+        "providers": {
+            "novita": {"apiKey": "sk-test"},
+        },
+        "agents": {
+            "defaults": {
+                "model": "novita/deepseek/deepseek-v4-pro",
+            }
+        },
+    })
+
+    assert config.get_provider_name() == "novita"
+    assert config.get_api_base() == "https://api.novita.ai/openai"

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -441,6 +441,15 @@ def test_openrouter_spec_is_gateway() -> None:
     assert spec.default_api_base == "https://openrouter.ai/api/v1"
 
 
+def test_novita_spec_uses_openai_compatible_gateway() -> None:
+    spec = find_by_name("novita")
+    assert spec is not None
+    assert spec.is_gateway is True
+    assert spec.backend == "openai_compat"
+    assert spec.env_key == "NOVITA_API_KEY"
+    assert spec.default_api_base == "https://api.novita.ai/openai"
+
+
 def test_gemma_routes_to_gemini_provider() -> None:
     """gemma models (e.g. gemma-3-27b-it) must auto-route to Gemini when GEMINI_API_KEY is set.
     Users running gemma via the Gemini API endpoint expect automatic provider detection."""

--- a/tests/providers/test_novita_provider.py
+++ b/tests/providers/test_novita_provider.py
@@ -1,0 +1,78 @@
+"""Tests for the Novita AI provider registration."""
+
+from unittest.mock import patch
+
+from nanobot.config.schema import Config, ProvidersConfig
+from nanobot.providers.openai_compat_provider import OpenAICompatProvider
+from nanobot.providers.registry import PROVIDERS, find_by_name
+
+
+def test_novita_config_field_exists() -> None:
+    config = ProvidersConfig()
+
+    assert hasattr(config, "novita")
+
+
+def test_novita_provider_in_registry() -> None:
+    specs = {spec.name: spec for spec in PROVIDERS}
+
+    assert "novita" in specs
+    novita = specs["novita"]
+    assert novita.backend == "openai_compat"
+    assert novita.env_key == "NOVITA_API_KEY"
+    assert novita.display_name == "Novita AI"
+    assert novita.is_gateway is True
+    assert novita.detect_by_base_keyword == "novita"
+    assert novita.default_api_base == "https://api.novita.ai/openai"
+    assert novita.strip_model_prefix is False
+
+
+def test_find_by_name_novita() -> None:
+    spec = find_by_name("novita")
+
+    assert spec is not None
+    assert spec.name == "novita"
+
+
+def test_novita_forced_provider_uses_default_api_base() -> None:
+    config = Config.model_validate({
+        "providers": {
+            "novita": {
+                "apiKey": "novita-key",
+            },
+        },
+        "agents": {
+            "defaults": {
+                "model": "deepseek-v4-pro",
+                "provider": "novita",
+            },
+        },
+    })
+
+    assert config.get_provider_name("deepseek-v4-pro") == "novita"
+    assert config.get_api_key("deepseek-v4-pro") == "novita-key"
+    assert config.get_api_base("deepseek-v4-pro") == "https://api.novita.ai/openai"
+
+
+def test_novita_preserves_model_api_id() -> None:
+    spec = find_by_name("novita")
+    with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):
+        provider = OpenAICompatProvider(
+            api_key="novita-key",
+            default_model="deepseek-v4-pro",
+            spec=spec,
+        )
+
+    kwargs = provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model="deepseek-v4-pro",
+        max_tokens=1024,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assert kwargs["model"] == "deepseek-v4-pro"
+    assert kwargs["max_tokens"] == 1024
+    assert "max_completion_tokens" not in kwargs

--- a/tests/providers/test_novita_provider.py
+++ b/tests/providers/test_novita_provider.py
@@ -54,6 +54,25 @@ def test_novita_forced_provider_uses_default_api_base() -> None:
     assert config.get_api_base("deepseek-v4-pro") == "https://api.novita.ai/openai"
 
 
+def test_novita_gateway_routes_unprefixed_models_when_configured() -> None:
+    config = Config.model_validate({
+        "providers": {
+            "novita": {
+                "apiKey": "novita-key",
+            },
+        },
+        "agents": {
+            "defaults": {
+                "model": "deepseek-v4-pro",
+            },
+        },
+    })
+
+    assert config.get_provider_name("deepseek-v4-pro") == "novita"
+    assert config.get_api_key("deepseek-v4-pro") == "novita-key"
+    assert config.get_api_base("deepseek-v4-pro") == "https://api.novita.ai/openai"
+
+
 def test_novita_preserves_model_api_id() -> None:
     spec = find_by_name("novita")
     with patch("nanobot.providers.openai_compat_provider.AsyncOpenAI"):


### PR DESCRIPTION
## Summary

Add Novita AI as a built-in LLM provider using the existing OpenAI-compatible provider path.

## Changes

- Add Novita provider registration with NOVITA_API_KEY and https://api.novita.ai/openai
- Add providers.novita config support
- Document Novita in the provider table
- Add focused provider/config tests for Novita routing and defaults

## Tests

- UV_CACHE_DIR=/tmp/uv-cache-nanobot uv run --extra dev python -m pytest tests/providers/test_litellm_kwargs.py::test_novita_spec_uses_openai_compatible_gateway tests/config/test_model_presets.py::test_match_provider_routes_novita_prefixed_models -q