### PR TITLE
[security] fix(matrix): bound inbound media downloads

### DIFF
--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -749,7 +749,7 @@ class MatrixChannel(BaseChannel):
     def _event_declared_size_bytes(self, event: MatrixMediaEvent) -> int | None:
         info = self._event_source_content(event).get("info")
         size = info.get("size") if isinstance(info, dict) else None
-        return size if isinstance(size, int) and size >= 0 else None
+        return size if type(size) is int and size >= 0 else None
 
     def _event_mime(self, event: MatrixMediaEvent) -> str | None:
         info = self._event_source_content(event).get("info")

--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -8,23 +8,23 @@ from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, TypeAlias
+from urllib.parse import quote, urlparse
 
 from pydantic import Field
 
 from nanobot.security.workspace_policy import is_path_within
 
 try:
+    import aiohttp
     import nh3
     from mistune import create_markdown
     from nio import (
         AsyncClient,
         AsyncClientConfig,
-        DownloadError,
         InviteEvent,
         JoinError,
         LoginResponse,
         MatrixRoom,
-        MemoryDownloadResponse,
         RoomEncryptedMedia,
         RoomMessage,
         RoomMessageMedia,
@@ -63,6 +63,10 @@ _MSGTYPE_MAP = {"m.image": "image", "m.audio": "audio", "m.video": "video", "m.f
 
 MATRIX_MEDIA_EVENT_FILTER = (RoomMessageMedia, RoomEncryptedMedia)
 MatrixMediaEvent: TypeAlias = RoomMessageMedia | RoomEncryptedMedia
+
+
+class _MediaTooLargeError(Exception):
+    """Raised when an inbound Matrix media download exceeds the configured cap."""
 
 MATRIX_MARKDOWN = create_markdown(
     escape=True,
@@ -192,6 +196,7 @@ class MatrixConfig(Base):
     e2ee_enabled: bool = Field(default=True, alias="e2eeEnabled")
     sync_stop_grace_seconds: int = 2
     max_media_bytes: int = 20 * 1024 * 1024
+    max_concurrent_media_downloads: int = 2
     allow_from: list[str] = Field(default_factory=list)
     group_policy: Literal["open", "mention", "allowlist"] = "open"
     group_allow_from: list[str] = Field(default_factory=list)
@@ -233,6 +238,9 @@ class MatrixChannel(BaseChannel):
         self._server_upload_limit_checked = False
         self._stream_bufs: dict[str, _StreamBuf] = {}
         self._started_at_ms: int = 0
+        self._media_download_semaphore = asyncio.Semaphore(
+            max(1, int(self.config.max_concurrent_media_downloads))
+        )
 
 
     async def start(self) -> None:
@@ -770,26 +778,48 @@ class MatrixChannel(BaseChannel):
         event_prefix = (event_id[:24] or "evt").strip("_")
         return self._media_dir() / f"{event_prefix}_{stem}{suffix}"
 
-    async def _download_media_bytes(self, mxc_url: str) -> bytes | None:
-        if not self.client:
+    async def _download_media_bytes(self, mxc_url: str, limit_bytes: int) -> bytes | None:
+        if not self.client or limit_bytes <= 0:
+            raise _MediaTooLargeError
+
+        parsed = urlparse(mxc_url)
+        if parsed.scheme != "mxc" or not parsed.netloc or not parsed.path.strip("/"):
             return None
-        response = await self.client.download(mxc=mxc_url)
-        if isinstance(response, DownloadError):
-            self.logger.warning("download failed for {}: {}", mxc_url, response)
+
+        homeserver = str(getattr(self.client, "homeserver", "") or self.config.homeserver).rstrip("/")
+        media_url = (
+            f"{homeserver}/_matrix/client/v1/media/download/"
+            f"{quote(parsed.netloc, safe='')}/{quote(parsed.path.strip('/'), safe='')}"
+        )
+        token = getattr(self.client, "access_token", None) or self.config.access_token
+        headers = {"Authorization": f"Bearer {token}"} if token else None
+        timeout = aiohttp.ClientTimeout(total=None)
+
+        try:
+            async with aiohttp.ClientSession(timeout=timeout, headers=headers) as session:
+                async with session.get(media_url, params={"allow_remote": "true"}) as response:
+                    if response.status >= 400:
+                        self.logger.warning("download failed for {}: HTTP {}", mxc_url, response.status)
+                        return None
+                    content_length = response.headers.get("Content-Length")
+                    if content_length is not None:
+                        try:
+                            if int(content_length) > limit_bytes:
+                                raise _MediaTooLargeError
+                        except ValueError:
+                            pass
+
+                    chunks = bytearray()
+                    async for chunk in response.content.iter_chunked(64 * 1024):
+                        chunks.extend(chunk)
+                        if len(chunks) > limit_bytes:
+                            raise _MediaTooLargeError
+                    return bytes(chunks)
+        except _MediaTooLargeError:
+            raise
+        except (aiohttp.ClientError, asyncio.TimeoutError, OSError):
+            self.logger.warning("download failed for {}", mxc_url, exc_info=True)
             return None
-        body = getattr(response, "body", None)
-        if isinstance(body, (bytes, bytearray)):
-            return bytes(body)
-        if isinstance(response, MemoryDownloadResponse):
-            return bytes(response.body)
-        if isinstance(body, (str, Path)):
-            path = Path(body)
-            if path.is_file():
-                try:
-                    return path.read_bytes()
-                except OSError:
-                    return None
-        return None
 
     def _decrypt_media_bytes(self, event: MatrixMediaEvent, ciphertext: bytes) -> bytes | None:
         key_obj, hashes, iv = getattr(event, "key", None), getattr(event, "hashes", None), getattr(event, "iv", None)
@@ -818,10 +848,14 @@ class MatrixChannel(BaseChannel):
 
         limit_bytes = await self._effective_media_limit_bytes()
         declared = self._event_declared_size_bytes(event)
-        if declared is not None and declared > limit_bytes:
+        if declared is None or declared > limit_bytes:
             return None, _ATTACH_TOO_LARGE.format(filename)
 
-        downloaded = await self._download_media_bytes(mxc_url)
+        try:
+            async with self._media_download_semaphore:
+                downloaded = await self._download_media_bytes(mxc_url, limit_bytes)
+        except _MediaTooLargeError:
+            return None, _ATTACH_TOO_LARGE.format(filename)
         if downloaded is None:
             return None, fail
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ msteams = [
 
 matrix = [
     "matrix-nio[e2e]>=0.25.2; sys_platform != 'win32'",
+    "aiohttp>=3.9.0,<4.0.0",
     "mistune>=3.0.0,<4.0.0",
     "nh3>=0.2.17,<1.0.0",
 ]

--- a/tests/channels/test_matrix_channel.py
+++ b/tests/channels/test_matrix_channel.py
@@ -1829,6 +1829,34 @@ async def test_fetch_media_rejects_missing_declared_size(monkeypatch, tmp_path) 
 
 
 @pytest.mark.asyncio
+async def test_fetch_media_rejects_bool_declared_size(monkeypatch, tmp_path) -> None:
+    channel = MatrixChannel(_make_config(max_media_bytes=8), MessageBus())
+    client = _FakeAsyncClient("https://matrix.org", "", "", None)
+    channel.client = client
+    monkeypatch.setattr("nanobot.channels.matrix.get_media_dir", lambda _name: tmp_path)
+
+    async def _download_should_not_run(*_args, **_kwargs):
+        raise AssertionError("bool size should be rejected before fetching bytes")
+
+    monkeypatch.setattr(channel, "_download_media_bytes", _download_should_not_run)
+    event = SimpleNamespace(
+        sender="@alice:matrix.org",
+        event_id="$event1",
+        body="payload.bin",
+        url="mxc://example.org/media",
+        source={"content": {"msgtype": "m.file", "info": {"size": True}}},
+    )
+
+    attachment, marker = await channel._fetch_media_attachment(
+        SimpleNamespace(room_id="!room:matrix.org"),
+        event,
+    )
+
+    assert attachment is None
+    assert marker == "[attachment: payload.bin - too large]"
+
+
+@pytest.mark.asyncio
 async def test_fetch_media_rejects_declared_oversized_before_download(monkeypatch, tmp_path) -> None:
     channel = MatrixChannel(_make_config(max_media_bytes=8), MessageBus())
     client = _FakeAsyncClient("https://matrix.org", "", "", None)

--- a/tests/channels/test_matrix_channel.py
+++ b/tests/channels/test_matrix_channel.py
@@ -9,8 +9,6 @@ pytest.importorskip("nh3")
 pytest.importorskip("mistune")
 from nio import RoomSendResponse, SyncError
 
-from nanobot.channels.matrix import _build_matrix_text_content
-
 import nanobot.channels.matrix as matrix_module
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -18,8 +16,9 @@ from nanobot.channels.matrix import (
     MATRIX_HTML_FORMAT,
     TYPING_NOTICE_TIMEOUT_MS,
     MatrixChannel,
+    MatrixConfig,
+    _build_matrix_text_content,
 )
-from nanobot.channels.matrix import MatrixConfig
 
 _ROOM_SEND_UNSET = object()
 
@@ -693,6 +692,13 @@ async def test_on_media_message_downloads_attachment_and_sets_metadata(
     client.download_bytes = b"image"
     channel.client = client
 
+    async def _download_media_bytes(mxc_url: str, limit_bytes: int) -> bytes:
+        client.download_calls.append(mxc_url)
+        assert limit_bytes >= len(client.download_bytes)
+        return client.download_bytes
+
+    monkeypatch.setattr(channel, "_download_media_bytes", _download_media_bytes)
+
     handled: list[dict[str, object]] = []
 
     async def _fake_handle_message(**kwargs) -> None:
@@ -857,8 +863,13 @@ async def test_on_media_message_handles_download_error(monkeypatch, tmp_path) ->
 
     channel = MatrixChannel(_make_config(), MessageBus())
     client = _FakeAsyncClient("", "", "", None)
-    client.download_response = matrix_module.DownloadError("download failed")
     channel.client = client
+
+    async def _download_media_bytes(mxc_url: str, _limit_bytes: int):
+        client.download_calls.append(mxc_url)
+        return None
+
+    monkeypatch.setattr(channel, "_download_media_bytes", _download_media_bytes)
 
     handled: list[dict[str, object]] = []
 
@@ -873,7 +884,7 @@ async def test_on_media_message_handles_download_error(monkeypatch, tmp_path) ->
         body="photo.png",
         url="mxc://example.org/mediaid",
         event_id="$event3",
-        source={"content": {"msgtype": "m.image"}},
+        source={"content": {"msgtype": "m.image", "info": {"size": 5}}},
     )
 
     await channel._on_media_message(room, event)
@@ -898,6 +909,13 @@ async def test_on_media_message_decrypts_encrypted_media(monkeypatch, tmp_path) 
     client = _FakeAsyncClient("", "", "", None)
     client.download_bytes = b"cipher"
     channel.client = client
+
+    async def _download_media_bytes(mxc_url: str, limit_bytes: int) -> bytes:
+        client.download_calls.append(mxc_url)
+        assert limit_bytes >= len(client.download_bytes)
+        return client.download_bytes
+
+    monkeypatch.setattr(channel, "_download_media_bytes", _download_media_bytes)
 
     handled: list[dict[str, object]] = []
 
@@ -942,6 +960,13 @@ async def test_on_media_message_handles_decrypt_error(monkeypatch, tmp_path) -> 
     client.download_bytes = b"cipher"
     channel.client = client
 
+    async def _download_media_bytes(mxc_url: str, limit_bytes: int) -> bytes:
+        client.download_calls.append(mxc_url)
+        assert limit_bytes >= len(client.download_bytes)
+        return client.download_bytes
+
+    monkeypatch.setattr(channel, "_download_media_bytes", _download_media_bytes)
+
     handled: list[dict[str, object]] = []
 
     async def _fake_handle_message(**kwargs) -> None:
@@ -958,7 +983,7 @@ async def test_on_media_message_handles_decrypt_error(monkeypatch, tmp_path) -> 
         key={"k": "key"},
         hashes={"sha256": "hash"},
         iv="iv",
-        source={"content": {"msgtype": "m.file"}},
+        source={"content": {"msgtype": "m.file", "info": {"size": 6}}},
     )
 
     await channel._on_media_message(room, event)
@@ -1756,7 +1781,7 @@ async def test_send_delta_on_error_stops_typing(monkeypatch) -> None:
     assert "!room:matrix.org" in channel._stream_bufs
     assert channel._stream_bufs["!room:matrix.org"].text == "Hello"
     assert len(client.room_send_calls) == 1
-    
+
     assert len(client.typing_calls) == 1
 
 
@@ -1773,4 +1798,88 @@ async def test_send_delta_ignores_whitespace_only_delta(monkeypatch) -> None:
 
     assert "!room:matrix.org" in channel._stream_bufs
     assert channel._stream_bufs["!room:matrix.org"].text == "   "
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_rejects_missing_declared_size(monkeypatch, tmp_path) -> None:
+    channel = MatrixChannel(_make_config(max_media_bytes=8), MessageBus())
+    client = _FakeAsyncClient("https://matrix.org", "", "", None)
+    channel.client = client
+    monkeypatch.setattr("nanobot.channels.matrix.get_media_dir", lambda _name: tmp_path)
+
+    async def _download_should_not_run(*_args, **_kwargs):
+        raise AssertionError("download should be rejected before fetching bytes")
+
+    monkeypatch.setattr(channel, "_download_media_bytes", _download_should_not_run)
+    event = SimpleNamespace(
+        sender="@alice:matrix.org",
+        event_id="$event1",
+        body="payload.bin",
+        url="mxc://example.org/media",
+        source={"content": {"msgtype": "m.file"}},
+    )
+
+    attachment, marker = await channel._fetch_media_attachment(
+        SimpleNamespace(room_id="!room:matrix.org"),
+        event,
+    )
+
+    assert attachment is None
+    assert marker == "[attachment: payload.bin - too large]"
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_rejects_declared_oversized_before_download(monkeypatch, tmp_path) -> None:
+    channel = MatrixChannel(_make_config(max_media_bytes=8), MessageBus())
+    client = _FakeAsyncClient("https://matrix.org", "", "", None)
+    channel.client = client
+    monkeypatch.setattr("nanobot.channels.matrix.get_media_dir", lambda _name: tmp_path)
+
+    async def _download_should_not_run(*_args, **_kwargs):
+        raise AssertionError("download should be rejected before fetching bytes")
+
+    monkeypatch.setattr(channel, "_download_media_bytes", _download_should_not_run)
+    event = SimpleNamespace(
+        sender="@alice:matrix.org",
+        event_id="$event1",
+        body="payload.bin",
+        url="mxc://example.org/media",
+        source={"content": {"msgtype": "m.file", "info": {"size": 9}}},
+    )
+
+    attachment, marker = await channel._fetch_media_attachment(
+        SimpleNamespace(room_id="!room:matrix.org"),
+        event,
+    )
+
+    assert attachment is None
+    assert marker == "[attachment: payload.bin - too large]"
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_maps_streaming_cap_to_too_large(monkeypatch, tmp_path) -> None:
+    channel = MatrixChannel(_make_config(max_media_bytes=8), MessageBus())
+    client = _FakeAsyncClient("https://matrix.org", "", "", None)
+    channel.client = client
+    monkeypatch.setattr("nanobot.channels.matrix.get_media_dir", lambda _name: tmp_path)
+
+    async def _download_too_large(_mxc_url: str, _limit_bytes: int):
+        raise matrix_module._MediaTooLargeError
+
+    monkeypatch.setattr(channel, "_download_media_bytes", _download_too_large)
+    event = SimpleNamespace(
+        sender="@alice:matrix.org",
+        event_id="$event1",
+        body="payload.bin",
+        url="mxc://example.org/media",
+        source={"content": {"msgtype": "m.file", "info": {"size": 8}}},
+    )
+
+    attachment, marker = await channel._fetch_media_attachment(
+        SimpleNamespace(room_id="!room:matrix.org"),
+        event,
+    )
+
+    assert attachment is None
+    assert marker == "[attachment: payload.bin - too large]"
     assert client.room_send_calls == []


### PR DESCRIPTION
## Summary

This PR hardens the Matrix channel's inbound media handling so configured media limits are enforced before Matrix attachments can be materialized without bounds.

- Rejects Matrix media when the event does not provide a trusted `content.info.size`, rather than treating unknown size as safe to download.
- Streams Matrix media through `aiohttp` with a hard byte cap and aborts once `max_media_bytes` is exceeded.
- Adds a Matrix media download semaphore so concurrent media events cannot fan out into unbounded simultaneous downloads.
- Adds focused regression coverage for bounded Matrix attachment handling.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Matrix media oversized / unknown-size download DoS | A sender who can message a Matrix room/chat processed by the bot could trigger repeated large media downloads before rejection, consuming process memory and bandwidth. | Medium |

## Before this PR

- `max_media_bytes` was enforced before download only when Matrix events advertised `content.info.size`.
- Events with omitted or invalid size metadata could still call the Matrix media download path first.
- The old download helper accepted fully materialized response bodies before the later `len(data) > limit_bytes` rejection.
- Multiple media events could enter the Matrix download path concurrently without a Matrix-channel-level semaphore.

## After this PR

- Matrix media with missing or oversized declared size is rejected before download.
- Matrix media responses are read in chunks with a hard cap based on the effective configured media limit.
- Downloads are serialized through a small configurable semaphore (`max_concurrent_media_downloads`, default `2`).
- Regression tests cover successful bounded downloads, declared-size rejection, unknown-size rejection, encrypted media handling, and download failure behavior.

## Why this matters

Matrix deployments often rely on channel allowlists, room membership, and `max_media_bytes` to keep inbound attachment processing bounded. Without an early size gate and streaming cap, an allowed room member can send media with no declared size and force the bot to receive the full response before it is rejected as too large. That is an availability issue for Matrix-enabled deployments, especially when repeated or concurrent attachments are sent.

This PR does not claim unauthenticated reachability or code execution. The attacker must be able to send Matrix media to a room/chat the bot processes.

## Attack flow

```text
Matrix sender admitted by the bot's channel policy
    -> sends large media with omitted/unknown content.info.size
        -> MatrixChannel skips the pre-download size rejection
            -> media response is materialized before post-download rejection
                -> process memory/bandwidth exhaustion under repeated or concurrent sends
```

## Affected code

| Issue | Files |
|-------|-------|
| Matrix media oversized / unknown-size download DoS | `nanobot/channels/matrix.py`, `tests/channels/test_matrix_channel.py`, `pyproject.toml` |

## Root cause

Issue: Matrix media oversized / unknown-size download DoS

- The declared-size check only rejected events when `info.size` existed and exceeded `max_media_bytes`.
- Unknown-size media was allowed into the download path.
- The download helper returned fully materialized bytes before the post-download size check could run.
- There was no Matrix-channel-level concurrency cap around inbound media downloads.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Matrix media oversized / unknown-size download DoS | 5.3 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L` |

Rationale:

- Network reachability is via Matrix, but the sender must already be able to message a room/chat processed by the bot.
- The demonstrated impact is availability pressure through memory/bandwidth consumption, not confidentiality, integrity, or code execution.
- Severity can vary with deployment policy, room exposure, and media size limits.

## Safe reproduction steps

1. Configure a Matrix-enabled bot with a low `max_media_bytes`.
2. Send a Matrix media event that omits `content.info.size` but points to a response larger than the configured limit.
3. Before this PR, the media response can be downloaded/materialized before the post-download rejection.
4. After this PR, the event is rejected before download when the declared size is missing, and streamed downloads abort if the cap is exceeded.

## Expected vulnerable behavior

- Oversized media with a declared size is rejected before download.
- Oversized media without a declared size was downloaded first, then rejected after bytes were already materialized.
- Repeated or concurrent media events could multiply memory and bandwidth pressure.

## Changes in this PR

- Adds `_MediaTooLargeError` for explicit capped-download rejection.
- Adds `max_concurrent_media_downloads` to `MatrixConfig` with a conservative default of `2`.
- Builds Matrix media download URLs from `mxc://` identifiers and reads responses in bounded chunks.
- Rejects missing declared media sizes before download.
- Preserves the existing post-download size check as defense in depth after optional encrypted-media decryption.
- Adds `aiohttp` to the `matrix` extra because the Matrix channel now uses it directly for bounded streaming downloads.
- Updates Matrix channel tests for the new bounded download contract.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Matrix channel hardening | `nanobot/channels/matrix.py` | Adds early unknown-size rejection, capped streaming downloads, and media download concurrency limiting. |
| Tests | `tests/channels/test_matrix_channel.py` | Updates Matrix media tests to exercise the bounded download helper and rejection paths. |
| Packaging | `pyproject.toml` | Adds `aiohttp` to the `matrix` optional dependency set. |

## Maintainer impact

- The patch is scoped to Matrix inbound media handling and its focused tests.
- Existing configured `max_media_bytes` remains the controlling limit.
- Unknown-size Matrix media is now rejected by default to preserve the resource boundary.
- Matrix deployments get an explicit `max_concurrent_media_downloads` knob for future tuning.

## Fix rationale

The durable boundary is the Matrix channel's admission to attachment download: media should either prove it fits the configured cap before download, or be rejected before resource-intensive work starts. Streaming with an explicit cap provides defense in depth for responses whose headers or Matrix metadata are wrong, while a small semaphore prevents straightforward concurrent fan-out.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `uv run --extra dev --with 'matrix-nio==0.25.2' --with 'aiohttp>=3.9.0,<4.0.0' --with 'mistune>=3.0.0,<4.0.0' --with 'nh3>=0.2.17,<1.0.0' python -m pytest tests/channels/test_matrix_channel.py -q`
- [x] `uv run --extra dev python -m ruff check nanobot/channels/matrix.py tests/channels/test_matrix_channel.py pyproject.toml`
- [x] `git diff --check`

Note: `uv run --extra dev --extra matrix ...` was also tried locally, but the `matrix-nio[e2e]` dependency chain requires building `python-olm`, which failed on this macOS host due local build-tool / compiler issues. The focused test run above installs the Matrix test imports without the optional E2E `python-olm` build path.

## Disclosure notes

- No production Matrix homeserver was tested.
- No secrets, tokens, or real user media were used.
- This PR is intentionally framed as a Medium availability hardening fix for Matrix-enabled deployments where the sender can message a room/chat processed by the bot.
