### PR TITLE
feat(memory): enhance Dream + Consolidator prompts for MECE long-term memory

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -618,9 +618,13 @@ class Consolidator:
         """Available input token budget for consolidation LLM."""
         return self.context_window_tokens - self.max_completion_tokens - self._SAFETY_BUFFER
 
-    def _truncate_to_token_budget(self, text: str) -> str:
-        """Truncate text so it fits within the consolidation LLM's token budget."""
-        budget = self._input_token_budget
+    def _truncate_to_token_budget(self, text: str, reserve_tokens: int = 0) -> str:
+        """Truncate text so it fits within the consolidation LLM's token budget.
+
+        reserve_tokens: additional tokens to reserve for dedup context or other
+        overhead that will be appended after truncation.
+        """
+        budget = self._input_token_budget - reserve_tokens
         if budget <= 0:
             return truncate_text(text, _RAW_ARCHIVE_MAX_CHARS)
         try:
@@ -641,7 +645,30 @@ class Consolidator:
             return None
         try:
             formatted = MemoryStore._format_messages(messages)
-            formatted = self._truncate_to_token_budget(formatted)
+
+            # Inject current memory context for dedup-aware summarization.
+            memory_preview = self.store.read_memory()[:4000]
+            user_preview = self.store.read_user()[:2000]
+            dedup_context = ""
+            if memory_preview:
+                dedup_context += f"\n\n## Current MEMORY.md (for dedup)\n{memory_preview}"
+            if user_preview:
+                dedup_context += f"\n\n## Current USER.md (for dedup)\n{user_preview}"
+
+            # Reserve token budget for dedup_context so the total prompt does not
+            # exceed the LLM context window.
+            reserve_tokens = 0
+            if dedup_context:
+                try:
+                    enc = tiktoken.get_encoding("cl100k_base")
+                    reserve_tokens = len(enc.encode(dedup_context)) + 100
+                except Exception:
+                    reserve_tokens = len(dedup_context) // 4 + 100
+
+            formatted = self._truncate_to_token_budget(
+                formatted, reserve_tokens=reserve_tokens
+            )
+
             response = await self.provider.chat_with_retry(
                 model=self.model,
                 messages=[
@@ -652,7 +679,7 @@ class Consolidator:
                             strip=True,
                         ),
                     },
-                    {"role": "user", "content": formatted},
+                    {"role": "user", "content": formatted + dedup_context},
                 ],
                 tools=None,
                 tool_choice=None,
@@ -907,6 +934,7 @@ class Dream:
     def _build_tools(self) -> ToolRegistry:
         """Build a minimal tool registry for the Dream agent."""
         from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+        from nanobot.agent.tools.apply_patch import ApplyPatchTool
         from nanobot.agent.tools.file_state import FileStates
         from nanobot.agent.tools.filesystem import EditFileTool, ReadFileTool, WriteFileTool
 
@@ -924,6 +952,7 @@ class Dream:
             file_states=file_states,
         ))
         tools.register(EditFileTool(workspace=workspace, allowed_dir=workspace, file_states=file_states))
+        tools.register(ApplyPatchTool(workspace=workspace, allowed_dir=workspace, file_states=file_states))
         # write_file resolves relative paths from workspace root, but can only
         # write under skills/ so the prompt can safely use skills/<name>/SKILL.md.
         skills_dir = workspace / "skills"

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -1120,6 +1120,9 @@ class Dream:
             )
             analysis = phase1_response.content or ""
             logger.debug("Dream Phase 1 analysis ({} chars): {}", len(analysis), analysis[:500])
+            if phase1_response.finish_reason == "error":
+                logger.warning("Dream Phase 1 returned error: {}", analysis)
+                return False
         except Exception:
             logger.exception("Dream Phase 1 failed")
             return False

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import re
+import time
 import weakref
 from contextlib import suppress
 from datetime import datetime
@@ -21,6 +22,13 @@ try:
     _TIKTOKEN_ENC = tiktoken.get_encoding("cl100k_base")
 except Exception:  # pragma: no cover
     _TIKTOKEN_ENC = None
+
+
+def _estimate_tokens(text: str) -> int:
+    """Approximate token count for a text string."""
+    if _TIKTOKEN_ENC is not None:
+        return len(_TIKTOKEN_ENC.encode(text))
+    return len(text) // 4
 
 from nanobot.agent.runner import AgentRunner, AgentRunSpec
 from nanobot.agent.tools.registry import ToolRegistry
@@ -648,8 +656,13 @@ class Consolidator:
         """
         if not messages:
             return None
+        t_start = time.perf_counter()
         try:
             formatted = MemoryStore._format_messages(messages)
+            logger.debug(
+                "Consolidator: {} messages, formatted={} chars",
+                len(messages), len(formatted),
+            )
 
             # Inject current memory context for dedup-aware summarization.
             # Char limits assume ~1 token/char for English; CJK content may
@@ -674,12 +687,27 @@ class Consolidator:
             # If dedup_context alone would exhaust the budget, drop it rather than
             # sending a truncated message + oversized context that risks overflow.
             if self._input_token_budget <= reserve_tokens:
+                logger.warning(
+                    "Consolidator: dedup_context ({} tokens) exceeds budget ({}), dropping it",
+                    reserve_tokens, self._input_token_budget,
+                )
                 dedup_context = ""
                 reserve_tokens = 0
+            else:
+                logger.debug(
+                    "Consolidator: dedup_context={} chars, reserve_tokens={}",
+                    len(dedup_context), reserve_tokens,
+                )
 
+            formatted_before = len(formatted)
             formatted = self._truncate_to_token_budget(
                 formatted, reserve_tokens=reserve_tokens
             )
+            if len(formatted) < formatted_before:
+                logger.warning(
+                    "Consolidator: truncated formatted messages from {} to {} chars",
+                    formatted_before, len(formatted),
+                )
 
             response = await self.provider.chat_with_retry(
                 model=self.model,
@@ -696,13 +724,26 @@ class Consolidator:
                 tools=None,
                 tool_choice=None,
             )
+            elapsed = time.perf_counter() - t_start
             if response.finish_reason == "error":
+                logger.warning(
+                    "Consolidator LLM error after {:.1f}s: {}",
+                    elapsed, response.content,
+                )
                 raise RuntimeError(f"LLM returned error: {response.content}")
             summary = response.content or "[no summary]"
+            logger.info(
+                "Consolidator: {} entries → {} chars summary in {:.1f}s",
+                len(messages), len(summary), elapsed,
+            )
             self.store.append_history(summary, max_chars=_ARCHIVE_SUMMARY_MAX_CHARS)
             return summary
         except Exception:
-            logger.warning("Consolidation LLM call failed, raw-dumping to history")
+            elapsed = time.perf_counter() - t_start
+            logger.warning(
+                "Consolidation LLM call failed after {:.1f}s, raw-dumping to history",
+                elapsed,
+            )
             self.store.raw_archive(messages)
             return None
 
@@ -908,10 +949,10 @@ class Dream:
     # context window just because a file (or a legacy large history entry) grew
     # unexpectedly. Each file still appears in full via read_file when the agent
     # needs it in Phase 2 — these caps only bound the Phase 1/2 prompt preview.
-    _MEMORY_FILE_MAX_CHARS = 32_000
-    _SOUL_FILE_MAX_CHARS = 16_000
-    _USER_FILE_MAX_CHARS = 16_000
-    _HISTORY_ENTRY_PREVIEW_MAX_CHARS = 4_000
+    _MEMORY_FILE_MAX_CHARS = 8_000
+    _SOUL_FILE_MAX_CHARS = 4_000
+    _USER_FILE_MAX_CHARS = 4_000
+    _HISTORY_ENTRY_PREVIEW_MAX_CHARS = 2_000
 
     def __init__(
         self,
@@ -1062,6 +1103,11 @@ class Dream:
             "Dream: processing {} entries (cursor {}→{}), batch={}",
             len(entries), last_cursor, batch[-1]["cursor"], len(batch),
         )
+        for i, e in enumerate(batch):
+            logger.debug(
+                "Dream batch[{}] cursor={} ts={} content={} chars",
+                i, e["cursor"], e["timestamp"], len(e["content"]),
+            )
 
         # Build history text for LLM — cap each entry so a legacy oversized
         # record (e.g. pre-#3412 raw_archive dump) can't blow up the prompt.
@@ -1096,11 +1142,21 @@ class Dream:
             f"## Current USER.md ({len(current_user)} chars)\n{current_user}"
         )
 
+        logger.info(
+            "Dream file context: MEMORY.md={} chars ({} lines), SOUL.md={} chars ({} lines), USER.md={} chars ({} lines)",
+            len(current_memory), current_memory.count("\n"),
+            len(current_soul), current_soul.count("\n"),
+            len(current_user), current_user.count("\n"),
+        )
+
         # Phase 1: Analyze (no skills list — dedup is Phase 2's job)
         phase1_prompt = (
             f"## Conversation History\n{history_text}\n\n{file_context}"
         )
+        phase1_tokens = _estimate_tokens(phase1_prompt)
+        logger.info("Dream Phase 1 prompt: {} chars, ~{} tokens", len(phase1_prompt), phase1_tokens)
 
+        t1_start = time.perf_counter()
         try:
             phase1_response = await self.provider.chat_with_retry(
                 model=self.model,
@@ -1118,13 +1174,21 @@ class Dream:
                 tools=None,
                 tool_choice=None,
             )
+            t1_elapsed = time.perf_counter() - t1_start
             analysis = phase1_response.content or ""
+            logger.info(
+                "Dream Phase 1 complete in {:.1f}s: {} chars, finish_reason={}",
+                t1_elapsed, len(analysis), phase1_response.finish_reason,
+            )
             logger.debug("Dream Phase 1 analysis ({} chars): {}", len(analysis), analysis[:500])
-            if phase1_response.finish_reason == "error":
-                logger.warning("Dream Phase 1 returned error: {}", analysis)
+            if phase1_response.finish_reason != "stop":
+                logger.warning(
+                    "Dream Phase 1 finish_reason={}: {}",
+                    phase1_response.finish_reason, analysis,
+                )
                 return False
         except Exception:
-            logger.exception("Dream Phase 1 failed")
+            logger.exception("Dream Phase 1 failed after {:.1f}s", time.perf_counter() - t1_start)
             return False
 
         # Phase 2: Delegate to AgentRunner with read_file / edit_file
@@ -1136,6 +1200,8 @@ class Dream:
                 + "\n".join(f"- {s}" for s in existing_skills)
             )
         phase2_prompt = f"## Analysis Result\n{analysis}\n\n{file_context}{skills_section}"
+        phase2_tokens = _estimate_tokens(phase2_prompt)
+        logger.info("Dream Phase 2 prompt: {} chars, ~{} tokens", len(phase2_prompt), phase2_tokens)
 
         tools = self._tools
         skill_creator_path = BUILTIN_SKILLS_DIR / "skill-creator" / "SKILL.md"
@@ -1151,6 +1217,7 @@ class Dream:
             {"role": "user", "content": phase2_prompt},
         ]
 
+        t2_start = time.perf_counter()
         try:
             result = await self._runner.run(AgentRunSpec(
                 initial_messages=messages,
@@ -1160,14 +1227,18 @@ class Dream:
                 max_tool_result_chars=self.max_tool_result_chars,
                 fail_on_tool_error=False,
             ))
-            logger.debug(
-                "Dream Phase 2 complete: stop_reason={}, tool_events={}",
-                result.stop_reason, len(result.tool_events),
+            t2_elapsed = time.perf_counter() - t2_start
+            logger.info(
+                "Dream Phase 2 complete in {:.1f}s: stop_reason={}, tool_events={}",
+                t2_elapsed, result.stop_reason, len(result.tool_events),
             )
             for ev in (result.tool_events or []):
-                logger.info("Dream tool_event: name={}, status={}, detail={}", ev.get("name"), ev.get("status"), ev.get("detail", "")[:200])
+                logger.info(
+                    "Dream tool_event: name={}, status={}, detail={}",
+                    ev.get("name"), ev.get("status"), ev.get("detail", "")[:200],
+                )
         except Exception:
-            logger.exception("Dream Phase 2 failed")
+            logger.exception("Dream Phase 2 failed after {:.1f}s", time.perf_counter() - t2_start)
             result = None
 
         # Build changelog from tool events

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -949,7 +949,7 @@ class Dream:
     # context window just because a file (or a legacy large history entry) grew
     # unexpectedly. Each file still appears in full via read_file when the agent
     # needs it in Phase 2 — these caps only bound the Phase 1/2 prompt preview.
-    _MEMORY_FILE_MAX_CHARS = 8_000
+    _MEMORY_FILE_MAX_CHARS = 16_000
     _SOUL_FILE_MAX_CHARS = 4_000
     _USER_FILE_MAX_CHARS = 4_000
     _HISTORY_ENTRY_PREVIEW_MAX_CHARS = 2_000
@@ -1157,20 +1157,22 @@ class Dream:
         logger.info("Dream Phase 1 prompt: {} chars, ~{} tokens", len(phase1_prompt), phase1_tokens)
 
         t1_start = time.perf_counter()
+        phase1_messages = [
+            {
+                "role": "system",
+                "content": render_template(
+                    "agent/dream_phase1.md",
+                    strip=True,
+                    stale_threshold_days=_STALE_THRESHOLD_DAYS,
+                ),
+            },
+            {"role": "user", "content": phase1_prompt},
+        ]
         try:
-            phase1_response = await self.provider.chat_with_retry(
+            # Use streaming to avoid HTTP timeout on slow providers.
+            phase1_response = await self.provider.chat_stream_with_retry(
                 model=self.model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": render_template(
-                            "agent/dream_phase1.md",
-                            strip=True,
-                            stale_threshold_days=_STALE_THRESHOLD_DAYS,
-                        ),
-                    },
-                    {"role": "user", "content": phase1_prompt},
-                ],
+                messages=phase1_messages,
                 tools=None,
                 tool_choice=None,
             )
@@ -1192,19 +1194,9 @@ class Dream:
                     "Dream Phase 1 hit max_tokens (base={}), retrying with max_tokens={}",
                     base_max, retry_max,
                 )
-                phase1_response = await self.provider.chat_with_retry(
+                phase1_response = await self.provider.chat_stream_with_retry(
                     model=self.model,
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": render_template(
-                                "agent/dream_phase1.md",
-                                strip=True,
-                                stale_threshold_days=_STALE_THRESHOLD_DAYS,
-                            ),
-                        },
-                        {"role": "user", "content": phase1_prompt},
-                    ],
+                    messages=phase1_messages,
                     tools=None,
                     tool_choice=None,
                     max_tokens=retry_max,

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -1181,6 +1181,41 @@ class Dream:
                 t1_elapsed, len(analysis), phase1_response.finish_reason,
             )
             logger.debug("Dream Phase 1 analysis ({} chars): {}", len(analysis), analysis[:500])
+
+            # Retry once with doubled max_tokens if the model ran out of room.
+            # This often happens with reasoning models whose thinking tokens
+            # consume the default 8 k budget before emitting any content.
+            if phase1_response.finish_reason == "length":
+                base_max = self.provider.generation.max_tokens
+                retry_max = min(base_max * 2, 32_000)
+                logger.warning(
+                    "Dream Phase 1 hit max_tokens (base={}), retrying with max_tokens={}",
+                    base_max, retry_max,
+                )
+                phase1_response = await self.provider.chat_with_retry(
+                    model=self.model,
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": render_template(
+                                "agent/dream_phase1.md",
+                                strip=True,
+                                stale_threshold_days=_STALE_THRESHOLD_DAYS,
+                            ),
+                        },
+                        {"role": "user", "content": phase1_prompt},
+                    ],
+                    tools=None,
+                    tool_choice=None,
+                    max_tokens=retry_max,
+                )
+                t1_elapsed = time.perf_counter() - t1_start
+                analysis = phase1_response.content or ""
+                logger.info(
+                    "Dream Phase 1 retry complete in {:.1f}s: {} chars, finish_reason={}",
+                    t1_elapsed, len(analysis), phase1_response.finish_reason,
+                )
+
             if phase1_response.finish_reason != "stop":
                 logger.warning(
                     "Dream Phase 1 finish_reason={}: {}",

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -15,6 +15,13 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator
 import tiktoken
 from loguru import logger
 
+# Cache the tiktoken encoding to avoid repeated instantiation on every
+# truncate/encode call. Encoding objects are thread-safe and reusable.
+try:
+    _TIKTOKEN_ENC = tiktoken.get_encoding("cl100k_base")
+except Exception:  # pragma: no cover
+    _TIKTOKEN_ENC = None
+
 from nanobot.agent.runner import AgentRunner, AgentRunSpec
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.session.manager import Session
@@ -627,14 +634,12 @@ class Consolidator:
         budget = self._input_token_budget - reserve_tokens
         if budget <= 0:
             return truncate_text(text, _RAW_ARCHIVE_MAX_CHARS)
-        try:
-            enc = tiktoken.get_encoding("cl100k_base")
-            tokens = enc.encode(text)
+        if _TIKTOKEN_ENC is not None:
+            tokens = _TIKTOKEN_ENC.encode(text)
             if len(tokens) <= budget:
                 return text
-            return enc.decode(tokens[:budget]) + "\n... (truncated)"
-        except Exception:
-            return truncate_text(text, budget * 4)
+            return _TIKTOKEN_ENC.decode(tokens[:budget]) + "\n... (truncated)"
+        return truncate_text(text, budget * 4)
 
     async def archive(self, messages: list[dict]) -> str | None:
         """Summarize messages via LLM and append to history.jsonl.
@@ -661,10 +666,9 @@ class Consolidator:
             # exceed the LLM context window.
             reserve_tokens = 0
             if dedup_context:
-                try:
-                    enc = tiktoken.get_encoding("cl100k_base")
-                    reserve_tokens = len(enc.encode(dedup_context)) + 100
-                except Exception:
+                if _TIKTOKEN_ENC is not None:
+                    reserve_tokens = len(_TIKTOKEN_ENC.encode(dedup_context)) + 100
+                else:
                     reserve_tokens = len(dedup_context) // 4 + 100
 
             # If dedup_context alone would exhaust the budget, drop it rather than

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -647,6 +647,8 @@ class Consolidator:
             formatted = MemoryStore._format_messages(messages)
 
             # Inject current memory context for dedup-aware summarization.
+            # Char limits assume ~1 token/char for English; CJK content may
+            # require proportionally lower limits to stay within token budget.
             memory_preview = self.store.read_memory()[:4000]
             user_preview = self.store.read_user()[:2000]
             dedup_context = ""
@@ -664,6 +666,12 @@ class Consolidator:
                     reserve_tokens = len(enc.encode(dedup_context)) + 100
                 except Exception:
                     reserve_tokens = len(dedup_context) // 4 + 100
+
+            # If dedup_context alone would exhaust the budget, drop it rather than
+            # sending a truncated message + oversized context that risks overflow.
+            if self._input_token_budget <= reserve_tokens:
+                dedup_context = ""
+                reserve_tokens = 0
 
             formatted = self._truncate_to_token_budget(
                 formatted, reserve_tokens=reserve_tokens

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -355,10 +355,19 @@ def _format_changed_files(diff: str) -> str:
 
 def _format_dream_log_content(commit, diff: str, *, requested_sha: str | None = None) -> str:
     files_line = _format_changed_files(diff)
-    # Show the first line of the commit message as a human-readable summary.
-    from loguru import logger
-    logger.debug("_format_dream_log_content: commit.type={} commit.sha={} commit.message={!r}", type(commit).__name__, getattr(commit, "sha", "?"), getattr(commit, "message", "?"))
-    msg_summary = commit.message.splitlines()[0] if commit.message else ""
+    msg_lines = commit.message.splitlines() if commit.message else []
+    msg_summary = msg_lines[0] if msg_lines else ""
+    # Body lines: everything after the first blank line in the commit message
+    msg_body = []
+    in_body = False
+    for line in msg_lines[1:]:
+        if not in_body:
+            if not line:
+                in_body = True
+            continue
+        msg_body.append(line)
+    body_text = "\n".join(msg_body).strip()
+
     lines = [
         "## Dream Update",
         "",
@@ -369,6 +378,8 @@ def _format_dream_log_content(commit, diff: str, *, requested_sha: str | None = 
         f"- Summary: {msg_summary}" if msg_summary else "",
         f"- Changed files: {files_line}",
     ]
+    if body_text:
+        lines.extend(["", "### Analysis", "", body_text])
     if diff:
         lines.extend([
             "",
@@ -394,7 +405,8 @@ def _format_dream_restore_list(commits: list) -> str:
         "",
     ]
     for c in commits:
-        lines.append(f"- `{c.sha}` {c.timestamp} - {c.message.splitlines()[0]}")
+        summary = c.message.splitlines()[0] if c.message else "(no message)"
+        lines.append(f"- `{c.sha}` {c.timestamp} - {summary}")
     lines.extend([
         "",
         "Preview a version with `/dream-log <sha>` before restoring it.",

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -356,6 +356,8 @@ def _format_changed_files(diff: str) -> str:
 def _format_dream_log_content(commit, diff: str, *, requested_sha: str | None = None) -> str:
     files_line = _format_changed_files(diff)
     # Show the first line of the commit message as a human-readable summary.
+    from loguru import logger
+    logger.debug("_format_dream_log_content: commit.type={} commit.sha={} commit.message={!r}", type(commit).__name__, getattr(commit, "sha", "?"), getattr(commit, "message", "?"))
     msg_summary = commit.message.splitlines()[0] if commit.message else ""
     lines = [
         "## Dream Update",

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -355,6 +355,8 @@ def _format_changed_files(diff: str) -> str:
 
 def _format_dream_log_content(commit, diff: str, *, requested_sha: str | None = None) -> str:
     files_line = _format_changed_files(diff)
+    # Show the first line of the commit message as a human-readable summary.
+    msg_summary = commit.message.splitlines()[0] if commit.message else ""
     lines = [
         "## Dream Update",
         "",
@@ -362,6 +364,7 @@ def _format_dream_log_content(commit, diff: str, *, requested_sha: str | None = 
         "",
         f"- Commit: `{commit.sha}`",
         f"- Time: {commit.timestamp}",
+        f"- Summary: {msg_summary}" if msg_summary else "",
         f"- Changed files: {files_line}",
     ]
     if diff:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -52,8 +52,7 @@ class DreamConfig(Base):
         default=None,
         validation_alias=AliasChoices("modelOverride", "model", "model_override"),
     )  # Optional Dream-specific model override
-    max_batch_size: int = Field(default=20, ge=1)  # Max history entries per run
-    # Bumped from 10 to 15 in #3212 (exp002: +30% dedup, no accuracy loss; >15 plateaus).
+    max_batch_size: int = Field(default=5, ge=1)  # Max history entries per run
     max_iterations: int = Field(default=15, ge=1)  # Max tool calls per Phase 2
     # Per-line git-blame age annotation in Phase 1 prompt (see #3212). Default
     # on — set to False to feed MEMORY.md raw if a specific LLM reacts poorly

--- a/nanobot/templates/agent/consolidator_archive.md
+++ b/nanobot/templates/agent/consolidator_archive.md
@@ -1,5 +1,11 @@
 Extract key facts from this conversation. For each fact, annotate its memory attributes.
 
+Only SNIP facts deserve a non-[skip] mark:
+- Signal: would the user need to repeat this if forgotten?
+- Novel: not already in MEMORY.md or USER.md (check context below)
+- Important: prevents rework or captures preferences / rules
+- Persistent: still relevant after 2 weeks
+
 Output one fact per line in this format:
 - [mark] fact content
 
@@ -8,15 +14,9 @@ Marks (choose the best match):
 - [durable] Technical discoveries, project knowledge, config details — valid for months
 - [ephemeral] Active task state, temporary decisions — may change in weeks
 - [correction] Correction to a previous memory — must state what it replaces (e.g., location is Tokyo, not Osaka)
-- [skip] Chitchat, debug noise, info already in existing memory — still written to history.jsonl for audit, but Dream will ignore it
+- [skip] Does not meet SNIP criteria — still written to history.jsonl for audit, but Dream will ignore it
 
 Priority: user corrections and preferences > solutions > decisions > events > environment facts.
-The most valuable memory prevents the user from having to repeat themselves.
-
-Mark as [skip]:
-- Info already captured in existing memory (check the context below)
-- Transient debugging, error messages, conversational filler
-- Facts derivable from source code or git history
 
 Output as concise bullet points, one fact per line. No preamble, no commentary.
 If nothing noteworthy happened, output: (nothing)

--- a/nanobot/templates/agent/consolidator_archive.md
+++ b/nanobot/templates/agent/consolidator_archive.md
@@ -1,13 +1,22 @@
-Extract key facts from this conversation. Only output items matching these categories, skip everything else:
-- User facts: personal info, preferences, stated opinions, habits
-- Decisions: choices made, conclusions reached
-- Solutions: working approaches discovered through trial and error, especially non-obvious methods that succeeded after failed attempts
-- Events: plans, deadlines, notable occurrences
-- Preferences: communication style, tool preferences
+Extract key facts from this conversation. For each fact, annotate its memory attributes.
 
-Priority: user corrections and preferences > solutions > decisions > events > environment facts. The most valuable memory prevents the user from having to repeat themselves.
+Output one fact per line in this format:
+- [mark] fact content
 
-Skip: code patterns derivable from source, git history, or anything already captured in existing memory.
+Marks (choose the best match):
+- [permanent] Core preferences, personal traits, habits — never becomes stale
+- [durable] Technical discoveries, project knowledge, config details — valid for months
+- [ephemeral] Active task state, temporary decisions — may change in weeks
+- [correction] Correction to a previous memory — must state what it replaces (e.g., "location is Tokyo, not Osaka")
+- [skip] Chitchat, debug noise, info already in existing memory — still written to history.jsonl for audit, but Dream will ignore it
+
+Priority: user corrections and preferences > solutions > decisions > events > environment facts.
+The most valuable memory prevents the user from having to repeat themselves.
+
+Mark as [skip]:
+- Info already captured in existing memory (check the context below)
+- Transient debugging, error messages, conversational filler
+- Facts derivable from source code or git history
 
 Output as concise bullet points, one fact per line. No preamble, no commentary.
 If nothing noteworthy happened, output: (nothing)

--- a/nanobot/templates/agent/consolidator_archive.md
+++ b/nanobot/templates/agent/consolidator_archive.md
@@ -7,7 +7,7 @@ Marks (choose the best match):
 - [permanent] Core preferences, personal traits, habits — never becomes stale
 - [durable] Technical discoveries, project knowledge, config details — valid for months
 - [ephemeral] Active task state, temporary decisions — may change in weeks
-- [correction] Correction to a previous memory — must state what it replaces (e.g., "location is Tokyo, not Osaka")
+- [correction] Correction to a previous memory — must state what it replaces (e.g., location is Tokyo, not Osaka)
 - [skip] Chitchat, debug noise, info already in existing memory — still written to history.jsonl for audit, but Dream will ignore it
 
 Priority: user corrections and preferences > solutions > decisions > events > environment facts.

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -5,7 +5,7 @@ You have THREE tasks:
 
 Output one line per finding:
 [FILE] atomic fact →TARGET #DECAY
-[FILE-REMOVE] exact content to remove (copy the line verbatim from the file)
+[FILE-REMOVE] →TARGET: exact line to remove (copy the line verbatim from the file)
 [SKILL] kebab-case-name: one-line description of the reusable pattern
 
 Targets (where the fact belongs — choose one):

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -4,7 +4,7 @@ You have THREE tasks:
 3. Assign decay metadata so the system can manage memory lifecycle
 
 Output one line per finding:
-[FILE] atomic fact →TARGET #DECAY
+[ADD] atomic fact →TARGET #DECAY
 [REMOVE] →TARGET: exact line to remove (copy the line verbatim from the file)
 [SKILL] kebab-case-name: one-line description of the reusable pattern
 

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -1,18 +1,28 @@
-You have TWO equally important tasks:
-1. Extract new facts from conversation history
-2. Deduplicate existing memory files — find and flag redundant, overlapping, or stale content even if NOT mentioned in history
+You have THREE tasks:
+1. Extract new facts from conversation history and route them to the correct file
+2. Deduplicate existing memory files — find and flag redundant, overlapping, or stale content
+3. Assign decay metadata so the system can manage memory lifecycle
 
 Output one line per finding:
-[FILE] atomic fact (not already in memory)
+[FILE] atomic fact →TARGET #DECAY
 [FILE-REMOVE] reason for removal
 [SKILL] kebab-case-name: one-line description of the reusable pattern
 
-Files: USER (identity, preferences), SOUL (bot behavior, tone), MEMORY (knowledge, project context)
+Targets (where the fact belongs — choose one):
+- →USER: personal info, preferences, communication style, habits, work context
+- →SOUL: behavioral rules, guardrails, interaction patterns the agent should follow
+- →MEMORY: technical knowledge, project context, infrastructure, tool configurations
+
+Decay (how long until the fact likely becomes stale):
+- #permanent: core preferences, personal traits, identity — never expires
+- #durable: technical knowledge, project structure — valid for months
+- #ephemeral: active tasks, temporary state — may change in weeks
 
 Rules:
 - Atomic facts: "has a cat named Luna" not "discussed pet care"
-- Corrections: [USER] location is Tokyo, not Osaka
+- Corrections: [FILE] location is Tokyo, not Osaka →USER #permanent
 - Capture confirmed approaches the user validated
+- Route facts to their canonical file — do not let USER preferences leak into MEMORY, do not let technical config leak into USER
 
 Deduplication — scan ALL memory files for these redundancy patterns:
 - Same fact stated in multiple places (e.g., "communicates in Chinese" in both USER.md and multiple MEMORY.md entries)
@@ -21,10 +31,15 @@ Deduplication — scan ALL memory files for these redundancy patterns:
 - Verbose entries that can be condensed without losing information
 For each duplicate found, output [FILE-REMOVE] for the less authoritative copy (prefer keeping facts in their canonical location)
 
+Merge — when the same fact appears with different detail levels, output one consolidated [FILE] entry instead of multiple:
+- Keep the most complete version
+- Merge related details into one atomic fact
+
 Staleness — MEMORY.md lines may have a ``← Nd`` suffix showing days since last modification:
 - SOUL.md and USER.md have no age annotations — they are permanent, only update with corrections
 - Age only indicates when content was last touched, not whether it should be removed
 - Use content judgment: user habits/preferences/personality traits are permanent regardless of age
+- Facts tagged #ephemeral that are older than {{ stale_threshold_days }} days deserve closer review as removal candidates
 - Only prune content that is objectively outdated: passed events, resolved tracking, superseded approaches
 - Lines with ``← Nd`` (N>{{ stale_threshold_days }}) deserve closer review but are NOT automatically removable
 - When removing: prefer deleting individual items over entire sections

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -1,6 +1,6 @@
-You have THREE tasks:
-1. Extract new facts from conversation history and route them to the correct file
-2. Deduplicate existing memory files — find and flag redundant, overlapping, or stale content
+You have THREE tasks (prune before adding — removing stale content is as important as adding new facts):
+1. Prune redundant, overlapping, or stale content from existing memory files
+2. Extract new facts from conversation history and route them to the correct file
 3. Assign decay metadata so the system can manage memory lifecycle
 
 Output one line per finding:
@@ -18,33 +18,43 @@ Decay (how long until the fact likely becomes stale):
 - #durable: technical knowledge, project structure — valid for months
 - #ephemeral: active tasks, temporary state — may change in weeks
 
-Rules:
+## Pruning rules — be aggressive about removing these:
+
+### Definite remove (no judgment needed):
+- Content already stated in a more canonical location (e.g., a fact in MEMORY.md that also appears in USER.md — keep USER.md copy only)
+- Merged/closed PR debug notes (step-by-step debugging trails, intermediate findings, "PR #XXXX by author" headers for already-merged PRs)
+- Resolved incidents (bugs already fixed, workarounds no longer needed)
+- Superseded information (old version numbers, outdated instructions replaced by new ones)
+- Verbose entries restatable in fewer words (replace with a condensed [ADD])
+
+### Likely remove (apply judgment):
+- Same fact at different detail levels — keep only the most complete version, [REMOVE] the rest
+- Very specific debugging steps that are unlikely to recur (e.g., "send 11111 to 1069419047777777 + call 10000")
+- Ephemeral facts past their useful life (e.g., "considering buying X" when user already bought it)
+- Tool/service details already documented upstream (don't memorize man pages)
+
+### Never remove:
+- User preferences and personality traits (regardless of age)
+- Active project context still referenced in conversations
+- Behavioral rules in SOUL.md
+
+## Extraction rules:
 - Atomic facts: "has a cat named Luna" not "discussed pet care"
-- Corrections: [FILE] location is Tokyo, not Osaka →USER #permanent
+- Corrections: [ADD] corrected fact with the right value →USER #permanent (then [REMOVE] the old line)
 - Capture confirmed approaches the user validated
 - Route facts to their canonical file — do not let USER preferences leak into MEMORY, do not let technical config leak into USER
 
-Deduplication — scan ALL memory files for these redundancy patterns:
-- Same fact stated in multiple places (e.g., "communicates in Chinese" in both USER.md and multiple MEMORY.md entries)
-- Overlapping or nested sections covering the same topic
-- Information in MEMORY.md that is already captured in USER.md or SOUL.md (MEMORY.md should not duplicate permanent-file content)
-- Verbose entries that can be condensed without losing information
-For each duplicate found, output [FILE-REMOVE] for the less authoritative copy (prefer keeping facts in their canonical location)
+## Merge — when the same fact appears with different detail levels:
+- Output [REMOVE] for the less complete copies
+- Output one consolidated [ADD] with the most complete version
 
-Merge — when the same fact appears with different detail levels, output one consolidated [FILE] entry instead of multiple:
-- Keep the most complete version
-- Merge related details into one atomic fact
-
-Staleness — MEMORY.md lines may have a ``← Nd`` suffix showing days since last modification:
+## Staleness — MEMORY.md lines may have a ``← Nd`` suffix showing days since last modification:
 - SOUL.md and USER.md have no age annotations — they are permanent, only update with corrections
 - Age only indicates when content was last touched, not whether it should be removed
 - Use content judgment: user habits/preferences/personality traits are permanent regardless of age
-- Facts tagged #ephemeral that are older than {{ stale_threshold_days }} days deserve closer review as removal candidates
-- Only prune content that is objectively outdated: passed events, resolved tracking, superseded approaches
 - Lines with ``← Nd`` (N>{{ stale_threshold_days }}) deserve closer review but are NOT automatically removable
-- When removing: prefer deleting individual items over entire sections
 
-Skill discovery — flag [SKILL] when ALL of these are true:
+## Skill discovery — flag [SKILL] when ALL of these are true:
 - A specific, repeatable workflow appeared 2+ times in the conversation history
 - It involves clear steps (not vague preferences like "likes concise answers")
 - It is substantial enough to warrant its own instruction set (not trivial like "read a file")

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -5,7 +5,7 @@ You have THREE tasks:
 
 Output one line per finding:
 [FILE] atomic fact →TARGET #DECAY
-[FILE-REMOVE] reason for removal
+[FILE-REMOVE] exact content to remove (copy the line verbatim from the file)
 [SKILL] kebab-case-name: one-line description of the reusable pattern
 
 Targets (where the fact belongs — choose one):

--- a/nanobot/templates/agent/dream_phase1.md
+++ b/nanobot/templates/agent/dream_phase1.md
@@ -5,7 +5,7 @@ You have THREE tasks:
 
 Output one line per finding:
 [FILE] atomic fact →TARGET #DECAY
-[FILE-REMOVE] →TARGET: exact line to remove (copy the line verbatim from the file)
+[REMOVE] →TARGET: exact line to remove (copy the line verbatim from the file)
 [SKILL] kebab-case-name: one-line description of the reusable pattern
 
 Targets (where the fact belongs — choose one):

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -1,6 +1,8 @@
 Update memory files based on the analysis below.
 - [FILE] entries: add the described content to the appropriate file (use the →TARGET routing)
 - [FILE-REMOVE] entries: delete the corresponding content from memory files
+  - To remove a line: use apply_patch Update File with the exact line prefixed by `-`
+  - To remove an entire file: use apply_patch Delete File
 - [SKILL] entries: create a new skill under skills/<name>/SKILL.md using write_file
 
 ## Routing rules (→TARGET tells you which file)

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -1,6 +1,7 @@
 Update memory files based on the analysis below.
 - [FILE] entries: add the described content to the appropriate file (use the →TARGET routing)
-- [FILE-REMOVE] entries: delete the corresponding content from memory files
+- [FILE-REMOVE] →TARGET entries: delete the line from the specified file
+  - The target (→USER/→SOUL/→MEMORY) tells you which file to edit
   - To remove a line: use apply_patch Update File with the exact line prefixed by `-`
   - To remove an entire file: use apply_patch Delete File
 - [SKILL] entries: create a new skill under skills/<name>/SKILL.md using write_file

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -1,7 +1,13 @@
 Update memory files based on the analysis below.
-- [FILE] entries: add the described content to the appropriate file
+- [FILE] entries: add the described content to the appropriate file (use the →TARGET routing)
 - [FILE-REMOVE] entries: delete the corresponding content from memory files
 - [SKILL] entries: create a new skill under skills/<name>/SKILL.md using write_file
+
+## Routing rules (→TARGET tells you which file)
+- →USER → write to USER.md
+- →SOUL → write to SOUL.md
+- →MEMORY → write to memory/MEMORY.md
+- No target specified → default to memory/MEMORY.md
 
 ## File paths (relative to workspace root)
 - SOUL.md
@@ -12,12 +18,18 @@ Update memory files based on the analysis below.
 Do NOT guess paths.
 
 ## Editing rules
-- Edit directly — file contents provided below, no read_file needed
-- Use exact text as old_text, include surrounding blank lines for unique match
-- Batch changes to the same file into one edit_file call
-- For deletions: section header + all bullets as old_text, new_text empty
-- Surgical edits only — never rewrite entire files
-- If nothing to update, stop without calling tools
+- Default tool for edits: apply_patch. Use edit_file only for small exact replacements.
+- File contents are provided below — no read_file needed for editing.
+- Batch all changes (across files) into a single apply_patch call.
+- Surgical edits only — never rewrite entire files unless necessary.
+- Set dry_run=true to preview changes before writing.
+- If nothing to update, stop without calling tools.
+
+## MECE enforcement
+- USER.md: personal info, preferences, habits, work context — no technical configs
+- SOUL.md: agent behavior rules, guardrails, communication patterns — no user facts
+- MEMORY.md: technical knowledge, project context, infrastructure — no user preferences
+- If a fact belongs in multiple files, keep it in the most specific one and remove from others
 
 ## Skill creation rules (for [SKILL] entries)
 - Use write_file to create skills/<name>/SKILL.md
@@ -27,11 +39,19 @@ Do NOT guess paths.
 - Keep SKILL.md under 2000 words — concise and actionable
 - Include: when to use, steps, output format, at least one example
 - Do NOT overwrite existing skills — skip if the skill directory already exists
+- **Skill-to-skill MECE**: if a new skill overlaps with an existing skill, merge the delta into the existing skill via edit_file instead of creating a redundant one
 - Reference specific tools the agent has access to (read_file, write_file, exec, web_search, etc.)
 - Skills are instruction sets, not code — do not include implementation code
+
+## MECE for skills
+- SKILL.md = reusable workflow template (steps, syntax reminders, output format, examples)
+- MEMORY.md = concrete config values, credentials, paths, infrastructure details
+- Keep concrete values in MEMORY.md; skill should use placeholders or reference MEMORY.md entries
+- Do not let technical configs leak into skills, do not let workflow steps leak into MEMORY.md
 
 ## Quality
 - Every line must carry standalone value
 - Concise bullets under clear headers
 - When reducing (not deleting): keep essential facts, drop verbose details
 - If uncertain whether to delete, keep but add "(verify currency)"
+- Do NOT include the →TARGET or #DECAY tags in the actual file content — they are metadata for routing only

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -1,5 +1,5 @@
 Update memory files based on the analysis below.
-- [FILE] entries: add the described content to the appropriate file (use the →TARGET routing)
+- [ADD] entries: add the described content to the appropriate file (use the →TARGET routing)
 - [REMOVE] →TARGET entries: delete the line from the specified file
   - The target (→USER/→SOUL/→MEMORY) tells you which file to edit
   - To remove a line: use apply_patch Update File with the exact line prefixed by `-`

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -43,7 +43,7 @@ Do NOT guess paths.
 - Reference specific tools the agent has access to (read_file, write_file, exec, web_search, etc.)
 - Skills are instruction sets, not code — do not include implementation code
 
-## MECE for skills
+## Skill vs MEMORY.md boundary
 - SKILL.md = reusable workflow template (steps, syntax reminders, output format, examples)
 - MEMORY.md = concrete config values, credentials, paths, infrastructure details
 - Keep concrete values in MEMORY.md; skill should use placeholders or reference MEMORY.md entries

--- a/nanobot/templates/agent/dream_phase2.md
+++ b/nanobot/templates/agent/dream_phase2.md
@@ -1,6 +1,6 @@
 Update memory files based on the analysis below.
 - [FILE] entries: add the described content to the appropriate file (use the →TARGET routing)
-- [FILE-REMOVE] →TARGET entries: delete the line from the specified file
+- [REMOVE] →TARGET entries: delete the line from the specified file
   - The target (→USER/→SOUL/→MEMORY) tells you which file to edit
   - To remove a line: use apply_patch Update File with the exact line prefixed by `-`
   - To remove an entire file: use apply_patch Delete File

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -19,7 +19,8 @@ class CommitInfo:
 
     def format(self, diff: str = "") -> str:
         """Format this commit for display, optionally with a diff."""
-        header = f"## {self.message.splitlines()[0]}\n`{self.sha}` — {self.timestamp}\n"
+        summary = self.message.splitlines()[0] if self.message else "(no message)"
+        header = f"## {summary}\n`{self.sha}` — {self.timestamp}\n"
         if diff:
             return f"{header}\n```diff\n{diff}\n```"
         return f"{header}\n(no file changes)"

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -24,7 +24,7 @@ def store(tmp_path):
 @pytest.fixture
 def mock_provider():
     p = MagicMock()
-    p.chat_with_retry = AsyncMock()
+    p.chat_stream_with_retry = AsyncMock()
     p.generation.max_tokens = 8_192
     return p
 
@@ -62,13 +62,13 @@ class TestDreamRun:
         """Dream should not call LLM when there's nothing to process."""
         result = await dream.run()
         assert result is False
-        mock_provider.chat_with_retry.assert_not_called()
+        mock_provider.chat_stream_with_retry.assert_not_called()
         mock_runner.run.assert_not_called()
 
     async def test_calls_runner_for_unprocessed_entries(self, dream, mock_provider, mock_runner, store):
         """Dream should call AgentRunner when there are unprocessed history entries."""
         store.append_history("User prefers dark mode")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="New fact", finish_reason="stop")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(content="New fact", finish_reason="stop")
         mock_runner.run = AsyncMock(return_value=_make_run_result(
             tool_events=[{"name": "edit_file", "status": "ok", "detail": "memory/MEMORY.md"}],
         ))
@@ -83,7 +83,7 @@ class TestDreamRun:
         """Dream should advance the cursor after processing."""
         store.append_history("event 1")
         store.append_history("event 2")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="Nothing new")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="Nothing new")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
         await dream.run()
         assert store.get_last_dream_cursor() == 2
@@ -93,7 +93,7 @@ class TestDreamRun:
         store.append_history("event 1")
         store.append_history("event 2")
         store.append_history("event 3")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="Nothing new")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="Nothing new")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
         await dream.run()
         # After Dream, cursor is advanced and 3, compact keeps last max_history_entries
@@ -104,7 +104,7 @@ class TestDreamRun:
         """Dream should point skill creation guidance at the builtin skill-creator template."""
         store.append_history("Repeated workflow one")
         store.append_history("Repeated workflow two")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKILL] test-skill: test description")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKILL] test-skill: test description")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
@@ -130,7 +130,7 @@ class TestDreamRun:
     async def test_phase1_prompt_includes_line_age_annotations(self, dream, mock_provider, mock_runner, store):
         """Phase 1 prompt should have per-line age suffixes in MEMORY.md when git is available."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         # Init git so line_ages works
@@ -140,14 +140,14 @@ class TestDreamRun:
         await dream.run()
 
         # The MEMORY.md section should not crash and should contain the memory content
-        call_args = mock_provider.chat_with_retry.call_args
+        call_args = mock_provider.chat_stream_with_retry.call_args
         user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
         assert "## Current MEMORY.md" in user_msg
 
     async def test_phase1_annotates_only_memory_not_soul_or_user(self, dream, mock_provider, mock_runner, store):
         """SOUL.md and USER.md should never have age annotations — they are permanent."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         store.git.init()
@@ -155,7 +155,7 @@ class TestDreamRun:
 
         await dream.run()
 
-        call_args = mock_provider.chat_with_retry.call_args
+        call_args = mock_provider.chat_stream_with_retry.call_args
         user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
         # The ← suffix should only appear in MEMORY.md section
         memory_section = user_msg.split("## Current MEMORY.md")[1].split("## Current SOUL.md")[0]
@@ -168,14 +168,14 @@ class TestDreamRun:
     async def test_phase1_prompt_works_without_git(self, dream, mock_provider, mock_runner, store):
         """Phase 1 should work fine even if git is not initialized (no age annotations)."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
 
         # Should still succeed — just without age annotations
-        mock_provider.chat_with_retry.assert_called_once()
-        call_args = mock_provider.chat_with_retry.call_args
+        mock_provider.chat_stream_with_retry.assert_called_once()
+        call_args = mock_provider.chat_stream_with_retry.call_args
         user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
         assert "## Current MEMORY.md" in user_msg
 
@@ -187,7 +187,7 @@ class TestDreamRun:
         # Inject four ages to cover threshold boundaries: >14 suffix, ==14 no suffix, <14 no suffix.
         store.write_memory("# Memory\n- Project X active\n- fresh item\n- edge case line")
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         fake_ages = [
@@ -199,7 +199,7 @@ class TestDreamRun:
         with patch.object(store.git, "line_ages", return_value=fake_ages):
             await dream.run()
 
-        call_args = mock_provider.chat_with_retry.call_args
+        call_args = mock_provider.chat_stream_with_retry.call_args
         user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
         memory_section = user_msg.split("## Current MEMORY.md")[1].split("## Current SOUL.md")[0]
         assert "\u2190 30d" in memory_section
@@ -212,7 +212,7 @@ class TestDreamRun:
     ):
         """`annotate_line_ages=False` must bypass the git lookup entirely and keep MEMORY.md raw."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         dream.annotate_line_ages = False
@@ -223,7 +223,7 @@ class TestDreamRun:
             await dream.run()
             mock_line_ages.assert_not_called()
 
-        call_args = mock_provider.chat_with_retry.call_args
+        call_args = mock_provider.chat_stream_with_retry.call_args
         user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
         assert "\u2190" not in user_msg
 
@@ -233,13 +233,13 @@ class TestDreamRun:
         """If ages length != lines length (dirty working tree), skip annotation instead of mis-tagging."""
         # MEMORY.md has 2 non-blank lines but we hand back only 1 age → mismatch.
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         with patch.object(store.git, "line_ages", return_value=[LineAge(age_days=999)]):
             await dream.run()
 
-        call_args = mock_provider.chat_with_retry.call_args
+        call_args = mock_provider.chat_stream_with_retry.call_args
         user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
         memory_section = user_msg.split("## Current MEMORY.md")[1].split("## Current SOUL.md")[0]
         # No age arrow at all — we refused to annotate rather than tag the wrong line.
@@ -250,12 +250,12 @@ class TestDreamRun:
     ):
         """System prompt should reference the stale-threshold constant, not a hardcoded 14."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
 
-        system_msg = mock_provider.chat_with_retry.call_args.kwargs["messages"][0]["content"]
+        system_msg = mock_provider.chat_stream_with_retry.call_args.kwargs["messages"][0]["content"]
         # The template renders with stale_threshold_days=14 → LLM must see "N>14"
         assert "N>14" in system_msg
 
@@ -265,7 +265,7 @@ class TestDreamRun:
         """Phase 1 must retry with doubled max_tokens when finish_reason=length."""
         store.append_history("some event")
         # First call hits token limit, second call succeeds.
-        mock_provider.chat_with_retry.side_effect = [
+        mock_provider.chat_stream_with_retry.side_effect = [
             MagicMock(finish_reason="length", content=""),
             MagicMock(finish_reason="stop", content="New fact"),
         ]
@@ -275,9 +275,9 @@ class TestDreamRun:
 
         result = await dream.run()
         assert result is True
-        assert mock_provider.chat_with_retry.call_count == 2
+        assert mock_provider.chat_stream_with_retry.call_count == 2
         # Retry should use max_tokens = min(8192 * 2, 32000) = 16384
-        retry_call = mock_provider.chat_with_retry.call_args_list[1]
+        retry_call = mock_provider.chat_stream_with_retry.call_args_list[1]
         assert retry_call.kwargs["max_tokens"] == 16_384
 
 
@@ -295,12 +295,12 @@ class TestDreamPromptCaps:
         in the prompt preview (full content is still reachable via read_file)."""
         store.write_memory("M" * (dream._MEMORY_FILE_MAX_CHARS * 5))
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
 
-        user_msg = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
+        user_msg = mock_provider.chat_stream_with_retry.call_args.kwargs["messages"][1]["content"]
         memory_section = user_msg.split("## Current MEMORY.md")[1].split("## Current SOUL.md")[0]
         assert len(memory_section) < dream._MEMORY_FILE_MAX_CHARS + 500
 
@@ -320,12 +320,12 @@ class TestDreamPromptCaps:
             }) + "\n",
             encoding="utf-8",
         )
-        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
+        mock_provider.chat_stream_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
 
-        user_msg = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
+        user_msg = mock_provider.chat_stream_with_retry.call_args.kwargs["messages"][1]["content"]
         history_section = user_msg.split("## Conversation History\n")[1].split("\n\n## Current Date")[0]
         assert len(history_section) < dream._HISTORY_ENTRY_PREVIEW_MAX_CHARS + 500
 

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -67,7 +67,7 @@ class TestDreamRun:
     async def test_calls_runner_for_unprocessed_entries(self, dream, mock_provider, mock_runner, store):
         """Dream should call AgentRunner when there are unprocessed history entries."""
         store.append_history("User prefers dark mode")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="New fact")
+        mock_provider.chat_with_retry.return_value = MagicMock(content="New fact", finish_reason="stop")
         mock_runner.run = AsyncMock(return_value=_make_run_result(
             tool_events=[{"name": "edit_file", "status": "ok", "detail": "memory/MEMORY.md"}],
         ))
@@ -82,7 +82,7 @@ class TestDreamRun:
         """Dream should advance the cursor after processing."""
         store.append_history("event 1")
         store.append_history("event 2")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="Nothing new")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="Nothing new")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
         await dream.run()
         assert store.get_last_dream_cursor() == 2
@@ -92,7 +92,7 @@ class TestDreamRun:
         store.append_history("event 1")
         store.append_history("event 2")
         store.append_history("event 3")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="Nothing new")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="Nothing new")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
         await dream.run()
         # After Dream, cursor is advanced and 3, compact keeps last max_history_entries
@@ -103,7 +103,7 @@ class TestDreamRun:
         """Dream should point skill creation guidance at the builtin skill-creator template."""
         store.append_history("Repeated workflow one")
         store.append_history("Repeated workflow two")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKILL] test-skill: test description")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKILL] test-skill: test description")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
@@ -129,7 +129,7 @@ class TestDreamRun:
     async def test_phase1_prompt_includes_line_age_annotations(self, dream, mock_provider, mock_runner, store):
         """Phase 1 prompt should have per-line age suffixes in MEMORY.md when git is available."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         # Init git so line_ages works
@@ -146,7 +146,7 @@ class TestDreamRun:
     async def test_phase1_annotates_only_memory_not_soul_or_user(self, dream, mock_provider, mock_runner, store):
         """SOUL.md and USER.md should never have age annotations — they are permanent."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         store.git.init()
@@ -167,7 +167,7 @@ class TestDreamRun:
     async def test_phase1_prompt_works_without_git(self, dream, mock_provider, mock_runner, store):
         """Phase 1 should work fine even if git is not initialized (no age annotations)."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
@@ -186,7 +186,7 @@ class TestDreamRun:
         # Inject four ages to cover threshold boundaries: >14 suffix, ==14 no suffix, <14 no suffix.
         store.write_memory("# Memory\n- Project X active\n- fresh item\n- edge case line")
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         fake_ages = [
@@ -211,7 +211,7 @@ class TestDreamRun:
     ):
         """`annotate_line_ages=False` must bypass the git lookup entirely and keep MEMORY.md raw."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         dream.annotate_line_ages = False
@@ -232,7 +232,7 @@ class TestDreamRun:
         """If ages length != lines length (dirty working tree), skip annotation instead of mis-tagging."""
         # MEMORY.md has 2 non-blank lines but we hand back only 1 age → mismatch.
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         with patch.object(store.git, "line_ages", return_value=[LineAge(age_days=999)]):
@@ -249,7 +249,7 @@ class TestDreamRun:
     ):
         """System prompt should reference the stale-threshold constant, not a hardcoded 14."""
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
@@ -273,7 +273,7 @@ class TestDreamPromptCaps:
         in the prompt preview (full content is still reachable via read_file)."""
         store.write_memory("M" * (dream._MEMORY_FILE_MAX_CHARS * 5))
         store.append_history("some event")
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()
@@ -298,7 +298,7 @@ class TestDreamPromptCaps:
             }) + "\n",
             encoding="utf-8",
         )
-        mock_provider.chat_with_retry.return_value = MagicMock(content="[SKIP]")
+        mock_provider.chat_with_retry.return_value = MagicMock(finish_reason="stop", content="[SKIP]")
         mock_runner.run = AsyncMock(return_value=_make_run_result())
 
         await dream.run()

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -25,6 +25,7 @@ def store(tmp_path):
 def mock_provider():
     p = MagicMock()
     p.chat_with_retry = AsyncMock()
+    p.generation.max_tokens = 8_192
     return p
 
 
@@ -257,6 +258,27 @@ class TestDreamRun:
         system_msg = mock_provider.chat_with_retry.call_args.kwargs["messages"][0]["content"]
         # The template renders with stale_threshold_days=14 → LLM must see "N>14"
         assert "N>14" in system_msg
+
+    async def test_phase1_retries_with_doubled_max_tokens_on_length(
+        self, dream, mock_provider, mock_runner, store,
+    ):
+        """Phase 1 must retry with doubled max_tokens when finish_reason=length."""
+        store.append_history("some event")
+        # First call hits token limit, second call succeeds.
+        mock_provider.chat_with_retry.side_effect = [
+            MagicMock(finish_reason="length", content=""),
+            MagicMock(finish_reason="stop", content="New fact"),
+        ]
+        mock_runner.run = AsyncMock(return_value=_make_run_result(
+            tool_events=[{"name": "edit_file", "status": "ok", "detail": "memory/MEMORY.md"}],
+        ))
+
+        result = await dream.run()
+        assert result is True
+        assert mock_provider.chat_with_retry.call_count == 2
+        # Retry should use max_tokens = min(8192 * 2, 32000) = 16384
+        retry_call = mock_provider.chat_with_retry.call_args_list[1]
+        assert retry_call.kwargs["max_tokens"] == 16_384
 
 
 class TestDreamPromptCaps:

--- a/tests/command/test_builtin_dream.py
+++ b/tests/command/test_builtin_dream.py
@@ -55,7 +55,11 @@ def _make_ctx(raw: str, git: _FakeGit, *, args: str = "", last_dream_cursor: int
 
 @pytest.mark.asyncio
 async def test_dream_log_latest_is_more_user_friendly() -> None:
-    commit = CommitInfo(sha="abcd1234", message="dream: 2026-04-04, 2 change(s)", timestamp="2026-04-04 12:00")
+    commit = CommitInfo(
+        sha="abcd1234",
+        message="dream: 2026-04-04, 2 change(s)\n\n[ADD] fact A →USER #permanent\n[REMOVE] →MEMORY: old fact",
+        timestamp="2026-04-04 12:00",
+    )
     diff = (
         "diff --git a/SOUL.md b/SOUL.md\n"
         "--- a/SOUL.md\n"
@@ -71,7 +75,11 @@ async def test_dream_log_latest_is_more_user_friendly() -> None:
     assert "## Dream Update" in out.content
     assert "Here is the latest Dream memory change." in out.content
     assert "- Commit: `abcd1234`" in out.content
+    assert "- Summary: dream: 2026-04-04, 2 change(s)" in out.content
     assert "- Changed files: `SOUL.md`" in out.content
+    assert "### Analysis" in out.content
+    assert "[ADD] fact A →USER #permanent" in out.content
+    assert "[REMOVE] →MEMORY: old fact" in out.content
     assert "Use `/dream-restore abcd1234` to undo this change." in out.content
     assert "```diff" in out.content
 
@@ -94,6 +102,26 @@ async def test_dream_log_before_first_run_is_clear() -> None:
 
     assert "Dream has not run yet." in out.content
     assert "Run `/dream`" in out.content
+
+
+@pytest.mark.asyncio
+async def test_dream_log_with_empty_commit_message() -> None:
+    commit = CommitInfo(sha="abcd1234", message="", timestamp="2026-04-04 12:00")
+    diff = (
+        "diff --git a/SOUL.md b/SOUL.md\n"
+        "--- a/SOUL.md\n"
+        "+++ b/SOUL.md\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    git = _FakeGit(commits=[commit], diff_map={commit.sha: (commit, diff)})
+
+    out = await cmd_dream_log(_make_ctx("/dream-log", git))
+
+    assert "## Dream Update" in out.content
+    assert "- Commit: `abcd1234`" in out.content
+    assert "- Summary:" not in out.content  # no summary when message is empty
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

nanobot's long-term memory system has three core issues:

### 1. Memory Duplication Bloat
`MEMORY.md` and `history.jsonl` contain a large amount of redundant information. For example, "user communicates in Chinese" appears more than 10 times across multiple entries. The current Consolidator is unaware of existing memories, and Dream Phase 1 deduplication relies on post-hoc scanning rather than source filtering.

### 2. Non-MECE Information Ownership
Facts are scattered across multiple files without clear assignment rules:
- User preferences appear simultaneously in `SOUL.md`, `USER.md`, and `MEMORY.md`
- Technical configs and behavioral rules have blurred boundaries
- PR review related preferences are distributed across three files

### 3. Lack of Lifecycle Management
Currently there is only a coarse-grained `← Nd` age annotation and a fixed 14-day threshold. There is no importance distinction — "user height 167cm" and "today's arxiv filtering completed" are treated equally.

## Experimental Validation

Three controlled experiments were conducted on real workspace data (426 history entries, 222 lines of MEMORY.md):

### Experiment 1: LLM Value Judgment Verification
30 random history entries were evaluated by LLM for memorability, category, and decay speed. Results:
- 67% marked as worth remembering, 33% correctly marked as forget
- 100% accuracy on erroneous/noisy/duplicate entry identification
- Decay judgments are reasonable: preferences → permanent, technical configs → slow, transient errors → fast

### Experiment 2: Enhanced Consolidator vs Current
- Enhanced version output dropped from 13 entries to 6 (-54%), with 100% valid fact rate
- Successfully marked "user communicates in Chinese" as `[skip]` (dedup)
- Automatically annotated decay levels, directly consumable by downstream Dream

### Experiment 3: Enhanced Dream Phase 1 vs Current
- Enhanced Dream output includes `→USER`/`→SOUL`/`→MEMORY` routing tags
- Added merge operation: different versions of the same fact are consolidated into one
- When paired with enhanced Consolidator, output is more precise (fewer invalid extractions)

## Recommended Configuration

Based on production validation with DeepSeek V4 Flash, the following settings balance prompt size, timeout risk, and output quality:

```json
{
  "agents": {
    "defaults": {
      "modelPreset": "dsflash",
      "maxTokens": 8192,
      "dream": {
        "intervalH": 2,
        "maxBatchSize": 5,
        "maxIterations": 200,
        "annotateLineAges": true
      }
    }
  },
  "model_presets": {
    "dsflash": {
      "model": "deepseek-v4-flash",
      "provider": "deepseek",
      "maxTokens": 8192,
      "contextWindowTokens": 200000,
      "temperature": 0.2,
      "reasoningEffort": "none"
    }
  }
}
```

Key tuning decisions:
- **`maxBatchSize: 5`** (down from 20): keeps Phase 1 prompt under ~25k chars, preventing timeout on thinking models
- **`maxIterations: 200`** (up from 15): Phase 2 may need many tool calls when dedup + add + remove are batched together
- **`reasoningEffort: "none"`** for DeepSeek V4 Flash: this model burns most of the 8k token budget on internal thinking; set to `"none"` to leave headroom for visible output
- **`annotateLineAges: true`**: enables `← Nd` staleness hints in Phase 1; set to `false` if your LLM reacts poorly to the suffix

## Changes

### 1. Consolidator Prompt (`consolidator_archive.md`)
- Added **SNIP** principle for memory eligibility: Signal, Novel, Important, Persistent
- Added memory attribute tags: `[permanent]`/`[durable]`/`[ephemeral]`/`[correction]`/`[skip]`
- Entries marked `[skip]` are still written to history.jsonl (for audit), but Dream can filter them out

### 2. Consolidator Code (`memory.py`)
- `archive()` now injects a summary of current `MEMORY.md` + `USER.md` as dedup context
- LLM becomes aware of existing memories during summarization, enabling source-level deduplication
- Reserve token budget for dedup_context before truncating messages to prevent prompt overflow
- Cache tiktoken encoding instance to avoid repeated instantiation on every call

### 3. Dream Phase 1 Prompt (`dream_phase1.md`)
- Added `→TARGET` routing (`→USER`/`→SOUL`/`→MEMORY`) for MECE assignment
- Added `#DECAY` metadata (`#permanent`/`#durable`/`#ephemeral`)
- Added merge operation: duplicate facts are consolidated rather than merely flagged for deletion
- `#ephemeral` + stale threshold jointly determine deletion priority

### 4. Dream Phase 2 Prompt (`dream_phase2.md`)
- Supports `→TARGET` routing, writing facts to the correct file
- Added MECE enforcement rules: USER = preferences, SOUL = behavior, MEMORY = knowledge
- Renamed `MECE for skills` to `Skill vs MEMORY.md boundary` to avoid confusion with `Skill-to-skill MECE`
- Metadata tags are used for routing only, not written to file content

### 5. Dream Tooling (`memory.py`)
- Registered `ApplyPatchTool` in Dream's tool registry alongside the updated editing rules that default to `apply_patch`
- Added Phase 1 `finish_reason=length` retry with doubled `max_tokens` (up to 32k) for reasoning models
- Added observability: prompt size logging, phase timing, token estimation

### 6. Dream Log (`builtin.py`)
- `/dream-log` now displays the commit message summary (e.g. `dream: 2026-04-02 14:05, 50 change(s)`)

## Design Principles

- **No heavy infrastructure**: pure prompt improvement, no embedding / vector DB required
- **No structured formats for LLM**: tags are part of natural language, which LLMs natively understand
- **Backward compatible**: `[skip]`/`[permanent]` etc. tags do not break existing flow even if the LLM omits them
- **Incremental improvement**: no storage format changes, no code architecture changes — only information quality optimization

## Test Plan
- [x] All 3517 existing tests pass (zero regression)
- [x] Run `/dream` on a real workspace to validate end-to-end effect
- [x] Compare pre/post Dream MEMORY.md information density and MECE compliance
- [x] Validate SNIP principle on synthetic conversation: correctly tags chitchat as `[skip]`, preferences as `[permanent]`, active tasks as `[ephemeral]`
