### PR TITLE
chore: fill remaining WebUI locale keys

### DIFF
--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -9,6 +9,18 @@
       "title": "No se pudo conectar con nanobot",
       "gatewayHint": "Asegúrate de que la gateway esté en ejecución (`nanobot gateway`) y de que esta página esté abierta en la misma máquina."
     },
+    "auth": {
+      "title": "Autenticación requerida",
+      "hint": "Introduce el secreto configurado como tokenIssueSecret en la configuración del gateway.",
+      "placeholder": "Contraseña",
+      "submit": "Conectar",
+      "invalid": "Contraseña no válida. Inténtalo de nuevo."
+    },
+    "account": {
+      "section": "Cuenta",
+      "logoutHint": "Desconecta este navegador del gateway.",
+      "logout": "Cerrar sesión"
+    },
     "system": {
       "section": "Sistema",
       "restartHint": "Reinicia nanobot para aplicar los cambios de ejecución.",
@@ -27,9 +39,13 @@
     }
   },
   "sidebar": {
+    "navigation": "Navegación de la barra lateral",
+    "globalActions": "Acciones globales",
     "collapse": "Contraer barra lateral",
     "toggleTheme": "Cambiar tema",
+    "home": "Inicio",
     "newChat": "Nuevo chat",
+    "searchAria": "Buscar",
     "viewOptions": "View",
     "compactList": "Compact list",
     "showPreviews": "Show previews",
@@ -38,17 +54,16 @@
     "sortUpdated": "Recently updated",
     "sortCreated": "Recently created",
     "sortTitle": "Title A-Z",
+    "searchPlaceholder": "Buscar",
+    "searchResults": "Resultados",
+    "noSearchResults": "No hay chats coincidentes.",
     "recent": "Recientes",
     "refreshSessions": "Actualizar sesiones",
     "settings": "Configuración",
     "language": {
       "label": "Idioma",
       "ariaLabel": "Cambiar idioma"
-    },
-    "searchAria": "Buscar",
-    "searchPlaceholder": "Buscar",
-    "searchResults": "Resultados",
-    "noSearchResults": "No hay chats coincidentes."
+    }
   },
   "settings": {
     "backToChat": "Volver al chat",
@@ -75,10 +90,13 @@
       "status": "Status",
       "localPreferences": "Local preferences",
       "presets": "Presets",
+      "imageGeneration": "Generación de imágenes",
+      "imageDefaults": "Valores predeterminados",
       "webSearch": "Web search",
       "webBehavior": "Behavior",
       "identity": "Identity",
       "safety": "Safety",
+      "capabilities": "Capacidades",
       "integrations": "Integrations"
     },
     "rows": {
@@ -91,6 +109,7 @@
       "activePreset": "Active preset",
       "gateway": "Gateway",
       "restartState": "Restart state",
+      "pendingChanges": "Cambios pendientes",
       "selectedPreset": "Selected preset",
       "presetModel": "Preset model",
       "density": "Density",
@@ -99,6 +118,15 @@
       "maxResults": "Max results",
       "timeout": "Timeout",
       "jinaReader": "Jina reader",
+      "imageGeneration": "Generación de imágenes",
+      "imageProvider": "Proveedor de imágenes",
+      "imageProviderStatus": "Estado del proveedor",
+      "imageProviderBase": "Base del proveedor",
+      "imageModel": "Modelo de imagen",
+      "defaultAspectRatio": "Relación predeterminada",
+      "defaultImageSize": "Tamaño predeterminado",
+      "maxImagesPerTurn": "Máximo de imágenes por turno",
+      "imageSaveDir": "Directorio de guardado",
       "botName": "Bot name",
       "botIcon": "Bot icon",
       "timezone": "Timezone",
@@ -129,6 +157,13 @@
       "maxResults": "Results returned by each web_search call.",
       "timeout": "Seconds before a search provider request times out.",
       "jinaReader": "Use Jina Reader for web_fetch when available.",
+      "imageGeneration": "Expone generate_image en los chats cuando hay un proveedor de imágenes configurado disponible.",
+      "imageProvider": "Elige el proveedor del registro que usará generate_image.",
+      "imageProviderStatus": "La generación de imágenes reutiliza las credenciales de Proveedores.",
+      "imageModel": "Nombre del modelo enviado al proveedor de imágenes seleccionado.",
+      "defaultAspectRatio": "Se usa cuando el prompt no elige una relación de aspecto.",
+      "defaultImageSize": "Sugerencia de tamaño enviada a los proveedores que la admiten.",
+      "maxImagesPerTurn": "Límite superior para una solicitud generate_image.",
       "botName": "Shown in runtime surfaces that use the configured bot identity.",
       "botIcon": "Short emoji or text shown beside the bot name.",
       "timezone": "IANA timezone used by runtime context and schedules.",
@@ -141,8 +176,8 @@
       "notAvailable": "No disponible",
       "enabled": "Enabled",
       "disabled": "Disabled",
-      "restartRequired": "Restart required",
-      "liveReload": "Live reload ready",
+      "restartPending": "Reinicio pendiente",
+      "ready": "Listo",
       "comfortable": "Comfortable",
       "compact": "Compact",
       "auto": "Auto",
@@ -150,13 +185,19 @@
       "on": "On",
       "off": "Off",
       "configured": "Configured",
-      "notConfigured": "Not configured"
+      "notConfigured": "Not configured",
+      "restartRequired": "Restart required",
+      "liveReload": "Live reload ready"
     },
     "status": {
       "loading": "Cargando configuración...",
       "loadError": "No se pudo cargar la configuración",
       "unsaved": "Hay cambios sin guardar.",
-      "savedRestart": "Guardado. Reinicia nanobot para aplicar."
+      "upToDate": "Actualizado.",
+      "savedRestart": "Guardado. Reinicia nanobot para aplicar.",
+      "restartAfterSaving": "Guarda los cambios y reinicia cuando estés listo.",
+      "savedRestartApply": "Guardado. Reinicia cuando estés listo.",
+      "imageProviderRestart": "Cambios del proveedor de imágenes guardados. Reinicia cuando estés listo."
     },
     "actions": {
       "save": "Guardar",
@@ -213,18 +254,25 @@
       "configuredCount": "{{count}} configured",
       "totalProviders": "{{count}} available",
       "webSearch": "Web search",
+      "imageGeneration": "Generación de imágenes",
       "workspace": "Workspace"
     },
     "providers": {
       "searchPlaceholder": "Search providers",
       "noMatches": "No providers match this search."
+    },
+    "image": {
+      "selectProvider": "Seleccionar proveedor",
+      "selectAspect": "Seleccionar relación",
+      "selectSize": "Seleccionar tamaño",
+      "configureProvider": "Configurar proveedor",
+      "missingCredential": "Configura este proveedor antes de activar la generación de imágenes."
     }
   },
   "chat": {
     "fallbackTitle": "Chat {{id}}",
     "loading": "Cargando…",
     "noSessions": "Todavía no hay sesiones.",
-    "showMore": "Mostrar {{count}} más",
     "actions": "Acciones del chat {{title}}",
     "activity": {
       "running": "Agent running",
@@ -269,7 +317,6 @@
   "thread": {
     "loadingConversation": "Cargando conversación…",
     "empty": {
-      "description": "Haz preguntas, continúa tu trabajo local o inicia un nuevo hilo.",
       "greeting": "¿Qué puedo hacer por ti?",
       "quickActions": {
         "plan": {
@@ -322,10 +369,14 @@
           "title": "Editar una imagen",
           "prompt": "Ayúdame a editar una imagen. Primero pídeme que suba o indique la imagen, y luego genera el resultado editado."
         }
-      }
+      },
+      "description": "Haz preguntas, continúa tu trabajo local o inicia un nuevo hilo."
     },
     "header": {
-      "toggleSidebar": "Mostrar u ocultar la barra lateral"
+      "toggleSidebar": "Mostrar u ocultar la barra lateral",
+      "newChat": "Iniciar un chat nuevo",
+      "toggleTheme": "Cambiar tema desde el encabezado",
+      "settings": "Abrir configuración"
     },
     "composer": {
       "placeholderThread": "Escribe tu mensaje…",
@@ -339,6 +390,7 @@
       "goalStateFallback": "Objetivo",
       "goalStateExpandAria": "Ver objetivo completo",
       "goalStateSheetTitle": "Objetivo",
+      "goalStateCloseAria": "Cerrar objetivo",
       "send": "Enviar mensaje",
       "stop": "Detener respuesta",
       "attachImage": "Adjuntar imagen",
@@ -357,16 +409,11 @@
           "16_9": "Panorámico 16:9"
         }
       },
-      "encoding": "Procesando…",
-      "remove": "Quitar adjunto",
-      "normalizedSizeHint": "{{orig}} → {{current}} (auto)",
-      "imageRejected": {
-        "unsupported_type": "Tipo de archivo no compatible",
-        "too_many_images": "Máximo {{max}} imágenes por mensaje",
-        "magic_mismatch": "El archivo no parece una imagen real",
-        "decode_failed": "No se pudo decodificar esta imagen",
-        "too_large": "Imagen demasiado grande — prueba una más pequeña",
-        "io": "No se pudo leer este archivo"
+      "tools": {
+        "search": "Buscar",
+        "reason": "Razonar",
+        "deepResearch": "Investigación profunda",
+        "voice": "Entrada de voz"
       },
       "slash": {
         "ariaLabel": "Comandos slash",
@@ -417,7 +464,17 @@
           }
         }
       },
-      "goalStateCloseAria": "Cerrar objetivo"
+      "encoding": "Procesando…",
+      "remove": "Quitar adjunto",
+      "normalizedSizeHint": "{{orig}} → {{current}} (auto)",
+      "imageRejected": {
+        "unsupported_type": "Tipo de archivo no compatible",
+        "too_many_images": "Máximo {{max}} imágenes por mensaje",
+        "magic_mismatch": "El archivo no parece una imagen real",
+        "decode_failed": "No se pudo decodificar esta imagen",
+        "too_large": "Imagen demasiado grande — prueba una más pequeña",
+        "io": "No se pudo leer este archivo"
+      }
     },
     "scrollToBottom": "Desplazarse al final",
     "loadEarlier": "Cargar mensajes anteriores"
@@ -439,6 +496,8 @@
     "agentActivityLiveSummary": "En curso… · {{reasoning}} pasos · {{tools}} llamadas a herramientas",
     "agentActivityLiveToolsOnly": "En curso… · {{tools}} llamadas a herramientas",
     "imageAttachment": "Imagen adjunta",
+    "copyReply": "Copiar respuesta",
+    "copiedReply": "Respuesta copiada",
     "turnLatencyTitle": "Tiempo de respuesta (extremo a extremo)"
   },
   "lightbox": {

--- a/webui/src/i18n/locales/es/common.json
+++ b/webui/src/i18n/locales/es/common.json
@@ -273,6 +273,7 @@
     "fallbackTitle": "Chat {{id}}",
     "loading": "Cargando…",
     "noSessions": "Todavía no hay sesiones.",
+    "showMore": "Mostrar {{count}} más",
     "actions": "Acciones del chat {{title}}",
     "activity": {
       "running": "Agent running",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -273,6 +273,7 @@
     "fallbackTitle": "Discussion {{id}}",
     "loading": "Chargement…",
     "noSessions": "Aucune session pour le moment.",
+    "showMore": "Afficher {{count}} de plus",
     "actions": "Actions de la discussion {{title}}",
     "activity": {
       "running": "Agent running",

--- a/webui/src/i18n/locales/fr/common.json
+++ b/webui/src/i18n/locales/fr/common.json
@@ -9,6 +9,18 @@
       "title": "Impossible de joindre nanobot",
       "gatewayHint": "Assurez-vous que la gateway est en cours d’exécution (`nanobot gateway`) et que cette page est ouverte sur la même machine."
     },
+    "auth": {
+      "title": "Authentification requise",
+      "hint": "Saisissez le secret configuré comme tokenIssueSecret dans la configuration de votre gateway.",
+      "placeholder": "Mot de passe",
+      "submit": "Se connecter",
+      "invalid": "Mot de passe invalide. Réessayez."
+    },
+    "account": {
+      "section": "Compte",
+      "logoutHint": "Déconnecter ce navigateur du gateway.",
+      "logout": "Se déconnecter"
+    },
     "system": {
       "section": "Système",
       "restartHint": "Redémarrez nanobot pour appliquer les changements d’exécution.",
@@ -27,9 +39,13 @@
     }
   },
   "sidebar": {
+    "navigation": "Navigation de la barre latérale",
+    "globalActions": "Actions globales",
     "collapse": "Réduire la barre latérale",
     "toggleTheme": "Changer de thème",
+    "home": "Accueil",
     "newChat": "Nouvelle discussion",
+    "searchAria": "Rechercher",
     "viewOptions": "View",
     "compactList": "Compact list",
     "showPreviews": "Show previews",
@@ -38,17 +54,16 @@
     "sortUpdated": "Recently updated",
     "sortCreated": "Recently created",
     "sortTitle": "Title A-Z",
+    "searchPlaceholder": "Rechercher",
+    "searchResults": "Résultats",
+    "noSearchResults": "Aucun chat correspondant.",
     "recent": "Récentes",
     "refreshSessions": "Actualiser les sessions",
     "settings": "Paramètres",
     "language": {
       "label": "Langue",
       "ariaLabel": "Changer de langue"
-    },
-    "searchAria": "Rechercher",
-    "searchPlaceholder": "Rechercher",
-    "searchResults": "Résultats",
-    "noSearchResults": "Aucun chat correspondant."
+    }
   },
   "settings": {
     "backToChat": "Retour à la discussion",
@@ -75,10 +90,13 @@
       "status": "Status",
       "localPreferences": "Local preferences",
       "presets": "Presets",
+      "imageGeneration": "Génération d'images",
+      "imageDefaults": "Valeurs par défaut",
       "webSearch": "Web search",
       "webBehavior": "Behavior",
       "identity": "Identity",
       "safety": "Safety",
+      "capabilities": "Capacités",
       "integrations": "Integrations"
     },
     "rows": {
@@ -91,6 +109,7 @@
       "activePreset": "Active preset",
       "gateway": "Gateway",
       "restartState": "Restart state",
+      "pendingChanges": "Modifications en attente",
       "selectedPreset": "Selected preset",
       "presetModel": "Preset model",
       "density": "Density",
@@ -99,6 +118,15 @@
       "maxResults": "Max results",
       "timeout": "Timeout",
       "jinaReader": "Jina reader",
+      "imageGeneration": "Génération d'images",
+      "imageProvider": "Fournisseur d'images",
+      "imageProviderStatus": "État du fournisseur",
+      "imageProviderBase": "Base du fournisseur",
+      "imageModel": "Modèle d'image",
+      "defaultAspectRatio": "Format par défaut",
+      "defaultImageSize": "Taille par défaut",
+      "maxImagesPerTurn": "Nombre max. d'images par tour",
+      "imageSaveDir": "Répertoire de sauvegarde",
       "botName": "Bot name",
       "botIcon": "Bot icon",
       "timezone": "Timezone",
@@ -129,6 +157,13 @@
       "maxResults": "Results returned by each web_search call.",
       "timeout": "Seconds before a search provider request times out.",
       "jinaReader": "Use Jina Reader for web_fetch when available.",
+      "imageGeneration": "Expose generate_image dans les chats lorsqu’un fournisseur d’images configuré est disponible.",
+      "imageProvider": "Choisissez le fournisseur du registre utilisé par generate_image.",
+      "imageProviderStatus": "La génération d’images réutilise les identifiants de Fournisseurs.",
+      "imageModel": "Nom du modèle envoyé au fournisseur d’images sélectionné.",
+      "defaultAspectRatio": "Utilisé lorsque le prompt ne choisit pas de format.",
+      "defaultImageSize": "Indication de taille envoyée aux fournisseurs qui la prennent en charge.",
+      "maxImagesPerTurn": "Limite supérieure pour une requête generate_image.",
       "botName": "Shown in runtime surfaces that use the configured bot identity.",
       "botIcon": "Short emoji or text shown beside the bot name.",
       "timezone": "IANA timezone used by runtime context and schedules.",
@@ -141,8 +176,8 @@
       "notAvailable": "Indisponible",
       "enabled": "Enabled",
       "disabled": "Disabled",
-      "restartRequired": "Restart required",
-      "liveReload": "Live reload ready",
+      "restartPending": "Redémarrage en attente",
+      "ready": "Prêt",
       "comfortable": "Comfortable",
       "compact": "Compact",
       "auto": "Auto",
@@ -150,13 +185,19 @@
       "on": "On",
       "off": "Off",
       "configured": "Configured",
-      "notConfigured": "Not configured"
+      "notConfigured": "Not configured",
+      "restartRequired": "Restart required",
+      "liveReload": "Live reload ready"
     },
     "status": {
       "loading": "Chargement des paramètres...",
       "loadError": "Impossible de charger les paramètres",
       "unsaved": "Modifications non enregistrées.",
-      "savedRestart": "Enregistré. Redémarrez nanobot pour appliquer."
+      "upToDate": "À jour.",
+      "savedRestart": "Enregistré. Redémarrez nanobot pour appliquer.",
+      "restartAfterSaving": "Enregistrez les modifications, puis redémarrez lorsque vous êtes prêt.",
+      "savedRestartApply": "Enregistré. Redémarrez lorsque vous êtes prêt.",
+      "imageProviderRestart": "Modifications du fournisseur d’images enregistrées. Redémarrez lorsque vous êtes prêt."
     },
     "actions": {
       "save": "Enregistrer",
@@ -213,18 +254,25 @@
       "configuredCount": "{{count}} configured",
       "totalProviders": "{{count}} available",
       "webSearch": "Web search",
+      "imageGeneration": "Génération d'images",
       "workspace": "Workspace"
     },
     "providers": {
       "searchPlaceholder": "Search providers",
       "noMatches": "No providers match this search."
+    },
+    "image": {
+      "selectProvider": "Sélectionner un fournisseur",
+      "selectAspect": "Sélectionner un format",
+      "selectSize": "Sélectionner une taille",
+      "configureProvider": "Configurer le fournisseur",
+      "missingCredential": "Configurez ce fournisseur avant d’activer la génération d’images."
     }
   },
   "chat": {
     "fallbackTitle": "Discussion {{id}}",
     "loading": "Chargement…",
     "noSessions": "Aucune session pour le moment.",
-    "showMore": "Afficher {{count}} de plus",
     "actions": "Actions de la discussion {{title}}",
     "activity": {
       "running": "Agent running",
@@ -269,7 +317,6 @@
   "thread": {
     "loadingConversation": "Chargement de la conversation…",
     "empty": {
-      "description": "Posez des questions, poursuivez votre travail local ou démarrez un nouveau fil.",
       "greeting": "Que puis-je faire pour vous ?",
       "quickActions": {
         "plan": {
@@ -322,10 +369,14 @@
           "title": "Modifier une image",
           "prompt": "Aidez-moi à modifier une image. Demandez-moi d’abord de téléverser ou d’indiquer l’image, puis générez le résultat modifié."
         }
-      }
+      },
+      "description": "Posez des questions, poursuivez votre travail local ou démarrez un nouveau fil."
     },
     "header": {
-      "toggleSidebar": "Afficher ou masquer la barre latérale"
+      "toggleSidebar": "Afficher ou masquer la barre latérale",
+      "newChat": "Démarrer un nouveau chat",
+      "toggleTheme": "Changer le thème depuis l’en-tête",
+      "settings": "Ouvrir les paramètres"
     },
     "composer": {
       "placeholderThread": "Saisissez votre message…",
@@ -339,6 +390,7 @@
       "goalStateFallback": "Objectif",
       "goalStateExpandAria": "Afficher l’objectif complet",
       "goalStateSheetTitle": "Objectif",
+      "goalStateCloseAria": "Fermer l’objectif",
       "send": "Envoyer le message",
       "stop": "Arrêter la réponse",
       "attachImage": "Joindre une image",
@@ -357,16 +409,11 @@
           "16_9": "Large 16:9"
         }
       },
-      "encoding": "Traitement…",
-      "remove": "Retirer la pièce jointe",
-      "normalizedSizeHint": "{{orig}} → {{current}} (auto)",
-      "imageRejected": {
-        "unsupported_type": "Type de fichier non pris en charge",
-        "too_many_images": "Maximum {{max}} images par message",
-        "magic_mismatch": "Ce fichier n'est pas une image",
-        "decode_failed": "Impossible de décoder cette image",
-        "too_large": "Image trop grande — essayez-en une plus petite",
-        "io": "Impossible de lire ce fichier"
+      "tools": {
+        "search": "Rechercher",
+        "reason": "Raisonner",
+        "deepResearch": "Recherche approfondie",
+        "voice": "Entrée vocale"
       },
       "slash": {
         "ariaLabel": "Commandes slash",
@@ -417,7 +464,17 @@
           }
         }
       },
-      "goalStateCloseAria": "Fermer l’objectif"
+      "encoding": "Traitement…",
+      "remove": "Retirer la pièce jointe",
+      "normalizedSizeHint": "{{orig}} → {{current}} (auto)",
+      "imageRejected": {
+        "unsupported_type": "Type de fichier non pris en charge",
+        "too_many_images": "Maximum {{max}} images par message",
+        "magic_mismatch": "Ce fichier n'est pas une image",
+        "decode_failed": "Impossible de décoder cette image",
+        "too_large": "Image trop grande — essayez-en une plus petite",
+        "io": "Impossible de lire ce fichier"
+      }
     },
     "scrollToBottom": "Faire défiler vers le bas",
     "loadEarlier": "Charger les messages précédents"
@@ -439,6 +496,8 @@
     "agentActivityLiveSummary": "En cours… · {{reasoning}} étapes · {{tools}} appels d’outils",
     "agentActivityLiveToolsOnly": "En cours… · {{tools}} appels d’outils",
     "imageAttachment": "Pièce jointe image",
+    "copyReply": "Copier la réponse",
+    "copiedReply": "Réponse copiée",
     "turnLatencyTitle": "Temps de réponse (de bout en bout)"
   },
   "lightbox": {

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -9,6 +9,18 @@
       "title": "Tidak dapat menjangkau nanobot",
       "gatewayHint": "Pastikan gateway sedang berjalan (`nanobot gateway`) dan halaman ini dibuka pada mesin yang sama."
     },
+    "auth": {
+      "title": "Autentikasi diperlukan",
+      "hint": "Masukkan secret yang dikonfigurasi sebagai tokenIssueSecret di konfigurasi gateway.",
+      "placeholder": "Kata sandi",
+      "submit": "Hubungkan",
+      "invalid": "Kata sandi tidak valid. Coba lagi."
+    },
+    "account": {
+      "section": "Akun",
+      "logoutHint": "Putuskan browser ini dari gateway.",
+      "logout": "Keluar"
+    },
     "system": {
       "section": "Sistem",
       "restartHint": "Mulai ulang nanobot untuk menerapkan perubahan runtime.",
@@ -27,9 +39,13 @@
     }
   },
   "sidebar": {
+    "navigation": "Navigasi bilah samping",
+    "globalActions": "Aksi global",
     "collapse": "Ciutkan sidebar",
     "toggleTheme": "Ganti tema",
+    "home": "Beranda",
     "newChat": "Obrolan baru",
+    "searchAria": "Cari",
     "viewOptions": "View",
     "compactList": "Compact list",
     "showPreviews": "Show previews",
@@ -38,17 +54,16 @@
     "sortUpdated": "Recently updated",
     "sortCreated": "Recently created",
     "sortTitle": "Title A-Z",
+    "searchPlaceholder": "Cari",
+    "searchResults": "Hasil",
+    "noSearchResults": "Tidak ada chat yang cocok.",
     "recent": "Terbaru",
     "refreshSessions": "Segarkan sesi",
     "settings": "Pengaturan",
     "language": {
       "label": "Bahasa",
       "ariaLabel": "Ganti bahasa"
-    },
-    "searchAria": "Cari",
-    "searchPlaceholder": "Cari",
-    "searchResults": "Hasil",
-    "noSearchResults": "Tidak ada chat yang cocok."
+    }
   },
   "settings": {
     "backToChat": "Kembali ke obrolan",
@@ -75,10 +90,13 @@
       "status": "Status",
       "localPreferences": "Local preferences",
       "presets": "Presets",
+      "imageGeneration": "Pembuatan gambar",
+      "imageDefaults": "Default",
       "webSearch": "Web search",
       "webBehavior": "Behavior",
       "identity": "Identity",
       "safety": "Safety",
+      "capabilities": "Kapabilitas",
       "integrations": "Integrations"
     },
     "rows": {
@@ -91,6 +109,7 @@
       "activePreset": "Active preset",
       "gateway": "Gateway",
       "restartState": "Restart state",
+      "pendingChanges": "Perubahan tertunda",
       "selectedPreset": "Selected preset",
       "presetModel": "Preset model",
       "density": "Density",
@@ -99,6 +118,15 @@
       "maxResults": "Max results",
       "timeout": "Timeout",
       "jinaReader": "Jina reader",
+      "imageGeneration": "Pembuatan gambar",
+      "imageProvider": "Penyedia gambar",
+      "imageProviderStatus": "Status penyedia",
+      "imageProviderBase": "Basis penyedia",
+      "imageModel": "Model gambar",
+      "defaultAspectRatio": "Rasio default",
+      "defaultImageSize": "Ukuran default",
+      "maxImagesPerTurn": "Maks. gambar per giliran",
+      "imageSaveDir": "Direktori penyimpanan",
       "botName": "Bot name",
       "botIcon": "Bot icon",
       "timezone": "Timezone",
@@ -129,6 +157,13 @@
       "maxResults": "Results returned by each web_search call.",
       "timeout": "Seconds before a search provider request times out.",
       "jinaReader": "Use Jina Reader for web_fetch when available.",
+      "imageGeneration": "Tampilkan generate_image di chat saat penyedia gambar yang dikonfigurasi tersedia.",
+      "imageProvider": "Pilih penyedia registry yang digunakan oleh generate_image.",
+      "imageProviderStatus": "Pembuatan gambar menggunakan ulang kredensial penyedia dari Providers.",
+      "imageModel": "Nama model yang dikirim ke penyedia gambar yang dipilih.",
+      "defaultAspectRatio": "Digunakan saat prompt tidak memilih rasio aspek.",
+      "defaultImageSize": "Petunjuk ukuran yang dikirim ke penyedia yang mendukungnya.",
+      "maxImagesPerTurn": "Batas atas untuk satu permintaan generate_image.",
       "botName": "Shown in runtime surfaces that use the configured bot identity.",
       "botIcon": "Short emoji or text shown beside the bot name.",
       "timezone": "IANA timezone used by runtime context and schedules.",
@@ -141,8 +176,8 @@
       "notAvailable": "Tidak tersedia",
       "enabled": "Enabled",
       "disabled": "Disabled",
-      "restartRequired": "Restart required",
-      "liveReload": "Live reload ready",
+      "restartPending": "Menunggu restart",
+      "ready": "Siap",
       "comfortable": "Comfortable",
       "compact": "Compact",
       "auto": "Auto",
@@ -150,13 +185,19 @@
       "on": "On",
       "off": "Off",
       "configured": "Configured",
-      "notConfigured": "Not configured"
+      "notConfigured": "Not configured",
+      "restartRequired": "Restart required",
+      "liveReload": "Live reload ready"
     },
     "status": {
       "loading": "Memuat pengaturan...",
       "loadError": "Tidak dapat memuat pengaturan",
       "unsaved": "Ada perubahan yang belum disimpan.",
-      "savedRestart": "Tersimpan. Mulai ulang nanobot untuk menerapkan."
+      "upToDate": "Sudah terbaru.",
+      "savedRestart": "Tersimpan. Mulai ulang nanobot untuk menerapkan.",
+      "restartAfterSaving": "Simpan perubahan, lalu restart saat siap.",
+      "savedRestartApply": "Tersimpan. Restart saat siap.",
+      "imageProviderRestart": "Perubahan penyedia gambar tersimpan. Restart saat siap."
     },
     "actions": {
       "save": "Simpan",
@@ -213,18 +254,25 @@
       "configuredCount": "{{count}} configured",
       "totalProviders": "{{count}} available",
       "webSearch": "Web search",
+      "imageGeneration": "Pembuatan gambar",
       "workspace": "Workspace"
     },
     "providers": {
       "searchPlaceholder": "Search providers",
       "noMatches": "No providers match this search."
+    },
+    "image": {
+      "selectProvider": "Pilih penyedia",
+      "selectAspect": "Pilih rasio",
+      "selectSize": "Pilih ukuran",
+      "configureProvider": "Konfigurasi penyedia",
+      "missingCredential": "Konfigurasikan penyedia ini sebelum mengaktifkan pembuatan gambar."
     }
   },
   "chat": {
     "fallbackTitle": "Obrolan {{id}}",
     "loading": "Memuat…",
     "noSessions": "Belum ada sesi.",
-    "showMore": "Tampilkan {{count}} lagi",
     "actions": "Aksi obrolan untuk {{title}}",
     "activity": {
       "running": "Agent running",
@@ -269,7 +317,6 @@
   "thread": {
     "loadingConversation": "Memuat percakapan…",
     "empty": {
-      "description": "Ajukan pertanyaan, lanjutkan pekerjaan lokal, atau mulai thread baru.",
       "greeting": "Apa yang bisa saya bantu?",
       "quickActions": {
         "plan": {
@@ -322,10 +369,14 @@
           "title": "Edit gambar",
           "prompt": "Bantu saya mengedit gambar. Minta saya mengunggah atau menyebutkan gambar terlebih dahulu, lalu buat hasil editnya."
         }
-      }
+      },
+      "description": "Ajukan pertanyaan, lanjutkan pekerjaan lokal, atau mulai thread baru."
     },
     "header": {
-      "toggleSidebar": "Tampilkan atau sembunyikan sidebar"
+      "toggleSidebar": "Tampilkan atau sembunyikan sidebar",
+      "newChat": "Mulai chat baru",
+      "toggleTheme": "Alihkan tema dari header",
+      "settings": "Buka pengaturan"
     },
     "composer": {
       "placeholderThread": "Ketik pesan Anda…",
@@ -339,6 +390,7 @@
       "goalStateFallback": "Tujuan",
       "goalStateExpandAria": "Lihat tujuan lengkap",
       "goalStateSheetTitle": "Tujuan",
+      "goalStateCloseAria": "Tutup tujuan",
       "send": "Kirim pesan",
       "stop": "Hentikan respons",
       "attachImage": "Lampirkan gambar",
@@ -357,16 +409,11 @@
           "16_9": "Lebar 16:9"
         }
       },
-      "encoding": "Memproses…",
-      "remove": "Hapus lampiran",
-      "normalizedSizeHint": "{{orig}} → {{current}} (auto)",
-      "imageRejected": {
-        "unsupported_type": "Tipe file tidak didukung",
-        "too_many_images": "Maksimal {{max}} gambar per pesan",
-        "magic_mismatch": "File ini tampaknya bukan gambar asli",
-        "decode_failed": "Tidak dapat mendekode gambar ini",
-        "too_large": "Gambar terlalu besar — coba yang lebih kecil",
-        "io": "Tidak dapat membaca file ini"
+      "tools": {
+        "search": "Cari",
+        "reason": "Bernalar",
+        "deepResearch": "Riset mendalam",
+        "voice": "Input suara"
       },
       "slash": {
         "ariaLabel": "Perintah slash",
@@ -417,7 +464,17 @@
           }
         }
       },
-      "goalStateCloseAria": "Tutup tujuan"
+      "encoding": "Memproses…",
+      "remove": "Hapus lampiran",
+      "normalizedSizeHint": "{{orig}} → {{current}} (auto)",
+      "imageRejected": {
+        "unsupported_type": "Tipe file tidak didukung",
+        "too_many_images": "Maksimal {{max}} gambar per pesan",
+        "magic_mismatch": "File ini tampaknya bukan gambar asli",
+        "decode_failed": "Tidak dapat mendekode gambar ini",
+        "too_large": "Gambar terlalu besar — coba yang lebih kecil",
+        "io": "Tidak dapat membaca file ini"
+      }
     },
     "scrollToBottom": "Gulir ke bawah",
     "loadEarlier": "Muat pesan sebelumnya"
@@ -439,6 +496,8 @@
     "agentActivityLiveSummary": "Berjalan… · {{reasoning}} langkah · {{tools}} panggilan alat",
     "agentActivityLiveToolsOnly": "Berjalan… · {{tools}} panggilan alat",
     "imageAttachment": "Lampiran gambar",
+    "copyReply": "Salin balasan",
+    "copiedReply": "Balasan disalin",
     "turnLatencyTitle": "Waktu respons (ujung ke ujung)"
   },
   "lightbox": {

--- a/webui/src/i18n/locales/id/common.json
+++ b/webui/src/i18n/locales/id/common.json
@@ -273,6 +273,7 @@
     "fallbackTitle": "Obrolan {{id}}",
     "loading": "Memuat…",
     "noSessions": "Belum ada sesi.",
+    "showMore": "Tampilkan {{count}} lagi",
     "actions": "Aksi obrolan untuk {{title}}",
     "activity": {
       "running": "Agent running",

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -9,6 +9,18 @@
       "title": "nanobot에 연결할 수 없습니다",
       "gatewayHint": "gateway(`nanobot gateway`)가 실행 중인지, 그리고 이 페이지가 같은 머신에서 열려 있는지 확인하세요."
     },
+    "auth": {
+      "title": "인증이 필요합니다",
+      "hint": "gateway 설정의 tokenIssueSecret에 구성된 비밀 값을 입력하세요.",
+      "placeholder": "비밀번호",
+      "submit": "연결",
+      "invalid": "비밀번호가 올바르지 않습니다. 다시 시도하세요."
+    },
+    "account": {
+      "section": "계정",
+      "logoutHint": "이 브라우저를 gateway에서 연결 해제합니다.",
+      "logout": "로그아웃"
+    },
     "system": {
       "section": "시스템",
       "restartHint": "런타임 변경 사항을 적용하려면 nanobot을 다시 시작하세요.",
@@ -27,9 +39,13 @@
     }
   },
   "sidebar": {
+    "navigation": "사이드바 탐색",
+    "globalActions": "전역 작업",
     "collapse": "사이드바 접기",
     "toggleTheme": "테마 전환",
+    "home": "홈",
     "newChat": "새 채팅",
+    "searchAria": "검색",
     "viewOptions": "View",
     "compactList": "Compact list",
     "showPreviews": "Show previews",
@@ -38,17 +54,16 @@
     "sortUpdated": "Recently updated",
     "sortCreated": "Recently created",
     "sortTitle": "Title A-Z",
+    "searchPlaceholder": "검색",
+    "searchResults": "결과",
+    "noSearchResults": "일치하는 채팅이 없습니다.",
     "recent": "최근 대화",
     "refreshSessions": "세션 새로고침",
     "settings": "설정",
     "language": {
       "label": "언어",
       "ariaLabel": "언어 변경"
-    },
-    "searchAria": "검색",
-    "searchPlaceholder": "검색",
-    "searchResults": "결과",
-    "noSearchResults": "일치하는 채팅이 없습니다."
+    }
   },
   "settings": {
     "backToChat": "채팅으로 돌아가기",
@@ -75,10 +90,13 @@
       "status": "Status",
       "localPreferences": "Local preferences",
       "presets": "Presets",
+      "imageGeneration": "이미지 생성",
+      "imageDefaults": "기본값",
       "webSearch": "Web search",
       "webBehavior": "Behavior",
       "identity": "Identity",
       "safety": "Safety",
+      "capabilities": "기능",
       "integrations": "Integrations"
     },
     "rows": {
@@ -91,6 +109,7 @@
       "activePreset": "Active preset",
       "gateway": "Gateway",
       "restartState": "Restart state",
+      "pendingChanges": "대기 중인 변경 사항",
       "selectedPreset": "Selected preset",
       "presetModel": "Preset model",
       "density": "Density",
@@ -99,6 +118,15 @@
       "maxResults": "Max results",
       "timeout": "Timeout",
       "jinaReader": "Jina reader",
+      "imageGeneration": "이미지 생성",
+      "imageProvider": "이미지 제공자",
+      "imageProviderStatus": "제공자 상태",
+      "imageProviderBase": "제공자 기준 주소",
+      "imageModel": "이미지 모델",
+      "defaultAspectRatio": "기본 비율",
+      "defaultImageSize": "기본 크기",
+      "maxImagesPerTurn": "턴당 최대 이미지 수",
+      "imageSaveDir": "저장 디렉터리",
       "botName": "Bot name",
       "botIcon": "Bot icon",
       "timezone": "Timezone",
@@ -129,6 +157,13 @@
       "maxResults": "Results returned by each web_search call.",
       "timeout": "Seconds before a search provider request times out.",
       "jinaReader": "Use Jina Reader for web_fetch when available.",
+      "imageGeneration": "구성된 이미지 제공자를 사용할 수 있을 때 채팅에서 generate_image를 노출합니다.",
+      "imageProvider": "generate_image가 사용할 레지스트리 제공자를 선택합니다.",
+      "imageProviderStatus": "이미지 생성은 Providers의 제공자 자격 증명을 재사용합니다.",
+      "imageModel": "선택한 이미지 제공자에 보낼 모델 이름입니다.",
+      "defaultAspectRatio": "프롬프트에서 가로세로 비율을 선택하지 않았을 때 사용됩니다.",
+      "defaultImageSize": "지원하는 제공자에게 보내는 크기 힌트입니다.",
+      "maxImagesPerTurn": "한 번의 generate_image 요청에 대한 상한입니다.",
       "botName": "Shown in runtime surfaces that use the configured bot identity.",
       "botIcon": "Short emoji or text shown beside the bot name.",
       "timezone": "IANA timezone used by runtime context and schedules.",
@@ -141,8 +176,8 @@
       "notAvailable": "사용할 수 없음",
       "enabled": "Enabled",
       "disabled": "Disabled",
-      "restartRequired": "Restart required",
-      "liveReload": "Live reload ready",
+      "restartPending": "재시작 대기 중",
+      "ready": "준비됨",
       "comfortable": "Comfortable",
       "compact": "Compact",
       "auto": "Auto",
@@ -150,13 +185,19 @@
       "on": "On",
       "off": "Off",
       "configured": "Configured",
-      "notConfigured": "Not configured"
+      "notConfigured": "Not configured",
+      "restartRequired": "Restart required",
+      "liveReload": "Live reload ready"
     },
     "status": {
       "loading": "설정을 불러오는 중...",
       "loadError": "설정을 불러올 수 없습니다",
       "unsaved": "저장되지 않은 변경 사항이 있습니다.",
-      "savedRestart": "저장되었습니다. 적용하려면 nanobot을 재시작하세요."
+      "upToDate": "최신 상태입니다.",
+      "savedRestart": "저장되었습니다. 적용하려면 nanobot을 재시작하세요.",
+      "restartAfterSaving": "변경 사항을 저장한 뒤 준비되면 재시작하세요.",
+      "savedRestartApply": "저장되었습니다. 준비되면 재시작하세요.",
+      "imageProviderRestart": "이미지 제공자 변경 사항이 저장되었습니다. 준비되면 재시작하세요."
     },
     "actions": {
       "save": "저장",
@@ -213,18 +254,25 @@
       "configuredCount": "{{count}} configured",
       "totalProviders": "{{count}} available",
       "webSearch": "Web search",
+      "imageGeneration": "이미지 생성",
       "workspace": "Workspace"
     },
     "providers": {
       "searchPlaceholder": "Search providers",
       "noMatches": "No providers match this search."
+    },
+    "image": {
+      "selectProvider": "제공자 선택",
+      "selectAspect": "비율 선택",
+      "selectSize": "크기 선택",
+      "configureProvider": "제공자 구성",
+      "missingCredential": "이미지 생성을 활성화하기 전에 이 제공자를 구성하세요."
     }
   },
   "chat": {
     "fallbackTitle": "채팅 {{id}}",
     "loading": "불러오는 중…",
     "noSessions": "아직 세션이 없습니다.",
-    "showMore": "{{count}}개 더 보기",
     "actions": "{{title}} 채팅 작업",
     "activity": {
       "running": "Agent running",
@@ -269,7 +317,6 @@
   "thread": {
     "loadingConversation": "대화 불러오는 중…",
     "empty": {
-      "description": "질문을 하거나, 로컬 작업을 이어가거나, 새 스레드를 시작할 수 있습니다.",
       "greeting": "무엇을 도와드릴까요?",
       "quickActions": {
         "plan": {
@@ -322,10 +369,14 @@
           "title": "이미지 편집",
           "prompt": "이미지 편집을 도와주세요. 먼저 편집할 이미지를 업로드하거나 지정하게 한 뒤, 편집된 결과를 생성해 주세요."
         }
-      }
+      },
+      "description": "질문을 하거나, 로컬 작업을 이어가거나, 새 스레드를 시작할 수 있습니다."
     },
     "header": {
-      "toggleSidebar": "사이드바 전환"
+      "toggleSidebar": "사이드바 전환",
+      "newChat": "새 채팅 시작",
+      "toggleTheme": "헤더에서 테마 전환",
+      "settings": "설정 열기"
     },
     "composer": {
       "placeholderThread": "메시지를 입력하세요…",
@@ -339,6 +390,7 @@
       "goalStateFallback": "목표",
       "goalStateExpandAria": "전체 목표 보기",
       "goalStateSheetTitle": "목표",
+      "goalStateCloseAria": "목표 닫기",
       "send": "메시지 보내기",
       "stop": "응답 중지",
       "attachImage": "이미지 첨부",
@@ -357,16 +409,11 @@
           "16_9": "와이드 16:9"
         }
       },
-      "encoding": "처리 중…",
-      "remove": "첨부 제거",
-      "normalizedSizeHint": "{{orig}} → {{current}} (자동 압축)",
-      "imageRejected": {
-        "unsupported_type": "지원하지 않는 파일 형식입니다",
-        "too_many_images": "메시지당 최대 {{max}}장까지 가능합니다",
-        "magic_mismatch": "이미지 파일이 아닌 것 같습니다",
-        "decode_failed": "이 이미지를 디코딩할 수 없습니다",
-        "too_large": "이미지가 너무 큽니다. 더 작은 걸로 시도해 주세요",
-        "io": "이 파일을 읽을 수 없습니다"
+      "tools": {
+        "search": "검색",
+        "reason": "추론",
+        "deepResearch": "심층 조사",
+        "voice": "음성 입력"
       },
       "slash": {
         "ariaLabel": "슬래시 명령",
@@ -417,7 +464,17 @@
           }
         }
       },
-      "goalStateCloseAria": "목표 닫기"
+      "encoding": "처리 중…",
+      "remove": "첨부 제거",
+      "normalizedSizeHint": "{{orig}} → {{current}} (자동 압축)",
+      "imageRejected": {
+        "unsupported_type": "지원하지 않는 파일 형식입니다",
+        "too_many_images": "메시지당 최대 {{max}}장까지 가능합니다",
+        "magic_mismatch": "이미지 파일이 아닌 것 같습니다",
+        "decode_failed": "이 이미지를 디코딩할 수 없습니다",
+        "too_large": "이미지가 너무 큽니다. 더 작은 걸로 시도해 주세요",
+        "io": "이 파일을 읽을 수 없습니다"
+      }
     },
     "scrollToBottom": "맨 아래로 스크롤",
     "loadEarlier": "이전 메시지 불러오기"
@@ -439,6 +496,8 @@
     "agentActivityLiveSummary": "진행 중… · {{reasoning}}단계 · 도구 호출 {{tools}}회",
     "agentActivityLiveToolsOnly": "진행 중… · 도구 호출 {{tools}}회",
     "imageAttachment": "이미지 첨부",
+    "copyReply": "답변 복사",
+    "copiedReply": "답변이 복사됨",
     "turnLatencyTitle": "응답 시간(엔드투엔드)"
   },
   "lightbox": {

--- a/webui/src/i18n/locales/ko/common.json
+++ b/webui/src/i18n/locales/ko/common.json
@@ -273,6 +273,7 @@
     "fallbackTitle": "채팅 {{id}}",
     "loading": "불러오는 중…",
     "noSessions": "아직 세션이 없습니다.",
+    "showMore": "{{count}}개 더 보기",
     "actions": "{{title}} 채팅 작업",
     "activity": {
       "running": "Agent running",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -273,6 +273,7 @@
     "fallbackTitle": "Trò chuyện {{id}}",
     "loading": "Đang tải…",
     "noSessions": "Chưa có phiên nào.",
+    "showMore": "Hiển thị thêm {{count}}",
     "actions": "Tác vụ cho cuộc trò chuyện {{title}}",
     "activity": {
       "running": "Agent running",

--- a/webui/src/i18n/locales/vi/common.json
+++ b/webui/src/i18n/locales/vi/common.json
@@ -9,6 +9,18 @@
       "title": "Không thể kết nối tới nanobot",
       "gatewayHint": "Hãy chắc chắn gateway đang chạy (`nanobot gateway`) và trang này được mở trên cùng máy."
     },
+    "auth": {
+      "title": "Cần xác thực",
+      "hint": "Nhập secret được cấu hình là tokenIssueSecret trong cấu hình gateway.",
+      "placeholder": "Mật khẩu",
+      "submit": "Kết nối",
+      "invalid": "Mật khẩu không hợp lệ. Hãy thử lại."
+    },
+    "account": {
+      "section": "Tài khoản",
+      "logoutHint": "Ngắt kết nối trình duyệt này khỏi gateway.",
+      "logout": "Đăng xuất"
+    },
     "system": {
       "section": "Hệ thống",
       "restartHint": "Khởi động lại nanobot để áp dụng thay đổi runtime.",
@@ -27,9 +39,13 @@
     }
   },
   "sidebar": {
+    "navigation": "Điều hướng thanh bên",
+    "globalActions": "Hành động toàn cục",
     "collapse": "Thu gọn thanh bên",
     "toggleTheme": "Chuyển giao diện",
+    "home": "Trang chủ",
     "newChat": "Cuộc trò chuyện mới",
+    "searchAria": "Tìm kiếm",
     "viewOptions": "View",
     "compactList": "Compact list",
     "showPreviews": "Show previews",
@@ -38,17 +54,16 @@
     "sortUpdated": "Recently updated",
     "sortCreated": "Recently created",
     "sortTitle": "Title A-Z",
+    "searchPlaceholder": "Tìm kiếm",
+    "searchResults": "Kết quả",
+    "noSearchResults": "Không có cuộc trò chuyện phù hợp.",
     "recent": "Gần đây",
     "refreshSessions": "Làm mới phiên",
     "settings": "Cài đặt",
     "language": {
       "label": "Ngôn ngữ",
       "ariaLabel": "Đổi ngôn ngữ"
-    },
-    "searchAria": "Tìm kiếm",
-    "searchPlaceholder": "Tìm kiếm",
-    "searchResults": "Kết quả",
-    "noSearchResults": "Không có cuộc trò chuyện phù hợp."
+    }
   },
   "settings": {
     "backToChat": "Quay lại trò chuyện",
@@ -75,10 +90,13 @@
       "status": "Status",
       "localPreferences": "Local preferences",
       "presets": "Presets",
+      "imageGeneration": "Tạo ảnh",
+      "imageDefaults": "Mặc định",
       "webSearch": "Web search",
       "webBehavior": "Behavior",
       "identity": "Identity",
       "safety": "Safety",
+      "capabilities": "Khả năng",
       "integrations": "Integrations"
     },
     "rows": {
@@ -91,6 +109,7 @@
       "activePreset": "Active preset",
       "gateway": "Gateway",
       "restartState": "Restart state",
+      "pendingChanges": "Thay đổi đang chờ",
       "selectedPreset": "Selected preset",
       "presetModel": "Preset model",
       "density": "Density",
@@ -99,6 +118,15 @@
       "maxResults": "Max results",
       "timeout": "Timeout",
       "jinaReader": "Jina reader",
+      "imageGeneration": "Tạo ảnh",
+      "imageProvider": "Nhà cung cấp ảnh",
+      "imageProviderStatus": "Trạng thái nhà cung cấp",
+      "imageProviderBase": "Cơ sở nhà cung cấp",
+      "imageModel": "Mô hình ảnh",
+      "defaultAspectRatio": "Tỷ lệ mặc định",
+      "defaultImageSize": "Kích thước mặc định",
+      "maxImagesPerTurn": "Số ảnh tối đa mỗi lượt",
+      "imageSaveDir": "Thư mục lưu",
       "botName": "Bot name",
       "botIcon": "Bot icon",
       "timezone": "Timezone",
@@ -129,6 +157,13 @@
       "maxResults": "Results returned by each web_search call.",
       "timeout": "Seconds before a search provider request times out.",
       "jinaReader": "Use Jina Reader for web_fetch when available.",
+      "imageGeneration": "Hiển thị generate_image trong chat khi có nhà cung cấp ảnh đã cấu hình.",
+      "imageProvider": "Chọn nhà cung cấp registry được generate_image sử dụng.",
+      "imageProviderStatus": "Tạo ảnh dùng lại thông tin xác thực nhà cung cấp từ Providers.",
+      "imageModel": "Tên mô hình gửi tới nhà cung cấp ảnh đã chọn.",
+      "defaultAspectRatio": "Được dùng khi prompt không chọn tỷ lệ khung hình.",
+      "defaultImageSize": "Gợi ý kích thước gửi tới các nhà cung cấp hỗ trợ.",
+      "maxImagesPerTurn": "Giới hạn trên cho một yêu cầu generate_image.",
       "botName": "Shown in runtime surfaces that use the configured bot identity.",
       "botIcon": "Short emoji or text shown beside the bot name.",
       "timezone": "IANA timezone used by runtime context and schedules.",
@@ -141,8 +176,8 @@
       "notAvailable": "Không khả dụng",
       "enabled": "Enabled",
       "disabled": "Disabled",
-      "restartRequired": "Restart required",
-      "liveReload": "Live reload ready",
+      "restartPending": "Đang chờ khởi động lại",
+      "ready": "Sẵn sàng",
       "comfortable": "Comfortable",
       "compact": "Compact",
       "auto": "Auto",
@@ -150,13 +185,19 @@
       "on": "On",
       "off": "Off",
       "configured": "Configured",
-      "notConfigured": "Not configured"
+      "notConfigured": "Not configured",
+      "restartRequired": "Restart required",
+      "liveReload": "Live reload ready"
     },
     "status": {
       "loading": "Đang tải cài đặt...",
       "loadError": "Không thể tải cài đặt",
       "unsaved": "Có thay đổi chưa lưu.",
-      "savedRestart": "Đã lưu. Khởi động lại nanobot để áp dụng."
+      "upToDate": "Đã cập nhật.",
+      "savedRestart": "Đã lưu. Khởi động lại nanobot để áp dụng.",
+      "restartAfterSaving": "Lưu thay đổi, rồi khởi động lại khi sẵn sàng.",
+      "savedRestartApply": "Đã lưu. Khởi động lại khi sẵn sàng.",
+      "imageProviderRestart": "Đã lưu thay đổi nhà cung cấp ảnh. Khởi động lại khi sẵn sàng."
     },
     "actions": {
       "save": "Lưu",
@@ -213,18 +254,25 @@
       "configuredCount": "{{count}} configured",
       "totalProviders": "{{count}} available",
       "webSearch": "Web search",
+      "imageGeneration": "Tạo ảnh",
       "workspace": "Workspace"
     },
     "providers": {
       "searchPlaceholder": "Search providers",
       "noMatches": "No providers match this search."
+    },
+    "image": {
+      "selectProvider": "Chọn nhà cung cấp",
+      "selectAspect": "Chọn tỷ lệ",
+      "selectSize": "Chọn kích thước",
+      "configureProvider": "Cấu hình nhà cung cấp",
+      "missingCredential": "Cấu hình nhà cung cấp này trước khi bật tạo ảnh."
     }
   },
   "chat": {
     "fallbackTitle": "Trò chuyện {{id}}",
     "loading": "Đang tải…",
     "noSessions": "Chưa có phiên nào.",
-    "showMore": "Hiển thị thêm {{count}}",
     "actions": "Tác vụ cho cuộc trò chuyện {{title}}",
     "activity": {
       "running": "Agent running",
@@ -269,7 +317,6 @@
   "thread": {
     "loadingConversation": "Đang tải cuộc trò chuyện…",
     "empty": {
-      "description": "Hãy đặt câu hỏi, tiếp tục công việc cục bộ hoặc bắt đầu một luồng mới.",
       "greeting": "Tôi có thể giúp gì cho bạn?",
       "quickActions": {
         "plan": {
@@ -322,10 +369,14 @@
           "title": "Chỉnh sửa ảnh",
           "prompt": "Giúp tôi chỉnh sửa một ảnh. Trước tiên hãy yêu cầu tôi tải lên hoặc chỉ định ảnh, rồi tạo kết quả đã chỉnh sửa."
         }
-      }
+      },
+      "description": "Hãy đặt câu hỏi, tiếp tục công việc cục bộ hoặc bắt đầu một luồng mới."
     },
     "header": {
-      "toggleSidebar": "Bật/tắt thanh bên"
+      "toggleSidebar": "Bật/tắt thanh bên",
+      "newChat": "Bắt đầu chat mới",
+      "toggleTheme": "Chuyển chủ đề từ header",
+      "settings": "Mở cài đặt"
     },
     "composer": {
       "placeholderThread": "Nhập tin nhắn…",
@@ -339,6 +390,7 @@
       "goalStateFallback": "Mục tiêu",
       "goalStateExpandAria": "Xem đầy đủ mục tiêu",
       "goalStateSheetTitle": "Mục tiêu",
+      "goalStateCloseAria": "Đóng mục tiêu",
       "send": "Gửi tin nhắn",
       "stop": "Dừng phản hồi",
       "attachImage": "Đính kèm ảnh",
@@ -357,16 +409,11 @@
           "16_9": "Rộng 16:9"
         }
       },
-      "encoding": "Đang xử lý…",
-      "remove": "Xóa tệp đính kèm",
-      "normalizedSizeHint": "{{orig}} → {{current}} (tự động)",
-      "imageRejected": {
-        "unsupported_type": "Loại tệp không được hỗ trợ",
-        "too_many_images": "Tối đa {{max}} ảnh mỗi tin nhắn",
-        "magic_mismatch": "Tệp này không phải là một ảnh thực",
-        "decode_failed": "Không thể giải mã ảnh này",
-        "too_large": "Ảnh quá lớn — hãy thử ảnh nhỏ hơn",
-        "io": "Không thể đọc tệp này"
+      "tools": {
+        "search": "Tìm kiếm",
+        "reason": "Suy luận",
+        "deepResearch": "Nghiên cứu sâu",
+        "voice": "Nhập bằng giọng nói"
       },
       "slash": {
         "ariaLabel": "Lệnh slash",
@@ -417,7 +464,17 @@
           }
         }
       },
-      "goalStateCloseAria": "Đóng mục tiêu"
+      "encoding": "Đang xử lý…",
+      "remove": "Xóa tệp đính kèm",
+      "normalizedSizeHint": "{{orig}} → {{current}} (tự động)",
+      "imageRejected": {
+        "unsupported_type": "Loại tệp không được hỗ trợ",
+        "too_many_images": "Tối đa {{max}} ảnh mỗi tin nhắn",
+        "magic_mismatch": "Tệp này không phải là một ảnh thực",
+        "decode_failed": "Không thể giải mã ảnh này",
+        "too_large": "Ảnh quá lớn — hãy thử ảnh nhỏ hơn",
+        "io": "Không thể đọc tệp này"
+      }
     },
     "scrollToBottom": "Cuộn xuống cuối",
     "loadEarlier": "Tải tin nhắn trước đó"
@@ -439,6 +496,8 @@
     "agentActivityLiveSummary": "Đang chạy… · {{reasoning}} bước · {{tools}} lần gọi công cụ",
     "agentActivityLiveToolsOnly": "Đang chạy… · {{tools}} lần gọi công cụ",
     "imageAttachment": "Tệp hình ảnh đính kèm",
+    "copyReply": "Sao chép trả lời",
+    "copiedReply": "Đã sao chép trả lời",
     "turnLatencyTitle": "Thời gian phản hồi (end-to-end)"
   },
   "lightbox": {


### PR DESCRIPTION
## Summary

- Fill missing WebUI locale keys for `es`, `fr`, `id`, `ko`, and `vi`.
- Cover the same auth/account, sidebar, image generation settings, thread controls, composer tools, and reply copy strings recently added to the English baseline.
- Preserve existing locale-only keys while aligning the updated locale structure with `en/common.json`.

## Validation

- JSON parse check for all five updated locale files
- Locale completeness check against `en/common.json`: `es`, `fr`, `id`, `ko`, and `vi` all report `missing=0`
- `git diff --check`
- `npm ci --ignore-scripts --no-audit --no-fund --prefer-offline`
- `npm run build`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test` (20 files, 174 tests)

## Notes

- `npm run lint` could not start because the script references `eslint`, but `eslint` is not declared in `webui/package.json` and there is no ESLint config file in the checkout.
- Running tests under the default `/opt/homebrew/bin/node` (`v25.9.0`) exposes Node's experimental `localStorage` object without `setItem`, which breaks the happy-dom setup. Pinning validation to Node 22 resolves it.
