### PR TITLE
fix(security): normalize IPv6-mapped IPv4 addresses in SSRF checks

### DIFF
--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -149,7 +149,7 @@ def _is_allowed_loopback_target(
     hostname: str,
     addrs: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
 ) -> bool:
-    if not addrs or not all(addr.is_loopback for addr in addrs):
+    if not addrs or not all(_normalize_addr(addr).is_loopback for addr in addrs):
         return False
     normalized = hostname.rstrip(".").lower()
     if normalized == "localhost":

--- a/nanobot/security/network.py
+++ b/nanobot/security/network.py
@@ -36,10 +36,26 @@ def configure_ssrf_whitelist(cidrs: list[str]) -> None:
     _allowed_networks = nets
 
 
+def _normalize_addr(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    """Normalize IPv6-mapped IPv4 addresses to their IPv4 form.
+
+    ``::ffff:127.0.0.1`` is semantically identical to ``127.0.0.1`` but
+    Python's ipaddress treats it as an IPv6Address that matches neither
+    ``127.0.0.0/8`` nor ``::1/128``.  Converting it to IPv4 ensures
+    blocklist/allowlist checks work correctly.
+    """
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        return addr.ipv4_mapped
+    return addr
+
+
 def _is_private(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    if _allowed_networks and any(addr in net for net in _allowed_networks):
+    normalized = _normalize_addr(addr)
+    if _allowed_networks and any(normalized in net for net in _allowed_networks):
         return False
-    return any(addr in net for net in _BLOCKED_NETWORKS)
+    return any(normalized in net for net in _BLOCKED_NETWORKS)
 
 
 def validate_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool, str]:

--- a/tests/security/test_security_network.py
+++ b/tests/security/test_security_network.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from nanobot.security.network import configure_ssrf_whitelist, contains_internal_url, validate_url_target
+from nanobot.security.network import (
+    configure_ssrf_whitelist,
+    contains_internal_url,
+    validate_url_target,
+)
 
 
 def _fake_resolve(host: str, results: list[str]):
@@ -155,6 +159,12 @@ def test_loopback_exception_rejects_metadata():
         assert contains_internal_url("curl http://169.254.169.254/latest/meta-data/", allow_loopback=True)
 
 
+def test_detects_ipv6_mapped_loopback():
+    """contains_internal_url must catch IPv6-mapped loopback in shell commands."""
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_v6("evil.com", ["::ffff:127.0.0.1"])):
+        assert contains_internal_url("curl http://evil.com/secret")
+
+
 def test_allows_normal_curl():
     with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve("example.com", ["93.184.216.34"])):
         assert not contains_internal_url("curl https://example.com/api/data")
@@ -204,5 +214,16 @@ def test_whitelist_invalid_cidr_ignored():
         with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve("ts.local", ["100.100.1.1"])):
             ok, _ = validate_url_target("http://ts.local/api")
             assert ok
+    finally:
+        configure_ssrf_whitelist([])
+
+
+def test_whitelist_allows_ipv6_mapped_cgnat():
+    """Whitelist must work when DNS returns IPv6-mapped CGNAT address."""
+    configure_ssrf_whitelist(["100.64.0.0/10"])
+    try:
+        with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_v6("ts.local", ["::ffff:100.100.1.1"])):
+            ok, err = validate_url_target("http://ts.local/api")
+            assert ok, f"Whitelisted IPv6-mapped CGNAT should be allowed, got: {err}"
     finally:
         configure_ssrf_whitelist([])

--- a/tests/security/test_security_network.py
+++ b/tests/security/test_security_network.py
@@ -63,6 +63,54 @@ def test_blocks_ipv6_loopback():
 
 
 # ---------------------------------------------------------------------------
+# validate_url_target — IPv6-mapped IPv4 bypass prevention
+# ---------------------------------------------------------------------------
+
+def _fake_resolve_v6(host: str, results: list[str]):
+    """Like _fake_resolve but returns AF_INET6 tuples for IPv6 addresses."""
+    def _resolver(hostname, port, family=0, type_=0):
+        if hostname == host:
+            entries = []
+            for ip in results:
+                if ":" in ip:
+                    entries.append((socket.AF_INET6, socket.SOCK_STREAM, 0, "", (ip, 0, 0, 0)))
+                else:
+                    entries.append((socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0)))
+            return entries
+        raise socket.gaierror(f"cannot resolve {hostname}")
+    return _resolver
+
+
+def test_blocks_ipv6_mapped_loopback():
+    """::ffff:127.0.0.1 must be blocked just like 127.0.0.1."""
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_v6("evil.com", ["::ffff:127.0.0.1"])):
+        ok, err = validate_url_target("http://evil.com/")
+        assert not ok
+        assert "blocked" in err.lower()
+
+
+def test_blocks_ipv6_mapped_metadata():
+    """::ffff:169.254.169.254 must be blocked just like 169.254.169.254."""
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_v6("evil.com", ["::ffff:169.254.169.254"])):
+        ok, err = validate_url_target("http://evil.com/")
+        assert not ok
+
+
+def test_blocks_ipv6_mapped_rfc1918():
+    """::ffff:10.0.0.1 must be blocked just like 10.0.0.1."""
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_v6("evil.com", ["::ffff:10.0.0.1"])):
+        ok, err = validate_url_target("http://evil.com/")
+        assert not ok
+
+
+def test_allows_public_ipv6():
+    """Public IPv6 addresses must still be allowed."""
+    with patch("nanobot.security.network.socket.getaddrinfo", _fake_resolve_v6("example.com", ["2606:4700::6810:84e5"])):
+        ok, err = validate_url_target("http://example.com/")
+        assert ok, f"Should allow public IPv6, got: {err}"
+
+
+# ---------------------------------------------------------------------------
 # validate_url_target — allows public IPs
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem                                                                                                                                                                                             
                                                                                                                                                                                                           
`_is_private()` in `network.py` checks resolved IPs against `_BLOCKED_NETWORKS`, but IPv6-mapped IPv4 addresses like `::ffff:127.0.0.1` are `IPv6Address` objects that match **neither** the IPv4 blocklists (`127.0.0.0/8`, `169.254.0.0/16`, etc.) **nor** the IPv6 ones (`::1/128`). This allows SSRF bypass when DNS returns IPv6-mapped IPv4 addresses.                                               
                                                                                                                                                                                                           
Verified with Python:                                                                                                                                                                                  
                                                                                                                                                                                                           
::ffff:127.0.0.1 in 127.0.0.0/8  → False                                                                                                                                                                 
::ffff:169.254.169.254 in 169.254.0.0/16  → False                                                                                                                                                        
                                                                                                                                                                                                           
                                                                                                                                                                                                           
## Fix                                                                                                                                                                                                 
                                                                                                                                                                                                           
Add `_normalize_addr()` that converts IPv6 addresses with `ipv4_mapped` to their IPv4 form before blocklist/allowlist matching. Applied in `_is_private()` so all callers (`validate_url_target`,`validate_resolved_url`, `contains_internal_url`) benefit.                                                                                                                                               
                                                                                                                                                                                                           
## Changes                                                                                                                                                                                             
                                                                                                                                                                                                           
- `nanobot/security/network.py`: Add `_normalize_addr()`, use it in `_is_private()`                                                                                                                    
- `tests/security/test_security_network.py`: Add 4 tests covering IPv6-mapped loopback, metadata, RFC1918, and public IPv6  