### PR TITLE
feat(providers): add OpenAI API type and extra body configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,6 +168,26 @@ ANTHROPIC_API_KEY="$(bw get password api/anthropic)" nanobot agent
 | `qianfan` | LLM (Baidu Qianfan) | [cloud.baidu.com](https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26) |
 
 <details>
+<summary><b>OpenAI</b></summary>
+
+By default, OpenAI uses `apiType: "auto"`: nanobot calls Chat Completions normally and routes GPT-5/o-series or explicit `reasoningEffort` requests through the Responses API when useful. You can force a specific API surface:
+
+```json
+{
+  "providers": {
+    "openai": {
+      "apiKey": "${OPENAI_API_KEY}",
+      "apiType": "chat_completions"
+    }
+  }
+}
+```
+
+Valid `apiType` values are exactly `auto`, `chat_completions`, and `responses`.
+
+</details>
+
+<details>
 <summary><b>Skywork / APIFree</b></summary>
 
 Skywork uses APIFree's OpenAI-compatible Agent API endpoint. Configure the provider

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,6 +185,23 @@ By default, OpenAI uses `apiType: "auto"`: nanobot calls Chat Completions normal
 
 Valid `apiType` values are exactly `auto`, `chat_completions`, and `responses`.
 
+`extraBody` follows the selected OpenAI API surface. With Chat Completions, nanobot passes it through as the SDK `extra_body` value. With Responses, configure it in Responses API body shape; nanobot merges ordinary top-level fields into the Responses request body, appends `extraBody.tools` after generated function tools, and merges `extraBody.include` without duplicates:
+
+```json
+{
+  "providers": {
+    "openai": {
+      "apiKey": "${OPENAI_API_KEY}",
+      "apiType": "responses",
+      "extraBody": {
+        "tools": [{ "type": "web_search" }],
+        "include": ["web_search_call.action.sources"]
+      }
+    }
+  }
+}
+```
+
 </details>
 
 <details>

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -171,6 +171,7 @@ class ProviderConfig(Base):
 
     api_key: str | None = None
     api_base: str | None = None
+    api_type: Literal["auto", "chat_completions", "responses"] = "auto"  # Request API surface
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
     extra_body: dict[str, Any] | None = None  # Extra fields merged into every request body
 

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -173,7 +173,7 @@ class ProviderConfig(Base):
     api_base: str | None = None
     api_type: Literal["auto", "chat_completions", "responses"] = "auto"  # Request API surface
     extra_headers: dict[str, str] | None = None  # Custom headers (e.g. APP-Code for AiHubMix)
-    extra_body: dict[str, Any] | None = None  # Extra fields merged into every request body
+    extra_body: dict[str, Any] | None = None  # Extra provider request fields; shape depends on provider/API surface
 
 
 class BedrockProviderConfig(ProviderConfig):
@@ -223,6 +223,16 @@ class ProvidersConfig(Base):
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
     qianfan: ProviderConfig = Field(default_factory=ProviderConfig)  # Qianfan (百度千帆)
     nvidia: ProviderConfig = Field(default_factory=ProviderConfig)  # NVIDIA NIM (nvapi- keys)
+
+    @model_validator(mode="after")
+    def _validate_api_type_scope(self) -> "ProvidersConfig":
+        for name in self.__class__.model_fields:
+            if name == "openai":
+                continue
+            provider = getattr(self, name, None)
+            if isinstance(provider, ProviderConfig) and provider.api_type != "auto":
+                raise ValueError("providers.<name>.api_type is only supported for providers.openai")
+        return self
 
 
 class HeartbeatConfig(Base):

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -98,6 +98,7 @@ def _make_provider_core(
             extra_headers=p.extra_headers if p else None,
             spec=spec,
             extra_body=p.extra_body if p else None,
+            api_type=p.api_type if p else "auto",
         )
 
     provider.generation = resolved.to_generation_settings()
@@ -183,6 +184,7 @@ def provider_signature(
             config.get_api_base(fallback.model, preset=fallback),
             fp.extra_headers if fp else None,
             fp.extra_body if fp else None,
+            fp.api_type if fp else "auto",
             getattr(fp, "region", None) if fp else None,
             getattr(fp, "profile", None) if fp else None,
             fallback.max_tokens,
@@ -199,6 +201,7 @@ def provider_signature(
         config.get_api_base(resolved.model, preset=resolved),
         p.extra_headers if p else None,
         p.extra_body if p else None,
+        p.api_type if p else "auto",
         getattr(p, "region", None) if p else None,
         getattr(p, "profile", None) if p else None,
         resolved.max_tokens,

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -98,7 +98,7 @@ def _make_provider_core(
             extra_headers=p.extra_headers if p else None,
             spec=spec,
             extra_body=p.extra_body if p else None,
-            api_type=p.api_type if p else "auto",
+            api_type=p.api_type if p and provider_name == "openai" else "auto",
         )
 
     provider.generation = resolved.to_generation_settings()

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -274,6 +274,47 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     return merged
 
 
+def _merge_unique_list(base: Any, override: Any) -> Any:
+    """Append list values while preserving order and removing duplicates."""
+    if not isinstance(base, list) or not isinstance(override, list):
+        return override
+    result: list[Any] = []
+    seen: set[str] = set()
+    for value in [*base, *override]:
+        try:
+            key = json.dumps(value, sort_keys=True, ensure_ascii=False)
+        except Exception:
+            key = repr(value)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(value)
+    return result
+
+
+def _merge_responses_extra_body(
+    body: dict[str, Any],
+    extra_body: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge configured Responses API body fields without clobbering tools."""
+    reserved = {"include", "tools"}
+    regular_extra = {key: value for key, value in extra_body.items() if key not in reserved}
+    merged = _deep_merge(body, regular_extra)
+
+    if "include" in extra_body:
+        merged["include"] = _merge_unique_list(body.get("include"), extra_body["include"])
+
+    if "tools" in extra_body:
+        current_tools = body.get("tools")
+        configured_tools = extra_body["tools"]
+        if isinstance(current_tools, list) and isinstance(configured_tools, list):
+            merged["tools"] = [*current_tools, *configured_tools]
+        else:
+            merged["tools"] = configured_tools
+
+    return merged
+
+
 class OpenAICompatProvider(LLMProvider):
     """Unified provider for all OpenAI-compatible APIs.
 
@@ -296,7 +337,7 @@ class OpenAICompatProvider(LLMProvider):
         self.extra_headers = extra_headers or {}
         self._spec = spec
         self._extra_body = extra_body or {}
-        self._api_type = api_type
+        self._api_type = api_type if spec and spec.name == "openai" else "auto"
 
         if api_key and spec and spec.env_key:
             self._setup_env(api_key, api_base)
@@ -690,12 +731,9 @@ class OpenAICompatProvider(LLMProvider):
         if self._api_type == "chat_completions":
             return False
         if self._spec and self._spec.name not in ("openai", "github_copilot"):
-            if self._api_type != "responses":
-                return False
+            return False
         if self._api_type == "responses":
             return self._responses_circuit_allows_probe(model, reasoning_effort)
-        if self._spec and self._spec.name not in ("openai", "github_copilot"):
-            return False
         if self._spec is None or self._spec.name != "github_copilot":
             if not _is_direct_openai_base(self._effective_base):
                 return False
@@ -807,6 +845,10 @@ class OpenAICompatProvider(LLMProvider):
         if tools:
             body["tools"] = convert_tools(tools)
             body["tool_choice"] = tool_choice or "auto"
+
+        extra_body = getattr(self, "_extra_body", {})
+        if extra_body:
+            body = _merge_responses_extra_body(body, extra_body)
 
         return body
 

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -733,7 +733,9 @@ class OpenAICompatProvider(LLMProvider):
         if self._spec and self._spec.name not in ("openai", "github_copilot"):
             return False
         if self._api_type == "responses":
-            return self._responses_circuit_allows_probe(model, reasoning_effort)
+            # Explicit configuration means Responses is mandatory; do not
+            # consult the circuit breaker or fall back to Chat Completions.
+            return True
         if self._spec is None or self._spec.name != "github_copilot":
             if not _is_direct_openai_base(self._effective_base):
                 return False

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -289,12 +289,14 @@ class OpenAICompatProvider(LLMProvider):
         extra_headers: dict[str, str] | None = None,
         spec: ProviderSpec | None = None,
         extra_body: dict[str, Any] | None = None,
+        api_type: str = "auto",
     ):
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
         self._spec = spec
         self._extra_body = extra_body or {}
+        self._api_type = api_type
 
         if api_key and spec and spec.env_key:
             self._setup_env(api_key, api_base)
@@ -685,6 +687,13 @@ class OpenAICompatProvider(LLMProvider):
         reasoning_effort: str | None,
     ) -> bool:
         """Use Responses API only for direct OpenAI requests that benefit from it."""
+        if self._api_type == "chat_completions":
+            return False
+        if self._spec and self._spec.name not in ("openai", "github_copilot"):
+            if self._api_type != "responses":
+                return False
+        if self._api_type == "responses":
+            return self._responses_circuit_allows_probe(model, reasoning_effort)
         if self._spec and self._spec.name not in ("openai", "github_copilot"):
             return False
         if self._spec is None or self._spec.name != "github_copilot":
@@ -700,7 +709,14 @@ class OpenAICompatProvider(LLMProvider):
         if not wants:
             return False
 
-        # Circuit breaker: skip after repeated failures, probe periodically.
+        return self._responses_circuit_allows_probe(model, reasoning_effort)
+
+    def _responses_circuit_allows_probe(
+        self,
+        model: str | None,
+        reasoning_effort: str | None,
+    ) -> bool:
+        """Return False when the Responses API circuit breaker is open."""
         key = _responses_circuit_key(model, self.default_model, reasoning_effort)
         failures = self._responses_failures.get(key, 0)
         if failures >= _RESPONSES_FAILURE_THRESHOLD:
@@ -1262,6 +1278,8 @@ class OpenAICompatProvider(LLMProvider):
                         # falling back to /chat/completions cannot succeed and would
                         # hide the real error.
                         raise
+                    if self._api_type == "responses":
+                        raise
                     if not self._should_fallback_from_responses_error(responses_error):
                         raise
                     self._record_responses_failure(model, reasoning_effort)
@@ -1334,6 +1352,8 @@ class OpenAICompatProvider(LLMProvider):
                         # Copilot gateway exposes GPT-5/o-series only via /responses;
                         # falling back to /chat/completions cannot succeed and would
                         # hide the real error.
+                        raise
+                    if self._api_type == "responses":
                         raise
                     if not self._should_fallback_from_responses_error(responses_error):
                         raise

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -190,6 +190,7 @@ def settings_payload(*, requires_restart: bool = False) -> dict[str, Any]:
                 "api_key_hint": _mask_secret_hint(provider_config.api_key),
                 "api_base": provider_config.api_base,
                 "default_api_base": spec.default_api_base or None,
+                "api_type": provider_config.api_type,
             }
         )
 
@@ -469,6 +470,16 @@ def update_provider_settings(query: QueryParams) -> dict[str, Any]:
         api_base = (api_base or "").strip() or None
         if provider_config.api_base != api_base:
             provider_config.api_base = api_base
+            changed = True
+
+    if "api_type" in query or "apiType" in query:
+        api_type = (_query_first_alias(query, "api_type", "apiType") or "").strip()
+        try:
+            parsed_api_type = type(provider_config)(api_type=api_type).api_type
+        except Exception:
+            raise WebUISettingsError("api_type must be auto, chat_completions, or responses") from None
+        if provider_config.api_type != parsed_api_type:
+            provider_config.api_type = parsed_api_type
             changed = True
 
     if changed:

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -181,18 +181,18 @@ def settings_payload(*, requires_restart: bool = False) -> dict[str, Any]:
         provider_config = getattr(config.providers, spec.name, None)
         if provider_config is None or spec.is_oauth:
             continue
-        providers.append(
-            {
-                "name": spec.name,
-                "label": spec.label,
-                "configured": _provider_configured_for_settings(spec, provider_config),
-                "api_key_required": _provider_requires_api_key(spec),
-                "api_key_hint": _mask_secret_hint(provider_config.api_key),
-                "api_base": provider_config.api_base,
-                "default_api_base": spec.default_api_base or None,
-                "api_type": provider_config.api_type,
-            }
-        )
+        row = {
+            "name": spec.name,
+            "label": spec.label,
+            "configured": _provider_configured_for_settings(spec, provider_config),
+            "api_key_required": _provider_requires_api_key(spec),
+            "api_key_hint": _mask_secret_hint(provider_config.api_key),
+            "api_base": provider_config.api_base,
+            "default_api_base": spec.default_api_base or None,
+        }
+        if spec.name == "openai":
+            row["api_type"] = provider_config.api_type
+        providers.append(row)
 
     search_config = config.tools.web.search
     image_config = config.tools.image_generation
@@ -472,15 +472,16 @@ def update_provider_settings(query: QueryParams) -> dict[str, Any]:
             provider_config.api_base = api_base
             changed = True
 
-    if "api_type" in query or "apiType" in query:
-        api_type = (_query_first_alias(query, "api_type", "apiType") or "").strip()
-        try:
-            parsed_api_type = type(provider_config)(api_type=api_type).api_type
-        except Exception:
-            raise WebUISettingsError("api_type must be auto, chat_completions, or responses") from None
-        if provider_config.api_type != parsed_api_type:
-            provider_config.api_type = parsed_api_type
-            changed = True
+    if "api_type" in query:
+        if spec.name == "openai":
+            api_type = (_query_first(query, "api_type") or "").strip()
+            try:
+                parsed_api_type = type(provider_config)(api_type=api_type).api_type
+            except Exception:
+                raise WebUISettingsError("api_type must be auto, chat_completions, or responses") from None
+            if provider_config.api_type != parsed_api_type:
+                provider_config.api_type = parsed_api_type
+                changed = True
 
     if changed:
         save_config(config)

--- a/tests/agent/test_runner_fallback.py
+++ b/tests/agent/test_runner_fallback.py
@@ -241,7 +241,7 @@ def test_inline_fallback_reasoning_effort_does_not_inherit_primary() -> None:
     signature = provider_signature(config)
     fallback_signatures = signature[-1]
 
-    assert fallback_signatures[0][11] is None
+    assert fallback_signatures[0][12] is None
 
 
 # -- FallbackProvider tests --

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -30,7 +30,7 @@ from nanobot.channels.websocket import (
 )
 from nanobot.config.loader import load_config, save_config
 from nanobot.config.schema import Config, ModelPresetConfig
-from nanobot.webui.settings_api import settings_payload
+from nanobot.webui.settings_api import settings_payload, update_provider_settings
 
 # -- Shared helpers (aligned with test_websocket_integration.py) ---------------
 
@@ -1349,6 +1349,37 @@ def test_settings_payload_normalizes_camel_case_provider(
     body = settings_payload()
 
     assert body["agent"]["provider"] == "minimax_anthropic"
+
+
+def test_settings_payload_exposes_api_type_only_for_openai(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config()
+    config.providers.openai.api_type = "responses"
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    body = settings_payload()
+    providers = {provider["name"]: provider for provider in body["providers"]}
+
+    assert providers["openai"]["api_type"] == "responses"
+    assert "api_type" not in providers["custom"]
+
+
+def test_update_provider_settings_ignores_api_type_for_non_openai(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    body = update_provider_settings({
+        "provider": ["custom"],
+        "api_base": ["https://example.test/v1"],
+        "api_type": ["responses"],
+    })
+
+    assert body["providers"]
+    config = load_config(config_path)
+    assert config.providers.custom.api_base == "https://example.test/v1"
+    assert config.providers.custom.api_type == "auto"
 
 
 @pytest.mark.asyncio

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -1,3 +1,5 @@
+import pytest
+
 from nanobot.config.schema import Config
 
 
@@ -10,6 +12,28 @@ def test_resolve_preset_returns_defaults_when_no_preset() -> None:
     assert resolved.context_window_tokens == config.agents.defaults.context_window_tokens
     assert resolved.temperature == config.agents.defaults.temperature
     assert resolved.reasoning_effort == config.agents.defaults.reasoning_effort
+
+
+def test_provider_api_type_accepts_exact_values_only() -> None:
+    config = Config.model_validate({
+        "providers": {
+            "openai": {
+                "apiKey": "sk-test",
+                "apiType": "responses",
+            }
+        }
+    })
+    assert config.providers.openai.api_type == "responses"
+
+    with pytest.raises(ValueError):
+        Config.model_validate({
+            "providers": {
+                "openai": {
+                    "apiKey": "sk-test",
+                    "apiType": "response",
+                }
+            }
+        })
 
 
 def test_legacy_defaults_config_without_presets_still_resolves() -> None:

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -36,6 +36,18 @@ def test_provider_api_type_accepts_exact_values_only() -> None:
         })
 
 
+def test_provider_api_type_is_openai_only() -> None:
+    with pytest.raises(ValueError, match="only supported"):
+        Config.model_validate({
+            "providers": {
+                "custom": {
+                    "apiBase": "https://example.test/v1",
+                    "apiType": "responses",
+                }
+            }
+        })
+
+
 def test_legacy_defaults_config_without_presets_still_resolves() -> None:
     config = Config.model_validate({
         "agents": {

--- a/tests/providers/test_extra_body_config.py
+++ b/tests/providers/test_extra_body_config.py
@@ -9,6 +9,7 @@ from nanobot.providers.openai_compat_provider import (
     OpenAICompatProvider,
     _deep_merge,
 )
+from nanobot.providers.registry import find_by_name
 
 # ---------------------------------------------------------------------------
 # _deep_merge unit tests
@@ -183,6 +184,86 @@ class TestBuildKwargsExtraBody:
             temperature=0.1, reasoning_effort=None, tool_choice=None,
         )
         assert kwargs["extra_body"]["repetition_penalty"] == 1.15
+
+
+class TestBuildResponsesBodyExtraBody:
+    """Verify extra_body flows into Responses API request bodies."""
+
+    def test_responses_extra_body_merges_top_level_fields(self) -> None:
+        provider = OpenAICompatProvider(
+            api_key="test-key",
+            default_model="gpt-5",
+            spec=find_by_name("openai"),
+            extra_body={
+                "metadata": {"source": "test"},
+                "parallel_tool_calls": False,
+            },
+        )
+
+        body = provider._build_responses_body(
+            messages=_simple_messages(),
+            tools=None, model=None, max_tokens=100,
+            temperature=0.1, reasoning_effort=None, tool_choice=None,
+        )
+
+        assert body["metadata"] == {"source": "test"}
+        assert body["parallel_tool_calls"] is False
+
+    def test_responses_extra_body_appends_tools(self) -> None:
+        provider = OpenAICompatProvider(
+            api_key="test-key",
+            default_model="gpt-5",
+            spec=find_by_name("openai"),
+            extra_body={"tools": [{"type": "web_search"}]},
+        )
+
+        body = provider._build_responses_body(
+            messages=_simple_messages(),
+            tools=[{
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {"type": "object"},
+                },
+            }],
+            model=None, max_tokens=100, temperature=0.1,
+            reasoning_effort=None, tool_choice=None,
+        )
+
+        assert body["tools"] == [
+            {
+                "type": "function",
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {"type": "object"},
+            },
+            {"type": "web_search"},
+        ]
+
+    def test_responses_extra_body_merges_include_without_duplicates(self) -> None:
+        provider = OpenAICompatProvider(
+            api_key="test-key",
+            default_model="gpt-5",
+            spec=find_by_name("openai"),
+            extra_body={
+                "include": [
+                    "reasoning.encrypted_content",
+                    "web_search_call.action.sources",
+                ],
+            },
+        )
+
+        body = provider._build_responses_body(
+            messages=_simple_messages(),
+            tools=None, model=None, max_tokens=100,
+            temperature=0.1, reasoning_effort="high", tool_choice=None,
+        )
+
+        assert body["include"] == [
+            "reasoning.encrypted_content",
+            "web_search_call.action.sources",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_github_copilot_routing.py
+++ b/tests/providers/test_github_copilot_routing.py
@@ -20,6 +20,7 @@ def _make_copilot_provider() -> OpenAICompatProvider:
     p.default_model = "github_copilot/gpt-5.4-mini"
     p._spec = find_by_name("github_copilot")
     p._effective_base = "https://api.githubcopilot.com"
+    p._api_type = "auto"
     p._responses_failures = {}
     p._responses_tripped_at = {}
     return p

--- a/tests/providers/test_responses_circuit_breaker.py
+++ b/tests/providers/test_responses_circuit_breaker.py
@@ -18,6 +18,7 @@ def provider():
     p.default_model = "gpt-5"
     p._spec = type("Spec", (), {"name": "openai"})()
     p._effective_base = "https://api.openai.com/v1"
+    p._api_type = "auto"
     p._responses_failures = {}
     p._responses_tripped_at = {}
     return p
@@ -25,6 +26,17 @@ def provider():
 
 def test_responses_api_available_by_default(provider):
     assert provider._should_use_responses_api("gpt-5", None) is True
+
+
+def test_api_type_chat_completions_disables_responses(provider):
+    provider._api_type = "chat_completions"
+    assert provider._should_use_responses_api("gpt-5", None) is False
+
+
+def test_api_type_responses_forces_responses_for_openai(provider):
+    provider.default_model = "gpt-4o"
+    provider._api_type = "responses"
+    assert provider._should_use_responses_api("gpt-4o", None) is True
 
 
 def test_circuit_opens_after_threshold(provider):

--- a/tests/providers/test_responses_circuit_breaker.py
+++ b/tests/providers/test_responses_circuit_breaker.py
@@ -39,6 +39,15 @@ def test_api_type_responses_forces_responses_for_openai(provider):
     assert provider._should_use_responses_api("gpt-4o", None) is True
 
 
+def test_api_type_responses_ignores_circuit_breaker(provider):
+    provider.default_model = "gpt-4o"
+    provider._api_type = "responses"
+    provider._responses_failures = {"gpt-4o|gpt-4o|": _RESPONSES_FAILURE_THRESHOLD}
+    provider._responses_tripped_at = {"gpt-4o|gpt-4o|": 0.0}
+
+    assert provider._should_use_responses_api("gpt-4o", None) is True
+
+
 def test_api_type_responses_does_not_force_non_openai(provider):
     provider._spec = type("Spec", (), {"name": "custom"})()
     provider._api_type = "responses"

--- a/tests/providers/test_responses_circuit_breaker.py
+++ b/tests/providers/test_responses_circuit_breaker.py
@@ -39,6 +39,13 @@ def test_api_type_responses_forces_responses_for_openai(provider):
     assert provider._should_use_responses_api("gpt-4o", None) is True
 
 
+def test_api_type_responses_does_not_force_non_openai(provider):
+    provider._spec = type("Spec", (), {"name": "custom"})()
+    provider._api_type = "responses"
+
+    assert provider._should_use_responses_api("gpt-4o", None) is False
+
+
 def test_circuit_opens_after_threshold(provider):
     for _ in range(_RESPONSES_FAILURE_THRESHOLD):
         provider._record_responses_failure("gpt-5", None)

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -142,6 +142,8 @@ interface ModelConfigurationDraft {
 
 type PendingRestartSection = "runtime" | "web" | "image";
 type PendingRestartSections = Record<PendingRestartSection, boolean>;
+type ProviderApiType = "auto" | "chat_completions" | "responses";
+type ProviderForm = { apiKey: string; apiBase: string; apiType: ProviderApiType };
 type CustomMcpTransport = "stdio" | "streamableHttp" | "sse";
 
 const NANOBOT_ICON_SRC = "/brand/nanobot_icon.png";
@@ -189,6 +191,11 @@ const DEFAULT_LOCAL_PREFS: LocalPreferences = {
   codeWrap: true,
   brandLogos: true,
 };
+const OPENAI_API_TYPE_OPTIONS: Array<{ value: ProviderApiType; label: string }> = [
+  { value: "auto", label: "Auto" },
+  { value: "chat_completions", label: "Chat Completions" },
+  { value: "responses", label: "Responses" },
+];
 
 const LOCAL_UNCONFIGURED_PROVIDER_ORDER = new Map(
   ["vllm", "ollama", "lm_studio", "atomic_chat", "ovms"].map((name, index) => [
@@ -303,7 +310,7 @@ export function SettingsView({
   const [mcpFieldValues, setMcpFieldValues] = useState<Record<string, Record<string, string>>>({});
   const [customMcpForm, setCustomMcpForm] = useState<CustomMcpForm>(DEFAULT_CUSTOM_MCP_FORM);
   const [mcpConfigImport, setMcpConfigImport] = useState("");
-  const [providerForms, setProviderForms] = useState<Record<string, { apiKey: string; apiBase: string }>>({});
+  const [providerForms, setProviderForms] = useState<Record<string, ProviderForm>>({});
   const [visibleProviderKeys, setVisibleProviderKeys] = useState<Record<string, boolean>>({});
   const [editingProviderKeys, setEditingProviderKeys] = useState<Record<string, boolean>>({});
   const [pendingRestartSections, setPendingRestartSections] = useState<PendingRestartSections>(
@@ -460,6 +467,7 @@ export function SettingsView({
         next[provider.name] = {
           apiKey: next[provider.name]?.apiKey ?? "",
           apiBase: next[provider.name]?.apiBase ?? provider.api_base ?? provider.default_api_base ?? "",
+          apiType: next[provider.name]?.apiType ?? provider.api_type ?? "auto",
         };
       }
       return next;
@@ -620,7 +628,7 @@ export function SettingsView({
     if (providerSaving) return;
     const provider = settings?.providers.find((item) => item.name === providerName);
     if (!provider) return;
-    const providerForm = providerForms[providerName] ?? { apiKey: "", apiBase: "" };
+    const providerForm = providerForms[providerName] ?? { apiKey: "", apiBase: "", apiType: "auto" };
     const apiKey = providerForm.apiKey.trim();
     const apiKeyRequired = provider.api_key_required ?? true;
     if (!provider.configured && apiKeyRequired && !apiKey) {
@@ -633,6 +641,7 @@ export function SettingsView({
         provider: providerName,
         apiKey: apiKey || undefined,
         apiBase: providerForm.apiBase.trim(),
+        apiType: providerForm.apiType,
       });
       applyPayload(payload);
       if (payload.requires_restart) {
@@ -643,6 +652,7 @@ export function SettingsView({
         [providerName]: {
           apiKey: "",
           apiBase: providerForm.apiBase.trim(),
+          apiType: providerForm.apiType,
         },
       }));
       setVisibleProviderKeys((prev) => ({ ...prev, [providerName]: false }));
@@ -719,6 +729,7 @@ export function SettingsView({
       [providerName]: {
         apiKey: "",
         apiBase: provider.api_base ?? provider.default_api_base ?? "",
+        apiType: provider.api_type ?? "auto",
       },
     }));
     setVisibleProviderKeys((prev) => ({ ...prev, [providerName]: false }));
@@ -772,6 +783,7 @@ export function SettingsView({
           [providerName]: {
             apiKey: "",
             apiBase: forms[providerName]?.apiBase ?? "",
+            apiType: forms[providerName]?.apiType ?? "auto",
           },
         }));
         setVisibleProviderKeys((visible) => ({ ...visible, [providerName]: false }));
@@ -957,6 +969,7 @@ export function SettingsView({
                   [provider]: {
                     apiKey: prev[provider]?.apiKey ?? "",
                     apiBase: prev[provider]?.apiBase ?? "",
+                    apiType: prev[provider]?.apiType ?? "auto",
                     ...value,
                   },
                 }))
@@ -1713,7 +1726,7 @@ function ProvidersSettings({
 }: {
   settings: SettingsPayload;
   expandedProvider: string | null;
-  providerForms: Record<string, { apiKey: string; apiBase: string }>;
+  providerForms: Record<string, ProviderForm>;
   visibleProviderKeys: Record<string, boolean>;
   editingProviderKeys: Record<string, boolean>;
   providerSaving: string | null;
@@ -1723,7 +1736,7 @@ function ProvidersSettings({
   onToggleProvider: (provider: string) => void;
   onToggleProviderKey: (provider: string) => void;
   onToggleProviderKeyEditing: (provider: string) => void;
-  onChangeProviderForm: (provider: string, value: Partial<{ apiKey: string; apiBase: string }>) => void;
+  onChangeProviderForm: (provider: string, value: Partial<ProviderForm>) => void;
   onSaveProvider: (provider: string) => void;
   onResetProviderDraft: (provider: string) => void;
   imageProviderRestartPending: boolean;
@@ -1744,6 +1757,7 @@ function ProvidersSettings({
     const form = providerForms[provider.name] ?? {
       apiKey: "",
       apiBase: provider.api_base ?? provider.default_api_base ?? "",
+      apiType: provider.api_type ?? "auto",
     };
     const saving = providerSaving === provider.name;
     const keyVisible = !!visibleProviderKeys[provider.name];
@@ -1855,6 +1869,38 @@ function ProvidersSettings({
                 className="h-9 rounded-full text-[13px]"
               />
             </label>
+            {provider.name === "openai" ? (
+              <label className="block space-y-1.5">
+                <span className="text-[12px] font-medium text-muted-foreground">
+                  {tx("settings.byok.apiType", "API type")}
+                </span>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="h-9 w-full justify-between rounded-full px-3 text-[13px]"
+                    >
+                      <span>
+                        {OPENAI_API_TYPE_OPTIONS.find((option) => option.value === form.apiType)?.label ??
+                          form.apiType}
+                      </span>
+                      <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" className="min-w-[220px]">
+                    {OPENAI_API_TYPE_OPTIONS.map((option) => (
+                      <DropdownMenuItem
+                        key={option.value}
+                        onSelect={() => onChangeProviderForm(provider.name, { apiType: option.value })}
+                      >
+                        {option.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </label>
+            ) : null}
             <div className="flex items-center justify-end gap-2">
               <Button
                 size="sm"

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -290,6 +290,7 @@ export async function updateProviderSettings(
   query.set("provider", update.provider);
   if (update.apiKey !== undefined) query.set("api_key", update.apiKey);
   if (update.apiBase !== undefined) query.set("api_base", update.apiBase);
+  if (update.apiType !== undefined) query.set("api_type", update.apiType);
   return request<SettingsPayload>(
     `${base}/api/settings/provider/update?${query}`,
     token,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -206,6 +206,7 @@ export interface SettingsPayload {
     api_key_hint?: string | null;
     api_base?: string | null;
     default_api_base?: string | null;
+    api_type?: "auto" | "chat_completions" | "responses";
   }>;
   web_search: {
     provider: string;
@@ -391,6 +392,7 @@ export interface ProviderSettingsUpdate {
   provider: string;
   apiKey?: string;
   apiBase?: string;
+  apiType?: "auto" | "chat_completions" | "responses";
 }
 
 export interface WebSearchSettingsUpdate {


### PR DESCRIPTION
  ## Summary

  - Add `providers.openai.apiType` with `auto`, `chat_completions`, and `responses` modes.
  - Wire OpenAI API type selection through config, provider creation, WebUI settings, and provider cache signatures.
  - Support configured `extraBody` fields for both Chat Completions and Responses API requests.
  - Ensure explicit `apiType: "responses"` never falls back to Chat Completions.

  ## Testing

  - `uv run pytest tests/config/test_model_presets.py tests/providers/test_extra_body_config.py tests/providers/test_responses_circuit_breaker.py
  tests/providers/test_github_copilot_routing.py tests/channels/test_websocket_channel.py -q`