### PR TITLE
Keep filesystem extra roots read-only

### DIFF
--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -73,7 +73,7 @@ class _FsTool(Tool):
             return self._explicit_file_states
         return current_file_states(self._fallback_file_states)
 
-    def _resolve(self, path: str) -> Path:
+    def _resolve(self, path: str, *, include_extra_allowed_dirs: bool = True) -> Path:
         access = current_tool_workspace(
             self._workspace,
             restrict_to_workspace=self._restrict_to_workspace,
@@ -83,8 +83,11 @@ class _FsTool(Tool):
             path,
             access.project_path,
             access.allowed_root,
-            self._extra_allowed_dirs,
+            self._extra_allowed_dirs if include_extra_allowed_dirs else None,
         )
+
+    def _resolve_write(self, path: str) -> Path:
+        return self._resolve(path, include_extra_allowed_dirs=False)
 
     def _display_workspace(self) -> Path | None:
         return current_tool_workspace(self._workspace).project_path
@@ -419,7 +422,7 @@ class WriteFileTool(_FsTool):
                 raise ValueError("Unknown path")
             if content is None:
                 raise ValueError("Unknown content")
-            fp = self._resolve(path)
+            fp = self._resolve_write(path)
             fp.parent.mkdir(parents=True, exist_ok=True)
             fp.write_text(content, encoding="utf-8")
             self._file_states.record_write(fp)
@@ -769,7 +772,7 @@ class EditFileTool(_FsTool):
             if expected_replacements is not None and expected_replacements < 1:
                 return "Error: expected_replacements must be >= 1."
 
-            fp = self._resolve(path)
+            fp = self._resolve_write(path)
 
             # Create-file semantics: old_text='' + file doesn't exist → create
             if not fp.exists():

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -6,6 +6,7 @@ from nanobot.agent.tools.filesystem import (
     EditFileTool,
     ListDirTool,
     ReadFileTool,
+    WriteFileTool,
     _find_match,
 )
 
@@ -90,6 +91,40 @@ class TestReadFileTool:
         result = await tool.execute(path=str(f))
         assert len(result) <= ReadFileTool._MAX_CHARS + 500  # small margin for footer
         assert "Use offset=" in result
+
+    @pytest.mark.asyncio
+    async def test_extra_allowed_dirs_are_readable_but_not_writable(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        extra = tmp_path / "extra"
+        extra.mkdir()
+        target = extra / "note.txt"
+        target.write_text("original", encoding="utf-8")
+
+        reader = ReadFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_allowed_dirs=[extra],
+        )
+        writer = WriteFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_allowed_dirs=[extra],
+        )
+        editor = EditFileTool(
+            workspace=workspace,
+            allowed_dir=workspace,
+            extra_allowed_dirs=[extra],
+        )
+
+        read_result = await reader.execute(path=str(target))
+        write_result = await writer.execute(path=str(target), content="changed")
+        edit_result = await editor.execute(path=str(target), old_text="original", new_text="changed")
+
+        assert "original" in read_result
+        assert write_result.startswith("Error")
+        assert edit_result.startswith("Error")
+        assert target.read_text(encoding="utf-8") == "original"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Scope
Filesystem extra allowed roots remain read-only for write-capable tools.

## Issues Fixed
- Fixes #4073: prevents write_file and edit_file from treating extra_allowed_dirs as writable roots while preserving read_file access.

## Key Files
- nanobot/agent/tools/filesystem.py
- tests/tools/test_filesystem_tools.py

## Validation
- uv run pytest tests/tools/test_filesystem_tools.py::TestReadFileTool::test_extra_allowed_dirs_are_readable_but_not_writable -q
