### PR TITLE
fix(mcp): reject unsafe HTTP URLs before probe

### DIFF
--- a/.agent/security.md
+++ b/.agent/security.md
@@ -12,9 +12,11 @@ Shell execution (`ExecTool`, `agent/tools/shell.py`) also respects `restrict_to_
 
 ## SSRF Protection
 
-All outbound HTTP requests from agent tools must pass through `validate_url_target` (`security/network.py`). By default it blocks RFC1918 private addresses, link-local ranges, and cloud metadata endpoints (including `169.254.169.254`).
+All outbound HTTP requests from agent tools must pass through `validate_url_target` (`security/network.py`). By default it blocks loopback, RFC1918 private addresses, CGNAT ranges, link-local ranges, and cloud metadata endpoints (including `169.254.169.254`).
 
 The only escape hatch is `configure_ssrf_whitelist(cidrs)`, which reads from `config.tools.ssrf_whitelist` at load time.
+
+HTTP/SSE MCP transports are part of this boundary: validate configured MCP URLs before probing or constructing clients, and validate each outgoing HTTP request before redirects are followed. Local/private HTTP MCP endpoints are allowed only through the explicit SSRF whitelist. Stdio MCP servers are not part of the HTTP SSRF path.
 
 **Rule**: Do not add direct `httpx.get` / `requests.get` calls in tools. Route through the existing web fetch utilities or replicate the `validate_url_target` check.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1184,7 +1184,7 @@ If you want to disable them, which removes both `web_search` and `web_fetch` fro
 }
 ```
 
-If you need to allow trusted private ranges such as Tailscale / CGNAT addresses, you can explicitly exempt them from SSRF blocking with `tools.ssrfWhitelist`:
+nanobot uses a shared SSRF guard for built-in web fetches and HTTP/SSE MCP connections. By default it blocks loopback, RFC1918/private ranges, CGNAT/Tailscale ranges, link-local addresses, and cloud metadata endpoints. If you need to allow trusted private ranges, explicitly exempt them from SSRF blocking with `tools.ssrfWhitelist`:
 
 ```json
 {
@@ -1193,6 +1193,8 @@ If you need to allow trusted private ranges such as Tailscale / CGNAT addresses,
   }
 }
 ```
+
+Keep whitelist entries as narrow as possible, such as a single host CIDR (`192.168.1.50/32`). The whitelist is global for the shared SSRF guard; it is not limited to one tool or one MCP server.
 
 > [!TIP]
 > Use `proxy` in `tools.web` to route all web requests (search + fetch) through a proxy:
@@ -1423,6 +1425,9 @@ Two transport modes are supported:
 | **Stdio** | `command` + `args` | Local process via `npx` / `uvx` |
 | **HTTP** | `url` + `headers` (optional) | Remote endpoint (`https://mcp.example.com/sse`) |
 
+> [!IMPORTANT]
+> HTTP/SSE MCP URLs are validated before probing or connecting, and every outgoing MCP HTTP request is validated again before redirects are followed. `localhost`, `127.0.0.1`, RFC1918/private IPs, CGNAT/Tailscale ranges, link-local addresses, and cloud metadata endpoints are blocked by default. This can break previously working local or private HTTP MCP configs until the endpoint is explicitly allowed with `tools.ssrfWhitelist`, preferably with a single-host CIDR such as `127.0.0.1/32`, `::1/128`, or `192.168.1.50/32`. Stdio MCP servers are not affected.
+
 Use `toolTimeout` to override the default 30s per-call timeout for slow servers:
 
 ```json
@@ -1479,6 +1484,7 @@ For API keys, tokens, and other secrets, see [Environment Variables for Secrets]
 | `tools.exec.enable` | `true` | When `false`, the shell `exec` tool is not registered at all. Use this to completely disable shell command execution. |
 | `tools.exec.timeout` | `60` | Default hard timeout in seconds for shell commands. Config values may exceed the per-call tool cap; set `0` to disable the hard timeout for trusted long-running commands. |
 | `tools.exec.pathAppend` | `""` | Extra directories to append to `PATH` when running shell commands (e.g. `/usr/sbin` for `ufw`). |
+| `tools.ssrfWhitelist` | `[]` | CIDR ranges exempted from the shared SSRF guard used by web fetches and HTTP/SSE MCP connections. Prefer exact host CIDRs such as `192.168.1.50/32`; broad ranges increase SSRF exposure. |
 | `channels.*.allowFrom` | omitted | Access control per channel. Omit to use pairing-only mode; set `["*"]` to allow everyone; or list specific user IDs. See [Pairing](#pairing) for details. |
 
 **Docker security**: The official Docker image runs as a non-root user (`nanobot`, UID 1000) with bubblewrap pre-installed. When using `docker-compose.yml`, the container drops all Linux capabilities except `SYS_ADMIN` (required for bwrap's namespace isolation).

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -21,6 +21,7 @@ from nanobot.bus.events import (
     RUNTIME_CONTROL_MCP_RELOAD,
     InboundMessage,
 )
+from nanobot.security.network import validate_url_target
 
 # Transient connection errors that warrant a single retry.
 # These typically happen when an MCP server restarts or a network
@@ -87,10 +88,21 @@ async def _probe_http_url(url: str, timeout: float = 3.0) -> bool:
             timeout=timeout,
         )
         writer.close()
-        await writer.wait_closed()
+        with suppress(OSError, asyncio.TimeoutError):
+            await asyncio.wait_for(writer.wait_closed(), timeout=0.2)
         return True
     except (OSError, asyncio.TimeoutError):
         return False
+
+
+async def _validate_mcp_request_url(request: httpx.Request) -> None:
+    """Validate each outgoing MCP HTTP request, including redirect targets."""
+    ok, error = validate_url_target(str(request.url))
+    if not ok:
+        raise httpx.RequestError(
+            f"Blocked unsafe MCP URL {request.url} ({error})",
+            request=request,
+        )
 
 
 def _windows_command_basename(command: str) -> str:
@@ -595,6 +607,18 @@ async def connect_mcp_servers(
                     await server_stack.aclose()
                     return name, None
 
+            if transport_type in {"sse", "streamableHttp"}:
+                ok, error = validate_url_target(cfg.url)
+                if not ok:
+                    logger.warning(
+                        "MCP server '{}': blocked unsafe URL {} ({})",
+                        name,
+                        cfg.url,
+                        error,
+                    )
+                    await server_stack.aclose()
+                    return name, None
+
             if transport_type == "stdio":
                 command, args, env = _normalize_windows_stdio_command(
                     cfg.command,
@@ -626,6 +650,7 @@ async def connect_mcp_servers(
                     }
                     return httpx.AsyncClient(
                         headers=merged_headers or None,
+                        event_hooks={"request": [_validate_mcp_request_url]},
                         follow_redirects=True,
                         timeout=timeout,
                         auth=auth,
@@ -643,6 +668,7 @@ async def connect_mcp_servers(
                 http_client = await server_stack.enter_async_context(
                     httpx.AsyncClient(
                         headers=cfg.headers or None,
+                        event_hooks={"request": [_validate_mcp_request_url]},
                         follow_redirects=True,
                         timeout=None,
                     )

--- a/tests/tools/test_mcp_probe.py
+++ b/tests/tools/test_mcp_probe.py
@@ -16,9 +16,11 @@ from nanobot.agent.tools.registry import ToolRegistry
 @pytest.mark.asyncio
 async def test_probe_returns_true_for_open_port(tmp_path):
     """Start a trivial TCP server, probe should return True."""
-    server = await asyncio.start_server(
-        lambda r, w: None, "127.0.0.1", 0,
-    )
+    async def _close_connection(_reader, writer):
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(_close_connection, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
     try:
         assert await _probe_http_url(f"http://127.0.0.1:{port}/mcp") is True
@@ -59,9 +61,13 @@ def _make_http_cfg(url: str, transport: str = "streamableHttp"):
 @pytest.mark.asyncio
 async def test_connect_skips_unreachable_streamable_http():
     """Unreachable streamableHttp server should be skipped with a warning, no crash."""
+    async def _unreachable(_url: str) -> bool:
+        return False
+
     registry = ToolRegistry()
-    servers = {"dead": _make_http_cfg("http://127.0.0.1:19999/mcp")}
-    stacks = await connect_mcp_servers(servers, registry)
+    servers = {"dead": _make_http_cfg("http://93.184.216.34:19999/mcp")}
+    with patch("nanobot.agent.tools.mcp._probe_http_url", _unreachable):
+        stacks = await connect_mcp_servers(servers, registry)
     assert stacks == {}
     assert len(registry._tools) == 0
 
@@ -69,9 +75,13 @@ async def test_connect_skips_unreachable_streamable_http():
 @pytest.mark.asyncio
 async def test_connect_skips_unreachable_sse():
     """Unreachable SSE server should be skipped with a warning, no crash."""
+    async def _unreachable(_url: str) -> bool:
+        return False
+
     registry = ToolRegistry()
-    servers = {"dead": _make_http_cfg("http://127.0.0.1:19999/sse", transport="sse")}
-    stacks = await connect_mcp_servers(servers, registry)
+    servers = {"dead": _make_http_cfg("http://93.184.216.34:19999/sse", transport="sse")}
+    with patch("nanobot.agent.tools.mcp._probe_http_url", _unreachable):
+        stacks = await connect_mcp_servers(servers, registry)
     assert stacks == {}
     assert len(registry._tools) == 0
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -522,17 +522,33 @@ async def test_connect_mcp_servers_rejects_unsafe_http_urls_before_probe(
 
 
 @pytest.mark.asyncio
-async def test_mcp_http_request_hook_rejects_unsafe_redirect_targets(
+@pytest.mark.parametrize(
+    ("config", "expected_transport"),
+    [
+        (MCPServerConfig(type="sse", url="https://mcp.example.com/sse"), "sse"),
+        (
+            MCPServerConfig(type="streamableHttp", url="https://mcp.example.com/mcp"),
+            "streamableHttp",
+        ),
+    ],
+)
+async def test_connect_mcp_servers_http_clients_reject_unsafe_redirect_targets(
+    config: MCPServerConfig,
+    expected_transport: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     checked_urls: list[str] = []
     sent_urls: list[str] = []
+    used_transports: list[str] = []
 
     def _validate(url: str) -> tuple[bool, str]:
         checked_urls.append(url)
         if url == "http://127.0.0.1/private":
             return False, "loopback blocked"
         return True, ""
+
+    async def _reachable(_url: str) -> bool:
+        return True
 
     def _handler(request: httpx.Request) -> httpx.Response:
         sent_urls.append(str(request.url))
@@ -544,17 +560,45 @@ async def test_mcp_http_request_hook_rejects_unsafe_redirect_targets(
             )
         raise AssertionError("unsafe redirect target should be blocked before transport")
 
-    monkeypatch.setattr(mcp_mod, "validate_url_target", _validate)
+    original_async_client = httpx.AsyncClient
 
-    async with httpx.AsyncClient(
-        event_hooks={"request": [mcp_mod._validate_mcp_request_url]},
-        follow_redirects=True,
-        transport=httpx.MockTransport(_handler),
-    ) as client:
-        with pytest.raises(httpx.RequestError, match="loopback blocked"):
+    def _async_client_with_mock_transport(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        kwargs.setdefault("transport", httpx.MockTransport(_handler))
+        return original_async_client(*args, **kwargs)
+
+    @asynccontextmanager
+    async def _fake_sse_client(_url: str, httpx_client_factory=None):
+        assert httpx_client_factory is not None
+        used_transports.append("sse")
+        async with httpx_client_factory() as client:
             await client.get("https://example.com/start")
+        yield object(), object()
 
+    @asynccontextmanager
+    async def _fake_streamable_http_client(_url: str, http_client=None):
+        assert http_client is not None
+        used_transports.append("streamableHttp")
+        await http_client.get("https://example.com/start")
+        yield object(), object(), object()
+
+    monkeypatch.setattr(mcp_mod, "validate_url_target", _validate)
+    monkeypatch.setattr(mcp_mod, "_probe_http_url", _reachable)
+    monkeypatch.setattr(mcp_mod.httpx, "AsyncClient", _async_client_with_mock_transport)
+    monkeypatch.setattr(sys.modules["mcp.client.sse"], "sse_client", _fake_sse_client)
+    monkeypatch.setattr(
+        sys.modules["mcp.client.streamable_http"],
+        "streamable_http_client",
+        _fake_streamable_http_client,
+    )
+
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers({"remote": config}, registry)
+
+    assert stacks == {}
+    assert registry.tool_names == []
+    assert used_transports == [expected_transport]
     assert checked_urls == [
+        config.url,
         "https://example.com/start",
         "http://127.0.0.1/private",
     ]

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -5,6 +5,7 @@ import sys
 from contextlib import asynccontextmanager
 from types import ModuleType, SimpleNamespace
 
+import httpx
 import pytest
 
 import nanobot.agent.tools.mcp as mcp_mod
@@ -484,6 +485,80 @@ async def test_connect_mcp_servers_logs_stdio_pollution_hint(
     assert "stdio protocol pollution" in messages[-1]
     assert "stdout" in messages[-1]
     assert "stderr" in messages[-1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config",
+    [
+        MCPServerConfig(url="http://127.0.0.1:9/sse"),
+        MCPServerConfig(type="streamableHttp", url="http://127.0.0.1:9/mcp"),
+    ],
+)
+async def test_connect_mcp_servers_rejects_unsafe_http_urls_before_probe(
+    config: MCPServerConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempted_connections: list[tuple[object, ...]] = []
+    warnings: list[str] = []
+
+    async def _open_connection(*args: object, **_kwargs: object):
+        attempted_connections.append(args)
+        raise AssertionError("unsafe MCP URL should be rejected before TCP probe")
+
+    def _warning(message: str, *args: object) -> None:
+        warnings.append(message.format(*args))
+
+    monkeypatch.setattr(mcp_mod.asyncio, "open_connection", _open_connection)
+    monkeypatch.setattr("nanobot.agent.tools.mcp.logger.warning", _warning)
+
+    registry = ToolRegistry()
+    stacks = await connect_mcp_servers({"local": config}, registry)
+
+    assert stacks == {}
+    assert registry.tool_names == []
+    assert attempted_connections == []
+    assert any("blocked unsafe URL" in warning for warning in warnings)
+
+
+@pytest.mark.asyncio
+async def test_mcp_http_request_hook_rejects_unsafe_redirect_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked_urls: list[str] = []
+    sent_urls: list[str] = []
+
+    def _validate(url: str) -> tuple[bool, str]:
+        checked_urls.append(url)
+        if url == "http://127.0.0.1/private":
+            return False, "loopback blocked"
+        return True, ""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        sent_urls.append(str(request.url))
+        if str(request.url) == "https://example.com/start":
+            return httpx.Response(
+                302,
+                headers={"Location": "http://127.0.0.1/private"},
+                request=request,
+            )
+        raise AssertionError("unsafe redirect target should be blocked before transport")
+
+    monkeypatch.setattr(mcp_mod, "validate_url_target", _validate)
+
+    async with httpx.AsyncClient(
+        event_hooks={"request": [mcp_mod._validate_mcp_request_url]},
+        follow_redirects=True,
+        transport=httpx.MockTransport(_handler),
+    ) as client:
+        with pytest.raises(httpx.RequestError, match="loopback blocked"):
+            await client.get("https://example.com/start")
+
+    assert checked_urls == [
+        "https://example.com/start",
+        "http://127.0.0.1/private",
+    ]
+    assert sent_urls == ["https://example.com/start"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- validate MCP SSE and streamable HTTP URLs with the shared SSRF guard before probing or constructing clients
- validate each outgoing MCP HTTP request through an `httpx` request hook so redirect targets follow the same SSRF policy
- keep the low-level HTTP probe focused on TCP reachability so existing probe semantics and tests continue to work
- avoid hanging while closing a successful probe connection when the peer does not actively close
- add regression coverage proving loopback MCP URLs are rejected before `asyncio.open_connection` is called and unsafe redirect targets are blocked by the request hook

Closes #4074.

## Tests
- GitHub Actions test matrix: ubuntu/windows, Python 3.13/3.14 (pass)
- uv run --extra dev pytest tests/tools/test_mcp_probe.py::test_probe_returns_true_for_open_port tests/tools/test_mcp_tool.py::test_connect_mcp_servers_rejects_unsafe_http_urls_before_probe -q
- uv run --extra dev pytest tests/tools/test_mcp_probe.py tests/tools/test_mcp_tool.py tests/agent/test_mcp_connection.py tests/agent/test_mcp_transient_retry.py tests/security/test_security_network.py -q
- uv run --extra dev ruff check nanobot/agent/tools/mcp.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_probe.py --select F
