### PR TITLE
fix(providers): parse text-format tool_calls in openai-compat responses

### DIFF
--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -27,6 +27,7 @@ from nanobot.providers.openai_responses import (
     convert_tools,
     parse_response_output,
 )
+from nanobot.providers.text_tool_calls import maybe_inject_text_tool_calls
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI as AsyncOpenAIType
@@ -1031,13 +1032,13 @@ class OpenAICompatProvider(LLMProvider):
                     function_provider_specific_fields=fn_prov,
                 ))
 
-            return LLMResponse(
+            return maybe_inject_text_tool_calls(LLMResponse(
                 content=content,
                 tool_calls=parsed_tool_calls,
                 finish_reason=finish_reason,
                 usage=self._extract_usage(response_map),
                 reasoning_content=reasoning_content if isinstance(reasoning_content, str) else None,
-            )
+            ))
 
         if not response.choices:
             return LLMResponse(content="Error: API returned empty choices.", finish_reason="error")
@@ -1078,13 +1079,13 @@ class OpenAICompatProvider(LLMProvider):
         if not reasoning_content and getattr(msg, "reasoning", None):
             reasoning_content = msg.reasoning
 
-        return LLMResponse(
+        return maybe_inject_text_tool_calls(LLMResponse(
             content=content,
             tool_calls=tool_calls,
             finish_reason=finish_reason or "stop",
             usage=self._extract_usage(response),
             reasoning_content=reasoning_content,
-        )
+        ))
 
     @classmethod
     def _parse_chunks(cls, chunks: list[Any]) -> LLMResponse:
@@ -1198,7 +1199,7 @@ class OpenAICompatProvider(LLMProvider):
                 b["id"] = _short_tool_id()
             _seen_tc_ids.add(b["id"])
 
-        return LLMResponse(
+        return maybe_inject_text_tool_calls(LLMResponse(
             content="".join(content_parts) or None,
             tool_calls=[
                 ToolCallRequest(
@@ -1214,7 +1215,7 @@ class OpenAICompatProvider(LLMProvider):
             finish_reason=finish_reason,
             usage=usage,
             reasoning_content="".join(reasoning_parts) or None,
-        )
+        ))
 
     @classmethod
     def _extract_error_metadata(cls, e: Exception) -> dict[str, Any]:
@@ -1391,13 +1392,13 @@ class OpenAICompatProvider(LLMProvider):
                         on_tool_call_delta=on_tool_call_delta,
                     )
                     self._record_responses_success(model, reasoning_effort)
-                    return LLMResponse(
+                    return maybe_inject_text_tool_calls(LLMResponse(
                         content=content or None,
                         tool_calls=tool_calls,
                         finish_reason=finish_reason,
                         usage=usage,
                         reasoning_content=reasoning_content,
-                    )
+                    ))
                 except Exception as responses_error:
                     if self._spec and self._spec.name == "github_copilot":
                         # Copilot gateway exposes GPT-5/o-series only via /responses;

--- a/nanobot/providers/text_tool_calls.py
+++ b/nanobot/providers/text_tool_calls.py
@@ -31,6 +31,9 @@ from __future__ import annotations
 
 import re
 import secrets
+import string
+
+from loguru import logger
 
 from nanobot.providers.base import LLMResponse, ToolCallRequest
 
@@ -47,9 +50,12 @@ _PARAMETER_RE = re.compile(
     re.DOTALL,
 )
 
+_ALNUM = string.ascii_letters + string.digits
+
 
 def _short_tool_id() -> str:
-    return "call_" + secrets.token_hex(6)
+    """9-char alphanumeric ID compatible with all providers (incl. Mistral)."""
+    return "".join(secrets.choice(_ALNUM) for _ in range(9))
 
 
 def parse_text_tool_calls(content: str) -> tuple[str, list[ToolCallRequest]]:
@@ -68,6 +74,7 @@ def parse_text_tool_calls(content: str) -> tuple[str, list[ToolCallRequest]]:
         body = block_match.group(1)
         func_match = _FUNCTION_RE.search(body)
         if not func_match:
+            logger.warning("Malformed <tool_call> block: missing <function=...> tag")
             continue
         name = func_match.group(1).strip()
         params_body = func_match.group(2)
@@ -77,6 +84,7 @@ def parse_text_tool_calls(content: str) -> tuple[str, list[ToolCallRequest]]:
             value = param_match.group(2)
             args[key] = value
         if not name:
+            logger.warning("Malformed <tool_call> block: empty function name")
             continue
         tool_calls.append(ToolCallRequest(
             id=_short_tool_id(),

--- a/nanobot/providers/text_tool_calls.py
+++ b/nanobot/providers/text_tool_calls.py
@@ -1,0 +1,114 @@
+"""Fallback parser for text-format tool calls in openai-compatible responses.
+
+Some openai-compatible providers occasionally emit tool calls as plain text
+inside the assistant message ``content`` instead of populating the structured
+``tool_calls`` field of the OpenAI Chat Completions response. Observed in
+practice with Xiaomi MiMo (``xiaomi_mimo`` provider); the exact format is:
+
+    <tool_call>
+    <function=tool_name>
+    <parameter=key1>value1</parameter>
+    <parameter=key2>value2</parameter>
+    </function>
+    </tool_call>
+
+The agent runner only dispatches ``LLMResponse.tool_calls`` — any text in
+``content`` is shown to the user verbatim, which breaks tool-using flows on
+those providers (the user sees the raw XML markup instead of the tool result).
+
+``maybe_inject_text_tool_calls`` post-processes an ``LLMResponse``: when the
+structured ``tool_calls`` field is empty and the content contains one or more
+``<tool_call>`` blocks, it parses them into ``ToolCallRequest`` objects, strips
+the markup from content, and flips ``finish_reason`` from ``"stop"`` to
+``"tool_calls"`` so the runner dispatches them like native calls.
+
+The helper is a no-op when the provider already returned structured tool calls,
+the content is empty, or the response is an error envelope — so providers that
+behave correctly (GPT, Claude via openai-compat, etc.) are unaffected.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+
+from nanobot.providers.base import LLMResponse, ToolCallRequest
+
+_TOOL_CALL_BLOCK_RE = re.compile(
+    r"<tool_call>\s*(.*?)\s*</tool_call>",
+    re.DOTALL,
+)
+_FUNCTION_RE = re.compile(
+    r"<function=([^>]+)>\s*(.*?)\s*</function>",
+    re.DOTALL,
+)
+_PARAMETER_RE = re.compile(
+    r"<parameter=([^>]+)>(.*?)</parameter>",
+    re.DOTALL,
+)
+
+
+def _short_tool_id() -> str:
+    return "call_" + secrets.token_hex(6)
+
+
+def parse_text_tool_calls(content: str) -> tuple[str, list[ToolCallRequest]]:
+    """Extract ``<tool_call>`` blocks (text-format) from *content*.
+
+    Returns ``(cleaned_content, tool_calls)``. When no blocks are found,
+    returns ``(content, [])`` unchanged. Parameter values are kept as
+    strings — the tool registry's ``cast_params`` handles type coercion
+    against the tool's JSON schema downstream.
+    """
+    if not content or "<tool_call>" not in content:
+        return content, []
+
+    tool_calls: list[ToolCallRequest] = []
+    for block_match in _TOOL_CALL_BLOCK_RE.finditer(content):
+        body = block_match.group(1)
+        func_match = _FUNCTION_RE.search(body)
+        if not func_match:
+            continue
+        name = func_match.group(1).strip()
+        params_body = func_match.group(2)
+        args: dict[str, str] = {}
+        for param_match in _PARAMETER_RE.finditer(params_body):
+            key = param_match.group(1).strip()
+            value = param_match.group(2)
+            args[key] = value
+        if not name:
+            continue
+        tool_calls.append(ToolCallRequest(
+            id=_short_tool_id(),
+            name=name,
+            arguments=args,
+        ))
+
+    if not tool_calls:
+        return content, []
+
+    cleaned = _TOOL_CALL_BLOCK_RE.sub("", content).strip()
+    return cleaned, tool_calls
+
+
+def maybe_inject_text_tool_calls(response: LLMResponse) -> LLMResponse:
+    """Lift any text-format tool calls into ``response.tool_calls``.
+
+    No-op when the provider already returned structured tool calls, when
+    content is empty, or when the response is an error envelope. Mutates
+    and returns the same ``response`` for convenience.
+    """
+    if response.tool_calls or not response.content:
+        return response
+    if response.finish_reason == "error":
+        return response
+
+    cleaned, parsed = parse_text_tool_calls(response.content)
+    if not parsed:
+        return response
+
+    response.content = cleaned or None
+    response.tool_calls = parsed
+    if response.finish_reason == "stop":
+        response.finish_reason = "tool_calls"
+    return response

--- a/tests/providers/test_text_tool_calls.py
+++ b/tests/providers/test_text_tool_calls.py
@@ -1,0 +1,216 @@
+"""Tests for the text-format tool-call fallback parser."""
+
+import logging
+import re
+
+from loguru import logger as loguru_logger
+
+from nanobot.providers.base import LLMResponse, ToolCallRequest
+from nanobot.providers.text_tool_calls import (
+    _ALNUM,
+    _short_tool_id,
+    maybe_inject_text_tool_calls,
+    parse_text_tool_calls,
+)
+
+_MIMO_BLOCK = (
+    "<tool_call>\n"
+    "<function=read_file>\n"
+    "<parameter=path>/etc/hosts</parameter>\n"
+    "<parameter=encoding>utf-8</parameter>\n"
+    "</function>\n"
+    "</tool_call>"
+)
+
+
+def test_short_tool_id_is_9_char_alphanumeric():
+    """Mistral and other strict providers require short alphanumeric IDs."""
+    tool_id = _short_tool_id()
+    assert len(tool_id) == 9
+    assert all(ch in _ALNUM for ch in tool_id)
+
+
+def test_parse_extracts_function_and_parameters():
+    cleaned, calls = parse_text_tool_calls(_MIMO_BLOCK)
+    assert cleaned == ""
+    assert len(calls) == 1
+    call = calls[0]
+    assert isinstance(call, ToolCallRequest)
+    assert call.name == "read_file"
+    assert call.arguments == {"path": "/etc/hosts", "encoding": "utf-8"}
+
+
+def test_parse_strips_blocks_from_mixed_content():
+    """After stripping tool-call XML the surrounding prose must remain clean."""
+    content = (
+        "Sure, I'll read that file for you.\n\n"
+        f"{_MIMO_BLOCK}\n\n"
+        "Let me know if you want me to do anything else."
+    )
+    cleaned, calls = parse_text_tool_calls(content)
+    assert len(calls) == 1
+    assert "<tool_call>" not in cleaned
+    assert "</tool_call>" not in cleaned
+    assert "I'll read that file" in cleaned
+    assert "Let me know" in cleaned
+    # No leading/trailing whitespace artifacts from the strip.
+    assert cleaned == cleaned.strip()
+
+
+def test_parse_handles_multiple_blocks():
+    content = (
+        f"{_MIMO_BLOCK}\n"
+        "<tool_call>\n"
+        "<function=list_dir>\n"
+        "<parameter=path>/tmp</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+    cleaned, calls = parse_text_tool_calls(content)
+    assert cleaned == ""
+    assert [c.name for c in calls] == ["read_file", "list_dir"]
+    assert calls[1].arguments == {"path": "/tmp"}
+
+
+def test_parse_no_blocks_is_noop():
+    cleaned, calls = parse_text_tool_calls("just plain text, no tools here")
+    assert cleaned == "just plain text, no tools here"
+    assert calls == []
+
+
+def test_parse_empty_content_is_noop():
+    assert parse_text_tool_calls("") == ("", [])
+    assert parse_text_tool_calls(None) == (None, [])
+
+
+def test_parse_malformed_block_emits_warning(caplog):
+    """Missing <function=...> inside <tool_call> should warn, not silently drop."""
+    bad = "<tool_call>\n<parameter=x>1</parameter>\n</tool_call>"
+    handler_id = loguru_logger.add(caplog.handler, format="{message}", level="WARNING")
+    try:
+        with caplog.at_level(logging.WARNING):
+            cleaned, calls = parse_text_tool_calls(bad)
+    finally:
+        loguru_logger.remove(handler_id)
+    assert calls == []
+    assert cleaned == bad  # malformed -> unchanged content
+    assert any(
+        "Malformed <tool_call> block" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_parse_empty_function_name_emits_warning(caplog):
+    bad = "<tool_call>\n<function=>\n</function>\n</tool_call>"
+    handler_id = loguru_logger.add(caplog.handler, format="{message}", level="WARNING")
+    try:
+        with caplog.at_level(logging.WARNING):
+            cleaned, calls = parse_text_tool_calls(bad)
+    finally:
+        loguru_logger.remove(handler_id)
+    # Regex requires at least one char inside function=...; either no match
+    # (warns about missing function tag) or empty name (warns about empty name).
+    assert calls == []
+    assert any("Malformed <tool_call> block" in r.getMessage() for r in caplog.records)
+
+
+# ---------- integration: maybe_inject_text_tool_calls ----------
+
+
+def test_inject_lifts_calls_and_flips_finish_reason():
+    """The reviewer-requested integration test: text tool_calls get lifted into
+    the structured field and finish_reason is flipped from "stop" to "tool_calls"."""
+    response = LLMResponse(
+        content=f"Reading the file now.\n{_MIMO_BLOCK}",
+        tool_calls=[],
+        finish_reason="stop",
+    )
+    out = maybe_inject_text_tool_calls(response)
+
+    # Same object, mutated in place.
+    assert out is response
+    # tool_calls populated.
+    assert len(out.tool_calls) == 1
+    assert out.tool_calls[0].name == "read_file"
+    assert out.tool_calls[0].arguments == {"path": "/etc/hosts", "encoding": "utf-8"}
+    # ID format matches the rest of the provider (9 alphanumeric chars).
+    assert re.fullmatch(r"[A-Za-z0-9]{9}", out.tool_calls[0].id)
+    # finish_reason flipped so AgentRunner dispatches the call.
+    assert out.finish_reason == "tool_calls"
+    # Surrounding prose preserved, XML stripped.
+    assert out.content == "Reading the file now."
+
+
+def test_inject_noop_when_tool_calls_already_present():
+    """Providers returning structured tool_calls must not be touched."""
+    existing = ToolCallRequest(id="abc123def", name="foo", arguments={"x": 1})
+    response = LLMResponse(
+        content=_MIMO_BLOCK,  # would parse if asked, but we shouldn't
+        tool_calls=[existing],
+        finish_reason="tool_calls",
+    )
+    out = maybe_inject_text_tool_calls(response)
+    assert out.tool_calls == [existing]
+    assert out.content == _MIMO_BLOCK  # untouched
+    assert out.finish_reason == "tool_calls"
+
+
+def test_inject_noop_when_content_empty():
+    response = LLMResponse(content=None, tool_calls=[], finish_reason="stop")
+    out = maybe_inject_text_tool_calls(response)
+    assert out.tool_calls == []
+    assert out.content is None
+    assert out.finish_reason == "stop"
+
+
+def test_inject_noop_on_error_envelope():
+    """Error responses must not have their finish_reason mutated."""
+    response = LLMResponse(
+        content=_MIMO_BLOCK,
+        tool_calls=[],
+        finish_reason="error",
+        error_kind="timeout",
+    )
+    out = maybe_inject_text_tool_calls(response)
+    assert out.tool_calls == []
+    assert out.finish_reason == "error"
+    assert out.content == _MIMO_BLOCK
+
+
+def test_inject_noop_when_content_has_no_blocks():
+    response = LLMResponse(
+        content="Just a plain response, no tool calls.",
+        tool_calls=[],
+        finish_reason="stop",
+    )
+    out = maybe_inject_text_tool_calls(response)
+    assert out.tool_calls == []
+    assert out.finish_reason == "stop"
+    assert out.content == "Just a plain response, no tool calls."
+
+
+def test_inject_content_becomes_none_when_only_tool_block():
+    """If the message was ONLY a tool call, content should drop to None
+    (not an empty string), matching native tool-call responses."""
+    response = LLMResponse(
+        content=_MIMO_BLOCK,
+        tool_calls=[],
+        finish_reason="stop",
+    )
+    out = maybe_inject_text_tool_calls(response)
+    assert out.tool_calls and out.tool_calls[0].name == "read_file"
+    assert out.content is None
+    assert out.finish_reason == "tool_calls"
+
+
+def test_inject_preserves_non_stop_finish_reason():
+    """If finish_reason is something other than "stop" (e.g. "length"),
+    we still lift the calls but leave the finish_reason alone — the reason
+    why generation ended is preserved."""
+    response = LLMResponse(
+        content=_MIMO_BLOCK,
+        tool_calls=[],
+        finish_reason="length",
+    )
+    out = maybe_inject_text_tool_calls(response)
+    assert len(out.tool_calls) == 1
+    assert out.finish_reason == "length"


### PR DESCRIPTION
Some openai-compatible providers occasionally emit tool calls as plain text inside the assistant message content instead of populating the structured `tool_calls` field of the OpenAI Chat Completions response — observed in practice with Xiaomi MiMo (`xiaomi_mimo` provider). The exact format is:

    <tool_call>
    <function=tool_name>
    <parameter=key>value</parameter>
    </function>
    </tool_call>

The agent runner only dispatches `LLMResponse.tool_calls`, so the markup is shown to the user verbatim and any tool-using flow breaks on those providers (users see raw XML where they expected a tool result).

This patch adds a post-processing step in `openai_compat_provider`: after each `LLMResponse` is built, when `tool_calls` is empty and the content contains `<tool_call>` blocks, parse them into `ToolCallRequest` objects, strip the markup from content, and flip `finish_reason` from "stop" to "tool_calls" so the runner dispatches them like native calls. The helper is a no-op when the provider already returned structured tool calls, content is empty, or the response is an error envelope — so well-behaved providers (GPT, Claude via openai-compat, etc.) are unaffected.

- new `nanobot/providers/text_tool_calls.py`: parser + `maybe_inject_text_tool_calls`
- 4 return sites in `openai_compat_provider.py` wrapped (dict response path, SDK object path, streaming chunks aggregator, Responses API streaming)