### PR TITLE
feat(ws): accept target_chat_id hint in new_chat for session recovery

### DIFF
--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -646,7 +646,8 @@ class WebSocketChannel(BaseChannel):
         """Route one typed inbound envelope (``new_chat`` / ``attach`` / ``message``)."""
         t = envelope.get("type")
         if t == "new_chat":
-            new_id = str(uuid.uuid4())
+            target_cid = envelope.get("target_chat_id")
+            new_id = target_cid if _is_valid_chat_id(target_cid) else str(uuid.uuid4())
             scope = await self._workspace_scope_or_error(
                 connection,
                 lambda: self._workspaces.scope_for_new_chat(


### PR DESCRIPTION
## 背景

这是原始云平台 PR（#4139）讨论后拆出的第二个小 PR。
审核者 @chengyongru 建议将大的部署层改动拆分为聚焦的单点 PR。

本 PR 处理 **会话恢复**：云/本地部署中，页面刷新后 WebUI 发送 `new_chat`
导致历史丢失的问题。

## 问题

nanobot WebSocket 的 `_dispatch_envelope` 在处理 `new_chat` 时无条件生成新
`chat_id`：

```python
if t == "new_chat":
    new_id = str(uuid.uuid4())  # 永远新建
```

这意味着页面刷新 → WebUI 重新连接 → `new_chat` → 全新会话 → 历史清空。

外部身份层（OAuth proxy / gatekeeper）无法干预——envelope 里没有字段能提示
"请回到之前的会话"。

## 解决方案

在 `new_chat` envelope 中接受可选的 `target_chat_id` 字段。存在且有效时复用，
否则回退到 `uuid.uuid4()`。

### 改动

`nanobot/channels/websocket.py` — `_dispatch_envelope` 中 `new_chat` 分支：

```diff
 if t == "new_chat":
+    target_cid = envelope.get("target_chat_id")
+    new_id = target_cid if _is_valid_chat_id(target_cid) else str(uuid.uuid4())
-    new_id = str(uuid.uuid4())
```

仅用现有 API（`_is_valid_chat_id`），零新抽象。

### 端到端场景

```
用户刷新页面 → OAuth proxy / gatekeeper 注入 target_chat_id
                ↓
        envelope: {"type": "new_chat", "target_chat_id": "abc123"}
                ↓
        _dispatch_envelope → 复用 "abc123"，会话恢复
```

Gatekeeper 维护 `external_user → chat_id` 映射，在转发前注入字段——与客户端
使用 `attach` 恢复会话等价，但不需要客户端感知 chat_id。

## 为什么这个改动不同于 #4134

#4134 试图在 `_dispatch_envelope` 里加 `is_allowed` 权限检查——但那已经被
WebSocket upgrade 阶段的 token 校验覆盖了，是死代码。

本 PR 的 `new_chat` 分支**不在任何前置鉴权之后**——只要客户端通过了 WS upgrade
（token 认证已由 nanobot 自身处理），发送 `new_chat` envelope 必然走到这里。
不涉及安全模型的改动，纯粹是协议能力增强。

## 影响

- **向后兼容**：无 `target_chat_id` 时，回退到 `uuid.uuid4()`，行为完全不变
- **1 文件，2 行**：`nanobot/channels/websocket.py`
- **无安全影响**：不影响 token 认证流程，不新增攻击面

## 关联

- PR #4134（已关）：从中确认了 token 是唯一安全边界的设计哲学
- PR #4139（原始）：完整云平台部署层讨论，按建议拆分
