### PR TITLE
feat: add GitHub CLI and gogcli to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ RUN apt-get update && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nodejs && \
+    apt-get install -y --no-install-recommends nodejs gh && \
+    curl -fsSL https://github.com/openclaw/gogcli/releases/download/v0.19.0/gogcli_0.19.0_linux_amd64.tar.gz | tar -xz -C /usr/local/bin gog && \
     apt-get purge -y gnupg && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add two CLI tools to the Docker image:

- **GitHub CLI (gh)**: Installed via official apt repository, enables GitHub API/CLI usage inside containers.
- **gogcli** ([openclaw/gogcli](https://github.com/openclaw/gogcli)): Google Workspace CLI, installed from GitHub releases (v0.19.0 linux amd64).

Both are added in the existing Node.js installation RUN layer to keep layer count unchanged.