### PR TITLE
fix(runner): preserve tool-call fallbacks after empty responses

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -6,7 +6,7 @@ import asyncio
 import inspect
 import os
 from contextlib import suppress
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -15,13 +15,16 @@ from loguru import logger
 from nanobot.agent.hook import AgentHook, AgentHookContext
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.providers.fallback_provider import FallbackProvider
 from nanobot.utils.file_edit_events import (
+    StreamingFileEditTracker,
     build_file_edit_end_event,
     build_file_edit_error_event,
     build_file_edit_start_event,
-    prepare_file_edit_tracker as _prepare_file_edit_tracker,
     prepare_file_edit_trackers,
-    StreamingFileEditTracker,
+)
+from nanobot.utils.file_edit_events import (
+    prepare_file_edit_tracker as _prepare_file_edit_tracker,
 )
 from nanobot.utils.helpers import (
     IncrementalThinkExtractor,
@@ -111,6 +114,22 @@ class AgentRunResult:
     error: str | None = None
     tool_events: list[dict[str, str]] = field(default_factory=list)
     had_injections: bool = False
+
+
+@dataclass(slots=True)
+class _ToolPhaseResult:
+    """Outcome of :meth:`AgentRunner._dispatch_tool_calls_phase`.
+
+    Tells the outer iteration loop whether to ``continue`` (with updated
+    injection state) or ``break`` (carrying error / final_content / stop_reason).
+    """
+
+    proceed: str  # "continue" or "break"
+    injection_cycles: int = 0
+    had_injections: bool = False
+    error: str | None = None
+    final_content: str | None = None
+    stop_reason: str | None = None
 
 
 class AgentRunner:
@@ -310,95 +329,33 @@ class AgentRunner:
                 context.streamed_reasoning = True
 
             if response.should_execute_tools:
-                context.tool_calls = list(response.tool_calls)
-                if hook.wants_streaming():
-                    await hook.on_stream_end(context, resuming=True)
-
-                assistant_message = build_assistant_message(
-                    response.content or "",
-                    tool_calls=[tc.to_openai_tool_call() for tc in response.tool_calls],
-                    reasoning_content=response.reasoning_content,
-                    thinking_blocks=response.thinking_blocks,
+                phase_result = await self._dispatch_tool_calls_phase(
+                    spec=spec,
+                    response=response,
+                    messages=messages,
+                    tools_used=tools_used,
+                    tool_events=tool_events,
+                    external_lookup_counts=external_lookup_counts,
+                    workspace_violation_counts=workspace_violation_counts,
+                    injection_cycles=injection_cycles,
+                    iteration=iteration,
+                    context=context,
+                    hook=hook,
                 )
-                messages.append(assistant_message)
-                tools_used.extend(tc.name for tc in response.tool_calls)
-                await self._emit_checkpoint(
-                    spec,
-                    {
-                        "phase": "awaiting_tools",
-                        "iteration": iteration,
-                        "model": spec.model,
-                        "assistant_message": assistant_message,
-                        "completed_tool_results": [],
-                        "pending_tool_calls": [tc.to_openai_tool_call() for tc in response.tool_calls],
-                    },
-                )
-
-                await hook.before_execute_tools(context)
-
-                results, new_events, fatal_error = await self._execute_tools(
-                    spec,
-                    response.tool_calls,
-                    external_lookup_counts,
-                    workspace_violation_counts,
-                )
-                tool_events.extend(new_events)
-                context.tool_results = list(results)
-                context.tool_events = list(new_events)
-                completed_tool_results: list[dict[str, Any]] = []
-                for tool_call, result in zip(response.tool_calls, results):
-                    tool_message = {
-                        "role": "tool",
-                        "tool_call_id": tool_call.id,
-                        "name": tool_call.name,
-                        "content": self._normalize_tool_result(
-                            spec,
-                            tool_call.id,
-                            tool_call.name,
-                            result,
-                        ),
-                    }
-                    messages.append(tool_message)
-                    completed_tool_results.append(tool_message)
-                if fatal_error is not None:
-                    error = f"Error: {type(fatal_error).__name__}: {fatal_error}"
-                    final_content = error
-                    stop_reason = "tool_error"
-                    self._append_final_message(messages, final_content)
-                    context.final_content = final_content
-                    context.error = error
-                    context.stop_reason = stop_reason
-                    await hook.after_iteration(context)
-                    should_continue, injection_cycles = await self._try_drain_injections(
-                        spec, messages, None, injection_cycles,
-                        phase="after tool error",
-                    )
-                    if should_continue:
-                        had_injections = True
-                        continue
-                    break
-                await self._emit_checkpoint(
-                    spec,
-                    {
-                        "phase": "tools_completed",
-                        "iteration": iteration,
-                        "model": spec.model,
-                        "assistant_message": assistant_message,
-                        "completed_tool_results": completed_tool_results,
-                        "pending_tool_calls": [],
-                    },
-                )
-                empty_content_retries = 0
-                length_recovery_count = 0
-                # Checkpoint 1: drain injections after tools, before next LLM call
-                _drained, injection_cycles = await self._try_drain_injections(
-                    spec, messages, None, injection_cycles,
-                    phase="after tool execution",
-                )
-                if _drained:
+                injection_cycles = phase_result.injection_cycles
+                if phase_result.had_injections:
                     had_injections = True
-                await hook.after_iteration(context)
-                continue
+                if phase_result.proceed == "continue":
+                    empty_content_retries = 0
+                    length_recovery_count = 0
+                    continue
+                if phase_result.error is not None:
+                    error = phase_result.error
+                if phase_result.final_content is not None:
+                    final_content = phase_result.final_content
+                if phase_result.stop_reason is not None:
+                    stop_reason = phase_result.stop_reason
+                break
 
             if response.has_tool_calls:
                 logger.warning(
@@ -422,22 +379,90 @@ class AgentRunner:
                         await hook.on_stream_end(context, resuming=False)
                     await hook.after_iteration(context)
                     continue
-                logger.warning(
-                    "Empty response on turn {} for {} after {} retries; attempting finalization",
-                    iteration,
-                    spec.session_key or "default",
-                    empty_content_retries,
+                fb_response = await self._try_empty_response_fallback(
+                    spec, messages_for_model, hook, context
                 )
-                if hook.wants_streaming():
-                    await hook.on_stream_end(context, resuming=False)
-                response = await self._request_finalization_retry(spec, messages_for_model)
-                retry_usage = self._usage_dict(response.usage)
-                self._accumulate_usage(usage, retry_usage)
-                raw_usage = self._merge_usage(raw_usage, retry_usage)
-                context.response = response
-                context.usage = dict(raw_usage)
-                context.tool_calls = list(response.tool_calls)
-                clean = hook.finalize_content(context, response.content)
+                if fb_response is not None:
+                    response = fb_response
+                    retry_usage = self._usage_dict(response.usage)
+                    self._accumulate_usage(usage, retry_usage)
+                    raw_usage = self._merge_usage(raw_usage, retry_usage)
+                    context.response = response
+                    context.usage = dict(raw_usage)
+                    context.tool_calls = list(response.tool_calls)
+                    clean = hook.finalize_content(context, response.content)
+                    empty_content_retries = 0
+                    # If the fallback returned executable tool calls, run them
+                    # in this same iteration instead of falling through to the
+                    # empty-final-response path (which would silently drop them).
+                    if response.should_execute_tools:
+                        phase_result = await self._dispatch_tool_calls_phase(
+                            spec=spec,
+                            response=response,
+                            messages=messages,
+                            tools_used=tools_used,
+                            tool_events=tool_events,
+                            external_lookup_counts=external_lookup_counts,
+                            workspace_violation_counts=workspace_violation_counts,
+                            injection_cycles=injection_cycles,
+                            iteration=iteration,
+                            context=context,
+                            hook=hook,
+                        )
+                        injection_cycles = phase_result.injection_cycles
+                        if phase_result.had_injections:
+                            had_injections = True
+                        if phase_result.proceed == "continue":
+                            length_recovery_count = 0
+                            continue
+                        if phase_result.error is not None:
+                            error = phase_result.error
+                        if phase_result.final_content is not None:
+                            final_content = phase_result.final_content
+                        if phase_result.stop_reason is not None:
+                            stop_reason = phase_result.stop_reason
+                        break
+                elif is_blank_text(clean):
+                    logger.warning(
+                        "Empty response on turn {} for {} after {} retries; attempting finalization",
+                        iteration,
+                        spec.session_key or "default",
+                        empty_content_retries,
+                    )
+                    if hook.wants_streaming():
+                        await hook.on_stream_end(context, resuming=False)
+                    response, retry_messages = await self._request_finalization_retry(
+                        spec, messages_for_model,
+                    )
+                    retry_usage = self._usage_dict(response.usage)
+                    self._accumulate_usage(usage, retry_usage)
+                    raw_usage = self._merge_usage(raw_usage, retry_usage)
+                    context.response = response
+                    context.usage = dict(raw_usage)
+                    context.tool_calls = list(response.tool_calls)
+                    clean = hook.finalize_content(context, response.content)
+
+                    if is_blank_text(clean):
+                        logger.warning(
+                            "Empty finalization for {}; trying fallback",
+                            spec.session_key or "default",
+                        )
+                        # Reuse the finalization-retry messages and disable tools
+                        # so the fallback is forced to produce a textual answer.
+                        fb_after = await self._try_empty_response_fallback(
+                            spec, retry_messages, hook, context,
+                            disable_tools=True,
+                            accept_tool_calls=False,
+                        )
+                        if fb_after is not None:
+                            response = fb_after
+                            retry_usage = self._usage_dict(fb_after.usage)
+                            self._accumulate_usage(usage, retry_usage)
+                            raw_usage = self._merge_usage(raw_usage, retry_usage)
+                            context.response = response
+                            context.usage = dict(raw_usage)
+                            context.tool_calls = list(response.tool_calls)
+                            clean = hook.finalize_content(context, response.content)
 
             if response.finish_reason == "length" and not is_blank_text(clean):
                 length_recovery_count += 1
@@ -606,7 +631,11 @@ class AgentRunner:
         messages: list[dict[str, Any]],
         hook: AgentHook,
         context: AgentHookContext,
+        *,
+        provider: LLMProvider | None = None,
+        disable_tools: bool = False,
     ):
+        active_provider = provider or self.provider
         timeout_s: float | None = spec.llm_timeout_s
         if timeout_s is None:
             # Default to a finite timeout to avoid per-session lock starvation when an LLM
@@ -623,14 +652,14 @@ class AgentRunner:
         kwargs = self._build_request_kwargs(
             spec,
             messages,
-            tools=spec.tools.get_definitions(),
+            tools=None if disable_tools else spec.tools.get_definitions(),
         )
         wants_streaming = hook.wants_streaming()
         wants_progress_streaming = (
             not wants_streaming
             and spec.stream_progress_deltas
             and spec.progress_callback is not None
-            and getattr(self.provider, "supports_progress_deltas", False) is True
+            and getattr(active_provider, "supports_progress_deltas", False) is True
         )
 
         progress_state: dict[str, bool] | None = None
@@ -665,7 +694,7 @@ class AgentRunner:
                 context.streamed_reasoning = True
                 await hook.emit_reasoning(delta)
 
-            coro = self.provider.chat_stream_with_retry(
+            coro = active_provider.chat_stream_with_retry(
                 **kwargs,
                 on_content_delta=_stream,
                 on_thinking_delta=_thinking,
@@ -696,13 +725,13 @@ class AgentRunner:
                     context.streamed_content = True
                     await spec.progress_callback(incremental)
 
-            coro = self.provider.chat_stream_with_retry(
+            coro = active_provider.chat_stream_with_retry(
                 **kwargs,
                 on_content_delta=_stream_progress,
                 on_tool_call_delta=_tool_call_delta if live_file_edits is not None else None,
             )
         else:
-            coro = self.provider.chat_with_retry(**kwargs)
+            coro = active_provider.chat_with_retry(**kwargs)
 
         # Streaming requests already have provider-level idle timeouts
         # (NANOBOT_STREAM_IDLE_TIMEOUT_S). Do not also apply the outer wall-clock
@@ -742,11 +771,57 @@ class AgentRunner:
         self,
         spec: AgentRunSpec,
         messages: list[dict[str, Any]],
-    ):
+    ) -> tuple[LLMResponse, list[dict[str, Any]]]:
+        """Issue the finalization retry. Return both the response and the
+        message list actually sent so the caller can reuse the same shape
+        (finalization prompt appended, ``tools=None``) for any downstream
+        fallback attempt against the same prompt.
+        """
         retry_messages = list(messages)
         retry_messages.append(build_finalization_retry_message())
         kwargs = self._build_request_kwargs(spec, retry_messages, tools=None)
-        return await self.provider.chat_with_retry(**kwargs)
+        response = await self.provider.chat_with_retry(**kwargs)
+        return response, retry_messages
+
+    async def _try_empty_response_fallback(
+        self,
+        spec: AgentRunSpec,
+        messages: list[dict[str, Any]],
+        hook: AgentHook,
+        context: AgentHookContext,
+        *,
+        disable_tools: bool = False,
+        accept_tool_calls: bool = True,
+    ) -> LLMResponse | None:
+        """Run the configured fallback chain when the primary returned blank.
+
+        On the finalization-recovery path callers pass ``disable_tools=True``
+        and ``accept_tool_calls=False`` so the fallback model is forced to
+        produce a textual final answer instead of another tool invocation.
+        """
+        if not isinstance(self.provider, FallbackProvider):
+            return None
+        if not self.provider.has_fallbacks or context.streamed_content:
+            return None
+
+        async def request_fn(underlying: LLMProvider, preset: Any) -> LLMResponse:
+            fb_spec = replace(
+                spec,
+                model=preset.model,
+                max_tokens=preset.max_tokens,
+                temperature=preset.temperature,
+                reasoning_effort=preset.reasoning_effort,
+            )
+            return await self._request_model(
+                fb_spec, messages, hook, context,
+                provider=underlying, disable_tools=disable_tools,
+            )
+
+        return await self.provider.try_on_empty_response(
+            request_fn,
+            skip_if_streamed=context.streamed_content,
+            accept_tool_calls=accept_tool_calls,
+        )
 
     @staticmethod
     def _usage_dict(usage: dict[str, Any] | None) -> dict[str, int]:
@@ -771,6 +846,124 @@ class AgentRunner:
         for key, value in right.items():
             merged[key] = merged.get(key, 0) + value
         return merged
+
+    async def _dispatch_tool_calls_phase(
+        self,
+        *,
+        spec: AgentRunSpec,
+        response: LLMResponse,
+        messages: list[dict[str, Any]],
+        tools_used: list[str],
+        tool_events: list[dict[str, str]],
+        external_lookup_counts: dict[str, int],
+        workspace_violation_counts: dict[str, int],
+        injection_cycles: int,
+        iteration: int,
+        context: AgentHookContext,
+        hook: AgentHook,
+    ) -> _ToolPhaseResult:
+        """Execute tool calls from *response* and update conversation state.
+
+        Used inline at the top of each iteration and as a re-dispatch path
+        when an empty-response fallback returns executable tool calls.
+        Mutates *messages*, *tools_used*, *tool_events* and the per-tool
+        counter dicts in place.
+        """
+        context.tool_calls = list(response.tool_calls)
+        if hook.wants_streaming():
+            await hook.on_stream_end(context, resuming=True)
+
+        assistant_message = build_assistant_message(
+            response.content or "",
+            tool_calls=[tc.to_openai_tool_call() for tc in response.tool_calls],
+            reasoning_content=response.reasoning_content,
+            thinking_blocks=response.thinking_blocks,
+        )
+        messages.append(assistant_message)
+        tools_used.extend(tc.name for tc in response.tool_calls)
+        await self._emit_checkpoint(
+            spec,
+            {
+                "phase": "awaiting_tools",
+                "iteration": iteration,
+                "model": spec.model,
+                "assistant_message": assistant_message,
+                "completed_tool_results": [],
+                "pending_tool_calls": [tc.to_openai_tool_call() for tc in response.tool_calls],
+            },
+        )
+
+        await hook.before_execute_tools(context)
+
+        results, new_events, fatal_error = await self._execute_tools(
+            spec,
+            response.tool_calls,
+            external_lookup_counts,
+            workspace_violation_counts,
+        )
+        tool_events.extend(new_events)
+        context.tool_results = list(results)
+        context.tool_events = list(new_events)
+        completed_tool_results: list[dict[str, Any]] = []
+        for tool_call, result in zip(response.tool_calls, results):
+            tool_message = {
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "name": tool_call.name,
+                "content": self._normalize_tool_result(
+                    spec,
+                    tool_call.id,
+                    tool_call.name,
+                    result,
+                ),
+            }
+            messages.append(tool_message)
+            completed_tool_results.append(tool_message)
+
+        if fatal_error is not None:
+            error = f"Error: {type(fatal_error).__name__}: {fatal_error}"
+            final_content = error
+            stop_reason = "tool_error"
+            self._append_final_message(messages, final_content)
+            context.final_content = final_content
+            context.error = error
+            context.stop_reason = stop_reason
+            await hook.after_iteration(context)
+            should_continue, injection_cycles = await self._try_drain_injections(
+                spec, messages, None, injection_cycles,
+                phase="after tool error",
+            )
+            return _ToolPhaseResult(
+                proceed="continue" if should_continue else "break",
+                injection_cycles=injection_cycles,
+                had_injections=should_continue,
+                error=error,
+                final_content=final_content,
+                stop_reason=stop_reason,
+            )
+
+        await self._emit_checkpoint(
+            spec,
+            {
+                "phase": "tools_completed",
+                "iteration": iteration,
+                "model": spec.model,
+                "assistant_message": assistant_message,
+                "completed_tool_results": completed_tool_results,
+                "pending_tool_calls": [],
+            },
+        )
+        # Checkpoint 1: drain injections after tools, before next LLM call
+        _drained, injection_cycles = await self._try_drain_injections(
+            spec, messages, None, injection_cycles,
+            phase="after tool execution",
+        )
+        await hook.after_iteration(context)
+        return _ToolPhaseResult(
+            proceed="continue",
+            injection_cycles=injection_cycles,
+            had_injections=_drained,
+        )
 
     async def _execute_tools(
         self,

--- a/nanobot/providers/fallback_provider.py
+++ b/nanobot/providers/fallback_provider.py
@@ -9,6 +9,7 @@ from typing import Any
 from loguru import logger
 
 from nanobot.providers.base import LLMProvider, LLMResponse
+from nanobot.utils.runtime import is_blank_text
 
 # Circuit breaker tuned to match OpenAICompatProvider's Responses API breaker.
 _PRIMARY_FAILURE_THRESHOLD = 3
@@ -94,6 +95,10 @@ class FallbackProvider(LLMProvider):
 
     def get_default_model(self) -> str:
         return self._primary.get_default_model()
+
+    @property
+    def has_fallbacks(self) -> bool:
+        return self._has_fallbacks
 
     @property
     def supports_progress_deltas(self) -> bool:
@@ -247,6 +252,95 @@ class FallbackProvider(LLMProvider):
             content=f"Primary model '{primary_model}' circuit open and no fallbacks available",
             finish_reason="error",
         )
+
+    async def try_on_empty_response(
+        self,
+        request_fn: Callable[[LLMProvider, Any], Awaitable[LLMResponse]],
+        *,
+        skip_if_streamed: bool = False,
+        accept_tool_calls: bool = True,
+    ) -> LLMResponse | None:
+        """Try fallback models when the primary returned a blank successful reply.
+
+        A fallback response counts as "successful" when it has non-blank text
+        content **or** at least one tool call (when *accept_tool_calls* is True).
+        Set *accept_tool_calls* to False on the finalization-recovery path where
+        we explicitly need a textual answer rather than another tool invocation.
+        """
+        if skip_if_streamed or not self._has_fallbacks:
+            return None
+
+        for idx, fallback in enumerate(self._fallback_presets):
+            fallback_model = fallback.model
+            if idx == 0:
+                logger.info(
+                    "Primary model returned empty response, trying fallback '{}'",
+                    fallback_model,
+                )
+            else:
+                logger.info(
+                    "Fallback '{}' also returned empty, trying next fallback '{}'",
+                    self._fallback_presets[idx - 1].model,
+                    fallback_model,
+                )
+            try:
+                fallback_provider = self._provider_factory(fallback)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to create provider for fallback '{}': {}",
+                    fallback_model,
+                    exc,
+                )
+                continue
+
+            try:
+                fallback_response = await request_fn(fallback_provider, fallback)
+            except Exception as exc:
+                logger.warning(
+                    "Fallback '{}' request failed after empty primary response: {}",
+                    fallback_model,
+                    exc,
+                )
+                continue
+
+            if fallback_response.finish_reason == "error":
+                logger.warning(
+                    "Fallback '{}' returned error after empty primary response: {}",
+                    fallback_model,
+                    (fallback_response.content or "")[:120],
+                )
+                continue
+
+            has_text = not is_blank_text(fallback_response.content)
+            has_tool_calls = bool(fallback_response.tool_calls)
+            if has_text or (accept_tool_calls and has_tool_calls):
+                logger.info(
+                    "Fallback '{}' succeeded after primary empty response "
+                    "(content={}, tool_calls={})",
+                    fallback_model,
+                    has_text,
+                    len(fallback_response.tool_calls),
+                )
+                return fallback_response
+
+            if has_tool_calls and not accept_tool_calls:
+                logger.warning(
+                    "Fallback '{}' produced tool_calls but text answer was required "
+                    "(content empty, tool_calls={}); discarding",
+                    fallback_model,
+                    len(fallback_response.tool_calls),
+                )
+            else:
+                logger.warning(
+                    "Fallback '{}' returned empty response after primary empty response",
+                    fallback_model,
+                )
+
+        logger.warning(
+            "All {} fallback model(s) returned empty after primary empty response",
+            len(self._fallback_presets),
+        )
+        return None
 
     @staticmethod
     def _should_fallback(response: LLMResponse) -> bool:

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -139,6 +139,26 @@ def _short_tool_id() -> str:
     return "".join(secrets.choice(_ALNUM) for _ in range(9))
 
 
+def _warn_if_degenerate_tool_calls(response: LLMResponse, model: str | None) -> None:
+    """Log when a response signals tool_calls but emits an empty tool_calls list.
+
+    Some upstreams (notably Moonshot Kimi via OpenRouter) occasionally return
+    ``finish_reason="tool_calls"`` with a missing/malformed ``tool_calls``
+    payload, which the runner then treats as an empty response. Surfacing the
+    shape explicitly makes it easier to correlate with provider-side logs.
+    """
+    if response.finish_reason in ("tool_calls", "function_call") and not response.tool_calls:
+        logger.warning(
+            "Provider returned finish_reason='{}' with zero tool_calls "
+            "(model={}, content_len={}, reasoning_len={}); treating as empty. "
+            "Likely the provider dropped a malformed tool_calls payload.",
+            response.finish_reason,
+            model or "?",
+            len(response.content or ""),
+            len(response.reasoning_content or ""),
+        )
+
+
 def _get(obj: Any, key: str) -> Any:
     """Get a value from dict or object attribute, returning None if absent."""
     if isinstance(obj, dict):
@@ -1339,7 +1359,9 @@ class OpenAICompatProvider(LLMProvider):
                 messages, tools, model, max_tokens, temperature,
                 reasoning_effort, tool_choice,
             )
-            return self._parse(await self._client.chat.completions.create(**kwargs))
+            parsed = self._parse(await self._client.chat.completions.create(**kwargs))
+            _warn_if_degenerate_tool_calls(parsed, model or self.default_model)
+            return parsed
         except Exception as e:
             return self._handle_error(e, spec=self._spec, api_base=self.api_base)
 
@@ -1469,7 +1491,9 @@ class OpenAICompatProvider(LLMProvider):
                                 "name": str(_get(function_call, "name") or ""),
                                 "arguments_delta": str(_get(function_call, "arguments") or ""),
                             })
-            return self._parse_chunks(chunks)
+            parsed = self._parse_chunks(chunks)
+            _warn_if_degenerate_tool_calls(parsed, model or self.default_model)
+            return parsed
         except asyncio.TimeoutError:
             return LLMResponse(
                 content=(

--- a/tests/agent/test_runner_core.py
+++ b/tests/agent/test_runner_core.py
@@ -392,6 +392,109 @@ async def test_runner_accumulates_usage_and_preserves_cached_tokens():
 
 
 @pytest.mark.asyncio
+async def test_runner_empty_response_fallback_dispatches_tool_calls() -> None:
+    """Tool calls returned from empty-response fallback must be executed."""
+    from typing import Any
+
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+    from nanobot.providers.base import LLMProvider
+    from nanobot.providers.fallback_provider import FallbackProvider
+    from tests.agent.test_runner_fallback import _FakeProvider, _fallback, _make_response
+
+    class _StatefulProvider(LLMProvider):
+        def __init__(self, responses: list[LLMResponse]):
+            super().__init__()
+            self._responses = list(responses)
+            self.chat_calls: list[dict[str, Any]] = []
+
+        def get_default_model(self) -> str:
+            return "stateful/model"
+
+        async def chat(self, **kwargs: Any) -> LLMResponse:
+            self.chat_calls.append(dict(kwargs))
+            if self._responses:
+                return self._responses.pop(0)
+            return _make_response("")
+
+        async def chat_stream(self, **kwargs: Any) -> LLMResponse:
+            return await self.chat(**kwargs)
+
+    primary = _StatefulProvider([
+        _make_response(""),  # iter 0: empty -> silent retry
+        _make_response(""),  # iter 1: empty -> fallback
+        _make_response("done"),  # iter 2: after tool result
+    ])
+    fallback = _FakeProvider(
+        "fallback",
+        LLMResponse(
+            content="",
+            tool_calls=[ToolCallRequest(id="tc1", name="read_file", arguments={"path": "a.txt"})],
+            finish_reason="tool_calls",
+        ),
+    )
+    provider = FallbackProvider(
+        primary=primary,
+        fallback_presets=[_fallback("fallback-a")],
+        provider_factory=MagicMock(return_value=fallback),
+    )
+
+    tools = MagicMock()
+    tools.get_definitions.return_value = [{"type": "function", "function": {"name": "read_file"}}]
+    tools.execute = AsyncMock(return_value="file content")
+
+    runner = AgentRunner(provider)
+    result = await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "read file"}],
+        tools=tools,
+        model="primary-model",
+        max_iterations=6,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert result.final_content == "done"
+    tools.execute.assert_awaited_once()
+    assert "read_file" in result.tools_used
+    tool_msgs = [m for m in result.messages if m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0]["tool_call_id"] == "tc1"
+
+
+@pytest.mark.asyncio
+async def test_runner_finalization_fallback_uses_retry_messages_without_tools() -> None:
+    """Fallback after empty finalization should reuse finalization retry shape."""
+    from nanobot.agent.runner import AgentRunSpec, AgentRunner
+    from nanobot.providers.fallback_provider import FallbackProvider
+    from nanobot.utils.runtime import FINALIZATION_RETRY_PROMPT
+    from tests.agent.test_runner_fallback import _FakeProvider, _fallback, _make_response
+
+    primary = _FakeProvider("primary", _make_response(""))
+    fallback = _FakeProvider("fallback", _make_response(""))
+    provider = FallbackProvider(
+        primary=primary,
+        fallback_presets=[_fallback("fallback-a")],
+        provider_factory=MagicMock(return_value=fallback),
+    )
+
+    tools = MagicMock()
+    tools.get_definitions.return_value = [{"type": "function", "function": {"name": "read_file"}}]
+
+    runner = AgentRunner(provider)
+    await runner.run(AgentRunSpec(
+        initial_messages=[{"role": "user", "content": "do task"}],
+        tools=tools,
+        model="primary-model",
+        max_iterations=3,
+        max_tool_result_chars=_MAX_TOOL_RESULT_CHARS,
+    ))
+
+    assert len(fallback.chat_calls) == 2
+    finalization_call = fallback.chat_calls[1]
+    assert finalization_call.get("tools") is None
+    assert finalization_call["messages"][-1]["role"] == "user"
+    assert finalization_call["messages"][-1]["content"] == FINALIZATION_RETRY_PROMPT
+
+
+@pytest.mark.asyncio
 async def test_runner_binds_on_retry_wait_to_retry_callback_not_progress():
     """Regression: provider retry heartbeats must route through
     ``retry_wait_callback``, not ``progress_callback``. Binding them to

--- a/tests/agent/test_runner_fallback.py
+++ b/tests/agent/test_runner_fallback.py
@@ -611,3 +611,128 @@ class TestGenerationForwarded:
         )
         assert fb.generation.temperature == 0.5
         assert fb.generation.max_tokens == 1024
+
+
+class TestHasFallbacks:
+    def test_true_when_presets_configured(self) -> None:
+        fb = FallbackProvider(
+            primary=_FakeProvider("primary"),
+            fallback_presets=[_fallback("a")],
+            provider_factory=MagicMock(),
+        )
+        assert fb.has_fallbacks is True
+
+    def test_false_when_empty(self) -> None:
+        fb = FallbackProvider(
+            primary=_FakeProvider("primary"),
+            fallback_presets=[],
+            provider_factory=MagicMock(),
+        )
+        assert fb.has_fallbacks is False
+
+
+class TestTryOnEmptyResponse:
+    @pytest.mark.asyncio
+    async def test_first_fallback_blank_second_succeeds(self) -> None:
+        fallback_a = _FakeProvider("a", _make_response(content=""))
+        fallback_b = _FakeProvider("b", _make_response("fallback ok"))
+        factory = MagicMock(side_effect=[fallback_a, fallback_b])
+
+        fb = FallbackProvider(
+            primary=_FakeProvider("primary"),
+            fallback_presets=[_fallback("fallback-a"), _fallback("fallback-b")],
+            provider_factory=factory,
+        )
+
+        async def request_fn(provider: LLMProvider, preset) -> LLMResponse:
+            return await provider.chat(model=preset.model)
+
+        result = await fb.try_on_empty_response(request_fn)
+        assert result is not None
+        assert result.content == "fallback ok"
+        assert factory.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_skip_if_streamed(self) -> None:
+        fb = FallbackProvider(
+            primary=_FakeProvider("primary"),
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=MagicMock(),
+        )
+
+        async def request_fn(provider: LLMProvider, preset) -> LLMResponse:
+            return await provider.chat(model=preset.model)
+
+        assert await fb.try_on_empty_response(request_fn, skip_if_streamed=True) is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_fallbacks(self) -> None:
+        fb = FallbackProvider(
+            primary=_FakeProvider("primary"),
+            fallback_presets=[],
+            provider_factory=MagicMock(),
+        )
+
+        async def request_fn(provider: LLMProvider, preset) -> LLMResponse:
+            return await provider.chat(model=preset.model)
+
+        assert await fb.try_on_empty_response(request_fn) is None
+
+    @pytest.mark.asyncio
+    async def test_accepts_tool_calls_only_response_by_default(self) -> None:
+        """A fallback response with tool_calls and no text content is success.
+
+        Counterpart to the production failure where a model returned
+        ``finish_reason=tool_calls`` with zero tool_calls and fallback model correctly
+        proposed an ``edit_file`` tool call. The wrapper must
+        treat the tool-call fallback as successful instead of discarding it.
+        """
+        from nanobot.providers.base import ToolCallRequest
+
+        tool_response = LLMResponse(
+            content="",
+            tool_calls=[ToolCallRequest(id="tc1", name="edit_file", arguments={"path": "x"})],
+            finish_reason="tool_calls",
+        )
+        fallback_a = _FakeProvider("a", tool_response)
+        factory = MagicMock(return_value=fallback_a)
+
+        fb = FallbackProvider(
+            primary=_FakeProvider("primary"),
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=factory,
+        )
+
+        async def request_fn(provider: LLMProvider, preset) -> LLMResponse:
+            return await provider.chat(model=preset.model)
+
+        result = await fb.try_on_empty_response(request_fn)
+        assert result is tool_response
+        assert len(result.tool_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_rejects_tool_calls_when_text_required(self) -> None:
+        """When ``accept_tool_calls=False`` (finalization recovery path), a
+        tool-call-only response must NOT count as success — the caller
+        explicitly needs a textual answer."""
+        from nanobot.providers.base import ToolCallRequest
+
+        tool_response = LLMResponse(
+            content="",
+            tool_calls=[ToolCallRequest(id="tc1", name="edit_file", arguments={"path": "x"})],
+            finish_reason="tool_calls",
+        )
+        fallback_a = _FakeProvider("a", tool_response)
+        factory = MagicMock(return_value=fallback_a)
+
+        fb = FallbackProvider(
+            primary=_FakeProvider("primary"),
+            fallback_presets=[_fallback("fallback-a")],
+            provider_factory=factory,
+        )
+
+        async def request_fn(provider: LLMProvider, preset) -> LLMResponse:
+            return await provider.chat(model=preset.model)
+
+        result = await fb.try_on_empty_response(request_fn, accept_tool_calls=False)
+        assert result is None


### PR DESCRIPTION
## Summary

Some models (notably Kimi 2.6 via OpenRouter) occasionally return only reasoning tokens with no usable `content` or executable `tool_calls`. In those cases, nanobot should recover via its fallback chain — but several orchestration bugs prevented that from working correctly.

When fallback recovery failed, users often saw:

> I completed the tool steps but couldn't produce a final answer. Please try again or narrow the task.

This PR fixes the fallback path so recovery can succeed instead of falling through to that synthetic empty-final response:

- Treat fallback responses with executable tool calls as valid recovery, not as another empty failure
- Re-dispatch tool calls returned by empty-response fallbacks in the same iteration (instead of silently dropping them)
- Reuse the finalization-retry message shape for finalization fallback, with tools disabled, so the fallback model is asked for a textual final answer rather than another tool invocation
- Log when a provider returns `finish_reason=tool_calls` with an empty `tool_calls` list (a shape seen with Kimi), to make future diagnosis easier