### PR TITLE
perf(agent): pre-warm shared tokenizer and add build-state timing logs

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1372,10 +1372,17 @@ class AgentLoop:
         return "dispatch"
 
     async def _state_build(self, ctx: TurnContext) -> str:
+        t_step = time.perf_counter()
         await self.consolidator.maybe_consolidate_by_tokens(
             ctx.session,
             replay_max_messages=self._max_messages,
         )
+        logger.debug(
+            "[turn {}] BUILD consolidate took {:.1f}ms",
+            ctx.turn_id,
+            (time.perf_counter() - t_step) * 1000,
+        )
+        t_step = time.perf_counter()
         self._set_tool_context(
             ctx.msg.channel,
             ctx.msg.chat_id,
@@ -1386,32 +1393,70 @@ class AgentLoop:
         if message_tool := self.tools.get("message"):
             if isinstance(message_tool, MessageTool):
                 message_tool.start_turn()
+        logger.debug(
+            "[turn {}] BUILD tool_context took {:.1f}ms",
+            ctx.turn_id,
+            (time.perf_counter() - t_step) * 1000,
+        )
 
+        t_step = time.perf_counter()
         _hist_kwargs: dict[str, Any] = {
             "max_messages": self._max_messages,
             "max_tokens": self._replay_token_budget(),
             "include_timestamps": True,
         }
         ctx.history = ctx.session.get_history(**_hist_kwargs)
+        logger.debug(
+            "[turn {}] BUILD get_history took {:.1f}ms (history={} msgs)",
+            ctx.turn_id,
+            (time.perf_counter() - t_step) * 1000,
+            len(ctx.history),
+        )
+        t_step = time.perf_counter()
         self._runtime_events().record_turn_runtime(
             ctx.session_key,
             self.llm_runtime(),
         )
+        logger.debug(
+            "[turn {}] BUILD runtime_context took {:.1f}ms",
+            ctx.turn_id,
+            (time.perf_counter() - t_step) * 1000,
+        )
 
+        t_step = time.perf_counter()
         ctx.initial_messages = self._build_initial_messages(
             ctx.msg,
             ctx.session,
             ctx.history,
             ctx.pending_summary,
         )
+        logger.debug(
+            "[turn {}] BUILD initial_messages took {:.1f}ms (messages={})",
+            ctx.turn_id,
+            (time.perf_counter() - t_step) * 1000,
+            len(ctx.initial_messages),
+        )
+        t_step = time.perf_counter()
         ctx.user_persisted_early = self._persist_user_message_early(
             ctx.msg, ctx.session
         )
+        logger.debug(
+            "[turn {}] BUILD persist_user took {:.1f}ms (persisted={})",
+            ctx.turn_id,
+            (time.perf_counter() - t_step) * 1000,
+            ctx.user_persisted_early,
+        )
 
+        t_step = time.perf_counter()
         if ctx.on_progress is None:
             ctx.on_progress = await self._build_bus_progress_callback(ctx.msg)
         if ctx.on_retry_wait is None:
             ctx.on_retry_wait = await self._build_retry_wait_callback(ctx.msg)
+        logger.debug(
+            "[turn {}] BUILD callbacks took {:.1f}ms",
+            ctx.turn_id,
+            (time.perf_counter() - t_step) * 1000,
+        )
 
         return "ok"
 

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -53,7 +53,10 @@ from nanobot.session.goal_state import (
 )
 from nanobot.session.manager import Session, SessionManager
 from nanobot.utils.document import extract_documents, reference_non_image_attachments
-from nanobot.utils.helpers import image_placeholder_text
+from nanobot.utils.helpers import (
+    image_placeholder_text,
+    warmup_tokenizer,
+)
 from nanobot.utils.helpers import truncate_text as truncate_text_fn
 from nanobot.utils.image_generation_intent import image_generation_prompt
 from nanobot.utils.llm_runtime import LLMRuntime
@@ -840,7 +843,7 @@ class AgentLoop:
     async def run(self) -> None:
         """Run the agent loop, dispatching messages as tasks to stay responsive to /stop."""
         self._running = True
-        await self._connect_mcp()
+        await self.startup()
         logger.info("Agent loop started")
 
         while self._running:
@@ -1078,6 +1081,11 @@ class AgentLoop:
         task = asyncio.create_task(coro)
         self._background_tasks.append(task)
         task.add_done_callback(self._background_tasks.remove)
+
+    async def startup(self) -> None:
+        """Initialize resources needed before accepting messages."""
+        await self._connect_mcp()
+        warmup_tokenizer()
 
     def stop(self) -> None:
         """Stop the agent loop."""
@@ -1767,7 +1775,7 @@ class AgentLoop:
         on_stream_end: Callable[..., Awaitable[None]] | None = None,
     ) -> OutboundMessage | None:
         """Process a message directly and return the outbound payload."""
-        await self._connect_mcp()
+        await self.startup()
         msg = InboundMessage(
             channel=channel, sender_id="user", chat_id=chat_id,
             content=content, media=media or [],

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -12,7 +12,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterator
 
-import tiktoken
 from loguru import logger
 
 from nanobot.agent.runner import AgentRunner, AgentRunSpec
@@ -24,6 +23,7 @@ from nanobot.utils.helpers import (
     estimate_message_tokens,
     estimate_prompt_tokens_chain,
     find_legal_message_start,
+    get_tokenizer_encoding,
     strip_think,
     truncate_text,
 )
@@ -624,7 +624,7 @@ class Consolidator:
         if budget <= 0:
             return truncate_text(text, _RAW_ARCHIVE_MAX_CHARS)
         try:
-            enc = tiktoken.get_encoding("cl100k_base")
+            enc = get_tokenizer_encoding()
             tokens = enc.encode(text)
             if len(tokens) <= budget:
                 return text

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -696,7 +696,7 @@ def serve(
     api_app = create_app(agent_loop, model_name=model_name, request_timeout=timeout)
 
     async def on_startup(_app):
-        await agent_loop._connect_mcp()
+        await agent_loop.startup()
 
     async def on_cleanup(_app):
         await agent_loop.close_mcp()

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -4,6 +4,7 @@ import base64
 import json
 import re
 import shutil
+import threading
 import time
 import uuid
 from contextlib import suppress
@@ -13,6 +14,33 @@ from typing import Any
 
 import tiktoken
 from loguru import logger
+
+_TOKENIZER_ENCODING: Any | None = None
+_TOKENIZER_LOCK = threading.RLock()
+
+
+def get_tokenizer_encoding() -> Any:
+    """Return the shared tiktoken encoding."""
+    global _TOKENIZER_ENCODING
+    with _TOKENIZER_LOCK:
+        if _TOKENIZER_ENCODING is None:
+            _TOKENIZER_ENCODING = tiktoken.get_encoding("cl100k_base")
+        return _TOKENIZER_ENCODING
+
+
+def warmup_tokenizer() -> None:
+    """Best-effort initialize the shared tokenizer before message processing starts."""
+    t0 = time.perf_counter()
+    try:
+        with _TOKENIZER_LOCK:
+            enc = get_tokenizer_encoding()
+            enc.encode("warmup")
+        logger.debug(
+            "tiktoken warmup completed in {:.1f}ms",
+            (time.perf_counter() - t0) * 1000,
+        )
+    except Exception:
+        logger.debug("tiktoken warmup failed", exc_info=True)
 
 
 def strip_think(text: str) -> str:
@@ -427,7 +455,7 @@ def estimate_prompt_tokens(
     reasoning_content, tool_call_id, name, plus per-message framing overhead.
     """
     try:
-        enc = tiktoken.get_encoding("cl100k_base")
+        enc = get_tokenizer_encoding()
         parts: list[str] = []
         for msg in messages:
             content = msg.get("content")
@@ -494,7 +522,7 @@ def estimate_message_tokens(message: dict[str, Any]) -> int:
     if not payload:
         return 4
     try:
-        enc = tiktoken.get_encoding("cl100k_base")
+        enc = get_tokenizer_encoding()
         return max(4, len(enc.encode(payload)) + 4)
     except Exception:
         return max(4, len(payload) // 4 + 4)

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -31,6 +31,26 @@ def _make_loop(tmp_path, *, estimated_tokens: int, context_window_tokens: int) -
 
 
 @pytest.mark.asyncio
+async def test_process_direct_warms_tokenizer_before_processing(tmp_path, monkeypatch) -> None:
+    loop = _make_loop(tmp_path, estimated_tokens=100, context_window_tokens=200)
+    calls: list[str] = []
+
+    def fake_warmup() -> None:
+        calls.append("warmup")
+
+    async def fake_run_agent_loop(*_args, **_kwargs):
+        calls.append("run")
+        return "ok", [], [{"role": "assistant", "content": "ok"}], "stop", False
+
+    monkeypatch.setattr("nanobot.agent.loop.warmup_tokenizer", fake_warmup)
+    loop._run_agent_loop = fake_run_agent_loop  # type: ignore[method-assign]
+
+    await loop.process_direct("hello", session_key="cli:test")
+
+    assert calls == ["warmup", "run"]
+
+
+@pytest.mark.asyncio
 async def test_prompt_below_threshold_does_not_consolidate(tmp_path) -> None:
     loop = _make_loop(tmp_path, estimated_tokens=100, context_window_tokens=200)
     loop.consolidator.archive = AsyncMock(return_value=True)  # type: ignore[method-assign]

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -1050,6 +1050,48 @@ async def test_stop_preserves_runtime_checkpoint_for_next_turn(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_startup_warms_tokenizer_after_mcp_connect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop = _make_full_loop(tmp_path)
+    calls: list[str] = []
+
+    async def fake_connect_mcp() -> None:
+        calls.append("mcp")
+
+    def sync_warmup() -> None:
+        calls.append("warmup")
+
+    loop._connect_mcp = fake_connect_mcp  # type: ignore[method-assign]
+    monkeypatch.setattr("nanobot.agent.loop.warmup_tokenizer", sync_warmup)
+
+    await loop.startup()
+
+    assert calls == ["mcp", "warmup"]
+
+
+@pytest.mark.asyncio
+async def test_startup_continues_when_tokenizer_warmup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop = _make_full_loop(tmp_path)
+
+    async def fake_connect_mcp() -> None:
+        return None
+
+    def failing_get_encoding(_name: str):
+        raise RuntimeError("tokenizer unavailable")
+
+    loop._connect_mcp = fake_connect_mcp  # type: ignore[method-assign]
+    monkeypatch.setattr("nanobot.utils.helpers._TOKENIZER_ENCODING", None)
+    monkeypatch.setattr("nanobot.utils.helpers.tiktoken.get_encoding", failing_get_encoding)
+
+    await loop.startup()
+
+
+@pytest.mark.asyncio
 async def test_system_subagent_followup_is_persisted_before_prompt_assembly(tmp_path: Path) -> None:
     loop = _make_full_loop(tmp_path)
     loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]

--- a/tests/utils/test_token_estimation.py
+++ b/tests/utils/test_token_estimation.py
@@ -1,3 +1,8 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+
+from nanobot.utils import helpers
 from nanobot.utils.helpers import estimate_prompt_tokens_chain
 
 
@@ -30,3 +35,57 @@ def test_estimate_prompt_tokens_chain_falls_back_when_provider_counter_fails() -
 
     assert tokens > 0
     assert source == "tiktoken"
+
+
+def test_tokenizer_lookup_waits_for_inflight_warmup(monkeypatch) -> None:
+    warmup_entered = Event()
+    release_warmup = Event()
+
+    class _FakeEncoding:
+        def encode(self, text: str) -> list[int]:
+            if text == "warmup":
+                warmup_entered.set()
+                assert release_warmup.wait(timeout=2)
+            return [1]
+
+    fake_encoding = _FakeEncoding()
+
+    monkeypatch.setattr(helpers, "_TOKENIZER_ENCODING", None)
+    monkeypatch.setattr(
+        helpers.tiktoken,
+        "get_encoding",
+        lambda _name: fake_encoding,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        warmup_future = executor.submit(helpers.warmup_tokenizer)
+        assert warmup_entered.wait(timeout=2)
+
+        lookup_future = executor.submit(helpers.get_tokenizer_encoding)
+        time.sleep(0.05)
+        assert not lookup_future.done()
+
+        release_warmup.set()
+        assert lookup_future.result(timeout=2) is fake_encoding
+        warmup_future.result(timeout=2)
+
+
+def test_warmup_tokenizer_reuses_cached_encoding(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class _FakeEncoding:
+        def encode(self, _text: str) -> list[int]:
+            return [1]
+
+    monkeypatch.setattr(helpers, "_TOKENIZER_ENCODING", None)
+
+    def fake_get_encoding(name: str) -> _FakeEncoding:
+        calls.append(name)
+        return _FakeEncoding()
+
+    monkeypatch.setattr(helpers.tiktoken, "get_encoding", fake_get_encoding)
+
+    helpers.warmup_tokenizer()
+    helpers.warmup_tokenizer()
+
+    assert calls == ["cl100k_base"]


### PR DESCRIPTION
  ## Summary

  - Reuse a shared `tiktoken` encoding instance for prompt/message token estimation
  - Pre-warm the tokenizer during agent startup before message processing begins
  - Add debug timing logs for AgentLoop build-state steps to make startup/turn latency easier to diagnose
  - Add tests covering tokenizer reuse and token-estimation behavior in agent flows

  ## Testing

  - `uv run pytest tests/agent/test_loop_consolidation_tokens.py tests/agent/test_loop_save_turn.py tests/utils/test_token_estimation.py`