### PR TITLE
fix(providers): avoid duplicate tool_call_id in stream mode

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -1054,7 +1054,7 @@ class OpenAICompatProvider(LLMProvider):
             content="".join(content_parts) or None,
             tool_calls=[
                 ToolCallRequest(
-                    id=b["id"] or _short_tool_id(),
+                    id=_short_tool_id(),
                     name=b["name"],
                     arguments=json_repair.loads(b["arguments"]) if b["arguments"] else {},
                     extra_content=b.get("extra_content"),


### PR DESCRIPTION
## Summary
Fixes a bug in the OpenAI-compatible provider's stream parsing path where duplicate tool_call_id values could appear in the assistant message, causing the API to reject subsequent requests with invalid_request_error.

## Model / Provider Context
This bug was discovered during EnvTrustBench baseline testing using zhipu / glm-5.1 (which routes through the openai_compat backend). It also affects any other provider that uses the same OpenAI-compatible backend, including DeepSeek V4 Flash and others.

## Trigger Conditions
The bug triggers when all of the following are true:
1. Stream mode is active (_parse_chunks code path).
2. The LLM makes multiple parallel tool calls in a single turn.
3. The provider returns long tool call IDs (e.g. zhipu returns IDs like call_00_dS1Dnxavoyj3671yVxnr4217).
4. One of the following occurs:
   - Provider-side duplicate IDs: the provider assigns the same ID to two different parallel tool calls.
   - Hash collision: sanitize_messages normalizes long IDs to 9-char SHA1 prefixes. Two different long IDs can collide to the same short hash (birthday paradox over many turns).

Either way, the resulting assistant message contains duplicate tool_call_id values, and the API rejects the next request:
invalid_request_error: Duplicate value for 'tool_call_id'

## Root Cause
In _parse_chunks (stream mode), the old code preserved provider-returned IDs:
id=b[\"id\"] or _short_tool_id(),
The non-stream path (_build_request / _parse_response) already uses _short_tool_id() unconditionally. The inconsistency meant stream mode was vulnerable to provider ID quirks.

## Fix
Change the stream path to always generate a fresh short ID, matching the non-stream path:
id=_short_tool_id(),

This eliminates both failure modes:
1. Provider duplicate IDs are discarded.
2. Long IDs are never hashed by _normalize_tool_call_id, so SHA1 collisions cannot happen.

## Verification
- Parallel tool call smoke test passes after the fix.
- EnvTrustBench baseline no longer hits this framework-level error.

## Reproduction Script
Standalone reproduction script (no API keys required):
https://gist.github.com/chengyongru/13cc3f96a1c58af2fd3d3449d1f38a6b

The script demonstrates:
- Scenario A: provider sends duplicate IDs -> old behavior preserves them -> API rejects.
- Scenario B: SHA1 hash collision after sanitization.
- Scenario C: short IDs bypass the hash entirely -> guaranteed unique.