### PR TITLE
fix channel dispatch durability and stream identity

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -713,8 +713,23 @@ class AgentLoop:
                 if media:
                     content, media = self._prepare_message_media(content, media)
                     media = media or None
-                user_content = self.context._build_user_content(content, media)
-                return {"role": "user", "content": user_content}
+                scope = self.workspace_scopes.for_message(
+                    pending_msg,
+                    session.metadata if session is not None else None,
+                )
+                built = self.context.build_messages(
+                    history=[],
+                    current_message=image_generation_prompt(content, pending_msg.metadata),
+                    media=media,
+                    channel=pending_msg.channel,
+                    chat_id=self._runtime_chat_id(pending_msg),
+                    sender_id=pending_msg.sender_id,
+                    session_metadata=session.metadata if session is not None else None,
+                    workspace=scope.project_path,
+                    runtime_state=self,
+                    inbound_message=pending_msg,
+                )
+                return built[-1]
 
             items: list[dict[str, Any]] = []
             while len(items) < limit:

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -397,7 +397,7 @@ class ChannelManager:
     def _coalesce_stream_deltas(
         self, first_msg: OutboundMessage
     ) -> tuple[OutboundMessage, list[OutboundMessage]]:
-        """Merge consecutive _stream_delta messages for the same (channel, chat_id).
+        """Merge consecutive _stream_delta messages for the same stream.
 
         This reduces the number of API calls when the queue has accumulated multiple
         deltas, which happens when LLM generates faster than the channel can process.
@@ -405,7 +405,11 @@ class ChannelManager:
         Returns:
             tuple of (merged_message, list_of_non_matching_messages)
         """
-        target_key = (first_msg.channel, first_msg.chat_id)
+        target_key = (
+            first_msg.channel,
+            first_msg.chat_id,
+            (first_msg.metadata or {}).get("_stream_id"),
+        )
         combined_content = first_msg.content
         final_metadata = dict(first_msg.metadata or {})
         non_matching: list[OutboundMessage] = []
@@ -419,7 +423,12 @@ class ChannelManager:
                 break
 
             # Check if this message belongs to the same stream
-            same_target = (next_msg.channel, next_msg.chat_id) == target_key
+            next_key = (
+                next_msg.channel,
+                next_msg.chat_id,
+                (next_msg.metadata or {}).get("_stream_id"),
+            )
+            same_target = next_key == target_key
             is_delta = next_msg.metadata and next_msg.metadata.get("_stream_delta")
             is_end = next_msg.metadata and next_msg.metadata.get("_stream_end")
 

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -1926,9 +1926,9 @@ class WebSocketChannel(BaseChannel):
                 or msg.metadata.get("_goal_state_sync")
             ):
                 self.logger.debug("no active subscribers for chat_id={}", msg.chat_id)
+                return
             else:
                 self.logger.warning("no active subscribers for chat_id={}", msg.chat_id)
-            return
         if msg.metadata.get("_goal_state_sync"):
             blob = msg.metadata.get("goal_state")
             await self.send_goal_state(msg.chat_id, blob if isinstance(blob, dict) else {"active": False})
@@ -2005,6 +2005,8 @@ class WebSocketChannel(BaseChannel):
         transcript_payload = dict(payload)
         transcript_payload["text"] = text
         self._try_append_webui_transcript(msg.chat_id, transcript_payload)
+        if not conns:
+            return
         raw = json.dumps(payload, ensure_ascii=False)
         for connection in conns:
             await self._safe_send_to(connection, raw, label=" ")


### PR DESCRIPTION
## Scope
Channel dispatch fixes

## Issues Fixed
- Fixes #4062: WebSocket normal outbound messages are persisted before subscriber checks, so disconnected clients can replay proactive messages.
- Fixes #4063: ChannelManager stream-delta coalescing includes _stream_id in the stream key.
- Fixes #4064: pending mid-turn injected messages preserve runtime channel, chat, sender, and workspace context.

## Key Files
- nanobot/channels/manager.py
- nanobot/channels/websocket.py
- nanobot/agent/loop.py

## Validation
- uv run pytest tests/channels/test_channel_manager_delta_coalescing.py -q