### PR TITLE
Enforce Dream skill ownership markers

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -855,6 +855,29 @@ class Consolidator:
 # Keep code and prompt aligned — if you bump this, the LLM's instruction string
 # updates automatically.
 _STALE_THRESHOLD_DAYS = 14
+_DREAM_MANAGED_RE = re.compile(r"(?im)^\s*dream_managed\s*:\s*true\s*$")
+
+
+def _dream_skill_write_allowed(workspace: Path, path: str) -> tuple[bool, str]:
+    """Return whether Dream may write a workspace skill file."""
+    try:
+        resolved = (workspace / path).expanduser().resolve(strict=False)
+        skills_dir = (workspace / "skills").expanduser().resolve(strict=False)
+        resolved.relative_to(skills_dir)
+    except (OSError, RuntimeError, ValueError):
+        return True, ""
+
+    if resolved.name != "SKILL.md":
+        return True, ""
+    if not resolved.exists():
+        return True, ""
+    try:
+        content = resolved.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False, "Dream cannot verify ownership for this existing skill."
+    if _DREAM_MANAGED_RE.search(content):
+        return True, ""
+    return False, "Dream may only overwrite existing skills marked dream_managed: true."
 
 
 class Dream:
@@ -910,6 +933,22 @@ class Dream:
         from nanobot.agent.tools.file_state import FileStates
         from nanobot.agent.tools.filesystem import EditFileTool, ReadFileTool, WriteFileTool
 
+        class DreamWriteFileTool(WriteFileTool):
+            async def execute(self, path: str | None = None, content: str | None = None, **kwargs: Any) -> str:
+                if path:
+                    allowed, reason = _dream_skill_write_allowed(workspace, path)
+                    if not allowed:
+                        return f"Error writing file: {reason}"
+                return await super().execute(path=path, content=content, **kwargs)
+
+        class DreamEditFileTool(EditFileTool):
+            async def execute(self, path: str | None = None, *args: Any, **kwargs: Any) -> str:
+                if path:
+                    allowed, reason = _dream_skill_write_allowed(workspace, path)
+                    if not allowed:
+                        return f"Error editing file: {reason}"
+                return await super().execute(path=path, *args, **kwargs)
+
         tools = ToolRegistry()
         workspace = self.store.workspace
         # Allow reading builtin skills for reference during skill creation
@@ -923,12 +962,12 @@ class Dream:
             extra_allowed_dirs=extra_read,
             file_states=file_states,
         ))
-        tools.register(EditFileTool(workspace=workspace, allowed_dir=workspace, file_states=file_states))
+        tools.register(DreamEditFileTool(workspace=workspace, allowed_dir=workspace, file_states=file_states))
         # write_file resolves relative paths from workspace root, but can only
         # write under skills/ so the prompt can safely use skills/<name>/SKILL.md.
         skills_dir = workspace / "skills"
         skills_dir.mkdir(parents=True, exist_ok=True)
-        tools.register(WriteFileTool(workspace=workspace, allowed_dir=skills_dir, file_states=file_states))
+        tools.register(DreamWriteFileTool(workspace=workspace, allowed_dir=skills_dir, file_states=file_states))
         return tools
 
     # -- skill listing --------------------------------------------------------

--- a/tests/agent/test_dream.py
+++ b/tests/agent/test_dream.py
@@ -126,6 +126,48 @@ class TestDreamRun:
         assert "Successfully wrote" in result
         assert (store.workspace / "skills" / "test-skill" / "SKILL.md").exists()
 
+    async def test_skill_write_tool_rejects_user_skill_without_dream_marker(self, dream, store):
+        skill = store.workspace / "skills" / "user-skill" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text("---\nname: user-skill\n---\n# User Skill\n", encoding="utf-8")
+        write_tool = dream._tools.get("write_file")
+        edit_tool = dream._tools.get("edit_file")
+        assert write_tool is not None
+        assert edit_tool is not None
+
+        write_result = await write_tool.execute(
+            path="skills/user-skill/SKILL.md",
+            content="overwritten",
+        )
+        edit_result = await edit_tool.execute(
+            path="skills/user-skill/SKILL.md",
+            old_text="# User Skill",
+            new_text="# Dream Skill",
+        )
+
+        assert "dream_managed: true" in write_result
+        assert "dream_managed: true" in edit_result
+        assert skill.read_text(encoding="utf-8").startswith("---\nname: user-skill")
+
+    async def test_skill_write_tool_allows_dream_managed_skill(self, dream, store):
+        skill = store.workspace / "skills" / "dream-skill" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text(
+            "---\nname: dream-skill\ndream_managed: true\n---\n# Old\n",
+            encoding="utf-8",
+        )
+        edit_tool = dream._tools.get("edit_file")
+        assert edit_tool is not None
+
+        result = await edit_tool.execute(
+            path="skills/dream-skill/SKILL.md",
+            old_text="# Old",
+            new_text="# New",
+        )
+
+        assert "Successfully edited" in result
+        assert "# New" in skill.read_text(encoding="utf-8")
+
     async def test_phase1_prompt_includes_line_age_annotations(self, dream, mock_provider, mock_runner, store):
         """Phase 1 prompt should have per-line age suffixes in MEMORY.md when git is available."""
         store.append_history("some event")
@@ -306,4 +348,3 @@ class TestDreamPromptCaps:
         user_msg = mock_provider.chat_with_retry.call_args.kwargs["messages"][1]["content"]
         history_section = user_msg.split("## Conversation History\n")[1].split("\n\n## Current Date")[0]
         assert len(history_section) < dream._HISTORY_ENTRY_PREVIEW_MAX_CHARS + 500
-


### PR DESCRIPTION
## Scope
Dream skill ownership enforcement.

## Issues Fixed
- Fixes #4075: prevents Dream from overwriting existing user-created skills unless the skill is explicitly marked dream_managed: true.

## Key Files
- nanobot/agent/memory.py
- tests/agent/test_dream.py

## Validation
- uv run pytest tests/agent/test_dream.py::TestDreamRun::test_skill_write_tool_accepts_workspace_relative_skill_path tests/agent/test_dream.py::TestDreamRun::test_skill_write_tool_rejects_user_skill_without_dream_marker tests/agent/test_dream.py::TestDreamRun::test_skill_write_tool_allows_dream_managed_skill -q
