### PR TITLE
[codex] Authorize message tool outbound targets

### DIFF
--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -1,6 +1,7 @@
 """Message tool for sending messages to users."""
 
 from contextvars import ContextVar
+import inspect
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
@@ -10,7 +11,8 @@ from nanobot.agent.tools.path_utils import resolve_workspace_path
 from nanobot.agent.tools.schema import ArraySchema, StringSchema, tool_parameters_schema
 from nanobot.security.workspace_access import current_tool_workspace
 from nanobot.bus.events import OutboundMessage
-from nanobot.config.paths import get_workspace_path
+from nanobot.config.paths import get_media_dir, get_workspace_path
+from nanobot.security.workspace_policy import is_path_within
 
 
 @tool_parameters(
@@ -54,8 +56,11 @@ class MessageTool(Tool, ContextAware):
         default_message_id: str | None = None,
         workspace: str | Path | None = None,
         restrict_to_workspace: bool = False,
+        authorize_callback: Callable[[str, str], bool | Awaitable[bool]] | None = None,
     ):
         self._send_callback = send_callback
+        self._authorize_callback = authorize_callback
+        self._explicit_workspace = workspace is not None
         self._workspace = (
             Path(workspace).expanduser() if workspace is not None else get_workspace_path()
         )
@@ -103,6 +108,13 @@ class MessageTool(Tool, ContextAware):
     def set_send_callback(self, callback: Callable[[OutboundMessage], Awaitable[None]]) -> None:
         """Set the callback for sending messages."""
         self._send_callback = callback
+
+    def set_authorize_callback(
+        self,
+        callback: Callable[[str, str], bool | Awaitable[bool]] | None,
+    ) -> None:
+        """Set the callback used to authorize proactive delivery targets."""
+        self._authorize_callback = callback
 
     def start_turn(self) -> None:
         """Reset per-turn send tracking."""
@@ -160,6 +172,17 @@ class MessageTool(Tool, ContextAware):
                 resolved.append(p)
             elif not access.restrict_to_workspace:
                 path = Path(p).expanduser()
+                if self._explicit_workspace and path.is_absolute() and path.exists():
+                    media_root = get_media_dir().resolve(strict=False)
+                    resolved_path = path.resolve(strict=False)
+                    workspace_root = Path(workspace).expanduser().resolve(strict=False)
+                    if not (
+                        is_path_within(resolved_path, workspace_root)
+                        or is_path_within(resolved_path, media_root)
+                    ):
+                        raise PermissionError(
+                            f"absolute media path {path} is outside workspace and media directory"
+                        )
                 resolved.append(p if path.is_absolute() else str(workspace / path))
             else:
                 resolved.append(str(resolve_workspace_path(p, workspace, access.allowed_root)))
@@ -219,6 +242,13 @@ class MessageTool(Tool, ContextAware):
 
         if not self._send_callback:
             return "Error: Message sending not configured"
+
+        if self._authorize_callback is not None:
+            authorized = self._authorize_callback(channel, chat_id)
+            if inspect.isawaitable(authorized):
+                authorized = await authorized
+            if not authorized:
+                return f"Error: outbound recipient is not authorized: {channel}:{chat_id}"
 
         if media:
             try:

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1095,6 +1095,13 @@ def _run_gateway(
         webui_runtime_capabilities=webui_runtime_capabilities,
     )
 
+    if isinstance(message_tool, MessageTool):
+        def _authorize_message_target(channel: str, chat_id: str) -> bool:
+            target = channels.channels.get(channel)
+            return bool(target and target.is_allowed(chat_id))
+
+        message_tool.set_authorize_callback(_authorize_message_target)
+
     def _pick_heartbeat_target() -> tuple[str, str]:
         """Pick a routable channel/chat target for heartbeat-triggered messages."""
         enabled = set(channels.enabled_channels)

--- a/tests/tools/test_message_tool.py
+++ b/tests/tools/test_message_tool.py
@@ -210,6 +210,51 @@ async def test_message_tool_rejects_outside_workspace_absolute_media_when_restri
 
 
 @pytest.mark.asyncio
+async def test_message_tool_requires_outbound_recipient_authorization() -> None:
+    sent: list[OutboundMessage] = []
+
+    async def _send(msg: OutboundMessage) -> None:
+        sent.append(msg)
+
+    tool = MessageTool(
+        send_callback=_send,
+        authorize_callback=lambda channel, chat_id: channel == "telegram" and chat_id == "allowed",
+    )
+
+    denied = await tool.execute(content="hi", channel="telegram", chat_id="blocked")
+    allowed = await tool.execute(content="hi", channel="telegram", chat_id="allowed")
+
+    assert denied == "Error: outbound recipient is not authorized: telegram:blocked"
+    assert allowed == "Message sent to telegram:allowed"
+    assert [msg.chat_id for msg in sent] == ["allowed"]
+
+
+@pytest.mark.asyncio
+async def test_message_tool_rejects_unrestricted_absolute_media_outside_workspace(tmp_path) -> None:
+    sent: list[OutboundMessage] = []
+
+    async def _send(msg: OutboundMessage) -> None:
+        sent.append(msg)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.png"
+    outside.write_text("image", encoding="utf-8")
+    tool = MessageTool(send_callback=_send, workspace=workspace, restrict_to_workspace=False)
+
+    result = await tool.execute(
+        content="see attached",
+        channel="telegram",
+        chat_id="1",
+        media=[str(outside)],
+    )
+
+    assert result.startswith("Error: media path is not allowed:")
+    assert "outside workspace" in result
+    assert sent == []
+
+
+@pytest.mark.asyncio
 async def test_message_tool_allows_workspace_absolute_media_when_restricted(tmp_path) -> None:
     sent: list[OutboundMessage] = []
 


### PR DESCRIPTION
## Scope
Message tool outbound authorization and media path policy.

## Issues Fixed
- Fixes #4076: requires outbound message recipients to pass channel authorization and rejects explicit absolute media paths outside the workspace/media roots.

## Key Files
- nanobot/agent/tools/message.py
- nanobot/cli/commands.py
- tests/tools/test_message_tool.py

## Validation
- uv run pytest tests/tools/test_message_tool.py::test_message_tool_requires_outbound_recipient_authorization tests/tools/test_message_tool.py::test_message_tool_rejects_unrestricted_absolute_media_outside_workspace tests/tools/test_message_tool.py::test_message_tool_passes_through_absolute_media_paths -q
