### PR TITLE
feat(dingtalk): add group_user_isolation to separate sessions per use…

### DIFF
--- a/docs/chat-apps.md
+++ b/docs/chat-apps.md
@@ -445,13 +445,18 @@ Uses **Stream Mode** — no public IP required.
       "enabled": true,
       "clientId": "YOUR_APP_KEY",
       "clientSecret": "YOUR_APP_SECRET",
-      "allowFrom": ["YOUR_STAFF_ID"]
+      "allowFrom": ["YOUR_STAFF_ID"],
+      "groupUserIsolation": false
     }
   }
 }
 ```
 
 > `allowFrom`: Add your staff ID. Use `["*"]` to allow all users.
+>
+> `groupUserIsolation`: Optional. Defaults to `false`, which keeps one shared session per
+> group chat. Set it to `true` to give each sender in a DingTalk group chat a separate
+> session while replies still go back to the same group.
 
 **3. Run**
 

--- a/nanobot/channels/dingtalk.py
+++ b/nanobot/channels/dingtalk.py
@@ -160,6 +160,7 @@ class DingTalkConfig(Base):
     allow_from: list[str] = Field(default_factory=list)
     allow_remote_media_redirects: bool = False
     remote_media_redirect_allowed_hosts: list[str] = Field(default_factory=list)
+    group_user_isolation: bool = False  # If True, each user in group chat gets their own session
 
 
 class DingTalkChannel(BaseChannel):
@@ -693,6 +694,9 @@ class DingTalkChannel(BaseChannel):
             self.logger.info("inbound: {} from {}", content, sender_name)
             is_group = conversation_type == "2" and conversation_id
             chat_id = f"group:{conversation_id}" if is_group else sender_id
+            session_key = None
+            if is_group and self.config.group_user_isolation:
+                session_key = f"{self.name}:group:{conversation_id}:{sender_id}"
             await self._handle_message(
                 sender_id=sender_id,
                 chat_id=chat_id,
@@ -702,6 +706,7 @@ class DingTalkChannel(BaseChannel):
                     "platform": "dingtalk",
                     "conversation_type": conversation_type,
                 },
+                session_key=session_key,
             )
         except Exception:
             self.logger.exception("Error publishing message")

--- a/tests/channels/test_dingtalk_channel.py
+++ b/tests/channels/test_dingtalk_channel.py
@@ -99,6 +99,55 @@ async def test_group_message_keeps_sender_id_and_routes_chat_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_group_user_isolation_false_uses_shared_session() -> None:
+    """By default group messages share the same session_key."""
+    config = DingTalkConfig(
+        client_id="app", client_secret="secret", allow_from=["*"], group_user_isolation=False
+    )
+    bus = MessageBus()
+    channel = DingTalkChannel(config, bus)
+
+    for user_id in ("user1", "user2"):
+        await channel._on_message(
+            "hello",
+            sender_id=user_id,
+            sender_name=user_id,
+            conversation_type="2",
+            conversation_id="conv123",
+        )
+
+    msg1 = await bus.consume_inbound()
+    msg2 = await bus.consume_inbound()
+    assert msg1.session_key == msg2.session_key == "dingtalk:group:conv123"
+    assert msg1.chat_id == msg2.chat_id == "group:conv123"
+
+
+@pytest.mark.asyncio
+async def test_group_user_isolation_true_separates_sessions() -> None:
+    """When group_user_isolation is True, each user gets their own session_key."""
+    config = DingTalkConfig(
+        client_id="app", client_secret="secret", allow_from=["*"], group_user_isolation=True
+    )
+    bus = MessageBus()
+    channel = DingTalkChannel(config, bus)
+
+    for user_id in ("user1", "user2"):
+        await channel._on_message(
+            "hello",
+            sender_id=user_id,
+            sender_name=user_id,
+            conversation_type="2",
+            conversation_id="conv123",
+        )
+
+    msg1 = await bus.consume_inbound()
+    msg2 = await bus.consume_inbound()
+    assert msg1.session_key == "dingtalk:group:conv123:user1"
+    assert msg2.session_key == "dingtalk:group:conv123:user2"
+    assert msg1.chat_id == msg2.chat_id == "group:conv123"
+
+
+@pytest.mark.asyncio
 async def test_group_send_uses_group_messages_api() -> None:
     config = DingTalkConfig(client_id="app", client_secret="secret", allow_from=["*"])
     channel = DingTalkChannel(config, MessageBus())


### PR DESCRIPTION
## 功能：DingTalk 群聊按用户隔离 Session

   ### 问题
   当前 DingTalk 群聊中所有用户共用同一个 session，导致不同用户的对话上下文互相干扰。

   ### 解决方案
   新增配置项 `group_user_isolation`，开启后群聊中每个用户拥有独立的 session key，但机器人回复仍会路由到同一个群聊。

   ### 配置示例
   ```json
   {
     "channels": {
       "dingtalk": {
         "enabled": true,
         "clientId": "your-client-id",
         "clientSecret": "your-client-secret",
         "groupUserIsolation": true
       }
     }
   }
 ```

 ### 向后兼容

 - 默认值为 false，现有行为完全不变
 - 不涉及破坏性变更

 ### 测试

 - 新增 2 个单元测试覆盖隔离开启/关闭的场景
 - 全部 22 个 DingTalk 通道测试通过

 ```
   pytest tests/channels/test_dingtalk_channel.py -v
   # 22 passed
 ```

 ### 变更文件

 - nanobot/channels/dingtalk.py — 新增配置项和 session key 逻辑
 - tests/channels/test_dingtalk_channel.py — 补充测试