### PR TITLE
fix config and stream timeout validation

### DIFF
--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -55,8 +55,8 @@ def load_config(config_path: Path | None = None) -> Config:
             data = _migrate_config(data)
             config = Config.model_validate(data)
         except (json.JSONDecodeError, ValueError, pydantic.ValidationError) as e:
-            logger.warning("Failed to load config from {}: {}", path, e)
-            logger.warning("Using default configuration.")
+            logger.error("Failed to load config from {}: {}", path, e)
+            raise
 
     _apply_ssrf_whitelist(config)
     return config

--- a/nanobot/providers/anthropic_provider.py
+++ b/nanobot/providers/anthropic_provider.py
@@ -13,6 +13,7 @@ from typing import Any
 import json_repair
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 _ALNUM = string.ascii_letters + string.digits
 
@@ -596,7 +597,9 @@ class AnthropicProvider(LLMProvider):
             messages, tools, model, max_tokens, temperature,
             reasoning_effort, tool_choice,
         )
-        idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
+        idle_timeout_s = resolve_stream_idle_timeout_s(
+            os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S"), default=90,
+        )
         try:
             async with self._client.messages.stream(**kwargs) as stream:
                 if on_content_delta or on_thinking_delta or on_tool_call_delta:

--- a/nanobot/providers/bedrock_provider.py
+++ b/nanobot/providers/bedrock_provider.py
@@ -13,6 +13,7 @@ from typing import Any
 import json_repair
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 _IMAGE_DATA_URL = re.compile(r"^data:image/([a-zA-Z0-9.+-]+);base64,(.*)$", re.DOTALL)
 _TEXT_BLOCK_TYPES = {"text", "input_text", "output_text"}
@@ -707,7 +708,9 @@ class BedrockProvider(LLMProvider):
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
     ) -> LLMResponse:
         _ = on_thinking_delta, on_tool_call_delta
-        idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
+        idle_timeout_s = resolve_stream_idle_timeout_s(
+            os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S"), default=90,
+        )
         content_parts: list[str] = []
         reasoning_parts: list[str] = []
         thinking_blocks: list[dict[str, Any]] = []

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -19,6 +19,7 @@ from nanobot.providers.openai_responses import (
     convert_messages,
     convert_tools,
 )
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 DEFAULT_CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_ORIGINATOR = "nanobot"
@@ -198,7 +199,9 @@ async def _request_codex(
     on_thinking_delta: Callable[[str], Awaitable[None]] | None = None,
     on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
 ) -> tuple[str, list[ToolCallRequest], str, str | None]:
-    idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
+    idle_timeout_s = resolve_stream_idle_timeout_s(
+        os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S"), default=90,
+    )
     async with httpx.AsyncClient(timeout=idle_timeout_s, verify=verify) as client:
         async with client.stream("POST", url, headers=headers, json=body) as response:
             if response.status_code != 200:

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -27,6 +27,7 @@ from nanobot.providers.openai_responses import (
     convert_tools,
     parse_response_output,
 )
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI as AsyncOpenAIType
@@ -1357,7 +1358,9 @@ class OpenAICompatProvider(LLMProvider):
         on_tool_call_delta: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
     ) -> LLMResponse:
         await self._ensure_client()
-        idle_timeout_s = int(os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S", "90"))
+        idle_timeout_s = resolve_stream_idle_timeout_s(
+            os.environ.get("NANOBOT_STREAM_IDLE_TIMEOUT_S"), default=90,
+        )
         try:
             if self._should_use_responses_api(model, reasoning_effort):
                 try:

--- a/nanobot/utils/helpers.py
+++ b/nanobot/utils/helpers.py
@@ -255,6 +255,23 @@ def find_legal_message_start(messages: list[dict[str, Any]]) -> int:
     return start
 
 
+def resolve_stream_idle_timeout_s(
+    value: Any,
+    *,
+    default: int = 90,
+    minimum: int = 1,
+    maximum: int = 3600,
+) -> int:
+    """Parse and clamp stream idle timeout seconds."""
+    try:
+        timeout = int(value)
+    except (TypeError, ValueError):
+        return default
+    if timeout < minimum:
+        return default
+    return min(timeout, maximum)
+
+
 def stringify_text_blocks(content: list[dict[str, Any]]) -> str | None:
     parts: list[str] = []
     for block in content:

--- a/tests/config/test_env_interpolation.py
+++ b/tests/config/test_env_interpolation.py
@@ -10,6 +10,14 @@ from nanobot.config.loader import (
 )
 
 
+def test_load_config_invalid_json_fails_closed(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{invalid", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        load_config(config_path)
+
+
 class TestResolveEnvVars:
     def test_replaces_string_value(self, monkeypatch):
         monkeypatch.setenv("MY_SECRET", "hunter2")

--- a/tests/providers/test_custom_provider.py
+++ b/tests/providers/test_custom_provider.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from nanobot.providers.openai_compat_provider import OpenAICompatProvider
 from nanobot.providers.registry import find_by_name
+from nanobot.utils.helpers import resolve_stream_idle_timeout_s
 
 
 def test_custom_provider_parse_handles_empty_choices() -> None:
@@ -83,6 +84,11 @@ def test_custom_provider_parse_chunks_deduplicates_parallel_tool_call_ids() -> N
     assert ids[0] == "call_dup"
     assert len(ids) == 2
     assert len(set(ids)) == 2
+
+
+def test_invalid_stream_idle_timeout_falls_back_to_default() -> None:
+    assert resolve_stream_idle_timeout_s("abc", default=90) == 90
+    assert resolve_stream_idle_timeout_s("-1", default=90) == 90
 
 
 def test_local_provider_502_error_includes_reachability_hint() -> None:


### PR DESCRIPTION
## Scope
Config and environment validation

## Issues Fixed
- Fixes #4065: invalid NANOBOT_STREAM_IDLE_TIMEOUT_S values fall back to safe defaults across streaming providers.
- Fixes #4067: invalid config parse or schema errors now fail closed instead of silently continuing with defaults.

## Key Files
- nanobot/config/loader.py
- nanobot/utils/helpers.py
- nanobot/providers/anthropic_provider.py
- nanobot/providers/bedrock_provider.py
- nanobot/providers/openai_codex_provider.py
- nanobot/providers/openai_compat_provider.py
- tests/config/test_env_interpolation.py
- tests/providers/test_custom_provider.py

## Validation
- uv run pytest tests/config/test_env_interpolation.py::test_load_config_invalid_json_fails_closed tests/providers/test_custom_provider.py::test_invalid_stream_idle_timeout_falls_back_to_default tests/providers/test_anthropic_stream_idle.py tests/providers/test_openai_codex_provider.py::test_codex_request_honors_stream_idle_timeout_env -q