### PR TITLE
fix(webui): sort Chats group among projects by recency

### DIFF
--- a/webui/src/components/ChatList.tsx
+++ b/webui/src/components/ChatList.tsx
@@ -175,6 +175,7 @@ export const ChatList = memo(function ChatList({
   const running = new Set(runningChatIds);
   const completed = new Set(completedChatIds);
   const compact = density === "compact";
+  const firstProjectGroupIndex = limitedGroups.findIndex((group) => group.kind === "project");
 
   return (
     <div className="h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto overscroll-contain scrollbar-thin scrollbar-track-transparent">
@@ -192,12 +193,11 @@ export const ChatList = memo(function ChatList({
 
           return (
             <section key={group.id} aria-label={group.label}>
-              {group.kind === "project"
-                && limitedGroups[index - 1]?.kind !== "project" ? (
-                  <div className="px-2 pb-1 text-[12px] font-medium text-muted-foreground/65">
-                    {labels.projects}
-                  </div>
-                ) : null}
+              {index === firstProjectGroupIndex ? (
+                <div className="px-2 pb-1 text-[12px] font-medium text-muted-foreground/65">
+                  {labels.projects}
+                </div>
+              ) : null}
               {group.kind === "project" ? (
                 <ProjectGroupHeader
                   label={group.label}

--- a/webui/src/lib/chat-groups.ts
+++ b/webui/src/lib/chat-groups.ts
@@ -281,19 +281,18 @@ function groupSessionsByProject(
     ),
   }));
 
-  groups.sort((a, b) => {
-    const timeOrder = dateToTime(b.updatedAt) - dateToTime(a.updatedAt);
-    if (timeOrder !== 0) return timeOrder;
-    return a.label.localeCompare(b.label, "en", {
-      numeric: true,
-      sensitivity: "base",
-    });
-  });
-
   if (conversations.length) {
+    const chatsUpdatedAt = conversations.reduce<string | null>(
+      (best, s) => {
+        const candidate = s.updatedAt ?? s.createdAt ?? null;
+        return isNewerDate(candidate, best) ? candidate : best;
+      },
+      null,
+    );
     groups.push({
       id: "workspace:chats",
       label: labels.all,
+      updatedAt: chatsUpdatedAt,
       sessions: sortProjectSessions(
         conversations,
         options.sort,
@@ -303,6 +302,15 @@ function groupSessionsByProject(
       ),
     });
   }
+
+  groups.sort((a, b) => {
+    const timeOrder = dateToTime(b.updatedAt) - dateToTime(a.updatedAt);
+    if (timeOrder !== 0) return timeOrder;
+    return a.label.localeCompare(b.label, "en", {
+      numeric: true,
+      sensitivity: "base",
+    });
+  });
 
   return groups;
 }

--- a/webui/src/tests/chat-list.test.tsx
+++ b/webui/src/tests/chat-list.test.tsx
@@ -256,4 +256,60 @@ describe("ChatList", () => {
     expect(within(chatsSection).getByText("Chat 0")).toBeInTheDocument();
     expect(within(chatsSection).getByRole("button", { name: "Show less" })).toBeInTheDocument();
   });
+
+  it("sorts Chats section among project groups by recency, not always last", () => {
+    const sessions = [
+      session({
+        chatId: "recent-chat",
+        title: "Recent chat",
+        updatedAt: "2026-05-21T12:00:00Z",
+      }),
+      session({
+        chatId: "project-a",
+        title: "Project A task",
+        updatedAt: "2026-05-21T10:00:00Z",
+        workspaceScope: {
+          project_path: "/Users/me/project-a",
+          project_name: "project-a",
+          access_mode: "restricted",
+        },
+      }),
+      session({
+        chatId: "project-b",
+        title: "Project B task",
+        updatedAt: "2026-05-21T11:00:00Z",
+        workspaceScope: {
+          project_path: "/Users/me/project-b",
+          project_name: "project-b",
+          access_mode: "restricted",
+        },
+      }),
+    ];
+
+    render(
+      <ChatList
+        sessions={sessions}
+        activeKey="websocket:recent-chat"
+        onSelect={vi.fn()}
+        onRequestDelete={vi.fn()}
+        onTogglePin={vi.fn()}
+        onRequestRename={vi.fn()}
+        onToggleArchive={vi.fn()}
+        showTimestamps
+      />,
+    );
+
+    const allRegions = screen.getAllByRole("region");
+    const regionNames = allRegions.map((r) => r.getAttribute("aria-label") ?? r.textContent);
+
+    // The most recently updated conversation ("Recent chat" at 12:00) must be
+    // in the first group — Chats should come before both projects.
+    const chatsIdx = regionNames.findIndex((n) => n?.includes("Chats"));
+    const projAIdx = regionNames.findIndex((n) => n?.includes("project-a"));
+    const projBIdx = regionNames.findIndex((n) => n?.includes("project-b"));
+
+    expect(chatsIdx).toBeLessThan(projAIdx);
+    expect(chatsIdx).toBeLessThan(projBIdx);
+    expect(within(allRegions[chatsIdx]).getByText("Recent chat")).toBeInTheDocument();
+  });
 });

--- a/webui/src/tests/chat-list.test.tsx
+++ b/webui/src/tests/chat-list.test.tsx
@@ -312,4 +312,104 @@ describe("ChatList", () => {
     expect(chatsIdx).toBeLessThan(projBIdx);
     expect(within(allRegions[chatsIdx]).getByText("Recent chat")).toBeInTheDocument();
   });
+
+  it("keeps one Projects heading when Chats sorts between project groups", () => {
+    const sessions = [
+      session({
+        chatId: "project-a",
+        title: "Project A task",
+        updatedAt: "2026-05-21T12:00:00Z",
+        workspaceScope: {
+          project_path: "/Users/me/project-a",
+          project_name: "project-a",
+          access_mode: "restricted",
+        },
+      }),
+      session({
+        chatId: "middle-chat",
+        title: "Middle chat",
+        updatedAt: "2026-05-21T11:00:00Z",
+      }),
+      session({
+        chatId: "project-b",
+        title: "Project B task",
+        updatedAt: "2026-05-21T10:00:00Z",
+        workspaceScope: {
+          project_path: "/Users/me/project-b",
+          project_name: "project-b",
+          access_mode: "restricted",
+        },
+      }),
+    ];
+
+    render(
+      <ChatList
+        sessions={sessions}
+        activeKey="websocket:middle-chat"
+        onSelect={vi.fn()}
+        onRequestDelete={vi.fn()}
+        onTogglePin={vi.fn()}
+        onRequestRename={vi.fn()}
+        onToggleArchive={vi.fn()}
+        showTimestamps
+      />,
+    );
+
+    const regionNames = screen
+      .getAllByRole("region")
+      .map((r) => r.getAttribute("aria-label") ?? "");
+
+    expect(regionNames).toEqual(["project-a", "Chats", "project-b"]);
+    expect(screen.getAllByText("Projects")).toHaveLength(1);
+  });
+
+  it("keeps Chats last when its latest conversation is older than all projects", () => {
+    const sessions = [
+      session({
+        chatId: "project-a",
+        title: "Project A task",
+        updatedAt: "2026-05-21T12:00:00Z",
+        workspaceScope: {
+          project_path: "/Users/me/project-a",
+          project_name: "project-a",
+          access_mode: "restricted",
+        },
+      }),
+      session({
+        chatId: "project-b",
+        title: "Project B task",
+        updatedAt: "2026-05-21T11:00:00Z",
+        workspaceScope: {
+          project_path: "/Users/me/project-b",
+          project_name: "project-b",
+          access_mode: "restricted",
+        },
+      }),
+      session({
+        chatId: "old-chat",
+        title: "Old chat",
+        updatedAt: "2026-05-21T10:00:00Z",
+      }),
+    ];
+
+    render(
+      <ChatList
+        sessions={sessions}
+        activeKey="websocket:old-chat"
+        onSelect={vi.fn()}
+        onRequestDelete={vi.fn()}
+        onTogglePin={vi.fn()}
+        onRequestRename={vi.fn()}
+        onToggleArchive={vi.fn()}
+        showTimestamps
+      />,
+    );
+
+    const regionNames = screen
+      .getAllByRole("region")
+      .map((r) => r.getAttribute("aria-label") ?? "");
+
+    expect(regionNames).toEqual(["project-a", "project-b", "Chats"]);
+    expect(screen.getAllByText("Projects")).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

- Fix sidebar "Chats" section (non-project conversations) always appearing at the bottom of the project groups, regardless of its most recent `updated_at` timestamp
- Move Chats group insertion before the global sort, compute its `updatedAt` from the most recently updated session, and sort all groups together by `updatedAt` descending
- Add regression test and boundary-case tests (Chats first / middle / last)

## Root Cause

In `groupSessionsByProject()` (`chat-groups.ts`), the "workspace:chats" group was unconditionally appended at the end via `groups.push(...)` _after_ project groups were already sorted. So even if a regular chat was the most recently updated conversation, it always appeared below all project groups.

## Fix

1. Compute `updatedAt` for the Chats group from its most recently updated session
2. Insert the Chats group _before_ the global sort (instead of after)
3. Sort all groups (projects + chats) together by `updatedAt` DESC

## Test plan

- [x] Existing 5 chat-list tests pass
- [x] New regression test: "sorts Chats section among project groups by recency, not always last"
- [x] New boundary tests: Chats first / middle / last among projects
- [x] Full suite: 310/310 tests pass
- [x] Build succeeds
- [x] Black-box: gateway + headless browser verified correct sidebar ordering