### PR TITLE
[codex] Reject unsafe MCP HTTP probes before connect

### DIFF
--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -20,6 +20,7 @@ from nanobot.bus.events import (
     RUNTIME_CONTROL_MCP_RELOAD,
     InboundMessage,
 )
+from nanobot.security.network import validate_url_target
 
 # Transient connection errors that warrant a single retry.
 # These typically happen when an MCP server restarts or a network
@@ -61,6 +62,11 @@ async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
     ``RuntimeError`` / ``ExceptionGroup`` that escape the caller's try/except
     and crash the event loop.
     """
+    ok, err = validate_url_target(url)
+    if not ok:
+        logger.warning("MCP HTTP URL rejected by network policy: {}", err)
+        return False
+
     parsed = urllib.parse.urlparse(url)
     host = parsed.hostname or "127.0.0.1"
     port = parsed.port

--- a/tests/agent/test_mcp_connection.py
+++ b/tests/agent/test_mcp_connection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import socket
 from contextlib import AsyncExitStack
 from typing import Any
 from unittest.mock import MagicMock
@@ -15,6 +16,10 @@ from nanobot.agent.tools.base import Tool
 from nanobot.bus.queue import MessageBus
 from nanobot.config.loader import load_config, save_config
 from nanobot.config.schema import MCPServerConfig
+
+
+def _fake_resolve_localhost(hostname, port, family=0, type_=0):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))]
 
 
 class _FakeMcpTool(Tool):
@@ -69,6 +74,22 @@ async def test_connect_mcp_retries_when_no_servers_connect(tmp_path, monkeypatch
     assert attempts == 2
     assert loop._mcp_connected is False
     assert loop._mcp_stacks == {}
+
+
+@pytest.mark.asyncio
+async def test_mcp_http_probe_rejects_loopback_before_connect(monkeypatch: pytest.MonkeyPatch):
+    attempted = False
+
+    async def _connect(*_args, **_kwargs):
+        nonlocal attempted
+        attempted = True
+        raise AssertionError("loopback probe attempted a socket connection")
+
+    monkeypatch.setattr("nanobot.security.network.socket.getaddrinfo", _fake_resolve_localhost)
+    monkeypatch.setattr("asyncio.open_connection", _connect)
+
+    assert await mcp_runtime._probe_http_url("http://localhost:8765/mcp") is False
+    assert attempted is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope
MCP HTTP/SSE URL probing security.

## Issues Fixed
- Fixes #4074: validates MCP HTTP targets with SSRF policy before attempting any loopback/private socket connection.

## Key Files
- nanobot/agent/tools/mcp.py
- tests/agent/test_mcp_connection.py

## Validation
- uv run pytest tests/agent/test_mcp_connection.py::test_mcp_http_probe_rejects_loopback_before_connect -q
