### PR TITLE
fix bugs 4055-4069

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -713,8 +713,23 @@ class AgentLoop:
                 if media:
                     content, media = self._prepare_message_media(content, media)
                     media = media or None
-                user_content = self.context._build_user_content(content, media)
-                return {"role": "user", "content": user_content}
+                scope = self.workspace_scopes.for_message(
+                    pending_msg,
+                    session.metadata if session is not None else None,
+                )
+                built = self.context.build_messages(
+                    history=[],
+                    current_message=image_generation_prompt(content, pending_msg.metadata),
+                    media=media,
+                    channel=pending_msg.channel,
+                    chat_id=self._runtime_chat_id(pending_msg),
+                    sender_id=pending_msg.sender_id,
+                    session_metadata=session.metadata if session is not None else None,
+                    workspace=scope.project_path,
+                    runtime_state=self,
+                    inbound_message=pending_msg,
+                )
+                return built[-1]
 
             items: list[dict[str, Any]] = []
             while len(items) < limit:

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -319,14 +319,34 @@ class MemoryStore:
         """Return history entries with a valid cursor > *since_cursor*."""
         return [e for e, c in self._iter_valid_entries() if c > since_cursor]
 
-    def compact_history(self) -> None:
-        """Drop oldest entries if the file exceeds *max_history_entries*."""
+    def compact_history(self, *, protect_after_cursor: int | None = None) -> None:
+        """Drop oldest processed entries if the file exceeds *max_history_entries*."""
         if self.max_history_entries <= 0:
             return
         entries = self._read_entries()
         if len(entries) <= self.max_history_entries:
             return
-        kept = entries[-self.max_history_entries:]
+        if protect_after_cursor is None:
+            kept = entries[-self.max_history_entries:]
+        else:
+            protected: list[dict[str, Any]] = []
+            processed: list[dict[str, Any]] = []
+            for entry in entries:
+                cursor = self._valid_cursor(entry.get("cursor"))
+                if cursor is not None and cursor > protect_after_cursor:
+                    protected.append(entry)
+                else:
+                    processed.append(entry)
+            if len(protected) >= self.max_history_entries:
+                logger.warning(
+                    "Dream history compaction kept {} unprocessed entries above cursor {}, "
+                    "exceeding max_history_entries={}",
+                    len(protected), protect_after_cursor, self.max_history_entries,
+                )
+                kept = protected
+            else:
+                room = self.max_history_entries - len(protected)
+                kept = processed[-room:] + protected
         self._write_entries(kept)
 
     # -- JSONL helpers -------------------------------------------------------
@@ -1134,9 +1154,11 @@ class Dream:
                     changelog.append(f"{event['name']}: {event['detail']}")
 
         # Only advance cursor on successful completion to prevent silent loss
+        protect_cursor = last_cursor
         if result and result.stop_reason == "completed":
             new_cursor = batch[-1]["cursor"]
             self.store.set_last_dream_cursor(new_cursor)
+            protect_cursor = new_cursor
             logger.info(
                 "Dream done: {} change(s), cursor advanced to {}",
                 len(changelog), new_cursor,
@@ -1148,7 +1170,7 @@ class Dream:
                 reason,
             )
 
-        self.store.compact_history()
+        self.store.compact_history(protect_after_cursor=protect_cursor)
 
         # Git auto-commit (only when there are actual changes)
         if changelog and self.store.git.is_initialized():

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -1298,9 +1298,22 @@ class AgentRunner:
         kept.reverse()
 
         if kept:
+            latest_user_idx = next(
+                (i for i in range(len(non_system) - 1, -1, -1)
+                 if non_system[i].get("role") == "user"),
+                None,
+            )
+            if latest_user_idx and non_system[latest_user_idx - 1].get("role") == "assistant":
+                latest_user = non_system[latest_user_idx]
+                previous_assistant = non_system[latest_user_idx - 1]
+                if latest_user in kept and previous_assistant not in kept:
+                    kept.insert(0, previous_assistant)
             for i, message in enumerate(kept):
                 if message.get("role") == "user":
-                    kept = kept[i:]
+                    start = i
+                    if i > 0 and kept[i - 1].get("role") == "assistant":
+                        start = i - 1
+                    kept = kept[start:]
                     break
             else:
                 # Recover nearest user message from outside the kept window;

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -397,7 +397,7 @@ class ChannelManager:
     def _coalesce_stream_deltas(
         self, first_msg: OutboundMessage
     ) -> tuple[OutboundMessage, list[OutboundMessage]]:
-        """Merge consecutive _stream_delta messages for the same (channel, chat_id).
+        """Merge consecutive _stream_delta messages for the same stream.
 
         This reduces the number of API calls when the queue has accumulated multiple
         deltas, which happens when LLM generates faster than the channel can process.
@@ -405,7 +405,11 @@ class ChannelManager:
         Returns:
             tuple of (merged_message, list_of_non_matching_messages)
         """
-        target_key = (first_msg.channel, first_msg.chat_id)
+        target_key = (
+            first_msg.channel,
+            first_msg.chat_id,
+            (first_msg.metadata or {}).get("_stream_id"),
+        )
         combined_content = first_msg.content
         final_metadata = dict(first_msg.metadata or {})
         non_matching: list[OutboundMessage] = []
@@ -419,7 +423,12 @@ class ChannelManager:
                 break
 
             # Check if this message belongs to the same stream
-            same_target = (next_msg.channel, next_msg.chat_id) == target_key
+            next_key = (
+                next_msg.channel,
+                next_msg.chat_id,
+                (next_msg.metadata or {}).get("_stream_id"),
+            )
+            same_target = next_key == target_key
             is_delta = next_msg.metadata and next_msg.metadata.get("_stream_delta")
             is_end = next_msg.metadata and next_msg.metadata.get("_stream_end")
 

--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -231,7 +231,7 @@ class MatrixChannel(BaseChannel):
         )
         self._server_upload_limit_bytes: int | None = None
         self._server_upload_limit_checked = False
-        self._stream_bufs: dict[str, _StreamBuf] = {}
+        self._stream_bufs: dict[tuple[str, str | None], _StreamBuf] = {}
         self._started_at_ms: int = 0
 
 
@@ -515,9 +515,10 @@ class MatrixChannel(BaseChannel):
     async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None) -> None:
         meta = metadata or {}
         relates_to = self._build_thread_relates_to(metadata)
+        stream_key = (chat_id, meta.get("_stream_id") if isinstance(meta.get("_stream_id"), str) else None)
 
         if meta.get("_stream_end"):
-            buf = self._stream_bufs.pop(chat_id, None)
+            buf = self._stream_bufs.pop(stream_key, None)
             if not buf or not buf.event_id or not buf.text:
                 return
 
@@ -531,10 +532,10 @@ class MatrixChannel(BaseChannel):
             await self._send_room_content(chat_id, content)
             return
 
-        buf = self._stream_bufs.get(chat_id)
+        buf = self._stream_bufs.get(stream_key)
         if buf is None:
             buf = _StreamBuf()
-            self._stream_bufs[chat_id] = buf
+            self._stream_bufs[stream_key] = buf
         buf.text += delta
 
         if not buf.text.strip():

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -1926,9 +1926,9 @@ class WebSocketChannel(BaseChannel):
                 or msg.metadata.get("_goal_state_sync")
             ):
                 self.logger.debug("no active subscribers for chat_id={}", msg.chat_id)
+                return
             else:
                 self.logger.warning("no active subscribers for chat_id={}", msg.chat_id)
-            return
         if msg.metadata.get("_goal_state_sync"):
             blob = msg.metadata.get("goal_state")
             await self.send_goal_state(msg.chat_id, blob if isinstance(blob, dict) else {"active": False})
@@ -2005,6 +2005,8 @@ class WebSocketChannel(BaseChannel):
         transcript_payload = dict(payload)
         transcript_payload["text"] = text
         self._try_append_webui_transcript(msg.chat_id, transcript_payload)
+        if not conns:
+            return
         raw = json.dumps(payload, ensure_ascii=False)
         for connection in conns:
             await self._safe_send_to(connection, raw, label=" ")

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1174,13 +1174,16 @@ def _run_gateway(
     agent.dream.max_iterations = dream_cfg.max_iterations
     agent.dream.annotate_line_ages = dream_cfg.annotate_line_ages
     from nanobot.cron.types import CronJob, CronPayload, CronSchedule
-    cron.register_system_job(CronJob(
-        id="dream",
-        name="dream",
-        schedule=dream_cfg.build_schedule(config.agents.defaults.timezone),
-        payload=CronPayload(kind="system_event"),
-    ))
-    console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
+    if dream_cfg.enabled:
+        cron.register_system_job(CronJob(
+            id="dream",
+            name="dream",
+            schedule=dream_cfg.build_schedule(config.agents.defaults.timezone),
+            payload=CronPayload(kind="system_event"),
+        ))
+        console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
+    else:
+        console.print("[yellow]•[/yellow] Dream: disabled")
 
     # Register Heartbeat system job (idempotent on restart)
     if hb_cfg.enabled:

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -55,8 +55,8 @@ def load_config(config_path: Path | None = None) -> Config:
             data = _migrate_config(data)
             config = Config.model_validate(data)
         except (json.JSONDecodeError, ValueError, pydantic.ValidationError) as e:
-            logger.warning("Failed to load config from {}: {}", path, e)
-            logger.warning("Using default configuration.")
+            logger.error("Failed to load config from {}: {}", path, e)
+            raise
 
     _apply_ssrf_whitelist(config)
     return config

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -49,6 +49,7 @@ class DreamConfig(Base):
     _HOUR_MS = 3_600_000
 
     interval_h: int = Field(default=2, ge=1)  # Every 2 hours by default
+    enabled: bool = True
     cron: str | None = Field(default=None, exclude=True)  # Legacy compatibility override
     model_override: str | None = Field(
         default=None,

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -13,6 +13,7 @@ from typing import Any
 import json_repair
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 _ALNUM = string.ascii_letters + string.digits
 
@@ -192,7 +193,15 @@ class AnthropicProvider(LLMProvider):
             blocks.append({"type": "text", "text": content})
         elif isinstance(content, list):
             for item in content:
-                blocks.append(item if isinstance(item, dict) else {"type": "text", "text": str(item)})
+                if isinstance(item, dict):
+                    if item.get("type"):
+                        blocks.append(item)
+                    elif isinstance(item.get("text"), str):
+                        blocks.append({"type": "text", "text": item["text"]})
+                    else:
+                        blocks.append({"type": "text", "text": str(item)})
+                else:
+                    blocks.append({"type": "text", "text": str(item)})
 
         for tc in msg.get("tool_calls") or []:
             if not isinstance(tc, dict):
@@ -596,7 +605,9 @@ class AnthropicProvider(LLMProvider):
             messages, tools, model, max_tokens, temperature,
             reasoning_effort, tool_choice,
         )
-        idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
+        idle_timeout_s = resolve_stream_idle_timeout_s(
+            os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S"), default=90,
+        )
         try:
             async with self._client.messages.stream(**kwargs) as stream:
                 if on_content_delta or on_thinking_delta or on_tool_call_delta:

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from loguru import logger
 
-from nanobot.utils.helpers import image_placeholder_text
+from nanobot.utils.helpers import image_placeholder_text, repair_tool_result_protocol
 
 
 @dataclass
@@ -262,7 +262,7 @@ class LLMProvider(ABC):
             if clean.get("role") == "assistant" and "content" not in clean:
                 clean["content"] = None
             sanitized.append(clean)
-        return sanitized
+        return repair_tool_result_protocol(sanitized)
 
     @abstractmethod
     async def chat(

--- a/nanobot/providers/bedrock_provider.py
+++ b/nanobot/providers/bedrock_provider.py
@@ -13,6 +13,7 @@ from typing import Any
 import json_repair
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 _IMAGE_DATA_URL = re.compile(r"^data:image/([a-zA-Z0-9.+-]+);base64,(.*)$", re.DOTALL)
 _TEXT_BLOCK_TYPES = {"text", "input_text", "output_text"}
@@ -707,7 +708,9 @@ class BedrockProvider(LLMProvider):
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
     ) -> LLMResponse:
         _ = on_thinking_delta, on_tool_call_delta
-        idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
+        idle_timeout_s = resolve_stream_idle_timeout_s(
+            os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S"), default=90,
+        )
         content_parts: list[str] = []
         reasoning_parts: list[str] = []
         thinking_blocks: list[dict[str, Any]] = []

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -19,6 +19,7 @@ from nanobot.providers.openai_responses import (
     convert_messages,
     convert_tools,
 )
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 DEFAULT_CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_ORIGINATOR = "nanobot"
@@ -198,7 +199,9 @@ async def _request_codex(
     on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,
     on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
 ) -> tuple[str, list[ToolCallRequest], str, str | None]:
-    idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
+    idle_timeout_s = resolve_stream_idle_timeout_s(
+        os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S"), default=90,
+    )
     async with httpx.AsyncClient(timeout=idle_timeout_s, verify=verify) as client:
         async with client.stream("POST", url, headers=headers, json=body) as response:
             if response.status_code != 200:

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -7,12 +7,14 @@ import hashlib
 import importlib.util
 import json
 import os
+import re
 import secrets
 import string
 import time
 import uuid
 from collections import deque
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -27,6 +29,7 @@ from nanobot.providers.openai_responses import (
     convert_tools,
     parse_response_output,
 )
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI as AsyncOpenAIType
@@ -966,6 +969,61 @@ class OpenAICompatProvider(LLMProvider):
                 current = getattr(current, segment, None)
         return int(current or 0) if current is not None else 0
 
+    @staticmethod
+    def _unique_parsed_tool_id(value: Any, used_ids: set[str]) -> str:
+        base = str(value) if isinstance(value, str) and value else _short_tool_id()
+        if base not in used_ids:
+            used_ids.add(base)
+            return base
+        salt = 1
+        while True:
+            candidate = f"{base}_{salt}"
+            if candidate not in used_ids:
+                used_ids.add(candidate)
+                return candidate
+            salt += 1
+
+    @classmethod
+    def _parse_text_tool_calls(cls, content: str | None) -> tuple[str | None, list[ToolCallRequest]]:
+        """Parse common text-format tool call blocks from OpenAI-compatible gateways."""
+        if not isinstance(content, str) or "<tool_call" not in content:
+            return content, []
+
+        calls: list[ToolCallRequest] = []
+        used_ids: set[str] = set()
+
+        def _parse_payload(raw: str) -> ToolCallRequest | None:
+            try:
+                payload = json_repair.loads(raw)
+            except Exception:
+                return None
+            if not isinstance(payload, dict):
+                return None
+            fn = payload.get("function") if isinstance(payload.get("function"), dict) else payload
+            name = fn.get("name") if isinstance(fn, dict) else None
+            if not isinstance(name, str) or not name:
+                return None
+            args = fn.get("arguments", {}) if isinstance(fn, dict) else {}
+            if isinstance(args, str):
+                with suppress(Exception):
+                    args = json_repair.loads(args)
+            return ToolCallRequest(
+                id=cls._unique_parsed_tool_id(payload.get("id"), used_ids),
+                name=name,
+                arguments=args if isinstance(args, dict) else {},
+            )
+
+        def _replace(match: re.Match[str]) -> str:
+            parsed = _parse_payload(match.group(1))
+            if parsed is None:
+                return match.group(0)
+            calls.append(parsed)
+            return ""
+
+        stripped = re.sub(r"<tool_call>\s*(.*?)\s*</tool_call>", _replace, content, flags=re.DOTALL)
+        stripped = stripped.strip() or None
+        return stripped, calls
+
     def _parse(self, response: Any) -> LLMResponse:
         if isinstance(response, str):
             return LLMResponse(content=response, finish_reason="stop")
@@ -1015,6 +1073,7 @@ class OpenAICompatProvider(LLMProvider):
                     reasoning_content = m.get("reasoning_content")
 
             parsed_tool_calls = []
+            used_tool_ids: set[str] = set()
             for tc in raw_tool_calls:
                 tc_map = self._maybe_mapping(tc) or {}
                 fn = self._maybe_mapping(tc_map.get("function")) or {}
@@ -1023,13 +1082,18 @@ class OpenAICompatProvider(LLMProvider):
                     args = json_repair.loads(args)
                 ec, prov, fn_prov = _extract_tc_extras(tc)
                 parsed_tool_calls.append(ToolCallRequest(
-                    id=str(tc_map.get("id") or _short_tool_id()),
+                    id=self._unique_parsed_tool_id(tc_map.get("id"), used_tool_ids),
                     name=str(fn.get("name") or ""),
                     arguments=args if isinstance(args, dict) else {},
                     extra_content=ec,
                     provider_specific_fields=prov,
                     function_provider_specific_fields=fn_prov,
                 ))
+
+            if not parsed_tool_calls:
+                content, parsed_tool_calls = self._parse_text_tool_calls(content)
+                if parsed_tool_calls:
+                    finish_reason = "tool_calls"
 
             return LLMResponse(
                 content=content,
@@ -1060,13 +1124,14 @@ class OpenAICompatProvider(LLMProvider):
                 content = m.reasoning
 
         tool_calls = []
+        used_tool_ids: set[str] = set()
         for tc in raw_tool_calls:
             args = tc.function.arguments
             if isinstance(args, str):
                 args = json_repair.loads(args)
             ec, prov, fn_prov = _extract_tc_extras(tc)
             tool_calls.append(ToolCallRequest(
-                id=str(getattr(tc, "id", None) or _short_tool_id()),
+                id=self._unique_parsed_tool_id(getattr(tc, "id", None), used_tool_ids),
                 name=tc.function.name,
                 arguments=args,
                 extra_content=ec,
@@ -1077,6 +1142,11 @@ class OpenAICompatProvider(LLMProvider):
         reasoning_content = getattr(msg, "reasoning_content", None) or None
         if not reasoning_content and getattr(msg, "reasoning", None):
             reasoning_content = msg.reasoning
+
+        if not tool_calls:
+            content, tool_calls = self._parse_text_tool_calls(content)
+            if tool_calls:
+                finish_reason = "tool_calls"
 
         return LLMResponse(
             content=content,
@@ -1198,9 +1268,7 @@ class OpenAICompatProvider(LLMProvider):
                 b["id"] = _short_tool_id()
             _seen_tc_ids.add(b["id"])
 
-        return LLMResponse(
-            content="".join(content_parts) or None,
-            tool_calls=[
+        parsed_tool_calls = [
                 ToolCallRequest(
                     id=b["id"] or _short_tool_id(),
                     name=b["name"],
@@ -1210,7 +1278,16 @@ class OpenAICompatProvider(LLMProvider):
                     function_provider_specific_fields=b.get("fn_prov"),
                 )
                 for b in tc_bufs.values()
-            ],
+            ]
+        content = "".join(content_parts) or None
+        if not parsed_tool_calls:
+            content, parsed_tool_calls = cls._parse_text_tool_calls(content)
+            if parsed_tool_calls:
+                finish_reason = "tool_calls"
+
+        return LLMResponse(
+            content=content,
+            tool_calls=parsed_tool_calls,
             finish_reason=finish_reason,
             usage=usage,
             reasoning_content="".join(reasoning_parts) or None,
@@ -1357,7 +1434,9 @@ class OpenAICompatProvider(LLMProvider):
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
     ) -> LLMResponse:
         await self._ensure_client()
-        idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
+        idle_timeout_s = resolve_stream_idle_timeout_s(
+            os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S"), default=90,
+        )
         try:
             if self._should_use_responses_api(model, reasoning_effort):
                 try:

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -1,5 +1,6 @@
 """Session management for conversation history."""
 
+import base64
 import json
 import os
 import re
@@ -18,6 +19,7 @@ from nanobot.utils.helpers import (
     estimate_message_tokens,
     find_legal_message_start,
     image_placeholder_text,
+    repair_tool_result_protocol,
     safe_filename,
 )
 from nanobot.utils.subagent_channel_display import scrub_subagent_announce_body
@@ -129,6 +131,14 @@ class Session:
         History is sliced by message count first (``max_messages``), then by
         token budget from the tail (``max_tokens``) when provided.
         """
+        if not isinstance(self.last_consolidated, int):
+            self.last_consolidated = 0
+        if self.last_consolidated < 0 or self.last_consolidated > len(self.messages):
+            logger.warning(
+                "Clamping invalid last_consolidated={} for session {} with {} messages",
+                self.last_consolidated, self.key, len(self.messages),
+            )
+            self.last_consolidated = 0 if self.last_consolidated > len(self.messages) else max(self.last_consolidated, 0)
         unconsolidated = self.messages[self.last_consolidated:]
         max_messages = max_messages if max_messages > 0 else 120
         sliced = unconsolidated[-max_messages:]
@@ -144,6 +154,7 @@ class Session:
                 break
 
         # Drop orphan tool results at the front.
+        sliced = repair_tool_result_protocol(sliced)
         start = find_legal_message_start(sliced)
         if start:
             sliced = sliced[start:]
@@ -248,7 +259,7 @@ class Session:
             if start:
                 kept = kept[start:]
             out = kept
-        return out
+        return repair_tool_result_protocol(out)
 
     def clear(self) -> None:
         """Clear all messages and reset session to initial state."""
@@ -345,7 +356,12 @@ class SessionManager:
 
     @staticmethod
     def safe_key(key: str) -> str:
-        """Public helper used by HTTP handlers to map an arbitrary key to a stable filename stem."""
+        """Map an arbitrary session key to a collision-resistant filename stem."""
+        encoded = base64.urlsafe_b64encode(key.encode("utf-8")).decode("ascii").rstrip("=")
+        return f"b64_{encoded or '_'}"
+
+    @staticmethod
+    def _legacy_safe_key(key: str) -> str:
         return safe_filename(key.replace(":", "_"))
 
     def _get_session_path(self, key: str) -> Path:
@@ -355,6 +371,14 @@ class SessionManager:
     def _get_legacy_session_path(self, key: str) -> Path:
         """Legacy global session path (~/.nanobot/sessions/)."""
         return self.legacy_sessions_dir / f"{self.safe_key(key)}.jsonl"
+
+    def _get_old_session_path(self, key: str) -> Path:
+        """Pre-base64 local session path."""
+        return self.sessions_dir / f"{self._legacy_safe_key(key)}.jsonl"
+
+    def _get_old_legacy_session_path(self, key: str) -> Path:
+        """Pre-base64 global session path."""
+        return self.legacy_sessions_dir / f"{self._legacy_safe_key(key)}.jsonl"
 
     def get_or_create(self, key: str) -> Session:
         """
@@ -380,8 +404,18 @@ class SessionManager:
         """Load a session from disk."""
         path = self._get_session_path(key)
         if not path.exists():
-            legacy_path = self._get_legacy_session_path(key)
-            if legacy_path.exists():
+            for candidate in (
+                self._get_old_session_path(key),
+                self._get_legacy_session_path(key),
+                self._get_old_legacy_session_path(key),
+            ):
+                if not candidate.exists() or candidate == path:
+                    continue
+                legacy_path = candidate
+                break
+            else:
+                legacy_path = None
+            if legacy_path is not None:
                 try:
                     shutil.move(str(legacy_path), str(path))
                     logger.info("Migrated session {} from legacy path", key)
@@ -414,6 +448,7 @@ class SessionManager:
                     else:
                         messages.append(data)
 
+            last_consolidated = self._clamp_last_consolidated(key, last_consolidated, len(messages))
             return Session(
                 key=key,
                 messages=messages,
@@ -472,6 +507,7 @@ class SessionManager:
             if not messages and not metadata:
                 return None
 
+            last_consolidated = self._clamp_last_consolidated(key, last_consolidated, len(messages))
             return Session(
                 key=key,
                 messages=messages,
@@ -483,6 +519,19 @@ class SessionManager:
         except Exception as e:
             logger.warning("Repair failed for session {}: {}", key, e)
             return None
+
+    @staticmethod
+    def _clamp_last_consolidated(key: str, value: Any, message_count: int) -> int:
+        if not isinstance(value, int):
+            logger.warning("Ignoring non-integer last_consolidated for session {}: {}", key, value)
+            return 0
+        clamped = 0 if value > message_count else max(value, 0)
+        if clamped != value:
+            logger.warning(
+                "Clamped invalid last_consolidated for session {} from {} to {}",
+                key, value, clamped,
+            )
+        return clamped
 
     @staticmethod
     def _session_payload(session: Session) -> dict[str, Any]:
@@ -518,7 +567,7 @@ class SessionManager:
                     "last_consolidated": session.last_consolidated
                 }
                 f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
-                for msg in session.messages:
+                for msg in repair_tool_result_protocol(session.messages):
                     f.write(json.dumps(msg, ensure_ascii=False) + "\n")
                 if fsync:
                     f.flush()

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -255,6 +255,60 @@ def find_legal_message_start(messages: list[dict[str, Any]]) -> int:
     return start
 
 
+def repair_tool_result_protocol(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop malformed, orphan, or duplicate tool-result messages.
+
+    Provider protocols require each tool result to reference exactly one
+    preceding assistant tool call. Histories can be edited or recovered from
+    partial checkpoints, so validate this invariant before replay.
+    """
+    repaired: list[dict[str, Any]] = []
+    pending: set[str] = set()
+    answered: set[str] = set()
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                if isinstance(tc, dict) and tc.get("id"):
+                    tid = str(tc["id"])
+                    pending.add(tid)
+                    answered.discard(tid)
+            repaired.append(msg)
+            continue
+
+        if role == "tool":
+            tid_raw = msg.get("tool_call_id")
+            tid = str(tid_raw) if isinstance(tid_raw, str) and tid_raw else ""
+            if not tid or tid not in pending or tid in answered:
+                continue
+            answered.add(tid)
+            pending.discard(tid)
+            repaired.append(msg)
+            continue
+
+        repaired.append(msg)
+
+    return repaired
+
+
+def resolve_stream_idle_timeout_s(
+    value: Any,
+    *,
+    default: int = 90,
+    minimum: int = 1,
+    maximum: int = 3600,
+) -> int:
+    """Parse and clamp stream idle timeout seconds."""
+    try:
+        timeout = int(value)
+    except (TypeError, ValueError):
+        return default
+    if timeout < minimum:
+        return default
+    return min(timeout, maximum)
+
+
 def stringify_text_blocks(content: list[dict[str, Any]]) -> str | None:
     parts: list[str] = []
     for block in content:

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -141,6 +141,17 @@ class TestHistoryWithCursor:
         assert len(entries) == 2
         assert entries[0]["cursor"] in {4, 5}
 
+    def test_compact_history_preserves_unprocessed_entries(self, tmp_path):
+        store = MemoryStore(tmp_path, max_history_entries=50)
+        for idx in range(100):
+            store.append_history(f"event {idx + 1}")
+
+        store.compact_history(protect_after_cursor=20)
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        cursors = {entry["cursor"] for entry in entries}
+        assert set(range(21, 101)).issubset(cursors)
+
     def test_write_entries_uses_atomic_write(self, tmp_path):
         """_write_entries uses temp file + os.replace for atomicity."""
         store = MemoryStore(tmp_path)

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -43,6 +43,55 @@ def test_list_sessions_includes_metadata_title(tmp_path):
     assert rows[0]["title"] == "自动生成标题"
 
 
+def test_safe_key_distinguishes_sanitization_collisions() -> None:
+    keys = [
+        "telegram:a_b",
+        "telegram:a:b",
+        "telegram/a:b",
+        "telegram_a:b",
+    ]
+
+    stems = {SessionManager.safe_key(key) for key in keys}
+
+    assert len(stems) == len(keys)
+
+
+def test_get_history_clamps_high_last_consolidated() -> None:
+    session = Session(
+        key="k",
+        messages=[{"role": "user", "content": f"m{i}"} for i in range(10)],
+        last_consolidated=999,
+    )
+
+    history = session.get_history(max_messages=100)
+
+    assert history
+    assert history[-1]["content"] == "m9"
+
+
+def test_get_history_drops_duplicate_and_malformed_tool_results() -> None:
+    session = Session(
+        key="k",
+        messages=[
+            {"role": "user", "content": "run"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "tc", "type": "function", "function": {"name": "x", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "tc", "content": "one"},
+            {"role": "tool", "tool_call_id": "tc", "content": "duplicate"},
+            {"role": "tool", "content": "missing id"},
+            {"role": "tool", "tool_call_id": "unknown", "content": "unknown"},
+        ],
+    )
+
+    history = session.get_history(max_messages=100)
+
+    tool_results = [m for m in history if m.get("role") == "tool"]
+    assert [m["content"] for m in tool_results] == ["one"]
+
+
 def test_list_sessions_includes_user_preview(tmp_path):
     manager = SessionManager(tmp_path)
     session = manager.get_or_create("websocket:chat-preview")

--- a/tests/config/test_dream_config.py
+++ b/tests/config/test_dream_config.py
@@ -4,6 +4,7 @@ from nanobot.config.schema import DreamConfig
 def test_dream_config_defaults_to_interval_hours() -> None:
     cfg = DreamConfig()
 
+    assert cfg.enabled is True
     assert cfg.interval_h == 2
     assert cfg.cron is None
 

--- a/tests/config/test_env_interpolation.py
+++ b/tests/config/test_env_interpolation.py
@@ -10,6 +10,14 @@ from nanobot.config.loader import (
 )
 
 
+def test_load_config_invalid_json_fails_closed(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{invalid", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        load_config(config_path)
+
+
 class TestResolveEnvVars:
     def test_replaces_string_value(self, monkeypatch):
         monkeypatch.setenv("MY_SECRET", "hunter2")

--- a/tests/providers/test_anthropic_tool_result.py
+++ b/tests/providers/test_anthropic_tool_result.py
@@ -55,3 +55,12 @@ def test_tool_result_block_preserves_string_content():
     assert block["type"] == "tool_result"
     assert block["tool_use_id"] == "call_2"
     assert block["content"] == "plain tool output"
+
+
+def test_assistant_blocks_adds_missing_text_type():
+    blocks = AnthropicProvider._assistant_blocks({
+        "role": "assistant",
+        "content": [{"text": "hi"}],
+    })
+
+    assert blocks == [{"type": "text", "text": "hi"}]

--- a/tests/providers/test_custom_provider.py
+++ b/tests/providers/test_custom_provider.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 from nanobot.providers.registry import find_by_name
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 
 def test_custom_provider_parse_handles_empty_choices() -> None:
@@ -83,6 +84,53 @@ def test_custom_provider_parse_chunks_deduplicates_parallel_tool_call_ids() -> N
     assert ids[0] == "call_dup"
     assert len(ids) == 2
     assert len(set(ids)) == 2
+
+
+def test_parse_non_stream_response_deduplicates_tool_call_ids() -> None:
+    provider = OpenAICompatProvider(api_key="test")
+    response = {
+        "choices": [{
+            "finish_reason": "tool_calls",
+            "message": {
+                "content": None,
+                "tool_calls": [
+                    {"id": "same", "function": {"name": "a", "arguments": "{}"}},
+                    {"id": "same", "function": {"name": "b", "arguments": "{}"}},
+                ],
+            },
+        }],
+    }
+
+    result = provider._parse(response)
+    ids = [tool_call.id for tool_call in result.tool_calls]
+
+    assert ids[0] == "same"
+    assert len(set(ids)) == 2
+
+
+def test_parse_text_format_tool_call_block() -> None:
+    provider = OpenAICompatProvider(api_key="test")
+    response = {
+        "choices": [{
+            "finish_reason": "stop",
+            "message": {
+                "content": 'before <tool_call>{"name":"read_file","arguments":{"path":"x"}}</tool_call> after',
+            },
+        }],
+    }
+
+    result = provider._parse(response)
+
+    assert result.finish_reason == "tool_calls"
+    assert result.content == "before  after"
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "read_file"
+    assert result.tool_calls[0].arguments == {"path": "x"}
+
+
+def test_invalid_stream_idle_timeout_falls_back_to_default() -> None:
+    assert resolve_stream_idle_timeout_s("abc", default=90) == 90
+    assert resolve_stream_idle_timeout_s("-1", default=90) == 90
 
 
 def test_local_provider_502_error_includes_reachability_hint() -> None:


### PR DESCRIPTION
## Summary
- Fix persistence, context trimming, provider parsing, streaming, config, and Dream scheduling regressions reported in #4055 through #4069.
- Add regression coverage for the high-risk invariants around Dream history, sessions, tool-call protocol state, provider conversion, and config parsing.

## Issues Fixed
- Fixes #4055: Dream compaction now protects entries newer than the Dream cursor.
- Fixes #4056: context trimming preserves the latest assistant/user continuity pair when it fits the remaining budget.
- Fixes #4057: session storage keys now use collision-resistant base64url stems with legacy migration fallback.
- Fixes #4058: malformed, orphan, and duplicate tool-result states are repaired at session/provider boundaries.
- Fixes #4059: OpenAI-compatible non-stream tool-call parsing deduplicates duplicate IDs.
- Fixes #4060: Anthropic assistant content blocks with text but no type are normalized to text blocks.
- Fixes #4061: OpenAI-compatible text-format <tool_call> blocks are parsed into structured tool calls.
- Fixes #4062: WebSocket normal outbound messages are persisted before subscriber checks.
- Fixes #4063: ChannelManager stream-delta coalescing keys by stream ID.
- Fixes #4064: pending mid-turn messages preserve runtime sender/channel/chat context.
- Fixes #4065: invalid NANOBOT_STREAM_IDLE_TIMEOUT_S values fall back to safe defaults.
- Fixes #4066: invalid high last_consolidated values no longer hide session history at runtime.
- Fixes #4067: invalid config now fails closed instead of silently using defaults.
- Fixes #4068: Matrix stream buffers are independent per stream ID while preserving legacy chat-key behavior for streams without IDs.
- Fixes #4069: scheduled Dream registration now respects dream.enabled.

## Validation
- uv run pytest tests/agent/test_runner_governance.py::test_snip_history_reserves_budget_for_tool_definitions tests/agent/test_session_atomic.py::TestRepairCorruptFile::test_repair_with_bad_timestamp_uses_fallback tests/agent/test_session_atomic.py::TestRepairCorruptFile::test_list_sessions_keeps_repaired_corrupt_file tests/providers/test_litellm_kwargs.py::test_openai_compat_deduplicates_duplicate_tool_call_ids_in_history -q
- uv run --extra matrix pytest tests/channels/test_matrix_channel.py::test_send_delta_creates_stream_buffer_and_sends_initial_message tests/channels/test_matrix_channel.py::test_send_delta_appends_without_sending_before_edit_interval tests/channels/test_matrix_channel.py::test_send_delta_stream_end_replaces_existing_message tests/channels/test_matrix_channel.py::test_send_delta_on_error_stops_typing tests/channels/test_matrix_channel.py::test_send_delta_ignores_whitespace_only_delta -q
- Earlier focused regression suite passed locally.
- Started uv run pytest tests/; it progressed past the previously failing runner/session/Matrix/provider areas and was stopped after a long quiet stretch around tests/tools/test_mcp_probe.py per follow-up instruction to push the draft.