### PR TITLE
feature: Add Discord model slash command

### DIFF
--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -207,6 +207,16 @@ if DISCORD_AVAILABLE:
                 ) -> None:
                     await self._forward_slash_command(interaction, _command_text)
 
+            @self.tree.command(name="model", description="Show or switch runtime model preset")
+            @app_commands.describe(preset="Optional model preset name, such as default")
+            async def model_command(
+                interaction: discord.Interaction,
+                preset: str | None = None,
+            ) -> None:
+                preset = (preset or "").strip()
+                command_text = f"/model {preset}" if preset else "/model"
+                await self._forward_slash_command(interaction, command_text)
+
             @self.tree.command(name="help", description="Show available commands")
             async def help_command(interaction: discord.Interaction) -> None:
                 sender_id = str(interaction.user.id)

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -865,7 +865,7 @@ async def test_slash_new_is_blocked_for_disallowed_user() -> None:
     assert handled == []
 
 
-@pytest.mark.parametrize("slash_name", ["stop", "restart", "status", "history"])
+@pytest.mark.parametrize("slash_name", ["stop", "restart", "status", "history", "model"])
 @pytest.mark.asyncio
 async def test_slash_commands_forward_via_handle_message(slash_name: str) -> None:
     channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), MessageBus())
@@ -888,6 +888,31 @@ async def test_slash_commands_forward_via_handle_message(slash_name: str) -> Non
     ]
     assert len(handled) == 1
     assert handled[0]["content"] == f"/{slash_name}"
+    assert handled[0]["metadata"]["is_slash_command"] is True
+
+
+@pytest.mark.asyncio
+async def test_slash_model_forwards_optional_preset() -> None:
+    channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["*"]), MessageBus())
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle  # type: ignore[method-assign]
+    client = DiscordBotClient(channel, intents=discord.Intents.none())
+    interaction = _make_interaction()
+    interaction.command.qualified_name = "model"
+
+    model_cmd = client.tree.get_command("model")
+    assert model_cmd is not None
+    await model_cmd.callback(interaction, preset="fast")
+
+    assert interaction.response.messages == [
+        {"content": "Processing /model fast...", "ephemeral": True}
+    ]
+    assert len(handled) == 1
+    assert handled[0]["content"] == "/model fast"
     assert handled[0]["metadata"]["is_slash_command"] is True
 
 


### PR DESCRIPTION
## Goal

Let users switch runtime model presets with `/model` from chat connectors where the connector exposes native slash commands.

## Changes

- Adds a native Discord `/model` app command.
- Supports an optional `preset` argument and forwards either `/model` or `/model <preset>` into the existing shared command router.
- Extends Discord channel tests to cover the new native command and optional preset forwarding.

## Why This Was Needed

Nanobot already had shared backend support for `/model`, and text-based connector messages could reach it. Discord also exposes native app commands, but its native command list did not include `/model`, so Discord users had no first-class slash-command entry point for inspecting or switching model presets from the Discord command menu.

This keeps Discord aligned with the shared in-chat command surface and reuses the existing model switching implementation instead of adding a connector-specific model path.

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/command/test_model_command.py tests/command/test_router_dispatchable.py -q`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev --extra discord pytest tests/channels/test_discord_channel.py -q`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev ruff check nanobot/channels/discord.py`

Note: full-file ruff on `tests/channels/test_discord_channel.py` still reports pre-existing E402 import-order warnings around `pytest.importorskip`; this PR leaves that unrelated pattern unchanged.