### PR TITLE
fix(webui): handle undefined language in code blocks

### DIFF
--- a/webui/src/components/CodeBlock.tsx
+++ b/webui/src/components/CodeBlock.tsx
@@ -33,7 +33,7 @@ const LazyHighlightedCode = lazy(async () => {
     default({ language, code, isDark }: HighlightedCodeProps) {
       return (
         <SyntaxHighlighter
-          language={language}
+          language={language || "text"}
           style={isDark ? oneDark : oneLight}
           customStyle={{
             margin: 0,

--- a/webui/src/components/MarkdownTextRenderer.tsx
+++ b/webui/src/components/MarkdownTextRenderer.tsx
@@ -264,7 +264,7 @@ export default function MarkdownTextRenderer({
         if (fence) {
           return (
             <CodeBlock
-              language={fence.language}
+              language={fence.language || "text"}
               code={fence.code}
               className="my-3"
               highlight={highlightCode}

--- a/webui/src/tests/code-block.test.tsx
+++ b/webui/src/tests/code-block.test.tsx
@@ -48,6 +48,22 @@ describe("CodeBlock", () => {
     expect(screen.getByTestId("plain-code-fallback")).toHaveClass("text-foreground/90");
   });
 
+  it("falls back to 'text' language when language is undefined", async () => {
+    render(
+      <ThemeProvider theme="dark">
+        <CodeBlock language={undefined} code="const value = 1;" />
+      </ThemeProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("highlighted-code")).toBeInTheDocument();
+    expect(screen.getByText("const value = 1;")).toBeInTheDocument();
+  });
+
   it("reads theme from context without creating per-block observers", async () => {
     const originalMutationObserver = globalThis.MutationObserver;
     const observer = vi.fn();

--- a/webui/src/tests/code-block.test.tsx
+++ b/webui/src/tests/code-block.test.tsx
@@ -12,13 +12,16 @@ const mockedStyles = vi.hoisted(() => ({
 vi.mock("react-syntax-highlighter/dist/esm/prism-async-light", () => ({
   default: ({
     children,
+    language,
     style,
   }: {
     children: string;
+    language?: string;
     style: Record<string, unknown>;
   }) => (
     <pre
       data-testid="highlighted-code"
+      data-language={language}
       data-theme={style === mockedStyles.dark ? "dark" : "light"}
     >
       <code>{children}</code>
@@ -61,6 +64,7 @@ describe("CodeBlock", () => {
     });
 
     expect(screen.getByTestId("highlighted-code")).toBeInTheDocument();
+    expect(screen.getByTestId("highlighted-code")).toHaveAttribute("data-language", "text");
     expect(screen.getByText("const value = 1;")).toBeInTheDocument();
   });
 

--- a/webui/src/tests/markdown-text-renderer.test.tsx
+++ b/webui/src/tests/markdown-text-renderer.test.tsx
@@ -24,6 +24,7 @@ describe("MarkdownTextRenderer", () => {
     );
 
     expect(screen.getByText("code without language")).toBeInTheDocument();
+    expect(screen.getByText("text")).toBeInTheDocument();
     expect(container.querySelectorAll("pre")).toHaveLength(1);
   });
 

--- a/webui/src/tests/markdown-text-renderer.test.tsx
+++ b/webui/src/tests/markdown-text-renderer.test.tsx
@@ -16,6 +16,17 @@ describe("MarkdownTextRenderer", () => {
     expect(container.querySelector("pre div")).toBeNull();
   });
 
+  it("renders bare fenced code blocks without crashing", () => {
+    const { container } = render(
+      <MarkdownTextRenderer highlightCode={false}>
+        {"Some text\n\n```\ncode without language\n```"}
+      </MarkdownTextRenderer>,
+    );
+
+    expect(screen.getByText("code without language")).toBeInTheDocument();
+    expect(container.querySelectorAll("pre")).toHaveLength(1);
+  });
+
   it("keeps streaming unfinished fenced code blocks to a single shell", () => {
     const { container } = render(
       <MarkdownTextRenderer highlightCode={false}>


### PR DESCRIPTION
Fixes #4116

When fenced code blocks have no language specifier (bare ```), `react-syntax-highlighter` receives `undefined` for the `language` prop, causing a white screen crash.

## Changes

- `webui/src/components/CodeBlock.tsx:36` — fallback to `"text"` when language is undefined
- `webui/src/components/MarkdownTextRenderer.tsx:267` — defensive fallback at fence rendering site
- Added test cases for both components

## Testing

```
✓ src/tests/code-block.test.tsx (3 tests)
✓ src/tests/markdown-text-renderer.test.tsx (13 tests)
```