### PR TITLE
feat(agent): add observation-reflection prompt after tool execution

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -409,7 +409,6 @@ class AgentRunner:
                 empty_content_retries = 0
                 length_recovery_count = 0
                 strip_observation_reflections(messages)
-                messages.append(build_observation_reflection_message())
                 # Checkpoint 1: drain injections after tools, before next LLM call
                 _drained, injection_cycles = await self._try_drain_injections(
                     spec, messages, None, injection_cycles,
@@ -417,6 +416,9 @@ class AgentRunner:
                 )
                 if _drained:
                     had_injections = True
+                self._append_injected_messages(
+                    messages, [build_observation_reflection_message()],
+                )
                 await hook.after_iteration(context)
                 continue
 

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -46,10 +46,12 @@ from nanobot.utils.runtime import (
     build_finalization_retry_message,
     build_goal_continue_message,
     build_length_recovery_message,
+    build_observation_reflection_message,
     ensure_nonempty_tool_result,
     is_blank_text,
     repeated_external_lookup_error,
     repeated_workspace_violation_error,
+    strip_observation_reflections,
 )
 
 _DEFAULT_ERROR_MESSAGE = "Sorry, I encountered an error calling the AI model."
@@ -406,6 +408,8 @@ class AgentRunner:
                 )
                 empty_content_retries = 0
                 length_recovery_count = 0
+                strip_observation_reflections(messages)
+                messages.append(build_observation_reflection_message())
                 # Checkpoint 1: drain injections after tools, before next LLM call
                 _drained, injection_cycles = await self._try_drain_injections(
                     spec, messages, None, injection_cycles,

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -34,6 +34,15 @@ SUSTAINED_GOAL_CONTINUE_PROMPT = (
     "objective using your tools, or call complete_goal if the work is truly finished."
 )
 
+OBSERVATION_REFLECTION_PROMPT = (
+    "[Inner monologue, based on the tool results above:"
+    "1.Think: Analyze the results and evaluate current progress."
+    "2.Verify: If there are intermediate outputs, verify their correctness."
+    "3.Update User: Briefly inform the user of your findings and next action."
+    "4.Act: If further steps are needed, call the appropriate tools to continue;"
+    "if the task is complete, provide the final answer.]"
+)
+
 
 def empty_tool_result_message(tool_name: str) -> str:
     """Short prompt-safe marker for tools that completed without visible output."""
@@ -73,6 +82,27 @@ def build_length_recovery_message() -> dict[str, str]:
 def build_goal_continue_message(custom: str | None = None) -> dict[str, str]:
     """Prompt the model to continue when a sustained goal is still active."""
     return {"role": "user", "content": custom or SUSTAINED_GOAL_CONTINUE_PROMPT}
+
+
+def build_observation_reflection_message() -> dict[str, str]:
+    """Prompt the model to observe tool results, narrate findings, and continue."""
+    return {"role": "user", "content": OBSERVATION_REFLECTION_PROMPT}
+
+
+def strip_observation_reflections(messages: list[dict[str, Any]]) -> None:
+    """Remove all historical observation-reflection prompts in-place.
+
+    Only the latest prompt (which will be appended after this call) should
+    be present in the context so accumulated boilerplate doesn't bloat history.
+    """
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
+        if (
+            msg.get("role") == "user"
+            and not msg.get("tool_call_id")
+            and msg.get("content") == OBSERVATION_REFLECTION_PROMPT
+        ):
+            del messages[idx]
 
 
 def external_lookup_signature(tool_name: str, arguments: dict[str, Any]) -> str | None:

--- a/nanobot/utils/runtime.py
+++ b/nanobot/utils/runtime.py
@@ -92,17 +92,23 @@ def build_observation_reflection_message() -> dict[str, str]:
 def strip_observation_reflections(messages: list[dict[str, Any]]) -> None:
     """Remove all historical observation-reflection prompts in-place.
 
-    Only the latest prompt (which will be appended after this call) should
-    be present in the context so accumulated boilerplate doesn't bloat history.
+    Standalone prompts are deleted entirely.  When a prompt has been merged
+    into a real user message (by ``_append_injected_messages``), only the
+    prompt text is stripped out so the user's content is preserved.
     """
     for idx in range(len(messages) - 1, -1, -1):
         msg = messages[idx]
-        if (
-            msg.get("role") == "user"
-            and not msg.get("tool_call_id")
-            and msg.get("content") == OBSERVATION_REFLECTION_PROMPT
-        ):
+        if msg.get("role") != "user" or msg.get("tool_call_id"):
+            continue
+        content = msg.get("content")
+        if not isinstance(content, str):
+            continue
+        if content == OBSERVATION_REFLECTION_PROMPT:
             del messages[idx]
+            continue
+        if OBSERVATION_REFLECTION_PROMPT in content:
+            cleaned = content.replace(OBSERVATION_REFLECTION_PROMPT, "").strip()
+            messages[idx] = {**msg, "content": cleaned}
 
 
 def external_lookup_signature(tool_name: str, arguments: dict[str, Any]) -> str | None:

--- a/tests/agent/test_runner_injections.py
+++ b/tests/agent/test_runner_injections.py
@@ -224,7 +224,7 @@ async def test_checkpoint1_injects_after_tool_execution():
     # The second call should have the injected user message
     assert call_count["n"] == 2
     last_messages = captured_messages[-1]
-    injected = [m for m in last_messages if m.get("role") == "user" and m.get("content") == "follow-up question"]
+    injected = [m for m in last_messages if m.get("role") == "user" and "follow-up question" in (m.get("content") or "")]
     assert len(injected) == 1
 
 
@@ -920,7 +920,7 @@ async def test_drain_injections_on_max_iterations():
     # The injection message is appended to conversation history
     injected = [
         m for m in result.messages
-        if m.get("role") == "user" and m.get("content") == "follow-up after max iters"
+        if m.get("role") == "user" and "follow-up after max iters" in (m.get("content") or "")
     ]
     assert len(injected) == 1
 
@@ -983,7 +983,7 @@ async def test_drain_injections_set_flag_when_followup_arrives_after_last_iterat
     assert injection_queue.empty()
     injected = [
         m for m in result.messages
-        if m.get("role") == "user" and m.get("content") == "late follow-up after max iters"
+        if m.get("role") == "user" and "late follow-up after max iters" in (m.get("content") or "")
     ]
     assert len(injected) == 1
 


### PR DESCRIPTION
> 用最小代价实现Agent Loop自循环。

## 文件变更

- nanobot/utils/runtime.py
  - 新增 OBSERVATION_REFLECTION_PROMPT 常量（Think→Verify→Update User→Act）
  - 新增 build_observation_reflection_message() 构建内向独白提示词函数
  - 新增 strip_observation_reflections() 在注入新提示前清理上下文所有旧的观察提示， 确保上下文中永远只有最新一条
- nanobot/agent/runner.py
  - 导入 build_observation_reflection_message 和 strip_observation_reflections
  - 在工具连续执行完毕后、下一轮 LLM 分析前注入观察提示（先清理旧的再追加新的）

## 我的尝试

经过多种方案尝试，最终实现此功能。
我的尝试：

1. 方式一：做了内循环runner的框架验证，想要对流式输出进行观察，用户需要忍受完整输出和每轮外置检查带来的慢速，对纯聊天内容不友好。
2. 方式二：做了外循环Agent Loop的多次验证机制，但工具调用、流式输出产生在runner中，无法对过程进行干预。

## 解决方案

现有 Agent Loop 缺失"暂停观察→反思"环节：工具执行后结果被静默追加到 messages 中，模型直接进入下一轮 LLM 调用，大模型无法自动纠正中间进展。

在 AgentRunner 内循环的工具执行完毕后、下一轮 LLM 调用前，注入一条
结构化观察提示，引导模型执行 Think→Verify→Update User→Act 四步。

选择在内循环而非外循环（loop.py）加入此机制，是因为内循环是模型流式
输出和工具调用的自然执行点，注入提示与模型的推理节奏一致，不会中断
流式传输。外循环是 Turn 级别的状态机（RESTORE→COMPACT→...→DONE），
在此时机注入会与流式输出和模型的工具调用行为冲突。举个例子：内循环会解析用户需求，接着不断调用工具完成任务，过程会不断流式反馈给用户，在外循环进行干预没有作用，回到外循环时，内循环已经将内容回馈给用户。

## 效果对比

**相同测试提示词如下：**

```
请你读取D:\报表测试\门店纯利润收入统计表.xlsx，给我制作每个门店共计12个月的利润折线图excel表，所有门店绘制在同一张图表上，方便我进行查看，最后你还要保存一个通用的脚本，下次我能按照excel格式批量生成这种折线图表。所有产物放在表格所在位置。
```

### 优化前的表现

```
2026-05-26 20:42:51 | INFO  | - | Registered 17 tools: ['apply_patch', 'run_cli_app', 'complete_goal', 'cron', 'edit_file', 'exec', 'find_files', 'grep', 'list_dir', 'list_exec_sessions', 'long_task', 'message', 'read_file', 'spawn', 'write_file', 'write_stdin', 'my']
🐈 Interactive mode (glm-5-turbo) — type exit or Ctrl+C to quit

You: 2026-05-26 20:42:53 | INFO  | - | MCP server 'playwright': connected, 23 capabilities registered
2026-05-26 20:42:53 | INFO  | - | MCP connected servers: ['playwright']
2026-05-26 20:42:53 | INFO  | - | Agent loop started
You: /new
2026-05-26 20:42:56 | INFO  | - | Processing message from cli:user: /new

🐈 nanobot
New session started.

You: 请你读取D:\报表测试\门店纯利润收入统计表.xlsx，给我制作每个门店共计12个月的利润折线图excel表，所有门店绘制在同一张
图表上，方便我进行查看，最后你还要保存一个通用的脚本，下次我能按照excel格式批量生成这种折线图表。所有产物放在表格所在位
置。
2026-05-26 20:43:13 | INFO  | - | Processing message from cli:user: 请你读取D:\报表测试\门店纯利润收入统计表.xlsx，给我制作每个门店共计12个月的利润折线图excel表，所有门店绘制在同一张图表上，方便我进行查看，最后你...

✻ The user wants me to:
✻ 1.
✻ Read the Excel file at D:\报表测试\门店纯利润收入统计表.xlsx
✻ 2.
✻ Create a line chart showing 12 months of profit for each store
✻ , all on one chart
✻ 3.
✻ Save the chart as an image in the same directory
✻ 4.
✻ Save a reusable generic script in the same directory
✻ Let me first read the Excel file to understand its structure
✻ , then create the chart and script.
2026-05-26 20:43:34 | INFO  | - | Tool call: read_file({"path": "D:\\报表测试\\门店纯利润收入统计表.xlsx"})
  ↳ read D:/报表测试/门店纯利润收入统计表.xlsx
数据结构清楚了，三门店 × 12个月。直接生成图表和脚本。                                                                   2026-05-26 20:44:21 | INFO  | - | Tool call: exec({"command": "python -c \"\nimport openpyxl\nfrom openpyxl.chart import LineChart, Reference\n\nwb = openpyxl.load_workbook(r'D:\\报表测试\\门店纯利润收入统计表.xlsx')\nws = wb.active\n\nchart = LineChart()\nchart.t)
数据结构清楚了，三门店 × 12个月。直接生成图表和脚本。
  ↳ $ python -c "
import openpyxl
from openpyxl.chart i…
图表已嵌入原 Excel。现在保存通用脚本：                                                                                  2026-05-26 20:44:54 | INFO  | - | Tool call: write_file({"path": "D:\\报表测试\\profit_line_chart.py", "content": "\"\"\"\n通用门店利润折线图生成器\n用法: python profit_line_chart.py <excel文件路径>\n  - 自动读取第一个 Sheet\n  - 第一列为月份标签，第一行为门店名称，其余为数值\n  - 所有门店绘制在同一张图表上，嵌入 Excel 原文件)
图表已嵌入原 Excel。现在保存通用脚本：
  ↳ write D:/报表测试/profit_line_chart.py
搞定，两个产物都在 D:\报表测试\：

 1 门店纯利润收入统计表.xlsx — 已在数据下方嵌入折线图，打开 Excel 直接可见，门店A/B/C 三条线在同一张图上
 2 profit_line_chart.py — 通用脚本，用法：

搞定，两个产物都在 D:\报表测试\：

 1 门店纯利润收入统计表.xlsx — 已在数据下方嵌入折线图，打开 Excel 直接可见，门店A/B/C 三条线在同一张图上
 2 profit_line_chart.py — 通用脚本，用法：

 python profit_line_chart.py <excel文件路径>

脚本会自动识别第一列为月份、第一行为门店名，生成折线图嵌入原文件。配色和图表尺寸已经预设好，换表直接跑就行。
You:
```

由于没有明说产物交付，智能体要求我们自行手动运行结果：

```
完成! 折线图已嵌入: D:\报表测试\门店纯利润收入统计表.xlsx
(nanobot) D:\报表测试>python profit_line_chart.py D:\报表测试\门店纯利润收入统计表.xlsx
```

整体正确，但是智能体没有自己尝试运行脚本交付产物和验证脚本的可行性，说明智能体仅凭自觉在完成任务，走交付捷径。

### 优化后的表现

```
2026-05-27 01:13:22 | INFO  | - | Registered 17 tools: ['apply_patch', 'run_cli_app', 'complete_goal', 'cron', 'edit_file', 'exec', 'find_files', 'grep', 'list_dir', 'list_exec_sessions', 'long_task', 'message', 'read_file', 'spawn', 'write_file', 'write_stdin', 'my']
🐈 Interactive mode (glm-5-turbo) — type exit or Ctrl+C to quit

You: 2026-05-27 01:13:24 | INFO  | - | MCP server 'playwright': connected, 23 capabilities registered
2026-05-27 01:13:24 | INFO  | - | MCP connected servers: ['playwright']
2026-05-27 01:13:24 | INFO  | - | Agent loop started
You: 请你读取D:\报表测试\门店纯利润收入统计表.xlsx，给我制作每个门店共计12个月的利润折线图excel表，所有门店绘制在同一张
图表上，方便我进行查看，最后你还要保存一个通用的脚本，下次我能按照excel格式批量生成这种折线图表。所有产物放在表格所在位
置。
2026-05-27 01:13:30 | INFO  | - | Processing message from cli:user: 请你读取D:\报表测试\门店纯利润收入统计表.xlsx，给我制作每个门店共计12个月的利润折线图excel表，所有门店绘制在同一张图表上，方便我进行查看，最后你...

✻ Let me start by reading the Excel file to understand its structure
✻ , then create the chart and a reusable script.
2026-05-27 01:13:52 | INFO  | - | Tool call: read_file({"path": "D:\\报表测试\\门店纯利润收入统计表.xlsx"})
  ↳ read D:/报表测试/门店纯利润收入统计表.xlsx
✻ Good, I can see the Excel file structure:
✻ - 3 stores: 门店A, 门店B, 门店C
✻ - 12 months: 一月 through 十二月
✻ - Monthly profit data for each store
✻ Now I need to:
✻ 1.
✻ Read the excel-xlsx skill to understand how to create charts
✻ 2.
✻ Create the chart in the Excel file
✻ 3.
✻ Save a reusable script
✻ Let me read the excel-xlsx skill first.
2026-05-27 01:13:54 | INFO  | - | Tool call: read_file({"path": "C:\\Users\\Jinsn\\.nanobot\\workspace\\skills\\excel-xlsx\\SKILL.md"})
  ↳ read ~/.nanobot/workspace/skills/excel-xlsx/SKILL.md
✻ The user wants me to:
✻ 1.
✻ Read the Excel file (already done) - it has 3 stores (门店A, B
✻ , C) with 12 months of profit data
✻ 2.
✻ Create a line chart in Excel showing all 3 stores on the same
✻ chart
✻ 3.
✻ Save a reusable Python script for batch-generating similar charts
✻ 4.
✻ Put all outputs in `D:\报表测试\`
✻ Let me write a Python script using openpyxl to create the chart
✻ , then save it.
✻ I'll also create a reusable generic script.
✻ The data structure is:
✻ - Row 1: headers (门店A, 门店B, 门店C) - actually the first column
✻ is the month names
✻ - Actually looking at the read_file output: it seems like the
✻ first row is headers and first column is month names
✻ Let me write the script now.
数据已读取，3个门店12个月利润数据。现在写脚本生成图表和通用工具。                                                       2026-05-27 01:14:08 | INFO  | - | Tool call: apply_patch({"edits": [{"path": "D:/报表测试/generate_profit_chart.py", "action": "add", "new_text": "\"\"\"\n门店利润折线图生成器\n\n通用脚本：读取 Excel 利润统计表，自动生成所有门店12个月利润折线图（同一张图表）。\n\n用法：\n  python generate_profit_chart.py <输入x)
数据已读取，3个门店12个月利润数据。现在写脚本生成图表和通用工具。
  ↳ apply_patch
✻ The apply_patch tool requires relative paths.
✻ I need to use write_file or exec to create files outside the
✻ workspace.
✻ Let me use write_file for the script, and exec to run it.
路径需要用相对路径或者直接用 write_file/exec 处理外部目录。换个方式来。                                                 2026-05-27 01:14:17 | INFO  | - | Tool call: write_file({"path": "D:\\报表测试\\generate_profit_chart.py", "content": "\"\"\"\n门店利润折线图生成器\n\n通用脚本：读取 Excel 利润统计表，自动生成所有门店12个月利润折线图（同一张图表）。\n\n用法：\n  python generate_profit_chart.py <输入xlsx路径> [--sheet Sheet名] [--)
路径需要用相对路径或者直接用 write_file/exec 处理外部目录。换个方式来。
  ↳ write D:/报表测试/generate_profit_chart.py
✻ The script is written.
✻ Now I need to run it to generate the chart.
✻ Let me execute the script against the input file.
脚本已写好，现在执行生成图表。                                                                                          2026-05-27 01:14:18 | INFO  | - | Tool call: exec({"command": "cd /d D:\\报表测试 && D:\\Projects\\Python\\nanobot\\.venv\\Scripts\\python.exe generate_profit_chart.py \"D:\\报表测试\\门店纯利润收入统计表.xlsx\"", "timeout": 30})
脚本已写好，现在执行生成图表。
  ↳ $ cd /d D:/报表测试 && …/Scripts/python.exe generate_pr…
✻ The script ran successfully and generated the chart file.
✻ Let me verify the output file exists and looks correct by reading
✻ it back.
验证一下产物：                                                                                                          2026-05-27 01:14:20 | INFO  | - | Tool call: exec({"command": "dir \"D:\\报表测试\\门店纯利润收入统计表_利润折线图.xlsx\" && dir \"D:\\报表测试\\generate_profit_chart.py\"", "timeout": 10})
验证一下产物：
  ↳ $ dir "…/门店纯利润收入统计表_利润折线图.xlsx" && dir "…/generate_…
✻ The chart Excel file and the script have been generated successfully
✻ .
✻ Let me verify the output by reading the generated Excel file
✻ to make sure it looks correct.
全部搞定，产物都在 D:\报表测试\ 下：

生成的文件：

 文件                                  说明
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────
 门店纯利润收入统计表_利润折线图.xlsx  原数据 + 新增「利润折线图」工作表，3条折线（门店A/B/C）在同一张图上
全部搞定，产物都在 D:\报表测试\ 下：

生成的文件：

 文件                                  说明
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────
 门店纯利润收入统计表_利润折线图.xlsx  原数据 + 新增「利润折线图」工作表，3条折线（门店A/B/C）在同一张图上
 generate_profit_chart.py              通用脚本，以后换个表直接跑

折线图特点：

 • 3条不同颜色的折线（红/青/蓝），每个数据点带圆圈标记
 • 显示每个点的数值标签
 • 图表标题、坐标轴标签齐全

通用脚本用法：

 python generate_profit_chart.py <输入xlsx路径> [--sheet 工作表名] [--output 输出路径]

只要求输入格式：第一行表头、第一列月份标签、其余列门店数据。不管几个门店，脚本都会自动全部画到同一张图上，超过16个门店会
循环配色。
You:
```

模型在每轮工具执行后主动汇报发现、分析结果、说明下一步动作，过程透明可追踪，且自动验证中间产物。
*注：以上修改不影响纯聊天场景，只对工具调用后进行优化，实现`分析→执行→观察→再分析`的循环。*