### PR TITLE
refactor: add registry-driven provider config fields

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from nanobot.agent.tools.self import MyToolConfig
     from nanobot.agent.tools.shell import ExecToolConfig
     from nanobot.agent.tools.web import WebToolsConfig
+    from nanobot.providers.registry import ProviderResolution
 
 
 class Base(BaseModel):
@@ -228,12 +229,18 @@ class ProvidersConfig(Base):
 
     @model_validator(mode="after")
     def _validate_api_type_scope(self) -> "ProvidersConfig":
+        from nanobot.providers.registry import find_by_name
+
         for name in self.__class__.model_fields:
-            if name == "openai":
-                continue
+            spec = find_by_name(name)
             provider = getattr(self, name, None)
-            if isinstance(provider, ProviderConfig) and provider.api_type != "auto":
-                raise ValueError("providers.<name>.api_type is only supported for providers.openai")
+            if (
+                spec is not None
+                and isinstance(provider, ProviderConfig)
+                and provider.api_type != "auto"
+                and not spec.supports_config_field("api_type")
+            ):
+                raise ValueError("providers.<name>.api_type is not supported for this provider")
         return self
 
 
@@ -365,13 +372,14 @@ class Config(BaseSettings):
         """Get expanded workspace path."""
         return Path(self.agents.defaults.workspace).expanduser()
 
-    def _match_provider(
-        self, model: str | None = None,
+    def resolve_provider_ref(
+        self,
+        model: str | None = None,
         *,
         preset: ModelPresetConfig | None = None,
-    ) -> tuple["ProviderConfig | None", str | None]:
-        """Match provider config and its registry name. Returns (config, spec_name)."""
-        from nanobot.providers.registry import PROVIDERS, find_by_name
+    ) -> "ProviderResolution":
+        """Resolve a preset provider reference to registry metadata and config."""
+        from nanobot.providers.registry import PROVIDERS, ProviderResolution, find_by_name
 
         resolved = preset or self.resolve_preset()
         forced = resolved.provider
@@ -379,8 +387,14 @@ class Config(BaseSettings):
             spec = find_by_name(forced)
             if spec:
                 p = getattr(self.providers, spec.name, None)
-                return (p, spec.name) if p else (None, None)
-            return None, None
+                if p:
+                    return ProviderResolution(
+                        requested_name=forced,
+                        name=spec.name,
+                        spec=spec,
+                        config=p,
+                    )
+            return ProviderResolution(requested_name=forced, name=None, spec=None, config=None)
 
         model_lower = (model or resolved.model).lower()
         model_normalized = model_lower.replace("-", "_")
@@ -396,20 +410,32 @@ class Config(BaseSettings):
             p = getattr(self.providers, spec.name, None)
             if p and model_prefix and normalized_prefix == spec.name:
                 if spec.is_oauth or spec.is_local or spec.is_direct or p.api_key:
-                    return p, spec.name
+                    return ProviderResolution(
+                        requested_name=forced,
+                        name=spec.name,
+                        spec=spec,
+                        config=p,
+                        is_auto=True,
+                    )
 
         # Match by keyword (order follows PROVIDERS registry)
         for spec in PROVIDERS:
             p = getattr(self.providers, spec.name, None)
             if p and any(_kw_matches(kw) for kw in spec.keywords):
                 if spec.is_oauth or spec.is_local or spec.is_direct or p.api_key:
-                    return p, spec.name
+                    return ProviderResolution(
+                        requested_name=forced,
+                        name=spec.name,
+                        spec=spec,
+                        config=p,
+                        is_auto=True,
+                    )
 
         # Fallback: configured local providers can route models without
         # provider-specific keywords (for example plain "llama3.2" on Ollama).
         # Prefer providers whose detect_by_base_keyword matches the configured api_base
         # (e.g. Ollama's "11434" in "http://localhost:11434") over plain registry order.
-        local_fallback: tuple[ProviderConfig, str] | None = None
+        local_fallback = None
         for spec in PROVIDERS:
             if not spec.is_local:
                 continue
@@ -417,9 +443,21 @@ class Config(BaseSettings):
             if not (p and p.api_base):
                 continue
             if spec.detect_by_base_keyword and spec.detect_by_base_keyword in p.api_base:
-                return p, spec.name
+                return ProviderResolution(
+                    requested_name=forced,
+                    name=spec.name,
+                    spec=spec,
+                    config=p,
+                    is_auto=True,
+                )
             if local_fallback is None:
-                local_fallback = (p, spec.name)
+                local_fallback = ProviderResolution(
+                    requested_name=forced,
+                    name=spec.name,
+                    spec=spec,
+                    config=p,
+                    is_auto=True,
+                )
         if local_fallback:
             return local_fallback
 
@@ -430,8 +468,14 @@ class Config(BaseSettings):
                 continue
             p = getattr(self.providers, spec.name, None)
             if p and p.api_key:
-                return p, spec.name
-        return None, None
+                return ProviderResolution(
+                    requested_name=forced,
+                    name=spec.name,
+                    spec=spec,
+                    config=p,
+                    is_auto=True,
+                )
+        return ProviderResolution(requested_name=forced, name=None, spec=None, config=None, is_auto=True)
 
     def get_provider(
         self,
@@ -440,8 +484,7 @@ class Config(BaseSettings):
         preset: ModelPresetConfig | None = None,
     ) -> ProviderConfig | None:
         """Get matched provider config (api_key, api_base, extra_headers). Falls back to first available."""
-        p, _ = self._match_provider(model, preset=preset)
-        return p
+        return self.resolve_provider_ref(model, preset=preset).config
 
     def get_provider_name(
         self,
@@ -450,8 +493,7 @@ class Config(BaseSettings):
         preset: ModelPresetConfig | None = None,
     ) -> str | None:
         """Get the registry name of the matched provider (e.g. "deepseek", "openrouter")."""
-        _, name = self._match_provider(model, preset=preset)
-        return name
+        return self.resolve_provider_ref(model, preset=preset).name
 
     def get_api_key(
         self,
@@ -470,16 +512,7 @@ class Config(BaseSettings):
         preset: ModelPresetConfig | None = None,
     ) -> str | None:
         """Get API base URL for the given model, falling back to the provider default when present."""
-        from nanobot.providers.registry import find_by_name
-
-        p, name = self._match_provider(model, preset=preset)
-        if p and p.api_base:
-            return p.api_base
-        if name:
-            spec = find_by_name(name)
-            if spec and spec.default_api_base:
-                return spec.default_api_base
-        return None
+        return self.resolve_provider_ref(model, preset=preset).api_base
 
     model_config = ConfigDict(env_prefix="NANOBOT_", env_nested_delimiter="__")
 

--- a/nanobot/providers/factory.py
+++ b/nanobot/providers/factory.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from nanobot.config.schema import Config, InlineFallbackConfig, ModelPresetConfig
 from nanobot.providers.base import LLMProvider
 from nanobot.providers.fallback_provider import FallbackProvider
-from nanobot.providers.registry import find_by_name
 
 
 @dataclass(frozen=True)
@@ -38,9 +37,10 @@ def _make_provider_core(
     """Create a plain LLM provider without failover wrapping."""
     resolved = _resolve_model_preset(config, preset_name=preset_name, preset=preset)
     model = model or resolved.model
-    provider_name = config.get_provider_name(model, preset=resolved)
-    p = config.get_provider(model, preset=resolved)
-    spec = find_by_name(provider_name) if provider_name else None
+    provider_ref = config.resolve_provider_ref(model, preset=resolved)
+    provider_name = provider_ref.name
+    p = provider_ref.config
+    spec = provider_ref.spec
     backend = spec.backend if spec else "openai_compat"
 
     if backend == "azure_openai":
@@ -84,8 +84,8 @@ def _make_provider_core(
             api_key=p.api_key if p else None,
             api_base=p.api_base if p else None,
             default_model=model,
-            region=getattr(p, "region", None) if p else None,
-            profile=getattr(p, "profile", None) if p else None,
+            region=provider_ref.region,
+            profile=provider_ref.profile,
             extra_body=p.extra_body if p else None,
         )
     else:
@@ -98,7 +98,7 @@ def _make_provider_core(
             extra_headers=p.extra_headers if p else None,
             spec=spec,
             extra_body=p.extra_body if p else None,
-            api_type=p.api_type if p and provider_name == "openai" else "auto",
+            api_type=provider_ref.api_type,
         )
 
     provider.generation = resolved.to_generation_settings()
@@ -171,22 +171,15 @@ def provider_signature(
 ) -> tuple[object, ...]:
     """Return the config fields that affect the active provider chain."""
     resolved = _resolve_model_preset(config, preset_name=preset_name, preset=preset)
-    p = config.get_provider(resolved.model, preset=resolved)
+    provider_ref = config.resolve_provider_ref(resolved.model, preset=resolved)
     fallback_presets = _resolve_fallback_presets(config, resolved)
 
     def _fallback_signature(fallback: ModelPresetConfig) -> tuple[object, ...]:
-        fp = config.get_provider(fallback.model, preset=fallback)
+        fallback_ref = config.resolve_provider_ref(fallback.model, preset=fallback)
         return (
             fallback.model,
             fallback.provider,
-            config.get_provider_name(fallback.model, preset=fallback),
-            config.get_api_key(fallback.model, preset=fallback),
-            config.get_api_base(fallback.model, preset=fallback),
-            fp.extra_headers if fp else None,
-            fp.extra_body if fp else None,
-            fp.api_type if fp else "auto",
-            getattr(fp, "region", None) if fp else None,
-            getattr(fp, "profile", None) if fp else None,
+            *fallback_ref.signature_fields(),
             fallback.max_tokens,
             fallback.temperature,
             fallback.reasoning_effort,
@@ -196,14 +189,7 @@ def provider_signature(
     return (
         resolved.model,
         resolved.provider,
-        config.get_provider_name(resolved.model, preset=resolved),
-        config.get_api_key(resolved.model, preset=resolved),
-        config.get_api_base(resolved.model, preset=resolved),
-        p.extra_headers if p else None,
-        p.extra_body if p else None,
-        p.api_type if p else "auto",
-        getattr(p, "region", None) if p else None,
-        getattr(p, "profile", None) if p else None,
+        *provider_ref.signature_fields(),
         resolved.max_tokens,
         resolved.temperature,
         resolved.reasoning_effort,

--- a/nanobot/providers/oauth.py
+++ b/nanobot/providers/oauth.py
@@ -1,0 +1,136 @@
+"""OAuth provider status and actions.
+
+The provider registry declares which providers use OAuth. This module owns the
+runtime token lookups and login/logout side effects.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any
+
+from nanobot.providers.registry import ProviderSpec
+
+
+@dataclass(frozen=True)
+class OAuthProviderError(RuntimeError):
+    message: str
+    status: int = 400
+
+
+def _oauth_provider_name(spec: ProviderSpec) -> str:
+    return spec.oauth_provider or spec.name
+
+
+def oauth_provider_status(spec: ProviderSpec) -> dict[str, Any]:
+    if not getattr(spec, "is_oauth", False):
+        return {"configured": False, "account": None, "expires_at": None, "login_supported": False}
+
+    provider = _oauth_provider_name(spec)
+    if provider == "openai_codex":
+        try:
+            from oauth_cli_kit import get_token as get_codex_token
+        except Exception:
+            return {
+                "configured": False,
+                "account": None,
+                "expires_at": None,
+                "login_supported": False,
+            }
+        token = None
+        with suppress(Exception):
+            token = get_codex_token()
+        expires_at = getattr(token, "expires", None) if token else None
+        return {
+            "configured": bool(token and token.access),
+            "account": getattr(token, "account_id", None) if token else None,
+            "expires_at": expires_at,
+            "login_supported": True,
+        }
+
+    if provider == "github_copilot":
+        try:
+            from nanobot.providers.github_copilot_provider import get_github_copilot_login_status
+        except Exception:
+            return {
+                "configured": False,
+                "account": None,
+                "expires_at": None,
+                "login_supported": False,
+            }
+        token = None
+        with suppress(Exception):
+            token = get_github_copilot_login_status()
+        return {
+            "configured": bool(token and token.access and token.expires > int(time.time() * 1000)),
+            "account": getattr(token, "account_id", None) if token else None,
+            "expires_at": getattr(token, "expires", None) if token else None,
+            "login_supported": True,
+        }
+
+    return {"configured": False, "account": None, "expires_at": None, "login_supported": False}
+
+
+def login_oauth_provider(spec: ProviderSpec) -> None:
+    provider = _oauth_provider_name(spec)
+    if provider == "openai_codex":
+        try:
+            from oauth_cli_kit import get_token, login_oauth_interactive
+        except ImportError:
+            raise OAuthProviderError("oauth_cli_kit is not installed", status=500) from None
+
+        token = None
+        with suppress(Exception):
+            token = get_token()
+        if not (token and token.access):
+            messages: list[str] = []
+            token = login_oauth_interactive(
+                print_fn=lambda message: messages.append(str(message)),
+                prompt_fn=lambda _prompt: "",
+            )
+        if not (token and token.access):
+            raise OAuthProviderError("OAuth login failed", status=401)
+        return
+
+    if provider == "github_copilot":
+        try:
+            from nanobot.providers.github_copilot_provider import (
+                get_github_copilot_login_status,
+                login_github_copilot,
+            )
+        except ImportError:
+            raise OAuthProviderError("GitHub Copilot OAuth support is unavailable", status=500) from None
+
+        token = get_github_copilot_login_status()
+        if not token:
+            token = login_github_copilot(print_fn=lambda _message: None)
+        if not (token and token.access):
+            raise OAuthProviderError("OAuth login failed", status=401)
+        return
+
+    raise OAuthProviderError("OAuth login is not supported for this provider")
+
+
+def logout_oauth_provider(spec: ProviderSpec) -> None:
+    provider = _oauth_provider_name(spec)
+    if provider == "openai_codex":
+        try:
+            from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
+            from oauth_cli_kit.storage import FileTokenStorage
+        except ImportError:
+            raise OAuthProviderError("oauth_cli_kit is not installed", status=500) from None
+        token_path = FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename).get_token_path()
+    elif provider == "github_copilot":
+        try:
+            from nanobot.providers.github_copilot_provider import get_storage
+        except ImportError:
+            raise OAuthProviderError("GitHub Copilot OAuth support is unavailable", status=500) from None
+        token_path = get_storage().get_token_path()
+    else:
+        raise OAuthProviderError("OAuth logout is not supported for this provider")
+
+    for path in (token_path, token_path.with_suffix(".lock")):
+        with suppress(FileNotFoundError):
+            path.unlink()

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -56,6 +56,7 @@ class ProviderSpec:
 
     # OAuth-based providers (e.g., OpenAI Codex) don't use API keys
     is_oauth: bool = False
+    oauth_provider: str = ""
 
     # Direct providers skip API-key validation (user supplies everything)
     is_direct: bool = False
@@ -81,9 +82,71 @@ class ProviderSpec:
     # whose API returns the actual answer in "reasoning" instead of "content".
     reasoning_as_content: bool = False
 
+    # Provider-specific config fields beyond the common API connection fields.
+    config_fields: tuple[str, ...] = ()
+
     @property
     def label(self) -> str:
         return self.display_name or self.name.title()
+
+    def supports_config_field(self, field: str) -> bool:
+        return (
+            field in {"api_key", "api_base", "extra_headers", "extra_body"}
+            or field in self.config_fields
+        )
+
+
+@dataclass(frozen=True)
+class ProviderResolution:
+    """Resolved provider reference from config, including auto-detected providers."""
+
+    requested_name: str
+    name: str | None
+    spec: ProviderSpec | None
+    config: Any
+    is_auto: bool = False
+
+    @property
+    def resolved_name(self) -> str | None:
+        return self.name
+
+    @property
+    def api_base(self) -> str | None:
+        if self.config and self.config.api_base:
+            return self.config.api_base
+        if self.spec and self.spec.default_api_base:
+            return self.spec.default_api_base
+        return None
+
+    @property
+    def api_type(self) -> str:
+        if self.spec and self.spec.supports_config_field("api_type") and self.config:
+            return self.config.api_type
+        return "auto"
+
+    @property
+    def region(self) -> str | None:
+        if self.spec and self.spec.supports_config_field("region") and self.config:
+            return getattr(self.config, "region", None)
+        return None
+
+    @property
+    def profile(self) -> str | None:
+        if self.spec and self.spec.supports_config_field("profile") and self.config:
+            return getattr(self.config, "profile", None)
+        return None
+
+    def signature_fields(self) -> tuple[Any, ...]:
+        return (
+            self.name,
+            self.config.api_key if self.config else None,
+            self.api_base,
+            self.config.extra_headers if self.config else None,
+            self.config.extra_body if self.config else None,
+            self.api_type,
+            self.region,
+            self.profile,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +195,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="AWS Bedrock",
         backend="bedrock",
         is_direct=True,
+        config_fields=("region", "profile"),
     ),
     # === Gateways (detected by api_key / api_base, not model name) =========
     # Gateways can route any model, so they win in fallback.
@@ -285,6 +349,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="OpenAI",
         backend="openai_compat",
         supports_max_completion_tokens=True,
+        config_fields=("api_type",),
     ),
     # OpenAI Codex: OAuth-based, dedicated provider
     ProviderSpec(
@@ -296,6 +361,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_base_keyword="codex",
         default_api_base="https://chatgpt.com/backend-api",
         is_oauth=True,
+        oauth_provider="openai_codex",
     ),
     # GitHub Copilot: OAuth-based
     ProviderSpec(
@@ -307,6 +373,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://api.githubcopilot.com",
         strip_model_prefix=True,
         is_oauth=True,
+        oauth_provider="github_copilot",
         supports_max_completion_tokens=True,
     ),
     # DeepSeek: OpenAI-compatible at api.deepseek.com

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 import os
 import re
-import time
-from contextlib import suppress
 from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
@@ -20,6 +18,12 @@ from nanobot.config.schema import ModelPresetConfig
 from nanobot.providers.image_generation import (
     get_image_gen_provider,
     image_gen_provider_names,
+)
+from nanobot.providers.oauth import (
+    OAuthProviderError,
+    login_oauth_provider as login_provider_oauth,
+    logout_oauth_provider as logout_provider_oauth,
+    oauth_provider_status,
 )
 from nanobot.providers.registry import PROVIDERS, find_by_name
 from nanobot.security.workspace_access import workspace_sandbox_status
@@ -253,57 +257,9 @@ def _provider_requires_api_key(spec: Any) -> bool:
     return True
 
 
-def _oauth_provider_status(spec: Any) -> dict[str, Any]:
-    if not getattr(spec, "is_oauth", False):
-        return {"configured": False, "account": None, "expires_at": None, "login_supported": False}
-
-    if spec.name == "openai_codex":
-        try:
-            from oauth_cli_kit import get_token as get_codex_token
-        except Exception:
-            return {
-                "configured": False,
-                "account": None,
-                "expires_at": None,
-                "login_supported": False,
-            }
-        token = None
-        with suppress(Exception):
-            token = get_codex_token()
-        expires_at = getattr(token, "expires", None) if token else None
-        return {
-            "configured": bool(token and token.access),
-            "account": getattr(token, "account_id", None) if token else None,
-            "expires_at": expires_at,
-            "login_supported": True,
-        }
-
-    if spec.name == "github_copilot":
-        try:
-            from nanobot.providers.github_copilot_provider import get_github_copilot_login_status
-        except Exception:
-            return {
-                "configured": False,
-                "account": None,
-                "expires_at": None,
-                "login_supported": False,
-            }
-        token = None
-        with suppress(Exception):
-            token = get_github_copilot_login_status()
-        return {
-            "configured": bool(token and token.access and token.expires > int(time.time() * 1000)),
-            "account": getattr(token, "account_id", None) if token else None,
-            "expires_at": getattr(token, "expires", None) if token else None,
-            "login_supported": True,
-        }
-
-    return {"configured": False, "account": None, "expires_at": None, "login_supported": False}
-
-
 def _provider_configured_for_settings(spec: Any, provider_config: Any) -> bool:
     if spec.is_oauth:
-        return bool(_oauth_provider_status(spec)["configured"])
+        return bool(oauth_provider_status(spec)["configured"])
     if _provider_requires_api_key(spec):
         return bool(provider_config.api_key)
     return bool(
@@ -536,7 +492,7 @@ def _validate_configured_provider(config: Any, provider: str) -> None:
     spec = find_by_name(provider)
     if spec is None:
         raise WebUISettingsError("unknown provider")
-    provider_config = getattr(config.providers, provider, None)
+    provider_config = getattr(config.providers, spec.name, None)
     if (
         provider_config is None
         or not _provider_configured_for_settings(spec, provider_config)
@@ -604,7 +560,7 @@ def settings_payload(
         provider_config = getattr(config.providers, spec.name, None)
         if provider_config is None:
             continue
-        oauth_status = _oauth_provider_status(spec) if spec.is_oauth else None
+        oauth_status = oauth_provider_status(spec) if spec.is_oauth else None
         row = {
             "name": spec.name,
             "label": spec.label,
@@ -618,13 +574,18 @@ def settings_payload(
             "api_key_hint": _mask_secret_hint(provider_config.api_key),
             "api_base": provider_config.api_base,
             "default_api_base": spec.default_api_base or None,
+            "config_fields": list(spec.config_fields),
         }
         if oauth_status is not None:
             row["oauth_account"] = oauth_status["account"]
             row["oauth_expires_at"] = oauth_status["expires_at"]
             row["oauth_login_supported"] = oauth_status["login_supported"]
-        if spec.name == "openai":
+        if spec.supports_config_field("api_type"):
             row["api_type"] = provider_config.api_type
+        if spec.supports_config_field("region"):
+            row["region"] = getattr(provider_config, "region", None)
+        if spec.supports_config_field("profile"):
+            row["profile"] = getattr(provider_config, "profile", None)
         providers.append(row)
 
     search_config = config.tools.web.search
@@ -990,7 +951,7 @@ def update_provider_settings(query: QueryParams) -> dict[str, Any]:
             changed = True
 
     if "api_type" in query:
-        if spec.name == "openai":
+        if spec.supports_config_field("api_type"):
             api_type = (_query_first(query, "api_type") or "").strip()
             try:
                 parsed_api_type = type(provider_config)(api_type=api_type).api_type
@@ -999,6 +960,18 @@ def update_provider_settings(query: QueryParams) -> dict[str, Any]:
             if provider_config.api_type != parsed_api_type:
                 provider_config.api_type = parsed_api_type
                 changed = True
+
+    if "region" in query and spec.supports_config_field("region"):
+        region = (_query_first(query, "region") or "").strip() or None
+        if getattr(provider_config, "region", None) != region:
+            provider_config.region = region
+            changed = True
+
+    if "profile" in query and spec.supports_config_field("profile"):
+        profile = (_query_first(query, "profile") or "").strip() or None
+        if getattr(provider_config, "profile", None) != profile:
+            provider_config.profile = profile
+            changed = True
 
     if changed:
         save_config(config)
@@ -1020,42 +993,11 @@ def login_oauth_provider(query: QueryParams) -> dict[str, Any]:
     if spec is None or not spec.is_oauth:
         raise WebUISettingsError("unknown OAuth provider")
 
-    if spec.name == "openai_codex":
-        try:
-            from oauth_cli_kit import get_token, login_oauth_interactive
-        except ImportError:
-            raise WebUISettingsError("oauth_cli_kit is not installed", status=500) from None
-
-        token = None
-        with suppress(Exception):
-            token = get_token()
-        if not (token and token.access):
-            messages: list[str] = []
-            token = login_oauth_interactive(
-                print_fn=lambda message: messages.append(str(message)),
-                prompt_fn=lambda _prompt: "",
-            )
-        if not (token and token.access):
-            raise WebUISettingsError("OAuth login failed", status=401)
-        return settings_payload()
-
-    if spec.name == "github_copilot":
-        try:
-            from nanobot.providers.github_copilot_provider import (
-                get_github_copilot_login_status,
-                login_github_copilot,
-            )
-        except ImportError:
-            raise WebUISettingsError("GitHub Copilot OAuth support is unavailable", status=500) from None
-
-        token = get_github_copilot_login_status()
-        if not token:
-            token = login_github_copilot(print_fn=lambda _message: None)
-        if not (token and token.access):
-            raise WebUISettingsError("OAuth login failed", status=401)
-        return settings_payload()
-
-    raise WebUISettingsError("OAuth login is not supported for this provider")
+    try:
+        login_provider_oauth(spec)
+    except OAuthProviderError as exc:
+        raise WebUISettingsError(exc.message, status=exc.status) from exc
+    return settings_payload()
 
 
 def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
@@ -1066,25 +1008,10 @@ def logout_oauth_provider(query: QueryParams) -> dict[str, Any]:
     if spec is None or not spec.is_oauth:
         raise WebUISettingsError("unknown OAuth provider")
 
-    if spec.name == "openai_codex":
-        try:
-            from oauth_cli_kit.providers import OPENAI_CODEX_PROVIDER
-            from oauth_cli_kit.storage import FileTokenStorage
-        except ImportError:
-            raise WebUISettingsError("oauth_cli_kit is not installed", status=500) from None
-        token_path = FileTokenStorage(token_filename=OPENAI_CODEX_PROVIDER.token_filename).get_token_path()
-    elif spec.name == "github_copilot":
-        try:
-            from nanobot.providers.github_copilot_provider import get_storage
-        except ImportError:
-            raise WebUISettingsError("GitHub Copilot OAuth support is unavailable", status=500) from None
-        token_path = get_storage().get_token_path()
-    else:
-        raise WebUISettingsError("OAuth logout is not supported for this provider")
-
-    for path in (token_path, token_path.with_suffix(".lock")):
-        with suppress(FileNotFoundError):
-            path.unlink()
+    try:
+        logout_provider_oauth(spec)
+    except OAuthProviderError as exc:
+        raise WebUISettingsError(exc.message, status=exc.status) from exc
     return settings_payload()
 
 

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import re
+import time
 from typing import Any, Literal
 from zoneinfo import ZoneInfo
 

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -1385,7 +1385,7 @@ async def test_settings_api_returns_safe_subset_and_updates_whitelist(
     save_config(config, config_path)
     monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
     monkeypatch.setattr(
-        "nanobot.webui.settings_api._oauth_provider_status",
+        "nanobot.webui.settings_api.oauth_provider_status",
         lambda _spec: {
             "configured": False,
             "account": None,

--- a/tests/config/test_model_presets.py
+++ b/tests/config/test_model_presets.py
@@ -36,8 +36,8 @@ def test_provider_api_type_accepts_exact_values_only() -> None:
         })
 
 
-def test_provider_api_type_is_openai_only() -> None:
-    with pytest.raises(ValueError, match="only supported"):
+def test_provider_api_type_uses_registry_field_capabilities() -> None:
+    with pytest.raises(ValueError, match="not supported"):
         Config.model_validate({
             "providers": {
                 "custom": {
@@ -46,6 +46,57 @@ def test_provider_api_type_is_openai_only() -> None:
                 }
             }
         })
+
+
+def test_resolve_provider_ref_exposes_registry_metadata() -> None:
+    config = Config.model_validate({
+        "providers": {
+            "openai": {
+                "apiKey": "sk-test",
+                "apiType": "responses",
+            },
+        },
+        "agents": {
+            "defaults": {
+                "model": "openai/gpt-4.1",
+                "provider": "auto",
+            }
+        },
+    })
+
+    provider_ref = config.resolve_provider_ref()
+
+    assert provider_ref.requested_name == "auto"
+    assert provider_ref.name == "openai"
+    assert provider_ref.spec is not None
+    assert provider_ref.spec.supports_config_field("api_type")
+    assert provider_ref.api_type == "responses"
+
+
+def test_bedrock_provider_ref_exposes_region_and_profile() -> None:
+    config = Config.model_validate({
+        "providers": {
+            "bedrock": {
+                "region": "us-east-1",
+                "profile": "work",
+            },
+        },
+        "agents": {
+            "defaults": {
+                "model": "bedrock/anthropic.claude-opus-4-5",
+                "provider": "bedrock",
+            }
+        },
+    })
+
+    provider_ref = config.resolve_provider_ref()
+
+    assert provider_ref.name == "bedrock"
+    assert provider_ref.spec is not None
+    assert provider_ref.spec.supports_config_field("region")
+    assert provider_ref.spec.supports_config_field("profile")
+    assert provider_ref.region == "us-east-1"
+    assert provider_ref.profile == "work"
 
 
 def test_legacy_defaults_config_without_presets_still_resolves() -> None:

--- a/tests/webui/test_settings_api.py
+++ b/tests/webui/test_settings_api.py
@@ -7,17 +7,18 @@ import pytest
 
 from nanobot.config.loader import load_config, save_config
 from nanobot.config.schema import Config, ModelPresetConfig
+from nanobot.providers.oauth import oauth_provider_status
+from nanobot.providers.registry import find_by_name
 from nanobot.webui.settings_api import (
     WebUISettingsError,
-    _oauth_provider_status,
     create_model_configuration,
     provider_models_payload,
     settings_payload,
     update_agent_settings,
     update_model_configuration,
     update_network_safety_settings,
+    update_provider_settings,
 )
-from nanobot.providers.registry import find_by_name
 
 
 def test_create_model_configuration_writes_label_and_selects(
@@ -95,7 +96,7 @@ def test_update_model_configuration_edits_named_preset_and_selects(
     save_config(config, config_path)
     monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
     monkeypatch.setattr(
-        "nanobot.webui.settings_api._oauth_provider_status",
+        "nanobot.webui.settings_api.oauth_provider_status",
         lambda spec: {
             "configured": spec.name == "openai_codex",
             "account": "acct-test",
@@ -176,6 +177,29 @@ def test_update_context_window_rejects_unknown_values(
         update_agent_settings({"context_window_tokens": ["128000"]})
 
 
+def test_settings_payload_uses_provider_registry_config_fields(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config = Config.model_validate({
+        "providers": {
+            "openai": {"apiKey": "sk-test", "apiType": "responses"},
+            "bedrock": {"region": "us-east-1", "profile": "work"},
+        }
+    })
+    save_config(config, config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    rows = {row["name"]: row for row in settings_payload()["providers"]}
+
+    assert rows["openai"]["config_fields"] == ["api_type"]
+    assert rows["openai"]["api_type"] == "responses"
+    assert rows["bedrock"]["config_fields"] == ["region", "profile"]
+    assert rows["bedrock"]["region"] == "us-east-1"
+    assert rows["bedrock"]["profile"] == "work"
+
+
 def test_update_model_configuration_rejects_default_preset(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -186,6 +210,25 @@ def test_update_model_configuration_rejects_default_preset(
 
     with pytest.raises(WebUISettingsError, match="model configuration is required"):
         update_model_configuration({"name": ["default"], "model": ["openai/gpt-4.1"]})
+
+
+def test_update_provider_settings_uses_registry_config_fields(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    save_config(Config(), config_path)
+    monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
+
+    update_provider_settings({
+        "provider": ["bedrock"],
+        "region": ["us-west-2"],
+        "profile": ["prod"],
+    })
+
+    saved = load_config(config_path)
+    assert saved.providers.bedrock.region == "us-west-2"
+    assert saved.providers.bedrock.profile == "prod"
 
 
 def test_settings_payload_includes_oauth_provider_status(
@@ -211,7 +254,7 @@ def test_settings_payload_includes_oauth_provider_status(
             "login_supported": True,
         }
 
-    monkeypatch.setattr("nanobot.webui.settings_api._oauth_provider_status", fake_oauth_status)
+    monkeypatch.setattr("nanobot.webui.settings_api.oauth_provider_status", fake_oauth_status)
 
     payload = settings_payload()
     providers = {row["name"]: row for row in payload["providers"]}
@@ -318,7 +361,7 @@ def test_openai_codex_oauth_status_uses_available_token(
 
     monkeypatch.setattr("oauth_cli_kit.get_token", fake_get_token)
 
-    status = _oauth_provider_status(find_by_name("openai_codex"))
+    status = oauth_provider_status(find_by_name("openai_codex"))
 
     assert status["configured"] is True
     assert status["account"] == "acct-codex"
@@ -332,7 +375,7 @@ def test_openai_codex_oauth_status_rejects_unavailable_token(
 
     monkeypatch.setattr("oauth_cli_kit.get_token", fake_get_token)
 
-    status = _oauth_provider_status(find_by_name("openai_codex"))
+    status = oauth_provider_status(find_by_name("openai_codex"))
 
     assert status["configured"] is False
     assert status["account"] is None
@@ -441,7 +484,7 @@ def test_create_model_configuration_accepts_configured_oauth_provider(
     save_config(Config(), config_path)
     monkeypatch.setattr("nanobot.config.loader._current_config_path", config_path)
     monkeypatch.setattr(
-        "nanobot.webui.settings_api._oauth_provider_status",
+        "nanobot.webui.settings_api.oauth_provider_status",
         lambda spec: {
             "configured": spec.name == "openai_codex",
             "account": "acct-test",

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -108,6 +108,7 @@ import type {
   McpPresetsPayload,
   NetworkSafetySettingsUpdate,
   ProviderModelsPayload,
+  ProviderSettingsUpdate,
   SettingsPayload,
   WebSearchSettingsUpdate,
   WebuiDefaultAccessMode,
@@ -164,7 +165,15 @@ type RestartAwarePayload = {
   runtime_capabilities?: SettingsPayload["runtime_capabilities"];
 };
 type ProviderApiType = "auto" | "chat_completions" | "responses";
-type ProviderForm = { apiKey: string; apiBase: string; apiType: ProviderApiType };
+type ProviderConfigField = "api_type" | "region" | "profile";
+type ProviderTextConfigField = "region" | "profile";
+type ProviderForm = {
+  apiKey: string;
+  apiBase: string;
+  apiType: ProviderApiType;
+  region: string;
+  profile: string;
+};
 type CustomMcpTransport = "stdio" | "streamableHttp" | "sse";
 
 const NANOBOT_ICON_SRC = "/brand/nanobot_icon.png";
@@ -235,6 +244,28 @@ const OPENAI_API_TYPE_OPTIONS: Array<{ value: ProviderApiType; label: string }> 
   { value: "chat_completions", label: "Chat Completions" },
   { value: "responses", label: "Responses" },
 ];
+const PROVIDER_TEXT_CONFIG_FIELD_DEFS: Record<
+  ProviderTextConfigField,
+  {
+    labelKey: string;
+    label: string;
+    placeholderKey: string;
+    placeholder: string;
+  }
+> = {
+  region: {
+    labelKey: "settings.byok.region",
+    label: "Region",
+    placeholderKey: "settings.byok.regionPlaceholder",
+    placeholder: "us-east-1",
+  },
+  profile: {
+    labelKey: "settings.byok.profile",
+    label: "Profile",
+    placeholderKey: "settings.byok.profilePlaceholder",
+    placeholder: "default",
+  },
+};
 
 const LOCAL_UNCONFIGURED_PROVIDER_ORDER = new Map(
   ["vllm", "ollama", "lm_studio", "atomic_chat", "ovms"].map((name, index) => [
@@ -250,6 +281,36 @@ const EMPTY_PENDING_RESTART_SECTIONS: PendingRestartSections = {
   browser: false,
   image: false,
 };
+
+function providerFormDefaults(
+  provider: SettingsPayload["providers"][number],
+  existing?: ProviderForm,
+): ProviderForm {
+  return {
+    apiKey: existing?.apiKey ?? "",
+    apiBase: existing?.apiBase ?? provider.api_base ?? provider.default_api_base ?? "",
+    apiType: existing?.apiType ?? provider.api_type ?? "auto",
+    region: existing?.region ?? provider.region ?? "",
+    profile: existing?.profile ?? provider.profile ?? "",
+  };
+}
+
+function providerSupportsConfigField(
+  provider: SettingsPayload["providers"][number],
+  field: ProviderConfigField,
+): boolean {
+  return provider.config_fields?.includes(field) ?? false;
+}
+
+function isProviderTextConfigField(field: string): field is ProviderTextConfigField {
+  return field === "region" || field === "profile";
+}
+
+function providerTextConfigFields(
+  provider: SettingsPayload["providers"][number],
+): ProviderTextConfigField[] {
+  return (provider.config_fields ?? []).filter(isProviderTextConfigField);
+}
 
 const DEFAULT_CUSTOM_MCP_FORM: CustomMcpForm = {
   name: "",
@@ -541,11 +602,7 @@ export function SettingsView({
     setProviderForms((prev) => {
       const next = { ...prev };
       for (const provider of settings.providers) {
-        next[provider.name] = {
-          apiKey: next[provider.name]?.apiKey ?? "",
-          apiBase: next[provider.name]?.apiBase ?? provider.api_base ?? provider.default_api_base ?? "",
-          apiType: next[provider.name]?.apiType ?? provider.api_type ?? "auto",
-        };
+        next[provider.name] = providerFormDefaults(provider, next[provider.name]);
       }
       return next;
     });
@@ -807,7 +864,7 @@ export function SettingsView({
     const provider = settings?.providers.find((item) => item.name === providerName);
     if (!provider) return;
     if (provider.auth_type === "oauth") return;
-    const providerForm = providerForms[providerName] ?? { apiKey: "", apiBase: "", apiType: "auto" };
+    const providerForm = providerForms[providerName] ?? providerFormDefaults(provider);
     const apiKey = providerForm.apiKey.trim();
     const apiKeyRequired = provider.api_key_required ?? true;
     if (!provider.configured && apiKeyRequired && !apiKey) {
@@ -816,12 +873,21 @@ export function SettingsView({
     }
     setProviderSaving(providerName);
     try {
-      const payload = await updateProviderSettings(token, {
+      const update: ProviderSettingsUpdate = {
         provider: providerName,
         apiKey: apiKey || undefined,
         apiBase: providerForm.apiBase.trim(),
-        apiType: providerForm.apiType,
-      });
+      };
+      if (providerSupportsConfigField(provider, "api_type")) {
+        update.apiType = providerForm.apiType;
+      }
+      if (providerSupportsConfigField(provider, "region")) {
+        update.region = providerForm.region.trim();
+      }
+      if (providerSupportsConfigField(provider, "profile")) {
+        update.profile = providerForm.profile.trim();
+      }
+      const payload = await updateProviderSettings(token, update);
       applyPayload(payload);
       if (payload.requires_restart) {
         setPendingRestartSections((prev) => ({ ...prev, image: true }));
@@ -833,6 +899,8 @@ export function SettingsView({
           apiKey: "",
           apiBase: providerForm.apiBase.trim(),
           apiType: providerForm.apiType,
+          region: providerForm.region.trim(),
+          profile: providerForm.profile.trim(),
         },
       }));
       setVisibleProviderKeys((prev) => ({ ...prev, [providerName]: false }));
@@ -925,11 +993,7 @@ export function SettingsView({
     if (!provider) return;
     setProviderForms((prev) => ({
       ...prev,
-      [providerName]: {
-        apiKey: "",
-        apiBase: provider.api_base ?? provider.default_api_base ?? "",
-        apiType: provider.api_type ?? "auto",
-      },
+      [providerName]: providerFormDefaults(provider),
     }));
     setVisibleProviderKeys((prev) => ({ ...prev, [providerName]: false }));
     setEditingProviderKeys((prev) => ({ ...prev, [providerName]: false }));
@@ -983,6 +1047,8 @@ export function SettingsView({
             apiKey: "",
             apiBase: forms[providerName]?.apiBase ?? "",
             apiType: forms[providerName]?.apiType ?? "auto",
+            region: forms[providerName]?.region ?? "",
+            profile: forms[providerName]?.profile ?? "",
           },
         }));
         setVisibleProviderKeys((visible) => ({ ...visible, [providerName]: false }));
@@ -1176,6 +1242,8 @@ export function SettingsView({
                     apiKey: prev[provider]?.apiKey ?? "",
                     apiBase: prev[provider]?.apiBase ?? "",
                     apiType: prev[provider]?.apiType ?? "auto",
+                    region: prev[provider]?.region ?? "",
+                    profile: prev[provider]?.profile ?? "",
                     ...value,
                   },
                 }))
@@ -2089,11 +2157,7 @@ function ProvidersSettings({
   const filteredUnconfigured = filterProviders(unconfiguredProviders, query);
   const renderProviderRow = (provider: SettingsPayload["providers"][number]) => {
     const expanded = expandedProvider === provider.name;
-    const form = providerForms[provider.name] ?? {
-      apiKey: "",
-      apiBase: provider.api_base ?? provider.default_api_base ?? "",
-      apiType: provider.api_type ?? "auto",
-    };
+    const form = providerForms[provider.name] ?? providerFormDefaults(provider);
     const saving = providerSaving === provider.name;
     const isOauthProvider = provider.auth_type === "oauth";
     const keyVisible = !!visibleProviderKeys[provider.name];
@@ -2101,9 +2165,11 @@ function ProvidersSettings({
     const apiKeyRequired = provider.api_key_required ?? true;
     const apiKey = form.apiKey.trim();
     const apiBase = form.apiBase.trim();
+    const textConfigFields = providerTextConfigFields(provider);
+    const hasTextConfigValue = textConfigFields.some((field) => form[field].trim());
     const missingRequiredApiKey = !isOauthProvider && apiKeyRequired && !provider.configured && !apiKey;
     const missingOptionalCredential =
-      !isOauthProvider && !apiKeyRequired && !provider.configured && !apiKey && !apiBase;
+      !isOauthProvider && !apiKeyRequired && !provider.configured && !apiKey && !apiBase && !hasTextConfigValue;
     return (
       <div key={provider.name} className="divide-y divide-border/45">
         <button
@@ -2254,7 +2320,7 @@ function ProvidersSettings({
                 className="h-9 rounded-full text-[13px]"
               />
             </label>
-            {provider.name === "openai" ? (
+            {providerSupportsConfigField(provider, "api_type") ? (
               <label className="block space-y-1.5">
                 <span className="text-[12px] font-medium text-muted-foreground">
                   {tx("settings.byok.apiType", "API type")}
@@ -2286,6 +2352,24 @@ function ProvidersSettings({
                 </DropdownMenu>
               </label>
             ) : null}
+            {textConfigFields.map((field) => {
+              const fieldDef = PROVIDER_TEXT_CONFIG_FIELD_DEFS[field];
+              return (
+                <label key={field} className="block space-y-1.5">
+                  <span className="text-[12px] font-medium text-muted-foreground">
+                    {tx(fieldDef.labelKey, fieldDef.label)}
+                  </span>
+                  <Input
+                    value={form[field]}
+                    onChange={(event) =>
+                      onChangeProviderForm(provider.name, { [field]: event.target.value })
+                    }
+                    placeholder={tx(fieldDef.placeholderKey, fieldDef.placeholder)}
+                    className="h-9 rounded-full text-[13px]"
+                  />
+                </label>
+              );
+            })}
             <div className="flex items-center justify-end gap-2">
               <Button
                 size="sm"

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -352,6 +352,8 @@ export async function updateProviderSettings(
   if (update.apiKey !== undefined) query.set("api_key", update.apiKey);
   if (update.apiBase !== undefined) query.set("api_base", update.apiBase);
   if (update.apiType !== undefined) query.set("api_type", update.apiType);
+  if (update.region !== undefined) query.set("region", update.region);
+  if (update.profile !== undefined) query.set("profile", update.profile);
   return request<SettingsPayload>(
     `${base}/api/settings/provider/update?${query}`,
     token,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -289,10 +289,13 @@ export interface SettingsPayload {
     api_key_hint?: string | null;
     api_base?: string | null;
     default_api_base?: string | null;
+    config_fields?: string[];
     api_type?: "auto" | "chat_completions" | "responses";
     oauth_account?: string | null;
     oauth_expires_at?: number | null;
     oauth_login_supported?: boolean;
+    region?: string | null;
+    profile?: string | null;
   }>;
   web_search: {
     provider: string;
@@ -567,6 +570,8 @@ export interface ProviderSettingsUpdate {
   apiKey?: string;
   apiBase?: string;
   apiType?: "auto" | "chat_completions" | "responses";
+  region?: string;
+  profile?: string;
 }
 
 export interface WebSearchSettingsUpdate {

--- a/webui/src/tests/api.test.ts
+++ b/webui/src/tests/api.test.ts
@@ -195,6 +195,21 @@ describe("webui API helpers", () => {
     );
   });
 
+  it("serializes provider registry config fields", async () => {
+    await updateProviderSettings("tok", {
+      provider: "bedrock",
+      region: "us-west-2",
+      profile: "prod",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/settings/provider/update?provider=bedrock&region=us-west-2&profile=prod",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer tok" },
+      }),
+    );
+  });
+
   it("serializes web search settings updates", async () => {
     await updateWebSearchSettings("tok", {
       provider: "searxng",


### PR DESCRIPTION
  ## Summary

  - introduce registry-driven provider config fields for provider-specific settings
  - expose Bedrock `region` and `profile` through the settings payload and update API
  - render and submit supported provider config fields in the Web UI
  - add coverage for provider config field payloads, updates, and frontend serialization

  ## Tests

  - `uv run pytest tests/config/test_model_presets.py tests/webui/test_settings_api.py`
  - `npm run test -- api.test.ts`
  - `npm run build`