### PR TITLE
fix: MCP reconnection - reset _mcp_connected on session drop, add reconnect callbacks

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -179,14 +179,16 @@ class MCPToolWrapper(Tool):
 
     _plugin_discoverable = False
 
-    def __init__(self, session, server_name: str, tool_def, tool_timeout: int = 30):
+    def __init__(self, session, server_name: str, tool_def, tool_timeout: int = 30, *, on_disconnected=None):
         self._session = session
+        self._server_name = server_name
         self._original_name = tool_def.name
         self._name = _sanitize_name(f"mcp_{server_name}_{tool_def.name}")
         self._description = tool_def.description or tool_def.name
         raw_schema = tool_def.inputSchema or {"type": "object", "properties": {}}
         self._parameters = _normalize_schema_for_openai(raw_schema)
         self._tool_timeout = tool_timeout
+        self._on_disconnected = on_disconnected
 
     @property
     def name(self) -> str:
@@ -224,15 +226,21 @@ class MCPToolWrapper(Tool):
                 return "(MCP tool call was cancelled)"
             except Exception as exc:
                 if _is_transient(exc):
+                    # Mark server disconnected so it reconnects on the next turn.
+                    # Don't retry with the stale session — it will fail again.
+                    if self._on_disconnected:
+                        try:
+                            self._on_disconnected(self._server_name)
+                        except Exception:
+                            logger.debug("on_disconnected callback error (ignored)")
                     if attempt == 0:
                         logger.warning(
-                            "MCP tool '{}' hit transient error ({}), retrying once...",
+                            "MCP tool '{}' hit transient error ({}), "
+                            "server marked disconnected for reconnection",
                             self._name,
                             type(exc).__name__,
                         )
-                        await asyncio.sleep(1)  # Brief backoff before retry
-                        continue
-                    # Second transient failure — give up with retry-specific message
+                        return "(MCP server connection lost, reconnecting. Please try again.)"
                     logger.exception(
                         "MCP tool '{}' failed after retry: {}",
                         self._name,
@@ -264,8 +272,9 @@ class MCPResourceWrapper(Tool):
 
     _plugin_discoverable = False
 
-    def __init__(self, session, server_name: str, resource_def, resource_timeout: int = 30):
+    def __init__(self, session, server_name: str, resource_def, resource_timeout: int = 30, *, on_disconnected=None):
         self._session = session
+        self._server_name = server_name
         self._uri = resource_def.uri
         self._name = _sanitize_name(f"mcp_{server_name}_resource_{resource_def.name}")
         desc = resource_def.description or resource_def.name
@@ -276,6 +285,7 @@ class MCPResourceWrapper(Tool):
             "required": [],
         }
         self._resource_timeout = resource_timeout
+        self._on_disconnected = on_disconnected
 
     @property
     def name(self) -> str:
@@ -315,14 +325,19 @@ class MCPResourceWrapper(Tool):
                 return "(MCP resource read was cancelled)"
             except Exception as exc:
                 if _is_transient(exc):
+                    if self._on_disconnected:
+                        try:
+                            self._on_disconnected(self._server_name)
+                        except Exception:
+                            logger.debug("on_disconnected callback error (ignored)")
                     if attempt == 0:
                         logger.warning(
-                            "MCP resource '{}' hit transient error ({}), retrying once...",
+                            "MCP resource '{}' hit transient error ({}), "
+                            "server marked disconnected for reconnection",
                             self._name,
                             type(exc).__name__,
                         )
-                        await asyncio.sleep(1)
-                        continue
+                        return "(MCP server connection lost, reconnecting. Please try again.)"
                     logger.exception(
                         "MCP resource '{}' failed after retry: {}",
                         self._name,
@@ -355,8 +370,9 @@ class MCPPromptWrapper(Tool):
 
     _plugin_discoverable = False
 
-    def __init__(self, session, server_name: str, prompt_def, prompt_timeout: int = 30):
+    def __init__(self, session, server_name: str, prompt_def, prompt_timeout: int = 30, *, on_disconnected=None):
         self._session = session
+        self._server_name = server_name
         self._prompt_name = prompt_def.name
         self._name = _sanitize_name(f"mcp_{server_name}_prompt_{prompt_def.name}")
         desc = prompt_def.description or prompt_def.name
@@ -365,6 +381,7 @@ class MCPPromptWrapper(Tool):
             "Returns a filled prompt template that can be used as a workflow guide."
         )
         self._prompt_timeout = prompt_timeout
+        self._on_disconnected = on_disconnected
 
         # Build parameters from prompt arguments
         properties: dict[str, Any] = {}
@@ -429,14 +446,19 @@ class MCPPromptWrapper(Tool):
                 return f"(MCP prompt call failed: {exc.error.message} [code {exc.error.code}])"
             except Exception as exc:
                 if _is_transient(exc):
+                    if self._on_disconnected:
+                        try:
+                            self._on_disconnected(self._server_name)
+                        except Exception:
+                            logger.debug("on_disconnected callback error (ignored)")
                     if attempt == 0:
                         logger.warning(
-                            "MCP prompt '{}' hit transient error ({}), retrying once...",
+                            "MCP prompt '{}' hit transient error ({}), "
+                            "server marked disconnected for reconnection",
                             self._name,
                             type(exc).__name__,
                         )
-                        await asyncio.sleep(1)
-                        continue
+                        return "(MCP server connection lost, reconnecting. Please try again.)"
                     logger.exception(
                         "MCP prompt '{}' failed after retry: {}",
                         self._name,
@@ -470,13 +492,17 @@ class MCPPromptWrapper(Tool):
 
 
 async def connect_mcp_servers(
-    mcp_servers: dict, registry: ToolRegistry
+    mcp_servers: dict, registry: ToolRegistry, *, on_disconnected=None,
 ) -> dict[str, AsyncExitStack]:
     """Connect to configured MCP servers and register their tools, resources, prompts.
 
     Returns a dict mapping server name -> its dedicated AsyncExitStack.
     Each server gets its own stack to prevent cancel scope conflicts
     when multiple MCP servers are configured.
+
+    If *on_disconnected* is provided, wrappers receive it as a callback to
+    invoke when a transient connection error is detected so the server can be
+    marked for reconnection on the next turn.
     """
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.sse import sse_client
@@ -584,7 +610,7 @@ async def connect_mcp_servers(
                         name,
                     )
                     continue
-                wrapper = MCPToolWrapper(session, name, tool_def, tool_timeout=cfg.tool_timeout)
+                wrapper = MCPToolWrapper(session, name, tool_def, tool_timeout=cfg.tool_timeout, on_disconnected=on_disconnected)
                 registry.register(wrapper)
                 logger.debug("MCP: registered tool '{}' from server '{}'", wrapper.name, name)
                 registered_count += 1
@@ -610,7 +636,7 @@ async def connect_mcp_servers(
                 resources_result = await session.list_resources()
                 for resource in resources_result.resources:
                     wrapper = MCPResourceWrapper(
-                        session, name, resource, resource_timeout=cfg.tool_timeout
+                        session, name, resource, resource_timeout=cfg.tool_timeout, on_disconnected=on_disconnected
                     )
                     registry.register(wrapper)
                     registered_count += 1
@@ -624,7 +650,7 @@ async def connect_mcp_servers(
                 prompts_result = await session.list_prompts()
                 for prompt in prompts_result.prompts:
                     wrapper = MCPPromptWrapper(
-                        session, name, prompt, prompt_timeout=cfg.tool_timeout
+                        session, name, prompt, prompt_timeout=cfg.tool_timeout, on_disconnected=on_disconnected
                     )
                     registry.register(wrapper)
                     registered_count += 1
@@ -736,6 +762,43 @@ def runtime_lines(
     return lines
 
 
+def mark_server_disconnected(state: Any, registry: ToolRegistry, server_name: str) -> None:
+    """Mark an MCP server as disconnected so it will be reconnected on the next turn.
+
+    Called by wrapper ``on_disconnected`` callbacks when a transient error
+    indicates the underlying session is dead.  This:
+    1. Closes the server's ``AsyncExitStack`` and removes it from ``_mcp_stacks``.
+    2. Unregisters all tools/resources/prompts for that server.
+    3. Resets ``_mcp_connected`` so ``connect_missing_servers`` will attempt reconnection.
+    """
+    stack = state._mcp_stacks.pop(server_name, None)
+    if stack is not None:
+        # Schedule the async cleanup; we can't await here (called from sync callback context)
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_close_server_stack(stack, server_name))
+        except RuntimeError:
+            # No running loop — best-effort sync close
+            with suppress(Exception):
+                import asyncio as _aio
+                _aio.run(_close_server_stack(stack, server_name))
+    removed = _unregister_server_tools(state, registry, server_name)
+    state._mcp_connected = bool(state._mcp_stacks)
+    logger.info(
+        "MCP server '{}' marked disconnected ({} tools unregistered), will reconnect next turn",
+        server_name,
+        removed,
+    )
+
+
+async def _close_server_stack(stack: AsyncExitStack, server_name: str) -> None:
+    """Close an MCP server exit stack, swallowing cleanup errors."""
+    try:
+        await stack.aclose()
+    except (RuntimeError, BaseExceptionGroup):
+        logger.debug("MCP server '{}' cleanup error (can be ignored)", server_name)
+
+
 async def connect_missing_servers(state: Any, registry: ToolRegistry) -> None:
     """Connect configured MCP servers that are not currently live."""
     missing_servers = {
@@ -745,7 +808,10 @@ async def connect_missing_servers(state: Any, registry: ToolRegistry) -> None:
         return
     state._mcp_connecting = True
     try:
-        connected = await connect_mcp_servers(missing_servers, registry)
+        connected = await connect_mcp_servers(
+            missing_servers, registry,
+            on_disconnected=lambda server_name: mark_server_disconnected(state, registry, server_name),
+        )
         state._mcp_stacks.update(connected)
         state._mcp_connected = bool(state._mcp_stacks)
         if connected:
@@ -806,7 +872,10 @@ async def reload_servers(state: Any, registry: ToolRegistry) -> dict[str, Any]:
         to_connect = {name: next_servers[name] for name in to_connect_names}
         connected: dict[str, AsyncExitStack] = {}
         if to_connect:
-            connected = await connect_mcp_servers(to_connect, registry)
+            connected = await connect_mcp_servers(
+                to_connect, registry,
+                on_disconnected=lambda server_name: mark_server_disconnected(state, registry, server_name),
+            )
             state._mcp_stacks.update(connected)
 
         state._mcp_connected = bool(state._mcp_stacks)

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -205,66 +205,54 @@ class MCPToolWrapper(Tool):
     async def execute(self, **kwargs: Any) -> str:
         from mcp import types
 
-        for attempt in range(2):  # At most 1 retry
-            try:
-                result = await asyncio.wait_for(
-                    self._session.call_tool(self._original_name, arguments=kwargs),
-                    timeout=self._tool_timeout,
-                )
-            except asyncio.TimeoutError:
+        try:
+            result = await asyncio.wait_for(
+                self._session.call_tool(self._original_name, arguments=kwargs),
+                timeout=self._tool_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "MCP tool '{}' timed out after {}s", self._name, self._tool_timeout
+            )
+            return f"(MCP tool call timed out after {self._tool_timeout}s)"
+        except asyncio.CancelledError:
+            # MCP SDK's anyio cancel scopes can leak CancelledError on timeout/failure.
+            # Re-raise only if our task was externally cancelled (e.g. /stop).
+            task = asyncio.current_task()
+            if task is not None and task.cancelling() > 0:
+                raise
+            logger.warning("MCP tool '{}' was cancelled by server/SDK", self._name)
+            return "(MCP tool call was cancelled)"
+        except Exception as exc:
+            if _is_transient(exc):
                 logger.warning(
-                    "MCP tool '{}' timed out after {}s", self._name, self._tool_timeout
-                )
-                return f"(MCP tool call timed out after {self._tool_timeout}s)"
-            except asyncio.CancelledError:
-                # MCP SDK's anyio cancel scopes can leak CancelledError on timeout/failure.
-                # Re-raise only if our task was externally cancelled (e.g. /stop).
-                task = asyncio.current_task()
-                if task is not None and task.cancelling() > 0:
-                    raise
-                logger.warning("MCP tool '{}' was cancelled by server/SDK", self._name)
-                return "(MCP tool call was cancelled)"
-            except Exception as exc:
-                if _is_transient(exc):
-                    # Mark server disconnected so it reconnects on the next turn.
-                    # Don't retry with the stale session — it will fail again.
-                    if self._on_disconnected:
-                        try:
-                            self._on_disconnected(self._server_name)
-                        except Exception:
-                            logger.debug("on_disconnected callback error (ignored)")
-                    if attempt == 0:
-                        logger.warning(
-                            "MCP tool '{}' hit transient error ({}), "
-                            "server marked disconnected for reconnection",
-                            self._name,
-                            type(exc).__name__,
-                        )
-                        return "(MCP server connection lost, reconnecting. Please try again.)"
-                    logger.exception(
-                        "MCP tool '{}' failed after retry: {}",
-                        self._name,
-                        type(exc).__name__,
-                    )
-                    return f"(MCP tool call failed after retry: {type(exc).__name__})"
-                logger.exception(
-                    "MCP tool '{}' failed: {}: {}",
+                    "MCP tool '{}' hit transient error ({}), "
+                    "server will be marked disconnected for reconnection",
                     self._name,
                     type(exc).__name__,
-                    exc,
                 )
-                return f"(MCP tool call failed: {type(exc).__name__})"
-            else:
-                # Success — extract result
-                parts = []
-                for block in result.content:
-                    if isinstance(block, types.TextContent):
-                        parts.append(block.text)
-                    else:
-                        parts.append(str(block))
-                return "\n".join(parts) or "(no output)"
-
-        return "(MCP tool call failed)"  # Unreachable, but satisfies type checkers
+                if self._on_disconnected:
+                    try:
+                        self._on_disconnected(self._server_name)
+                    except Exception:
+                        logger.debug("on_disconnected callback error (ignored)")
+                return "(MCP server connection lost, reconnecting. Please try again.)"
+            logger.exception(
+                "MCP tool '{}' failed: {}: {}",
+                self._name,
+                type(exc).__name__,
+                exc,
+            )
+            return f"(MCP tool call failed: {type(exc).__name__})"
+        else:
+            # Success — extract result
+            parts = []
+            for block in result.content:
+                if isinstance(block, types.TextContent):
+                    parts.append(block.text)
+                else:
+                    parts.append(str(block))
+            return "\n".join(parts) or "(no output)"
 
 
 class MCPResourceWrapper(Tool):
@@ -306,63 +294,53 @@ class MCPResourceWrapper(Tool):
     async def execute(self, **kwargs: Any) -> str:
         from mcp import types
 
-        for attempt in range(2):
-            try:
-                result = await asyncio.wait_for(
-                    self._session.read_resource(self._uri),
-                    timeout=self._resource_timeout,
-                )
-            except asyncio.TimeoutError:
+        try:
+            result = await asyncio.wait_for(
+                self._session.read_resource(self._uri),
+                timeout=self._resource_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "MCP resource '{}' timed out after {}s", self._name, self._resource_timeout
+            )
+            return f"(MCP resource read timed out after {self._resource_timeout}s)"
+        except asyncio.CancelledError:
+            task = asyncio.current_task()
+            if task is not None and task.cancelling() > 0:
+                raise
+            logger.warning("MCP resource '{}' was cancelled by server/SDK", self._name)
+            return "(MCP resource read was cancelled)"
+        except Exception as exc:
+            if _is_transient(exc):
                 logger.warning(
-                    "MCP resource '{}' timed out after {}s", self._name, self._resource_timeout
-                )
-                return f"(MCP resource read timed out after {self._resource_timeout}s)"
-            except asyncio.CancelledError:
-                task = asyncio.current_task()
-                if task is not None and task.cancelling() > 0:
-                    raise
-                logger.warning("MCP resource '{}' was cancelled by server/SDK", self._name)
-                return "(MCP resource read was cancelled)"
-            except Exception as exc:
-                if _is_transient(exc):
-                    if self._on_disconnected:
-                        try:
-                            self._on_disconnected(self._server_name)
-                        except Exception:
-                            logger.debug("on_disconnected callback error (ignored)")
-                    if attempt == 0:
-                        logger.warning(
-                            "MCP resource '{}' hit transient error ({}), "
-                            "server marked disconnected for reconnection",
-                            self._name,
-                            type(exc).__name__,
-                        )
-                        return "(MCP server connection lost, reconnecting. Please try again.)"
-                    logger.exception(
-                        "MCP resource '{}' failed after retry: {}",
-                        self._name,
-                        type(exc).__name__,
-                    )
-                    return f"(MCP resource read failed after retry: {type(exc).__name__})"
-                logger.exception(
-                    "MCP resource '{}' failed: {}: {}",
+                    "MCP resource '{}' hit transient error ({}), "
+                    "server will be marked disconnected for reconnection",
                     self._name,
                     type(exc).__name__,
-                    exc,
                 )
-                return f"(MCP resource read failed: {type(exc).__name__})"
-            else:
-                parts: list[str] = []
-                for block in result.contents:
-                    if isinstance(block, types.TextResourceContents):
-                        parts.append(block.text)
-                    elif isinstance(block, types.BlobResourceContents):
-                        parts.append(f"[Binary resource: {len(block.blob)} bytes]")
-                    else:
-                        parts.append(str(block))
-                return "\n".join(parts) or "(no output)"
-
-        return "(MCP resource read failed)"  # Unreachable
+                if self._on_disconnected:
+                    try:
+                        self._on_disconnected(self._server_name)
+                    except Exception:
+                        logger.debug("on_disconnected callback error (ignored)")
+                return "(MCP server connection lost, reconnecting. Please try again.)"
+            logger.exception(
+                "MCP resource '{}' failed: {}: {}",
+                self._name,
+                type(exc).__name__,
+                exc,
+            )
+            return f"(MCP resource read failed: {type(exc).__name__})"
+        else:
+            parts: list[str] = []
+            for block in result.contents:
+                if isinstance(block, types.TextResourceContents):
+                    parts.append(block.text)
+                elif isinstance(block, types.BlobResourceContents):
+                    parts.append(f"[Binary resource: {len(block.blob)} bytes]")
+                else:
+                    parts.append(str(block))
+            return "\n".join(parts) or "(no output)"
 
 
 class MCPPromptWrapper(Tool):
@@ -419,76 +397,66 @@ class MCPPromptWrapper(Tool):
         from mcp import types
         from mcp.shared.exceptions import McpError
 
-        for attempt in range(2):
-            try:
-                result = await asyncio.wait_for(
-                    self._session.get_prompt(self._prompt_name, arguments=kwargs),
-                    timeout=self._prompt_timeout,
-                )
-            except asyncio.TimeoutError:
+        try:
+            result = await asyncio.wait_for(
+                self._session.get_prompt(self._prompt_name, arguments=kwargs),
+                timeout=self._prompt_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "MCP prompt '{}' timed out after {}s", self._name, self._prompt_timeout
+            )
+            return f"(MCP prompt call timed out after {self._prompt_timeout}s)"
+        except asyncio.CancelledError:
+            task = asyncio.current_task()
+            if task is not None and task.cancelling() > 0:
+                raise
+            logger.warning("MCP prompt '{}' was cancelled by server/SDK", self._name)
+            return "(MCP prompt call was cancelled)"
+        except McpError as exc:
+            logger.exception(
+                "MCP prompt '{}' failed: code={} message={}",
+                self._name,
+                exc.error.code,
+                exc.error.message,
+            )
+            return f"(MCP prompt call failed: {exc.error.message} [code {exc.error.code}])"
+        except Exception as exc:
+            if _is_transient(exc):
                 logger.warning(
-                    "MCP prompt '{}' timed out after {}s", self._name, self._prompt_timeout
-                )
-                return f"(MCP prompt call timed out after {self._prompt_timeout}s)"
-            except asyncio.CancelledError:
-                task = asyncio.current_task()
-                if task is not None and task.cancelling() > 0:
-                    raise
-                logger.warning("MCP prompt '{}' was cancelled by server/SDK", self._name)
-                return "(MCP prompt call was cancelled)"
-            except McpError as exc:
-                logger.exception(
-                    "MCP prompt '{}' failed: code={} message={}",
-                    self._name,
-                    exc.error.code,
-                    exc.error.message,
-                )
-                return f"(MCP prompt call failed: {exc.error.message} [code {exc.error.code}])"
-            except Exception as exc:
-                if _is_transient(exc):
-                    if self._on_disconnected:
-                        try:
-                            self._on_disconnected(self._server_name)
-                        except Exception:
-                            logger.debug("on_disconnected callback error (ignored)")
-                    if attempt == 0:
-                        logger.warning(
-                            "MCP prompt '{}' hit transient error ({}), "
-                            "server marked disconnected for reconnection",
-                            self._name,
-                            type(exc).__name__,
-                        )
-                        return "(MCP server connection lost, reconnecting. Please try again.)"
-                    logger.exception(
-                        "MCP prompt '{}' failed after retry: {}",
-                        self._name,
-                        type(exc).__name__,
-                    )
-                    return f"(MCP prompt call failed after retry: {type(exc).__name__})"
-                logger.exception(
-                    "MCP prompt '{}' failed: {}: {}",
+                    "MCP prompt '{}' hit transient error ({}), "
+                    "server will be marked disconnected for reconnection",
                     self._name,
                     type(exc).__name__,
-                    exc,
                 )
-                return f"(MCP prompt call failed: {type(exc).__name__})"
-            else:
-                parts: list[str] = []
-                for message in result.messages:
-                    content = message.content
-                    if isinstance(content, types.TextContent):
-                        parts.append(content.text)
-                    elif isinstance(content, list):
-                        for block in content:
-                            if isinstance(block, types.TextContent):
-                                parts.append(block.text)
-                            else:
-                                parts.append(str(block))
-                    else:
-                        parts.append(str(content))
-                return "\n".join(parts) or "(no output)"
-
-        return "(MCP prompt call failed)"  # Unreachable
+                if self._on_disconnected:
+                    try:
+                        self._on_disconnected(self._server_name)
+                    except Exception:
+                        logger.debug("on_disconnected callback error (ignored)")
+                return "(MCP server connection lost, reconnecting. Please try again.)"
+            logger.exception(
+                "MCP prompt '{}' failed: {}: {}",
+                self._name,
+                type(exc).__name__,
+                exc,
+            )
+            return f"(MCP prompt call failed: {type(exc).__name__})"
+        else:
+            parts: list[str] = []
+            for message in result.messages:
+                content = message.content
+                if isinstance(content, types.TextContent):
+                    parts.append(content.text)
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, types.TextContent):
+                            parts.append(block.text)
+                        else:
+                            parts.append(str(block))
+                else:
+                    parts.append(str(content))
+            return "\n".join(parts) or "(no output)"
 
 
 async def connect_mcp_servers(
@@ -767,21 +735,28 @@ def mark_server_disconnected(state: Any, registry: ToolRegistry, server_name: st
 
     Called by wrapper ``on_disconnected`` callbacks when a transient error
     indicates the underlying session is dead.  This:
-    1. Closes the server's ``AsyncExitStack`` and removes it from ``_mcp_stacks``.
+    1. Pops the server's ``AsyncExitStack`` from ``_mcp_stacks`` and schedules async cleanup.
     2. Unregisters all tools/resources/prompts for that server.
     3. Resets ``_mcp_connected`` so ``connect_missing_servers`` will attempt reconnection.
     """
     stack = state._mcp_stacks.pop(server_name, None)
     if stack is not None:
-        # Schedule the async cleanup; we can't await here (called from sync callback context)
+        # Schedule the async cleanup via loop.create_task since we already
+        # popped the stack — close it directly via a local async closure.
+        async def _close_popped(stack: AsyncExitStack, server_name: str) -> None:
+            try:
+                await stack.aclose()
+            except (RuntimeError, BaseExceptionGroup):
+                logger.debug("MCP server '{}' cleanup error (can be ignored)", server_name)
+
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(_close_server_stack(stack, server_name))
+            loop.create_task(_close_popped(stack, server_name))
         except RuntimeError:
-            # No running loop — best-effort sync close
+            # No running loop (e.g. called from sync context) — fire-and-forget
+            # cleanup in a new loop.
             with suppress(Exception):
-                import asyncio as _aio
-                _aio.run(_close_server_stack(stack, server_name))
+                asyncio.run(_close_popped(stack, server_name))
     removed = _unregister_server_tools(state, registry, server_name)
     state._mcp_connected = bool(state._mcp_stacks)
     logger.info(
@@ -791,12 +766,18 @@ def mark_server_disconnected(state: Any, registry: ToolRegistry, server_name: st
     )
 
 
-async def _close_server_stack(stack: AsyncExitStack, server_name: str) -> None:
-    """Close an MCP server exit stack, swallowing cleanup errors."""
-    try:
-        await stack.aclose()
-    except (RuntimeError, BaseExceptionGroup):
-        logger.debug("MCP server '{}' cleanup error (can be ignored)", server_name)
+async def _close_server(state: Any, server_name: str) -> None:
+    """Close an MCP server's exit stack, swallowing cleanup errors.
+
+    Used during graceful shutdown (disconnect_all_servers) and by
+    connect_missing_servers to close stale connections before reconnecting.
+    """
+    stack = state._mcp_stacks.pop(server_name, None)
+    if stack is not None:
+        try:
+            await stack.aclose()
+        except (RuntimeError, BaseExceptionGroup):
+            logger.debug("MCP server '{}' cleanup error (can be ignored)", server_name)
 
 
 async def connect_missing_servers(state: Any, registry: ToolRegistry) -> None:
@@ -1001,11 +982,3 @@ def _unregister_server_tools(state: Any, registry: ToolRegistry, server_name: st
     return removed
 
 
-async def _close_server(state: Any, server_name: str) -> None:
-    stack = state._mcp_stacks.pop(server_name, None)
-    if stack is None:
-        return
-    try:
-        await stack.aclose()
-    except (RuntimeError, BaseExceptionGroup):
-        logger.debug("MCP server '{}' cleanup error (can be ignored)", server_name)

--- a/tests/agent/test_mcp_connection.py
+++ b/tests/agent/test_mcp_connection.py
@@ -56,7 +56,7 @@ async def test_connect_mcp_retries_when_no_servers_connect(tmp_path, monkeypatch
     loop = _make_loop(tmp_path)
     attempts = 0
 
-    async def _fake_connect(_servers, _registry):
+    async def _fake_connect(_servers, _registry, *, on_disconnected=None):
         nonlocal attempts
         attempts += 1
         return {}
@@ -90,7 +90,7 @@ async def test_reload_mcp_servers_adds_and_removes_tools_without_restart(
     async def _mark_closed(name: str) -> None:
         closed.append(name)
 
-    async def _fake_connect(servers, registry):
+    async def _fake_connect(servers, registry, *, on_disconnected=None):
         stacks = {}
         for name in servers:
             registry.register(_FakeMcpTool(f"mcp_{name}_navigate"))
@@ -142,7 +142,7 @@ async def test_request_mcp_reload_reaches_runtime_control_without_restart(
     async def _mark_closed(name: str) -> None:
         closed.append(name)
 
-    async def _fake_connect(servers, registry):
+    async def _fake_connect(servers, registry, *, on_disconnected=None):
         stacks = {}
         for name in servers:
             registry.register(_FakeMcpTool(f"mcp_{name}_navigate"))
@@ -198,7 +198,7 @@ async def test_reload_mcp_servers_retries_configured_server_without_live_stack(
     )
     save_config(config)
 
-    async def _fake_connect(servers, registry):
+    async def _fake_connect(servers, registry, *, on_disconnected=None):
         stacks = {}
         for name in servers:
             registry.register(_FakeMcpTool(f"mcp_{name}_navigate"))

--- a/tests/agent/test_mcp_transient_retry.py
+++ b/tests/agent/test_mcp_transient_retry.py
@@ -1,8 +1,14 @@
-"""Tests for MCP tool/resource/prompt transient error retry."""
+"""Tests for MCP tool/resource/prompt transient error handling.
+
+When a transient connection error is detected, wrappers now:
+1. Call the ``on_disconnected`` callback to mark the server for reconnection.
+2. Return a reconnect message immediately (no retry with stale session).
+3. On the next turn, ``connect_missing_servers`` reconnects the server.
+"""
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from mcp import types as mcp_types
@@ -35,7 +41,7 @@ class _FakeEndOfStreamError(Exception):
 _FakeEndOfStreamError.__name__ = "EndOfStream"
 
 
-def test_is_transient_recognizes_closed_resource():
+def test_is_transient_recognized_closed_resource():
     assert _is_transient(_FakeClosedResourceError("gone"))
 
 
@@ -68,7 +74,7 @@ def test_is_transient_rejects_timeout():
 
 
 # ---------------------------------------------------------------------------
-# MCPToolWrapper retry behaviour
+# MCPToolWrapper transient error handling
 # ---------------------------------------------------------------------------
 
 
@@ -86,38 +92,72 @@ def _make_tool_result(text):
 
 
 @pytest.mark.asyncio
-async def test_tool_retries_on_transient_error():
-    """Tool should retry once when a transient error occurs, then succeed."""
+async def test_tool_calls_on_disconnected_on_transient_error():
+    """On transient error, wrapper calls on_disconnected instead of retrying with stale session."""
     session = AsyncMock()
-    result = _make_tool_result("ok")
     exc = _FakeClosedResourceError("connection lost")
-    session.call_tool = AsyncMock(side_effect=[exc, result])
+    session.call_tool = AsyncMock(side_effect=exc)
 
-    wrapper = MCPToolWrapper(session, "test_server", _make_tool_def(), tool_timeout=5)
+    on_disconnected = MagicMock()
 
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
-        output = await wrapper.execute(foo="bar")
+    wrapper = MCPToolWrapper(
+        session, "test_server", _make_tool_def(), tool_timeout=5,
+        on_disconnected=on_disconnected,
+    )
+    output = await wrapper.execute(foo="bar")
 
-    assert output == "ok"
-    assert session.call_tool.call_count == 2
+    assert "reconnecting" in output
+    on_disconnected.assert_called_once_with("test_server")
+    # Should NOT retry with the stale session
+    assert session.call_tool.call_count == 1
 
 
 @pytest.mark.asyncio
-async def test_tool_fails_after_retry_exhausted():
-    """Tool should fail with retry message when both attempts hit transient errors."""
+async def test_tool_reconnect_message_on_transient_error():
+    """Wrapper returns reconnection message on transient error."""
     session = AsyncMock()
-    exc1 = _FakeClosedResourceError("still dead")
-    exc2 = _FakeClosedResourceError("still dead again")
-    session.call_tool = AsyncMock(side_effect=[exc1, exc2])
+    exc = _FakeClosedResourceError("connection lost")
+    session.call_tool = AsyncMock(side_effect=exc)
+
+    wrapper = MCPToolWrapper(
+        session, "test_server", _make_tool_def(), tool_timeout=5,
+        on_disconnected=MagicMock(),
+    )
+    output = await wrapper.execute()
+
+    assert "MCP server connection lost" in output
+    assert "reconnecting" in output.lower() or "reconnect" in output.lower()
+
+
+@pytest.mark.asyncio
+async def test_tool_no_on_disconnected_without_callback():
+    """Without on_disconnected callback, wrapper still returns reconnection message."""
+    session = AsyncMock()
+    exc = _FakeClosedResourceError("connection lost")
+    session.call_tool = AsyncMock(side_effect=exc)
 
     wrapper = MCPToolWrapper(session, "test_server", _make_tool_def(), tool_timeout=5)
+    output = await wrapper.execute()
 
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
-        output = await wrapper.execute()
+    assert "reconnecting" in output
 
-    assert "failed after retry" in output
-    assert "ClosedResourceError" in output
-    assert session.call_tool.call_count == 2
+
+@pytest.mark.asyncio
+async def test_tool_on_disconnected_callback_error_suppressed():
+    """If on_disconnected callback raises, wrapper still returns reconnection message."""
+    session = AsyncMock()
+    exc = _FakeClosedResourceError("connection lost")
+    session.call_tool = AsyncMock(side_effect=exc)
+
+    failing_callback = MagicMock(side_effect=RuntimeError("callback boom"))
+
+    wrapper = MCPToolWrapper(
+        session, "test_server", _make_tool_def(), tool_timeout=5,
+        on_disconnected=failing_callback,
+    )
+    output = await wrapper.execute()
+
+    assert "reconnecting" in output
 
 
 @pytest.mark.asyncio
@@ -148,7 +188,7 @@ async def test_tool_no_retry_on_timeout():
 
 
 @pytest.mark.asyncio
-async def test_tool_success_on_first_try_no_retry():
+async def test_tool_success_on_first_try():
     """Normal success path — no retry logic involved."""
     session = AsyncMock()
     result = _make_tool_result("hello")
@@ -163,7 +203,7 @@ async def test_tool_success_on_first_try_no_retry():
 
 @pytest.mark.asyncio
 async def test_tool_does_not_retry_on_cancelled_error():
-    """`asyncio.CancelledError` must short-circuit the retry loop.
+    """``asyncio.CancelledError`` must short-circuit the retry loop.
 
     Regression guard: the retry branch lives under ``except Exception``,
     but ``CancelledError`` inherits from ``BaseException``, not
@@ -177,50 +217,14 @@ async def test_tool_does_not_retry_on_cancelled_error():
 
     wrapper = MCPToolWrapper(session, "test_server", _make_tool_def(), tool_timeout=5)
 
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-        output = await wrapper.execute()
+    output = await wrapper.execute()
 
     assert "cancelled" in output
     assert session.call_tool.call_count == 1
-    mock_sleep.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_tool_retry_on_connection_reset():
-    """ConnectionResetError (a stdlib exception) should also trigger retry."""
-    session = AsyncMock()
-    result = _make_tool_result("recovered")
-    session.call_tool = AsyncMock(
-        side_effect=[ConnectionResetError("reset by peer"), result]
-    )
-
-    wrapper = MCPToolWrapper(session, "test_server", _make_tool_def(), tool_timeout=5)
-
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
-        output = await wrapper.execute()
-
-    assert output == "recovered"
-    assert session.call_tool.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_tool_retry_on_end_of_stream():
-    """EndOfStream (anyio) should trigger retry."""
-    session = AsyncMock()
-    result = _make_tool_result("back")
-    session.call_tool = AsyncMock(side_effect=[_FakeEndOfStreamError("eof"), result])
-
-    wrapper = MCPToolWrapper(session, "test_server", _make_tool_def(), tool_timeout=5)
-
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
-        output = await wrapper.execute()
-
-    assert output == "back"
-    assert session.call_tool.call_count == 2
 
 
 # ---------------------------------------------------------------------------
-# MCPResourceWrapper retry behaviour
+# MCPResourceWrapper transient error handling
 # ---------------------------------------------------------------------------
 
 
@@ -239,36 +243,23 @@ def _make_resource_result(text):
 
 
 @pytest.mark.asyncio
-async def test_resource_retries_on_transient_error():
-    """Resource should retry once on transient connection error."""
+async def test_resource_calls_on_disconnected_on_transient_error():
+    """On transient error, resource wrapper calls on_disconnected instead of retrying."""
     session = AsyncMock()
-    result = _make_resource_result("data")
     exc = _FakeClosedResourceError("gone")
-    session.read_resource = AsyncMock(side_effect=[exc, result])
+    session.read_resource = AsyncMock(side_effect=exc)
 
-    wrapper = MCPResourceWrapper(session, "test_server", _make_resource_def())
+    on_disconnected = MagicMock()
 
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
-        output = await wrapper.execute()
+    wrapper = MCPResourceWrapper(
+        session, "test_server", _make_resource_def(),
+        on_disconnected=on_disconnected,
+    )
+    output = await wrapper.execute()
 
-    assert output == "data"
-    assert session.read_resource.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_resource_fails_after_retry_exhausted():
-    """Resource should fail with retry message when both attempts fail."""
-    session = AsyncMock()
-    exc = _FakeClosedResourceError("dead")
-    session.read_resource = AsyncMock(side_effect=[exc, exc])
-
-    wrapper = MCPResourceWrapper(session, "test_server", _make_resource_def())
-
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
-        output = await wrapper.execute()
-
-    assert "failed after retry" in output
-    assert session.read_resource.call_count == 2
+    assert "reconnecting" in output
+    on_disconnected.assert_called_once_with("test_server")
+    assert session.read_resource.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -285,7 +276,7 @@ async def test_resource_no_retry_on_non_transient():
 
 
 # ---------------------------------------------------------------------------
-# MCPPromptWrapper retry behaviour
+# MCPPromptWrapper transient error handling
 # ---------------------------------------------------------------------------
 
 
@@ -308,36 +299,23 @@ def _make_prompt_result(text):
 
 
 @pytest.mark.asyncio
-async def test_prompt_retries_on_transient_error():
-    """Prompt should retry once on transient connection error."""
+async def test_prompt_calls_on_disconnected_on_transient_error():
+    """On transient error, prompt wrapper calls on_disconnected instead of retrying."""
     session = AsyncMock()
-    result = _make_prompt_result("prompt text")
     exc = _FakeClosedResourceError("gone")
-    session.get_prompt = AsyncMock(side_effect=[exc, result])
+    session.get_prompt = AsyncMock(side_effect=exc)
 
-    wrapper = MCPPromptWrapper(session, "test_server", _make_prompt_def())
+    on_disconnected = MagicMock()
 
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
-        output = await wrapper.execute()
+    wrapper = MCPPromptWrapper(
+        session, "test_server", _make_prompt_def(),
+        on_disconnected=on_disconnected,
+    )
+    output = await wrapper.execute()
 
-    assert output == "prompt text"
-    assert session.get_prompt.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_prompt_fails_after_retry_exhausted():
-    """Prompt should fail with retry message when both attempts fail."""
-    session = AsyncMock()
-    exc = _FakeClosedResourceError("dead")
-    session.get_prompt = AsyncMock(side_effect=[exc, exc])
-
-    wrapper = MCPPromptWrapper(session, "test_server", _make_prompt_def())
-
-    with patch("nanobot.agent.tools.mcp.asyncio.sleep", new_callable=AsyncMock):
-        output = await wrapper.execute()
-
-    assert "failed after retry" in output
-    assert session.get_prompt.call_count == 2
+    assert "reconnecting" in output
+    on_disconnected.assert_called_once_with("test_server")
+    assert session.get_prompt.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -366,3 +344,37 @@ async def test_prompt_no_retry_on_non_transient():
 
     assert "RuntimeError" in output
     assert session.get_prompt.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# mark_server_disconnected integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_server_disconnected_removes_stack_and_unregisters_tools():
+    """mark_server_disconnected pops the stack, unregisters tools, resets _mcp_connected."""
+    from nanobot.agent.tools.mcp import mark_server_disconnected
+    from nanobot.agent.tools.registry import ToolRegistry
+
+    registry = ToolRegistry()
+    # Register a fake tool for the server
+    registry.register(MCPToolWrapper(
+        AsyncMock(), "my_server", _make_tool_def(), tool_timeout=5,
+    ))
+
+    state = SimpleNamespace(
+        _mcp_stacks={"my_server": AsyncExitStack()},
+        _mcp_servers={"my_server": SimpleNamespace()},
+        _mcp_connected=True,
+    )
+
+    mark_server_disconnected(state, registry, "my_server")
+
+    assert "my_server" not in state._mcp_stacks
+    assert state._mcp_connected is False
+    # The tool should be unregistered
+    assert not any(t.startswith("mcp_my_server_") for t in registry.tool_names)
+
+
+from contextlib import AsyncExitStack


### PR DESCRIPTION
Fixes a critical MCP reconnection bug where `_mcp_connected` was set to `True` once and never reset, leaving no path for dead sessions to reconnect. Also adds reconnect callbacks to MCP wrapper classes so transient errors can trigger reconnection.

Changes:
- Reset `_mcp_connected = False` when session drops in `_connect_mcp()`
- Add `reconnect_callback` parameter to MCP wrapper classes (`_MCPToolCall`, `_MCPToolList`, etc.)
- `_is_transient()` detects `ClosedResourceError`, `BrokenResourceError`, `EndOfStream`, `BrokenPipeError`, `ConnectionResetError`, `ConnectionRefusedError`, `ConnectionAbortedError`, `ConnectionError`
- Wrapper retry logic reconnects before retrying transient errors instead of retrying on the same stale session