### PR TITLE
[codex] Fix exec workspace symlink guard and path precedence

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import shlex
 import shutil
 import sys
 from contextlib import suppress
@@ -411,7 +412,7 @@ class ExecTool(Tool):
                 env["PATH"] = env.get("PATH", "") + os.pathsep + self.path_append
             else:
                 env["NANOBOT_PATH_APPEND"] = self.path_append
-                command = f'export PATH="$PATH{os.pathsep}$NANOBOT_PATH_APPEND"; {command}'
+                command = f'export PATH="$NANOBOT_PATH_APPEND{os.pathsep}$PATH"; {command}'
 
         shell_program, shell_error = self._resolve_shell(shell)
         if shell_error:
@@ -593,6 +594,10 @@ class ExecTool(Tool):
 
             cwd_path = Path(cwd).resolve()
 
+            symlink_error = self._guard_relative_symlink_paths(cmd, cwd_path)
+            if symlink_error:
+                return symlink_error
+
             for raw in self._extract_absolute_paths(cmd):
                 try:
                     expanded = os.path.expandvars(raw.strip())
@@ -618,6 +623,42 @@ class ExecTool(Tool):
                         + _WORKSPACE_BOUNDARY_NOTE
                     )
 
+        return None
+
+    def _guard_relative_symlink_paths(self, command: str, cwd_path: Path) -> str | None:
+        """Block relative symlink operands that resolve outside the workspace."""
+        try:
+            parts = shlex.split(command, posix=not _IS_WINDOWS)
+        except ValueError:
+            return None
+
+        separators = {"&&", "||", ";", "|", "&"}
+        for raw in parts:
+            token = raw.strip()
+            if (
+                not token
+                or token in separators
+                or token.startswith("-")
+                or "://" in token
+                or "=" in token
+                or any(ch in token for ch in "*?[]{}")
+            ):
+                continue
+            path = Path(os.path.expandvars(token)).expanduser()
+            if path.is_absolute():
+                continue
+            candidate = cwd_path / path
+            try:
+                if not candidate.is_symlink():
+                    continue
+                resolved = candidate.resolve(strict=True)
+            except (OSError, RuntimeError, ValueError):
+                continue
+            if not is_path_within(resolved, cwd_path):
+                return (
+                    "Error: Command blocked by safety guard (relative symlink escapes working dir)"
+                    + _WORKSPACE_BOUNDARY_NOTE
+                )
         return None
 
     @classmethod

--- a/tests/tools/test_exec_platform.py
+++ b/tests/tools/test_exec_platform.py
@@ -177,9 +177,32 @@ class TestPathAppendPlatform:
             tool = ExecTool(path_append="/opt/bin; echo INJECTED")
             await tool.execute(command="ls")
 
-        assert captured_cmd == 'export PATH="$PATH:$NANOBOT_PATH_APPEND"; ls'
+        assert captured_cmd == 'export PATH="$NANOBOT_PATH_APPEND:$PATH"; ls'
         assert captured_env["NANOBOT_PATH_APPEND"] == "/opt/bin; echo INJECTED"
         assert "INJECTED" not in captured_cmd
+
+    @pytest.mark.asyncio
+    async def test_unix_path_append_takes_lookup_precedence(self):
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"ok", b"")
+        mock_proc.returncode = 0
+
+        captured_cmd = None
+
+        async def capture_spawn(cmd, cwd, env, shell_program=None, login=True):
+            nonlocal captured_cmd
+            captured_cmd = cmd
+            return mock_proc
+
+        with (
+            patch("nanobot.agent.tools.shell._IS_WINDOWS", False),
+            patch("nanobot.agent.tools.shell.os.pathsep", ":"),
+            patch.object(ExecTool, "_spawn", side_effect=capture_spawn),
+            patch.object(ExecTool, "_guard_command", return_value=None),
+        ):
+            await ExecTool(path_append="/custom/bin").execute(command="python --version")
+
+        assert captured_cmd == 'export PATH="$NANOBOT_PATH_APPEND:$PATH"; python --version'
 
     @pytest.mark.asyncio
     async def test_windows_modifies_env(self):

--- a/tests/tools/test_exec_security.py
+++ b/tests/tools/test_exec_security.py
@@ -238,6 +238,22 @@ async def test_exec_allows_working_dir_equal_to_workspace(tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+async def test_exec_restricted_workspace_blocks_relative_symlink_escape(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    (workspace / "leak.txt").symlink_to(outside)
+
+    tool = ExecTool(working_dir=str(workspace), restrict_to_workspace=True, timeout=5)
+    result = await tool.execute(command="cat leak.txt")
+
+    assert "relative symlink escapes working dir" in result
+    assert "secret" not in result
+
+
+@pytest.mark.asyncio
 async def test_exec_ignores_workspace_check_when_not_restricted(tmp_path):
     """Without restrict_to_workspace, the LLM may still choose any working_dir."""
     workspace = tmp_path / "workspace"


### PR DESCRIPTION
## Scope
ExecTool workspace boundary and PATH lookup fixes.

## Issues Fixed
- Fixes #4072: blocks restricted exec commands from following relative symlinks that escape the workspace.
- Fixes #4083: prepends pathAppend on Unix so configured tool paths take executable lookup precedence.

## Key Files
- nanobot/agent/tools/shell.py
- tests/tools/test_exec_security.py
- tests/tools/test_exec_platform.py

## Validation
- uv run pytest tests/tools/test_exec_security.py::test_exec_restricted_workspace_blocks_relative_symlink_escape tests/tools/test_exec_platform.py::TestPathAppendPlatform -q
