### PR TITLE
fix(webui): keep new chat during session refresh

### DIFF
--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -27,13 +27,25 @@ export function useSessions(): {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const tokenRef = useRef(token);
+  const optimisticKeysRef = useRef<Set<string>>(new Set());
   tokenRef.current = token;
 
   const refresh = useCallback(async () => {
     try {
       setLoading(true);
       const rows = await listSessions(tokenRef.current);
-      setSessions(rows);
+      const serverKeys = new Set(rows.map((row) => row.key));
+      setSessions((prev) => [
+        ...rows,
+        ...prev.filter(
+          (session) =>
+            optimisticKeysRef.current.has(session.key) &&
+            !serverKeys.has(session.key),
+        ),
+      ]);
+      for (const key of Array.from(optimisticKeysRef.current)) {
+        if (serverKeys.has(key)) optimisticKeysRef.current.delete(key);
+      }
       setError(null);
     } catch (e) {
       const msg =
@@ -57,6 +69,7 @@ export function useSessions(): {
   const createChat = useCallback(async (): Promise<string> => {
     const chatId = await client.newChat();
     const key = `websocket:${chatId}`;
+    optimisticKeysRef.current.add(key);
     // Optimistic insert; a subsequent refresh will replace it with the
     // authoritative row once the server persists the session.
     setSessions((prev) => [
@@ -77,6 +90,7 @@ export function useSessions(): {
   const deleteChat = useCallback(
     async (key: string) => {
       await apiDeleteSession(tokenRef.current, key);
+      optimisticKeysRef.current.delete(key);
       setSessions((prev) => prev.filter((s) => s.key !== key));
     },
     [],

--- a/webui/src/tests/useSessions.test.tsx
+++ b/webui/src/tests/useSessions.test.tsx
@@ -157,6 +157,53 @@ describe("useSessions", () => {
     expect(api.listSessions).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps a newly created chat visible until the server session list catches up", async () => {
+    vi.mocked(api.listSessions)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          key: "websocket:chat-new",
+          channel: "websocket",
+          chatId: "chat-new",
+          createdAt: "2026-05-20T10:00:00Z",
+          updatedAt: "2026-05-20T10:01:00Z",
+          title: "Generated title",
+          preview: "First message",
+        },
+      ]);
+    const client = fakeClient();
+    client.newChat.mockResolvedValue("chat-new");
+
+    const { result } = renderHook(() => useSessions(), {
+      wrapper: wrap(client),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sessions).toEqual([]);
+
+    await act(async () => {
+      await result.current.createChat();
+    });
+
+    expect(result.current.sessions.map((s) => s.key)).toEqual(["websocket:chat-new"]);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.sessions.map((s) => s.key)).toEqual(["websocket:chat-new"]);
+    expect(result.current.sessions[0]?.preview).toBe("");
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.sessions.map((s) => s.key)).toEqual(["websocket:chat-new"]);
+    expect(result.current.sessions[0]?.preview).toBe("First message");
+    expect(result.current.sessions[0]?.title).toBe("Generated title");
+  });
+
   it("passes through WebUI transcript user media as images and media", async () => {
     vi.mocked(api.fetchWebuiThread).mockResolvedValue({
       schemaVersion: 3,


### PR DESCRIPTION
## Summary

Fixes #3884.

- Preserve newly created WebUI chats during session-list refreshes until the server list catches up.
- Prevent a turn-end title/session refresh from dropping the optimistic active chat back to the blank new-chat screen.
- Add a regression test for the server session list temporarily returning no row for a just-created chat.

## Problem / Root Cause

- The WebUI inserts a newly created WebSocket chat optimistically so the first message can be sent immediately.
- `useSessions.refresh()` previously replaced local sessions with the server list every time.
- If a `turn_end` refresh happened before the server persisted/listed the new chat, the optimistic active row disappeared, `activeSession` became null, and the next message went through the blank-page new-chat path, minting a new `chat_id`.

## Scope

- Files/modules changed: `webui/src/hooks/useSessions.ts`, `webui/src/tests/useSessions.test.tsx`.
- Explicit non-goals: no WebSocket protocol changes, no transcript/storage format changes, no sidebar redesign.
- User-visible behavior changes: a just-created chat remains selected/visible while the server session list catches up.
- Compatibility notes: once the server returns the authoritative session row, it replaces the optimistic row as before.

## Design

- Track optimistic session keys created by `createChat()` in `useSessions`.
- Merge still-pending optimistic rows after server rows during refresh, but drop them as soon as the server includes the same key.
- Remove the optimistic marker if the user deletes that chat before it is confirmed by the server.
- This stays local to the existing session-list hook and avoids new global state or cross-layer parameters.

## Safety / Risk

- Default behavior impact: only affects WebUI session-list refreshes after local chat creation.
- Config/API/channel/session/storage/network impact: no API, config, channel, storage, or network contract changes.
- Rollback plan: revert this single commit.
- Residual risk: if the server never persists a created chat, the optimistic row can remain for the current WebUI session until deleted or reload; this is preferable to silently switching the user into a different chat.

## Validation

- `npm run test -- useSessions.test.tsx`
- `npm run test -- useSessions.test.tsx thread-shell.test.tsx app-layout.test.tsx`
- `npm run build`
- `uv run ruff check nanobot --select F401,F841`
