### PR TITLE
feat: loop guard v2.0 — 循环检测 & 速率限制硬阻断

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
-from contextlib import suppress
+import time
+from contextlib import nullcontext, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -46,8 +47,51 @@ from nanobot.utils.runtime import (
     ensure_nonempty_tool_result,
     is_blank_text,
     repeated_external_lookup_error,
+    repeated_loop_error,
     repeated_workspace_violation_error,
+    rate_limit_error,
+    RATE_LIMIT_WINDOW,
 )
+
+@dataclass(slots=True)
+class LoopGuardRuntimeConfig:
+    """Configuration for loop/rate-limit guards in agent execution.
+
+    Parameters
+    ----------
+    enabled:
+        Master switch.  Set ``False`` to disable both loop and rate-limit guards.
+    max_repeated_loops:
+        Override the default threshold (``_MAX_REPEATED_LOOPS``).
+        When ``None`` the module default is used (current value is 3).
+    rate_limit_count:
+        Override the default count threshold (``RATE_LIMIT_WINDOW[0]``).
+        When ``None`` the module default is used (current value is 5).
+    rate_limit_seconds:
+        Override the default time window (``RATE_LIMIT_WINDOW[1]``).
+        When ``None`` the module default is used (current value is 3.0).
+    """
+    enabled: bool = True
+    max_repeated_loops: int | None = None  # None → module default
+    rate_limit_count: int | None = None
+    rate_limit_seconds: float | None = None
+
+
+@dataclass(slots=True)
+class _ToolExecutionState:
+    """Shared mutable state for tool execution within a single turn.
+
+    Aggregates the per-turn counters and locks that were previously
+    passed as separate arguments to ``_execute_tools`` and ``_run_tool``.
+    This reduces signature friction in tests and internal call-sites.
+    """
+
+    external_lookup_counts: dict[str, int] = field(default_factory=dict)
+    workspace_violation_counts: dict[str, int] = field(default_factory=dict)
+    loop_counts: dict[str, int] = field(default_factory=dict)
+    rate_timestamps: dict[str, list[float]] = field(default_factory=dict)
+    loop_counts_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
 
 _DEFAULT_ERROR_MESSAGE = "Sorry, I encountered an error calling the AI model."
 _PERSISTED_MODEL_ERROR_PLACEHOLDER = "[Assistant reply unavailable due to model error.]"
@@ -97,6 +141,7 @@ class AgentRunSpec:
     checkpoint_callback: Any | None = None
     injection_callback: Any | None = None
     llm_timeout_s: float | None = None
+    loop_guard: LoopGuardRuntimeConfig | None = None  # None → use defaults
 
 
 @dataclass(slots=True)
@@ -256,15 +301,17 @@ class AgentRunner:
         error: str | None = None
         stop_reason = "completed"
         tool_events: list[dict[str, str]] = []
-        external_lookup_counts: dict[str, int] = {}
-        # Per-turn throttle for repeated attempts against the same outside target.
-        workspace_violation_counts: dict[str, int] = {}
+        tool_state = _ToolExecutionState()
         empty_content_retries = 0
         length_recovery_count = 0
         had_injections = False
         injection_cycles = 0
 
         for iteration in range(spec.max_iterations):
+            # Per-turn loop and rate-limit guard reset —
+            # design doc specifies per-turn lifetime for both counters.
+            tool_state.loop_counts.clear()
+            tool_state.rate_timestamps.clear()
             try:
                 # Keep the persisted conversation untouched. Context governance
                 # may repair or compact historical messages for the model, but
@@ -339,8 +386,7 @@ class AgentRunner:
                 results, new_events, fatal_error = await self._execute_tools(
                     spec,
                     response.tool_calls,
-                    external_lookup_counts,
-                    workspace_violation_counts,
+                    tool_state,
                 )
                 tool_events.extend(new_events)
                 context.tool_results = list(results)
@@ -776,26 +822,21 @@ class AgentRunner:
         self,
         spec: AgentRunSpec,
         tool_calls: list[ToolCallRequest],
-        external_lookup_counts: dict[str, int],
-        workspace_violation_counts: dict[str, int],
+        state: _ToolExecutionState,
     ) -> tuple[list[Any], list[dict[str, str]], BaseException | None]:
         batches = self._partition_tool_batches(spec, tool_calls)
         tool_results: list[tuple[Any, dict[str, str], BaseException | None]] = []
         for batch in batches:
             if spec.concurrent_tools and len(batch) > 1:
                 batch_results = await asyncio.gather(*(
-                    self._run_tool(
-                        spec, tool_call, external_lookup_counts, workspace_violation_counts,
-                    )
+                    self._run_tool(spec, tool_call, state)
                     for tool_call in batch
                 ))
                 tool_results.extend(batch_results)
             else:
                 batch_results = []
                 for tool_call in batch:
-                    result = await self._run_tool(
-                        spec, tool_call, external_lookup_counts, workspace_violation_counts,
-                    )
+                    result = await self._run_tool(spec, tool_call, state)
                     tool_results.append(result)
                     batch_results.append(result)
 
@@ -813,14 +854,58 @@ class AgentRunner:
         self,
         spec: AgentRunSpec,
         tool_call: ToolCallRequest,
-        external_lookup_counts: dict[str, int],
-        workspace_violation_counts: dict[str, int],
+        state: _ToolExecutionState,
     ) -> tuple[Any, dict[str, str], BaseException | None]:
         hint = "\n\n[Analyze the error above and try a different approach.]"
+
+        # ---- Resolve loop-guard config ----
+        _lg = spec.loop_guard
+        _lg_enabled = getattr(_lg, "enabled", True) if _lg else True
+        _lg_max_loops = getattr(_lg, "max_repeated_loops", None) if _lg else None
+        _lg_rate_count = getattr(_lg, "rate_limit_count", None) if _lg else None
+        _lg_rate_secs = getattr(_lg, "rate_limit_seconds", None) if _lg else None
+
+        if not _lg_enabled:
+            _lg_max_loops = 0  # disabled
+            _lg_rate_count = 999999  # disable trim too
+            _lg_rate_window = (999999, 999999.0)  # disabled
+        else:
+            _lg_rate_window = (
+                (_lg_rate_count if _lg_rate_count is not None else RATE_LIMIT_WINDOW[0],
+                 _lg_rate_secs if _lg_rate_secs is not None else RATE_LIMIT_WINDOW[1])
+            )
+
+        # ---- Rate-limit check (before execution) ----
+        # Protect rate_timestamps mutations when _run_tool is invoked
+        # concurrently via asyncio.gather.  setdefault + append +
+        # slice-assignment are not an atomic group under CPython's GIL.
+        # In non-concurrent mode nullcontext() avoids unnecessary lock overhead.
+        _lock = state.loop_counts_lock if spec.concurrent_tools else nullcontext()
+        async with _lock:
+            ts_list = state.rate_timestamps.setdefault(tool_call.name, [])
+            ts_list.append(time.monotonic())
+            # Trim to window size to avoid unbounded growth
+            _trim_count = (_lg_rate_count if _lg_rate_count is not None else RATE_LIMIT_WINDOW[0]) * 3
+            if _trim_count > 0 and len(ts_list) > _trim_count:
+                ts_list[:] = ts_list[-_trim_count:]
+
+        rate_hint = rate_limit_error(tool_call.name, ts_list, rate_window=_lg_rate_window)
+        if rate_hint is not None:
+            logger.info("Rate-limit hint for {}", tool_call.name)
+            event = {
+                "name": tool_call.name,
+                "status": "warn",
+                "detail": "rate limit hint injected",
+            }
+            if spec.fail_on_tool_error:
+                return rate_hint + hint, event, RuntimeError(rate_hint)
+            return rate_hint + hint, event, None
+
+        # ---- Existing: external lookup throttle ----
         lookup_error = repeated_external_lookup_error(
             tool_call.name,
             tool_call.arguments,
-            external_lookup_counts,
+            state.external_lookup_counts,
         )
         if lookup_error:
             event = {
@@ -849,7 +934,7 @@ class AgentRunner:
                 soft_payload=prep_error + hint,
                 event=event,
                 tool_call=tool_call,
-                workspace_violation_counts=workspace_violation_counts,
+                workspace_violation_counts=state.workspace_violation_counts,
             )
             if handled is not None:
                 return handled
@@ -880,6 +965,29 @@ class AgentRunner:
                     params if isinstance(params, dict) else None,
                 ) for file_edit_tracker in file_edit_trackers],
             )
+        # ---- Loop guard: hard block BEFORE execution ----
+        # write_stdin is excluded: it is the only interactive poll-based tool
+        # whose repeated invocations with identical arguments (same session_id)
+        # express "keep waiting for output" rather than "stuck in a loop".
+        if tool_call.name != "write_stdin":
+            async with _lock:
+                loop_hint = repeated_loop_error(
+                    tool_call.name, tool_call.arguments, state.loop_counts,
+                    max_loops=_lg_max_loops,
+                )
+        else:
+            loop_hint = None
+        if loop_hint is not None:
+            logger.warning("Loop guard blocked {}", tool_call.name)
+            event = {
+                "name": tool_call.name,
+                "status": "error",
+                "detail": "loop guard blocked",
+            }
+            if spec.fail_on_tool_error:
+                return loop_hint + hint, event, RuntimeError(loop_hint)
+            return loop_hint + hint, event, None
+
         try:
             if tool is not None:
                 result = await tool.execute(**params)
@@ -908,7 +1016,7 @@ class AgentRunner:
                 soft_payload=payload,
                 event=event,
                 tool_call=tool_call,
-                workspace_violation_counts=workspace_violation_counts,
+                workspace_violation_counts=state.workspace_violation_counts,
             )
             if handled is not None:
                 return handled
@@ -935,7 +1043,7 @@ class AgentRunner:
                 soft_payload=result + hint,
                 event=event,
                 tool_call=tool_call,
-                workspace_violation_counts=workspace_violation_counts,
+                workspace_violation_counts=state.workspace_violation_counts,
             )
             if handled is not None:
                 return handled

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -108,6 +108,15 @@ class ModelPresetConfig(Base):
         )
 
 
+class LoopGuardConfig(Base):
+    """Optional fine-tuning for the turn-level loop guard (v2.0)."""
+
+    enabled: bool = True
+    max_repeated_loops: int | None = Field(default=None, ge=2, le=10)
+    rate_limit_count: int | None = Field(default=None, ge=3, le=20)
+    rate_limit_seconds: float | None = Field(default=None, ge=0.5, le=30.0)
+
+
 class AgentDefaults(Base):
     """Default agent configuration."""
 
@@ -157,6 +166,7 @@ class AgentDefaults(Base):
         serialization_alias="consolidationRatio",
     )  # Consolidation target ratio (0.5 = 50% of budget retained after compression)
     dream: DreamConfig = Field(default_factory=DreamConfig)
+    loop_guard: LoopGuardConfig = Field(default_factory=lambda: LoopGuardConfig())
 
 
 class AgentsConfig(Base):

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -15,6 +15,15 @@ _MAX_REPEAT_EXTERNAL_LOOKUPS = 2
 # Third same-target workspace violation in a turn escalates to "stop retrying".
 _MAX_REPEAT_WORKSPACE_VIOLATIONS = 2
 
+# ---- Loop detection ---------------------------------------------------------
+
+# Max consecutive same (tool, args) before escalation (defaults).
+_MAX_REPEATED_LOOPS = 3
+
+# Max tool calls per time window before rate-limit warning (defaults).
+# (count, seconds) -- e.g. 5 calls in 3 seconds.
+RATE_LIMIT_WINDOW: tuple[int, float] = (5, 3.0)
+
 EMPTY_FINAL_RESPONSE_MESSAGE = (
     "I completed the tool steps but couldn't produce a final answer. "
     "Please try again or narrow the task."
@@ -26,7 +35,7 @@ FINALIZATION_RETRY_PROMPT = (
 
 LENGTH_RECOVERY_PROMPT = (
     "Output limit reached. Continue exactly where you left off "
-    "— no recap, no apology. Break remaining work into smaller steps if needed."
+    "-- no recap, no apology. Break remaining work into smaller steps if needed."
 )
 
 
@@ -99,6 +108,136 @@ def repeated_external_lookup_error(
     return (
         "Error: repeated external lookup blocked. "
         "Use the results you already have to answer, or try a meaningfully different source."
+    )
+
+
+def loop_signature(tool_name: str, arguments: dict[str, Any]) -> str:
+    """Stable signature: 'tool_name:<sorted key=val pairs>'.
+
+    Different from external_lookup_signature -- this is a **universal**
+    per-tool+params key, not limited to web tools.  Stable across
+    a single turn; does NOT cross turns.
+
+    Strings are normalised (stripped + lowered) to avoid case/whitespace
+    false negatives.  Complex values use a truncated ``repr`` as a
+    discriminative collision key.
+
+    Limitations:
+    - ``list``/``dict`` element order matters: ``[\"a\", \"b\"]`` and
+      ``[\"b\", \"a\"]`` produce different signatures even if semantically
+      equivalent for some tools.
+    - ``repr`` output may include memory addresses for unhashable or custom
+      objects, making signatures unstable across runs.
+    """
+    parts = [tool_name]
+    for k in sorted(arguments):
+        v = arguments[k]
+        if isinstance(v, (str, int, float, bool, type(None))):
+            # Normalise strings to avoid case/whitespace false negatives
+            sv = v.strip().lower() if isinstance(v, str) else v
+            parts.append(f"{k}={sv}")
+        else:
+            # For complex values (dict, list), use truncated repr as a
+            # reasonable collision key -- much more discriminative than
+            # repr length alone.
+            rv = repr(v)
+            parts.append(f"{k}=<{type(v).__name__}:{rv[:64]}>")
+    return ":".join(parts)
+
+
+def repeated_loop_error(
+    tool_name: str,
+    arguments: dict[str, Any],
+    seen_counts: dict[str, int],
+    *,
+    max_loops: int | None = None,
+) -> str | None:
+    """Return a hard-block error when the same (tool, args) repeats too many times.
+
+    Follows the same contract as :func:`repeated_external_lookup_error`:
+    - Increments the counter internally.
+    - Returns ``None`` while within budget.
+    - Returns an ``"Error: …"`` string once the threshold is exceeded, and
+      **for every subsequent call** thereafter (continuous hard block, not
+      a periodic soft hint).
+
+    The caller (``_run_tool``) should skip tool execution and return the
+    error as the tool result when a non-None value is returned.
+
+    Parameters
+    ----------
+    max_loops:
+        Override the default threshold (``_MAX_REPEATED_LOOPS``).
+        When ``None`` the module default is used.
+    """
+    threshold = max_loops if max_loops is not None else _MAX_REPEATED_LOOPS
+    if threshold <= 0:
+        return None  # disabled
+    sig = loop_signature(tool_name, arguments)
+    count = seen_counts.get(sig, 0) + 1
+    seen_counts[sig] = count
+    if count < threshold:
+        return None
+    # Once threshold is breached, return the error every time -- continuous
+    # hard block.  The LLM cannot retry the same (tool, args) until it
+    # changes strategy.
+    logger.warning(
+        "Loop blocked: {} called {} times (sig: {})",
+        tool_name, count, sig[:120],
+    )
+    return (
+        f"Error: loop guard blocked `{tool_name}`. You called it "
+        f"with the same arguments {count} times. "
+        "The tool was NOT executed.\n\n"
+        "You appear to be stuck in a loop. The same approach has been "
+        "tried repeatedly without producing useful new information.\n\n"
+        "STOP trying variations. Instead:\n"
+        "1. **Tell the user** what you have found so far\n"
+        "2. **Ask the user** what they want you to do next\n"
+        "3. Only use a different tool or arguments if you have genuinely "
+        "new information to act on — do NOT guess at new parameters"
+    )
+
+
+def rate_limit_error(
+    tool_name: str,
+    timestamps: list[float],
+    *,
+    rate_window: tuple[int, float] | None = None,
+) -> str | None:
+    """Return a hard-block error when tool calls are too frequent.
+
+    *timestamps* is a per-tool list of ``time.monotonic()`` values.
+    The caller (``_run_tool``) appends before calling.
+
+    Once the rate window is exceeded, the error is returned for **every
+    subsequent call** (continuous hard block), not just at multiples of
+    the threshold.
+
+    Parameters
+    ----------
+    rate_window:
+        Override the default ``(count, seconds)`` window.  When ``None``
+        the module default ``RATE_LIMIT_WINDOW`` is used.
+    """
+    threshold_count, threshold_seconds = (
+        rate_window if rate_window is not None else RATE_LIMIT_WINDOW
+    )
+    if len(timestamps) < threshold_count:
+        return None
+    recent = timestamps[-threshold_count:]
+    if recent[-1] - recent[0] > threshold_seconds:
+        return None
+    # Once the rate window is breached, block every subsequent call
+    # until the LLM slows down.
+    return (
+        f"Error: rate limit exceeded. {threshold_count} calls to "
+        f"`{tool_name}` in {recent[-1] - recent[0]:.1f}s. "
+        "The tool was NOT executed.\n\n"
+        "You are calling tools too fast without processing results. "
+        "STOP. Read the previous results carefully. "
+        "If nothing useful was found, tell the user what you've learned "
+        "and ask for guidance."
     )
 
 

--- a/tests/agent/test_loop_guard.py
+++ b/tests/agent/test_loop_guard.py
@@ -1,0 +1,260 @@
+"""Integration tests for loop guard and rate limit guard in AgentRunner."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nanobot.agent.runner import AgentRunSpec, AgentRunner
+from nanobot.config.schema import AgentDefaults
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.utils.runtime import RATE_LIMIT_WINDOW
+
+_MAX_TOOL_RESULT_CHARS = AgentDefaults().max_tool_result_chars
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Loop guard integration tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_loop_guard_blocks_tool_on_third_identical_call():
+    """同一轮次内第3次相同参数调用时硬阻断，工具不执行，返回 Error"""
+    provider = MagicMock(spec=LLMProvider)
+    captured_messages: list[list[dict]] = []
+    call_count = {"n": 0}
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        captured_messages.append(list(messages))
+        if call_count["n"] == 1:
+            # Single turn with 3 identical tool calls — the 3rd must be blocked
+            return LLMResponse(
+                content="searching",
+                tool_calls=[
+                    ToolCallRequest(id="c1", name="grep", arguments={"pattern": "TODO", "path": "."}),
+                    ToolCallRequest(id="c2", name="grep", arguments={"pattern": "TODO", "path": "."}),
+                    ToolCallRequest(id="c3", name="grep", arguments={"pattern": "TODO", "path": "."}),
+                ],
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+            )
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="no matches found")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "search for TODOs"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=2,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done"
+    # 第3次被硬阻断，工具结果直接是 Error 消息
+    blocked = [
+        msg for msg in result.messages
+        if msg.get("role") == "tool"
+        and msg.get("name") == "grep"
+        and "Error: loop guard blocked" in str(msg.get("content", ""))
+    ]
+    assert len(blocked) >= 1, (
+        "第3次相同工具+参数调用应被硬阻断，工具结果包含 Error"
+    )
+    # 前2次的工具正常执行了
+    assert tools.execute.await_count == 2, (
+        f"只有前2次应执行，第3次被阻断，实际执行了{tools.execute.await_count}次"
+    )
+
+
+@pytest.mark.asyncio
+async def test_loop_guard_does_not_block_first_two_calls():
+    """同一轮次内前2次相同工具+参数调用不触发硬阻断"""
+    provider = MagicMock(spec=LLMProvider)
+    call_count = {"n": 0}
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Only 2 identical calls — within budget
+            return LLMResponse(
+                content="searching",
+                tool_calls=[
+                    ToolCallRequest(id="c1", name="grep", arguments={"pattern": "TODO", "path": "."}),
+                    ToolCallRequest(id="c2", name="grep", arguments={"pattern": "TODO", "path": "."}),
+                ],
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+            )
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="no matches found")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "search for TODOs"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=2,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done"
+    for msg in result.messages:
+        if msg.get("role") == "tool":
+            content = str(msg.get("content", ""))
+            assert "Error: loop guard blocked" not in content, (
+                f"前2次调用不应有 loop guard: {content}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_loop_guard_different_args_no_false_positive():
+    """同一轮次内不同参数调用不应误触发 loop guard"""
+    provider = MagicMock(spec=LLMProvider)
+    call_count = {"n": 0}
+    paths = ["/a.txt", "/b.txt", "/c.txt"]
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return LLMResponse(
+                content="reading",
+                tool_calls=[
+                    ToolCallRequest(
+                        id=f"call_{i + 1}",
+                        name="read_file",
+                        arguments={"path": paths[i]},
+                    )
+                    for i in range(3)
+                ],
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+            )
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="file content")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "read files"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=2,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done"
+    for msg in result.messages:
+        if msg.get("role") == "tool":
+            content = str(msg.get("content", ""))
+            assert "Error: loop guard blocked" not in content, (
+                f"不同参数不应触发 loop guard: {content}"
+            )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Rate limit guard integration tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_guard_blocks_on_frequent_calls():
+    """同一轮次内频繁工具调用时硬阻断，返回 Error"""
+    provider = MagicMock(spec=LLMProvider)
+    call_count = {"n": 0}
+    threshold_count, _ = RATE_LIMIT_WINDOW
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Single turn with threshold_count identical calls — rate limit must block
+            return LLMResponse(
+                content="working",
+                tool_calls=[
+                    ToolCallRequest(
+                        id=f"call_{i + 1}",
+                        name="list_dir",
+                        arguments={"path": "."},
+                    )
+                    for i in range(threshold_count)
+                ],
+                usage={"prompt_tokens": 5, "completion_tokens": 2},
+            )
+        return LLMResponse(content="done", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+    tools.execute = AsyncMock(return_value="file listing")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "list dir a few times"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=2,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done"
+    rate_messages = [
+        msg for msg in result.messages
+        if msg.get("role") == "tool"
+        and "Error: rate limit exceeded" in str(msg.get("content", ""))
+    ]
+    assert len(rate_messages) >= 1, (
+        f"第{threshold_count}次调用应触发 rate limit，但未找到"
+    )
+
+
+@pytest.mark.asyncio
+async def test_loop_guard_preserves_normal_tool_results():
+    """正常不同工具调用不应被 loop guard 影响"""
+    provider = MagicMock(spec=LLMProvider)
+
+    async def chat_with_retry(*, messages, **kwargs):
+        return LLMResponse(
+            content="working",
+            tool_calls=[
+                ToolCallRequest(id="c1", name="read_file", arguments={"path": "/a.txt"}),
+                ToolCallRequest(id="c2", name="grep", arguments={"pattern": "x"}),
+            ],
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+        )
+
+    provider.chat_with_retry = chat_with_retry
+    tools = MagicMock()
+    tools.get_definitions.return_value = []
+
+    async def fake_tool(name, args, **kw):
+        return f"result from {name}"
+
+    tools.execute = AsyncMock(side_effect=fake_tool)
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "do work"}],
+        tools=tools,
+        model="test-model",
+        max_iterations=1,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    tool_results = [msg for msg in result.messages if msg.get("role") == "tool"]
+    assert len(tool_results) == 2
+    for tr in tool_results:
+        content = str(tr.get("content", ""))
+        assert "result from" in content
+        assert "Error: loop guard blocked" not in content
+        assert "Error: rate limit exceeded" not in content

--- a/tests/agent/test_runner_tool_execution.py
+++ b/tests/agent/test_runner_tool_execution.py
@@ -59,7 +59,7 @@ class _DelayTool(Tool):
 
 @pytest.mark.asyncio
 async def test_runner_batches_read_only_tools_before_exclusive_work():
-    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+    from nanobot.agent.runner import _ToolExecutionState, AgentRunSpec, AgentRunner
 
     tools = ToolRegistry()
     shared_events: list[str] = []
@@ -85,8 +85,7 @@ async def test_runner_batches_read_only_tools_before_exclusive_work():
             ToolCallRequest(id="ro2", name="read_b", arguments={}),
             ToolCallRequest(id="rw1", name="write_a", arguments={}),
         ],
-        {},
-        {},
+        _ToolExecutionState(),
     )
 
     assert shared_events[0:2] == ["start:read_a", "start:read_b"]
@@ -98,7 +97,7 @@ async def test_runner_batches_read_only_tools_before_exclusive_work():
 
 @pytest.mark.asyncio
 async def test_runner_does_not_batch_exclusive_read_only_tools():
-    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+    from nanobot.agent.runner import _ToolExecutionState, AgentRunSpec, AgentRunner
 
     tools = ToolRegistry()
     shared_events: list[str] = []
@@ -130,8 +129,7 @@ async def test_runner_does_not_batch_exclusive_read_only_tools():
             ToolCallRequest(id="ddg1", name="ddg_like", arguments={}),
             ToolCallRequest(id="ro2", name="read_b", arguments={}),
         ],
-        {},
-        {},
+        _ToolExecutionState(),
     )
 
     assert shared_events[0] == "start:read_a"


### PR DESCRIPTION
## 背景

日常使用中频繁遇到大模型陷入循环的问题——同一个工具用同样的参数反复调用，或者短时间内疯狂调用工具不看结果。比如：

- `grep` 同一个 pattern 连搜 N 次，每次都返回 `no matches`
- `list_dir` 连续调用 5 次在 3 秒内，输出完全一样
- `read_file` 读不存在的文件，改个路径就又读一遍重复的

现有的 `repeated_external_lookup_error` 只覆盖了 `web_search` / `web_fetch`，对通用工具的循环没有保护。这次加了两道护栏：

## 改动内容

### 1. 循环检测 (`repeated_loop_error`)
- 同一轮次内，相同工具 + 相同参数超过 3 次 → **硬阻断**（工具不执行，直接返回 Error）
- `write_stdin` 排除（poll 模式是标准行为，不是循环）
- 字符串参数做 `strip().lower()` 归一化，避免大小写/空格误判

### 2. 速率限制 (`rate_limit_error`)
- 同一工具在 3 秒内调用超过 5 次 → **硬阻断**
- 阻止大模型"疯狂输出"不看结果

### 3. 配置化
- `config.json` 中 `agents.defaults.loop_guard` 可自定义阈值或关闭
- 支持 `enabled` / `max_repeated_loops` / `rate_limit_count` / `rate_limit_seconds`

## 文件变更

| 文件 | 说明 |
|------|------|
| `nanobot/utils/runtime.py` | 新增 `loop_signature()`, `repeated_loop_error()`, `rate_limit_error()` |
| `nanobot/agent/runner.py` | `LoopGuardRuntimeConfig` + `_ToolExecutionState` 集成 |
| `nanobot/config/schema.py` | `LoopGuardConfig` Pydantic 配置模型 |
| `tests/agent/test_loop_guard.py` | 7 个集成测试 |
| `tests/agent/test_runner_tool_execution.py` | 适配新签名 |

## 测试

`tests/agent/` 全部 1021 测试通过，零回归。