### PR TITLE
feat: add manual memory mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1518,6 +1518,24 @@ How it works:
 >
 > This differs from the **token-driven soft consolidation** that fires when a prompt exceeds the context budget: that path only advances an internal `last_consolidated` cursor and leaves the session file untouched, so the raw tool-call trail stays on disk and can still be replayed or audited. If you rely on that trail for debugging or auditing, leave `idleCompactAfterMinutes` at the default `0` and let only the token-driven path run.
 
+## Manual Memory Mode
+
+Set `agents.defaults.memory.mode` to `"manual"` when ordinary conversation should not automatically become long-term memory material:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "memory": {
+        "mode": "manual"
+      }
+    }
+  }
+}
+```
+
+In manual mode, long-term memory is isolated in `memory/manual/MEMORY.md`; auto mode continues to use `memory/MEMORY.md`. Automatic conversation summaries are not written to `memory/history.jsonl`, and session-continuity summaries stay in session metadata as `_last_summary`. Automatic Dream scheduling is disabled, and `/dream` optimizes only `memory/manual/MEMORY.md` without reading conversation history. Switching modes does not migrate or merge the two memory files; copy facts manually when you want them in both.
+
 ## Timezone
 
 Time is context. Context should be precise.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -68,7 +68,9 @@ workspace/
 ├── SOUL.md              # The bot's long-term voice and communication style
 ├── USER.md              # Stable knowledge about the user
 └── memory/
-    ├── MEMORY.md        # Project facts, decisions, and durable context
+    ├── MEMORY.md        # Auto-mode project facts, decisions, and durable context
+    ├── manual/
+    │   └── MEMORY.md    # Manual-mode long-term memory, edited by the user
     ├── history.jsonl    # Append-only history summaries
     ├── .cursor          # Consolidator write cursor
     ├── .dream_cursor    # Dream consumption cursor
@@ -151,6 +153,9 @@ Dream is configured under `agents.defaults.dream`:
         "modelOverride": null,
         "maxBatchSize": 20,
         "maxIterations": 10
+      },
+      "memory": {
+        "mode": "auto"
       }
     }
   }
@@ -170,6 +175,29 @@ In practical terms:
 - `maxBatchSize` controls how many new `history.jsonl` entries Dream consumes in one run. Larger batches catch up faster; smaller batches are lighter and steadier.
 - `maxIterations` limits how many read/edit steps Dream can take while updating `SOUL.md`, `USER.md`, and `MEMORY.md`. It is a safety budget, not a quality score.
 - `intervalH` is the normal way to configure Dream. Internally it runs as an `every` schedule, not as a cron expression.
+
+### Manual memory mode
+
+Set `agents.defaults.memory.mode` to `"manual"` when ordinary conversation should not automatically become long-term memory material.
+
+In manual mode:
+
+- ordinary conversation still persists in `sessions/*.jsonl` for chat continuity
+- automatic summaries are not written to `memory/history.jsonl`
+- long-term memory is read from `memory/manual/MEMORY.md`, not `memory/MEMORY.md`
+- durable manual memory is edited directly in `memory/manual/MEMORY.md`
+- `/dream` optimizes only `memory/manual/MEMORY.md`; it does not read conversation history
+- session-continuity summaries stay in the session metadata as `_last_summary`
+
+Manual mode uses a separate long-term memory file:
+
+```text
+memory/
+└── manual/
+    └── MEMORY.md
+```
+
+Switching modes does not migrate or merge memory files. Auto mode reads `memory/MEMORY.md`; manual mode reads `memory/manual/MEMORY.md`. If you want the same facts in both modes, copy them manually.
 
 Legacy note:
 

--- a/nanobot/agent/autocompact.py
+++ b/nanobot/agent/autocompact.py
@@ -37,6 +37,33 @@ class AutoCompact:
     def _format_summary(text: str, last_active: datetime) -> str:
         return f"Previous conversation summary (last active {last_active.isoformat()}):\n{text}"
 
+    @staticmethod
+    def _metadata_summary(session: Session) -> tuple[str, datetime] | None:
+        meta = session.metadata.get("_last_summary")
+        if not isinstance(meta, dict):
+            return None
+        text = meta.get("text")
+        last_active = meta.get("last_active")
+        if not isinstance(text, str) or not isinstance(last_active, str):
+            return None
+        try:
+            return text, datetime.fromisoformat(last_active)
+        except ValueError:
+            return None
+
+    def _summary_entry(self, session: Session) -> tuple[str, datetime] | None:
+        getter = getattr(self.consolidator, "get_session_summary", None)
+        if callable(getter):
+            entry = getter(session)
+            if (
+                isinstance(entry, tuple)
+                and len(entry) == 2
+                and isinstance(entry[0], str)
+                and isinstance(entry[1], datetime)
+            ):
+                return entry
+        return self._metadata_summary(session)
+
     def check_expired(self, schedule_background: Callable[[Coroutine], None],
                       active_session_keys: Collection[str] = ()) -> None:
         """Schedule archival for idle sessions, skipping those with in-flight agent tasks."""
@@ -58,11 +85,11 @@ class AutoCompact:
             )
             if summary and summary != "(nothing)":
                 session = self.sessions.get_or_create(key)
-                meta = session.metadata.get("_last_summary")
-                if isinstance(meta, dict):
+                entry = self._summary_entry(session)
+                if entry:
                     self._summaries[key] = (
-                        meta["text"],
-                        datetime.fromisoformat(meta["last_active"]),
+                        entry[0],
+                        entry[1],
                     )
         except Exception:
             logger.exception("Auto-compact: failed for {}", key)
@@ -77,8 +104,8 @@ class AutoCompact:
         entry = self._summaries.pop(key, None)
         if entry:
             return session, self._format_summary(entry[0], entry[1])
-        # Cold path: summary persisted in session metadata (process restarted).
-        meta = session.metadata.get("_last_summary")
-        if isinstance(meta, dict):
-            return session, self._format_summary(meta["text"], datetime.fromisoformat(meta["last_active"]))
+        # Cold path: summary persisted by the consolidator (process restarted).
+        entry = self._summary_entry(session)
+        if entry:
+            return session, self._format_summary(entry[0], entry[1])
         return session, None

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -57,10 +57,16 @@ class ContextBuilder:
     _MAX_HISTORY_CHARS = 32_000  # hard cap on recent history section size
     _RUNTIME_CONTEXT_END = "[/Runtime Context]"
 
-    def __init__(self, workspace: Path, timezone: str | None = None, disabled_skills: list[str] | None = None):
+    def __init__(
+        self,
+        workspace: Path,
+        timezone: str | None = None,
+        disabled_skills: list[str] | None = None,
+        memory_mode: str = "auto",
+    ):
         self.workspace = workspace
         self.timezone = timezone
-        self.memory = MemoryStore(workspace)
+        self.memory = MemoryStore(workspace, memory_mode=memory_mode)
         self.skills = SkillsLoader(workspace, disabled_skills=set(disabled_skills) if disabled_skills else None)
 
     def build_system_prompt(
@@ -94,7 +100,9 @@ class ContextBuilder:
         if skills_summary:
             parts.append(render_template("agent/skills_section.md", skills_summary=skills_summary))
 
-        entries = self.memory.read_unprocessed_history(since_cursor=self.memory.get_last_dream_cursor())
+        entries = []
+        if self.memory.memory_mode == "auto":
+            entries = self.memory.read_unprocessed_history(since_cursor=self.memory.get_last_dream_cursor())
         if entries:
             capped = entries[-self._MAX_RECENT_HISTORY:]
             history_text = "\n".join(

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -206,6 +206,7 @@ class AgentLoop:
         preset_snapshot_loader: preset_helpers.PresetSnapshotLoader | None = None,
         runtime_events: RuntimeEventBus | None = None,
         runtime_model_publisher: Callable[[str, str | None], None] | None = None,
+        memory_mode: str = "auto",
     ):
         from nanobot.config.schema import ToolsConfig
 
@@ -243,6 +244,7 @@ class AgentLoop:
             else defaults.tool_hint_max_length
         )
         self.tools_config = _tc
+        self.memory_mode = memory_mode
         self.web_config = _tc.web
         self.exec_config = _tc.exec
         self._image_generation_provider_configs = dict(image_generation_provider_configs or {})
@@ -261,7 +263,12 @@ class AgentLoop:
         self._last_usage: dict[str, int] = {}
         self._extra_hooks: list[AgentHook] = hooks or []
 
-        self.context = ContextBuilder(workspace, timezone=timezone, disabled_skills=disabled_skills)
+        self.context = ContextBuilder(
+            workspace,
+            timezone=timezone,
+            disabled_skills=disabled_skills,
+            memory_mode=memory_mode,
+        )
         self.sessions = session_manager or SessionManager(workspace)
         self.tools = ToolRegistry()
         # One file-read/write tracker per logical session. The tool registry is
@@ -379,6 +386,7 @@ class AgentLoop:
             session_ttl_minutes=defaults.session_ttl_minutes,
             consolidation_ratio=defaults.consolidation_ratio,
             max_messages=defaults.max_messages,
+            memory_mode=defaults.memory.mode,
             tools_config=config.tools,
             model_presets=preset_helpers.configured_model_presets(config),
             model_preset=defaults.model_preset,
@@ -611,6 +619,19 @@ class AgentLoop:
             runtime_state=self,
             inbound_message=msg,
         )
+
+    @staticmethod
+    def _merge_session_summaries(
+        existing: str | None,
+        new: str | None,
+    ) -> str | None:
+        parts: list[str] = []
+        for value in (existing, new):
+            if not isinstance(value, str) or not value or value == "(nothing)":
+                continue
+            if value not in parts:
+                parts.append(value)
+        return "\n\n".join(parts) if parts else None
 
     async def _dispatch_command_inline(
         self,
@@ -1109,10 +1130,11 @@ class AgentLoop:
         if pending:
             logger.info("Memory compact triggered for session {}", key)
 
-        await self.consolidator.maybe_consolidate_by_tokens(
+        new_summary = await self.consolidator.maybe_consolidate_by_tokens(
             session,
             replay_max_messages=self._max_messages,
         )
+        pending = self._merge_session_summaries(pending, new_summary)
         is_subagent = msg.sender_id == "subagent"
         if is_subagent and self._persist_subagent_followup(session, msg):
             logger.debug("Subagent result persisted for session {}", key)
@@ -1156,7 +1178,11 @@ class AgentLoop:
         latency_ms = max(0, int((wall_done - t_wall) * 1000))
         self._save_turn(session, all_msgs, 1 + len(history), turn_latency_ms=latency_ms)
         self._runtime_events().record_turn_latency(key, latency_ms)
-        session.enforce_file_cap(on_archive=self.context.memory.raw_archive)
+        session.enforce_file_cap(
+            on_archive=self.context.memory.raw_archive
+            if self.context.memory.memory_mode == "auto"
+            else None
+        )
         self._clear_runtime_checkpoint(session)
         self.sessions.save(session)
         self._schedule_background(
@@ -1372,9 +1398,13 @@ class AgentLoop:
         return "dispatch"
 
     async def _state_build(self, ctx: TurnContext) -> str:
-        await self.consolidator.maybe_consolidate_by_tokens(
+        new_summary = await self.consolidator.maybe_consolidate_by_tokens(
             ctx.session,
             replay_max_messages=self._max_messages,
+        )
+        ctx.pending_summary = self._merge_session_summaries(
+            ctx.pending_summary,
+            new_summary,
         )
         self._set_tool_context(
             ctx.msg.channel,
@@ -1471,7 +1501,11 @@ class AgentLoop:
             ctx.session_key,
             ctx.turn_latency_ms,
         )
-        ctx.session.enforce_file_cap(on_archive=self.context.memory.raw_archive)
+        ctx.session.enforce_file_cap(
+            on_archive=self.context.memory.raw_archive
+            if self.context.memory.memory_mode == "auto"
+            else None
+        )
         self._clear_pending_user_turn(ctx.session)
         self._clear_runtime_checkpoint(ctx.session)
         self.sessions.save(ctx.session)

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 class MemoryStore:
-    """Pure file I/O for memory files: MEMORY.md, history.jsonl, SOUL.md, USER.md."""
+    """Pure file I/O for memory files, history, SOUL.md, and USER.md."""
 
     _DEFAULT_MAX_HISTORY = 1000
     _LEGACY_ENTRY_START_RE = re.compile(r"^\[(\d{4}-\d{2}-\d{2}[^\]]*)\]\s*")
@@ -48,11 +48,21 @@ class MemoryStore:
         r"^\[\d{4}-\d{2}-\d{2}[^\]]*\]\s+[A-Z][A-Z0-9_]*(?:\s+\[tools:\s*[^\]]+\])?:"
     )
 
-    def __init__(self, workspace: Path, max_history_entries: int = _DEFAULT_MAX_HISTORY):
+    def __init__(
+        self,
+        workspace: Path,
+        max_history_entries: int = _DEFAULT_MAX_HISTORY,
+        memory_mode: str = "auto",
+    ):
         self.workspace = workspace
         self.max_history_entries = max_history_entries
+        self.memory_mode = memory_mode
         self.memory_dir = ensure_dir(workspace / "memory")
-        self.memory_file = self.memory_dir / "MEMORY.md"
+        self.manual_dir = ensure_dir(self.memory_dir / "manual")
+        self.auto_memory_file = self.memory_dir / "MEMORY.md"
+        self.manual_memory_file = self.manual_dir / "MEMORY.md"
+        if not self.manual_memory_file.exists():
+            self.manual_memory_file.write_text("", encoding="utf-8")
         self.history_file = self.memory_dir / "history.jsonl"
         self.legacy_history_file = self.memory_dir / "HISTORY.md"
         self.soul_file = workspace / "SOUL.md"
@@ -61,14 +71,32 @@ class MemoryStore:
         self._dream_cursor_file = self.memory_dir / ".dream_cursor"
         self._corruption_logged = False  # rate-limit non-int cursor warning
         self._oversize_logged = False  # rate-limit oversized-entry warning
-        self._git = GitStore(workspace, tracked_files=[
-            "SOUL.md", "USER.md", "memory/MEMORY.md", "memory/.dream_cursor",
+        self._auto_git = GitStore(workspace, tracked_files=[
+            "SOUL.md",
+            "USER.md",
+            "memory/MEMORY.md",
+            "memory/.dream_cursor",
         ])
+        self._manual_git = GitStore(
+            self.manual_dir,
+            tracked_files=["MEMORY.md"],
+            allow_nested=True,
+        )
         self._maybe_migrate_legacy_history()
 
     @property
     def git(self) -> GitStore:
-        return self._git
+        if self.memory_mode == "manual":
+            return self._manual_git
+        return self._auto_git
+
+    @property
+    def auto_git(self) -> GitStore:
+        return self._auto_git
+
+    @property
+    def manual_git(self) -> GitStore:
+        return self._manual_git
 
     # -- generic helpers -----------------------------------------------------
 
@@ -202,6 +230,12 @@ class MemoryStore:
 
     # -- MEMORY.md (long-term facts) -----------------------------------------
 
+    @property
+    def memory_file(self) -> Path:
+        if self.memory_mode == "manual":
+            return self.manual_memory_file
+        return self.auto_memory_file
+
     def read_memory(self) -> str:
         return self.read_file(self.memory_file)
 
@@ -301,6 +335,33 @@ class MemoryStore:
                 poisoned,
             )
 
+    def _iter_valid_jsonl_entries(self, path: Path) -> Iterator[tuple[dict[str, Any], int]]:
+        poisoned: Any = None
+        with suppress(FileNotFoundError):
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    raw = entry.get("cursor")
+                    cursor = self._valid_cursor(raw)
+                    if cursor is None:
+                        poisoned = raw
+                        continue
+                    yield entry, cursor
+        if poisoned is not None and not self._corruption_logged:
+            self._corruption_logged = True
+            logger.warning(
+                "{} contains a non-int cursor ({!r}); dropping it. "
+                "Usually caused by an external writer; further occurrences suppressed.",
+                path.name,
+                poisoned,
+            )
+
     def _next_cursor(self) -> int:
         """Read the current cursor counter and return the next value."""
         if self._cursor_file.exists():
@@ -348,8 +409,12 @@ class MemoryStore:
 
     def _read_last_entry(self) -> dict[str, Any] | None:
         """Read the last entry from the JSONL file efficiently."""
+        return self._read_last_jsonl_entry(self.history_file)
+
+    def _read_last_jsonl_entry(self, path: Path) -> dict[str, Any] | None:
+        """Read the last entry from a JSONL file efficiently."""
         try:
-            with open(self.history_file, "rb") as f:
+            with open(path, "rb") as f:
                 f.seek(0, 2)
                 size = f.tell()
                 if size == 0:
@@ -439,10 +504,40 @@ class MemoryStore:
 _RAW_ARCHIVE_MAX_CHARS = 16_000       # fallback dump (LLM failed)
 _ARCHIVE_SUMMARY_MAX_CHARS = 8_000    # LLM-produced consolidation summary
 _HISTORY_ENTRY_HARD_CAP = 64_000      # emergency cap in append_history
+_MANUAL_ROLLING_SUMMARY_MAX_CHARS = 32_000
+
+
+_MANUAL_ROLLING_SUMMARY_SYSTEM = """Update the existing session summary with the new archived messages.
+
+The existing summary is already the compressed context for earlier parts of this same session.
+The new archived messages are raw conversation messages that are about to be hidden from live replay.
+
+Output one complete updated session summary that preserves the useful context from both inputs.
+Keep it concise and factual. Do not include preamble or commentary.
+If there is no useful context in either input, output: (nothing)
+"""
+
+_MANUAL_DREAM_SYSTEM = """You optimize the hand-written manual memory file for this workspace.
+
+Edit only `memory/manual/MEMORY.md`.
+Do not read conversation history.
+Do not add facts that are not already present in `memory/manual/MEMORY.md`.
+Do not edit `memory/MEMORY.md`, `SOUL.md`, `USER.md`, `AGENTS.md`, or skills.
+
+Your job is to make the manual memory clearer and easier to use:
+- deduplicate repeated points
+- group related facts
+- clarify wording without changing meaning
+- preserve user intent and important wording
+- remove only obvious formatting noise
+
+Use `read_file` first, then `edit_file` or `write_file` if an edit is useful.
+If the file is already clear, make no changes.
+"""
 
 
 class Consolidator:
-    """Lightweight consolidation: summarizes evicted messages into history.jsonl."""
+    """Lightweight consolidation for evicted session messages."""
 
     _MAX_CONSOLIDATION_ROUNDS = 5
 
@@ -574,7 +669,13 @@ class Consolidator:
             len(chunk),
             replay_max_messages,
         )
-        summary = await self.archive(chunk)
+        existing_summary = self.get_session_summary(session)
+        summary = await self.archive(
+            chunk,
+            existing_summary=existing_summary[0] if existing_summary else None,
+        )
+        if summary is None and self.store.memory_mode == "manual":
+            return None
         session.last_consolidated = end_idx
         self.sessions.save(session)
         return summary
@@ -587,6 +688,16 @@ class Consolidator:
             }
             self.sessions.save(session)
 
+    def get_session_summary(self, session: Session) -> tuple[str, datetime] | None:
+        meta = session.metadata.get("_last_summary")
+        if isinstance(meta, dict):
+            text = meta.get("text")
+            last_active = meta.get("last_active")
+            if isinstance(text, str) and isinstance(last_active, str):
+                with suppress(ValueError):
+                    return text, datetime.fromisoformat(last_active)
+        return None
+
     def estimate_session_prompt_tokens(
         self,
         session: Session,
@@ -595,8 +706,8 @@ class Consolidator:
         history = self._full_unconsolidated_history(session, include_timestamps=True)
         channel, chat_id = (session.key.split(":", 1) if ":" in session.key else (None, None))
         # Include archived summary in estimation so the budget accounts for it.
-        meta = session.metadata.get("_last_summary")
-        summary = meta.get("text") if isinstance(meta, dict) else (meta if isinstance(meta, str) else None)
+        summary_entry = self.get_session_summary(session)
+        summary = summary_entry[0] if summary_entry else None
         probe_messages = self._build_messages(
             history=history,
             current_message="[token-probe]",
@@ -632,27 +743,56 @@ class Consolidator:
         except Exception:
             return truncate_text(text, budget * 4)
 
-    async def archive(self, messages: list[dict]) -> str | None:
-        """Summarize messages via LLM and append to history.jsonl.
+    def _archive_prompt(
+        self,
+        formatted_messages: str,
+        *,
+        existing_summary: str | None = None,
+    ) -> tuple[str, str]:
+        if self.store.memory_mode != "manual" or not existing_summary:
+            return (
+                render_template("agent/consolidator_archive.md", strip=True),
+                formatted_messages,
+            )
+        existing = truncate_text(existing_summary, _MANUAL_ROLLING_SUMMARY_MAX_CHARS)
+        return (
+            _MANUAL_ROLLING_SUMMARY_SYSTEM,
+            (
+                "## Existing Session Summary\n"
+                f"{existing}\n\n"
+                "## New Archived Messages\n"
+                f"{formatted_messages}"
+            ),
+        )
 
-        Returns the summary text on success, None if nothing to archive.
+    async def archive(
+        self,
+        messages: list[dict],
+        *,
+        existing_summary: str | None = None,
+    ) -> str | None:
+        """Summarize messages via LLM.
+
+        Auto mode appends summaries to history.jsonl. Manual mode returns the
+        summary for session continuity without writing shared history.
         """
         if not messages:
             return None
         try:
             formatted = MemoryStore._format_messages(messages)
             formatted = self._truncate_to_token_budget(formatted)
+            system_prompt, user_prompt = self._archive_prompt(
+                formatted,
+                existing_summary=existing_summary,
+            )
             response = await self.provider.chat_with_retry(
                 model=self.model,
                 messages=[
                     {
                         "role": "system",
-                        "content": render_template(
-                            "agent/consolidator_archive.md",
-                            strip=True,
-                        ),
+                        "content": system_prompt,
                     },
-                    {"role": "user", "content": formatted},
+                    {"role": "user", "content": user_prompt},
                 ],
                 tools=None,
                 tool_choice=None,
@@ -660,11 +800,15 @@ class Consolidator:
             if response.finish_reason == "error":
                 raise RuntimeError(f"LLM returned error: {response.content}")
             summary = response.content or "[no summary]"
-            self.store.append_history(summary, max_chars=_ARCHIVE_SUMMARY_MAX_CHARS)
+            if self.store.memory_mode == "auto":
+                self.store.append_history(summary, max_chars=_ARCHIVE_SUMMARY_MAX_CHARS)
             return summary
         except Exception:
-            logger.warning("Consolidation LLM call failed, raw-dumping to history")
-            self.store.raw_archive(messages)
+            if self.store.memory_mode == "auto":
+                logger.warning("Consolidation LLM call failed, raw-dumping to history")
+                self.store.raw_archive(messages)
+            else:
+                logger.warning("Manual memory consolidation LLM call failed; not writing history")
             return None
 
     async def maybe_consolidate_by_tokens(
@@ -672,14 +816,14 @@ class Consolidator:
         session: Session,
         *,
         replay_max_messages: int | None = None,
-    ) -> None:
+    ) -> str | None:
         """Loop: archive old messages until prompt fits within safe budget.
 
         The budget reserves space for completion tokens and a safety buffer
         so the LLM request never exceeds the context window.
         """
         if self.context_window_tokens <= 0:
-            return
+            return None
 
         lock = self.get_lock(session.key)
         async with lock:
@@ -688,7 +832,10 @@ class Consolidator:
             if fresh is not session:
                 session = fresh
             if not session.messages:
-                return
+                return None
+
+            existing_summary = self.get_session_summary(session)
+            rolling_summary = existing_summary[0] if existing_summary else None
 
             budget = self._input_token_budget
             target = int(budget * self.consolidation_ratio)
@@ -696,6 +843,8 @@ class Consolidator:
                 session,
                 replay_max_messages,
             )
+            if last_summary:
+                rolling_summary = last_summary
             try:
                 estimated, source = self.estimate_session_prompt_tokens(
                     session,
@@ -705,7 +854,7 @@ class Consolidator:
                 estimated, source = 0, "error"
             if estimated <= 0:
                 self._persist_last_summary(session, last_summary)
-                return
+                return last_summary
             if estimated < budget:
                 unconsolidated_count = len(session.messages) - session.last_consolidated
                 logger.debug(
@@ -717,7 +866,7 @@ class Consolidator:
                     unconsolidated_count,
                 )
                 self._persist_last_summary(session, last_summary)
-                return
+                return last_summary
 
             for round_num in range(self._MAX_CONSOLIDATION_ROUNDS):
                 if estimated <= target:
@@ -747,13 +896,19 @@ class Consolidator:
                     source,
                     len(chunk),
                 )
-                summary = await self.archive(chunk)
+                summary = await self.archive(
+                    chunk,
+                    existing_summary=rolling_summary,
+                )
+                if summary is None and self.store.memory_mode == "manual":
+                    break
                 # Advance the cursor either way: on success the chunk was
                 # summarized; on failure archive() already raw-archived it as
                 # a breadcrumb. Re-archiving the same chunk on the next call
                 # would just emit duplicate [RAW] entries.
                 if summary:
                     last_summary = summary
+                    rolling_summary = summary
                 session.last_consolidated = end_idx
                 self.sessions.save(session)
                 if not summary:
@@ -775,6 +930,7 @@ class Consolidator:
             # into the runtime context on the next prepare_session() call, aligning
             # the summary injection strategy with AutoCompact._archive().
             self._persist_last_summary(session, last_summary)
+            return last_summary
 
     async def compact_idle_session(
         self,
@@ -819,7 +975,17 @@ class Consolidator:
             last_active = session.updated_at
             summary: str | None = ""
             if archive_msgs:
-                summary = await self.archive(archive_msgs)
+                existing_summary = self.get_session_summary(session)
+                summary = await self.archive(
+                    archive_msgs,
+                    existing_summary=existing_summary[0] if existing_summary else None,
+                )
+                if summary is None and self.store.memory_mode == "manual":
+                    logger.warning(
+                        "Idle-session compact for {} skipped: manual summary failed",
+                        session_key,
+                    )
+                    return None
 
             if summary and summary != "(nothing)":
                 session.metadata["_last_summary"] = {
@@ -895,6 +1061,7 @@ class Dream:
         self.annotate_line_ages = annotate_line_ages
         self._runner = AgentRunner(provider)
         self._tools = self._build_tools()
+        self._manual_tools = self._build_manual_tools()
 
     def set_provider(self, provider: LLMProvider, model: str) -> None:
         self.provider = provider
@@ -930,6 +1097,33 @@ class Dream:
         tools.register(WriteFileTool(workspace=workspace, allowed_dir=skills_dir, file_states=file_states))
         return tools
 
+    def _build_manual_tools(self) -> ToolRegistry:
+        """Build tools restricted to the manual memory directory."""
+        from nanobot.agent.tools.file_state import FileStates
+        from nanobot.agent.tools.filesystem import EditFileTool, ReadFileTool, WriteFileTool
+
+        tools = ToolRegistry()
+        workspace = self.store.workspace
+        manual_dir = self.store.manual_dir
+        manual_dir.mkdir(parents=True, exist_ok=True)
+        file_states = FileStates()
+        tools.register(ReadFileTool(
+            workspace=workspace,
+            allowed_dir=manual_dir,
+            file_states=file_states,
+        ))
+        tools.register(EditFileTool(
+            workspace=workspace,
+            allowed_dir=manual_dir,
+            file_states=file_states,
+        ))
+        tools.register(WriteFileTool(
+            workspace=workspace,
+            allowed_dir=manual_dir,
+            file_states=file_states,
+        ))
+        return tools
+
     # -- skill listing --------------------------------------------------------
 
     def _list_existing_skills(self) -> list[str]:
@@ -959,6 +1153,57 @@ class Dream:
         return [f"{name} — {desc}" for name, desc in sorted(entries.items())]
 
     # -- main entry ----------------------------------------------------------
+
+    async def _run_manual(self) -> bool:
+        current = self.store.read_memory()
+        if not current.strip():
+            return False
+
+        manual_path = "memory/manual/MEMORY.md"
+        prompt = (
+            f"## Target File\n{manual_path}\n\n"
+            f"## Current Content\n{truncate_text(current, self._MEMORY_FILE_MAX_CHARS)}"
+        )
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": _MANUAL_DREAM_SYSTEM},
+            {"role": "user", "content": prompt},
+        ]
+
+        try:
+            result = await self._runner.run(AgentRunSpec(
+                initial_messages=messages,
+                tools=self._manual_tools,
+                model=self.model,
+                max_iterations=self.max_iterations,
+                max_tool_result_chars=self.max_tool_result_chars,
+                fail_on_tool_error=False,
+            ))
+        except Exception:
+            logger.exception("Manual Dream failed")
+            return False
+
+        changelog: list[str] = []
+        for event in (result.tool_events or []):
+            if event["status"] == "ok":
+                changelog.append(f"{event['name']}: {event['detail']}")
+
+        if result.stop_reason != "completed":
+            logger.warning(
+                "Manual Dream incomplete ({}): no cursor changes needed",
+                result.stop_reason,
+            )
+            return False
+
+        if changelog and self.store.git.is_initialized():
+            commit_msg = (
+                f"dream(manual): optimize manual memory, {len(changelog)} change(s)"
+            )
+            sha = self.store.git.auto_commit(commit_msg)
+            if sha:
+                logger.info("Manual Dream commit: {}", sha)
+
+        logger.info("Manual Dream done: {} change(s)", len(changelog))
+        return True
 
     def _annotate_with_ages(self, content: str) -> str:
         """Append per-line age suffixes to MEMORY.md content.
@@ -1010,6 +1255,9 @@ class Dream:
         """Process unprocessed history entries. Returns True if work was done."""
         from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 
+        if self.store.memory_mode == "manual":
+            return await self._run_manual()
+
         last_cursor = self.store.get_last_dream_cursor()
         entries = self.store.read_unprocessed_history(since_cursor=last_cursor)
         if not entries:
@@ -1017,8 +1265,11 @@ class Dream:
 
         batch = entries[: self.max_batch_size]
         logger.info(
-            "Dream: processing {} entries (cursor {}→{}), batch={}",
-            len(entries), last_cursor, batch[-1]["cursor"], len(batch),
+            "Dream: processing {} history entries (cursor {}→{}), batch={}",
+            len(entries),
+            last_cursor,
+            batch[-1]["cursor"],
+            len(batch),
         )
 
         # Build history text for LLM — cap each entry so a legacy oversized

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1206,7 +1206,14 @@ def _run_gateway(
     agent.dream.max_iterations = dream_cfg.max_iterations
     agent.dream.annotate_line_ages = dream_cfg.annotate_line_ages
     from nanobot.cron.types import CronJob, CronPayload, CronSchedule
-    if dream_cfg.enabled:
+
+    if not dream_cfg.enabled:
+        console.print("[yellow]○[/yellow] Dream: disabled")
+    elif config.agents.defaults.memory.mode == "manual":
+        if cron.get_job("dream") is not None:
+            cron.enable_job("dream", False)
+        console.print("[green]✓[/green] Dream: manual mode (/dream only)")
+    else:
         cron.register_system_job(CronJob(
             id="dream",
             name="dream",
@@ -1214,8 +1221,6 @@ def _run_gateway(
             payload=CronPayload(kind="system_event"),
         ))
         console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
-    else:
-        console.print("[yellow]○[/yellow] Dream: disabled")
 
     # Register Heartbeat system job (idempotent on restart)
     if hb_cfg.enabled:

--- a/nanobot/command/builtin.py
+++ b/nanobot/command/builtin.py
@@ -205,7 +205,12 @@ async def cmd_new(ctx: CommandContext) -> OutboundMessage:
     session.clear()
     loop.sessions.save(session)
     loop.sessions.invalidate(session.key)
-    if snapshot:
+    memory_mode = getattr(
+        getattr(getattr(loop, "context", None), "memory", None),
+        "memory_mode",
+        "auto",
+    )
+    if snapshot and memory_mode == "auto":
         loop._schedule_background(loop.consolidator.archive(snapshot))
     return OutboundMessage(
         channel=ctx.msg.channel, chat_id=ctx.msg.chat_id,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -77,6 +77,12 @@ class DreamConfig(Base):
         return f"every {hours}h"
 
 
+class MemoryConfig(Base):
+    """Long-term memory behavior configuration."""
+
+    mode: Literal["auto", "manual"] = "auto"
+
+
 class InlineFallbackConfig(Base):
     """One inline fallback model configuration."""
 
@@ -159,6 +165,7 @@ class AgentDefaults(Base):
         validation_alias=AliasChoices("consolidationRatio"),
         serialization_alias="consolidationRatio",
     )  # Consolidation target ratio (0.5 = 50% of budget retained after compression)
+    memory: MemoryConfig = Field(default_factory=MemoryConfig)
     dream: DreamConfig = Field(default_factory=DreamConfig)
 
 

--- a/nanobot/utils/gitstore.py
+++ b/nanobot/utils/gitstore.py
@@ -6,7 +6,7 @@ import io
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from loguru import logger
 
@@ -45,9 +45,16 @@ def _compute_line_ages(annotated) -> list[LineAge]:
 class GitStore:
     """Git-backed version control for memory files."""
 
-    def __init__(self, workspace: Path, tracked_files: list[str]):
+    def __init__(
+        self,
+        workspace: Path,
+        tracked_files: list[str],
+        *,
+        allow_nested: bool = False,
+    ):
         self._workspace = workspace
         self._tracked_files = tracked_files
+        self._allow_nested = allow_nested
 
     def is_initialized(self) -> bool:
         """Check if the git repo has been initialized."""
@@ -64,7 +71,7 @@ class GitStore:
         if self.is_initialized():
             return False
 
-        if self._is_inside_git_repo():
+        if not self._allow_nested and self._is_inside_git_repo():
             logger.warning(
                 "Workspace {} is already inside a git repo; "
                 "skipping nested repo initialization",
@@ -196,9 +203,12 @@ class GitStore:
         """Generate .gitignore content from tracked files."""
         dirs: set[str] = set()
         for f in self._tracked_files:
-            parent = str(Path(f).parent)
-            if parent != ".":
-                dirs.add(parent)
+            parent = PurePosixPath(f).parent
+            if str(parent) == ".":
+                continue
+            parts = parent.parts
+            for i in range(1, len(parts) + 1):
+                dirs.add(str(PurePosixPath(*parts[:i])))
         lines = ["/*"]
         for d in sorted(dirs):
             lines.append(f"!{d}/")

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -621,7 +621,13 @@ def sync_workspace_templates(workspace: Path, silent: bool = False) -> list[str]
                 "memory/MEMORY.md",
             ],
         )
-        gs.init()
+        if gs.init() or gs.is_initialized():
+            manual_gs = GitStore(
+                workspace / "memory" / "manual",
+                tracked_files=["MEMORY.md"],
+                allow_nested=True,
+            )
+            manual_gs.init()
     except Exception:
         logger.exception("Failed to initialize git store for {}", workspace)
 

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -75,6 +75,31 @@ class TestConsolidatorSummarize:
         result = await consolidator.archive([])
         assert result is None
 
+    async def test_manual_mode_archive_does_not_write_history(self, tmp_path, mock_provider):
+        store = MemoryStore(tmp_path, memory_mode="manual")
+        sessions = MagicMock()
+        sessions.save = MagicMock()
+        sessions.get_or_create = MagicMock()
+        consolidator = Consolidator(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            sessions=sessions,
+            context_window_tokens=1000,
+            build_messages=MagicMock(return_value=[]),
+            get_tool_definitions=MagicMock(return_value=[]),
+            max_completion_tokens=100,
+        )
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Manual session summary.",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive([{"role": "user", "content": "hello"}])
+
+        assert result == "Manual session summary."
+        assert store.read_unprocessed_history(since_cursor=0) == []
+
 
 class TestConsolidatorArchiveErrorHandling:
     """archive() must fall back to raw_archive when the LLM returns an error
@@ -262,6 +287,209 @@ class TestConsolidatorTokenBudget:
         # so last_consolidated must have moved past it.
         assert session.last_consolidated == 50
 
+    async def test_manual_archive_failure_does_not_advance_last_consolidated(
+        self,
+        tmp_path,
+        mock_provider,
+    ):
+        store = MemoryStore(tmp_path, memory_mode="manual")
+        sessions = MagicMock()
+        sessions.save = MagicMock()
+        sessions.get_or_create = MagicMock()
+        consolidator = Consolidator(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            sessions=sessions,
+            context_window_tokens=1000,
+            build_messages=MagicMock(return_value=[]),
+            get_tool_definitions=MagicMock(return_value=[]),
+            max_completion_tokens=100,
+        )
+        consolidator._SAFETY_BUFFER = 0
+        session = MagicMock()
+        session.last_consolidated = 0
+        session.key = "test:key"
+        session.messages = [
+            {"role": "user" if i in {0, 50} else "assistant", "content": f"m{i}"}
+            for i in range(70)
+        ]
+        session.metadata = {}
+        sessions.get_or_create.return_value = session
+        consolidator.estimate_session_prompt_tokens = MagicMock(
+            side_effect=[(1200, "tiktoken")]
+        )
+        consolidator.archive = AsyncMock(return_value=None)
+
+        await consolidator.maybe_consolidate_by_tokens(session)
+
+        consolidator.archive.assert_awaited_once()
+        assert session.last_consolidated == 0
+        sessions.save.assert_not_called()
+
+    def test_session_summary_is_mode_independent(self, tmp_path, mock_provider):
+        session = Session(key="cli:switch")
+        session.metadata["_last_summary"] = {
+            "text": "Cross-mode summary.",
+            "last_active": "2026-05-28T12:00:00",
+        }
+        sessions = MagicMock()
+
+        auto = Consolidator(
+            store=MemoryStore(tmp_path, memory_mode="auto"),
+            provider=mock_provider,
+            model="test-model",
+            sessions=sessions,
+            context_window_tokens=1000,
+            build_messages=MagicMock(return_value=[]),
+            get_tool_definitions=MagicMock(return_value=[]),
+            max_completion_tokens=100,
+        )
+        manual = Consolidator(
+            store=MemoryStore(tmp_path, memory_mode="manual"),
+            provider=mock_provider,
+            model="test-model",
+            sessions=sessions,
+            context_window_tokens=1000,
+            build_messages=MagicMock(return_value=[]),
+            get_tool_definitions=MagicMock(return_value=[]),
+            max_completion_tokens=100,
+        )
+
+        assert auto.get_session_summary(session)[0] == "Cross-mode summary."
+        assert manual.get_session_summary(session)[0] == "Cross-mode summary."
+
+    async def test_manual_archive_rolls_existing_summary_into_prompt(self, tmp_path, mock_provider):
+        store = MemoryStore(tmp_path, memory_mode="manual")
+        sessions = MagicMock()
+        sessions.save = MagicMock()
+        consolidator = Consolidator(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            sessions=sessions,
+            context_window_tokens=1000,
+            build_messages=MagicMock(return_value=[]),
+            get_tool_definitions=MagicMock(return_value=[]),
+            max_completion_tokens=100,
+        )
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="updated rolling context",
+            finish_reason="stop",
+        )
+
+        result = await consolidator.archive(
+            [{"role": "user", "content": "new raw context"}],
+            existing_summary="older compacted context",
+        )
+
+        assert result == "updated rolling context"
+        messages = mock_provider.chat_with_retry.call_args.kwargs["messages"]
+        assert "Update the existing session summary" in messages[0]["content"]
+        assert "older compacted context" in messages[1]["content"]
+        assert "new raw context" in messages[1]["content"]
+
+    def test_manual_summary_persistence_replaces_with_rolling_summary(self, tmp_path, mock_provider):
+        store = MemoryStore(tmp_path, memory_mode="manual")
+        sessions = MagicMock()
+        sessions.save = MagicMock()
+        consolidator = Consolidator(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            sessions=sessions,
+            context_window_tokens=1000,
+            build_messages=MagicMock(return_value=[]),
+            get_tool_definitions=MagicMock(return_value=[]),
+            max_completion_tokens=100,
+        )
+        session = Session(key="cli:manual")
+        session.metadata["_last_summary"] = {
+            "text": "older compacted context",
+            "last_active": "2026-05-28T10:00:00",
+        }
+
+        consolidator._persist_last_summary(session, "updated rolling context")
+
+        text = session.metadata["_last_summary"]["text"]
+        assert text == "updated rolling context"
+
+    async def test_manual_token_consolidation_rolls_summary_across_rounds(
+        self,
+        tmp_path,
+        mock_provider,
+    ):
+        store = MemoryStore(tmp_path, memory_mode="manual")
+        sessions = MagicMock()
+        sessions.save = MagicMock()
+        sessions.get_or_create = MagicMock()
+        consolidator = Consolidator(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            sessions=sessions,
+            context_window_tokens=1000,
+            build_messages=MagicMock(return_value=[]),
+            get_tool_definitions=MagicMock(return_value=[]),
+            max_completion_tokens=100,
+        )
+        consolidator._SAFETY_BUFFER = 0
+        session = MagicMock()
+        session.last_consolidated = 0
+        session.key = "test:key"
+        session.messages = [
+            {"role": "user" if i in {0, 20, 40} else "assistant", "content": f"m{i}"}
+            for i in range(50)
+        ]
+        session.metadata = {
+            "_last_summary": {
+                "text": "older compacted context",
+                "last_active": "2026-05-28T10:00:00",
+            }
+        }
+        sessions.get_or_create.return_value = session
+        consolidator.estimate_session_prompt_tokens = MagicMock(
+            side_effect=[(1200, "tiktoken"), (1200, "tiktoken"), (400, "tiktoken")]
+        )
+        consolidator.pick_consolidation_boundary = MagicMock(
+            side_effect=[(20, 1000), (40, 1000)]
+        )
+        consolidator.archive = AsyncMock(
+            side_effect=["updated context after round one", "updated context after round two"]
+        )
+
+        await consolidator.maybe_consolidate_by_tokens(session)
+
+        assert consolidator.archive.await_count == 2
+        first_call, second_call = consolidator.archive.await_args_list
+        assert first_call.kwargs["existing_summary"] == "older compacted context"
+        assert second_call.kwargs["existing_summary"] == "updated context after round one"
+        assert session.metadata["_last_summary"]["text"] == "updated context after round two"
+
+    def test_auto_summary_persistence_keeps_latest_summary(self, tmp_path, mock_provider):
+        store = MemoryStore(tmp_path, memory_mode="auto")
+        sessions = MagicMock()
+        sessions.save = MagicMock()
+        consolidator = Consolidator(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            sessions=sessions,
+            context_window_tokens=1000,
+            build_messages=MagicMock(return_value=[]),
+            get_tool_definitions=MagicMock(return_value=[]),
+            max_completion_tokens=100,
+        )
+        session = Session(key="cli:auto")
+        session.metadata["_last_summary"] = {
+            "text": "older compacted context",
+            "last_active": "2026-05-28T10:00:00",
+        }
+
+        consolidator._persist_last_summary(session, "new compacted context")
+
+        assert session.metadata["_last_summary"]["text"] == "new compacted context"
+
     async def test_raw_archive_fallback_breaks_round_loop(self, consolidator):
         """A degraded LLM should not trigger more archive() calls within the
         same maybe_consolidate_by_tokens invocation — bail after one fallback."""
@@ -414,6 +642,37 @@ class TestCompactIdleSession:
         # Session should still be truncated
         reloaded = sessions.get_or_create("cli:fail")
         assert len(reloaded.messages) <= 4
+
+    @pytest.mark.asyncio
+    async def test_manual_llm_failure_keeps_session_untrimmed(self, tmp_path, mock_provider):
+        from nanobot.session.manager import SessionManager
+
+        store = MemoryStore(tmp_path, memory_mode="manual")
+        sessions = SessionManager(store.workspace)
+        consolidator = Consolidator(
+            store=store,
+            provider=mock_provider,
+            model="test-model",
+            sessions=sessions,
+            context_window_tokens=1000,
+            build_messages=MagicMock(return_value=[]),
+            get_tool_definitions=MagicMock(return_value=[]),
+            max_completion_tokens=100,
+        )
+        mock_provider.chat_with_retry.side_effect = RuntimeError("LLM unavailable")
+        session = sessions.get_or_create("cli:manual-fail")
+        for i in range(10):
+            session.add_message("user", f"u{i}")
+            session.add_message("assistant", f"a{i}")
+        sessions.save(session)
+
+        result = await consolidator.compact_idle_session("cli:manual-fail", max_suffix=4)
+
+        assert result is None
+        assert store.read_unprocessed_history(since_cursor=0) == []
+        reloaded = sessions.get_or_create("cli:manual-fail")
+        assert len(reloaded.messages) == 20
+        assert reloaded.last_consolidated == 0
 
     @pytest.mark.asyncio
     async def test_respects_last_consolidated(self, real_consolidator, mock_provider):

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -1,10 +1,9 @@
 """Tests for the Dream class — two-phase memory consolidation via AgentRunner."""
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from nanobot.agent.memory import Dream, MemoryStore
 from nanobot.agent.runner import AgentRunResult
@@ -77,6 +76,50 @@ class TestDreamRun:
         spec = mock_runner.run.call_args[0][0]
         assert spec.max_iterations == 10
         assert spec.fail_on_tool_error is False
+
+    async def test_manual_mode_dream_optimizes_manual_memory_only(
+        self,
+        tmp_path,
+        mock_provider,
+        mock_runner,
+    ):
+        store = MemoryStore(tmp_path, memory_mode="manual")
+        store.write_soul("# Soul\n- Helpful")
+        store.write_user("# User\n- Developer")
+        store.write_memory("# Memory\n- Project X active")
+        auto_store = MemoryStore(tmp_path, memory_mode="auto")
+        auto_store.write_memory("# Auto Memory\n- Auto-only fact")
+        dream = Dream(store=store, provider=mock_provider, model="test-model", max_batch_size=5)
+        dream._runner = mock_runner
+        mock_runner.run = AsyncMock(return_value=_make_run_result(
+            tool_events=[{"name": "edit_file", "status": "ok", "detail": "memory/manual/MEMORY.md"}],
+        ))
+
+        result = await dream.run()
+
+        assert result is True
+        mock_provider.chat_with_retry.assert_not_called()
+        mock_runner.run.assert_awaited_once()
+        spec = mock_runner.run.call_args.args[0]
+        assert "memory/manual/MEMORY.md" in spec.initial_messages[1]["content"]
+        assert "Project X active" in spec.initial_messages[1]["content"]
+        assert "Auto-only fact" not in spec.initial_messages[1]["content"]
+
+    async def test_manual_mode_dream_noops_when_manual_memory_empty(
+        self,
+        tmp_path,
+        mock_provider,
+        mock_runner,
+    ):
+        store = MemoryStore(tmp_path, memory_mode="manual")
+        dream = Dream(store=store, provider=mock_provider, model="test-model", max_batch_size=5)
+        dream._runner = mock_runner
+
+        result = await dream.run()
+
+        assert result is False
+        mock_provider.chat_with_retry.assert_not_called()
+        mock_runner.run.assert_not_called()
 
     async def test_advances_dream_cursor(self, dream, mock_provider, mock_runner, store):
         """Dream should advance the cursor after processing."""
@@ -157,7 +200,6 @@ class TestDreamRun:
         call_args = mock_provider.chat_with_retry.call_args
         user_msg = call_args.kwargs.get("messages", call_args[1].get("messages"))[1]["content"]
         # The ← suffix should only appear in MEMORY.md section
-        memory_section = user_msg.split("## Current MEMORY.md")[1].split("## Current SOUL.md")[0]
         soul_section = user_msg.split("## Current SOUL.md")[1].split("## Current USER.md")[0]
         user_section = user_msg.split("## Current USER.md")[1]
         # SOUL and USER should not contain age arrows
@@ -306,4 +348,3 @@ class TestDreamPromptCaps:
         user_msg = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
         history_section = user_msg.split("## Conversation History\n")[1].split("\n\n## Current Date")[0]
         assert len(history_section) < dream._HISTORY_ENTRY_PREVIEW_MAX_CHARS + 500
-

--- a/tests/agent/test_git_store.py
+++ b/tests/agent/test_git_store.py
@@ -59,6 +59,13 @@ class TestBuildGitignore:
             assert f"!{f}\n" in content
         assert content.startswith("/*\n")
 
+    def test_nested_subdirectory_dirs_include_all_ancestors(self, tmp_path):
+        gs = GitStore(tmp_path, tracked_files=["a/b/c.md"])
+        content = gs._build_gitignore()
+        assert "!a/\n" in content
+        assert "!a/b/\n" in content
+        assert "!a/b/c.md\n" in content
+
     def test_root_level_files_no_dir_entries(self, tmp_path):
         gs = GitStore(tmp_path, tracked_files=["a.md", "b.md"])
         content = gs._build_gitignore()
@@ -228,7 +235,29 @@ class TestMemoryStoreGitProperty:
         store = MemoryStore(tmp_path)
         assert isinstance(store.git, GitStore)
 
-    def test_git_property_is_same_object(self, tmp_path):
+    def test_auto_mode_git_property_uses_auto_store(self, tmp_path):
         from nanobot.agent.memory import MemoryStore
         store = MemoryStore(tmp_path)
-        assert store.git is store._git
+        assert store.git is store.auto_git
+
+    def test_manual_mode_git_property_uses_manual_store(self, tmp_path):
+        from nanobot.agent.memory import MemoryStore
+        store = MemoryStore(tmp_path, memory_mode="manual")
+        assert store.git is store.manual_git
+        assert store.git._workspace == tmp_path / "memory" / "manual"
+        assert store.git._tracked_files == ["MEMORY.md"]
+
+    def test_auto_git_does_not_track_manual_memory_file(self, tmp_path):
+        from nanobot.agent.memory import MemoryStore
+        store = MemoryStore(tmp_path)
+        assert "memory/manual/MEMORY.md" not in store.auto_git._tracked_files
+
+    def test_manual_git_can_initialize_inside_auto_git_workspace(self, tmp_path):
+        from nanobot.agent.memory import MemoryStore
+        auto = MemoryStore(tmp_path, memory_mode="auto")
+        assert auto.git.init() is True
+
+        manual = MemoryStore(tmp_path, memory_mode="manual")
+        assert manual.git.init() is True
+        assert (tmp_path / "memory" / "manual" / ".git").is_dir()
+        assert len(manual.git.log()) == 1

--- a/tests/agent/test_loop_consolidation_tokens.py
+++ b/tests/agent/test_loop_consolidation_tokens.py
@@ -213,13 +213,39 @@ async def test_preflight_consolidation_receives_pending_summary(tmp_path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_preflight_consolidation_summary_reaches_current_prompt(tmp_path) -> None:
+    loop = _make_loop(tmp_path, estimated_tokens=100, context_window_tokens=200)
+    session = loop.sessions.get_or_create("cli:test")
+    loop.auto_compact.prepare_session = MagicMock(
+        return_value=(session, "earlier context")
+    )  # type: ignore[method-assign]
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(
+        return_value="fresh compacted context"
+    )  # type: ignore[method-assign]
+    loop._schedule_background = lambda coro: coro.close()  # type: ignore[method-assign]
+    captured: dict[str, str] = {}
+
+    async def track_llm(*args, **kwargs):
+        captured["system"] = kwargs["messages"][0]["content"]
+        return LLMResponse(content="ok", tool_calls=[])
+
+    loop.provider.chat_with_retry = track_llm
+    loop.provider.chat_stream_with_retry = track_llm
+
+    await loop.process_direct("hello", session_key="cli:test")
+
+    assert "earlier context" in captured["system"]
+    assert "fresh compacted context" in captured["system"]
+
+
+@pytest.mark.asyncio
 async def test_preflight_consolidation_before_llm_call(tmp_path, monkeypatch) -> None:
     """Verify preflight consolidation runs before the LLM call in process_direct."""
     order: list[str] = []
 
     loop = _make_loop(tmp_path, estimated_tokens=0, context_window_tokens=200)
 
-    async def track_consolidate(messages):
+    async def track_consolidate(messages, **_kwargs):
         order.append("consolidate")
         return True
     loop.consolidator.archive = track_consolidate  # type: ignore[method-assign]

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -21,6 +21,20 @@ class TestMemoryStoreBasicIO:
         store.write_memory("hello")
         assert store.read_memory() == "hello"
 
+    def test_manual_memory_uses_isolated_file(self, tmp_path):
+        auto = MemoryStore(tmp_path, memory_mode="auto")
+        manual = MemoryStore(tmp_path, memory_mode="manual")
+
+        auto.write_memory("auto memory")
+        manual.write_memory("manual memory")
+
+        assert auto.read_memory() == "auto memory"
+        assert manual.read_memory() == "manual memory"
+        assert (tmp_path / "memory" / "MEMORY.md").read_text(encoding="utf-8") == "auto memory"
+        assert (
+            tmp_path / "memory" / "manual" / "MEMORY.md"
+        ).read_text(encoding="utf-8") == "manual memory"
+
     def test_read_soul_returns_empty_when_missing(self, store):
         assert store.read_soul() == ""
 

--- a/tests/agent/test_onboard_logic.py
+++ b/tests/agent/test_onboard_logic.py
@@ -374,6 +374,25 @@ class TestSyncWorkspaceTemplates:
 
         assert (workspace / "memory").exists() or (workspace / "skills").exists()
 
+    def test_initializes_manual_memory_git_when_root_store_exists(self, tmp_path):
+        workspace = tmp_path / "workspace"
+
+        sync_workspace_templates(workspace, silent=True)
+
+        assert (workspace / ".git").is_dir()
+        assert (workspace / "memory" / "manual" / ".git").is_dir()
+
+    def test_skips_manual_memory_git_inside_external_git_repo(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+        workspace = project / "workspace"
+
+        sync_workspace_templates(workspace, silent=True)
+
+        assert not (workspace / ".git").exists()
+        assert not (workspace / "memory" / "manual" / ".git").exists()
+
     def test_returns_list_of_added_files(self, tmp_path):
         """Should return list of relative paths for added files."""
         workspace = tmp_path / "workspace"

--- a/tests/command/test_builtin_dream.py
+++ b/tests/command/test_builtin_dream.py
@@ -14,6 +14,7 @@ class _FakeStore:
     def __init__(self, git, last_dream_cursor: int = 1):
         self.git = git
         self._last_dream_cursor = last_dream_cursor
+        self.memory_mode = "auto"
 
     def get_last_dream_cursor(self) -> int:
         return self._last_dream_cursor
@@ -50,6 +51,7 @@ def _make_ctx(raw: str, git: _FakeGit, *, args: str = "", last_dream_cursor: int
     msg = InboundMessage(channel="cli", sender_id="u1", chat_id="direct", content=raw)
     store = _FakeStore(git, last_dream_cursor=last_dream_cursor)
     loop = SimpleNamespace(consolidator=SimpleNamespace(store=store))
+    loop.context = SimpleNamespace(memory=store)
     return CommandContext(msg=msg, session=None, key=msg.session_key, raw=raw, args=args, loop=loop)
 
 

--- a/tests/config/test_dream_config.py
+++ b/tests/config/test_dream_config.py
@@ -1,4 +1,4 @@
-from nanobot.config.schema import DreamConfig
+from nanobot.config.schema import Config, DreamConfig
 
 
 def test_dream_config_defaults_to_interval_hours() -> None:
@@ -46,3 +46,13 @@ def test_dream_config_uses_model_override_name_and_accepts_legacy_model() -> Non
     assert cfg.model_override == "openrouter/sonnet"
     assert dumped["modelOverride"] == "openrouter/sonnet"
     assert "model" not in dumped
+
+
+def test_memory_mode_defaults_to_auto_and_accepts_manual() -> None:
+    assert Config().agents.defaults.memory.mode == "auto"
+
+    cfg = Config.model_validate({
+        "agents": {"defaults": {"memory": {"mode": "manual"}}},
+    })
+
+    assert cfg.agents.defaults.memory.mode == "manual"


### PR DESCRIPTION
  ## Summary
  Introduce manual memory mode with an isolated memory flow from the existing automatic memory mode.

  ## Related Issues
  - Relates to https://github.com/HKUDS/nanobot/issues/3885
  - Related to https://github.com/HKUDS/nanobot/issues/3948

  ## Changes
  - add `manual` memory mode to config schema and docs
  - keep automatic and manual memory flows isolated
  - preserve existing automatic mode behavior unchanged
  - in automatic mode, continue writing memory events to `history.jsonl`
  - in manual mode, avoid writing to `history.jsonl` and use rolling summaries for continuity instead
  - disable scheduled Dream in manual mode, while keeping `/dream` available
  - update loop, context, autocompact, memory, and git store handling for the separated flows
  - add and update tests for consolidation, Dream behavior, config wiring, and manual-mode memory behavior

  ## Notes
  Manual mode is intended for workflows where persistent history is curated explicitly. It preserves short-term continuity through rolling summaries without feeding automatic history writes into `history.jsonl`. Existing automatic memory behavior is unchanged.

  ## Verification
  - updated unit tests for agent memory, Dream, git store, and config behavior