### PR TITLE
fix(agent): acquire per-session lock in process_direct (#4080)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -1667,14 +1667,17 @@ class AgentLoop:
             channel=channel, sender_id="user", chat_id=chat_id,
             content=content, media=media or [],
         )
+        # Share the dispatch lock so direct calls serialize with bus turns.
+        lock = self._session_locks.setdefault(session_key, asyncio.Lock())
         try:
-            return await self._process_message(
-                msg,
-                session_key=session_key,
-                on_progress=on_progress,
-                on_stream=on_stream,
-                on_stream_end=on_stream_end,
-            )
+            async with lock:
+                return await self._process_message(
+                    msg,
+                    session_key=session_key,
+                    on_progress=on_progress,
+                    on_stream=on_stream,
+                    on_stream_end=on_stream_end,
+                )
         finally:
             if channel == "websocket":
                 await self._webui_turns.publish_run_status(msg, "idle")

--- a/tests/agent/test_loop_direct_websocket_status.py
+++ b/tests/agent/test_loop_direct_websocket_status.py
@@ -1,8 +1,10 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from nanobot.agent.loop import AgentLoop
+from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.providers.base import GenerationSettings, LLMResponse
 
@@ -53,3 +55,37 @@ async def test_process_direct_websocket_clears_run_status(tmp_path) -> None:
     assert [status["goal_status"] for status in statuses] == ["running", "idle"]
     assert isinstance(statuses[0].get("started_at"), float)
     assert "started_at" not in statuses[1]
+
+
+@pytest.mark.asyncio
+async def test_process_direct_reuses_existing_session_lock(tmp_path) -> None:
+    loop = _make_loop(tmp_path)
+    loop._connect_mcp = AsyncMock()
+    session_key = "api:fixed"
+    lock = loop._session_locks.setdefault(session_key, asyncio.Lock())
+    await lock.acquire()
+    entered = asyncio.Event()
+
+    async def _process_message(msg, **_kwargs):
+        entered.set()
+        return OutboundMessage(channel=msg.channel, chat_id=msg.chat_id, content=msg.content)
+
+    loop._process_message = _process_message
+    task = asyncio.create_task(loop.process_direct("direct", session_key=session_key))
+    try:
+        await asyncio.sleep(0)
+        assert not entered.is_set()
+
+        lock.release()
+        response = await asyncio.wait_for(task, timeout=1.0)
+
+        assert entered.is_set()
+        assert response is not None
+        assert response.content == "direct"
+    finally:
+        if lock.locked():
+            lock.release()
+        if not task.done():
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -406,6 +406,7 @@ async def test_process_direct_accepts_media() -> None:
 
     loop = AgentLoop.__new__(AgentLoop)
     loop._connect_mcp = AsyncMock()
+    loop._session_locks = {}
 
     captured_msg = None
 


### PR DESCRIPTION
Closes #4080.

`process_direct` bypassed the per-session dispatch lock used by `_dispatch`, so direct calls (API, cron, webui, SDK) could run concurrently with bus turns on the same session and corrupt history. Now it reuses the same lock. All callers are external entry points, so no re-entrancy/deadlock.