### PR TITLE
fix(codex): dedup reasoning items before send, retry on duplicate-item 400 [AI-assisted]

### DIFF
--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import re
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -26,6 +27,8 @@ from nanobot.providers.openai_responses import (
 
 DEFAULT_CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_ORIGINATOR = "nanobot"
+
+_REASONING_ID_RE = re.compile(r"rs_[A-Za-z0-9_-]+")
 
 
 class OpenAICodexProvider(LLMProvider):
@@ -62,7 +65,7 @@ class OpenAICodexProvider(LLMProvider):
             "store": False,
             "stream": True,
             "instructions": system_prompt,
-            "input": input_items,
+            "input": _dedup_reasoning_items(input_items),
             "text": {"verbosity": "medium"},
             "include": ["reasoning.encrypted_content"],
             "prompt_cache_key": _prompt_cache_key(messages[:2]),
@@ -80,8 +83,10 @@ class OpenAICodexProvider(LLMProvider):
             headers = _build_headers(token.account_id, token.access)
 
             try:
-                content, tool_calls, finish_reason, usage, reasoning_content = await _request_codex(
-                    DEFAULT_CODEX_URL, headers, body, verify=True,
+                content, tool_calls, finish_reason, usage, reasoning_content = await _send_codex_request(
+                    body,
+                    headers,
+                    verify=True,
                     proxy=self.proxy,
                     on_content_delta=on_content_delta,
                     on_thinking_delta=on_thinking_delta,
@@ -91,8 +96,10 @@ class OpenAICodexProvider(LLMProvider):
                 if "CERTIFICATE_VERIFY_FAILED" not in str(e):
                     raise
                 logger.warning("SSL verification failed for Codex API; retrying with verify=False")
-                content, tool_calls, finish_reason, usage, reasoning_content = await _request_codex(
-                    DEFAULT_CODEX_URL, headers, body, verify=False,
+                content, tool_calls, finish_reason, usage, reasoning_content = await _send_codex_request(
+                    body,
+                    headers,
+                    verify=False,
                     proxy=self.proxy,
                     on_content_delta=on_content_delta,
                     on_thinking_delta=on_thinking_delta,
@@ -170,6 +177,115 @@ def _build_reasoning_options(reasoning_effort: str | None) -> dict[str, str] | N
     return options
 
 
+def _dedup_reasoning_items(input_items: list[Any]) -> list[Any]:
+    """Drop duplicate ``{type: "reasoning", id: "rs_..."}`` entries.
+
+    The Codex Responses backend rejects requests whose ``input`` array
+    re-sends a reasoning item it has already accepted, producing
+    ``400 Duplicate item found with id rs_...`` and breaking multi-turn
+    conversations (see HKUDS/nanobot#3633). This helper walks the list once
+    and keeps only the first occurrence of each ``rs_*`` id; non-reasoning
+    items and reasoning items without a recognized id are passed through
+    untouched.
+    """
+    seen: set[str] = set()
+    out: list[Any] = []
+    for item in input_items:
+        if (
+            isinstance(item, dict)
+            and item.get("type") == "reasoning"
+            and isinstance(item.get("id"), str)
+            and item["id"].startswith("rs_")
+        ):
+            rs_id = item["id"]
+            if rs_id in seen:
+                continue
+            seen.add(rs_id)
+        out.append(item)
+    return out
+
+
+def _drop_reasoning_id(input_items: list[Any], rs_id: str) -> list[Any]:
+    """Return ``input_items`` with every ``{type:"reasoning", id: rs_id}`` removed."""
+    return [
+        item
+        for item in input_items
+        if not (
+            isinstance(item, dict)
+            and item.get("type") == "reasoning"
+            and item.get("id") == rs_id
+        )
+    ]
+
+
+def _extract_duplicate_id(raw: str, message: str) -> str | None:
+    """Pull the offending ``rs_*`` id from a duplicate-item 400 payload.
+
+    The Responses API surfaces the duplicate id inline ("Duplicate item
+    found with id rs_abc123"). Prefer the structured upstream body and
+    fall back to the friendly message string the provider already built.
+    """
+    for source in (raw, message):
+        if not source:
+            continue
+        match = _REASONING_ID_RE.search(source)
+        if match:
+            return match.group(0)
+    return None
+
+
+async def _send_codex_request(
+    body: dict[str, Any],
+    headers: dict[str, str],
+    *,
+    verify: bool,
+    proxy: str | None = None,
+    on_content_delta: Callable[[str], Awaitable[None]] | None,
+    on_thinking_delta: Callable[[str], Awaitable[None]] | None,
+    on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None,
+) -> tuple[str, list[ToolCallRequest], str, dict[str, int], str | None]:
+    """Send the Codex request, retrying once after a duplicate-item 400.
+
+    A retry is only attempted when the upstream payload identifies a
+    specific ``rs_*`` id; in that case the duplicate is stripped from the
+    outgoing ``input`` array (in place — same body dict) before the
+    second attempt. Any other error is re-raised for the caller's normal
+    error path.
+    """
+    try:
+        return await _request_codex(
+            DEFAULT_CODEX_URL,
+            headers,
+            body,
+            verify=verify,
+            proxy=proxy,
+            on_content_delta=on_content_delta,
+            on_thinking_delta=on_thinking_delta,
+            on_tool_call_delta=on_tool_call_delta,
+        )
+    except _CodexHTTPError as exc:
+        if exc.status_code != 400 or exc.error_code != "duplicate_item":
+            raise
+        rs_id = exc.duplicate_id
+        if not rs_id:
+            raise
+        logger.warning(
+            "Codex API rejected duplicate reasoning id {}; retrying once after dedup",
+            rs_id,
+        )
+        body["input"] = _drop_reasoning_id(body["input"], rs_id)
+        return await _request_codex(
+            DEFAULT_CODEX_URL,
+            headers,
+            body,
+            verify=verify,
+            proxy=proxy,
+            on_content_delta=on_content_delta,
+            on_thinking_delta=on_thinking_delta,
+            on_tool_call_delta=on_tool_call_delta,
+        )
+
+
 def _build_headers(account_id: str, token: str) -> dict[str, str]:
     return {
         "Authorization": f"Bearer {token}",
@@ -192,6 +308,7 @@ class _CodexHTTPError(RuntimeError):
         error_type: str | None = None,
         error_code: str | None = None,
         should_retry: bool | None = None,
+        duplicate_id: str | None = None,
     ):
         super().__init__(message)
         self.status_code = status_code
@@ -199,6 +316,7 @@ class _CodexHTTPError(RuntimeError):
         self.error_type = error_type
         self.error_code = error_code
         self.should_retry = should_retry
+        self.duplicate_id = duplicate_id
 
 
 async def _request_codex(
@@ -223,13 +341,21 @@ async def _request_codex(
                 raw = text.decode("utf-8", "ignore")
                 retry_after = LLMProvider._extract_retry_after_from_headers(response.headers)
                 error_type, error_code = LLMProvider._extract_error_type_code(raw)
+                friendly = _friendly_error(response.status_code, raw)
+                duplicate_id: str | None = None
+                if response.status_code == 400 and _is_duplicate_item_error(error_code, raw):
+                    # Normalize the error_code so the retry path can detect it
+                    # regardless of how upstream framed the payload.
+                    error_code = "duplicate_item"
+                    duplicate_id = _extract_duplicate_id(raw, friendly)
                 raise _CodexHTTPError(
-                    _friendly_error(response.status_code, raw),
+                    friendly,
                     status_code=response.status_code,
                     retry_after=retry_after,
                     error_type=error_type,
                     error_code=error_code,
                     should_retry=_should_retry_status(response.status_code, error_type, error_code, raw),
+                    duplicate_id=duplicate_id,
                 )
             return await consume_sse_with_reasoning(
                 response,
@@ -237,6 +363,12 @@ async def _request_codex(
                 on_tool_call_delta=on_tool_call_delta,
                 on_reasoning_delta=on_thinking_delta,
             )
+
+
+def _is_duplicate_item_error(error_code: str | None, raw: str) -> bool:
+    if error_code and "duplicate_item" in error_code:
+        return True
+    return "Duplicate item found" in raw
 
 
 def _prompt_cache_key(messages: list[dict[str, Any]]) -> str:

--- a/tests/providers/test_openai_codex_provider.py
+++ b/tests/providers/test_openai_codex_provider.py
@@ -14,6 +14,9 @@ from nanobot.providers.openai_codex_provider import (
     _build_reasoning_options,
     _codex_error_response,
     _CodexHTTPError,
+    _dedup_reasoning_items,
+    _drop_reasoning_id,
+    _extract_duplicate_id,
     _friendly_error,
     _request_codex,
     _should_retry_status,
@@ -538,3 +541,251 @@ async def test_codex_stream_surfaces_reasoning_summary(monkeypatch) -> None:
 
 async def _append(target: list[str], value: str) -> None:
     target.append(value)
+
+
+# --- HKUDS/nanobot#3633: dedup reasoning items + duplicate-item 400 retry -----
+
+
+def test_dedup_reasoning_items_drops_repeated_rs_ids_keeping_first() -> None:
+    items = [
+        {"type": "message", "id": "msg_1", "content": "hi"},
+        {"type": "reasoning", "id": "rs_alpha", "encrypted_content": "first"},
+        {"type": "message", "id": "msg_2", "content": "ok"},
+        {"type": "reasoning", "id": "rs_alpha", "encrypted_content": "second"},
+        {"type": "reasoning", "id": "rs_beta", "encrypted_content": "third"},
+        {"type": "reasoning", "id": "rs_alpha", "encrypted_content": "fourth"},
+    ]
+
+    result = _dedup_reasoning_items(items)
+
+    rs_alphas = [item for item in result if item.get("id") == "rs_alpha"]
+    assert len(rs_alphas) == 1
+    assert rs_alphas[0]["encrypted_content"] == "first"
+    rs_betas = [item for item in result if item.get("id") == "rs_beta"]
+    assert len(rs_betas) == 1
+    # Non-reasoning items must pass through untouched and in order.
+    assert [item.get("id") for item in result if item.get("type") == "message"] == [
+        "msg_1",
+        "msg_2",
+    ]
+
+
+def test_dedup_reasoning_items_ignores_non_reasoning_and_non_rs_ids() -> None:
+    items = [
+        {"type": "message", "id": "rs_alpha", "content": "not a reasoning item"},
+        {"type": "message", "id": "rs_alpha", "content": "still not"},
+        {"type": "reasoning", "id": "not_rs_prefix", "encrypted_content": "skip"},
+        {"type": "reasoning", "id": "not_rs_prefix", "encrypted_content": "skip2"},
+    ]
+
+    result = _dedup_reasoning_items(items)
+
+    # No rs_* id was present on a reasoning item — nothing should be dropped.
+    assert result == items
+
+
+def test_extract_duplicate_id_pulls_id_from_friendly_or_raw_payload() -> None:
+    raw = (
+        '{"error":{"type":"invalid_request_error","code":"duplicate_item",'
+        '"message":"Duplicate item found with id rs_xyz789"}}'
+    )
+
+    assert _extract_duplicate_id(raw, "") == "rs_xyz789"
+    assert _extract_duplicate_id("", "Duplicate item found with id rs_only_message") == (
+        "rs_only_message"
+    )
+    assert _extract_duplicate_id("", "") is None
+
+
+def test_drop_reasoning_id_removes_only_matching_reasoning_entries() -> None:
+    items = [
+        {"type": "reasoning", "id": "rs_keep"},
+        {"type": "reasoning", "id": "rs_drop"},
+        {"type": "message", "id": "rs_drop", "content": "different type — keep"},
+        {"type": "reasoning", "id": "rs_drop"},
+    ]
+
+    result = _drop_reasoning_id(items, "rs_drop")
+
+    assert result == [
+        {"type": "reasoning", "id": "rs_keep"},
+        {"type": "message", "id": "rs_drop", "content": "different type — keep"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_codex_dedups_reasoning_items_before_outgoing_request(monkeypatch) -> None:
+    """Outgoing payload must carry each rs_* id at most once (HKUDS/nanobot#3633)."""
+    _mock_codex_token(monkeypatch)
+    captured_bodies: list[dict[str, Any]] = []
+
+    async def fake_request(
+        url,
+        headers,
+        body,
+        verify,
+        proxy=None,
+        on_content_delta=None,
+        on_thinking_delta=None,
+        on_tool_call_delta=None,
+    ):
+        captured_bodies.append(body)
+        return "ok", [], "stop", {}, None
+
+    def fake_convert_messages(_messages):
+        return (
+            "sys",
+            [
+                {"type": "message", "role": "user", "content": "first turn"},
+                {"type": "reasoning", "id": "rs_duplicate", "encrypted_content": "a"},
+                {"type": "message", "role": "assistant", "content": "answer"},
+                {"type": "reasoning", "id": "rs_duplicate", "encrypted_content": "b"},
+                {"type": "message", "role": "user", "content": "second turn"},
+            ],
+        )
+
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_provider._request_codex", fake_request
+    )
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_provider.convert_messages", fake_convert_messages
+    )
+
+    provider = OpenAICodexProvider()
+    response = await provider.chat([{"role": "user", "content": "hi"}])
+
+    assert response.content == "ok"
+    assert len(captured_bodies) == 1
+    sent_input = captured_bodies[0]["input"]
+    rs_duplicates = [
+        item
+        for item in sent_input
+        if isinstance(item, dict) and item.get("id") == "rs_duplicate"
+    ]
+    assert len(rs_duplicates) == 1, (
+        f"expected exactly one rs_duplicate in outgoing payload, got "
+        f"{len(rs_duplicates)} (full payload: {sent_input})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_retries_once_on_duplicate_item_400(monkeypatch) -> None:
+    """On 400 code:duplicate_item, strip the offending id and retry once."""
+    _mock_codex_token(monkeypatch)
+    calls: list[dict[str, Any]] = []
+
+    async def fake_request(
+        url,
+        headers,
+        body,
+        verify,
+        proxy=None,
+        on_content_delta=None,
+        on_thinking_delta=None,
+        on_tool_call_delta=None,
+    ):
+        # Snapshot the body the caller saw on each attempt.
+        calls.append({"input": list(body["input"])})
+        if len(calls) == 1:
+            raise _CodexHTTPError(
+                "HTTP 400: Codex API request failed",
+                status_code=400,
+                error_code="duplicate_item",
+                duplicate_id="rs_offender",
+            )
+        return "ok", [], "stop", {}, None
+
+    def fake_convert_messages(_messages):
+        return (
+            "sys",
+            [
+                {"type": "message", "role": "user", "content": "first"},
+                {"type": "reasoning", "id": "rs_keep", "encrypted_content": "k"},
+                {"type": "reasoning", "id": "rs_offender", "encrypted_content": "x"},
+            ],
+        )
+
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_provider._request_codex", fake_request
+    )
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_provider.convert_messages", fake_convert_messages
+    )
+
+    provider = OpenAICodexProvider()
+    response = await provider.chat([{"role": "user", "content": "hi"}])
+
+    assert response.content == "ok"
+    assert len(calls) == 2, "expected exactly one retry after duplicate_item 400"
+    first_payload_ids = [
+        item.get("id") for item in calls[0]["input"] if isinstance(item, dict)
+    ]
+    retry_payload_ids = [
+        item.get("id") for item in calls[1]["input"] if isinstance(item, dict)
+    ]
+    assert "rs_offender" in first_payload_ids
+    assert "rs_offender" not in retry_payload_ids
+    assert "rs_keep" in retry_payload_ids
+
+
+@pytest.mark.asyncio
+async def test_codex_does_not_retry_when_duplicate_id_is_unknown(monkeypatch) -> None:
+    """If the upstream payload didn't surface a duplicate_id, bubble through normally."""
+    _mock_codex_token(monkeypatch)
+    calls = 0
+
+    async def fake_request(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise _CodexHTTPError(
+            "HTTP 400: Codex API request failed",
+            status_code=400,
+            error_code="duplicate_item",
+            duplicate_id=None,
+        )
+
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_provider._request_codex", fake_request
+    )
+
+    provider = OpenAICodexProvider()
+    response = await provider.chat([{"role": "user", "content": "hi"}])
+
+    assert response.finish_reason == "error"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_codex_request_marks_duplicate_item_400_and_extracts_id(monkeypatch) -> None:
+    """Upstream 400 duplicate-item payloads must surface as structured metadata."""
+    original_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "duplicate_item",
+                    "message": "Duplicate item found with id rs_abc123",
+                }
+            },
+            request=request,
+        )
+
+    def fake_client(*, timeout: float, verify: bool) -> httpx.AsyncClient:
+        return original_client(transport=httpx.MockTransport(handler), timeout=timeout)
+
+    monkeypatch.setattr(
+        "nanobot.providers.openai_codex_provider.httpx.AsyncClient", fake_client
+    )
+
+    with pytest.raises(_CodexHTTPError) as caught:
+        await _request_codex(
+            "https://codex.example/responses", {}, {"input": []}, verify=True
+        )
+
+    error = caught.value
+    assert error.status_code == 400
+    assert error.error_code == "duplicate_item"
+    assert error.duplicate_id == "rs_abc123"


### PR DESCRIPTION
Closes #3633.

## Problem
`openai_codex_provider` occasionally re-sends a `{type:"reasoning", id:"rs_..."}` item the Responses API has already accepted, producing `400 Duplicate item found with id rs_…` and breaking multi-turn conversations.

## Fix
- **Dedup pass before send.** Walks the outgoing `input` array and drops duplicate `rs_*` reasoning items (keeps first occurrence).
- **One-shot retry on duplicate-item 400.** If the API still returns `400 code:duplicate_item`, strip the reported id and retry once.

Complements merged #3984 (tool_call_id preservation) — that PR fixed message-id round-trips; this one closes the dedup gap on the reasoning-item path. Note that contributor @Yuxin-Lou commented "this issue can be closed" without elaboration; the upstream-symptom 400 is still reproducible against current `main` because #3984 only touched `tool_call_id`, not `rs_*` reasoning ids.

## Files
- `nanobot/providers/openai_codex_provider.py` — added `_dedup_reasoning_items`, `_drop_reasoning_id`, `_extract_duplicate_id`, `_send_codex_request`, `_is_duplicate_item_error`; extended `_CodexHTTPError` with `duplicate_id`; `_call_codex` now dedups pre-send and `_send_codex_request` retries once after stripping the reported id.
- `tests/providers/test_openai_codex_provider.py` — 8 new tests (4 unit-level helpers + 4 integration-level monkeypatch tests).

## Verification
- `pytest tests/providers/test_openai_codex_provider.py -v` — **green (23 passed in 0.08s)**
- `pytest tests/providers/` — **green (518 passed in 1.18s)**
- `pytest tests/` — 3645 passed; 12 pre-existing failures in unrelated files (dingtalk/exec-session/tool-validation — confirmed identical on `upstream/main` via baseline worktree). **0 new failures.**
- `ruff check nanobot/providers/openai_codex_provider.py tests/providers/test_openai_codex_provider.py` — clean

🤖 AI disclosure: drafted with Claude.