### PR TITLE
fix context trimming continuity

### DIFF
--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -1298,9 +1298,28 @@ class AgentRunner:
         kept.reverse()
 
         if kept:
+            latest_user_idx = next(
+                (i for i in range(len(non_system) - 1, -1, -1)
+                 if non_system[i].get("role") == "user"),
+                None,
+            )
+            if latest_user_idx and non_system[latest_user_idx - 1].get("role") == "assistant":
+                latest_user = non_system[latest_user_idx]
+                previous_assistant = non_system[latest_user_idx - 1]
+                previous_tokens = estimate_message_tokens(previous_assistant)
+                if (
+                    latest_user in kept
+                    and previous_assistant not in kept
+                    and kept_tokens + previous_tokens <= remaining_budget
+                ):
+                    kept.insert(0, previous_assistant)
+                    kept_tokens += previous_tokens
             for i, message in enumerate(kept):
                 if message.get("role") == "user":
-                    kept = kept[i:]
+                    start = i
+                    if i > 0 and kept[i - 1].get("role") == "assistant":
+                        start = i - 1
+                    kept = kept[start:]
                     break
             else:
                 # Recover nearest user message from outside the kept window;


### PR DESCRIPTION
## Scope
Context trimming

## Issues Fixed
- Fixes #4056: context trimming keeps the immediately preceding assistant turn with the latest user reply when that continuity pair fits the remaining history budget.

## Key Files
- nanobot/agent/runner.py

## Validation
- uv run pytest tests/agent/test_runner_governance.py::test_snip_history_reserves_budget_for_tool_definitions -q