### PR TITLE
docs: use xiaomi_mimo provider for MiMo token plan

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -492,7 +492,7 @@ the model name contains `mimo`. The default API base is
 > {
 >   "providers": {
 >     "xiaomi_mimo": {
->       "apiKey": "${MIMOMIMO_API_KEY}",
+>       "apiKey": "${XIAOMIMIMO_API_KEY}",
 >       "apiBase": "https://token-plan-sgp.xiaomimimo.com/v1"
 >     }
 >   },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,7 @@ ANTHROPIC_API_KEY="$(bw get password api/anthropic)" nanobot agent
 > - **Alibaba Cloud BaiLian**: If you're using Alibaba Cloud BaiLian's OpenAI-compatible endpoint, set `"apiBase": "https://dashscope.aliyuncs.com/compatible-mode/v1"` in your dashscope provider config.
 > - **Step Fun (Mainland China)**: If your API key is from Step Fun's mainland China platform (stepfun.com), set `"apiBase": "https://api.stepfun.com/v1"` in your stepfun provider config.
 > - **Xiaomi MiMo thinking mode**: MiMo models (e.g. `mimo-v2.5-pro`) default to enabled thinking. Use `agents.defaults.reasoningEffort: "none"` to disable it, or `"low"` / `"medium"` / `"high"` to keep it on. Omitting the field preserves the provider's per-model default.
+> - **Xiaomi MiMo Token Plan**: If you're on MiMo's token plan, set `"apiBase": "https://token-plan-sgp.xiaomimimo.com/v1"` in your xiaomi_mimo provider config.
 
 | Provider | Purpose | Get API Key |
 |----------|---------|-------------|
@@ -474,6 +475,39 @@ usually only need to set `apiKey`.
 
 Official model names include `LongCat-Flash-Chat`, `LongCat-Flash-Thinking`,
 `LongCat-Flash-Thinking-2601`, and `LongCat-Flash-Lite`.
+
+</details>
+
+<details>
+<summary><b>Xiaomi MiMo</b></summary>
+
+Xiaomi MiMo models are automatically detected by the `xiaomi_mimo` provider when
+the model name contains `mimo`. The default API base is
+`https://api.xiaomimimo.com/v1`.
+
+> **Token Plan**: If you're using MiMo's token plan, override `apiBase` with the
+> dedicated endpoint:
+>
+> ```json
+> {
+>   "providers": {
+>     "xiaomi_mimo": {
+>       "apiKey": "${MIMOMIMO_API_KEY}",
+>       "apiBase": "https://token-plan-sgp.xiaomimimo.com/v1"
+>     }
+>   },
+>   "agents": {
+>     "defaults": {
+>       "model": "xiaomi/mimo-v2.5-pro"
+>     }
+>   }
+> }
+> ```
+>
+> No need to set `provider` explicitly — the model name contains `mimo`, which
+> auto-matches to the `xiaomi_mimo` provider spec. Use an API key from the MiMo
+> token plan console and check the MiMo platform for the latest supported model
+> names.
 
 </details>
 


### PR DESCRIPTION
This PR supersedes #3619 based on reviewer feedback.

### Changes

Replaced the standalone **Xiaomi MiMo Token Plan** section (which used `custom` provider) with a general **Xiaomi MiMo** section using the built-in `xiaomi_mimo` provider. The token plan config is now a note within the section since it is just an `apiBase` override.

**Before** — standalone section using `custom` provider, explicit `provider` field:
```
"providers": { "custom": { ... } },
"agents": { "defaults": { "provider": "custom", "model": "xiaomi/mimo-v2.5-pro" } }
```

**After** — general section using `xiaomi_mimo`, no explicit provider needed:
```
"providers": { "xiaomi_mimo": { "apiKey": "...", "apiBase": "https://token-plan-sgp.xiaomimimo.com/v1" } },
"agents": { "defaults": { "model": "xiaomi/mimo-v2.5-pro" } }
```

### Why this works
- The `xiaomi_mimo` provider (registry.py:370-378) already exists with keyword matching on `"mimo"`
- Model name `xiaomi/mimo-v2.5-pro` contains `mimo`, auto-matching to the provider
- The token plan endpoint is just an `apiBase` override — same pattern as other plan-type notes (Zhipu Coding Plan, Step Fun China, etc.)

### Additional
- Added token plan quick-reference tip to the providers tips block
- Preserved existing `Xiaomi MiMo thinking mode` tip