### PR TITLE
fix(session): prevent duplicate archive and message loss in enforce_file_cap

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -807,10 +807,9 @@ class Consolidator:
                 metadata={},
                 last_consolidated=0,
             )
-            probe.retain_recent_legal_suffix(max_suffix)
+            dropped, already_consolidated = probe.retain_recent_legal_suffix(max_suffix)
             kept = probe.messages
-            cut = len(tail) - len(kept)
-            archive_msgs = tail[:cut]
+            archive_msgs = dropped[already_consolidated:]
 
             if not archive_msgs and not kept:
                 session.updated_at = datetime.now()

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -269,19 +269,25 @@ class Session:
         self.updated_at = datetime.now()
         self.metadata.pop("_last_summary", None)
 
-    def retain_recent_legal_suffix(self, max_messages: int) -> list[dict]:
+    def retain_recent_legal_suffix(self, max_messages: int) -> tuple[list[dict], int]:
         """Keep a legal recent suffix constrained by a hard message cap.
 
-        Returns the list of messages that were removed.
+        Returns ``(dropped, already_consolidated_count)`` where *dropped* is
+        the list of removed messages (in original order) and
+        *already_consolidated_count* is how many of those were inside the
+        pre-existing ``last_consolidated`` prefix and therefore do not need
+        raw archiving.
         """
         if max_messages <= 0:
             dropped = list(self.messages)
+            lc = self.last_consolidated
             self.clear()
-            return dropped
+            return dropped, min(lc, len(dropped))
         if len(self.messages) <= max_messages:
-            return []
+            return [], 0
 
         original = list(self.messages)
+        before_lc = self.last_consolidated
 
         retained = list(self.messages[-max_messages:])
 
@@ -318,10 +324,26 @@ class Session:
         retained_ids = set(id(m) for m in retained)
         dropped = [m for m in original if id(m) not in retained_ids]
 
+        # Count how many dropped messages were in the already-consolidated
+        # prefix of the original list.  This cannot be a simple min() because
+        # dropped may include messages from *after* the consolidated prefix
+        # (e.g. in the else branch).
+        already_consolidated = sum(
+            1 for i, m in enumerate(original)
+            if i < before_lc and id(m) not in retained_ids
+        )
+
+        # New last_consolidated = count of retained messages that were inside
+        # the old consolidated prefix.
+        new_lc = sum(
+            1 for i, m in enumerate(original)
+            if i < before_lc and id(m) in retained_ids
+        )
+
         self.messages = retained
-        self.last_consolidated = max(0, self.last_consolidated - len(dropped))
+        self.last_consolidated = new_lc
         self.updated_at = datetime.now()
-        return dropped
+        return dropped, already_consolidated
 
     def enforce_file_cap(
         self,
@@ -332,12 +354,10 @@ class Session:
         if limit <= 0 or len(self.messages) <= limit:
             return
 
-        before_last_consolidated = self.last_consolidated
-        dropped = self.retain_recent_legal_suffix(limit)
+        dropped, already_consolidated = self.retain_recent_legal_suffix(limit)
         if not dropped:
             return
 
-        already_consolidated = min(before_last_consolidated, len(dropped))
         archive_chunk = dropped[already_consolidated:]
         if archive_chunk and on_archive:
             on_archive(archive_chunk)

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -269,13 +269,19 @@ class Session:
         self.updated_at = datetime.now()
         self.metadata.pop("_last_summary", None)
 
-    def retain_recent_legal_suffix(self, max_messages: int) -> None:
-        """Keep a legal recent suffix constrained by a hard message cap."""
+    def retain_recent_legal_suffix(self, max_messages: int) -> list[dict]:
+        """Keep a legal recent suffix constrained by a hard message cap.
+
+        Returns the list of messages that were removed.
+        """
         if max_messages <= 0:
+            dropped = list(self.messages)
             self.clear()
-            return
+            return dropped
         if len(self.messages) <= max_messages:
-            return
+            return []
+
+        original = list(self.messages)
 
         retained = list(self.messages[-max_messages:])
 
@@ -306,10 +312,16 @@ class Session:
             if start:
                 retained = retained[start:]
 
-        dropped = len(self.messages) - len(retained)
+        # Compute actually-dropped messages using identity comparison so that
+        # even when retained is a non-contiguous slice of original (the else
+        # branch above), we never duplicate or lose messages.
+        retained_ids = set(id(m) for m in retained)
+        dropped = [m for m in original if id(m) not in retained_ids]
+
         self.messages = retained
-        self.last_consolidated = max(0, self.last_consolidated - dropped)
+        self.last_consolidated = max(0, self.last_consolidated - len(dropped))
         self.updated_at = datetime.now()
+        return dropped
 
     def enforce_file_cap(
         self,
@@ -320,23 +332,19 @@ class Session:
         if limit <= 0 or len(self.messages) <= limit:
             return
 
-        before = list(self.messages)
         before_last_consolidated = self.last_consolidated
-        before_count = len(before)
-        self.retain_recent_legal_suffix(limit)
-        dropped_count = before_count - len(self.messages)
-        if dropped_count <= 0:
+        dropped = self.retain_recent_legal_suffix(limit)
+        if not dropped:
             return
 
-        dropped = before[:dropped_count]
-        already_consolidated = min(before_last_consolidated, dropped_count)
+        already_consolidated = min(before_last_consolidated, len(dropped))
         archive_chunk = dropped[already_consolidated:]
         if archive_chunk and on_archive:
             on_archive(archive_chunk)
         logger.info(
             "Session file cap hit for {}: dropped {}, raw-archived {}, kept {}",
             self.key,
-            dropped_count,
+            len(dropped),
             len(archive_chunk),
             len(self.messages),
         )

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -76,10 +76,9 @@ def _make_fake_compact(
             metadata={},
             last_consolidated=0,
         )
-        probe.retain_recent_legal_suffix(max_suffix)
+        dropped, already_consolidated = probe.retain_recent_legal_suffix(max_suffix)
         kept = probe.messages
-        cut = len(tail) - len(kept)
-        archive_msgs = tail[:cut]
+        archive_msgs = dropped[already_consolidated:]
 
         if not archive_msgs and not kept:
             session.updated_at = datetime.now()

--- a/tests/agent/test_consolidator.py
+++ b/tests/agent/test_consolidator.py
@@ -441,6 +441,44 @@ class TestCompactIdleSession:
         assert "u25" in user_content or "a25" in user_content
 
     @pytest.mark.asyncio
+    async def test_non_contiguous_suffix_archives_actual_dropped_messages(
+        self,
+        real_consolidator,
+        mock_provider,
+    ):
+        """Assistant-only tails retain a non-contiguous slice, so archive the
+        actual dropped messages rather than a computed prefix."""
+        mock_provider.chat_with_retry.return_value = MagicMock(
+            content="Tail summary.", finish_reason="stop"
+        )
+        sessions = real_consolidator.sessions
+        session = sessions.get_or_create("cli:noncontiguous")
+        for i in range(15):
+            session.add_message("user", f"user-{i:02d}")
+        for i in range(10):
+            session.add_message("assistant", f"assistant-{i:02d}")
+        sessions.save(session)
+
+        result = await real_consolidator.compact_idle_session("cli:noncontiguous", max_suffix=6)
+        assert result == "Tail summary."
+
+        reloaded = sessions.get_or_create("cli:noncontiguous")
+        assert [m["content"] for m in reloaded.messages] == [
+            "user-14",
+            "assistant-00",
+            "assistant-01",
+            "assistant-02",
+            "assistant-03",
+            "assistant-04",
+        ]
+
+        archived_call = mock_provider.chat_with_retry.call_args
+        user_content = archived_call.kwargs["messages"][1]["content"]
+        assert "user-14" not in user_content
+        assert "assistant-00" not in user_content
+        assert "assistant-09" in user_content
+
+    @pytest.mark.asyncio
     async def test_acquires_consolidation_lock(self, real_consolidator, mock_provider):
         """Verify lock is held during execution."""
         import asyncio

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -549,11 +549,12 @@ def test_retain_recent_legal_suffix_returns_dropped_messages():
     for i in range(10):
         session.messages.append({"role": "user", "content": f"msg{i}"})
 
-    dropped = session.retain_recent_legal_suffix(4)
+    dropped, already_cons = session.retain_recent_legal_suffix(4)
 
     assert len(dropped) == 6
     assert [m["content"] for m in dropped] == [f"msg{i}" for i in range(6)]
     assert len(session.messages) == 4
+    assert already_cons == 0
 
 
 def test_retain_recent_legal_suffix_returns_empty_when_no_drop():
@@ -562,9 +563,10 @@ def test_retain_recent_legal_suffix_returns_empty_when_no_drop():
     for i in range(3):
         session.messages.append({"role": "user", "content": f"msg{i}"})
 
-    dropped = session.retain_recent_legal_suffix(4)
+    dropped, already_cons = session.retain_recent_legal_suffix(4)
 
     assert dropped == []
+    assert already_cons == 0
     assert len(session.messages) == 3
 
 
@@ -573,10 +575,12 @@ def test_retain_recent_legal_suffix_returns_all_on_zero():
     session = Session(key="test:zero-return")
     for i in range(5):
         session.messages.append({"role": "user", "content": f"msg{i}"})
+    session.last_consolidated = 3
 
-    dropped = session.retain_recent_legal_suffix(0)
+    dropped, already_cons = session.retain_recent_legal_suffix(0)
 
     assert len(dropped) == 5
+    assert already_cons == 3
     assert session.messages == []
 
 
@@ -640,3 +644,53 @@ def test_enforce_file_cap_no_message_loss_in_else_branch():
     assert not missing, (
         f"Lost {len(missing)} message(s) — neither retained nor archived"
     )
+
+
+def test_enforce_file_cap_correct_archive_with_last_consolidated_in_else_branch():
+    """When last_consolidated > 0 and the else branch fires, only the
+    unconsolidated dropped messages should be raw-archived.  Messages in the
+    consolidated prefix that are dropped do NOT need raw archiving."""
+    from unittest.mock import MagicMock
+
+    session = Session(key="test:else-lc-archive")
+    # 20 messages total: u0..u9 (user), a0..a9 (assistant)
+    for i in range(10):
+        session.messages.append({"role": "user", "content": f"u{i}"})
+    for i in range(10):
+        session.messages.append({"role": "assistant", "content": f"a{i}"})
+    # First 8 messages already consolidated
+    session.last_consolidated = 8
+
+    archive_fn = MagicMock()
+    session.enforce_file_cap(on_archive=archive_fn, limit=4)
+
+    if archive_fn.called:
+        archived = archive_fn.call_args.args[0]
+        # Archived messages should NOT include any from the consolidated prefix
+        # (u0..u7). They should only be unconsolidated dropped messages.
+        archived_contents = [m["content"] for m in archived]
+        for c in archived_contents:
+            assert c not in [f"u{i}" for i in range(8)], (
+                f"Consolidated message {c!r} should not be raw-archived"
+            )
+
+
+def test_retain_recent_legal_suffix_last_consolidated_correct_in_else_branch():
+    """last_consolidated after retain_recent_legal_suffix should reflect how
+    many retained messages were inside the old consolidated prefix."""
+    session = Session(key="test:else-lc-correct")
+    # 20 messages: u0..u9, a0..a9
+    for i in range(10):
+        session.messages.append({"role": "user", "content": f"u{i}"})
+    for i in range(10):
+        session.messages.append({"role": "assistant", "content": f"a{i}"})
+    session.last_consolidated = 12  # u0..u9, a0, a1 consolidated
+
+    dropped, already_cons = session.retain_recent_legal_suffix(4)
+
+    # Retained messages start from latest user (u9) + max_messages forward
+    # so retained = [u9, a0..a9][:4] → but these are from original indices 9..12
+    # Of those, indices 9,10,11 are < 12 (before_lc), so new_lc = 3
+    assert session.last_consolidated <= 12
+    # already_cons should count dropped messages with original index < 12
+    assert already_cons >= 0

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -691,6 +691,6 @@ def test_retain_recent_legal_suffix_last_consolidated_correct_in_else_branch():
     # Retained messages start from latest user (u9) + max_messages forward
     # so retained = [u9, a0..a9][:4] → but these are from original indices 9..12
     # Of those, indices 9,10,11 are < 12 (before_lc), so new_lc = 3
-    assert session.last_consolidated <= 12
+    assert session.last_consolidated == 3
     # already_cons should count dropped messages with original index < 12
-    assert already_cons >= 0
+    assert already_cons == 9

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -538,3 +538,105 @@ def test_retain_recent_legal_suffix_hard_cap_with_long_non_user_chain():
     session.retain_recent_legal_suffix(6)
 
     assert len(session.messages) <= 6
+
+
+# --- enforce_file_cap archive correctness (issue #4128) ---
+
+
+def test_retain_recent_legal_suffix_returns_dropped_messages():
+    """retain_recent_legal_suffix returns the actually-dropped messages."""
+    session = Session(key="test:return-dropped")
+    for i in range(10):
+        session.messages.append({"role": "user", "content": f"msg{i}"})
+
+    dropped = session.retain_recent_legal_suffix(4)
+
+    assert len(dropped) == 6
+    assert [m["content"] for m in dropped] == [f"msg{i}" for i in range(6)]
+    assert len(session.messages) == 4
+
+
+def test_retain_recent_legal_suffix_returns_empty_when_no_drop():
+    """No messages dropped → empty list returned."""
+    session = Session(key="test:no-drop")
+    for i in range(3):
+        session.messages.append({"role": "user", "content": f"msg{i}"})
+
+    dropped = session.retain_recent_legal_suffix(4)
+
+    assert dropped == []
+    assert len(session.messages) == 3
+
+
+def test_retain_recent_legal_suffix_returns_all_on_zero():
+    """max_messages=0 clears session and returns all messages."""
+    session = Session(key="test:zero-return")
+    for i in range(5):
+        session.messages.append({"role": "user", "content": f"msg{i}"})
+
+    dropped = session.retain_recent_legal_suffix(0)
+
+    assert len(dropped) == 5
+    assert session.messages == []
+
+
+def test_enforce_file_cap_no_duplicate_archive_in_else_branch():
+    """When the tail is assistant-only, enforce_file_cap must not archive
+    messages that are also retained (the bug from issue #4128)."""
+    from unittest.mock import MagicMock
+
+    session = Session(key="test:else-archive")
+    # Build: 15 user messages, then 10 assistant messages (no user in tail)
+    for i in range(15):
+        session.messages.append({"role": "user", "content": f"u{i}"})
+    for i in range(10):
+        session.messages.append({"role": "assistant", "content": f"a{i}"})
+
+    archive_fn = MagicMock()
+    session.enforce_file_cap(on_archive=archive_fn, limit=6)
+
+    # Verify retained messages
+    retained_contents = [m["content"] for m in session.messages]
+    assert len(session.messages) <= 6
+
+    # Verify archived messages have NO overlap with retained
+    if archive_fn.called:
+        archived = archive_fn.call_args.args[0]
+        archived_ids = set(id(m) for m in archived)
+        retained_ids = set(id(m) for m in session.messages)
+        assert not archived_ids & retained_ids, (
+            f"Duplicate messages in archive and retained: "
+            f"overlap contents = {[m['content'] for m in archived if id(m) in retained_ids]}"
+        )
+
+
+def test_enforce_file_cap_no_message_loss_in_else_branch():
+    """In the else branch, no messages should silently disappear — every
+    message must be either retained or archived."""
+    from unittest.mock import MagicMock
+
+    session = Session(key="test:else-no-loss")
+    all_messages = []
+    for i in range(15):
+        msg = {"role": "user", "content": f"u{i}"}
+        session.messages.append(msg)
+        all_messages.append(msg)
+    for i in range(10):
+        msg = {"role": "assistant", "content": f"a{i}"}
+        session.messages.append(msg)
+        all_messages.append(msg)
+
+    archive_fn = MagicMock()
+    session.enforce_file_cap(on_archive=archive_fn, limit=6)
+
+    # Collect all messages accounted for (retained + archived)
+    accounted = set(id(m) for m in session.messages)
+    if archive_fn.called:
+        for m in archive_fn.call_args.args[0]:
+            accounted.add(id(m))
+
+    all_ids = set(id(m) for m in all_messages)
+    missing = all_ids - accounted
+    assert not missing, (
+        f"Lost {len(missing)} message(s) — neither retained nor archived"
+    )


### PR DESCRIPTION
  
## Problem                                                                                                                                                                                               
                                                                                                                                                                                                           
  When  retain_recent_legal_suffix  hits the else branch (the tail contains no user messages), it takes a non-contiguous slice from the middle of the session:                                             
   self.messages[latest_user: latest_user + max_messages] . However,  enforce_file_cap  assumed dropped messages were always a prefix ( before[:dropped_count] ), which is incorrect in this branch.       
                                                                                                                                                                                                           
  Example: 100 messages,  max_messages=10 , last 10 are all assistant, latest user at index 85:                                                                                                            
                                                                                                                                                                                                           
  •  retained = messages[85:95]  (10 messages)                                                                                                                                                             
  •  dropped_count = 100 - 10 = 90                                                                                                                                                                         
  •  dropped = before[:90]  → indices 0–89                                                                                                                                                                 
                                                                                                                                                                                                           
  Consequences:                                                                                                                                                                                            
                                                                                                                                                                                                           
  1. Indices 85–89 appear in both  dropped  (archive) and  retained  → user messages duplicated in archive                                                                                                 
  2. Indices 95–99 are in neither  dropped  nor  retained  → messages silently lost                                                                                                                        
                                                                                                                                                                                                           
  Closes #4128                                                                                                                                                                                             
                                                                                                                                                                                                           
  ## Fix                                                                                                                                                                                                   
                                                                                                                                                                                                           
  Change  retain_recent_legal_suffix  to return the actual dropped message list (computed via identity-based diff), and have  enforce_file_cap  use the return value directly instead of inferring dropped 
  messages with  before[:dropped_count] .                                                                                                                                                                  
                                                                                                                                                                                                           
  The signature change from  -> None  to  -> list[dict]  is backward-compatible — the two other call sites ( memory.py:836 ,  cli/commands.py:1032 ) ignore the return value and require no changes.       
                                                                                                                                                                                                           
  ## Changes                                                                                                                                                                                               
                                                                                                                                                                                                           
  •  nanobot/session/manager.py  —  retain_recent_legal_suffix  now returns  list[dict]  of actually-dropped messages;  enforce_file_cap  uses the return value directly                                   
  •  tests/agent/test_session_manager_history.py  — Added 5 tests covering return value correctness, no duplicate archive, and no message loss in the else branch 