### PR TITLE
[security] fix(msteams): trust service URLs before replies

### DIFF
--- a/nanobot/channels/msteams.py
+++ b/nanobot/channels/msteams.py
@@ -55,6 +55,9 @@ MSTEAMS_REF_TTL_DAYS = 30
 MSTEAMS_WEBCHAT_HOST = "webchat.botframework.com"
 MSTEAMS_DEFAULT_TRUSTED_SERVICE_URL_HOSTS = [
     "smba.trafficmanager.net",
+    "smba.infra.gcc.teams.microsoft.com",
+    "smba.infra.gov.teams.microsoft.us",
+    "smba.infra.dod.teams.microsoft.us",
     "*.botframework.com",
 ]
 MSTEAMS_REF_META_FILENAME = "msteams_conversations_meta.json"

--- a/nanobot/channels/msteams.py
+++ b/nanobot/channels/msteams.py
@@ -53,6 +53,10 @@ if MSTEAMS_AVAILABLE:
 
 MSTEAMS_REF_TTL_DAYS = 30
 MSTEAMS_WEBCHAT_HOST = "webchat.botframework.com"
+MSTEAMS_DEFAULT_TRUSTED_SERVICE_URL_HOSTS = [
+    "smba.trafficmanager.net",
+    "*.botframework.com",
+]
 MSTEAMS_REF_META_FILENAME = "msteams_conversations_meta.json"
 MSTEAMS_REF_LOCK_FILENAME = "msteams_conversations.lock"
 MSTEAMS_REF_TOUCH_INTERVAL_S = 300
@@ -76,6 +80,9 @@ class MSTeamsConfig(Base):
     prune_web_chat_refs: bool = True
     prune_non_personal_refs: bool = True
     ref_touch_interval_s: int = Field(default=MSTEAMS_REF_TOUCH_INTERVAL_S, ge=0)
+    trusted_service_url_hosts: list[str] = Field(
+        default_factory=lambda: MSTEAMS_DEFAULT_TRUSTED_SERVICE_URL_HOSTS.copy()
+    )
 
 
 @dataclass
@@ -242,6 +249,11 @@ class MSTeamsChannel(BaseChannel):
         if not ref:
             raise RuntimeError(f"MSTeams conversation ref not found for chat_id={msg.chat_id}")
 
+        if not self._is_trusted_service_url(ref.service_url):
+            raise RuntimeError(
+                f"MSTeams conversation ref has untrusted service_url for chat_id={msg.chat_id}"
+            )
+
         token = await self._get_access_token()
         base_url = f"{ref.service_url.rstrip('/')}/v3/conversations/{ref.conversation_id}/activities"
         use_thread_reply = self.config.reply_in_thread and bool(ref.activity_id)
@@ -282,6 +294,13 @@ class MSTeamsChannel(BaseChannel):
         conversation_type = str(conversation.get("conversationType") or "").strip()
 
         if not sender_id or not conversation_id or not service_url:
+            return
+
+        if not self._is_trusted_service_url(service_url):
+            self.logger.warning(
+                "Ignoring MSTeams activity with untrusted serviceUrl host: {}",
+                service_url,
+            )
             return
 
         if recipient.get("id") and from_user.get("id") == recipient.get("id"):
@@ -626,6 +645,29 @@ class MSTeamsChannel(BaseChannel):
             return host == MSTEAMS_WEBCHAT_HOST or host.endswith(f".{MSTEAMS_WEBCHAT_HOST}")
         return MSTEAMS_WEBCHAT_HOST in normalized.lower()
 
+    def _is_trusted_service_url(self, service_url: str) -> bool:
+        """Return True for HTTPS Bot Framework service URLs trusted for bearer replies."""
+        parsed = urlparse(service_url.strip())
+        if parsed.scheme.lower() != "https":
+            return False
+
+        host = (parsed.hostname or "").strip().lower().rstrip(".")
+        if not host:
+            return False
+
+        for pattern in self.config.trusted_service_url_hosts:
+            trusted_host = str(pattern or "").strip().lower().rstrip(".")
+            if not trusted_host:
+                continue
+            if trusted_host.startswith("*."):
+                suffix = trusted_host[1:]
+                if host.endswith(suffix) and host != suffix.lstrip("."):
+                    return True
+                continue
+            if host == trusted_host:
+                return True
+        return False
+
     def _prune_conversation_refs(self, *, now: float | None = None) -> bool:
         """Remove stale and unsupported conversation refs from memory."""
         if not self._conversation_refs:
@@ -637,6 +679,10 @@ class MSTeamsChannel(BaseChannel):
         keys_to_drop: list[str] = []
 
         for key, ref in self._conversation_refs.items():
+            if not self._is_trusted_service_url(ref.service_url):
+                keys_to_drop.append(key)
+                continue
+
             if self.config.prune_web_chat_refs and self._is_webchat_service_url(ref.service_url):
                 keys_to_drop.append(key)
                 continue

--- a/tests/test_msteams.py
+++ b/tests/test_msteams.py
@@ -186,6 +186,18 @@ def test_init_prunes_stale_and_unsupported_conversation_refs(make_channel, tmp_p
     assert set(persisted.keys()) == {"conv-valid", "conv-missing-ts"}
 
 
+def test_default_trusted_service_urls_cover_official_teams_clouds(make_channel):
+    ch = make_channel()
+
+    assert ch._is_trusted_service_url("https://smba.trafficmanager.net/amer/")
+    assert ch._is_trusted_service_url("https://smba.infra.gcc.teams.microsoft.com/amer/")
+    assert ch._is_trusted_service_url("https://smba.infra.gov.teams.microsoft.us/amer/")
+    assert ch._is_trusted_service_url("https://smba.infra.dod.teams.microsoft.us/amer/")
+    assert ch._is_trusted_service_url("https://westus-api.botframework.com/")
+    assert not ch._is_trusted_service_url("http://smba.trafficmanager.net/amer/")
+    assert not ch._is_trusted_service_url("https://smba.trafficmanager.net.evil.example/")
+
+
 def test_save_prunes_unsupported_conversation_refs(make_channel, tmp_path, monkeypatch):
     now = 1_800_000_000.0
     monkeypatch.setattr(msteams_module.time, "time", lambda: now)

--- a/tests/test_msteams.py
+++ b/tests/test_msteams.py
@@ -435,6 +435,38 @@ async def test_handle_activity_denied_sender_does_not_store_ref(make_channel, tm
 
 
 @pytest.mark.asyncio
+async def test_handle_activity_rejects_untrusted_service_url(make_channel, tmp_path):
+    ch = make_channel(validateInboundAuth=False, allowFrom=["*"])
+
+    activity = {
+        "type": "message",
+        "id": "activity-poison",
+        "text": "Hello from forged Teams activity",
+        "serviceUrl": "https://attacker.example/collect",
+        "channelId": "msteams",
+        "conversation": {
+            "id": "conv-poison",
+            "conversationType": "personal",
+        },
+        "from": {
+            "id": "29:attacker-user-id",
+            "aadObjectId": "attacker-user-id",
+            "name": "Attacker",
+        },
+        "recipient": {
+            "id": "28:bot-id",
+            "name": "nanobot",
+        },
+    }
+
+    await ch._handle_activity(activity)
+
+    assert ch.bus.inbound == []
+    assert ch._conversation_refs == {}
+    assert not (tmp_path / "state" / "msteams_conversations.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_handle_activity_mention_only_uses_default_response(make_channel):
     ch = make_channel()
 
@@ -737,6 +769,25 @@ async def test_send_raises_when_conversation_ref_missing(make_channel):
 
     with pytest.raises(RuntimeError, match="conversation ref not found"):
         await ch.send(OutboundMessage(channel="msteams", chat_id="missing", content="Reply text"))
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_untrusted_service_url_before_bearer_post(make_channel):
+    ch = make_channel()
+    fake_http = FakeHttpClient()
+    ch._http = fake_http
+    ch._token = "tok"
+    ch._token_expires_at = 9999999999
+    ch._conversation_refs["conv-poison"] = ConversationRef(
+        service_url="https://attacker.example/collect",
+        conversation_id="conv-poison",
+        activity_id="activity-poison",
+    )
+
+    with pytest.raises(RuntimeError, match="untrusted service_url"):
+        await ch.send(OutboundMessage(channel="msteams", chat_id="conv-poison", content="Reply text"))
+
+    assert fake_http.calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR hardens the Microsoft Teams channel so Nanobot does not trust arbitrary `activity.serviceUrl` values when storing conversation references or sending Bot Framework replies.

The important boundary is the Bot Framework service URL: outbound replies are sent to that URL with an `Authorization: Bearer ...` token. If a forged or otherwise untrusted activity can poison the stored service URL, a later reply can become SSRF plus Bot Framework bearer-token disclosure.

This patch adds a small trusted-host boundary for Teams/Bot Framework service URLs and refuses token-bearing replies to untrusted conversation references.

## Security issues covered

- **Issue:** Microsoft Teams `serviceUrl` poisoning can redirect token-bearing Bot Framework replies to an attacker-controlled host.
- **Affected surface:** `MSTeamsChannel` conversation reference storage and outbound replies.
- **Severity:** High, conditional on Teams webhook authentication being disabled, bypassed, or otherwise not enforced for a reachable webhook.

## Before this PR

- The Teams channel accepted the inbound activity `serviceUrl` as the base URL for later replies.
- `_handle_activity()` stored conversation references without constraining the `serviceUrl` host.
- `send()` later used the stored URL as the outbound base and attached a Bot Framework bearer token.
- If inbound Teams/Bot Framework auth was disabled or bypassed, a direct forged webhook request could poison a conversation reference.

## After this PR

- Teams conversation references are only stored when `serviceUrl` is HTTPS and matches the configured trusted host patterns.
- Existing or legacy untrusted conversation refs are pruned by the existing ref-pruning path.
- `send()` performs a final trust check before requesting/sending a bearer token.
- The default trusted service URL hosts cover expected Bot Framework/Teams hosts:
  - `smba.trafficmanager.net`
  - `*.botframework.com`

## Why this matters

Bot Framework replies are token-bearing outbound requests. Treating a client-controlled `serviceUrl` as trusted can turn a forged Teams activity into:

- SSRF from the Nanobot host;
- disclosure of a Bot Framework bearer token to an attacker-controlled URL;
- follow-on spoofed Teams conversation state if a poisoned ref is persisted.

The bug is most relevant for deployments where the Teams webhook is reachable and `validateInboundAuth` has been disabled, bypassed, or misconfigured. With the default `validateInboundAuth=true`, arbitrary forged Teams webhook JSON is normally blocked by Bot Framework JWT validation, including service URL claim checks.

## How this differs from related issue/PR

This is separate from the public OpenAI-compatible `/v1/*` API authentication and browser-localhost CSRF hardening work. That issue concerns Nanobot's OpenAI-compatible API control plane.

This PR instead hardens the Microsoft Teams channel's Bot Framework reply trust boundary. The distinguishing primitive here is token-bearing outbound egress to a stored `serviceUrl` value that originated from an inbound Teams activity.

This is also distinct from generic Teams message spoofing. The security-sensitive sink is not just accepting a message; it is later sending a Bot Framework bearer token to the stored service URL.

## Attack flow

1. An operator exposes the Teams webhook, for example `/api/messages`.
2. Inbound Teams/Bot Framework auth is disabled, bypassed, or otherwise not enforced.
3. An attacker sends a direct crafted activity JSON request to Nanobot's webhook.
4. The request includes an attacker-controlled value such as:

   ```json
   {
     "type": "message",
     "serviceUrl": "https://attacker.example/collect",
     "channelId": "msteams",
     "conversation": {
       "id": "conv-poison",
       "conversationType": "personal"
     },
     "from": {
       "id": "29:attacker-user-id",
       "aadObjectId": "attacker-user-id"
     },
     "recipient": {
       "id": "28:bot-id"
     },
     "text": "hello"
   }
   ```

5. Vulnerable code stores `https://attacker.example/collect` in `_conversation_refs`.
6. A later Nanobot reply uses that stored URL as the Bot Framework Connector API base.
7. The outbound POST includes `Authorization: Bearer [REDACTED]` and is sent to the attacker-controlled host.

`allowFrom` affects practical exploitability:

- `allowFrom: ["*"]` is the straightforward exploitable case.
- With a non-wildcard allowlist, the attacker would need to match or spoof an allowed `from.aadObjectId` / `from.id`.
- An empty allowlist normally blocks the forged sender unless another pairing or approval path has already admitted that identity.

## Affected code

- `nanobot/channels/msteams.py`
  - conversation reference admission in `_handle_activity()`;
  - outbound Bot Framework reply handling in `send()`;
  - conversation reference pruning.
- `tests/test_msteams.py`
  - regression tests for rejecting untrusted service URLs and avoiding token-bearing egress.

## Root cause

- `serviceUrl` is an inbound activity field and should not be treated as an unrestricted outbound authority.
- The channel stored the inbound `serviceUrl` without a trusted-host boundary.
- The outbound reply path later attached a Bot Framework bearer token to requests derived from that stored URL.
- The final outbound sink did not re-check the stored URL before getting/sending the token.

## CVSS assessment

- **Issue:** Microsoft Teams `serviceUrl` poisoning leading to SSRF and Bot Framework bearer-token disclosure.
- **CVSS v3.1:** 8.1 High.
- **Vector:** `CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N`

Rationale:

- Network attack vector when the Teams webhook is reachable.
- High attack complexity because the default `validateInboundAuth=true` normally blocks simple forged activity JSON; the practical path requires disabled/bypassed inbound auth or equivalent misconfiguration.
- No application privileges are needed once the vulnerable webhook boundary is reachable under those conditions.
- Confidentiality impact is high because a Bot Framework bearer token can be sent to an attacker-controlled endpoint.
- Integrity impact is high because the poisoned conversation reference can steer later Bot Framework reply behavior.

## Safe reproduction steps

A safe local reproduction can be performed with a test Teams channel configured with `validateInboundAuth=false` and `allowFrom=["*"]`.

1. Create a forged Teams activity with an attacker-controlled `serviceUrl`, such as `https://attacker.example/collect`.
2. Pass the activity to the Teams activity handler.
3. Trigger a reply for the stored conversation reference.
4. Observe vulnerable behavior on an unpatched build: the outbound Bot Framework reply target is derived from the attacker-controlled service URL and includes an Authorization bearer token.

This PR includes regression tests for the patched behavior instead of contacting any real external attacker endpoint.

## Expected vulnerable behavior

On vulnerable code, a forged auth-disabled activity can store an attacker-controlled service URL. A later reply can target:

```text
https://attacker.example/collect/v3/conversations/conv-poison/activities
```

with an outbound authorization header equivalent to:

```text
Authorization: Bearer [REDACTED]
```

## Changes in this PR

- Adds default trusted Teams/Bot Framework service URL host patterns.
- Adds `trustedServiceUrlHosts` / `trusted_service_url_hosts` configuration support through the existing config model style.
- Rejects inbound activities with untrusted `serviceUrl` hosts before publishing/storing conversation refs.
- Refuses outbound sends to untrusted stored conversation refs before requesting a Bot Framework access token.
- Prunes untrusted existing conversation refs alongside the existing stale/Web Chat/non-personal pruning behavior.
- Adds regression tests for both the inbound poisoning path and the outbound token-bearing sink.

## Files changed

- `nanobot/channels/msteams.py`
  - trusted service URL host defaults;
  - service URL trust helper;
  - inbound storage guard;
  - outbound send guard;
  - pruning for legacy untrusted refs.
- `tests/test_msteams.py`
  - regression coverage for rejecting forged untrusted activity service URLs;
  - regression coverage for rejecting poisoned stored refs before outbound HTTP/token use.

## Maintainer impact

- Default Teams/Bot Framework service URLs continue to work.
- Deployments that legitimately use additional Bot Framework service hosts can configure `trustedServiceUrlHosts`.
- The change is intentionally narrow: it does not alter general Teams auth behavior, message parsing, or allowlist semantics.
- The webhook remains protected by the existing `validateInboundAuth=true` default; this PR adds defense-in-depth for the token-bearing reply boundary.

## Fix rationale

The trust boundary should be enforced where the sensitive egress is created. A Teams activity may legitimately contain a `serviceUrl`, but Nanobot should only use it for bearer-authenticated Connector API replies when it belongs to an expected Bot Framework service host.

The patch checks both admission and use:

- admission check prevents poisoning new conversation refs;
- send-time check protects against legacy persisted refs or future code paths that may populate `_conversation_refs`;
- pruning removes stale unsafe state naturally through the existing persistence flow.

## Type of change

- [x] Security fix
- [x] Regression tests
- [ ] Breaking change
- [ ] Documentation-only change

## Test plan

Ran targeted Microsoft Teams tests three times:

```bash
uv run --extra dev python -m pytest tests/test_msteams.py -q
uv run --extra dev python -m pytest tests/test_msteams.py -q
uv run --extra dev python -m pytest tests/test_msteams.py -q
```

Result:

```text
35 passed
35 passed
35 passed
```

Ran lint and whitespace checks:

```bash
uv run --extra dev python -m ruff check nanobot/channels/msteams.py tests/test_msteams.py
git diff --check
```

Result:

```text
All checks passed
```

Note: I intentionally did not apply broad `ruff format` churn to these legacy files because it reformats unrelated existing lines. The touched security diff is kept minimal and passes `ruff check` plus `git diff --check`.

## Disclosure notes

This PR does not claim that default Nanobot Teams deployments allow arbitrary forged Microsoft Teams requests. With `validateInboundAuth=true`, the default inbound Bot Framework JWT validation normally blocks direct attacker-crafted activity JSON, including mismatched service URL claims.

The issue addressed here is a conditional hardening issue for reachable Teams webhooks where inbound auth is disabled, bypassed, or otherwise not enforced. In that configuration, `activity.serviceUrl` must not be allowed to become an unrestricted bearer-token egress target.
