### PR TITLE
fix: Drop orphan tool results from session history

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1430,12 +1430,25 @@ class AgentLoop:
         from datetime import datetime
 
         last_assistant_idx: int | None = None
+        declared_tool_call_ids = self._collect_tool_call_ids(session.messages)
         for m in messages[skip:]:
             entry = dict(m)
             role, content = entry.get("role"), entry.get("content")
             if role == "assistant" and not content and not entry.get("tool_calls"):
                 continue  # skip empty assistant messages — they poison session context
+            if role == "assistant":
+                for tc in entry.get("tool_calls") or []:
+                    if isinstance(tc, dict) and tc.get("id"):
+                        declared_tool_call_ids.add(str(tc["id"]))
             if role == "tool":
+                tool_call_id = entry.get("tool_call_id")
+                if not tool_call_id or str(tool_call_id) not in declared_tool_call_ids:
+                    logger.warning(
+                        "Skipping orphan tool result {} while saving session {}",
+                        tool_call_id or "(missing id)",
+                        session.key,
+                    )
+                    continue
                 if isinstance(content, str) and len(content) > self.max_tool_result_chars:
                     entry["content"] = truncate_text_fn(content, self.max_tool_result_chars)
                 elif isinstance(content, list):
@@ -1464,6 +1477,16 @@ class AgentLoop:
         if turn_latency_ms is not None and last_assistant_idx is not None:
             session.messages[last_assistant_idx]["latency_ms"] = int(turn_latency_ms)
         session.updated_at = datetime.now()
+
+    @staticmethod
+    def _collect_tool_call_ids(messages: list[dict[str, Any]]) -> set[str]:
+        return {
+            str(tc["id"])
+            for message in messages
+            if message.get("role") == "assistant"
+            for tc in (message.get("tool_calls") or [])
+            if isinstance(tc, dict) and tc.get("id")
+        }
 
     def _persist_subagent_followup(self, session: Session, msg: InboundMessage) -> bool:
         """Persist subagent follow-ups before prompt assembly so history stays durable.
@@ -1529,12 +1552,22 @@ class AgentLoop:
         pending_tool_calls = checkpoint.get("pending_tool_calls") or []
 
         restored_messages: list[dict[str, Any]] = []
+        declared_tool_call_ids = self._collect_tool_call_ids(session.messages)
         if isinstance(assistant_message, dict):
             restored = dict(assistant_message)
             restored.setdefault("timestamp", datetime.now().isoformat())
             restored_messages.append(restored)
+            declared_tool_call_ids.update(self._collect_tool_call_ids([restored]))
         for message in completed_tool_results:
             if isinstance(message, dict):
+                tool_call_id = message.get("tool_call_id")
+                if not tool_call_id or str(tool_call_id) not in declared_tool_call_ids:
+                    logger.warning(
+                        "Skipping orphan checkpoint tool result {} in session {}",
+                        tool_call_id or "(missing id)",
+                        session.key,
+                    )
+                    continue
                 restored = dict(message)
                 restored.setdefault("timestamp", datetime.now().isoformat())
                 restored_messages.append(restored)
@@ -1542,6 +1575,13 @@ class AgentLoop:
             if not isinstance(tool_call, dict):
                 continue
             tool_id = tool_call.get("id")
+            if not tool_id or str(tool_id) not in declared_tool_call_ids:
+                logger.warning(
+                    "Skipping orphan pending checkpoint tool result {} in session {}",
+                    tool_id or "(missing id)",
+                    session.key,
+                )
+                continue
             name = ((tool_call.get("function") or {}).get("name")) or "tool"
             restored_messages.append(
                 {

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -270,11 +270,73 @@ def test_save_turn_keeps_tool_results_under_16k() -> None:
 
     loop._save_turn(
         session,
-        [{"role": "tool", "tool_call_id": "call_1", "name": "read_file", "content": content}],
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "read_file",
+                "content": content,
+            },
+        ],
         skip=0,
     )
 
-    assert session.messages[0]["content"] == content
+    assert session.messages[1]["content"] == content
+
+
+def test_save_turn_drops_tool_results_without_matching_tool_call() -> None:
+    loop = _mk_loop()
+    session = Session(key="test:orphan-tool-result")
+
+    loop._save_turn(
+        session,
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_ok",
+                        "type": "function",
+                        "function": {"name": "exec", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_ok", "name": "exec", "content": "ok"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_orphan",
+                "name": "exec",
+                "content": "stale",
+            },
+            {"role": "assistant", "content": "done"},
+        ],
+        skip=0,
+    )
+
+    assert [
+        {
+            k: v
+            for k, v in message.items()
+            if k in {"role", "content", "tool_call_id", "name"}
+        }
+        for message in session.messages
+    ] == [
+        {"role": "assistant", "content": ""},
+        {"role": "tool", "tool_call_id": "call_ok", "name": "exec", "content": "ok"},
+        {"role": "assistant", "content": "done"},
+    ]
 
 
 def test_save_turn_stamps_latency_on_last_assistant() -> None:
@@ -345,6 +407,64 @@ def test_restore_runtime_checkpoint_rehydrates_completed_and_pending_tools() -> 
     assert session.messages[1]["tool_call_id"] == "call_done"
     assert session.messages[2]["tool_call_id"] == "call_pending"
     assert "interrupted before this tool finished" in session.messages[2]["content"].lower()
+
+
+def test_restore_runtime_checkpoint_drops_orphan_tool_results() -> None:
+    loop = _mk_loop()
+    session = Session(
+        key="test:checkpoint-orphan",
+        metadata={
+            AgentLoop._RUNTIME_CHECKPOINT_KEY: {
+                "assistant_message": {
+                    "role": "assistant",
+                    "content": "working",
+                    "tool_calls": [
+                        {
+                            "id": "call_done",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": "{}"},
+                        },
+                    ],
+                },
+                "completed_tool_results": [
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_done",
+                        "name": "read_file",
+                        "content": "ok",
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_orphan",
+                        "name": "exec",
+                        "content": "stale",
+                    },
+                ],
+                "pending_tool_calls": [
+                    {
+                        "id": "call_pending",
+                        "type": "function",
+                        "function": {"name": "exec", "arguments": "{}"},
+                    }
+                ],
+            }
+        },
+    )
+
+    restored = loop._restore_runtime_checkpoint(session)
+
+    assert restored is True
+    assert [
+        {
+            k: v
+            for k, v in message.items()
+            if k in {"role", "content", "tool_call_id", "name"}
+        }
+        for message in session.messages
+    ] == [
+        {"role": "assistant", "content": "working"},
+        {"role": "tool", "tool_call_id": "call_done", "name": "read_file", "content": "ok"},
+    ]
 
 
 def test_restore_runtime_checkpoint_dedupes_overlapping_tail() -> None:


### PR DESCRIPTION
## Summary

Fixes #4006.

This drops `role: "tool"` messages from durable session history when their `tool_call_id` does not match any preceding assistant `tool_calls[].id`. The same guard now applies when restoring runtime checkpoints, so stale completed or pending tool results cannot be rehydrated into future conversation history.

## Root cause

The model-facing runner path already repairs or drops orphan tool results before provider calls, but `_save_turn()` persisted raw tool-result messages without checking whether the corresponding assistant tool call existed. Runtime checkpoint restore had the same gap, which allowed invalid conversation history to survive across turns and later break strict OpenAI/Anthropic validation or trajectory rendering.

## Validation

- `uv run ruff check nanobot --select F401,F841`
- `uv run pytest tests/agent/test_loop_save_turn.py tests/agent/test_runner_governance.py tests/agent/test_session_manager_history.py -q`
- `git diff --check`

Full `uv run pytest tests/` was also run locally and ended with `3641 passed, 3 skipped, 10 failed`. The failures are existing environment/DNS-sensitive cases around `example.com` URL validation in DingTalk media redirect tests and exec guard public URL tests, not this agent-loop change path.
