### PR TITLE
fix dream scheduling guard

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1174,13 +1174,16 @@ def _run_gateway(
     agent.dream.max_iterations = dream_cfg.max_iterations
     agent.dream.annotate_line_ages = dream_cfg.annotate_line_ages
     from nanobot.cron.types import CronJob, CronPayload, CronSchedule
-    cron.register_system_job(CronJob(
-        id="dream",
-        name="dream",
-        schedule=dream_cfg.build_schedule(config.agents.defaults.timezone),
-        payload=CronPayload(kind="system_event"),
-    ))
-    console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
+    if dream_cfg.enabled:
+        cron.register_system_job(CronJob(
+            id="dream",
+            name="dream",
+            schedule=dream_cfg.build_schedule(config.agents.defaults.timezone),
+            payload=CronPayload(kind="system_event"),
+        ))
+        console.print(f"[green]✓[/green] Dream: {dream_cfg.describe_schedule()}")
+    else:
+        console.print("[yellow]•[/yellow] Dream: disabled")
 
     # Register Heartbeat system job (idempotent on restart)
     if hb_cfg.enabled:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -49,6 +49,7 @@ class DreamConfig(Base):
     _HOUR_MS = 3_600_000
 
     interval_h: int = Field(default=2, ge=1)  # Every 2 hours by default
+    enabled: bool = True
     cron: str | None = Field(default=None, exclude=True)  # Legacy compatibility override
     model_override: str | None = Field(
         default=None,

--- a/tests/config/test_dream_config.py
+++ b/tests/config/test_dream_config.py
@@ -4,6 +4,7 @@ from nanobot.config.schema import DreamConfig
 def test_dream_config_defaults_to_interval_hours() -> None:
     cfg = DreamConfig()
 
+    assert cfg.enabled is True
     assert cfg.interval_h == 2
     assert cfg.cron is None
 


### PR DESCRIPTION
## Scope
Dream scheduling guard

## Issues Fixed
- Fixes #4069: Dream config now has an explicit enabled flag, and gateway cron registration skips the Dream system job when disabled.

## Key Files
- nanobot/config/schema.py
- nanobot/cli/commands.py
- tests/config/test_dream_config.py

## Validation
- uv run pytest tests/config/test_dream_config.py -q