### PR TITLE
fix matrix stream buffer keys

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -231,7 +231,7 @@ class MatrixChannel(BaseChannel):
         )
         self._server_upload_limit_bytes: int | None = None
         self._server_upload_limit_checked = False
-        self._stream_bufs: dict[str, _StreamBuf] = {}
+        self._stream_bufs: dict[str | tuple[str, str], _StreamBuf] = {}
         self._started_at_ms: int = 0
 
 
@@ -515,9 +515,13 @@ class MatrixChannel(BaseChannel):
     async def send_delta(self, chat_id: str, delta: str, metadata: dict[str, Any] | None = None) -> None:
         meta = metadata or {}
         relates_to = self._build_thread_relates_to(metadata)
+        stream_id = meta.get("_stream_id")
+        stream_key: str | tuple[str, str] = (
+            (chat_id, stream_id) if isinstance(stream_id, str) and stream_id else chat_id
+        )
 
         if meta.get("_stream_end"):
-            buf = self._stream_bufs.pop(chat_id, None)
+            buf = self._stream_bufs.pop(stream_key, None)
             if not buf or not buf.event_id or not buf.text:
                 return
 
@@ -531,10 +535,10 @@ class MatrixChannel(BaseChannel):
             await self._send_room_content(chat_id, content)
             return
 
-        buf = self._stream_bufs.get(chat_id)
+        buf = self._stream_bufs.get(stream_key)
         if buf is None:
             buf = _StreamBuf()
-            self._stream_bufs[chat_id] = buf
+            self._stream_bufs[stream_key] = buf
         buf.text += delta
 
         if not buf.text.strip():


### PR DESCRIPTION
## Scope
Matrix stream buffers

## Issues Fixed
- Fixes #4068: Matrix stream buffers use (chat_id, stream_id) when a stream ID is present, while preserving the legacy chat-only key for streams without IDs.

## Key Files
- nanobot/channels/matrix.py

## Validation
- uv run --extra matrix pytest tests/channels/test_matrix_channel.py::test_send_delta_creates_stream_buffer_and_sends_initial_message tests/channels/test_matrix_channel.py::test_send_delta_appends_without_sending_before_edit_interval tests/channels/test_matrix_channel.py::test_send_delta_stream_end_replaces_existing_message tests/channels/test_matrix_channel.py::test_send_delta_on_error_stops_typing tests/channels/test_matrix_channel.py::test_send_delta_ignores_whitespace_only_delta -q