### PR TITLE
fix(provider): handle XML tool call emissions from mimo/glm models

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -224,6 +224,12 @@ class AgentLoop:
             if context_window_tokens is not None
             else defaults.context_window_tokens
         )
+        logger.info(
+            "Context window: {} tokens (max_output={}, budget={})",
+            self.context_window_tokens,
+            getattr(getattr(provider, "generation", None), "max_tokens", "?"),
+            self._replay_token_budget(),
+        )
         self.context_block_limit = context_block_limit
         self.max_tool_result_chars = (
             max_tool_result_chars
@@ -405,6 +411,12 @@ class AgentLoop:
         self.provider = provider
         self.model = model
         self.context_window_tokens = context_window_tokens
+        logger.info(
+            "Provider switched: model={} context_window={} tokens budget={}",
+            model,
+            context_window_tokens,
+            self._replay_token_budget(),
+        )
         self.runner.provider = provider
         self.subagents.set_provider(provider, model)
         self.consolidator.set_provider(provider, model, context_window_tokens)

--- a/nanobot/agent/progress_hook.py
+++ b/nanobot/agent/progress_hook.py
@@ -76,20 +76,25 @@ class AgentProgressHook(AgentHook):
         return name in sig.parameters
 
     async def on_stream(self, context: AgentHookContext, delta: str) -> None:
-        prev_clean = strip_think(self._stream_buf)
+        # The runner's XmlToolCallSanitizer has already cleaned *delta* of
+        # any XML tool-call artifacts.  We must use the sanitised delta
+        # directly rather than re-deriving incremental text from the raw
+        # _stream_buf (which still contains the un-sanitised content and
+        # would re-introduce the XML into the channel stream).
+        #
+        # _stream_buf is still updated for think-block extraction.
         self._stream_buf += delta
-        new_clean = strip_think(self._stream_buf)
-        incremental = new_clean[len(prev_clean) :]
 
         if await self._think_extractor.feed(self._stream_buf, self.emit_reasoning):
             context.streamed_reasoning = True
 
-        if incremental:
-            # Answer text has started; close the reasoning segment so the UI can
-            # lock the bubble before the answer renders below it.
+        # Use the already-clean delta directly instead of computing
+        # incremental from the raw buffer.
+        safe = strip_think(delta) or ""
+        if safe:
             await self.emit_reasoning_end()
             if self._on_stream:
-                await self._on_stream(incremental)
+                await self._on_stream(safe)
 
     async def on_stream_end(self, context: AgentHookContext, *, resuming: bool) -> None:
         await self.emit_reasoning_end()

--- a/nanobot/agent/runner.py
+++ b/nanobot/agent/runner.py
@@ -678,10 +678,14 @@ class AgentRunner:
                 await live_file_edits.update(delta)
 
         if wants_streaming:
+            from nanobot.providers.openai_compat_provider import XmlToolCallSanitizer
+            _xml_sanitizer = XmlToolCallSanitizer()
+
             async def _stream(delta: str) -> None:
-                if delta:
+                safe = _xml_sanitizer.feed(delta)
+                if safe:
                     context.streamed_content = True
-                await hook.on_stream(context, delta)
+                    await hook.on_stream(context, safe)
 
             async def _thinking(delta: str) -> None:
                 if not delta:

--- a/nanobot/agent/tools/base.py
+++ b/nanobot/agent/tools/base.py
@@ -235,6 +235,28 @@ class Tool(ABC):
             items = schema.get("items")
             return [self._cast_value(x, items) for x in val] if items else val
 
+        # Some models emit tool parameters as XML text (e.g. <parameter=media>["a","b"]</parameter>)
+        # which arrives as a JSON string instead of the expected native type.
+        if isinstance(val, str):
+            import json as _json
+
+            stripped = val.strip()
+            if t == "array" and stripped.startswith("["):
+                try:
+                    parsed = _json.loads(stripped)
+                    if isinstance(parsed, list):
+                        items = schema.get("items")
+                        return [self._cast_value(x, items) for x in parsed] if items else parsed
+                except (_json.JSONDecodeError, ValueError):
+                    pass
+            if t == "object" and stripped.startswith("{"):
+                try:
+                    parsed = _json.loads(stripped)
+                    if isinstance(parsed, dict):
+                        return self._cast_object(parsed, schema)
+                except (_json.JSONDecodeError, ValueError):
+                    pass
+
         if t == "object" and isinstance(val, dict):
             return self._cast_object(val, schema)
 

--- a/nanobot/providers/openai_compat_provider.py
+++ b/nanobot/providers/openai_compat_provider.py
@@ -7,6 +7,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import re as _re
 import secrets
 import string
 import time
@@ -137,6 +138,212 @@ def _float_env(name: str, default: float) -> float:
 def _short_tool_id() -> str:
     """9-char alphanumeric ID compatible with all providers (incl. Mistral)."""
     return "".join(secrets.choice(_ALNUM) for _ in range(9))
+
+
+# -- XML tool call fallback parser -------------------------------------------
+# Some models (mimo-v2.5, glm-5.1) occasionally emit tool calls as XML text
+# in the content field instead of the structured tool_calls field.  When
+# nanobot only sees the structured field, the raw XML leaks to channels.
+# These patterns detect and convert the text-format tool calls back into
+# ToolCallRequest objects so they are executed normally.
+
+_XML_FUNCTION_RE = _re.compile(
+    r"<function=(?P<name>[^>]+)>\s*"
+    r"(?P<params>(?:<parameter=[^>]+>[^<]*</parameter>\s*)*)"
+    r"</function>",
+    _re.DOTALL,
+)
+_XML_PARAM_RE = _re.compile(
+    r"<parameter=(?P<key>[^>]+)>(?P<value>[^<]*)</parameter>",
+    _re.DOTALL,
+)
+# Spurious tool-call markers emitted by some models (e.g. <tool_call_none>)
+_XML_TOOL_CALL_MARKER_RE = _re.compile(r"<tool_call[^>]*/?>")
+# Closing tool-call tags
+_XML_TOOL_CALL_CLOSE_RE = _re.compile(r"</tool_call[^>]*>")
+# Orphan function blocks where the leading '<' was emitted in a reasoning
+# delta and the rest arrived in content deltas: ``function=NAME>…</function>``
+_XML_ORPHAN_FUNCTION_RE = _re.compile(
+    r"function=(?P<oname>[^>]+)>\s*"
+    r"(?P<oparams>(?:<parameter=[^>]+>[^<]*</parameter>\s*)*)"
+    r"</function>",
+    _re.DOTALL,
+)
+
+
+def _extract_xml_tool_calls(
+    content: str | None,
+) -> tuple[str | None, list[ToolCallRequest]]:
+    """Parse XML-format tool calls embedded in content text.
+
+    Returns (cleaned_content, parsed_tool_calls).  When no XML patterns are
+    found the original *content* is returned unchanged with an empty list.
+
+    Handles two patterns:
+    - ``<function=NAME><parameter=KEY>VALUE</parameter>...</function>``
+    - Strips spurious markers like ``<tool_call_none>`` / ``</tool_call``.
+    """
+    if not content or ("<function=" not in content and "tool_call" not in content
+                       and "<tool" not in content):
+        return content, []
+
+    calls: list[ToolCallRequest] = []
+    for m in _XML_FUNCTION_RE.finditer(content):
+        name = m.group("name").strip()
+        args: dict[str, str] = {}
+        for pm in _XML_PARAM_RE.finditer(m.group("params")):
+            args[pm.group("key").strip()] = pm.group("value")
+        calls.append(
+            ToolCallRequest(
+                id=_short_tool_id(),
+                name=name,
+                arguments=args,
+            )
+        )
+
+    # Strip all XML artifacts even if no parseable tool calls were found
+    cleaned = content
+    if calls:
+        logger.info(
+            "Extracted {} XML tool call(s) from content: {}",
+            len(calls),
+            [c.name for c in calls],
+        )
+        cleaned = _XML_FUNCTION_RE.sub("", cleaned)
+    # Remove spurious tool_call markers
+    cleaned = _XML_TOOL_CALL_MARKER_RE.sub("", cleaned)
+    cleaned = _XML_TOOL_CALL_CLOSE_RE.sub("", cleaned)
+    cleaned = cleaned.strip() or None
+
+    if not calls and cleaned == content:
+        return content, []
+    return cleaned if cleaned is not None else None, calls
+
+
+def _apply_xml_tool_call_fallback(response: LLMResponse) -> LLMResponse:
+    """Apply XML tool call extraction to an LLMResponse.
+
+    When the response has no structured tool calls but the content contains
+    XML-format tool calls, parse them out and override finish_reason to
+    ``tool_calls`` so the agent runner executes them.
+    """
+    if response.tool_calls:
+        return response  # structured tool calls present — no fallback needed
+    clean, xml_tcs = _extract_xml_tool_calls(response.content)
+    if not xml_tcs:
+        return response
+    return LLMResponse(
+        content=clean,
+        tool_calls=xml_tcs,
+        finish_reason="tool_calls",
+        usage=response.usage,
+        reasoning_content=response.reasoning_content,
+    )
+
+
+class XmlToolCallSanitizer:
+    """Strip XML tool call patterns from streaming content deltas.
+
+    Buffers text that may be the start of a ``<function=…>``,
+    ``<tool_call…>``, or ``</tool_call…>`` block and only flushes
+    content that is confirmed safe (not XML tool calls).
+    """
+
+    # Opening markers that signal a potential XML artifact
+    _OPEN_MARKERS = ("<function=", "<tool_call", "<tool")
+    # Prefixes to buffer during streaming — includes partial forms like
+    # ``<function`` (without ``=``) because the model may emit the tag
+    # name across multiple deltas: ``<function`` then ``=name>``.
+    # Also includes ``<parameter`` for nested parameter tags and
+    # ``function=`` to catch orphan fragments where the leading ``<`` was
+    # emitted in a reasoning delta (bypassing the content sanitizer).
+    _BUFFER_PREFIXES = (
+        "<function=", "<function", "<tool_call", "<tool", "</tool", "</",
+        "<parameter", "function=",
+    )
+
+    def __init__(self) -> None:
+        self._buf = ""
+
+    def feed(self, delta: str) -> str:
+        """Process a streaming delta, returning safe text (empty if buffered)."""
+        self._buf += delta
+        out = ""
+        while self._buf:
+            # If buffer contains a complete <function=...> block, strip it
+            m = _XML_FUNCTION_RE.search(self._buf)
+            if m:
+                out += self._buf[: m.start()]
+                self._buf = self._buf[m.end():]
+                continue
+            # Strip complete <tool_call...> markers
+            m2 = _XML_TOOL_CALL_MARKER_RE.search(self._buf)
+            if m2:
+                out += self._buf[: m2.start()]
+                self._buf = self._buf[m2.end():]
+                continue
+            # Strip complete </tool_call...> markers
+            m3 = _XML_TOOL_CALL_CLOSE_RE.search(self._buf)
+            if m3:
+                out += self._buf[: m3.start()]
+                self._buf = self._buf[m3.end():]
+                continue
+            # Strip orphan function blocks (leading '<' was in reasoning delta)
+            m4 = _XML_ORPHAN_FUNCTION_RE.search(self._buf)
+            if m4:
+                out += self._buf[: m4.start()]
+                self._buf = self._buf[m4.end():]
+                continue
+            # Check if buffer might contain the START of an incomplete XML block
+            # Hold back from the earliest marker onward
+            earliest = len(self._buf)
+            for prefix in self._BUFFER_PREFIXES:
+                idx = self._buf.rfind(prefix)
+                if 0 <= idx < earliest:
+                    earliest = idx
+            if earliest < len(self._buf):
+                out += self._buf[:earliest]
+                self._buf = self._buf[earliest:]
+                break
+            # No XML pattern — flush everything
+            out += self._buf
+            self._buf = ""
+        return out
+
+    def flush(self) -> str:
+        """Flush any remaining buffer (call at end of stream).
+
+        Strips incomplete XML artifacts.  Complete ``<function=…>…</function>``
+        blocks were already removed by ``feed()``; anything left in the buffer
+        at flush time is by definition incomplete and safe to strip — *unless*
+        it looks like plain text that merely contains ``function=`` (e.g.
+        "the function=main is important").
+        """
+        remaining = self._buf
+        self._buf = ""
+        if not remaining:
+            return ""
+        # One last pass for complete orphan blocks that may have arrived in
+        # the final deltas.
+        m = _XML_ORPHAN_FUNCTION_RE.search(remaining)
+        if m:
+            remaining = remaining[: m.start()] + remaining[m.end():]
+        # Find the earliest prefix position (same strategy as feed()).
+        earliest = len(remaining)
+        for prefix in self._BUFFER_PREFIXES:
+            idx = remaining.rfind(prefix)
+            if idx < 0:
+                continue
+            # ``function=`` is ambiguous — only strip when the tail looks
+            # like an XML tag (``function=WORD>…``).  Plain text such as
+            # "function=main is important" is preserved.
+            if prefix == "function=" and not _re.search(r"function=\w+>", remaining[idx:]):
+                continue
+            if idx < earliest:
+                earliest = idx
+        if earliest < len(remaining):
+            remaining = remaining[:earliest]
+        return remaining
 
 
 def _get(obj: Any, key: str) -> Any:
@@ -1031,13 +1238,14 @@ class OpenAICompatProvider(LLMProvider):
                     function_provider_specific_fields=fn_prov,
                 ))
 
-            return LLMResponse(
+            result = LLMResponse(
                 content=content,
                 tool_calls=parsed_tool_calls,
                 finish_reason=finish_reason,
                 usage=self._extract_usage(response_map),
                 reasoning_content=reasoning_content if isinstance(reasoning_content, str) else None,
             )
+            return _apply_xml_tool_call_fallback(result)
 
         if not response.choices:
             return LLMResponse(content="Error: API returned empty choices.", finish_reason="error")
@@ -1078,13 +1286,14 @@ class OpenAICompatProvider(LLMProvider):
         if not reasoning_content and getattr(msg, "reasoning", None):
             reasoning_content = msg.reasoning
 
-        return LLMResponse(
+        result = LLMResponse(
             content=content,
             tool_calls=tool_calls,
             finish_reason=finish_reason or "stop",
             usage=self._extract_usage(response),
             reasoning_content=reasoning_content,
         )
+        return _apply_xml_tool_call_fallback(result)
 
     @classmethod
     def _parse_chunks(cls, chunks: list[Any]) -> LLMResponse:
@@ -1198,7 +1407,7 @@ class OpenAICompatProvider(LLMProvider):
                 b["id"] = _short_tool_id()
             _seen_tc_ids.add(b["id"])
 
-        return LLMResponse(
+        result = LLMResponse(
             content="".join(content_parts) or None,
             tool_calls=[
                 ToolCallRequest(
@@ -1215,6 +1424,7 @@ class OpenAICompatProvider(LLMProvider):
             usage=usage,
             reasoning_content="".join(reasoning_parts) or None,
         )
+        return _apply_xml_tool_call_fallback(result)
 
     @classmethod
     def _extract_error_metadata(cls, e: Exception) -> dict[str, Any]:

--- a/tests/providers/test_xml_sanitizer.py
+++ b/tests/providers/test_xml_sanitizer.py
@@ -1,0 +1,146 @@
+"""Tests for XmlToolCallSanitizer streaming content cleaner."""
+
+from __future__ import annotations
+
+import pytest
+
+from nanobot.providers.openai_compat_provider import XmlToolCallSanitizer
+
+
+class TestXmlToolCallSanitizerNormal:
+    """Cases where deltas contain complete <function=…> blocks."""
+
+    def test_no_xml_passes_through(self) -> None:
+        s = XmlToolCallSanitizer()
+        assert s.feed("hello world") == "hello world"
+
+    def test_complete_function_block_stripped(self) -> None:
+        s = XmlToolCallSanitizer()
+        result = s.feed("<function=read_file><parameter=path>/tmp/x</parameter></function>")
+        assert result == ""
+
+    def test_text_before_and_after_block(self) -> None:
+        s = XmlToolCallSanitizer()
+        result = s.feed(
+            "Sure!<function=read_file><parameter=path>/tmp</parameter></function>Done."
+        )
+        assert result == "Sure!Done."
+
+    def test_tool_call_marker_stripped(self) -> None:
+        s = XmlToolCallSanitizer()
+        assert s.feed("<tool_call_none/>") == ""
+
+    def test_closing_tool_call_stripped(self) -> None:
+        s = XmlToolCallSanitizer()
+        assert s.feed("</tool_call_none>") == ""
+
+    def test_buffered_incomplete_function(self) -> None:
+        s = XmlToolCallSanitizer()
+        # First delta: partial opening tag
+        assert s.feed("Hello <function") == "Hello "
+        # Second delta completes the block
+        assert s.feed("=exec><parameter=cmd>ls</parameter></function>") == ""
+
+
+class TestXmlToolCallSanitizerOrphan:
+    """Cases where leading '<' was emitted in reasoning delta."""
+
+    def test_orphan_function_block_stripped(self) -> None:
+        """Complete orphan block (function=…>…</function> without leading '<')."""
+        s = XmlToolCallSanitizer()
+        result = s.feed("function=exec><parameter=cmd>ls</parameter></function>")
+        assert result == ""
+
+    def test_orphan_block_with_surrounding_text(self) -> None:
+        s = XmlToolCallSanitizer()
+        result = s.feed(
+            "Prefix function=exec><parameter=cmd>ls</parameter></function> Suffix"
+        )
+        assert result == "Prefix  Suffix"
+
+    def test_orphan_block_multi_param(self) -> None:
+        s = XmlToolCallSanitizer()
+        result = s.feed(
+            "function=read_file>"
+            "<parameter=path>/etc/hosts</parameter>"
+            "<parameter=offset>10</parameter>"
+            "</function>"
+        )
+        assert result == ""
+
+    def test_orphan_fragment_buffered_until_complete(self) -> None:
+        """Orphan opening tag arrives alone; parameter tags in later deltas."""
+        s = XmlToolCallSanitizer()
+        # Delta 1: orphan opening (no '<')
+        assert s.feed("function=exec>") == ""
+        # Delta 2: parameter opening
+        assert s.feed("<parameter=command") == ""
+        # Delta 3: parameter value and close
+        assert s.feed(">ls -la /tmp</parameter>") == ""
+        # Delta 4: closing function tag
+        assert s.feed("</function>") == ""
+
+    def test_orphan_reproduces_reasoning_content_split(self) -> None:
+        """Exact delta sequence from WebSocket trace: '<' was in reasoning."""
+        deltas = [
+            "function=exec>",
+            "<parameter=command",
+            ">ls -la",
+            "/tmp",
+            "</parameter>",
+            "</function>",
+        ]
+        s = XmlToolCallSanitizer()
+        for d in deltas:
+            result = s.feed(d)
+            assert result == "", f"Leaked at delta {d!r}: got {result!r}"
+        assert s.flush() == ""
+
+
+class TestXmlToolCallSanitizerFlush:
+    """Flush behaviour for incomplete buffers."""
+
+    def test_flush_strips_incomplete_function_prefix(self) -> None:
+        s = XmlToolCallSanitizer()
+        s.feed("<function=read_file><parameter=path>/tmp")
+        remaining = s.flush()
+        assert remaining == ""
+
+    def test_flush_preserves_plain_function_equals(self) -> None:
+        """Plain text 'function=main is important' must NOT be stripped."""
+        s = XmlToolCallSanitizer()
+        s.feed("the function=main is important")
+        remaining = s.flush()
+        assert "function=main is important" in remaining
+
+    def test_flush_strips_xml_like_function_equals(self) -> None:
+        """'function=exec>' looks like XML and should be stripped."""
+        s = XmlToolCallSanitizer()
+        s.feed("function=exec>")
+        remaining = s.flush()
+        assert remaining == ""
+
+    def test_flush_orphan_block_in_final_deltas(self) -> None:
+        """Complete orphan block sitting in buffer at flush time."""
+        s = XmlToolCallSanitizer()
+        # Feed enough to buffer the orphan opening
+        s.feed("function=exec><parameter=cmd>ls</parameter>")
+        # Don't feed closing tag — simulates it arriving at the very end
+        # Actually feed it through flush by not closing
+        assert s.flush() == ""
+
+
+class TestXmlToolCallSanitizerParameter:
+    """Cases with <parameter=…> tags."""
+
+    def test_parameter_tag_buffered(self) -> None:
+        s = XmlToolCallSanitizer()
+        assert s.feed("<parameter=path") == ""
+        assert s.feed(">/tmp</parameter>") == ""
+
+    def test_parameter_inside_function_stripped(self) -> None:
+        s = XmlToolCallSanitizer()
+        result = s.feed(
+            "<function=exec><parameter=cmd>ls</parameter></function>"
+        )
+        assert result == ""

--- a/tests/providers/test_xml_tool_call_fallback.py
+++ b/tests/providers/test_xml_tool_call_fallback.py
@@ -1,0 +1,154 @@
+"""Tests for XML tool call fallback parser.
+
+When models like mimo-v2.5 or glm-5.1 emit tool calls as XML text in the
+content field instead of the structured tool_calls field, the fallback
+parser extracts them so they are executed instead of leaking to channels.
+"""
+
+from nanobot.providers.base import LLMResponse
+from nanobot.providers.openai_compat_provider import (
+    _apply_xml_tool_call_fallback,
+    _extract_xml_tool_calls,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_xml_tool_calls
+# ---------------------------------------------------------------------------
+
+
+class TestExtractXmlToolCalls:
+    """Unit tests for _extract_xml_tool_calls helper."""
+
+    def test_no_xml_returns_unchanged(self):
+        content, calls = _extract_xml_tool_calls("Hello world")
+        assert content == "Hello world"
+        assert calls == []
+
+    def test_none_returns_unchanged(self):
+        content, calls = _extract_xml_tool_calls(None)
+        assert content is None
+        assert calls == []
+
+    def test_empty_string_returns_unchanged(self):
+        content, calls = _extract_xml_tool_calls("")
+        assert content == ""
+        assert calls == []
+
+    def test_single_tool_call_single_param(self):
+        raw = "<function=read_file>\n<parameter=path>/etc/hosts</parameter>\n</function>"
+        content, calls = _extract_xml_tool_calls(raw)
+        assert content is None
+        assert len(calls) == 1
+        assert calls[0].name == "read_file"
+        assert calls[0].arguments == {"path": "/etc/hosts"}
+
+    def test_single_tool_call_multi_param(self):
+        raw = (
+            "<function=write_file>\n"
+            "<parameter=path>/tmp/test.txt</parameter>\n"
+            "<parameter=content>hello world</parameter>\n"
+            "</function>"
+        )
+        content, calls = _extract_xml_tool_calls(raw)
+        assert content is None
+        assert len(calls) == 1
+        assert calls[0].name == "write_file"
+        assert calls[0].arguments == {"path": "/tmp/test.txt", "content": "hello world"}
+
+    def test_tool_call_with_surrounding_text(self):
+        raw = "gestalt\n<function=exec>\n<parameter=command>ls -la</parameter>\n</function>\nascus"
+        content, calls = _extract_xml_tool_calls(raw)
+        assert content == "gestalt\n\nascus"  # newline left after XML removal
+        assert len(calls) == 1
+        assert calls[0].name == "exec"
+        assert calls[0].arguments == {"command": "ls -la"}
+
+    def test_tool_name_with_dashes(self):
+        raw = "<function=minimax-web_search>\n<parameter=query>test</parameter>\n</function>"
+        content, calls = _extract_xml_tool_calls(raw)
+        assert len(calls) == 1
+        assert calls[0].name == "minimax-web_search"
+
+    def test_param_value_with_special_chars(self):
+        raw = (
+            "<function=exec>\n"
+            "<parameter=command>grep -r 'pattern' /var/log/ 2>/dev/null | head -20</parameter>\n"
+            "</function>"
+        )
+        content, calls = _extract_xml_tool_calls(raw)
+        assert len(calls) == 1
+        assert "grep -r" in calls[0].arguments["command"]
+
+    def test_param_value_with_json(self):
+        raw = (
+            "<function=call_tool>\n"
+            '<parameter=data>{"key": "value", "nested": [1, 2]}</parameter>\n'
+            "</function>"
+        )
+        content, calls = _extract_xml_tool_calls(raw)
+        assert len(calls) == 1
+        assert calls[0].arguments["data"] == '{"key": "value", "nested": [1, 2]}'
+
+    def test_id_is_generated(self):
+        raw = "<function=test>\n<parameter=x>1</parameter>\n</function>"
+        content, calls = _extract_xml_tool_calls(raw)
+        assert calls[0].id  # non-empty string
+        assert len(calls[0].id) == 9  # matches _short_tool_id format
+
+    def test_function_prefix_alone_no_close_is_not_matched(self):
+        """Incomplete XML should not be parsed."""
+        raw = "<function=read_file>\n<parameter=path>/etc/hosts</parameter>"
+        content, calls = _extract_xml_tool_calls(raw)
+        assert content == raw  # unchanged — no closing </function>
+        assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# _apply_xml_tool_call_fallback
+# ---------------------------------------------------------------------------
+
+
+class TestApplyXmlToolCallFallback:
+    """Tests for _apply_xml_tool_call_fallback response wrapper."""
+
+    def test_structured_tool_calls_untouched(self):
+        """When structured tool_calls exist, do not apply fallback."""
+        resp = LLMResponse(
+            content="Using tool...",
+            tool_calls=[__import__("nanobot.providers.base", fromlist=["ToolCallRequest"]).ToolCallRequest(
+                id="tc_123", name="read_file", arguments={"path": "/etc/hosts"},
+            )],
+            finish_reason="tool_calls",
+        )
+        result = _apply_xml_tool_call_fallback(resp)
+        assert result is resp  # same object, not modified
+
+    def test_xml_in_content_converted_to_tool_calls(self):
+        resp = LLMResponse(
+            content="<function=read_file>\n<parameter=path>/etc/hosts</parameter>\n</function>",
+            tool_calls=[],
+            finish_reason="stop",
+        )
+        result = _apply_xml_tool_call_fallback(resp)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "read_file"
+        assert result.finish_reason == "tool_calls"
+        assert result.content is None  # XML stripped
+
+    def test_no_xml_no_change(self):
+        resp = LLMResponse(content="Hello!", tool_calls=[], finish_reason="stop")
+        result = _apply_xml_tool_call_fallback(resp)
+        assert result is resp
+
+    def test_preserves_usage_and_reasoning(self):
+        resp = LLMResponse(
+            content="<function=exec>\n<parameter=command>echo hi</parameter>\n</function>",
+            tool_calls=[],
+            finish_reason="stop",
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+            reasoning_content="I need to run a command",
+        )
+        result = _apply_xml_tool_call_fallback(resp)
+        assert result.usage == {"prompt_tokens": 10, "completion_tokens": 5}
+        assert result.reasoning_content == "I need to run a command"


### PR DESCRIPTION
## Problem

Some OpenAI-compatible models (mimo-v2.5, glm-5.1) emit tool calls as XML text in the `content` field instead of structured `tool_calls`. This causes:

1. **Raw XML leaks to chat channels** — Users see `<function=exec><parameter=cmd>ls</parameter></function>` in Telegram/WebSocket messages.
2. **Tools never execute** — The agent sees only text content, not tool calls, so nothing runs.
3. **Streaming artifacts** — Even when the final response is cleaned, XML fragments appear in real-time streaming deltas.

A particularly tricky variant occurs when the model splits the XML across reasoning and content deltas: the leading `<` is emitted in `reasoning_delta` (which bypasses content processing), and `function=exec>...` arrives in `content_delta` without the opening bracket.

## Solution

### Part 1: XML fallback parser (`openai_compat_provider.py`)

`_extract_xml_tool_calls()` parses `<function=NAME><parameter=KEY>VALUE</parameter>...</function>` patterns from content and converts them to structured `ToolCallRequest` objects. Applied via `_apply_xml_tool_call_fallback()` at all three LLM response return points (dict parsing, SDK parsing, chunk accumulation). Also strips spurious markers like `<tool_call_none/>`.

### Part 2: Streaming sanitizer (`XmlToolCallSanitizer`)

Buffers content deltas that may contain XML fragments and only flushes confirmed-safe text. Handles:
- Complete `<function=...>...</function>` blocks
- `<tool_call.../>` markers
- Orphan fragments where `function=NAME>...</function>` arrives without leading `<` (reasoning/content delta split)
- Partial tags split across multiple deltas

The sanitizer has a smart `flush()` that preserves plain text containing `function=` (e.g. "the function=main is important") while stripping XML-like patterns.

### Part 3: Related fixes

- **`progress_hook.py`**: Use the already-sanitized delta directly instead of re-deriving incremental text from the raw buffer (which re-introduces XML).
- **`tools/base.py`**: Parse JSON strings for array/object parameter types, since the XML parser returns all values as strings (e.g. `media: "[\"path\"]"` → proper list).

## Testing

- **32 new tests**: 17 for `XmlToolCallSanitizer`, 15 for XML fallback parser
- All existing provider tests pass
- Verified on production deployment with mimo-v2.5 model via WebSocket gateway

## Files Changed

| File | Change |
|------|--------|
| `nanobot/providers/openai_compat_provider.py` | XML regex patterns, fallback parser, `XmlToolCallSanitizer` class |
| `nanobot/agent/runner.py` | Wire sanitizer into streaming pipeline |
| `nanobot/agent/progress_hook.py` | Use sanitized delta directly in `on_stream()` |
| `nanobot/agent/tools/base.py` | Parse JSON strings for array/object types |
| `tests/providers/test_xml_sanitizer.py` | 17 tests for streaming sanitizer |
| `tests/providers/test_xml_tool_call_fallback.py` | 15 tests for fallback parser |