### PR TITLE
Feature modular system prompt

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -22,6 +22,8 @@ from nanobot.utils.helpers import (
 )
 from nanobot.utils.prompt_templates import render_template
 
+from nanobot.config.loader import load_config
+
 
 def session_extra(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
     """Return persisted kwargs for turn-attached capabilities."""
@@ -71,39 +73,53 @@ class ContextBuilder:
         session_summary: str | None = None,
     ) -> str:
         """Build the system prompt from identity, bootstrap files, memory, and skills."""
-        parts = [self._get_identity(channel=channel)]
+        config = load_config().context
+        parts = []
 
-        bootstrap = self._load_bootstrap_files()
+        if config.custom_prompt:
+            parts.append(config.custom_prompt)
+            
+        master_on = config.master_toggle
+            
+        if master_on and config.include_identity:
+            parts.append(self._get_identity(channel=channel))
+
+        bootstrap = self._load_bootstrap_files(config, master_on)
         if bootstrap:
             parts.append(bootstrap)
+            
+        if master_on and config.include_tool_usage:
+            parts.append(render_template("agent/tool_contract.md"))
 
-        parts.append(render_template("agent/tool_contract.md"))
+        if master_on and config.include_memory:
+            memory = self.memory.get_memory_context()
+            if memory and not self._is_template_content(self.memory.read_memory(), "memory/MEMORY.md"):
+                parts.append(f"# Memory\n\n{memory}")
 
-        memory = self.memory.get_memory_context()
-        if memory and not self._is_template_content(self.memory.read_memory(), "memory/MEMORY.md"):
-            parts.append(f"# Memory\n\n{memory}")
+        if master_on and config.include_skills:
+            always_skills = self.skills.get_always_skills()
+            if always_skills:
+                always_content = self.skills.load_skills_for_context(always_skills)
+                if always_content:
+                    parts.append(f"# Active Skills\n\n{always_content}")
 
-        always_skills = self.skills.get_always_skills()
-        if always_skills:
-            always_content = self.skills.load_skills_for_context(always_skills)
-            if always_content:
-                parts.append(f"# Active Skills\n\n{always_content}")
+            skills_summary = self.skills.build_skills_summary(exclude=set(always_skills))
+            if skills_summary:
+                parts.append(render_template("agent/skills_section.md", skills_summary=skills_summary))
 
-        skills_summary = self.skills.build_skills_summary(exclude=set(always_skills))
-        if skills_summary:
-            parts.append(render_template("agent/skills_section.md", skills_summary=skills_summary))
+        if master_on and config.include_recent_history:
+            entries = self.memory.read_unprocessed_history(since_cursor=self.memory.get_last_dream_cursor())
+            if entries:
+                capped = entries[-self._MAX_RECENT_HISTORY:]
+                history_text = "\n".join(
+                    f"- [{e['timestamp']}] {e['content']}" for e in capped
+                )
+                history_text = truncate_text(history_text, self._MAX_HISTORY_CHARS)
+                parts.append("# Recent History\n\n" + history_text)
 
-        entries = self.memory.read_unprocessed_history(since_cursor=self.memory.get_last_dream_cursor())
-        if entries:
-            capped = entries[-self._MAX_RECENT_HISTORY:]
-            history_text = "\n".join(
-                f"- [{e['timestamp']}] {e['content']}" for e in capped
-            )
-            history_text = truncate_text(history_text, self._MAX_HISTORY_CHARS)
-            parts.append("# Recent History\n\n" + history_text)
-
-        if session_summary:
-            parts.append(f"[Archived Context Summary]\n\n{session_summary}")
+        if master_on and config.include_session_summary:
+            if session_summary:
+                parts.append(f"[Archived Context Summary]\n\n{session_summary}")
 
         return "\n\n---\n\n".join(parts)
 
@@ -153,11 +169,20 @@ class ContextBuilder:
 
         return _to_blocks(left) + _to_blocks(right)
 
-    def _load_bootstrap_files(self) -> str:
+    def _load_bootstrap_files(self, config: Any, master_on: bool) -> str:
         """Load all bootstrap files from workspace."""
         parts = []
+        if not master_on:
+            return ""
 
         for filename in self.BOOTSTRAP_FILES:
+            if filename == "AGENTS.md" and not config.include_agents:
+                continue
+            if filename == "SOUL.md" and not config.include_soul:
+                continue
+            if filename == "USER.md" and not config.include_user:
+                continue
+                
             file_path = self.workspace / filename
             if file_path.exists():
                 content = file_path.read_text(encoding="utf-8")

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -14,6 +14,7 @@ from nanobot.agent.tools import mcp as mcp_tools
 from nanobot.agent.tools.registry import ToolRegistry
 from nanobot.bus.events import InboundMessage
 from nanobot.cli_apps import utils as cli_app_utils
+from nanobot.config.loader import load_config
 from nanobot.session.goal_state import goal_state_runtime_lines
 from nanobot.utils.helpers import (
     current_time_str,
@@ -21,8 +22,6 @@ from nanobot.utils.helpers import (
     truncate_text,
 )
 from nanobot.utils.prompt_templates import render_template
-
-from nanobot.config.loader import load_config
 
 
 def session_extra(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -78,16 +77,16 @@ class ContextBuilder:
 
         if config.custom_prompt:
             parts.append(config.custom_prompt)
-            
+
         master_on = config.master_toggle
-            
+
         if master_on and config.include_identity:
             parts.append(self._get_identity(channel=channel))
 
         bootstrap = self._load_bootstrap_files(config, master_on)
         if bootstrap:
             parts.append(bootstrap)
-            
+
         if master_on and config.include_tool_usage:
             parts.append(render_template("agent/tool_contract.md"))
 
@@ -184,7 +183,7 @@ class ContextBuilder:
                 continue
             if filename == "USER.md" and not config.include_user:
                 continue
-                
+
             file_path = self.workspace / filename
             if file_path.exists():
                 content = file_path.read_text(encoding="utf-8")

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -169,8 +169,10 @@ class ContextBuilder:
 
         return _to_blocks(left) + _to_blocks(right)
 
-    def _load_bootstrap_files(self, config: Any, master_on: bool) -> str:
+    def _load_bootstrap_files(self, config: Any = None, master_on: bool = True) -> str:
         """Load all bootstrap files from workspace."""
+        if config is None:
+            config = load_config().context
         parts = []
         if not master_on:
             return ""

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -53,6 +53,7 @@ from nanobot.webui.settings_api import (
     update_image_generation_settings,
     update_provider_settings,
     update_web_search_settings,
+    update_context_settings,
 )
 from nanobot.webui.cli_apps_api import (
     cli_apps_action,
@@ -712,6 +713,9 @@ class WebSocketChannel(BaseChannel):
 
         if got == "/api/settings/web-search/update":
             return self._handle_settings_web_search_update(request)
+            
+        if got == "/api/settings/context/update":
+            return self._handle_settings_context_update(request)
 
         if got == "/api/settings/image-generation/update":
             return self._handle_settings_image_generation_update(request)
@@ -958,6 +962,16 @@ class WebSocketChannel(BaseChannel):
         except WebUISettingsError as e:
             return _http_error(e.status, e.message)
         return _http_json_response(self._with_settings_restart_state(payload, section="web"))
+        
+    def _handle_settings_context_update(self, request: WsRequest) -> Response:
+        if not self._check_api_token(request):
+            return _http_error(401, "Unauthorized")
+        query = _parse_query(request.path)
+        try:
+            payload = update_context_settings(query)
+        except WebUISettingsError as e:
+            return _http_error(e.status, e.message)
+        return _http_json_response(payload)
 
     def _handle_settings_image_generation_update(self, request: WsRequest) -> Response:
         if not self._check_api_token(request):

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -50,10 +50,10 @@ from nanobot.webui.settings_api import (
     create_model_configuration,
     settings_payload,
     update_agent_settings,
+    update_context_settings,
     update_image_generation_settings,
     update_provider_settings,
     update_web_search_settings,
-    update_context_settings,
 )
 from nanobot.webui.cli_apps_api import (
     cli_apps_action,
@@ -713,7 +713,7 @@ class WebSocketChannel(BaseChannel):
 
         if got == "/api/settings/web-search/update":
             return self._handle_settings_web_search_update(request)
-            
+
         if got == "/api/settings/context/update":
             return self._handle_settings_context_update(request)
 
@@ -962,7 +962,7 @@ class WebSocketChannel(BaseChannel):
         except WebUISettingsError as e:
             return _http_error(e.status, e.message)
         return _http_json_response(self._with_settings_restart_state(payload, section="web"))
-        
+
     def _handle_settings_context_update(self, request: WsRequest) -> Response:
         if not self._check_api_token(request):
             return _http_error(401, "Unauthorized")

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -299,6 +299,19 @@ class ToolsConfig(Base):
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
     ssrf_whitelist: list[str] = Field(default_factory=list)  # CIDR ranges to exempt from SSRF blocking (e.g. ["100.64.0.0/10"] for Tailscale)
 
+class ContextConfig(Base):
+    """System prompt context toggle configuration."""
+    master_toggle: bool = True
+    custom_prompt: str = ""
+    include_identity: bool = True
+    include_agents: bool = True
+    include_soul: bool = True
+    include_user: bool = True
+    include_tool_usage: bool = True
+    include_memory: bool = True
+    include_skills: bool = True
+    include_recent_history: bool = True
+    include_session_summary: bool = True
 
 class Config(BaseSettings):
     """Root configuration for nanobot."""
@@ -309,6 +322,7 @@ class Config(BaseSettings):
     api: ApiConfig = Field(default_factory=ApiConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    context: ContextConfig = Field(default_factory=ContextConfig)
     model_presets: dict[str, ModelPresetConfig] = Field(
         default_factory=dict,
         validation_alias=AliasChoices("modelPresets", "model_presets"),

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -455,7 +455,7 @@ def create_model_configuration(query: QueryParams) -> dict[str, Any]:
     config.agents.defaults.model_preset = name
     save_config(config)
     return settings_payload()
-    
+
 def update_context_settings(query: QueryParams) -> dict[str, Any]:
     config = load_config()
     ctx = config.context

--- a/nanobot/webui/settings_api.py
+++ b/nanobot/webui/settings_api.py
@@ -258,6 +258,19 @@ def settings_payload(*, requires_restart: bool = False) -> dict[str, Any]:
             "tool_hint_max_length": defaults.tool_hint_max_length,
         },
         "model_presets": model_presets,
+        "context": {
+            "master_toggle": config.context.master_toggle,
+            "custom_prompt": config.context.custom_prompt,
+            "include_identity": config.context.include_identity,
+            "include_agents": config.context.include_agents,
+            "include_soul": config.context.include_soul,
+            "include_user": config.context.include_user,
+            "include_tool_usage": config.context.include_tool_usage,
+            "include_memory": config.context.include_memory,
+            "include_skills": config.context.include_skills,
+            "include_recent_history": config.context.include_recent_history,
+            "include_session_summary": config.context.include_session_summary,
+        },
         "providers": providers,
         "web_search": {
             "provider": search_provider,
@@ -442,7 +455,41 @@ def create_model_configuration(query: QueryParams) -> dict[str, Any]:
     config.agents.defaults.model_preset = name
     save_config(config)
     return settings_payload()
+    
+def update_context_settings(query: QueryParams) -> dict[str, Any]:
+    config = load_config()
+    ctx = config.context
+    changed = False
 
+    def _update_bool(key: str, alias: str):
+        nonlocal changed
+        val = _query_first_alias(query, key, alias)
+        if val is not None:
+            parsed = _parse_bool(val, key)
+            if getattr(ctx, key) != parsed:
+                setattr(ctx, key, parsed)
+                changed = True
+
+    _update_bool("master_toggle", "masterToggle")
+    _update_bool("include_identity", "includeIdentity")
+    _update_bool("include_agents", "includeAgents")
+    _update_bool("include_soul", "includeSoul")
+    _update_bool("include_user", "includeUser")
+    _update_bool("include_tool_usage", "includeToolUsage")
+    _update_bool("include_memory", "includeMemory")
+    _update_bool("include_skills", "includeSkills")
+    _update_bool("include_recent_history", "includeRecentHistory")
+    _update_bool("include_session_summary", "includeSessionSummary")
+
+    custom_prompt = _query_first_alias(query, "custom_prompt", "customPrompt")
+    if custom_prompt is not None:
+        if ctx.custom_prompt != custom_prompt:
+            ctx.custom_prompt = custom_prompt
+            changed = True
+
+    if changed:
+        save_config(config)
+    return settings_payload()
 
 def update_provider_settings(query: QueryParams) -> dict[str, Any]:
     provider_name = (_query_first(query, "provider") or "").strip()

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -9,10 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.4",
-        "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
-        "@radix-ui/react-scroll-area": "^1.2.2",
         "@radix-ui/react-separator": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.1.6",
@@ -810,10 +808,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@radix-ui/number": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "license": "MIT"
@@ -865,65 +859,6 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-avatar": {
-      "version": "1.1.11",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-context": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.4",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1367,35 +1302,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-scroll-area": {
-      "version": "1.2.10",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.8",
       "license": "MIT",
@@ -1553,22 +1459,6 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1747,9 +1637,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1764,9 +1651,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1781,9 +1665,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1798,9 +1679,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1815,9 +1693,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1832,9 +1707,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1849,9 +1721,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1866,9 +1735,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1883,9 +1749,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1900,9 +1763,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1917,9 +1777,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -83,6 +83,7 @@ import {
   updateProviderSettings,
   updateSettings,
   updateWebSearchSettings,
+  updateContextSettings,
 } from "@/lib/api";
 import { notifyCliAppsChanged } from "@/lib/cli-app-events";
 import { notifyMcpPresetsChanged } from "@/lib/mcp-preset-events";
@@ -101,12 +102,14 @@ import type {
   McpPresetsPayload,
   SettingsPayload,
   WebSearchSettingsUpdate,
+  ContextSettingsUpdate,
 } from "@/lib/types";
 
 type SettingsSectionKey =
   | "overview"
   | "appearance"
   | "models"
+  | "context"		 
   | "image"
   | "web"
   | "cliApps"
@@ -291,6 +294,7 @@ export function SettingsView({
   const [mcpPresetAction, setMcpPresetAction] = useState<string | null>(null);
   const [providerSaving, setProviderSaving] = useState<string | null>(null);
   const [webSearchSaving, setWebSearchSaving] = useState(false);
+  const [contextSaving, setContextSaving] = useState(false);
   const [imageGenerationSaving, setImageGenerationSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeSection, setActiveSection] = useState<SettingsSectionKey>("overview");
@@ -324,6 +328,19 @@ export function SettingsView({
     maxResults: 5,
     timeout: 30,
     useJinaReader: true,
+  });
+  const [contextForm, setContextForm] = useState<ContextSettingsUpdate>({
+    masterToggle: true,
+    customPrompt: "",
+    includeIdentity: true,
+    includeAgents: true,
+    includeSoul: true,
+    includeUser: true,
+	includeToolUsage: true,
+    includeMemory: true,
+    includeSkills: true,
+    includeRecentHistory: true,
+	includeSessionSummary: true,
   });
   const [imageGenerationForm, setImageGenerationForm] = useState<ImageGenerationSettingsUpdate>({
     enabled: false,
@@ -371,6 +388,19 @@ export function SettingsView({
       timeout: payload.web_search.timeout,
       useJinaReader: payload.web.fetch.use_jina_reader,
     }));
+	setContextForm({
+      masterToggle: payload.context.master_toggle,
+      customPrompt: payload.context.custom_prompt,
+      includeIdentity: payload.context.include_identity,
+      includeAgents: payload.context.include_agents,
+      includeSoul: payload.context.include_soul,
+      includeUser: payload.context.include_user,
+	  includeToolUsage: payload.context.include_tool_usage,
+      includeMemory: payload.context.include_memory,
+      includeSkills: payload.context.include_skills,
+      includeRecentHistory: payload.context.include_recent_history,
+	  includeSessionSummary: payload.context.include_session_summary,
+    });
     setImageGenerationForm({
       enabled: payload.image_generation.enabled,
       provider: payload.image_generation.provider,
@@ -721,6 +751,20 @@ export function SettingsView({
     }
   };
 
+  const saveContextSettings = async () => {
+    if (!settings || contextSaving) return;
+    setContextSaving(true);
+    try {
+      const payload = await updateContextSettings(token, contextForm);
+      applyPayload(payload);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setContextSaving(false);
+    }
+  };
+  
   const resetProviderDraft = useCallback((providerName: string) => {
     const provider = settings?.providers.find((item) => item.name === providerName);
     if (!provider) return;
@@ -982,6 +1026,16 @@ export function SettingsView({
             />
           </div>
         );
+	  case "context":
+	    return (
+		  <ContextSettings
+            settings={settings}
+            form={contextForm}
+            onChangeForm={setContextForm}
+            onSave={saveContextSettings}
+            saving={contextSaving}
+          />
+		);
       case "image":
         return (
           <ImageGenerationSettings
@@ -1163,6 +1217,7 @@ const SETTINGS_NAV_ITEMS: Array<{ key: SettingsSectionKey; icon: LucideIcon; fal
   { key: "overview", icon: Activity, fallback: "Overview" },
   { key: "appearance", icon: Palette, fallback: "Appearance" },
   { key: "models", icon: SlidersHorizontal, fallback: "Models" },
+  { key: "context", icon: Layers, fallback: "Context" },
   { key: "image", icon: ImageIcon, fallback: "Image" },
   { key: "web", icon: Globe2, fallback: "Web" },
   { key: "cliApps", icon: Package, fallback: "CLI Apps" },
@@ -3706,6 +3761,100 @@ function AdvancedSettings({ settings }: { settings: SettingsPayload }) {
         </SettingsGroup>
       </section>
     </div>
+  );
+}
+
+function ContextSettings({
+  settings,
+  form,
+  onChangeForm,
+  onSave,
+  saving,
+}: {
+  settings: SettingsPayload;
+  form: ContextSettingsUpdate;
+  onChangeForm: Dispatch<SetStateAction<ContextSettingsUpdate>>;
+  onSave: () => void;
+  saving: boolean;
+}) {
+  const { t } = useTranslation();
+  const tx = (key: string, fallback: string) => t(key, { defaultValue: fallback });
+  const masterEnabled = form.masterToggle ?? true;
+
+  const dirty =
+    form.masterToggle !== settings.context.master_toggle ||
+    form.customPrompt !== settings.context.custom_prompt ||
+    form.includeIdentity !== settings.context.include_identity ||
+    form.includeAgents !== settings.context.include_agents ||
+    form.includeSoul !== settings.context.include_soul ||
+    form.includeUser !== settings.context.include_user ||
+	form.includeToolUsage !== settings.context.include_tool_usage ||
+    form.includeMemory !== settings.context.include_memory ||
+    form.includeSkills !== settings.context.include_skills ||
+    form.includeRecentHistory !== settings.context.include_recent_history ||
+	form.includeSessionSummary !== settings.context.include_session_summary;
+
+  const ToggleRow = ({ label, stateKey }: { label: string, stateKey: keyof ContextSettingsUpdate }) => (
+    <SettingsRow title={label}>
+      <ToggleButton
+        checked={Boolean(form[stateKey])}
+        onChange={(checked) => onChangeForm((prev) => ({ ...prev, [stateKey]: checked }))}
+        label={Boolean(form[stateKey]) ? "On" : "Off"}
+      />
+    </SettingsRow>
+  );
+
+  return (
+    <section>
+      <SettingsSectionTitle>{tx("settings.sections.context", "Context")}</SettingsSectionTitle>
+      <SettingsGroup>
+        <SettingsRow
+          title={tx("settings.context.customPrompt", "Custom System Prompt")}
+          description={tx("settings.context.customPromptDesc", "Added at the very beginning of the system prompt.")}
+        >
+          <Textarea
+            value={form.customPrompt ?? ""}
+            onChange={(e) => onChangeForm((prev) => ({ ...prev, customPrompt: e.target.value }))}
+            placeholder="Enter custom instructions here..."
+            className="mt-2 min-h-[80px] w-full resize-y rounded-[12px] text-[13px] sm:w-[320px] sm:mt-0"
+          />
+        </SettingsRow>
+        <SettingsRow
+          title={tx("settings.context.masterToggle", "Master Context Toggle")}
+          description={tx("settings.context.masterToggleDesc", "Enable or disable all context file inclusions.")}
+        >
+          <ToggleButton
+            checked={masterEnabled}
+            onChange={(checked) => onChangeForm((prev) => ({ ...prev, masterToggle: checked }))}
+            label={masterEnabled ? "On" : "Off"}
+          />
+        </SettingsRow>
+
+        <div className={cn("transition-opacity", !masterEnabled && "pointer-events-none opacity-50")}>
+          <div className="border-t border-border/45 bg-muted/15 px-5 py-2.5 text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">
+            {tx("settings.context.toggleSystemPrompt", "Toggle system prompt")}
+          </div>
+          <div className="divide-y divide-border/45">
+            <ToggleRow label="Identity (identity.md)" stateKey="includeIdentity" />
+            <ToggleRow label="Agents (AGENTS.md)" stateKey="includeAgents" />
+            <ToggleRow label="Soul (SOUL.md)" stateKey="includeSoul" />
+            <ToggleRow label="User (USER.md)" stateKey="includeUser" />
+			<ToggleRow label="Tool usage (tool_contract.md)" stateKey="includeToolUsage" />
+            <ToggleRow label="Memory" stateKey="includeMemory" />
+            <ToggleRow label="Skills" stateKey="includeSkills" />
+            <ToggleRow label="Recent History" stateKey="includeRecentHistory" />
+			<ToggleRow label="Session Summary" stateKey="includeSessionSummary" />
+          </div>
+        </div>
+
+        <SettingsFooter
+          dirty={dirty}
+          saving={saving}
+          saved={false}
+          onSave={onSave}
+        />
+      </SettingsGroup>
+    </section>
   );
 }
 

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   SlashCommand,
   WebSearchSettingsUpdate,
   WebuiThreadPersistedPayload,
+  ContextSettingsUpdate,
 } from "./types";
 
 export class ApiError extends Error {
@@ -281,6 +282,30 @@ export async function createModelConfiguration(
   );
 }
 
+export async function updateContextSettings(
+  token: string,
+  update: ContextSettingsUpdate,
+  base: string = "",
+): Promise<SettingsPayload> {
+  const query = new URLSearchParams();
+  if (update.masterToggle !== undefined) query.set("master_toggle", String(update.masterToggle));
+  if (update.customPrompt !== undefined) query.set("custom_prompt", update.customPrompt);
+  if (update.includeIdentity !== undefined) query.set("include_identity", String(update.includeIdentity));
+  if (update.includeAgents !== undefined) query.set("include_agents", String(update.includeAgents));
+  if (update.includeSoul !== undefined) query.set("include_soul", String(update.includeSoul));
+  if (update.includeUser !== undefined) query.set("include_user", String(update.includeUser));
+  if (update.includeToolUsage !== undefined) query.set("include_tool_usage", String(update.includeToolUsage));
+  if (update.includeMemory !== undefined) query.set("include_memory", String(update.includeMemory));
+  if (update.includeSkills !== undefined) query.set("include_skills", String(update.includeSkills));
+  if (update.includeRecentHistory !== undefined) query.set("include_recent_history", String(update.includeRecentHistory));
+  if (update.includeSessionSummary !== undefined) query.set("include_session_summary", String(update.includeSessionSummary));
+
+  return request<SettingsPayload>(
+    `${base}/api/settings/context/update?${query}`,
+    token,
+  );
+}
+
 export async function updateProviderSettings(
   token: string,
   update: ProviderSettingsUpdate,
@@ -333,4 +358,4 @@ export async function updateImageGenerationSettings(
     `${base}/api/settings/image-generation/update?${query}`,
     token,
   );
-}
+}									

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -198,6 +198,19 @@ export interface SettingsPayload {
     temperature: number;
     reasoning_effort: string | null;
   }>;
+  context: {
+    master_toggle: boolean;
+    custom_prompt: string;
+    include_identity: boolean;
+    include_agents: boolean;
+    include_soul: boolean;
+    include_user: boolean;
+	include_tool_usage: boolean;
+    include_memory: boolean;
+    include_skills: boolean;
+    include_recent_history: boolean;
+	include_session_summary: boolean;
+  };
   providers: Array<{
     name: string;
     label: string;
@@ -386,6 +399,20 @@ export interface ModelConfigurationCreate {
   label: string;
   provider: string;
   model: string;
+}
+
+export interface ContextSettingsUpdate {
+  masterToggle?: boolean;
+  customPrompt?: string;
+  includeIdentity?: boolean;
+  includeAgents?: boolean;
+  includeSoul?: boolean;
+  includeUser?: boolean;
+  includeToolUsage?: boolean;
+  includeMemory?: boolean;
+  includeSkills?: boolean;
+  includeRecentHistory?: boolean;
+  includeSessionSummary?: boolean;
 }
 
 export interface ProviderSettingsUpdate {


### PR DESCRIPTION
Adds the ability to toggle system prompt components. Marginal improvements might be gained by setting `if not master_on or not (config.include_agents or config.include_soul or config.include_user)` instead of `if not master_on` in `context.py` to skip the loop completely as well as using a mtime cache with `os.stat()` to avoid repeated file reads due to repeated `load_config()` calls.

All pytest tests pass when the toggles are set to enabled but the ones that rely on those components being in the system prompt fail when the toggles are set to disabled (so this is ironically a success as it additionally confirms that the toggles work).

Addresses issue #1831.

At the moment with everything disabled, only tools are sent in the context. I am working on deferred tools as well, but this is more complex and needs more testing.