### PR TITLE
fix: coerce typeless Anthropic content blocks + add Dream enable toggle (#3993, #3885)

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1174,13 +1174,16 @@ def _run_gateway(
     agent.dream.max_iterations = dream_cfg.max_iterations
     agent.dream.annotate_line_ages = dream_cfg.annotate_line_ages
     from nanobot.cron.types import CronJob, CronPayload, CronSchedule
-    cron.register_system_job(CronJob(
-        id="dream",
-        name="dream",
-        schedule=dream_cfg.build_schedule(config.agents.defaults.timezone),
-        payload=CronPayload(kind="system_event"),
-    ))
-    console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
+    if dream_cfg.enabled:
+        cron.register_system_job(CronJob(
+            id="dream",
+            name="dream",
+            schedule=dream_cfg.build_schedule(config.agents.defaults.timezone),
+            payload=CronPayload(kind="system_event"),
+        ))
+        console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
+    else:
+        console.print("[yellow]○[/yellow] Dream: disabled")
 
     # Register Heartbeat system job (idempotent on restart)
     if hb_cfg.enabled:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1166,7 +1166,7 @@ def _run_gateway(
         console.print(f"[green]✓[/green] Health endpoint: http://{host}:{health_port}/health")
         async with server:
             await server.serve_forever()
-    # Register Dream system job (always-on, idempotent on restart)
+    # Register Dream system job (idempotent on restart)
     dream_cfg = config.agents.defaults.dream
     if dream_cfg.model_override:
         agent.dream.model = dream_cfg.model_override

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -48,6 +48,7 @@ class DreamConfig(Base):
 
     _HOUR_MS = 3_600_000
 
+    enabled: bool = True  # Register the periodic Dream consolidation job on startup
     interval_h: int = Field(default=2, ge=1)  # Every 2 hours by default
     cron: str | None = Field(default=None, exclude=True)  # Legacy compatibility override
     model_override: str | None = Field(

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -228,6 +228,13 @@ class AnthropicProvider(LLMProvider):
                 if converted:
                     result.append(converted)
                 continue
+            if not item.get("type"):
+                # Anthropic requires every content block to declare a "type".
+                # A tool that returned a bare dict (or a list of dicts) lands
+                # here; coerce it to a text block instead of emitting a block
+                # the API rejects with "content.0.type: Field required".
+                result.append({"type": "text", "text": str(item)})
+                continue
             result.append(item)
         return result or "(empty)"
 

--- a/tests/providers/test_anthropic_tool_result.py
+++ b/tests/providers/test_anthropic_tool_result.py
@@ -5,6 +5,9 @@ Regression for: tool results containing OpenAI-format image_url blocks
 were passed to Anthropic unconverted, causing silent image drops with a
 "Non-transient LLM error with image content, retrying without images"
 warning.
+
+Also tests that bare dicts without a "type" field are coerced to text
+blocks, fixing Anthropic "content.0.type: Field required" rejections (#3993).
 """
 
 from nanobot.providers.anthropic_provider import AnthropicProvider
@@ -55,3 +58,25 @@ def test_tool_result_block_preserves_string_content():
     assert block["type"] == "tool_result"
     assert block["tool_use_id"] == "call_2"
     assert block["content"] == "plain tool output"
+
+
+def test_convert_user_content_coerces_typeless_dict():
+    """Bare dicts without a "type" field must be coerced to text blocks.
+    Regression for #3993: tools returning plain dicts caused Anthropic to
+    reject the request with "content.0.type: Field required"."""
+    result = AnthropicProvider._convert_user_content([
+        {"foo": "bar"},
+        {"type": "text", "text": "ok"},
+    ])
+    assert result[0] == {"type": "text", "text": str({"foo": "bar"})}
+    assert result[1] == {"type": "text", "text": "ok"}
+
+
+def test_convert_user_content_coerces_mixed_typeless():
+    """Multiple typeless items and non-dict items are all handled."""
+    result = AnthropicProvider._convert_user_content([
+        42,
+        {"key": "val"},
+    ])
+    assert result[0] == {"type": "text", "text": "42"}
+    assert result[1] == {"type": "text", "text": str({"key": "val"})}

--- a/tests/tools/test_exec_session_tools.py
+++ b/tests/tools/test_exec_session_tools.py
@@ -159,13 +159,13 @@ def test_write_stdin_can_close_stdin(tmp_path):
             "data=sys.stdin.read(); print('got:' + data, flush=True)"
         )
 
-        initial = await exec_tool.execute(command=command, yield_time_ms=500)
+        initial = await exec_tool.execute(command=command, yield_time_ms=1500)
         sid = _session_id(initial)
         result = await stdin_tool.execute(
             session_id=sid,
             chars="payload",
             close_stdin=True,
-            yield_time_ms=1000,
+            yield_time_ms=1500,
         )
         return initial, result
 


### PR DESCRIPTION
Closes #3993  
Closes #3885

providers/anthropic: coerce typeless dict content blocks to text, fixing Anthropic `content.0.type: Field required` rejection when a tool returns a bare dict. (#3993)

dream: add `DreamConfig.enabled` (default `true`); when `false`, skip Dream cron registration. Manual `/dream` still works. (#3885)

