### PR TITLE
Refactor session retention result

### DIFF
--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -799,7 +799,7 @@ class Consolidator:
                 self.sessions.save(session)
                 return ""
 
-            probe = Session(
+            retention_source = Session(
                 key=session.key,
                 messages=tail.copy(),
                 created_at=session.created_at,
@@ -807,10 +807,9 @@ class Consolidator:
                 metadata={},
                 last_consolidated=0,
             )
-            probe.retain_recent_legal_suffix(max_suffix)
-            kept = probe.messages
-            cut = len(tail) - len(kept)
-            archive_msgs = tail[:cut]
+            retention = retention_source.calculate_retention(max_suffix)
+            kept = retention.retained
+            archive_msgs = retention.archive_messages
 
             if not archive_msgs and not kept:
                 session.updated_at = datetime.now()

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -77,6 +77,20 @@ def _message_preview_text(message: dict[str, Any]) -> str:
 
 
 @dataclass
+class RetentionResult:
+    """Result of applying the recent-message retention policy."""
+
+    retained: list[dict[str, Any]]
+    dropped: list[dict[str, Any]]
+    already_consolidated_count: int
+    new_last_consolidated: int
+
+    @property
+    def archive_messages(self) -> list[dict[str, Any]]:
+        return self.dropped[self.already_consolidated_count:]
+
+
+@dataclass
 class Session:
     """A conversation session."""
 
@@ -257,19 +271,31 @@ class Session:
         self.updated_at = datetime.now()
         self.metadata.pop("_last_summary", None)
 
-    def retain_recent_legal_suffix(self, max_messages: int) -> None:
-        """Keep a legal recent suffix constrained by a hard message cap."""
+    def calculate_retention(self, max_messages: int) -> RetentionResult:
+        """Calculate retained and dropped messages without mutating the session."""
         if max_messages <= 0:
-            self.clear()
-            return
+            dropped = list(self.messages)
+            return RetentionResult(
+                retained=[],
+                dropped=dropped,
+                already_consolidated_count=min(self.last_consolidated, len(dropped)),
+                new_last_consolidated=0,
+            )
         if len(self.messages) <= max_messages:
-            return
+            return RetentionResult(
+                retained=list(self.messages),
+                dropped=[],
+                already_consolidated_count=0,
+                new_last_consolidated=self.last_consolidated,
+            )
 
-        retained = list(self.messages[-max_messages:])
+        retained_indices = list(range(len(self.messages) - max_messages, len(self.messages)))
+        retained = [self.messages[i] for i in retained_indices]
 
         # Prefer starting at a user turn when one exists within the tail.
         first_user = next((i for i, m in enumerate(retained) if m.get("role") == "user"), None)
         if first_user is not None:
+            retained_indices = retained_indices[first_user:]
             retained = retained[first_user:]
         else:
             # If the tail is assistant/tool-only, anchor to the latest user in
@@ -280,24 +306,56 @@ class Session:
                 None,
             )
             if latest_user is not None:
-                retained = list(self.messages[latest_user: latest_user + max_messages])
+                retained_indices = list(range(latest_user, min(latest_user + max_messages, len(self.messages))))
+                retained = [self.messages[i] for i in retained_indices]
 
         # Mirror get_history(): avoid persisting orphan tool results at the front.
         start = find_legal_message_start(retained)
         if start:
+            retained_indices = retained_indices[start:]
             retained = retained[start:]
 
         # Hard-cap guarantee: never keep more than max_messages.
         if len(retained) > max_messages:
+            retained_indices = retained_indices[-max_messages:]
             retained = retained[-max_messages:]
             start = find_legal_message_start(retained)
             if start:
+                retained_indices = retained_indices[start:]
                 retained = retained[start:]
 
-        dropped = len(self.messages) - len(retained)
-        self.messages = retained
-        self.last_consolidated = max(0, self.last_consolidated - dropped)
+        retained_index_set = set(retained_indices)
+        dropped = [
+            message
+            for i, message in enumerate(self.messages)
+            if i not in retained_index_set
+        ]
+        new_last_consolidated = sum(
+            1 for i in retained_indices
+            if i < self.last_consolidated
+        )
+        already_consolidated_count = sum(
+            1
+            for i in range(min(self.last_consolidated, len(self.messages)))
+            if i not in retained_index_set
+        )
+        return RetentionResult(
+            retained=retained,
+            dropped=dropped,
+            already_consolidated_count=already_consolidated_count,
+            new_last_consolidated=new_last_consolidated,
+        )
+
+    def retain_recent_legal_suffix(self, max_messages: int) -> RetentionResult:
+        """Keep a legal recent suffix constrained by a hard message cap."""
+        result = self.calculate_retention(max_messages)
+        if max_messages <= 0:
+            self.clear()
+            return result
+        self.messages = result.retained
+        self.last_consolidated = result.new_last_consolidated
         self.updated_at = datetime.now()
+        return result
 
     def enforce_file_cap(
         self,
@@ -308,23 +366,17 @@ class Session:
         if limit <= 0 or len(self.messages) <= limit:
             return
 
-        before = list(self.messages)
-        before_last_consolidated = self.last_consolidated
-        before_count = len(before)
-        self.retain_recent_legal_suffix(limit)
-        dropped_count = before_count - len(self.messages)
-        if dropped_count <= 0:
+        result = self.retain_recent_legal_suffix(limit)
+        if not result.dropped:
             return
 
-        dropped = before[:dropped_count]
-        already_consolidated = min(before_last_consolidated, dropped_count)
-        archive_chunk = dropped[already_consolidated:]
+        archive_chunk = result.archive_messages
         if archive_chunk and on_archive:
             on_archive(archive_chunk)
         logger.info(
             "Session file cap hit for {}: dropped {}, raw-archived {}, kept {}",
             self.key,
-            dropped_count,
+            len(result.dropped),
             len(archive_chunk),
             len(self.messages),
         )

--- a/tests/agent/test_auto_compact.py
+++ b/tests/agent/test_auto_compact.py
@@ -68,7 +68,7 @@ def _make_fake_compact(
             loop.sessions.save(session)
             return ""
 
-        probe = _Session(
+        retention_source = _Session(
             key=session.key,
             messages=tail.copy(),
             created_at=session.created_at,
@@ -76,10 +76,9 @@ def _make_fake_compact(
             metadata={},
             last_consolidated=0,
         )
-        probe.retain_recent_legal_suffix(max_suffix)
-        kept = probe.messages
-        cut = len(tail) - len(kept)
-        archive_msgs = tail[:cut]
+        retention = retention_source.calculate_retention(max_suffix)
+        kept = retention.retained
+        archive_msgs = retention.archive_messages
 
         if not archive_msgs and not kept:
             session.updated_at = datetime.now()
@@ -229,6 +228,47 @@ class TestAgentLoopTTLParam:
         archive_fn.assert_called_once()
         archived = archive_fn.call_args.args[0]
         assert [m["content"] for m in archived] == ["u2", "u3"]
+
+    def test_session_enforce_file_cap_archives_non_contiguous_dropped_messages(self, tmp_path):
+        from nanobot.session.manager import Session
+        archive_fn = MagicMock()
+        session = Session(key="cli:direct")
+        for role, content in [
+            ("user", "u0"),
+            ("assistant", "a0"),
+            ("user", "u1"),
+            ("assistant", "a1"),
+            ("assistant", "a2"),
+            ("assistant", "a3"),
+        ]:
+            session.add_message(role, content)
+        session.last_consolidated = 1
+
+        result = session.retain_recent_legal_suffix(3)
+
+        assert [m["content"] for m in result.retained] == ["u1", "a1", "a2"]
+        assert [m["content"] for m in result.dropped] == ["u0", "a0", "a3"]
+        assert result.already_consolidated_count == 1
+        assert [m["content"] for m in result.archive_messages] == ["a0", "a3"]
+
+        session = Session(key="cli:direct")
+        for role, content in [
+            ("user", "u0"),
+            ("assistant", "a0"),
+            ("user", "u1"),
+            ("assistant", "a1"),
+            ("assistant", "a2"),
+            ("assistant", "a3"),
+        ]:
+            session.add_message(role, content)
+        session.last_consolidated = 1
+
+        session.enforce_file_cap(on_archive=archive_fn, limit=3)
+
+        archive_fn.assert_called_once()
+        archived = archive_fn.call_args.args[0]
+        assert [m["content"] for m in archived] == ["a0", "a3"]
+        assert [m["content"] for m in session.messages] == ["u1", "a1", "a2"]
 
 
 class TestAutoCompact:

--- a/tests/agent/test_session_manager_history.py
+++ b/tests/agent/test_session_manager_history.py
@@ -108,11 +108,22 @@ def test_retain_recent_legal_suffix_keeps_recent_messages():
     for i in range(10):
         session.messages.append({"role": "user", "content": f"msg{i}"})
 
-    session.retain_recent_legal_suffix(4)
+    result = session.retain_recent_legal_suffix(4)
 
     assert len(session.messages) == 4
     assert session.messages[0]["content"] == "msg6"
     assert session.messages[-1]["content"] == "msg9"
+    assert [m["content"] for m in result.retained] == ["msg6", "msg7", "msg8", "msg9"]
+    assert [m["content"] for m in result.dropped] == [
+        "msg0",
+        "msg1",
+        "msg2",
+        "msg3",
+        "msg4",
+        "msg5",
+    ]
+    assert result.already_consolidated_count == 0
+    assert result.new_last_consolidated == 0
 
 
 def test_retain_recent_legal_suffix_adjusts_last_consolidated():
@@ -121,10 +132,12 @@ def test_retain_recent_legal_suffix_adjusts_last_consolidated():
         session.messages.append({"role": "user", "content": f"msg{i}"})
     session.last_consolidated = 7
 
-    session.retain_recent_legal_suffix(4)
+    result = session.retain_recent_legal_suffix(4)
 
     assert len(session.messages) == 4
     assert session.last_consolidated == 1
+    assert result.already_consolidated_count == 6
+    assert result.new_last_consolidated == 1
 
 
 def test_retain_recent_legal_suffix_zero_clears_session():
@@ -132,11 +145,15 @@ def test_retain_recent_legal_suffix_zero_clears_session():
     for i in range(10):
         session.messages.append({"role": "user", "content": f"msg{i}"})
     session.last_consolidated = 5
+    session.metadata["_last_summary"] = {"text": "old"}
 
-    session.retain_recent_legal_suffix(0)
+    result = session.retain_recent_legal_suffix(0)
 
     assert session.messages == []
     assert session.last_consolidated == 0
+    assert "_last_summary" not in session.metadata
+    assert [m["content"] for m in result.dropped] == [f"msg{i}" for i in range(10)]
+    assert result.already_consolidated_count == 5
 
 
 def test_retain_recent_legal_suffix_keeps_legal_tool_boundary():


### PR DESCRIPTION
## Summary

Refactors session retention so retained messages, actual dropped messages, archive skip count, and the updated consolidation cursor are returned as a named `RetentionResult` instead of being inferred at each call site.

## Why

Issue #4136 noted that the retention/archive contract was hidden behind prefix-based inference and tuple-style semantics. This keeps the behavior from #4129 while making the archive boundary explicit, especially for assistant-only tails where the retained slice can be non-contiguous with the original session suffix.

## Changes

- Add `RetentionResult` with `retained`, `dropped`, `already_consolidated_count`, `new_last_consolidated`, and `archive_messages`.
- Extract pure retention calculation into `Session.calculate_retention()` and have `retain_recent_legal_suffix()` apply that result.
- Update `enforce_file_cap()` and `Consolidator.compact_idle_session()` to consume `RetentionResult.archive_messages` instead of recomputing dropped prefixes.
- Add regression coverage for explicit retention result fields and non-contiguous dropped archive semantics.

Fixes #4136

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/agent/test_session_manager_history.py tests/agent/test_auto_compact.py tests/agent/test_consolidator.py`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run ruff check nanobot/session/manager.py nanobot/agent/memory.py tests/agent/test_session_manager_history.py tests/agent/test_auto_compact.py`