### PR TITLE
feat(webui): add prompt rail and polish links

### DIFF
--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -27,16 +27,16 @@ from websockets.exceptions import ConnectionClosed
 from websockets.http11 import Request as WsRequest
 from websockets.http11 import Response
 
-from nanobot.security.workspace_access import (
-    WORKSPACE_SCOPE_METADATA_KEY,
-    WorkspaceScopeError,
-)
 from nanobot.bus.events import OUTBOUND_META_AGENT_UI, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 from nanobot.command.builtin import builtin_command_palette
 from nanobot.config.paths import get_media_dir, get_workspace_path
 from nanobot.config.schema import Base
+from nanobot.security.workspace_access import (
+    WORKSPACE_SCOPE_METADATA_KEY,
+    WorkspaceScopeError,
+)
 from nanobot.session.goal_state import goal_state_ws_blob
 from nanobot.session.webui_turns import websocket_turn_wall_started_at
 from nanobot.utils.media_decode import (
@@ -44,14 +44,14 @@ from nanobot.utils.media_decode import (
     save_base64_data_url,
 )
 from nanobot.utils.subagent_channel_display import scrub_subagent_messages_for_channel
-from nanobot.webui.settings_api import runtime_capabilities
 from nanobot.webui.cli_apps_api import normalize_cli_app_mentions
+from nanobot.webui.mcp_presets_api import normalize_mcp_preset_mentions
 from nanobot.webui.media_api import (
     serve_signed_media,
     sign_media_path,
     sign_or_stage_media_path,
 )
-from nanobot.webui.mcp_presets_api import normalize_mcp_preset_mentions
+from nanobot.webui.settings_api import runtime_capabilities
 from nanobot.webui.settings_routes import WebUISettingsRouter
 from nanobot.webui.sidebar_state import (
     read_webui_sidebar_state,
@@ -990,7 +990,8 @@ class WebSocketChannel(BaseChannel):
         scope = self._webui_workspaces.scope_for_session_key(decoded_key)
         data = build_webui_thread_response(
             decoded_key,
-            augment_user_media=self._augment_transcript_user_media,
+            augment_user_media=self._augment_transcript_media,
+            augment_assistant_media=self._augment_transcript_media,
             augment_assistant_text=lambda text: rewrite_local_markdown_images(
                 text,
                 workspace_path=scope.project_path,
@@ -1010,7 +1011,7 @@ class WebSocketChannel(BaseChannel):
         except (ValueError, TypeError) as e:
             self.logger.warning("webui transcript append failed: {}", e)
 
-    def _augment_transcript_user_media(self, paths: list[str]) -> list[dict[str, Any]]:
+    def _augment_transcript_media(self, paths: list[str]) -> list[dict[str, Any]]:
         out: list[dict[str, Any]] = []
         for pstr in paths:
             path = Path(pstr)
@@ -1018,7 +1019,12 @@ class WebSocketChannel(BaseChannel):
             if att is None:
                 continue
             mime, _ = mimetypes.guess_type(path.name)
-            kind = "video" if mime and mime.startswith("video/") else "image"
+            if mime and mime.startswith("video/"):
+                kind = "video"
+            elif mime and mime.startswith("image/"):
+                kind = "image"
+            else:
+                kind = "file"
             out.append(
                 {"kind": kind, "url": att["url"], "name": att.get("name", path.name)},
             )

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -7,6 +7,7 @@ import email.utils
 import hmac
 import http
 import json
+import logging
 import mimetypes
 import re
 import secrets
@@ -114,6 +115,45 @@ def _host_for_url(host: str, port: int) -> str:
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
     return f"{host}:{port}"
+
+
+_OPENING_HANDSHAKE_FAILED_MESSAGE = "opening handshake failed"
+
+
+def _exception_chain_has_disconnect(exc: BaseException | None) -> bool:
+    seen: set[int] = set()
+    while exc is not None:
+        ident = id(exc)
+        if ident in seen:
+            return False
+        seen.add(ident)
+        if isinstance(exc, (
+            BrokenPipeError,
+            ConnectionAbortedError,
+            ConnectionResetError,
+            ConnectionClosed,
+        )):
+            return True
+        exc = exc.__cause__ or exc.__context__
+    return False
+
+
+class _WebSocketHandshakeNoiseFilter(logging.Filter):
+    """Suppress noisy restart-time handshakes where the client already disconnected."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.getMessage() != _OPENING_HANDSHAKE_FAILED_MESSAGE:
+            return True
+        exc_info = record.exc_info
+        exc = exc_info[1] if isinstance(exc_info, tuple) and len(exc_info) >= 2 else None
+        return not _exception_chain_has_disconnect(exc)
+
+
+def _websockets_server_logger() -> logging.Logger:
+    ws_logger = logging.getLogger("websockets.server")
+    if not any(isinstance(f, _WebSocketHandshakeNoiseFilter) for f in ws_logger.filters):
+        ws_logger.addFilter(_WebSocketHandshakeNoiseFilter())
+    return ws_logger
 
 
 class WebSocketConfig(Base):
@@ -1239,6 +1279,7 @@ class WebSocketChannel(BaseChannel):
         from nanobot.utils.logging_bridge import redirect_lib_logging
 
         redirect_lib_logging("websockets", level="WARNING")
+        ws_logger = _websockets_server_logger()
 
         self._running = True
         self._stop_event = asyncio.Event()
@@ -1290,6 +1331,7 @@ class WebSocketChannel(BaseChannel):
                     max_size=self.config.max_message_bytes,
                     ping_interval=self.config.ping_interval_s,
                     ping_timeout=self.config.ping_timeout_s,
+                    logger=ws_logger,
                 )
                 with suppress(OSError):
                     path_obj.chmod(0o600)
@@ -1303,6 +1345,7 @@ class WebSocketChannel(BaseChannel):
                     ping_interval=self.config.ping_interval_s,
                     ping_timeout=self.config.ping_timeout_s,
                     ssl=ssl_context,
+                    logger=ws_logger,
                 )
             try:
                 assert self._stop_event is not None

--- a/nanobot/channels/websocket.py
+++ b/nanobot/channels/websocket.py
@@ -7,7 +7,6 @@ import email.utils
 import hmac
 import http
 import json
-import logging
 import mimetypes
 import re
 import secrets
@@ -16,6 +15,7 @@ import time
 import uuid
 from collections.abc import Callable
 from contextlib import suppress
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 from urllib.parse import parse_qs, unquote, urlparse
@@ -48,9 +48,11 @@ from nanobot.utils.subagent_channel_display import scrub_subagent_messages_for_c
 from nanobot.webui.cli_apps_api import normalize_cli_app_mentions
 from nanobot.webui.mcp_presets_api import normalize_mcp_preset_mentions
 from nanobot.webui.media_api import (
+    attach_signed_media_urls,
     serve_signed_media,
     sign_media_path,
     sign_or_stage_media_path,
+    signed_media_attachments,
 )
 from nanobot.webui.settings_api import runtime_capabilities
 from nanobot.webui.settings_routes import WebUISettingsRouter
@@ -64,6 +66,7 @@ from nanobot.webui.transcript import (
     build_webui_thread_response,
     rewrite_local_markdown_images,
 )
+from nanobot.webui.websocket_logging import websockets_server_logger
 from nanobot.webui.workspaces import (
     WebUIWorkspaceController,
 )
@@ -115,45 +118,6 @@ def _host_for_url(host: str, port: int) -> str:
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
     return f"{host}:{port}"
-
-
-_OPENING_HANDSHAKE_FAILED_MESSAGE = "opening handshake failed"
-
-
-def _exception_chain_has_disconnect(exc: BaseException | None) -> bool:
-    seen: set[int] = set()
-    while exc is not None:
-        ident = id(exc)
-        if ident in seen:
-            return False
-        seen.add(ident)
-        if isinstance(exc, (
-            BrokenPipeError,
-            ConnectionAbortedError,
-            ConnectionResetError,
-            ConnectionClosed,
-        )):
-            return True
-        exc = exc.__cause__ or exc.__context__
-    return False
-
-
-class _WebSocketHandshakeNoiseFilter(logging.Filter):
-    """Suppress noisy restart-time handshakes where the client already disconnected."""
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        if record.getMessage() != _OPENING_HANDSHAKE_FAILED_MESSAGE:
-            return True
-        exc_info = record.exc_info
-        exc = exc_info[1] if isinstance(exc_info, tuple) and len(exc_info) >= 2 else None
-        return not _exception_chain_has_disconnect(exc)
-
-
-def _websockets_server_logger() -> logging.Logger:
-    ws_logger = logging.getLogger("websockets.server")
-    if not any(isinstance(f, _WebSocketHandshakeNoiseFilter) for f in ws_logger.filters):
-        ws_logger.addFilter(_WebSocketHandshakeNoiseFilter())
-    return ws_logger
 
 
 class WebSocketConfig(Base):
@@ -1016,7 +980,7 @@ class WebSocketChannel(BaseChannel):
         # client can render previews. The raw on-disk ``media`` paths are
         # stripped on the way out — they leak server filesystem layout and
         # the client never needs them once it has the signed fetch URL.
-        self._augment_media_urls(data)
+        attach_signed_media_urls(data, sign_path=self._sign_media_path)
         return _http_json_response(data)
 
     def _handle_webui_thread_get(self, request: WsRequest, key: str) -> Response:
@@ -1028,10 +992,14 @@ class WebSocketChannel(BaseChannel):
         if not self._is_websocket_channel_session_key(decoded_key):
             return _http_error(404, "session not found")
         scope = self._webui_workspaces.scope_for_session_key(decoded_key)
+        augment_media = partial(
+            signed_media_attachments,
+            sign_path=self._sign_or_stage_media_path,
+        )
         data = build_webui_thread_response(
             decoded_key,
-            augment_user_media=self._augment_transcript_media,
-            augment_assistant_media=self._augment_transcript_media,
+            augment_user_media=augment_media,
+            augment_assistant_media=augment_media,
             augment_assistant_text=lambda text: rewrite_local_markdown_images(
                 text,
                 workspace_path=scope.project_path,
@@ -1050,25 +1018,6 @@ class WebSocketChannel(BaseChannel):
             append_transcript_object(sk, dup)
         except (ValueError, TypeError) as e:
             self.logger.warning("webui transcript append failed: {}", e)
-
-    def _augment_transcript_media(self, paths: list[str]) -> list[dict[str, Any]]:
-        out: list[dict[str, Any]] = []
-        for pstr in paths:
-            path = Path(pstr)
-            att = self._sign_or_stage_media_path(path)
-            if att is None:
-                continue
-            mime, _ = mimetypes.guess_type(path.name)
-            if mime and mime.startswith("video/"):
-                kind = "video"
-            elif mime and mime.startswith("image/"):
-                kind = "image"
-            else:
-                kind = "file"
-            out.append(
-                {"kind": kind, "url": att["url"], "name": att.get("name", path.name)},
-            )
-        return out
 
     async def _handle_message(
         self,
@@ -1105,37 +1054,6 @@ class WebSocketChannel(BaseChannel):
             session_key,
             is_dm,
         )
-
-    def _augment_media_urls(self, payload: dict[str, Any]) -> None:
-        """Mutate *payload* in place: each message's ``media`` path list is
-        replaced by a parallel ``media_urls`` list of signed fetch URLs.
-
-        Messages without media or with non-string path entries are left
-        untouched. Paths that no longer live inside ``media_dir`` (e.g. the
-        file was deleted, or the dir was relocated) are silently skipped;
-        the client falls back to the historical-replay placeholder tile.
-        """
-        messages = payload.get("messages")
-        if not isinstance(messages, list):
-            return
-        for msg in messages:
-            if not isinstance(msg, dict):
-                continue
-            media = msg.get("media")
-            if not isinstance(media, list) or not media:
-                continue
-            urls: list[dict[str, str]] = []
-            for entry in media:
-                if not isinstance(entry, str) or not entry:
-                    continue
-                signed = self._sign_media_path(Path(entry))
-                if signed is None:
-                    continue
-                urls.append({"url": signed, "name": Path(entry).name})
-            if urls:
-                msg["media_urls"] = urls
-            # Always drop the raw paths from the wire payload.
-            msg.pop("media", None)
 
     def _sign_media_path(self, abs_path: Path) -> str | None:
         """Return a ``/api/media/<sig>/<payload>`` URL for *abs_path*, or
@@ -1279,7 +1197,7 @@ class WebSocketChannel(BaseChannel):
         from nanobot.utils.logging_bridge import redirect_lib_logging
 
         redirect_lib_logging("websockets", level="WARNING")
-        ws_logger = _websockets_server_logger()
+        ws_logger = websockets_server_logger()
 
         self._running = True
         self._stop_event = asyncio.Event()

--- a/nanobot/webui/media_api.py
+++ b/nanobot/webui/media_api.py
@@ -24,6 +24,8 @@ from nanobot.config.paths import get_media_dir
 from nanobot.utils.helpers import safe_filename
 
 MediaDirProvider = Callable[[str | None], Path]
+SignedMediaPath = Callable[[Path], dict[str, str] | None]
+SignedMediaUrl = Callable[[Path], str | None]
 
 
 def b64url_encode(data: bytes) -> str:
@@ -170,6 +172,64 @@ def sign_or_stage_media_path(
     if signed is None:
         return None
     return {"url": signed, "name": path.name}
+
+
+def media_attachment_kind(name: str) -> str:
+    """Infer the WebUI media attachment kind from a filename."""
+    mime, _ = mimetypes.guess_type(name)
+    if mime and mime.startswith("video/"):
+        return "video"
+    if mime and mime.startswith("image/"):
+        return "image"
+    return "file"
+
+
+def signed_media_attachments(
+    paths: list[str],
+    *,
+    sign_path: SignedMediaPath,
+) -> list[dict[str, Any]]:
+    """Map persisted media paths to WebUI attachment dicts with fresh signed URLs."""
+    out: list[dict[str, Any]] = []
+    for pstr in paths:
+        path = Path(pstr)
+        att = sign_path(path)
+        if att is None:
+            continue
+        url = att.get("url")
+        if not url:
+            continue
+        name = att.get("name") or path.name
+        out.append({"kind": media_attachment_kind(name), "url": url, "name": name})
+    return out
+
+
+def attach_signed_media_urls(
+    payload: dict[str, Any],
+    *,
+    sign_path: SignedMediaUrl,
+) -> None:
+    """Replace raw media path lists in a WebUI session payload with signed URLs."""
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        media = msg.get("media")
+        if not isinstance(media, list) or not media:
+            continue
+        urls: list[dict[str, str]] = []
+        for entry in media:
+            if not isinstance(entry, str) or not entry:
+                continue
+            signed = sign_path(Path(entry))
+            if signed is None:
+                continue
+            urls.append({"url": signed, "name": Path(entry).name})
+        if urls:
+            msg["media_urls"] = urls
+        msg.pop("media", None)
 
 
 def serve_signed_media(

--- a/nanobot/webui/transcript.py
+++ b/nanobot/webui/transcript.py
@@ -353,17 +353,36 @@ def _merge_unique_tool_trace_lines(
     return traces, added
 
 
+def _media_from_signed_urls(value: Any) -> list[dict[str, Any]]:
+    media: list[dict[str, Any]] = []
+    urls = value if isinstance(value, list) else []
+    for m in urls:
+        if isinstance(m, dict) and m.get("url"):
+            name = str(m.get("name") or "")
+            media.append(
+                {
+                    "kind": _media_kind_from_name(name),
+                    "url": str(m["url"]),
+                    "name": name,
+                },
+            )
+    return media
+
+
 def replay_transcript_to_ui_messages(
     lines: list[dict[str, Any]],
     *,
     augment_user_media: Callable[[list[str]], list[dict[str, Any]]] | None = None,
+    augment_assistant_media: Callable[[list[str]], list[dict[str, Any]]] | None = None,
     augment_assistant_text: Callable[[str], str] | None = None,
 ) -> list[dict[str, Any]]:
     """Fold JSONL records into ``UIMessage``-shaped dicts for the WebUI.
 
     Mirrors the core fold in ``useNanobotStream.ts`` (delta, reasoning,
     message+kind, turn_end). ``augment_user_media`` maps persisted filesystem
-    paths to ``{url, name?}`` / attachment dicts the client expects.
+    paths to ``{url, name?}`` / attachment dicts the client expects. Assistant
+    media gets a separate hook so replay can re-sign outbound attachments after
+    a gateway restart instead of reusing stale process-local signed URLs.
     """
     messages: list[dict[str, Any]] = []
     buffer_message_id: str | None = None
@@ -832,19 +851,14 @@ def replay_transcript_to_ui_messages(
             buffer_parts = []
             text = rec.get("text")
             content_s = text if isinstance(text, str) else ""
-            media_urls = rec.get("media_urls")
             media: list[dict[str, Any]] = []
-            if isinstance(media_urls, list):
-                for m in media_urls:
-                    if isinstance(m, dict) and m.get("url"):
-                        name = str(m.get("name") or "")
-                        media.append(
-                            {
-                                "kind": _media_kind_from_name(name),
-                                "url": str(m["url"]),
-                                "name": name,
-                            },
-                        )
+            raw_media = rec.get("media")
+            raw_media_list = raw_media if isinstance(raw_media, list) else []
+            media_paths = [path for path in raw_media_list if isinstance(path, str) and path]
+            if media_paths and augment_assistant_media is not None:
+                media = augment_assistant_media(media_paths)
+            if not media and (not media_paths or augment_assistant_media is None):
+                media = _media_from_signed_urls(rec.get("media_urls"))
             extra: dict[str, Any] = {"content": content_s}
             if media:
                 extra["media"] = media
@@ -888,6 +902,7 @@ def build_webui_thread_response(
     session_key: str,
     *,
     augment_user_media: Callable[[list[str]], list[dict[str, Any]]] | None = None,
+    augment_assistant_media: Callable[[list[str]], list[dict[str, Any]]] | None = None,
     augment_assistant_text: Callable[[str], str] | None = None,
 ) -> dict[str, Any] | None:
     """Return a payload compatible with ``WebuiThreadPersistedPayload``."""
@@ -897,6 +912,7 @@ def build_webui_thread_response(
     msgs = replay_transcript_to_ui_messages(
         lines,
         augment_user_media=augment_user_media,
+        augment_assistant_media=augment_assistant_media,
         augment_assistant_text=augment_assistant_text,
     )
     return {

--- a/nanobot/webui/websocket_logging.py
+++ b/nanobot/webui/websocket_logging.py
@@ -1,0 +1,45 @@
+"""Logging helpers for the WebUI WebSocket server surface."""
+
+from __future__ import annotations
+
+import logging
+
+from websockets.exceptions import ConnectionClosed
+
+OPENING_HANDSHAKE_FAILED_MESSAGE = "opening handshake failed"
+
+
+def _exception_chain_has_disconnect(exc: BaseException | None) -> bool:
+    seen: set[int] = set()
+    while exc is not None:
+        ident = id(exc)
+        if ident in seen:
+            return False
+        seen.add(ident)
+        if isinstance(exc, (
+            BrokenPipeError,
+            ConnectionAbortedError,
+            ConnectionResetError,
+            ConnectionClosed,
+        )):
+            return True
+        exc = exc.__cause__ or exc.__context__
+    return False
+
+
+class WebSocketHandshakeNoiseFilter(logging.Filter):
+    """Suppress restart-time handshakes where the browser already disconnected."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.getMessage() != OPENING_HANDSHAKE_FAILED_MESSAGE:
+            return True
+        exc_info = record.exc_info
+        exc = exc_info[1] if isinstance(exc_info, tuple) and len(exc_info) >= 2 else None
+        return not _exception_chain_has_disconnect(exc)
+
+
+def websockets_server_logger() -> logging.Logger:
+    ws_logger = logging.getLogger("websockets.server")
+    if not any(isinstance(f, WebSocketHandshakeNoiseFilter) for f in ws_logger.filters):
+        ws_logger.addFilter(WebSocketHandshakeNoiseFilter())
+    return ws_logger

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -3,7 +3,6 @@
 import asyncio
 import functools
 import json
-import logging
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -17,7 +16,6 @@ from websockets.frames import Close
 from nanobot.bus.events import OUTBOUND_META_AGENT_UI, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.websocket import (
-    _OPENING_HANDSHAKE_FAILED_MESSAGE,
     WebSocketChannel,
     WebSocketConfig,
     _is_valid_chat_id,
@@ -28,7 +26,6 @@ from nanobot.channels.websocket import (
     _parse_inbound_payload,
     _parse_query,
     _parse_request_path,
-    _WebSocketHandshakeNoiseFilter,
     publish_runtime_model_update,
 )
 from nanobot.config.loader import load_config, save_config
@@ -40,18 +37,6 @@ from nanobot.webui.settings_api import settings_payload, update_provider_setting
 # -- Shared helpers (aligned with test_websocket_integration.py) ---------------
 
 _PORT = 29876
-
-
-def _log_record(message: str, exc: BaseException) -> logging.LogRecord:
-    return logging.LogRecord(
-        name="websockets.server",
-        level=logging.ERROR,
-        pathname=__file__,
-        lineno=1,
-        msg=message,
-        args=(),
-        exc_info=(type(exc), exc, exc.__traceback__),
-    )
 
 
 def _ch(bus: Any, **kw: Any) -> WebSocketChannel:
@@ -126,22 +111,6 @@ def test_websocket_config_accepts_absolute_unix_socket(tmp_path) -> None:
 def test_websocket_config_rejects_relative_unix_socket() -> None:
     with pytest.raises(ValueError, match="absolute path"):
         WebSocketConfig(unix_socket_path="engine.sock")
-
-
-def test_websocket_handshake_noise_filter_suppresses_disconnects() -> None:
-    filter_ = _WebSocketHandshakeNoiseFilter()
-    wrapped = RuntimeError("wrapped")
-    wrapped.__cause__ = BrokenPipeError(32, "Broken pipe")
-
-    assert not filter_.filter(_log_record(_OPENING_HANDSHAKE_FAILED_MESSAGE, BrokenPipeError()))
-    assert not filter_.filter(_log_record(_OPENING_HANDSHAKE_FAILED_MESSAGE, wrapped))
-
-
-def test_websocket_handshake_noise_filter_keeps_real_errors() -> None:
-    filter_ = _WebSocketHandshakeNoiseFilter()
-
-    assert filter_.filter(_log_record(_OPENING_HANDSHAKE_FAILED_MESSAGE, RuntimeError("boom")))
-    assert filter_.filter(_log_record("connection handler failed", BrokenPipeError()))
 
 
 def test_parse_query_extracts_token_and_client_id() -> None:

--- a/tests/channels/test_websocket_channel.py
+++ b/tests/channels/test_websocket_channel.py
@@ -3,6 +3,7 @@
 import asyncio
 import functools
 import json
+import logging
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -16,6 +17,7 @@ from websockets.frames import Close
 from nanobot.bus.events import OUTBOUND_META_AGENT_UI, OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.websocket import (
+    _OPENING_HANDSHAKE_FAILED_MESSAGE,
     WebSocketChannel,
     WebSocketConfig,
     _is_valid_chat_id,
@@ -26,6 +28,7 @@ from nanobot.channels.websocket import (
     _parse_inbound_payload,
     _parse_query,
     _parse_request_path,
+    _WebSocketHandshakeNoiseFilter,
     publish_runtime_model_update,
 )
 from nanobot.config.loader import load_config, save_config
@@ -37,6 +40,18 @@ from nanobot.webui.settings_api import settings_payload, update_provider_setting
 # -- Shared helpers (aligned with test_websocket_integration.py) ---------------
 
 _PORT = 29876
+
+
+def _log_record(message: str, exc: BaseException) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="websockets.server",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=(type(exc), exc, exc.__traceback__),
+    )
 
 
 def _ch(bus: Any, **kw: Any) -> WebSocketChannel:
@@ -111,6 +126,22 @@ def test_websocket_config_accepts_absolute_unix_socket(tmp_path) -> None:
 def test_websocket_config_rejects_relative_unix_socket() -> None:
     with pytest.raises(ValueError, match="absolute path"):
         WebSocketConfig(unix_socket_path="engine.sock")
+
+
+def test_websocket_handshake_noise_filter_suppresses_disconnects() -> None:
+    filter_ = _WebSocketHandshakeNoiseFilter()
+    wrapped = RuntimeError("wrapped")
+    wrapped.__cause__ = BrokenPipeError(32, "Broken pipe")
+
+    assert not filter_.filter(_log_record(_OPENING_HANDSHAKE_FAILED_MESSAGE, BrokenPipeError()))
+    assert not filter_.filter(_log_record(_OPENING_HANDSHAKE_FAILED_MESSAGE, wrapped))
+
+
+def test_websocket_handshake_noise_filter_keeps_real_errors() -> None:
+    filter_ = _WebSocketHandshakeNoiseFilter()
+
+    assert filter_.filter(_log_record(_OPENING_HANDSHAKE_FAILED_MESSAGE, RuntimeError("boom")))
+    assert filter_.filter(_log_record("connection handler failed", BrokenPipeError()))
 
 
 def test_parse_query_extracts_token_and_client_id() -> None:

--- a/tests/channels/test_websocket_http_routes.py
+++ b/tests/channels/test_websocket_http_routes.py
@@ -515,6 +515,66 @@ async def test_session_routes_accept_percent_encoded_websocket_keys(
 
 
 @pytest.mark.asyncio
+async def test_webui_thread_resigns_assistant_media_urls(
+    bus: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nanobot.webui.transcript import append_transcript_object
+
+    monkeypatch.setattr("nanobot.config.paths.get_data_dir", lambda: tmp_path)
+    media_root = tmp_path / "media"
+    websocket_media = media_root / "websocket"
+    websocket_media.mkdir(parents=True)
+    external = tmp_path / "clip.mp4"
+    external.write_bytes(b"video")
+
+    def fake_media_dir(channel: str | None = None) -> Path:
+        return websocket_media if channel == "websocket" else media_root
+
+    monkeypatch.setattr("nanobot.channels.websocket.get_media_dir", fake_media_dir)
+
+    append_transcript_object(
+        "websocket:video-replay",
+        {"event": "user", "chat_id": "video-replay", "text": "make a video"},
+    )
+    append_transcript_object(
+        "websocket:video-replay",
+        {
+            "event": "message",
+            "chat_id": "video-replay",
+            "text": "video ready",
+            "media": [str(external)],
+            "media_urls": [{"url": "/api/media/old-sig/old-payload", "name": "clip.mp4"}],
+        },
+    )
+
+    channel = _ch(bus, port=29914)
+    server_task = asyncio.create_task(channel.start())
+    await asyncio.sleep(0.3)
+    try:
+        boot = await _http_get("http://127.0.0.1:29914/webui/bootstrap")
+        token = boot.json()["token"]
+        auth = {"Authorization": f"Bearer {token}"}
+        resp = await _http_get(
+            "http://127.0.0.1:29914/api/sessions/websocket:video-replay/webui-thread",
+            headers=auth,
+        )
+        assert resp.status_code == 200
+        assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+        media = assistant["media"]
+        assert media[0]["kind"] == "video"
+        assert media[0]["name"] == "clip.mp4"
+        assert media[0]["url"].startswith("/api/media/")
+        assert media[0]["url"] != "/api/media/old-sig/old-payload"
+
+        fetched = await _http_get(f"http://127.0.0.1:29914{media[0]['url']}")
+        assert fetched.status_code == 200
+        assert fetched.content == b"video"
+    finally:
+        await channel.stop()
+        await server_task
+
+
+@pytest.mark.asyncio
 async def test_session_routes_reject_non_websocket_keys(
     bus: MagicMock, tmp_path: Path
 ) -> None:

--- a/tests/utils/test_webui_transcript.py
+++ b/tests/utils/test_webui_transcript.py
@@ -84,6 +84,28 @@ def test_replay_infers_video_media_from_attachment_name() -> None:
     ]
 
 
+def test_replay_resigns_assistant_media_paths_before_stale_urls() -> None:
+    msgs = replay_transcript_to_ui_messages(
+        [
+            {"event": "user", "chat_id": "t-video-resign", "text": "render"},
+            {
+                "event": "message",
+                "chat_id": "t-video-resign",
+                "text": "video ready",
+                "media": ["/tmp/intro.mp4"],
+                "media_urls": [{"url": "/api/media/old-sig/old-payload", "name": "intro.mp4"}],
+            },
+        ],
+        augment_assistant_media=lambda paths: [
+            {"kind": "video", "url": f"/api/media/new-sig/{paths[0].split('/')[-1]}", "name": "intro.mp4"},
+        ],
+    )
+
+    assert msgs[1]["media"] == [
+        {"kind": "video", "url": "/api/media/new-sig/intro.mp4", "name": "intro.mp4"},
+    ]
+
+
 def test_replay_infers_svg_media_from_attachment_name() -> None:
     msgs = replay_transcript_to_ui_messages(
         [

--- a/tests/utils/test_webui_websocket_logging.py
+++ b/tests/utils/test_webui_websocket_logging.py
@@ -1,0 +1,38 @@
+"""Tests for WebUI websocket logging helpers."""
+
+from __future__ import annotations
+
+import logging
+
+from nanobot.webui.websocket_logging import (
+    OPENING_HANDSHAKE_FAILED_MESSAGE,
+    WebSocketHandshakeNoiseFilter,
+)
+
+
+def _log_record(message: str, exc: BaseException) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="websockets.server",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=(type(exc), exc, exc.__traceback__),
+    )
+
+
+def test_websocket_handshake_noise_filter_suppresses_disconnects() -> None:
+    filter_ = WebSocketHandshakeNoiseFilter()
+    wrapped = RuntimeError("wrapped")
+    wrapped.__cause__ = BrokenPipeError(32, "Broken pipe")
+
+    assert not filter_.filter(_log_record(OPENING_HANDSHAKE_FAILED_MESSAGE, BrokenPipeError()))
+    assert not filter_.filter(_log_record(OPENING_HANDSHAKE_FAILED_MESSAGE, wrapped))
+
+
+def test_websocket_handshake_noise_filter_keeps_real_errors() -> None:
+    filter_ = WebSocketHandshakeNoiseFilter()
+
+    assert filter_.filter(_log_record(OPENING_HANDSHAKE_FAILED_MESSAGE, RuntimeError("boom")))
+    assert filter_.filter(_log_record("connection handler failed", BrokenPipeError()))

--- a/webui/src/components/MarkdownTextRenderer.tsx
+++ b/webui/src/components/MarkdownTextRenderer.tsx
@@ -272,7 +272,7 @@ function InlineLinkPreviewRow({ link }: { link: InlineLinkPreview }) {
       aria-label={`Open link: ${label}`}
       className={cn(
         "not-prose inline-flex max-w-full items-center gap-2 align-baseline",
-        "text-blue-600 no-underline underline-offset-2 hover:underline dark:text-blue-300",
+        "text-blue-500 no-underline underline-offset-2 hover:underline dark:text-blue-300",
       )}
     >
       <span
@@ -410,7 +410,7 @@ export default function MarkdownTextRenderer({
             href={href}
             target="_blank"
             rel="noreferrer noopener"
-            className="text-blue-600 underline underline-offset-2 hover:text-blue-700 dark:text-blue-300 dark:hover:text-blue-200"
+            className="text-blue-500 underline underline-offset-2 hover:text-blue-600 dark:text-blue-300 dark:hover:text-blue-200"
             {...props}
           >
             {markdownChildren}
@@ -508,7 +508,7 @@ export default function MarkdownTextRenderer({
         "prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5",
         "prose-blockquote:my-3 prose-blockquote:border-l-2 prose-blockquote:font-normal",
         "prose-blockquote:not-italic prose-blockquote:text-foreground/80",
-        "prose-a:text-blue-600 prose-a:underline-offset-2 hover:prose-a:text-blue-700 dark:prose-a:text-blue-300 dark:hover:prose-a:text-blue-200",
+        "prose-a:text-blue-500 prose-a:underline-offset-2 hover:prose-a:text-blue-600 dark:prose-a:text-blue-300 dark:hover:prose-a:text-blue-200",
         "prose-hr:my-6",
         "prose-pre:my-0 prose-pre:bg-transparent prose-pre:p-0",
         "prose-code:before:content-none prose-code:after:content-none prose-code:font-normal",

--- a/webui/src/components/MarkdownTextRenderer.tsx
+++ b/webui/src/components/MarkdownTextRenderer.tsx
@@ -272,7 +272,7 @@ function InlineLinkPreviewRow({ link }: { link: InlineLinkPreview }) {
       aria-label={`Open link: ${label}`}
       className={cn(
         "not-prose inline-flex max-w-full items-center gap-2 align-baseline",
-        "text-primary no-underline underline-offset-2 hover:underline",
+        "text-blue-600 no-underline underline-offset-2 hover:underline dark:text-blue-300",
       )}
     >
       <span
@@ -410,7 +410,7 @@ export default function MarkdownTextRenderer({
             href={href}
             target="_blank"
             rel="noreferrer noopener"
-            className="text-primary underline underline-offset-2 hover:opacity-80"
+            className="text-blue-600 underline underline-offset-2 hover:text-blue-700 dark:text-blue-300 dark:hover:text-blue-200"
             {...props}
           >
             {markdownChildren}
@@ -508,7 +508,7 @@ export default function MarkdownTextRenderer({
         "prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5",
         "prose-blockquote:my-3 prose-blockquote:border-l-2 prose-blockquote:font-normal",
         "prose-blockquote:not-italic prose-blockquote:text-foreground/80",
-        "prose-a:text-primary prose-a:underline-offset-2 hover:prose-a:opacity-80",
+        "prose-a:text-blue-600 prose-a:underline-offset-2 hover:prose-a:text-blue-700 dark:prose-a:text-blue-300 dark:hover:prose-a:text-blue-200",
         "prose-hr:my-6",
         "prose-pre:my-0 prose-pre:bg-transparent prose-pre:p-0",
         "prose-code:before:content-none prose-code:after:content-none prose-code:font-normal",

--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -573,7 +573,7 @@ export function ReasoningBubble({
               "prose-headings:mt-2 prose-headings:mb-1 prose-headings:font-medium",
               "prose-headings:text-muted-foreground/92 prose-strong:text-muted-foreground",
               "prose-h1:text-[15px] prose-h2:text-[13.5px] prose-h3:text-[12.5px] prose-h4:text-[12px]",
-              "prose-a:text-blue-600 prose-a:underline hover:prose-a:text-blue-700 dark:prose-a:text-blue-300 dark:hover:prose-a:text-blue-200",
+              "prose-a:text-blue-500 prose-a:underline hover:prose-a:text-blue-600 dark:prose-a:text-blue-300 dark:hover:prose-a:text-blue-200",
               "prose-code:text-[0.92em]",
             )}
           >

--- a/webui/src/components/MessageBubble.tsx
+++ b/webui/src/components/MessageBubble.tsx
@@ -573,7 +573,7 @@ export function ReasoningBubble({
               "prose-headings:mt-2 prose-headings:mb-1 prose-headings:font-medium",
               "prose-headings:text-muted-foreground/92 prose-strong:text-muted-foreground",
               "prose-h1:text-[15px] prose-h2:text-[13.5px] prose-h3:text-[12.5px] prose-h4:text-[12px]",
-              "prose-a:text-muted-foreground/95 prose-a:underline hover:prose-a:opacity-90",
+              "prose-a:text-blue-600 prose-a:underline hover:prose-a:text-blue-700 dark:prose-a:text-blue-300 dark:hover:prose-a:text-blue-200",
               "prose-code:text-[0.92em]",
             )}
           >

--- a/webui/src/components/settings/SettingsView.tsx
+++ b/webui/src/components/settings/SettingsView.tsx
@@ -4755,7 +4755,7 @@ function timezonesWithCurrent(current: string): string[] {
   const intl = Intl as typeof Intl & {
     supportedValuesOf?: (key: "timeZone") => string[];
   };
-  let values: string[] = [];
+  let values: string[];
   try {
     values = intl.supportedValuesOf?.("timeZone") ?? [];
   } catch {

--- a/webui/src/components/thread/PromptRail.tsx
+++ b/webui/src/components/thread/PromptRail.tsx
@@ -27,6 +27,7 @@ interface MeasuredPrompt extends PromptAnchor {
 }
 
 interface PromptMarker {
+  count: number;
   ids: string[];
   label: string;
   topPercent: number;
@@ -34,7 +35,13 @@ interface PromptMarker {
 
 const MIN_PROMPTS_FOR_RAIL = 3;
 const RAIL_MIN_SCROLL_RANGE_PX = 240;
+const DENSE_PROMPT_THRESHOLD = 30;
+const DENSE_BUCKET_HEIGHT_PX = 12;
+const DENSE_BUCKET_FALLBACK_COUNT = 32;
+const DENSE_BUCKET_MAX_COUNT = 42;
 const MARKER_MIN_GAP_PX = 9;
+const MARKER_BASE_WIDTH_PX = 26;
+const MARKER_MAX_WIDTH_PX = 42;
 
 export function PromptRail({
   bottomOffset,
@@ -100,12 +107,14 @@ export function PromptRail({
 
   if (markers.length === 0) return null;
 
+  const maxMarkerCount = Math.max(...markers.map((marker) => marker.count));
+
   return (
     <div
       ref={railRef}
       aria-label="User prompt navigation"
       className={cn(
-        "pointer-events-none absolute right-2 top-12 z-20 hidden w-10 md:block",
+        "pointer-events-none absolute right-6 top-12 z-20 hidden w-12 md:block",
         "motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-200",
       )}
       style={{ bottom: Math.max(80, bottomOffset) }}
@@ -120,13 +129,17 @@ export function PromptRail({
             aria-label={`Jump to prompt: ${marker.label}`}
             onClick={() => jumpToPrompt(scrollRef.current, marker.ids[marker.ids.length - 1])}
             className={cn(
-              "pointer-events-auto absolute right-1 h-1.5 w-7 -translate-y-1/2 rounded-full",
+              "pointer-events-auto absolute right-0 h-1.5 -translate-y-1/2 rounded-full",
               "bg-muted-foreground/30 transition-all duration-150",
-              "hover:w-9 hover:bg-blue-500/80 focus-visible:w-9 focus-visible:bg-blue-500",
+              "hover:bg-blue-500/80 focus-visible:bg-blue-500",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60",
-              active && "w-9 bg-foreground shadow-sm",
+              marker.count > 1 && "bg-muted-foreground/45",
+              active && "bg-foreground shadow-sm",
             )}
-            style={{ top: `${marker.topPercent}%` }}
+            style={{
+              top: `${marker.topPercent}%`,
+              width: markerWidth(marker.count, maxMarkerCount, active),
+            }}
           />
         );
       })}
@@ -171,6 +184,10 @@ function groupPromptMarkers(
   railHeight: number,
 ): PromptMarker[] {
   if (measured.length === 0) return [];
+  if (measured.length >= DENSE_PROMPT_THRESHOLD) {
+    return bucketPromptMarkers(measured, railHeight);
+  }
+
   const minGapPercent = railHeight > 0
     ? (MARKER_MIN_GAP_PX / railHeight) * 100
     : 2;
@@ -179,11 +196,13 @@ function groupPromptMarkers(
   for (const prompt of measured) {
     const last = groups[groups.length - 1];
     if (last && prompt.topPercent - last.topPercent < minGapPercent) {
+      last.count += 1;
       last.ids.push(prompt.id);
-      last.label = `${last.ids.length} prompts, latest: ${prompt.label}`;
+      last.label = groupedPromptLabel(last.count, prompt.label);
       continue;
     }
     groups.push({
+      count: 1,
       ids: [prompt.id],
       label: prompt.label,
       topPercent: prompt.topPercent,
@@ -191,6 +210,44 @@ function groupPromptMarkers(
   }
 
   return groups;
+}
+
+function bucketPromptMarkers(
+  measured: MeasuredPrompt[],
+  railHeight: number,
+): PromptMarker[] {
+  const bucketCount = railHeight > 0
+    ? clamp(
+      Math.floor(railHeight / DENSE_BUCKET_HEIGHT_PX),
+      1,
+      DENSE_BUCKET_MAX_COUNT,
+    )
+    : DENSE_BUCKET_FALLBACK_COUNT;
+  const buckets = Array.from({ length: bucketCount }, () => [] as MeasuredPrompt[]);
+
+  for (const prompt of measured) {
+    const bucketIndex = clamp(
+      Math.floor((prompt.topPercent / 100) * bucketCount),
+      0,
+      bucketCount - 1,
+    );
+    buckets[bucketIndex].push(prompt);
+  }
+
+  return buckets.flatMap((bucket) => {
+    if (bucket.length === 0) return [];
+    const latest = bucket[bucket.length - 1];
+    const topPercent =
+      bucket.reduce((sum, prompt) => sum + prompt.topPercent, 0) / bucket.length;
+    return [{
+      count: bucket.length,
+      ids: bucket.map((prompt) => prompt.id),
+      label: bucket.length === 1
+        ? latest.label
+        : groupedPromptLabel(bucket.length, latest.label),
+      topPercent,
+    }];
+  });
 }
 
 function activePromptForScroll(
@@ -208,6 +265,18 @@ function activePromptForScroll(
     break;
   }
   return active.id;
+}
+
+function groupedPromptLabel(count: number, latestLabel: string): string {
+  return `${count} prompts, latest: ${latestLabel}`;
+}
+
+function markerWidth(count: number, maxCount: number, active: boolean): number {
+  if (maxCount <= 1) return active ? 34 : MARKER_BASE_WIDTH_PX;
+  const density = Math.log2(count + 1) / Math.log2(maxCount + 1);
+  const width = MARKER_BASE_WIDTH_PX
+    + (MARKER_MAX_WIDTH_PX - MARKER_BASE_WIDTH_PX) * density;
+  return Math.round(active ? width + 4 : width);
 }
 
 function jumpToPrompt(scrollEl: HTMLElement | null, promptId: string | undefined): void {

--- a/webui/src/components/thread/PromptRail.tsx
+++ b/webui/src/components/thread/PromptRail.tsx
@@ -1,0 +1,242 @@
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@/lib/utils";
+import type { UIMessage } from "@/lib/types";
+
+interface PromptRailProps {
+  bottomOffset: number;
+  messages: UIMessage[];
+  scrollRef: RefObject<HTMLDivElement>;
+}
+
+interface PromptAnchor {
+  id: string;
+  label: string;
+}
+
+interface MeasuredPrompt extends PromptAnchor {
+  top: number;
+  topPercent: number;
+}
+
+interface PromptMarker {
+  ids: string[];
+  label: string;
+  topPercent: number;
+}
+
+const MIN_PROMPTS_FOR_RAIL = 3;
+const RAIL_MIN_SCROLL_RANGE_PX = 240;
+const MARKER_MIN_GAP_PX = 9;
+
+export function PromptRail({
+  bottomOffset,
+  messages,
+  scrollRef,
+}: PromptRailProps) {
+  const railRef = useRef<HTMLDivElement>(null);
+  const promptAnchors = useMemo(() => userPromptAnchors(messages), [messages]);
+  const [markers, setMarkers] = useState<PromptMarker[]>([]);
+  const [activePromptId, setActivePromptId] = useState<string | null>(null);
+
+  const updateMarkers = useCallback(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl || promptAnchors.length < MIN_PROMPTS_FOR_RAIL) {
+      setMarkers([]);
+      setActivePromptId(null);
+      return;
+    }
+
+    const scrollRange = scrollEl.scrollHeight - scrollEl.clientHeight;
+    if (scrollRange < RAIL_MIN_SCROLL_RANGE_PX) {
+      setMarkers([]);
+      setActivePromptId(null);
+      return;
+    }
+
+    const measured = measurePrompts(scrollEl, promptAnchors, scrollRange);
+    setMarkers(groupPromptMarkers(measured, railRef.current?.clientHeight ?? 0));
+    setActivePromptId(activePromptForScroll(measured, scrollEl.scrollTop));
+  }, [promptAnchors, scrollRef]);
+
+  useEffect(() => {
+    updateMarkers();
+  }, [updateMarkers]);
+
+  useEffect(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return undefined;
+
+    let frame = 0;
+    const schedule = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(updateMarkers);
+    };
+
+    scrollEl.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("resize", schedule);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      scrollEl.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+    };
+  }, [scrollRef, updateMarkers]);
+
+  useEffect(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl || typeof ResizeObserver === "undefined") return undefined;
+    const observer = new ResizeObserver(() => updateMarkers());
+    observer.observe(scrollEl);
+    if (scrollEl.firstElementChild) observer.observe(scrollEl.firstElementChild);
+    return () => observer.disconnect();
+  }, [scrollRef, updateMarkers]);
+
+  if (markers.length === 0) return null;
+
+  return (
+    <div
+      ref={railRef}
+      aria-label="User prompt navigation"
+      className={cn(
+        "pointer-events-none absolute right-2 top-12 z-20 hidden w-10 md:block",
+        "motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-200",
+      )}
+      style={{ bottom: Math.max(80, bottomOffset) }}
+    >
+      {markers.map((marker) => {
+        const active = marker.ids.includes(activePromptId ?? "");
+        return (
+          <button
+            key={marker.ids.join("|")}
+            type="button"
+            title={marker.label}
+            aria-label={`Jump to prompt: ${marker.label}`}
+            onClick={() => jumpToPrompt(scrollRef.current, marker.ids[marker.ids.length - 1])}
+            className={cn(
+              "pointer-events-auto absolute right-1 h-1.5 w-7 -translate-y-1/2 rounded-full",
+              "bg-muted-foreground/30 transition-all duration-150",
+              "hover:w-9 hover:bg-blue-500/80 focus-visible:w-9 focus-visible:bg-blue-500",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60",
+              active && "w-9 bg-foreground shadow-sm",
+            )}
+            style={{ top: `${marker.topPercent}%` }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function userPromptAnchors(messages: UIMessage[]): PromptAnchor[] {
+  return messages
+    .filter((message) => message.role === "user")
+    .map((message, index) => ({
+      id: message.id,
+      label: promptLabel(message.content, index),
+    }));
+}
+
+function promptLabel(content: string, index: number): string {
+  const text = content.replace(/\s+/g, " ").trim();
+  if (!text) return `Prompt ${index + 1}`;
+  return text.length > 80 ? `${text.slice(0, 77)}...` : text;
+}
+
+function measurePrompts(
+  scrollEl: HTMLElement,
+  anchors: PromptAnchor[],
+  scrollRange: number,
+): MeasuredPrompt[] {
+  return anchors.flatMap((anchor) => {
+    const target = findPromptElement(scrollEl, anchor.id);
+    if (!target) return [];
+    const top = Math.max(0, Math.min(scrollRange, promptTop(scrollEl, target) - 16));
+    return [{
+      ...anchor,
+      top,
+      topPercent: clamp((top / scrollRange) * 100, 2, 98),
+    }];
+  });
+}
+
+function groupPromptMarkers(
+  measured: MeasuredPrompt[],
+  railHeight: number,
+): PromptMarker[] {
+  if (measured.length === 0) return [];
+  const minGapPercent = railHeight > 0
+    ? (MARKER_MIN_GAP_PX / railHeight) * 100
+    : 2;
+  const groups: PromptMarker[] = [];
+
+  for (const prompt of measured) {
+    const last = groups[groups.length - 1];
+    if (last && prompt.topPercent - last.topPercent < minGapPercent) {
+      last.ids.push(prompt.id);
+      last.label = `${last.ids.length} prompts, latest: ${prompt.label}`;
+      continue;
+    }
+    groups.push({
+      ids: [prompt.id],
+      label: prompt.label,
+      topPercent: prompt.topPercent,
+    });
+  }
+
+  return groups;
+}
+
+function activePromptForScroll(
+  measured: MeasuredPrompt[],
+  scrollTop: number,
+): string | null {
+  if (measured.length === 0) return null;
+  let active = measured[0];
+  const cursor = scrollTop + 96;
+  for (const prompt of measured) {
+    if (prompt.top <= cursor) {
+      active = prompt;
+      continue;
+    }
+    break;
+  }
+  return active.id;
+}
+
+function jumpToPrompt(scrollEl: HTMLElement | null, promptId: string | undefined): void {
+  if (!scrollEl || !promptId) return;
+  const target = findPromptElement(scrollEl, promptId);
+  if (!target) return;
+  scrollEl.scrollTo({
+    top: Math.max(0, promptTop(scrollEl, target) - 16),
+    behavior: "smooth",
+  });
+}
+
+function findPromptElement(scrollEl: HTMLElement, promptId: string): HTMLElement | null {
+  const candidates = scrollEl.querySelectorAll<HTMLElement>("[data-user-prompt-id]");
+  return Array.from(candidates).find(
+    (candidate) => candidate.dataset.userPromptId === promptId,
+  ) ?? null;
+}
+
+function promptTop(scrollEl: HTMLElement, target: HTMLElement): number {
+  const scrollRect = scrollEl.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  const hasLayoutRect = scrollRect.top !== 0 || targetRect.top !== 0;
+  if (hasLayoutRect) {
+    return targetRect.top - scrollRect.top + scrollEl.scrollTop;
+  }
+  return target.offsetTop;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/webui/src/components/thread/ThreadMessages.tsx
+++ b/webui/src/components/thread/ThreadMessages.tsx
@@ -98,8 +98,17 @@ export function ThreadMessages({
           && next?.type === "message"
           && next.message.role === "assistant";
 
+        const userPromptId =
+          unit.type === "message" && unit.message.role === "user"
+            ? unit.message.id
+            : undefined;
+
         return (
-          <div key={unitKey(unit, index)} className={marginTop}>
+          <div
+            key={unitKey(unit, index)}
+            className={marginTop}
+            data-user-prompt-id={userPromptId}
+          >
             {unit.type === "activity" ? (
               <AgentActivityCluster
                 messages={unit.messages}

--- a/webui/src/components/thread/ThreadViewport.tsx
+++ b/webui/src/components/thread/ThreadViewport.tsx
@@ -10,6 +10,7 @@ import {
 import { ArrowDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
+import { PromptRail } from "@/components/thread/PromptRail";
 import { ThreadMessages } from "@/components/thread/ThreadMessages";
 import { isAgentActivityMember } from "@/components/thread/AgentActivityCluster";
 import { Button } from "@/components/ui/button";
@@ -288,6 +289,14 @@ export function ThreadViewport({
         aria-hidden
         className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b from-background to-transparent"
       />
+
+      {hasMessages ? (
+        <PromptRail
+          messages={visibleMessages}
+          scrollRef={scrollRef}
+          bottomOffset={scrollButtonBottom}
+        />
+      ) : null}
 
       {showScrollToBottomButton && !atBottom && (
         <Button

--- a/webui/src/components/thread/activity/ReasoningRow.tsx
+++ b/webui/src/components/thread/activity/ReasoningRow.tsx
@@ -36,7 +36,7 @@ export function ReasoningRow({
             "prose-headings:mt-2 prose-headings:mb-1 prose-headings:font-medium",
             "prose-headings:text-muted-foreground/88 prose-strong:text-muted-foreground",
             "prose-h1:text-[15px] prose-h2:text-[13.5px] prose-h3:text-[12.5px] prose-h4:text-[12px]",
-            "prose-a:text-muted-foreground/95 prose-a:underline hover:prose-a:opacity-90",
+            "prose-a:text-blue-600 prose-a:underline hover:prose-a:text-blue-700 dark:prose-a:text-blue-300 dark:hover:prose-a:text-blue-200",
             "prose-code:text-[0.92em]",
           )}
         >

--- a/webui/src/components/thread/activity/ReasoningRow.tsx
+++ b/webui/src/components/thread/activity/ReasoningRow.tsx
@@ -36,7 +36,7 @@ export function ReasoningRow({
             "prose-headings:mt-2 prose-headings:mb-1 prose-headings:font-medium",
             "prose-headings:text-muted-foreground/88 prose-strong:text-muted-foreground",
             "prose-h1:text-[15px] prose-h2:text-[13.5px] prose-h3:text-[12.5px] prose-h4:text-[12px]",
-            "prose-a:text-blue-600 prose-a:underline hover:prose-a:text-blue-700 dark:prose-a:text-blue-300 dark:hover:prose-a:text-blue-200",
+            "prose-a:text-blue-500 prose-a:underline hover:prose-a:text-blue-600 dark:prose-a:text-blue-300 dark:hover:prose-a:text-blue-200",
             "prose-code:text-[0.92em]",
           )}
         >

--- a/webui/src/hooks/useNanobotStream.ts
+++ b/webui/src/hooks/useNanobotStream.ts
@@ -145,7 +145,17 @@ function closeReasoningStream(prev: UIMessage[]): UIMessage[] {
   for (let i = prev.length - 1; i >= 0; i -= 1) {
     const candidate = prev[i];
     if (!candidate.reasoningStreaming) continue;
-    const merged: UIMessage = { ...candidate, reasoningStreaming: false };
+    const latencyMs =
+      candidate.latencyMs === undefined
+      && Number.isFinite(candidate.createdAt)
+      && candidate.createdAt > 1_000_000_000_000
+        ? Math.max(0, Math.round(Date.now() - candidate.createdAt))
+        : candidate.latencyMs;
+    const merged: UIMessage = {
+      ...candidate,
+      reasoningStreaming: false,
+      ...(latencyMs !== undefined ? { latencyMs } : {}),
+    };
     return [...prev.slice(0, i), merged, ...prev.slice(i + 1)];
   }
   return prev;

--- a/webui/src/lib/activity-timeline.ts
+++ b/webui/src/lib/activity-timeline.ts
@@ -132,7 +132,12 @@ function pushActivityUnits(units: TurnUnit[], activityMessages: UIMessage[], vis
   for (const message of activityMessages) {
     const bucket = isFileEditActivityMessage(message) ? "file" : "other";
     const segmentId = message.activitySegmentId;
-    const segmentChanged = !!runSegmentId && !!segmentId && runSegmentId !== segmentId;
+    const segmentChanged =
+      bucket === "file"
+      && runBucket === "file"
+      && !!runSegmentId
+      && !!segmentId
+      && runSegmentId !== segmentId;
     if ((runBucket && bucket !== runBucket) || segmentChanged) {
       flushRun();
     }

--- a/webui/src/tests/markdown-text-renderer.test.tsx
+++ b/webui/src/tests/markdown-text-renderer.test.tsx
@@ -4,6 +4,14 @@ import { describe, expect, it } from "vitest";
 import MarkdownTextRenderer from "@/components/MarkdownTextRenderer";
 
 describe("MarkdownTextRenderer", () => {
+  it("renders clickable markdown links in blue", () => {
+    render(<MarkdownTextRenderer>[local server](http://127.0.0.1:7891/)</MarkdownTextRenderer>);
+
+    const link = screen.getByRole("link", { name: "local server" });
+    expect(link).toHaveAttribute("href", "http://127.0.0.1:7891/");
+    expect(link).toHaveClass("text-blue-600", "dark:text-blue-300");
+  });
+
   it("does not wrap complete fenced code blocks in an extra pre", () => {
     const { container } = render(
       <MarkdownTextRenderer highlightCode={false}>

--- a/webui/src/tests/markdown-text-renderer.test.tsx
+++ b/webui/src/tests/markdown-text-renderer.test.tsx
@@ -9,7 +9,7 @@ describe("MarkdownTextRenderer", () => {
 
     const link = screen.getByRole("link", { name: "local server" });
     expect(link).toHaveAttribute("href", "http://127.0.0.1:7891/");
-    expect(link).toHaveClass("text-blue-600", "dark:text-blue-300");
+    expect(link).toHaveClass("text-blue-500", "dark:text-blue-300");
   });
 
   it("does not wrap complete fenced code blocks in an extra pre", () => {

--- a/webui/src/tests/thread-messages.test.tsx
+++ b/webui/src/tests/thread-messages.test.tsx
@@ -102,7 +102,7 @@ describe("ThreadMessages", () => {
     expect(units[2].type === "activity" ? units[2].messages.map((m) => m.id) : []).toEqual(["r2"]);
   });
 
-  it("splits ordinary tool activity when segment ids changed", () => {
+  it("keeps ordinary tool activity in one Thought block across segment ids", () => {
     const messages: UIMessage[] = [
       {
         id: "r1",
@@ -142,12 +142,10 @@ describe("ThreadMessages", () => {
 
     const units = buildDisplayUnits(messages);
 
-    expect(units).toHaveLength(2);
+    expect(units).toHaveLength(1);
     expect(units[0].type === "activity" ? units[0].messages.map((m) => m.id) : []).toEqual([
       "r1",
       "t1",
-    ]);
-    expect(units[1].type === "activity" ? units[1].messages.map((m) => m.id) : []).toEqual([
       "r2",
       "t2",
     ]);

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -215,6 +215,58 @@ describe("ThreadViewport", () => {
     });
   });
 
+  it("buckets dense prompt rails without rendering every prompt as a marker", async () => {
+    const promptMessages = makeLongMessages(100);
+    const { container } = render(
+      <ThreadViewport
+        messages={promptMessages}
+        isStreaming={false}
+        composer={<div />}
+      />,
+    );
+
+    const scroller = container.firstElementChild?.firstElementChild as HTMLElement;
+    const scrollTo = vi.fn();
+    Object.defineProperties(scroller, {
+      scrollHeight: { configurable: true, value: 10000 },
+      clientHeight: { configurable: true, value: 600 },
+      scrollTop: { configurable: true, value: 0 },
+      scrollTo: { configurable: true, value: scrollTo },
+    });
+
+    const promptEls = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-user-prompt-id]"),
+    );
+    expect(promptEls).toHaveLength(100);
+    promptEls.forEach((el, index) => {
+      Object.defineProperty(el, "offsetTop", {
+        configurable: true,
+        value: index * 90,
+      });
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    });
+
+    const promptMarkers = screen.getAllByRole("button", { name: /Jump to prompt:/ });
+    expect(promptMarkers.length).toBeGreaterThan(3);
+    expect(promptMarkers.length).toBeLessThan(100);
+    expect(
+      promptMarkers.some((marker) =>
+        marker.getAttribute("aria-label")?.includes("prompts, latest"),
+      ),
+    ).toBe(true);
+
+    fireEvent.click(promptMarkers[promptMarkers.length - 1]);
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 8894,
+      behavior: "smooth",
+    });
+  });
+
   it("expands the window start to avoid cutting an agent activity cluster", () => {
     const clustered = makeLongMessages(200);
     clustered.splice(

--- a/webui/src/tests/thread-viewport.test.tsx
+++ b/webui/src/tests/thread-viewport.test.tsx
@@ -170,6 +170,51 @@ describe("ThreadViewport", () => {
     expect(screen.getByText("message 299")).toBeInTheDocument();
   });
 
+  it("renders a prompt rail that jumps to user messages", async () => {
+    const promptMessages = makeLongMessages(5);
+    const { container } = render(
+      <ThreadViewport
+        messages={promptMessages}
+        isStreaming={false}
+        composer={<div />}
+      />,
+    );
+
+    const scroller = container.firstElementChild?.firstElementChild as HTMLElement;
+    const scrollTo = vi.fn();
+    Object.defineProperties(scroller, {
+      scrollHeight: { configurable: true, value: 1800 },
+      clientHeight: { configurable: true, value: 600 },
+      scrollTop: { configurable: true, value: 0 },
+      scrollTo: { configurable: true, value: scrollTo },
+    });
+
+    const promptEls = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-user-prompt-id]"),
+    );
+    expect(promptEls).toHaveLength(5);
+    promptEls.forEach((el, index) => {
+      Object.defineProperty(el, "offsetTop", {
+        configurable: true,
+        value: index * 360,
+      });
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    });
+
+    expect(screen.getByLabelText("User prompt navigation")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Jump to prompt: message 3" }));
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 1064,
+      behavior: "smooth",
+    });
+  });
+
   it("expands the window start to avoid cutting an agent activity cluster", () => {
     const clustered = makeLongMessages(200);
     clustered.splice(

--- a/webui/src/tests/useNanobotStream.test.tsx
+++ b/webui/src/tests/useNanobotStream.test.tsx
@@ -1039,6 +1039,41 @@ describe("useNanobotStream", () => {
     expect(result.current.messages[1].reasoningStreaming).toBe(false);
   });
 
+  it("stamps completed live Thought blocks with their own latency", async () => {
+    const dateNow = vi.spyOn(Date, "now");
+    let now = Date.UTC(2026, 5, 1, 0, 0, 0);
+    dateNow.mockImplementation(() => now);
+    try {
+      const fake = fakeClient();
+      const { result } = renderHook(() => useNanobotStream("chat-r5-lat", EMPTY_MESSAGES), {
+        wrapper: wrap(fake.client),
+      });
+      await act(async () => {});
+
+      act(() => {
+        fake.emit("chat-r5-lat", {
+          event: "reasoning_delta",
+          chat_id: "chat-r5-lat",
+          text: "Thinking through the tests.",
+        });
+      });
+      await act(async () => {
+        await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+      });
+
+      expect(result.current.messages[0].createdAt).toBe(now);
+      now += 2100;
+      act(() => {
+        fake.emit("chat-r5-lat", { event: "reasoning_end", chat_id: "chat-r5-lat" });
+      });
+
+      expect(result.current.messages[0].reasoningStreaming).toBe(false);
+      expect(result.current.messages[0].latencyMs).toBe(2100);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it("keeps alternating reasoning and answer deltas in separate ordered blocks", async () => {
     const fake = fakeClient();
     const { result } = renderHook(() => useNanobotStream("chat-r5b", EMPTY_MESSAGES), {


### PR DESCRIPTION
## Summary
- add a wide-screen WebUI prompt rail that marks user prompts and smooth-scrolls back to them
- bucket dense prompt rails so long conversations show density instead of one marker per prompt
- keep ordinary tool/reasoning activity in one Thought block unless a visible assistant response or file-edit boundary separates it
- re-sign replayed assistant media so videos/images survive gateway restarts
- suppress noisy WebSocket opening-handshake disconnect tracebacks during gateway restarts
- keep WebUI media replay and websocket logging helpers in nanobot/webui instead of growing the channel implementation
- render clickable markdown links in a lighter blue across assistant replies, reasoning panels, and compact link rows
- preserve per-Thought latency when a live reasoning block completes
- remove a useless timezone-option assignment caught by WebUI lint

## Why
Long conversations need a lightweight way to jump back to user prompts. Dense histories should preserve scroll-position signal without flooding the rail. Activity chunks from the same assistant turn should not split into multiple Thought blocks merely because internal segment ids changed. Replayed media must not reuse process-local signed URLs after a gateway restart. Browser clients can also disconnect during the WebSocket opening handshake while the gateway is restarting; those broken-pipe traces should stay out of user-facing logs while real handshake failures remain visible. Links were too close to body text, live reasoning-only blocks could finish without showing their own duration, and lint surfaced one harmless but unnecessary timezone assignment. The WebSocket channel now stays thinner by delegating WebUI-specific media/logging helpers to the WebUI package.

## Tests
- bun run lint
- bun run test -- src/tests/thread-messages.test.tsx src/tests/thread-viewport.test.tsx src/tests/markdown-text-renderer.test.tsx src/tests/message-bubble.test.tsx src/tests/agent-activity-cluster.test.tsx src/tests/useNanobotStream.test.tsx
- bun run build
- ruff check nanobot/channels/websocket.py nanobot/webui/media_api.py nanobot/webui/transcript.py nanobot/webui/websocket_logging.py tests/channels/test_websocket_channel.py tests/channels/test_websocket_http_routes.py tests/utils/test_webui_transcript.py tests/utils/test_webui_websocket_logging.py
- pytest tests/utils/test_webui_transcript.py tests/utils/test_webui_websocket_logging.py tests/channels/test_websocket_http_routes.py::test_webui_thread_resigns_assistant_media_urls tests/channels/test_websocket_channel.py::test_send_stages_external_media_as_signed_url tests/channels/test_websocket_channel.py::test_end_to_end_client_receives_ready_and_agent_sees_inbound tests/channels/test_websocket_media_route.py::test_session_messages_exposes_signed_media_urls tests/channels/test_websocket_media_route.py::test_session_messages_skips_vanished_media -q

## Scope
Desktop cleanup remains local and is not included in this PR.