### PR TITLE
Add chat sender identity context

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -12,8 +12,8 @@ from nanobot.agent.memory import MemoryStore
 from nanobot.agent.skills import SkillsLoader
 from nanobot.agent.tools import mcp as mcp_tools
 from nanobot.agent.tools.registry import ToolRegistry
-from nanobot.bus.events import InboundMessage
 from nanobot.apps.cli import utils as cli_app_utils
+from nanobot.bus.events import InboundMessage
 from nanobot.session.goal_state import goal_state_runtime_lines
 from nanobot.utils.helpers import (
     current_time_str,
@@ -21,6 +21,7 @@ from nanobot.utils.helpers import (
     truncate_text,
 )
 from nanobot.utils.prompt_templates import render_template
+from nanobot.utils.sender_identity import sender_runtime_lines
 
 
 def session_extra(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -31,6 +32,10 @@ def session_extra(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
 def runtime_lines(state: Any, msg: Any, workspace: Path, *, skip: bool = False) -> list[str]:
     """Return model-visible runtime annotations for turn-attached capabilities."""
     return [
+        *sender_runtime_lines(
+            getattr(msg, "metadata", None),
+            sender_id=getattr(msg, "sender_id", None),
+        ),
         *cli_app_utils.runtime_lines(msg, workspace, skip=skip),
         *mcp_tools.runtime_lines(
             msg,

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -53,6 +53,10 @@ from nanobot.utils.runtime import (
     EMPTY_FINAL_RESPONSE_MESSAGE,
     SUSTAINED_GOAL_CONTINUE_PROMPT,
 )
+from nanobot.utils.sender_identity import (
+    annotate_user_content_with_sender,
+    sender_session_extra,
+)
 
 if TYPE_CHECKING:
     from nanobot.config.schema import (
@@ -558,7 +562,11 @@ class AgentLoop:
         media_paths = [p for p in (msg.media or []) if isinstance(p, str) and p]
         has_text = isinstance(msg.content, str) and msg.content.strip()
         if has_text or media_paths:
-            extra: dict[str, Any] = ({"media": list(media_paths)} if media_paths else {}) | agent_context.session_extra(msg.metadata)
+            extra: dict[str, Any] = (
+                ({"media": list(media_paths)} if media_paths else {})
+                | agent_context.session_extra(msg.metadata)
+                | sender_session_extra(msg.metadata, sender_id=msg.sender_id)
+            )
             extra.update(kwargs)
             text = msg.content if isinstance(msg.content, str) else ""
             session.add_message("user", text, **extra)
@@ -700,6 +708,13 @@ class AgentLoop:
                     content, media = extract_documents(content, media)
                     media = media or None
                 user_content = self.context._build_user_content(content, media)
+                user_content = annotate_user_content_with_sender(
+                    sender_session_extra(
+                        pending_msg.metadata,
+                        sender_id=pending_msg.sender_id,
+                    ),
+                    user_content,
+                )
                 return {"role": "user", "content": user_content}
 
             items: list[dict[str, Any]] = []

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -19,6 +19,7 @@ from nanobot.command.builtin import build_help_text
 from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 from nanobot.utils.helpers import safe_filename, split_message
+from nanobot.utils.sender_identity import SENDER_DISPLAY_NAME_KEY, SENDER_USERNAME_KEY
 
 DISCORD_AVAILABLE = importlib.util.find_spec("discord") is not None
 if TYPE_CHECKING:
@@ -171,6 +172,7 @@ if DISCORD_AVAILABLE:
                 "interaction_id": str(interaction.id),
                 "guild_id": str(interaction.guild_id) if interaction.guild_id else None,
                 "is_slash_command": True,
+                **self._channel._author_identity_metadata(interaction.user),
             }
             session_key = None
             if channel is not None:
@@ -692,7 +694,23 @@ class DiscordChannel(BaseChannel):
         return message_type not in {discord.MessageType.default, discord.MessageType.reply}
 
     @staticmethod
-    def _build_inbound_metadata(message: discord.Message) -> dict[str, str | None]:
+    def _author_identity_metadata(author: Any) -> dict[str, str]:
+        """Return model-visible Discord user identity metadata."""
+        username = getattr(author, "name", None)
+        display_name = (
+            getattr(author, "display_name", None)
+            or getattr(author, "global_name", None)
+            or username
+        )
+        metadata: dict[str, str] = {}
+        if display_name:
+            metadata[SENDER_DISPLAY_NAME_KEY] = str(display_name)
+        if username:
+            metadata[SENDER_USERNAME_KEY] = str(username)
+        return metadata
+
+    @classmethod
+    def _build_inbound_metadata(cls, message: discord.Message) -> dict[str, str | None]:
         """Build metadata for inbound Discord messages."""
         reply_to = (
             str(message.reference.message_id)
@@ -703,6 +721,7 @@ class DiscordChannel(BaseChannel):
             "message_id": str(message.id),
             "guild_id": str(message.guild.id) if message.guild else None,
             "reply_to": reply_to,
+            **cls._author_identity_metadata(message.author),
         }
 
     def _should_respond_in_group(self, message: discord.Message, content: str) -> bool:

--- a/nanobot/channels/msteams.py
+++ b/nanobot/channels/msteams.py
@@ -39,6 +39,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.config.paths import get_workspace_path
 from nanobot.config.schema import Base
+from nanobot.utils.sender_identity import SENDER_DISPLAY_NAME_KEY
 
 MSTEAMS_AVAILABLE = (
     importlib.util.find_spec("jwt") is not None
@@ -324,6 +325,7 @@ class MSTeamsChannel(BaseChannel):
             chat_id=conversation_id,
             content=text,
             metadata={
+                SENDER_DISPLAY_NAME_KEY: from_user.get("name"),
                 "msteams": {
                     "activity_id": activity_id,
                     "conversation_id": conversation_id,

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -20,6 +20,7 @@ from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 from nanobot.pairing import is_approved
 from nanobot.utils.helpers import safe_filename, split_message
+from nanobot.utils.sender_identity import SENDER_DISPLAY_NAME_KEY, SENDER_USERNAME_KEY
 
 
 class SlackDMConfig(Base):
@@ -432,12 +433,26 @@ class SlackChannel(BaseChannel):
             return
 
         try:
+            user_profile = event.get("user_profile") if isinstance(event, dict) else None
+            identity_meta: dict[str, Any] = {}
+            if isinstance(user_profile, dict):
+                display_name = (
+                    user_profile.get("display_name")
+                    or user_profile.get("real_name")
+                    or user_profile.get("name")
+                )
+                username = user_profile.get("name")
+                if display_name:
+                    identity_meta[SENDER_DISPLAY_NAME_KEY] = display_name
+                if username:
+                    identity_meta[SENDER_USERNAME_KEY] = username
             await self._handle_message(
                 sender_id=sender_id,
                 chat_id=chat_id,
                 content=content,
                 media=media_paths,
                 metadata={
+                    **identity_meta,
                     "slack": {
                         "event": event,
                         "thread_ts": thread_ts,

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -33,6 +33,7 @@ from nanobot.config.paths import get_media_dir
 from nanobot.config.schema import Base
 from nanobot.security.network import validate_url_target
 from nanobot.utils.helpers import split_message
+from nanobot.utils.sender_identity import SENDER_DISPLAY_NAME_KEY, SENDER_USERNAME_KEY
 
 TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
 # Telegram's actual API limit is 4096; we split raw markdown at 4000 as a
@@ -903,11 +904,18 @@ class TelegramChannel(BaseChannel):
     def _build_message_metadata(message, user) -> dict:
         """Build common Telegram inbound metadata payload."""
         reply_to = getattr(message, "reply_to_message", None)
+        display_name = getattr(user, "full_name", None) or " ".join(
+            part
+            for part in (getattr(user, "first_name", None), getattr(user, "last_name", None))
+            if part
+        )
         return {
             "message_id": message.message_id,
             "user_id": user.id,
             "username": user.username,
             "first_name": user.first_name,
+            SENDER_DISPLAY_NAME_KEY: display_name or None,
+            SENDER_USERNAME_KEY: user.username,
             "is_group": message.chat.type != "private",
             "message_thread_id": getattr(message, "message_thread_id", None),
             "is_forum": bool(getattr(message.chat, "is_forum", False)),

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -20,6 +20,7 @@ from nanobot.utils.helpers import (
     image_placeholder_text,
     safe_filename,
 )
+from nanobot.utils.sender_identity import annotate_user_content_with_sender
 from nanobot.utils.subagent_channel_display import scrub_subagent_announce_body
 
 FILE_MAX_MESSAGES = 2000
@@ -206,6 +207,8 @@ class Session:
                 if mcp_lines:
                     breadcrumbs = "\n".join(mcp_lines)
                     content = f"{content}\n{breadcrumbs}" if content else breadcrumbs
+            if role == "user":
+                content = annotate_user_content_with_sender(message, content)
             if include_timestamps:
                 content = self._annotate_message_time(message, content)
             if role == "assistant" and isinstance(content, str) and not content.strip():

--- a/nanobot/utils/sender_identity.py
+++ b/nanobot/utils/sender_identity.py
@@ -1,0 +1,93 @@
+"""Normalize chat sender identity for model-visible context."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+_MAX_IDENTITY_CHARS = 200
+_SPACE_RE = re.compile(r"\s+")
+
+SENDER_DISPLAY_NAME_KEY = "sender_display_name"
+SENDER_USERNAME_KEY = "sender_username"
+SENDER_ID_KEY = "sender_id"
+
+
+def _clean_identity_value(value: Any) -> str | None:
+    """Return a compact single-line identity value, or None when blank."""
+    if value is None:
+        return None
+    text = _SPACE_RE.sub(" ", str(value).replace("\x00", "")).strip()
+    if not text:
+        return None
+    if len(text) > _MAX_IDENTITY_CHARS:
+        text = text[: _MAX_IDENTITY_CHARS - 1].rstrip() + "..."
+    return text
+
+
+def sender_session_extra(
+    metadata: Mapping[str, Any] | None,
+    *,
+    sender_id: str | None = None,
+) -> dict[str, str]:
+    """Return normalized sender identity fields safe to persist in a session."""
+    meta = metadata or {}
+    extra: dict[str, str] = {}
+
+    display_name = _clean_identity_value(meta.get(SENDER_DISPLAY_NAME_KEY))
+    username = _clean_identity_value(meta.get(SENDER_USERNAME_KEY))
+    clean_sender_id = _clean_identity_value(sender_id or meta.get(SENDER_ID_KEY))
+
+    if clean_sender_id:
+        extra[SENDER_ID_KEY] = clean_sender_id
+    if display_name:
+        extra[SENDER_DISPLAY_NAME_KEY] = display_name
+    if username:
+        extra[SENDER_USERNAME_KEY] = username
+    return extra
+
+
+def sender_runtime_lines(
+    metadata: Mapping[str, Any] | None,
+    *,
+    sender_id: str | None = None,
+) -> list[str]:
+    """Return runtime context lines describing the sender."""
+    extra = sender_session_extra(metadata, sender_id=sender_id)
+    lines: list[str] = []
+    if display_name := extra.get(SENDER_DISPLAY_NAME_KEY):
+        lines.append(f"Sender Display Name: {display_name}")
+    if username := extra.get(SENDER_USERNAME_KEY):
+        lines.append(f"Sender Username: {username}")
+    return lines
+
+
+def sender_history_prefix(message: Mapping[str, Any]) -> str | None:
+    """Return a compact sender prefix for replayed user turns."""
+    extra = sender_session_extra(message)
+    if not extra:
+        return None
+
+    parts: list[str] = []
+    if display_name := extra.get(SENDER_DISPLAY_NAME_KEY):
+        parts.append(f"display_name={display_name}")
+    if username := extra.get(SENDER_USERNAME_KEY):
+        parts.append(f"username={username}")
+    if sender_id := extra.get(SENDER_ID_KEY):
+        parts.append(f"id={sender_id}")
+    return "[Message Sender: " + "; ".join(parts) + "]"
+
+
+def annotate_user_content_with_sender(
+    message: Mapping[str, Any],
+    content: Any,
+) -> Any:
+    """Prepend sender identity metadata to a replayed user message."""
+    prefix = sender_history_prefix(message)
+    if not prefix:
+        return content
+    if isinstance(content, str):
+        return f"{prefix}\n{content}" if content else prefix
+    if isinstance(content, list):
+        return [{"type": "text", "text": prefix}, *content]
+    return content

--- a/tests/agent/test_context_builder.py
+++ b/tests/agent/test_context_builder.py
@@ -37,6 +37,20 @@ class TestBuildRuntimeContext:
         ctx = ContextBuilder._build_runtime_context("cli", "direct", sender_id="user1")
         assert "Sender ID: user1" in ctx
 
+    def test_with_sender_identity_lines(self):
+        ctx = ContextBuilder._build_runtime_context(
+            "discord",
+            "123",
+            sender_id="42",
+            supplemental_lines=[
+                "Sender Display Name: Alice Example",
+                "Sender Username: alice",
+            ],
+        )
+        assert "Sender Display Name: Alice Example" in ctx
+        assert "Sender Username: alice" in ctx
+        assert "Sender ID: 42" in ctx
+
     def test_with_timezone(self):
         ctx = ContextBuilder._build_runtime_context(None, None, timezone="Asia/Shanghai")
         assert "Current Time:" in ctx

--- a/tests/agent/test_runner_injections.py
+++ b/tests/agent/test_runner_injections.py
@@ -403,6 +403,59 @@ async def test_loop_injected_followup_preserves_image_media(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_loop_injected_followup_includes_sender_identity(tmp_path):
+    from nanobot.agent.loop import AgentLoop
+    from nanobot.bus.events import InboundMessage
+    from nanobot.bus.queue import MessageBus
+
+    bus = MessageBus()
+    provider = MagicMock()
+    provider.get_default_model.return_value = "test-model"
+    captured_messages: list[list[dict]] = []
+    call_count = {"n": 0}
+
+    async def chat_with_retry(*, messages, **kwargs):
+        call_count["n"] += 1
+        captured_messages.append(list(messages))
+        if call_count["n"] == 1:
+            return LLMResponse(content="first answer", tool_calls=[], usage={})
+        return LLMResponse(content="second answer", tool_calls=[], usage={})
+
+    provider.chat_with_retry = chat_with_retry
+    loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, model="test-model")
+    loop.tools.get_definitions = MagicMock(return_value=[])
+
+    pending_queue = asyncio.Queue()
+    await pending_queue.put(InboundMessage(
+        channel="discord",
+        sender_id="123",
+        chat_id="c",
+        content="another point",
+        metadata={
+            "sender_display_name": "Alice Example",
+            "sender_username": "alice",
+        },
+    ))
+
+    await loop._run_agent_loop(
+        [{"role": "user", "content": "hello"}],
+        channel="discord",
+        chat_id="c",
+        pending_queue=pending_queue,
+    )
+
+    injected = [
+        message for message in captured_messages[-1]
+        if message.get("role") == "user"
+        and "another point" in str(message.get("content"))
+    ][-1]
+    assert (
+        "[Message Sender: display_name=Alice Example; username=alice; id=123]"
+        in str(injected["content"])
+    )
+
+
+@pytest.mark.asyncio
 async def test_runner_merges_multiple_injected_user_messages_without_losing_media():
     """Multiple injected follow-ups should not create lossy consecutive user messages."""
     from nanobot.agent.runner import AgentRunSpec, AgentRunner
@@ -1035,4 +1088,3 @@ async def test_injection_cycle_cap_on_error_path():
     assert result.had_injections is True
     # Should cap: _MAX_INJECTION_CYCLES drained rounds + 1 final round that breaks
     assert call_count["n"] == _MAX_INJECTION_CYCLES + 1
-

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -314,6 +314,31 @@ def test_get_history_does_not_annotate_tool_results_with_timestamps():
     assert tool_result["content"] == "ok"
 
 
+def test_get_history_includes_sender_identity_for_user_turns():
+    session = Session(key="discord:shared")
+    session.messages.append({
+        "role": "user",
+        "content": "please summarize this",
+        "timestamp": "2026-04-26T22:00:00",
+        "sender_id": "123",
+        "sender_display_name": "Alice Example",
+        "sender_username": "alice",
+    })
+
+    history = session.get_history(max_messages=500, include_timestamps=True)
+
+    assert history == [
+        {
+            "role": "user",
+            "content": (
+                "[Message Time: 2026-04-26T22:00:00]\n"
+                "[Message Sender: display_name=Alice Example; username=alice; id=123]\n"
+                "please summarize this"
+            ),
+        },
+    ]
+
+
 # --- Window cuts mid-group: assistant present but some tool results orphaned ---
 
 def test_window_cuts_mid_tool_group():

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -154,13 +154,20 @@ class _FakeInteractionResponse:
 def _make_interaction(
     *,
     user_id: int = 123,
+    username: str | None = None,
+    display_name: str | None = None,
     channel_id: int | None = 456,
     channel=None,
     guild_id: int | None = None,
     interaction_id: int = 999,
 ):
+    user = SimpleNamespace(id=user_id)
+    if username is not None:
+        user.name = username
+    if display_name is not None:
+        user.display_name = display_name
     return SimpleNamespace(
-        user=SimpleNamespace(id=user_id),
+        user=user,
         channel_id=channel_id,
         channel=channel,
         guild_id=guild_id,
@@ -173,6 +180,8 @@ def _make_interaction(
 def _make_message(
     *,
     author_id: int = 123,
+    username: str | None = None,
+    display_name: str | None = None,
     author_bot: bool = False,
     channel_id: int = 456,
     parent_channel_id: int | None = None,
@@ -197,8 +206,13 @@ def _make_message(
         if reply_to is not None
         else None
     )
+    author = SimpleNamespace(id=author_id, bot=author_bot)
+    if username is not None:
+        author.name = username
+    if display_name is not None:
+        author.display_name = display_name
     return SimpleNamespace(
-        author=SimpleNamespace(id=author_id, bot=author_bot),
+        author=author,
         channel=_FakeChannel(channel_id, parent_channel_id),
         content=content,
         guild=guild,
@@ -358,6 +372,30 @@ async def test_on_message_accepts_allowlisted_dm() -> None:
     assert len(handled) == 1
     assert handled[0]["chat_id"] == "456"
     assert handled[0]["metadata"] == {"message_id": "789", "guild_id": None, "reply_to": None}
+
+
+@pytest.mark.asyncio
+async def test_on_message_includes_author_identity_metadata() -> None:
+    channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["123"]), MessageBus())
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle  # type: ignore[method-assign]
+
+    await channel._on_message(
+        _make_message(
+            author_id=123,
+            username="alice",
+            display_name="Alice Example",
+            channel_id=456,
+            message_id=789,
+        )
+    )
+
+    assert handled[0]["metadata"]["sender_display_name"] == "Alice Example"
+    assert handled[0]["metadata"]["sender_username"] == "alice"
 
 
 @pytest.mark.asyncio
@@ -776,6 +814,32 @@ async def test_slash_new_forwards_when_user_is_allowlisted() -> None:
     assert handled[0]["chat_id"] == "456"
     assert handled[0]["metadata"]["interaction_id"] == "321"
     assert handled[0]["metadata"]["is_slash_command"] is True
+
+
+@pytest.mark.asyncio
+async def test_slash_command_includes_user_identity() -> None:
+    channel = DiscordChannel(DiscordConfig(enabled=True, allow_from=["123"]), MessageBus())
+    handled: list[dict] = []
+
+    async def capture_handle(**kwargs) -> None:
+        handled.append(kwargs)
+
+    channel._handle_message = capture_handle  # type: ignore[method-assign]
+    client = DiscordBotClient(channel, intents=discord.Intents.none())
+    interaction = _make_interaction(
+        user_id=123,
+        username="alice",
+        display_name="Alice Example",
+        channel_id=456,
+        interaction_id=321,
+    )
+
+    status_cmd = client.tree.get_command("status")
+    assert status_cmd is not None
+    await status_cmd.callback(interaction)
+
+    assert handled[0]["metadata"]["sender_display_name"] == "Alice Example"
+    assert handled[0]["metadata"]["sender_username"] == "alice"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Goal

Let nanobot distinguish who is speaking when multiple people chat with it in the same shared channel, especially Discord guild channels and threads.

## Changes

- Added a shared sender identity helper that normalizes display names, usernames, and sender IDs for model-visible context.
- Discord now attaches sender display name and username metadata for normal messages and slash commands.
- Telegram, Slack, and Microsoft Teams attach the same standard metadata where their inbound events already expose it.
- Persisted user turns now retain sender identity, and replayed history prefixes user messages with compact sender metadata.
- Current turns expose sender display name and username in runtime context, and mid-turn injected follow-ups include sender identity as well.
- Added focused tests for Discord metadata capture, runtime context, session history replay, and pending follow-up injection.

## Why

In shared channels, all human turns previously reached the model as generic user messages plus an opaque sender ID. That made it hard for the model to answer group conversations naturally, attribute requests correctly, or understand when a different person had joined the same session. The new metadata gives the model stable human-facing names without changing connector routing behavior.

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev --extra discord pytest tests/agent/test_context_builder.py tests/agent/test_session_manager_history.py tests/agent/test_runner_injections.py tests/channels/test_discord_channel.py -q`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev --extra msteams pytest tests/channels/test_telegram_channel.py tests/channels/test_slack_channel.py tests/test_msteams.py -q`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev ruff check nanobot/utils/sender_identity.py nanobot/agent/context.py nanobot/agent/loop.py nanobot/session/manager.py nanobot/channels/discord.py nanobot/channels/telegram.py nanobot/channels/slack.py nanobot/channels/msteams.py`
- `git diff --check`
