### PR TITLE
Add optional AUTHORITY bootstrap file

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -14,7 +14,7 @@ It separates memory into layers, because different kinds of remembering deserve 
 
 - `session.messages` holds the living short-term conversation.
 - `memory/history.jsonl` is the running archive of compressed past turns.
-- `SOUL.md`, `USER.md`, and `memory/MEMORY.md` are the durable knowledge files.
+- `AUTHORITY.md`, `SOUL.md`, `USER.md`, and `memory/MEMORY.md` are the durable knowledge files.
 - `GitStore` records how those durable files change over time.
 
 This keeps the system light in the moment, but reflective over time.
@@ -61,10 +61,15 @@ Then it works in two phases:
 
 This is why nanobot's memory is not just archival. It is interpretive.
 
+`AUTHORITY.md` is separate from Dream-managed memory: when it has content,
+nanobot injects it near the start of the system prompt as user-authored
+authority for model behavior.
+
 ## The Files
 
 ```text
 workspace/
+├── AUTHORITY.md         # Optional high-priority moral/behavioral authority
 ├── SOUL.md              # The bot's long-term voice and communication style
 ├── USER.md              # Stable knowledge about the user
 └── memory/
@@ -77,6 +82,7 @@ workspace/
 
 These files play different roles:
 
+- `AUTHORITY.md` is intentionally blank by default. Fill it only when you want high-priority moral or behavioral authority text injected near the start of the system prompt.
 - `SOUL.md` remembers how nanobot should sound.
 - `USER.md` remembers who the user is and what they prefer.
 - `MEMORY.md` remembers what remains true about the work itself.
@@ -110,7 +116,7 @@ python -c "import json; [print(json.loads(l).get('content','')) for l in open('m
 The difference is philosophical as much as technical:
 
 - `history.jsonl` is for structure
-- `SOUL.md`, `USER.md`, and `MEMORY.md` are for meaning
+- `AUTHORITY.md`, `SOUL.md`, `USER.md`, and `MEMORY.md` are for meaning
 
 ## Commands
 

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -12,8 +12,8 @@ from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
 from nanobot.agent.tools import mcp as mcp_tools
 from nanobot.agent.tools.registry import ToolRegistry
-from nanobot.bus.events import InboundMessage
 from nanobot.apps.cli import utils as cli_app_utils
+from nanobot.bus.events import InboundMessage
 from nanobot.session.goal_state import goal_state_runtime_lines
 from nanobot.utils.helpers import (
     current_time_str,
@@ -52,7 +52,7 @@ async def handle_runtime_control(state: Any, msg: InboundMessage, tools: ToolReg
 class ContextBuilder:
     """Builds the context (system prompt + messages) for the agent."""
 
-    BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md"]
+    BOOTSTRAP_FILES = ["AUTHORITY.md", "AGENTS.md", "SOUL.md", "USER.md"]
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
     _MAX_RECENT_HISTORY = 50
     _MAX_HISTORY_CHARS = 32_000  # hard cap on recent history section size
@@ -161,6 +161,8 @@ class ContextBuilder:
             file_path = self.workspace / filename
             if file_path.exists():
                 content = file_path.read_text(encoding="utf-8")
+                if not content.strip():
+                    continue
                 parts.append(f"## {filename}\n\n{content}")
 
         return "\n\n".join(parts) if parts else ""

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -62,7 +62,7 @@ class MemoryStore:
         self._corruption_logged = False  # rate-limit non-int cursor warning
         self._oversize_logged = False  # rate-limit oversized-entry warning
         self._git = GitStore(workspace, tracked_files=[
-            "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor",
+            "AUTHORITY.md", "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor",
         ])
         self._maybe_migrate_legacy_history()
 

--- a/nanobot/templates/AGENTS.md
+++ b/nanobot/templates/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Workspace Guidance
 
-Use this file for project-specific preferences, recurring workflow conventions, and instructions you want the agent to remember for this workspace. Keep durable facts about the user in `USER.md`, personality/style guidance in `SOUL.md`, and long-term memory in `memory/MEMORY.md`.
+Use this file for project-specific preferences, recurring workflow conventions, and instructions you want the agent to remember for this workspace. Keep high-priority moral or behavioral authority in `AUTHORITY.md`, durable facts about the user in `USER.md`, personality/style guidance in `SOUL.md`, and long-term memory in `memory/MEMORY.md`.
 
 ## Scheduled Reminders
 

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -616,6 +616,7 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
         gs = GitStore(
             workspace,
             tracked_files=[
+                "AUTHORITY.md",
                 "SOUL.md",
                 "USER.md",
                 "memory/MEMORY.md",

--- a/tests/agent/test_context_builder.py
+++ b/tests/agent/test_context_builder.py
@@ -122,14 +122,26 @@ class TestLoadBootstrapFiles:
         assert "Be helpful." in result
 
     def test_multiple_bootstrap_files(self, tmp_path):
+        (tmp_path / "AUTHORITY.md").write_text("Authority.", encoding="utf-8")
         (tmp_path / "AGENTS.md").write_text("Rules.", encoding="utf-8")
         (tmp_path / "SOUL.md").write_text("Soul.", encoding="utf-8")
         builder = _builder(tmp_path)
         result = builder._load_bootstrap_files()
+        assert "## AUTHORITY.md" in result
         assert "## AGENTS.md" in result
         assert "## SOUL.md" in result
+        assert "Authority." in result
         assert "Rules." in result
         assert "Soul." in result
+        assert result.index("## AUTHORITY.md") < result.index("## AGENTS.md")
+
+    def test_empty_bootstrap_files_are_skipped(self, tmp_path):
+        (tmp_path / "AUTHORITY.md").write_text("", encoding="utf-8")
+        (tmp_path / "AGENTS.md").write_text("Rules.", encoding="utf-8")
+        builder = _builder(tmp_path)
+        result = builder._load_bootstrap_files()
+        assert "## AUTHORITY.md" not in result
+        assert "## AGENTS.md" in result
 
     def test_all_bootstrap_files(self, tmp_path):
         for name in ContextBuilder.BOOTSTRAP_FILES:

--- a/tests/agent/test_onboard_logic.py
+++ b/tests/agent/test_onboard_logic.py
@@ -332,6 +332,8 @@ class TestSyncWorkspaceTemplates:
 
         # Check that some files were created
         assert isinstance(added, list)
+        assert "AUTHORITY.md" in added
+        assert (workspace / "AUTHORITY.md").read_text(encoding="utf-8") == ""
         # The actual files depend on the templates directory
 
     def test_does_not_overwrite_existing_files(self, tmp_path):


### PR DESCRIPTION
## Goal

Add an optional `AUTHORITY.md` workspace file that can be filled by users to provide high-priority moral or behavioral authority near the start of the agent system prompt.

## Changes

- Adds an empty bundled `nanobot/templates/AUTHORITY.md` template.
- Includes `AUTHORITY.md` as the first bootstrap file in system prompt assembly, before `AGENTS.md`, `SOUL.md`, and `USER.md`.
- Skips blank bootstrap files so the empty default template does not add an empty prompt section.
- Creates `AUTHORITY.md` during workspace template sync without overwriting user content.
- Tracks `AUTHORITY.md` in GitStore alongside other durable workspace prompt/memory files.
- Updates docs and default `AGENTS.md` guidance to describe the file.
- Adds focused tests for injection order, blank-file skipping, and template creation.

## Why This Was Needed

`SOUL.md` already gives users a durable way to shape the bot's voice and style, but there was no separate first-class file for higher-priority behavior or morality instructions that should be treated as user-authored authority rather than ordinary memory.

This introduces that layer while keeping the default file empty and inert until the user explicitly fills it.

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/agent/test_context_builder.py tests/agent/test_onboard_logic.py tests/agent/test_context_prompt_cache.py tests/agent/test_memory_store.py -q`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev ruff check nanobot/agent/context.py nanobot/agent/memory.py nanobot/utils/helpers.py`
- `git diff --check`

The bundled `AUTHORITY.md` template is intentionally 0 bytes.