### PR TITLE
fix: drop redundant reasoning_effort for Kimi thinking models

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -633,6 +633,14 @@ class OpenAICompatProvider(LLMProvider):
                 if extra:
                     kwargs.setdefault("extra_body", {}).update(extra)
 
+            # Moonshot rejects requests that carry both 'reasoning_effort'
+            # and the native 'thinking' param.  We already expressed the
+            # user's intent via the provider-native shape, so drop the
+            # redundant wire-level kwarg.  Only kimi models need this —
+            # Xiaomi's API accepts both params.
+            if _model_slug(model_name) in _KIMI_THINKING_MODELS:
+                kwargs.pop("reasoning_effort", None)
+
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"

--- a/tests/providers/test_litellm_kwargs.py
+++ b/tests/providers/test_litellm_kwargs.py
@@ -1420,12 +1420,15 @@ def test_kimi_k25_thinking_enabled() -> None:
     """kimi-k2.5 with reasoning_effort set should opt in to thinking."""
     kw = _build_kwargs_for("moonshot", "kimi-k2.5", reasoning_effort="medium")
     assert kw.get("extra_body") == {"thinking": {"type": "enabled"}}
+    # Moonshot rejects both 'reasoning_effort' and 'thinking' (#3939)
+    assert "reasoning_effort" not in kw
 
 
 def test_kimi_k25_thinking_disabled_for_minimal() -> None:
     """reasoning_effort='minimal' maps to thinking disabled for kimi-k2.5."""
     kw = _build_kwargs_for("moonshot", "kimi-k2.5", reasoning_effort="minimal")
     assert kw.get("extra_body") == {"thinking": {"type": "disabled"}}
+    assert "reasoning_effort" not in kw
 
 
 def test_kimi_k25_no_extra_body_when_reasoning_effort_none() -> None:
@@ -1445,12 +1448,15 @@ def test_kimi_k25_thinking_enabled_with_openrouter_prefix() -> None:
         "thinking": {"type": "enabled"},
         "reasoning": {"effort": "medium"},
     }
+    # Even via OR, reasoning_effort wire kwarg is dropped for kimi models
+    assert "reasoning_effort" not in kw
 
 
 def test_kimi_k26_thinking_enabled() -> None:
     """kimi-k2.6 with reasoning_effort set should opt in to thinking."""
     kw = _build_kwargs_for("moonshot", "kimi-k2.6", reasoning_effort="medium")
     assert kw.get("extra_body") == {"thinking": {"type": "enabled"}}
+    assert "reasoning_effort" not in kw
 
 
 def test_kimi_k26_thinking_enabled_with_openrouter_prefix() -> None:
@@ -1461,6 +1467,7 @@ def test_kimi_k26_thinking_enabled_with_openrouter_prefix() -> None:
         "thinking": {"type": "enabled"},
         "reasoning": {"effort": "medium"},
     }
+    assert "reasoning_effort" not in kw
 
 
 def test_moonshot_kimi_k26_temperature_override() -> None:
@@ -1479,6 +1486,7 @@ def test_kimi_k26_code_preview_thinking_enabled() -> None:
     """k2.6-code-preview also supports thinking; should behave like k2.5."""
     kw = _build_kwargs_for("moonshot", "k2.6-code-preview", reasoning_effort="high")
     assert kw.get("extra_body") == {"thinking": {"type": "enabled"}}
+    assert "reasoning_effort" not in kw
 
 
 def test_kimi_k2_series_no_thinking_injection() -> None:
@@ -1508,6 +1516,7 @@ def test_kimi_k25_thinking_disabled_for_none_string() -> None:
     """reasoning_effort='none' maps to thinking disabled for kimi-k2.5."""
     kw = _build_kwargs_for("moonshot", "kimi-k2.5", reasoning_effort="none")
     assert kw.get("extra_body") == {"thinking": {"type": "disabled"}}
+    assert "reasoning_effort" not in kw
 
 
 def test_dashscope_thinking_disabled_for_none_string() -> None:


### PR DESCRIPTION
## Problem

Moonshot rejects kimi-k2.5/k2.6 requests with:
```
cannot specify both 'thinking' and 'reasoning_effort'
```

`_build_kwargs` injects both `reasoning_effort` (top-level kwarg) **and** `thinking: {"type": "enabled"}` (extra_body) when `reasoning_effort` is set. The Moonshot API rejects this combination, so there is no working way to enable thinking for Kimi models.

## Fix

After the Kimi thinking injection block, pop `reasoning_effort` from kwargs. The native `thinking` param already encodes the user's intent; the wire-level `reasoning_effort` is redundant and actively rejected.

One line added, zero removed:

```python
kwargs.pop("reasoning_effort", None)
```

| Params sent | Before fix | After fix |
|---|---|---|
| `reasoning_effort` + `thinking` | ❌ Rejected | N/A |
| `thinking` only | — | ✅ Works |
| `reasoning_effort` only | ✅ (no thinking) | N/A (Kimi uses `thinking`) |

## Scope

- **Kimi models only.** The `pop` runs inside `_is_kimi_thinking_model()`, so non-Kimi models are untouched.
- **MiMo models unaffected** — Xiaomi's API accepts both params (confirmed by existing tests).
- **No behavior change** for `reasoning_effort=None` — the Kimi block short-circuits before reaching this code.

## Tests

Updated 7 existing kimi tests to assert `reasoning_effort` is absent from kwargs. All 12 kimi tests + 11 MiMo tests pass.

Closes #3939