### PR TITLE
fix(exec): stabilize Windows shell tests

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -414,7 +414,8 @@ class ExecTool(Tool):
             )
         shell_program = shell_program or shutil.which("bash") or "/bin/bash"
         args = [shell_program]
-        if login and Path(shell_program).name in {"bash", "zsh"}:
+        shell_name = Path(shell_program).name.lower()
+        if login and shell_name in {"bash", "bash.exe", "zsh", "zsh.exe"}:
             args.append("-l")
         args.extend(["-c", command])
         return await asyncio.create_subprocess_exec(

--- a/tests/tools/test_exec_session_tools.py
+++ b/tests/tools/test_exec_session_tools.py
@@ -37,7 +37,10 @@ def test_exec_keeps_one_shot_behavior_without_yield_time_ms(tmp_path):
 def test_exec_accepts_command_aliases(tmp_path):
     async def run() -> str:
         tool = ExecTool(working_dir="/")
-        return await tool.execute(cmd="pwd", workdir=str(tmp_path))
+        return await tool.execute(
+            cmd=_python_command("import os; print(os.getcwd())"),
+            workdir=str(tmp_path),
+        )
 
     result = asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- Treat Git Bash / zsh executable names case-insensitively when deciding whether to pass login shell flags.
- Avoid shell-dependent `pwd` output in the exec alias test by printing cwd through Python, which is stable across Windows Git Bash/MSYS and native paths.

## Test Plan
- `pytest tests/tools/test_exec_session_tools.py tests/tools/test_exec_platform.py -q`
- `python -m py_compile nanobot/agent/tools/shell.py`
- `git diff --check`