### PR TITLE
fix(provider): honor NANOBOT_STREAM_IDLE_TIMEOUT_S in Codex provider

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import os
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -177,7 +178,8 @@ async def _request_codex(
     on_content_delta: Callable[[str], Awaitable[None]] | None = None,
     on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
 ) -> tuple[str, list[ToolCallRequest], str]:
-    async with httpx.AsyncClient(timeout=60.0, verify=verify) as client:
+    idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
+    async with httpx.AsyncClient(timeout=idle_timeout_s, verify=verify) as client:
         async with client.stream("POST", url, headers=headers, json=body) as response:
             if response.status_code != 200:
                 text = await response.aread()

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -76,8 +76,8 @@ async def test_codex_request_non_200_populates_http_metadata(monkeypatch) -> Non
             request=request,
         )
 
-    def fake_client(*, timeout: float, verify: bool) -> httpx.AsyncClient:
-        assert timeout == 60.0
+    def fake_client(*, timeout: int, verify: bool) -> httpx.AsyncClient:
+        assert timeout == 90
         assert verify is True
         return original_client(transport=httpx.MockTransport(handler), timeout=timeout)
 
@@ -93,6 +93,27 @@ async def test_codex_request_non_200_populates_http_metadata(monkeypatch) -> Non
     assert error.error_type == "rate_limit_exceeded"
     assert error.error_code == "rate_limit_exceeded"
     assert error.should_retry is True
+
+
+@pytest.mark.asyncio
+async def test_codex_request_honors_stream_idle_timeout_env(monkeypatch) -> None:
+    """NANOBOT_STREAM_IDLE_TIMEOUT_S overrides the default Codex stream timeout."""
+    monkeypatch.setenv("NANOBOT_STREAM_IDLE_TIMEOUT_S", "5")
+    original_client = httpx.AsyncClient
+    seen: dict[str, int] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, request=request)
+
+    def fake_client(*, timeout: int, verify: bool) -> httpx.AsyncClient:
+        seen["timeout"] = timeout
+        return original_client(transport=httpx.MockTransport(handler), timeout=timeout)
+
+    monkeypatch.setattr("nanobot.providers.openai_codex_provider.httpx.AsyncClient", fake_client)
+
+    await _request_codex("https://codex.example/responses", {}, {"input": []}, verify=True)
+
+    assert seen["timeout"] == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context

Three streaming providers (`anthropic`, `bedrock`, `openai_compat`) already read `NANOBOT_STREAM_IDLE_TIMEOUT_S` with a 90s default. The Codex provider is the only one that hardcodes its timeout (at 60s) and ignores the env var, so operators cannot tune it the way they tune the peers, and Codex streams abort sooner than the established baseline.

This PR restores the missing parity — it's a consistency fix, not a new configuration surface.

#4009 normalized the error response when the timeout fires; this PR fixes the timeout knob itself.

## Changes

- `_request_codex` reads `NANOBOT_STREAM_IDLE_TIMEOUT_S` (default `90`) and passes it to the existing `httpx.AsyncClient(timeout=...)`. Variable name (`idle_timeout_s`), int parsing, and the 90 default match `anthropic_provider.py` / `bedrock_provider.py` / `openai_compat_provider.py` verbatim.
- Update the `timeout == 60.0` assertion in `test_codex_request_non_200_populates_http_metadata` to `90`.
- Add `test_codex_request_honors_stream_idle_timeout_env`.

Codex uses raw `httpx.stream(...)` rather than an SDK SSE iterator, so the idle watchdog stays at the httpx read-timeout layer. The effect (abort if no bytes flow for N seconds) matches the `asyncio.wait_for(stream.__anext__(), timeout=…)` pattern peer providers use over their SDK streams.

## Verification

```
ruff check nanobot/providers/openai_codex_provider.py tests/providers/test_openai_codex_provider.py
pytest tests/providers/test_openai_codex_provider.py -q
```
