### PR TITLE
fix tool-result protocol repair

### DIFF
--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from loguru import logger
 
-from nanobot.utils.helpers import image_placeholder_text
+from nanobot.utils.helpers import image_placeholder_text, repair_tool_result_protocol
 
 
 @dataclass
@@ -262,7 +262,7 @@ class LLMProvider(ABC):
             if clean.get("role") == "assistant" and "content" not in clean:
                 clean["content"] = None
             sanitized.append(clean)
-        return sanitized
+        return repair_tool_result_protocol(sanitized)
 
     @abstractmethod
     async def chat(

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -27,6 +27,7 @@ from nanobot.providers.openai_responses import (
     convert_tools,
     parse_response_output,
 )
+from nanobot.utils.helpers import repair_tool_result_protocol
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI as AsyncOpenAIType
@@ -509,7 +510,12 @@ class OpenAICompatProvider(LLMProvider):
 
     def _sanitize_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Strip non-standard keys, normalize tool_call IDs."""
-        sanitized = LLMProvider._sanitize_request_messages(messages, _ALLOWED_MSG_KEYS)
+        sanitized = []
+        for msg in messages:
+            clean = {k: v for k, v in msg.items() if k in _ALLOWED_MSG_KEYS}
+            if clean.get("role") == "assistant" and "content" not in clean:
+                clean["content"] = None
+            sanitized.append(clean)
         id_map: dict[str, str] = {}
         pending_tool_ids: dict[str, deque[str]] = {}
         force_string_content = bool(self._spec and self._spec.name == "deepseek")
@@ -588,7 +594,7 @@ class OpenAICompatProvider(LLMProvider):
                 and not (clean.get("role") == "assistant" and clean.get("tool_calls"))
             ):
                 clean["content"] = self._coerce_content_to_string(clean.get("content"))
-        return self._enforce_role_alternation(sanitized)
+        return self._enforce_role_alternation(repair_tool_result_protocol(sanitized))
 
     # ------------------------------------------------------------------
     # Build kwargs

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -18,6 +18,7 @@ from nanobot.utils.helpers import (
     estimate_message_tokens,
     find_legal_message_start,
     image_placeholder_text,
+    repair_tool_result_protocol,
     safe_filename,
 )
 from nanobot.utils.subagent_channel_display import scrub_subagent_announce_body
@@ -143,6 +144,8 @@ class Session:
                 sliced = sliced[start:]
                 break
 
+        # Drop malformed, duplicate, and orphan tool results before legal-start trimming.
+        sliced = repair_tool_result_protocol(sliced)
         # Drop orphan tool results at the front.
         start = find_legal_message_start(sliced)
         if start:
@@ -248,7 +251,7 @@ class Session:
             if start:
                 kept = kept[start:]
             out = kept
-        return out
+        return repair_tool_result_protocol(out)
 
     def clear(self) -> None:
         """Clear all messages and reset session to initial state."""
@@ -518,7 +521,7 @@ class SessionManager:
                     "last_consolidated": session.last_consolidated
                 }
                 f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
-                for msg in session.messages:
+                for msg in repair_tool_result_protocol(session.messages):
                     f.write(json.dumps(msg, ensure_ascii=False) + "\n")
                 if fsync:
                     f.flush()

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -255,6 +255,43 @@ def find_legal_message_start(messages: list[dict[str, Any]]) -> int:
     return start
 
 
+def repair_tool_result_protocol(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop malformed, orphan, or duplicate tool-result messages.
+
+    Provider protocols require each tool result to reference exactly one
+    preceding assistant tool call. Histories can be edited or recovered from
+    partial checkpoints, so validate this invariant before replay.
+    """
+    repaired: list[dict[str, Any]] = []
+    pending: set[str] = set()
+    answered: set[str] = set()
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                if isinstance(tc, dict) and tc.get("id"):
+                    tid = str(tc["id"])
+                    pending.add(tid)
+                    answered.discard(tid)
+            repaired.append(msg)
+            continue
+
+        if role == "tool":
+            tid_raw = msg.get("tool_call_id")
+            tid = str(tid_raw) if isinstance(tid_raw, str) and tid_raw else ""
+            if not tid or tid not in pending or tid in answered:
+                continue
+            answered.add(tid)
+            pending.discard(tid)
+            repaired.append(msg)
+            continue
+
+        repaired.append(msg)
+
+    return repaired
+
+
 def stringify_text_blocks(content: list[dict[str, Any]]) -> str | None:
     parts: list[str] = []
     for block in content:

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -43,6 +43,29 @@ def test_list_sessions_includes_metadata_title(tmp_path):
     assert rows[0]["title"] == "自动生成标题"
 
 
+def test_get_history_drops_duplicate_and_malformed_tool_results() -> None:
+    session = Session(
+        key="k",
+        messages=[
+            {"role": "user", "content": "run"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "tc", "type": "function", "function": {"name": "x", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "tc", "content": "one"},
+            {"role": "tool", "tool_call_id": "tc", "content": "duplicate"},
+            {"role": "tool", "content": "missing id"},
+            {"role": "tool", "tool_call_id": "unknown", "content": "unknown"},
+        ],
+    )
+
+    history = session.get_history(max_messages=100)
+
+    tool_results = [m for m in history if m.get("role") == "tool"]
+    assert [m["content"] for m in tool_results] == ["one"]
+
+
 def test_list_sessions_includes_user_preview(tmp_path):
     manager = SessionManager(tmp_path)
     session = manager.get_or_create("websocket:chat-preview")


### PR DESCRIPTION
## Scope
Tool-result protocol repair

## Issues Fixed
- Fixes #4058: malformed, orphan, and duplicate tool-result messages are removed before session replay, persistence, and provider-bound request conversion.

## Key Files
- nanobot/utils/helpers.py
- nanobot/session/manager.py
- nanobot/providers/base.py
- nanobot/providers/openai_compat_provider.py
- tests/agent/test_session_manager_history.py

## Validation
- uv run pytest tests/agent/test_session_manager_history.py::test_get_history_drops_duplicate_and_malformed_tool_results tests/providers/test_litellm_kwargs.py::test_openai_compat_deduplicates_duplicate_tool_call_ids_in_history -q