### PR TITLE
[security] fix(web): validate redirect targets before fetching

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -114,6 +114,46 @@ async def _get_with_safe_redirects(
 
     return None, f"Too many redirects: exceeded limit of {MAX_REDIRECTS}"
 
+
+async def _stream_with_safe_redirects(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: dict[str, str] | None = None,
+) -> tuple[httpx.Response | None, Any | None, str | None]:
+    """Open a streamed response while validating every redirect target first."""
+    current_url = url
+    for _ in range(MAX_REDIRECTS + 1):
+        is_valid, error_msg = _validate_url_safe(current_url)
+        if not is_valid:
+            return None, None, f"Redirect blocked: {error_msg}"
+
+        stream = client.stream(
+            "GET",
+            current_url,
+            headers=headers,
+            follow_redirects=False,
+        )
+        response = await stream.__aenter__()
+        is_redirect = 300 <= response.status_code < 400
+        if not is_redirect:
+            return response, stream, None
+
+        location = response.headers.get("location")
+        if not location:
+            return response, stream, None
+
+        next_url = urljoin(str(response.url), location)
+        is_valid, error_msg = _validate_url_safe(next_url)
+        if not is_valid:
+            await stream.__aexit__(None, None, None)
+            return None, None, f"Redirect blocked: {error_msg}"
+
+        await stream.__aexit__(None, None, None)
+        current_url = next_url
+
+    return None, None, f"Too many redirects: exceeded limit of {MAX_REDIRECTS}"
+
+
 def _format_results(query: str, items: list[dict[str, Any]], n: int) -> str:
     """Format provider results into shared plaintext output."""
     if not items:
@@ -522,7 +562,7 @@ class WebFetchTool(Tool):
         # Detect and fetch images directly to avoid Jina's textual image captioning
         try:
             async with httpx.AsyncClient(proxy=self.proxy, timeout=15.0) as client:
-                r, redirect_error = await _get_with_safe_redirects(
+                r, stream, redirect_error = await _stream_with_safe_redirects(
                     client,
                     url,
                     headers={"User-Agent": self.user_agent},
@@ -532,11 +572,15 @@ class WebFetchTool(Tool):
                 if r is None:
                     return json.dumps({"error": "Fetch failed", "url": url}, ensure_ascii=False)
 
-                ctype = r.headers.get("content-type", "")
-                if ctype.startswith("image/"):
-                    r.raise_for_status()
-                    raw = r.content
-                    return build_image_content_blocks(raw, ctype, url, f"(Image fetched from: {url})")
+                try:
+                    ctype = r.headers.get("content-type", "")
+                    if ctype.startswith("image/"):
+                        r.raise_for_status()
+                        raw = await r.aread()
+                        return build_image_content_blocks(raw, ctype, url, f"(Image fetched from: {url})")
+                finally:
+                    if stream is not None:
+                        await stream.__aexit__(None, None, None)
         except Exception as e:
             logger.debug("Pre-fetch image detection failed for {}: {}", url, e)
 
@@ -585,8 +629,6 @@ class WebFetchTool(Tool):
 
     async def _fetch_readability(self, url: str, extract_mode: str, max_chars: int) -> Any:
         """Local fallback using readability-lxml."""
-        from readability import Document
-
         try:
             async with httpx.AsyncClient(
                 timeout=30.0,
@@ -610,6 +652,8 @@ class WebFetchTool(Tool):
             if "application/json" in ctype:
                 text, extractor = json.dumps(r.json(), indent=2, ensure_ascii=False), "json"
             elif "text/html" in ctype or r.text[:256].lower().startswith(("<!doctype", "<html")):
+                from readability import Document
+
                 doc = Document(r.text)
                 content = self._to_markdown(doc.summary()) if extract_mode == "markdown" else _strip_tags(doc.summary())
                 text = f"# {doc.title()}\n\n{content}" if doc.title() else content

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -8,7 +8,7 @@ import json
 import os
 import re
 from typing import Any, Callable
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 import httpx
 from loguru import logger
@@ -78,8 +78,40 @@ def _validate_url(url: str) -> tuple[bool, str]:
 def _validate_url_safe(url: str) -> tuple[bool, str]:
     """Validate URL with SSRF protection: scheme, domain, and resolved IP check."""
     from nanobot.security.network import validate_url_target
+
     return validate_url_target(url)
 
+
+async def _get_with_safe_redirects(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: dict[str, str] | None = None,
+) -> tuple[httpx.Response | None, str | None]:
+    """GET a URL while validating every redirect target before requesting it."""
+    current_url = url
+    for _ in range(MAX_REDIRECTS + 1):
+        is_valid, error_msg = _validate_url_safe(current_url)
+        if not is_valid:
+            return None, f"Redirect blocked: {error_msg}"
+
+        response = await client.get(current_url, headers=headers, follow_redirects=False)
+        if not response.is_redirect:
+            return response, None
+
+        location = response.headers.get("location")
+        if not location:
+            return response, None
+
+        next_url = urljoin(str(response.url), location)
+        is_valid, error_msg = _validate_url_safe(next_url)
+        if not is_valid:
+            await response.aclose()
+            return None, f"Redirect blocked: {error_msg}"
+
+        await response.aclose()
+        current_url = next_url
+
+    return None, f"Too many redirects: exceeded limit of {MAX_REDIRECTS}"
 
 def _format_results(query: str, items: list[dict[str, Any]], n: int) -> str:
     """Format provider results into shared plaintext output."""
@@ -488,19 +520,22 @@ class WebFetchTool(Tool):
 
         # Detect and fetch images directly to avoid Jina's textual image captioning
         try:
-            async with httpx.AsyncClient(proxy=self.proxy, follow_redirects=True, max_redirects=MAX_REDIRECTS, timeout=15.0) as client:
-                async with client.stream("GET", url, headers={"User-Agent": self.user_agent}) as r:
-                    from nanobot.security.network import validate_resolved_url
+            async with httpx.AsyncClient(proxy=self.proxy, timeout=15.0) as client:
+                r, redirect_error = await _get_with_safe_redirects(
+                    client,
+                    url,
+                    headers={"User-Agent": self.user_agent},
+                )
+                if redirect_error:
+                    return json.dumps({"error": redirect_error, "url": url}, ensure_ascii=False)
+                if r is None:
+                    return json.dumps({"error": "Fetch failed", "url": url}, ensure_ascii=False)
 
-                    redir_ok, redir_err = validate_resolved_url(str(r.url))
-                    if not redir_ok:
-                        return json.dumps({"error": f"Redirect blocked: {redir_err}", "url": url}, ensure_ascii=False)
-
-                    ctype = r.headers.get("content-type", "")
-                    if ctype.startswith("image/"):
-                        r.raise_for_status()
-                        raw = await r.aread()
-                        return build_image_content_blocks(raw, ctype, url, f"(Image fetched from: {url})")
+                ctype = r.headers.get("content-type", "")
+                if ctype.startswith("image/"):
+                    r.raise_for_status()
+                    raw = r.content
+                    return build_image_content_blocks(raw, ctype, url, f"(Image fetched from: {url})")
         except Exception as e:
             logger.debug("Pre-fetch image detection failed for {}: {}", url, e)
 
@@ -553,18 +588,19 @@ class WebFetchTool(Tool):
 
         try:
             async with httpx.AsyncClient(
-                follow_redirects=True,
-                max_redirects=MAX_REDIRECTS,
                 timeout=30.0,
                 proxy=self.proxy,
             ) as client:
-                r = await client.get(url, headers={"User-Agent": self.user_agent})
+                r, redirect_error = await _get_with_safe_redirects(
+                    client,
+                    url,
+                    headers={"User-Agent": self.user_agent},
+                )
+                if redirect_error:
+                    return json.dumps({"error": redirect_error, "url": url}, ensure_ascii=False)
+                if r is None:
+                    return json.dumps({"error": "Fetch failed", "url": url}, ensure_ascii=False)
                 r.raise_for_status()
-
-            from nanobot.security.network import validate_resolved_url
-            redir_ok, redir_err = validate_resolved_url(str(r.url))
-            if not redir_ok:
-                return json.dumps({"error": f"Redirect blocked: {redir_err}", "url": url}, ensure_ascii=False)
 
             ctype = r.headers.get("content-type", "")
             if ctype.startswith("image/"):

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -95,7 +95,8 @@ async def _get_with_safe_redirects(
             return None, f"Redirect blocked: {error_msg}"
 
         response = await client.get(current_url, headers=headers, follow_redirects=False)
-        if not response.is_redirect:
+        is_redirect = 300 <= response.status_code < 400
+        if not is_redirect:
             return response, None
 
         location = response.headers.get("location")

--- a/tests/tools/test_web_fetch_security.py
+++ b/tests/tools/test_web_fetch_security.py
@@ -86,6 +86,7 @@ async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
         raise AssertionError("Jina Reader should be skipped when disabled")
 
     class FakeStreamResponse:
+        status_code = 200
         headers = {"content-type": "text/html"}
         url = "https://example.com/page"
 
@@ -94,6 +95,9 @@ async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
 
         async def __aexit__(self, exc_type, exc, tb):
             return False
+
+        async def aread(self):
+            raise AssertionError("non-image prefetch body should not be read")
 
     class FakeResponse:
         status_code = 200
@@ -115,7 +119,7 @@ async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-        def stream(self, method, url, headers=None):
+        def stream(self, method, url, headers=None, **kwargs):
             seen_headers.append(headers or {})
             return FakeStreamResponse()
 
@@ -135,6 +139,68 @@ async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
         "nanobot-test-agent",
         "nanobot-test-agent",
     ]
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_blocks_private_redirect_before_readability_request(monkeypatch):
+    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=False))
+    requested: list[str] = []
+
+    class FakeStreamResponse:
+        status_code = 200
+        headers = {"content-type": "text/html"}
+        url = "https://attacker.example/start"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def aread(self):
+            raise AssertionError("non-image prefetch body should not be read")
+
+    class FakeRedirectResponse:
+        status_code = 302
+        headers = {"location": "http://127.0.0.1:8765/metadata"}
+        url = "https://attacker.example/start"
+
+        async def aclose(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, headers=None, **kwargs):
+            return FakeStreamResponse()
+
+        async def get(self, url, headers=None, **kwargs):
+            requested.append(url)
+            if url == "http://127.0.0.1:8765/metadata":
+                raise AssertionError("private redirect target should not be requested")
+            return FakeRedirectResponse()
+
+    monkeypatch.setattr(web_module.httpx, "AsyncClient", FakeClient)
+
+    def resolve_public_start_only(hostname, port, family=0, type_=0):
+        if hostname == "attacker.example":
+            return _fake_resolve_public(hostname, port, family, type_)
+        return _REAL_GETADDRINFO(hostname, port, family, type_)
+
+    with patch("nanobot.security.network.socket.getaddrinfo", resolve_public_start_only):
+        result = await tool.execute(url="https://attacker.example/start")
+
+    data = json.loads(result)
+    assert "error" in data
+    assert "redirect blocked" in data["error"].lower()
+    assert requested == ["https://attacker.example/start"]
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_web_fetch_security.py
+++ b/tests/tools/test_web_fetch_security.py
@@ -6,10 +6,14 @@ import json
 import socket
 from unittest.mock import patch
 
+import httpx
 import pytest
 
+from nanobot.agent.tools import web as web_module
 from nanobot.agent.tools.web import WebFetchTool
 from nanobot.config.schema import WebFetchConfig
+
+_REAL_GETADDRINFO = socket.getaddrinfo
 
 
 def _fake_resolve_private(hostname, port, family=0, type_=0):
@@ -54,6 +58,7 @@ async def test_web_fetch_result_contains_untrusted_flag():
         url = "https://example.com/page"
         text = fake_html
         headers = {"content-type": "text/html"}
+        is_redirect = False
         def raise_for_status(self): pass
         def json(self): return {}
 
@@ -95,6 +100,7 @@ async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
         url = "https://example.com/page"
         text = "<html><head><title>Test</title></head><body><p>Hello world</p></body></html>"
         headers = {"content-type": "text/html"}
+        is_redirect = False
 
         def raise_for_status(self):
             return None
@@ -113,7 +119,7 @@ async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
             seen_headers.append(headers or {})
             return FakeStreamResponse()
 
-        async def get(self, url, headers=None):
+        async def get(self, url, headers=None, **kwargs):
             seen_headers.append(headers or {})
             return FakeResponse()
 
@@ -133,43 +139,83 @@ async def test_web_fetch_can_skip_jina_and_use_custom_user_agent(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_web_fetch_blocks_private_redirect_before_returning_image(monkeypatch):
-    tool = WebFetchTool()
+    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=False))
 
-    class FakeStreamResponse:
-        headers = {"content-type": "image/png"}
-        url = "http://127.0.0.1/secret.png"
-        content = b"\x89PNG\r\n\x1a\n"
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "https://example.com/image.png":
+            return httpx.Response(
+                302,
+                headers={"Location": "http://127.0.0.1/secret.png"},
+                request=request,
+            )
+        if str(request.url) == "http://127.0.0.1/secret.png":
+            return httpx.Response(
+                200,
+                headers={"content-type": "image/png"},
+                content=b"\x89PNG\r\n\x1a\n",
+                request=request,
+            )
+        return httpx.Response(404, request=request)
 
-        async def __aenter__(self):
-            return self
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
 
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        async def aread(self):
-            return self.content
-
-        def raise_for_status(self):
-            return None
-
-    class FakeClient:
+    class TransportAsyncClient(real_async_client):
         def __init__(self, *args, **kwargs):
-            pass
+            kwargs.pop("proxy", None)
+            super().__init__(*args, transport=transport, **kwargs)
 
-        async def __aenter__(self):
-            return self
+    monkeypatch.setattr("nanobot.agent.tools.web.httpx.AsyncClient", TransportAsyncClient)
 
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
+    def resolve_public_start_only(hostname, port, family=0, type_=0):
+        if hostname == "example.com":
+            return _fake_resolve_public(hostname, port, family, type_)
+        return _REAL_GETADDRINFO(hostname, port, family, type_)
 
-        def stream(self, method, url, headers=None):
-            return FakeStreamResponse()
-
-    monkeypatch.setattr("nanobot.agent.tools.web.httpx.AsyncClient", FakeClient)
-
-    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_public):
+    with patch("nanobot.security.network.socket.getaddrinfo", resolve_public_start_only):
         result = await tool.execute(url="https://example.com/image.png")
 
     data = json.loads(result)
     assert "error" in data
     assert "redirect blocked" in data["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_does_not_request_private_redirect_target(monkeypatch):
+    tool = WebFetchTool(config=WebFetchConfig(use_jina_reader=False))
+    requested: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        if str(request.url) == "https://attacker.example/start":
+            return httpx.Response(
+                302,
+                headers={"Location": "http://127.0.0.1:8765/metadata"},
+                request=request,
+            )
+        if str(request.url) == "http://127.0.0.1:8765/metadata":
+            return httpx.Response(200, content=b"internal secret", request=request)
+        return httpx.Response(404, request=request)
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    class TransportAsyncClient(real_async_client):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(web_module.httpx, "AsyncClient", TransportAsyncClient)
+
+    def resolve_public_start_only(hostname, port, family=0, type_=0):
+        if hostname == "attacker.example":
+            return _fake_resolve_public(hostname, port, family, type_)
+        return _REAL_GETADDRINFO(hostname, port, family, type_)
+
+    with patch("nanobot.security.network.socket.getaddrinfo", resolve_public_start_only):
+        result = await tool.execute(url="https://attacker.example/start")
+
+    data = json.loads(result)
+    assert "error" in data
+    assert "redirect blocked" in data["error"].lower()
+    assert requested == ["https://attacker.example/start"]


### PR DESCRIPTION
## Summary
This PR hardens `web_fetch` redirect handling so redirect targets are validated before the tool makes the next outbound request.

- Fixes a redirect-time SSRF gap where the initial URL was validated, but automatic redirect following could still request a private/internal `Location` target before the final URL check ran.
- Replaces automatic redirect following with a manual redirect loop that validates every hop before fetching it.
- Applies the same redirect boundary to both the image prefetch path and the readability fetch path.
- Adds regression coverage proving loopback/private redirect targets are blocked before the internal URL is requested.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| `web_fetch` validates redirects after the redirected request has already been sent | A user-controlled public URL can redirect `web_fetch` toward loopback/private/internal hosts before the post-fetch resolved-URL block runs | Medium |

## Before this PR

- `WebFetchTool.execute()` validated the initial URL before fetching.
- The HTTP client used automatic redirect following for the image prefetch path.
- `_fetch_readability()` also used automatic redirect following.
- The final resolved URL was checked only after redirects had already been followed.
- A redirect to a private or loopback host could therefore be requested before the tool returned a blocked result.
- Existing tests did not assert that the private redirect target was never requested.

## After this PR

- Redirect following is performed manually with `follow_redirects=False`.
- Each redirect `Location` is resolved with `urljoin()` and validated before the next request is made.
- Redirect depth remains capped by `MAX_REDIRECTS`.
- Private/loopback/internal redirect targets are rejected before they receive a request.
- Regression tests cover both the blocked result and the no-request-to-private-target property.

## Why this matters

`web_fetch` is intended to fetch user-supplied web URLs while enforcing SSRF protections. For SSRF defenses, validating only the starting URL and the final response URL is not enough when the HTTP client follows redirects automatically: a blocked internal target can already have received a request by the time the final URL is inspected.

Validating each redirect target before following it keeps redirect compatibility for safe public targets while preserving the SSRF trust boundary for private, loopback, and internal destinations.

## Attack flow

```text
Attacker supplies a public URL to web_fetch
    -> public URL returns 302 Location: http://127.0.0.1:8765/metadata
        -> httpx automatically follows the redirect
            -> loopback/private target receives a request
                -> final resolved-URL validation blocks only after the unsafe request was already sent
```

## Affected code

| Issue | Files |
|-------|-------|
| Redirect-time SSRF in `web_fetch` | `nanobot/agent/tools/web.py`, `tests/tools/test_web_fetch_security.py` |

## Root cause

Issue: redirect-time SSRF in `web_fetch`

- SSRF validation covered the initial user-supplied URL.
- The code relied on `httpx` automatic redirects for follow-up requests.
- The resolved URL was validated after the client had already followed redirects.
- That ordering left a request-time gap for redirect targets that resolve to private, loopback, or otherwise blocked addresses.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Redirect-time SSRF in `web_fetch` | 5.0 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:N/A:N` |

Rationale:

- The attacker needs access to a configured path that can invoke `web_fetch` with a chosen URL.
- Attack complexity is low once that access exists, because a standard HTTP redirect is enough to reach the vulnerable behavior.
- Impact is bounded to unauthorized network reachability / possible low-confidentiality exposure from internal services reachable by the nanobot runtime.
- This PR does not claim unauthenticated reachability, arbitrary code execution, or unrestricted internal data disclosure.

## Safe reproduction steps

1. Configure a public test URL that returns a redirect such as:

   ```http
   HTTP/1.1 302 Found
   Location: http://127.0.0.1:8765/metadata
   ```

2. Run `web_fetch` against the public test URL on vulnerable code.
3. Observe that the local/private target can receive a request before the tool returns a redirect-blocked error.
4. Run the new regression test `test_web_fetch_does_not_request_private_redirect_target`.
5. Observe that fixed code only requests the public start URL and rejects the private redirect target before making the second request.

## Expected vulnerable behavior

- The initial public URL passes validation.
- The automatic redirect follows `Location` to a loopback/private address.
- The internal target receives a request before the final resolved URL validation rejects the result.
- The safe proof signal is the observed request list containing only the public URL after this PR, rather than containing both the public URL and the private redirect URL.

## Changes in this PR

- Adds `_get_with_safe_redirects()` for GET requests that need redirect support with SSRF validation before every hop.
- Uses `follow_redirects=False` so the tool controls redirect validation order explicitly.
- Resolves relative redirect locations with `urljoin()`.
- Validates each candidate redirect URL with the existing `validate_url_target()` path before requesting it.
- Preserves the existing redirect-depth limit through `MAX_REDIRECTS`.
- Updates image prefetch detection to use the safe redirect helper.
- Updates readability fetching to use the safe redirect helper.
- Adds regression tests for blocked private redirects and for preventing the private redirect target request entirely.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Web fetch SSRF hardening | `nanobot/agent/tools/web.py` | Adds a safe redirect helper and switches image/readability fetches away from automatic redirect following |
| Regression tests | `tests/tools/test_web_fetch_security.py` | Adds redirect SSRF tests and adapts fake clients for explicit `follow_redirects=False` calls |

## Maintainer impact

- Safe public redirects remain supported.
- Redirect targets that resolve to private, loopback, or otherwise blocked hosts are rejected before any request is made to them.
- The patch is limited to `web_fetch` URL fetching and its tests.
- Search providers, channel adapters, filesystem tools, and unrelated agent tools are not changed.
- The helper centralizes this ordering so future `web_fetch` GET paths can reuse the same pre-request redirect validation.

## Fix rationale

- SSRF controls need to be enforced before network I/O to the candidate target, not only after a response is received.
- Manual redirect handling is the narrowest way to preserve redirect support while making the validation order explicit.
- Reusing the existing `validate_url_target()` check keeps the patch aligned with nanobot's current network security policy.
- The regression tests assert the security property that matters for SSRF: blocked private redirect targets are not requested.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `uv run --extra dev python -m ruff check nanobot/agent/tools/web.py tests/tools/test_web_fetch_security.py tests/tools/test_web_fetch_url_sanitization.py`
- [x] `uv run --extra dev python -m pytest tests/tools/test_web_fetch_security.py tests/tools/test_web_fetch_url_sanitization.py -q` (`22 passed`)
- [x] `uv run --extra dev python -m pytest tests/tools -q` started and ran without failures in the completed portion, but timed out after 600 seconds before the full command completed.

Executed with:

```bash
uv run --extra dev python -m ruff check nanobot/agent/tools/web.py tests/tools/test_web_fetch_security.py tests/tools/test_web_fetch_url_sanitization.py
uv run --extra dev python -m pytest tests/tools/test_web_fetch_security.py tests/tools/test_web_fetch_url_sanitization.py -q
uv run --extra dev python -m pytest tests/tools -q
```

## Disclosure notes

- This PR is intentionally bounded to redirect handling inside `web_fetch`.
- The claim is redirect-time SSRF prevention before the redirected request is sent.
- This PR does not claim unauthenticated exploitability, remote code execution, credential disclosure, or unrestricted internal network access.
- No production services or real secrets were used in the regression tests.
- No unrelated files are changed.
