### PR TITLE
feat(email): add file attachment support to email channel

### DIFF
--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -3,6 +3,7 @@
 import asyncio
 import html
 import imaplib
+import mimetypes
 import re
 import smtplib
 import ssl
@@ -212,6 +213,28 @@ class EmailChannel(BaseChannel):
         email_msg["To"] = to_addr
         email_msg["Subject"] = subject
         email_msg.set_content(msg.content or "")
+
+        # Attach media files
+        for media_path in msg.media or []:
+            path = Path(media_path)
+            if not path.is_file():
+                self.logger.warning("Attachment not found, skipping: {}", media_path)
+                continue
+            try:
+                data = path.read_bytes()
+                ctype, encoding = mimetypes.guess_type(str(path))
+                if ctype is None:
+                    ctype = "application/octet-stream"
+                maintype, subtype = ctype.split("/", 1)
+                email_msg.add_attachment(
+                    data,
+                    maintype=maintype,
+                    subtype=subtype,
+                    filename=path.name,
+                )
+                self.logger.info("Attached file: {}", path.name)
+            except Exception:
+                self.logger.exception("Failed to attach file {}", media_path)
 
         in_reply_to = self._last_message_id_by_chat.get(to_addr)
         if in_reply_to:

--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -208,33 +208,61 @@ class EmailChannel(BaseChannel):
             if override:
                 subject = override
 
+        attachments: list[tuple[bytes, str, str, str]] = []
+        failed_attachments: list[str] = []
+        max_attachment_size = max(0, int(self.config.max_attachment_size))
+        max_attachment_count = max(0, int(self.config.max_attachments_per_email))
+        for media_path in msg.media or []:
+            path = Path(media_path)
+            filename = path.name or "attachment"
+            if len(attachments) >= max_attachment_count:
+                failed_attachments.append(f"[attachment: {filename} - too many attachments]")
+                self.logger.warning("Attachment count limit reached, skipping: {}", media_path)
+                continue
+            if not path.is_file():
+                failed_attachments.append(f"[attachment: {filename} - send failed]")
+                self.logger.warning("Attachment not found, skipping: {}", media_path)
+                continue
+            try:
+                size = path.stat().st_size
+                if max_attachment_size <= 0 or size > max_attachment_size:
+                    failed_attachments.append(f"[attachment: {filename} - too large]")
+                    self.logger.warning(
+                        "Attachment too large, skipping: {} ({} > {} bytes)",
+                        media_path,
+                        size,
+                        max_attachment_size,
+                    )
+                    continue
+                data = path.read_bytes()
+                ctype, _ = mimetypes.guess_type(str(path))
+                if ctype is None:
+                    ctype = "application/octet-stream"
+                maintype, subtype = ctype.split("/", 1)
+                attachments.append((data, maintype, subtype, filename))
+                self.logger.info("Attached file: {}", filename)
+            except Exception:
+                failed_attachments.append(f"[attachment: {filename} - send failed]")
+                self.logger.exception("Failed to attach file {}", media_path)
+
+        content = msg.content or ""
+        if failed_attachments:
+            fallback = "\n".join(failed_attachments)
+            content = f"{content.rstrip()}\n\n{fallback}" if content.strip() else fallback
+
         email_msg = EmailMessage()
         email_msg["From"] = self.config.from_address or self.config.smtp_username or self.config.imap_username
         email_msg["To"] = to_addr
         email_msg["Subject"] = subject
-        email_msg.set_content(msg.content or "")
+        email_msg.set_content(content)
 
-        # Attach media files
-        for media_path in msg.media or []:
-            path = Path(media_path)
-            if not path.is_file():
-                self.logger.warning("Attachment not found, skipping: {}", media_path)
-                continue
-            try:
-                data = path.read_bytes()
-                ctype, encoding = mimetypes.guess_type(str(path))
-                if ctype is None:
-                    ctype = "application/octet-stream"
-                maintype, subtype = ctype.split("/", 1)
-                email_msg.add_attachment(
-                    data,
-                    maintype=maintype,
-                    subtype=subtype,
-                    filename=path.name,
-                )
-                self.logger.info("Attached file: {}", path.name)
-            except Exception:
-                self.logger.exception("Failed to attach file {}", media_path)
+        for data, maintype, subtype, filename in attachments:
+            email_msg.add_attachment(
+                data,
+                maintype=maintype,
+                subtype=subtype,
+                filename=filename,
+            )
 
         in_reply_to = self._last_message_id_by_chat.get(to_addr)
         if in_reply_to:

--- a/tests/channels/test_email_channel.py
+++ b/tests/channels/test_email_channel.py
@@ -1001,3 +1001,286 @@ def test_extract_attachments_sanitizes_filename(tmp_path, monkeypatch) -> None:
     saved_path = Path(items[0]["media"][0])
     # File must be inside the media dir, not escaped via path traversal
     assert saved_path.parent == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Agent-initiated file attachment tests (send with media)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_with_single_file_attachment(tmp_path, monkeypatch) -> None:
+    """Agent sends an email with a single file attached."""
+    sent_messages: list[EmailMessage] = []
+
+    class FakeSMTP:
+        def __init__(self, _host: str, _port: int, timeout: int = 30) -> None:
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def starttls(self, context=None):
+            return None
+
+        def login(self, _user: str, _pw: str):
+            return None
+
+        def send_message(self, msg: EmailMessage):
+            sent_messages.append(msg)
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP", lambda h, p, timeout=30: FakeSMTP(h, p, timeout=timeout))
+
+    # Create a real temp file to attach
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"%PDF-1.4 fake pdf content")
+
+    channel = EmailChannel(_make_config(), MessageBus())
+    await channel.send(
+        OutboundMessage(
+            channel="email",
+            chat_id="alice@example.com",
+            content="Please find the report attached.",
+            media=[str(attachment)],
+        )
+    )
+
+    assert len(sent_messages) == 1
+    sent = sent_messages[0]
+    assert sent["To"] == "alice@example.com"
+    assert sent.is_multipart(), "Email with attachment should be multipart"
+
+    # Walk parts to find the attachment
+    attachment_parts = []
+    for part in sent.walk():
+        if part.get_content_disposition() == "attachment":
+            attachment_parts.append(part)
+    assert len(attachment_parts) == 1
+    att = attachment_parts[0]
+    assert att.get_filename() == "report.pdf"
+    assert att.get_content_type() == "application/pdf"
+    assert att.get_payload(decode=True) == b"%PDF-1.4 fake pdf content"
+
+
+@pytest.mark.asyncio
+async def test_send_with_multiple_file_attachments(tmp_path, monkeypatch) -> None:
+    """Agent sends an email with multiple files attached."""
+    sent_messages: list[EmailMessage] = []
+
+    class FakeSMTP:
+        def __init__(self, _host: str, _port: int, timeout: int = 30) -> None:
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def starttls(self, context=None):
+            return None
+
+        def login(self, _user: str, _pw: str):
+            return None
+
+        def send_message(self, msg: EmailMessage):
+            sent_messages.append(msg)
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP", lambda h, p, timeout=30: FakeSMTP(h, p, timeout=timeout))
+
+    file1 = tmp_path / "doc.pdf"
+    file1.write_bytes(b"%PDF-1.4 doc")
+    file2 = tmp_path / "image.png"
+    file2.write_bytes(b"\x89PNG fake image")
+    file3 = tmp_path / "notes.txt"
+    file3.write_bytes(b"Hello, this is a text note.")
+
+    channel = EmailChannel(_make_config(), MessageBus())
+    await channel.send(
+        OutboundMessage(
+            channel="email",
+            chat_id="bob@example.com",
+            content="Multiple files attached.",
+            media=[str(file1), str(file2), str(file3)],
+        )
+    )
+
+    assert len(sent_messages) == 1
+    sent = sent_messages[0]
+    assert sent.is_multipart()
+
+    attachment_parts = []
+    for part in sent.walk():
+        if part.get_content_disposition() == "attachment":
+            attachment_parts.append(part)
+    assert len(attachment_parts) == 3
+
+    filenames = {p.get_filename() for p in attachment_parts}
+    assert filenames == {"doc.pdf", "image.png", "notes.txt"}
+
+
+@pytest.mark.asyncio
+async def test_send_skips_missing_attachment_file(tmp_path, monkeypatch) -> None:
+    """Non-existent attachment file is skipped without breaking the send."""
+    sent_messages: list[EmailMessage] = []
+
+    class FakeSMTP:
+        def __init__(self, _host: str, _port: int, timeout: int = 30) -> None:
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def starttls(self, context=None):
+            return None
+
+        def login(self, _user: str, _pw: str):
+            return None
+
+        def send_message(self, msg: EmailMessage):
+            sent_messages.append(msg)
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP", lambda h, p, timeout=30: FakeSMTP(h, p, timeout=timeout))
+
+    existing = tmp_path / "real.txt"
+    existing.write_text("I exist")
+
+    channel = EmailChannel(_make_config(), MessageBus())
+    await channel.send(
+        OutboundMessage(
+            channel="email",
+            chat_id="alice@example.com",
+            content="One attachment is missing.",
+            media=[
+                str(existing),
+                str(tmp_path / "nonexistent.pdf"),
+            ],
+        )
+    )
+
+    assert len(sent_messages) == 1
+    sent = sent_messages[0]
+    assert sent.is_multipart()
+
+    attachment_parts = []
+    for part in sent.walk():
+        if part.get_content_disposition() == "attachment":
+            attachment_parts.append(part)
+    # Only the existing file should be attached
+    assert len(attachment_parts) == 1
+    assert attachment_parts[0].get_filename() == "real.txt"
+
+
+@pytest.mark.asyncio
+async def test_send_with_unknown_mime_type_attachment(tmp_path, monkeypatch) -> None:
+    """File with unknown extension gets application/octet-stream MIME type."""
+    sent_messages: list[EmailMessage] = []
+
+    class FakeSMTP:
+        def __init__(self, _host: str, _port: int, timeout: int = 30) -> None:
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def starttls(self, context=None):
+            return None
+
+        def login(self, _user: str, _pw: str):
+            return None
+
+        def send_message(self, msg: EmailMessage):
+            sent_messages.append(msg)
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP", lambda h, p, timeout=30: FakeSMTP(h, p, timeout=timeout))
+
+    attachment = tmp_path / "data.unknown_ext_xyz"
+    attachment.write_bytes(b"some binary data")
+
+    channel = EmailChannel(_make_config(), MessageBus())
+    await channel.send(
+        OutboundMessage(
+            channel="email",
+            chat_id="alice@example.com",
+            content="Unknown MIME type.",
+            media=[str(attachment)],
+        )
+    )
+
+    assert len(sent_messages) == 1
+    sent = sent_messages[0]
+    assert sent.is_multipart()
+
+    attachment_parts = []
+    for part in sent.walk():
+        if part.get_content_disposition() == "attachment":
+            attachment_parts.append(part)
+    assert len(attachment_parts) == 1
+    att = attachment_parts[0]
+    assert att.get_content_type() == "application/octet-stream"
+    assert att.get_filename() == "data.unknown_ext_xyz"
+
+
+@pytest.mark.asyncio
+async def test_send_with_media_and_reply_subject_and_in_reply_to(tmp_path, monkeypatch) -> None:
+    """Attachments work together with reply subject and In-Reply-To headers."""
+    sent_messages: list[EmailMessage] = []
+
+    class FakeSMTP:
+        def __init__(self, _host: str, _port: int, timeout: int = 30) -> None:
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def starttls(self, context=None):
+            return None
+
+        def login(self, _user: str, _pw: str):
+            return None
+
+        def send_message(self, msg: EmailMessage):
+            sent_messages.append(msg)
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP", lambda h, p, timeout=30: FakeSMTP(h, p, timeout=timeout))
+
+    attachment = tmp_path / "summary.pdf"
+    attachment.write_bytes(b"%PDF-1.4 summary")
+
+    channel = EmailChannel(_make_config(), MessageBus())
+    channel._last_subject_by_chat["alice@example.com"] = "Original subject"
+    channel._last_message_id_by_chat["alice@example.com"] = "<orig@example.com>"
+
+    await channel.send(
+        OutboundMessage(
+            channel="email",
+            chat_id="alice@example.com",
+            content="Reply with attachment.",
+            media=[str(attachment)],
+        )
+    )
+
+    assert len(sent_messages) == 1
+    sent = sent_messages[0]
+    assert sent["Subject"] == "Re: Original subject"
+    assert sent["In-Reply-To"] == "<orig@example.com>"
+    assert sent["References"] == "<orig@example.com>"
+
+    attachment_parts = []
+    for part in sent.walk():
+        if part.get_content_disposition() == "attachment":
+            attachment_parts.append(part)
+    assert len(attachment_parts) == 1
+    assert attachment_parts[0].get_filename() == "summary.pdf"

--- a/tests/channels/test_email_channel.py
+++ b/tests/channels/test_email_channel.py
@@ -1175,6 +1175,108 @@ async def test_send_skips_missing_attachment_file(tmp_path, monkeypatch) -> None
     # Only the existing file should be attached
     assert len(attachment_parts) == 1
     assert attachment_parts[0].get_filename() == "real.txt"
+    body = sent.get_body(preferencelist=("plain",))
+    assert body is not None
+    assert "[attachment: nonexistent.pdf - send failed]" in body.get_content()
+
+
+@pytest.mark.asyncio
+async def test_send_skips_oversized_attachment_file(tmp_path, monkeypatch) -> None:
+    """Attachment exceeding max_attachment_size is skipped with a visible note."""
+    sent_messages: list[EmailMessage] = []
+
+    class FakeSMTP:
+        def __init__(self, _host: str, _port: int, timeout: int = 30) -> None:
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def starttls(self, context=None):
+            return None
+
+        def login(self, _user: str, _pw: str):
+            return None
+
+        def send_message(self, msg: EmailMessage):
+            sent_messages.append(msg)
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP", lambda h, p, timeout=30: FakeSMTP(h, p, timeout=timeout))
+
+    attachment = tmp_path / "too-large.bin"
+    attachment.write_bytes(b"1234")
+
+    channel = EmailChannel(_make_config(max_attachment_size=3), MessageBus())
+    await channel.send(
+        OutboundMessage(
+            channel="email",
+            chat_id="alice@example.com",
+            content="Attachment should be skipped.",
+            media=[str(attachment)],
+        )
+    )
+
+    assert len(sent_messages) == 1
+    sent = sent_messages[0]
+    assert not sent.is_multipart()
+    assert "[attachment: too-large.bin - too large]" in sent.get_content()
+
+
+@pytest.mark.asyncio
+async def test_send_limits_outbound_attachment_count(tmp_path, monkeypatch) -> None:
+    """Only max_attachments_per_email outbound attachments are included."""
+    sent_messages: list[EmailMessage] = []
+
+    class FakeSMTP:
+        def __init__(self, _host: str, _port: int, timeout: int = 30) -> None:
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def starttls(self, context=None):
+            return None
+
+        def login(self, _user: str, _pw: str):
+            return None
+
+        def send_message(self, msg: EmailMessage):
+            sent_messages.append(msg)
+
+    monkeypatch.setattr("nanobot.channels.email.smtplib.SMTP", lambda h, p, timeout=30: FakeSMTP(h, p, timeout=timeout))
+
+    file1 = tmp_path / "first.txt"
+    file1.write_text("first")
+    file2 = tmp_path / "second.txt"
+    file2.write_text("second")
+
+    channel = EmailChannel(_make_config(max_attachments_per_email=1), MessageBus())
+    await channel.send(
+        OutboundMessage(
+            channel="email",
+            chat_id="alice@example.com",
+            content="Only one attachment should be sent.",
+            media=[str(file1), str(file2)],
+        )
+    )
+
+    assert len(sent_messages) == 1
+    sent = sent_messages[0]
+    attachment_parts = []
+    for part in sent.walk():
+        if part.get_content_disposition() == "attachment":
+            attachment_parts.append(part)
+    assert len(attachment_parts) == 1
+    assert attachment_parts[0].get_filename() == "first.txt"
+    body = sent.get_body(preferencelist=("plain",))
+    assert body is not None
+    assert "[attachment: second.txt - too many attachments]" in body.get_content()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds the ability to attach files when sending emails via the email channel.

### Changes
- **`nanobot/channels/email.py`**: attach media files from `OutboundMessage.media` using `mimetypes.guess_type` for MIME detection and `EmailMessage.add_attachment` for proper multipart MIME encoding
- **`tests/channels/test_email_channel.py`**: 283 lines of test coverage covering single file, multiple files, missing file skips, unknown MIME types, and attachment + reply header interaction

### Testing
- Single file attachment with correct MIME type and filename
- Multiple file attachments
- Graceful skip of missing/nonexistent files
- Fallback to `application/octet-stream` for unknown extensions
- Compatibility with reply headers (Subject, In-Reply-To, References)