### PR TITLE
fix: uncap exec config timeout and normalize transcription apiBase (#3595, #3637)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -956,7 +956,7 @@ Global settings that apply to all channels. Configure under the `channels` secti
 | `sendToolHints` | `false` | Stream tool-call hints (e.g. `read_file("…")`) |
 | `showReasoning` | `true` | Allow channels to surface model reasoning/thinking content (DeepSeek-R1 `reasoning_content`, Anthropic `thinking_blocks`, inline `<think>` tags). Reasoning flows as a dedicated stream with `_reasoning_delta` / `_reasoning_end` markers — channels override `send_reasoning_delta` / `send_reasoning_end` to render in-place updates. Even with `true`, channels without those overrides stay no-op silently. Currently surfaced on CLI and WebSocket/WebUI (italic shimmer header, auto-collapses after the stream ends); Telegram / Slack / Discord / Feishu / WeChat / Matrix keep the base no-op until their bubble UI is adapted. Independent of `sendProgress`. |
 | `sendMaxRetries` | `3` | Max delivery attempts per outbound message, including the initial send (0-10 configured, minimum 1 actual attempt) |
-| `transcriptionProvider` | `"groq"` | Voice transcription backend: `"groq"` (free tier, default) or `"openai"`. API key is auto-resolved from the matching provider config. |
+| `transcriptionProvider` | `"groq"` | Voice transcription backend: `"groq"` (free tier, default) or `"openai"`. API key and optional `apiBase` are auto-resolved from the matching provider config. Chat-style bases such as `https://api.groq.com/openai/v1` are normalized to the audio transcription endpoint. |
 | `transcriptionLanguage` | `null` | Optional ISO-639-1 language hint for audio transcription, e.g. `"en"`, `"ko"`, `"ja"`. |
 
 `sendProgress` and `sendToolHints` can also be overridden per channel. The
@@ -1288,6 +1288,7 @@ For API keys, tokens, and other secrets, see [Environment Variables for Secrets]
 | `tools.restrictToWorkspace` | `false` | When `true`, restricts **all** agent tools (shell, file read/write/edit, list) to the workspace directory. Prevents path traversal and out-of-scope access. |
 | `tools.exec.sandbox` | `""` | Sandbox backend for shell commands. Set to `"bwrap"` to wrap exec calls in a [bubblewrap](https://github.com/containers/bubblewrap) sandbox — the process can only see the workspace (read-write) and media directory (read-only); config files and API keys are hidden. Automatically enables `restrictToWorkspace` for file tools. **Linux only** — requires `bwrap` installed (`apt install bubblewrap`; pre-installed in the Docker image). Not available on macOS or Windows (bwrap depends on Linux kernel namespaces). |
 | `tools.exec.enable` | `true` | When `false`, the shell `exec` tool is not registered at all. Use this to completely disable shell command execution. |
+| `tools.exec.timeout` | `60` | Default hard timeout in seconds for shell commands. Config values may exceed the per-call tool cap; set `0` to disable the hard timeout for trusted long-running commands. |
 | `tools.exec.pathAppend` | `""` | Extra directories to append to `PATH` when running shell commands (e.g. `/usr/sbin` for `ufw`). |
 | `channels.*.allowFrom` | omitted | Access control per channel. Omit to use pairing-only mode; set `["*"]` to allow everyone; or list specific user IDs. See [Pairing](#pairing) for details. |
 

--- a/nanobot/agent/tools/exec_session.py
+++ b/nanobot/agent/tools/exec_session.py
@@ -53,14 +53,15 @@ class _ExecSession:
         process: asyncio.subprocess.Process,
         command: str,
         cwd: str,
-        timeout: int,
+        timeout: int | None,
     ) -> None:
         self.session_id = session_id
         self.process = process
         self.command = command
         self.cwd = cwd
         self.started_at = time.monotonic()
-        self.deadline = time.monotonic() + timeout
+        # timeout None/0 means no limit; an infinite deadline is never reached.
+        self.deadline = time.monotonic() + timeout if timeout else float("inf")
         self.last_access = time.monotonic()
         self._chunks: list[str] = []
         self._lock = asyncio.Lock()
@@ -169,7 +170,7 @@ class ExecSessionManager:
         command: str,
         cwd: str,
         env: dict[str, str],
-        timeout: int,
+        timeout: int | None,
         shell_program: str | None,
         login: bool,
         yield_time_ms: int,

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -46,7 +46,7 @@ _WORKSPACE_BOUNDARY_NOTE = (
 class ExecToolConfig(Base):
     """Shell exec tool configuration."""
     enable: bool = True
-    timeout: int = 60
+    timeout: int = Field(default=60, ge=0)  # Hard timeout (s); 0 = no limit. Not capped by the per-call max.
     path_append: str = ""
     sandbox: str = ""
     allowed_env_keys: list[str] = Field(default_factory=list)
@@ -59,7 +59,7 @@ class _PreparedCommand:
     command: str
     cwd: str
     env: dict[str, str]
-    timeout: int
+    timeout: int | None
     shell_program: str | None
     login: bool
 
@@ -324,6 +324,20 @@ class ExecTool(Tool):
         except Exception as exc:
             return f"Error executing command: {exc}"
 
+    def _resolve_timeout(self, timeout: int | None) -> int | None:
+        """Resolve the effective hard timeout in seconds (None = no limit).
+
+        A per-call timeout supplied by the model stays capped at _MAX_TIMEOUT so
+        the LLM cannot request unbounded execution. The config-level default
+        (self.timeout) may exceed that cap, and 0 disables the limit entirely
+        for trusted long-running tasks (#3595).
+        """
+        if timeout:
+            return min(timeout, self._MAX_TIMEOUT)
+        if self.timeout and self.timeout > 0:
+            return self.timeout
+        return None
+
     def _prepare_command(
         self,
         command: str,
@@ -369,7 +383,7 @@ class ExecTool(Tool):
                 command = wrap_command(self.sandbox, command, workspace, cwd)
                 cwd = str(Path(workspace).resolve())
 
-        effective_timeout = min(timeout or self.timeout, self._MAX_TIMEOUT)
+        effective_timeout = self._resolve_timeout(timeout)
         env = self._build_env()
 
         if self.path_append:

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -7,6 +7,25 @@ from pathlib import Path
 import httpx
 from loguru import logger
 
+_TRANSCRIPTIONS_PATH = "audio/transcriptions"
+
+
+def _resolve_transcription_url(api_base: str | None, default_url: str) -> str:
+    """Resolve the full transcription endpoint URL.
+
+    Accepts either a chat-style base (e.g. ``https://api.groq.com/openai/v1``)
+    or a complete URL already ending in ``/audio/transcriptions``. A chat-style
+    base — the form users naturally copy from their LLM provider config — gets
+    the path appended instead of being POSTed verbatim and 404ing (#3637).
+    """
+    if not api_base:
+        return default_url
+    base = api_base.rstrip("/")
+    if base.endswith(_TRANSCRIPTIONS_PATH):
+        return base
+    return f"{base}/{_TRANSCRIPTIONS_PATH}"
+
+
 # Up to 3 retries (4 attempts total) with exponential backoff on transient
 # failures. Whisper endpoints occasionally return 502/503 under load, and
 # mobile-network transcription callers hit sporadic connect/read errors.
@@ -127,12 +146,12 @@ class OpenAITranscriptionProvider:
         language: str | None = None,
     ):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
-        self.api_url = (
-            api_base
-            or os.environ.get("OPENAI_TRANSCRIPTION_BASE_URL")
-            or "https://api.openai.com/v1/audio/transcriptions"
+        self.api_url = _resolve_transcription_url(
+            api_base or os.environ.get("OPENAI_TRANSCRIPTION_BASE_URL"),
+            "https://api.openai.com/v1/audio/transcriptions",
         )
         self.language = language or None
+        logger.debug("OpenAI transcription endpoint: {}", self.api_url)
 
     async def transcribe(self, file_path: str | Path) -> str:
         if not self.api_key:
@@ -166,12 +185,12 @@ class GroqTranscriptionProvider:
         language: str | None = None,
     ):
         self.api_key = api_key or os.environ.get("GROQ_API_KEY")
-        self.api_url = (
-            api_base
-            or os.environ.get("GROQ_BASE_URL")
-            or "https://api.groq.com/openai/v1/audio/transcriptions"
+        self.api_url = _resolve_transcription_url(
+            api_base or os.environ.get("GROQ_BASE_URL"),
+            "https://api.groq.com/openai/v1/audio/transcriptions",
         )
         self.language = language or None
+        logger.debug("Groq transcription endpoint: {}", self.api_url)
 
     async def transcribe(self, file_path: str | Path) -> str:
         """

--- a/tests/providers/test_transcription.py
+++ b/tests/providers/test_transcription.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from nanobot.providers.transcription import GroqTranscriptionProvider, OpenAITranscriptionProvider
+from nanobot.providers.transcription import (
+    GroqTranscriptionProvider,
+    OpenAITranscriptionProvider,
+    _resolve_transcription_url,
+)
 
 
 @pytest.fixture
@@ -290,3 +294,37 @@ async def test_retries_on_every_advertised_transient_exception(
         result = await provider.transcribe(audio_file)
     assert result == "recovered"
     assert post.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# apiBase normalization (#3637): a chat-style base must not be POSTed verbatim
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_transcription_url_falls_back_to_default() -> None:
+    default = "https://api.openai.com/v1/audio/transcriptions"
+    assert _resolve_transcription_url(None, default) == default
+    assert _resolve_transcription_url("", default) == default
+
+
+def test_resolve_transcription_url_appends_path_to_chat_style_base() -> None:
+    assert (
+        _resolve_transcription_url("https://api.groq.com/openai/v1", "https://x/audio/transcriptions")
+        == "https://api.groq.com/openai/v1/audio/transcriptions"
+    )
+    # Trailing slash must not produce a doubled separator.
+    assert (
+        _resolve_transcription_url("https://api.groq.com/openai/v1/", "https://x/audio/transcriptions")
+        == "https://api.groq.com/openai/v1/audio/transcriptions"
+    )
+
+
+def test_resolve_transcription_url_keeps_full_endpoint() -> None:
+    full = "https://api.groq.com/openai/v1/audio/transcriptions"
+    assert _resolve_transcription_url(full, "https://x/audio/transcriptions") == full
+
+
+def test_groq_provider_normalizes_chat_style_api_base() -> None:
+    """Regression for #3637: apiBase set to the v1 base resolves to the audio endpoint."""
+    provider = GroqTranscriptionProvider(api_key="gsk-test", api_base="https://api.groq.com/openai/v1")
+    assert provider.api_url == "https://api.groq.com/openai/v1/audio/transcriptions"

--- a/tests/tools/test_tool_validation.py
+++ b/tests/tools/test_tool_validation.py
@@ -4,6 +4,7 @@ import sys
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from nanobot.agent.tools import (
     ArraySchema,
@@ -16,7 +17,7 @@ from nanobot.agent.tools import (
 )
 from nanobot.agent.tools.base import Tool
 from nanobot.agent.tools.registry import ToolRegistry
-from nanobot.agent.tools.shell import ExecTool
+from nanobot.agent.tools.shell import ExecTool, ExecToolConfig
 from nanobot.security.network import configure_ssrf_whitelist
 
 
@@ -661,6 +662,26 @@ async def test_exec_timeout_capped_at_max() -> None:
     # Should not raise — just clamp to 600
     result = await tool.execute(command="echo ok", timeout=9999)
     assert "Exit code: 0" in result
+
+
+def test_exec_config_timeout_uncapped_and_zero() -> None:
+    """Config timeout is no longer capped at 600 and accepts 0 = no limit (#3595)."""
+    assert ExecToolConfig(timeout=0).timeout == 0
+    assert ExecToolConfig(timeout=3600).timeout == 3600
+    with pytest.raises(ValidationError):
+        ExecToolConfig(timeout=-1)
+
+
+def test_resolve_timeout_config_uncapped_and_unlimited() -> None:
+    """Config timeout drives the hard timeout uncapped; 0 means no limit (#3595)."""
+    assert ExecTool(timeout=3600)._resolve_timeout(None) == 3600
+    assert ExecTool(timeout=0)._resolve_timeout(None) is None
+
+
+def test_resolve_timeout_per_call_still_capped() -> None:
+    """Per-call (LLM) timeout stays capped at _MAX_TIMEOUT even with unlimited config."""
+    assert ExecTool(timeout=0)._resolve_timeout(9999) == ExecTool._MAX_TIMEOUT
+    assert ExecTool(timeout=60)._resolve_timeout(120) == 120
 
 
 # --- _resolve_type and nullable param tests ---


### PR DESCRIPTION
- **exec timeout** (Closes #3595): decouple `tools.exec.timeout` from the per-call cap — config timeout may
   exceed 600s or be `0` for no limit; model-supplied per-call timeout stays capped at 600.

- **transcription apiBase** (Closes #3637): a chat-style `apiBase` (e.g. `https://api.groq.com/openai/v1`)
  was POSTed verbatim and 404'd; now `/audio/transcriptions` is appended when missing (Groq + OpenAI).