### PR TITLE
fix anthropic assistant block normalization

### DIFF
--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -13,7 +13,6 @@ from typing import Any
 import json_repair
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
-
 _ALNUM = string.ascii_letters + string.digits
 
 
@@ -192,7 +191,15 @@ class AnthropicProvider(LLMProvider):
             blocks.append({"type": "text", "text": content})
         elif isinstance(content, list):
             for item in content:
-                blocks.append(item if isinstance(item, dict) else {"type": "text", "text": str(item)})
+                if isinstance(item, dict):
+                    if item.get("type"):
+                        blocks.append(item)
+                    elif isinstance(item.get("text"), str):
+                        blocks.append({"type": "text", "text": item["text"]})
+                    else:
+                        blocks.append({"type": "text", "text": str(item)})
+                else:
+                    blocks.append({"type": "text", "text": str(item)})
 
         for tc in msg.get("tool_calls") or []:
             if not isinstance(tc, dict):

--- a/tests/providers/test_anthropic_tool_result.py
+++ b/tests/providers/test_anthropic_tool_result.py
@@ -55,3 +55,12 @@ def test_tool_result_block_preserves_string_content():
     assert block["type"] == "tool_result"
     assert block["tool_use_id"] == "call_2"
     assert block["content"] == "plain tool output"
+
+
+def test_assistant_blocks_adds_missing_text_type():
+    blocks = AnthropicProvider._assistant_blocks({
+        "role": "assistant",
+        "content": [{"text": "hi"}],
+    })
+
+    assert blocks == [{"type": "text", "text": "hi"}]


### PR DESCRIPTION
## Scope
Anthropic block normalization

## Issues Fixed
- Fixes #4060: assistant content dicts with text but no type are normalized into Anthropic text blocks before request conversion.

## Key Files
- nanobot/providers/anthropic_provider.py
- tests/providers/test_anthropic_tool_result.py

## Validation
- uv run pytest tests/providers/test_anthropic_tool_result.py::test_assistant_blocks_adds_missing_text_type -q