### PR TITLE
fix dream compaction cursor safety

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -319,14 +319,34 @@ class MemoryStore:
         """Return history entries with a valid cursor > *since_cursor*."""
         return [e for e, c in self._iter_valid_entries() if c > since_cursor]
 
-    def compact_history(self) -> None:
-        """Drop oldest entries if the file exceeds *max_history_entries*."""
+    def compact_history(self, *, protect_after_cursor: int | None = None) -> None:
+        """Drop oldest processed entries if the file exceeds *max_history_entries*."""
         if self.max_history_entries <= 0:
             return
         entries = self._read_entries()
         if len(entries) <= self.max_history_entries:
             return
-        kept = entries[-self.max_history_entries:]
+        if protect_after_cursor is None:
+            kept = entries[-self.max_history_entries:]
+        else:
+            protected: list[dict[str, Any]] = []
+            processed: list[dict[str, Any]] = []
+            for entry in entries:
+                cursor = self._valid_cursor(entry.get("cursor"))
+                if cursor is not None and cursor > protect_after_cursor:
+                    protected.append(entry)
+                else:
+                    processed.append(entry)
+            if len(protected) >= self.max_history_entries:
+                logger.warning(
+                    "Dream history compaction kept {} unprocessed entries above cursor {}, "
+                    "exceeding max_history_entries={}",
+                    len(protected), protect_after_cursor, self.max_history_entries,
+                )
+                kept = protected
+            else:
+                room = self.max_history_entries - len(protected)
+                kept = processed[-room:] + protected
         self._write_entries(kept)
 
     # -- JSONL helpers -------------------------------------------------------
@@ -1134,9 +1154,11 @@ class Dream:
                     changelog.append(f"{event['name']}: {event['detail']}")
 
         # Only advance cursor on successful completion to prevent silent loss
+        protect_cursor = last_cursor
         if result and result.stop_reason == "completed":
             new_cursor = batch[-1]["cursor"]
             self.store.set_last_dream_cursor(new_cursor)
+            protect_cursor = new_cursor
             logger.info(
                 "Dream done: {} change(s), cursor advanced to {}",
                 len(changelog), new_cursor,
@@ -1148,7 +1170,7 @@ class Dream:
                 reason,
             )
 
-        self.store.compact_history()
+        self.store.compact_history(protect_after_cursor=protect_cursor)
 
         # Git auto-commit (only when there are actual changes)
         if changelog and self.store.git.is_initialized():

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -141,6 +141,17 @@ class TestHistoryWithCursor:
         assert len(entries) == 2
         assert entries[0]["cursor"] in {4, 5}
 
+    def test_compact_history_preserves_unprocessed_entries(self, tmp_path):
+        store = MemoryStore(tmp_path, max_history_entries=50)
+        for idx in range(100):
+            store.append_history(f"event {idx + 1}")
+
+        store.compact_history(protect_after_cursor=20)
+
+        entries = store.read_unprocessed_history(since_cursor=0)
+        cursors = {entry["cursor"] for entry in entries}
+        assert set(range(21, 101)).issubset(cursors)
+
     def test_write_entries_uses_atomic_write(self, tmp_path):
         """_write_entries uses temp file + os.replace for atomicity."""
         store = MemoryStore(tmp_path)


### PR DESCRIPTION
## Scope
Dream compaction

## Issues Fixed
- Fixes #4055: Dream history compaction now preserves entries newer than the Dream cursor instead of trimming unprocessed history by count alone.

## Key Files
- nanobot/agent/memory.py
- tests/agent/test_memory_store.py

## Validation
- uv run pytest tests/agent/test_memory_store.py::TestHistoryWithCursor::test_compact_history_preserves_unprocessed_entries -q