### PR TITLE
feat(apps): add nanobot extension registry

### DIFF
--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -302,6 +302,11 @@ def _brand_candidates(app: dict[str, Any]) -> list[str]:
 
 
 def _brand_payload(app: dict[str, Any]) -> tuple[str | None, str | None]:
+    declared_logo = str(app.get("logo_url") or "").strip()
+    if declared_logo.startswith(("https://", "/")):
+        declared_color = str(app.get("brand_color") or "").strip()
+        return declared_logo, declared_color or None
+
     brand = None
     domain_brand = None
     for candidate in _brand_candidates(app):

--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -25,7 +25,13 @@ from nanobot.security.workspace_policy import is_path_within
 CLI_ANYTHING_REGISTRY_URL = "https://hkuds.github.io/CLI-Anything/registry.json"
 CLI_ANYTHING_PUBLIC_REGISTRY_URL = "https://hkuds.github.io/CLI-Anything/public_registry.json"
 CLI_ANYTHING_RAW_BASE = "https://raw.githubusercontent.com/HKUDS/CLI-Anything/main"
-CLI_ANYTHING_RAW_SKILLS_BASE = f"{CLI_ANYTHING_RAW_BASE}/skills/"
+NANOBOT_EXTENSION_REGISTRY_URL = "https://raw.githubusercontent.com/Re-bin/nanobot-extension/main/registry.json"
+NANOBOT_EXTENSION_RAW_BASE = "https://raw.githubusercontent.com/Re-bin/nanobot-extension/main"
+_CATALOG_SOURCES = (
+    ("harness", CLI_ANYTHING_REGISTRY_URL, CLI_ANYTHING_RAW_BASE, True),
+    ("public", CLI_ANYTHING_PUBLIC_REGISTRY_URL, CLI_ANYTHING_RAW_BASE, True),
+    ("extensions", NANOBOT_EXTENSION_REGISTRY_URL, NANOBOT_EXTENSION_RAW_BASE, False),
+)
 
 _MAX_TOOL_OUTPUT_CHARS = 12_000
 _MAX_ARTIFACT_SCAN_PATHS = 4_000
@@ -344,16 +350,17 @@ def _safe_skill_path(value: str) -> str | None:
     return value if parts[-1] == "SKILL.md" else None
 
 
-def _skill_content_url(skill_md: str) -> str | None:
+def _skill_content_url(skill_md: str, *, raw_base: str = CLI_ANYTHING_RAW_BASE) -> str | None:
     safe_path = _safe_skill_path(skill_md)
     if safe_path:
-        return f"{CLI_ANYTHING_RAW_BASE}/{safe_path}"
+        return f"{raw_base.rstrip('/')}/{safe_path}"
     parsed = urlparse(skill_md)
     if parsed.scheme != "https" or parsed.netloc != "raw.githubusercontent.com":
         return None
-    if not skill_md.startswith(CLI_ANYTHING_RAW_SKILLS_BASE):
+    raw_prefix = raw_base.rstrip("/") + "/"
+    if not skill_md.startswith(raw_prefix):
         return None
-    suffix = skill_md.removeprefix(f"{CLI_ANYTHING_RAW_BASE}/")
+    suffix = skill_md.removeprefix(raw_prefix)
     return skill_md if _safe_skill_path(suffix) else None
 
 
@@ -435,27 +442,22 @@ class CliAppManager:
         return data
 
     def catalog(self, *, force_refresh: bool = False) -> tuple[list[dict[str, Any]], str | None]:
-        registries = [
-            (
-                "harness",
-                self._fetch_registry(
-                    CLI_ANYTHING_REGISTRY_URL,
-                    self._cache_path("harness"),
+        registries: list[tuple[str, str, dict[str, Any]]] = []
+        for source, url, raw_base, required in _CATALOG_SOURCES:
+            try:
+                registry = self._fetch_registry(
+                    url,
+                    self._cache_path(source),
                     force_refresh=force_refresh,
-                ),
-            ),
-            (
-                "public",
-                self._fetch_registry(
-                    CLI_ANYTHING_PUBLIC_REGISTRY_URL,
-                    self._cache_path("public"),
-                    force_refresh=force_refresh,
-                ),
-            ),
-        ]
+                )
+            except Exception:
+                if required:
+                    raise
+                continue
+            registries.append((source, raw_base, registry))
         apps_by_name: dict[str, dict[str, Any]] = {}
         updated_values: list[str] = []
-        for source, registry in registries:
+        for source, raw_base, registry in registries:
             meta = registry.get("meta")
             if isinstance(meta, dict) and isinstance(meta.get("updated"), str):
                 updated_values.append(meta["updated"])
@@ -464,6 +466,7 @@ class CliAppManager:
                     continue
                 entry = dict(row)
                 entry["_source"] = source
+                entry["_raw_base"] = raw_base
                 key = str(entry["name"]).lower()
                 previous = apps_by_name.get(key)
                 if previous:
@@ -475,6 +478,15 @@ class CliAppManager:
                 else:
                     apps_by_name[key] = entry
         return list(apps_by_name.values()), max(updated_values) if updated_values else None
+
+    def _manifest_source(self, app: dict[str, Any]) -> str:
+        source = str(app.get("_source") or "harness")
+        if source == "extensions":
+            return "nanobot-extension"
+        return f"cli-anything:{source}"
+
+    def _trust_registry(self, app: dict[str, Any]) -> str:
+        return "nanobot-extension" if str(app.get("_source") or "") == "extensions" else "cli-anything"
 
     def get_app(self, name: str, *, force_refresh: bool = False) -> dict[str, Any]:
         wanted = name.lower()
@@ -640,14 +652,14 @@ class CliAppManager:
             version=str(app.get("version") or ""),
             description=_catalog_description(app),
             category=str(app.get("category") or "uncategorized"),
-            source=f"cli-anything:{app.get('_source') or 'harness'}",
+            source=self._manifest_source(app),
             logo_url=logo_url,
             brand_color=brand_color,
             capabilities=capabilities,
             install=install,
             remove=remove,
             trust={
-                "registry": "cli-anything",
+                "registry": self._trust_registry(app),
                 "level": "catalog",
                 "review_status": "catalog_entry",
             },
@@ -793,7 +805,7 @@ class CliAppManager:
         skill_md = str(app.get("skill_md") or "").strip()
         if not skill_md:
             return None
-        url = _skill_content_url(skill_md)
+        url = _skill_content_url(skill_md, raw_base=str(app.get("_raw_base") or CLI_ANYTHING_RAW_BASE))
         if not url:
             return None
         try:

--- a/nanobot/apps/cli/service.py
+++ b/nanobot/apps/cli/service.py
@@ -37,6 +37,7 @@ _MAX_TOOL_OUTPUT_CHARS = 12_000
 _MAX_ARTIFACT_SCAN_PATHS = 4_000
 _MAX_ARTIFACT_REPORT = 12
 _SAFE_NAME_RE = re.compile(r"[^a-z0-9_-]+")
+_SAFE_NPM_DIR_RE = re.compile(r"^[a-z0-9._-]+$", re.IGNORECASE)
 _MENTION_RE = re.compile(r"(^|[\s([{])@([a-z0-9_-]+)\b", re.IGNORECASE)
 _SHELL_META_CHARS = ("|", "&&", "||", ";", "$(", "`", ">", "<")
 _ENDORSEMENT_WORD_RE = re.compile(r"\bofficial\s+", re.IGNORECASE)
@@ -740,6 +741,45 @@ class CliAppManager:
             return [npm, "install", "-g", package + "@latest"]
         return [npm, "uninstall", "-g", package]
 
+    def _cleanup_stale_npm_install(self, app: dict[str, Any]) -> bool:
+        npm = shutil.which("npm")
+        package = str(app.get("npm_package") or "").strip()
+        if not npm or not package or "/" in package or _SAFE_NPM_DIR_RE.match(package) is None:
+            return False
+        result = self._run_argv([npm, "root", "-g"], timeout=min(self.runtime.install_timeout, 30))
+        if result.returncode != 0:
+            return False
+        root = Path(result.stdout.strip()).expanduser()
+        try:
+            root = root.resolve(strict=True)
+        except OSError:
+            return False
+        targets = [root / package, *root.glob(f".{package}-*")]
+        removed = False
+        for target in targets:
+            try:
+                resolved = target.resolve(strict=False)
+                if not is_path_within(resolved, root) or not target.is_dir():
+                    continue
+                shutil.rmtree(target)
+                removed = True
+            except OSError:
+                continue
+        return removed
+
+    def _retry_stale_npm_install(
+        self,
+        app: dict[str, Any],
+        argv: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        output = f"{result.stderr}\n{result.stdout}"
+        if "ENOTEMPTY" not in output or "rename" not in output:
+            return result
+        if not self._cleanup_stale_npm_install(app):
+            return result
+        return self._run_argv(argv, timeout=self.runtime.install_timeout)
+
     def _split_safe_command(self, app: dict[str, Any], key: str, expected: str) -> list[str]:
         command = str(app.get(key) or "")
         if not command:
@@ -893,6 +933,17 @@ Use the `run_cli_app` tool with `name="{name}"` for command execution. Do not in
         if not self._install_supported(app):
             raise CliAppError("this CLI app uses an unsupported install strategy")
         strategy = self._strategy(app)
+        entry_point = str(app.get("entry_point") or "")
+        if entry_point and shutil.which(entry_point):
+            self._record_installed(app)
+            return self.payload() | {
+                "last_action": {
+                    "ok": True,
+                    "message": f"CLI for {app['display_name']} is already available.",
+                    "installed": True,
+                    "verification": ["entry_point_available", "state_recorded", "managed_paths_present"],
+                }
+            }
         if strategy == "bundled":
             detect_cmd = str(app.get("detect_cmd") or app.get("entry_point") or "")
             if detect_cmd and _command_exists(detect_cmd):
@@ -910,6 +961,8 @@ Use the `run_cli_app` tool with `name="{name}"` for command execution. Do not in
         argv = self._argv_for_action(app, "install")
         assert argv is not None
         result = self._run_argv(argv, timeout=self.runtime.install_timeout)
+        if strategy == "npm" and result.returncode != 0:
+            result = self._retry_stale_npm_install(app, argv, result)
         if result.returncode != 0:
             raise CliAppError(_truncate(result.stderr or result.stdout or "install failed"), status=500)
         self._record_installed(app)

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -730,22 +730,64 @@ class WebSocketChannel(BaseChannel):
         """Route an inbound HTTP request to a handler or to the WS upgrade path."""
         got, query = _parse_request_path(request.path)
 
-        # 1. Token issue endpoint (legacy, optional, gated by configured secret).
         if self.config.token_issue_path:
             issue_expected = _normalize_config_path(self.config.token_issue_path)
             if got == issue_expected:
                 return self._handle_token_issue_http(connection, request)
 
-        # 2. Bootstrap (`/webui/bootstrap`): mint WS/API tokens + shared session metadata.
         if got == "/webui/bootstrap":
             return self._handle_bootstrap(connection, request)
 
-        # 3. REST handlers co-located with this channel (sessions, settings, …).
+        api_response = await self._dispatch_api_route(connection, request, got)
+        if api_response is not None:
+            return api_response
+
+        ws_matched, ws_response = self._dispatch_websocket_upgrade(
+            connection, request, got, query
+        )
+        if ws_matched:
+            return ws_response
+
+        # API clients should never receive the SPA shell for an unknown route.
+        # Returning HTML here makes the WebUI fail with "Unexpected token <"
+        # when a dev server is pointed at an older gateway.
+        if got.startswith("/api/"):
+            return _http_error(404, "API route not found")
+
+        if self._static_dist_path is not None:
+            response = self._serve_static(got)
+            if response is not None:
+                return response
+
+        return connection.respond(404, "Not Found")
+
+    async def _dispatch_api_route(
+        self,
+        connection: Any,
+        request: WsRequest,
+        got: str,
+    ) -> Any | None:
+        """Route REST-ish WebUI requests served beside the WebSocket endpoint."""
+        response = await self._dispatch_settings_api_route(request, got)
+        if response is not None:
+            return response
+        response = self._dispatch_session_api_route(request, got)
+        if response is not None:
+            return response
+        response = self._dispatch_media_api_route(request, got)
+        if response is not None:
+            return response
+        return self._dispatch_misc_api_route(connection, request, got)
+
+    def _dispatch_misc_api_route(
+        self,
+        connection: Any,
+        request: WsRequest,
+        got: str,
+    ) -> Response | None:
+        """Route small API endpoints that do not belong to a larger route group."""
         if got == "/api/sessions":
             return self._handle_sessions_list(request)
-
-        if got == "/api/settings":
-            return self._handle_settings(request)
 
         if got == "/api/commands":
             return self._handle_commands(request)
@@ -758,6 +800,16 @@ class WebSocketChannel(BaseChannel):
 
         if got == "/api/webui/sidebar-state/update":
             return self._handle_webui_sidebar_state_update(request)
+
+        return None
+
+    async def _dispatch_settings_api_route(
+        self,
+        request: WsRequest,
+        got: str,
+    ) -> Response | None:
+        if got == "/api/settings":
+            return self._handle_settings(request)
 
         if got == "/api/settings/update":
             return self._handle_settings_update(request)
@@ -808,6 +860,13 @@ class WebSocketChannel(BaseChannel):
         if mcp_action is not None:
             return await self._handle_settings_mcp_presets(request, mcp_action)
 
+        return None
+
+    def _dispatch_session_api_route(
+        self,
+        request: WsRequest,
+        got: str,
+    ) -> Response | None:
         m = re.match(r"^/api/sessions/([^/]+)/messages$", got)
         if m:
             return self._handle_session_messages(request, m.group(1))
@@ -822,40 +881,36 @@ class WebSocketChannel(BaseChannel):
         if m:
             return self._handle_session_delete(request, m.group(1))
 
-        # Signed media fetch: ``<sig>`` is an HMAC over ``<payload>``; the
-        # payload decodes to a path inside :func:`get_media_dir`. See
-        # :meth:`_sign_media_path` for the inverse direction used to build
-        # these URLs when replaying a session.
+        return None
+
+    def _dispatch_media_api_route(
+        self,
+        request: WsRequest,
+        got: str,
+    ) -> Response | None:
         m = re.match(r"^/api/media/([A-Za-z0-9_-]+)/([A-Za-z0-9_-]+)$", got)
         if m:
             return self._handle_media_fetch(m.group(1), m.group(2), request)
 
-        # 4. WebSocket upgrade (the channel's primary purpose). Only run the
-        # handshake gate on requests that actually ask to upgrade; otherwise
-        # a bare ``GET /`` from the browser would be rejected as an
-        # unauthorized WS handshake instead of serving the SPA's index.html.
+        return None
+
+    def _dispatch_websocket_upgrade(
+        self,
+        connection: Any,
+        request: WsRequest,
+        got: str,
+        query: dict[str, list[str]],
+    ) -> tuple[bool, Any | None]:
+        """Authorize only real WS upgrade requests for the configured path."""
         expected_ws = self._expected_path()
-        if got == expected_ws and _is_websocket_upgrade(request):
-            client_id = _query_first(query, "client_id") or ""
-            if len(client_id) > 128:
-                client_id = client_id[:128]
-            if not self.is_allowed(client_id):
-                return connection.respond(403, "Forbidden")
-            return self._authorize_websocket_handshake(connection, query)
-
-        # API clients should never receive the SPA shell for an unknown route.
-        # Returning HTML here makes the WebUI fail with "Unexpected token <"
-        # when a dev server is pointed at an older gateway.
-        if got.startswith("/api/"):
-            return _http_error(404, "API route not found")
-
-        # 5. Static SPA serving (only if a build directory was wired in).
-        if self._static_dist_path is not None:
-            response = self._serve_static(got)
-            if response is not None:
-                return response
-
-        return connection.respond(404, "Not Found")
+        if got != expected_ws or not _is_websocket_upgrade(request):
+            return False, None
+        client_id = _query_first(query, "client_id") or ""
+        if len(client_id) > 128:
+            client_id = client_id[:128]
+        if not self.is_allowed(client_id):
+            return True, connection.respond(403, "Forbidden")
+        return True, self._authorize_websocket_handshake(connection, query)
 
     # -- HTTP route handlers ------------------------------------------------
 
@@ -1164,6 +1219,8 @@ class WebSocketChannel(BaseChannel):
             self._with_settings_restart_state(payload, section="runtime")
         )
 
+    # -- Session replay, transcript, and signed media ----------------------
+
     @staticmethod
     def _is_websocket_channel_session_key(key: str) -> bool:
         """True when *key* is a ``websocket:…`` session exposed on this HTTP surface."""
@@ -1376,6 +1433,8 @@ class WebSocketChannel(BaseChannel):
         delete_webui_thread(decoded_key)
         return _http_json_response({"deleted": bool(deleted)})
 
+    # -- Static files and WebSocket handshake ------------------------------
+
     def _serve_static(self, request_path: str) -> Response | None:
         """Resolve *request_path* against the built SPA directory; SPA fallback to index.html."""
         assert self._static_dist_path is not None
@@ -1439,6 +1498,8 @@ class WebSocketChannel(BaseChannel):
         if supplied:
             self._take_issued_token_if_valid(supplied)
         return None
+
+    # -- Server lifecycle and connection ingress ---------------------------
 
     async def start(self) -> None:
         from nanobot.utils.logging_bridge import redirect_lib_logging
@@ -1582,6 +1643,8 @@ class WebSocketChannel(BaseChannel):
             self.logger.debug("connection ended: {}", e)
         finally:
             self._cleanup_connection(connection)
+
+    # -- Inbound WebSocket envelopes ---------------------------------------
 
     def _save_envelope_media(
         self,
@@ -1811,6 +1874,8 @@ class WebSocketChannel(BaseChannel):
                 **({"chat_id": chat_id} if chat_id else {}),
             )
             return None
+
+    # -- Outbound WebSocket events -----------------------------------------
 
     async def stop(self) -> None:
         if not self._running:

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -538,6 +538,35 @@ _MEDIA_ALLOWED_MIMES: frozenset[str] = frozenset({
     "video/webm",
     "video/quicktime",
 })
+
+_BYTE_RANGE_RE = re.compile(r"^bytes=(\d*)-(\d*)$")
+
+
+def _parse_single_byte_range(range_header: str, size: int) -> tuple[int, int]:
+    """Parse a single HTTP byte range for signed media responses."""
+    if size <= 0 or "," in range_header:
+        raise ValueError("invalid byte range")
+    m = _BYTE_RANGE_RE.fullmatch(range_header.strip())
+    if m is None:
+        raise ValueError("invalid byte range")
+    start_text, end_text = m.groups()
+    if not start_text and not end_text:
+        raise ValueError("invalid byte range")
+    if not start_text:
+        suffix_length = int(end_text)
+        if suffix_length <= 0:
+            raise ValueError("invalid byte range")
+        start = max(size - suffix_length, 0)
+        end = size - 1
+    else:
+        start = int(start_text)
+        end = int(end_text) if end_text else size - 1
+        if start >= size or start > end:
+            raise ValueError("invalid byte range")
+        end = min(end, size - 1)
+    return start, end
+
+
 def _issue_route_secret_matches(headers: Any, configured_secret: str) -> bool:
     """Return True if the token-issue HTTP request carries credentials matching ``token_issue_secret``."""
     if not configured_secret:
@@ -852,7 +881,7 @@ class WebSocketChannel(BaseChannel):
         # these URLs when replaying a session.
         m = re.match(r"^/api/media/([A-Za-z0-9_-]+)/([A-Za-z0-9_-]+)$", got)
         if m:
-            return self._handle_media_fetch(m.group(1), m.group(2))
+            return self._handle_media_fetch(m.group(1), m.group(2), request)
 
         # 4. WebSocket upgrade (the channel's primary purpose). Only run the
         # handshake gate on requests that actually ask to upgrade; otherwise
@@ -1384,7 +1413,9 @@ class WebSocketChannel(BaseChannel):
             sign_path=self._sign_or_stage_media_path,
         )
 
-    def _handle_media_fetch(self, sig: str, payload: str) -> Response:
+    def _handle_media_fetch(
+        self, sig: str, payload: str, request: WsRequest | None = None
+    ) -> Response:
         """Serve a single media file previously signed via
         :meth:`_sign_media_path`. Validates the signature, decodes the
         payload to a relative path, and streams the file bytes with a
@@ -1414,22 +1445,62 @@ class WebSocketChannel(BaseChannel):
             return _http_error(404, "not found")
         if not candidate.is_file():
             return _http_error(404, "not found")
+        mime, _ = mimetypes.guess_type(candidate.name)
+        if mime not in _MEDIA_ALLOWED_MIMES:
+            mime = "application/octet-stream"
+        common_headers = [
+            ("Accept-Ranges", "bytes"),
+            ("Cache-Control", "private, max-age=31536000, immutable"),
+            # Paired with the MIME whitelist above: prevents browsers from
+            # MIME-sniffing an octet-stream fallback into executable HTML.
+            ("X-Content-Type-Options", "nosniff"),
+        ]
+        try:
+            size = candidate.stat().st_size
+        except OSError:
+            return _http_error(500, "read error")
+
+        range_header = (
+            _case_insensitive_header(request.headers, "Range") if request else ""
+        )
+        if range_header:
+            try:
+                start, end = _parse_single_byte_range(range_header, size)
+            except ValueError:
+                return _http_response(
+                    b"range not satisfiable",
+                    status=416,
+                    extra_headers=[
+                        ("Accept-Ranges", "bytes"),
+                        ("Content-Range", f"bytes */{size}"),
+                        ("X-Content-Type-Options", "nosniff"),
+                    ],
+                )
+            try:
+                length = end - start + 1
+                with candidate.open("rb") as fh:
+                    fh.seek(start)
+                    body = fh.read(length)
+            except OSError:
+                return _http_error(500, "read error")
+            return _http_response(
+                body,
+                status=206,
+                content_type=mime,
+                extra_headers=[
+                    *common_headers,
+                    ("Content-Range", f"bytes {start}-{end}/{size}"),
+                ],
+            )
+
         try:
             body = candidate.read_bytes()
         except OSError:
             return _http_error(500, "read error")
-        mime, _ = mimetypes.guess_type(candidate.name)
-        if mime not in _MEDIA_ALLOWED_MIMES:
-            mime = "application/octet-stream"
         return _http_response(
             body,
             content_type=mime,
-            extra_headers=[
-                ("Cache-Control", "private, max-age=31536000, immutable"),
-                # Paired with the MIME whitelist above: prevents browsers from
-                # MIME-sniffing an octet-stream fallback into executable HTML.
-                ("X-Content-Type-Options", "nosniff"),
-            ],
+            extra_headers=common_headers,
         )
 
     def _handle_session_delete(self, request: WsRequest, key: str) -> Response:

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import base64
-import binascii
 import email.utils
-import hashlib
 import hmac
 import http
 import json
 import mimetypes
 import re
 import secrets
-import shutil
 import ssl
 import time
 import uuid
@@ -44,7 +40,6 @@ from nanobot.config.paths import get_media_dir, get_workspace_path
 from nanobot.config.schema import Base
 from nanobot.session.goal_state import goal_state_ws_blob
 from nanobot.session.webui_turns import websocket_turn_wall_started_at
-from nanobot.utils.helpers import safe_filename
 from nanobot.utils.media_decode import (
     FileSizeExceeded,
     save_base64_data_url,
@@ -69,6 +64,11 @@ from nanobot.webui.cli_apps_api import (
     cli_apps_action,
     cli_apps_payload,
     normalize_cli_app_mentions,
+)
+from nanobot.webui.media_api import (
+    serve_signed_media,
+    sign_media_path,
+    sign_or_stage_media_path,
 )
 from nanobot.webui.mcp_presets_api import (
     mcp_presets_settings_action,
@@ -512,59 +512,6 @@ def _is_websocket_upgrade(request: WsRequest) -> bool:
     if not connection or "upgrade" not in connection.lower():
         return False
     return True
-
-
-def _b64url_encode(data: bytes) -> str:
-    """URL-safe base64 without padding — compact + friendly in URL paths."""
-    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
-
-
-def _b64url_decode(s: str) -> bytes:
-    """Reverse of :func:`_b64url_encode`; caller handles ``ValueError``."""
-    pad = "=" * (-len(s) % 4)
-    return base64.urlsafe_b64decode(s + pad)
-
-
-# Allowed MIME types we actually serve from the media endpoint. Anything
-# outside this set is degraded to ``application/octet-stream`` so an
-# attacker who somehow gets a signed URL for an unexpected file type can't
-# trick the browser into sniffing executable content.
-_MEDIA_ALLOWED_MIMES: frozenset[str] = frozenset({
-    "image/png",
-    "image/jpeg",
-    "image/webp",
-    "image/gif",
-    "video/mp4",
-    "video/webm",
-    "video/quicktime",
-})
-
-_BYTE_RANGE_RE = re.compile(r"^bytes=(\d*)-(\d*)$")
-
-
-def _parse_single_byte_range(range_header: str, size: int) -> tuple[int, int]:
-    """Parse a single HTTP byte range for signed media responses."""
-    if size <= 0 or "," in range_header:
-        raise ValueError("invalid byte range")
-    m = _BYTE_RANGE_RE.fullmatch(range_header.strip())
-    if m is None:
-        raise ValueError("invalid byte range")
-    start_text, end_text = m.groups()
-    if not start_text and not end_text:
-        raise ValueError("invalid byte range")
-    if not start_text:
-        suffix_length = int(end_text)
-        if suffix_length <= 0:
-            raise ValueError("invalid byte range")
-        start = max(size - suffix_length, 0)
-        end = size - 1
-    else:
-        start = int(start_text)
-        end = int(end_text) if end_text else size - 1
-        if start >= size or start > end:
-            raise ValueError("invalid byte range")
-        end = min(end, size - 1)
-    return start, end
 
 
 def _issue_route_secret_matches(headers: Any, configured_secret: str) -> bool:
@@ -1368,16 +1315,11 @@ class WebSocketChannel(BaseChannel):
         be fetched. The returned path is relative to the server origin; the
         client joins it against this server's HTTP origin (same host as WS).
         """
-        try:
-            media_root = get_media_dir().resolve()
-            rel = abs_path.resolve().relative_to(media_root)
-        except (OSError, ValueError):
-            return None
-        payload = _b64url_encode(rel.as_posix().encode("utf-8"))
-        mac = hmac.new(
-            self._media_secret, payload.encode("ascii"), hashlib.sha256
-        ).digest()[:16]
-        return f"/api/media/{_b64url_encode(mac)}/{payload}"
+        return sign_media_path(
+            abs_path,
+            secret=self._media_secret,
+            media_dir=lambda channel=None: get_media_dir(channel),
+        )
 
     def _sign_or_stage_media_path(self, path: Path) -> dict[str, str] | None:
         """Return a signed media URL payload for *path*.
@@ -1388,23 +1330,12 @@ class WebSocketChannel(BaseChannel):
         can fetch them through the existing signed media route without
         exposing arbitrary filesystem paths.
         """
-        signed = self._sign_media_path(path)
-        if signed is not None:
-            return {"url": signed, "name": path.name}
-        try:
-            if not path.is_file():
-                return None
-            media_dir = get_media_dir("websocket")
-            safe_name = safe_filename(path.name) or "attachment"
-            staged = media_dir / f"{uuid.uuid4().hex[:12]}-{safe_name}"
-            shutil.copyfile(path, staged)
-        except OSError as exc:
-            self.logger.warning("failed to stage outbound media {}: {}", path, exc)
-            return None
-        signed = self._sign_media_path(staged)
-        if signed is None:
-            return None
-        return {"url": signed, "name": path.name}
+        return sign_or_stage_media_path(
+            path,
+            secret=self._media_secret,
+            media_dir=lambda channel=None: get_media_dir(channel),
+            logger=self.logger,
+        )
 
     def _rewrite_local_markdown_images(self, text: str) -> str:
         return rewrite_local_markdown_images(
@@ -1421,86 +1352,12 @@ class WebSocketChannel(BaseChannel):
         payload to a relative path, and streams the file bytes with a
         long-lived immutable cache header (the URL already encodes the
         file identity, so caches can be aggressive)."""
-        try:
-            provided_mac = _b64url_decode(sig)
-        except (ValueError, binascii.Error):
-            return _http_error(401, "invalid signature")
-        expected_mac = hmac.new(
-            self._media_secret, payload.encode("ascii"), hashlib.sha256
-        ).digest()[:16]
-        if not hmac.compare_digest(expected_mac, provided_mac):
-            return _http_error(401, "invalid signature")
-        try:
-            rel_bytes = _b64url_decode(payload)
-            rel_str = rel_bytes.decode("utf-8")
-        except (ValueError, binascii.Error, UnicodeDecodeError):
-            return _http_error(400, "invalid payload")
-        # An attacker who somehow bypassed the HMAC check would still need
-        # the resolved path to escape the media root; guard defensively.
-        try:
-            media_root = get_media_dir().resolve()
-            candidate = (media_root / rel_str).resolve()
-            candidate.relative_to(media_root)
-        except (OSError, ValueError):
-            return _http_error(404, "not found")
-        if not candidate.is_file():
-            return _http_error(404, "not found")
-        mime, _ = mimetypes.guess_type(candidate.name)
-        if mime not in _MEDIA_ALLOWED_MIMES:
-            mime = "application/octet-stream"
-        common_headers = [
-            ("Accept-Ranges", "bytes"),
-            ("Cache-Control", "private, max-age=31536000, immutable"),
-            # Paired with the MIME whitelist above: prevents browsers from
-            # MIME-sniffing an octet-stream fallback into executable HTML.
-            ("X-Content-Type-Options", "nosniff"),
-        ]
-        try:
-            size = candidate.stat().st_size
-        except OSError:
-            return _http_error(500, "read error")
-
-        range_header = (
-            _case_insensitive_header(request.headers, "Range") if request else ""
-        )
-        if range_header:
-            try:
-                start, end = _parse_single_byte_range(range_header, size)
-            except ValueError:
-                return _http_response(
-                    b"range not satisfiable",
-                    status=416,
-                    extra_headers=[
-                        ("Accept-Ranges", "bytes"),
-                        ("Content-Range", f"bytes */{size}"),
-                        ("X-Content-Type-Options", "nosniff"),
-                    ],
-                )
-            try:
-                length = end - start + 1
-                with candidate.open("rb") as fh:
-                    fh.seek(start)
-                    body = fh.read(length)
-            except OSError:
-                return _http_error(500, "read error")
-            return _http_response(
-                body,
-                status=206,
-                content_type=mime,
-                extra_headers=[
-                    *common_headers,
-                    ("Content-Range", f"bytes {start}-{end}/{size}"),
-                ],
-            )
-
-        try:
-            body = candidate.read_bytes()
-        except OSError:
-            return _http_error(500, "read error")
-        return _http_response(
-            body,
-            content_type=mime,
-            extra_headers=common_headers,
+        return serve_signed_media(
+            sig,
+            payload,
+            secret=self._media_secret,
+            request=request,
+            media_dir=lambda channel=None: get_media_dir(channel),
         )
 
     def _handle_session_delete(self, request: WsRequest, key: str) -> Response:

--- a/nanobot/webui/media_api.py
+++ b/nanobot/webui/media_api.py
@@ -1,0 +1,246 @@
+"""Signed media helpers for the WebUI HTTP surface."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import email.utils
+import hashlib
+import hmac
+import http
+import mimetypes
+import re
+import shutil
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from websockets.datastructures import Headers
+from websockets.http11 import Request as WsRequest
+from websockets.http11 import Response
+
+from nanobot.config.paths import get_media_dir
+from nanobot.utils.helpers import safe_filename
+
+MediaDirProvider = Callable[[str | None], Path]
+
+
+def b64url_encode(data: bytes) -> str:
+    """URL-safe base64 without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def b64url_decode(value: str) -> bytes:
+    """Reverse of :func:`b64url_encode`; caller handles decode errors."""
+    pad = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + pad)
+
+
+def _default_media_dir(channel: str | None = None) -> Path:
+    return get_media_dir(channel)
+
+
+# Allowed MIME types we actually serve from the media endpoint. Anything
+# outside this set is degraded to ``application/octet-stream`` so an
+# attacker who somehow gets a signed URL for an unexpected file type can't
+# trick the browser into sniffing executable content.
+_MEDIA_ALLOWED_MIMES: frozenset[str] = frozenset({
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+    "video/mp4",
+    "video/webm",
+    "video/quicktime",
+})
+
+_BYTE_RANGE_RE = re.compile(r"^bytes=(\d*)-(\d*)$")
+
+
+def _http_response(
+    body: bytes,
+    *,
+    status: int = 200,
+    content_type: str = "text/plain; charset=utf-8",
+    extra_headers: list[tuple[str, str]] | None = None,
+) -> Response:
+    headers = [
+        ("Date", email.utils.formatdate(usegmt=True)),
+        ("Connection", "close"),
+        ("Content-Length", str(len(body))),
+        ("Content-Type", content_type),
+    ]
+    if extra_headers:
+        headers.extend(extra_headers)
+    reason = http.HTTPStatus(status).phrase
+    return Response(status, reason, Headers(headers), body)
+
+
+def _http_error(status: int, message: str | None = None) -> Response:
+    body = (message or http.HTTPStatus(status).phrase).encode("utf-8")
+    return _http_response(body, status=status)
+
+
+def _case_insensitive_header(headers: Any, key: str) -> str:
+    try:
+        value = headers.get(key)
+    except Exception:
+        value = None
+    if value is None:
+        try:
+            value = headers.get(key.lower())
+        except Exception:
+            value = None
+    return str(value or "").strip()
+
+
+def _parse_single_byte_range(range_header: str, size: int) -> tuple[int, int]:
+    """Parse a single HTTP byte range for signed media responses."""
+    if size <= 0 or "," in range_header:
+        raise ValueError("invalid byte range")
+    m = _BYTE_RANGE_RE.fullmatch(range_header.strip())
+    if m is None:
+        raise ValueError("invalid byte range")
+    start_text, end_text = m.groups()
+    if not start_text and not end_text:
+        raise ValueError("invalid byte range")
+    if not start_text:
+        suffix_length = int(end_text)
+        if suffix_length <= 0:
+            raise ValueError("invalid byte range")
+        start = max(size - suffix_length, 0)
+        end = size - 1
+    else:
+        start = int(start_text)
+        end = int(end_text) if end_text else size - 1
+        if start >= size or start > end:
+            raise ValueError("invalid byte range")
+        end = min(end, size - 1)
+    return start, end
+
+
+def sign_media_path(
+    abs_path: Path,
+    *,
+    secret: bytes,
+    media_dir: MediaDirProvider = _default_media_dir,
+) -> str | None:
+    """Return a signed ``/api/media/<sig>/<payload>`` URL for a media-root path."""
+    try:
+        media_root = media_dir(None).resolve()
+        rel = abs_path.resolve().relative_to(media_root)
+    except (OSError, ValueError):
+        return None
+    payload = b64url_encode(rel.as_posix().encode("utf-8"))
+    mac = hmac.new(secret, payload.encode("ascii"), hashlib.sha256).digest()[:16]
+    return f"/api/media/{b64url_encode(mac)}/{payload}"
+
+
+def sign_or_stage_media_path(
+    path: Path,
+    *,
+    secret: bytes,
+    media_dir: MediaDirProvider = _default_media_dir,
+    logger: Any | None = None,
+) -> dict[str, str] | None:
+    """Sign an existing media-root path, or stage an arbitrary file before signing."""
+    signed = sign_media_path(path, secret=secret, media_dir=media_dir)
+    if signed is not None:
+        return {"url": signed, "name": path.name}
+    try:
+        if not path.is_file():
+            return None
+        target_dir = media_dir("websocket")
+        safe_name = safe_filename(path.name) or "attachment"
+        staged = target_dir / f"{uuid.uuid4().hex[:12]}-{safe_name}"
+        shutil.copyfile(path, staged)
+    except OSError as exc:
+        if logger is not None:
+            logger.warning("failed to stage outbound media {}: {}", path, exc)
+        return None
+    signed = sign_media_path(staged, secret=secret, media_dir=media_dir)
+    if signed is None:
+        return None
+    return {"url": signed, "name": path.name}
+
+
+def serve_signed_media(
+    sig: str,
+    payload: str,
+    *,
+    secret: bytes,
+    request: WsRequest | None = None,
+    media_dir: MediaDirProvider = _default_media_dir,
+) -> Response:
+    """Serve a signed media URL, including browser-friendly byte ranges."""
+    try:
+        provided_mac = b64url_decode(sig)
+    except (ValueError, binascii.Error):
+        return _http_error(401, "invalid signature")
+    expected_mac = hmac.new(secret, payload.encode("ascii"), hashlib.sha256).digest()[:16]
+    if not hmac.compare_digest(expected_mac, provided_mac):
+        return _http_error(401, "invalid signature")
+    try:
+        rel_bytes = b64url_decode(payload)
+        rel_str = rel_bytes.decode("utf-8")
+    except (ValueError, binascii.Error, UnicodeDecodeError):
+        return _http_error(400, "invalid payload")
+    try:
+        media_root = media_dir(None).resolve()
+        candidate = (media_root / rel_str).resolve()
+        candidate.relative_to(media_root)
+    except (OSError, ValueError):
+        return _http_error(404, "not found")
+    if not candidate.is_file():
+        return _http_error(404, "not found")
+
+    mime, _ = mimetypes.guess_type(candidate.name)
+    if mime not in _MEDIA_ALLOWED_MIMES:
+        mime = "application/octet-stream"
+    common_headers = [
+        ("Accept-Ranges", "bytes"),
+        ("Cache-Control", "private, max-age=31536000, immutable"),
+        ("X-Content-Type-Options", "nosniff"),
+    ]
+    try:
+        size = candidate.stat().st_size
+    except OSError:
+        return _http_error(500, "read error")
+
+    range_header = _case_insensitive_header(request.headers, "Range") if request else ""
+    if range_header:
+        try:
+            start, end = _parse_single_byte_range(range_header, size)
+        except ValueError:
+            return _http_response(
+                b"range not satisfiable",
+                status=416,
+                extra_headers=[
+                    ("Accept-Ranges", "bytes"),
+                    ("Content-Range", f"bytes */{size}"),
+                    ("X-Content-Type-Options", "nosniff"),
+                ],
+            )
+        try:
+            length = end - start + 1
+            with candidate.open("rb") as fh:
+                fh.seek(start)
+                body = fh.read(length)
+        except OSError:
+            return _http_error(500, "read error")
+        return _http_response(
+            body,
+            status=206,
+            content_type=mime,
+            extra_headers=[
+                *common_headers,
+                ("Content-Range", f"bytes {start}-{end}/{size}"),
+            ],
+        )
+
+    try:
+        body = candidate.read_bytes()
+    except OSError:
+        return _http_error(500, "read error")
+    return _http_response(body, content_type=mime, extra_headers=common_headers)

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -28,6 +28,12 @@ _INLINE_MARKDOWN_IMAGE_EXTS: frozenset[str] = frozenset({
     ".webp",
     ".gif",
 })
+_INLINE_MARKDOWN_VIDEO_EXTS: frozenset[str] = frozenset({
+    ".mp4",
+    ".mov",
+    ".webm",
+})
+_INLINE_MARKDOWN_MEDIA_EXTS = _INLINE_MARKDOWN_IMAGE_EXTS | _INLINE_MARKDOWN_VIDEO_EXTS
 _FILE_EDIT_TOOL_NAMES: frozenset[str] = frozenset({
     "write_file",
     "edit_file",
@@ -41,7 +47,7 @@ def rewrite_local_markdown_images(
     workspace_path: Path,
     sign_path: Callable[[Path], Mapping[str, Any] | None],
 ) -> str:
-    """Rewrite markdown image paths inside the workspace to signed WebUI media URLs."""
+    """Rewrite markdown media paths inside the workspace to signed WebUI media URLs."""
     if "![" not in text:
         return text
 
@@ -55,7 +61,7 @@ def rewrite_local_markdown_images(
         if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment:
             return None
         path_text = unquote(url)
-        if Path(path_text).suffix.lower() not in _INLINE_MARKDOWN_IMAGE_EXTS:
+        if Path(path_text).suffix.lower() not in _INLINE_MARKDOWN_MEDIA_EXTS:
             return None
         candidate = Path(path_text).expanduser()
         if not candidate.is_absolute():
@@ -78,6 +84,10 @@ def rewrite_local_markdown_images(
         return f"![{match.group(1)}]({signed_url}{title})"
 
     return _MARKDOWN_LOCAL_IMAGE_RE.sub(replace, text)
+
+
+def _media_kind_from_name(name: str) -> str:
+    return "video" if Path(name).suffix.lower() in _INLINE_MARKDOWN_VIDEO_EXTS else "image"
 
 
 def webui_transcript_path(session_key: str) -> Path:
@@ -821,11 +831,12 @@ def replay_transcript_to_ui_messages(
             if isinstance(media_urls, list):
                 for m in media_urls:
                     if isinstance(m, dict) and m.get("url"):
+                        name = str(m.get("name") or "")
                         media.append(
                             {
-                                "kind": "image",
+                                "kind": _media_kind_from_name(name),
                                 "url": str(m["url"]),
-                                "name": str(m.get("name") or ""),
+                                "name": name,
                             },
                         )
             extra: dict[str, Any] = {"content": content_s}

--- a/tests/agent/test_workspace_scope.py
+++ b/tests/agent/test_workspace_scope.py
@@ -261,6 +261,10 @@ async def test_cli_app_scope_controls_working_dir(
         json.dumps({"_cached_at": time.time(), "data": {"meta": {}, "clis": []}}),
         encoding="utf-8",
     )
+    (data_dir / "extensions_registry_cache.json").write_text(
+        json.dumps({"_cached_at": time.time(), "data": {"meta": {}, "clis": []}}),
+        encoding="utf-8",
+    )
     CliAppManager(workspace=project, data_dir=data_dir)._save_installed(
         {"demo": {"entry_point": "demo-cli"}}
     )

--- a/tests/channels/test_websocket_media_route.py
+++ b/tests/channels/test_websocket_media_route.py
@@ -21,10 +21,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from nanobot.channels.websocket import (
-    WebSocketChannel,
-    _b64url_decode,
-    _b64url_encode,
+from nanobot.channels.websocket import WebSocketChannel
+from nanobot.webui.media_api import (
+    b64url_decode,
+    b64url_encode,
 )
 from nanobot.session.manager import Session, SessionManager
 
@@ -129,9 +129,9 @@ def test_sign_media_path_round_trips_via_hmac(
     expected = hmac.new(
         channel._media_secret, payload.encode("ascii"), hashlib.sha256
     ).digest()[:16]
-    assert _b64url_decode(sig) == expected
+    assert b64url_decode(sig) == expected
     # The payload decodes back to the *relative* path — no absolute-path leaks.
-    assert _b64url_decode(payload).decode() == "a.png"
+    assert b64url_decode(payload).decode() == "a.png"
 
 
 def test_local_markdown_image_is_staged_and_rewritten(
@@ -346,7 +346,7 @@ async def test_media_route_rejects_bad_signature(
         forged_mac = hmac.new(
             b"\x00" * 32, payload.encode("ascii"), hashlib.sha256
         ).digest()[:16]
-        forged = f"/api/media/{_b64url_encode(forged_mac)}/{payload}"
+        forged = f"/api/media/{b64url_encode(forged_mac)}/{payload}"
 
         server_task = asyncio.create_task(channel.start())
         await asyncio.sleep(0.3)
@@ -375,11 +375,11 @@ async def test_media_route_rejects_path_traversal_payload(
 
     channel = _ch(bus, port=29922)
     # Hand-craft a traversal payload the legit signer would refuse to mint.
-    payload = _b64url_encode(b"../secret.txt")
+    payload = b64url_encode(b"../secret.txt")
     mac = hmac.new(
         channel._media_secret, payload.encode("ascii"), hashlib.sha256
     ).digest()[:16]
-    url = f"/api/media/{_b64url_encode(mac)}/{payload}"
+    url = f"/api/media/{b64url_encode(mac)}/{payload}"
 
     with patch("nanobot.channels.websocket.get_media_dir", return_value=media):
         server_task = asyncio.create_task(channel.start())
@@ -434,11 +434,11 @@ async def test_media_route_degrades_non_image_to_octet_stream(
 
     channel = _ch(bus, port=29924)
     with patch("nanobot.channels.websocket.get_media_dir", return_value=media):
-        payload = _b64url_encode(b"scary.html")
+        payload = b64url_encode(b"scary.html")
         mac = hmac.new(
             channel._media_secret, payload.encode("ascii"), hashlib.sha256
         ).digest()[:16]
-        url = f"/api/media/{_b64url_encode(mac)}/{payload}"
+        url = f"/api/media/{b64url_encode(mac)}/{payload}"
         server_task = asyncio.create_task(channel.start())
         await asyncio.sleep(0.3)
         try:

--- a/tests/channels/test_websocket_media_route.py
+++ b/tests/channels/test_websocket_media_route.py
@@ -155,6 +155,28 @@ def test_local_markdown_image_is_staged_and_rewritten(
     assert staged[0].read_bytes() == _PNG_BYTES
 
 
+def test_local_markdown_video_is_staged_and_rewritten(
+    bus: MagicMock,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    video_bytes = b"fake mp4"
+    (workspace / "nanobot-intro.mp4").write_bytes(video_bytes)
+    media = tmp_path / "media"
+    channel = _ch(bus, workspace_path=workspace, port=0)
+
+    with patch("nanobot.channels.websocket.get_media_dir", side_effect=_fake_media_dir(media)):
+        rewritten = channel._rewrite_local_markdown_images(
+            "The result:\n![nanobot-intro.mp4](nanobot-intro.mp4)"
+        )
+
+    assert "![nanobot-intro.mp4](/api/media/" in rewritten
+    staged = list((media / "websocket").iterdir())
+    assert len(staged) == 1
+    assert staged[0].read_bytes() == video_bytes
+
+
 def test_local_markdown_image_rejects_workspace_escape(
     bus: MagicMock,
     tmp_path: Path,

--- a/tests/channels/test_websocket_media_route.py
+++ b/tests/channels/test_websocket_media_route.py
@@ -227,8 +227,101 @@ async def test_media_route_serves_signed_file(
     assert resp.headers["content-type"].startswith("image/png")
     # Immutable cache header lets the browser skip round-trips on replay.
     assert "immutable" in resp.headers.get("cache-control", "")
+    # Video players rely on byte ranges; images get the header for consistency.
+    assert resp.headers.get("accept-ranges") == "bytes"
     # nosniff keeps the browser from second-guessing our Content-Type.
     assert resp.headers.get("x-content-type-options") == "nosniff"
+
+
+@pytest.mark.asyncio
+async def test_media_route_serves_video_byte_ranges(
+    bus: MagicMock, tmp_path: Path
+) -> None:
+    """MP4 playback needs HTTP Range support for mid-stream reads and seeking."""
+    media = tmp_path / "media"
+    media.mkdir()
+    target = media / "clip.mp4"
+    target.write_bytes(b"0123456789")
+
+    channel = _ch(bus, port=29927)
+    with patch("nanobot.channels.websocket.get_media_dir", return_value=media):
+        url_path = channel._sign_media_path(target)
+        assert url_path is not None
+        server_task = asyncio.create_task(channel.start())
+        await asyncio.sleep(0.3)
+        try:
+            resp = await _http_get(
+                f"http://127.0.0.1:29927{url_path}",
+                headers={"Range": "bytes=2-5"},
+            )
+        finally:
+            await channel.stop()
+            await server_task
+
+    assert resp.status_code == 206
+    assert resp.content == b"2345"
+    assert resp.headers["content-type"].startswith("video/mp4")
+    assert resp.headers.get("accept-ranges") == "bytes"
+    assert resp.headers.get("content-range") == "bytes 2-5/10"
+    assert resp.headers.get("content-length") == "4"
+
+
+@pytest.mark.asyncio
+async def test_media_route_serves_suffix_video_byte_ranges(
+    bus: MagicMock, tmp_path: Path
+) -> None:
+    media = tmp_path / "media"
+    media.mkdir()
+    target = media / "clip.mp4"
+    target.write_bytes(b"0123456789")
+
+    channel = _ch(bus, port=29928)
+    with patch("nanobot.channels.websocket.get_media_dir", return_value=media):
+        url_path = channel._sign_media_path(target)
+        assert url_path is not None
+        server_task = asyncio.create_task(channel.start())
+        await asyncio.sleep(0.3)
+        try:
+            resp = await _http_get(
+                f"http://127.0.0.1:29928{url_path}",
+                headers={"Range": "bytes=-3"},
+            )
+        finally:
+            await channel.stop()
+            await server_task
+
+    assert resp.status_code == 206
+    assert resp.content == b"789"
+    assert resp.headers.get("content-range") == "bytes 7-9/10"
+
+
+@pytest.mark.asyncio
+async def test_media_route_rejects_unsatisfiable_byte_range(
+    bus: MagicMock, tmp_path: Path
+) -> None:
+    media = tmp_path / "media"
+    media.mkdir()
+    target = media / "clip.mp4"
+    target.write_bytes(b"0123456789")
+
+    channel = _ch(bus, port=29929)
+    with patch("nanobot.channels.websocket.get_media_dir", return_value=media):
+        url_path = channel._sign_media_path(target)
+        assert url_path is not None
+        server_task = asyncio.create_task(channel.start())
+        await asyncio.sleep(0.3)
+        try:
+            resp = await _http_get(
+                f"http://127.0.0.1:29929{url_path}",
+                headers={"Range": "bytes=100-200"},
+            )
+        finally:
+            await channel.stop()
+            await server_task
+
+    assert resp.status_code == 416
+    assert resp.headers.get("accept-ranges") == "bytes"
+    assert resp.headers.get("content-range") == "bytes */10"
 
 
 @pytest.mark.asyncio

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -121,6 +121,7 @@ def _seed_catalog(manager: CliAppManager) -> None:
     }
     _write_cache(manager._cache_path("harness"), harness)
     _write_cache(manager._cache_path("public"), public)
+    _write_cache(manager._cache_path("extensions"), {"meta": {}, "clis": []})
 
 
 def test_payload_merges_catalog_and_marks_unsupported_installs(tmp_path: Path) -> None:
@@ -187,12 +188,82 @@ def test_payload_uses_anygen_official_domain_for_logo(tmp_path: Path) -> None:
             ],
         },
     )
+    _write_cache(manager._cache_path("extensions"), {"meta": {}, "clis": []})
 
     payload = manager.payload()
 
     app = payload["apps"][0]
     assert app["name"] == "anygen"
     assert app["logo_url"] == "https://www.google.com/s2/favicons?domain=anygen.io&sz=64"
+
+
+def test_payload_includes_nanobot_extension_registry(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    _write_cache(manager._cache_path("harness"), {"meta": {"updated": "2026-04-16"}, "clis": []})
+    _write_cache(manager._cache_path("public"), {"meta": {"updated": "2026-04-18"}, "clis": []})
+    _write_cache(
+        manager._cache_path("extensions"),
+        {
+            "meta": {"updated": "2026-05-29"},
+            "clis": [
+                {
+                    "name": "hyperframes",
+                    "display_name": "HyperFrames",
+                    "version": "latest",
+                    "description": "HTML-to-MP4 motion graphics CLI",
+                    "category": "video",
+                    "package_manager": "npm",
+                    "npm_package": "hyperframes",
+                    "install_cmd": "npm install -g hyperframes",
+                    "entry_point": "hyperframes",
+                    "skill_md": "skills/hyperframes/SKILL.md",
+                }
+            ],
+        },
+    )
+
+    payload = manager.payload()
+
+    assert payload["catalog_updated_at"] == "2026-05-29"
+    app = payload["apps"][0]
+    assert app["name"] == "hyperframes"
+    assert app["source"] == "extensions"
+    assert app["install_supported"] is True
+    assert app["manifest"]["source"] == "nanobot-extension"
+    assert app["manifest"]["trust"]["registry"] == "nanobot-extension"
+
+
+def test_optional_extension_registry_failure_does_not_break_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    _write_cache(
+        manager._cache_path("harness"),
+        {
+            "meta": {"updated": "2026-04-16"},
+            "clis": [
+                {
+                    "name": "gimp",
+                    "display_name": "GIMP",
+                    "description": "Image editing",
+                    "install_cmd": "pip install cli-anything-gimp",
+                    "entry_point": "cli-anything-gimp",
+                }
+            ],
+        },
+    )
+    _write_cache(manager._cache_path("public"), {"meta": {"updated": "2026-04-18"}, "clis": []})
+
+    def fail_get(*args, **kwargs):
+        raise RuntimeError("network unavailable")
+
+    monkeypatch.setattr("nanobot.apps.cli.service.httpx.get", fail_get)
+
+    payload = manager.payload()
+
+    assert payload["catalog_updated_at"] == "2026-04-18"
+    assert [app["name"] for app in payload["apps"]] == ["gimp"]
 
 
 def test_install_dispatches_safe_pip_and_installs_skill(
@@ -330,6 +401,38 @@ def test_fetch_skill_content_allows_cli_anything_raw_skill_url(
     assert content and "# Test" in content
     assert seen == [
         "https://raw.githubusercontent.com/HKUDS/CLI-Anything/main/skills/cli-anything-gimp/SKILL.md"
+    ]
+
+
+def test_fetch_skill_content_uses_extension_raw_base_for_relative_skills(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    seen: list[str] = []
+
+    class Response:
+        text = "---\nname: hyperframes\ndescription: HyperFrames\n---\n# HyperFrames\n"
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+    def fake_get(url: str, **kwargs):
+        seen.append(url)
+        return Response()
+
+    monkeypatch.setattr("nanobot.apps.cli.service.httpx.get", fake_get)
+
+    content = manager._fetch_skill_content({
+        "name": "hyperframes",
+        "skill_md": "skills/hyperframes/SKILL.md",
+        "_raw_base": "https://raw.githubusercontent.com/Re-bin/nanobot-extension/main",
+    })
+
+    assert content and "# HyperFrames" in content
+    assert seen == [
+        "https://raw.githubusercontent.com/Re-bin/nanobot-extension/main/skills/hyperframes/SKILL.md"
     ]
 
 

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -216,6 +216,8 @@ def test_payload_includes_nanobot_extension_registry(tmp_path: Path) -> None:
                     "npm_package": "hyperframes",
                     "install_cmd": "npm install -g hyperframes",
                     "entry_point": "hyperframes",
+                    "logo_url": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/assets/logo.png",
+                    "brand_color": "#111827",
                     "skill_md": "skills/hyperframes/SKILL.md",
                 }
             ],
@@ -228,6 +230,8 @@ def test_payload_includes_nanobot_extension_registry(tmp_path: Path) -> None:
     app = payload["apps"][0]
     assert app["name"] == "hyperframes"
     assert app["source"] == "extensions"
+    assert app["logo_url"] == "https://raw.githubusercontent.com/heygen-com/hyperframes/main/assets/logo.png"
+    assert app["brand_color"] == "#111827"
     assert app["install_supported"] is True
     assert app["manifest"]["source"] == "nanobot-extension"
     assert app["manifest"]["trust"]["registry"] == "nanobot-extension"

--- a/tests/cli_apps/test_service.py
+++ b/tests/cli_apps/test_service.py
@@ -302,6 +302,101 @@ def test_install_dispatches_safe_pip_and_installs_skill(
     assert 'run_cli_app` tool with `name="gimp"' in skill.read_text(encoding="utf-8")
 
 
+def test_install_records_available_cli_without_reinstalling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    _seed_catalog(manager)
+    resolved = tmp_path / "bin" / "lark-cli"
+    resolved.parent.mkdir()
+    resolved.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    def fail_run(argv: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+        raise AssertionError(f"unexpected install command: {argv}")
+
+    monkeypatch.setattr(manager, "_run_argv", fail_run)
+    monkeypatch.setattr(
+        "nanobot.apps.cli.service.shutil.which",
+        lambda command: str(resolved) if command == "lark-cli" else None,
+    )
+
+    payload = manager.install("feishu")
+
+    assert payload["last_action"]["ok"] is True
+    assert payload["last_action"]["installed"] is True
+    assert "entry_point_available" in payload["last_action"]["verification"]
+    installed = json.loads(manager.installed_path.read_text(encoding="utf-8"))["apps"]
+    assert installed["feishu"]["entry_point_path"] == str(resolved)
+    skill = manager.workspace / "skills" / "cli-app-feishu" / "SKILL.md"
+    assert skill.is_file()
+    assert 'run_cli_app` tool with `name="feishu"' in skill.read_text(encoding="utf-8")
+
+
+def test_install_recovers_stale_npm_global_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    _write_cache(manager._cache_path("harness"), {"meta": {"updated": "2026-04-16"}, "clis": []})
+    _write_cache(manager._cache_path("public"), {"meta": {"updated": "2026-04-18"}, "clis": []})
+    _write_cache(
+        manager._cache_path("extensions"),
+        {
+            "meta": {"updated": "2026-05-29"},
+            "clis": [
+                {
+                    "name": "hyperframes",
+                    "display_name": "HyperFrames",
+                    "package_manager": "npm",
+                    "npm_package": "hyperframes",
+                    "install_cmd": "npm install -g hyperframes",
+                    "entry_point": "hyperframes",
+                    "skill_md": "skills/hyperframes/SKILL.md",
+                }
+            ],
+        },
+    )
+    npm = str(tmp_path / "bin" / "npm")
+    global_root = tmp_path / "global"
+    stale_package = global_root / "hyperframes"
+    stale_temp = global_root / ".hyperframes-broken"
+    stale_package.mkdir(parents=True)
+    stale_temp.mkdir()
+    install_attempts = 0
+
+    def fake_run(argv: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+        nonlocal install_attempts
+        if argv == [npm, "root", "-g"]:
+            return subprocess.CompletedProcess(argv, 0, stdout=str(global_root), stderr="")
+        if argv == [npm, "install", "-g", "hyperframes"]:
+            install_attempts += 1
+            if install_attempts == 1:
+                return subprocess.CompletedProcess(
+                    argv,
+                    1,
+                    stdout="",
+                    stderr="npm error ENOTEMPTY\nnpm error syscall rename",
+                )
+            return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(manager, "_run_argv", fake_run)
+    monkeypatch.setattr(
+        "nanobot.apps.cli.service.shutil.which",
+        lambda command: npm if command == "npm" else None,
+    )
+
+    payload = manager.install("hyperframes")
+
+    assert install_attempts == 2
+    assert not stale_package.exists()
+    assert not stale_temp.exists()
+    assert payload["last_action"]["ok"] is True
+    installed = json.loads(manager.installed_path.read_text(encoding="utf-8"))["apps"]
+    assert installed["hyperframes"]["strategy"] == "npm"
+
+
 def test_install_records_entry_point_path_and_pip_distribution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli_apps/test_tool.py
+++ b/tests/cli_apps/test_tool.py
@@ -41,6 +41,7 @@ def test_run_cli_app_uses_installed_registry_app(
     }
     _write_cache(data_dir / "harness_registry_cache.json", registry)
     _write_cache(data_dir / "public_registry_cache.json", {"meta": {}, "clis": []})
+    _write_cache(data_dir / "extensions_registry_cache.json", {"meta": {}, "clis": []})
     CliAppManager(workspace=workspace, data_dir=data_dir)._save_installed(
         {"gimp": {"entry_point": "cli-anything-gimp"}}
     )
@@ -102,6 +103,7 @@ def test_run_cli_app_rejects_uninstalled_app(tmp_path: Path, monkeypatch) -> Non
     }
     _write_cache(data_dir / "harness_registry_cache.json", registry)
     _write_cache(data_dir / "public_registry_cache.json", {"meta": {}, "clis": []})
+    _write_cache(data_dir / "extensions_registry_cache.json", {"meta": {}, "clis": []})
     monkeypatch.setattr("nanobot.apps.cli.service.get_runtime_subdir", lambda _name: data_dir)
     tool = CliAppsTool(workspace=workspace, restrict_to_workspace=True)
 

--- a/tests/utils/test_webui_transcript.py
+++ b/tests/utils/test_webui_transcript.py
@@ -66,6 +66,24 @@ def test_replay_uses_stream_end_final_text() -> None:
     assert msgs[1]["content"] == "![Diagram](/api/media/sig/payload)"
 
 
+def test_replay_infers_video_media_from_attachment_name() -> None:
+    msgs = replay_transcript_to_ui_messages(
+        [
+            {"event": "user", "chat_id": "t-video", "text": "render"},
+            {
+                "event": "message",
+                "chat_id": "t-video",
+                "text": "video ready",
+                "media_urls": [{"url": "/api/media/sig/payload", "name": "intro.mp4"}],
+            },
+        ],
+    )
+
+    assert msgs[1]["media"] == [
+        {"kind": "video", "url": "/api/media/sig/payload", "name": "intro.mp4"},
+    ]
+
+
 def test_replay_file_edit_event_creates_file_activity(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
     key = "websocket:t-file"

--- a/webui/src/components/MarkdownTextRenderer.tsx
+++ b/webui/src/components/MarkdownTextRenderer.tsx
@@ -8,6 +8,7 @@ import remarkMath from "remark-math";
 
 import { CodeBlock } from "@/components/CodeBlock";
 import { FileReferenceChip, isLikelyFilePath } from "@/components/FileReferenceChip";
+import { inferMediaKind } from "@/lib/media";
 import { cn } from "@/lib/utils";
 
 import "katex/dist/katex.min.css";
@@ -114,6 +115,29 @@ export default function MarkdownTextRenderer({
         const source = typeof src === "string" ? src : "";
         if (!source) return null;
         const label = typeof alt === "string" ? alt : "";
+        if (inferMediaKind({ url: source, name: label }) === "video") {
+          return (
+            <span
+              className={cn(
+                "not-prose my-3 block w-fit max-w-full overflow-hidden rounded-[14px]",
+                "border border-border/70 bg-background shadow-sm",
+              )}
+            >
+              <video
+                src={source}
+                controls
+                preload="metadata"
+                className="block max-h-[26rem] max-w-full bg-black"
+                aria-label={label ? `Video attachment: ${label}` : "Video attachment"}
+              />
+              {label ? (
+                <span className="block max-w-full truncate px-3 py-2 text-xs text-muted-foreground">
+                  {label}
+                </span>
+              ) : null}
+            </span>
+          );
+        }
         return (
           <span
             className={cn(

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -40,7 +40,8 @@ async function request<T>(
     credentials: "same-origin",
   });
   if (!res.ok) {
-    throw new ApiError(res.status, `HTTP ${res.status}`);
+    const text = typeof res.text === "function" ? (await res.text()).trim() : "";
+    throw new ApiError(res.status, text || `HTTP ${res.status}`);
   }
   const contentType = res.headers?.get?.("content-type") ?? "";
   if (contentType && !contentType.toLowerCase().includes("application/json")) {

--- a/webui/src/tests/api.test.ts
+++ b/webui/src/tests/api.test.ts
@@ -134,6 +134,22 @@ describe("webui API helpers", () => {
     });
   });
 
+  it("surfaces API error response bodies", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => "npm error ENOTEMPTY",
+      }),
+    );
+
+    await expect(runCliAppAction("tok", "install", "hyperframes")).rejects.toMatchObject({
+      status: 500,
+      message: "npm error ENOTEMPTY",
+    });
+  });
+
   it("serializes provider settings updates without returning secrets", async () => {
     await updateProviderSettings("tok", {
       provider: "openrouter",

--- a/webui/src/tests/markdown-text-renderer.test.tsx
+++ b/webui/src/tests/markdown-text-renderer.test.tsx
@@ -15,4 +15,14 @@ describe("MarkdownTextRenderer", () => {
     );
     expect(screen.getByText("Diagram")).toBeInTheDocument();
   });
+
+  it("renders markdown videos as inline players", () => {
+    render(<MarkdownTextRenderer>![nanobot-intro.mp4](/api/media/sig/video)</MarkdownTextRenderer>);
+
+    const video = screen.getByLabelText("Video attachment: nanobot-intro.mp4");
+    expect(video.tagName).toBe("VIDEO");
+    expect(video).toHaveAttribute("src", "/api/media/sig/video");
+    expect(video).toHaveAttribute("controls");
+    expect(screen.queryByRole("img", { name: "nanobot-intro.mp4" })).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add an optional nanobot extension registry source to the Apps catalog
- register HyperFrames from the external Re-bin/nanobot-extension registry
- resolve registry-relative skill files against each catalog source while preserving path validation

## Details
This keeps CLI-Anything as the primary Apps catalog and adds https://raw.githubusercontent.com/Re-bin/nanobot-extension/main/registry.json as an optional source. If the extension registry is unavailable, Apps still loads the existing harness and public catalogs.

HyperFrames lives outside the main nanobot repository:
- repo: https://github.com/Re-bin/nanobot-extension
- registry: https://raw.githubusercontent.com/Re-bin/nanobot-extension/main/registry.json
- skill: skills/hyperframes/SKILL.md
- install: npm install -g hyperframes

## Compatibility
- existing CLI-Anything catalog behavior is unchanged
- existing app install, update, and uninstall paths are unchanged
- the new registry is optional, so failures do not break Apps
- relative skill paths remain constrained to skills/.../SKILL.md and are resolved only against known registry raw bases

## Validation
- python -m pytest tests/cli_apps/test_service.py tests/cli_apps/test_tool.py tests/agent/test_workspace_scope.py -q
- python -m ruff check nanobot/apps/cli/service.py tests/cli_apps/test_service.py tests/cli_apps/test_tool.py tests/agent/test_workspace_scope.py --select F
- git diff --check
- verified Re-bin/nanobot-extension raw registry resolves
- verified CliAppManager payload includes hyperframes from source extensions
