### PR TITLE
fix(web): update Kagi search API integration

### DIFF
--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -455,17 +455,16 @@ class WebSearchTool(Tool):
             return await self._search_duckduckgo(query, n)
         try:
             async with httpx.AsyncClient(proxy=self.proxy) as client:
-                r = await client.get(
-                    "https://kagi.com/api/v0/search",
-                    params={"q": query, "limit": n},
-                    headers={"Authorization": f"Bot {api_key}", "User-Agent": self.user_agent},
+                r = await client.post(
+                    "https://kagi.com/api/v1/search",
+                    json={"query": query, "limit": n},
+                    headers={"Authorization": f"Bearer {api_key}", "User-Agent": self.user_agent},
                     timeout=10.0,
                 )
                 r.raise_for_status()
-            # t=0 items are search results; other values are related searches, etc.
             items = [
                 {"title": d.get("title", ""), "url": d.get("url", ""), "content": d.get("snippet", "")}
-                for d in r.json().get("data", []) if d.get("t") == 0
+                for d in r.json().get("data", {}).get("search", [])
             ]
             return _format_results(query, items, n)
         except Exception as e:

--- a/tests/tools/test_web_search_tool.py
+++ b/tests/tools/test_web_search_tool.py
@@ -202,19 +202,23 @@ async def test_jina_search(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_kagi_search(monkeypatch):
-    async def mock_get(self, url, **kw):
-        assert "kagi.com/api/v0/search" in url
-        assert kw["headers"]["Authorization"] == "Bot kagi-key"
+    async def mock_post(self, url, **kw):
+        assert "kagi.com/api/v1/search" in url
+        assert kw["headers"]["Authorization"] == "Bearer kagi-key"
         assert kw["headers"]["User-Agent"] == "nanobot-search-test"
-        assert kw["params"] == {"q": "test", "limit": 2}
+        assert kw["json"] == {"query": "test", "limit": 2}
         return _response(json={
-            "data": [
-                {"t": 0, "title": "Kagi Result", "url": "https://kagi.com", "snippet": "Premium search"},
-                {"t": 1, "list": ["ignored related search"]},
-            ]
+            "data": {
+                "search": [
+                    {"title": "Kagi Result", "url": "https://kagi.com", "snippet": "Premium search"},
+                ],
+                "related_search": [
+                    {"title": "ignored related search", "url": "", "snippet": ""},
+                ],
+            }
         })
 
-    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
     tool = _tool(provider="kagi", api_key="kagi-key", user_agent="nanobot-search-test")
     result = await tool.execute(query="test", count=2)
     assert "Kagi Result" in result


### PR DESCRIPTION
## Summary

Updates the Kagi web search provider to use Kagi's current v1 Search API shape.

## What changed

- Use `POST https://kagi.com/api/v1/search`
- Use `Authorization: Bearer <KAGI_API_KEY>`
- Send JSON body with `query` and `limit`
- Parse organic search results from `data.search[]`
- Update the focused Kagi provider test to assert the v1 request/response shape

## Why

The existing implementation used the legacy v0 API shape:

- `GET https://kagi.com/api/v0/search`
- `Authorization: Bot <key>`
- query parameter `q`
- response parsing from `data[]` filtered by `t == 0`

Kagi's current OpenAPI spec documents the v1 API as `POST /search` under `https://kagi.com/api/v1`, with HTTP bearer auth, a required JSON `query` field, optional `limit`, and search results under `data.search[]`.

Spec reference: https://kagi.com/api/docs/_bundle/openapi.json?download

## Test plan

- [x] `uv run ruff check nanobot/agent/tools/web.py tests/tools/test_web_search_tool.py`
- [x] `uv run python -m pytest tests/tools/test_web_search_tool.py`
