### PR TITLE
feat(command): add /skill slash command to list enabled skills

### DIFF
--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -15,6 +15,7 @@ These commands work inside chat channels and interactive agent sessions:
 | `/dream-log <sha>` | Show a specific Dream memory change |
 | `/dream-restore` | List recent Dream memory versions |
 | `/dream-restore <sha>` | Restore memory to the state before a specific change |
+| `/skill` | List enabled skills and their descriptions |
 | `/pairing` | List pending pairing requests |
 | `/pairing approve <code>` | Approve a pairing code |
 | `/pairing deny <code>` | Deny a pending pairing request |

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -264,6 +264,7 @@ class TelegramChannel(BaseChannel):
         BotCommand("goal", "Start a sustained objective (long-running task)"),
         BotCommand("pairing", "Manage DM pairing (approve/deny/list)"),
         BotCommand("model", "Switch runtime model preset"),
+        BotCommand("skill", "List enabled skills"),
         BotCommand("dream", "Run Dream memory consolidation now"),
         BotCommand("dream_log", "Show the latest Dream memory change"),
         BotCommand("dream_restore", "Restore Dream memory to an earlier version"),
@@ -273,7 +274,7 @@ class TelegramChannel(BaseChannel):
     # Regex for slash commands routed to AgentLoop via ``_forward_command``.
     # Hyphenated ``dream-*`` commands stay on a separate handler (below).
     TELEGRAM_BUS_SLASH_COMMAND_RE = re.compile(
-        r"^/(?:new|stop|restart|status|dream|history|goal|pairing|model)(?:@\w+)?(?:\s+.*)?$"
+        r"^/(?:new|stop|restart|status|dream|history|goal|pairing|model|skill)(?:@\w+)?(?:\s+.*)?$"
     )
 
     @classmethod

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -99,6 +99,12 @@ BUILTIN_COMMAND_SPECS: tuple[BuiltinCommandSpec, ...] = (
         "undo-2",
     ),
     BuiltinCommandSpec(
+        "/skill",
+        "List skills",
+        "List all enabled skills available to the agent.",
+        "wrench",
+    ),
+    BuiltinCommandSpec(
         "/help",
         "Show help",
         "List available slash commands.",
@@ -607,6 +613,25 @@ async def cmd_pairing(ctx: CommandContext) -> OutboundMessage:
     )
 
 
+async def cmd_skill(ctx: CommandContext) -> OutboundMessage:
+    """List all enabled skills (name and description only)."""
+    loop = ctx.loop
+    skills = loop.context.skills.list_skills(filter_unavailable=False)
+    if not skills:
+        content = "No skills available."
+    else:
+        lines = [f"Available skills ({len(skills)}):", ""]
+        for entry in skills:
+            desc = loop.context.skills._get_skill_description(entry["name"])
+            lines.append(f"- **{entry['name']}** — {desc}")
+        content = "\n".join(lines)
+    return OutboundMessage(
+        channel=ctx.msg.channel,
+        chat_id=ctx.msg.chat_id,
+        content=content,
+        metadata=dict(ctx.msg.metadata or {}),
+    )
+
 async def cmd_help(ctx: CommandContext) -> OutboundMessage:
     """Return available slash commands."""
     return OutboundMessage(
@@ -646,6 +671,7 @@ def register_builtin_commands(router: CommandRouter) -> None:
     router.prefix("/dream-log ", cmd_dream_log)
     router.exact("/dream-restore", cmd_dream_restore)
     router.prefix("/dream-restore ", cmd_dream_restore)
+    router.exact("/skill", cmd_skill)
     router.exact("/help", cmd_help)
     router.exact("/pairing", cmd_pairing)
     router.prefix("/pairing ", cmd_pairing)

--- a/tests/channels/test_telegram_channel.py
+++ b/tests/channels/test_telegram_channel.py
@@ -197,6 +197,7 @@ async def test_start_creates_separate_pools_with_proxy(monkeypatch) -> None:
     assert callable(app.updater.start_polling_kwargs["error_callback"])
     assert any(cmd.command == "status" for cmd in app.bot.commands)
     assert any(cmd.command == "history" for cmd in app.bot.commands)
+    assert any(cmd.command == "skill" for cmd in app.bot.commands)
     assert any(cmd.command == "dream" for cmd in app.bot.commands)
     assert any(cmd.command == "dream_log" for cmd in app.bot.commands)
     assert any(cmd.command == "dream_restore" for cmd in app.bot.commands)
@@ -1302,6 +1303,8 @@ def test_telegram_bus_slash_command_regex_matches_agent_loop_commands() -> None:
     assert pat.fullmatch("/goal ship the feature")
     assert pat.fullmatch("/pairing list")
     assert pat.fullmatch("/model fast")
+    assert pat.fullmatch("/skill")
+    assert pat.fullmatch("/skill@nanobot_bot")
     assert pat.fullmatch("/new@nanobot_bot")
     assert pat.fullmatch("/goal@nanobot_bot refine objective")
     assert pat.fullmatch("/dream-log deadbeef") is None
@@ -1323,6 +1326,7 @@ async def test_on_help_includes_restart_command() -> None:
     help_text = update.message.reply_text.await_args.args[0]
     assert "/restart" in help_text
     assert "/status" in help_text
+    assert "/skill" in help_text
     assert "/dream" in help_text
     assert "/dream-log" in help_text
     assert "/goal" in help_text

--- a/tests/command/test_skill_command.py
+++ b/tests/command/test_skill_command.py
@@ -1,0 +1,138 @@
+"""Tests for the /skill built-in command."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot.agent.loop import AgentLoop
+from nanobot.agent.skills import SkillsLoader
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.command.builtin import cmd_skill, register_builtin_commands
+from nanobot.command.router import CommandContext, CommandRouter
+from nanobot.config.schema import ModelPresetConfig
+
+
+def _provider(default_model: str = "test-model") -> MagicMock:
+    provider = MagicMock()
+    provider.get_default_model.return_value = default_model
+    provider.generation = MagicMock()
+    provider.generation.max_tokens = 4096
+    provider.generation.temperature = 0.1
+    provider.generation.reasoning_effort = None
+    return provider
+
+
+def _make_loop(tmp_path: Path) -> AgentLoop:
+    return AgentLoop(
+        bus=MessageBus(),
+        provider=_provider(),
+        workspace=tmp_path,
+        model="test-model",
+        context_window_tokens=8000,
+        model_presets={
+            "default": ModelPresetConfig(
+                model="test-model",
+                max_tokens=4096,
+                context_window_tokens=8000,
+            ),
+        },
+    )
+
+
+def _ctx(loop: AgentLoop, raw: str = "/skill") -> CommandContext:
+    msg = InboundMessage(channel="cli", sender_id="user", chat_id="direct", content=raw)
+    return CommandContext(msg=msg, session=None, key=msg.session_key, raw=raw, args="", loop=loop)
+
+
+def _write_skill(base: Path, name: str, *, description: str = "", body: str = "# Skill\n") -> None:
+    skill_dir = base / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    frontmatter = f"---\nname: {name}\n"
+    if description:
+        frontmatter += f"description: {description}\n"
+    frontmatter += "---\n\n"
+    (skill_dir / "SKILL.md").write_text(frontmatter + body, encoding="utf-8")
+
+
+def _loop_with_skills(tmp_path: Path) -> AgentLoop:
+    """Create a loop with an empty builtin dir so only workspace skills appear."""
+    loop = _make_loop(tmp_path)
+    empty_builtin = tmp_path / "empty_builtin"
+    empty_builtin.mkdir()
+    loop.context.skills = SkillsLoader(tmp_path, builtin_skills_dir=empty_builtin)
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_skill_command_no_skills(tmp_path: Path) -> None:
+    loop = _loop_with_skills(tmp_path)
+    out = await cmd_skill(_ctx(loop))
+    assert out.content == "No skills available."
+
+
+@pytest.mark.asyncio
+async def test_skill_command_lists_names_and_descriptions(tmp_path: Path) -> None:
+    ws_skills = tmp_path / "skills"
+    ws_skills.mkdir()
+    _write_skill(ws_skills, "weather", description="Get current weather and forecasts")
+    _write_skill(ws_skills, "cron", description="Schedule recurring tasks")
+
+    loop = _loop_with_skills(tmp_path)
+    out = await cmd_skill(_ctx(loop))
+
+    assert "Available skills (2):" in out.content
+    assert "**weather** — Get current weather and forecasts" in out.content
+    assert "**cron** — Schedule recurring tasks" in out.content
+    # Must NOT contain file paths
+    assert ".md" not in out.content
+    assert "/skills/" not in out.content
+
+
+@pytest.mark.asyncio
+async def test_skill_command_excludes_disabled(tmp_path: Path) -> None:
+    ws_skills = tmp_path / "skills"
+    ws_skills.mkdir()
+    _write_skill(ws_skills, "alpha", description="Alpha skill")
+    _write_skill(ws_skills, "beta", description="Beta skill")
+
+    loop = _make_loop(tmp_path)
+    loop.context.skills.disabled_skills = {"alpha"}
+
+    out = await cmd_skill(_ctx(loop))
+
+    assert "alpha" not in out.content
+    assert "**beta** — Beta skill" in out.content
+
+
+@pytest.mark.asyncio
+async def test_skill_command_fallback_description(tmp_path: Path) -> None:
+    ws_skills = tmp_path / "skills"
+    ws_skills.mkdir()
+    _write_skill(ws_skills, "plain", description="", body="# Plain Skill\n")
+
+    loop = _loop_with_skills(tmp_path)
+    out = await cmd_skill(_ctx(loop))
+
+    assert "**plain** — plain" in out.content
+
+
+@pytest.mark.asyncio
+async def test_skill_command_no_render_as_text(tmp_path: Path) -> None:
+    """Output is markdown; CLI should render it (not forced as plain text)."""
+    loop = _make_loop(tmp_path)
+    out = await cmd_skill(_ctx(loop))
+    assert out.metadata.get("render_as") != "text"
+
+
+@pytest.mark.asyncio
+async def test_skill_command_registered_on_router(tmp_path: Path) -> None:
+    router = CommandRouter()
+    register_builtin_commands(router)
+    loop = _loop_with_skills(tmp_path)
+
+    out = await router.dispatch(_ctx(loop, "/skill"))
+
+    assert out is not None
+    assert "No skills available." in out.content


### PR DESCRIPTION
Adds a `/skill` built-in slash command that lists all enabled skills (name and description). This addresses the missing command reported in #3959, where users had no way to discover which skills are available.

   ## Changes

   - **`nanobot/command/builtin.py`**: Register `/skill` in `BUILTIN_COMMAND_SPECS`, add `cmd_skill` handler, and register on the command router
   - **`tests/command/test_skill_command.py`**: 6 test cases covering:
     - Empty skill list output
     - Name and description formatting (markdown)
     - Disabled skills excluded from listing
     - Fallback description when frontmatter has no description field
     - Markdown output (no `render_as: \"text\"` override)
     - Router registration

   ## Behavior

   ```
   /skill
   → Available skills (2):
   →
   → - **weather** — Get current weather and forecasts (no API key required).
   → - **cron** — Schedule reminders and recurring tasks.
   ```

   Skills listed in `disabledSkills` config are excluded. The output uses markdown format for proper rendering in CLI and UI channels.

   ## Testing

   - All 6 new tests pass
   - All 37 existing command tests still pass (no regressions)
   - `ruff check` passes with no issues

   Closes #3959