### PR TITLE
docs(readme): add multi-language doc site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 <div align="center">
   <p>
+    <a href="https://nanobot.wiki/docs/latest/getting-started/nanobot-overview">English</a> |
+    <a href="https://nanobot.wiki/cn/docs/latest/getting-started/nanobot-overview">简体中文</a> |
+    <a href="https://nanobot.wiki/zh-Hant/docs/latest/getting-started/nanobot-overview">繁體中文</a> |
+    <a href="https://nanobot.wiki/es/docs/latest/getting-started/nanobot-overview">Español</a> |
+    <a href="https://nanobot.wiki/fr/docs/latest/getting-started/nanobot-overview">Français</a> |
+    <a href="https://nanobot.wiki/id/docs/latest/getting-started/nanobot-overview">Bahasa Indonesia</a> |
+    <a href="https://nanobot.wiki/ja/docs/latest/getting-started/nanobot-overview">日本語</a> |
+    <a href="https://nanobot.wiki/ko/docs/latest/getting-started/nanobot-overview">한국어</a> |
+    <a href="https://nanobot.wiki/ru/docs/latest/getting-started/nanobot-overview">Русский</a> |
+    <a href="https://nanobot.wiki/vi/docs/latest/getting-started/nanobot-overview">Tiếng Việt</a>
+  </p>
+  <p>
     <a href="https://pypi.org/project/nanobot-ai/"><img src="https://img.shields.io/pypi/v/nanobot-ai" alt="PyPI"></a>
     <a href="https://pepy.tech/project/nanobot-ai"><img src="https://static.pepy.tech/badge/nanobot-ai" alt="Downloads"></a>
     <img src="https://img.shields.io/badge/python-≥3.11-blue" alt="Python">


### PR DESCRIPTION
## Summary

Add multi-language navigation links to the README header, pointing to nanobot.wiki documentation in 10 supported languages.

## Languages

| Language | Wiki URL |
|----------|----------|
| English | `/docs/latest/...` |
| 简体中文 | `/cn/docs/latest/...` |
| 繁體中文 | `/zh-Hant/docs/latest/...` |
| Español | `/es/docs/latest/...` |
| Français | `/fr/docs/latest/...` |
| Bahasa Indonesia | `/id/docs/latest/...` |
| 日本語 | `/ja/docs/latest/...` |
| 한국어 | `/ko/docs/latest/...` |
| Русский | `/ru/docs/latest/...` |
| Tiếng Việt | `/vi/docs/latest/...` |