### PR TITLE
Add tools.file.enable to toggle built-in filesystem tools

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -16,16 +16,16 @@ from nanobot.agent.tools.context import ToolContext
 from nanobot.agent.tools.file_state import FileStates
 from nanobot.agent.tools.loader import ToolLoader
 from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.bus.events import InboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import AgentDefaults, ToolsConfig
+from nanobot.providers.base import LLMProvider
 from nanobot.security.workspace_access import (
     WorkspaceScope,
     bind_workspace_scope,
     reset_workspace_scope,
     workspace_sandbox_status,
 )
-from nanobot.bus.events import InboundMessage
-from nanobot.bus.queue import MessageBus
-from nanobot.config.schema import AgentDefaults, ToolsConfig
-from nanobot.providers.base import LLMProvider
 from nanobot.utils.prompt_templates import render_template
 
 
@@ -118,6 +118,7 @@ class SubagentManager:
         return ToolsConfig(
             exec=self.tools_config.exec,
             web=self.tools_config.web,
+            file=self.tools_config.file,
             restrict_to_workspace=self.restrict_to_workspace,
         )
 

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -16,7 +16,7 @@ from nanobot.agent.tools.schema import (
     StringSchema,
     tool_parameters_schema,
 )
-from nanobot.config.schema import Base
+from nanobot.config_base import Base
 from nanobot.security.workspace_access import current_tool_workspace
 from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
 

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -10,14 +10,14 @@ from typing import Any
 from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.file_state import FileStates, _hash_file, current_file_states
 from nanobot.agent.tools.path_utils import resolve_workspace_path
-from nanobot.config.schema import Base
-from nanobot.security.workspace_access import current_tool_workspace
 from nanobot.agent.tools.schema import (
     BooleanSchema,
     IntegerSchema,
     StringSchema,
     tool_parameters_schema,
 )
+from nanobot.config.schema import Base
+from nanobot.security.workspace_access import current_tool_workspace
 from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
 
 

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -24,7 +24,7 @@ from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
 class FileToolsConfig(Base):
     """Filesystem tools configuration."""
 
-    enable: bool = True  # built-in file tools on by default; set false to act only through MCP servers
+    enable: bool = True  # built-in file tools on by default
 
 
 class _FsTool(Tool):

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -10,6 +10,7 @@ from typing import Any
 from nanobot.agent.tools.base import Tool, tool_parameters
 from nanobot.agent.tools.file_state import FileStates, _hash_file, current_file_states
 from nanobot.agent.tools.path_utils import resolve_workspace_path
+from nanobot.config.schema import Base
 from nanobot.security.workspace_access import current_tool_workspace
 from nanobot.agent.tools.schema import (
     BooleanSchema,
@@ -20,8 +21,24 @@ from nanobot.agent.tools.schema import (
 from nanobot.utils.helpers import build_image_content_blocks, detect_image_mime
 
 
+class FileToolsConfig(Base):
+    """Filesystem tools configuration."""
+
+    enable: bool = True  # built-in file tools on by default; set false to act only through MCP servers
+
+
 class _FsTool(Tool):
     """Shared base for filesystem tools — common init and path resolution."""
+
+    config_key = "file"
+
+    @classmethod
+    def config_cls(cls):
+        return FileToolsConfig
+
+    @classmethod
+    def enabled(cls, ctx: Any) -> bool:
+        return ctx.config.file.enable
 
     def __init__(
         self,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -12,6 +12,7 @@ from nanobot.cron.types import CronSchedule
 
 if TYPE_CHECKING:
     from nanobot.agent.tools.cli_apps import CliAppsToolConfig
+    from nanobot.agent.tools.filesystem import FileToolsConfig
     from nanobot.agent.tools.image_generation import ImageGenerationToolConfig
     from nanobot.agent.tools.self import MyToolConfig
     from nanobot.agent.tools.shell import ExecToolConfig
@@ -320,6 +321,7 @@ class ToolsConfig(Base):
 
     web: WebToolsConfig = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.web", "WebToolsConfig"))
     exec: ExecToolConfig = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.shell", "ExecToolConfig"))
+    file: FileToolsConfig = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.filesystem", "FileToolsConfig"))
     cli_apps: CliAppsToolConfig = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.cli_apps", "CliAppsToolConfig"))
     my: MyToolConfig = Field(default_factory=lambda: _lazy_default("nanobot.agent.tools.self", "MyToolConfig"))
     image_generation: ImageGenerationToolConfig = Field(
@@ -558,6 +560,7 @@ def _resolve_tool_config_refs() -> None:
     import sys
 
     from nanobot.agent.tools.cli_apps import CliAppsToolConfig
+    from nanobot.agent.tools.filesystem import FileToolsConfig
     from nanobot.agent.tools.image_generation import ImageGenerationToolConfig
     from nanobot.agent.tools.self import MyToolConfig
     from nanobot.agent.tools.shell import ExecToolConfig
@@ -566,6 +569,7 @@ def _resolve_tool_config_refs() -> None:
     # Re-export into this module's namespace
     mod = sys.modules[__name__]
     mod.ExecToolConfig = ExecToolConfig  # type: ignore[attr-defined]
+    mod.FileToolsConfig = FileToolsConfig  # type: ignore[attr-defined]
     mod.CliAppsToolConfig = CliAppsToolConfig  # type: ignore[attr-defined]
     mod.WebToolsConfig = WebToolsConfig  # type: ignore[attr-defined]
     mod.WebSearchConfig = WebSearchConfig  # type: ignore[attr-defined]

--- a/tests/agent/test_subagent.py
+++ b/tests/agent/test_subagent.py
@@ -6,7 +6,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from nanobot.agent.subagent import SubagentManager
+from nanobot.agent.tools.filesystem import FileToolsConfig
 from nanobot.bus.queue import MessageBus
+from nanobot.config.schema import ToolsConfig
 from nanobot.providers.base import LLMProvider
 
 
@@ -51,3 +53,29 @@ async def test_subagent_build_tools_isolates_file_read_state(tmp_path):
     second_result = await second_read.execute(path="note.txt")
     assert second_result.startswith("1| hello")
     assert "File unchanged" not in second_result
+
+
+def test_subagent_respects_file_tool_toggle(tmp_path):
+    provider = MagicMock(spec=LLMProvider)
+    provider.get_default_model.return_value = "test"
+    sm = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=MessageBus(),
+        model="test",
+        max_tool_result_chars=16_000,
+        tools_config=ToolsConfig(file=FileToolsConfig(enable=False)),
+    )
+
+    tools = sm._build_tools()
+
+    file_tools = {
+        "apply_patch",
+        "edit_file",
+        "find_files",
+        "grep",
+        "list_dir",
+        "read_file",
+        "write_file",
+    }
+    assert file_tools.isdisjoint(tools.tool_names)

--- a/tests/test_file_tool_toggle.py
+++ b/tests/test_file_tool_toggle.py
@@ -1,7 +1,21 @@
 from types import SimpleNamespace
 
-from nanobot.config.schema import Config, ToolsConfig
+from nanobot.agent.tools.context import ToolContext
+from nanobot.agent.tools.file_state import FileStates
 from nanobot.agent.tools.filesystem import FileToolsConfig, ReadFileTool
+from nanobot.agent.tools.loader import ToolLoader
+from nanobot.agent.tools.registry import ToolRegistry
+from nanobot.config.schema import Config, ToolsConfig
+
+FILE_TOOL_NAMES = {
+    "apply_patch",
+    "edit_file",
+    "find_files",
+    "grep",
+    "list_dir",
+    "read_file",
+    "write_file",
+}
 
 
 def test_file_tools_enabled_by_default():
@@ -14,3 +28,17 @@ def test_file_tool_gate_follows_flag():
     cfg.file.enable = False
     assert ReadFileTool.enabled(SimpleNamespace(config=cfg)) is False
     assert ReadFileTool.enabled(SimpleNamespace(config=ToolsConfig())) is True
+
+
+def test_file_tool_loader_skips_all_builtin_file_tools_when_disabled(tmp_path):
+    cfg = ToolsConfig(file=FileToolsConfig(enable=False))
+    ctx = ToolContext(
+        config=cfg,
+        workspace=str(tmp_path),
+        file_state_store=FileStates(),
+    )
+    registry = ToolRegistry()
+
+    ToolLoader().load(ctx, registry)
+
+    assert FILE_TOOL_NAMES.isdisjoint(registry.tool_names)

--- a/tests/test_file_tool_toggle.py
+++ b/tests/test_file_tool_toggle.py
@@ -1,0 +1,16 @@
+from types import SimpleNamespace
+
+from nanobot.config.schema import Config, ToolsConfig
+from nanobot.agent.tools.filesystem import FileToolsConfig, ReadFileTool
+
+
+def test_file_tools_enabled_by_default():
+    assert FileToolsConfig().enable is True
+    assert Config().tools.file.enable is True
+
+
+def test_file_tool_gate_follows_flag():
+    cfg = ToolsConfig()
+    cfg.file.enable = False
+    assert ReadFileTool.enabled(SimpleNamespace(config=cfg)) is False
+    assert ReadFileTool.enabled(SimpleNamespace(config=ToolsConfig())) is True


### PR DESCRIPTION
## Motivation

The `exec` and `web` tool groups already expose an `enable` flag (`tools.exec.enable`, `tools.web.enable`), but the built-in filesystem tools do not. Deployments that want the model to act **only** through configured MCP servers (for example, a remote sandbox that provides its own file surface) currently cannot disable the local read/write/edit/list/find/grep tools without patching the code.

## Change

- Adds `FileToolsConfig` with a single `enable: bool = True` field.
- Wires it into `ToolsConfig` as `tools.file` via the existing `_lazy_default(...)` factory, the `TYPE_CHECKING` import block, and `_resolve_tool_config_refs()` — mirroring how `exec`/`web` are done.
- Gates the shared `_FsTool` base via `config_key` / `config_cls` / `enabled(cls, ctx)`, so the toggle also covers the search `find`/`grep` tools and `apply_patch` (all built on `_FsTool`).

The flag defaults to `True`, so behavior is fully backward-compatible — existing deployments are unaffected. Setting `tools.file.enable: false` turns off the built-in filesystem tools.

## Tests

Adds `tests/test_file_tool_toggle.py` covering the default-on behavior and that the gate follows the flag.