### PR TITLE
fix(tools): keep read-only roots out of write paths

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -31,6 +31,8 @@ class _FsTool(Tool):
     """Shared base for filesystem tools — common init and path resolution."""
 
     config_key = "file"
+    _allow_extra_allowed_dirs = False
+    _allow_media_dir = False
 
     @classmethod
     def config_cls(cls):
@@ -74,7 +76,7 @@ class _FsTool(Tool):
         )
         sandbox_restricts = bool(ctx.config.exec.sandbox)
         allowed_dir = Path(ctx.workspace) if restrict else None
-        extra_read = [BUILTIN_SKILLS_DIR]
+        extra_read = [BUILTIN_SKILLS_DIR] if cls._allow_extra_allowed_dirs else None
         return cls(
             workspace=Path(ctx.workspace),
             allowed_dir=allowed_dir,
@@ -100,7 +102,8 @@ class _FsTool(Tool):
             path,
             access.project_path,
             access.allowed_root,
-            self._extra_allowed_dirs,
+            self._extra_allowed_dirs if self._allow_extra_allowed_dirs else None,
+            include_media_dir=self._allow_media_dir,
         )
 
     def _display_workspace(self) -> Path | None:
@@ -179,6 +182,8 @@ def _parse_page_range(pages: str, total: int) -> tuple[int, int]:
 class ReadFileTool(_FsTool):
     """Read file contents with optional line-based pagination."""
     _scopes = {"core", "subagent", "memory"}
+    _allow_extra_allowed_dirs = True
+    _allow_media_dir = True
 
     _MAX_CHARS = 128_000
     _DEFAULT_LIMIT = 2000
@@ -968,6 +973,8 @@ class EditFileTool(_FsTool):
 class ListDirTool(_FsTool):
     """List directory contents with optional recursion."""
     _scopes = {"core", "subagent"}
+    _allow_extra_allowed_dirs = True
+    _allow_media_dir = True
 
     _DEFAULT_MAX = 200
     _IGNORE_DIRS = {

--- a/nanobot/agent/tools/path_utils.py
+++ b/nanobot/agent/tools/path_utils.py
@@ -19,9 +19,16 @@ def resolve_workspace_path(
     workspace: Path | None = None,
     allowed_dir: Path | None = None,
     extra_allowed_dirs: list[Path] | None = None,
+    *,
+    include_media_dir: bool = True,
 ) -> Path:
     """Resolve path against workspace and enforce allowed directory containment."""
-    extra_roots = [get_media_dir(), *(extra_allowed_dirs or [])] if allowed_dir else None
+    extra_roots = None
+    if allowed_dir:
+        extra_roots = [
+            *([get_media_dir()] if include_media_dir else []),
+            *(extra_allowed_dirs or []),
+        ]
     return resolve_allowed_path(
         path,
         workspace=workspace,

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -342,13 +342,36 @@ class TestWorkspaceRestriction:
 
         workspace = tmp_path / "ws"
         workspace.mkdir()
-        outside = tmp_path / "outside"
-        outside.mkdir()
+        extra = tmp_path / "extra"
+        extra.mkdir()
 
-        tool = WriteFileTool(workspace=workspace, allowed_dir=workspace)
-        result = await tool.execute(path=str(outside / "hack.txt"), content="pwned")
+        tool = WriteFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_allowed_dirs=[extra],
+        )
+        target = extra / "hack.txt"
+        result = await tool.execute(path=str(target), content="pwned")
         assert "Error" in result
         assert "outside" in result.lower()
+        assert not target.exists()
+
+    @pytest.mark.asyncio
+    async def test_media_dir_does_not_widen_write(self, tmp_path, monkeypatch):
+        from nanobot.agent.tools.filesystem import WriteFileTool
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        media_dir = tmp_path / "media"
+        media_dir.mkdir()
+        monkeypatch.setattr("nanobot.agent.tools.path_utils.get_media_dir", lambda: media_dir)
+
+        tool = WriteFileTool(workspace=workspace, allowed_dir=workspace)
+        target = media_dir / "generated.txt"
+        result = await tool.execute(path=str(target), content="pwned")
+        assert "Error" in result
+        assert "outside" in result.lower()
+        assert not target.exists()
 
     @pytest.mark.asyncio
     async def test_read_still_blocked_for_unrelated_dir(self, tmp_path):
@@ -398,7 +421,11 @@ class TestWorkspaceRestriction:
         skill_file.parent.mkdir()
         skill_file.write_text("# Weather\nOriginal content.")
 
-        tool = EditFileTool(workspace=workspace, allowed_dir=workspace)
+        tool = EditFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_allowed_dirs=[skills_dir],
+        )
         result = await tool.execute(
             path=str(skill_file),
             old_text="Original content.",


### PR DESCRIPTION
## Summary
- keep filesystem extra allowed roots read-only by applying them only to read/list tools
- stop write/edit tools from inheriting media-dir access under workspace restriction
- add regression coverage for extra allowed dirs and media dirs staying write-protected

## Tests
- uv run --extra dev pytest tests/tools/test_filesystem_tools.py::TestWorkspaceRestriction tests/security/test_workspace_policy.py tests/security/test_workspace_sandbox.py tests/tools/test_message_tool.py -q
- uv run --extra dev pytest tests/tools/test_filesystem_tools.py tests/tools/test_sandbox.py tests/security/test_workspace_policy.py tests/security/test_workspace_sandbox.py -q
- uv run --extra dev ruff check nanobot/agent/tools/path_utils.py nanobot/agent/tools/filesystem.py tests/tools/test_filesystem_tools.py --select F