### PR TITLE
test(cli): cover CLI Apps on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","windows-latest"]') }}
+        os: ${{ fromJSON('["ubuntu-latest","windows-latest"]') }}
         # CI concentrates on newer runtimes (3.11/3.12 still supported per pyproject requires-python).
         python-version: ${{ fromJSON('["3.13","3.14"]') }}
 

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import stat
 import subprocess
 import sys
 import time
@@ -341,17 +339,22 @@ def test_run_installed_cli_uses_argv_without_shell(
 ) -> None:
     manager = _manager(tmp_path)
     _seed_catalog(manager)
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    cli = bin_dir / "cli-anything-gimp"
-    cli.write_text(
-        "#!/usr/bin/env python3\n"
-        "import sys\n"
-        "print('ARGS=' + repr(sys.argv[1:]))\n",
-        encoding="utf-8",
+    resolved = str(tmp_path / "bin" / "cli-anything-gimp")
+    monkeypatch.setattr(
+        "nanobot.cli_apps.service.shutil.which",
+        lambda entry: resolved if entry == "cli-anything-gimp" else None,
     )
-    cli.chmod(cli.stat().st_mode | stat.S_IEXEC)
-    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    def fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert "shell" not in kwargs or kwargs["shell"] is False
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="ARGS=" + repr(argv[1:]),
+            stderr="",
+        )
+
+    monkeypatch.setattr("nanobot.cli_apps.service.subprocess.run", fake_run)
     manager._save_installed(
         {
             "gimp": {

--- a/tests/cli_apps/test_tool.py
+++ b/tests/cli_apps/test_tool.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import stat
+import subprocess
 import time
 from pathlib import Path
 
@@ -45,17 +44,22 @@ def test_run_cli_app_uses_installed_registry_app(
     CliAppManager(workspace=workspace, data_dir=data_dir)._save_installed(
         {"gimp": {"entry_point": "cli-anything-gimp"}}
     )
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    cli = bin_dir / "cli-anything-gimp"
-    cli.write_text(
-        "#!/usr/bin/env python3\n"
-        "import sys\n"
-        "print('tool:' + ' '.join(sys.argv[1:]))\n",
-        encoding="utf-8",
+    resolved = str(tmp_path / "bin" / "cli-anything-gimp")
+    monkeypatch.setattr(
+        "nanobot.cli_apps.service.shutil.which",
+        lambda entry: resolved if entry == "cli-anything-gimp" else None,
     )
-    cli.chmod(cli.stat().st_mode | stat.S_IEXEC)
-    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    def fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert "shell" not in kwargs or kwargs["shell"] is False
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="tool:" + " ".join(argv[1:]),
+            stderr="",
+        )
+
+    monkeypatch.setattr("nanobot.cli_apps.service.subprocess.run", fake_run)
     monkeypatch.setattr("nanobot.cli_apps.service.get_runtime_subdir", lambda _name: data_dir)
 
     tool = CliAppsTool(


### PR DESCRIPTION
## Summary
- Make CLI Apps runner tests platform-neutral by mocking `shutil.which` and `subprocess.run` instead of relying on Unix shebang/chmod behavior.
- Run the main test workflow on Windows for pull requests as well as pushes, so Windows-only regressions are caught before merge.

## Why
The merged CLI Apps tests created extensionless executable files and relied on shebang + chmod. That works on Linux/macOS, but Windows PATH resolution requires executable extensions such as `.exe`, `.cmd`, or `.bat`, so `shutil.which("cli-anything-gimp")` returned `None` on Windows.

## Validation
- `python3 -m pytest tests/cli_apps -q` (`17 passed`)
- `python3 -m compileall -q tests/cli_apps nanobot/cli_apps`
- `git diff --check`

Note: local shell does not have `uv` or `ruff` installed, so full CI validation is delegated to GitHub Actions.
